### PR TITLE
test: fix github2629 repro on nix

### DIFF
--- a/test/blackbox-tests/test-cases/github2629.t
+++ b/test/blackbox-tests/test-cases/github2629.t
@@ -9,7 +9,7 @@
   $ export DUNE_BUILD_DIR=$(mktemp -d -t github2629XXXXXX);
   > dune build @install;
   > cat $DUNE_BUILD_DIR/default/foo.install | sed s#$DUNE_BUILD_DIR#DUNE_BUILD_DIR#g;
-  > dune install --dry-run
+  > dune install --dry-run --prefix lib/foo
   lib: [
     "DUNE_BUILD_DIR/install/default/lib/foo/META"
     "DUNE_BUILD_DIR/install/default/lib/foo/dune-package"


### PR DESCRIPTION
This test was relying on the implicit opam install location behaviour. We make the install location explicit with the --prefix argument to make the test reproducible on Nix.