### PR TITLE
test: use custom wait for watching/helpers.sh

### DIFF
--- a/test/blackbox-tests/test-cases/watching/helpers.sh
+++ b/test/blackbox-tests/test-cases/watching/helpers.sh
@@ -22,7 +22,16 @@ with_timeout () {
 
 stop_dune () {
     with_timeout dune shutdown;
-    wait $DUNE_PID;
+    # On Linux, we may run into a bash pid aliasing bug that causes wait to
+    # reject the pid. Therefore we use tail to wait instead.
+    if [ "$(uname -s)" = "Linux" ]
+    then
+        # wait for all child processes
+        tail --pid=$DUNE_PID -f /dev/null;
+    else
+        # wait for dune to exit
+        wait $DUNE_PID;
+    fi
     cat .#dune-output;
 }
 


### PR DESCRIPTION
This allows the fs-memo.t test to succeed on Nix. Before the pid of Dune was being thrown away by a bash bug causing wait to think it was not a child process and rejecting it. We therefore wait instead for all child processes.