### PR TITLE
refactor(engine): decouple from Dune_lang

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -10,6 +10,7 @@
   memo
   ocaml
   dune_lang
+  predicate_lang
   fiber
   stdune
   dune_console

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -29,6 +29,7 @@ let local_libraries =
     None)
   ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("src/dune_util", Some "Dune_util", false, None)
+  ; ("src/predicate_lang", Some "Predicate_lang", false, None)
   ; ("src/section", Some "Dune_section", false, None)
   ; ("src/dune_lang", Some "Dune_lang", false, None)
   ; ("src/fiber_util", Some "Fiber_util", false, None)

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -1,8 +1,6 @@
 open Import
+include Dune_util.Action
 module Ext = Action_intf.Ext
-module File_perm = File_perm
-module Outputs = Outputs
-module Inputs = Inputs
 
 module type T = sig
   type t

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -5,23 +5,44 @@
     the user in [Action_dune_lang.t] *)
 
 open! Import
-
-module Outputs : sig
-  include
-    module type of Dune_lang.Action.Outputs
-      with type t = Dune_lang.Action.Outputs.t
-end
+open Dune_util.Action
 
 module Inputs : sig
-  include
-    module type of Dune_lang.Action.Inputs
-      with type t = Dune_lang.Action.Inputs.t
+  type t = Inputs.t = Stdin
 end
 
 module File_perm : sig
-  include
-    module type of Dune_lang.Action.File_perm
-      with type t = Dune_lang.Action.File_perm.t
+  type t = File_perm.t =
+    | Normal
+    | Executable
+
+  val to_unix_perm : t -> int
+end
+
+module Outputs : sig
+  type t = Outputs.t =
+    | Stdout
+    | Stderr
+    | Outputs
+
+  val to_string : t -> string
+end
+
+module Diff : sig
+  open Diff
+
+  module Mode : sig
+    type t = Mode.t =
+      | Binary
+      | Text
+  end
+
+  type nonrec ('path, 'target) t = ('path, 'target) t =
+    { optional : bool
+    ; mode : Mode.t
+    ; file1 : 'path
+    ; file2 : 'target
+    }
 end
 
 module Ext : module type of Action_intf.Ext

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -238,10 +238,10 @@ let restrict_env
   { Action.Ext.working_dir; env; stdout_to; stderr_to; stdin_from; exit_codes }
 
 let compare_files = function
-  | Diff.Mode.Binary -> Io.compare_files
+  | Action.Diff.Mode.Binary -> Io.compare_files
   | Text -> Io.compare_text_files
 
-let diff_eq_files { Diff.optional; mode; file1; file2 } =
+let diff_eq_files { Action.Diff.optional; mode; file1; file2 } =
   let file1 = if Path.Untracked.exists file1 then file1 else Dev_null.path in
   let file2 = Path.build file2 in
   (optional && not (Path.Untracked.exists file2))

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -1,4 +1,5 @@
 open Import
+open Dune_util.Action
 
 module Simplified = struct
   type destination =

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -11,9 +11,9 @@ module Simplified = struct
     | Run of string * string list
     | Chdir of string
     | Setenv of string * string
-    | Redirect_out of t list * Outputs.t * destination
-    | Redirect_in of t list * Inputs.t * source
-    | Pipe of t list list * Outputs.t
+    | Redirect_out of t list * Action.Outputs.t * destination
+    | Redirect_in of t list * Action.Inputs.t * source
+    | Pipe of t list list * Action.Outputs.t
     | Sh of string
     | Concurrent of t list list
 end

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -1,19 +1,8 @@
 open Import
 
 module Name : sig
-  type t
-
-  val decode : t Dune_sexp.Decoder.t
-
-  val of_string : string -> t
-
-  val equal : t -> t -> bool
-
-  val parse_string_exn : Loc.t * string -> t
-
-  val to_string : t -> string
-
-  val to_dyn : t -> Dyn.t
+  include
+    module type of Dune_util.Alias_name with type t = Dune_util.Alias_name.t
 
   val default : t
 

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -12,7 +12,8 @@
   fiber
   memo
   threads.posix
-  dune_lang
+  predicate_lang
+  dune_sexp
   dune_cache
   dune_cache_storage
   dune_glob

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -7,12 +7,7 @@ module Stringlike = Dune_util.Stringlike
 module Stringlike_intf = Dune_util.Stringlike_intf
 module Persistent = Dune_util.Persistent
 module Execution_env = Dune_util.Execution_env
-module Predicate_lang = Dune_lang.Predicate_lang
 module Glob = Dune_glob.V1
-module Outputs = Dune_lang.Action.Outputs
-module Inputs = Dune_lang.Action.Inputs
-module File_perm = Dune_lang.Action.File_perm
-module Diff = Dune_lang.Action.Diff
 include No_io
 
 (* To make bug reports usable *)

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -1,5 +1,6 @@
 open Stdune
 open Dune_sexp
+open Dune_util.Action
 
 module Action_plugin = struct
   let syntax =
@@ -9,38 +10,24 @@ module Action_plugin = struct
 end
 
 module Diff = struct
-  module Mode = struct
-    type t =
-      | Binary
-      | Text
-  end
-
-  type ('path, 'target) t =
-    { optional : bool
-    ; mode : Mode.t
-    ; file1 : 'path
-    ; file2 : 'target
-    }
-
-  let map t ~path ~target =
-    { t with file1 = path t.file1; file2 = target t.file2 }
+  include Diff
 
   let decode path target ~optional =
     let open Decoder in
     let+ file1 = path
     and+ file2 = target in
-    { optional; file1; file2; mode = Text }
+    { Diff.optional; file1; file2; mode = Text }
 
   let decode_binary path target =
     let open Decoder in
     let+ () = Syntax.since Stanza.syntax (1, 0)
     and+ file1 = path
     and+ file2 = target in
-    { optional = false; file1; file2; mode = Binary }
+    { Diff.optional = false; file1; file2; mode = Binary }
 end
 
 module Outputs = struct
-  type t =
+  type t = Outputs.t =
     | Stdout
     | Stderr
     | Outputs
@@ -52,14 +39,14 @@ module Outputs = struct
 end
 
 module Inputs = struct
-  type t = Stdin
+  type t = Inputs.t = Stdin
 
   let to_string = function
     | Stdin -> "stdin"
 end
 
 module File_perm = struct
-  type t =
+  type t = File_perm.t =
     | Normal
     | Executable
 

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -6,26 +6,27 @@
 
 open Stdune
 open Dune_sexp
+open Dune_util.Action
 
 module Action_plugin : sig
   val syntax : Syntax.t
 end
 
 module Diff : sig
+  open Diff
+
   module Mode : sig
-    type t =
-      | Binary  (** no diffing, just raw comparison *)
-      | Text  (** diffing after newline normalization *)
+    type t = Mode.t =
+      | Binary
+      | Text
   end
 
-  type ('path, 'target) t =
+  type nonrec ('path, 'target) t = ('path, 'target) t =
     { optional : bool
     ; mode : Mode.t
     ; file1 : 'path
     ; file2 : 'target
     }
-
-  val map : ('p, 't) t -> path:('p -> 'x) -> target:('t -> 'y) -> ('x, 'y) t
 
   val decode :
        'path Decoder.t
@@ -38,7 +39,7 @@ module Diff : sig
 end
 
 module Outputs : sig
-  type t =
+  type t = Outputs.t =
     | Stdout
     | Stderr
     | Outputs  (** Both Stdout and Stderr *)
@@ -47,7 +48,7 @@ module Outputs : sig
 end
 
 module Inputs : sig
-  type t = Stdin
+  type t = Inputs.t = Stdin
 
   val to_string : t -> string
 end
@@ -56,7 +57,7 @@ module File_perm : sig
   (** File mode, for when creating files. We only allow what Dune takes into
       account when memoizing commands. *)
 
-  type t =
+  type t = File_perm.t =
     | Normal
     | Executable
 

--- a/src/dune_lang/alias.ml
+++ b/src/dune_lang/alias.ml
@@ -1,0 +1,17 @@
+open Stdune
+open Dune_util.Alias_name
+
+let invalid_alias = Pp.textf "%S is not a valid alias name"
+
+let decode =
+  let parse_string_exn ~syntax (loc, s) =
+    let of_string_opt =
+      if syntax >= (2, 0) then of_string_opt else of_string_opt_loose
+    in
+    match of_string_opt s with
+    | None -> User_error.raise ~loc [ invalid_alias s ]
+    | Some s -> s
+  in
+  let open Dune_sexp.Decoder in
+  let* syntax = Dune_sexp.Syntax.get_exn Stanza.syntax in
+  plain_string (fun ~loc s -> parse_string_exn ~syntax (loc, s))

--- a/src/dune_lang/alias.mli
+++ b/src/dune_lang/alias.mli
@@ -1,0 +1,1 @@
+val decode : Dune_util.Alias_name.t Dune_sexp.Decoder.t

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -10,6 +10,7 @@
   dune_util
   dyn
   ordering
+  predicate_lang
   dune_section
   (re_export dune_sexp))
  (instrumentation

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1,7 +1,7 @@
 include Dune_sexp
+module Alias = Alias
 module Format = Format
 module Stanza = Stanza
-module Predicate_lang = Predicate_lang
 module Glob = Glob
 module String_with_vars = String_with_vars
 module Pform = Pform
@@ -14,3 +14,7 @@ module Package_name = Package_name
 module Pkg = Pkg
 module Ordered_set_lang = Ordered_set_lang
 module Format_config = Format_config
+
+let decode_predicate_lang_glob : Predicate_lang.Glob.t Dune_sexp.Decoder.t =
+  Predicate_lang.decode
+    (Dune_sexp.Decoder.map Glob.decode ~f:Predicate_lang.Glob.create_glob)

--- a/src/dune_rules/case_lang.ml
+++ b/src/dune_rules/case_lang.ml
@@ -29,7 +29,7 @@ end
 
 type 'a t = (Predicate_lang.Glob.t, 'a) Ast.t
 
-let decode f = Ast.decode Predicate_lang.Glob.decode f
+let decode f = Ast.decode Dune_lang.decode_predicate_lang_glob f
 
 let eval (t : _ t) ~f =
   let elem = f t.on in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -31,7 +31,8 @@ let decode =
   fields
     (let+ loc = loc
      and+ files =
-       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.any
+       field "files" Dune_lang.decode_predicate_lang_glob
+         ~default:Predicate_lang.any
      and+ preprocess, preprocessor_deps = Stanza_common.preprocess_fields
      and+ libraries =
        field "libraries" (Lib_dep.L.decode ~allow_re_export:false) ~default:[]
@@ -39,7 +40,7 @@ let decode =
        field ~default:[] "runtime_deps"
          (Dune_lang.Syntax.since syntax (1, 1) >>> repeat Dep_conf.decode)
      and+ cinaps_version = Dune_lang.Syntax.get_exn syntax
-     and+ alias = field_o "alias" Alias.Name.decode
+     and+ alias = field_o "alias" Dune_lang.Alias.decode
      and+ link_flags =
        Link_flags.Spec.decode
          ~check:(Some (Dune_lang.Syntax.since syntax (1, 3)))

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -14,7 +14,7 @@ let decode_applies_to =
     Whole_subtree
   in
   let predicate =
-    let+ predicate = Predicate_lang.Glob.decode in
+    let+ predicate = Dune_lang.decode_predicate_lang_glob in
     Files_matching_in_this_dir predicate
   in
   subtree <|> predicate
@@ -36,7 +36,7 @@ let decode =
     (let+ loc = loc
      and+ applies_to =
        field "applies_to" decode_applies_to ~default:default_applies_to
-     and+ alias = field_o "alias" Alias.Name.decode
+     and+ alias = field_o "alias" Dune_lang.Alias.decode
      and+ deps = field_o "deps" (Bindings.decode Dep_conf.decode)
      and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
      and+ locks =

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -9,6 +9,7 @@
   memo
   ocaml
   dune_re
+  predicate_lang
   dune_console
   dune_digest
   opam_file_format

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1701,11 +1701,12 @@ module Rule = struct
            >>> Stanza_common.Pkg.decode)
        and+ alias =
          field_o "alias"
-           (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Alias.Name.decode)
+           (Dune_lang.Syntax.since Stanza.syntax (2, 0)
+           >>> Dune_lang.Alias.decode)
        and+ aliases =
          field_o "aliases"
            (Dune_lang.Syntax.since Stanza.syntax (3, 5)
-           >>> repeat Alias.Name.decode)
+           >>> repeat Dune_lang.Alias.decode)
        in
        let aliases =
          match alias with
@@ -1873,7 +1874,7 @@ module Alias_conf = struct
          field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty
        in
        String_with_vars.add_user_vars_to_decoding_env (Bindings.var_names deps)
-         (let+ name = field "name" Alias.Name.decode
+         (let+ name = field "name" Dune_lang.Alias.decode
           and+ package = field_o "package" Stanza_common.Pkg.decode
           and+ action =
             field_o "action"
@@ -2001,7 +2002,7 @@ module Copy_files = struct
 
   let long_form =
     let check = Dune_lang.Syntax.since Stanza.syntax (2, 7) in
-    let+ alias = field_o "alias" (check >>> Alias.Name.decode)
+    let+ alias = field_o "alias" (check >>> Dune_lang.Alias.decode)
     and+ mode =
       field "mode" ~default:Rule.Mode.Standard (check >>> Rule.Mode.decode)
     and+ enabled_if =

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -44,7 +44,6 @@ module Re = Dune_re
 module Format_config = Dune_lang.Format_config
 module Ordered_set_lang = Dune_lang.Ordered_set_lang
 module Stanza = Dune_lang.Stanza
-module Predicate_lang = Dune_lang.Predicate_lang
 module Predicate_with_id = Dune_engine.File_selector.Predicate_with_id
 module String_with_vars = Dune_lang.String_with_vars
 module Pform = Dune_lang.Pform

--- a/src/dune_rules/jsoo/js_of_ocaml.ml
+++ b/src/dune_rules/jsoo/js_of_ocaml.ml
@@ -161,7 +161,7 @@ module Env = struct
     fields
     @@ let+ compilation_mode =
          field_o "compilation_mode" Compilation_mode.decode
-       and+ runtest_alias = field_o "runtest_alias" Alias.Name.decode
+       and+ runtest_alias = field_o "runtest_alias" Dune_lang.Alias.decode
        and+ flags = Flags.decode in
        Option.iter ~f:Alias.register_as_standard runtest_alias;
        { compilation_mode; runtest_alias; flags }

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -190,8 +190,8 @@ let syntax =
     ; ((0, 4), `Since (3, 8))
     ]
 
-let glob_predicate repr =
-  repr |> Dune_lang.Glob.of_string_exn Loc.none |> Predicate_lang.Glob.of_glob
+let glob_predicate repr : Predicate_lang.Glob.t =
+  Dune_lang.Glob.of_string_exn Loc.none repr |> Predicate_lang.Glob.of_glob
 
 let default_files_of_version version =
   let md_files = glob_predicate "*.md" in
@@ -207,7 +207,8 @@ let decode =
     (let+ loc = loc
      and+ version = Dune_lang.Syntax.get_exn syntax
      and+ files =
-       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.Standard
+       field "files" Dune_lang.decode_predicate_lang_glob
+         ~default:Predicate_lang.Standard
      and+ enabled_if =
        Enabled_if.decode ~allowed_vars:Any ~since:(Some (2, 9)) ()
      and+ package =

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -95,7 +95,7 @@ module Emit = struct
                  ])
          in
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
-       and+ alias = field_o "alias" Alias.Name.decode
+       and+ alias = field_o "alias" Dune_lang.Alias.decode
        and+ module_systems =
          field "module_systems" module_systems
            ~default:[ Melange.Module_system.default ]

--- a/src/dune_rules/rule_mode_decoder.ml
+++ b/src/dune_rules/rule_mode_decoder.ml
@@ -17,7 +17,7 @@ module Promote = struct
        and+ only =
          field_o "only"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)
-           >>> Predicate_lang.decode Glob.decode)
+           >>> Predicate_lang.decode Dune_lang.Glob.decode)
        in
        let only =
          Option.map only ~f:(fun only ->

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -288,7 +288,7 @@ let decode =
   let dirs =
     located
       (Dune_lang.Syntax.since Stanza.syntax (1, 6)
-      >>> Predicate_lang.Glob.decode)
+      >>> Dune_lang.decode_predicate_lang_glob)
   in
   let data_only_dirs =
     located

--- a/src/dune_util/action.ml
+++ b/src/dune_util/action.ml
@@ -1,0 +1,50 @@
+module Diff = struct
+  module Mode = struct
+    type t =
+      | Binary
+      | Text
+  end
+
+  type ('path, 'target) t =
+    { optional : bool
+    ; mode : Mode.t
+    ; file1 : 'path
+    ; file2 : 'target
+    }
+
+  let map t ~path ~target =
+    { t with file1 = path t.file1; file2 = target t.file2 }
+end
+
+module Outputs = struct
+  type t =
+    | Stdout
+    | Stderr
+    | Outputs
+
+  let to_string = function
+    | Stdout -> "stdout"
+    | Stderr -> "stderr"
+    | Outputs -> "outputs"
+end
+
+module Inputs = struct
+  type t = Stdin
+
+  let to_string = function
+    | Stdin -> "stdin"
+end
+
+module File_perm = struct
+  type t =
+    | Normal
+    | Executable
+
+  let suffix = function
+    | Normal -> ""
+    | Executable -> "-executable"
+
+  let to_unix_perm = function
+    | Normal -> 0o666
+    | Executable -> 0o777
+end

--- a/src/dune_util/action.mli
+++ b/src/dune_util/action.mli
@@ -1,0 +1,44 @@
+module Diff : sig
+  module Mode : sig
+    type t =
+      | Binary  (** no diffing, just raw comparison *)
+      | Text  (** diffing after newline normalization *)
+  end
+
+  type nonrec ('path, 'target) t =
+    { optional : bool
+    ; mode : Mode.t
+    ; file1 : 'path
+    ; file2 : 'target
+    }
+
+  val map : ('p, 't) t -> path:('p -> 'a) -> target:('t -> 'b) -> ('a, 'b) t
+end
+
+module Outputs : sig
+  type t =
+    | Stdout
+    | Stderr
+    | Outputs  (** Both Stdout and Stderr *)
+
+  val to_string : t -> string
+end
+
+module Inputs : sig
+  type t = Stdin
+
+  val to_string : t -> string
+end
+
+module File_perm : sig
+  (** File mode, for when creating files. We only allow what Dune takes into
+      account when memoizing commands. *)
+
+  type t =
+    | Normal
+    | Executable
+
+  val suffix : t -> string
+
+  val to_unix_perm : t -> int
+end

--- a/src/dune_util/alias_name.ml
+++ b/src/dune_util/alias_name.ml
@@ -1,0 +1,29 @@
+open Stdune
+include String
+
+(* DUNE3 once we get rid the "loose" validation, implement this module using
+   [Stringlike] *)
+let of_string_opt_loose s = Option.some_if (Filename.basename s = s) s
+
+let of_string_opt = function
+  (* The [""] case is caught by of_string_opt_loose. But there's no harm in
+     being more explicit about it *)
+  | "" | "." | "/" | ".." -> None
+  | s -> of_string_opt_loose s
+
+let of_string s =
+  match of_string_opt s with
+  | Some s -> s
+  | None -> Code_error.raise "invalid alias name" [ ("s", Dyn.string s) ]
+
+let to_string s = s
+
+let to_dyn = String.to_dyn
+
+let parse_local_path (loc, p) =
+  match Path.Local.parent p with
+  | Some dir -> (dir, Path.Local.basename p)
+  | None ->
+    User_error.raise ~loc
+      [ Pp.textf "Invalid alias path: %S" (Path.Local.to_string_maybe_quoted p)
+      ]

--- a/src/dune_util/alias_name.mli
+++ b/src/dune_util/alias_name.mli
@@ -1,0 +1,23 @@
+open Stdune
+
+type t
+
+val compare : t -> t -> Ordering.t
+
+val hash : t -> int
+
+val of_string_opt_loose : string -> t option
+
+val of_string_opt : string -> t option
+
+val of_string : string -> t
+
+val equal : t -> t -> bool
+
+val to_string : t -> string
+
+val to_dyn : t -> Dyn.t
+
+val parse_local_path : Loc.t * Path.Local.t -> Path.Local.t * t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -6,6 +6,9 @@
  (libraries
   stdune
   xdg
+  dyn
+  ordering
+  pp
   dune_console
   build_path_prefix_map
   dune_sexp

--- a/src/dune_util/dune_util.ml
+++ b/src/dune_util/dune_util.ml
@@ -7,6 +7,8 @@ module Stringlike_intf = Stringlike_intf
 module Build_path_prefix_map = Build_path_prefix_map0
 module Flock = Flock
 module Global_lock = Global_lock
+module Action = Action
+module Alias_name = Alias_name
 open Stdune
 
 let xdg =

--- a/src/predicate_lang/dune
+++ b/src/predicate_lang/dune
@@ -1,0 +1,3 @@
+(library
+ (name predicate_lang)
+ (libraries stdune dune_glob dune_sexp dyn))

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -122,10 +122,6 @@ module Glob = struct
 
   let to_dyn t = to_dyn (fun _ -> Dyn.string "opaque") t
 
-  let decode : t Decoder.t =
-    let open Decoder in
-    decode (Glob.decode >>| Glob.test)
-
   let exec (t : t) ~standard elem = exec t ~standard (fun f -> f elem)
 
   let filter (t : t) ~standard elems =
@@ -133,7 +129,9 @@ module Glob = struct
     | Inter [] | Union [] -> []
     | _ -> List.filter elems ~f:(fun elem -> exec t ~standard elem)
 
-  let of_glob g = Element (Glob.test g)
+  let create_glob g = Dune_glob.V1.test g
+
+  let of_glob g = Element (create_glob g)
 
   let of_pred p = Element p
 

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -49,13 +49,13 @@ module Glob : sig
 
   val to_dyn : t -> Dyn.t
 
-  val decode : t Decoder.t
-
   val exec : t -> standard:t -> string -> bool
 
   val filter : t -> standard:t -> string list -> string list
 
-  val of_glob : Glob.t -> t
+  val create_glob : Dune_glob.V1.t -> glob
+
+  val of_glob : Dune_glob.V1.t -> t
 
   val of_pred : (string -> bool) -> t
 

--- a/test/expect-tests/dune_engine/action_to_sh_tests.ml
+++ b/test/expect-tests/dune_engine/action_to_sh_tests.ml
@@ -1,5 +1,6 @@
 open Dune_engine
 open Action.For_shell
+module Action = Dune_engine.Action
 
 let print x = x |> Action_to_sh.pp |> Dune_tests_common.print
 
@@ -107,7 +108,7 @@ let%expect_test "with-stdin-from" =
 (* TODO currently no special printing for with-accepted-exit-codes *)
 let%expect_test "with-accepted-exit-codes" =
   With_accepted_exit_codes
-    ( Dune_lang.Predicate_lang.Union [ Element 0; Element 1; Element 123 ]
+    ( Predicate_lang.Union [ Element 0; Element 1; Element 123 ]
     , Bash {|
     echo Hello world
     exit 123
@@ -177,10 +178,10 @@ let%expect_test "bash" =
 
 let%expect_test "diff" =
   Diff
-    { optional = false
+    { Action.Diff.optional = false
     ; file1 = "foo"
     ; file2 = "bar"
-    ; mode = Dune_lang.Action.Diff.Mode.Text
+    ; mode = Action.Diff.Mode.Text
     }
   |> print;
   [%expect {|
@@ -188,10 +189,10 @@ let%expect_test "diff" =
 
 let%expect_test "diff optional" =
   Diff
-    { optional = true
+    { Action.Diff.optional = true
     ; file1 = "foo"
     ; file2 = "bar"
-    ; mode = Dune_lang.Action.Diff.Mode.Text
+    ; mode = Action.Diff.Mode.Text
     }
   |> print;
   [%expect {|
@@ -199,10 +200,10 @@ let%expect_test "diff optional" =
 
 let%expect_test "cmp" =
   Diff
-    { optional = false
+    { Action.Diff.optional = false
     ; file1 = "foo"
     ; file2 = "bar"
-    ; mode = Dune_lang.Action.Diff.Mode.Binary
+    ; mode = Action.Diff.Mode.Binary
     }
   |> print;
   [%expect {|

--- a/test/expect-tests/dune_engine/dune
+++ b/test/expect-tests/dune_engine/dune
@@ -4,6 +4,7 @@
  (libraries
   dune_tests_common
   dune_lang
+  predicate_lang
   stdune
   dune_engine
   ;; This is because of the (implicit_transitive_deps false)


### PR DESCRIPTION
This requires the following 3 general moves:

* Moving predicate_lang into its own library
* Moving various action definitions from Dune_lang to Dune_util
* Moving the definition of alias names to Dune_util.

The last refactoring of the aliases isn't yet completed. I think we'd
rather have rules specific aliases such as fmt and install to live in
dune_lang rather than in the engine, but for now this is good enough.

Also, this refactoring caught some missing validation bugs in the alias
module. I've added some TODO's to address them eventually.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9e878180-d0eb-4668-b5ec-1441c4301687 -->