### PR TITLE
fix(rpc): do not ignore unsent notifications

### DIFF
--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -206,14 +206,11 @@ module Session = struct
   let of_stage1 (base : _ Stage1.t) handler =
     { base; handler; pollers = Dune_rpc_private.Id.Map.empty }
 
-  let notification t decl n =
-    let* () = Fiber.return () in
-    match V.Handler.prepare_notification t.handler decl with
-    | Error _ ->
-      (* cwong: What to do here? *)
-      Fiber.return ()
-    | Ok { Versioned.Staged.encode } ->
-      t.base.send (Some [ Notification (encode n) ])
+  let prepare_notification t decl =
+    V.Handler.prepare_notification t.handler decl
+
+  let send_notification t { Versioned.Staged.encode } n =
+    t.base.send (Some [ Notification (encode n) ])
 
   let request t decl id req =
     let* () = Fiber.return () in

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -16,9 +16,17 @@ module Session : sig
   (** [get session a] sets the current state to [a].*)
   val set : 'a t -> 'a -> unit
 
-  (** [notification session n a] Send notification [a] defined by [n] to
+  (** [prepare t n] prepares a notification [n] by checking if [t] supports it.
+      If it supports it, [Ok _] is returned. Otherwise [Error _] is returned. *)
+  val prepare_notification :
+       _ t
+    -> 'payload Decl.Notification.witness
+    -> ('payload Versioned.Staged.notification, Version_error.t) result
+
+  (** [send_notification session n a] Send notification [a] defined by [n] to
       [session] *)
-  val notification : _ t -> 'a Decl.Notification.witness -> 'a -> unit Fiber.t
+  val send_notification :
+    _ t -> 'a Versioned.Staged.notification -> 'a -> unit Fiber.t
 
   (** [request t r id payload] sends a request [r] to [t] with [id] and
       [payload].


### PR DESCRIPTION
If we try to send a notification that the client doens't understand, we
just drop it on the floor. Now, we raise a code error.

This new behavior isn't ideal, but it's better than leaving this
function in this state.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7cef6366-6207-486f-9ffb-3f10607504d8 -->