### PR TITLE
fix: diffing empty files against /dev/null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Unreleased
 - Disable background operations on MacOS and other Unixes where we rely on
   fork. (#8100, fixes #8083, @rgrinberg)
 
+- Empty files are now registered for promotion. (#8077, fixes #8074, @Alizter)
+
 - Add `dune build --dump-gc-stats FILE` argument to dump Garbage Collection
   stats to a named file. (#8072, @Alizter)
 

--- a/doc/concepts/promotion.rst
+++ b/doc/concepts/promotion.rst
@@ -31,7 +31,8 @@ However, it is different for the following reason:
   produce ``b``, for cases where commands optionally produce a
   *corrected* file
 
-- If ``<file1>`` doesn't exist, it will compare with the empty file.
+- If ``<file1>`` doesn't exist, it will compare with the empty file. If
+  ``<file2>`` is also empty then the comparison will fail.
 
 - It allows promotion. See below.
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -215,10 +215,13 @@ let compare_files = function
   | Text -> Io.compare_text_files
 
 let diff_eq_files { Action.Diff.optional; mode; file1; file2 } =
-  let file1 = if Path.Untracked.exists file1 then file1 else Dev_null.path in
   let file2 = Path.build file2 in
+  (* We consider a diff equal if one of the following happens:
+     - The diff is set to optional and the built file does not exist.
+     - The original file exists and has the same contents (in binary or text
+       form) as the built file. *)
   (optional && not (Path.Untracked.exists file2))
-  || compare_files mode file1 file2 = Eq
+  || (Path.Untracked.exists file1 && compare_files mode file1 file2 = Eq)
 
 let zero = Predicate_lang.element 0
 

--- a/test/blackbox-tests/test-cases/promote/non-existent-empty.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent-empty.t/run.t
@@ -7,9 +7,11 @@ Tests for promoting with non existent reference
   [1]
 
   $ dune build @blah-non-existent
+  File "x-non-existent", line 1, characters 0-0:
+  Error: Files _build/default/x-non-existent and _build/default/x.gen differ.
+  [1]
 
   $ dune promote
+  Promoting _build/default/x.gen to x-non-existent.
 
   $ cat x-non-existent
-  cat: x-non-existent: No such file or directory
-  [1]


### PR DESCRIPTION
The old logic would set the first file as `Dev_null.path`. While cute, it doesn't have the correct semantics for when the file you are comparing to is also empty as reproduced in #8074. We therefore simplify the logic and only compare files when they exist, since we know when they don't exist they will never be equal.

- fixes #8074 
- [x] changelog
- [x] documentation
- [x] tests