### PR TITLE
fix: block on interrupting async_io

### DIFF
--- a/src/dune_async_io/async_io.ml
+++ b/src/dune_async_io/async_io.ml
@@ -223,7 +223,6 @@ let with_io scheduler f =
         (udp_sock, udp_sock)
     in
     Unix.set_nonblock pipe_read;
-    Unix.set_nonblock pipe_write;
     { readers = Table.create (module Fd) 64
     ; writers = Table.create (module Fd) 64
     ; mutex = Mutex.create ()


### PR DESCRIPTION
The write end of the pipe should be blocking when interrupting async_io.
The code does not handle the interrupt returning non blocking writes.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 75f0ee68-300b-4967-bf49-14392d956f71 -->