### PR TITLE
fix: correctly terminate jobs

### DIFF
--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -775,8 +775,8 @@ let run_internal ?dir ~(display : Display.t) ?(stdout_to = Io.stdout)
       in
       Io.release stdout_to;
       Io.release stderr_to;
-      let* process_info =
-        Scheduler.wait_for_process pid ~is_process_group_leader:true
+      let* process_info, _termination_reason =
+        Scheduler.wait_for_build_process pid ~is_process_group_leader:true
       in
       let+ () = Running_jobs.stop id in
       let times =

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -100,6 +100,16 @@ val wait_for_process :
   -> Pid.t
   -> Proc.Process_info.t Fiber.t
 
+type termination_reason =
+  | Normal
+  | Cancel
+
+val wait_for_build_process :
+     ?timeout:float
+  -> ?is_process_group_leader:bool
+  -> Pid.t
+  -> (Proc.Process_info.t * termination_reason) Fiber.t
+
 (** If the current build was cancelled, raise
     [Memo.Non_reproducible Run.Build_cancelled]. *)
 val abort_if_build_was_cancelled : unit Fiber.t


### PR DESCRIPTION
Previously, we would raise on cancelled jobs. This would introduce the
following two bugs:

* It would leak resources that were supposed to be released after the
  proces terminated
* We would not report running jobs correctly.

This PR fixes both issues.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0e10c6a8-5865-40a8-8bcf-14878440ae97 -->