### PR TITLE
rpc: add Comparable module for Diagnostics

### DIFF
--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -93,6 +93,8 @@ module Diagnostic : sig
     ; related : Related.t list
     }
 
+  include Stdune.Comparable_intf.S with type key := t
+
   val related : t -> Related.t list
 
   val id : t -> Id.t


### PR DESCRIPTION
I want to be able to have sets of diagnostics for the internal state of dune monitor. In order to do this, I made the `Diagnostic` type comparable. I wasn't able to finish the definition fully so I would appreciate some help doing so. I'm not even sure this is the best way to go about it.

cc @rgrinberg 