### PR TITLE
[3.8] backport #7849, #7925

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Switch back to threaded console for all systems; fix unresponsive console on
   Windows (#7906, @nojb)
 
+- Respect `-p` / `--only-packages` for `melange.emit` artifacts (#7849, @anmonteiro)
+
 3.8.1 (2023-06-05)
 ------------------
 

--- a/src/dune_rules/resolve.mli
+++ b/src/dune_rules/resolve.mli
@@ -108,6 +108,10 @@ type error
 
 val to_result : 'a t -> ('a, error) result
 
+val raise_error : error -> 'a
+
+val push_frames : error -> (unit -> 'a Memo.t) -> 'a Memo.t
+
 val of_error : error -> 'a t
 
 (** Read a [Resolve.t] value inside the action builder monad. *)

--- a/test/blackbox-tests/test-cases/melange/melange-emit-package.t
+++ b/test/blackbox-tests/test-cases/melange/melange-emit-package.t
@@ -42,8 +42,52 @@ don't belong to.
 when building the other library
 
   $ dune build -p my-ppx
-  File "test/dune", line 5, characters 12-19:
-  5 |  (libraries mel-foo))
+
+It still builds everything normally with the alias
+
+  $ dune build @melange
+  $ ls _build/default/test/js-out/test/
+  test_entry.js
+
+Now define a 3rd lib that we'll use to preprocess the melange.emit entries:
+
+  $ dune clean
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name my-ppx))
+  > (package (name mel-foo))
+  > (package (name my-ppx2))
+  > (using melange 0.1)
+  > EOF
+  $ mkdir ppx2
+  $ cat > ppx2/dune <<EOF
+  > (library
+  >  (name my_ppx2)
+  >  (kind ppx_rewriter) (libraries ppxlib)
+  >  (public_name my-ppx2))
+  > EOF
+  $ touch ppx2/my_ppx2.ml
+  $ cat > test/dune <<EOF
+  > (melange.emit
+  >  (package mel-foo)
+  >  (target js-out)
+  >  (preprocess (pps my-ppx2))
+  >  (emit_stdlib false)
+  >  (libraries mel-foo))
+  > EOF
+
+we can still build my-ppx independently
+
+  $ dune build -p my-ppx
+
+and fails if it can't resolve libraries to build the alias
+
+  $ dune build @melange -p my-ppx
+  File "test/dune", line 6, characters 12-19:
+  6 |  (libraries mel-foo))
                   ^^^^^^^
   Error: Library "mel-foo" not found.
+  -> required by _build/default/test/js-out/test/test_entry.js
+  -> required by alias test/melange
   [1]
+

--- a/test/blackbox-tests/test-cases/melange/melange-emit-package.t
+++ b/test/blackbox-tests/test-cases/melange/melange-emit-package.t
@@ -1,0 +1,49 @@
+Test that melange.emit targets are not included in @install for packages they
+don't belong to.
+
+  $ mkdir lib test ppx
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name my-ppx))
+  > (package (name mel-foo))
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name my_ppx)
+  >  (public_name my-ppx))
+  > EOF
+  $ touch ppx/my_ppx.ml
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (public_name mel-foo)
+  >  (name mel_foo)
+  >  (modes melange)
+  >  (preprocess (pps melange.ppx)))
+  > EOF
+  $ cat > lib/mel_foo.ml <<EOF
+  > let x = "lib"
+  > EOF
+
+  $ cat > test/dune <<EOF
+  > (melange.emit
+  >  (package mel-foo)
+  >  (target js-out)
+  >  (emit_stdlib false)
+  >  (libraries mel-foo))
+  > EOF
+  $ cat > test/test_entry.ml <<EOF
+  > let () = Js.log Mel_foo.x
+  > EOF
+
+`melange.emit` is attached to the package `mel-foo`, so it shouldn't be built
+when building the other library
+
+  $ dune build -p my-ppx
+  File "test/dune", line 5, characters 12-19:
+  5 |  (libraries mel-foo))
+                  ^^^^^^^
+  Error: Library "mel-foo" not found.
+  [1]


### PR DESCRIPTION
- test(melange): demonstrate melange.emit doesn't respect `-p`
- fix(melange): resolve libraries lazily for melange.emit
- chore: add changelog entry for #7849 (#7925)
