### PR TITLE
test: make toplevel-integration.t Nix compatible

### DIFF
--- a/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
+++ b/test/blackbox-tests/test-cases/toplevel/toplevel-integration.t
@@ -19,7 +19,6 @@ Test toplevel-init-file on a tiny project
   #load "$TESTCASE_ROOT/_build/default/test.cma";;
 
   $ ocaml -stdin <<EOF
-  > #use "topfind";;
   > #use_output "dune ocaml top";;
   > Test.Main.hello ();;
   > EOF
@@ -37,7 +36,6 @@ Test toplevel-init-file on a tiny project
   [1]
 
   $ ocaml -stdin <<EOF
-  > #use "topfind";;
   > #use_output "dune ocaml top";;
   > EOF
   File "error.ml", line 1, characters 14-32:


### PR DESCRIPTION
`topfind` is not installed in the usual place next to OCaml on Nix meaning that this test would not succeed. The use statement is not actually needed so we remove it from this test allowing for the test to succeed on Nix.