### PR TITLE
refactor: separate loc types

### DIFF
--- a/bin/internal_action_runner.ml
+++ b/bin/internal_action_runner.ml
@@ -13,7 +13,8 @@ let action_runner runners server =
   let module Action_runner = Dune_engine.Action_runner in
   Staged.stage @@ fun (input : Dune_engine.Action_exec.input) ->
   match
-    Path.Source.of_string input.rule_loc.start.pos_fname |> Path.Source.explode
+    Path.Source.of_string (Loc.start input.rule_loc).pos_fname
+    |> Path.Source.explode
   with
   | [] -> None
   | runner :: _ ->

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -32,7 +32,7 @@ let subst_string s path ~map =
           ; pos_bol = bol
           }
         in
-        { Loc.start = pos; stop = { pos with pos_cnum = pos.pos_cnum + len } }
+        Loc.create ~start:pos ~stop:{ pos with pos_cnum = pos.pos_cnum + len }
       else
         match s.[i] with
         | '\n' -> loop (lnum + 1) (i + 1) (i + 1)
@@ -175,7 +175,8 @@ module Dune_project = struct
         match t.version with
         | Some v ->
           (* There is a [version] field, overwrite its argument *)
-          replace_text v.loc_of_arg.start.pos_cnum v.loc_of_arg.stop.pos_cnum
+          replace_text (Loc.start v.loc_of_arg).pos_cnum
+            (Loc.stop v.loc_of_arg).pos_cnum
             (Dune_lang.to_string (Dune_lang.atom_or_quoted_string version))
         | None ->
           let version_field =
@@ -192,7 +193,7 @@ module Dune_project = struct
               | Some { loc; _ } ->
                 (* There is no [version] field but there is a [name] one, add
                    the version after it *)
-                loc.stop.pos_cnum
+                (Loc.stop loc).pos_cnum
               | None ->
                 (* If all else fails, add the [version] field after the first
                    line of the file *)

--- a/otherlibs/dune-rpc/private/exported_types.ml
+++ b/otherlibs/dune-rpc/private/exported_types.ml
@@ -1,7 +1,10 @@
 open Import
 
 module Loc = struct
-  include Loc
+  type t = Stdune.Lexbuf.Loc.t =
+    { start : Lexing.position
+    ; stop : Lexing.position
+    }
 
   let start t = t.start
 
@@ -286,7 +289,10 @@ module Diagnostic = struct
       match t.loc with
       | None -> []
       | Some l ->
-        [ Pp.map_tags ~f:(fun _ -> Stdune.User_message.Style.Loc) (Loc.pp l) ]
+        [ Pp.map_tags
+            ~f:(fun _ -> Stdune.User_message.Style.Loc)
+            (Stdune.Loc.of_lexbuf_loc l |> Stdune.Loc.pp)
+        ]
     in
     Stdune.User_message.make ?prefix
       (directory @ formatted_loc

--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -1,7 +1,7 @@
 (** Types exposed to end-user consumers of [dune_rpc.mli]. *)
 
 module Loc : sig
-  type t = Stdune.Loc.t =
+  type t = Stdune.Lexbuf.Loc.t =
     { start : Lexing.position
     ; stop : Lexing.position
     }

--- a/otherlibs/stdune/src/caller_id.ml
+++ b/otherlibs/stdune/src/caller_id.ml
@@ -23,6 +23,6 @@ let get ~skip =
             }
           in
           let stop = { start with pos_cnum = loc.end_char } in
-          Some { Loc.start; stop }
+          Some (Loc.create ~start ~stop)
   in
   loop 0

--- a/otherlibs/stdune/src/lexbuf.ml
+++ b/otherlibs/stdune/src/lexbuf.ml
@@ -1,5 +1,22 @@
 type t = Lexing.lexbuf
 
+module Position = struct
+  type t = Lexing.position
+
+  let equal
+      { Lexing.pos_fname = f_a; pos_lnum = l_a; pos_bol = b_a; pos_cnum = c_a }
+      { Lexing.pos_fname = f_b; pos_lnum = l_b; pos_bol = b_b; pos_cnum = c_b }
+      =
+    f_a = f_b && l_a = l_b && b_a = b_b && c_a = c_b
+end
+
+module Loc = struct
+  type t =
+    { start : Lexing.position
+    ; stop : Lexing.position
+    }
+end
+
 let init (t : t) ~fname =
   t.lex_curr_p <- { pos_fname = fname; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
 

--- a/otherlibs/stdune/src/lexbuf.mli
+++ b/otherlibs/stdune/src/lexbuf.mli
@@ -2,6 +2,19 @@
 
 type t = Lexing.lexbuf
 
+module Position : sig
+  type t = Lexing.position
+
+  val equal : t -> t -> bool
+end
+
+module Loc : sig
+  type t =
+    { start : Lexing.position
+    ; stop : Lexing.position
+    }
+end
+
 (** Same as [Lexing.from_xxx] but also initialise the location to the beginning
     of the given file *)
 val from_string : string -> fname:string -> t

--- a/otherlibs/stdune/src/loc.ml
+++ b/otherlibs/stdune/src/loc.ml
@@ -4,36 +4,30 @@ include O
 
 let in_file p =
   let pos = none_pos (Path.to_string p) in
-  { start = pos; stop = pos }
+  create ~start:pos ~stop:pos
 
 let in_dir = in_file
 
 let drop_position (t : t) =
-  let pos = none_pos t.start.pos_fname in
-  { start = pos; stop = pos }
+  let pos = none_pos (start t).pos_fname in
+  create ~start:pos ~stop:pos
 
 let of_lexbuf lexbuf : t =
-  { start = Lexing.lexeme_start_p lexbuf; stop = Lexing.lexeme_end_p lexbuf }
-
-let equal_position
-    { Lexing.pos_fname = f_a; pos_lnum = l_a; pos_bol = b_a; pos_cnum = c_a }
-    { Lexing.pos_fname = f_b; pos_lnum = l_b; pos_bol = b_b; pos_cnum = c_b } =
-  f_a = f_b && l_a = l_b && b_a = b_b && c_a = c_b
-
-let equal { start = start_a; stop = stop_a } { start = start_b; stop = stop_b }
-    =
-  equal_position start_a start_b && equal_position stop_a stop_b
+  create
+    ~start:(Lexing.lexeme_start_p lexbuf)
+    ~stop:(Lexing.lexeme_end_p lexbuf)
 
 let of_pos (fname, lnum, cnum, enum) =
   let pos : Lexing.position =
     { pos_fname = fname; pos_lnum = lnum; pos_cnum = cnum; pos_bol = 0 }
   in
-  { start = pos; stop = { pos with pos_cnum = enum } }
+  create ~start:pos ~stop:{ pos with pos_cnum = enum }
 
 let is_none = equal none
 
 let to_file_colon_line t =
-  Printf.sprintf "%s:%d" t.start.pos_fname t.start.pos_lnum
+  let start = start t in
+  Printf.sprintf "%s:%d" start.pos_fname start.pos_lnum
 
 let to_dyn_hum t : Dyn.t = String (to_file_colon_line t)
 
@@ -51,8 +45,9 @@ let pp_line padding_width (lnum, l) =
 
 type tag = Loc
 
-let pp_file_excerpt ~context_lines ~max_lines_to_print_in_full { start; stop } :
-    tag Pp.t =
+let pp_file_excerpt ~context_lines ~max_lines_to_print_in_full loc : tag Pp.t =
+  let start = start loc in
+  let stop = stop loc in
   let start_c = start.pos_cnum - start.pos_bol in
   let stop_c = stop.pos_cnum - start.pos_bol in
   let file = start.pos_fname in
@@ -131,7 +126,9 @@ let pp_file_excerpt ~context_lines ~max_lines_to_print_in_full { start; stop } :
         exn;
       Pp.nop
 
-let pp ({ start; stop } as loc) =
+let pp loc =
+  let start = start loc in
+  let stop = stop loc in
   let start_c = start.pos_cnum - start.pos_bol in
   let stop_c = stop.pos_cnum - start.pos_bol in
   let open Pp.O in
@@ -143,13 +140,13 @@ let pp ({ start; stop } as loc) =
   ++ pp_file_excerpt ~context_lines:2 ~max_lines_to_print_in_full:10 loc
 
 let on_same_line loc1 loc2 =
-  let start1 = loc1.start in
-  let start2 = loc2.start in
+  let start1 = start loc1 in
+  let start2 = start loc2 in
   let same_file = String.equal start1.pos_fname start2.pos_fname in
   let same_line = Int.equal start1.pos_lnum start2.pos_lnum in
   same_file && same_line
 
-let span begin_ end_ = { begin_ with stop = end_.stop }
+let span begin_ end_ = set_stop begin_ (stop end_)
 
 let rec render ppf pp =
   Pp.to_fmt_with_tags ppf pp ~tag_handler:(fun ppf Loc pp ->

--- a/otherlibs/stdune/src/loc0.ml
+++ b/otherlibs/stdune/src/loc0.ml
@@ -1,9 +1,27 @@
-type t =
+type t = Lexbuf.Loc.t =
   { start : Lexing.position
   ; stop : Lexing.position
   }
 
+let to_lexbuf_loc x = x
+
+let of_lexbuf_loc x = x
+
+let start t = t.start
+
+let stop t = t.stop
+
+let set_stop t stop = { t with stop }
+
+let set_start t start = { t with start }
+
+let create ~start ~stop = { start; stop }
+
+let map_pos { start; stop } ~f = { start = f start; stop = f stop }
+
 let compare = Poly.compare
+
+let equal x y = Ordering.is_eq (compare x y)
 
 let none_pos p : Lexing.position =
   { pos_fname = p; pos_lnum = 1; pos_cnum = 0; pos_bol = 0 }

--- a/otherlibs/stdune/src/loc0.mli
+++ b/otherlibs/stdune/src/loc0.mli
@@ -1,0 +1,29 @@
+type t
+
+val to_lexbuf_loc : t -> Lexbuf.Loc.t
+
+val of_lexbuf_loc : Lexbuf.Loc.t -> t
+
+val start : t -> Lexing.position
+
+val map_pos : t -> f:(Lexing.position -> Lexing.position) -> t
+
+val create : start:Lexing.position -> stop:Lexing.position -> t
+
+val set_stop : t -> Lexing.position -> t
+
+val set_start : t -> Lexing.position -> t
+
+val stop : t -> Lexing.position
+
+val compare : t -> t -> Ordering.t
+
+val equal : t -> t -> bool
+
+val none_pos : string -> Lexing.position
+
+val none : t
+
+val dyn_of_position_no_file : Lexing.position -> Dyn.t
+
+val to_dyn : t -> Dyn.t

--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -152,7 +152,9 @@ let pp { loc; paragraphs; hints; annots = _ } =
   let paragraphs =
     match loc with
     | None -> paragraphs
-    | Some { Loc0.start; stop } ->
+    | Some loc ->
+      let start = Loc0.start loc in
+      let stop = Loc0.stop loc in
       let start_c = start.pos_cnum - start.pos_bol in
       let stop_c = stop.pos_cnum - start.pos_bol in
       Pp.box

--- a/otherlibs/stdune/test/loc_tests.ml
+++ b/otherlibs/stdune/test/loc_tests.ml
@@ -12,7 +12,7 @@ let f () () = function
   let pos_fname = Path.to_string file in
   let start = { Lexing.pos_fname; pos_lnum = 4; pos_bol = 0; pos_cnum = 14 } in
   let stop = { start with pos_lnum = 5; pos_cnum = 11 } in
-  let loc = { Loc.start; stop } in
+  let loc = Loc.create ~start ~stop in
   Format.printf "%a@." Pp.to_fmt (Loc.pp loc);
   let output =
     [%expect.output] |> String.split_lines |> List.tl |> String.concat ~sep:"\n"

--- a/src/dune_engine/compound_user_error.ml
+++ b/src/dune_engine/compound_user_error.ml
@@ -55,10 +55,11 @@ let make_loc ~dir { Ocamlc_loc.path; chars; lines } : Loc.t =
     | Some (x, y) -> (x, y)
   in
   let pos = { Lexing.pos_fname; pos_lnum = 0; pos_bol = 0; pos_cnum = 0 } in
-  { Loc.start =
-      { pos with pos_lnum = pos_lnum_start; pos_cnum = pos_cnum_start }
-  ; Loc.stop = { pos with pos_lnum = pos_lnum_stop; pos_cnum = pos_cnum_stop }
-  }
+  let start =
+    { pos with pos_lnum = pos_lnum_start; pos_cnum = pos_cnum_start }
+  in
+  let stop = { pos with pos_lnum = pos_lnum_stop; pos_cnum = pos_cnum_stop } in
+  Loc.create ~start ~stop
 
 let parse_output ~dir s =
   Ocamlc_loc.parse s

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -145,7 +145,8 @@ let describe_rule (rule : Rule.t) =
   Pp.text
   @@
   match rule.info with
-  | From_dune_file { start; _ } ->
+  | From_dune_file loc ->
+    let start = Loc.start loc in
     start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
   | Internal -> "<internal location>"
   | Source_file_copy _ -> "file present in source tree"

--- a/src/dune_rpc_impl/diagnostics.ml
+++ b/src/dune_rpc_impl/diagnostics.ml
@@ -9,9 +9,9 @@ let absolutize_paths ~dir (loc : Loc.t) =
          Path.append_local dir (Path.Local.parse_string_exn ~loc name)
        else Path.of_string name)
   in
-  { Loc.start = { loc.start with pos_fname = make_path loc.start.pos_fname }
-  ; stop = { loc.stop with pos_fname = make_path loc.stop.pos_fname }
-  }
+  Loc.map_pos loc ~f:(fun (pos : Lexing.position) ->
+      { pos with pos_fname = make_path pos.pos_fname })
+  |> Loc.to_lexbuf_loc
 
 let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
     =

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -90,7 +90,7 @@ end = struct
               ; pos_bol = 0
               }
             in
-            { start; stop = { start with pos_cnum = String.length line } }
+            Loc.create ~start ~stop:{ start with pos_cnum = String.length line }
           in
           User_error.raise ~loc
             [ Pp.text "#require is no longer supported in dune files."

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -726,7 +726,7 @@ let forbid_opam_files_relative_to_project opam_file_location packages =
              files must live in the opam/ subdirecotry. The following opam \
              files must be moved:"
         ; Pp.enumerate (Package.Name.Map.values packages)
-            ~f:(fun ((loc : Loc.t), _) -> Pp.text loc.start.pos_fname)
+            ~f:(fun ((loc : Loc.t), _) -> Pp.text (Loc.start loc).pos_fname)
         ]
 
 let parse_packages (name : Name.t option) ~info ~dir ~version packages

--- a/src/dune_rules/include_stanza.ml
+++ b/src/dune_rules/include_stanza.ml
@@ -17,7 +17,7 @@ let error { current_file = file; include_stack } =
   let line_loc (loc, file) =
     sprintf "%s:%d"
       (Path.Source.to_string_maybe_quoted file)
-      loc.Loc.start.pos_lnum
+      (Loc.start loc).pos_lnum
   in
   User_error.raise ~loc
     [ Pp.text "Recursive inclusion of dune files detected:"

--- a/src/dune_sexp/cst.ml
+++ b/src/dune_sexp/cst.ml
@@ -57,11 +57,15 @@ let tokenize ts =
     | Comment (loc, comment) -> emit loc (Comment comment)
     | List (loc, l) ->
       emit
-        { loc with stop = { loc.start with pos_cnum = loc.start.pos_cnum + 1 } }
+        (Loc.set_stop loc
+           (let start = Loc.start loc in
+            { start with pos_cnum = start.pos_cnum + 1 }))
         Lparen;
       List.iter l ~f:iter;
       emit
-        { loc with start = { loc.stop with pos_cnum = loc.stop.pos_cnum - 1 } }
+        (Loc.set_start loc
+           (let stop = Loc.stop loc in
+            { stop with pos_cnum = stop.pos_cnum - 1 }))
         Rparen
   in
   List.iter ts ~f:iter;

--- a/src/dune_sexp/lexer.mll
+++ b/src/dune_sexp/lexer.mll
@@ -18,10 +18,9 @@ type t = with_comments:bool -> Lexing.lexbuf -> Token.t
 
 let error ?(delta = 0) lexbuf message =
   let start = Lexing.lexeme_start_p lexbuf in
-  let loc : Loc.t =
-    { start = { start with pos_cnum = start.pos_cnum + delta }
-    ; stop = Lexing.lexeme_end_p lexbuf
-    }
+  let loc =
+    Loc.create ~start:{ start with pos_cnum = start.pos_cnum + delta }
+      ~stop:(Lexing.lexeme_end_p lexbuf)
   in
   User_error.raise ~loc [ Pp.text message ]
 
@@ -57,11 +56,7 @@ type block_string_line_kind =
 module Template = struct
   include Template
 
-  let dummy_loc =
-    { Loc.
-      start = Lexing.dummy_pos
-    ; stop = Lexing.dummy_pos
-    }
+  let dummy_loc = Loc.create ~start:Lexing.dummy_pos ~stop:Lexing.dummy_pos
 
   let add_text parts s =
     match parts with
@@ -352,14 +347,8 @@ and template_variable = parse
       let start = Lexing.lexeme_start_p lexbuf in
       (* -2 to account for the "%{" *)
       let start = { start with pos_cnum = start.pos_cnum - 2 } in
-      Template.Pform
-        { loc =
-            { start
-            ; stop = Lexing.lexeme_end_p lexbuf
-            }
-        ; name
-        ; payload
-        }
+      let loc = Loc.create ~start ~stop:(Lexing.lexeme_end_p lexbuf) in
+      Template.Pform { loc ; name ; payload }
   }
   | '}' | eof
     { error lexbuf "%{...} forms cannot be empty" }

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -93,7 +93,8 @@ let get_error_from_exn = function
           { pos_fname = fname; pos_lnum = line; pos_cnum = start; pos_bol = 0 }
         in
         let stop = { start with pos_cnum = stop } in
-        (Some { Loc.start; stop }, Pp.text s)
+        let loc = Loc.create ~start ~stop in
+        (Some loc, Pp.text s)
     in
     { responsible = Developer
     ; msg = User_message.make ?loc [ pp ]
@@ -170,7 +171,7 @@ let gen_report exn backtrace =
         match msg.loc with
         | None -> if has_embedded_location then [] else memo_stack
         | Some loc ->
-          if Filename.is_relative loc.start.pos_fname then
+          if Filename.is_relative (Loc.start loc).pos_fname then
             (* If the error points to a local file, we assume that we don't need
                to explain to the user how we reached this error. *)
             []

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -251,7 +251,8 @@ let load_install_file path =
     in
     let start = position_of_loc start in
     let stop = position_of_loc stop in
-    User_error.raise ~loc:{ start; stop } [ Pp.text msg ]
+    let loc = Loc.create ~start ~stop in
+    User_error.raise ~loc [ Pp.text msg ]
   in
   List.concat_map file.file_contents ~f:(function
     | { pelem = Variable (section, files); pos } -> (

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -36,10 +36,10 @@ let on_diagnostic_event diagnostics =
     let sanitize_position (p : Lexing.position) =
       { p with pos_fname = sanitize_path p.pos_fname }
     in
-    fun (loc : Loc.t) ->
-      { Loc.start = sanitize_position loc.start
-      ; stop = sanitize_position loc.stop
-      }
+    fun (loc : Lexbuf.Loc.t) ->
+      Loc.of_lexbuf_loc loc
+      |> Loc.map_pos ~f:sanitize_position
+      |> Loc.to_lexbuf_loc
   in
   (* function to remove remove pp tags and hide junk from paths *)
   let map_event (d : Diagnostic.Event.t) f : Diagnostic.Event.t =


### PR DESCRIPTION
Introduce a Lexbuf.Loc.t that now represents the raw
locations we get from the lexer.

Dune's own locations are now abstract. This gives us an opportunity to
pick a better representation for them.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2507f1a9-f205-47bc-bec4-8ceb0fca5f0a -->