### PR TITLE
refactor: remove useless addition of dirs

### DIFF
--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -265,13 +265,7 @@ module Facts = struct
             let p = Path.Build.parent_exn p in
             Path.Build.Set.add acc p)
         | File_selector (_, ps) | Alias ps ->
-          Path.Build.Set.union_all
-            [ acc
-            ; Path.Map.keys ps.dirs
-              |> List.filter_map ~f:as_in_build_dir_no_source
-              |> Path.Build.Set.of_list
-            ; Fact.Files.necessary_dirs_for_sandboxing ps
-            ])
+          Path.Build.Set.union acc (Fact.Files.necessary_dirs_for_sandboxing ps))
 
   let digest t ~env =
     let facts =


### PR DESCRIPTION
[Fact.Files.necessary_dirs_for_sandboxing] already includes the
directories in [ps.dirs], we don't need to add them again

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cb32d72a-e411-45d6-b3c6-c8ff4d1be460 -->