### PR TITLE
Added XDG_STATE_HOME support to xdg library

### DIFF
--- a/otherlibs/xdg/xdg.ml
+++ b/otherlibs/xdg/xdg.ml
@@ -5,6 +5,7 @@ type t =
   ; mutable cache_dir : string
   ; mutable config_dir : string
   ; mutable data_dir : string
+  ; mutable state_dir : string
   ; mutable runtime_dir : string option
   }
 
@@ -42,6 +43,10 @@ let data_dir t =
   let home = t.home_dir in
   make t "XDG_DATA_HOME" (home / ".local" / "share") LocalAppData
 
+let state_dir t =
+  let home = t.home_dir in
+  make t "XDG_STATE_HOME" (home / ".local" / "state") LocalAppData
+
 let create ?win32 ~env () =
   let win32 =
     match win32 with
@@ -61,12 +66,14 @@ let create ?win32 ~env () =
     ; cache_dir = ""
     ; config_dir = ""
     ; data_dir = ""
+    ; state_dir = ""
     ; runtime_dir = None
     }
   in
   t.cache_dir <- cache_dir t;
   t.config_dir <- config_dir t;
   t.data_dir <- data_dir t;
+  t.state_dir <- state_dir t;
   t.runtime_dir <- env "XDG_RUNTIME_DIR";
   t
 
@@ -77,5 +84,7 @@ let config_dir t = t.config_dir
 let data_dir t = t.data_dir
 
 let cache_dir t = t.cache_dir
+
+let state_dir t = t.state_dir
 
 let runtime_dir t = t.runtime_dir

--- a/otherlibs/xdg/xdg.mli
+++ b/otherlibs/xdg/xdg.mli
@@ -15,6 +15,9 @@ val data_dir : t -> string
 (** The directory where the application should read/write cached files. *)
 val cache_dir : t -> string
 
+(** The directory where the application should read/write state files. *)
+val state_dir : t -> string
+
 (** The directory where the application should store socket files. *)
 val runtime_dir : t -> string option
 


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) was updated to include a new directory: the user state directory. This PR adds support for said directory.