### PR TITLE
fix(merlin): make merlin output more reproducible

### DIFF
--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -17,9 +17,7 @@ end = struct
 
     let make_error msg = Sexp.(List [ List [ Atom "ERROR"; Atom msg ] ])
 
-    let to_stdout (t : t) =
-      Csexp.to_channel stdout t;
-      flush stdout
+    let print (t : t) = Console.print [ Pp.vbox (Sexp.pp t) ]
   end
 
   module Commands = struct
@@ -138,7 +136,7 @@ end = struct
       | Error s -> Merlin_conf.make_error s
       | Ok file -> load_merlin_file file
     in
-    Merlin_conf.to_stdout answer
+    Merlin_conf.print answer
 
   let dump s =
     let+ file = to_local s in
@@ -163,7 +161,7 @@ end = struct
         let* () = print_merlin_conf path in
         main ()
       | Unknown msg ->
-        Merlin_conf.to_stdout (Merlin_conf.make_error msg);
+        Merlin_conf.print (Merlin_conf.make_error msg);
         main ()
     in
     main ()

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -40,14 +40,16 @@ up a project with instrumentation and testing checking the merlin config.
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/findlib)
    (B /OCAMLC_WHERE)
+   (B
+    lib/findlib)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
    (B
     $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S lib/findlib)
    (S /OCAMLC_WHERE)
+   (S
+    lib/findlib)
    (S
     $TESTCASE_ROOT/lib)
    (S
@@ -58,14 +60,16 @@ up a project with instrumentation and testing checking the merlin config.
   Privmod
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/findlib)
    (B /OCAMLC_WHERE)
+   (B
+    lib/findlib)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
    (B
     $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S lib/findlib)
    (S /OCAMLC_WHERE)
+   (S
+    lib/findlib)
    (S
     $TESTCASE_ROOT/lib)
    (S

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -9,14 +9,16 @@ CRAM sanitization
   X
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/findlib)
    (B /OCAMLC_WHERE)
+   (B
+    lib/findlib)
    (B
     $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S lib/findlib)
    (S /OCAMLC_WHERE)
+   (S
+    lib/findlib)
    (S
     $TESTCASE_ROOT/exe)
    (S
@@ -64,12 +66,14 @@ CRAM sanitization
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/findlib)
    (B /OCAMLC_WHERE)
    (B
+    lib/findlib)
+   (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S lib/findlib)
    (S /OCAMLC_WHERE)
+   (S
+    lib/findlib)
    (S
     $TESTCASE_ROOT/lib)
    (S
@@ -84,12 +88,14 @@ CRAM sanitization
   Privmod
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/findlib)
    (B /OCAMLC_WHERE)
    (B
+    lib/findlib)
+   (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S lib/findlib)
    (S /OCAMLC_WHERE)
+   (S
+    lib/findlib)
    (S
     $TESTCASE_ROOT/lib)
    (S


### PR DESCRIPTION
I'm putting a vbox around the merlin sexp so that it always breaks. On Nix the paths are long so it was causing some of the output to break. This should make the test more reproducible.

I'm not 100% confident this will work so keeping as draft to see what CI reports.