### PR TITLE
feature: allow specifying path of system/bash shell for user actions and cram tests

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1263,6 +1263,19 @@ let envs =
           "If different than $(b,0), ANSI colors should be enabled no matter \
            what."
         "CLICOLOR_FORCE"
+    ; info
+        ~doc:
+          "If set, the specified shell (either the name of the shell program \
+           or an absolute path) will be used to execute the $(i,(system ..)) \
+           user actions and cram test commands."
+        "DUNE_ACTION_SYSTEM_SHELL"
+    ; info
+        ~doc:
+          "If set, the specified shell (either the name of the shell program \
+           or an absolute path) will be used to execute the $(i,(bash ..)) \
+           user actions and cram test commands when option $(i,(shell :bash)) \
+           is set."
+        "DUNE_ACTION_BASH_SHELL"
     ]
 
 let config_from_config_file = Options_implied_by_dash_p.config_term

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -142,7 +142,7 @@ let prepare ~skip_trailing_cr annots path1 path2 =
   match !Clflags.diff_command with
   | Some "-" -> fallback
   | Some cmd ->
-    let sh, arg = Utils.system_shell_exn ~needed_to:"print diffs" in
+    let sh, arg = Utils.system_shell_exn () ~needed_to:"print diffs" in
     let cmd =
       sprintf "%s %s %s" cmd
         (String.quote_for_shell file1)

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -4,7 +4,7 @@ open Import
 
 (** Return the absolute path to the shell and the argument to pass it (-c or
     /c). Raise in case in cannot be found. *)
-val system_shell_exn : needed_to:string -> Path.t * string
+val system_shell_exn : ?env:Env.t -> needed_to:string -> unit -> Path.t * string
 
 (** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found :
@@ -19,3 +19,5 @@ val program_not_found_message :
 
 (** Pretty-printer for suggesting a given shell command to the user *)
 val pp_command_hint : string -> _ Pp.t
+
+val lookup_os_shell_path : ?env:Env.t -> [ `system | `bash ] -> Path.t option

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -414,8 +414,7 @@ let run ~env ~script lexbuf : string Fiber.t =
   let open Fiber.O in
   let+ () =
     let sh =
-      let path = Env_path.path Env.initial in
-      Option.value_exn (Bin.which ~path "sh")
+      Dune_engine.Utils.lookup_os_shell_path ~env `system |> Option.value_exn
     in
     let metadata =
       let name =


### PR DESCRIPTION
- add Dune_engine.Utils.lookup_os_shell_path
- add config env var DUNE_ACTION_SYSTEM_SHELL and DUNE_ACTION_BASH_SHELL
- make cram test use Dune_engine.Utils.lookup_os_shell_path
