### PR TITLE
Prefer newest packages by default

### DIFF
--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -177,6 +177,31 @@ module Local_repo_with_env = struct
     }
 end
 
+module Version_preference = struct
+  type t =
+    | Newest
+    | Oldest
+
+  let equal a b =
+    match (a, b) with
+    | Newest, Newest | Oldest, Oldest -> true
+    | _ -> false
+
+  let to_string = function
+    | Newest -> "newest"
+    | Oldest -> "oldest"
+
+  let to_dyn t = Dyn.variant (to_string t) []
+
+  let default = Newest
+
+  let all = [ Newest; Oldest ]
+
+  let all_by_string = List.map all ~f:(fun t -> (to_string t, t))
+
+  let decode = Dune_sexp.Decoder.enum all_by_string
+end
+
 module Opam_solver = struct
   module type CONTEXT = Opam_0install.S.CONTEXT
 
@@ -255,9 +280,7 @@ module Opam_solver = struct
     include
       Context_with_local_packages (Context_either (Dir_context) (Switch_context))
 
-    let prefer_oldest = true
-
-    let create_dir_context ~local_repo_with_env ~local_packages =
+    let create_dir_context ~prefer_oldest ~local_repo_with_env ~local_packages =
       let { Local_repo_with_env.local_repo = { Local_repo.packages_dir_path }
           ; env
           } =
@@ -270,7 +293,7 @@ module Opam_solver = struct
       in
       create ~base_context:(Left dir_context) ~local_packages
 
-    let create_switch_context ~switch_state ~local_packages =
+    let create_switch_context ~prefer_oldest ~switch_state ~local_packages =
       let switch_context =
         Switch_context.create ~prefer_oldest
           ~constraints:OpamPackage.Name.Map.empty switch_state
@@ -329,18 +352,21 @@ end
 module Summary = struct
   type t = { opam_packages_to_lock : OpamPackage.t list }
 
-  let selected_packages_message t =
-    match t.opam_packages_to_lock with
-    | [] ->
-      User_message.make
-        [ Pp.tag User_message.Style.Success (Pp.text "No dependencies to lock")
+  let selected_packages_message t ~lock_dir_path =
+    let parts =
+      match t.opam_packages_to_lock with
+      | [] ->
+        [ Pp.tag User_message.Style.Success
+            (Pp.text "(no dependencies to lock)")
         ]
-    | opam_packages_to_lock ->
-      User_message.make
-        (Pp.tag User_message.Style.Success
-           (Pp.text "Selected the following packages:")
-        :: List.map opam_packages_to_lock ~f:(fun package ->
-               Pp.text (OpamPackage.to_string package)))
+      | opam_packages_to_lock ->
+        List.map opam_packages_to_lock ~f:(fun package ->
+            Pp.text (OpamPackage.to_string package))
+    in
+    User_message.make
+      (Pp.textf "Solution for %s:"
+         (Path.Source.to_string_maybe_quoted lock_dir_path)
+      :: parts)
 end
 
 let opam_package_to_lock_file_pkg ~repo_state ~local_packages opam_package =
@@ -399,12 +425,19 @@ let solve_package_list local_packages context =
   | Error e -> User_error.raise [ Pp.text (Solver.diagnostics e) ]
   | Ok packages -> Solver.packages_of_result packages
 
-let solve_lock_dir ~repo_selection local_packages =
+let solve_lock_dir ~version_preference ~repo_selection local_packages =
+  let prefer_oldest =
+    match (version_preference : Version_preference.t) with
+    | Oldest -> true
+    | Newest -> false
+  in
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
   Repo_selection.with_state repo_selection ~f:(fun repo_state ->
-      let context = Repo_state.create_context repo_state local_packages in
+      let context =
+        Repo_state.create_context repo_state local_packages ~prefer_oldest
+      in
       let opam_packages_to_lock =
         solve_package_list local_packages context
         (* don't include local packages in the lock dir *)

--- a/src/dune_pkg/opam.mli
+++ b/src/dune_pkg/opam.mli
@@ -48,10 +48,30 @@ module Summary : sig
   type t
 
   (** A message listing selected packages *)
-  val selected_packages_message : t -> User_message.t
+  val selected_packages_message :
+    t -> lock_dir_path:Path.Source.t -> User_message.t
+end
+
+module Version_preference : sig
+  type t =
+    | Newest
+    | Oldest
+
+  val equal : t -> t -> bool
+
+  val to_string : t -> string
+
+  val to_dyn : t -> Dyn.t
+
+  val default : t
+
+  val all_by_string : (string * t) list
+
+  val decode : t Dune_sexp.Decoder.t
 end
 
 val solve_lock_dir :
-     repo_selection:Repo_selection.t
+     version_preference:Version_preference.t
+  -> repo_selection:Repo_selection.t
   -> OpamFile.OPAM.t OpamTypes.name_map
   -> Summary.t * Lock_dir.t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -568,6 +568,7 @@ end = struct
     match context with
     | Default
         { lock = _
+        ; version_preference = _
         ; base =
             { targets
             ; name

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -48,6 +48,7 @@ module Context : sig
     type t =
       { base : Common.t
       ; lock : Path.Source.t option
+      ; version_preference : Dune_pkg.Opam.Version_preference.t option
       }
   end
 

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -1,12 +1,14 @@
 Create a lock directory that didn't originally exist
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  No dependencies to lock
+  Solution for dune.lock:
+  (no dependencies to lock)
   $ cat dune.lock/lock.dune
   (lang package 0.1)
 
 Re-create a lock directory in the newly created lock dir
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  No dependencies to lock
+  Solution for dune.lock:
+  (no dependencies to lock)
   $ cat dune.lock/lock.dune
   (lang package 0.1)
 
@@ -14,7 +16,8 @@ Attempt to create a lock directory inside an existing directory without a lock.d
   $ rm -rf dune.lock
   $ cp -r dir-without-metadata dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  No dependencies to lock
+  Solution for dune.lock:
+  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir lacks metadata file (lock.dune)
   [1]
@@ -23,7 +26,8 @@ Attempt to create a lock directory inside an existing directory with an invalid 
   $ rm -rf dune.lock
   $ cp -r dir-with-invalid-metadata dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  No dependencies to lock
+  Solution for dune.lock:
+  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   File "dune.lock/lock.dune", line 1, characters 0-12:
   Error: Invalid first line, expected: (lang <lang> <version>)
@@ -34,7 +38,8 @@ Attempt to create a lock directory with the same name as an existing regular fil
   $ rm -rf dune.lock
   $ touch dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  No dependencies to lock
+  Solution for dune.lock:
+  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir path is not a directory
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -7,7 +7,13 @@ Create a workspace with multiple contexts, each specifying a lockdir name.
   > (context
   >  (default
   >   (name foo)
+  >   (version_preference newest) ; this is the default
   >   (lock bar.lock)))
+  > (context
+  >  (default
+  >   (name prefers_oldest)
+  >   (version_preference oldest)
+  >   (lock prefers_oldest.lock)))
   > (context
   >  (opam
   >   (name bar)
@@ -42,8 +48,8 @@ Test that we get an error if an opam context is specified.
 
 Generate the lockdir for the default context.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  Selected the following packages:
-  bar.0.4.0
+  Solution for foo.lock:
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -58,8 +64,8 @@ Only foo.lock (the default context's lockdir) was generated.
 
 Generate the lockdir with the default context explicitly specified.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
-  Selected the following packages:
-  bar.0.4.0
+  Solution for foo.lock:
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -74,8 +80,8 @@ Again, only foo.lock (the default context's lockdir) was generated.
 
 Generate the lockdir for the non-default context.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=foo
-  Selected the following packages:
-  bar.0.4.0
+  Solution for bar.lock:
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -88,10 +94,33 @@ Now only bar.lock was generated.
   bar.lock/lock.dune
   $ rm -rf *.lock
 
+Generate the lockdir for a context which prefers oldest package versions.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=prefers_oldest
+  Solution for prefers_oldest.lock:
+  bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+
+Re-generate the lockdir for a context which prefers oldest package versions,
+but override it to prefer newest with a command line argument.
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=prefers_oldest --version-preference=newest
+  Solution for prefers_oldest.lock:
+  bar.0.5.0
+  baz.0.1.0
+  foo.0.0.1
+
 Generate the lockdir for all (non-opam) contexts.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
-  Selected the following packages:
+  Solution for prefers_oldest.lock:
   bar.0.4.0
+  baz.0.1.0
+  foo.0.0.1
+  Solution for bar.lock:
+  bar.0.5.0
+  baz.0.1.0
+  foo.0.0.1
+  Solution for foo.lock:
+  bar.0.5.0
   baz.0.1.0
   foo.0.0.1
 
@@ -107,4 +136,9 @@ Now both lockdirs were generated.
   foo.lock/baz.pkg
   foo.lock/foo.pkg
   foo.lock/lock.dune
+  prefers_oldest.lock
+  prefers_oldest.lock/bar.pkg
+  prefers_oldest.lock/baz.pkg
+  prefers_oldest.lock/foo.pkg
+  prefers_oldest.lock/lock.dune
   $ rm -rf *.lock

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -13,14 +13,55 @@ Generate a `dune-project` file.
 
 Run the solver and generate a lock directory.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  Selected the following packages:
+  Solution for dune.lock:
+  bar.0.5.0
+  baz.0.1.0
+  foo.0.0.1
+
+Helper to the name and contents of each file in the lock directory separated by
+"---", sorting by filename for consistency.
+  $ print_all() { find dune.lock -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"; }
+
+Print the contents of each file in the lockdir:
+  $ print_all
+  dune.lock/bar.pkg:
+  
+  (version 0.5.0)
+  
+  
+  ---
+  
+  dune.lock/baz.pkg:
+  
+  (version 0.1.0)
+  
+  
+  ---
+  
+  dune.lock/foo.pkg:
+  
+  (version 0.0.1)
+  (deps baz bar)
+  
+  
+  ---
+  
+  dune.lock/lock.dune:
+  
+  (lang package 0.1)
+  
+  
+  ---
+  
+
+Run the solver again preferring oldest versions of dependencies:
+  $ dune pkg lock --opam-env=pure --version-preference=oldest --opam-repository=mock-opam-repository
+  Solution for dune.lock:
   bar.0.4.0
   baz.0.1.0
   foo.0.0.1
 
-Print the name and contents of each file in the lock directory separated by
-"---", sorting by filename for consistency.
-  $ find dune.lock -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"
+  $ print_all
   dune.lock/bar.pkg:
   
   (version 0.4.0)


### PR DESCRIPTION
Based on the discussion at https://github.com/ocaml/dune/issues/8021, dune will prefer the newest versions of packages when solving dependencies. This policy can be configured by a command line argument to `dune pkg lock` and by a field of each context in dune-workspace.

This change includes some formatting changes to the messages printed when solving dependencies which were necessary to handle the fact that different build contexts can now have different package solutions.