### PR TITLE
refactor(odoc): remove dummy file

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/github1645.t
+++ b/test/blackbox-tests/test-cases/odoc/github1645.t
@@ -28,7 +28,7 @@ built. See #1645.
   $ dune build @install
   $ dune build @doc
   Error: Multiple rules generated for
-  _build/default/_doc/_html/l/Module/.dummy:
+  _build/default/_doc/_html/l/Module/index.html:
   - <internal location>
   - <internal location>
   -> required by alias _doc/_html/l/doc

--- a/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
@@ -8,5 +8,5 @@ This test checks that there is no clash when two private libraries have the same
           odoc b/.test.objs/byte/test.odoc
           odoc _doc/_odocls/test@6aabb9861046/test.odocl
           odoc _doc/_odocls/test@ea8c79305c05/test.odocl
-          odoc _doc/_html/test@6aabb9861046/Test/.dummy,_doc/_html/test@6aabb9861046/Test/index.html
-          odoc _doc/_html/test@ea8c79305c05/Test/.dummy,_doc/_html/test@ea8c79305c05/Test/index.html
+          odoc _doc/_html/test@6aabb9861046/Test/index.html
+          odoc _doc/_html/test@ea8c79305c05/Test/index.html

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
@@ -11,7 +11,7 @@ Duplicate mld's in different scope
           odoc _doc/_odocls/scope1/page-index.odocl
           odoc _doc/_odocls/scope2/scope2.odocl
           odoc _doc/_odocls/scope2/page-index.odocl
-          odoc _doc/_html/scope1/Scope1/.dummy,_doc/_html/scope1/Scope1/index.html
+          odoc _doc/_html/scope1/Scope1/index.html
           odoc _doc/_html/scope1/index.html
-          odoc _doc/_html/scope2/Scope2/.dummy,_doc/_html/scope2/Scope2/index.html
+          odoc _doc/_html/scope2/Scope2/index.html
           odoc _doc/_html/scope2/index.html

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
@@ -9,6 +9,6 @@ Duplicate mld's in the same scope
           odoc _doc/_odocls/root/root_lib1.odocl
           odoc _doc/_odocls/root/root_lib2.odocl
           odoc _doc/_odocls/root/page-index.odocl
-          odoc _doc/_html/root/Root_lib1/.dummy,_doc/_html/root/Root_lib1/index.html
-          odoc _doc/_html/root/Root_lib2/.dummy,_doc/_html/root/Root_lib2/index.html
+          odoc _doc/_html/root/Root_lib1/index.html
+          odoc _doc/_html/root/Root_lib2/index.html
           odoc _doc/_html/root/index.html


### PR DESCRIPTION
It might have been the case that Dune wouldn't work without it but it now seems fine.
