### PR TITLE
Unify lockdir loading with functor

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -78,4 +78,16 @@ module Write_disk : sig
   val commit : t -> unit
 end
 
-val read_disk : lock_dir_path:Path.Source.t -> t Or_exn.t
+val read_disk : Path.Source.t -> t
+
+module Make_load (Io : sig
+  include Monad.S
+
+  val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
+
+  val readdir_with_kinds : Path.Source.t -> (Filename.t * Unix.file_kind) list t
+
+  val with_lexbuf_from_file : Path.Source.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
+end) : sig
+  val load : Path.Source.t -> t Io.t
+end

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -156,9 +156,7 @@ let%expect_test "downloading, without any checksum" =
 let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
   let lock_dir_path = Path.Source.of_string lock_dir_path in
   Lock_dir.Write_disk.(prepare ~lock_dir_path lock_dir |> commit);
-  let lock_dir_round_tripped =
-    Lock_dir.read_disk ~lock_dir_path |> Result.ok_exn
-  in
+  let lock_dir_round_tripped = Lock_dir.read_disk lock_dir_path in
   if
     Lock_dir.equal
       (Lock_dir.remove_locs lock_dir_round_tripped)


### PR DESCRIPTION
We have two use cases for loading lockdirs:
- rules, which memoise the result of file IO
- tests, where we just want a simple function that loads lockdirs

We had two separate loaders for rules and tests which both read lockdirs from disk - one memoised and one not. This change introduces a functor which generalises ofe these two use cases with a common implementation of lockdir loading.