### PR TITLE
refactor: remove make from context

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -51,7 +51,6 @@ type t =
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; lib_config : Lib_config.t
   ; build_context : Build_context.t
-  ; make : Path.t option Memo.Lazy.t
   }
 
 let equal x y = Context_name.equal x.name y.name
@@ -421,17 +420,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     let dynamically_linked_foreign_archives =
       supports_shared_libraries && dynamically_linked_foreign_archives
     in
-    let make =
-      let make = Memo.lazy_ (fun () -> which "make") in
-      match Sys.unix with
-      | false -> make
-      | true ->
-        Memo.lazy_ (fun () ->
-            let* res = which "gmake" in
-            match res with
-            | Some _ as s -> Memo.return s
-            | None -> Memo.Lazy.force make)
-    in
     let t =
       let build_context =
         Build_context.create ~name ~host:(Option.map host ~f:(fun c -> c.name))
@@ -456,7 +444,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
           Dynlink_supported.By_the_os.of_bool supports_shared_libraries
       ; lib_config
       ; build_context
-      ; make
       }
     in
     if Ocaml.Version.supports_response_file ocaml.version then (
@@ -715,5 +702,3 @@ let roots t =
     let setup_roots = Roots.map ~f:(Option.map ~f:Path.of_string) Setup.roots in
     Roots.first_has_priority setup_roots prefix_roots
   | Opam _ -> prefix_roots
-
-let make t = Memo.Lazy.force t.make

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -76,7 +76,6 @@ type t = private
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; lib_config : Lib_config.t
   ; build_context : Build_context.t
-  ; make : Path.t option Memo.Lazy.t
   }
 
 val which : t -> string -> Path.t option Memo.t
@@ -91,9 +90,6 @@ val to_dyn_concise : t -> Dyn.t
 
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t
-
-(** Return what [%{make}] should expand into *)
-val make : t -> Path.t option Memo.t
 
 val name : t -> Context_name.t
 

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -401,6 +401,28 @@ let expand_lib_variable t source ~arg:s ~lib_exec ~lib_private =
   in
   Action_builder.of_memo_join p
 
+let make =
+  let open Memo.O in
+  let make context =
+    let which = Context.which context in
+    match Sys.unix with
+    | false -> which "make"
+    | true -> (
+      let* res = which "gmake" in
+      match res with
+      | Some _ as s -> Memo.return s
+      | None -> which "make")
+  in
+  let memo =
+    Memo.create "make"
+      ~input:(module Context_name)
+      ~cutoff:(Option.equal Path.equal)
+      (fun name ->
+        let* context = Context.DB.get name in
+        make context)
+  in
+  fun (context : Context.t) -> Memo.exec memo context.name
+
 let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source
     (pform : Pform.t) : expansion_result =
   match Pform.Map.find bindings pform with
@@ -441,7 +463,7 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source
         let open Memo.O in
         Direct
           (Without
-             (Context.make context >>| function
+             (make context >>| function
               | Some p -> path p
               | None ->
                 Utils.program_not_found ~context:context.name


### PR DESCRIPTION
it's only used in the expander so this is where it should be defined.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3e6e01b3-8b82-45a6-a3f5-93c1bb81a0db -->