### PR TITLE
Remove custom lockdir argument from `dune pkg lock`

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -2,42 +2,6 @@ open Stdune
 open Import
 module Lock_dir = Dune_pkg.Lock_dir
 
-(* Takes a string containing a possibly absolute path and returns a
-   [Path.Source.t] referring to that path. In the case of an absolute path,
-   [Error `Absolute_path_outside_source_directory] is returned in the case that
-   the specified path is outside the source directory. *)
-let source_path_from_possibly_absolute_path path_string =
-  if Filename.is_relative path_string then
-    Ok (Path.Source.of_string path_string)
-  else
-    let path = Path.External.of_string path_string |> Path.external_ in
-    let source_dir_path = Path.external_ Path.External.initial_cwd in
-    match Path.drop_prefix path ~prefix:source_dir_path with
-    | None -> Error `Absolute_path_outside_source_directory
-    | Some relative_path -> Ok (Path.Source.of_local relative_path)
-
-let lock_dir_term =
-  let+ lock_dir_opt =
-    Arg.(
-      value
-      & opt (some string) None
-      & info [ "lock-dir" ] ~docv:"PATH"
-          ~doc:
-            (sprintf "Path to lock directory (default: %s)"
-               (Stdune.Path.Source.to_string Lock_dir.default_path)))
-  in
-  Option.map lock_dir_opt ~f:(fun path_string ->
-      match source_path_from_possibly_absolute_path path_string with
-      | Ok source_path -> source_path
-      | Error `Absolute_path_outside_source_directory ->
-        User_error.raise
-          [ Pp.textf
-              "Specified lock directory (%s) is not a descendant of the source \
-               directory."
-              (String.maybe_quoted path_string)
-          ])
-  |> Option.value ~default:Lock_dir.default_path
-
 module Lock = struct
   module Repo_selection = struct
     module Env = struct
@@ -139,8 +103,7 @@ module Lock = struct
 
   let term =
     let+ (common : Common.t) = Common.term
-    and+ repo_selection = Repo_selection.term
-    and+ lock_dir_path = lock_dir_term in
+    and+ repo_selection = Repo_selection.term in
     let config = Common.init common in
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
@@ -150,6 +113,7 @@ module Lock = struct
         let opam_file_map =
           opam_file_map_of_dune_package_map dune_package_map
         in
+        let lock_dir_path = Lock_dir.default_path in
         let summary, lock_dir =
           Dune_pkg.Opam.solve_lock_dir ~repo_selection ~lock_dir_path
             opam_file_map

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -1,35 +1,40 @@
 Create a lock directory that didn't originally exist
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --lock-dir=new-dir
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   No dependencies to lock
-  $ cat new-dir/lock.dune
+  $ cat dune.lock/lock.dune
   (lang package 0.1)
 
 Re-create a lock directory in the newly created lock dir
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --lock-dir=new-dir
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   No dependencies to lock
-  $ cat new-dir/lock.dune
+  $ cat dune.lock/lock.dune
   (lang package 0.1)
 
-Attempt to create a lock directory inside a directory without a lock.dune file
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --lock-dir=dir-without-metadata
+Attempt to create a lock directory inside an existing directory without a lock.dune file
+  $ rm -rf dune.lock
+  $ cp -r dir-without-metadata dune.lock
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   No dependencies to lock
-  Error: Refusing to regenerate lock directory dir-without-metadata
+  Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir lacks metadata file (lock.dune)
   [1]
 
-Attempt to create a lock directory inside a directory with an invalid lock.dune file
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --lock-dir=dir-with-invalid-metadata
+Attempt to create a lock directory inside an existing directory with an invalid lock.dune file
+  $ rm -rf dune.lock
+  $ cp -r dir-with-invalid-metadata dune.lock
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   No dependencies to lock
-  Error: Refusing to regenerate lock directory dir-with-invalid-metadata
-  File "dir-with-invalid-metadata/lock.dune", line 1, characters 0-12:
+  Error: Refusing to regenerate lock directory dune.lock
+  File "dune.lock/lock.dune", line 1, characters 0-12:
   Error: Invalid first line, expected: (lang <lang> <version>)
   
   [1]
 
-Attempt to create a lock directory with the same name as a regular file
-  $ touch regular-file
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --lock-dir=regular-file
+Attempt to create a lock directory with the same name as an existing regular file
+  $ rm -rf dune.lock
+  $ touch dune.lock
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   No dependencies to lock
-  Error: Refusing to regenerate lock directory regular-file
+  Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir path is not a directory
   [1]


### PR DESCRIPTION
This feature let users specify a custom lockdir to create when running `dune pkg lock`. It was added before dune allowed custom lockdirs to be associated with build contexts. Removing this feature will make it conceptually simpler (for users) to know which lockdir will be used. Presently it has no well defined use case and no commands support it besides `dune pkg lock`. It will be easy to add this back in the future if we decide it's a feature we want to support.