### PR TITLE
Run short monorepo benchmarks multiple times

### DIFF
--- a/bench/monorepo/Makefile
+++ b/bench/monorepo/Makefile
@@ -5,7 +5,7 @@ BUILD_TARGET = ./monorepo_bench.exe
 MONOREPO_PATH = /home/user/monorepo-benchmark/benchmark
 
 bench:
-	$(RUNNER) --dune-exe-path=$(DUNE_EXE_PATH) --build-target=$(BUILD_TARGET) --monorepo-path=$(MONOREPO_PATH) --print-dune-output
+	$(RUNNER) --dune-exe-path=$(DUNE_EXE_PATH) --build-target=$(BUILD_TARGET) --monorepo-path=$(MONOREPO_PATH) --print-dune-output --num-short-job-repeats=3
 
 clean:
 	dune clean

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -136,7 +136,7 @@ RUN opam switch create prepare 4.14.1
 RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl yojson logs fmt
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-05-17.0
+ENV MONOREPO_BENCHMARK_TAG=2023-05-24.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
   tar xf ocaml-monorepo-benchmark.tar.gz && \
   mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark


### PR DESCRIPTION
This is an attempt to make the benchmarks less noisy by running them 3 times and having current-bench report the mean. Fortunately the amount of noise we see in monorepo benchmarks is constant, so long running benchmarks (mainly the initial build from scratch) have only a small amount of noise when expressed as a percentage of the running  time. Thus we can get away with only running the shorter benchmarks several times.