### PR TITLE
refactor: remove [Univ_map.to_dyns]

### DIFF
--- a/otherlibs/stdune/src/univ_map.ml
+++ b/otherlibs/stdune/src/univ_map.ml
@@ -109,12 +109,6 @@ module Make () = struct
       |> List.map ~f:(fun (Binding.T (key, v)) ->
              let (module K) = key in
              (string K.name, K.to_dyn v)))
-
-  let to_dyns (t : t) =
-    Int.Map.values t
-    |> List.map ~f:(fun (Binding.T (key, v)) ->
-           let (module K) = key in
-           (K.name, K.to_dyn v))
 end
 
 include Make ()

--- a/otherlibs/stdune/src/univ_map_intf.ml
+++ b/otherlibs/stdune/src/univ_map_intf.ml
@@ -35,7 +35,4 @@ module type S = sig
   val superpose : t -> t -> t
 
   val to_dyn : t -> Dyn.t
-
-  (** [to_dyns m] is an assoc list pairing keys to (representations of) values *)
-  val to_dyns : t -> (string * Dyn.t) list
 end


### PR DESCRIPTION
this function is unused and not particularly useful

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8425d1eb-d86e-4476-b745-c8d5b61834a4 -->