### PR TITLE
feature: allow arch_sixtyfour in enabled_if

### DIFF
--- a/doc/changes/8023.md
+++ b/doc/changes/8023.md
@@ -1,0 +1,3 @@
+
+- `enabled_if` now supports `arch_sixtyfour` variable (#8023, fixes #7997,
+  @Alizter)

--- a/src/dune_rules/enabled_if.ml
+++ b/src/dune_rules/enabled_if.ml
@@ -18,6 +18,7 @@ let common_vars_list =
   ; "profile"
   ; "ocaml_version"
   ; "context_name"
+  ; "arch_sixtyfour"
   ]
 ;;
 
@@ -27,6 +28,7 @@ let common_vars ~since =
        ~f:(fun var ->
          match var with
          | "context_name" -> var, (2, 7)
+         | "arch_sixtyfour" -> var, (3, 11)
          | _ -> var, since)
        common_vars_list)
 ;;

--- a/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/dune
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/dune
@@ -1,0 +1,4 @@
+(executable
+ (name hello)
+ (enabled_if
+  (= %{arch_sixtyfour} %{arch_sixtyfour})))

--- a/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/hello.ml
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/hello.ml
@@ -1,0 +1,1 @@
+let () = Printf.printf "Hello, World!\n"

--- a/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-arch_sixtyfour.t/run.t
@@ -1,0 +1,22 @@
+Testing %{arch_sixtyfour} in enabled_if
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.11)
+  > EOF
+
+  $ dune exec -- ./hello.exe
+  Hello, World!
+
+Testing the version guard
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.10)
+  > EOF
+
+  $ dune exec -- ./hello.exe
+  File "dune", line 4, characters 5-22:
+  4 |   (= %{arch_sixtyfour} %{arch_sixtyfour})))
+           ^^^^^^^^^^^^^^^^^
+  Error: %{arch_sixtyfour} is only available since version 3.11 of the dune
+  language. Please update your dune-project file to have (lang dune 3.11).
+  [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-exec-forbidden_var.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-exec-forbidden_var.t/run.t
@@ -8,9 +8,9 @@ The next ones use forbidden variables For dune 2.3 -> 2.5 it is a warning
   3 |  (enabled_if (<> %{project_root} "")))
                        ^^^^^^^^^^^^^^^
   Warning: Only architecture, system, model, os_type, ccomp_type, profile,
-  ocaml_version and context_name variables are allowed in this 'enabled_if'
-  field. If you think that project_root should also be allowed, please file an
-  issue about it.
+  ocaml_version, context_name and arch_sixtyfour variables are allowed in this
+  'enabled_if' field. If you think that project_root should also be allowed,
+  please file an issue about it.
   bar
 
 For dune >= 2.6 it is an error
@@ -22,7 +22,7 @@ For dune >= 2.6 it is an error
   3 |  (enabled_if (<> %{project_root} "")))
                        ^^^^^^^^^^^^^^^
   Error: Only architecture, system, model, os_type, ccomp_type, profile,
-  ocaml_version and context_name variables are allowed in this 'enabled_if'
-  field. If you think that project_root should also be allowed, please file an
-  issue about it.
+  ocaml_version, context_name and arch_sixtyfour variables are allowed in this
+  'enabled_if' field. If you think that project_root should also be allowed,
+  please file an issue about it.
   [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-install-forbidden_var.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-install-forbidden_var.t/run.t
@@ -4,7 +4,7 @@ Tests for enabled_if in install stanza using forbidden variable.
   6 |  (enabled_if (= %{project_root} ""))
                       ^^^^^^^^^^^^^^^
   Error: Only architecture, system, model, os_type, ccomp_type, profile,
-  ocaml_version and context_name variables are allowed in this 'enabled_if'
-  field. If you think that project_root should also be allowed, please file an
-  issue about it.
+  ocaml_version, context_name and arch_sixtyfour variables are allowed in this
+  'enabled_if' field. If you think that project_root should also be allowed,
+  please file an issue about it.
   [1]


### PR DESCRIPTION
We allow the `arch_sixtyfour` variable in `enabled_if`.

- fix #7997 
- [x] changelog
- [ ] docs (apparently we don't document enabled_if in this much detail).
- [x] tests