### PR TITLE
fix(pkg): do not set OCAMLTOP_INCLUDE_PATH twice

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -308,10 +308,6 @@ module Pkg = struct
                |> Env.Map.add_multi env "OCAMLTOP_INCLUDE_PATH"
              in
              let env =
-               Value.Dir (Install.Section.Paths.get paths Toplevel)
-               |> Env.Map.add_multi env "OCAMLTOP_INCLUDE_PATH"
-             in
-             let env =
                Value.Dir (Install.Section.Paths.get paths Lib)
                |> Env.Map.add_multi env "OCAMLPATH"
              in


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5dc0e1fe-97b3-45ab-ac9e-d777cd9be097 -->