### PR TITLE
Generate lockdir from current switch

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -39,60 +39,88 @@ let lock_dir_term =
   |> Option.value ~default:Lock_dir.default_path
 
 module Lock = struct
-  module Repo = struct
-    open Dune_pkg.Opam.Repo
+  module Repo_selection = struct
+    module Env = struct
+      module Source = struct
+        type t =
+          | Global
+          | Pure
+
+        let to_string = function
+          | Global -> "global"
+          | Pure -> "pure"
+
+        let default = Global
+
+        let term =
+          let all = [ Global; Pure ] in
+          let all_with_strings = List.map all ~f:(fun t -> (to_string t, t)) in
+          let all_strings = List.map all_with_strings ~f:fst in
+          let doc =
+            sprintf
+              "How to initialize the opam environment when taking the opam \
+               repository from a local directory (may only be used along with \
+               the --opam-repository-path option). Possible values are %s. \
+               '%s' will use the environment associated with the current opam \
+               switch. '%s' will use an empty environment. The default is \
+               '%s'."
+              (String.enumerate_and all_strings)
+              (to_string Global) (to_string Pure) (to_string default)
+          in
+          Arg.(
+            value
+            & opt (some (enum all_with_strings)) None
+            & info [ "opam-env" ] ~doc)
+      end
+
+      let of_source =
+        let open Dune_pkg.Opam.Env in
+        function
+        | Source.Global -> global ()
+        | Pure -> empty
+    end
 
     let term =
       let+ opam_repository_path =
         Arg.(
-          required
+          value
           & opt (some string) None
           & info [ "opam-repository-path" ] ~docv:"PATH"
               ~doc:
                 "Path to a local opam repository. This should be a directory \
                  containing a valid opam repository such as the one at \
-                 https://github.com/ocaml/opam-repository.")
-      in
-      of_opam_repo_dir_path opam_repository_path
-  end
-
-  module Env = struct
-    module Source = struct
-      type t =
-        | Global
-        | Pure
-
-      let to_string = function
-        | Global -> "global"
-        | Pure -> "pure"
-
-      let default = Global
-
-      let term =
-        let all = [ Global; Pure ] in
-        let all_with_strings = List.map all ~f:(fun t -> (to_string t, t)) in
-        let all_strings = List.map all_with_strings ~f:fst in
-        let doc =
-          sprintf
-            "How to initialize the opam environment. Possible values are %s. \
-             '%s' will use the environment associated with the current opam \
-             switch. '%s' will use an empty environment. The default is '%s'."
-            (String.enumerate_and all_strings)
-            (to_string Global) (to_string Pure) (to_string default)
-        in
+                 https://github.com/ocaml/opam-repository. If this option is \
+                 omitted the dependencies will be locked using the current \
+                 switch instead.")
+      and+ opam_switch_name =
         Arg.(
           value
-          & opt (some (enum all_with_strings)) None
-          & info [ "opam-env" ] ~doc)
-    end
-
-    open Dune_pkg.Opam.Env
-
-    let term =
-      let+ source = Source.term in
-      match Option.value source ~default:Source.default with
-      | Global -> global ()
-      | Pure -> empty
+          & opt (some string) None
+          & info [ "opam-switch" ] ~docv:"SWITCH"
+              ~doc:
+                "Name or path of opam switch to use while solving \
+                 dependencies. Local switches may be specified with relative \
+                 paths (e.g. `--opam-switch=.`)")
+      and+ env_source = Env.Source.term in
+      let module Repo_selection = Dune_pkg.Opam.Repo_selection in
+      match (opam_switch_name, opam_repository_path, env_source) with
+      | None, None, _env_source | Some _, Some _, _env_source ->
+        User_error.raise
+          [ Pp.text
+              "Exactly one of --opam-switch and --opam-repository-path must be \
+               specified"
+          ]
+      | Some _opam_switch, None, Some _env_source ->
+        User_error.raise
+          [ Pp.text "--opam-env may only used with --opam-repository-path" ]
+      | Some opam_switch_name, None, None ->
+        Repo_selection.switch_with_name opam_switch_name
+      | None, Some opam_repo_dir_path, env_source_opt ->
+        let env =
+          Option.value env_source_opt ~default:Env.Source.default
+          |> Env.of_source
+        in
+        Repo_selection.local_repo_with_env ~opam_repo_dir_path ~env
   end
 
   (* Converts the package table found inside a [Dune_project.t] into the
@@ -111,8 +139,7 @@ module Lock = struct
 
   let term =
     let+ (common : Common.t) = Common.term
-    and+ env = Env.term
-    and+ repo = Repo.term
+    and+ repo_selection = Repo_selection.term
     and+ lock_dir_path = lock_dir_term in
     let config = Common.init common in
     Scheduler.go ~common ~config (fun () ->
@@ -124,7 +151,8 @@ module Lock = struct
           opam_file_map_of_dune_package_map dune_package_map
         in
         let summary, lock_dir =
-          Dune_pkg.Opam.solve_lock_dir ~env ~repo ~lock_dir_path opam_file_map
+          Dune_pkg.Opam.solve_lock_dir ~repo_selection ~lock_dir_path
+            opam_file_map
         in
         Console.print_user_message
           (Dune_pkg.Opam.Summary.selected_packages_message summary);

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -7,10 +7,12 @@
   dune_engine
   dune_util
   dune_lang
+  dune_console
   opam_core
   opam_repository
   opam_format
   opam_state
-  opam_0install)
+  opam_0install
+  fmt)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -1,7 +1,61 @@
 open Stdune
 module Package_name = Dune_lang.Package_name
 
-module Repo = struct
+module Global : sig
+  val with_switch_state :
+       switch_name:string
+    -> f:(OpamStateTypes.unlocked OpamStateTypes.switch_state -> 'a)
+    -> 'a
+end = struct
+  let initialized = ref false
+
+  let ensure_initialized () =
+    if not !initialized then (
+      OpamSystem.init ();
+      let root = OpamStateConfig.opamroot () in
+      let (_ : OpamFile.Config.t option) =
+        OpamStateConfig.load_defaults ~lock_kind:`Lock_read root
+      in
+      OpamFormatConfig.init ();
+      OpamCoreConfig.init ~safe_mode:true ();
+      OpamRepositoryConfig.init ();
+      OpamStateConfig.init ~root_dir:root ();
+      initialized := true)
+
+  let with_switch_state ~switch_name ~f =
+    ensure_initialized ();
+    try
+      OpamGlobalState.with_ `Lock_read (fun global_state ->
+          Dune_console.print
+            [ Pp.textf "Using opam installation: %s"
+                (OpamFilename.Dir.to_string global_state.root)
+            ];
+          let switch = OpamSwitch.of_string switch_name in
+          if not (OpamGlobalState.switch_exists global_state switch) then
+            User_error.raise
+              [ Pp.textf
+                  "There is no opam switch named %s. Run `opam switch list` to \
+                   see a list of switches."
+                  (String.maybe_quoted switch_name)
+              ];
+          OpamSwitchState.with_ ~switch `Lock_read global_state
+            (fun switch_state ->
+              Dune_console.print
+                [ Pp.textf "Using opam switch: %s"
+                    (OpamSwitch.to_string switch_state.switch)
+                ];
+              f switch_state))
+    with
+    | OpamPp.Bad_version _ as bad_version ->
+      User_error.raise [ Pp.text (OpamPp.string_of_bad_format bad_version) ]
+    | OpamGlobalState.Configuration_error configuration_error ->
+      User_error.raise
+        [ Pp.text
+            (OpamGlobalState.string_of_configuration_error configuration_error)
+        ]
+end
+
+module Local_repo = struct
   let ( / ) = Filename.concat
 
   type t = { packages_dir_path : Filename.t }
@@ -116,50 +170,159 @@ module Env = struct
     OpamVariable.Map.find_opt (OpamVariable.of_string name) t
 end
 
-(* A custom solver context based on [Opam_0install.Dir_context] with a set
-   of local packages (ie. the packages defined in the current project).
-   When looking up a package during solving, the local packages are
-   searched before falling back to packages defined in a directory in the
-   style of opam-repository. *)
-module Solver_context = struct
-  module Dir_context = Opam_0install.Dir_context
-
-  (* Version to use for local packages with no version number *)
-  let local_package_default_version = OpamPackage.Version.of_string "LOCAL"
-
+module Local_repo_with_env = struct
   type t =
-    { dir_context : Dir_context.t
-    ; local_packages : OpamFile.OPAM.t OpamPackage.Name.Map.t
+    { local_repo : Local_repo.t
+    ; env : Env.t
     }
-
-  type rejection = Dir_context.rejection
-
-  let pp_rejection = Dir_context.pp_rejection
-
-  let candidates t name =
-    match OpamPackage.Name.Map.find_opt name t.local_packages with
-    | None -> Dir_context.candidates t.dir_context name
-    | Some opam_file ->
-      let version =
-        Option.value opam_file.version ~default:local_package_default_version
-      in
-      [ (version, Ok opam_file) ]
-
-  let user_restrictions t = Dir_context.user_restrictions t.dir_context
-
-  let filter_deps t = Dir_context.filter_deps t.dir_context
-
-  let create ~env ~repo ~local_packages =
-    let env name = Env.find_by_name env ~name in
-    let { Repo.packages_dir_path } = repo in
-    let dir_context =
-      Dir_context.create ~prefer_oldest:true
-        ~constraints:OpamPackage.Name.Map.empty ~env packages_dir_path
-    in
-    { dir_context; local_packages }
 end
 
-module Solver = Opam_0install.Solver.Make (Solver_context)
+module Opam_solver = struct
+  module type CONTEXT = Opam_0install.S.CONTEXT
+
+  (* Helper functor which implements [CONTEXT] for [(L.t, R.t) Either.t] where
+     [L] and [R] both implement [CONTEXT] *)
+  module Context_either (L : CONTEXT) (R : CONTEXT) :
+    CONTEXT with type t = (L.t, R.t) Either.t = struct
+    type t = (L.t, R.t) Either.t
+
+    type rejection = (L.rejection, R.rejection) Either.t
+
+    let pp_rejection f = function
+      | Left l -> L.pp_rejection f l
+      | Right r -> R.pp_rejection f r
+
+    let candidates t name =
+      let convert_rejections ~f =
+        List.map ~f:(fun (version, result) ->
+            (version, Result.map_error ~f result))
+      in
+      match t with
+      | Left l -> L.candidates l name |> convert_rejections ~f:Either.left
+      | Right r -> R.candidates r name |> convert_rejections ~f:Either.right
+
+    let user_restrictions = function
+      | Left l -> L.user_restrictions l
+      | Right r -> R.user_restrictions r
+
+    let filter_deps = function
+      | Left l -> L.filter_deps l
+      | Right r -> R.filter_deps r
+  end
+
+  (* Helper functor which adds a set of local packages to a [CONTEXT] *)
+  module Context_with_local_packages (Base_context : CONTEXT) : sig
+    include CONTEXT
+
+    val create :
+         base_context:Base_context.t
+      -> local_packages:OpamFile.OPAM.t OpamPackage.Name.Map.t
+      -> t
+  end = struct
+    let local_package_default_version = OpamPackage.Version.of_string "LOCAL"
+
+    type t =
+      { base_context : Base_context.t
+      ; local_packages : OpamFile.OPAM.t OpamPackage.Name.Map.t
+      }
+
+    let create ~base_context ~local_packages = { base_context; local_packages }
+
+    type rejection = Base_context.rejection
+
+    let pp_rejection = Base_context.pp_rejection
+
+    let candidates t name =
+      match OpamPackage.Name.Map.find_opt name t.local_packages with
+      | None -> Base_context.candidates t.base_context name
+      | Some opam_file ->
+        let version =
+          Option.value opam_file.version ~default:local_package_default_version
+        in
+        [ (version, Ok opam_file) ]
+
+    let user_restrictions t = Base_context.user_restrictions t.base_context
+
+    let filter_deps t = Base_context.filter_deps t.base_context
+  end
+
+  (* A [CONTEXT] that can be based on an opam repository in a local directory
+     or an opam repository taken from the current switch with an additional set
+     of local packages *)
+  module Context = struct
+    module Dir_context = Opam_0install.Dir_context
+    module Switch_context = Opam_0install.Switch_context
+    include
+      Context_with_local_packages (Context_either (Dir_context) (Switch_context))
+
+    let create_dir_context ~local_repo_with_env ~local_packages =
+      let { Local_repo_with_env.local_repo = { Local_repo.packages_dir_path }
+          ; env
+          } =
+        local_repo_with_env
+      in
+      let env name = Env.find_by_name env ~name in
+      let dir_context =
+        Dir_context.create ~prefer_oldest:true
+          ~constraints:OpamPackage.Name.Map.empty ~env packages_dir_path
+      in
+      create ~base_context:(Left dir_context) ~local_packages
+
+    let create_switch_context ~switch_state ~local_packages =
+      let switch_context =
+        Switch_context.create ~constraints:OpamPackage.Name.Map.empty
+          switch_state
+      in
+      create ~base_context:(Right switch_context) ~local_packages
+  end
+end
+
+module Solver = Opam_0install.Solver.Make (Opam_solver.Context)
+
+module Repo_state = struct
+  type t =
+    | Switch of OpamStateTypes.unlocked OpamStateTypes.switch_state
+    | Local_repo_with_env of Local_repo_with_env.t
+
+  let load_opam_package t opam_package =
+    match t with
+    | Switch switch_state -> OpamSwitchState.opam switch_state opam_package
+    | Local_repo_with_env { local_repo; _ } ->
+      Local_repo.load_opam_package local_repo opam_package
+
+  let create_context t local_packages =
+    match t with
+    | Switch switch_state ->
+      Opam_solver.Context.create_switch_context ~local_packages ~switch_state
+    | Local_repo_with_env local_repo_with_env ->
+      Opam_solver.Context.create_dir_context ~local_packages
+        ~local_repo_with_env
+end
+
+module Repo_selection = struct
+  type t =
+    | Switch_with_name of string
+    | Local_repo_with_env of Local_repo_with_env.t
+
+  let switch_with_name switch_name = Switch_with_name switch_name
+
+  let local_repo_with_env ~opam_repo_dir_path ~env =
+    Local_repo_with_env
+      { Local_repo_with_env.local_repo =
+          Local_repo.of_opam_repo_dir_path opam_repo_dir_path
+      ; env
+      }
+
+  (* [with_state ~f t] calls [f] on a [Repo_state.t] implied by [t] and
+     returns the result. Don't let the [Repo_state.t] escape the function [f].
+  *)
+  let with_state ~f = function
+    | Switch_with_name switch_name ->
+      Global.with_switch_state ~switch_name ~f:(fun switch_state ->
+          f (Repo_state.Switch switch_state))
+    | Local_repo_with_env local_repo_with_env ->
+      f (Repo_state.Local_repo_with_env local_repo_with_env)
+end
 
 module Summary = struct
   type t = { opam_packages_to_lock : OpamPackage.t list }
@@ -178,7 +341,7 @@ module Summary = struct
                Pp.text (OpamPackage.to_string package)))
 end
 
-let opam_package_to_lock_file_pkg ~repo ~local_packages ~lock_dir_path
+let opam_package_to_lock_file_pkg ~repo_state ~local_packages ~lock_dir_path
     opam_package =
   let name = OpamPackage.name opam_package in
   let version =
@@ -195,7 +358,7 @@ let opam_package_to_lock_file_pkg ~repo ~local_packages ~lock_dir_path
   in
   let opam_file =
     match OpamPackage.Name.Map.find_opt name local_packages with
-    | None -> Repo.load_opam_package repo opam_package
+    | None -> Repo_state.load_opam_package repo_state opam_package
     | Some local_package -> local_package
   in
   (* This will collect all the atoms from the package's dependency formula regardless of conditions *)
@@ -214,8 +377,7 @@ let opam_package_to_lock_file_pkg ~repo ~local_packages ~lock_dir_path
   ; exported_env = []
   }
 
-let solve_package_list local_packages ~env ~repo =
-  let context = Solver_context.create ~env ~repo ~local_packages in
+let solve_package_list local_packages context =
   let result =
     try
       (* [Solver.solve] returns [Error] when it's unable to find a solution to
@@ -236,30 +398,33 @@ let solve_package_list local_packages ~env ~repo =
   | Error e -> User_error.raise [ Pp.text (Solver.diagnostics e) ]
   | Ok packages -> Solver.packages_of_result packages
 
-let solve_lock_dir ~env ~repo ~lock_dir_path local_packages =
+let solve_lock_dir ~repo_selection ~lock_dir_path local_packages =
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
-  let opam_packages_to_lock =
-    solve_package_list local_packages ~env ~repo
-    (* don't include local packages in the lock dir *)
-    |> List.filter ~f:(Fun.negate is_local_package)
-  in
-  let summary = { Summary.opam_packages_to_lock } in
-  let lock_dir =
-    List.map opam_packages_to_lock ~f:(fun opam_package ->
-        let pkg =
-          opam_package_to_lock_file_pkg ~repo ~local_packages ~lock_dir_path
-            opam_package
-        in
-        (pkg.info.name, pkg))
-    |> Package_name.Map.of_list
-    |> function
-    | Error (name, _pkg1, _pkg2) ->
-      Code_error.raise
-        (sprintf "Solver selected multiple packages named \"%s\""
-           (Package_name.to_string name))
-        []
-    | Ok pkgs_by_name -> Lock_dir.create_latest_version pkgs_by_name
-  in
-  (summary, lock_dir)
+  Repo_selection.with_state repo_selection ~f:(fun repo_state ->
+      let context = Repo_state.create_context repo_state local_packages in
+      let opam_packages_to_lock =
+        solve_package_list local_packages context
+        (* don't include local packages in the lock dir *)
+        |> List.filter ~f:(Fun.negate is_local_package)
+      in
+      let summary = { Summary.opam_packages_to_lock } in
+      let lock_dir =
+        match
+          List.map opam_packages_to_lock ~f:(fun opam_package ->
+              let pkg =
+                opam_package_to_lock_file_pkg ~repo_state ~local_packages
+                  ~lock_dir_path opam_package
+              in
+              (pkg.info.name, pkg))
+          |> Package_name.Map.of_list
+        with
+        | Error (name, _pkg1, _pkg2) ->
+          Code_error.raise
+            (sprintf "Solver selected multiple packages named \"%s\""
+               (Package_name.to_string name))
+            []
+        | Ok pkgs_by_name -> Lock_dir.create_latest_version pkgs_by_name
+      in
+      (summary, lock_dir))

--- a/src/dune_pkg/opam.mli
+++ b/src/dune_pkg/opam.mli
@@ -1,15 +1,5 @@
 open Stdune
 
-module Repo : sig
-  (** An opam repository *)
-  type t
-
-  (** Create a [t] from a path to a local directory containing a opam
-      repository. Raises an exception if the directory is not a valid opam
-      repository. *)
-  val of_opam_repo_dir_path : Filename.t -> t
-end
-
 module Env : sig
   (** An opam environment consisting of assignments to variables (e.g. "arch"
       and "os") *)
@@ -22,6 +12,15 @@ module Env : sig
   val global : unit -> t
 end
 
+module Repo_selection : sig
+  (** An opam repository *)
+  type t
+
+  val switch_with_name : string -> t
+
+  val local_repo_with_env : opam_repo_dir_path:Filename.t -> env:Env.t -> t
+end
+
 module Summary : sig
   (** Some intermediate state from the solve exposed for logging purposes *)
   type t
@@ -31,8 +30,7 @@ module Summary : sig
 end
 
 val solve_lock_dir :
-     env:Env.t
-  -> repo:Repo.t
+     repo_selection:Repo_selection.t
   -> lock_dir_path:Path.Source.t
   -> OpamFile.OPAM.t OpamTypes.name_map
   -> Summary.t * Lock_dir.t

--- a/vendor/opam/src/state/opamGlobalState.mli
+++ b/vendor/opam/src/state/opamGlobalState.mli
@@ -14,6 +14,12 @@
 open OpamTypes
 open OpamStateTypes
 
+type configuration_error
+
+exception Configuration_error of configuration_error
+
+val string_of_configuration_error : configuration_error -> string
+
 (** Loads the global state (from the opam root obtained through
     [OpamStateConfig.(!r.root)]) *)
 val load: 'a lock -> 'a global_state

--- a/vendor/update-opam.sh
+++ b/vendor/update-opam.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=69bcb51db15e27563583bddb8edf5c505ae6e10f
+version=d261e3d4a487f0346dffdf6eadd868095a7d128f
 
 set -e -o pipefail
 


### PR DESCRIPTION
This makes it possible for `dune pkg lock` to solve dependencies using the current opam switch in the case where no path to an opam repository directory is specified.