### PR TITLE
doc: add index.mld for dune-glob

### DIFF
--- a/otherlibs/dune-glob/dune
+++ b/otherlibs/dune-glob/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package dune-glob))

--- a/otherlibs/dune-glob/index.mld
+++ b/otherlibs/dune-glob/index.mld
@@ -30,3 +30,9 @@ let () =
 {2 API documentation}
 
 The entry point for this library is {!Dune_glob.V1}.
+
+{2 Note on stability}
+
+This library is fairly stable, but does not come with strong stability
+guarantees. In particular, while the module name suggests the API is versioned,
+it is not in the strict sense.

--- a/otherlibs/dune-glob/index.mld
+++ b/otherlibs/dune-glob/index.mld
@@ -1,0 +1,32 @@
+{1 dune-glob - file globbing}
+
+{2 Introduction}
+
+A {e glob} is a way of referring to a set of files that match a certain
+pattern, such as "files with the [.ml] extension" or "files with [test] in
+their name".
+
+[dune-glob] exposes an abstraction so that we can refer to the first group as
+[*.ml] and the second one as [*test*].
+
+This library is used by Dune to implement this syntax in several places in
+[dune] files, but it can be used in other contexts as well.
+
+{2 Example}
+
+This is an executable that takes a glob as a command line argument, and lists
+the contents of the current directory that matches it:
+
+{[
+let () =
+  let glob_string = Sys.argv.(1) in
+  let glob = Dune_glob.V1.of_string glob_string in
+  let files = Sys.readdir "." in
+  ArrayLabels.iter files ~f:(fun n ->
+    if Dune_glob.V1.test glob n then
+      print_endline n)
+]}
+
+{2 API documentation}
+
+The entry point for this library is {!Dune_glob.V1}.


### PR DESCRIPTION
As for other packages: an introduction, an example, a proper link.

The doc for `of_string` could point to a `syntax.mld` (this lives in `dependency-spec.rst` at the moment), but that would be better with table support. See #7988.
