### PR TITLE
refator: rename [Stringlike_intf] to [Stringlike]

### DIFF
--- a/src/dune_engine/context_name.ml
+++ b/src/dune_engine/context_name.ml
@@ -30,7 +30,7 @@ include (
       then None
       else Some name
   end) :
-    Stringlike_intf.S with type t := t)
+    Stringlike with type t := t)
 
 let target t ~toolchain = sprintf "%s.%s" (to_string t) (to_string toolchain)
 

--- a/src/dune_engine/context_name.mli
+++ b/src/dune_engine/context_name.mli
@@ -16,7 +16,7 @@ val equal : t -> t -> bool
 
 val compare : t -> t -> Ordering.t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 module Infix : Comparator.OPS with type t = t
 

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -4,7 +4,9 @@ module Console = Dune_console
 module Metrics = Dune_metrics
 module Log = Dune_util.Log
 module Stringlike = Dune_util.Stringlike
-module Stringlike_intf = Dune_util.Stringlike_intf
+
+module type Stringlike = Dune_util.Stringlike
+
 module Persistent = Dune_util.Persistent
 module Execution_env = Dune_util.Execution_env
 module Glob = Dune_glob.V1

--- a/src/dune_lang/package_name.ml
+++ b/src/dune_lang/package_name.ml
@@ -19,4 +19,4 @@ include (
       (* DUNE3 verify no dots or spaces *)
       if s = "" then None else Some s
   end) :
-    Dune_util.Stringlike_intf.S with type t := t)
+    Dune_util.Stringlike with type t := t)

--- a/src/dune_lang/package_name.mli
+++ b/src/dune_lang/package_name.mli
@@ -13,4 +13,4 @@ include Comparable_intf.S with type key := t
 
 include Dune_sexp.Conv.S with type t := t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t

--- a/src/dune_lang/profile.ml
+++ b/src/dune_lang/profile.ml
@@ -1,6 +1,7 @@
 open Stdune
 module Stringlike = Dune_util.Stringlike
-module Stringlike_intf = Dune_util.Stringlike_intf
+
+module type Stringlike = Dune_util.Stringlike
 
 type t =
   | Dev
@@ -32,7 +33,7 @@ include (
       | Release -> "release"
       | User_defined s -> s
   end) :
-    Stringlike_intf.S with type t := t)
+    Stringlike with type t := t)
 
 let equal x y =
   match (x, y) with

--- a/src/dune_lang/profile.mli
+++ b/src/dune_lang/profile.mli
@@ -14,6 +14,6 @@ val is_release : t -> bool
 
 val is_inline_test : t -> bool
 
-include Dune_util.Stringlike_intf.S with type t := t
+include Dune_util.Stringlike with type t := t
 
 val default : t

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -20,7 +20,7 @@ include (
       (* verify through OpamHash *)
       OpamHash.of_string_opt s
   end) :
-    Stringlike_intf.S with type t := t)
+    Stringlike with type t := t)
 
 let to_opam_hash v = v
 

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -4,7 +4,7 @@ open Import
     fetched already. *)
 type t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 (** [to_opam_hash c] converts [c] to the representation of has values used by
     OPAM *)

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -1,3 +1,4 @@
 include Stdune
 module Stringlike = Dune_util.Stringlike
-module Stringlike_intf = Dune_util.Stringlike_intf
+
+module type Stringlike = Dune_util.Stringlike

--- a/src/dune_rules/ctypes/external_lib_name.mli
+++ b/src/dune_rules/ctypes/external_lib_name.mli
@@ -3,7 +3,7 @@ open Import
 (** Represents a valid external lib name *)
 type t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 val equal : t -> t -> bool
 

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -10,7 +10,8 @@ include struct
   module Log = Log
   module Persistent = Persistent
   module Stringlike = Stringlike
-  module Stringlike_intf = Stringlike_intf
+
+  module type Stringlike = Stringlike
 end
 
 include Dune_config_file

--- a/src/dune_rules/lib_name.ml
+++ b/src/dune_rules/lib_name.ml
@@ -53,7 +53,7 @@ module Local = struct
             in
             loop false 0
     end) :
-      Stringlike_intf.S with type t := t)
+      Stringlike with type t := t)
 
   let mangled_path_under_package local_name =
     [ private_key; to_string local_name ]

--- a/src/dune_rules/lib_name.mli
+++ b/src/dune_rules/lib_name.mli
@@ -4,10 +4,10 @@ type t
 
 val hash : t -> int
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 module Local : sig
-  include Stringlike_intf.S
+  include Stringlike
 
   (** Description of valid library names *)
   val valid_format_doc : User_message.Style.t Pp.t

--- a/src/dune_rules/module_name.mli
+++ b/src/dune_rules/module_name.mli
@@ -6,7 +6,7 @@ type t
 (** Description of valid module names *)
 val valid_format_doc : User_message.Style.t Pp.t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 val add_suffix : t -> string -> t
 

--- a/src/dune_rules/site.ml
+++ b/src/dune_rules/site.ml
@@ -64,7 +64,7 @@ include (
 
     let make s = s
   end) :
-    Stringlike_intf.S with type t := t)
+    Stringlike with type t := t)
 
 module Infix = Comparator.Operators (String)
 

--- a/src/dune_rules/site.mli
+++ b/src/dune_rules/site.mli
@@ -8,7 +8,7 @@ include Dune_sexp.Conv.S with type t := t
 
 module Infix : Comparator.OPS with type t = t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t
 
 val dune_site_syntax : Dune_sexp.Syntax.t
 
@@ -27,6 +27,6 @@ module Modulelike (S : sig
 
   (** The string is always a correct module name, except not capitalized *)
   val make : string -> t
-end) : Stringlike_intf.S with type t = S.t
+end) : Stringlike with type t = S.t
 
 val valid_format_doc : User_message.Style.t Pp.t

--- a/src/dune_rules/sub_system_name.mli
+++ b/src/dune_rules/sub_system_name.mli
@@ -10,4 +10,4 @@ val equal : t -> t -> bool
 
 include Comparable_intf.S with type key := t
 
-include Stringlike_intf.S with type t := t
+include Stringlike with type t := t

--- a/src/dune_util/dune_util.ml
+++ b/src/dune_util/dune_util.ml
@@ -3,7 +3,9 @@ module Log = Log
 module Persistent = Persistent
 module Report_error = Report_error
 module Stringlike = Stringlike
-module Stringlike_intf = Stringlike_intf
+
+module type Stringlike = Stringlike_intf.S
+
 module Build_path_prefix_map = Build_path_prefix_map0
 module Flock = Flock
 module Global_lock = Global_lock

--- a/src/install/import.ml
+++ b/src/install/import.ml
@@ -1,6 +1,8 @@
 include Stdune
 module Stringlike = Dune_util.Stringlike
-module Stringlike_intf = Dune_util.Stringlike_intf
+
+module type Stringlike = Dune_util.Stringlike
+
 module Package_name = Dune_lang.Package_name
 module String_with_vars = Dune_lang.String_with_vars
 module Context_name = Dune_engine.Context_name


### PR DESCRIPTION
to match our convention with other functors (e.g. [Monad])

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 238f69bd-0eed-4acd-9dc0-cc330837dd2a -->