### PR TITLE
chore: explain why we flush new digests

### DIFF
--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -92,6 +92,9 @@ let delete_very_recent_entries () =
   let cache = Lazy.force cache in
   if !Clflags.wait_for_filesystem_clock then wait_for_fs_clock_to_advance ();
   let now = get_current_filesystem_time () in
+  (* We can only trust digests with timestamps in the past. We had issues in
+     the past with file systems having a slow internal clock, where we cached
+     digests too aggressively. *)
   match Float.compare cache.max_timestamp now with
   | Lt -> ()
   | Eq | Gt ->


### PR DESCRIPTION
<!-- ps-id: 5f98c91d-5e08-44b4-987b-a5312aff2f87 -->