### PR TITLE
fix(pkg): use correct ocamlpath

### DIFF
--- a/src/install/roots.ml
+++ b/src/install/roots.ml
@@ -11,17 +11,19 @@ type 'a t =
   ; man : 'a
   }
 
-let opam_from_prefix prefix =
-  let lib_root = Path.relative prefix "lib" in
+let make prefix ~relative =
+  let lib_root = relative prefix "lib" in
   { lib_root
   ; libexec_root = lib_root
-  ; bin = Path.relative prefix "bin"
-  ; sbin = Path.relative prefix "sbin"
-  ; share_root = Path.relative prefix "share"
-  ; man = Path.relative prefix "man"
-  ; doc_root = Path.relative prefix "doc"
-  ; etc_root = Path.relative prefix "etc"
+  ; bin = relative prefix "bin"
+  ; sbin = relative prefix "sbin"
+  ; share_root = relative prefix "share"
+  ; man = relative prefix "man"
+  ; doc_root = relative prefix "doc"
+  ; etc_root = relative prefix "etc"
   }
+
+let opam_from_prefix prefix = make prefix ~relative:Path.relative
 
 let complete x =
   match x.libexec_root with
@@ -55,3 +57,24 @@ let first_has_priority x y =
       match x with
       | Some _ -> x
       | None -> y)
+
+let ocamlpath_sep = if Sys.cygwin then ';' else Bin.path_sep
+
+let to_env_without_path t =
+  [ ("CAML_LD_LIBRARY_PATH", Path.Build.relative t.lib_root "stublibs")
+  ; ("OCAMLPATH", t.lib_root)
+  ; ("OCAMLTOP_INCLUDE_PATH", Path.Build.relative t.lib_root "toplevel")
+  ; ("OCAMLFIND_IGNORE_DUPS_IN", t.lib_root)
+  ; ("MANPATH", t.man)
+  ]
+
+let sep = function
+  | "OCAMLFIND_IGNORE_DUPS_IN" | "OCAMLPATH" -> Some ocamlpath_sep
+  | _ -> None
+
+let add_to_env t env =
+  to_env_without_path t
+  |> List.fold_left ~init:env ~f:(fun env (var, path) ->
+         Env.update env ~var ~f:(fun _PATH ->
+             let path_sep = sep var in
+             Some (Bin.cons_path ?path_sep (Path.build path) ~_PATH)))

--- a/src/install/roots.mli
+++ b/src/install/roots.mli
@@ -21,3 +21,9 @@ val map : f:('a -> 'b) -> 'a t -> 'b t
 
 (** return the roots of the first argument if present *)
 val first_has_priority : 'a option t -> 'a option t -> 'a option t
+
+val to_env_without_path : Path.Build.t t -> (Env.Var.t * Path.Build.t) list
+
+val add_to_env : Path.Build.t t -> Env.t -> Env.t
+
+val make : 'a -> relative:('a -> string -> 'a) -> 'a t

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -24,7 +24,7 @@ Some environment variables are automatically exported by packages:
   $ dune=$(which dune)
   $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" $dune build .pkg/usetest/target/
   MANPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/man
-  OCAMLPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/test
+  OCAMLPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib
   CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/stublibs
   OCAMLTOP_INCLUDE_PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/toplevel
   PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/bin


### PR DESCRIPTION
also take this opportunity to share the paths between contexts and
installed packages.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e4c54a45-97d1-4ce1-aa15-7cff7ca4f012 -->