### PR TITLE
chore: remove dune_threaded_console from dune_config

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -70,9 +70,9 @@ let local_libraries =
   ; ("otherlibs/dune-private-libs/meta_parser", Some "Dune_meta_parser",
     false, None)
   ; ("src/dune_vcs", Some "Dune_vcs", false, None)
-  ; ("src/dune_threaded_console", Some "Dune_threaded_console", false, None)
   ; ("vendor/notty/src", None, true, None)
   ; ("vendor/notty/src-unix", None, true, None)
+  ; ("src/dune_threaded_console", Some "Dune_threaded_console", false, None)
   ; ("src/dune_tui", Some "Dune_tui", false, None)
   ; ("src/dune_config_file", Some "Dune_config_file", false, None)
   ; ("src/dune_rules", Some "Dune_rules", true, None)

--- a/src/dune_config_file/dune
+++ b/src/dune_config_file/dune
@@ -5,7 +5,6 @@
   xdg
   dune_config
   dune_console
-  dune_threaded_console
   dune_lang
   dune_cache
   dune_cache_storage


### PR DESCRIPTION
it doesn't seem to be used

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 64b47aee-31cd-445e-bbdc-f1374941db27 -->