### PR TITLE
show: print_rules now part of show command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
 
 - Initialize async IO thread lazily. (#8122, @emillon)
 
+- Add `dune show rules` as alias of `dune rules` command. (#8000, @Alizter)
+
 - Add `dune build --dump-gc-stats FILE` argument to dump Garbage Collection
   stats to a named file. (#8072, @Alizter)
 

--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -13,6 +13,7 @@ let subcommands =
   ; Describe_opam_files.command
   ; Describe_pp.command
   ; Printenv.command
+  ; Print_rules.command
   ; Aliases_targets.Targets_cmd.command
   ; Aliases_targets.Aliases_cmd.command
   ]


### PR DESCRIPTION
- [x] changelog

Not sure if we want to mention `dune show rules` in help for `dune rules`.