### PR TITLE
fix: dune init project checks that PATH is relative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix `dune init project` crash when passed an absolute directory. Now it gives
+  an error message. (#8223, fixes #7806, @Alizter)
+
 - Add `dune show rules` as alias of the `dune rules` command. (#8000, @Alizter)
 
 - Add `dune show installed-libraries` as an alias of the `dune

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -169,7 +169,14 @@ module Init_context = struct
     let dir =
       match path with
       | None -> Path.root
-      | Some p -> Path.of_string p
+      | Some p ->
+        let dir = Path.of_string p in
+        if Filename.is_relative p then dir
+        else
+          User_error.raise
+            [ Pp.textf "Path %s is not relative."
+                (Path.to_string_maybe_quoted dir)
+            ]
     in
     File.create_dir dir;
     { dir; project }

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -81,7 +81,10 @@ let common : Component.Options.Common.t Term.t =
 
 let path =
   let docv = "PATH" in
-  Arg.(value & pos 1 (some string) None & info [] ~docv)
+  let doc =
+    "A relative path inside the project in which to create the project files."
+  in
+  Arg.(value & pos 1 (some string) None & info [] ~docv ~doc)
 
 let context_cwd : Init_context.t Term.t =
   let+ common_term = Common.term_with_default_root_is_cwd

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -134,11 +134,12 @@ Clean up from the dune file created in ./_test_dir
 
   $ rm -rf ./_test_dir
 
-Add a library to a dune file in a directory specified with an absolute path
-
+Adding a library to a dune file with using an absolute path is forbidden.
   $ dune init lib test_lib $PWD/_test_dir
-  Success: initialized library component named test_lib
-  $ test -f $PWD/_test_dir/dune
+  Error: Path
+  $TESTCASE_ROOT/_test_dir
+  is not relative.
+  [1]
 
 Clean up from the dune file created at an absolute path
 

--- a/test/blackbox-tests/test-cases/github7806.t
+++ b/test/blackbox-tests/test-cases/github7806.t
@@ -1,9 +1,7 @@
-  $ dune init project name $PWD 2>&1 | head -n 8
+  $ dune init project name $PWD
   Entering directory 'name'
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("[as_in_source_tree_exn] called on something not in source tree",
-    { t =
-        External
-          "$TESTCASE_ROOT"
-    })
+  Error: Path
+  $TESTCASE_ROOT
+  is not relative.
+  Leaving directory 'name'
+  [1]


### PR DESCRIPTION
This should always be the case since the project directory might not exist, there is little point allowing for absolute directories here. We therefore enforce this with a nice user message instead of failing badly.
- [x] changelog