### PR TITLE
refactor(dap): hide the implementation of dynamic dependencies

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -65,7 +65,7 @@ module Dynamic_dep = struct
 end
 
 module Exec_result = struct
-  type t = { dynamic_deps_stages : (Dynamic_dep.Set.t * Dep.Facts.t) List.t }
+  type t = { dynamic_deps_stages : (Dep.Set.t * Dep.Facts.t) list }
 end
 
 type done_or_more_deps =
@@ -540,9 +540,8 @@ let exec_until_all_deps_ready ~display ~ectx ~eenv t =
     match result with
     | Done -> Fiber.return stages
     | Need_more_deps (relative_deps, deps_to_build) ->
-      let* fact_map =
-        ectx.build_deps (Dynamic_dep.Set.to_dep_set deps_to_build)
-      in
+      let deps_to_build = Dynamic_dep.Set.to_dep_set deps_to_build in
+      let* fact_map = ectx.build_deps deps_to_build in
       let stages = (deps_to_build, fact_map) :: stages in
       let eenv =
         { eenv with

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -1,29 +1,12 @@
 open Import
 
-(** Type for dependency requested by the dynamic action.
-
-    Must be different from [Dep.t] type because we require it to be
-    marshallable. *)
-module Dynamic_dep : sig
-  type t =
-    | File of Path.t
-    | Glob of Path.t * Glob.t
-
-  val to_dep : t -> Dep.t
-
-  val compare : t -> t -> Ordering.t
-
-  module Map : Map.S with type key := t
-
-  module Set : sig
-    include Set.S with type elt = t and type 'a map = 'a Map.t
-
-    val to_dep_set : t -> Dep.Set.t
-  end
-end
-
 module Exec_result : sig
-  type t = { dynamic_deps_stages : (Dynamic_dep.Set.t * Dep.Facts.t) List.t }
+  type t =
+    { dynamic_deps_stages :
+        (* The set can be derived from the facts by getting the keys of the
+           facts map. We don't do it because conversion isn't free *)
+        (Dep.Set.t * Dep.Facts.t) list
+    }
 end
 
 type input =

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -14,7 +14,7 @@ module Workspace_local = struct
     module Entry = struct
       type t =
         { rule_digest : Digest.t
-        ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
+        ; dynamic_deps_stages : (Dep.Set.t * Digest.t) list
         ; targets_digest : Digest.t
         }
 
@@ -23,7 +23,7 @@ module Workspace_local = struct
           [ ("rule_digest", Digest.to_dyn rule_digest)
           ; ( "dynamic_deps_stages"
             , Dyn.list
-                (Dyn.pair Action_exec.Dynamic_dep.Set.to_dyn Digest.to_dyn)
+                (Dyn.pair Dep.Set.to_dyn Digest.to_dyn)
                 dynamic_deps_stages )
           ; ("targets_digest", Digest.to_dyn targets_digest)
           ]
@@ -167,7 +167,6 @@ module Workspace_local = struct
         match stages with
         | [] -> Fiber.return (Result.Hit produced_targets)
         | (deps, old_digest) :: rest -> (
-          let deps = Action_exec.Dynamic_dep.Set.to_dep_set deps in
           let open Fiber.O in
           let* deps = Memo.run (build_deps deps) in
           let new_digest = Dep.Facts.digest deps ~env in

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -25,7 +25,7 @@ module Workspace_local : sig
   val store :
        head_target:Path.Build.t
     -> rule_digest:Digest.t
-    -> dynamic_deps_stages:(Action_exec.Dynamic_dep.Set.t * Digest.t) list
+    -> dynamic_deps_stages:(Dep.Set.t * Digest.t) list
     -> targets_digest:Digest.t
     -> unit
 end


### PR DESCRIPTION
The representation of dynamic dependencies as they're implemented by DAP
is an implementation detail that the engine shouldn't be concerned with.

Instead, we reuse the standard representation of dependencies.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7ca7a61a-8237-4043-b716-a937b4073c22 -->