### PR TITLE
feature: --all option for dune show targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+- Add `--all` option to `dune show targets` which shows source files in addition
+  to targets. Souce files are no longer shown by default in `dune show targets`.
+  (#8167, @Alizter)
+
 - Add `dune show rules` as alias of the `dune rules` command. (#8000, @Alizter)
 
 - Add `dune show installed-libraries` as an alias of the `dune

--- a/test/blackbox-tests/test-cases/describe/targets.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/targets.t/run.t
@@ -8,6 +8,17 @@ With no directory provided to the command, it should default to the current
 working directory.
 
   $ dune show targets
+  d/
+  simple.a
+  simple.cma
+  simple.cmxa
+  simple.cmxs
+  simple.ml-gen
+
+The --all argument will show all targets since source files are omitted by
+default.
+
+  $ dune show targets --all
   a.ml
   d/
   dune
@@ -23,10 +34,7 @@ used, and only the targets available in that directory will be displayed.
 
   $ dune show targets . b/
   .:
-  a.ml
   d/
-  dune
-  dune-project
   simple.a
   simple.cma
   simple.cmxa
@@ -34,8 +42,6 @@ used, and only the targets available in that directory will be displayed.
   simple.ml-gen
   
   b:
-  c.ml
-  dune
   simple2.a
   simple2.cma
   simple2.cmxa
@@ -45,10 +51,7 @@ used, and only the targets available in that directory will be displayed.
 The command also works with files in the _build directory.
 
   $ dune show targets _build/default/
-  a.ml
   d/
-  dune
-  dune-project
   simple.a
   simple.cma
   simple.cmxa
@@ -56,8 +59,6 @@ The command also works with files in the _build directory.
   simple.ml-gen
 
   $ dune show targets _build/default/b
-  c.ml
-  dune
   simple2.a
   simple2.cma
   simple2.cmxa


### PR DESCRIPTION
We change `dune show targets` to omit source files by default and add an `--all` option which will show all targets including those that come from the source tree.

Addresses wish in #7784.

- [x] changelog
- [x] tests