### PR TITLE
test: repro #7430

### DIFF
--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
@@ -7,3 +7,8 @@ We can also show the original source if it is not preprocessed
 
   $ dune describe pp src/util.ml
   let log str = print_endline str
+
+We also make sure that the dump file is not present
+
+  $ dune_cmd exists profile.dump
+  true


### PR DESCRIPTION
Test case for #7430. We demonstrate that the `dune describe pp` command
leaves behind the dump file.
