### PR TITLE
[3.8] backport #7949 and #7950

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 - Fix RPC buffer corruption issues due to multi threading. This issue was only
   reproducible with large RPC payloads (#7418)
 
+- Fix printing errors from excerpts whenever character offsets span multiple
+  lines (#7950, fixes #7905, @rgrinberg)
+
 3.8.1 (2023-06-05)
 ------------------
 

--- a/otherlibs/stdune/test/loc_tests.ml
+++ b/otherlibs/stdune/test/loc_tests.ml
@@ -1,0 +1,23 @@
+open Stdune
+
+let%expect_test "#7905 - inverted char offsets" =
+  let dir = Temp.create Dir ~prefix:"" ~suffix:"loc" in
+  let file = Path.relative dir "file.ml" in
+  Io.write_file file {|
+type t = A | B
+
+let f () () = function
+  | A -> ()
+|};
+  let pos_fname = Path.to_string file in
+  let start = { Lexing.pos_fname; pos_lnum = 4; pos_bol = 0; pos_cnum = 14 } in
+  let stop = { start with pos_lnum = 5; pos_cnum = 11 } in
+  let loc = { Loc.start; stop } in
+  Format.printf "%a@." Pp.to_fmt (Loc.pp loc);
+  let output =
+    [%expect.output] |> String.split_lines |> List.tl |> String.concat ~sep:"\n"
+  in
+  Temp.destroy Dir file;
+  print_endline output;
+  [%expect.unreachable]
+  [@@expect.uncaught_exn {| (Invalid_argument Bytes.create) |}]

--- a/otherlibs/stdune/test/loc_tests.ml
+++ b/otherlibs/stdune/test/loc_tests.ml
@@ -19,5 +19,6 @@ let f () () = function
   in
   Temp.destroy Dir file;
   print_endline output;
-  [%expect.unreachable]
-  [@@expect.uncaught_exn {| (Invalid_argument Bytes.create) |}]
+  [%expect {|
+    4 | let f () () = function
+    5 |   | A -> () |}]


### PR DESCRIPTION
- test: reproduce #7905 (#7949)
- fix: correctly print multi-line excerpts (#7950)
