### PR TITLE
refactor: use stdlib for filter_inplace

### DIFF
--- a/otherlibs/stdune/src/hashtbl.ml
+++ b/otherlibs/stdune/src/hashtbl.ml
@@ -73,15 +73,10 @@ struct
       |> List.sort ~compare:(fun (k, _) (k', _) -> Dyn.compare k k'))
 
   let filteri_inplace t ~f =
-    (* Surely there's a more performant way of writing this. (e.g. using
-       filter_map_inplace), but starting with a simple thing for now, in part
-       because [filter_map_inplace] is not available in 4.02. *)
-    let to_delete = ref [] in
-    iter t ~f:(fun ~key ~data ->
+    filter_map_inplace t ~f:(fun ~key ~data ->
         match f ~key ~data with
-        | false -> to_delete := key :: !to_delete
-        | true -> ());
-    List.iter !to_delete ~f:(fun k -> remove t k)
+        | true -> Some data
+        | false -> None)
 
   let iter t ~f = iter t ~f:(fun ~key:_ ~data -> f data)
 end


### PR DESCRIPTION
The primitive from the stdlib is a lot faster

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0ff6da4f-cdd5-407d-aa65-e464ebffbfb9 -->