### PR TITLE
doc: correct doc for (map_workspace_root)

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -653,24 +653,17 @@ map_workspace_root
 
    - with ``(map_workspace_root true)``, dune rewrites references to the
      workspace root to ``/workspace_root``. Note that when this mapping is
-     enabled, the debug information produced by the bytecode compiler gives
-     locations relative to the workspace root. If the developer chooses a
-     source layout that mirrors the installation layout, then by mapping paths
-     with ``/workspace_root`` replaced by the install root, the installed
-     artifacts (e.g. source files) can be found. This mapping will be done by a
-     combination of an updated ``ocamldebug`` and the new ``dune ocaml debug``
-     command. However, if the source layout is different than the install
-     layout, this will not work.
+     enabled, the debug information produced by the bytecode compiler is
+     incorrect, as the location information is lost.
 
    - with ``(map_workspace_root false)``, the references are not rewritten.
 
    The default is ``(map_workspace_root true)``.
 
    .. versionadded:: 3.0
+        Initial version with the mapping always enabled.
    .. versionchanged:: 3.7
         Add a way to disable the mapping.
-   .. versionchanged:: 3.8
-        Also rewrite the installation directory (usually ``~/.opam/<switch>``).
 
 .. _dune-files:
 


### PR DESCRIPTION
Change the documentation for `(map_workspace_root)` so that it matches the existing situation.

See #7743 which had been incorrectly merged.
