### PR TITLE
refactor: change representation of Predicate_lang.Glob

### DIFF
--- a/otherlibs/dune-glob/src/glob.ml
+++ b/otherlibs/dune-glob/src/glob.ml
@@ -17,6 +17,8 @@ let empty = Re { re = Re.compile Re.empty; repr = "\000" }
 
 let universal = Re { re = Re.compile (Re.rep Re.any); repr = "**" }
 
+let literal s = Literal s
+
 let of_string_result repr =
   Lexer.parse_string repr
   |> Result.map ~f:(function

--- a/otherlibs/dune-glob/src/glob.mli
+++ b/otherlibs/dune-glob/src/glob.mli
@@ -26,4 +26,6 @@ val to_dyn : t -> Dyn.t
 
 val of_string_exn : Loc.t -> string -> t
 
+val literal : string -> t
+
 val compare : t -> t -> Ordering.t

--- a/otherlibs/dune-glob/test/dune_glob_tests.ml
+++ b/otherlibs/dune-glob/test/dune_glob_tests.ml
@@ -67,3 +67,12 @@ let%expect_test _ =
   [%expect {| [pass] "*" matches "foo.ml" == true |}];
   test glob "foo/" ~expect:false;
   [%expect {| [pass] "*" matches "foo/" == false |}]
+
+let%expect_test _ =
+  let glob = Glob.of_string "[!._]*" in
+  test glob ".foo" ~expect:false;
+  [%expect {| [pass] "[!._]*" matches ".foo" == false |}];
+  test glob "foo.ml" ~expect:true;
+  [%expect {| [pass] "[!._]*" matches "foo.ml" == true |}];
+  test glob "a" ~expect:true;
+  [%expect {| [pass] "[!._]*" matches "a" == true |}]

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -17,6 +17,4 @@ module Format_config = Format_config
 module Bindings = Bindings
 module Subst_config = Subst_config
 
-let decode_predicate_lang_glob : Predicate_lang.Glob.t Dune_sexp.Decoder.t =
-  Predicate_lang.decode
-    (Dune_sexp.Decoder.map Glob.decode ~f:Predicate_lang.Glob.create_glob)
+let decode_predicate_lang_glob = Predicate_lang.decode Glob.decode

--- a/src/dune_lang/glob.ml
+++ b/src/dune_lang/glob.ml
@@ -2,10 +2,6 @@ open! Stdune
 open Dune_sexp
 include Dune_glob.V1
 
-let of_string = `shadowed
-
-let _ = of_string
-
 let to_dyn t = Dyn.variant "Glob" [ Dyn.string (to_string t) ]
 
 let compare x y = String.compare (to_string x) (to_string y)

--- a/src/dune_lang/glob.mli
+++ b/src/dune_lang/glob.mli
@@ -25,4 +25,6 @@ val universal : t
 
 val of_string_exn : Loc.t -> string -> t
 
+val of_string : string -> t
+
 val to_predicate : t -> Filename.t Predicate.t

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -140,8 +140,7 @@ let rules ~sctx ~expander ~dir tests =
               match spec.applies_to with
               | Whole_subtree -> true
               | Files_matching_in_this_dir pred ->
-                Predicate_lang.Glob.exec pred
-                  ~standard:Predicate_lang.Glob.true_ name
+                Predicate_lang.Glob.exec pred ~standard:Predicate_lang.any name
             with
             | false -> acc
             | true ->

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -5,7 +5,7 @@ type applies_to =
   | Whole_subtree
   | Files_matching_in_this_dir of Predicate_lang.Glob.t
 
-let default_applies_to = Files_matching_in_this_dir Predicate_lang.Glob.true_
+let default_applies_to = Files_matching_in_this_dir Predicate_lang.any
 
 let decode_applies_to =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -79,11 +79,7 @@ let status status_by_dir ~dir : Status.Or_ignored.t =
   | Some d -> Status d
 
 let default =
-  let standard_dirs =
-    Predicate_lang.Glob.of_pred (function
-      | "" -> false
-      | s -> s.[0] <> '.' && s.[0] <> '_')
-  in
+  let standard_dirs = Predicate_lang.Glob.of_glob (Glob.of_string "[!._]*") in
   { Status.Map.normal = standard_dirs
   ; data_only = Predicate_lang.empty
   ; vendored = Predicate_lang.empty
@@ -273,7 +269,7 @@ let decode =
   let ignored_sub_dirs =
     let ignored =
       let+ l = enter (repeat (strict_subdir "ignored_sub_dirs")) in
-      Predicate_lang.Glob.of_string_set (String.Set.of_list_map ~f:snd l)
+      Predicate_lang.Glob.of_string_list (List.rev_map ~f:snd l)
     in
     let+ version = Dune_lang.Syntax.get_exn Stanza.syntax
     and+ loc, ignored = located ignored in

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -116,26 +116,24 @@ let to_predicate (type a) (t : a Predicate.t t) ~standard : a Predicate.t =
       exec t ~standard (fun pred -> Predicate.test pred a))
 
 module Glob = struct
-  type glob = string -> bool
+  module Glob = Dune_glob.V1
 
-  type nonrec t = glob t
+  type nonrec t = Glob.t t
 
-  let to_dyn t = to_dyn (fun _ -> Dyn.string "opaque") t
+  let to_dyn t = to_dyn Glob.to_dyn t
 
-  let exec (t : t) ~standard elem = exec t ~standard (fun f -> f elem)
+  let exec (t : t) ~standard elem = exec t ~standard (fun f -> Glob.test f elem)
 
   let filter (t : t) ~standard elems =
     match t with
     | Inter [] | Union [] -> []
     | _ -> List.filter elems ~f:(fun elem -> exec t ~standard elem)
 
-  let create_glob g = Dune_glob.V1.test g
+  let of_glob g = Element g
 
-  let of_glob g = Element (create_glob g)
+  let of_string_list s =
+    Union (List.rev_map s ~f:(fun x -> Element (Glob.literal x)))
 
-  let of_pred p = Element p
-
-  let true_ = Element (fun _ -> true)
-
-  let of_string_set s = Element (String.Set.mem s)
+  let of_string_set s =
+    Union (String.Set.to_list_map ~f:(fun x -> Element (Glob.literal x)) s)
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -40,12 +40,7 @@ val to_predicate :
   'a Predicate.t t -> standard:'a Predicate.t t -> 'a Predicate.t
 
 module Glob : sig
-  (** The underlying type for the string predicate is not an actual glob, so
-      this module is confusingly named. *)
-
-  type glob
-
-  type nonrec t = glob t
+  type nonrec t = Dune_glob.V1.t t
 
   val to_dyn : t -> Dyn.t
 
@@ -53,13 +48,9 @@ module Glob : sig
 
   val filter : t -> standard:t -> string list -> string list
 
-  val create_glob : Dune_glob.V1.t -> glob
-
   val of_glob : Dune_glob.V1.t -> t
 
-  val of_pred : (string -> bool) -> t
+  val of_string_list : string list -> t
 
   val of_string_set : String.Set.t -> t
-
-  val true_ : t
 end


### PR DESCRIPTION
Represent it directly with a glob rather than going through a predicate.

This makes it simple, serializable, and safe to use for memoization.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b26c316f-3abb-47fc-b9fe-5ef1c31f12f4 -->