### PR TITLE
fix: disable threaded console when we use fork

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 Unreleased
 ----------
 
-- Disable background operations on MacOS and other Unixes where we rely on
-  fork. (#8100, fixes #8083, @rgrinberg)
+- Disable background operations and threaded console on MacOS and other Unixes
+  where we rely on fork. (#8100, #8121, fixes #8083, @rgrinberg, @emillon)
 
 - Add `dune build --dump-gc-stats FILE` argument to dump Garbage Collection
   stats to a named file. (#8072, @Alizter)

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -146,7 +146,7 @@ let threaded_console =
   let t =
     { name = "threaded_console"
     ; of_string = Toggle.of_string
-    ; value = `Enabled
+    ; value = background_default
     }
   in
   register t;


### PR DESCRIPTION
This is similar to #8100 for the threaded console. The reason we're doing that is to avoid threads when fork is involved.
