### PR TITLE
test: repro for #8210 (EACCESS if sendfile fails)

### DIFF
--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -1,12 +1,14 @@
   $ cat > dune-project << EOF
-  > (lang dune 1.0)
+  > (lang dune 2.4)
   > (package
   >  (name p))
   > EOF
 
   $ cat > dune << EOF
+  > (rule (copy data.txt data2.txt))
+  > 
   > (install
-  >  (files data.txt)
+  >  (files data.txt data2.txt)
   >  (section share))
   > EOF
 
@@ -15,3 +17,12 @@
 If sendfile fails, we should fallback to the portable implementation.
 
   $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
+  Error: _build/default/data2.txt: Permission denied
+  -> required by _build/default/data2.txt
+  -> required by _build/install/default/share/p/data2.txt
+  -> required by _build/default/p.install
+  -> required by alias install
+  [1]
+
+#8210: data2.txt is copied from readonly-file data.txt (#3092), so it needs to
+be adequately unlinked before starting the fallback.


### PR DESCRIPTION
What's happening here is:

- input and output files are open
- sendfile is attempted and fails
- both files are closed
- input file is opened again
- output file is opened again (but already exists)

This throws an error if the output file is not writable.
