### PR TITLE
test: demonstrate cinaps rules bug

### DIFF
--- a/test/blackbox-tests/test-cases/cinaps/concurrent-promotions.t
+++ b/test/blackbox-tests/test-cases/cinaps/concurrent-promotions.t
@@ -1,0 +1,30 @@
+Cinaps should offer all promotions at once
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using cinaps 1.3)
+  > EOF
+
+  $ cat > t1.ml <<"EOF"
+  > (*$ print_endline "\nhello" *)
+  > (*$*)
+  > let x = 1
+  > EOF
+
+  $ cat > t2.ml <<"EOF"
+  > (*$ print_endline "\nhello" *)
+  > (*$*)
+  > let x = 1
+  > EOF
+
+  $ cat >dune <<EOF
+  > (cinaps
+  >  (files *.ml)
+  >  (alias cinaps))
+  > EOF
+
+  $ dune build @cinaps
+  File "t1.ml", line 1, characters 0-0:
+  Error: Files _build/default/t1.ml and _build/default/t1.ml.cinaps-corrected
+  differ.
+  [1]


### PR DESCRIPTION
The cinaps rules will run the promotions sequentially, and will stop
once they find one that fails.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f0d5c06c-e8c8-4e15-b592-6cf6662d1a5b -->