### PR TITLE
refactor(predicate_lang): make abstract and rename

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -247,7 +247,7 @@ let diff_eq_files { Action.Diff.optional; mode; file1; file2 } =
   (optional && not (Path.Untracked.exists file2))
   || compare_files mode file1 file2 = Eq
 
-let zero = Predicate_lang.Element 0
+let zero = Predicate_lang.element 0
 
 let rec exec t ~display ~ectx ~eenv =
   match (t : Action.t) with

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -311,7 +311,7 @@ module Set = struct
      depending on [(source_tree x)]. Otherwise, we wouldn't clean up stale
      directories in directories that contain no file. *)
   let dir_without_files_dep dir =
-    file_selector (File_selector.of_predicate_lang ~dir Predicate_lang.empty)
+    file_selector (File_selector.of_predicate_lang ~dir Predicate_lang.false_)
 
   let of_source_files ~files ~empty_directories =
     let init =

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -44,5 +44,5 @@ let hash { dir; predicate; only_generated_files } =
     (dir, predicate, only_generated_files)
 
 let test t path =
-  Predicate_lang.Glob.test t.predicate ~standard:Predicate_lang.empty
+  Predicate_lang.Glob.test t.predicate ~standard:Predicate_lang.false_
     (Path.basename path)

--- a/src/dune_rules/case_lang.ml
+++ b/src/dune_rules/case_lang.ml
@@ -35,5 +35,5 @@ let eval (t : _ t) ~f =
   let elem = f t.on in
   List.find_map t.clauses ~f:(fun (keys, v) ->
       Option.some_if
-        (Predicate_lang.Glob.test keys ~standard:Predicate_lang.empty elem)
+        (Predicate_lang.Glob.test keys ~standard:Predicate_lang.false_ elem)
         v)

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -31,7 +31,7 @@ let decode =
   fields
     (let+ loc = loc
      and+ files =
-       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.any
+       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.true_
      and+ preprocess, preprocessor_deps = Stanza_common.preprocess_fields
      and+ libraries =
        field "libraries" (Lib_dep.L.decode ~allow_re_export:false) ~default:[]
@@ -71,7 +71,7 @@ let gen_rules sctx t ~dir ~scope =
     >>| List.filter_map ~f:(fun p ->
             if
               Predicate_lang.Glob.test t.files (Path.Source.basename p)
-                ~standard:Predicate_lang.any
+                ~standard:Predicate_lang.true_
             then
               Some
                 (Path.Build.append_source (Super_context.context sctx).build_dir

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -140,7 +140,8 @@ let rules ~sctx ~expander ~dir tests =
               match spec.applies_to with
               | Whole_subtree -> true
               | Files_matching_in_this_dir pred ->
-                Predicate_lang.Glob.test pred ~standard:Predicate_lang.any name
+                Predicate_lang.Glob.test pred ~standard:Predicate_lang.true_
+                  name
             with
             | false -> acc
             | true ->

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -5,7 +5,7 @@ type applies_to =
   | Whole_subtree
   | Files_matching_in_this_dir of Predicate_lang.Glob.t
 
-let default_applies_to = Files_matching_in_this_dir Predicate_lang.any
+let default_applies_to = Files_matching_in_this_dir Predicate_lang.true_
 
 let decode_applies_to =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -62,7 +62,8 @@ let include_dir_flags ~expander ~dir ~include_dirs =
                 (sprintf "%S is not a directory" (Path.to_string include_dir))
           in
           let deps =
-            File_selector.of_predicate_lang ~dir:include_dir Predicate_lang.any
+            File_selector.of_predicate_lang ~dir:include_dir
+              Predicate_lang.true_
             |> Dep.file_selector |> Dep.Set.singleton
           in
           Command.Args.Hidden_deps deps
@@ -88,7 +89,7 @@ let include_dir_flags ~expander ~dir ~include_dirs =
                               (Source_tree.Dir.path t)
                           in
                           File_selector.of_predicate_lang ~dir
-                            Predicate_lang.any
+                            Predicate_lang.true_
                           |> Dep.file_selector |> Dep.Set.singleton
                         in
                         Command.Args.Hidden_deps deps

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -181,11 +181,11 @@ let lib_src_dirs ~dir_contents =
 let define_all_alias ~dir ~project ~js_targets =
   let deps =
     let predicate =
-      if Dune_project.explicit_js_mode project then Predicate_lang.any
+      if Dune_project.explicit_js_mode project then Predicate_lang.true_
       else (
         List.iter js_targets ~f:(fun js_target ->
             assert (Path.Build.equal (Path.Build.parent_exn js_target) dir));
-        Compl
+        Predicate_lang.compl
           (Predicate_lang.Glob.of_string_set
              (String.Set.of_list_map js_targets ~f:Path.Build.basename)))
     in

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -198,7 +198,7 @@ let default_files_of_version version =
   let mld_files = glob_predicate "*.mld" in
   let mld_support_since = (0, 4) in
   match Syntax.Version.Infix.(version >= mld_support_since) with
-  | true -> Predicate_lang.union [ md_files; mld_files ]
+  | true -> Predicate_lang.or_ [ md_files; mld_files ]
   | false -> md_files
 
 let decode =
@@ -207,7 +207,7 @@ let decode =
     (let+ loc = loc
      and+ version = Dune_lang.Syntax.get_exn syntax
      and+ files =
-       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.Standard
+       field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.standard
      and+ enabled_if =
        Enabled_if.decode ~allowed_vars:Any ~since:(Some (2, 9)) ()
      and+ package =

--- a/src/dune_rules/rule_mode_decoder.ml
+++ b/src/dune_rules/rule_mode_decoder.ml
@@ -22,7 +22,7 @@ module Promote = struct
        let only =
          Option.map only ~f:(fun only ->
              Predicate.create
-               (Predicate_lang.Glob.test only ~standard:Predicate_lang.any))
+               (Predicate_lang.Glob.test only ~standard:Predicate_lang.true_))
        in
        { Rule.Promote.lifetime =
            (if until_clean then Until_clean else Unlimited)

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -81,8 +81,8 @@ let status status_by_dir ~dir : Status.Or_ignored.t =
 let default =
   let standard_dirs = Predicate_lang.Glob.of_glob (Glob.of_string "[!._]*") in
   { Status.Map.normal = standard_dirs
-  ; data_only = Predicate_lang.empty
-  ; vendored = Predicate_lang.empty
+  ; data_only = Predicate_lang.false_
+  ; vendored = Predicate_lang.false_
   }
 
 let or_default (t : _ Status.Map.t) : _ Status.Map.t =
@@ -98,7 +98,7 @@ let make ~dirs ~data_only ~ignored_sub_dirs ~vendored_dirs =
     | Some (loc, data_only), [] -> Some (loc, data_only)
     | None, (loc, _) :: _ ->
       let ignored_sub_dirs = List.map ~f:snd ignored_sub_dirs in
-      Some (loc, Predicate_lang.union ignored_sub_dirs)
+      Some (loc, Predicate_lang.or_ ignored_sub_dirs)
     | Some _data_only, _ :: _ -> assert false
   in
   { Status.Map.normal = dirs; data_only; vendored = vendored_dirs }
@@ -262,7 +262,7 @@ let strict_subdir_glob field_name =
       (let+ loc, l = strict_subdir field_name in
        Predicate_lang.Glob.of_glob (Glob.of_string_exn loc l))
   in
-  Predicate_lang.union globs
+  Predicate_lang.or_ globs
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -3,24 +3,23 @@
 open! Stdune
 open Dune_sexp
 
-type 'a t =
-  | Element of 'a
-  | Compl of 'a t
-  | Standard
-  | Union of 'a t list
-  | Inter of 'a t list
+type 'a t
+
+val of_list : 'a list -> 'a t
+
+val element : 'a -> 'a t
+
+val standard : 'a t
 
 val diff : 'a t -> 'a t -> 'a t
 
-val inter : 'a t list -> 'a t
+val and_ : 'a t list -> 'a t
 
 val compl : 'a t -> 'a t
 
-val union : 'a t list -> 'a t
+val or_ : 'a t list -> 'a t
 
-val not_union : 'a t list -> 'a t
-
-val any : 'a t
+val true_ : 'a t
 
 val decode_one : 'a Decoder.t -> 'a t Decoder.t
 
@@ -32,7 +31,7 @@ val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
 val test : 'a t -> standard:'a t -> test:('a -> 'b -> bool) -> 'b -> bool
 
-val empty : 'a t
+val false_ : 'a t
 
 val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
 

--- a/test/expect-tests/dune_engine/action_to_sh_tests.ml
+++ b/test/expect-tests/dune_engine/action_to_sh_tests.ml
@@ -108,7 +108,7 @@ let%expect_test "with-stdin-from" =
 (* TODO currently no special printing for with-accepted-exit-codes *)
 let%expect_test "with-accepted-exit-codes" =
   With_accepted_exit_codes
-    ( Predicate_lang.Union [ Element 0; Element 1; Element 123 ]
+    ( Predicate_lang.of_list [ 0; 1; 123 ]
     , Bash {|
     echo Hello world
     exit 123


### PR DESCRIPTION
Make the predicate language abstract and apply some simplicifations when
[Union]/[Inter] are created.

Rename [any] and [emtpy] to [true_] and [false_]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0f040d3b-b491-4174-ac2f-36a0f06c0867 -->