### PR TITLE
fix: value tracking mechanism for [Persistent]

### DIFF
--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -57,6 +57,16 @@ module P = Persistent.Make (struct
   let version = 6
 
   let to_dyn = to_dyn
+
+  let test_example () =
+    let table = Path.Table.create () in
+    Path.Table.set table
+      (Path.external_ (Path.External.of_string "/"))
+      { stats_checked = 1
+      ; digest = Digest.string "xxx"
+      ; stats = { Reduced_stats.mtime = 0.; size = 1; perm = 0 }
+      };
+    { checked_key = 1; max_timestamp = 0.; table }
 end)
 
 let needs_dumping = ref false

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -103,6 +103,13 @@ module P = Persistent.Make (struct
   let version = 2
 
   let to_dyn = Dyn.list File.to_dyn
+
+  let test_example () =
+    [ { File.src = Path.Build.(relative root "foo")
+      ; dst = Path.Source.of_string "bar"
+      ; staging = Some Path.Build.(relative root "baz")
+      }
+    ]
 end)
 
 let db_file = Path.relative Path.build_dir ".to-promote"

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -44,6 +44,16 @@ module Workspace_local = struct
       let version = 5
 
       let to_dyn = to_dyn
+
+      let test_example () =
+        let table = Path.Table.create () in
+        Path.Table.set table
+          (Path.external_ (Path.External.of_string "/"))
+          { Entry.rule_digest = Digest.string "foo"
+          ; dynamic_deps_stages = [ (Dep.Set.empty, Digest.string "bar") ]
+          ; targets_digest = Digest.string "zzz"
+          };
+        table
     end)
 
     let needs_dumping = ref false

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -16,6 +16,8 @@ module To_delete = struct
     let version = 2
 
     let to_dyn = Path.Source.Set.to_dyn
+
+    let test_example () = Path.Source.Set.empty
   end)
 
   let fn = Path.relative Path.build_dir ".to-delete-in-source-tree"

--- a/src/dune_rules/copy_line_directive.ml
+++ b/src/dune_rules/copy_line_directive.ml
@@ -14,6 +14,8 @@ module DB = struct
     let version = 1
 
     let to_dyn = Path.Build.Table.to_dyn Path.Build.to_dyn
+
+    let test_example () = Path.Build.Table.create 1
   end)
 
   let needs_dumping = ref false

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -100,6 +100,28 @@ module Processed = struct
     let version = 4
 
     let to_dyn _ = Dyn.String "Use [dune ocaml dump-dot-merlin] instead"
+
+    let test_example () =
+      { config =
+          { stdlib_dir = None
+          ; obj_dirs = Path.Set.empty
+          ; src_dirs = Path.Set.empty
+          ; flags = [ "-x" ]
+          ; extensions = [ { Ml_kind.Dict.intf = None; impl = Some "ext" } ]
+          ; melc_flags = [ "-y" ]
+          }
+      ; per_module_config = Path.Build.Map.empty
+      ; pp_config =
+          (match
+             Module_name.Per_item.of_mapping
+               [ ( [ Module_name.of_string "Test" ]
+                 , Some { flag = Ppx; args = "-x" } )
+               ]
+               ~default:None
+           with
+          | Ok s -> s
+          | Error (_, _, _) -> assert false)
+      }
   end
 
   module Persist = Dune_util.Persistent.Make (D)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -220,6 +220,8 @@ module Install_cookie = struct
     let version = 1
 
     let to_dyn = to_dyn
+
+    let test_example () = { files = Section.Map.empty; variables = [] }
   end)
 
   let load_exn f =

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -8,6 +8,8 @@ module type Desc = sig
   val version : int
 
   val to_dyn : t -> Dyn.t
+
+  val test_example : unit -> t
 end
 
 type data = ..
@@ -117,6 +119,12 @@ module Make (D : Desc) = struct
 end
 
 type t = T : (module Desc with type t = 'a) * 'a -> t
+
+let test_examples () =
+  String.Table.to_seq_values registry
+  |> Seq.map ~f:(fun desc ->
+         let module Desc = (val desc : Desc_with_data) in
+         T ((module Desc), Desc.test_example ()))
 
 let load_exn path =
   Io.with_file_in path ~f:(fun ic ->

--- a/src/dune_util/persistent.mli
+++ b/src/dune_util/persistent.mli
@@ -20,6 +20,8 @@ module type Desc = sig
   val version : int
 
   val to_dyn : t -> Dyn.t
+
+  val test_example : unit -> t
 end
 
 type data = private ..
@@ -55,3 +57,5 @@ end
 type t = T : (module Desc with type t = 'a) * 'a -> t
 
 val load_exn : Path.t -> t
+
+val test_examples : unit -> t Seq.t

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_unit_tests)
- (modules :standard \ vcs_tests findlib_tests)
+ (modules :standard \ vcs_tests findlib_tests persistent_tests)
  (libraries
   ocaml_config
   spawn
@@ -76,3 +76,24 @@
   ppx_inline_test.config)
  (preprocess
   (pps ppx_expect)))
+
+(library
+ (name persistent_tests)
+ (modules persistent_tests)
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
+ (libraries
+  dune_util
+  dyn
+  stdune
+  dune_engine
+  dune_rules
+  dune_digest
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_expect.common
+  base
+  ppx_inline_test.config))

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -1,0 +1,52 @@
+open Stdune
+module Persistent = Dune_util.Persistent
+module Digest = Dune_digest
+
+let test (type a) (module Persistent : Persistent.Desc with type t = a)
+    (example : a) =
+  let digest = Digest.generic example |> Digest.to_string in
+  printfn "%s version %d\n%s\n---\n" Persistent.name Persistent.version digest
+
+let%expect_test "persistent digests" =
+  Persistent.test_examples ()
+  (* These digests are to make sure that we're bumping the version whenever we
+     change the format of the values stored with [Persistent].
+
+     The usual workflow goes something like this:
+
+       1. The format of [Persistent.t] changes
+       2. The new value is reflected by the value returned [test_example]
+       3. The digest in this test suite changes and the test therefore fails
+
+       To fix the test, the correct thing to do is to bump the appropriate
+       version number where the persistent module is defined *)
+  |> Stdlib.Seq.iter (fun (Persistent.T (desc, example)) -> test desc example);
+  [%expect
+    {|
+    PROMOTED-TO-DELETE version 2
+    c5e35411975aef719f04a574b4ff5940
+    ---
+
+    DIGEST-DB version 6
+    a4ae8e07cf52a9fb38c47c32b6d59fa6
+    ---
+
+    INSTALL-COOKIE version 1
+    b9cd4cde10e1e3e883032dd57f86c54d
+    ---
+
+    TO-PROMOTE version 2
+    eba77c5dce16c91bdb3b54c3d48cb5f8
+    ---
+
+    COPY-LINE-DIRECTIVE-MAP version 1
+    7e311b06ebde9ff1708e4c3a1d3f5633
+    ---
+
+    merlin-conf version 4
+    0a56dee94d10f6a2a2ad8558266ee877
+    ---
+
+    INCREMENTAL-DB version 5
+    fa67cc9b60c9f3a1b9b1ad93a56df691
+    --- |}]


### PR DESCRIPTION
Every instantce of [Persistence] will now need to provide a
[test_example] that can be constructed of the data being stored. This
data is used to record a digest number that will be committed. Anytime,
the test data type changes, the example should also change and so should
the digest. This way, we won't forget to update the digest version.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1b706968-2a53-4a3d-8569-7594cbdf0b98 -->