### PR TITLE
Improve JSON string quoting in Dune tracing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix string quoting in the json file written by `--trace-file` (#7773,
+  @rleshchinskiy)
+
 - Read `pkg-config` arguments from the `PKG_CONFIG_ARGN` environment variable
   (#1492, #7734, @anmonteiro)
 


### PR DESCRIPTION
We want to include more things in the trace file and we should always produce valid JSON here.