### PR TITLE
async_io: adapt self-pipe trick to Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@ Unreleased
 - Add necessary parentheses in generated opam constraints (#7682, fixes #3431,
   @Lucccyo)
 
+- Fix deadlock on Windows (#8044, @nojb)
+
 3.8.2 (2023-06-16)
 ------------------
 


### PR DESCRIPTION
The Dune RPC server uses the "self-pipe trick" to interrupt `Unix.select`. Unfortunately, on Windows, pipes cannot be passed to the native `select` system call, which means that `Unix.select` falls back to a complicated emulation using threads to poll for data on the pipe. This, plus the fact that pipes are always blocking, seem to be causing some deadlock somewhere which makes the RPC server hang under certain circumstances.

This PR proposes an alternative form of the self-pipe trick using a self-connected UDP socket. The advantages is that no pipes are involved, so only the native `select` call is used by `Unix.select`, completely bypassing all the complexity of the emulation and the associated blocking pipes.