### PR TITLE
Monorepo benchmark tidy up

### DIFF
--- a/bench/monorepo/Makefile
+++ b/bench/monorepo/Makefile
@@ -1,5 +1,5 @@
 # Intended to be used from inside docker containers built from bench.Dockerfile
-RUNNER = /home/user/monorepo-benchmark/dune-benchmark-runner/_build/default/src/main.exe
+RUNNER = /home/user/monorepo-benchmark/dune-monorepo-benchmark-runner/_build/default/src/main.exe
 DUNE_EXE_PATH = /home/user/dune/_build/default/bin/main.exe
 BUILD_TARGET = ./monorepo_bench.exe
 MONOREPO_PATH = /home/user/monorepo-benchmark/benchmark
@@ -16,8 +16,18 @@ duniverse:
 	sudo cp -a $(DUNIVERSE_MOUNT_POINT) .
 	sudo chown -hR $(USER_GROUP) duniverse
 
+# Run the dune benchmark runner. To reduce noise, short benchmarks are run 5
+# times each, and the max and min results of each benchmark are discarded. The
+# remaining 3 results are presented to current-bench. Short benchmarks are all
+# benchmarks except for the initial build from scratch.
 bench: duniverse
-	$(RUNNER) --dune-exe-path=$(DUNE_EXE_PATH) --build-target=$(BUILD_TARGET) --monorepo-path=$(MONOREPO_PATH) --print-dune-output --num-short-job-repeats=5 --remove-outliers=1
+	$(RUNNER) \
+		--dune-exe-path=$(DUNE_EXE_PATH) \
+		--build-target=$(BUILD_TARGET) \
+		--monorepo-path=$(MONOREPO_PATH) \
+		--print-dune-output \
+		--num-short-job-repeats=5 \
+		--remove-outliers=1
 
 clean:
 	dune clean

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -133,13 +133,14 @@ RUN opam install -y dune ocamlbuild
 
 # make an opam switch for preparing the files for the benchmark
 RUN opam switch create prepare 4.14.1
-RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl yojson logs fmt
+RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-06-03.0
+ENV MONOREPO_BENCHMARK_TAG=2023-06-15.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
   tar xf ocaml-monorepo-benchmark.tar.gz && \
-  mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark
+  mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark && \
+  opam install -y monorepo-benchmark/dune-monorepo-benchmark-runner
 
 # Build the dune binary that we'll be benchmarking.
 # Only copy the files needed to build dune so that changes to other files in this project
@@ -168,7 +169,7 @@ COPY --chown=user:users bench/monorepo/Makefile .
 
 # Build the benchmark runner
 RUN . ~/.profile && \
-    cd /home/user/monorepo-benchmark/dune-benchmark-runner && \
+    cd /home/user/monorepo-benchmark/dune-monorepo-benchmark-runner && \
     dune build src/main.exe --release
 
 # Change to the benchmarking switch to run the benchmark


### PR DESCRIPTION
Several changes aimed to make the monorepo benchmark easier to maintain:
- Use the benchmark runner's opam file to install its dependencies rather than explicitly installing them in the dockerfile.
- Stop pinning dune-rpc and dune-rpc-lwt. This was needed prior to dune 3.8 due to some recent bug fixes which have since been released.
- Document the runner command in the makefile.