### PR TITLE
Expose user environment when running pkg actions

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -327,7 +327,14 @@ module Pkg = struct
         ]
     in
     let env = build_env t |> Env.Map.map ~f:Env_update.string_of_env_values in
-    Env.extend Env.empty ~vars:(Env.Map.superpose base env)
+    (* TODO: Run actions in a constrained environment. [Env.initial] is the
+       environment from which dune was executed, and some of the environment
+       variables may affect builds in unintended ways and make builds less
+       reproducible. However other environment variables must be set in order
+       for build actions to run successfully, such as $PATH on systems where the
+       shell's default $PATH variable doesn't include the location of standard
+       programs or build tools (e.g. NixOS). *)
+    Env.extend Env.initial ~vars:(Env.Map.superpose base env)
 end
 
 module Pkg_installed = struct

--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -1,0 +1,23 @@
+Make sure we can run exes from the user's PATH variable.
+
+Create a directory containing a shell script and add the directory to PATH.
+  $ mkdir bin
+  $ cat > bin/hello <<EOF
+  > #!/bin/sh
+  > echo "Hello, World!"
+  > EOF
+  $ chmod a+x bin/hello
+  $ PATH=$PATH:$PWD/bin
+
+Create a lockdir with a lockfile that runs the shell script in a build command.
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (build (system hello))
+  > EOF
+
+The build command is run from an environment including the custom PATH variable.
+  $ dune build .pkg/test/target/
+  Hello, World!


### PR DESCRIPTION
Currently nixos users are unable to run pkg tests that run system actions because the `$PATH` environment variable is unset in the environment in which the action runs resulting in the shell being unable to find standard unix tools such as `cat`. This is intended as a quick fix to unblock nixos users but it introduces a new problem of builds being (unintentionally) influenced by environment variables. This will require some careful design so we'll solve it later.