### PR TITLE
path: change is_file to be false if doesn't exist

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1097,7 +1097,8 @@ let is_directory_with_error t =
   | exception Sys_error e -> Error e
   | bool -> Ok bool
 
-let is_file t = not (is_directory t)
+let is_file t =
+  try not (Sys.is_directory (to_string t)) with Sys_error _ -> false
 
 let rmdir t = Unix.rmdir (to_string t)
 


### PR DESCRIPTION
Before it would be true if the file didn't exist since it was just the negation of is_directory.

I used this existence checking in #8195.