### PR TITLE
dune_util: record exceptions to the _build/log

### DIFF
--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -197,6 +197,7 @@ let gen_report exn backtrace =
       | User -> msg
       | Developer -> append msg (i_must_not_crash ())
     in
+    Log.info_user_message msg;
     Console.print_user_message msg
 
 let report { Exn_with_backtrace.exn; backtrace } =


### PR DESCRIPTION
There are times when the detailed error becomes unavailable to view in the terminal such as when working with tui. Therefore recording them to the _build/log can help record what went wrong.