### PR TITLE
doc: fix dune-workspace example version number lagging behind

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -781,7 +781,7 @@ containing exactly:
 
 .. code:: dune
 
-    (lang dune 3.2)
+    (lang dune 3.10)
     (context default)
 
 This allows you to use an empty ``dune-workspace`` file to mark the root of your

--- a/doc/test/run.t
+++ b/doc/test/run.t
@@ -8,6 +8,5 @@ is fine, but you then need to update the list of such exceptions below.
 
   $ DUNE_LANG=$(dune internal latest-lang-version)
   $ grep '(lang dune' ../*.rst | grep -v "$DUNE_LANG"
-  ../dune-files.rst:    (lang dune 3.2)
   ../hacking.rst:``(lang dune 2.7)`` in their ``dune`` project file to use it.
   ../tests.rst:   (lang dune 2.7)


### PR DESCRIPTION
I don't think this was intentionally 3.2.