### PR TITLE
doc: expand actions documentation with a special directive

### DIFF
--- a/doc/exts/sphinx_dunedomain.py
+++ b/doc/exts/sphinx_dunedomain.py
@@ -134,12 +134,32 @@ class FieldDirective(ObjectDescription):
         domain.add_field(path, sig)
 
 
+class ActionDirective(ObjectDescription):
+    """
+    The action directive.
+    """
+
+    option_spec = {
+        "param": directives.unchanged_required,
+    }
+
+    def handle_signature(self, sig, signode):
+        param = self.options.get("param", "...")
+        text = f"({sig} {param})"
+        signode += addnodes.desc_name(text=text)
+        return sig
+
+    def add_target_and_index(self, name_cls, sig, signode):
+        signode["ids"].append(f"action-{sig}")
+
+
 class DuneDomain(Domain):
     name = "dune"
 
     directives = {
         "stanza": StanzaDirective,
         "field": FieldDirective,
+        "action": ActionDirective,
     }
     roles = {"ref": XRefRole()}
     indices = {StanzaIndex, FieldIndex}

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -22,61 +22,143 @@ source code.
 
 The following constructions are available:
 
-- ``(run <prog> <args>)`` to execute a program. ``<prog>`` is resolved
-  locally if it is available in the current workspace, otherwise it is
-  resolved using the ``PATH``
-- ``(dynamic-run <prog> <args>)`` to execute a program that was linked
-  against ``dune-action-plugin`` library. ``<prog>`` is resolved in
-  the same way as in ``run``
-- ``(chdir <dir> <DSL>)`` to change the current directory
-- ``(setenv <var> <value> <DSL>)`` to set an environment variable
-- ``(with-<outputs>-to <file> <DSL>)`` to redirect the output to a file, where
-  ``<outputs>`` is one of: ``stdout``, ``stderr`` or ``outputs`` (for both
-  ``stdout`` and ``stderr``)
-- ``(ignore-<outputs> <DSL>)`` to ignore the output, where
-  ``<outputs>`` is one of: ``stdout``, ``stderr``, or ``outputs``
-- ``(with-stdin-from <file> <DSL>)`` to redirect the input from a file
-- ``(with-accepted-exit-codes <pred> <DSL>)`` specifies the list of expected exit codes
-  for the programs executed in ``<DSL>``. ``<pred>`` is a predicate on integer
-  values, and it's specified using the :doc:`predicate-language`. ``<DSL>`` can
-  only contain nested occurrences of ``run``, ``bash``, ``system``, ``chdir``,
-  ``setenv``, ``ignore-<outputs>``, ``with-stdin-from``, and
-  ``with-<outputs>-to``. This action is available since Dune 2.0.
-- ``(progn <DSL>...)`` to execute several commands in sequence
-- ``(concurrent <DSL>...)``` to execute several commands concurrently
-  and collect all resulting errors, if any.
-  **Warning:** The concurrency is limited by the `-j` flag passed to Dune.
-  In particular, if Dune is running with `-j 1`, these commands will actually
-  run sequentially, which may cause a deadlock if they talk to each other.
-- ``(echo <string>)`` to output a string on ``stdout``
-- ``(write-file <file> <string>)`` writes ``<string>`` to ``<file>``
-- ``(cat <file> ...)`` to sequentially print the contents of files to stdout
-- ``(copy <src> <dst>)`` to copy a file. If these files are OCaml sources, you
-  should follow the ``module_name.xxx.ml``
-  :ref:`naming convention <merlin-filenames>` to preserve Merlin's
-  functionality.
-- ``(copy# <src> <dst>)`` to copy a file and add a line directive at
-  the beginning
-- ``(system <cmd>)`` to execute a command using the system shell: ``sh`` on Unix
-  and ``cmd`` on Windows
-- ``(bash <cmd>)`` to execute a command using ``/bin/bash``. This is obviously
-  not very portable.
-- ``(diff <file1> <file2>)`` is similar to ``(run diff <file1> <file2>)`` but
-  is better and allows promotion. See :doc:`../concepts/promotion` for more
-  details.
-- ``(diff? <file1> <file2>)`` is similar to ``(diff <file1>
-  <file2>)`` except that ``<file2>`` should be produced by a part of the
-  same action rather than be a dependency, is optional and will
-  be consumed by ``diff?``.
-- ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1> <file2>)`` but
-  allows promotion. See :doc:`../concepts/promotion` for more details.
-- ``(no-infer <DSL>)`` to perform an action without inference of dependencies
-  and targets. This is useful if you are generating dependencies in a way
-  that Dune doesn't know about, for instance by calling an external build system.
-- ``(pipe-<outputs> <DSL> <DSL> <DSL>...)`` to execute several actions (at least two)
-  in sequence, filtering the ``<outputs>`` of the first command through the other
-  command, piping the standard output of each one into the input of the next.
-  This action is available since Dune 2.7.
+.. dune:stanza:: run
+   :param: <prog> <args>
+
+   Execute a program. ``<prog>`` is resolved locally if it is available in the
+   current workspace, otherwise it is resolved using the ``PATH``.
+
+.. dune:stanza:: dynamic-run
+   :param: <prog> <args>
+
+   Execute a program that was linked against the ``dune-action-plugin`` library.
+   ``<prog>`` is resolved in the same way as in ``run``.
+
+.. dune:stanza:: chdir
+   :param: <dir> <DSL>
+
+   Change the current directory.
+
+.. dune:stanza:: setenv
+   :param: <var> <value> <DSL>
+
+   Set an environment variable.
+
+.. dune:stanza:: with-<outputs>-to
+   :param: <file> <DSL>
+
+   Redirect the output to a file, where ``<outputs>`` is one of: ``stdout``,
+   ``stderr`` or ``outputs`` (for both ``stdout`` and ``stderr``).
+
+.. dune:stanza:: ignore-<outputs>
+   :param: <DSL>
+
+   Ignore the output, where ``<outputs>`` is one of: ``stdout``, ``stderr``, or
+   ``outputs``.
+
+.. dune:stanza:: with-stdin-from
+   :param: <file> <DSL>
+
+   Redirect the input from a file.
+
+.. dune:stanza:: with-accepted-exit-codes
+   :param: <pred> <DSL>
+
+   .. versionadded:: 2.0
+
+   Specifies the list of expected exit codes for the programs executed in
+   ``<DSL>``. ``<pred>`` is a predicate on integer values, and it's specified
+   using the :doc:`predicate-language`. ``<DSL>`` can only contain nested
+   occurrences of ``run``, ``bash``, ``system``, ``chdir``, ``setenv``,
+   ``ignore-<outputs>``, ``with-stdin-from``, and ``with-<outputs>-to``.
+
+.. dune:stanza:: progn
+   :param: <DSL>...
+
+   Execute several commands in sequence.
+
+.. dune:stanza:: concurrent
+   :param: <DSL>...
+
+   Execute several commands concurrently and collect all resulting errors, if any.
+
+   .. warning:: The concurrency is limited by the ``-j`` flag passed to Dune.
+      In particular, if Dune is running with ``-j 1``, these commands will
+      actually run sequentially, which may cause a deadlock if they talk to
+      each other.
+
+.. dune:stanza:: echo
+   :param: <string>
+
+   Output a string on ``stdout``.
+
+.. dune:stanza:: write-file
+   :param: <file> <string>
+
+   Writes ``<string>`` to ``<file>``.
+
+.. dune:stanza:: cat
+   :param: <file> ...
+
+   Sequentially print the contents of files to stdout.
+
+.. dune:stanza:: copy
+   :param: <src> <dst>
+
+   Copy a file. If these files are OCaml sources, you should follow the
+   ``module_name.xxx.ml`` :ref:`naming convention <merlin-filenames>` to
+   preserve Merlin's functionality.
+
+.. dune:stanza:: copy#
+   :param: <src> <dst>
+
+   Copy a file and add a line directive at the beginning.
+
+.. dune:stanza:: system
+   :param: <cmd>
+
+   Execute a command using the system shell: ``sh`` on Unix and ``cmd`` on Windows.
+
+.. dune:stanza:: bash
+   :param: <cmd>
+
+   Execute a command using ``/bin/bash``. This is obviously not very portable.
+
+.. dune:stanza:: diff
+   :param: <file1> <file2>
+
+   ``(diff <file1> <file2>)`` is similar to ``(run diff <file1> <file2>)`` but
+   is better and allows promotion. See :doc:`../concepts/promotion` for more
+   details.
+
+.. dune:stanza:: diff?
+   :param: <file1> <file2>
+
+   ``(diff? <file1> <file2>)`` is similar to ``(diff <file1> <file2>)`` except
+   that ``<file2>`` should be produced by a part of the same action rather than
+   be a dependency, is optional and will be consumed by ``diff?``.
+
+.. dune:stanza:: cmp
+   :param: <file1> <file2>
+
+   ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1> <file2>)`` but
+   allows promotion. See :doc:`../concepts/promotion` for more details.
+
+.. dune:stanza:: no-infer
+   :param: <DSL>
+
+   Perform an action without inference of dependencies and targets. This is
+   useful if you are generating dependencies in a way that Dune doesn't know
+   about, for instance by calling an external build system.
+
+.. dune:stanza:: pipe-<outputs>
+   :param: <DSL> <DSL> <DSL>...
+
+   .. versionadded:: 2.7
+
+   Execute several actions (at least two) in sequence, filtering the
+   ``<outputs>`` of the first command through the other command, piping the
+   standard output of each one into the input of the next.
 
 As mentioned, ``copy#`` inserts a line directive at the beginning of
 the destination file. More precisely, it inserts the following line:

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -2,6 +2,7 @@ User Actions
 ============
 
 .. default-domain:: dune
+.. highlight:: dune
 
 ``(action ...)`` fields describe user actions.
 
@@ -30,21 +31,40 @@ The following constructions are available:
    Execute a program. ``<prog>`` is resolved locally if it is available in the
    current workspace, otherwise it is resolved using the ``PATH``.
 
+   Example::
+
+   (run capnp compile -o %{bin:capnpc-ocaml} schema.capnp)
+
 .. action:: dynamic-run
    :param: <prog> <args>
 
    Execute a program that was linked against the ``dune-action-plugin`` library.
    ``<prog>`` is resolved in the same way as in ``run``.
 
+   Example::
+
+   (dynamic-run ./plugin.exe)
+
 .. action:: chdir
    :param: <dir> <DSL>
 
-   Change the current directory.
+   Run an action in a different directory.
+
+   Example::
+
+     (chdir src
+      (run ./build.exe))
 
 .. action:: setenv
    :param: <var> <value> <DSL>
 
-   Set an environment variable.
+   Run an action with an environment variable set.
+
+   Example::
+
+     (setenv
+       VAR value
+       (bash "echo $VAR"))
 
 .. action:: with-<outputs>-to
    :param: <file> <DSL>
@@ -52,16 +72,31 @@ The following constructions are available:
    Redirect the output to a file, where ``<outputs>`` is one of: ``stdout``,
    ``stderr`` or ``outputs`` (for both ``stdout`` and ``stderr``).
 
+   Example::
+
+     (with-stdout-to conf.txt
+      (run ./get-conf.exe))
+
 .. action:: ignore-<outputs>
    :param: <DSL>
 
    Ignore the output, where ``<outputs>`` is one of: ``stdout``, ``stderr``, or
    ``outputs``.
 
+   Example::
+
+     (ignore-stderr
+      (run ./get-conf.exe))
+
 .. action:: with-stdin-from
    :param: <file> <DSL>
 
    Redirect the input from a file.
+
+   Example::
+
+     (with-stdin-from data.txt
+      (run ./tests.exe))
 
 .. action:: with-accepted-exit-codes
    :param: <pred> <DSL>
@@ -74,10 +109,22 @@ The following constructions are available:
    occurrences of ``run``, ``bash``, ``system``, ``chdir``, ``setenv``,
    ``ignore-<outputs>``, ``with-stdin-from``, and ``with-<outputs>-to``.
 
+   Example::
+
+     (with-accepted-exit-codes
+      (or 1 2)
+      (run false))
+
 .. action:: progn
    :param: <DSL>...
 
    Execute several commands in sequence.
+
+   Example::
+
+     (progn
+      (run ./proga.exe)
+      (run ./progb.exe))
 
 .. action:: concurrent
    :param: <DSL>...
@@ -89,20 +136,38 @@ The following constructions are available:
       actually run sequentially, which may cause a deadlock if they talk to
       each other.
 
+   Example::
+
+     (concurrent
+      (run ./proga.exe)
+      (run ./progb.exe))
+
 .. action:: echo
    :param: <string>
 
    Output a string on ``stdout``.
+
+   Example::
+
+   (echo "Hello, world")
 
 .. action:: write-file
    :param: <file> <string>
 
    Writes ``<string>`` to ``<file>``.
 
+   Example::
+
+   (write-file users.txt jane,joe)
+
 .. action:: cat
    :param: <file> ...
 
    Sequentially print the contents of files to stdout.
+
+   Example::
+
+   (cat data.txt)
 
 .. action:: copy
    :param: <src> <dst>
@@ -111,20 +176,36 @@ The following constructions are available:
    ``module_name.xxx.ml`` :ref:`naming convention <merlin-filenames>` to
    preserve Merlin's functionality.
 
+   Example::
+
+   (copy data.txt.template data.txt)
+
 .. action:: copy#
    :param: <src> <dst>
 
    Copy a file and add a line directive at the beginning.
+
+   Example::
+
+   (copy# config.windows.ml config.ml)
 
 .. action:: system
    :param: <cmd>
 
    Execute a command using the system shell: ``sh`` on Unix and ``cmd`` on Windows.
 
+   Example::
+
+   (system "command arg1 arg2")
+
 .. action:: bash
    :param: <cmd>
 
    Execute a command using ``/bin/bash``. This is obviously not very portable.
+
+   Example::
+
+   (bash "echo $PATH")
 
 .. action:: diff
    :param: <file1> <file2>
@@ -133,6 +214,10 @@ The following constructions are available:
    is better and allows promotion. See :doc:`../concepts/promotion` for more
    details.
 
+   Example::
+
+   (diff test.expected test.output)
+
 .. action:: diff?
    :param: <file1> <file2>
 
@@ -140,11 +225,21 @@ The following constructions are available:
    that ``<file2>`` should be produced by a part of the same action rather than
    be a dependency, is optional and will be consumed by ``diff?``.
 
+   Example::
+
+     (progn
+      (with-stdout-to test.output (run ./test.exe))
+      (diff? test.expected test.output))
+
 .. action:: cmp
    :param: <file1> <file2>
 
    ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1> <file2>)`` but
    allows promotion. See :doc:`../concepts/promotion` for more details.
+
+   Example::
+
+   (cmp bin.expected bin.output)
 
 .. action:: no-infer
    :param: <DSL>
@@ -152,6 +247,13 @@ The following constructions are available:
    Perform an action without inference of dependencies and targets. This is
    useful if you are generating dependencies in a way that Dune doesn't know
    about, for instance by calling an external build system.
+
+   Example::
+
+     (no-infer
+      (progn
+       (run make)
+       (copy mylib.a lib.a)))
 
 .. action:: pipe-<outputs>
    :param: <DSL> <DSL> <DSL>...
@@ -161,6 +263,12 @@ The following constructions are available:
    Execute several actions (at least two) in sequence, filtering the
    ``<outputs>`` of the first command through the other command, piping the
    standard output of each one into the input of the next.
+
+   Example::
+
+      (pipe-stdout
+       (run ./list-tests.exe)
+       (run ./exec-tests.exe))
 
 As mentioned, ``copy#`` inserts a line directive at the beginning of
 the destination file. More precisely, it inserts the following line:

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -299,14 +299,13 @@ As a result, if you execute the command from the original directory, it will
 only see the basename.
 
 To understand why this is important, let's consider this ``dune`` file living in
-``src/foo``:
+``src/foo``::
 
-::
-
-    (rule
-     (target blah.ml)
-     (deps   blah.mll)
-     (action (run ocamllex -o %{target} %{deps})))
+  (rule
+   (target blah.ml)
+   (deps blah.mll)
+   (action
+    (run ocamllex -o %{target} %{deps})))
 
 Here the command that will be executed is:
 
@@ -323,11 +322,11 @@ is an error in the generated ``blah.ml`` file, it will be reported as:
     Error: ...
 
 Which can be a problem, as your editor might think that ``blah.ml`` is at the root
-of your project. Instead, this is a better way to write it:
+of your project. Instead, this is a better way to write it::
 
-::
-
-    (rule
-     (target blah.ml)
-     (deps   blah.mll)
-     (action (chdir %{workspace_root} (run ocamllex -o %{target} %{deps}))))
+  (rule
+   (target blah.ml)
+   (deps blah.mll)
+   (action
+    (chdir %{workspace_root}
+     (run ocamllex -o %{target} %{deps}))))

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -1,6 +1,8 @@
 User Actions
 ============
 
+.. default-domain:: dune
+
 ``(action ...)`` fields describe user actions.
 
 User actions are always run from the same subdirectory of the current build
@@ -22,46 +24,46 @@ source code.
 
 The following constructions are available:
 
-.. dune:action:: run
+.. action:: run
    :param: <prog> <args>
 
    Execute a program. ``<prog>`` is resolved locally if it is available in the
    current workspace, otherwise it is resolved using the ``PATH``.
 
-.. dune:action:: dynamic-run
+.. action:: dynamic-run
    :param: <prog> <args>
 
    Execute a program that was linked against the ``dune-action-plugin`` library.
    ``<prog>`` is resolved in the same way as in ``run``.
 
-.. dune:action:: chdir
+.. action:: chdir
    :param: <dir> <DSL>
 
    Change the current directory.
 
-.. dune:action:: setenv
+.. action:: setenv
    :param: <var> <value> <DSL>
 
    Set an environment variable.
 
-.. dune:action:: with-<outputs>-to
+.. action:: with-<outputs>-to
    :param: <file> <DSL>
 
    Redirect the output to a file, where ``<outputs>`` is one of: ``stdout``,
    ``stderr`` or ``outputs`` (for both ``stdout`` and ``stderr``).
 
-.. dune:action:: ignore-<outputs>
+.. action:: ignore-<outputs>
    :param: <DSL>
 
    Ignore the output, where ``<outputs>`` is one of: ``stdout``, ``stderr``, or
    ``outputs``.
 
-.. dune:action:: with-stdin-from
+.. action:: with-stdin-from
    :param: <file> <DSL>
 
    Redirect the input from a file.
 
-.. dune:action:: with-accepted-exit-codes
+.. action:: with-accepted-exit-codes
    :param: <pred> <DSL>
 
    .. versionadded:: 2.0
@@ -72,12 +74,12 @@ The following constructions are available:
    occurrences of ``run``, ``bash``, ``system``, ``chdir``, ``setenv``,
    ``ignore-<outputs>``, ``with-stdin-from``, and ``with-<outputs>-to``.
 
-.. dune:action:: progn
+.. action:: progn
    :param: <DSL>...
 
    Execute several commands in sequence.
 
-.. dune:action:: concurrent
+.. action:: concurrent
    :param: <DSL>...
 
    Execute several commands concurrently and collect all resulting errors, if any.
@@ -87,71 +89,71 @@ The following constructions are available:
       actually run sequentially, which may cause a deadlock if they talk to
       each other.
 
-.. dune:action:: echo
+.. action:: echo
    :param: <string>
 
    Output a string on ``stdout``.
 
-.. dune:action:: write-file
+.. action:: write-file
    :param: <file> <string>
 
    Writes ``<string>`` to ``<file>``.
 
-.. dune:action:: cat
+.. action:: cat
    :param: <file> ...
 
    Sequentially print the contents of files to stdout.
 
-.. dune:action:: copy
+.. action:: copy
    :param: <src> <dst>
 
    Copy a file. If these files are OCaml sources, you should follow the
    ``module_name.xxx.ml`` :ref:`naming convention <merlin-filenames>` to
    preserve Merlin's functionality.
 
-.. dune:action:: copy#
+.. action:: copy#
    :param: <src> <dst>
 
    Copy a file and add a line directive at the beginning.
 
-.. dune:action:: system
+.. action:: system
    :param: <cmd>
 
    Execute a command using the system shell: ``sh`` on Unix and ``cmd`` on Windows.
 
-.. dune:action:: bash
+.. action:: bash
    :param: <cmd>
 
    Execute a command using ``/bin/bash``. This is obviously not very portable.
 
-.. dune:action:: diff
+.. action:: diff
    :param: <file1> <file2>
 
    ``(diff <file1> <file2>)`` is similar to ``(run diff <file1> <file2>)`` but
    is better and allows promotion. See :doc:`../concepts/promotion` for more
    details.
 
-.. dune:action:: diff?
+.. action:: diff?
    :param: <file1> <file2>
 
    ``(diff? <file1> <file2>)`` is similar to ``(diff <file1> <file2>)`` except
    that ``<file2>`` should be produced by a part of the same action rather than
    be a dependency, is optional and will be consumed by ``diff?``.
 
-.. dune:action:: cmp
+.. action:: cmp
    :param: <file1> <file2>
 
    ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1> <file2>)`` but
    allows promotion. See :doc:`../concepts/promotion` for more details.
 
-.. dune:action:: no-infer
+.. action:: no-infer
    :param: <DSL>
 
    Perform an action without inference of dependencies and targets. This is
    useful if you are generating dependencies in a way that Dune doesn't know
    about, for instance by calling an external build system.
 
-.. dune:action:: pipe-<outputs>
+.. action:: pipe-<outputs>
    :param: <DSL> <DSL> <DSL>...
 
    .. versionadded:: 2.7

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -189,6 +189,21 @@ The following constructions are available:
 
    (copy# config.windows.ml config.ml)
 
+   More precisely, ``copy#`` inserts the following line:
+
+   .. code:: ocaml
+
+      # 1 "<source file name>"
+
+   Most languages recognize such lines and update their current location to
+   report errors in the original file rather than the copy. This is important
+   because the copy exists only under the ``_build`` directory, and in order
+   for editors to jump to errors when parsing the build system's output, errors
+   must point to files that exist in the source tree. In the beta versions of
+   Dune, ``copy#`` was called ``copy-and-add-line-directive``. However, most of
+   time, one wants this behavior rather than a bare copy, so it was renamed to
+   something shorter.
+
 .. action:: system
    :param: <cmd>
 
@@ -269,23 +284,6 @@ The following constructions are available:
       (pipe-stdout
        (run ./list-tests.exe)
        (run ./exec-tests.exe))
-
-As mentioned, ``copy#`` inserts a line directive at the beginning of
-the destination file. More precisely, it inserts the following line:
-
-.. code:: ocaml
-
-    # 1 "<source file name>"
-
-Most languages recognize such lines and update their current location
-to report errors in the original file rather than the
-copy. This is important because the copy exists only under the ``_build``
-directory, and in order for editors to jump to errors when parsing the
-build system's output, errors must point to files that exist in
-the source tree. In the beta versions of Dune, ``copy#`` was
-called ``copy-and-add-line-directive``. However, most of time, one
-wants this behavior rather than a bare copy, so it was renamed to
-something shorter.
 
 Note: expansion of the special ``%{<kind>:...}`` is done relative to the current
 working directory of the DSL being executed. So for instance, if you

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -22,46 +22,46 @@ source code.
 
 The following constructions are available:
 
-.. dune:stanza:: run
+.. dune:action:: run
    :param: <prog> <args>
 
    Execute a program. ``<prog>`` is resolved locally if it is available in the
    current workspace, otherwise it is resolved using the ``PATH``.
 
-.. dune:stanza:: dynamic-run
+.. dune:action:: dynamic-run
    :param: <prog> <args>
 
    Execute a program that was linked against the ``dune-action-plugin`` library.
    ``<prog>`` is resolved in the same way as in ``run``.
 
-.. dune:stanza:: chdir
+.. dune:action:: chdir
    :param: <dir> <DSL>
 
    Change the current directory.
 
-.. dune:stanza:: setenv
+.. dune:action:: setenv
    :param: <var> <value> <DSL>
 
    Set an environment variable.
 
-.. dune:stanza:: with-<outputs>-to
+.. dune:action:: with-<outputs>-to
    :param: <file> <DSL>
 
    Redirect the output to a file, where ``<outputs>`` is one of: ``stdout``,
    ``stderr`` or ``outputs`` (for both ``stdout`` and ``stderr``).
 
-.. dune:stanza:: ignore-<outputs>
+.. dune:action:: ignore-<outputs>
    :param: <DSL>
 
    Ignore the output, where ``<outputs>`` is one of: ``stdout``, ``stderr``, or
    ``outputs``.
 
-.. dune:stanza:: with-stdin-from
+.. dune:action:: with-stdin-from
    :param: <file> <DSL>
 
    Redirect the input from a file.
 
-.. dune:stanza:: with-accepted-exit-codes
+.. dune:action:: with-accepted-exit-codes
    :param: <pred> <DSL>
 
    .. versionadded:: 2.0
@@ -72,12 +72,12 @@ The following constructions are available:
    occurrences of ``run``, ``bash``, ``system``, ``chdir``, ``setenv``,
    ``ignore-<outputs>``, ``with-stdin-from``, and ``with-<outputs>-to``.
 
-.. dune:stanza:: progn
+.. dune:action:: progn
    :param: <DSL>...
 
    Execute several commands in sequence.
 
-.. dune:stanza:: concurrent
+.. dune:action:: concurrent
    :param: <DSL>...
 
    Execute several commands concurrently and collect all resulting errors, if any.
@@ -87,71 +87,71 @@ The following constructions are available:
       actually run sequentially, which may cause a deadlock if they talk to
       each other.
 
-.. dune:stanza:: echo
+.. dune:action:: echo
    :param: <string>
 
    Output a string on ``stdout``.
 
-.. dune:stanza:: write-file
+.. dune:action:: write-file
    :param: <file> <string>
 
    Writes ``<string>`` to ``<file>``.
 
-.. dune:stanza:: cat
+.. dune:action:: cat
    :param: <file> ...
 
    Sequentially print the contents of files to stdout.
 
-.. dune:stanza:: copy
+.. dune:action:: copy
    :param: <src> <dst>
 
    Copy a file. If these files are OCaml sources, you should follow the
    ``module_name.xxx.ml`` :ref:`naming convention <merlin-filenames>` to
    preserve Merlin's functionality.
 
-.. dune:stanza:: copy#
+.. dune:action:: copy#
    :param: <src> <dst>
 
    Copy a file and add a line directive at the beginning.
 
-.. dune:stanza:: system
+.. dune:action:: system
    :param: <cmd>
 
    Execute a command using the system shell: ``sh`` on Unix and ``cmd`` on Windows.
 
-.. dune:stanza:: bash
+.. dune:action:: bash
    :param: <cmd>
 
    Execute a command using ``/bin/bash``. This is obviously not very portable.
 
-.. dune:stanza:: diff
+.. dune:action:: diff
    :param: <file1> <file2>
 
    ``(diff <file1> <file2>)`` is similar to ``(run diff <file1> <file2>)`` but
    is better and allows promotion. See :doc:`../concepts/promotion` for more
    details.
 
-.. dune:stanza:: diff?
+.. dune:action:: diff?
    :param: <file1> <file2>
 
    ``(diff? <file1> <file2>)`` is similar to ``(diff <file1> <file2>)`` except
    that ``<file2>`` should be produced by a part of the same action rather than
    be a dependency, is optional and will be consumed by ``diff?``.
 
-.. dune:stanza:: cmp
+.. dune:action:: cmp
    :param: <file1> <file2>
 
    ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1> <file2>)`` but
    allows promotion. See :doc:`../concepts/promotion` for more details.
 
-.. dune:stanza:: no-infer
+.. dune:action:: no-infer
    :param: <DSL>
 
    Perform an action without inference of dependencies and targets. This is
    useful if you are generating dependencies in a way that Dune doesn't know
    about, for instance by calling an external build system.
 
-.. dune:stanza:: pipe-<outputs>
+.. dune:action:: pipe-<outputs>
    :param: <DSL> <DSL> <DSL>...
 
    .. versionadded:: 2.7


### PR DESCRIPTION
This expands the dune sphinx domain with an `action:` directive to document
actions.

The `reference/actions.rst` document is updated to use this, with additional
examples.

Possible followup work:
- create an action index (not sure if needed)
- add action xrefs to link to the documentation of a given action directly.
- document inference (target, deps) for each action
