### PR TITLE
create dune show command group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Add `dune show` command group which is an alias of `dune describe`. (#7946,
+  @Alizter)
+
 - Fix printing errors from excerpts whenever character offsets span multiple
   lines (#7950, fixes #7905, @rgrinberg)
 

--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -7,6 +7,13 @@ open Import
 
    - duniverse people for "describe opam-files" *)
 
+let subcommands =
+  [ Describe_workspace.command
+  ; Describe_external_lib_deps.command
+  ; Describe_opam_files.command
+  ; Describe_pp.command
+  ]
+
 let group =
   let doc = "Describe the workspace." in
   let man =
@@ -27,9 +34,10 @@ let group =
   in
   let info = Cmd.info "describe" ~doc ~man in
   let default = Describe_workspace.term in
-  Cmd.group ~default info
-    [ Describe_workspace.command
-    ; Describe_external_lib_deps.command
-    ; Describe_opam_files.command
-    ; Describe_pp.command
-    ]
+  Cmd.group ~default info subcommands
+
+module Show = struct
+  let group =
+    let doc = "Command group for showing information about the workspace" in
+    Cmd.group (Cmd.info ~doc "show") subcommands
+end

--- a/bin/describe/describe.mli
+++ b/bin/describe/describe.mli
@@ -1,3 +1,9 @@
 open Import
 
+(** Command group for dune describe *)
 val group : unit Cmd.t
+
+module Show : sig
+  (** Command group for dune show (alias of describe) *)
+  val group : unit Cmd.t
+end

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -32,6 +32,7 @@ let all : _ Cmdliner.Cmd.t list =
     [ Ocaml_cmd.group
     ; Coq.group
     ; Describe.group
+    ; Describe.Show.group
     ; Rpc.group
     ; Internal.group
     ; Init.group


### PR DESCRIPTION
We ad a command group `dune show` which is an alias of `dune describe`. Motivation is that it is more convenient and easier to remember. 