### PR TITLE
swap order of target and targets in mutually exclusive field error

### DIFF
--- a/src/dune_lang/targets_spec.ml
+++ b/src/dune_lang/targets_spec.ml
@@ -77,6 +77,6 @@ let decode_one_static ~allow_directory_targets =
 let field ~allow_directory_targets =
   let open Dune_sexp.Decoder in
   fields_mutually_exclusive ~default:Infer
-    [ ("targets", decode_static ~allow_directory_targets)
-    ; ("target", decode_one_static ~allow_directory_targets)
+    [ ("target", decode_one_static ~allow_directory_targets)
+    ; ("targets", decode_static ~allow_directory_targets)
     ]

--- a/test/blackbox-tests/test-cases/multiple-targets.t
+++ b/test/blackbox-tests/test-cases/multiple-targets.t
@@ -68,7 +68,7 @@ to get a better error message:
   2 |   (targets a)
   3 |   (target a)
   4 |   (action (bash "echo hola > %{target}")))
-  Error: fields "targets" and "target" are mutually exclusive.
+  Error: fields "target" and "targets" are mutually exclusive.
   [1]
 
 ^ Specifying both [targets] and [target] is not allowed


### PR DESCRIPTION
This is to make it more consistent with the analagous error for alias and aliases.