### PR TITLE
melange - add `melange.emit` targets to `@all` alias as well by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ Unreleased
 - Allow multiple globs in library's `(stdlib (internal_modules ..))`
   (@anmonteiro, #7878)
 
+- Attach melange rules to the default alias (#7926, @haochenx)
+
 3.8.1 (2023-06-05)
 ------------------
 

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -172,6 +172,17 @@ let build_js ~loc ~dir ~pkg_name ~mode ~module_systems ~output ~obj_dir ~sctx
            ; Dep src
            ]))
 
+(* attach [deps] to the specified [alias] AND the (dune default) [all] alias.
+
+   when [alias] is not supplied, {!Melange_stanzas.Emit.implicit_alias} is
+   assumed. *)
+let add_deps_to_aliases ?(alias = Melange_stanzas.Emit.implicit_alias) ~dir deps
+    =
+  let alias = Alias.make alias ~dir in
+  let dune_default_alias = Alias.all ~dir in
+  let attach alias = Rules.Produce.Alias.add_deps alias deps in
+  Memo.parallel_iter ~f:attach [ alias; dune_default_alias ]
+
 let setup_emit_cmj_rules ~sctx ~dir ~scope ~expander ~dir_contents
     (mel : Melange_stanzas.Emit.t) =
   let open Memo.O in
@@ -235,13 +246,7 @@ let setup_emit_cmj_rules ~sctx ~dir ~scope ~expander ~dir_contents
         in
         ()
       in
-      match mel.alias with
-      | None ->
-        let alias = Alias.make Melange_stanzas.Emit.implicit_alias ~dir in
-        Rules.Produce.Alias.add_deps alias emit_and_libs_deps
-      | Some alias_name ->
-        let alias = Alias.make alias_name ~dir in
-        Rules.Produce.Alias.add_deps alias emit_and_libs_deps
+      add_deps_to_aliases ?alias:mel.alias emit_and_libs_deps ~dir
     in
     ( cctx
     , Merlin.make ~requires:requires_compile ~stdlib_dir ~flags ~modules
@@ -323,17 +328,7 @@ let setup_runtime_assets_rules sctx ~dir ~target_dir ~mode ~output ~for_ mel =
     Memo.parallel_iter copy ~f:(fun (src, dst) ->
         Super_context.add_rule ~loc ~dir ~mode sctx
           (Action_builder.copy ~src ~dst))
-  and+ () =
-    match mel.alias with
-    | None ->
-      let alias =
-        Alias.make Melange_stanzas.Emit.implicit_alias ~dir:target_dir
-      in
-      Rules.Produce.Alias.add_deps alias deps
-    | Some alias_name ->
-      let alias = Alias.make alias_name ~dir:target_dir in
-      Rules.Produce.Alias.add_deps alias deps
-  in
+  and+ () = add_deps_to_aliases ?alias:mel.alias deps ~dir:target_dir in
   ()
 
 let modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope

--- a/test/blackbox-tests/test-cases/melange/aliases.t
+++ b/test/blackbox-tests/test-cases/melange/aliases.t
@@ -67,37 +67,9 @@ Dune default alias works
   $ dune clean
   $ dune build
   $ node _build/default/output/main.js
-  node:internal/modules/cjs/loader:1078
-    throw err;
-    ^
-  
-  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
-      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
-      at Module._load (node:internal/modules/cjs/loader:920:27)
-      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
-      at node:internal/main/run_main_module:23:47 {
-    code: 'MODULE_NOT_FOUND',
-    requireStack: []
-  }
-  
-  Node.js v18.16.0
-  [1]
+  hello
   $ node _build/default/output2/main2.js
-  node:internal/modules/cjs/loader:1078
-    throw err;
-    ^
-  
-  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output2/main2.js'
-      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
-      at Module._load (node:internal/modules/cjs/loader:920:27)
-      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
-      at node:internal/main/run_main_module:23:47 {
-    code: 'MODULE_NOT_FOUND',
-    requireStack: []
-  }
-  
-  Node.js v18.16.0
-  [1]
+  hello
 
 Users can override melange alias (even if useless)
 
@@ -139,18 +111,4 @@ Even if user defines an alias, dune default alias should still work
   $ dune clean
   $ dune build
   $ node _build/default/output/main.js
-  node:internal/modules/cjs/loader:1078
-    throw err;
-    ^
-  
-  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
-      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
-      at Module._load (node:internal/modules/cjs/loader:920:27)
-      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
-      at node:internal/main/run_main_module:23:47 {
-    code: 'MODULE_NOT_FOUND',
-    requireStack: []
-  }
-  
-  Node.js v18.16.0
-  [1]
+  hello

--- a/test/blackbox-tests/test-cases/melange/aliases.t
+++ b/test/blackbox-tests/test-cases/melange/aliases.t
@@ -8,12 +8,13 @@ Test alias field on melange.emit stanzas
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
   >  (alias app))
   > EOF
 
   $ cat > main.ml <<EOF
   > let () =
-  >   print_endline "hello"
+  >   Js.log "hello"
   > EOF
 
   $ dune build @app
@@ -25,15 +26,17 @@ Default alias melange works
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
   >  (modules main))
   > (melange.emit
   >  (target output2)
+  >  (emit_stdlib false)
   >  (modules main2))
   > EOF
 
   $ cat > main2.ml <<EOF
   > let () =
-  >   print_endline "hello"
+  >   Js.log "hello"
   > EOF
 
   $ dune clean
@@ -43,22 +46,77 @@ Default alias melange works
   $ node _build/default/output2/main2.js
   hello
 
+Dune default alias works
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (modules main)
+  >  (emit_stdlib false))
+  > (melange.emit
+  >  (target output2)
+  >  (modules main2)
+  >  (emit_stdlib false))
+  > EOF
+
+  $ cat > main2.ml <<EOF
+  > let () =
+  >   Js.log "hello"
+  > EOF
+
+  $ dune clean
+  $ dune build
+  $ node _build/default/output/main.js
+  node:internal/modules/cjs/loader:1078
+    throw err;
+    ^
+  
+  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
+      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
+      at Module._load (node:internal/modules/cjs/loader:920:27)
+      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
+      at node:internal/main/run_main_module:23:47 {
+    code: 'MODULE_NOT_FOUND',
+    requireStack: []
+  }
+  
+  Node.js v18.16.0
+  [1]
+  $ node _build/default/output2/main2.js
+  node:internal/modules/cjs/loader:1078
+    throw err;
+    ^
+  
+  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output2/main2.js'
+      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
+      at Module._load (node:internal/modules/cjs/loader:920:27)
+      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
+      at node:internal/main/run_main_module:23:47 {
+    code: 'MODULE_NOT_FOUND',
+    requireStack: []
+  }
+  
+  Node.js v18.16.0
+  [1]
+
 Users can override melange alias (even if useless)
 
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
   >  (alias melange))
   > EOF
 
   $ dune clean
   $ dune build @melange
 
-If user defines an alias, the default alias is not used for that stanza 
+If user defines an alias, the default alias is not used for that stanza
 
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
   >  (alias foo))
   > EOF
 
@@ -66,4 +124,33 @@ If user defines an alias, the default alias is not used for that stanza
   $ dune build @melange
   Error: Alias "melange" specified on the command line is empty.
   It is not defined in . or any of its descendants.
+  [1]
+
+Even if user defines an alias, dune default alias should still work
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (modules main)
+  >  (emit_stdlib false)
+  >  (alias foo))
+  > EOF
+
+  $ dune clean
+  $ dune build
+  $ node _build/default/output/main.js
+  node:internal/modules/cjs/loader:1078
+    throw err;
+    ^
+  
+  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
+      at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
+      at Module._load (node:internal/modules/cjs/loader:920:27)
+      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
+      at node:internal/main/run_main_module:23:47 {
+    code: 'MODULE_NOT_FOUND',
+    requireStack: []
+  }
+  
+  Node.js v18.16.0
   [1]

--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -19,7 +19,7 @@ Test dune rules
 Calling dune rules with the 'all' alias works fine
 
   $ dune rules @all | grep In_build_dir
-  [1]
+      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
 
 Calling dune rules with the alias works fine
 

--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -13,8 +13,13 @@ Test dune rules
   > EOF
 
   $ cat > main.ml <<EOF
-  > print_endline "hello"
+  > Js.log "hello"
   > EOF
+
+Calling dune rules with the 'all' alias works fine
+
+  $ dune rules @all | grep In_build_dir
+  [1]
 
 Calling dune rules with the alias works fine
 
@@ -31,5 +36,6 @@ Creating dir fixes the problem
 
   $ mkdir output
 
-  $ dune rules output | grep In_build_dir
+  $ dune rules output | grep "\.cmj"
       (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
+      .output.mobjs/melange/melange__Main.cmj))))


### PR DESCRIPTION
It is confusing that `dune build` does not build targets specified by a `melange.emit` stanza by default.
This PR intends to address this by adding `melange.emit` targets to `@all` alias as well as (the current default) `@melange` alias by default.

This stems from the discussion of https://github.com/ocaml/dune/pull/7924.
more specifically, this PR implements the suggestion in https://github.com/ocaml/dune/pull/7924#issuecomment-1583215590

- related: https://github.com/ocaml/dune/pull/7924
  - implementing (1) in https://github.com/ocaml/dune/pull/7924#issuecomment-1583215590

## Subtasks
- [x] adding `melange.emit` stanza targets to `@all` alias by default (*in addition* to the `@melange` alias)
- [x] add test cases
- ~[ ] fix existing test cases if necessary~ (update: does not seem to break any existing test)
- [x] change log entry