### PR TITLE
refactor(rpc): move format call to own library

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1163,7 +1163,8 @@ let build (builder : Builder.t) ~default_root_is_cwd =
          in
          let action_runner = Dune_engine.Action_runner.Rpc_server.create () in
          Dune_rpc_impl.Server.create ~lock_timeout ~registry ~root:root.dir
-           ~watch_mode_config:builder.watch stats action_runner))
+           ~handle:Dune_rules_rpc.register ~watch_mode_config:builder.watch
+           stats action_runner))
   in
   if builder.store_digest_preimage then Dune_engine.Reversible_digest.enable ();
   if builder.print_metrics then (

--- a/bin/dune
+++ b/bin/dune
@@ -35,6 +35,7 @@
   csexp
   csexp_rpc
   dune_rpc_impl
+  dune_rules_rpc
   dune_rpc_private
   dune_rpc_client
   spawn)

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -71,6 +71,7 @@ let local_libraries =
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "Build_info_data")
   ; ("src/dune_rpc_impl", Some "Dune_rpc_impl", false, None)
+  ; ("src/dune_rules_rpc", Some "Dune_rules_rpc", false, None)
   ]
 
 let link_flags =

--- a/src/dune_rpc_impl/dune_rpc_impl.ml
+++ b/src/dune_rpc_impl/dune_rpc_impl.ml
@@ -1,6 +1,7 @@
 module Decl = Decl
 module Client = Client
 module Server = Server
+module For_handlers = For_handlers
 module Private = Dune_rpc_client.Private
 module Watch_mode_config = Watch_mode_config
 module Where = Dune_rpc_client.Where

--- a/src/dune_rpc_impl/for_handlers.ml
+++ b/src/dune_rpc_impl/for_handlers.ml
@@ -1,0 +1,13 @@
+open Stdune
+
+let source_path_of_string path =
+  if Filename.is_relative path then Path.Source.(relative root path)
+  else
+    let source_root =
+      Path.to_absolute_filename (Path.source Path.Source.root)
+    in
+    match String.drop_prefix path ~prefix:source_root with
+    | None -> User_error.raise [ Pp.textf "path isn't available in workspace" ]
+    | Some s ->
+      let s = String.drop_prefix_if_exists s ~prefix:"/" in
+      Path.Source.(relative root s)

--- a/src/dune_rpc_impl/for_handlers.mli
+++ b/src/dune_rpc_impl/for_handlers.mli
@@ -1,0 +1,5 @@
+(** Utilities for implementors of rpc functions *)
+
+open Stdune
+
+val source_path_of_string : string -> Path.Source.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -7,6 +7,8 @@ val create :
   -> registry:[ `Add | `Skip ]
   -> root:string
   -> watch_mode_config:Watch_mode_config.t
+  -> handle:(unit Dune_rpc_server.Handler.t -> unit)
+       (** register additional requests or notifications *)
   -> Dune_stats.t option
   -> Dune_engine.Action_runner.Rpc_server.t
   -> t

--- a/src/dune_rules_rpc/dune
+++ b/src/dune_rules_rpc/dune
@@ -1,0 +1,15 @@
+(library
+ (name dune_rules_rpc)
+ (synopsis "rpc functionality that depends on dune's public rules")
+ (libraries
+  stdune
+  fiber
+  memo
+  dune_lang
+  dune_engine
+  dune_rpc_impl
+  dune_rpc_private
+  dune_rpc_server
+  dune_rules)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/dune_rules_rpc/dune_rules_rpc.ml
+++ b/src/dune_rules_rpc/dune_rules_rpc.ml
@@ -1,0 +1,36 @@
+include struct
+  open Dune_rules
+  module Dep_conf = Dep_conf
+  module Source_tree = Source_tree
+  module Dune_project = Dune_project
+end
+
+include struct
+  open Dune_rpc_private
+  module Procedures = Procedures
+end
+
+include struct
+  open Dune_rpc_server
+  module Handler = Handler
+end
+
+let register rpc =
+  let open Fiber.O in
+  let () =
+    let f _ (path, `Contents contents) =
+      let+ version =
+        Memo.run
+          (let open Memo.O in
+          let source_path =
+            Dune_rpc_impl.For_handlers.source_path_of_string path
+          in
+          let+ dir = Source_tree.nearest_dir source_path in
+          let project = Source_tree.Dir.project dir in
+          Dune_project.dune_version project)
+      in
+      Dune_lang.Format.format_string ~version contents
+    in
+    Handler.implement_request rpc Procedures.Public.format_dune_file f
+  in
+  ()

--- a/src/dune_rules_rpc/dune_rules_rpc.mli
+++ b/src/dune_rules_rpc/dune_rules_rpc.mli
@@ -1,0 +1,1 @@
+val register : _ Dune_rpc_server.Handler.t -> unit


### PR DESCRIPTION
[Dune_rpc_impl] should be generic and not depend on dune's own rules.

To do so, we create a dune_rpc_dune_lang library that will register the
formatting request that depends on dune.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 293712e7-4388-4bc9-813d-84acfe6988a0 -->