### PR TITLE
chore: set latest heading to unreleased

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-3.8.0 (2023-05-23)
+Unreleased
 ------------------
 
 - Add additional metadata to the traces provided by `--trace-file` whenever

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 Unreleased
-------------------
+----------
 
 - Add additional metadata to the traces provided by `--trace-file` whenever
   `--trace-extended` is passed (#7778, @rleshchinskiy)


### PR DESCRIPTION
must be an artifact of the latest release. 3.8.0 looks confusing when there's another just below.