### PR TITLE
refactor: make Action.File_perm.t a polymorphic variant

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -1,12 +1,13 @@
 open Import
 module Ext = Action_intf.Ext
-module File_perm = File_perm
 module Outputs = Outputs
 module Inputs = Inputs
 
 module type T = sig
   type t
 end
+
+module File_perm = Action_intf.File_perm
 
 module Make
     (Program : T)
@@ -29,13 +30,13 @@ struct
 
   let setenv var value t = Setenv (var, value, t)
 
-  let with_stdout_to ?(perm = File_perm.Normal) path t =
+  let with_stdout_to ?(perm = `Normal) path t =
     Redirect_out (Stdout, path, perm, t)
 
-  let with_stderr_to ?(perm = File_perm.Normal) path t =
+  let with_stderr_to ?(perm = `Normal) path t =
     Redirect_out (Stderr, path, perm, t)
 
-  let with_outputs_to ?(perm = File_perm.Normal) path t =
+  let with_outputs_to ?(perm = `Normal) path t =
     Redirect_out (Outputs, path, perm, t)
 
   let with_stdin_from path t = Redirect_in (Stdin, path, t)
@@ -62,7 +63,7 @@ struct
 
   let bash s = Bash s
 
-  let write_file ?(perm = File_perm.Normal) p s = Write_file (p, perm, s)
+  let write_file ?(perm = `Normal) p s = Write_file (p, perm, s)
 
   let rename a b = Rename (a, b)
 

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -19,9 +19,10 @@ module Inputs : sig
 end
 
 module File_perm : sig
-  include
-    module type of Dune_lang.Action.File_perm
-      with type t = Dune_lang.Action.File_perm.t
+  type t =
+    [ `Normal
+    | `Executable
+    ]
 end
 
 module Ext : module type of Action_intf.Ext

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -201,7 +201,7 @@ module With_targets = struct
       in
       { build = all (List.rev build); targets }
 
-  let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
+  let write_file_dyn ?(perm = `Normal) fn s =
     add ~file_targets:[ fn ]
       (let+ s = s in
        Action.Full.make (Action.Write_file (fn, perm, s)))
@@ -219,16 +219,16 @@ let with_file_targets build ~file_targets : _ With_targets.t =
 let with_no_targets build : _ With_targets.t =
   { build; targets = Targets.empty }
 
-let write_file ?(perm = Action.File_perm.Normal) fn s =
+let write_file ?(perm = `Normal) fn s =
   with_file_targets ~file_targets:[ fn ]
     (return (Action.Full.make (Action.Write_file (fn, perm, s))))
 
-let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
+let write_file_dyn ?(perm = `Normal) fn s =
   with_file_targets ~file_targets:[ fn ]
     (let+ s = s in
      Action.Full.make (Action.Write_file (fn, perm, s)))
 
-let with_stdout_to ?(perm = Action.File_perm.Normal) fn t =
+let with_stdout_to ?(perm = `Normal) fn t =
   with_targets ~targets:(Targets.File.create fn)
     (let+ (act : Action.Full.t) = t in
      Action.Full.map act ~f:(Action.with_stdout_to ~perm fn))
@@ -248,7 +248,7 @@ let symlink_dir ~src ~dst =
          ~dirs:(Path.Build.Set.singleton dst))
     (path src >>> return (Action.Full.make (Action.Symlink (src, dst))))
 
-let create_file ?(perm = Action.File_perm.Normal) fn =
+let create_file ?(perm = `Normal) fn =
   with_file_targets ~file_targets:[ fn ]
     (return
        (Action.Full.make (Action.Redirect_out (Stdout, fn, perm, Action.empty))))

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -1,5 +1,12 @@
 open Import
 
+module File_perm = struct
+  type t =
+    [ `Normal
+    | `Executable
+    ]
+end
+
 module Simplified = struct
   type destination =
     | Dev_null

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -38,8 +38,8 @@ let mkdir p = Run ("mkdir", [ "-p"; p ])
 
 let interpret_perm (perm : Action.File_perm.t) fn acc =
   match perm with
-  | Normal -> acc
-  | Executable -> Run ("chmod", [ "+x"; fn ]) :: acc
+  | `Normal -> acc
+  | `Executable -> Run ("chmod", [ "+x"; fn ]) :: acc
 
 let simplify act =
   let rec loop (act : Action.For_shell.t) acc =

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -12,7 +12,6 @@ module Glob = Dune_glob.V1
 module String_with_vars = Dune_lang.String_with_vars
 module Outputs = Dune_lang.Action.Outputs
 module Inputs = Dune_lang.Action.Inputs
-module File_perm = Dune_lang.Action.File_perm
 module Diff = Dune_lang.Action.Diff
 include No_io
 

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -60,16 +60,13 @@ end
 
 module File_perm = struct
   type t =
-    | Normal
-    | Executable
+    [ `Normal
+    | `Executable
+    ]
 
   let suffix = function
-    | Normal -> ""
-    | Executable -> "-executable"
-
-  let to_unix_perm = function
-    | Normal -> 0o666
-    | Executable -> 0o777
+    | `Normal -> ""
+    | `Executable -> "-executable"
 end
 
 type t =
@@ -106,7 +103,7 @@ let is_dev_null t = String_with_vars.is_pform t (Var Dev_null)
 
 let translate_to_ignore fn output action =
   if is_dev_null fn then Ignore (output, action)
-  else Redirect_out (output, fn, Normal, action)
+  else Redirect_out (output, fn, `Normal, action)
 
 let two_or_more decode =
   let open Decoder in
@@ -245,7 +242,7 @@ let cstrs_dune_file t =
   ; ( "write-file"
     , let+ fn = sw
       and+ s = sw in
-      Write_file (fn, Normal, s) )
+      Write_file (fn, `Normal, s) )
   ; ( "diff"
     , let+ diff = Diff.decode sw sw ~optional:false in
       Diff diff )

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -57,12 +57,11 @@ module File_perm : sig
       account when memoizing commands. *)
 
   type t =
-    | Normal
-    | Executable
+    [ `Normal
+    | `Executable
+    ]
 
   val suffix : t -> string
-
-  val to_unix_perm : t -> int
 end
 
 type t =

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -99,7 +99,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
                 ; action =
                     ( loc
                     , Action_unexpanded.Redirect_out
-                        (Stdout, diff.file2, Normal, run_action) )
+                        (Stdout, diff.file2, `Normal, run_action) )
                 ; mode = Standard
                 ; patch_back_source_tree = false
                 ; locks = t.locks

--- a/test/expect-tests/dune_engine/action_to_sh_tests.ml
+++ b/test/expect-tests/dune_engine/action_to_sh_tests.ml
@@ -24,21 +24,13 @@ let%expect_test "setenv" =
     bash -e -u -o pipefail -c 'echo Hello world' |}]
 
 let%expect_test "with-stdout-to" =
-  Redirect_out
-    ( Action.Outputs.Stdout
-    , "foo"
-    , Action.File_perm.Normal
-    , Bash "echo Hello world" )
+  Redirect_out (Action.Outputs.Stdout, "foo", `Normal, Bash "echo Hello world")
   |> print;
   [%expect {|
     bash -e -u -o pipefail -c 'echo Hello world' > foo |}]
 
 let%expect_test "with-stderr-to" =
-  Redirect_out
-    ( Action.Outputs.Stderr
-    , "foo"
-    , Action.File_perm.Normal
-    , Bash "echo Hello world" )
+  Redirect_out (Action.Outputs.Stderr, "foo", `Normal, Bash "echo Hello world")
   |> print;
   [%expect {|
     bash -e -u -o pipefail -c 'echo Hello world' 2> foo |}]
@@ -47,7 +39,7 @@ let%expect_test "with-outputs-to" =
   Redirect_out
     ( Action.Outputs.Outputs
     , "foo"
-    , Action.File_perm.Normal
+    , `Normal
     , Progn [ Bash "first sometinhg"; Bash "then"; Bash "echo Hello world" ] )
   |> print;
   [%expect
@@ -60,10 +52,7 @@ let%expect_test "with-outputs-to" =
 
 let%expect_test "with-outputs-to executable" =
   Redirect_out
-    ( Action.Outputs.Outputs
-    , "foo"
-    , Action.File_perm.Executable
-    , Bash "echo Hello world" )
+    (Action.Outputs.Outputs, "foo", `Executable, Bash "echo Hello world")
   |> print;
   [%expect
     {|
@@ -140,12 +129,12 @@ let%expect_test "echo" =
     echo -n Helloworld |}]
 
 let%expect_test "write-file" =
-  Write_file ("foo", Action.File_perm.Normal, "Hello world") |> print;
+  Write_file ("foo", `Normal, "Hello world") |> print;
   [%expect {|
     echo -n 'Hello world' > foo |}]
 
 let%expect_test "write-file executable" =
-  Write_file ("foo", Action.File_perm.Executable, "Hello world") |> print;
+  Write_file ("foo", `Executable, "Hello world") |> print;
   [%expect {|
       echo -n 'Hello world' > foo;
       chmod +x foo |}]
@@ -215,10 +204,7 @@ let%expect_test "pipe-stdout-to" =
     ( Action.Outputs.Stdout
     , [ Bash "echo Hello world"
       ; Redirect_out
-          ( Action.Outputs.Stdout
-          , "foo"
-          , Action.File_perm.Normal
-          , Bash "echo Hello world" )
+          (Action.Outputs.Stdout, "foo", `Normal, Bash "echo Hello world")
       ] )
   |> print;
   [%expect
@@ -231,10 +217,7 @@ let%expect_test "pipe-stderr-to" =
     ( Action.Outputs.Stderr
     , [ Bash "echo Hello world"
       ; Redirect_out
-          ( Action.Outputs.Stderr
-          , "foo"
-          , Action.File_perm.Normal
-          , Bash "echo Hello world" )
+          (Action.Outputs.Stderr, "foo", `Normal, Bash "echo Hello world")
       ] )
   |> print;
   [%expect
@@ -247,10 +230,7 @@ let%expect_test "pipe-outputs-to" =
     ( Action.Outputs.Outputs
     , [ Bash "echo Hello world"
       ; Redirect_out
-          ( Action.Outputs.Outputs
-          , "foo"
-          , Action.File_perm.Normal
-          , Bash "echo Hello world" )
+          (Action.Outputs.Outputs, "foo", `Normal, Bash "echo Hello world")
       ] )
   |> print;
   [%expect


### PR DESCRIPTION
This allows to drop the dependency on Dune_lang.Action.File_perm in the
engine

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cfe8b40c-23ba-4ba0-9e5b-30c746c3c940 -->