### PR TITLE
refactor: use [Path.Table] for build system tables

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1069,7 +1069,10 @@ end = struct
          | `Disabled -> None
          | `Enabled -> Some (Tuple.T2.equal Digest.equal target_kind_equal)
        in
-       Memo.create "build-file" ~input:(module Path) ?cutoff build_file_impl)
+       Memo.create_with_store "build-file"
+         ~store:(module Path.Table)
+         ~input:(module Path)
+         ?cutoff build_file_impl)
 
   let build_file path = Memo.exec (Lazy.force build_file_memo) path >>| fst
 

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -885,7 +885,12 @@ end = struct
 
   let load_dir =
     let load_dir_impl dir = load_dir_impl ~dir in
-    let memo = Memo.create "load-dir" ~input:(module Path) load_dir_impl in
+    let memo =
+      Memo.create_with_store "load-dir"
+        ~store:(module Path.Table)
+        ~input:(module Path)
+        load_dir_impl
+    in
     fun ~dir -> Memo.exec memo dir
 
   let is_under_directory_target p =


### PR DESCRIPTION
It's a little faster than creating a table from [Table.create] since it
allows for inlining.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5dfe474f-ed53-45ca-9b69-788bfe6d609d -->