### PR TITLE
refactor: remove extra word from stable digest

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -360,7 +360,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 13
+  let rule_digest_version = 14
 
   let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode
       ~execution_parameters =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -172,11 +172,9 @@ module Fact = struct
       Dyn.Variant ("Alias", [ Dyn.Record [ ("files", Files.to_dyn files) ] ])
 
   module Stable_for_digest = struct
-    type file = string * Digest.t
-
     type t =
       | Env of string * string option
-      | File of file
+      | File of string * Digest.t
       | File_selector of Dyn.t * Digest.t
       | Alias of Digest.t
   end
@@ -277,7 +275,6 @@ module Facts = struct
 
   let digest t ~env =
     let facts =
-      let file (p, d) = (Path.to_string p, d) in
       Map.foldi t ~init:[]
         ~f:(fun dep fact acc : Fact.Stable_for_digest.t list ->
           match dep with
@@ -286,7 +283,7 @@ module Facts = struct
           | File _ | File_selector _ | Alias _ -> (
             match (fact : Fact.t) with
             | Nothing -> acc
-            | File (p, d) -> File (file (p, d)) :: acc
+            | File (p, d) -> File (Path.to_string p, d) :: acc
             | File_selector (id, ps) -> File_selector (id, ps.digest) :: acc
             | Alias ps -> Alias ps.digest :: acc))
     in

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -36,9 +36,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [d2795abc8100d9bed0c2d5281485488c] (_build/default/source): not found in cache
+  Shared cache miss [1318c0c9d4f4610410204b11d0b5b413] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [85cfda404207853df742b1c0edd00cb9] (_build/default/target1): not found in cache
+  Shared cache miss [313e07d4b9b0a131828ee51787757c97] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [d2795abc8100d9bed0c2d5281485488c] (_build/default/source): not found in cache
+  Shared cache miss [1318c0c9d4f4610410204b11d0b5b413] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [85cfda404207853df742b1c0edd00cb9] (_build/default/target1): not found in cache
+  Shared cache miss [313e07d4b9b0a131828ee51787757c97] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [5876ccb7e1d5ae92120d00714ca2223d]: ((in_cache
+  Warning: cache store error [521660ecec62ce8477c1927e6bd19946]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [5876ccb7e1d5ae92120d00714ca2223d]: ((in_cache
+  Warning: cache store error [521660ecec62ce8477c1927e6bd19946]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [5876ccb7e1d5ae92120d00714ca2223d]: ((in_cache
+  Warning: cache store error [521660ecec62ce8477c1927e6bd19946]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./aa/aa6ada3c81f6adf14b970c563c4fe64a:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./e5/e59da919c4e4d4c01506089aba536d6c:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./43/43fa723fabb4757b65b428fcd40614c1:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./d2/d226867c9aaf5af87f571ce8a1dd8f43:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/e5/e59da919c4e4d4c01506089aba536d6c"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/d2/d226867c9aaf5af87f571ce8a1dd8f43"
   70
 
 Trimming the cache at this point should not remove any file entries because all


### PR DESCRIPTION
The following constructor

```
File of (string * Digest.t)
```

Is strictly worse than:

```
File of string * Digest.t
```

Because of the extra layer of boxing.

I don't know if this was intentional, but it doesn't seem useful to me.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c0b06334-19ed-43fa-8598-8dc190c9a3d8 -->