### PR TITLE
feature: misc async operations

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -126,3 +126,13 @@ let background_sandboxes =
   in
   register t;
   t
+
+let background_file_system_operations_in_rule_execution =
+  let t =
+    { name = "background_file_system_operations_in_rule_execution"
+    ; of_string = Toggle.of_string
+    ; value = `Disabled
+    }
+  in
+  register t;
+  t

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -47,4 +47,7 @@ val background_digests : Toggle.t t
 (** Build and destroy sandboxes in background threads *)
 val background_sandboxes : Toggle.t t
 
+(** Run file operations when executing rules in background threads *)
+val background_file_system_operations_in_rule_execution : Toggle.t t
+
 val init : (Loc.t * string) String.Map.t -> unit

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -88,7 +88,8 @@ module Produced : sig
 
   (** Like [of_validated] but assumes the targets have been just produced by a
       rule. If some directory targets aren't readable, an error is raised *)
-  val produced_after_rule_executed_exn : loc:Loc.t -> Validated.t -> unit t
+  val produced_after_rule_executed_exn :
+    loc:Loc.t -> Validated.t -> unit t Fiber.t
 
   (** Populates only the [files] field, leaving [dirs] empty. Raises a code
       error if the list contains duplicates. *)
@@ -114,3 +115,7 @@ module Produced : sig
 
   val to_dyn : _ t -> Dyn.t
 end
+
+(** will run in a background thread if
+    [background_file_system_operations_in_rule_execution] is set *)
+val maybe_async : (unit -> 'a) -> 'a Fiber.t


### PR DESCRIPTION
This moves over the remaining operations in the engine into background
threads. They aren't really related to each other in any way, so I'm not
sure what to call the config to toggle them.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1bc80bf5-de07-403a-8bac-a34f65d9b867 -->