### PR TITLE
refactor(engine): optimize sandbox config storage

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -235,7 +235,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 19
+  let rule_digest_version = 20
 
   let compute_rule_digest
     (rule : Rule.t)

--- a/src/dune_engine/sandbox_config.ml
+++ b/src/dune_engine/sandbox_config.ml
@@ -70,5 +70,5 @@ module Partial = struct
 end
 
 let disallow (mode : Sandbox_mode.t) =
-  Sandbox_mode.Dict.of_func (fun mode' -> not (Sandbox_mode.equal mode mode'))
+  Sandbox_mode.Set.of_func (fun mode' -> not (Sandbox_mode.equal mode mode'))
 ;;

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -53,8 +53,8 @@ module Dict : sig
 end
 
 module Set : sig
-  type key = t
-  type t = bool Dict.t
+  type key := t
+  type t
 
   val singleton : key -> t
 

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [4c8aba9580c271d7ac111bf2d72a147a] (_build/default/source): not found in cache
+  Shared cache miss [790009feab9e691c98ad47625fd7047a] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [68e477811b0e612a0cc0bb83c205420a] (_build/default/target1): not found in cache
+  Shared cache miss [3aa5494f9cb89c79b5f41e9c6123a666] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [4a1c82562ca4c3348fe36436814a9842] (_build/default/source): not found in cache
+  Shared cache miss [1b443618b766306bf5c4846b19349675] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [3ffbc9519f4ca5e44997bf8ba62de0bb] (_build/default/target1): not found in cache
+  Shared cache miss [44158ca8448d6bb0366c050c668a168c] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [761869532e88535d64e09b60102c4416]: ((in_cache
+  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [761869532e88535d64e09b60102c4416]: ((in_cache
+  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [761869532e88535d64e09b60102c4416]: ((in_cache
+  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./50/50673e014878b6b71ee39f1f32ca4726:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./8f/8f658cc1fc1f083f42e98bbcd5a6ce2f:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./57/572f0d07f15fafa10217f0f78d2d4f39:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./5a/5a512ee6d64f5d7a29d7863269566506:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-e7a0efae1209023d2186a50341cd25fa
+  _build/.actions/default/blah-61c2a19beb7c9447302b9348604599d6
 
 And we check that it isn't copied in the source tree:
 


### PR DESCRIPTION
We store a sandbox configuration set for every single action we create.
For a large build, this can add up.

Our old representation was taking 6 words to represent this. This PR
changes it to use only a single word. Moreover, this new set now opaque
to the GC, speeds up comparison, hashing, etc.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8d6ab81b-57f7-4c94-b39c-617e78e9479d -->