### PR TITLE
feature(stdune): introduce compact positions

### DIFF
--- a/otherlibs/stdune/src/compact_position.ml
+++ b/otherlibs/stdune/src/compact_position.ml
@@ -1,0 +1,141 @@
+module Position = struct
+  (* We encode the position in three, 21 bit fields: [cnum][lnum][bol] *)
+  type t = int
+
+  let field_size = 21
+  let field_mask = (1 lsl field_size) - 1
+  let shift_bol = 0
+  let shift_lnum = field_size
+  let shift_cnum = 2 * field_size
+
+  let small_enough =
+    let max_size = 1 lsl field_size in
+    let test int = int <= max_size in
+    fun [@inline] { Lexing.pos_bol; pos_cnum; pos_lnum; pos_fname = _ } ->
+      test pos_bol && test pos_cnum && test pos_lnum
+  ;;
+
+  let[@inline] of_position { Lexing.pos_bol; pos_cnum; pos_lnum; pos_fname = _ } =
+    ((pos_bol land field_mask) lsl shift_bol)
+    lor ((pos_lnum land field_mask) lsl shift_lnum)
+    lor ((pos_cnum land field_mask) lsl shift_cnum)
+  ;;
+
+  let[@inline] bol t = (t lsr shift_bol) land field_mask
+  let[@inline] lnum t = (t lsr shift_lnum) land field_mask
+  let[@inline] cnum t = (t lsr shift_cnum) land field_mask
+
+  let to_position t ~fname:pos_fname =
+    let pos_bol = bol t in
+    let pos_cnum = cnum t in
+    let pos_lnum = lnum t in
+    { Lexing.pos_bol; pos_cnum; pos_lnum; pos_fname }
+  ;;
+end
+
+module Same_line_loc = struct
+  (* we encode the location in four, 15 bit chunks
+     [bol][lnum][start_cnum][stop_cnum]
+
+     Note that this leaves us with 3 spare bits. We should probably use them to
+     expand [bol] and [lnum] a little.
+
+     CR-someday jtov: Instead of [stop_cnum], we can store [stop_cnum -
+     start_cnum]. This should be smaller than [stop_cnum] and release more
+     bits for other fields.
+  *)
+  type t = int
+
+  let field_size = 15
+  let field_mask = (1 lsl field_size) - 1
+  let shift_bol = 0
+  let shift_lnum = field_size
+  let shift_start_cnum = 2 * field_size
+  let shift_stop_cnum = 3 * field_size
+
+  let create ~bol ~lnum ~start_cnum ~stop_cnum =
+    ((bol land field_mask) lsl shift_bol)
+    lor ((lnum land field_mask) lsl shift_lnum)
+    lor ((start_cnum land field_mask) lsl shift_start_cnum)
+    lor ((stop_cnum land field_mask) lsl shift_stop_cnum)
+  ;;
+
+  let[@inline] bol t = (t lsr shift_bol) land field_mask
+  let[@inline] lnum t = (t lsr shift_lnum) land field_mask
+  let[@inline] start_cnum t = (t lsr shift_start_cnum) land field_mask
+  let[@inline] stop_cnum t = (t lsr shift_stop_cnum) land field_mask
+
+  let set_start_to_stop t =
+    let bol = bol t in
+    let lnum = lnum t in
+    let stop_cnum = stop_cnum t in
+    (* this can be optimized more if necessary *)
+    create ~bol ~lnum ~start_cnum:stop_cnum ~stop_cnum
+  ;;
+
+  let small_enough =
+    let max_size = 1 lsl field_size in
+    fun [@inline] int -> int <= max_size
+  ;;
+
+  let[@inline] to_loc t ~fname:pos_fname =
+    let pos_lnum = lnum t in
+    let pos_bol = bol t in
+    let start = { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = start_cnum t } in
+    let stop = { start with pos_cnum = stop_cnum t } in
+    { Lexbuf.Loc.start; stop }
+  ;;
+
+  let[@inline] start t ~fname:pos_fname =
+    let pos_lnum = lnum t in
+    let pos_bol = bol t in
+    { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = start_cnum t }
+  ;;
+
+  let[@inline] stop t ~fname:pos_fname =
+    let pos_lnum = lnum t in
+    let pos_bol = bol t in
+    { Lexing.pos_fname; pos_lnum; pos_bol; pos_cnum = stop_cnum t }
+  ;;
+end
+
+include Position
+
+type of_loc =
+  | Same_line of Same_line_loc.t
+  | Loc of
+      { start : t
+      ; stop : t
+      }
+  | Loc_does_not_fit
+
+let[@inline] try_loc { Lexbuf.Loc.start; stop } =
+  if Position.small_enough start && Position.small_enough stop
+  then (
+    let start = Position.of_position start in
+    let stop = Position.of_position stop in
+    Loc { start; stop })
+  else Loc_does_not_fit
+;;
+
+let[@inline] of_loc ({ Lexbuf.Loc.start; stop } as loc) =
+  if start.pos_fname <> stop.pos_fname
+  then Loc_does_not_fit
+  else if start.pos_bol = stop.pos_bol && start.pos_lnum = stop.pos_lnum
+  then (
+    let bol = start.pos_bol in
+    let lnum = start.pos_lnum in
+    let start_cnum = start.pos_cnum in
+    let stop_cnum = stop.pos_cnum in
+    let test = Same_line_loc.small_enough in
+    if test bol && test lnum && test start_cnum && test stop_cnum
+    then Same_line (Same_line_loc.create ~bol ~lnum ~start_cnum ~stop_cnum)
+    else try_loc loc)
+  else try_loc loc
+;;
+
+let of_loc = if Sys.int_size = 63 then of_loc else fun _ -> Loc_does_not_fit
+
+module For_tests = struct
+  let small_enough = small_enough
+end

--- a/otherlibs/stdune/src/compact_position.mli
+++ b/otherlibs/stdune/src/compact_position.mli
@@ -1,0 +1,36 @@
+(** Positions information that can be encoded within a single immediate *)
+
+type t [@@immediate]
+
+val of_position : Lexbuf.Position.t -> t
+val to_position : t -> fname:string -> Lexbuf.Position.t
+val lnum : t -> int
+val cnum : t -> int
+val bol : t -> int
+
+module Same_line_loc : sig
+  type t [@@immediate]
+
+  val lnum : t -> int
+  val bol : t -> int
+  val start_cnum : t -> int
+  val stop_cnum : t -> int
+  val to_loc : t -> fname:string -> Lexbuf.Loc.t
+  val start : t -> fname:string -> Lexbuf.Position.t
+  val stop : t -> fname:string -> Lexbuf.Position.t
+  val set_start_to_stop : t -> t
+end
+
+type of_loc =
+  | Same_line of Same_line_loc.t
+  | Loc of
+      { start : t
+      ; stop : t
+      }
+  | Loc_does_not_fit
+
+val of_loc : Lexbuf.Loc.t -> of_loc
+
+module For_tests : sig
+  val small_enough : Lexbuf.Position.t -> bool
+end

--- a/otherlibs/stdune/src/loc.mli
+++ b/otherlibs/stdune/src/loc.mli
@@ -26,3 +26,4 @@ val render : Format.formatter -> tag Pp.t -> unit
 val on_same_line : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val span : t -> t -> t
+val set_start_to_stop : t -> t

--- a/otherlibs/stdune/src/loc0.mli
+++ b/otherlibs/stdune/src/loc0.mli
@@ -14,3 +14,5 @@ val equal : t -> t -> bool
 val none : t
 val is_none : t -> bool
 val to_dyn : t -> Dyn.t
+val set_start_to_stop : t -> t
+val start_pos_cnum : t -> int

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -127,3 +127,7 @@ type ordering = Ordering.t =
 let sprintf = Printf.sprintf
 let ksprintf = Printf.ksprintf
 let printfn a = ksprintf print_endline a
+
+module For_tests = struct
+  module Compact_position = Compact_position
+end

--- a/otherlibs/stdune/test/compact_position_tests.ml
+++ b/otherlibs/stdune/test/compact_position_tests.ml
@@ -1,0 +1,29 @@
+open Stdune
+module Position = Lexbuf.Position
+module Compact_position = For_tests.Compact_position
+
+let test (pos : Position.t) =
+  match Compact_position.For_tests.small_enough pos with
+  | false -> print_endline "position too large"
+  | true ->
+    let t = Compact_position.of_position pos in
+    let pos' = Compact_position.to_position t ~fname:pos.pos_fname in
+    if Position.equal pos pos'
+    then print_endline "[PASS]"
+    else (
+      print_endline "[FAIL]";
+      printfn "expected:\n%s" (Dyn.to_string (Position.to_dyn_no_file pos));
+      printfn "received:\n%s" (Dyn.to_string (Position.to_dyn_no_file pos')))
+;;
+
+let%expect_test "round trip tests" =
+  let base = Position.none in
+  test base;
+  [%expect {| [PASS] |}];
+  test { base with pos_cnum = 1; pos_lnum = 2; pos_bol = 3 };
+  [%expect {| [PASS] |}];
+  test { base with pos_cnum = 1_000; pos_lnum = 2_200; pos_bol = 300 };
+  [%expect {| [PASS] |}];
+  test { base with pos_cnum = 1 lsl 32; pos_lnum = 2_200; pos_bol = 300 };
+  [%expect {| position too large |}]
+;;

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-b4c6197b1e46d97994280f89ef27b024
+  _build/.actions/default/blah-816e5c65a636c4272db0accb4b6559f5
 
 And we check that it isn't copied in the source tree:
 


### PR DESCRIPTION
We make use of the fact that position offsets are often small integers
and store them all in a single OCaml int.

When this optimization works, we save 3-4 words per location. When it
doesn't, there's no harm and we fall back to our old "wide" offsets.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2493c6ca-5c12-46d2-8638-dca715aed846 -->