### PR TITLE
refactor: use Tuple.Tx.hash when possible

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -172,7 +172,7 @@ end = struct
         && Option.equal String.equal root_a root_b
         && String.equal switch_a switch_b
 
-      let hash (env, root, switch) = Poly.hash (Env.hash env, root, switch)
+      let hash = Tuple.T3.hash Env.hash Poly.hash Poly.hash
 
       let to_dyn (env, root, switch) =
         Dyn.Tuple [ Env.to_dyn env; Dyn.(option string root); String switch ]

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -644,7 +644,7 @@ let setup_lib_html_rules_def =
     let equal (sc1, l1) (sc2, l2) =
       Super_context.equal sc1 sc2 && Lib.Local.equal l1 l2
 
-    let hash (sc, l) = Poly.hash (Super_context.hash sc, Lib.Local.hash l)
+    let hash = Tuple.T2.hash Super_context.hash Lib.Local.hash
 
     let to_dyn _ = Dyn.Opaque
   end in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -574,7 +574,7 @@ module As_memo_key = struct
   module And_package = struct
     type nonrec t = t * Package.t
 
-    let hash (x, y) = Poly.hash (hash x, Package.hash y)
+    let hash = Tuple.T2.hash hash Package.hash
 
     let equal (x1, y1) (x2, y2) = equal x1 x2 && y1 == y2
 


### PR DESCRIPTION
This is Poly.hash under a different name but more monomorphic.
