### PR TITLE
fix(rpc): treat connection reset as eofs

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -173,7 +173,7 @@ module Session = struct
                 | exception
                     Unix.Unix_error ((EAGAIN | EINTR | EWOULDBLOCK), _, _) ->
                   `Refill
-                | 0 ->
+                | (exception Unix.Unix_error (ECONNRESET, _, _)) | 0 ->
                   open_.read_eof <- true;
                   `Eof
                 | len ->


### PR DESCRIPTION
The only thing this does in practice is hide ugly backtraces from the
user.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 99642df4-834f-48e5-8451-996c29600564 -->