### PR TITLE
doc: add reference info about aliases

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,6 +50,7 @@ Welcome to Dune's Documentation!
    reference/preprocessing-spec
    reference/packages
    reference/findlib
+   reference/aliases
    concepts/scopes
    concepts/variables
    concepts/dependency-spec

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -108,10 +108,7 @@ Terminology
      A build target that doesn't produce any file and has configurable
      dependencies. Targets starting with ``@`` on the command line are
      interpreted as aliases (e.g., ``dune build @src/runtest``). Aliases are
-     per-directory. However, asking to build an alias in a given directory will
-     also trigger alias construction in all children directories recursively.
-     If no target is specified, Dune builds the ``default`` alias. Dune defines
-     several :ref:`builtin-aliases`.
+     per-directory. See :doc:`reference/aliases`.
 
    environment
      Determines the default values of various parameters, such as the

--- a/doc/reference/aliases.rst
+++ b/doc/reference/aliases.rst
@@ -7,11 +7,9 @@ files. For example, the ``runtest`` alias corresponds to running tests.
 Model and Syntax
 ----------------
 
-Rules can be attached to an alias. When this alias is requested to be built,
-these rules fire and the actions attached to them are executed.
-
-Since rules are defined in a specific directory, aliases are attached to
-directories too.
+Dependencies and actions can be attached to an alias. When this alias is
+requested to be built, these dependencies are built and these actions are
+executed. Aliases are attached to specific directories.
 
 In commands such as ``dune build``, the syntax to refer to the ``x`` alias is
 ``@x``, for example ``dune build @x``. This is why it is common to refer to it

--- a/doc/reference/aliases.rst
+++ b/doc/reference/aliases.rst
@@ -41,7 +41,7 @@ Examples:
   the ``foo`` build context
 - ``dune build @runtest`` will run the tests for all build contexts
 
-User-defined Aliases
+User-Defined Aliases
 --------------------
 
 It is possible to use any name for alias names; it will then be available on
@@ -54,7 +54,7 @@ the command line. For example, if a Dune file contains the following, then
     (alias deploy)
     (action ./run-deployer.exe))
 
-Built-in Aliases
+Built-In Aliases
 ----------------
 
 Some aliases are defined and managed by Dune itself.
@@ -68,7 +68,7 @@ This alias corresponds to every known file target in a directory.
 ^^^^^^
 
 This alias corresponds to the set of targets necessary for development tools to
-work correctly. For example, it will build ``*.cmi``, ``*.cmt`` and ``*.cmti``
+work correctly. For example, it will build ``*.cmi``, ``*.cmt``, and ``*.cmti``
 files so that Merlin and ``ocaml-lsp-server`` can be used in the project.
 It is also useful in the development loop because it will catch compilation
 errors without executing expensive operations such as linking executables.
@@ -120,7 +120,7 @@ be executed (using :doc:`promotion <../concepts/promotion>`).
 
 ``dune fmt`` is a shortcut for ``dune build @fmt --auto-promote``.
 
-It is possible to build on top of this convention: if some actions are manually
+It is possible to build on top of this convention. If some actions are manually
 attached to the ``fmt`` alias, they will be executed by ``dune fmt``.
 
 Example:

--- a/doc/reference/aliases.rst
+++ b/doc/reference/aliases.rst
@@ -1,0 +1,160 @@
+Aliases
+=======
+
+:term:`Aliases <alias>` are build targets that do not correspond to specific
+files. For example, the ``runtest`` alias corresponds to running tests.
+
+Model and Syntax
+----------------
+
+Rules can be attached to an alias. When this alias is requested to be built,
+these rules fire and the actions attached to them are executed.
+
+Since rules are defined in a specific directory, aliases are attached to
+directories too.
+
+In commands such as ``dune build``, the syntax to refer to the ``x`` alias is
+``@x``, for example ``dune build @x``. This is why it is common to refer to it
+as "the ``@x`` alias", or "attaching a rule to ``@x``".
+
+Building ``@x`` will build ``x`` in all subdirectories of the current
+directory. This is the most common case, but it is possible to restrict this
+using different syntaxes:
+
+- ``@sub/dir/x`` will build ``x`` in ``sub/dir`` and its subdirectories.
+- ``@@x`` will build ``x`` in the current directory only.
+- ``@@sub/dir/x`` will build ``x`` in ``sub/dir`` only.
+
+If ``dir`` is the directory of a :term:`build context`, it restricts the alias
+to this context.
+
+To summarize, the syntax is:
+
+- ``@`` (recursive) or ``@@`` (non-recursive): determine if subdirectories are
+  included
+- optional :term:`build context root`: restrict to a particular :term:`build
+  context`
+- optional directory: only consider this subdirectory
+- alias name
+
+Examples:
+
+- ``dune build @_build/foo/runtest`` only runs the tests for
+  the ``foo`` build context
+- ``dune build @runtest`` will run the tests for all build contexts
+
+User-defined Aliases
+--------------------
+
+It is possible to use any name for alias names; it will then be available on
+the command line. For example, if a Dune file contains the following, then
+``dune build @deploy`` will execute that command.
+
+.. code:: dune
+
+   (rule
+    (alias deploy)
+    (action ./run-deployer.exe))
+
+Built-in Aliases
+----------------
+
+Some aliases are defined and managed by Dune itself.
+
+@all
+^^^^
+
+This alias corresponds to every known file target in a directory.
+
+@check
+^^^^^^
+
+This alias corresponds to the set of targets necessary for development tools to
+work correctly. For example, it will build ``*.cmi``, ``*.cmt`` and ``*.cmti``
+files so that Merlin and ``ocaml-lsp-server`` can be used in the project.
+It is also useful in the development loop because it will catch compilation
+errors without executing expensive operations such as linking executables.
+
+.. _default-alias:
+
+@default
+^^^^^^^^
+
+This alias corresponds to the default argument for ``dune build``: ``dune
+build`` is equivalent to ``dune build @@default``. Similarly, ``dune build
+dir`` is equivalent to ``dune build @@dir/default``.
+
+When a directory doesn't explicitly define what the ``default`` alias
+means via an :ref:`alias-stanza` stanza, the following implicit
+definition is assumed:
+
+.. code:: dune
+
+   (alias
+    (name default)
+    (deps (alias_rec all)))
+
+But if such a stanza is present in the ``dune`` file in a directory, it will be
+used instead. For example, if the following is present in ``tests/dune``,
+``dune build tests`` will run tests there:
+
+.. code:: dune
+
+   (alias
+    (name default)
+    (deps (alias_rec runtest)))
+
+@doc
+^^^^
+
+This alias builds documentation for public libraries.
+
+@doc-private
+^^^^^^^^^^^^
+
+This alias builds documentation for all libraries, both public & private.
+
+@fmt
+^^^^
+
+This alias is used by formatting rules: when it is built, code formatters will
+be executed (using :doc:`promotion <../concepts/promotion>`).
+
+``dune fmt`` is a shortcut for ``dune build @fmt --auto-promote``.
+
+It is possible to build on top of this convention: if some actions are manually
+attached to the ``fmt`` alias, they will be executed by ``dune fmt``.
+
+Example:
+
+.. code:: dune
+
+   (rule
+    (with-stdout-to
+     data.json.formatted
+     (run jq . %{dep:data.json})))
+
+   (rule
+    (alias fmt)
+    (action
+     (diff data.json data.json.formatted)))
+
+@install
+^^^^^^^^
+
+This alias depends on the ``*.install`` files used by the :doc:`opam
+integration <../explanation/opam-integration>`. In turn, these depend on
+installable files.
+
+@lint
+^^^^^
+
+This alias runs linting tools.
+
+@runtest
+^^^^^^^^
+
+Actions that run tests are attached to this alias. For example this convention
+is used by the ``(test)`` stanza.
+
+``dune runtest`` is a shortcut for ``dune build @runtest``.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -144,7 +144,7 @@ Interpretation of Targets
 
 This section describes how Dune interprets the targets provided on
 the command line. When no targets are specified, Dune builds the
-``default`` alias, see :ref:`default-alias` for more details.
+:ref:`default alias <default-alias>`.
 
 Resolution
 ----------
@@ -176,114 +176,8 @@ targets upon starting:
     - _build/4.03.0/bin/prog.exe
     - _build/4.04.0/bin/prog.exe
 
-Aliases
--------
-
-Targets starting with a ``@`` are interpreted as :term:`aliases <alias>`. For
-instance ``@src/runtest`` means the alias ``runtest`` in all descendants of
-``src`` in all build contexts where it is defined. If you want to refer to a
-target starting with a ``@``, simply write: ``./@foo``.
-
-To build and run the tests for a particular build context, use
-``@_build/default/runtest`` instead.
-
-For instance:
-
--  ``dune build @_build/foo/runtest`` only runs the tests for
-   the ``foo`` build context
--  ``dune build @runtest`` will run the tests for all build contexts
-
-You can also build an alias non-recursively by using ``@@`` instead of
-``@``. For instance, to run tests only from the current directory, use:
-
-.. code::
-
-   dune build @@runtest
-
-Please note: it's not currently possible to build a target directly if that target
-lives in a directory that starts with the ``@`` character. In the rare cases
-where you need to do that, you can declare an alias like so:
-
-.. code:: dune
-
-    (alias
-     (name foo)
-     (deps @foo/some.exe))
-
-``@foo/some.exe`` can then be built with:
-
-.. code::
-
-   dune build @foo
-
-
-.. _default-alias:
-
-Default Alias
--------------
-
-When no targets are given to ``dune build``, it builds the special ``default``
-:term:`alias`. Effectively ``dune build`` is equivalent to:
-
-.. code::
-
-   dune build @@default
-
-When a directory doesn't explicitly define what the ``default`` alias
-means via an :ref:`alias-stanza` stanza, the following implicit
-definition is assumed:
-
-.. code::
-
-   (alias
-    (name default)
-    (deps (alias_rec all)))
-
-Which means that by default ``dune build`` will build everything that
-is installable.
-
-When using a directory as a target, it will be interpreted as building the
-default target in the directory. The directory must exist in the source tree.
-
-.. code::
-
-   dune build dir
-
-Is equivalent to:
-
-.. code::
-
-   dune build @@dir/default
-
-.. _builtin-aliases:
-
-Built-in Aliases
-----------------
-
-There are a few :term:`aliases <alias>` that Dune automatically creates for the
-user:
-
-* ``default`` includes all the targets that Dune will build if a
-  target isn't specified, i.e., ``$ dune build``. By default, this is set to the
-  ``all`` alias. Note that for Dune 1.x, this was initially set to the ``install`` alias.
-
-* ``runtest`` runs all the tests, building them if
-  necessary.
-
-* ``install`` builds all public artifacts that will be installed.
-
-* ``doc`` builds documentation for public libraries.
-
-* ``doc-private`` builds documentation for all libraries, both public & private.
-
-* ``lint`` runs linting tools.
-
-* ``all`` builds all available targets in a directory and also builds installable artifacts
-  defined in that directory.
-
-* ``check`` builds the minimal set of targets required for
-  tooling support. Essentially, this is ``.cmi``, ``.cmt``, and ``.cmti`` files and
-  Merlin configurations.
+If a target starts with the ``@`` sign, it is interpreted as an :term:`alias`.
+See :doc:`reference/aliases`.
 
 Variables for Artifacts
 -----------------------


### PR DESCRIPTION
This reworks the info found in `usage` and expands it.

Fixes #7615
