### PR TITLE
fix(rpc): prompt closing of sessions

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -135,8 +135,8 @@ module Session = struct
     match t.state with
     | Closed -> Fiber.return ()
     | Open { fd; _ } ->
-      let+ () = Async_io.close fd in
-      t.state <- Closed
+      t.state <- Closed;
+      Async_io.close fd
 
   module Lexer = Csexp.Parser.Lexer
   module Stack = Csexp.Parser.Stack


### PR DESCRIPTION
Do not wait until the fd is  closed to signal that the session is closed

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7442a7d2-1f23-47c1-a8a6-0953cafd1a5d -->