### PR TITLE
fix: Downloading local repo doesn't work

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -70,7 +70,7 @@ type failure =
 let fetch ~checksum ~target url =
   let open Fiber.O in
   let path = Path.to_string target in
-  let fname = OpamFilename.of_string path in
+  let dirname = OpamFilename.Dir.of_string path in
   let label = "dune-fetch" in
   let event =
     Dune_stats.(
@@ -92,11 +92,11 @@ let fetch ~checksum ~target url =
   in
   (* hashes have to be empty otherwise OPAM deletes the file after
      downloading if the hash does not match *)
-  let job = OpamRepository.pull_file label fname [] [ url ] in
+  let job = OpamRepository.pull_tree label dirname [] [ url ] in
   let+ downloaded = Fiber_job.run job in
   Dune_stats.finish event;
   match downloaded with
-  | Up_to_date () | Result () -> (
+  | Up_to_date _ | Result _ -> (
     match checksum with
     | None -> Ok ()
     | Some expected -> (

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -67,10 +67,26 @@ type failure =
   | Checksum_mismatch of Checksum.t
   | Unavailable of User_message.t option
 
-let fetch ~checksum ~target url =
+let fetch ~checksum ~target (url : OpamUrl.t) =
   let open Fiber.O in
   let path = Path.to_string target in
-  let dirname = OpamFilename.Dir.of_string path in
+  let pull =
+    (* hashes have to be empty otherwise OPAM deletes the file after
+       downloading if the hash does not match *)
+    let hashes = [] in
+    match url.backend with
+    | #OpamUrl.version_control -> (
+      let dirname = OpamFilename.Dir.of_string path in
+      fun label url ->
+        let open OpamProcess.Job.Op in
+        OpamRepository.pull_tree label dirname hashes [ url ] @@| function
+        | Up_to_date _ -> OpamTypes.Up_to_date ()
+        | Result _ -> Result ()
+        | Not_available (a, b) -> Not_available (a, b))
+    | _ ->
+      let fname = OpamFilename.of_string path in
+      fun label url -> OpamRepository.pull_file label fname hashes [ url ]
+  in
   let label = "dune-fetch" in
   let event =
     Dune_stats.(
@@ -90,13 +106,10 @@ let fetch ~checksum ~target url =
                    ("checksum", `String (Checksum.to_string checksum)) :: args))
           }))
   in
-  (* hashes have to be empty otherwise OPAM deletes the file after
-     downloading if the hash does not match *)
-  let job = OpamRepository.pull_tree label dirname [] [ url ] in
-  let+ downloaded = Fiber_job.run job in
+  let+ downloaded = Fiber_job.run (pull label url) in
   Dune_stats.finish event;
   match downloaded with
-  | Up_to_date _ | Result _ -> (
+  | Up_to_date () | Result () -> (
     match checksum with
     | None -> Ok ()
     | Some expected -> (

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -20,7 +20,5 @@ Test fetching from git
   > (build (run cat foo))
   > EOF
 
-  $ dune build _build/default/.pkg/test/target 2>&1 | tail -n +4
-  Error: is a directory
-         is a directory
-         
+  $ dune build _build/default/.pkg/test/target
+  hello world


### PR DESCRIPTION
The OPAM API acts differently between `pull_file` (downloads a file and puts it in the desired location) and `pull_tree` (downloads a file or VCS repo, checks it out and unpacks it), so it needs to use the right function call depending on what we want to do.

Closes #7952.