### PR TITLE
makefile: slightly easier bootstrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ TEST_OCAMLVERSION := 4.14.1
 help:
 	@cat doc/make-help.txt
 
+.PHONY: bootstrap
+bootstrap:
+	$(MAKE) -B _boot/dune.exe
+
 .PHONY: release
 release: $(BIN)
 	@$(BIN) build @install -p dune --profile dune-bootstrap
@@ -216,7 +220,3 @@ docker-build-image:
 .PHONY: docker-compose
 docker-compose:
 	docker compose -f docker/dev.yml run dune bash
-
-.PHONY: bootstrap
-bootstrap:
-	$(BIN) build @install -p dune --profile dune-bootstrap

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -30,14 +30,16 @@ Running:
 ```
 make dev
 ```
-bootstraps (if necessary) and runs `./dune.exe build @install`.
+bootstraps (if necessary) and runs ``./dune.exe build @install``.
 
-If you want to just run the bootstrapping step itself, build the
-``_boot/dune.exe`` target with
+If you want to just run the bootstrapping step itself, build the ``bootstrap``
+phony target with
 
 .. code:: sh
 
-   make _boot/dune.exe
+   make bootstrap
+
+You can always rerun this to bootstrap again.
 
 Once you've bootstrapped Dune, you should be using it to develop Dune itself.
 Here are the most common commands you'll be running:

--- a/doc/make-help.txt
+++ b/doc/make-help.txt
@@ -27,6 +27,7 @@ work on Dune.
 
 Here are the following commands you can use:
 
+- make bootstrap to build the bootstrapped version of dune
 - make dev       to build the dune binary
 - make test      to build and run the testsuite
 - make doc       to build the Dune manual (requires sphinx)


### PR DESCRIPTION
We introduce a phony "dune.exe" target in the makefile that will always build the bootstrapped version of dune. Before the only way to bootstrap properly was to use `make _boot/dune.exe` and many times this would not work so it would have to be changed to `make -B _boot/dune.exe`.

This new target is easier to remember and write, and allows devs to quickly rebootstrap dune when needed. This is not something that needs to be done very often, but we make it easier anyway.