### PR TITLE
feature(pkg): Automatic fetching of opam-repository

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -42,7 +42,8 @@
   dune_rpc_private
   dune_rpc_client
   spawn
-  opam_format)
+  opam_format
+  xdg)
  (bootstrap_info bootstrap-info))
 
 ; Installing the dune binary depends on the kind of build:

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -67,15 +67,15 @@ type failure =
   | Checksum_mismatch of Checksum.t
   | Unavailable of User_message.t option
 
-let fetch ~checksum ~target (url : OpamUrl.t) =
+let fetch ~unpack ~checksum ~target (url : OpamUrl.t) =
   let open Fiber.O in
   let path = Path.to_string target in
   let pull =
     (* hashes have to be empty otherwise OPAM deletes the file after
        downloading if the hash does not match *)
     let hashes = [] in
-    match url.backend with
-    | #OpamUrl.version_control -> (
+    match (url.backend, unpack) with
+    | #OpamUrl.version_control, _ | _, true -> (
       let dirname = OpamFilename.Dir.of_string path in
       fun label url ->
         let open OpamProcess.Job.Op in

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -13,7 +13,8 @@ type failure =
     @raise Unavailable
       When the file can't be retrieved, e.g. not available at the location. *)
 val fetch :
-     checksum:Checksum.t option
+     unpack:bool
+  -> checksum:Checksum.t option
   -> target:Path.t
   -> OpamUrl.t
   -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/opam.mli
+++ b/src/dune_pkg/opam.mli
@@ -23,36 +23,8 @@ module Repo_selection : sig
   (** An opam repository *)
   type t
 
-  (** A t that does not yet have an environment added. Use [add_env]. *)
-  type pre
-
-  (** An opam repo associated with a switch of a given name or directory *)
-  val switch_with_name : string -> pre
-
-  (** An opam repo in a local directory given by [opam_repo_dir_path]. Note that
-      [opam_repo_dir_path] is a [Filename.t] rather than, say, a
-      [Path.Outside_build_dir.t]. This is due to a current limitation in what
-      that type (and other modules in [Path]) can represent. It's desirable that
-      the [opam_repo_dir_path] argument have the following properties:
-
-      - It should be possible to build a [Repo_selection.t] from command line
-        arguments during argument parsing, which precludes the use of a [Path.t]
-        here as creating a [Path.t] requires some global state to be set up (by
-        [Common.init]) which isn't setup at the time command line arguments are
-        parsed.
-      - This argument should accept both paths within the source directory and
-        external paths, since in practical usage it will usually be pointed to
-        some out-of-source copy of the opam repository, but for unit tests it's
-        convenient that this support paths within the source directory too. This
-        rules out using [Path.External.t], [Path.Source.t], and [Path.Local.t].
-      - We want to support relative paths external to the source directory to
-        handle the case where someone has the opam repository checkoud out next
-        to their project, and runs: `dune pkg lock --opam-repository-path
-        ../opam-repository`. This rules out [Path.Outside_build_dir.t] as it
-        doesn't permit relative paths outside the source directory. *)
-  val local_repo_with_env : opam_repo_dir_path:Filename.t -> env:Env.t -> pre
-
-  val add_env : Env.t -> pre -> t
+  (** An opam repo in a local directory given by [opam_repo_dir]. *)
+  val local_repo_with_env : opam_repo_dir:Path.t -> env:Env.t -> t
 end
 
 module Summary : sig

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -10,11 +10,4 @@ module Context_for_dune : sig
     -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
     -> version_preference:Version_preference.t
     -> t
-
-  val create_switch_context :
-       solver_env:Solver_env.t
-    -> switch_state:OpamStateTypes.unlocked OpamStateTypes.switch_state
-    -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
-    -> version_preference:Version_preference.t
-    -> t
 end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1043,8 +1043,8 @@ module Fetch = struct
       let* () = Fiber.return () in
       let* res =
         let checksum = Option.map checksum ~f:snd in
-        Dune_pkg.Fetch.fetch ~checksum ~target:(Path.build target_dir)
-          (OpamUrl.of_string url)
+        Dune_pkg.Fetch.fetch ~unpack:false ~checksum
+          ~target:(Path.build target_dir) (OpamUrl.of_string url)
       in
       match res with
       | Ok () -> Fiber.return ()

--- a/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
+++ b/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
@@ -15,21 +15,21 @@ Define several build contexts that all use the default lockdir
   > EOF
 
 Check that we can still generate lockdirs for individual contexts:
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
   
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=default
   Solution for dune.lock:
   (no dependencies to lock)
   
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=custom-context-with-default-lock-dir
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=custom-context-with-default-lock-dir
   Solution for dune.lock:
   (no dependencies to lock)
   
 
 It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --all-contexts
   File "dune-workspace", line 5, characters 1-56:
   5 |  (default
   6 |   (name custom-context-with-default-lock-dir)))
@@ -54,17 +54,17 @@ Define several build contexts that all use the same custom lockdir:
   > EOF
 
 Check that we can still generate lockdirs for individual contexts:
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=a
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=a
   Solution for foo.lock:
   (no dependencies to lock)
   
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=b
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=b
   Solution for foo.lock:
   (no dependencies to lock)
   
 
 It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --all-contexts
   File "dune-workspace", line 7, characters 1-39:
   7 |  (default
   8 |   (name a)

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -6,36 +6,49 @@ Test the error cases for invalid opam repositories
   >  (name lockfile_generation_test))
   > EOF
 
-  $ dune pkg lock --opam-env=pure --opam-repository=directory-that-does-not-exist
-  Error: directory-that-does-not-exist does not exist
+  $ dune pkg lock --opam-env=pure --opam-repository-path=directory-that-does-not-exist
+  Error:
+  $TESTCASE_ROOT/directory-that-does-not-exist
+  does not exist
   [1]
 
   $ touch empty
-  $ dune pkg lock --opam-env=pure --opam-repository=empty
-  Error: empty is not a directory
+  $ dune pkg lock --opam-env=pure --opam-repository-path=empty
+  Error:
+  $TESTCASE_ROOT/empty
+  is not a directory
   [1]
 
-  $ dune pkg lock --opam-env=pure --opam-repository=no-packages-dir
-  Error: no-packages-dir doesn't look like a path to an opam repository as it
-  lacks a subdirectory named "packages"
+  $ dune pkg lock --opam-env=pure --opam-repository-path=no-packages-dir
+  Error:
+  $TESTCASE_ROOT/no-packages-dir
+  doesn't look like a path to an opam repository as it lacks a subdirectory
+  named "packages"
   [1]
 
-  $ dune pkg lock --opam-env=pure --opam-repository=no-repo-file
-  Error: File no-repo-file/repo does not exist or can't be read
+  $ dune pkg lock --opam-env=pure --opam-repository-path=no-repo-file
+  Error: File
+  $TESTCASE_ROOT/no-repo-file/repo
+  does not exist or can't be read
   [1]
 
-  $ dune pkg lock --opam-env=pure --opam-repository=bad-repo-file
-  Error: At bad-repo-file/repo:1:4-1:8::
+  $ dune pkg lock --opam-env=pure --opam-repository-path=bad-repo-file
+  Error: At
+  $TESTCASE_ROOT/bad-repo-file/repo:1:4-1:8::
   Parse error
   [1]
 
-  $ dune pkg lock --opam-env=pure --opam-repository=no-repo-version
-  Error: The file no-repo-version/repo lacks an "opam-version" field.
+  $ dune pkg lock --opam-env=pure --opam-repository-path=no-repo-version
+  Error: The file
+  $TESTCASE_ROOT/no-repo-version/repo
+  lacks an "opam-version" field.
   Hint: Add `opam-version: "2.0"` to the file.
   [1]
 
-  $ dune pkg lock --opam-env=pure --opam-repository=bad-repo-version
-  Error: The file bad-repo-version/repo specifies an opam-version which is too
-  low (1.0). The minimum opam-version is 2.0.
+  $ dune pkg lock --opam-env=pure --opam-repository-path=bad-repo-version
+  Error: The file
+  $TESTCASE_ROOT/bad-repo-version/repo
+  specifies an opam-version which is too low (1.0). The minimum opam-version is
+  2.0.
   Hint: Change the opam-version field to `opam-version: "2.0"`.
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -1,5 +1,5 @@
 Create a lock directory that didn't originally exist
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
   
@@ -7,7 +7,7 @@ Create a lock directory that didn't originally exist
   (lang package 0.1)
 
 Re-create a lock directory in the newly created lock dir
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
   
@@ -17,7 +17,7 @@ Re-create a lock directory in the newly created lock dir
 Attempt to create a lock directory inside an existing directory without a lock.dune file
   $ rm -rf dune.lock
   $ cp -r dir-without-metadata dune.lock
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir lacks metadata file (lock.dune)
   [1]
@@ -25,7 +25,7 @@ Attempt to create a lock directory inside an existing directory without a lock.d
 Attempt to create a lock directory inside an existing directory with an invalid lock.dune file
   $ rm -rf dune.lock
   $ cp -r dir-with-invalid-metadata dune.lock
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Error: Refusing to regenerate lock directory dune.lock
   File "dune.lock/lock.dune", line 1, characters 0-12:
   Error: Invalid first line, expected: (lang <lang> <version>)
@@ -35,7 +35,7 @@ Attempt to create a lock directory inside an existing directory with an invalid 
 Attempt to create a lock directory with the same name as an existing regular file
   $ rm -rf dune.lock
   $ touch dune.lock
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir path is not a directory
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -32,22 +32,22 @@ Generate a `dune-project` file listing some dependencies.
   > EOF
 
 Test that we get an error when --context and --all-contexts are passed at the same time.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts --context=foo
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --all-contexts --context=foo
   Error: --context and --all-contexts are mutually exclusive
   [1]
 
 Test that we get an error if a non-existant context is specified.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=baz
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=baz
   Error: Unknown build context: baz
   [1]
 
 Test that we get an error if an opam context is specified.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=bar
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=bar
   Error: Unexpected opam build context: bar
   [1]
 
 Generate the lockdir for the default context.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Solution for foo.lock:
   bar.0.5.0
   baz.0.1.0
@@ -64,7 +64,7 @@ Only foo.lock (the default context's lockdir) was generated.
   $ rm -rf *.lock
 
 Generate the lockdir with the default context explicitly specified.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=default
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=default
   Solution for foo.lock:
   bar.0.5.0
   baz.0.1.0
@@ -81,7 +81,7 @@ Again, only foo.lock (the default context's lockdir) was generated.
   $ rm -rf *.lock
 
 Generate the lockdir for the non-default context.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=foo
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=foo
   Solution for bar.lock:
   bar.0.5.0
   baz.0.1.0
@@ -98,7 +98,7 @@ Now only bar.lock was generated.
   $ rm -rf *.lock
 
 Generate the lockdir for a context which prefers oldest package versions.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=prefers_oldest
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=prefers_oldest
   Solution for prefers_oldest.lock:
   bar.0.4.0
   baz.0.1.0
@@ -107,7 +107,7 @@ Generate the lockdir for a context which prefers oldest package versions.
 
 Re-generate the lockdir for a context which prefers oldest package versions,
 but override it to prefer newest with a command line argument.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --context=prefers_oldest --version-preference=newest
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --context=prefers_oldest --version-preference=newest
   Solution for prefers_oldest.lock:
   bar.0.5.0
   baz.0.1.0
@@ -115,7 +115,7 @@ but override it to prefer newest with a command line argument.
   
 
 Generate the lockdir for all (non-opam) contexts.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --all-contexts
   Solution for prefers_oldest.lock:
   bar.0.4.0
   baz.0.1.0

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -12,7 +12,7 @@ Generate a `dune-project` file.
   > EOF
 
 Run the solver and generate a lock directory.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   bar.0.5.0
   baz.0.1.0
@@ -56,7 +56,7 @@ Print the contents of each file in the lockdir:
   
 
 Run the solver again preferring oldest versions of dependencies:
-  $ dune pkg lock --opam-env=pure --version-preference=oldest --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --version-preference=oldest --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   bar.0.4.0
   baz.0.1.0
@@ -106,7 +106,7 @@ Regenerate the `dune-project` file introducing an unsatisfiable constraint.
   > EOF
 
 Run the solver again. This time it will fail.
-  $ dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  $ dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   Error: Can't find all required versions.
   Selected: baz.0.1.0 foo.0.0.1 lockfile_generation_test.dev
   - bar -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -1,0 +1,101 @@
+Helper shell function that generates an opam file for a package:
+
+  $ mkpkg() {
+  >   name=$1
+  >   mkdir -p mock-opam-repository/packages/$name/$name.0.0.1
+  >   cat >mock-opam-repository/packages/$name/$name.0.0.1/opam
+  > } 
+
+Make a mock repo tarball that will get used by dune to download the package
+
+  $ mkdir mock-opam-repository
+  $ cat > mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+  $ mkpkg foo <<EOF
+  > opam-version: "2.0"
+  > EOF
+  $ mkpkg bar <<EOF
+  > opam-version: "2.0"
+  > depends: [ "foo" ]
+  > EOF
+  $ cd mock-opam-repository
+  $ tar czf ../index.tar.gz *
+  $ cd ..
+
+Create a dune project with a minimal single-request HTTP server. This is built and used to
+serve our opam-repository as a mock.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (generate_opam_files true)
+  > 
+  > (package
+  >   (name baz)
+  >   (depends
+  >     bar))
+  > EOF
+  $ cat > dune <<EOF
+  > (executable
+  >   (public_name server)
+  >   (libraries stdune)
+  >   ;; stdune is showing the unstable alert but since this is part of the
+  >   ;; dune codebase, this test has to be adjusted in case the API changes
+  >   (flags -alert -unstable))
+  > EOF
+  > cat > server.ml <<EOF
+  > open Stdune
+  > let serve_once ~filename ~port () =
+  >   let host = Unix.inet_addr_loopback in
+  >   let addr = Unix.ADDR_INET (host, port) in
+  >   let sock = Unix.socket ~cloexec:true Unix.PF_INET Unix.SOCK_STREAM 0 in
+  >   Unix.setsockopt sock Unix.SO_REUSEADDR true;
+  >   Unix.bind sock addr;
+  >   Unix.listen sock 5;
+  >   (* signal we're done setting up *)
+  >   let pid = open_out "server.pid" in
+  >   close_out pid;
+  >   let descr, _sockaddr = Unix.accept sock in
+  >   let content = Io.String_path.read_file filename in
+  >   let content_length = String.length content in
+  >   let write_end = Unix.out_channel_of_descr descr in
+  >   Printf.fprintf write_end {|HTTP/1.1 200 Ok
+  > Content-Length: %d
+  > 
+  > %s|}
+  >     content_length content;
+  >   close_out write_end
+  > 
+  > let () =
+  >   let port = int_of_string (Sys.argv.(1)) in
+  >   serve_once ~filename:"index.tar.gz" ~port ()
+  > EOF
+  $ PORT=$(shuf -i 2048-65000 -n 1)
+  $ dune exec -- ./server.exe $PORT &
+  $ # wait for server to come up, this takes a bit
+  $ while [ ! -f server.pid ]; do sleep 0.01; done
+
+Run Dune and tell it to cache into our custom cache folder.
+
+  $ mkdir fake-xdg-cache
+  $ XDG_CACHE_HOME=$(pwd)/fake-xdg-cache dune pkg lock --opam-repository-url=http://localhost:$PORT/index.tar.gz
+  Solution for dune.lock:
+  bar.0.0.1
+  foo.0.0.1
+  
+
+Our custom cache folder should be populated with the unpacked tarball
+containing the repository:
+
+  $ find fake-xdg-cache | sort
+  fake-xdg-cache
+  fake-xdg-cache/dune
+  fake-xdg-cache/dune/opam-repository
+  fake-xdg-cache/dune/opam-repository/packages
+  fake-xdg-cache/dune/opam-repository/packages/bar
+  fake-xdg-cache/dune/opam-repository/packages/bar/bar.0.0.1
+  fake-xdg-cache/dune/opam-repository/packages/bar/bar.0.0.1/opam
+  fake-xdg-cache/dune/opam-repository/packages/foo
+  fake-xdg-cache/dune/opam-repository/packages/foo/foo.0.0.1
+  fake-xdg-cache/dune/opam-repository/packages/foo/foo.0.0.1/opam
+  fake-xdg-cache/dune/opam-repository/repo

--- a/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
@@ -9,7 +9,7 @@ Helper shell function that generates an opam file for a package:
 Helper shell function to generate a dune-project file and generate lockdir:
   $ solve_project() {
   >   cat >dune-project
-  >   dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository --all-contexts
+  >   dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository --all-contexts
   > }
 
 Create a workspace file with some contexts with different combinations of with-test and with-doc flags

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -48,7 +48,7 @@ Generate a mock opam repository including some test dependencies:
 Helper shell function to generate a dune-project file and generate lockdir:
   $ solve_project() {
   >   cat >dune-project
-  >   dune pkg lock --opam-env=pure --opam-repository=mock-opam-repository
+  >   dune pkg lock --opam-env=pure --opam-repository-path=mock-opam-repository
   > }
 
 Regular dependencies are resolved transitively:

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -39,7 +39,7 @@ let wrong_checksum =
 let download ~port ~filename ~target ?checksum () =
   let open Fiber.O in
   let url = url ~port ~filename in
-  let* res = Fetch.fetch ~checksum ~target url in
+  let* res = Fetch.fetch ~unpack:false ~checksum ~target url in
   match res with
   | Error (Unavailable None) ->
     let errs = [ Pp.text "Failure while downloading" ] in


### PR DESCRIPTION
This PR is an exploration on downloading a copy of opam-repository for locking. It is surprisingly easy to implement and it works rather fast. Currently the Git repo that it downloads is 142M but an initial lock of dune takes 11s and a consecutive lock with the repo downloaded takes about 3s.

I'm honestly rather pleasantly surprised how nicely this works.