### PR TITLE
feature: case statements

### DIFF
--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -124,6 +124,7 @@ type t =
   | Patch of String_with_vars.t
   | Substitute of String_with_vars.t * String_with_vars.t
   | Withenv of String_with_vars.t Env_update.t list * t
+  | Case of String_with_vars.t * (String_with_vars.t * t) list * t
 
 val encode : t Encoder.t
 

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -484,6 +484,14 @@ let rec expand (t : Dune_lang.Action.t) ~context : Action.t Action_expander.t =
   | Withenv _ | Substitute _ | Patch _ ->
     (* these can only be provided by the package language which isn't expanded here *)
     assert false
+  | Case (arg, cases, default) -> (
+    let+ arg = E.string arg
+    and+ cases =
+      A.all (List.map ~f:(fun (k, a) -> A.both (E.string k) (expand a)) cases)
+    and+ default = expand default in
+    match List.assoc cases arg with
+    | Some a -> a
+    | None -> default)
 
 let expand_no_targets t ~loc ~chdir ~deps:deps_written_by_user ~expander ~what =
   let open Action_builder.O in

--- a/test/blackbox-tests/test-cases/actions/case.t
+++ b/test/blackbox-tests/test-cases/actions/case.t
@@ -1,0 +1,149 @@
+Testing (case) action.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.10)
+  > EOF
+
+  $ cat > version << EOF
+  > 1
+  > EOF
+
+Basic usage:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (3 (echo "version is 3"))
+  >    (_ (echo "shouldn't happen, got %{read-lines:version}")))))
+  > EOF
+
+  $ dune build @foo
+  version is 1
+
+  $ cat > version << EOF
+  > 2
+  > EOF
+  $ dune build @foo
+  version is 2
+
+  $ cat > version << EOF
+  > 3
+  > EOF
+  $ dune build @foo
+  version is 3
+
+  $ cat > version << EOF
+  > 4
+  > EOF
+  $ dune build @foo
+  shouldn't happen, got 4
+
+  $ cat > version << EOF
+  > 1
+  > EOF
+
+Missing default field:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 5, characters 4-5:
+  5 |    (1 (echo "version is 1")))))
+          ^
+  Error: Only the default case can be at the end.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Two default fields:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (_ (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (_ (echo "version is 3")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Multiple default cases.
+  File "dune", line 5, characters 4-5:
+  5 |    (_ (echo "version is 1"))
+          ^
+  
+  File "dune", line 7, characters 4-5:
+  7 |    (_ (echo "version is 3")))))
+          ^
+  
+  [1]
+
+Last case is not default case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (_ (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (3 (echo "version is 3")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 7, characters 4-5:
+  7 |    (3 (echo "version is 3")))))
+          ^
+  Error: Only the default case can be at the end.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Empty case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version})))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 4, characters 2-30:
+  4 |   (case %{read-lines:version})))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Not enough arguments for case
+  [1]
+
+Duplicate cases:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1"))
+  >    (1 (echo "version is 1"))
+  >    (_ (echo "shouldn't happen")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Duplicate case.
+  File "dune", line 5, characters 4-5:
+  5 |    (1 (echo "version is 1"))
+          ^
+  
+  File "dune", line 6, characters 4-5:
+  6 |    (1 (echo "version is 1"))
+          ^
+  
+  [1]


### PR DESCRIPTION
We add a `(case ...)` constructor to dune_lang for actions which when expanded will reduce down to the matching branch. Basic use looks like:

```lisp
 (rule
  (alias foo)
  (action
   (case %{read-lines:version}
    (1 (echo "version is 1"))
    (2 (echo "version is 2"))
    (3 (echo "version is 3"))
    (_ (echo "shouldn't happen, got %{read-lines:version}")))))
```
which together with a `version` file containing `2` would print `2`.

- [ ] changelog
- [x] tests
- [ ] Should the default case be optional? I think no.
- [ ] Multicase branches?
- [ ] Also implement cond?
  - will be done in followup PR, currently blocked by #8196
-  addreses part of https://github.com/ocaml/dune/issues/924