### PR TITLE
Trace more data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Unreleased
 ----------
 
+- Add additional metadata to the traces provided by `--trace-file` whenever
+  `--trace-extended` is passed (#7778, @rleshchinskiy)
+
+3.8.0 (2023-05-23)
+------------------
+
 - Fix string quoting in the json file written by `--trace-file` (#7773,
   @rleshchinskiy)
 

--- a/otherlibs/chrome-trace/test/chrome_trace_tests.ml
+++ b/otherlibs/chrome-trace/test/chrome_trace_tests.ml
@@ -9,7 +9,9 @@ let c =
   let write s = Buffer.add_string buf s in
   let close () = () in
   let flush () = () in
-  Dune_stats.create (Custom { write; close; flush })
+  Dune_stats.create
+    (Custom { write; close; flush })
+    ~extended_build_job_info:false
 
 let () =
   let module Event = Chrome_trace.Event in

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -108,6 +108,7 @@ type t =
   { print : string -> unit
   ; close : unit -> unit
   ; flush : unit -> unit
+  ; extended_build_job_info : bool
   ; mutable after_first_event : bool
   }
 
@@ -117,7 +118,7 @@ let close { print; close; _ } =
   print "]\n";
   close ()
 
-let create dst =
+let create ~extended_build_job_info dst =
   let print =
     match dst with
     | Out out -> Stdlib.output_string out
@@ -133,9 +134,11 @@ let create dst =
     | Out out -> fun () -> flush out
     | Custom c -> c.flush
   in
-  { print; close; after_first_event = false; flush }
+  { print; close; after_first_event = false; flush; extended_build_job_info }
 
 let flush t = t.flush ()
+
+let extended_build_job_info t = t.extended_build_job_info
 
 let next_leading_char t =
   match t.after_first_event with

--- a/src/dune_stats/dune_stats.mli
+++ b/src/dune_stats/dune_stats.mli
@@ -12,13 +12,15 @@ type dst =
       ; flush : unit -> unit
       }
 
-val create : dst -> t
+val create : extended_build_job_info:bool -> dst -> t
 
 val emit : t -> Chrome_trace.Event.t -> unit
 
 val record_gc_and_fd : t -> unit
 
 val close : t -> unit
+
+val extended_build_job_info : t -> bool
 
 type event
 


### PR DESCRIPTION
This allows Dune to generate trace files which contain the same information as .jenga/debug files about processes that Dune runs. This can be quite a bit of information (including stdout and stderr) so this is controlled by the `--trace-extended` flag.