### PR TITLE
Lockdir package files have .pkg extension

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -53,6 +53,14 @@ val metadata : Filename.t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 
+module Package_filename : sig
+  type t = Filename.t
+
+  val of_package_name : Package_name.t -> t
+
+  val to_package_name : t -> (Package_name.t, [ `Bad_extension ]) result
+end
+
 val write_disk : lock_dir_path:Path.Source.t -> t -> unit
 
 val read_disk : lock_dir_path:Path.Source.t -> t Or_exn.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -89,9 +89,9 @@ module Lock_dir = struct
           Fs_cache.Dir_contents.to_list content
           |> List.filter_map ~f:(fun (name, (kind : Unix.file_kind)) ->
                  match kind with
-                 | S_REG when name <> metadata ->
-                   let name = Package.Name.of_string name in
-                   Some name
+                 | S_REG ->
+                   Lock_dir.Package_filename.to_package_name name
+                   |> Result.to_option
                  | _ ->
                    (* TODO *)
                    None)
@@ -99,7 +99,8 @@ module Lock_dir = struct
                  let+ package =
                    let+ sexp =
                      let path =
-                       Package.Name.to_string name |> Path.Source.relative path
+                       Lock_dir.Package_filename.of_package_name name
+                       |> Path.Source.relative path
                      in
                      Fs_memo.with_lexbuf_from_file (In_source_dir path)
                        ~f:(Dune_sexp.Parser.parse ~mode:Many)

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -5,9 +5,9 @@ Some environment variables are automatically exported by packages:
   > (lang package 0.1)
   > EOF
 
-  $ touch dune.lock/test
+  $ touch dune.lock/test.pkg
 
-  $ cat >dune.lock/usetest <<'EOF'
+  $ cat >dune.lock/usetest.pkg <<'EOF'
   > (deps test)
   > (build
   >  (system "\| echo MANPATH=$MANPATH

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -4,7 +4,7 @@ Packages can export environment variables
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (exported_env
   >  (= FOO bar)
   >  (= BAR xxx)
@@ -12,7 +12,7 @@ Packages can export environment variables
   >  (:= BAR zzz))
   > EOF
 
-  $ cat >dune.lock/usetest <<'EOF'
+  $ cat >dune.lock/usetest.pkg <<'EOF'
   > (deps test)
   > (version 1.2.3)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -7,7 +7,7 @@ Test that can fetch the sources from an external dir
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (source (copy $PWD/foo))
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -15,7 +15,7 @@ Test fetching from git
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (source (fetch (url "git+file://$MYGITREPO")))
   > (build (run cat foo))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -4,7 +4,7 @@ Install actions should have the switch directory prepared:
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<'EOF'
+  $ cat >dune.lock/test.pkg <<'EOF'
   > (install (system "find %{prefix} | sort"))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -4,7 +4,7 @@ Testing install actions
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<'EOF'
+  $ cat >dune.lock/test.pkg <<'EOF'
   > (install (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -5,7 +5,7 @@ Test missing entries in the .install file
   > (lang package 0.1)
   > EOF
   $ lockfile() {
-  > cat >dune.lock/test <<EOF
+  > cat >dune.lock/test.pkg <<EOF
   > (build
   >  (system "echo 'lib: [ \"$1\" ]' > test.install"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -4,7 +4,7 @@ Test that installed binaries are visible in dependent packages
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (build
   >  (system "\| echo "#!/bin/sh\necho from test package" > foo;
   >          "\| chmod +x foo;
@@ -18,7 +18,7 @@ Test that installed binaries are visible in dependent packages
   >  ))
   > EOF
 
-  $ cat >dune.lock/usetest <<EOF
+  $ cat >dune.lock/usetest.pkg <<EOF
   > (deps test)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -21,19 +21,19 @@ Run the solver and generate a lock directory.
 Print the name and contents of each file in the lock directory separated by
 "---", sorting by filename for consistency.
   $ find dune.lock -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"
-  dune.lock/bar:
+  dune.lock/bar.pkg:
   
   (version 0.4.0)
   
   ---
   
-  dune.lock/baz:
+  dune.lock/baz.pkg:
   
   (version 0.1.0)
   
   ---
   
-  dune.lock/foo:
+  dune.lock/foo.pkg:
   
   (version 0.0.1)
   (deps baz bar)

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -8,7 +8,7 @@ Additional files overlaid on top of the source can be found in the
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (source
   >  (copy $PWD/test-source))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -5,7 +5,7 @@ Applying patches
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (source (copy $PWD/test-source))
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -17,7 +17,7 @@ TODO: versioning will be added once this feature is stable
   $ cat >foo.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >foo.lock/test <<EOF
+  $ cat >foo.lock/test.pkg <<EOF
   > (build
   >  (system "echo building from %{context_name}"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -4,7 +4,7 @@ Test that we run the build command
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (build
   >  (progn
   >   (run mkdir -p %{prefix}/bin)

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -4,7 +4,7 @@ Test that we can set variables
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<EOF
+  $ cat >dune.lock/test.pkg <<EOF
   > (build
   >  (system "\| cat >test.config <<EOF
   >          "\| opam-version: "2.0"
@@ -17,7 +17,7 @@ Test that we can set variables
   >  ))
   > EOF
 
-  $ cat >dune.lock/usetest <<EOF
+  $ cat >dune.lock/usetest.pkg <<EOF
   > (deps test)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -4,7 +4,7 @@ Setting environment variables in actions
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat >dune.lock/test <<'EOF'
+  $ cat >dune.lock/test.pkg <<'EOF'
   > (build
   >  (withenv
   >   ((= FOO myfoo)


### PR DESCRIPTION
This will allow us to put a dune file in the lockdir without it conflicting with the package file for the package "dune".