### PR TITLE
Don't solve for multiple contexts if lockdirs collide

### DIFF
--- a/otherlibs/stdune/src/loc.ml
+++ b/otherlibs/stdune/src/loc.ml
@@ -138,7 +138,14 @@ let on_same_line loc1 loc2 =
   let same_line = Int.equal start1.pos_lnum start2.pos_lnum in
   same_file && same_line
 
-let span begin_ end_ = set_stop begin_ (stop end_)
+let span (a : t) (b : t) =
+  let earliest_start =
+    if (start a).pos_cnum < (start b).pos_cnum then start a else start b
+  in
+  let latest_stop =
+    if (stop a).pos_cnum > (stop b).pos_cnum then stop a else stop b
+  in
+  create ~start:earliest_start ~stop:latest_stop
 
 let rec render ppf pp =
   Pp.to_fmt_with_tags ppf pp ~tag_handler:(fun ppf Loc pp ->

--- a/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
+++ b/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
@@ -1,0 +1,79 @@
+Create empty opam repo
+  $ mkdir -p mock-opam-repository/packages
+  $ cat >mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+Define several build contexts that all use the default lockdir
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context
+  >  (default))
+  > (context
+  >  (default
+  >   (name custom-context-with-default-lock-dir)))
+  > EOF
+
+Check that we can still generate lockdirs for individual contexts:
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  Solution for dune.lock:
+  (no dependencies to lock)
+  
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
+  Solution for dune.lock:
+  (no dependencies to lock)
+  
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=custom-context-with-default-lock-dir
+  Solution for dune.lock:
+  (no dependencies to lock)
+  
+
+It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  File "dune-workspace", line 5, characters 1-56:
+  5 |  (default
+  6 |   (name custom-context-with-default-lock-dir)))
+  Error: Refusing to proceed as multiple selected contexts would create a lock
+  dir at the same path.
+  These contexts all create a lock dir: dune.lock
+  - custom-context-with-default-lock-dir (defined at dune-workspace:5)
+  - default (defined at dune-workspace:3)
+  [1]
+
+Define several build contexts that all use the same custom lockdir:
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context
+  >  (default
+  >   (name b)
+  >   (lock foo.lock)))
+  > (context
+  >  (default
+  >   (name a)
+  >   (lock foo.lock)))
+  > EOF
+
+Check that we can still generate lockdirs for individual contexts:
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=a
+  Solution for foo.lock:
+  (no dependencies to lock)
+  
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=b
+  Solution for foo.lock:
+  (no dependencies to lock)
+  
+
+It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
+  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  File "dune-workspace", line 7, characters 1-39:
+  7 |  (default
+  8 |   (name a)
+  9 |   (lock foo.lock)))
+  Error: Refusing to proceed as multiple selected contexts would create a lock
+  dir at the same path.
+  These contexts all create a lock dir: foo.lock
+  - a (defined at dune-workspace:7)
+  - b (defined at dune-workspace:3)
+  [1]
+
+

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -2,6 +2,7 @@ Create a lock directory that didn't originally exist
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
+  
   $ cat dune.lock/lock.dune
   (lang package 0.1)
 
@@ -9,6 +10,7 @@ Re-create a lock directory in the newly created lock dir
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
+  
   $ cat dune.lock/lock.dune
   (lang package 0.1)
 
@@ -16,8 +18,6 @@ Attempt to create a lock directory inside an existing directory without a lock.d
   $ rm -rf dune.lock
   $ cp -r dir-without-metadata dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  Solution for dune.lock:
-  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir lacks metadata file (lock.dune)
   [1]
@@ -26,8 +26,6 @@ Attempt to create a lock directory inside an existing directory with an invalid 
   $ rm -rf dune.lock
   $ cp -r dir-with-invalid-metadata dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  Solution for dune.lock:
-  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   File "dune.lock/lock.dune", line 1, characters 0-12:
   Error: Invalid first line, expected: (lang <lang> <version>)
@@ -38,8 +36,6 @@ Attempt to create a lock directory with the same name as an existing regular fil
   $ rm -rf dune.lock
   $ touch dune.lock
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
-  Solution for dune.lock:
-  (no dependencies to lock)
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir path is not a directory
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -52,6 +52,7 @@ Generate the lockdir for the default context.
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Only foo.lock (the default context's lockdir) was generated.
   $ find *.lock | sort
@@ -68,6 +69,7 @@ Generate the lockdir with the default context explicitly specified.
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Again, only foo.lock (the default context's lockdir) was generated.
   $ find *.lock | sort
@@ -84,6 +86,7 @@ Generate the lockdir for the non-default context.
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Now only bar.lock was generated.
   $ find *.lock | sort
@@ -100,6 +103,7 @@ Generate the lockdir for a context which prefers oldest package versions.
   bar.0.4.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Re-generate the lockdir for a context which prefers oldest package versions,
 but override it to prefer newest with a command line argument.
@@ -108,6 +112,7 @@ but override it to prefer newest with a command line argument.
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Generate the lockdir for all (non-opam) contexts.
   $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
@@ -115,14 +120,17 @@ Generate the lockdir for all (non-opam) contexts.
   bar.0.4.0
   baz.0.1.0
   foo.0.0.1
+  
   Solution for bar.lock:
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
   Solution for foo.lock:
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Now both lockdirs were generated.
   $ find *.lock | sort

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -17,6 +17,7 @@ Run the solver and generate a lock directory.
   bar.0.5.0
   baz.0.1.0
   foo.0.0.1
+  
 
 Helper to the name and contents of each file in the lock directory separated by
 "---", sorting by filename for consistency.
@@ -60,6 +61,7 @@ Run the solver again preferring oldest versions of dependencies:
   bar.0.4.0
   baz.0.1.0
   foo.0.0.1
+  
 
   $ print_all
   dune.lock/bar.pkg:

--- a/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
@@ -89,24 +89,36 @@ Generate a mock opam repository
   doc-package.0.0.1
   regular-package.0.0.1
   test-package.0.0.1
+  
   Solution for with-doc-and-with-test.lock:
   doc-package.0.0.1
   regular-package.0.0.1
   test-package.0.0.1
+  
   Solution for with-doc-only.lock:
   doc-package.0.0.1
   regular-package.0.0.1
+  
   Solution for with-test-only.lock:
   regular-package.0.0.1
   test-package.0.0.1
+  
   Solution for empty-solver-flags.lock:
   regular-package.0.0.1
+  
   Solution for default-solver-flags.lock:
   doc-package.0.0.1
   regular-package.0.0.1
   test-package.0.0.1
+  
   Solution for default-solver-env.lock:
   doc-package.0.0.1
   regular-package.0.0.1
   test-package.0.0.1
+  
+  Solution for dune.lock:
+  doc-package.0.0.1
+  regular-package.0.0.1
+  test-package.0.0.1
+  
 

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -62,6 +62,7 @@ Regular dependencies are resolved transitively:
   depends-on-foo.0.0.1
   foo.0.0.1
   foo-dependency.0.0.1
+  
 
 Transitive test dependencies are not included:
   $ solve_project <<EOF
@@ -72,6 +73,7 @@ Transitive test dependencies are not included:
   > EOF
   Solution for dune.lock:
   depends-on-foo-with-test.0.0.1
+  
 
 Test dependencies of the project are included:
   $ solve_project <<EOF
@@ -84,6 +86,7 @@ Test dependencies of the project are included:
   Solution for dune.lock:
   foo.0.0.1
   foo-dependency.0.0.1
+  
 
 Test dependencies of test dependencies are excluded:
   $ solve_project <<EOF
@@ -94,6 +97,7 @@ Test dependencies of test dependencies are excluded:
   > EOF
   Solution for dune.lock:
   depends-on-foo-with-test.0.0.1
+  
 
 Conflicting packages can't be co-installed:
   $ solve_project <<EOF
@@ -133,4 +137,5 @@ Conflicts with transitive test dependencies don't affect the solution:
   Solution for dune.lock:
   conflicts-with-foo.0.0.1
   depends-on-foo-with-test.0.0.1
+  
 


### PR DESCRIPTION
When running `dune pkg lock --all-contexts` it is now an error if there are multiple build contexts which specify the same lockdir path. Also adds whitespace between the log when solving dependencies to make it easier to read the output of `dune pkg lock --all-contexts`.