### PR TITLE
refactor(rpc): split close/write

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -126,10 +126,6 @@ module Session = struct
     | None -> "EOF"
     | Some csexp -> Dyn.to_string (Sexp.to_dyn csexp)
 
-  let string_of_packets = function
-    | None -> "EOF"
-    | Some sexps -> String.concat ~sep:" " (List.map ~f:Sexp.to_string sexps)
-
   let close t =
     let* () = Fiber.return () in
     match t.state with
@@ -143,97 +139,98 @@ module Session = struct
 
   let min_read = 8192
 
-  let read t =
-    let* () = Fiber.return () in
-    let debug res =
+  let read =
+    let debug id res =
       if debug then
         Log.info
-          [ Pp.verbatim
-              (sprintf "RPC (%d) <<\n%s" (Id.to_int t.id) (string_of_packet res))
+          [ Pp.verbatim (sprintf "RPC (%d) <<" (Id.to_int id))
+          ; Pp.seq (Pp.verbatim "<< ") (Pp.verbatim (string_of_packet res))
           ; Pp.text "<<"
           ]
     in
-    match t.state with
-    | Closed ->
-      debug None;
-      Fiber.return None
-    | Open ({ fd; in_buf; read_mutex; _ } as open_) ->
-      let lexer = Lexer.create () in
-      let buf = Buffer.create 16 in
-      let rec refill () =
-        if Io_buffer.length in_buf > 0 then Fiber.return (Ok `Continue)
-        else if open_.read_eof then Fiber.return (Ok `Eof)
-        else
-          let* task =
-            Async_io.ready fd `Read ~f:(fun () ->
-                let () = Io_buffer.maybe_resize_to_fit in_buf min_read in
-                let pos = Io_buffer.write_pos in_buf in
-                let len = Io_buffer.max_write_len in_buf in
-                match Unix.read fd (Io_buffer.bytes in_buf) pos len with
-                | exception
-                    Unix.Unix_error ((EAGAIN | EINTR | EWOULDBLOCK), _, _) ->
-                  `Refill
-                | (exception Unix.Unix_error (ECONNRESET, _, _)) | 0 ->
-                  open_.read_eof <- true;
-                  `Eof
-                | len ->
-                  Io_buffer.commit_write in_buf ~len;
-                  `Continue)
-          in
-          Async_io.Task.await task >>= function
-          | Error (`Exn e) -> Fiber.return (Error e)
-          | Error `Cancelled | Ok `Eof -> Fiber.return @@ Ok `Eof
-          | Ok `Continue -> Fiber.return @@ Ok `Continue
-          | Ok `Refill -> refill ()
-      and read parser =
-        let* res = refill () in
-        match res with
-        | Error _ as e -> Fiber.return e
-        | Ok `Eof -> Fiber.return (Ok None)
-        | Ok `Continue -> (
-          let char = Io_buffer.read_char_exn in_buf in
-          let token = Lexer.feed lexer char in
-          match token with
-          | Atom n ->
-            Buffer.clear buf;
-            atom parser n
-          | (Lparen | Rparen | Await) as token -> (
-            let parser = Stack.add_token token parser in
-            match parser with
-            | Sexp (sexp, Empty) -> Fiber.return (Ok (Some sexp))
-            | parser -> read parser))
-      and atom parser n =
-        if n = 0 then
-          let atom = Buffer.contents buf in
-          match Stack.add_atom atom parser with
-          | Sexp (sexp, Empty) -> Fiber.return (Ok (Some sexp))
-          | parser -> read parser
-        else
-          refill () >>= function
+    fun t ->
+      let* () = Fiber.return () in
+      match t.state with
+      | Closed ->
+        debug t.id None;
+        Fiber.return None
+      | Open ({ fd; in_buf; read_mutex; _ } as open_) ->
+        let lexer = Lexer.create () in
+        let buf = Buffer.create 16 in
+        let rec refill () =
+          if Io_buffer.length in_buf > 0 then Fiber.return (Ok `Continue)
+          else if open_.read_eof then Fiber.return (Ok `Eof)
+          else
+            let* task =
+              Async_io.ready fd `Read ~f:(fun () ->
+                  let () = Io_buffer.maybe_resize_to_fit in_buf min_read in
+                  let pos = Io_buffer.write_pos in_buf in
+                  let len = Io_buffer.max_write_len in_buf in
+                  match Unix.read fd (Io_buffer.bytes in_buf) pos len with
+                  | exception
+                      Unix.Unix_error ((EAGAIN | EINTR | EWOULDBLOCK), _, _) ->
+                    `Refill
+                  | (exception Unix.Unix_error (ECONNRESET, _, _)) | 0 ->
+                    open_.read_eof <- true;
+                    `Eof
+                  | len ->
+                    Io_buffer.commit_write in_buf ~len;
+                    `Continue)
+            in
+            Async_io.Task.await task >>= function
+            | Error (`Exn e) -> Fiber.return (Error e)
+            | Error `Cancelled | Ok `Eof -> Fiber.return @@ Ok `Eof
+            | Ok `Continue -> Fiber.return @@ Ok `Continue
+            | Ok `Refill -> refill ()
+        and read parser =
+          let* res = refill () in
+          match res with
           | Error _ as e -> Fiber.return e
           | Ok `Eof -> Fiber.return (Ok None)
-          | Ok `Continue ->
-            let n' = Io_buffer.read_into_buffer in_buf buf ~max_len:n in
-            atom parser (n - n')
-      in
-      let+ res =
-        let* res =
-          Fiber.Mutex.with_lock read_mutex ~f:(fun () -> read Stack.Empty)
+          | Ok `Continue -> (
+            let char = Io_buffer.read_char_exn in_buf in
+            let token = Lexer.feed lexer char in
+            match token with
+            | Atom n ->
+              Buffer.clear buf;
+              atom parser n
+            | (Lparen | Rparen | Await) as token -> (
+              let parser = Stack.add_token token parser in
+              match parser with
+              | Sexp (sexp, Empty) -> Fiber.return (Ok (Some sexp))
+              | parser -> read parser))
+        and atom parser n =
+          if n = 0 then
+            let atom = Buffer.contents buf in
+            match Stack.add_atom atom parser with
+            | Sexp (sexp, Empty) -> Fiber.return (Ok (Some sexp))
+            | parser -> read parser
+          else
+            refill () >>= function
+            | Error _ as e -> Fiber.return e
+            | Ok `Eof -> Fiber.return (Ok None)
+            | Ok `Continue ->
+              let n' = Io_buffer.read_into_buffer in_buf buf ~max_len:n in
+              atom parser (n - n')
         in
-        match res with
-        | Error exn ->
-          Log.info
-            [ Pp.textf "Unable to read (%d)" (Id.to_int t.id); Exn.pp exn ];
-          Dune_util.Report_error.report_exception exn;
-          let+ () = close t in
-          None
-        | Ok None ->
-          let+ () = close t in
-          None
-        | Ok (Some sexp) -> Fiber.return @@ Some sexp
-      in
-      debug res;
-      res
+        let+ res =
+          let* res =
+            Fiber.Mutex.with_lock read_mutex ~f:(fun () -> read Stack.Empty)
+          in
+          match res with
+          | Error exn ->
+            Log.info
+              [ Pp.textf "Unable to read (%d)" (Id.to_int t.id); Exn.pp exn ];
+            Dune_util.Report_error.report_exception exn;
+            let+ () = close t in
+            None
+          | Ok None ->
+            let+ () = close t in
+            None
+          | Ok (Some sexp) -> Fiber.return @@ Some sexp
+        in
+        debug t.id res;
+        res
 
   external send : Unix.file_descr -> Bytes.t -> int -> int -> int = "dune_send"
 
@@ -275,38 +272,40 @@ module Session = struct
     let* () = Fiber.return () in
     if debug then
       Log.info
-        [ Pp.verbatim
-            (sprintf "RPC (%id) >>\n%s" (Id.to_int t.id)
-               (string_of_packets sexps))
+        [ Pp.verbatim (sprintf "RPC (%id) >>" (Id.to_int t.id))
+        ; Pp.concat_map sexps ~f:(fun sexp ->
+              Pp.seq (Pp.verbatim ">> ") (Pp.verbatim (Sexp.to_string sexp)))
         ; Pp.text ">>"
         ];
     match t.state with
-    | Closed -> (
-      match sexps with
-      | None -> Fiber.return ()
-      | Some sexps ->
-        Code_error.raise "attempting to write to a closed channel"
-          [ ("sexp", Dyn.(list Sexp.to_dyn) sexps) ])
+    | Closed ->
+      Code_error.raise "attempting to write to a closed channel"
+        [ ("sexp", Dyn.(list Sexp.to_dyn) sexps) ]
     | Open { fd; out_buf; write_mutex; _ } -> (
-      match sexps with
-      | None ->
-        (try
-           (* TODO this hack is temporary until we get rid of dune rpc init *)
-           Unix.shutdown fd Unix.SHUTDOWN_ALL
-         with Unix.Unix_error (_, _, _) -> ());
-        close t
-      | Some sexps -> (
-        let* res =
-          Fiber.Mutex.with_lock write_mutex ~f:(fun () ->
-              Io_buffer.write_csexps out_buf sexps;
-              let flush_token = Io_buffer.flush_token out_buf in
-              csexp_write_loop fd out_buf flush_token)
-        in
-        match res with
-        | Ok () -> Fiber.return ()
-        | Error error ->
-          let+ () = close t in
-          fail error))
+      let* res =
+        Fiber.Mutex.with_lock write_mutex ~f:(fun () ->
+            Io_buffer.write_csexps out_buf sexps;
+            let flush_token = Io_buffer.flush_token out_buf in
+            csexp_write_loop fd out_buf flush_token)
+      in
+      match res with
+      | Ok () -> Fiber.return ()
+      | Error error ->
+        let+ () = close t in
+        fail error)
+
+  let close t =
+    let* () = Fiber.return () in
+    if debug then
+      Log.info [ Pp.verbatim (sprintf "RPC (%id) >> closing" (Id.to_int t.id)) ];
+    match t.state with
+    | Closed -> Fiber.return ()
+    | Open { fd; _ } ->
+      (try
+         (* TODO this hack is temporary until we get rid of dune rpc init *)
+         Unix.shutdown fd Unix.SHUTDOWN_ALL
+       with Unix.Unix_error (_, _, _) -> ());
+      close t
 end
 
 module Server = struct

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -20,9 +20,11 @@ module Session : sig
       writing *)
   type t
 
+  val close : t -> unit Fiber.t
+
   (* [write t x] writes the s-expression when [x] is [Some sexp], and closes the
      session if [x = None ] *)
-  val write : t -> Sexp.t list option -> unit Fiber.t
+  val write : t -> Sexp.t list -> unit Fiber.t
 
   (** If [read] returns [None], the session is closed and all subsequent reads
       will return [None] *)

--- a/src/dune_rpc_client/client.ml
+++ b/src/dune_rpc_client/client.ml
@@ -1,6 +1,16 @@
 open Import
 open Fiber.O
-include Dune_rpc.Client.Make (Private.Fiber) (Csexp_rpc.Session)
+
+include
+  Dune_rpc.Client.Make
+    (Private.Fiber)
+    (struct
+      include Csexp_rpc.Session
+
+      let write t = function
+        | None -> close t
+        | Some packets -> write t packets
+    end)
 
 type chan = Csexp_rpc.Session.t
 
@@ -32,6 +42,6 @@ let client ?handler ~private_menu connection init ~f =
   let f client =
     Fiber.finalize
       (fun () -> f client)
-      ~finally:(fun () -> Csexp_rpc.Session.write connection None)
+      ~finally:(fun () -> Csexp_rpc.Session.close connection)
   in
   connect_with_menu ?handler ~private_menu connection init ~f

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -132,13 +132,15 @@ val make : 'a Handler.t -> t
 module Make (S : sig
   type t
 
-  (* [write t x] writes the s-expression when [x] is [Some _], and closes the
-     session if [x = None] *)
-  val write : t -> Sexp.t list option -> unit Fiber.t
+  (** [close t] closes the session *)
+  val close : t -> unit Fiber.t
 
-  (* [read t] attempts to read from [t]. If an s-expression is read, it is
-     returned as [Some sexp], otherwise [None] is returned and the session is
-     closed. *)
+  (** [write t x] writes the s-expression *)
+  val write : t -> Sexp.t list -> unit Fiber.t
+
+  (** [read t] attempts to read from [t]. If an s-expression is read, it is
+      returned as [Some sexp], otherwise [None] is returned and the session is
+      closed. *)
   val read : t -> Sexp.t option Fiber.t
 end) : sig
   (** [serve sessions handler] serve all [sessions] using [handler] *)

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -54,13 +54,13 @@ let%expect_test "csexp server life cycle" =
       (fun () ->
         let log fmt = Logger.log client_log fmt in
         let* client = Client.connect_exn client in
-        let* () = Session.write client (Some [ List [ Atom "from client" ] ]) in
+        let* () = Session.write client [ List [ Atom "from client" ] ] in
         log "written";
         let* response = Session.read client in
         (match response with
         | None -> log "no response"
         | Some sexp -> log "received %s" (Csexp.to_string sexp));
-        let* () = Session.write client None in
+        let* () = Session.close client in
         log "closed";
         Server.stop server)
       (fun () ->
@@ -75,7 +75,7 @@ let%expect_test "csexp server life cycle" =
                 Fiber.return ()
               | Some csexp ->
                 log "received %s" (Csexp.to_string csexp);
-                Session.write session (Some [ List [ Atom "from server" ] ]))
+                Session.write session [ List [ Atom "from server" ] ])
         in
         log "sessions finished")
   in


### PR DESCRIPTION
Instead of having a single function for closing and writing, we now have
two. The advantage is that the signature of our [close] function never
raises, so unlike [write] we don't need to worry handling errors.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b1910806-7812-4daa-9afc-8759dd5c953c -->