### PR TITLE
feature(pkg): add field to indicate ocaml package

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -40,6 +40,7 @@ end
 type t =
   { version : Syntax.Version.t
   ; packages : Pkg.t Package_name.Map.t
+  ; ocaml : (Loc.t * Package_name.t) option
   }
 
 val remove_locs : t -> t
@@ -48,7 +49,8 @@ val equal : t -> t -> bool
 
 val to_dyn : t -> Dyn.t
 
-val create_latest_version : Pkg.t Package_name.Map.t -> t
+val create_latest_version :
+  Pkg.t Package_name.Map.t -> ocaml:(Loc.t * Package_name.t) option -> t
 
 val default_path : Path.Source.t
 

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -475,6 +475,7 @@ let solve_lock_dir ~version_preference ~repo_selection local_packages =
             (sprintf "Solver selected multiple packages named \"%s\""
                (Package_name.to_string name))
             []
-        | Ok pkgs_by_name -> Lock_dir.create_latest_version pkgs_by_name
+        | Ok pkgs_by_name ->
+          Lock_dir.create_latest_version pkgs_by_name ~ocaml:None
       in
       (summary, lock_dir))

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -169,11 +169,12 @@ let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
 
 let%expect_test "encode/decode round trip test for lockdir with no deps" =
   lock_dir_encode_decode_round_trip_test ~lock_dir_path:"empty_lock_dir"
-    ~lock_dir:(Lock_dir.create_latest_version Package_name.Map.empty);
+    ~lock_dir:
+      (Lock_dir.create_latest_version Package_name.Map.empty ~ocaml:None);
   [%expect
     {|
     lockdir matches after roundtrip:
-    { version = (0, 1); packages = map {} } |}]
+    { version = (0, 1); packages = map {}; ocaml = None } |}]
 
 let%expect_test "encode/decode round trip test for lockdir with simple deps" =
   lock_dir_encode_decode_round_trip_test ~lock_dir_path:"simple_lock_dir"
@@ -195,6 +196,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            } )
        in
        Lock_dir.create_latest_version
+         ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:"0.1.0"
             ; mk_pkg_basic ~name:"bar" ~version:"0.2.0"
@@ -232,6 +234,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               ; exported_env = []
               }
           }
+    ; ocaml = Some ("simple_lock_dir/lock.dune:2", "ocaml")
     } |}]
 
 let%expect_test "encode/decode round trip test for lockdir with complex deps" =
@@ -326,6 +329,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
            } )
        in
        Lock_dir.create_latest_version
+         ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
          (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ]));
   [%expect
     {|
@@ -380,4 +384,5 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; exported_env = []
               }
           }
+    ; ocaml = Some ("complex_lock_dir/lock.dune:2", "ocaml")
     } |}]


### PR DESCRIPTION
We can now write:

```
(ocaml foo)
```

To designate the package `foo` as the one providing the ocaml toolchain.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2a060c5f-d7ac-4be7-b9ef-96f03605cfec -->