### PR TITLE
Upgrade to ocamlformat 0.26.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.25.1
+version=0.26.0
 profile=conventional
 ocaml-version=4.08.0
 break-separators=before

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -14,9 +14,9 @@ let with_metrics ~common f =
                ; Pp.text "Timers:"
                ]
               @ List.map
-                  ~f:
-                    (fun ( timer
-                         , { Metrics.Timer.Measure.cumulative_time; count } ) ->
+                  ~f:(fun
+                      (timer, { Metrics.Timer.Measure.cumulative_time; count })
+                    ->
                     Pp.textf "%s - time spent = %.2fs, count = %d" timer
                       cumulative_time count)
                   (String.Map.to_list (Metrics.Timer.aggregated_timers ())))));

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -58,7 +58,7 @@ val init :
   -> t
   -> Dune_config.t
 
-(** [examples \[("description", "dune cmd foo"); ...\]] is an [EXAMPLES] manpage
+(** [examples [("description", "dune cmd foo"); ...]] is an [EXAMPLES] manpage
     section of enumerated examples illustrating how to run the documented
     commands. *)
 val examples : (string * string) list -> Cmdliner.Manpage.block

--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -340,11 +340,11 @@ module Lock = struct
       let+ () = Fiber.return () in
       List.iter per_context
         ~f:(fun
-             { Per_context.solver_env = solver_env_from_context
-             ; context_common = { name = context_name; _ }
-             ; _
-             }
-           ->
+            { Per_context.solver_env = solver_env_from_context
+            ; context_common = { name = context_name; _ }
+            ; _
+            }
+          ->
           let solver_env =
             merge_current_system_bindings_into_solver_env_from_context
               ~context_name ~solver_env_from_context
@@ -388,12 +388,12 @@ module Lock = struct
        in
        List.map per_context
          ~f:(fun
-              { Per_context.lock_dir_path
-              ; version_preference
-              ; solver_env = solver_env_from_context
-              ; context_common = { name = context_name; _ }
-              }
-            ->
+             { Per_context.lock_dir_path
+             ; version_preference
+             ; solver_env = solver_env_from_context
+             ; context_common = { name = context_name; _ }
+             }
+           ->
            let solver_env =
              merge_current_system_bindings_into_solver_env_from_context
                ~context_name ~solver_env_from_context

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -91,7 +91,7 @@ module Pkg_config : sig
   val query : t -> package:string -> package_conf option
 
   val query_expr : t -> package:string -> expr:string -> package_conf option
-    [@@ocaml.deprecated "please use [query_expr_err]"]
+  [@@ocaml.deprecated "please use [query_expr_err]"]
 
   (** [query_expr_err t ~package ~expr] query pkg-config for the [package].
       [expr] may contain a version constraint, for example "gtk+-3.0 >= 3.18".
@@ -107,7 +107,7 @@ with type configurator := t
 module Flags : sig
   (** [write_sexp fname s] writes the list of strings [s] to the file [fname] in
       an appropriate format so that it can used in [dune] files with
-      [(:include \[fname\])]. *)
+      [(:include [fname])]. *)
   val write_sexp : string -> string list -> unit
 
   (** [write_lines fname s] writes the list of string [s] to the file [fname]

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -149,7 +149,8 @@ module Client = struct
   end
 
   module Make
-      (Fiber : Fiber_intf.S) (Chan : sig
+      (Fiber : Fiber_intf.S)
+      (Chan : sig
         type t
 
         val write : t -> Sexp.t list option -> unit Fiber.t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -530,7 +530,8 @@ module Client : sig
   end
 
   module Make
-      (Fiber : Fiber) (Chan : sig
+      (Fiber : Fiber)
+      (Chan : sig
         type t
 
         val write : t -> Csexp.t list option -> unit Fiber.t

--- a/otherlibs/dune-site/src/helpers.ml
+++ b/otherlibs/dune-site/src/helpers.ml
@@ -35,7 +35,7 @@ let eval s =
     let vlen = min vlen (len - colon_pos - 1) in
     Some (String.sub s (colon_pos + 1) vlen)
   else None
-  [@@inline never]
+[@@inline never]
 
 let get_dir ~package ~section = Hashtbl.find_all dirs (package, section)
 
@@ -84,7 +84,7 @@ let site ~package ~section ~suffix ~encoded =
     | Some d -> relocate_if_needed d :: dirs
   in
   List.rev_map (fun dir -> Filename.concat dir suffix) dirs
-  [@@inline never]
+[@@inline never]
 
 let sourceroot local =
   match eval local with

--- a/otherlibs/fiber/src/fiber.mli
+++ b/otherlibs/fiber/src/fiber.mli
@@ -164,7 +164,7 @@ val map_reduce_errors :
   -> ('b, 'a) result t
 
 (** [collect_errors f] is:
-    [fold_errors f ~init:\[\] ~on_error:(fun e l -> e :: l)] *)
+    [fold_errors f ~init:[] ~on_error:(fun e l -> e :: l)] *)
 val collect_errors :
   (unit -> 'a t) -> ('a, Exn_with_backtrace.t list) Result.t t
 

--- a/otherlibs/fiber/test/fiber_tests.ml
+++ b/otherlibs/fiber/test/fiber_tests.ml
@@ -750,8 +750,8 @@ let%expect_test "Stream: multiple readers is an error" =
          printf "Reader 2 reading\n";
          let+ _x = Fiber.Stream.In.read stream in
          printf "Reader 2 done\n"))
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ("(\"Fiber.Stream.In: already reading\", {})")
   Trailing output
   ---------------
@@ -780,8 +780,8 @@ let%expect_test "Stream: multiple writers is an error" =
          printf "Writer 2 writing\n";
          let+ _x = Fiber.Stream.Out.write stream (Some 2) in
          printf "Writer 2 done\n"))
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ("(\"Fiber.Stream.Out: already writing\", {})")
   Trailing output
   ---------------
@@ -797,8 +797,8 @@ let%expect_test "Stream: writing on a closed stream is an error" =
      in
      let* () = Fiber.Stream.Out.write out None in
      Fiber.Stream.Out.write out (Some ()))
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ("(\"Fiber.Stream.Out: stream output closed\", {})")
   Trailing output
   ---------------
@@ -858,8 +858,8 @@ let%expect_test "double run a pool" =
   let pool = Pool.create () in
   Fiber.fork_and_join_unit (fun () -> Pool.run pool) (fun () -> Pool.run pool));
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
+[@@expect.uncaught_exn
+  {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
 
 let%expect_test "run -> stop -> run a pool" =
   (* We shouldn't be able to call [Pool.run] again after we already called
@@ -874,8 +874,8 @@ let%expect_test "run -> stop -> run a pool" =
   in
   Pool.run pool);
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
+[@@expect.uncaught_exn
+  {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
 
 let%expect_test "stop a pool and then run it" =
   (Scheduler.run
@@ -912,8 +912,8 @@ let%expect_test "nested run in task" =
   Fiber.fork_and_join_unit (fun () -> Pool.close pool) (fun () -> Pool.run pool)
   );
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
+[@@expect.uncaught_exn
+  {| ("(\"Fiber.Pool.run: concurent calls to run aren't allowed\", {})") |}]
 
 let%expect_test "nested tasks" =
   (Scheduler.run

--- a/otherlibs/stdune/src/caller_id.mli
+++ b/otherlibs/stdune/src/caller_id.mli
@@ -1,6 +1,6 @@
 (** Who called me? *)
 
 (** [get ~skip] returns the first element of the call stack that is not in
-    [skip]. For instance, [get ~skip:\[__FILE__\]] will return the first call
-    site outside of the current file. *)
+    [skip]. For instance, [get ~skip:[__FILE__]] will return the first call site
+    outside of the current file. *)
 val get : skip:string list -> Loc.t option

--- a/otherlibs/stdune/src/monoid.ml
+++ b/otherlibs/stdune/src/monoid.ml
@@ -132,10 +132,11 @@ module Product3 (A : Basic) (B : Basic) (C : Basic) = Make (struct
     (A.combine a1 a2, B.combine b1 b2, C.combine c1 c2)
 end)
 
-module Function (A : sig
-  type t
-end)
-(M : Basic) =
+module Function
+    (A : sig
+      type t
+    end)
+    (M : Basic) =
 Make (struct
   type t = A.t -> M.t
 
@@ -190,9 +191,10 @@ module Commutative = struct
   module Product (A : Basic) (B : Basic) = Make_commutative (Product (A) (B))
   module Product3 (A : Basic) (B : Basic) (C : Basic) =
     Make_commutative (Product3 (A) (B) (C))
-  module Function (A : sig
-    type t
-  end)
-  (M : Basic) =
+  module Function
+      (A : sig
+        type t
+      end)
+      (M : Basic) =
     Make_commutative (Function (A) (M))
 end

--- a/otherlibs/stdune/src/monoid.mli
+++ b/otherlibs/stdune/src/monoid.mli
@@ -17,12 +17,12 @@ module Forall : S with type t = bool
 (** The string concatenation monoid with [empty = ""] and [combine = ( ^ )]. *)
 module String : S with type t = string
 
-(** The list monoid with [empty = \[\]] and [combine = ( @ )]. *)
+(** The list monoid with [empty = []] and [combine = ( @ )]. *)
 module List (M : sig
   type t
 end) : S with type t = M.t list
 
-(** The list monoid with [empty = \[\]] and [combine = ( @ )]. *)
+(** The list monoid with [empty = []] and [combine = ( @ )]. *)
 module Appendable_list (M : sig
   type t
 end) : S with type t = M.t Appendable_list.t
@@ -68,10 +68,11 @@ module Product3 (A : Basic) (B : Basic) (C : Basic) :
 
     - empty = fun _ -> M.empty
     - combine f g = fun x -> M.combine (f x) (g x) *)
-module Function (A : sig
-  type t
-end)
-(M : Basic) : S with type t = A.t -> M.t
+module Function
+    (A : sig
+      type t
+    end)
+    (M : Basic) : S with type t = A.t -> M.t
 
 (** Endofunctions, i.e., functions of type [t -> t], form two monoids. *)
 module Endofunction : sig
@@ -155,8 +156,9 @@ module Commutative : sig
 
       - empty = fun _ -> M.empty
       - combine f g = fun x -> M.combine (f x) (g x) *)
-  module Function (A : sig
-    type t
-  end)
-  (M : Basic) : S with type t = A.t -> M.t
+  module Function
+      (A : sig
+        type t
+      end)
+      (M : Basic) : S with type t = A.t -> M.t
 end

--- a/otherlibs/stdune/src/state.ml
+++ b/otherlibs/stdune/src/state.ml
@@ -1,7 +1,8 @@
-module Make (S : sig
-  type t
-end)
-(M : Monad.S) =
+module Make
+    (S : sig
+      type t
+    end)
+    (M : Monad.S) =
 struct
   module T = struct
     type 'a t = S.t -> (S.t * 'a) M.t

--- a/otherlibs/stdune/src/state.mli
+++ b/otherlibs/stdune/src/state.mli
@@ -1,12 +1,13 @@
 (** State monad transformer. *)
 
-module Make (S : sig
-  (* The state isn't a type variable as is done traditionally, because we want
-     to reuse our existing monad machinery. All that machinery requires the
-     monad to have only one type variable *)
-  type t
-end)
-(M : Monad.S) : sig
+module Make
+    (S : sig
+      (* The state isn't a type variable as is done traditionally, because we want
+         to reuse our existing monad machinery. All that machinery requires the
+         monad to have only one type variable *)
+      type t
+    end)
+    (M : Monad.S) : sig
   include Monad.S
 
   (** [run t state] runs computation [t] with [state] as the initial state. The

--- a/otherlibs/stdune/src/univ_map.ml
+++ b/otherlibs/stdune/src/univ_map.ml
@@ -1,9 +1,10 @@
 module type S = Univ_map_intf.S
 
-module Make (Info : sig
-  type 'a t
-end)
-() =
+module Make
+    (Info : sig
+      type 'a t
+    end)
+    () =
 struct
   module Key = struct
     type 'a info = 'a Info.t

--- a/otherlibs/stdune/src/univ_map.mli
+++ b/otherlibs/stdune/src/univ_map.mli
@@ -2,10 +2,11 @@
 
 module type S = Univ_map_intf.S
 
-module Make (Info : sig
-  type 'a t
-end)
-() : sig
+module Make
+    (Info : sig
+      type 'a t
+    end)
+    () : sig
   module Key : Univ_map_intf.Key with type 'a info = 'a Info.t
 
   include S with module Key := Key

--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -53,13 +53,13 @@ module Annots = struct
     type 'a t = 'a Id.t
 
     let to_dyn : 'a. 'a t -> 'a -> Dyn.t =
-      fun (type a) (info : a t) (a : a) ->
-       let (E packed) = Table.find_exn all (Id.Packed.Id info) in
-       match Type_eq.Id.same info.id packed.id.id with
-       | Some eq -> packed.to_dyn (Type_eq.cast eq a)
-       | None ->
-         Code_error.raise "type id's disagree for the same name"
-           [ ("info.name", Dyn.string info.name) ]
+     fun (type a) (info : a t) (a : a) ->
+      let (E packed) = Table.find_exn all (Id.Packed.Id info) in
+      match Type_eq.Id.same info.id packed.id.id with
+      | Some eq -> packed.to_dyn (Type_eq.cast eq a)
+      | None ->
+        Code_error.raise "type id's disagree for the same name"
+          [ ("info.name", Dyn.string info.name) ]
 
     let create ~name to_dyn =
       let type_id = Type_eq.Id.create () in

--- a/otherlibs/stdune/test/io_tests.ml
+++ b/otherlibs/stdune/test/io_tests.ml
@@ -54,7 +54,7 @@ let%expect_test "copy file - src is a directory" =
   Unix.mkdir (Path.to_string src) 0o755;
   Io.copy_file ~src ~dst ();
   [%expect.unreachable]
-  [@@expect.uncaught_exn {| (Sys_error "Is a directory") |}]
+[@@expect.uncaught_exn {| (Sys_error "Is a directory") |}]
 
 let%expect_test "copy file - dst is a directory" =
   let dir = temp_dir () in

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -312,8 +312,8 @@ let%expect_test _ =
   Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
   |> Dyn.unit |> print_dyn;
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ( "(\"Path.rm_rf called on external dir\",\
    \n{ t = External \"/does/not/exist/foo/bar/baz\" })") |}]
 

--- a/src/async_inotify_for_dune/async_inotify.ml
+++ b/src/async_inotify_for_dune/async_inotify.ml
@@ -114,8 +114,8 @@ let process_raw_events t events =
   in
   let pending_mv, actions =
     List.fold_left ev_kinds ~init:(None, [])
-      ~f:(fun (pending_mv, actions) ((kind : Inotify.event_kind), trans_id, fn)
-         ->
+      ~f:(fun
+          (pending_mv, actions) ((kind : Inotify.event_kind), trans_id, fn) ->
         let add_pending lst =
           match pending_mv with
           | None -> lst

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -149,7 +149,8 @@ module Dune_config = struct
   module Make_superpose
       (A : S)
       (B : S)
-      (C : S) (Merge_field : sig
+      (C : S)
+      (Merge_field : sig
         val merge_field : 'a A.field -> 'a B.field -> 'a C.field
       end) =
   struct
@@ -175,7 +176,8 @@ module Dune_config = struct
   end
 
   module Make_to_dyn
-      (M : S) (To_dyn : sig
+      (M : S)
+      (To_dyn : sig
         val field : ('a -> Dyn.t) -> 'a M.field -> Dyn.t
       end) =
   struct

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -161,7 +161,7 @@ module Full : sig
 
   val make :
        ?env:Env.t (** default [Env.empty] *)
-    -> ?locks:Path.t list (** default [\[\]] *)
+    -> ?locks:Path.t list (** default [[]] *)
     -> ?can_go_in_shared_cache:bool (** default [true] *)
     -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
     -> action

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -290,10 +290,10 @@ and Exported : sig
      "Undefined_recursive_module" exception. *)
 
   val build_file_memo : (Path.t, Digest.t * target_kind) Memo.Table.t Lazy.t
-    [@@warning "-32"]
+  [@@warning "-32"]
 
   val build_alias_memo : (Alias.t, Dep.Fact.Files.t) Memo.Table.t
-    [@@warning "-32"]
+  [@@warning "-32"]
 
   val dep_on_alias_definition :
     Rules.Dir_rules.Alias_spec.item -> unit Action_builder.t

--- a/src/dune_engine/dir_set.ml
+++ b/src/dune_engine/dir_set.ml
@@ -59,7 +59,7 @@ let merge_nontrivial a b ~f_one ~f_set =
   let default = f_one a.default b.default in
   create ~here:(f_one a.here b.here) ~default
     ~exceptions:(merge_exceptions a b ~default ~f:f_set)
-  [@@inline always]
+[@@inline always]
 
 let rec union x y =
   match (x, y) with

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -660,7 +660,7 @@ end = struct
 
   let load_build_directory_exn
       ({ Dir_triage.Build_directory.dir; context_or_install; sub_dir } as
-      build_dir) =
+       build_dir) =
     (* Load all the rules *)
     Gen_rules.gen_rules build_dir >>= function
     | Under_directory_target { directory_target_ancestor } ->

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -35,7 +35,7 @@ let get_installed_binaries ~(context : Context.t) stanzas =
             binaries_from_install files
           | Dune_file.Executables
               ({ install_conf = Some { section = Section Bin; files; _ }; _ } as
-              exes) -> (
+               exes) -> (
             let* enabled_if =
               Expander.With_reduced_var_set.eval_blang ~context ~dir
                 exes.enabled_if

--- a/src/dune_rules/command.mli
+++ b/src/dune_rules/command.mli
@@ -92,7 +92,7 @@ val run' :
   -> Args.without_targets Args.t list
   -> Action.Full.t Action_builder.t
 
-(** [quote_args quote args] is [As \[quote; arg1; quote; arg2; ...\]] *)
+(** [quote_args quote args] is [As [quote; arg1; quote; arg2; ...]] *)
 val quote_args : string -> string list -> _ Args.t
 
 val fail : exn -> _ Args.t

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -844,8 +844,9 @@ let install_rules ~sctx ~dir s =
              Coq_module.obj_files ~wrapper_name ~mode ~obj_dir:dir
                ~obj_files_mode:Coq_module.Install vfile
              |> List.map
-                  ~f:(fun ((vo_file : Path.Build.t), (install_vo_file : string))
-                     -> make_entry vo_file install_vo_file)
+                  ~f:(fun
+                      ((vo_file : Path.Build.t), (install_vo_file : string)) ->
+                    make_entry vo_file install_vo_file)
            in
            let vfile = Coq_module.source vfile |> Path.as_in_build_dir_exn in
            let vfile_dst = to_path vfile in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -887,7 +887,7 @@ module Library = struct
   let to_lib_info conf ~dir
       ~lib_config:
         ({ Lib_config.has_native; ext_lib; ext_dll; natdynlink_supported; _ } as
-        lib_config) =
+         lib_config) =
     let open Memo.O in
     let obj_dir = obj_dir ~dir conf in
     let archive ?(dir = dir) ext = archive conf ~dir ~ext in

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -110,7 +110,8 @@ module Without_vars = struct
 end
 
 module Expand
-    (M : Memo.S) (C : sig
+    (M : Memo.S)
+    (C : sig
       val collect_files : loc:Loc.t -> File_selector.t -> Path.Set.t M.t
     end) =
 struct

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -510,9 +510,7 @@ end = struct
               for all. *)
            List.sort entries
              ~compare:(fun
-                        (a : Install.Entry.Sourced.t)
-                        (b : Install.Entry.Sourced.t)
-                      ->
+                 (a : Install.Entry.Sourced.t) (b : Install.Entry.Sourced.t) ->
                Install.Entry.compare Path.Build.compare a.entry b.entry))
 
   let stanzas_to_entries =
@@ -691,14 +689,13 @@ end = struct
               | Some entries ->
                 List.fold_left entries ~init:Lib_name.Map.empty
                   ~f:(fun
-                       acc
-                       { Dune_file.Library_redirect.old_name =
-                           old_public_name, _
-                       ; new_public_name = _, new_public_name
-                       ; loc
-                       ; _
-                       }
-                     ->
+                      acc
+                      { Dune_file.Library_redirect.old_name = old_public_name, _
+                      ; new_public_name = _, new_public_name
+                      ; loc
+                      ; _
+                      }
+                    ->
                     let old_public_name =
                       Dune_file.Public_lib.name old_public_name
                     in
@@ -986,8 +983,9 @@ include (
                 |> Install.Entry.map_dst ~f:(fun dst ->
                        Install.Entry.Dst.concat_all dst comps))
             |> List.sort
-                 ~compare:(fun (x : _ Install.Entry.t) (y : _ Install.Entry.t)
-                          -> Path.compare x.src y.src)
+                 ~compare:(fun
+                     (x : _ Install.Entry.t) (y : _ Install.Entry.t) ->
+                   Path.compare x.src y.src)
           | (dir, comps) :: dirs -> (
             match Path.Untracked.readdir_unsorted_with_kinds dir with
             | Error _ -> Code_error.raise "unable to read directory" []

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -29,5 +29,5 @@ val equal : t -> t -> bool
 
 val to_dyn : t -> Dyn.t
 
-(** [\["-g"\]] if [!Clflags.g] and [\[\]] otherwise *)
+(** [["-g"]] if [!Clflags.g] and [[]] otherwise *)
 val cc_g : t -> string list

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -300,19 +300,19 @@ module Processed = struct
             , init.config.extensions
             , init.config.melc_flags )
           ~f:(fun
-               (acc_pp, acc_obj, acc_src, acc_flags, acc_ext, acc_melc_flags)
-               { per_module_config = _
-               ; pp_config
-               ; config =
-                   { stdlib_dir = _
-                   ; obj_dirs
-                   ; src_dirs
-                   ; flags
-                   ; extensions
-                   ; melc_flags
-                   }
-               }
-             ->
+              (acc_pp, acc_obj, acc_src, acc_flags, acc_ext, acc_melc_flags)
+              { per_module_config = _
+              ; pp_config
+              ; config =
+                  { stdlib_dir = _
+                  ; obj_dirs
+                  ; src_dirs
+                  ; flags
+                  ; extensions
+                  ; melc_flags
+                  }
+              }
+            ->
             ( pp_config :: acc_pp
             , Path.Set.union acc_obj obj_dirs
             , Path.Set.union acc_src src_dirs

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -584,8 +584,8 @@ module Action_expander = struct
       let* action = expand action ~expander in
       let+ _env, updates =
         Memo.List.fold_left ~init:(expander.env, []) updates
-          ~f:(fun (env, updates) ({ Env_update.op = _; var; value } as update)
-             ->
+          ~f:(fun
+              (env, updates) ({ Env_update.op = _; var; value } as update) ->
             let+ value =
               let expander = { expander with env } in
               let+ value =
@@ -621,9 +621,9 @@ module Action_expander = struct
            List.fold_left cookies
              ~init:(Filename.Map.empty, Package.Name.Map.empty)
              ~f:(fun
-                  (bins, dep_info)
-                  ((pkg : Pkg.t), (cookie : Install_cookie.t))
-                ->
+                 (bins, dep_info)
+                 ((pkg : Pkg.t), (cookie : Install_cookie.t))
+               ->
                let bins =
                  Section.Map.Multi.find cookie.files Bin
                  |> List.fold_left ~init:bins ~f:(fun acc bin ->

--- a/src/dune_rules/which.ml
+++ b/src/dune_rules/which.ml
@@ -6,7 +6,8 @@ let programs_for_which_we_prefer_opt_ext =
 
 module Best_path = struct
   module Make
-      (Monad : Monad.S) (Fs : sig
+      (Monad : Monad.S)
+      (Fs : sig
         val file_exists : Path.t -> bool Monad.t
       end) =
   struct

--- a/src/dune_rules/which.mli
+++ b/src/dune_rules/which.mli
@@ -2,7 +2,8 @@ open Import
 
 module Best_path : sig
   module Make
-      (Monad : Monad.S) (_ : sig
+      (Monad : Monad.S)
+      (_ : sig
         val file_exists : Path.t -> bool Monad.t
       end) : sig
     (** [best_path ~dir prog] if [prog] is one of the special programs that can

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -266,31 +266,31 @@ let end_of_list (Values (loc, cstr, _)) =
     let loc = Loc.set_start loc (Loc.stop loc) in
     User_error.raise ~loc [ Pp.text "Premature end of list" ]
   | Some s -> User_error.raise ~loc [ Pp.textf "Not enough arguments for %s" s ]
-  [@@inline never] [@@specialise never] [@@local never]
+[@@inline never] [@@specialise never] [@@local never]
 
 let next f ctx sexps =
   match sexps with
   | [] -> end_of_list ctx
   | sexp :: sexps -> (f sexp, sexps)
-  [@@inline always]
+[@@inline always]
 
 let next_with_user_context f ctx sexps =
   match sexps with
   | [] -> end_of_list ctx
   | sexp :: sexps -> (f (get_user_context ctx) sexp, sexps)
-  [@@inline always]
+[@@inline always]
 
 let peek _ctx sexps =
   match sexps with
   | [] -> (None, sexps)
   | sexp :: _ -> (Some sexp, sexps)
-  [@@inline always]
+[@@inline always]
 
 let peek_exn ctx sexps =
   match sexps with
   | [] -> end_of_list ctx
   | sexp :: _ -> (sexp, sexps)
-  [@@inline always]
+[@@inline always]
 
 let junk = next ignore
 
@@ -587,7 +587,7 @@ let map_validate t ~f ctx state1 =
     field names: see [field_missing] and [field_present_too_many_times]. *)
 let field_missing loc name =
   User_error.raise ~loc [ Pp.textf "field %s missing" name ]
-  [@@inline never] [@@specialise never] [@@local never]
+[@@inline never] [@@specialise never] [@@local never]
 
 let field_present_too_many_times _ name entries =
   match entries with
@@ -697,14 +697,14 @@ let fields_missing_need_exactly_one loc names =
     [ Pp.textf "fields %s are all missing (exactly one is needed)"
         (String.concat ~sep:", " names)
     ]
-  [@@inline never] [@@specialise never] [@@local never]
+[@@inline never] [@@specialise never] [@@local never]
 
 let fields_mutual_exclusion_violation loc names =
   let names = List.map names ~f:String.quoted in
   User_error.raise ~loc
     [ Pp.textf "fields %s are mutually exclusive." (String.enumerate_and names)
     ]
-  [@@inline never] [@@specialise never] [@@local never]
+[@@inline never] [@@specialise never] [@@local never]
 
 let fields_mutually_exclusive ?on_dup ?default fields
     ((Fields (loc, _, _) : _ context) as ctx) state =

--- a/src/dune_sexp/decoder.mli
+++ b/src/dune_sexp/decoder.mli
@@ -13,10 +13,10 @@ type hint =
     The input can be seen either as a plain sequence of S-expressions or a list
     of fields. The ['kind] parameter indicates how the input is seen:
 
-    - with ['kind = \[values\]], the input is seen as an ordered sequence of
+    - with ['kind = [values]], the input is seen as an ordered sequence of
       S-expressions
 
-    - with [!'kind = \[fields\]], the input is seen as an unordered sequence of
+    - with [!'kind = [fields]], the input is seen as an unordered sequence of
       fields
 
     A field is a S-expression of the form: [(<atom> <values>...)] where [atom]

--- a/test/expect-tests/csexp_rpc/io_buffer_tests.ml
+++ b/test/expect-tests/csexp_rpc/io_buffer_tests.ml
@@ -43,8 +43,8 @@ let%expect_test "reading" =
   Io_buffer.read buf 2;
   print_dyn buf;
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ("(\"not enough bytes in buffer\", { len = 2; length = 1 })") |}]
 
 let%expect_test "reading" =

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -275,8 +275,8 @@ let%expect_test _ =
 let%expect_test _ =
   test Dune (t [ Text "x%{" ]);
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ( "({ pos_fname = \"<none>\"\
    \n ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
    \n ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
@@ -286,8 +286,8 @@ let%expect_test _ =
 let%expect_test _ =
   test Dune (t [ Text "x%"; Text "{" ]);
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ( "({ pos_fname = \"<none>\"\
    \n ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
    \n ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -129,8 +129,8 @@ let%expect_test "downloading but the checksums don't match" =
   Thread.join server;
   print_endline "Finished successfully?";
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   (Dune_util__Report_error.Already_reported)
   Trailing output
   ---------------

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -114,8 +114,8 @@ let%expect_test "no methods in common" =
   let init = init ~version:(2, 5) () in
   test ~init ~real_methods:false ~client:(fun _ -> assert false) ~handler ();
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ( "Server_aborted\
    \n  [ [ \"message\"; \"Server and client have no method versions in common\" ] ]")
   Trailing output
@@ -499,8 +499,8 @@ let%test_module "long polling" =
       in
       test ~init ~client ~handler ~private_menu:[ Poll sub_proc ] ();
       [%expect.unreachable]
-      [@@expect.uncaught_exn
-        {|
+    [@@expect.uncaught_exn
+      {|
       (Test_scheduler.Never)
       Trailing output
       ---------------

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -100,8 +100,8 @@ let%expect_test "empty invalidation wakes up waiter" =
     awaited invalidation |}];
   test `Ignore;
   [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
+[@@expect.uncaught_exn
+  {|
   ("shutdown: timeout")
   Trailing output
   ---------------


### PR DESCRIPTION
The changed formatting of `@@ let ...` (any operator) cause huge diffs in the command descriptions. The changed indentation of `if` and `let` in parentheses also has a big impact.  

The aim of this commit is to gather feedback.

Changelog can be found here: https://github.com/ocaml-ppx/ocamlformat/blob/main/CHANGES.md