### PR TITLE
Monorepo benchmark fixes

### DIFF
--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -136,7 +136,7 @@ RUN opam switch create prepare 4.14.1
 RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl yojson logs fmt
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-04-25.1
+ENV MONOREPO_BENCHMARK_TAG=2023-05-17.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
   tar xf ocaml-monorepo-benchmark.tar.gz && \
   mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -11,15 +11,9 @@ module V1 = struct
 
     let finalize f ~finally = Lwt.finalize f finally
 
-    let rec parallel_iter ls ~f =
-      let open Lwt.Syntax in
-      let* res = ls () in
-      match res with
-      | None -> Lwt.return_unit
-      | Some x ->
-        let+ () = f x
-        and+ () = parallel_iter ls ~f in
-        ()
+    let parallel_iter ls ~f =
+      let stream = Lwt_stream.from ls in
+      Lwt_stream.iter_p f stream
 
     module Ivar = struct
       type 'a t = 'a Lwt.t * 'a Lwt.u


### PR DESCRIPTION
Two fixes for problems preventing the monorepo benchmark from running:
1. Updates the revision of the monorepo repo to pull which fixes a problem where a broken version of several packages were being pulled (broken hashes, packages changed in place)
2. Changes the implementation of `parallel_iter` in dune-rpc-lwt to use `Lwt_stream.iter_p` which fixes a potential stack overflow when building large projects (such as the monorepo)