### PR TITLE
Add conditions to lockfile actions

### DIFF
--- a/src/dune_lang/package_constraint.mli
+++ b/src/dune_lang/package_constraint.mli
@@ -38,6 +38,8 @@ type t =
   | And of t list  (** The conjunction of a list of boolean expressions *)
   | Or of t list  (** The disjunction of a list of boolean expressions *)
 
+val equal : t -> t -> bool
+
 val encode : t Dune_sexp.Encoder.t
 
 val decode : t Dune_sexp.Decoder.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -26,10 +26,17 @@ module Pkg_info : sig
   val default_version : string
 end
 
+module Conditional_action : sig
+  type t =
+    { action : Action.t
+    ; constraint_ : Package_constraint.t option
+    }
+end
+
 module Pkg : sig
   type t =
-    { build_command : Action.t option
-    ; install_command : Action.t option
+    { build_commands : Conditional_action.t list
+    ; install_commands : Conditional_action.t list
     ; deps : (Loc.t * Package_name.t) list
     ; info : Pkg_info.t
     ; exported_env : String_with_vars.t Action.Env_update.t list

--- a/src/dune_pkg/opam.ml
+++ b/src/dune_pkg/opam.ml
@@ -213,8 +213,9 @@ let opam_package_to_lock_file_pkg ~repo_state ~local_packages opam_package =
     |> List.map ~f:(fun name ->
            (Loc.none, Package_name.of_string (OpamPackage.Name.to_string name)))
   in
-  { Lock_dir.Pkg.build_command = None
-  ; install_command = None
+  (* TODO set these from the commands in the opam file *)
+  { Lock_dir.Pkg.build_commands = []
+  ; install_commands = []
   ; deps
   ; info
   ; exported_env = []

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -10,12 +10,12 @@ Some environment variables are automatically exported by packages:
   $ cat >dune.lock/usetest.pkg <<'EOF'
   > (deps test)
   > (build
-  >  (system "\| echo MANPATH=$MANPATH
-  >          "\| echo OCAMLPATH=$OCAMLPATH
-  >          "\| echo CAML_LD_LIBRARY_PATH=$CAML_LD_LIBRARY_PATH
-  >          "\| echo OCAMLTOP_INCLUDE_PATH=$OCAMLTOP_INCLUDE_PATH
-  >          "\| echo PATH=$PATH
-  >  ))
+  >  ((action (system "\| echo MANPATH=$MANPATH
+  >                   "\| echo OCAMLPATH=$OCAMLPATH
+  >                   "\| echo CAML_LD_LIBRARY_PATH=$CAML_LD_LIBRARY_PATH
+  >                   "\| echo OCAMLTOP_INCLUDE_PATH=$OCAMLTOP_INCLUDE_PATH
+  >                   "\| echo PATH=$PATH
+  >  ))))
   > EOF
 
   $ mkdir .bin

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -16,13 +16,14 @@ Packages can export environment variables
   > (deps test)
   > (version 1.2.3)
   > (build
-  >  (progn
-  >   (system "\| echo FOO=$FOO
-  >           "\| echo BAR=$BAR
-  >           "\| echo OPAM_PACKAGE_NAME=$OPAM_PACKAGE_NAME
-  >           "\| echo OPAM_PACKAGE_VERSION=$OPAM_PACKAGE_VERSION
-  >   )
-  >   (run mkdir -p %{prefix})))
+  >  ((action
+  >    (progn
+  >     (system "\| echo FOO=$FOO
+  >             "\| echo BAR=$BAR
+  >             "\| echo OPAM_PACKAGE_NAME=$OPAM_PACKAGE_NAME
+  >             "\| echo OPAM_PACKAGE_VERSION=$OPAM_PACKAGE_VERSION
+  >     )
+  >     (run mkdir -p %{prefix})))))
   > EOF
 
   $ dune build .pkg/usetest/target/

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -10,9 +10,10 @@ Test that can fetch the sources from an external dir
   $ cat >dune.lock/test.pkg <<EOF
   > (source (copy $PWD/foo))
   > (build
-  >  (progn
-  >   (run mkdir -p %{prefix}/bin)
-  >   (run cp x %{prefix}/bin/x )))
+  >  ((action
+  >    (progn
+  >     (run mkdir -p %{prefix}/bin)
+  >     (run cp x %{prefix}/bin/x )))))
   > EOF
 
   $ dune build .pkg/test/target/bin/x

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -18,7 +18,7 @@ Fetch from more than one source
   > (source (copy $PWD/foo))
   > (extra_sources (mybaz (copy $PWD/baz)))
   > (build
-  >  (system "find . | sort -u"))
+  >  ((action (system "find . | sort -u"))))
   > EOF
 
   $ dune build .pkg/test/target/

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -17,7 +17,7 @@ Test fetching from git
   > EOF
   $ cat >dune.lock/test.pkg <<EOF
   > (source (fetch (url "git+file://$MYGITREPO")))
-  > (build (run cat foo))
+  > (build ((action (run cat foo))))
   > EOF
 
   $ dune build _build/default/.pkg/test/target

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -5,7 +5,7 @@ Install actions should have the switch directory prepared:
   > (lang package 0.1)
   > EOF
   $ cat >dune.lock/test.pkg <<'EOF'
-  > (install (system "find %{prefix} | sort"))
+  > (install ((action (system "find %{prefix} | sort"))))
   > EOF
 
   $ dune build .pkg/test/target/

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -5,7 +5,7 @@ Testing install actions
   > (lang package 0.1)
   > EOF
   $ cat >dune.lock/test.pkg <<'EOF'
-  > (install (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))
+  > (install ((action (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))))
   > EOF
 
   $ dune build .pkg/test/target/

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -7,7 +7,7 @@ Test missing entries in the .install file
   $ lockfile() {
   > cat >dune.lock/test.pkg <<EOF
   > (build
-  >  (system "echo 'lib: [ \"$1\" ]' > test.install"))
+  >  ((action (system "echo 'lib: [ \"$1\" ]' > test.install"))))
   > EOF
   > }
 

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -6,24 +6,24 @@ Test that installed binaries are visible in dependent packages
   > EOF
   $ cat >dune.lock/test.pkg <<EOF
   > (build
-  >  (system "\| echo "#!/bin/sh\necho from test package" > foo;
-  >          "\| chmod +x foo;
-  >          "\| touch libxxx lib_rootxxx;
-  >          "\| cat >test.install <<EOF
-  >          "\| bin: [ "foo" ]
-  >          "\| lib: [ "libxxx" ]
-  >          "\| lib_root: [ "lib_rootxxx" ]
-  >          "\| share_root: [ "lib_rootxxx" ]
-  >          "\| EOF
-  >  ))
+  >  ((action
+  >    (system "\| echo "#!/bin/sh\necho from test package" > foo;
+  >            "\| chmod +x foo;
+  >            "\| touch libxxx lib_rootxxx;
+  >            "\| cat >test.install <<EOF
+  >            "\| bin: [ "foo" ]
+  >            "\| lib: [ "libxxx" ]
+  >            "\| lib_root: [ "lib_rootxxx" ]
+  >            "\| share_root: [ "lib_rootxxx" ]
+  >            "\| EOF
+  >    ))))
   > EOF
 
   $ cat >dune.lock/usetest.pkg <<EOF
   > (deps test)
   > (build
-  >  (progn
-  >   (run foo)
-  >   (run mkdir -p %{prefix})))
+  >  ((action (run foo)))
+  >  ((action (run mkdir -p %{prefix}))))
   > EOF
 
   $ dune build .pkg/usetest/target/

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -12,7 +12,7 @@ Additional files overlaid on top of the source can be found in the
   > (source
   >  (copy $PWD/test-source))
   > (build
-  >  (system "echo foo:; cat foo; echo bar:; cat bar"))
+  >  ((action (system "echo foo:; cat foo; echo bar:; cat bar"))))
   > EOF
 
   $ mkdir dune.lock/test.files

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -8,9 +8,10 @@ Applying patches
   $ cat >dune.lock/test.pkg <<EOF
   > (source (copy $PWD/test-source))
   > (build
-  >  (progn
-  >   (patch foo.patch)
-  >   (system "cat foo.ml")))
+  >  ((action
+  >    (progn
+  >     (patch foo.patch)
+  >     (system "cat foo.ml")))))
   > EOF
 
   $ mkdir dune.lock/test.files

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -19,7 +19,7 @@ TODO: versioning will be added once this feature is stable
   > EOF
   $ cat >foo.lock/test.pkg <<EOF
   > (build
-  >  (system "echo building from %{context_name}"))
+  >  ((action (system "echo building from %{context_name}"))))
   > EOF
   $ ln -s foo.lock bar.lock
 

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -6,9 +6,8 @@ Test that we run the build command
   > EOF
   $ cat >dune.lock/test.pkg <<EOF
   > (build
-  >  (progn
-  >   (run mkdir -p %{prefix}/bin)
-  >   (run touch %{prefix}/bin/foo)))
+  >  ((action (run mkdir -p %{prefix}/bin)))
+  >  ((action (run touch %{prefix}/bin/foo))))
   > EOF
 
   $ dune build .pkg/test/target/bin/foo

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -6,26 +6,27 @@ Test that we can set variables
   > EOF
   $ cat >dune.lock/test.pkg <<EOF
   > (build
-  >  (system "\| cat >test.config <<EOF
-  >          "\| opam-version: "2.0"
-  >          "\| variables {
-  >          "\|   abool: true
-  >          "\|   astring: "foobar"
-  >          "\|   somestrings: ["foo" "bar"]
-  >          "\| }
-  >          "\| EOF
-  >  ))
+  >  ((action
+  >    (system "\| cat >test.config <<EOF
+  >            "\| opam-version: "2.0"
+  >            "\| variables {
+  >            "\|   abool: true
+  >            "\|   astring: "foobar"
+  >            "\|   somestrings: ["foo" "bar"]
+  >            "\| }
+  >            "\| EOF
+  >    ))))
   > EOF
 
   $ cat >dune.lock/usetest.pkg <<EOF
   > (deps test)
   > (build
-  >  (progn
-  >   (system "\| echo %{pkg:var:test:abool}
-  >           "\| echo %{pkg:var:test:astring}
-  >           "\| echo %{pkg:var:test:somestrings}
-  >   )
-  >   (run mkdir -p %{prefix})))
+  >  ((action
+  >    (system "\| echo %{pkg:var:test:abool}
+  >            "\| echo %{pkg:var:test:astring}
+  >            "\| echo %{pkg:var:test:somestrings}
+  >    )))
+  >  ((action (run mkdir -p %{prefix}))))
   > EOF
 
   $ dune build .pkg/usetest/target/

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -6,15 +6,16 @@ Setting environment variables in actions
   > EOF
   $ cat >dune.lock/test.pkg <<'EOF'
   > (build
-  >  (withenv
-  >   ((= FOO myfoo)
-  >    (= XYZ 000)
-  >    (+= XYZ 111)
-  >    (= BAR xxx)
-  >    (+= BAR yyy)
-  >    (:= BAR "")
-  >    (+= BAR ""))
-  >   (system "echo XYZ=$XYZ; echo FOO=$FOO; echo BAR=$BAR")))
+  >  ((action
+  >    (withenv
+  >     ((= FOO myfoo)
+  >      (= XYZ 000)
+  >      (+= XYZ 111)
+  >      (= BAR xxx)
+  >      (+= BAR yyy)
+  >      (:= BAR "")
+  >      (+= BAR ""))
+  >     (system "echo XYZ=$XYZ; echo FOO=$FOO; echo BAR=$BAR")))))
   > EOF
   $ dune build .pkg/test/target/
   XYZ=111:000


### PR DESCRIPTION
This adds an optional condition to build and install actions in lockfiles. Note that these conditions currently aren't checked. Conditions on actions is necessary to build opam packages as opam package manifests can contain build and install commands which are conditional on filters.