### PR TITLE
refactor: introduce specialized location constructors

### DIFF
--- a/otherlibs/stdune/src/lexbuf.ml
+++ b/otherlibs/stdune/src/lexbuf.ml
@@ -30,6 +30,10 @@ module Position = struct
       ; ("pos_bol", Int p.pos_bol)
       ; ("pos_cnum", Int p.pos_cnum)
       ]
+
+  let is_file_only { Lexing.pos_fname = _; pos_lnum; pos_cnum; pos_bol } =
+    pos_lnum = none.pos_lnum && pos_cnum = none.pos_cnum
+    && pos_bol = none.pos_bol
 end
 
 module Loc = struct
@@ -43,6 +47,17 @@ module Loc = struct
       { pos_fname; pos_lnum; pos_cnum = cnum; pos_bol = 0 }
     in
     { start; stop = { start with pos_cnum = enum } }
+
+  let map_pos { start; stop } ~f = { start = f start; stop = f stop }
+
+  let in_file ~fname =
+    let start = Position.in_file ~fname in
+    { start; stop = start }
+
+  let is_file_only t =
+    t.start.pos_fname = t.stop.pos_fname
+    && Position.is_file_only t.start
+    && Position.is_file_only t.stop
 
   let to_dyn t =
     let open Dyn in

--- a/otherlibs/stdune/src/lexbuf.mli
+++ b/otherlibs/stdune/src/lexbuf.mli
@@ -28,6 +28,12 @@ module Loc : sig
 
   val equal : t -> t -> bool
 
+  val map_pos : t -> f:(Position.t -> Position.t) -> t
+
+  val in_file : fname:string -> t
+
+  val is_file_only : t -> bool
+
   (** To be used with [__POS__] *)
   val of_pos : string * int * int * int -> t
 

--- a/otherlibs/stdune/src/loc.ml
+++ b/otherlibs/stdune/src/loc.ml
@@ -2,9 +2,7 @@ include Loc0
 module O = Comparable.Make (Loc0)
 include O
 
-let in_file p =
-  let pos = Lexbuf.Position.in_file ~fname:(Path.to_string p) in
-  create ~start:pos ~stop:pos
+let in_file p = Lexbuf.Loc.in_file ~fname:(Path.to_string p) |> of_lexbuf_loc
 
 let in_dir = in_file
 

--- a/otherlibs/stdune/src/loc0.ml
+++ b/otherlibs/stdune/src/loc0.ml
@@ -1,19 +1,133 @@
-include Lexbuf.Loc
+type t =
+  | No_loc
+  | In_file of string
+  | Lexbuf_loc of Lexbuf.Loc.t
+  | Same_file of
+      { pos_fname : string
+      ; start_lnum : int
+      ; start_bol : int
+      ; start_cnum : int
+      ; stop_lnum : int
+      ; stop_bol : int
+      ; stop_cnum : int
+      }
+  | Same_line of
+      { pos_fname : string
+      ; pos_lnum : int
+      ; pos_bol : int
+      ; start_cnum : int
+      ; stop_cnum : int
+      }
 
-let to_lexbuf_loc x = x
+module Position = Lexbuf.Position
+open Lexbuf.Loc
 
-let of_lexbuf_loc x = x
+let to_lexbuf_loc = function
+  | No_loc -> Lexbuf.Loc.none
+  | Lexbuf_loc loc -> loc
+  | In_file fname -> Lexbuf.Loc.in_file ~fname
+  | Same_file
+      { pos_fname
+      ; start_lnum
+      ; start_bol
+      ; start_cnum
+      ; stop_lnum
+      ; stop_bol
+      ; stop_cnum
+      } ->
+    let start =
+      { Lexing.pos_fname
+      ; pos_lnum = start_lnum
+      ; pos_bol = start_bol
+      ; pos_cnum = start_cnum
+      }
+    in
+    let stop =
+      { Lexing.pos_fname
+      ; pos_lnum = stop_lnum
+      ; pos_bol = stop_bol
+      ; pos_cnum = stop_cnum
+      }
+    in
+    { Lexbuf.Loc.start; stop }
+  | Same_line { pos_fname; pos_lnum; pos_bol; start_cnum; stop_cnum } ->
+    let start =
+      { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = start_cnum }
+    in
+    let stop = { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = stop_cnum } in
+    { Lexbuf.Loc.start; stop }
 
-let start t = t.start
+let in_file ~fname = In_file fname
 
-let stop t = t.stop
+let of_lexbuf_loc loc =
+  if Lexbuf.Loc.(equal none loc) then No_loc
+  else if Lexbuf.Loc.is_file_only loc then In_file loc.start.pos_fname
+  else
+    let start = loc.start in
+    let stop = loc.stop in
+    if start.pos_fname = stop.pos_fname then
+      if start.pos_bol = stop.pos_bol && start.pos_lnum = stop.pos_lnum then
+        Same_line
+          { pos_fname = start.pos_fname
+          ; pos_bol = start.pos_bol
+          ; pos_lnum = start.pos_lnum
+          ; start_cnum = start.pos_cnum
+          ; stop_cnum = stop.pos_cnum
+          }
+      else
+        Same_file
+          { pos_fname = start.pos_fname
+          ; start_lnum = start.pos_lnum
+          ; start_bol = start.pos_bol
+          ; start_cnum = start.pos_cnum
+          ; stop_lnum = stop.pos_lnum
+          ; stop_bol = stop.pos_bol
+          ; stop_cnum = stop.pos_cnum
+          }
+    else Lexbuf_loc loc
 
-let set_stop t stop = { t with stop }
+let start = function
+  | No_loc -> Lexbuf.Loc.none.start
+  | Lexbuf_loc loc -> loc.start
+  | In_file fname -> Position.in_file ~fname
+  | Same_file { pos_fname; start_lnum; start_bol; start_cnum; _ } ->
+    { Lexing.pos_fname
+    ; pos_lnum = start_lnum
+    ; pos_bol = start_bol
+    ; pos_cnum = start_cnum
+    }
+  | Same_line { pos_fname; pos_lnum; pos_bol; start_cnum; _ } ->
+    { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = start_cnum }
 
-let set_start t start = { t with start }
+let stop = function
+  | No_loc -> Lexbuf.Loc.none.stop
+  | Lexbuf_loc loc -> loc.stop
+  | In_file fname -> Position.in_file ~fname
+  | Same_file { pos_fname; stop_lnum; stop_bol; stop_cnum; _ } ->
+    { Lexing.pos_fname
+    ; pos_lnum = stop_lnum
+    ; pos_bol = stop_bol
+    ; pos_cnum = stop_cnum
+    }
+  | Same_line { pos_fname; pos_lnum; pos_bol; stop_cnum; _ } ->
+    { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = stop_cnum }
 
-let create ~start ~stop = { start; stop }
+let compare = Poly.compare
 
-let map_pos { start; stop } ~f = { start = f start; stop = f stop }
+let equal = Poly.equal
 
-let is_none = equal none
+let none = No_loc
+
+let is_none = function
+  | No_loc -> true
+  | _ -> false
+
+let to_dyn t = Lexbuf.Loc.to_dyn (to_lexbuf_loc t)
+
+let set_stop t stop = of_lexbuf_loc { (to_lexbuf_loc t) with stop }
+
+let set_start t start = of_lexbuf_loc { (to_lexbuf_loc t) with start }
+
+let create ~start ~stop = of_lexbuf_loc { start; stop }
+
+let map_pos t ~f = to_lexbuf_loc t |> Lexbuf.Loc.map_pos ~f |> of_lexbuf_loc

--- a/otherlibs/stdune/src/loc0.mli
+++ b/otherlibs/stdune/src/loc0.mli
@@ -10,6 +10,8 @@ val map_pos : t -> f:(Lexing.position -> Lexing.position) -> t
 
 val create : start:Lexing.position -> stop:Lexing.position -> t
 
+val in_file : fname:string -> t
+
 val set_stop : t -> Lexing.position -> t
 
 val set_start : t -> Lexing.position -> t

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-3209c92f18c7050c580114796b6023bd
+  _build/.actions/default/blah-b4c6197b1e46d97994280f89ef27b024
 
 And we check that it isn't copied in the source tree:
 


### PR DESCRIPTION
Introduce special constructors for:

* None locations
* A location in a particular file without the line/column set
* A location where start/stop are in the same file (basically all
  locations)
* A location where start/stop are on the same line (a large chunk of
  locations)

For [Same_file], we end up saving 2 words per location.

For [Same_line], we end up saving 5 words per location.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 15bf236a-2976-4188-8a06-f97c922ddd88 -->