### PR TITLE
refactor(stdune): improve path tables

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -84,6 +84,8 @@ module External : sig
   val of_filename_relative_to_initial_cwd : string -> t
 
   val append_local : t -> Local.t -> t
+
+  module Table : Hashtbl.S with type key = t
 end
 
 (** In the source section of the current workspace. *)
@@ -113,6 +115,8 @@ module Source : sig
   val descendant : t -> of_:t -> t option
 
   val to_local : t -> Local.t
+
+  module Table : Hashtbl.S with type key = t
 end
 
 module Permissions : sig
@@ -221,6 +225,8 @@ module Build : sig
   val lstat : t -> Unix.stats
 
   val unlink_no_err : t -> unit
+
+  module Table : Hashtbl.S with type key = t
 end
 
 type t = private
@@ -229,6 +235,39 @@ type t = private
   | In_build_dir of Build.t
 
 include Path_intf.S with type t := t
+
+module Table : sig
+  (** Specialized tables for path. We do implement all of [Hashtbl_intf.S] -
+      only what we use in dune. *)
+
+  type path := t
+
+  type key = path
+
+  type 'a t
+
+  val create : unit -> 'a t
+
+  val clear : 'a t -> unit
+
+  val mem : 'a t -> path -> bool
+
+  val set : 'a t -> path -> 'a -> unit
+
+  val remove : 'a t -> path -> unit
+
+  val iter : 'a t -> f:('a -> unit) -> unit
+
+  val find : 'a t -> path -> 'a option
+
+  val filteri_inplace : 'a t -> f:(key:path -> data:'a -> bool) -> unit
+
+  val filter_inplace : 'a t -> f:('a -> bool) -> unit
+
+  val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
+end
+
+val equal : t -> t -> bool
 
 val as_outside_build_dir_exn : t -> Outside_build_dir.t
 

--- a/otherlibs/stdune/src/path_intf.ml
+++ b/otherlibs/stdune/src/path_intf.ml
@@ -42,7 +42,7 @@ module type S = sig
     val of_listing : dir:elt -> filenames:string list -> t
   end
 
-  module Table : Hashtbl.S with type key = t
+  val equal : t -> t -> bool
 
   val relative : ?error_loc:Loc0.t -> t -> string -> t
 

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -82,7 +82,8 @@ let alias a = dep (Dep.alias a)
 let contents =
   let read_file =
     Memo.exec
-      (Memo.create "Action_builder.contents"
+      (Memo.create_with_store "Action_builder.contents"
+         ~store:(module Path.Table)
          ~input:(module Path)
          ~cutoff:String.equal
          (fun p -> Build_system.read_file p ~f:Io.read_file))

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1069,7 +1069,10 @@ end = struct
          | `Disabled -> None
          | `Enabled -> Some (Tuple.T2.equal Digest.equal target_kind_equal)
        in
-       Memo.create "build-file" ~input:(module Path) ?cutoff build_file_impl)
+       Memo.create_with_store "build-file"
+         ~store:(module Path.Table)
+         ~input:(module Path)
+         ?cutoff build_file_impl)
 
   let build_file path = Memo.exec (Lazy.force build_file_memo) path >>| fst
 

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -70,7 +70,7 @@ let cache =
   lazy
     (match P.load db_file with
     | None ->
-      { checked_key = 0; table = Path.Table.create 1024; max_timestamp = 0. }
+      { checked_key = 0; table = Path.Table.create (); max_timestamp = 0. }
     | Some cache ->
       cache.checked_key <- cache.checked_key + 1;
       cache)

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -885,7 +885,12 @@ end = struct
 
   let load_dir =
     let load_dir_impl dir = load_dir_impl ~dir in
-    let memo = Memo.create "load-dir" ~input:(module Path) load_dir_impl in
+    let memo =
+      Memo.create_with_store "load-dir"
+        ~store:(module Path.Table)
+        ~input:(module Path)
+        load_dir_impl
+    in
     fun ~dir -> Memo.exec memo dir
 
   let is_under_directory_target p =

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -55,7 +55,7 @@ module Workspace_local = struct
         (* This mutable table is safe: it's only used by [execute_rule_impl] to
            decide whether to rebuild a rule or not; [execute_rule_impl] ensures
            that the targets are produced deterministically. *)
-        | None -> Path.Table.create 1024)
+        | None -> Path.Table.create ())
 
     let dump () =
       if !needs_dumping && Path.build_dir_exists () then (


### PR DESCRIPTION
Use a more memory efficient path table. Instead of using the variant for
the key, combine 3 tables all for the individual paths.

This makes the empty table a little more bloated (3x bigger), but gives
us a saving of 2 words for every single key we store.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e86dc1fe-0661-4897-9444-2dfd5f99f050 -->