### PR TITLE
[3.8] Backport #8049 (sendfile fix on Linux)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 - Fix deadlock on Windows (#8044, @nojb)
 
+- When using `sendfile` to copy files on Linux, fall back to the portable
+  version if it fails at runtime for some reason (NFS, etc).
+  (#8049, fixes #8041, @emillon)
+
 3.8.2 (2023-06-16)
 ------------------
 

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -176,9 +176,14 @@ module Copyfile = struct
     Exn.protectx (setup_copy ?chmod ~src ~dst ()) ~finally:close_both
       ~f:(fun (ic, oc) -> copy_channels ic oc)
 
+  let sendfile_with_fallback ?chmod ~src ~dst () =
+    try sendfile ?chmod ~src ~dst ()
+    with Unix.Unix_error (EINVAL, "sendfile", _) ->
+      copy_file_portable ?chmod ~src ~dst ()
+
   let copy_file_best =
     match available with
-    | `Sendfile -> sendfile
+    | `Sendfile -> sendfile_with_fallback
     | `Copyfile -> copyfile
     | `Nothing -> copy_file_portable
 

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -128,3 +128,9 @@
 (cram
  (applies_to version-corruption)
  (deps %{bin:od} %{bin:git} %{bin:cmp} %{bin:sed} %{bin:chmod}))
+
+(cram
+ (applies_to github8041)
+ (enabled_if
+  (= %{system} linux))
+ (deps %{bin:strace}))

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -15,9 +15,3 @@
 If sendfile fails, we should fallback to the portable implementation.
 
   $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
-  Error: sendfile(): Invalid argument
-  -> required by _build/default/data.txt
-  -> required by _build/install/default/share/p/data.txt
-  -> required by _build/default/p.install
-  -> required by alias install
-  [1]

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -1,0 +1,23 @@
+  $ cat > dune-project << EOF
+  > (lang dune 1.0)
+  > (package
+  >  (name p))
+  > EOF
+
+  $ cat > dune << EOF
+  > (install
+  >  (files data.txt)
+  >  (section share))
+  > EOF
+
+  $ echo contents > data.txt
+
+If sendfile fails, we should fallback to the portable implementation.
+
+  $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
+  Error: sendfile(): Invalid argument
+  -> required by _build/default/data.txt
+  -> required by _build/install/default/share/p/data.txt
+  -> required by _build/default/p.install
+  -> required by alias install
+  [1]


### PR DESCRIPTION
- test: add repro for #8041 (#8048)
- fix: sendfile: fall back to portable copy (#8049)
