### PR TITLE
fix(rpc): proper finalization everywhere

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -132,8 +132,8 @@ module Clients = struct
     let result = { session } in
     Session.Id.Map.add_exn t id result
 
-  let remove_session t (session : _ Session.t) =
-    let id = Session.id session in
+  let remove_session t (session : _ Session.Stage1.t) =
+    let id = Session.Stage1.id session in
     Session.Id.Map.remove t id
 
   let to_list = Session.Id.Map.to_list
@@ -348,7 +348,7 @@ let handler (t : _ t Fdecl.t) action_runner_server handle :
       let terminate_sessions () =
         Fiber.fork_and_join_unit cancel_pending_jobs (fun () ->
             Fiber.parallel_iter (Clients.to_list t.clients)
-              ~f:(fun (_, entry) -> Session.Stage1.request_close entry.session))
+              ~f:(fun (_, entry) -> Session.Stage1.close entry.session))
       in
       let shutdown () =
         Fiber.fork_and_join_unit Scheduler.shutdown (fun () ->

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -60,7 +60,7 @@ module Session : sig
        session *)
     val initialize : _ t -> Initialize.Request.t
 
-    val request_close : 'a t -> unit Fiber.t
+    val close : 'a t -> unit Fiber.t
 
     val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
   end
@@ -75,7 +75,7 @@ module Handler : sig
   type 'a t
 
   val create :
-       ?on_terminate:('a Session.t -> unit Fiber.t)
+       ?on_terminate:('a Session.Stage1.t -> unit Fiber.t)
          (** Termination hook. It is guaranteed that the session state will not
              modified after this function is called *)
     -> on_init:('a Session.Stage1.t -> Initialize.Request.t -> 'a Fiber.t)


### PR DESCRIPTION
The callbacks to handle an RPC session are three fold:

1. `on_init` - called when the session is initiated
2. `on_upgrade` - called when a client and server agree on the common subset of rpc they can use
3. `on_terminate` - called when the session is terminated

We need to make sure the following two properties hold:

* When `on_init` is called, then `on_terminate` must also  be called
* When any of these raise, the appropriate finalizers are called

This PR makes sure that these properties hold. The tests demonstrate that this property didn't hold before, but now we can see everything is called correctly in the presence of exceptions.

@snowleopard this should fix the issue that we observe internally that some errors keep on looping. 