### PR TITLE
ci: add an action to test mirage

### DIFF
--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -8,19 +8,19 @@ jobs:
     name: Build caldav
     runs-on: ubuntu-latest
     steps:
-      - name: Clone caldav
-        uses: actions/checkout@v3
-        with:
-          repository: roburio/caldav
-          ref: 51f0d150542348dc259b7c9f7bc70ee592243f7f
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: 4.14.x
-          opam-depext: false
-      - run: sed -i s/1.3/2.7/ dune-project
-      - run: opam pin add -n dune.dev git+https://github.com/ocaml/dune#$GITHUB_SHA
-      - run: sudo apt install libseccomp-dev
-      - run: opam install mirage
-      - run: cd mirage; opam exec -- mirage configure -f config.ml -t hvt
-      - run: cd mirage; opam exec -- make depend lock pull build
+    - name: Clone caldav
+      uses: actions/checkout@v3
+      with:
+        repository: roburio/caldav
+        ref: 51f0d150542348dc259b7c9f7bc70ee592243f7f
+    - name: Use OCaml ${{ matrix.ocaml-compiler }}
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.14.x
+        opam-depext: false
+    - run: sed -i s/1.3/2.7/ dune-project
+    - run: opam pin add -n dune.dev git+https://github.com/ocaml/dune#$GITHUB_SHA
+    - run: sudo apt install libseccomp-dev
+    - run: opam install mirage
+    - run: cd mirage; opam exec -- mirage configure -f config.ml -t hvt
+    - run: cd mirage; opam exec -- make depend lock pull build

--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -1,0 +1,26 @@
+name: Mirage
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build caldav
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone caldav
+        uses: actions/checkout@v3
+        with:
+          repository: roburio/caldav
+          ref: 51f0d150542348dc259b7c9f7bc70ee592243f7f
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.x
+          opam-depext: false
+      - run: sed -i s/1.3/2.7/ dune-project
+      - run: opam pin add -n dune.dev git+https://github.com/ocaml/dune#$GITHUB_SHA
+      - run: sudo apt install libseccomp-dev
+      - run: opam install mirage
+      - run: cd mirage; opam exec -- mirage configure -f config.ml -t hvt
+      - run: cd mirage; opam exec -- make depend lock pull build


### PR DESCRIPTION
This gives us a known-good configuration of Mirage to test against. The vast majority of the changes on the Dune side will not affect this, so it is not useful to add this to the regular CI; instead, this gives us a manual run to trigger at release time or on changes for which that can be useful.