### PR TITLE
doc: more detail about make bench

### DIFF
--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -686,7 +686,8 @@ Dune Bench
 ----------
 
 You can benchmark Dune's performance by running `make bench`. This will run a
-subset of the Duniverse.
+subset of the Duniverse. If you are running the bench locally, make sure that
+you bootstrap since that is the executable that the bench will run.
 
 Inline Benchmarks
 -----------------


### PR DESCRIPTION
I noticed that `make bench` is using the bootstrap dune. This might be a footgun really.