### PR TITLE
refactor(dune_lang): use fields_mutually_exclusive for aliases

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1704,27 +1704,16 @@ module Rule = struct
          field_o "package"
            (Dune_lang.Syntax.since Stanza.syntax (2, 0)
            >>> Stanza_common.Pkg.decode)
-       and+ alias =
-         field_o "alias"
-           (Dune_lang.Syntax.since Stanza.syntax (2, 0)
-           >>> Dune_lang.Alias.decode)
        and+ aliases =
-         field_o "aliases"
-           (Dune_lang.Syntax.since Stanza.syntax (3, 5)
-           >>> repeat Dune_lang.Alias.decode)
-       in
-       let aliases =
-         match alias with
-         | None -> Option.value ~default:[] aliases
-         | Some alias -> (
-           match aliases with
-           | None -> [ alias ]
-           | Some _ ->
-             User_error.raise ~loc
-               [ Pp.text
-                   "The 'alias' and 'aliases' fields are mutually exclusive. \
-                    Please use only the 'aliases' field."
-               ])
+         let open Dune_sexp.Decoder in
+         fields_mutually_exclusive ~default:[]
+           [ ( "alias"
+             , Dune_lang.Syntax.since Stanza.syntax (2, 0)
+               >>> Dune_lang.Alias.decode >>| List.singleton )
+           ; ( "aliases"
+             , Dune_lang.Syntax.since Stanza.syntax (3, 5)
+               >>> repeat Dune_lang.Alias.decode )
+           ]
        in
        let mode, patch_back_source_tree =
          match mode with

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -698,9 +698,9 @@ let fields_missing_need_exactly_one loc names =
   [@@inline never] [@@specialise never] [@@local never]
 
 let fields_mutual_exclusion_violation loc names =
+  let names = List.map names ~f:String.quoted in
   User_error.raise ~loc
-    [ Pp.textf "fields %s are mutually exclusive"
-        (String.concat ~sep:", " names)
+    [ Pp.textf "fields %s are mutually exclusive." (String.enumerate_and names)
     ]
   [@@inline never] [@@specialise never] [@@local never]
 

--- a/test/blackbox-tests/test-cases/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias-multiple.t
@@ -82,7 +82,7 @@ not allowed
   2 |  (alias a)
   3 |  (aliases b)
   4 |  (action (echo "I have run")))
-  Error: fields alias, aliases are mutually exclusive
+  Error: fields "alias" and "aliases" are mutually exclusive.
   [1]
 
 Even if the aliases list is empty
@@ -99,5 +99,5 @@ Even if the aliases list is empty
   2 |  (alias a)
   3 |  (aliases)
   4 |  (action (echo "I have run")))
-  Error: fields alias, aliases are mutually exclusive
+  Error: fields "alias" and "aliases" are mutually exclusive.
   [1]

--- a/test/blackbox-tests/test-cases/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias-multiple.t
@@ -82,8 +82,7 @@ not allowed
   2 |  (alias a)
   3 |  (aliases b)
   4 |  (action (echo "I have run")))
-  Error: The 'alias' and 'aliases' fields are mutually exclusive. Please use
-  only the 'aliases' field.
+  Error: fields alias, aliases are mutually exclusive
   [1]
 
 Even if the aliases list is empty
@@ -100,6 +99,5 @@ Even if the aliases list is empty
   2 |  (alias a)
   3 |  (aliases)
   4 |  (action (echo "I have run")))
-  Error: The 'alias' and 'aliases' fields are mutually exclusive. Please use
-  only the 'aliases' field.
+  Error: fields alias, aliases are mutually exclusive
   [1]

--- a/test/blackbox-tests/test-cases/multiple-targets.t
+++ b/test/blackbox-tests/test-cases/multiple-targets.t
@@ -68,7 +68,7 @@ to get a better error message:
   2 |   (targets a)
   3 |   (target a)
   4 |   (action (bash "echo hola > %{target}")))
-  Error: fields targets, target are mutually exclusive
+  Error: fields "targets" and "target" are mutually exclusive.
   [1]
 
 ^ Specifying both [targets] and [target] is not allowed


### PR DESCRIPTION
I noticed that we have `fields_mutually_exclusive` so I've used it for the `aliases` field of the `rule` stanza.