### PR TITLE
feature(pkg): extra sources

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -4,12 +4,14 @@ open Import
 open Dune_lang
 
 module Source : sig
+  type fetch =
+    { url : Loc.t * string
+    ; checksum : (Loc.t * Checksum.t) option
+    }
+
   type t =
     | External_copy of Loc.t * Path.External.t
-    | Fetch of
-        { url : Loc.t * string
-        ; checksum : (Loc.t * Checksum.t) option
-        }
+    | Fetch of fetch
 end
 
 module Pkg_info : sig
@@ -18,6 +20,7 @@ module Pkg_info : sig
     ; version : string
     ; dev : bool
     ; source : Source.t option
+    ; extra_sources : (Path.Local.t * Source.t) list
     }
 end
 

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -355,6 +355,7 @@ let opam_package_to_lock_file_pkg ~repo_state ~local_packages opam_package =
     ; version
     ; dev
     ; source = None
+    ; extra_sources = []
     }
   in
   let opam_file =

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -1,0 +1,27 @@
+Fetch from more than one source
+
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+
+  $ mkdir foo
+  $ cat >foo/bar <<EOF
+  > this is bar
+  > EOF
+
+  $ cat >baz <<EOF
+  > this is baz
+  > EOF
+
+  $ cat >dune.lock/test.pkg <<EOF
+  > (source (copy $PWD/foo))
+  > (extra_sources (mybaz (copy $PWD/baz)))
+  > (build
+  >  (system "find . | sort -u"))
+  > EOF
+
+  $ dune build .pkg/test/target/
+  .
+  ./bar
+  ./mybaz

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -185,7 +185,12 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; install_command = None
            ; deps = []
            ; info =
-               { Lock_dir.Pkg_info.name; version; dev = false; source = None }
+               { Lock_dir.Pkg_info.name
+               ; version
+               ; dev = false
+               ; source = None
+               ; extra_sources = []
+               }
            ; exported_env = []
            } )
        in
@@ -205,7 +210,12 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               ; install_command = None
               ; deps = []
               ; info =
-                  { name = "bar"; version = "0.2.0"; dev = false; source = None }
+                  { name = "bar"
+                  ; version = "0.2.0"
+                  ; dev = false
+                  ; source = None
+                  ; extra_sources = []
+                  }
               ; exported_env = []
               }
           ; "foo" :
@@ -213,7 +223,12 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               ; install_command = None
               ; deps = []
               ; info =
-                  { name = "foo"; version = "0.1.0"; dev = false; source = None }
+                  { name = "foo"
+                  ; version = "0.1.0"
+                  ; dev = false
+                  ; source = None
+                  ; extra_sources = []
+                  }
               ; exported_env = []
               }
           }
@@ -226,6 +241,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     ~lock_dir:
       (let pkg_a =
          let name = Package_name.of_string "a" in
+         let extra_source : Lock_dir.Source.t =
+           External_copy (Loc.none, Path.External.of_string "/tmp/a")
+         in
          ( name
          , { Lock_dir.Pkg.build_command =
                Some
@@ -244,9 +262,13 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                { Lock_dir.Pkg_info.name
                ; version = "0.1.0"
                ; dev = false
-               ; source =
-                   Some
-                     (External_copy (Loc.none, Path.External.of_string "/tmp/a"))
+               ; source = Some extra_source
+               ; extra_sources =
+                   [ (Path.Local.of_string "one", extra_source)
+                   ; ( Path.Local.of_string "two"
+                     , Fetch { url = (Loc.none, "randomurl"); checksum = None }
+                     )
+                   ]
                }
            ; exported_env =
                [ { Action.Env_update.op = Eq
@@ -277,6 +299,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                                   "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
                               )
                         })
+               ; extra_sources = []
                }
            ; exported_env = []
            } )
@@ -297,6 +320,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                         { url = (Loc.none, "https://github.com/foo/c")
                         ; checksum = None
                         })
+               ; extra_sources = []
                }
            ; exported_env = []
            } )
@@ -318,6 +342,10 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; version = "0.1.0"
                   ; dev = false
                   ; source = Some External_copy External "/tmp/a"
+                  ; extra_sources =
+                      [ ("one", External_copy External "/tmp/a")
+                      ; ("two", Fetch "randomurl",None)
+                      ]
                   }
               ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
               }
@@ -334,6 +362,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                         Fetch
                           "https://github.com/foo/b",Some
                                                        "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                  ; extra_sources = []
                   }
               ; exported_env = []
               }
@@ -346,6 +375,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; version = "0.2"
                   ; dev = false
                   ; source = Some Fetch "https://github.com/foo/c",None
+                  ; extra_sources = []
                   }
               ; exported_env = []
               }


### PR DESCRIPTION
Opam allows for additional file sources to be specified. We add support
for these.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 25a0bd32-d5a1-45f9-8cee-bdaf7aeead46 -->