### PR TITLE
Lockdirs are data-only

### DIFF
--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -1,5 +1,6 @@
 module Fetch = Fetch
 module Checksum = Checksum
 module Lock_dir = Lock_dir
+module Lock_dir_path = Lock_dir_path
 module Opam = Opam
 module Opam_file = Opam_file

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -31,7 +31,7 @@ module Pkg : sig
     }
 
   val decode :
-    (lock_dir:Path.Source.t -> Package_name.t -> t) Dune_sexp.Decoder.t
+    (lock_dir:Lock_dir_path.t -> Package_name.t -> t) Dune_sexp.Decoder.t
 end
 
 type t =
@@ -47,12 +47,12 @@ val to_dyn : t -> Dyn.t
 
 val create_latest_version : Pkg.t Package_name.Map.t -> t
 
-val default_path : Path.Source.t
+val default_path : Lock_dir_path.t
 
 val metadata : Filename.t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 
-val write_disk : lock_dir_path:Path.Source.t -> t -> unit
+val write_disk : lock_dir_path:Lock_dir_path.t -> t -> unit
 
-val read_disk : lock_dir_path:Path.Source.t -> t Or_exn.t
+val read_disk : lock_dir_path:Lock_dir_path.t -> t Or_exn.t

--- a/src/dune_pkg/lock_dir_path.ml
+++ b/src/dune_pkg/lock_dir_path.ml
@@ -1,0 +1,25 @@
+open Import
+include Path.Source
+
+let required_extension = ".lock"
+
+let is_valid_source_path path_source =
+  String.equal (Path.Source.extension path_source) required_extension
+
+let of_path_source path_source =
+  if is_valid_source_path path_source then Ok path_source
+  else
+    Error
+      (`Msg
+        (sprintf "lockdir path %s does not have required extension \"%s\""
+           (Path.Source.to_string_maybe_quoted path_source)
+           required_extension))
+
+let of_path_source_exn path_source =
+  match of_path_source path_source with
+  | Ok t -> t
+  | Error (`Msg msg) -> User_error.raise [ Pp.text msg ]
+
+let to_path_source t = t
+
+let to_path = Path.source

--- a/src/dune_pkg/lock_dir_path.mli
+++ b/src/dune_pkg/lock_dir_path.mli
@@ -1,0 +1,21 @@
+open Import
+
+type t
+
+val to_dyn : t -> Dyn.t
+
+val equal : t -> t -> bool
+
+val is_valid_source_path : Path.Source.t -> bool
+
+val of_path_source : Path.Source.t -> (t, [ `Msg of string ]) result
+
+val of_path_source_exn : Path.Source.t -> t
+
+val to_path_source : t -> Path.Source.t
+
+val to_path : t -> Path.t
+
+val of_string : string -> t
+
+val to_string : t -> string

--- a/src/dune_rules/sub_dirs.ml
+++ b/src/dune_rules/sub_dirs.ml
@@ -74,9 +74,17 @@ module Status = struct
 end
 
 let status status_by_dir ~dir : Status.Or_ignored.t =
-  match String.Map.find status_by_dir dir with
-  | None -> Ignored
-  | Some d -> Status d
+  if Dune_pkg.Lock_dir_path.is_valid_source_path (Path.Source.of_string dir)
+  then
+    (* All directories whose names are valid lockdir names are treated as
+       data-only directories. This is because if a lockdir contains a file
+       named "dune" this file will contain data about the package "dune" and
+       won't be a valid dune file. *)
+    Status Status.Data_only
+  else
+    match String.Map.find status_by_dir dir with
+    | None -> Ignored
+    | Some d -> Status d
 
 let default =
   let standard_dirs = Predicate_lang.Glob.of_glob (Glob.of_string "[!._]*") in

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -47,7 +47,7 @@ module Context : sig
   module Default : sig
     type t =
       { base : Common.t
-      ; lock : Path.Source.t option
+      ; lock : Dune_pkg.Lock_dir_path.t option
       }
   end
 

--- a/test/blackbox-tests/test-cases/pkg/invalid-lockdir-path.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-lockdir-path.t
@@ -1,0 +1,14 @@
+Test that we get the expected error when a context specifies an invalid lockdir path
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context
+  >  (default
+  >   (lock foo)))
+
+  $ dune build
+  File "dune-workspace", line 4, characters 8-11:
+  4 |   (lock foo)))
+              ^^^
+  Error: lockdir path foo does not have required extension ".lock"
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/mock-opam-repository/packages/dune/dune.0.0.1/opam
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/mock-opam-repository/packages/dune/dune.0.0.1/opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/mock-opam-repository/repo
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/mock-opam-repository/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-is-data-only.t/run.t
@@ -1,0 +1,20 @@
+Test that if a package depends on dune, the presence of a file named "dune"
+inside the lockdir doesn't cause dune to attempt to parse it as a regular dune
+file.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends dune))
+  > EOF
+
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  Selected the following packages:
+  dune.0.0.1
+
+  $ cat dune.lock/dune
+  (version 0.0.1)
+
+  $ dune build

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -2,6 +2,7 @@ open Stdune
 module Fetch = Dune_pkg.Fetch
 module Checksum = Dune_pkg.Checksum
 module Lock_dir = Dune_pkg.Lock_dir
+module Lock_dir_path = Dune_pkg.Lock_dir_path
 module Scheduler = Dune_engine.Scheduler
 module Package_name = Dune_lang.Package_name
 
@@ -154,7 +155,7 @@ let%expect_test "downloading, without any checksum" =
     Finished successfully, no checksum verification |}]
 
 let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
-  let lock_dir_path = Path.Source.of_string lock_dir_path in
+  let lock_dir_path = Lock_dir_path.of_string lock_dir_path in
   Lock_dir.write_disk ~lock_dir_path lock_dir;
   let lock_dir_round_tripped =
     Lock_dir.read_disk ~lock_dir_path |> Result.ok_exn


### PR DESCRIPTION
When a package depends on dune the lockdir will contain a file named "dune" which is not a valid dune file (instead it contains information about the package "dune"). To prevent dune attempting to interpret the file as a dune file, we make all lockdirs data-only.

To simplify this (both conceptually for users and the implementation) we introduce a convention where only directories ending in ".lock" can be specified as lockdirs, and all directories ending in ".lock" are treated as data-only.

Fixes https://github.com/ocaml/dune/issues/7974