### PR TITLE
test: fix dune-site tests for Nix

### DIFF
--- a/otherlibs/dune-site/test/run.t
+++ b/otherlibs/dune-site/test/run.t
@@ -175,7 +175,7 @@ Test with an opam like installation
   $ test -e a/a.install
   [1]
 
-  $ dune install -p a --create-install-files a
+  $ dune install -p a --create-install-files a --prefix "_destdir"
 
   $ grep "_destdir" a/a.install -c
   7

--- a/otherlibs/dune-site/test/run_2_9.t
+++ b/otherlibs/dune-site/test/run_2_9.t
@@ -163,7 +163,7 @@ Test with an opam like installation
   $ test -e a/a.install
   [1]
 
-  $ dune install -p a --create-install-files a
+  $ dune install -p a --create-install-files a --prefix "_destdir"
 
   $ grep "_destdir" a/a.install -c
   7


### PR DESCRIPTION
These tests were relying on the implicit opam install location behaviour. We pass the --prefix argument so that they are explicit. This makes the tests succeed on Nix.