### PR TITLE
refactor: create Diagnostic.to_user_message so it can be reused

### DIFF
--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -111,6 +111,8 @@ module Diagnostic : sig
 
   val to_dyn : t -> Dyn.t
 
+  val to_user_message : t -> Stdune.User_message.t
+
   module Event : sig
     type nonrec t =
       | Add of t


### PR DESCRIPTION
Another patch wanted to use this function, so move it out of private bin/diagnostics.ml to somewhere it can be reused.