### PR TITLE
fix(coq): fix crash when COQ_NATIVE_COMPILER_DEFAULT missing 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+- Fix a crash when using a version of Coq < 8.13 due to the native compiler
+  config variable being missing. We now explicitly default to `(mode vo)` for
+  these older versions of Coq. (#7847, fixes #7846, @Alizter)
+
 - Remove some compatibility code for old version of dune that generated
   `.merlin` files. Now dune will never remove `.merlin` files automatically
   (#7562)

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -132,7 +132,8 @@ The semantics of the fields are:
   Coq theories are located by Dune.
 
 - If Coq has been configured with ``-native-compiler yes`` or ``ondemand``, Dune
-  will always build the ``cmxs`` files together with the ``vo`` files.
+  will always build the ``cmxs`` files together with the ``vo`` files. This only
+  works on Coq versions after 8.13 in which the option was introduced.
 
   You may override this by specifying ``(mode native)`` or ``(mode vo)``.
 

--- a/src/dune_rules/coq/coq_config.ml
+++ b/src/dune_rules/coq/coq_config.ml
@@ -11,8 +11,6 @@ module Vars : sig
   val get_path_opt : t -> string -> Path.t option
 
   val of_lines : string list -> (t, User_message.Style.t Pp.t) result
-
-  exception E of User_message.Style.t Pp.t
 end = struct
   open Result.O
 
@@ -32,16 +30,12 @@ end = struct
     Result.map_error (String.Map.of_list vars) ~f:(fun (var, _, _) ->
         Pp.(textf "Variable %S present twice." var))
 
-  exception E of User_message.Style.t Pp.t
-
-  let fail fmt msg = raise (E (Pp.textf fmt msg))
-
   let get_opt = String.Map.find
 
   let get t var =
     match get_opt t var with
     | Some s -> s
-    | None -> fail "Variable %S not found." var
+    | None -> Code_error.raise "Variable not found." [ ("var", Dyn.string var) ]
 
   let get_path t var = get t var |> Path.of_string
 

--- a/src/dune_rules/coq/coq_config.ml
+++ b/src/dune_rules/coq/coq_config.ml
@@ -4,7 +4,7 @@ open Memo.O
 module Vars : sig
   type t
 
-  val get : t -> string -> string
+  val get_opt : t -> string -> string option
 
   val get_path : t -> string -> Path.t
 
@@ -183,9 +183,14 @@ let make_res ~(coqc : Action.Prog.t) =
       match Vars.of_lines config_lines with
       | Ok vars ->
         let coqlib = Vars.get_path vars "COQLIB" in
+        (* this is not available in Coq < 8.14 *)
         let coqcorelib = Vars.get_path_opt vars "COQCORELIB" in
+        (* this is not available in Coq < 8.13 *)
         let coq_native_compiler_default =
-          Vars.get vars "COQ_NATIVE_COMPILER_DEFAULT"
+          match Vars.get_opt vars "COQ_NATIVE_COMPILER_DEFAULT" with
+          | Some s -> s
+          (* we will explicitly not support native compilation for Coq < 8.13 *)
+          | None -> "no"
         in
         Ok { version_info; coqlib; coqcorelib; coq_native_compiler_default }
       | Error msg ->

--- a/src/dune_rules/coq/coq_config.mli
+++ b/src/dune_rules/coq/coq_config.mli
@@ -10,16 +10,25 @@ val make : coqc:Action.Prog.t -> t Memo.t
 val make_opt : coqc:Action.Prog.t -> t Option.t Memo.t
 
 module Value : sig
-  type t =
+  type t = private
     | Int of int
     | Path of Path.t
     | String of string
+
+  val int : int -> t
+
+  val string : string -> t
+
+  val path : Path.t -> t
 
   val to_dyn : t -> Dyn.t
 end
 
 (** [by_name t name] returns the value of the option [name] in the Coq
-    configuration [t]. Currently supported names are:
+    configuration [t]. If the value is not available then [None] is returned.
+    Throws a code error if an invalid [name] is requested.
+
+    Currently supported names are:
 
     - version.major
     - version.minor

--- a/src/dune_rules/coq/coq_path.ml
+++ b/src/dune_rules/coq/coq_path.ml
@@ -39,7 +39,8 @@ let config_path_exn coq_config key =
     User_error.raise [ Pp.text "key not found from coqc --config"; Pp.text key ]
 
 let config_path ~default coq_config key =
-  Option.value ~default:(Coq_config.Value.Path default)
+  Option.value
+    ~default:(Coq_config.Value.path default)
     (Coq_config.by_name coq_config key)
   |> function
   | Coq_config.Value.Path p -> p (* We have found a path for key *)


### PR DESCRIPTION
Coq versions < 8.13 do not have COQ_NATIVE_COMPILER_DEFAULT and were causing dune to crash when searching for this var. We make it so that if dune does not find it, it defaults to "no". The docs should also be updated accordingly.

fix #7846

- [x] changelog
- [x] docs (need to mention native comp not supported < 8.13)