### PR TITLE
chore: dump-stats cleanups

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -716,7 +716,7 @@ module Builder = struct
         & opt (some string) None
         & info [ "dump-gc-stats" ] ~docs ~docv:"FILE"
             ~doc:
-              "Dumps the Garbage Collector stats to a file after the build is \
+              "Dump the garbage collector stats to a file after the build is \
                complete.")
     and+ { Options_implied_by_dash_p.root
          ; only_packages
@@ -1157,8 +1157,9 @@ let init ?action_runner ?log_file c =
       | Some file ->
         Gc.full_major ();
         Gc.compact ();
+        let stat = Gc.stat () in
         let path = Path.external_ file in
-        Dune_util.Gc.serialize ~path (Gc.stat ()));
+        Dune_util.Gc.serialize ~path stat);
   config
 
 let footer =

--- a/test/blackbox-tests/test-cases/dump-gc-stat.t
+++ b/test/blackbox-tests/test-cases/dump-gc-stat.t
@@ -1,7 +1,7 @@
-Testing the --dump-gc-stat option
+Testing the --dump-gc-stats option
 
-  $ dune build --dump-gc-stat stats
-  $ cat stats | sed -r 's/[ ]+[0-9]+//g'
+  $ dune build --dump-gc-stats stats
+  $ sed -r 's/[ ]+[0-9]+//g' < stats
   ((minor_words.)
    (promoted_words.)
    (major_words.)


### PR DESCRIPTION
Count stats immediately after compacting

Do not rely on prefix in tests

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f35d3441-436b-4b10-95b2-41a74b5ccec8 -->