### PR TITLE
refactor: allow bootstrap to have an Entry module

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -767,7 +767,9 @@ module Library = struct
         | None -> base ^ ext
         | Some t ->
           if String.capitalize_ascii base = t.toplevel_module then base ^ ext
-          else String.uncapitalize_ascii t.toplevel_module ^ "__" ^ base ^ ext)
+          else
+            let base = String.capitalize_ascii base in
+            String.uncapitalize_ascii t.toplevel_module ^ "__" ^ base ^ ext)
 
     let header t =
       match t with
@@ -783,8 +785,7 @@ module Library = struct
         StringSet.iter
           (fun m ->
             if m <> t.toplevel_module then
-              fprintf oc "module %s = %s__%s\n" m t.toplevel_module
-                (String.uncapitalize_ascii m))
+              fprintf oc "module %s = %s__%s\n" m t.toplevel_module m)
           modules;
         close_out oc;
         Some fn


### PR DESCRIPTION
The old name mangling scheme would produce symbols with the __entry
suffix already used by the compiler. We just capitalize the first letter
after the __. As a bonus, this also matches the dune rules convention.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: db1a412c-38af-469f-adf8-40603cbf1452 -->