### PR TITLE
refactor(rpc): add names to session

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -28,7 +28,13 @@ end
 
 module Run = struct
   module Registry = Dune_rpc_private.Registry
-  module Server = Dune_rpc_server.Make (Csexp_rpc.Session)
+
+  module Server = Dune_rpc_server.Make (struct
+    include Csexp_rpc.Session
+
+    (* only needed for action runners. can be safely omitted elsewhere *)
+    let name _ = "unnamed"
+  end)
 
   type t =
     { handler : Dune_rpc_server.t

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -150,6 +150,8 @@ module Make (S : sig
       returned as [Some sexp], otherwise [None] is returned and the session is
       closed. *)
   val read : t -> Sexp.t option Fiber.t
+
+  val name : t -> string
 end) : sig
   (** [serve sessions handler] serve all [sessions] using [handler] *)
   val serve : S.t Fiber.Stream.In.t -> Dune_stats.t option -> t -> unit Fiber.t

--- a/test/expect-tests/dune_action_runner/dune_action_runner.ml
+++ b/test/expect-tests/dune_action_runner/dune_action_runner.ml
@@ -4,7 +4,13 @@ module Action_runner = Dune_engine.Action_runner
 module Rpc_server = Action_runner.Rpc_server
 module Where = Dune_rpc_client.Where
 module Scheduler = Dune_engine.Scheduler
-module Server = Dune_rpc_server.Make (Csexp_rpc.Session)
+
+module Server = Dune_rpc_server.Make (struct
+  include Csexp_rpc.Session
+
+  let name _ = "unnamed"
+end)
+
 module Action_exec = Dune_engine.Action_exec
 
 let () = Dune_util.Log.init_disabled ()

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -40,6 +40,8 @@ module Chan = struct
     Fiber.fork_and_join_unit
       (fun () -> Fiber.Stream.connect (fst c1.out) (snd c2.in_))
       (fun () -> Fiber.Stream.connect (fst c2.out) (snd c1.in_))
+
+  let name _ = "unnamed"
 end
 
 module Drpc = struct


### PR DESCRIPTION
this feature is only needed for compatibility with upstream action
runners

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 76fe86f1-7d68-4d49-933b-e220ca4bc692 -->