### PR TITLE
feature: extend traces to include source scans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Include source tree scans in the traces produced by `--trace-file` (#7937,
+  @rgrinberg)
+
 - Cinaps: The promotion rules for cinaps would only offer one file at a time no
   matter how many promotions were available. Now we offer all the promotions at
   once (#7901, @rgrinberg)

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1175,6 +1175,7 @@ let build (builder : Builder.t) ~default_root_is_cwd =
             ~extended_build_job_info:builder.stats_trace_extended
             (Out (open_out f))
         in
+        Dune_stats.set_global stats;
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -118,6 +118,15 @@ let close { print; close; _ } =
   print "]\n";
   close ()
 
+let global = ref None
+
+let set_global t =
+  if Option.is_some !global then
+    Code_error.raise "global stats have been set" [];
+  global := Some t
+
+let global () = !global
+
 let create ~extended_build_job_info dst =
   let print =
     match dst with

--- a/src/dune_stats/dune_stats.mli
+++ b/src/dune_stats/dune_stats.mli
@@ -12,6 +12,10 @@ type dst =
       ; flush : unit -> unit
       }
 
+val global : unit -> t option
+
+val set_global : t -> unit
+
 val create : extended_build_job_info:bool -> dst -> t
 
 val emit : t -> Chrome_trace.Event.t -> unit

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -3,6 +3,7 @@
 This captures the commands that are being run:
 
   $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
+  {"args":{"dir":"."},"ph":"X","dur":...,"name":"Source tree scan","cat":"","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-config"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}


### PR DESCRIPTION
Source scans can be quite slow. Record them in the trace.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 373fb4fc-304f-43c1-9fe2-c67175f3ee40 -->