### PR TITLE
remove linkopts(javascript) from META

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- No longer emit linkopts(javascript) in META files (#8168, @hhugo)
+
 3.10.0 (2023-07-31)
 -------------------
 

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -163,12 +163,7 @@ let gen_lib pub_name lib ~path ~version =
       | l ->
         let root = Pub_name.root pub_name in
         let l = List.map l ~f:Path.basename in
-        [ rule "linkopts" [ Pos "javascript" ] Set
-            (List.map l
-               ~f:(sprintf "+%s/%s" (String.concat ~sep:"/" (root :: path)))
-            |> String.concat ~sep:" ")
-        ; rule "jsoo_runtime" [] Set (String.concat l ~sep:" ")
-        ])
+        [ rule "jsoo_runtime" [] Set (String.concat l ~sep:" ") ])
     ]
 
 let gen ~(package : Package.t) ~add_directory_entry entries =

--- a/test/blackbox-tests/test-cases/meta-gen.t/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen.t/run.t
@@ -60,8 +60,6 @@
     archive(native) = "foobar_runtime_lib2.cmxa"
     plugin(byte) = "foobar_runtime_lib2.cma"
     plugin(native) = "foobar_runtime_lib2.cmxs"
-    linkopts(javascript) = "+foobar/runtime-lib2/foobar_runtime.js
-                            +foobar/runtime-lib2/foobar_runtime2.js"
     jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
   )
   package "sub" (


### PR DESCRIPTION
Using `jsoo_runtime` (instead of `linkopts(javascript`) to retrieve jsoo runtime files has been advertised in the documentation since jsoo 4.1.0 (see https://ocsigen.org/js_of_ocaml/4.1.0/manual/runtime-files).

How to proceed with such cleanup wrt backward compatibility ?