### PR TITLE
Prefer oldest dependencies by default while solving packages

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -156,6 +156,13 @@ module Lock = struct
       Arg.(
         value & flag
         & info [ "all-contexts" ] ~doc:"Generate the lockdir for all contexts")
+    and+ prefer_oldest =
+      Arg.(
+        value & flag
+        & info [ "prefer-oldest" ]
+            ~doc:
+              "Use the oldest possible version of packages when solving \
+               dependencies")
     in
     let common = Common.forbid_builds common in
     let config = Common.init common in
@@ -173,7 +180,7 @@ module Lock = struct
        effects after performing validation so that if materializing any
        lockdir would fail then no side effect takes place. *)
     let summary, lock_dir =
-      Dune_pkg.Opam.solve_lock_dir ~repo_selection opam_file_map
+      Dune_pkg.Opam.solve_lock_dir ~repo_selection ~prefer_oldest opam_file_map
     in
     Console.print_user_message
       (Dune_pkg.Opam.Summary.selected_packages_message summary);

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -299,13 +299,13 @@ let solve_package_list local_packages context =
   | Error e -> User_error.raise [ Pp.text (Solver.diagnostics e) ]
   | Ok packages -> Solver.packages_of_result packages
 
-let solve_lock_dir ~repo_selection local_packages =
+let solve_lock_dir ~repo_selection ~prefer_oldest local_packages =
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
   Repo_selection.with_state repo_selection ~f:(fun repo_state ->
       let context =
-        Repo_state.create_context repo_state local_packages ~prefer_oldest:true
+        Repo_state.create_context repo_state local_packages ~prefer_oldest
       in
       let opam_packages_to_lock =
         solve_package_list local_packages context

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -177,109 +177,7 @@ module Local_repo_with_env = struct
     }
 end
 
-module Opam_solver = struct
-  module type CONTEXT = Opam_0install.S.CONTEXT
-
-  (* Helper functor which implements [CONTEXT] for [(L.t, R.t) Either.t] where
-     [L] and [R] both implement [CONTEXT] *)
-  module Context_either (L : CONTEXT) (R : CONTEXT) :
-    CONTEXT with type t = (L.t, R.t) Either.t = struct
-    type t = (L.t, R.t) Either.t
-
-    type rejection = (L.rejection, R.rejection) Either.t
-
-    let pp_rejection f = function
-      | Left l -> L.pp_rejection f l
-      | Right r -> R.pp_rejection f r
-
-    let candidates t name =
-      let convert_rejections ~f =
-        List.map ~f:(fun (version, result) ->
-            (version, Result.map_error ~f result))
-      in
-      match t with
-      | Left l -> L.candidates l name |> convert_rejections ~f:Either.left
-      | Right r -> R.candidates r name |> convert_rejections ~f:Either.right
-
-    let user_restrictions = function
-      | Left l -> L.user_restrictions l
-      | Right r -> R.user_restrictions r
-
-    let filter_deps = function
-      | Left l -> L.filter_deps l
-      | Right r -> R.filter_deps r
-  end
-
-  (* Helper functor which adds a set of local packages to a [CONTEXT] *)
-  module Context_with_local_packages (Base_context : CONTEXT) : sig
-    include CONTEXT
-
-    val create :
-         base_context:Base_context.t
-      -> local_packages:OpamFile.OPAM.t OpamPackage.Name.Map.t
-      -> t
-  end = struct
-    let local_package_default_version = OpamPackage.Version.of_string "LOCAL"
-
-    type t =
-      { base_context : Base_context.t
-      ; local_packages : OpamFile.OPAM.t OpamPackage.Name.Map.t
-      }
-
-    let create ~base_context ~local_packages = { base_context; local_packages }
-
-    type rejection = Base_context.rejection
-
-    let pp_rejection = Base_context.pp_rejection
-
-    let candidates t name =
-      match OpamPackage.Name.Map.find_opt name t.local_packages with
-      | None -> Base_context.candidates t.base_context name
-      | Some opam_file ->
-        let version =
-          Option.value opam_file.version ~default:local_package_default_version
-        in
-        [ (version, Ok opam_file) ]
-
-    let user_restrictions t = Base_context.user_restrictions t.base_context
-
-    let filter_deps t = Base_context.filter_deps t.base_context
-  end
-
-  (* A [CONTEXT] that can be based on an opam repository in a local directory
-     or an opam repository taken from the current switch with an additional set
-     of local packages *)
-  module Context = struct
-    module Dir_context = Opam_0install.Dir_context
-    module Switch_context = Opam_0install.Switch_context
-    include
-      Context_with_local_packages (Context_either (Dir_context) (Switch_context))
-
-    let prefer_oldest = true
-
-    let create_dir_context ~local_repo_with_env ~local_packages =
-      let { Local_repo_with_env.local_repo = { Local_repo.packages_dir_path }
-          ; env
-          } =
-        local_repo_with_env
-      in
-      let env name = Env.find_by_name env ~name in
-      let dir_context =
-        Dir_context.create ~prefer_oldest
-          ~constraints:OpamPackage.Name.Map.empty ~env packages_dir_path
-      in
-      create ~base_context:(Left dir_context) ~local_packages
-
-    let create_switch_context ~switch_state ~local_packages =
-      let switch_context =
-        Switch_context.create ~prefer_oldest
-          ~constraints:OpamPackage.Name.Map.empty switch_state
-      in
-      create ~base_context:(Right switch_context) ~local_packages
-  end
-end
-
-module Solver = Opam_0install.Solver.Make (Opam_solver.Context)
+module Solver = Opam_0install.Solver.Make (Opam_solver.Context_for_dune)
 
 module Repo_state = struct
   type t =
@@ -292,13 +190,15 @@ module Repo_state = struct
     | Local_repo_with_env { local_repo; _ } ->
       Local_repo.load_opam_package local_repo opam_package
 
-  let create_context t local_packages =
+  let create_context t local_packages ~prefer_oldest =
     match t with
     | Switch switch_state ->
-      Opam_solver.Context.create_switch_context ~local_packages ~switch_state
-    | Local_repo_with_env local_repo_with_env ->
-      Opam_solver.Context.create_dir_context ~local_packages
-        ~local_repo_with_env
+      Opam_solver.Context_for_dune.create_switch_context ~prefer_oldest
+        ~local_packages ~switch_state
+    | Local_repo_with_env { local_repo = { packages_dir_path }; env } ->
+      Opam_solver.Context_for_dune.create_dir_context ~prefer_oldest
+        ~env:(fun name -> Env.find_by_name env ~name)
+        ~packages_dir_path ~local_packages
 end
 
 module Repo_selection = struct
@@ -404,7 +304,9 @@ let solve_lock_dir ~repo_selection local_packages =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
   Repo_selection.with_state repo_selection ~f:(fun repo_state ->
-      let context = Repo_state.create_context repo_state local_packages in
+      let context =
+        Repo_state.create_context repo_state local_packages ~prefer_oldest:true
+      in
       let opam_packages_to_lock =
         solve_package_list local_packages context
         (* don't include local packages in the lock dir *)

--- a/src/dune_pkg/opam.mli
+++ b/src/dune_pkg/opam.mli
@@ -53,5 +53,6 @@ end
 
 val solve_lock_dir :
      repo_selection:Repo_selection.t
+  -> prefer_oldest:bool
   -> OpamFile.OPAM.t OpamTypes.name_map
   -> Summary.t * Lock_dir.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1,0 +1,91 @@
+open Stdune
+
+module type CONTEXT = Opam_0install.S.CONTEXT
+
+(* Helper functor which implements [CONTEXT] for [(L.t, R.t) Either.t] where
+   [L] and [R] both implement [CONTEXT] *)
+module Context_either (L : CONTEXT) (R : CONTEXT) :
+  CONTEXT with type t = (L.t, R.t) Either.t = struct
+  type t = (L.t, R.t) Either.t
+
+  type rejection = (L.rejection, R.rejection) Either.t
+
+  let pp_rejection f = function
+    | Left l -> L.pp_rejection f l
+    | Right r -> R.pp_rejection f r
+
+  let candidates t name =
+    let convert_rejections ~f =
+      List.map ~f:(fun (version, result) ->
+          (version, Result.map_error ~f result))
+    in
+    match t with
+    | Left l -> L.candidates l name |> convert_rejections ~f:Either.left
+    | Right r -> R.candidates r name |> convert_rejections ~f:Either.right
+
+  let user_restrictions = function
+    | Left l -> L.user_restrictions l
+    | Right r -> R.user_restrictions r
+
+  let filter_deps = function
+    | Left l -> L.filter_deps l
+    | Right r -> R.filter_deps r
+end
+
+(* Helper functor which adds a set of local packages to a [CONTEXT] *)
+module Context_with_local_packages (Base_context : CONTEXT) : sig
+  include CONTEXT
+
+  val create :
+       base_context:Base_context.t
+    -> local_packages:OpamFile.OPAM.t OpamPackage.Name.Map.t
+    -> t
+end = struct
+  let local_package_default_version = OpamPackage.Version.of_string "LOCAL"
+
+  type t =
+    { base_context : Base_context.t
+    ; local_packages : OpamFile.OPAM.t OpamPackage.Name.Map.t
+    }
+
+  let create ~base_context ~local_packages = { base_context; local_packages }
+
+  type rejection = Base_context.rejection
+
+  let pp_rejection = Base_context.pp_rejection
+
+  let candidates t name =
+    match OpamPackage.Name.Map.find_opt name t.local_packages with
+    | None -> Base_context.candidates t.base_context name
+    | Some opam_file ->
+      let version =
+        Option.value opam_file.version ~default:local_package_default_version
+      in
+      [ (version, Ok opam_file) ]
+
+  let user_restrictions t = Base_context.user_restrictions t.base_context
+
+  let filter_deps t = Base_context.filter_deps t.base_context
+end
+
+module Context_for_dune = struct
+  module Dir_context = Opam_0install.Dir_context
+  module Switch_context = Opam_0install.Switch_context
+  include
+    Context_with_local_packages (Context_either (Dir_context) (Switch_context))
+
+  let create_dir_context ~prefer_oldest ~env ~packages_dir_path ~local_packages
+      =
+    let dir_context =
+      Dir_context.create ~prefer_oldest ~constraints:OpamPackage.Name.Map.empty
+        ~env packages_dir_path
+    in
+    create ~base_context:(Left dir_context) ~local_packages
+
+  let create_switch_context ~prefer_oldest ~switch_state ~local_packages =
+    let switch_context =
+      Switch_context.create ~prefer_oldest
+        ~constraints:OpamPackage.Name.Map.empty switch_state
+    in
+    create ~base_context:(Right switch_context) ~local_packages
+end

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -1,0 +1,18 @@
+open Stdune
+
+module Context_for_dune : sig
+  include Opam_0install.S.CONTEXT
+
+  val create_dir_context :
+       prefer_oldest:bool
+    -> env:(string -> OpamVariable.variable_contents option)
+    -> packages_dir_path:Filename.t
+    -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
+    -> t
+
+  val create_switch_context :
+       prefer_oldest:bool
+    -> switch_state:OpamStateTypes.unlocked OpamStateTypes.switch_state
+    -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
+    -> t
+end

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -43,7 +43,7 @@ Test that we get an error if an opam context is specified.
 Generate the lockdir for the default context.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   Selected the following packages:
-  bar.0.4.0
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -59,7 +59,7 @@ Only foo.lock (the default context's lockdir) was generated.
 Generate the lockdir with the default context explicitly specified.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
   Selected the following packages:
-  bar.0.4.0
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -75,7 +75,7 @@ Again, only foo.lock (the default context's lockdir) was generated.
 Generate the lockdir for the non-default context.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=foo
   Selected the following packages:
-  bar.0.4.0
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -91,7 +91,7 @@ Now only bar.lock was generated.
 Generate the lockdir for all (non-opam) contexts.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
   Selected the following packages:
-  bar.0.4.0
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -14,7 +14,7 @@ Generate a `dune-project` file.
 Run the solver and generate a lock directory.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   Selected the following packages:
-  bar.0.4.0
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -23,7 +23,7 @@ Print the name and contents of each file in the lock directory separated by
   $ find dune.lock -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"
   dune.lock/bar.pkg:
   
-  (version 0.4.0)
+  (version 0.5.0)
   
   
   ---
@@ -50,6 +50,13 @@ Print the name and contents of each file in the lock directory separated by
   
   ---
   
+
+Run the solver again passing --prefer-oldest
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --prefer-oldest
+  Selected the following packages:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
 
 Regenerate the `dune-project` file introducing an unsatisfiable constraint.
   $ cat >dune-project <<EOF


### PR DESCRIPTION
This changes the default behaviour of `dune pkg lock` to prefer the newest versions of its dependencies and adds a flag to change it to prefer the oldest versions.

I also include a change that refactors the opam solver code into its own file to help readability.