### PR TITLE
fix: correctly print multi-line excerpts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix printing errors from excerpts whenever character offsets span multiple
+  lines (#7950, fixes #7905, @rgrinberg)
+
 - Include source tree scans in the traces produced by `--trace-file` (#7937,
   @rgrinberg)
 

--- a/otherlibs/stdune/test/loc_tests.ml
+++ b/otherlibs/stdune/test/loc_tests.ml
@@ -19,5 +19,6 @@ let f () () = function
   in
   Temp.destroy Dir file;
   print_endline output;
-  [%expect.unreachable]
-  [@@expect.uncaught_exn {| (Invalid_argument Bytes.create) |}]
+  [%expect {|
+    4 | let f () () = function
+    5 |   | A -> () |}]


### PR DESCRIPTION
The previous code would pretend that a multi-line excerpt was
single-line whenever the stop character was outside the line.

Fixes #7905

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9d20e3b2-2575-4910-b9a8-6722c6c6ccf3 -->