### PR TITLE
fix(predicate_lang): [Inter []] should be [true]

### DIFF
--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -9,7 +9,8 @@ type 'a t =
   | Inter of 'a t list
 
 let diff a = function
-  | Union [] | Inter [] -> a
+  | Union [] -> a
+  | Inter [] -> Union []
   | b -> Inter [ a; Compl b ]
 
 let inter a = Inter a


### PR DESCRIPTION
Since [Union []] is [false], [Inter []] should be [true] for symmetry.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: adaff6bc-d500-48bc-a596-07396eed34b0 -->