### PR TITLE
fix(chore): Fix actions/checkout to use the latest version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-depext: false


### PR DESCRIPTION
df1477bc30c353e7ccd3b78a45c4b33fd9aede52 incorrectly changed the version of setup-ocaml instead of actions/checkout. This commit fixes it.