### PR TITLE
fix(sendfile): reuse fd before fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ Unreleased
 - Improve `dune describe external-lib-deps` by adding the internal dependencies
   for more information. (#7478, @moyodiallo)
 
+- Fix permission errors when `sendfile` is not available (#8234, fixes #8120,
+  @emillon)
+
 3.9.1 (2023-07-06)
 ------------------
 

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -101,7 +101,7 @@ module Copyfile = struct
     | Linux -> `Sendfile
     | Windows | Other -> `Nothing
 
-  let sendfile =
+  let sendfile_with_fallback =
     let setup_copy ?(chmod = Fun.id) ~src ~dst () =
       match Unix.openfile src [ O_RDONLY ] 0 with
       | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Error `Src_missing
@@ -147,7 +147,12 @@ module Copyfile = struct
         raise (Sys_error message)
       | Ok (src, dst, src_size) ->
         Exn.protect
-          ~f:(fun () -> sendfile ~src ~dst src_size)
+          ~f:(fun () ->
+            try sendfile ~src ~dst src_size
+            with Unix.Unix_error (EINVAL, "sendfile", _) ->
+              let ic = Unix.in_channel_of_descr src in
+              let oc = Unix.out_channel_of_descr dst in
+              copy_channels ic oc)
           ~finally:(fun () ->
             Unix.close src;
             Unix.close dst)
@@ -175,11 +180,6 @@ module Copyfile = struct
   let copy_file_portable ?chmod ~src ~dst () =
     Exn.protectx (setup_copy ?chmod ~src ~dst ()) ~finally:close_both
       ~f:(fun (ic, oc) -> copy_channels ic oc)
-
-  let sendfile_with_fallback ?chmod ~src ~dst () =
-    try sendfile ?chmod ~src ~dst ()
-    with Unix.Unix_error (EINVAL, "sendfile", _) ->
-      copy_file_portable ?chmod ~src ~dst ()
 
   let copy_file_best =
     match available with

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -17,12 +17,6 @@
 If sendfile fails, we should fallback to the portable implementation.
 
   $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
-  Error: _build/default/data2.txt: Permission denied
-  -> required by _build/default/data2.txt
-  -> required by _build/install/default/share/p/data2.txt
-  -> required by _build/default/p.install
-  -> required by alias install
-  [1]
 
 #8210: data2.txt is copied from readonly-file data.txt (#3092), so it needs to
 be adequately unlinked before starting the fallback.


### PR DESCRIPTION
Fixes #8210

If the `sendfile` branch failed, it left an empty target file.
This file needs to be removed, otherwise the next `open` call can fail if the file is not writeable.
