### PR TITLE
refactor: simplify info type in rule

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -787,7 +787,8 @@ end = struct
       let { Rule.Anonymous_action.context; action = _; loc; dir = _; alias = _ } = act in
       Rule.make
         ~context
-        ~info:(if Loc.is_none loc then Internal else From_dune_file loc)
+        ~loc
+        ~info:(if Loc.is_none loc then Internal else From_dune_file)
         ~targets:(Targets.File.create target)
         ~mode:Standard
         (Action_builder.of_thunk
@@ -1065,7 +1066,7 @@ end = struct
           rules_here.by_file_targets
           ~f:(fun s { Rule.info; _ } acc ->
             match info with
-            | Rule.Info.Source_file_copy _ when only_generated_files -> acc
+            | Rule.Info.Source_file_copy when only_generated_files -> acc
             | _ ->
               let s = Path.build s in
               if File_selector.test g s then s :: acc else acc)

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -139,18 +139,18 @@ let describe_rule (rule : Rule.t) =
   Pp.text
   @@
   match rule.info with
-  | From_dune_file loc ->
-    let start = Loc.start loc in
+  | From_dune_file ->
+    let start = Loc.start rule.loc in
     start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
   | Internal -> "<internal location>"
-  | Source_file_copy _ -> "file present in source tree"
+  | Source_file_copy -> "file present in source tree"
 ;;
 
 let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
   let loc =
     match rule.info with
-    | From_dune_file loc -> loc
-    | Internal | Source_file_copy _ ->
+    | From_dune_file -> rule.loc
+    | Internal | Source_file_copy ->
       let dir =
         match Path.Build.drop_build_context dir with
         | None -> Path.build dir
@@ -183,7 +183,7 @@ let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
     ]
     ~hints:
       (match rule.info, rule'.info with
-       | Source_file_copy _, _ | _, Source_file_copy _ ->
+       | Source_file_copy, _ | _, Source_file_copy ->
          [ Pp.textf
              "rm -f %s"
              (Path.to_string_maybe_quoted (Path.drop_optional_build_context fn))
@@ -351,7 +351,7 @@ end = struct
       in
       Rule.make
         ~context:None
-        ~info:(Source_file_copy path)
+        ~info:Source_file_copy
         ~targets:(Targets.File.create ctx_path)
         build)
   ;;

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -6,11 +6,9 @@ module Action_builder := Action_builder0
 (** Information about the provenance of a build rule. *)
 module Info : sig
   type t =
-    | From_dune_file of Loc.t
+    | From_dune_file
     | Internal
-    | Source_file_copy of Path.Source.t
-
-  val of_loc_opt : Loc.t option -> t
+    | Source_file_copy
 end
 
 module Promote : sig
@@ -73,7 +71,8 @@ val to_dyn : t -> Dyn.t
 (** [make] raises an error if the set of [targets] is not well-formed. See the
     [Targets.Validation_result] data type for the list of possible problems. *)
 val make
-  :  ?mode:Mode.t
+  :  ?loc:Loc.t
+  -> ?mode:Mode.t
   -> context:Build_context.t option
   -> ?info:Info.t
   -> targets:Targets.t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -880,7 +880,7 @@ let symlink_installed_artifacts_to_build_install
     in
     let src = Path.build entry.src in
     let rule { Action_builder.With_targets.targets; build } =
-      Rule.make ~info:(From_dune_file loc) ~context:(Some ctx) ~targets build
+      Rule.make ~loc ~info:From_dune_file ~context:(Some ctx) ~targets build
     in
     match entry.kind with
     | `Source_tree ->

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1250,10 +1250,9 @@ let add_env env action =
   Action_builder.With_targets.map action ~f:(Action.Full.add_env env)
 ;;
 
-let rule ?loc { Action_builder.With_targets.build; targets } =
+let rule ~loc { Action_builder.With_targets.build; targets } =
   (* TODO this ignores the workspace file *)
-  Rule.make ~info:(Rule.Info.of_loc_opt loc) ~targets build ~context:None
-  |> Rules.Produce.rule
+  Rule.make ~loc ~info:From_dune_file ~targets build ~context:None |> Rules.Produce.rule
 ;;
 
 let gen_rules context_name (pkg : Pkg.t) =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -258,8 +258,12 @@ let extend_action t ~dir build =
 let make_rule t ?mode ?loc ~dir { Action_builder.With_targets.build; targets } =
   let build = extend_action t build ~dir in
   Rule.make
+    ?loc
     ?mode
-    ~info:(Rule.Info.of_loc_opt loc)
+    ~info:
+      (match loc with
+       | None -> Internal
+       | Some _ -> From_dune_file)
     ~context:(Some (Context.build_context (Env_tree.context t)))
     ~targets
     build


### PR DESCRIPTION
The current representation of `Rule.Info.t` is:

```
  type t =
    | From_dune_file of Loc.t
    | Internal
    | Source_file_copy of Path.Source.t
```

This representation contains redundant information:

* The location is already present as a field in `Rule.t` hence the `Loc.t` argument is unnecessary in `From_dune_file`.
* If we know the rule is copying from the source, then the source path can be easily derived from the target file.

I've removed both of those arguments and now compute their equivalents from `Rule.t` fields

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>