### PR TITLE
fix(rpc): do not re-reraise read errors

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -224,8 +224,9 @@ module Session = struct
         | Error exn ->
           Log.info
             [ Pp.textf "Unable to read (%d)" (Id.to_int t.id); Exn.pp exn ];
+          Dune_util.Report_error.report_exception exn;
           let+ () = close t in
-          reraise exn
+          None
         | Ok None ->
           let+ () = close t in
           None


### PR DESCRIPTION
There's no point in re-raising read errors even if we don't know what
they are. The callers can't handle them apart from dropping the
connection. Since the errors are unknown, we also report them to the
console.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ae7a738c-9b2b-417b-9121-28fb5f6fe107 -->