### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "OCaml",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": { "ghcr.io/avsm/ocaml-devcontainers-feature/ocaml:latest": {} },
+	"postCreateCommand": "opam init -ay --disable-sandboxing && sudo chown vscode _build && sudo apt-get update && make dev-switch && sudo apt install -y file npm",
+	"mounts": ["source=${localWorkspaceFolderBasename}-ocaml-build,target=${containerWorkspaceFolder}/_build,type=volume"],
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
This will allow developers to set up a dev environment in VSCode very easily even in a web browser.

I've tested it and its possible to run the entire test suite with this.

- fix https://github.com/ocaml/dune/issues/7297