### PR TITLE
Remove lock_dir field from Lock_dir.Pkg.t

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -151,8 +151,7 @@ module Lock = struct
           opam_file_map_of_dune_package_map dune_package_map
         in
         let summary, lock_dir =
-          Dune_pkg.Opam.solve_lock_dir ~repo_selection ~lock_dir_path
-            opam_file_map
+          Dune_pkg.Opam.solve_lock_dir ~repo_selection opam_file_map
         in
         Console.print_user_message
           (Dune_pkg.Opam.Summary.selected_packages_message summary);

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -125,24 +125,20 @@ module Pkg = struct
     ; install_command : Action.t option
     ; deps : Package_name.t list
     ; info : Pkg_info.t
-    ; lock_dir : Path.Source.t
     ; exported_env : String_with_vars.t Dune_lang.Action.Env_update.t list
     }
 
-  let equal
-      { build_command; install_command; deps; info; lock_dir; exported_env }
+  let equal { build_command; install_command; deps; info; exported_env }
       { build_command = other_build_command
       ; install_command = other_install_command
       ; deps = other_deps
       ; info = other_info
-      ; lock_dir = other_lock_dir
       ; exported_env = other_exported_env
       } =
     Option.equal Action.equal_no_locs build_command other_build_command
     && Option.equal Action.equal_no_locs install_command other_install_command
     && List.equal Package_name.equal deps other_deps
     && Pkg_info.equal info other_info
-    && Path.Source.equal lock_dir other_lock_dir
     && List.equal
          (Dune_lang.Action.Env_update.equal String_with_vars.equal)
          exported_env other_exported_env
@@ -155,14 +151,12 @@ module Pkg = struct
           ~f:(Dune_lang.Action.Env_update.map ~f:String_with_vars.remove_locs)
     }
 
-  let to_dyn
-      { build_command; install_command; deps; info; lock_dir; exported_env } =
+  let to_dyn { build_command; install_command; deps; info; exported_env } =
     Dyn.record
       [ ("build_command", Dyn.option Action.to_dyn build_command)
       ; ("install_command", Dyn.option Action.to_dyn install_command)
       ; ("deps", Dyn.list Package_name.to_dyn deps)
       ; ("info", Pkg_info.to_dyn info)
-      ; ("lock_dir", Path.Source.to_dyn lock_dir)
       ; ( "exported_env"
         , Dyn.list
             (Dune_lang.Action.Env_update.to_dyn String_with_vars.to_dyn)
@@ -207,14 +201,13 @@ module Pkg = struct
            in
            { Pkg_info.name; version; dev; source }
          in
-         { build_command; deps; install_command; info; exported_env; lock_dir }
+         { build_command; deps; install_command; info; exported_env }
 
   let encode
       { build_command
       ; install_command
       ; deps
       ; info = { Pkg_info.name = _; version; dev; source }
-      ; lock_dir = _
       ; exported_env
       } =
     let open Dune_lang.Encoder in

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -27,7 +27,6 @@ module Pkg : sig
     ; install_command : Action.t option
     ; deps : Package_name.t list
     ; info : Pkg_info.t
-    ; lock_dir : Path.Source.t
     ; exported_env : String_with_vars.t Action.Env_update.t list
     }
 

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -341,8 +341,7 @@ module Summary = struct
                Pp.text (OpamPackage.to_string package)))
 end
 
-let opam_package_to_lock_file_pkg ~repo_state ~local_packages ~lock_dir_path
-    opam_package =
+let opam_package_to_lock_file_pkg ~repo_state ~local_packages opam_package =
   let name = OpamPackage.name opam_package in
   let version =
     OpamPackage.version opam_package |> OpamPackage.Version.to_string
@@ -373,7 +372,6 @@ let opam_package_to_lock_file_pkg ~repo_state ~local_packages ~lock_dir_path
   ; install_command = None
   ; deps
   ; info
-  ; lock_dir = lock_dir_path
   ; exported_env = []
   }
 
@@ -398,7 +396,7 @@ let solve_package_list local_packages context =
   | Error e -> User_error.raise [ Pp.text (Solver.diagnostics e) ]
   | Ok packages -> Solver.packages_of_result packages
 
-let solve_lock_dir ~repo_selection ~lock_dir_path local_packages =
+let solve_lock_dir ~repo_selection local_packages =
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
@@ -415,7 +413,7 @@ let solve_lock_dir ~repo_selection ~lock_dir_path local_packages =
           List.map opam_packages_to_lock ~f:(fun opam_package ->
               let pkg =
                 opam_package_to_lock_file_pkg ~repo_state ~local_packages
-                  ~lock_dir_path opam_package
+                  opam_package
               in
               (pkg.info.name, pkg))
           |> Package_name.Map.of_list

--- a/src/dune_pkg/opam.mli
+++ b/src/dune_pkg/opam.mli
@@ -31,6 +31,5 @@ end
 
 val solve_lock_dir :
      repo_selection:Repo_selection.t
-  -> lock_dir_path:Path.Source.t
   -> OpamFile.OPAM.t OpamTypes.name_map
   -> Summary.t * Lock_dir.t


### PR DESCRIPTION
This field prevented us from representing package data with the lockdir path abstracted, and in cases where package data was read from a file in a lockdir, the value of the `lock_dir` field is always the path to the lockdir containing the file.