### PR TITLE
fix: rally action runner errors

### DIFF
--- a/src/dune_engine/action_runner.ml
+++ b/src/dune_engine/action_runner.ml
@@ -4,7 +4,9 @@ module Dune_rpc = Dune_rpc_private
 
 module Decl : sig
   val exec :
-    (Action_exec.input, Action_exec.Exec_result.t) Dune_rpc.Decl.request
+    ( Action_exec.input
+    , (Action_exec.Exec_result.t, Exn_with_backtrace.t list) result )
+    Dune_rpc.Decl.request
 
   val ready : (string, unit) Dune_rpc.Decl.request
 end = struct
@@ -189,7 +191,7 @@ module Worker = struct
         [ Pp.text "action runner executing action:"
         ; Action.for_shell action.action |> Action_to_sh.pp
         ];
-      Action_exec.exec ~build_deps action
+      Fiber.collect_errors (fun () -> Action_exec.exec ~build_deps action)
 
   let start ~name ~where =
     let* connection = Client.Connection.connect_exn where in

--- a/src/dune_engine/action_runner.mli
+++ b/src/dune_engine/action_runner.mli
@@ -1,3 +1,5 @@
+open Import
+
 (** Action runners are instances capabale of executing dune actions outside of
     the build engine's process. *)
 
@@ -27,7 +29,10 @@ val create : Rpc_server.t -> name:string -> t
 val name : t -> string
 
 (** [exec_action worker action] dispatches [action] to [worker] *)
-val exec_action : t -> Action_exec.input -> Action_exec.Exec_result.t Fiber.t
+val exec_action :
+     t
+  -> Action_exec.input
+  -> (Action_exec.Exec_result.t, Exn_with_backtrace.t list) result Fiber.t
 
 module Worker : sig
   (** A worker is a runner of action *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -503,7 +503,10 @@ end = struct
             in
             match (Build_config.get ()).action_runner input with
             | None -> Action_exec.exec input ~build_deps
-            | Some runner -> Action_runner.exec_action runner input
+            | Some runner -> (
+              Action_runner.exec_action runner input >>= function
+              | Ok res -> Fiber.return res
+              | Error exns -> Fiber.reraise_all exns)
           in
           let+ produced_targets =
             match sandbox with

--- a/test/expect-tests/dune_action_runner/dune_action_runner.ml
+++ b/test/expect-tests/dune_action_runner/dune_action_runner.ml
@@ -100,7 +100,8 @@ let run () =
           ; action
           }
         in
-        let+ (_ : Action_exec.Exec_result.t) =
+        let+ (_ : (Action_exec.Exec_result.t, Exn_with_backtrace.t list) result)
+            =
           Action_runner.exec_action worker action
         in
         print_endline "executed action";


### PR DESCRIPTION
Whenever an action runner raises, it would not send back the response
for executing the action.

This PR changes the behavior to catch the action runner errors and pass
them along to the server as needed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: abac89f6-576a-41a9-99a1-92c45b95afb0 -->