### PR TITLE
refactor: change representation of Predicate_lang.Glob

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -60,7 +60,7 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"
-      ; Predicate_lang.encode Dune_lang.Encoder.int (fun _ -> assert false) pred
+      ; Predicate_lang.encode Dune_lang.Encoder.int pred
       ; encode t
       ]
   | Dynamic_run (a, xs) ->

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -60,7 +60,7 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"
-      ; Predicate_lang.encode Dune_lang.Encoder.int pred
+      ; Predicate_lang.encode Dune_lang.Encoder.int (fun _ -> assert false) pred
       ; encode t
       ]
   | Dynamic_run (a, xs) ->

--- a/otherlibs/dune-glob/src/glob.ml
+++ b/otherlibs/dune-glob/src/glob.ml
@@ -43,3 +43,18 @@ let of_string_exn loc repr =
   | Ok t -> t
 
 let compare x y = String.compare (to_string x) (to_string y)
+
+let hash t = String.hash (to_string t)
+
+let matching_extensions extensions =
+  Re
+    { re =
+        Re.(
+          [ rep any; char '.'; List.map extensions ~f:str |> alt ]
+          |> seq |> compile)
+    ; repr =
+        (match extensions with
+        | [] -> Code_error.raise "empty list of extensions" []
+        | [ x ] -> sprintf "*.%s" x
+        | xs -> sprintf "*.{%s}" (String.concat xs ~sep:","))
+    }

--- a/otherlibs/dune-glob/src/glob.ml
+++ b/otherlibs/dune-glob/src/glob.ml
@@ -17,8 +17,6 @@ let empty = Re { re = Re.compile Re.empty; repr = "\000" }
 
 let universal = Re { re = Re.compile (Re.rep Re.any); repr = "**" }
 
-let literal s = Literal s
-
 let of_string_result repr =
   Lexer.parse_string repr
   |> Result.map ~f:(function
@@ -47,11 +45,24 @@ let compare x y = String.compare (to_string x) (to_string y)
 let hash t = String.hash (to_string t)
 
 let matching_extensions extensions =
+  let re =
+    let open Re in
+    [ rep any
+    ; char '.'
+    ; List.map extensions ~f:(fun s ->
+          match of_string s with
+          | Literal _ -> str s
+          | Re _ ->
+            (* we cannot allow anything that can be parsed as a regex
+               here b/c we want the string representation to match [of_string]
+            *)
+            Code_error.raise "invalid extension" [ ("s", Dyn.string s) ])
+      |> alt
+    ]
+    |> seq |> compile
+  in
   Re
-    { re =
-        Re.(
-          [ rep any; char '.'; List.map extensions ~f:str |> alt ]
-          |> seq |> compile)
+    { re
     ; repr =
         (match extensions with
         | [] -> Code_error.raise "empty list of extensions" []

--- a/otherlibs/dune-glob/src/glob.ml
+++ b/otherlibs/dune-glob/src/glob.ml
@@ -17,6 +17,8 @@ let empty = Re { re = Re.compile Re.empty; repr = "\000" }
 
 let universal = Re { re = Re.compile (Re.rep Re.any); repr = "**" }
 
+let literal s = Literal s
+
 let of_string_result repr =
   Lexer.parse_string repr
   |> Result.map ~f:(function

--- a/otherlibs/dune-glob/src/glob.mli
+++ b/otherlibs/dune-glob/src/glob.mli
@@ -26,8 +26,6 @@ val to_dyn : t -> Dyn.t
 
 val of_string_exn : Loc.t -> string -> t
 
-val literal : string -> t
-
 val compare : t -> t -> Ordering.t
 
 val hash : t -> int

--- a/otherlibs/dune-glob/src/glob.mli
+++ b/otherlibs/dune-glob/src/glob.mli
@@ -30,4 +30,6 @@ val compare : t -> t -> Ordering.t
 
 val hash : t -> int
 
+(** [matching_extensions xs] return a glob that will match any of the extensions
+    in [xs] *)
 val matching_extensions : Filename.Extension.t list -> t

--- a/otherlibs/dune-glob/src/glob.mli
+++ b/otherlibs/dune-glob/src/glob.mli
@@ -29,3 +29,7 @@ val of_string_exn : Loc.t -> string -> t
 val literal : string -> t
 
 val compare : t -> t -> Ordering.t
+
+val hash : t -> int
+
+val matching_extensions : Filename.Extension.t list -> t

--- a/otherlibs/dune-glob/src/glob.mli
+++ b/otherlibs/dune-glob/src/glob.mli
@@ -26,4 +26,6 @@ val to_dyn : t -> Dyn.t
 
 val of_string_exn : Loc.t -> string -> t
 
+val literal : string -> t
+
 val compare : t -> t -> Ordering.t

--- a/otherlibs/dune-glob/test/dune_glob_tests.ml
+++ b/otherlibs/dune-glob/test/dune_glob_tests.ml
@@ -67,3 +67,12 @@ let%expect_test _ =
   [%expect {| [pass] "*" matches "foo.ml" == true |}];
   test glob "foo/" ~expect:false;
   [%expect {| [pass] "*" matches "foo/" == false |}]
+
+let%expect_test _ =
+  let glob = Glob.of_string "[!._]*" in
+  test glob ".foo" ~expect:false;
+  [%expect {| [pass] "[!._]*" matches ".foo" == false |}];
+  test glob "foo.ml" ~expect:true;
+  [%expect {| [pass] "[!._]*" matches "foo.ml" == true |}];
+  test glob "a" ~expect:true;
+  [%expect {| [pass] "[!._]*" matches "a" == true |}]

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -247,6 +247,8 @@ let diff_eq_files { Action.Diff.optional; mode; file1; file2 } =
   (optional && not (Path.Untracked.exists file2))
   || compare_files mode file1 file2 = Eq
 
+let zero = Predicate_lang.Element 0
+
 let rec exec t ~display ~ectx ~eenv =
   match (t : Action.t) with
   | Run (Error e, _) -> Action.Prog.Not_found.raise e
@@ -255,11 +257,9 @@ let rec exec t ~display ~ectx ~eenv =
     Done
   | With_accepted_exit_codes (exit_codes, t) ->
     let eenv =
-      let standard = Predicate_lang.Element (Predicate.create (Int.equal 0)) in
       let exit_codes =
-        Predicate_lang.map exit_codes ~f:(fun i ->
-            Predicate.create (Int.equal i))
-        |> Predicate_lang.to_predicate ~standard
+        Predicate.create
+          (Predicate_lang.exec exit_codes ~equal:Int.equal ~standard:zero)
       in
       { eenv with exit_codes }
     in

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -259,7 +259,7 @@ let rec exec t ~display ~ectx ~eenv =
     let eenv =
       let exit_codes =
         Predicate.create
-          (Predicate_lang.exec exit_codes ~equal:Int.equal ~standard:zero)
+          (Predicate_lang.test exit_codes ~test:Int.equal ~standard:zero)
       in
       { eenv with exit_codes }
     in

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -311,8 +311,7 @@ module Set = struct
      depending on [(source_tree x)]. Otherwise, we wouldn't clean up stale
      directories in directories that contain no file. *)
   let dir_without_files_dep dir =
-    file_selector
-      (File_selector.create ~dir File_selector.Predicate_with_id.false_)
+    file_selector (File_selector.of_predicate_lang ~dir Predicate_lang.any)
 
   let of_source_files ~files ~empty_directories =
     let init =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -311,7 +311,7 @@ module Set = struct
      depending on [(source_tree x)]. Otherwise, we wouldn't clean up stale
      directories in directories that contain no file. *)
   let dir_without_files_dep dir =
-    file_selector (File_selector.of_predicate_lang ~dir Predicate_lang.any)
+    file_selector (File_selector.of_predicate_lang ~dir Predicate_lang.empty)
 
   let of_source_files ~files ~empty_directories =
     let init =

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -44,5 +44,5 @@ let hash { dir; predicate; only_generated_files } =
     (dir, predicate, only_generated_files)
 
 let test t path =
-  Predicate_lang.Glob.exec t.predicate ~standard:Predicate_lang.empty
+  Predicate_lang.Glob.test t.predicate ~standard:Predicate_lang.empty
     (Path.basename path)

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -1,64 +1,31 @@
 open Import
 
-module Predicate_with_id = struct
-  open Stdune
-  open Dune_sexp
-
-  type 'a t =
-    { id : Dyn.t Lazy.t
-    ; f : 'a Predicate.t
-    }
-
-  let compare x y = Dyn.compare (Lazy.force x.id) (Lazy.force y.id)
-
-  let equal x y = compare x y = Ordering.Eq
-
-  let hash t = Dyn.hash (Lazy.force t.id)
-
-  let to_dyn t =
-    let open Dyn in
-    Record [ ("id", Lazy.force t.id) ]
-
-  let encode _ = Encoder.string "predicate <opaque>"
-
-  let create ~id ~f = { id; f = Predicate.create f }
-
-  let true_ = { id = lazy (String "true_"); f = Predicate.true_ }
-
-  let false_ = { id = lazy (String "false_"); f = Predicate.false_ }
-
-  let test t e = Predicate.test t.f e
-end
-
 type t =
   { dir : Path.t
-  ; predicate : Filename.t Predicate_with_id.t
+  ; predicate : Predicate_lang.Glob.t
   ; only_generated_files : bool
   }
 
 let dir t = t.dir
-
-let predicate t = t.predicate
 
 let only_generated_files t = t.only_generated_files
 
 let compare { dir; predicate; only_generated_files } t =
   let open Ordering.O in
   let= () = Path.compare dir t.dir in
-  let= () = Predicate_with_id.compare predicate t.predicate in
+  let= () = Predicate_lang.Glob.compare predicate t.predicate in
   Bool.compare only_generated_files t.only_generated_files
 
-let create ~dir ?(only_generated_files = false) predicate =
+let of_predicate_lang ~dir ?(only_generated_files = false) predicate =
   { dir; predicate; only_generated_files }
 
 let of_glob ~dir glob =
-  let id = lazy (Glob.to_dyn glob) in
-  create ~dir (Predicate_with_id.create ~id ~f:(Glob.test glob))
+  of_predicate_lang ~dir (Predicate_lang.Glob.of_glob glob)
 
 let to_dyn { dir; predicate; only_generated_files } =
   Dyn.Record
     [ ("dir", Path.to_dyn dir)
-    ; ("predicate", Predicate_with_id.to_dyn predicate)
+    ; ("predicate", Predicate_lang.Glob.to_dyn predicate)
     ; ("only_generated_files", Bool only_generated_files)
     ]
 
@@ -66,14 +33,16 @@ let encode { dir; predicate; only_generated_files } =
   let open Dune_sexp.Encoder in
   record
     [ ("dir", Dpath.encode dir)
-    ; ("predicate", Predicate_with_id.encode predicate)
+    ; ("predicate", Predicate_lang.Glob.encode predicate)
     ; ("only_generated_files", bool only_generated_files)
     ]
 
 let equal x y = compare x y = Eq
 
 let hash { dir; predicate; only_generated_files } =
-  Tuple.T3.hash Path.hash Predicate_with_id.hash Bool.hash
+  Tuple.T3.hash Path.hash Predicate_lang.Glob.hash Bool.hash
     (dir, predicate, only_generated_files)
 
-let test t path = Predicate_with_id.test t.predicate (Path.basename path)
+let test t path =
+  Predicate_lang.Glob.exec t.predicate ~standard:Predicate_lang.empty
+    (Path.basename path)

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -3,43 +3,16 @@
 
 open Import
 
-(** TODO get rid of this *)
-module Predicate_with_id : sig
-  (** Predicates are functions from 'a -> bool along with a uniquely identifying
-      string. The uniquely identifying string allows us to safely memoize on the
-      predicate *)
-
-  type 'a t
-
-  val equal : 'a t -> 'a t -> bool
-
-  (**[create id ~f] creates a predicate defined by [f] identified uniquely with
-     [id]. [id] is used to safely compare predicates for equality for
-     memoization *)
-  val create : id:Dyn.t Lazy.t -> f:('a -> bool) -> 'a t
-
-  (** The predicate that evaluates to [true] for any query. *)
-  val true_ : _ t
-
-  (** The predicate that evaluates to [false] for any query. *)
-  val false_ : _ t
-end
-
 type t
 
 val dir : t -> Path.t
-
-val predicate : t -> Filename.t Predicate_with_id.t
 
 val only_generated_files : t -> bool
 
 val of_glob : dir:Path.t -> Glob.t -> t
 
-val create :
-     dir:Path.t
-  -> ?only_generated_files:bool
-  -> Filename.t Predicate_with_id.t
-  -> t
+val of_predicate_lang :
+  dir:Path.t -> ?only_generated_files:bool -> Predicate_lang.Glob.t -> t
 
 val equal : t -> t -> bool
 

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -122,7 +122,7 @@ let decode_with_accepted_exit_codes =
   fun t ->
     let open Decoder in
     Syntax.since Stanza.syntax (2, 0)
-    >>> let+ codes = Predicate_lang.decode_one Decoder.int
+    >>> let+ codes = Predicate_lang.decode_one Decoder.int (fun g -> Element g)
         and+ version = Syntax.get_exn Stanza.syntax
         and+ loc, t = located t in
         match
@@ -286,7 +286,7 @@ let rec encode =
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"
-      ; Predicate_lang.encode Encoder.int pred
+      ; Predicate_lang.encode Encoder.int (fun _ -> assert false) pred
       ; encode t
       ]
   | Dynamic_run (a, xs) -> List (atom "run_dynamic" :: sw a :: List.map xs ~f:sw)

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -122,7 +122,7 @@ let decode_with_accepted_exit_codes =
   fun t ->
     let open Decoder in
     Syntax.since Stanza.syntax (2, 0)
-    >>> let+ codes = Predicate_lang.decode_one Decoder.int (fun g -> Element g)
+    >>> let+ codes = Predicate_lang.decode_one Decoder.int
         and+ version = Syntax.get_exn Stanza.syntax
         and+ loc, t = located t in
         match
@@ -286,7 +286,7 @@ let rec encode =
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"
-      ; Predicate_lang.encode Encoder.int (fun _ -> assert false) pred
+      ; Predicate_lang.encode Encoder.int pred
       ; encode t
       ]
   | Dynamic_run (a, xs) -> List (atom "run_dynamic" :: sw a :: List.map xs ~f:sw)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -21,4 +21,5 @@ module Profile = Profile
 module Targets_spec = Targets_spec
 module Wrapped = Wrapped
 
-let decode_predicate_lang_glob = Predicate_lang.decode Glob.decode
+let decode_predicate_lang_glob =
+  Predicate_lang.decode Glob.decode (fun x -> Glob x)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -20,6 +20,3 @@ module Locks = Locks
 module Profile = Profile
 module Targets_spec = Targets_spec
 module Wrapped = Wrapped
-
-let decode_predicate_lang_glob =
-  Predicate_lang.decode Glob.decode (fun x -> Glob x)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -21,6 +21,4 @@ module Profile = Profile
 module Targets_spec = Targets_spec
 module Wrapped = Wrapped
 
-let decode_predicate_lang_glob : Predicate_lang.Glob.t Dune_sexp.Decoder.t =
-  Predicate_lang.decode
-    (Dune_sexp.Decoder.map Glob.decode ~f:Predicate_lang.Glob.create_glob)
+let decode_predicate_lang_glob = Predicate_lang.decode Glob.decode

--- a/src/dune_lang/glob.ml
+++ b/src/dune_lang/glob.ml
@@ -2,10 +2,6 @@ open! Stdune
 open Dune_sexp
 include Dune_glob.V1
 
-let of_string = `shadowed
-
-let _ = of_string
-
 let to_dyn t = Dyn.variant "Glob" [ Dyn.string (to_string t) ]
 
 let compare x y = String.compare (to_string x) (to_string y)

--- a/src/dune_lang/glob.mli
+++ b/src/dune_lang/glob.mli
@@ -25,4 +25,6 @@ val universal : t
 
 val of_string_exn : Loc.t -> string -> t
 
+val of_string : string -> t
+
 val to_predicate : t -> Filename.t Predicate.t

--- a/src/dune_lang/glob.mli
+++ b/src/dune_lang/glob.mli
@@ -28,3 +28,5 @@ val of_string_exn : Loc.t -> string -> t
 val of_string : string -> t
 
 val to_predicate : t -> Filename.t Predicate.t
+
+val matching_extensions : Filename.Extension.t list -> t

--- a/src/dune_rules/case_lang.ml
+++ b/src/dune_rules/case_lang.ml
@@ -29,11 +29,11 @@ end
 
 type 'a t = (Predicate_lang.Glob.t, 'a) Ast.t
 
-let decode f = Ast.decode Dune_lang.decode_predicate_lang_glob f
+let decode f = Ast.decode Predicate_lang.Glob.decode f
 
 let eval (t : _ t) ~f =
   let elem = f t.on in
   List.find_map t.clauses ~f:(fun (keys, v) ->
       Option.some_if
-        (Predicate_lang.Glob.exec keys ~standard:Predicate_lang.empty elem)
+        (Predicate_lang.Glob.test keys ~standard:Predicate_lang.empty elem)
         v)

--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -1,15 +1,9 @@
 open Import
 
 let dev_files =
-  let exts = [ Ml_kind.cmt_ext Impl; Ml_kind.cmt_ext Intf; Cm_kind.ext Cmi ] in
-  let id =
-    lazy
-      (let open Dyn in
-      variant "dev_files" (List.map ~f:string exts))
-  in
-  Predicate_with_id.create ~id ~f:(fun p ->
-      let ext = Filename.extension p in
-      List.mem exts ext ~equal:String.equal)
+  [ Ml_kind.cmt_ext Impl; Ml_kind.cmt_ext Intf; Cm_kind.ext Cmi ]
+  |> List.map ~f:(String.drop_prefix_if_exists ~prefix:".")
+  |> Glob.matching_extensions
 
 let add_obj_dir sctx ~obj_dir mode =
   if (Super_context.context sctx).merlin then
@@ -20,7 +14,7 @@ let add_obj_dir sctx ~obj_dir mode =
           | Lib_mode.Melange -> Obj_dir.melange_dir obj_dir
           | Ocaml _ -> Obj_dir.byte_dir obj_dir)
       in
-      File_selector.create ~dir dev_files
+      File_selector.of_glob ~dir dev_files
     in
     Rules.Produce.Alias.add_deps
       (Alias.check ~dir:(Obj_dir.dir obj_dir))

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -31,8 +31,7 @@ let decode =
   fields
     (let+ loc = loc
      and+ files =
-       field "files" Dune_lang.decode_predicate_lang_glob
-         ~default:Predicate_lang.any
+       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.any
      and+ preprocess, preprocessor_deps = Stanza_common.preprocess_fields
      and+ libraries =
        field "libraries" (Lib_dep.L.decode ~allow_re_export:false) ~default:[]
@@ -71,7 +70,7 @@ let gen_rules sctx t ~dir ~scope =
     >>| Path.Source.Set.to_list
     >>| List.filter_map ~f:(fun p ->
             if
-              Predicate_lang.Glob.exec t.files (Path.Source.basename p)
+              Predicate_lang.Glob.test t.files (Path.Source.basename p)
                 ~standard:Predicate_lang.any
             then
               Some

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -140,7 +140,7 @@ let rules ~sctx ~expander ~dir tests =
               match spec.applies_to with
               | Whole_subtree -> true
               | Files_matching_in_this_dir pred ->
-                Predicate_lang.Glob.exec pred ~standard:Predicate_lang.any name
+                Predicate_lang.Glob.test pred ~standard:Predicate_lang.any name
             with
             | false -> acc
             | true ->

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -140,8 +140,7 @@ let rules ~sctx ~expander ~dir tests =
               match spec.applies_to with
               | Whole_subtree -> true
               | Files_matching_in_this_dir pred ->
-                Predicate_lang.Glob.exec pred
-                  ~standard:Predicate_lang.Glob.true_ name
+                Predicate_lang.Glob.exec pred ~standard:Predicate_lang.any name
             with
             | false -> acc
             | true ->

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -14,7 +14,7 @@ let decode_applies_to =
     Whole_subtree
   in
   let predicate =
-    let+ predicate = Dune_lang.decode_predicate_lang_glob in
+    let+ predicate = Predicate_lang.Glob.decode in
     Files_matching_in_this_dir predicate
   in
   subtree <|> predicate

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -5,7 +5,7 @@ type applies_to =
   | Whole_subtree
   | Files_matching_in_this_dir of Predicate_lang.Glob.t
 
-let default_applies_to = Files_matching_in_this_dir Predicate_lang.Glob.true_
+let default_applies_to = Files_matching_in_this_dir Predicate_lang.any
 
 let decode_applies_to =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -62,7 +62,7 @@ let include_dir_flags ~expander ~dir ~include_dirs =
                 (sprintf "%S is not a directory" (Path.to_string include_dir))
           in
           let deps =
-            File_selector.create ~dir:include_dir Predicate_with_id.true_
+            File_selector.of_predicate_lang ~dir:include_dir Predicate_lang.any
             |> Dep.file_selector |> Dep.Set.singleton
           in
           Command.Args.Hidden_deps deps
@@ -87,7 +87,8 @@ let include_dir_flags ~expander ~dir ~include_dirs =
                             Path.append_source build_dir
                               (Source_tree.Dir.path t)
                           in
-                          File_selector.create ~dir Predicate_with_id.true_
+                          File_selector.of_predicate_lang ~dir
+                            Predicate_lang.any
                           |> Dep.file_selector |> Dep.Set.singleton
                         in
                         Command.Args.Hidden_deps deps

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -41,7 +41,6 @@ include struct
   module Load_rules = Load_rules
   module Response_file = Response_file
   module Subdir_set = Subdir_set
-  module Predicate_with_id = File_selector.Predicate_with_id
 end
 
 include struct

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -207,8 +207,7 @@ let decode =
     (let+ loc = loc
      and+ version = Dune_lang.Syntax.get_exn syntax
      and+ files =
-       field "files" Dune_lang.decode_predicate_lang_glob
-         ~default:Predicate_lang.Standard
+       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.Standard
      and+ enabled_if =
        Enabled_if.decode ~allowed_vars:Any ~since:(Some (2, 9)) ()
      and+ package =
@@ -259,7 +258,7 @@ let files_to_mdx t ~sctx ~dir =
   let must_mdx src_path =
     let file = Path.Source.basename src_path in
     let standard = default_files_of_version t.version in
-    Predicate_lang.Glob.exec t.files ~standard file
+    Predicate_lang.Glob.test t.files ~standard file
   in
   let build_path src_path =
     Path.Build.append_source (Super_context.context sctx).build_dir src_path

--- a/src/dune_rules/rule_mode_decoder.ml
+++ b/src/dune_rules/rule_mode_decoder.ml
@@ -17,13 +17,12 @@ module Promote = struct
        and+ only =
          field_o "only"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)
-           >>> Dune_lang.decode_predicate_lang_glob)
+           >>> Predicate_lang.Glob.decode)
        in
        let only =
          Option.map only ~f:(fun only ->
              Predicate.create
-               (Predicate_lang.exec only ~standard:Predicate_lang.any
-                  ~equal:Filename.equal))
+               (Predicate_lang.Glob.test only ~standard:Predicate_lang.any))
        in
        { Rule.Promote.lifetime =
            (if until_clean then Until_clean else Unlimited)

--- a/src/dune_rules/rule_mode_decoder.ml
+++ b/src/dune_rules/rule_mode_decoder.ml
@@ -17,12 +17,13 @@ module Promote = struct
        and+ only =
          field_o "only"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)
-           >>> Predicate_lang.decode Dune_lang.Glob.decode)
+           >>> Dune_lang.decode_predicate_lang_glob)
        in
        let only =
          Option.map only ~f:(fun only ->
-             let only = Predicate_lang.map only ~f:Glob.to_predicate in
-             Predicate_lang.to_predicate only ~standard:Predicate_lang.any)
+             Predicate.create
+               (Predicate_lang.exec only ~standard:Predicate_lang.any
+                  ~equal:Filename.equal))
        in
        { Rule.Promote.lifetime =
            (if until_clean then Until_clean else Unlimited)

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -116,7 +116,7 @@ let eval (t : _ Status.Map.t) ~dirs =
   |> String.Map.filter_mapi ~f:(fun dir () : Status.t option ->
          let statuses =
            Status.Map.merge t default ~f:(fun pred standard ->
-               Predicate_lang.Glob.exec pred ~standard dir)
+               Predicate_lang.Glob.test pred ~standard dir)
            |> Status.Set.to_list
          in
          match statuses with
@@ -284,7 +284,7 @@ let decode =
   let dirs =
     located
       (Dune_lang.Syntax.since Stanza.syntax (1, 6)
-      >>> Dune_lang.decode_predicate_lang_glob)
+      >>> Predicate_lang.Glob.decode)
   in
   let data_only_dirs =
     located

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -79,11 +79,7 @@ let status status_by_dir ~dir : Status.Or_ignored.t =
   | Some d -> Status d
 
 let default =
-  let standard_dirs =
-    Predicate_lang.Glob.of_pred (function
-      | "" -> false
-      | s -> s.[0] <> '.' && s.[0] <> '_')
-  in
+  let standard_dirs = Predicate_lang.Glob.of_glob (Glob.of_string "[!._]*") in
   { Status.Map.normal = standard_dirs
   ; data_only = Predicate_lang.empty
   ; vendored = Predicate_lang.empty
@@ -273,7 +269,7 @@ let decode =
   let ignored_sub_dirs =
     let ignored =
       let+ l = enter (repeat (strict_subdir "ignored_sub_dirs")) in
-      Predicate_lang.Glob.of_string_set (String.Set.of_list_map ~f:snd l)
+      Predicate_lang.Glob.of_string_list (List.rev_map ~f:snd l)
     in
     let+ version = Dune_lang.Syntax.get_exn Stanza.syntax
     and+ loc, ignored = located ignored in

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -116,26 +116,24 @@ let to_predicate (type a) (t : a Predicate.t t) ~standard : a Predicate.t =
       exec t ~standard (fun pred -> Predicate.test pred a))
 
 module Glob = struct
-  type glob = string -> bool
+  module Glob = Dune_glob.V1
 
-  type nonrec t = glob t
+  type nonrec t = Glob.t t
 
-  let to_dyn t = to_dyn (fun _ -> Dyn.string "opaque") t
+  let to_dyn t = to_dyn Glob.to_dyn t
 
-  let exec (t : t) ~standard elem = exec t ~standard (fun f -> f elem)
+  let exec (t : t) ~standard elem = exec t ~standard (fun f -> Glob.test f elem)
 
   let filter (t : t) ~standard elems =
     match t with
     | Inter [] | Union [] -> []
     | _ -> List.filter elems ~f:(fun elem -> exec t ~standard elem)
 
-  let create_glob g = Dune_glob.V1.test g
+  let of_glob g = Element g
 
-  let of_glob g = Element (create_glob g)
+  let of_string_list s =
+    Union (List.rev_map s ~f:(fun x -> Element (Glob.literal x)))
 
-  let of_pred p = Element p
-
-  let true_ = Element (fun _ -> true)
-
-  let of_string_set s = Element (String.Set.mem s)
+  let of_string_set s =
+    Union (String.Set.to_list_map ~f:(fun x -> Element (Glob.literal x)) s)
 end

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -115,6 +115,10 @@ let to_predicate (type a) (t : a Predicate.t t) ~standard : a Predicate.t =
   Predicate.create (fun a ->
       exec t ~standard (fun pred -> Predicate.test pred a))
 
+let compare _ _ _ = Ordering.Eq
+
+let hash _ _ = 1
+
 module Glob = struct
   module Glob = Dune_glob.V1
 
@@ -136,4 +140,11 @@ module Glob = struct
 
   let of_string_set s =
     Union (String.Set.to_list_map ~f:(fun x -> Element (Glob.literal x)) s)
+
+  let compare x y = compare Glob.compare x y
+
+  let hash t = hash Glob.hash t
+
+  let encode t =
+    encode (fun x -> Dune_sexp.atom_or_quoted_string (Glob.to_string x)) t
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -5,6 +5,7 @@ open Dune_sexp
 
 type 'a t =
   | Element of 'a
+  | Glob : Dune_glob.V1.t -> string t
   | Compl of 'a t
   | Standard
   | Union of 'a t list
@@ -22,27 +23,22 @@ val not_union : 'a t list -> 'a t
 
 val any : 'a t
 
-val decode_one : 'a Decoder.t -> 'a t Decoder.t
+val decode_one : 'a Decoder.t -> ('a -> 'b t) -> 'b t Decoder.t
 
-val decode : 'a Decoder.t -> 'a t Decoder.t
+val decode : 'a Decoder.t -> ('a -> 'b t) -> 'b t Decoder.t
 
-val encode : 'a Encoder.t -> 'a t Encoder.t
+val encode : 'a Encoder.t -> (Dune_glob.V1.t -> Dune_sexp.t) -> 'a t Encoder.t
 
 val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
-val exec : 'a t -> standard:'a t -> ('a -> bool) -> bool
+val exec : 'a t -> standard:'a t -> equal:('a -> 'a -> bool) -> 'a -> bool
 
 val empty : 'a t
-
-val map : 'a t -> f:('a -> 'b) -> 'b t
-
-val to_predicate :
-  'a Predicate.t t -> standard:'a Predicate.t t -> 'a Predicate.t
 
 val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
 
 module Glob : sig
-  type nonrec t = Dune_glob.V1.t t
+  type nonrec t = string t
 
   val to_dyn : t -> Dyn.t
 

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -40,12 +40,7 @@ val to_predicate :
   'a Predicate.t t -> standard:'a Predicate.t t -> 'a Predicate.t
 
 module Glob : sig
-  (** The underlying type for the string predicate is not an actual glob, so
-      this module is confusingly named. *)
-
-  type glob
-
-  type nonrec t = glob t
+  type nonrec t = Dune_glob.V1.t t
 
   val to_dyn : t -> Dyn.t
 
@@ -53,13 +48,9 @@ module Glob : sig
 
   val filter : t -> standard:t -> string list -> string list
 
-  val create_glob : Dune_glob.V1.t -> glob
-
   val of_glob : Dune_glob.V1.t -> t
 
-  val of_pred : (string -> bool) -> t
+  val of_string_list : string list -> t
 
   val of_string_set : String.Set.t -> t
-
-  val true_ : t
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -39,6 +39,8 @@ val map : 'a t -> f:('a -> 'b) -> 'b t
 val to_predicate :
   'a Predicate.t t -> standard:'a Predicate.t t -> 'a Predicate.t
 
+val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
+
 module Glob : sig
   type nonrec t = Dune_glob.V1.t t
 
@@ -53,4 +55,10 @@ module Glob : sig
   val of_string_list : string list -> t
 
   val of_string_set : String.Set.t -> t
+
+  val compare : t -> t -> Ordering.t
+
+  val hash : t -> int
+
+  val encode : t -> Dune_sexp.t
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -5,7 +5,6 @@ open Dune_sexp
 
 type 'a t =
   | Element of 'a
-  | Glob : Dune_glob.V1.t -> string t
   | Compl of 'a t
   | Standard
   | Union of 'a t list
@@ -23,38 +22,48 @@ val not_union : 'a t list -> 'a t
 
 val any : 'a t
 
-val decode_one : 'a Decoder.t -> ('a -> 'b t) -> 'b t Decoder.t
+val decode_one : 'a Decoder.t -> 'a t Decoder.t
 
-val decode : 'a Decoder.t -> ('a -> 'b t) -> 'b t Decoder.t
+val decode : 'a Decoder.t -> 'a t Decoder.t
 
-val encode : 'a Encoder.t -> (Dune_glob.V1.t -> Dune_sexp.t) -> 'a t Encoder.t
+val encode : 'a Encoder.t -> 'a t Encoder.t
 
 val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
-val exec : 'a t -> standard:'a t -> equal:('a -> 'a -> bool) -> 'a -> bool
+val test : 'a t -> standard:'a t -> test:('a -> 'b -> bool) -> 'b -> bool
 
 val empty : 'a t
 
 val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
 
 module Glob : sig
-  type nonrec t = string t
+  module Element : sig
+    type t =
+      | Glob of Dune_glob.V1.t
+      | Literal of string
+  end
+
+  type nonrec t = Element.t t
 
   val to_dyn : t -> Dyn.t
 
-  val exec : t -> standard:t -> string -> bool
-
-  val filter : t -> standard:t -> string list -> string list
+  val test : t -> standard:t -> string -> bool
 
   val of_glob : Dune_glob.V1.t -> t
 
+  (** [of_string_list xs] return an expression that will match any element
+      inside the list [xs] *)
   val of_string_list : string list -> t
 
+  (** [of_string_list xs] return an expression that will only match any element
+      inside the set [xs] *)
   val of_string_set : String.Set.t -> t
 
   val compare : t -> t -> Ordering.t
 
   val hash : t -> int
+
+  val decode : t Dune_sexp.Decoder.t
 
   val encode : t -> Dune_sexp.t
 end


### PR DESCRIPTION
Represent it directly with a glob rather than going through a predicate. This makes it simple, serializable, and safe to use for memoization.

Remove all the `Predicate_with_id` foot guns.

@snowleopard  Continuation of #7796 along with the suggestion we discussed.