### PR TITLE
Lockdir encode/decode roundtrip tests

### DIFF
--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -6,6 +6,8 @@ module Var : sig
   val temp_dir : t
 
   include Comparable_intf.S with type key := t
+
+  val to_dyn : t -> Dyn.t
 end
 
 type t

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -436,7 +436,7 @@ let validate ~loc t = ensure_at_most_one_dynamic_run ~loc t
 
 let rec map_string_with_vars t ~f =
   match t with
-  | Run (sw, xs) -> Run (f sw, xs)
+  | Run (sw, xs) -> Run (f sw, List.map ~f xs)
   | With_accepted_exit_codes (lang, t) ->
     With_accepted_exit_codes (lang, map_string_with_vars t ~f)
   | Dynamic_run (sw, sws) -> Dynamic_run (f sw, List.map sws ~f)
@@ -448,7 +448,7 @@ let rec map_string_with_vars t ~f =
   | Ignore (o, t) -> Ignore (o, map_string_with_vars t ~f)
   | Progn xs -> Progn (List.map xs ~f:(map_string_with_vars ~f))
   | Concurrent xs -> Concurrent (List.map xs ~f:(map_string_with_vars ~f))
-  | Echo xs -> Echo xs
+  | Echo xs -> Echo (List.map ~f xs)
   | Cat xs -> Cat (List.map ~f xs)
   | Copy (sw1, sw2) -> Copy (f sw1, f sw2)
   | Symlink (sw1, sw2) -> Symlink (f sw1, f sw2)

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -100,6 +100,8 @@ module Env_update = struct
     ; value : 'a
     }
 
+  let map t ~f = { t with value = f t.value }
+
   let equal value_equal { op; var; value }
       { op = other_op; var = other_var; value = other_value } =
     Op.equal op other_op

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -67,19 +67,25 @@ module File_perm : sig
 end
 
 module Env_update : sig
-  type op =
-    | Eq
-    | PlusEq
-    | EqPlus
-    | ColonEq
-    | EqColon
-    | EqPlusEq
+  module Op : sig
+    type t =
+      | Eq
+      | PlusEq
+      | EqPlus
+      | ColonEq
+      | EqColon
+      | EqPlusEq
+  end
 
   type 'a t =
-    { op : op
+    { op : Op.t
     ; var : Env.Var.t
     ; value : 'a
     }
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
   val decode : String_with_vars.t t Decoder.t
 
@@ -127,6 +133,8 @@ val decode_pkg : t Decoder.t
 val validate : loc:Loc.t -> t -> unit
 
 val compare_no_locs : t -> t -> Ordering.t
+
+val equal_no_locs : t -> t -> bool
 
 val to_dyn : t -> Dyn.t
 

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -83,6 +83,8 @@ module Env_update : sig
     ; value : 'a
     }
 
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
   val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder

--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -13,6 +13,22 @@ type t =
   ; loc : Loc.t
   }
 
+let compare { quoted; parts; loc } t =
+  let open Ordering.O in
+  let= () = Bool.compare quoted t.quoted in
+  let= () = Loc.compare loc t.loc in
+  List.compare parts t.parts ~compare:(fun a b ->
+      match (a, b) with
+      | Text a, Text b -> String.compare a b
+      | Pform (_, a), Pform (_, b) -> Pform.compare a b
+      | Error (_, a), Error (_, b) -> User_message.compare a b
+      | Text _, _ -> Lt
+      | _, Text _ -> Gt
+      | Pform _, _ -> Lt
+      | _, Pform _ -> Gt)
+
+let equal x y = Ordering.is_eq (compare x y)
+
 let compare_no_loc { quoted; parts; loc = _ } t =
   let open Ordering.O in
   let= () = Bool.compare quoted t.quoted in

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -9,6 +9,10 @@ open Dune_sexp
 (** A sequence of text and variables. *)
 type t
 
+val equal : t -> t -> bool
+
+val compare : t -> t -> Ordering.t
+
 val compare_no_loc : t -> t -> Ordering.t
 
 val equal_no_loc : t -> t -> bool

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -29,3 +29,5 @@ let of_opam_hash v = v
 let pp v =
   let s = to_string v in
   Pp.text s
+
+let equal = OpamHash.equal

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -14,3 +14,5 @@ val to_opam_hash : t -> OpamHash.t
 val of_opam_hash : OpamHash.t -> t
 
 val pp : t -> 'a Pp.t
+
+val equal : t -> t -> bool

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -84,10 +84,9 @@ module Source = struct
     | External_copy (_loc, path) ->
       constr Fields.copy string (Path.External.to_string path)
     | Fetch { url = _loc, url; checksum } ->
-      record
-        [ (Fields.url, string url)
-        ; ( Fields.checksum
-          , (option Checksum.encode) (Option.map checksum ~f:snd) )
+      named_record_fields Fields.fetch
+        [ field Fields.url string url
+        ; field_o Fields.checksum Checksum.encode (Option.map checksum ~f:snd)
         ]
 end
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -53,3 +53,5 @@ val metadata : Filename.t
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 
 val write_disk : lock_dir_path:Path.Source.t -> t -> unit
+
+val read_disk : lock_dir_path:Path.Source.t -> t Or_exn.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -40,6 +40,8 @@ type t =
   ; packages : Pkg.t Package_name.Map.t
   }
 
+val remove_locs : t -> t
+
 val equal : t -> t -> bool
 
 val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -40,6 +40,10 @@ type t =
   ; packages : Pkg.t Package_name.Map.t
   }
 
+val equal : t -> t -> bool
+
+val to_dyn : t -> Dyn.t
+
 val create_latest_version : Pkg.t Package_name.Map.t -> t
 
 val default_path : Path.Source.t

--- a/src/dune_sexp/encoder.ml
+++ b/src/dune_sexp/encoder.ml
@@ -67,6 +67,8 @@ let record_fields (l : field list) =
     | Normal (name, v) -> Some (List [ Atom (Atom.of_string name); v ])
     | Inlined_list (name, l) -> Some (List (Atom (Atom.of_string name) :: l)))
 
+let named_record_fields name fields = List (string name :: record_fields fields)
+
 let unknown _ = atom "<unknown>"
 
 let enum xs x =

--- a/src/dune_sexp/encoder.mli
+++ b/src/dune_sexp/encoder.mli
@@ -27,6 +27,9 @@ val field_i : string -> ('a -> T.t list) -> 'a -> field
 
 val record_fields : field list -> T.t list
 
+(** A named record, e.g.: (name (field1 value1) (field2 value2) ...) *)
+val named_record_fields : string -> field list t
+
 val unknown : _ t
 
 val enum : (string * 'a) list -> 'a t

--- a/test/expect-tests/dune_pkg/dune
+++ b/test/expect-tests/dune_pkg/dune
@@ -8,6 +8,7 @@
   dune_pkg
   dune_engine
   dune_util
+  dune_lang
   fiber
   opam_core
   threads.posix

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -1,7 +1,9 @@
 open Stdune
 module Fetch = Dune_pkg.Fetch
 module Checksum = Dune_pkg.Checksum
+module Lock_dir = Dune_pkg.Lock_dir
 module Scheduler = Dune_engine.Scheduler
+module Package_name = Dune_lang.Package_name
 
 let serve_once ~filename ~port () =
   let host = Unix.inet_addr_loopback in
@@ -150,3 +152,209 @@ let%expect_test "downloading, without any checksum" =
     {|
     Done downloading
     Finished successfully, no checksum verification |}]
+
+let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~make_lock_dir =
+  let lock_dir_path = Path.Source.of_string lock_dir_path in
+  let lock_dir_original = make_lock_dir ~lock_dir_path in
+  Lock_dir.write_disk ~lock_dir_path lock_dir_original;
+  let lock_dir_round_tripped =
+    Lock_dir.read_disk ~lock_dir_path |> Result.ok_exn
+  in
+  if Lock_dir.equal lock_dir_round_tripped lock_dir_original then
+    print_endline "lockdir matches after roundtrip:"
+  else print_endline "lockdir doesn't match after roundtrip:";
+  print_endline (Lock_dir.to_dyn lock_dir_round_tripped |> Dyn.to_string)
+
+let%expect_test "encode/decode round trip test for lockdir with no deps" =
+  lock_dir_encode_decode_round_trip_test ~lock_dir_path:"empty_lock_dir"
+    ~make_lock_dir:(fun ~lock_dir_path:_ ->
+      Lock_dir.create_latest_version Package_name.Map.empty);
+  [%expect
+    {|
+    lockdir matches after roundtrip:
+    { version = (0, 1); packages = map {} } |}]
+
+let%expect_test "encode/decode round trip test for lockdir with simple deps" =
+  lock_dir_encode_decode_round_trip_test ~lock_dir_path:"simple_lock_dir"
+    ~make_lock_dir:(fun ~lock_dir_path ->
+      let mk_pkg_basic ~name ~version =
+        let name = Package_name.of_string name in
+        ( name
+        , { Lock_dir.Pkg.build_command = None
+          ; install_command = None
+          ; deps = []
+          ; info =
+              { Lock_dir.Pkg_info.name; version; dev = false; source = None }
+          ; lock_dir = lock_dir_path
+          ; exported_env = []
+          } )
+      in
+      Lock_dir.create_latest_version
+        (Package_name.Map.of_list_exn
+           [ mk_pkg_basic ~name:"foo" ~version:"0.1.0"
+           ; mk_pkg_basic ~name:"bar" ~version:"0.2.0"
+           ]));
+  [%expect
+    {|
+    lockdir matches after roundtrip:
+    { version = (0, 1)
+    ; packages =
+        map
+          { "bar" :
+              { build_command = None
+              ; install_command = None
+              ; deps = []
+              ; info =
+                  { name = "bar"; version = "0.2.0"; dev = false; source = None }
+              ; lock_dir = In_source_tree "simple_lock_dir"
+              ; exported_env = []
+              }
+          ; "foo" :
+              { build_command = None
+              ; install_command = None
+              ; deps = []
+              ; info =
+                  { name = "foo"; version = "0.1.0"; dev = false; source = None }
+              ; lock_dir = In_source_tree "simple_lock_dir"
+              ; exported_env = []
+              }
+          }
+    } |}]
+
+let%expect_test "encode/decode round trip test for lockdir with complex deps" =
+  let module Action = Dune_lang.Action in
+  let module String_with_vars = Dune_lang.String_with_vars in
+  lock_dir_encode_decode_round_trip_test ~lock_dir_path:"complex_lock_dir"
+    ~make_lock_dir:(fun ~lock_dir_path ->
+      let pkg_a =
+        let name = Package_name.of_string "a" in
+        ( name
+        , { Lock_dir.Pkg.build_command =
+              Some
+                Action.(
+                  Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ])
+          ; install_command =
+              Some
+                (Action.System
+                   (* String_with_vars.t doesn't round trip so we have to set
+                      [quoted] if the string would be quoted *)
+                   (String_with_vars.make_text ~quoted:true Loc.none
+                      "echo 'world'"))
+          ; deps = []
+          ; info =
+              { Lock_dir.Pkg_info.name
+              ; version = "0.1.0"
+              ; dev = false
+              ; source =
+                  Some
+                    (External_copy (Loc.none, Path.External.of_string "/tmp/a"))
+              }
+          ; lock_dir = lock_dir_path
+          ; exported_env =
+              [ { Action.Env_update.op = Eq
+                ; var = "foo"
+                ; value = String_with_vars.make_text Loc.none "bar"
+                }
+              ]
+          } )
+      in
+      let pkg_b =
+        let name = Package_name.of_string "b" in
+        ( name
+        , { Lock_dir.Pkg.build_command = None
+          ; install_command = None
+          ; deps = [ fst pkg_a ]
+          ; info =
+              { Lock_dir.Pkg_info.name
+              ; version = "dev"
+              ; dev = true
+              ; source =
+                  Some
+                    (Fetch
+                       { url = (Loc.none, "https://github.com/foo/b")
+                       ; checksum =
+                           Some
+                             ( Loc.none
+                             , Checksum.of_string
+                                 "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                             )
+                       })
+              }
+          ; lock_dir = lock_dir_path
+          ; exported_env = []
+          } )
+      in
+      let pkg_c =
+        let name = Package_name.of_string "c" in
+        ( name
+        , { Lock_dir.Pkg.build_command = None
+          ; install_command = None
+          ; deps = [ fst pkg_a; fst pkg_b ]
+          ; info =
+              { Lock_dir.Pkg_info.name
+              ; version = "0.2"
+              ; dev = false
+              ; source =
+                  Some
+                    (Fetch
+                       { url = (Loc.none, "https://github.com/foo/c")
+                       ; checksum = None
+                       })
+              }
+          ; lock_dir = lock_dir_path
+          ; exported_env = []
+          } )
+      in
+      Lock_dir.create_latest_version
+        (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ]));
+  [%expect
+    {|
+    lockdir matches after roundtrip:
+    { version = (0, 1)
+    ; packages =
+        map
+          { "a" :
+              { build_command = Some [ "progn"; [ "echo"; "hello" ] ]
+              ; install_command = Some [ "system"; "echo 'world'" ]
+              ; deps = []
+              ; info =
+                  { name = "a"
+                  ; version = "0.1.0"
+                  ; dev = false
+                  ; source = Some External_copy External "/tmp/a"
+                  }
+              ; lock_dir = In_source_tree "complex_lock_dir"
+              ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
+              }
+          ; "b" :
+              { build_command = None
+              ; install_command = None
+              ; deps = [ "a" ]
+              ; info =
+                  { name = "b"
+                  ; version = "dev"
+                  ; dev = true
+                  ; source =
+                      Some
+                        Fetch
+                          "https://github.com/foo/b",Some
+                                                       "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                  }
+              ; lock_dir = In_source_tree "complex_lock_dir"
+              ; exported_env = []
+              }
+          ; "c" :
+              { build_command = None
+              ; install_command = None
+              ; deps = [ "a"; "b" ]
+              ; info =
+                  { name = "c"
+                  ; version = "0.2"
+                  ; dev = false
+                  ; source = Some Fetch "https://github.com/foo/c",None
+                  }
+              ; lock_dir = In_source_tree "complex_lock_dir"
+              ; exported_env = []
+              }
+          }
+    } |}]

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -160,8 +160,11 @@ let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~make_lock_dir =
   let lock_dir_round_tripped =
     Lock_dir.read_disk ~lock_dir_path |> Result.ok_exn
   in
-  if Lock_dir.equal lock_dir_round_tripped lock_dir_original then
-    print_endline "lockdir matches after roundtrip:"
+  if
+    Lock_dir.equal
+      (Lock_dir.remove_locs lock_dir_round_tripped)
+      (Lock_dir.remove_locs lock_dir_original)
+  then print_endline "lockdir matches after roundtrip:"
   else print_endline "lockdir doesn't match after roundtrip:";
   print_endline (Lock_dir.to_dyn lock_dir_round_tripped |> Dyn.to_string)
 


### PR DESCRIPTION
This adds some tests that a `Lock_dir.t` can be written do disk and then read back from disk to obtain a `Lock_dir.t` that matches the original.