### PR TITLE
feature(pkg): Arguments to specify contexts to `dune pkg lock`

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -282,63 +282,73 @@ let file_contents_by_path t =
      |> List.map ~f:(fun (name, pkg) ->
             (Package_filename.of_package_name name, Pkg.encode pkg)))
 
-(* Checks whether path refers to a valid lock directory and returns a value
-   indicating the status of the lock directory. [Ok _] values indicate that
-   it's safe to proceed with regenerating the lock directory. [Error _]
-   values indicate that it's unsafe to remove the existing directory and lock
-   directory regeneration should not proceed. *)
-let check_existing_lock_dir path =
-  match Path.exists path with
-  | false -> Ok `Non_existant
-  | true -> (
-    match Path.is_directory path with
-    | false -> Error `Not_directory
+module Write_disk = struct
+  (* Checks whether path refers to a valid lock directory and returns a value
+     indicating the status of the lock directory. [Ok _] values indicate that
+     it's safe to proceed with regenerating the lock directory. [Error _]
+     values indicate that it's unsafe to remove the existing directory and lock
+     directory regeneration should not proceed. *)
+  let check_existing_lock_dir path =
+    match Path.exists path with
+    | false -> Ok `Non_existant
     | true -> (
-      let metadata_path = Path.relative path metadata in
-      match
-        Path.exists metadata_path && not (Path.is_directory metadata_path)
-      with
-      | false -> Error `No_metadata_file
+      match Path.is_directory path with
+      | false -> Error `Not_directory
       | true -> (
+        let metadata_path = Path.relative path metadata in
         match
-          Metadata.load metadata_path
-            ~f:(Fun.const (Dune_lang.Decoder.return ()))
+          Path.exists metadata_path && not (Path.is_directory metadata_path)
         with
-        | Ok () -> Ok `Is_existing_lock_dir
-        | Error exn -> Error (`Failed_to_parse_metadata exn))))
+        | false -> Error `No_metadata_file
+        | true -> (
+          match
+            Metadata.load metadata_path
+              ~f:(Fun.const (Dune_lang.Decoder.return ()))
+          with
+          | Ok () -> Ok `Is_existing_lock_dir
+          | Error exn -> Error (`Failed_to_parse_metadata exn))))
 
-(* Removes the exitsing lock directory at the specified path if it exists and
-   is a valid lock directory *)
-let safely_remove_lock_dir_if_exists path =
-  match check_existing_lock_dir path with
-  | Ok `Non_existant -> ()
-  | Ok `Is_existing_lock_dir -> Path.rm_rf path
-  | Error e ->
-    let error_reason_pp =
-      match e with
-      | `Not_directory -> Pp.text "Specified lock dir path is not a directory"
-      | `No_metadata_file ->
-        Pp.textf "Specified lock dir lacks metadata file (%s)" metadata
-      | `Failed_to_parse_metadata exn -> Exn.pp exn
+  (* Removes the exitsing lock directory at the specified path if it exists and
+     is a valid lock directory. Checks the validity of the existing lockdir (if
+     any) and raises if it's invalid before constructing the returned thunk, so
+     validation can happen separately from executing the side effect that removes
+     the directory. *)
+  let safely_remove_lock_dir_if_exists_thunk path =
+    match check_existing_lock_dir path with
+    | Ok `Non_existant -> Fun.const ()
+    | Ok `Is_existing_lock_dir -> fun () -> Path.rm_rf path
+    | Error e ->
+      let error_reason_pp =
+        match e with
+        | `Not_directory -> Pp.text "Specified lock dir path is not a directory"
+        | `No_metadata_file ->
+          Pp.textf "Specified lock dir lacks metadata file (%s)" metadata
+        | `Failed_to_parse_metadata exn -> Exn.pp exn
+      in
+      User_error.raise
+        [ Pp.textf "Refusing to regenerate lock directory %s"
+            (Path.to_string_maybe_quoted path)
+        ; error_reason_pp
+        ]
+
+  type t = unit -> unit
+
+  let prepare ~lock_dir_path lock_dir =
+    let lock_dir_path = Path.source lock_dir_path in
+    let remove_dir_if_exists =
+      safely_remove_lock_dir_if_exists_thunk lock_dir_path
     in
-    User_error.raise
-      [ Pp.textf "Refusing to regenerate lock directory %s"
-          (Path.to_string_maybe_quoted path)
-      ; error_reason_pp
-      ]
+    fun () ->
+      remove_dir_if_exists ();
+      Path.mkdir_p lock_dir_path;
+      file_contents_by_path lock_dir
+      |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
+             let path = Path.relative lock_dir_path path_within_lock_dir in
+             Option.iter (Path.parent path) ~f:Path.mkdir_p;
+             List.map contents ~f:Dune_lang.to_string |> Io.write_lines path)
 
-let write_disk ~lock_dir_path t =
-  let lock_dir_path = Path.source lock_dir_path in
-  let () = safely_remove_lock_dir_if_exists lock_dir_path in
-  Path.mkdir_p lock_dir_path;
-  file_contents_by_path t
-  |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
-         let path = Path.relative lock_dir_path path_within_lock_dir in
-         Option.iter (Path.parent path) ~f:Path.mkdir_p;
-         let contents_string =
-           List.map contents ~f:Dune_lang.to_string |> String.concat ~sep:"\n"
-         in
-         Io.write_file path contents_string)
+  let commit t = t ()
+end
 
 let load_metadata_version source_path =
   let open Or_exn.O in

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -61,6 +61,14 @@ module Package_filename : sig
   val to_package_name : t -> (Package_name.t, [ `Bad_extension ]) result
 end
 
-val write_disk : lock_dir_path:Path.Source.t -> t -> unit
+module Write_disk : sig
+  type lock_dir := t
+
+  type t
+
+  val prepare : lock_dir_path:Path.Source.t -> lock_dir -> t
+
+  val commit : t -> unit
+end
 
 val read_disk : lock_dir_path:Path.Source.t -> t Or_exn.t

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.0.1/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.0.1/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.4.0/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.4.0/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.5.0/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/bar/bar.0.5.0/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/baz/baz.0.0.1/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/baz/baz.0.0.1/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/baz/baz.0.1.0/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/baz/baz.0.1.0/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/foo/foo.0.0.1/opam
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/packages/foo/foo.0.0.1/opam
@@ -1,0 +1,5 @@
+opam-version: "2.0"
+depends: [
+    "baz" {>= "0.1"}
+    "bar" {>= "0.2"}
+]

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/repo
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/mock-opam-repository/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -1,0 +1,110 @@
+Create a workspace with multiple contexts, each specifying a lockdir name.
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context
+  >  (default
+  >   (lock foo.lock)))
+  > (context
+  >  (default
+  >   (name foo)
+  >   (lock bar.lock)))
+  > (context
+  >  (opam
+  >   (name bar)
+  >   (switch default)))
+  > EOF
+
+Generate a `dune-project` file listing some dependencies.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name lockfile_generation_test)
+  >  (depends
+  >    foo
+  >    (bar (>= "0.3"))
+  >   ))
+  > EOF
+
+Test that we get an error when --context and --all-contexts are passed at the same time.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts --context=foo
+  Error: --context and --all-contexts are mutually exclusive
+  [1]
+
+Test that we get an error if a non-existant context is specified.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=baz
+  Error: Unknown build context: baz
+  [1]
+
+Test that we get an error if an opam context is specified.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=bar
+  Error: Unexpected opam build context: bar
+  [1]
+
+Generate the lockdir for the default context.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  Selected the following packages:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+
+Only foo.lock (the default context's lockdir) was generated.
+  $ find *.lock | sort
+  foo.lock
+  foo.lock/bar.pkg
+  foo.lock/baz.pkg
+  foo.lock/foo.pkg
+  foo.lock/lock.dune
+  $ rm -rf *.lock
+
+Generate the lockdir with the default context explicitly specified.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
+  Selected the following packages:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+
+Again, only foo.lock (the default context's lockdir) was generated.
+  $ find *.lock | sort
+  foo.lock
+  foo.lock/bar.pkg
+  foo.lock/baz.pkg
+  foo.lock/foo.pkg
+  foo.lock/lock.dune
+  $ rm -rf *.lock
+
+Generate the lockdir for the non-default context.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=foo
+  Selected the following packages:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+
+Now only bar.lock was generated.
+  $ find *.lock | sort
+  bar.lock
+  bar.lock/bar.pkg
+  bar.lock/baz.pkg
+  bar.lock/foo.pkg
+  bar.lock/lock.dune
+  $ rm -rf *.lock
+
+Generate the lockdir for all (non-opam) contexts.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  Selected the following packages:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+
+Now both lockdirs were generated.
+  $ find *.lock | sort
+  bar.lock
+  bar.lock/bar.pkg
+  bar.lock/baz.pkg
+  bar.lock/foo.pkg
+  bar.lock/lock.dune
+  foo.lock
+  foo.lock/bar.pkg
+  foo.lock/baz.pkg
+  foo.lock/foo.pkg
+  foo.lock/lock.dune
+  $ rm -rf *.lock

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -25,11 +25,13 @@ Print the name and contents of each file in the lock directory separated by
   
   (version 0.4.0)
   
+  
   ---
   
   dune.lock/baz.pkg:
   
   (version 0.1.0)
+  
   
   ---
   
@@ -38,11 +40,13 @@ Print the name and contents of each file in the lock directory separated by
   (version 0.0.1)
   (deps baz bar)
   
+  
   ---
   
   dune.lock/lock.dune:
   
   (lang package 0.1)
+  
   
   ---
   

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -155,7 +155,7 @@ let%expect_test "downloading, without any checksum" =
 
 let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
   let lock_dir_path = Path.Source.of_string lock_dir_path in
-  Lock_dir.write_disk ~lock_dir_path lock_dir;
+  Lock_dir.Write_disk.(prepare ~lock_dir_path lock_dir |> commit);
   let lock_dir_round_tripped =
     Lock_dir.read_disk ~lock_dir_path |> Result.ok_exn
   in


### PR DESCRIPTION
Build contexts can specify custom lockdir paths. This commit adds an option --context when generating lockfiles to choose which build context to create the lockdir for, and a flag --all-contexts which generates lockdirs for all build contexts.