### PR TITLE
melange: add `melange.dom` lib to merlin

### DIFF
--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -37,7 +37,9 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   B /MELC_STDLIB/melange
   B /MELC_STDLIB/melange
   B /MELC_STDLIB/melange
+  B /MELC_STDLIB/melange
   B $TESTCASE_ROOT/_build/default/.foo.objs/melange
+  S /MELC_STDLIB
   S /MELC_STDLIB
   S /MELC_STDLIB
   S /MELC_STDLIB
@@ -75,7 +77,9 @@ Dump-dot-merlin includes the melange flags
   B /MELC_STDLIB/melange
   B /MELC_STDLIB/melange
   B /MELC_STDLIB/melange
+  B /MELC_STDLIB/melange
   B $TESTCASE_ROOT/_build/default/.output.mobjs/melange
+  S /MELC_STDLIB
   S /MELC_STDLIB
   S /MELC_STDLIB
   S /MELC_STDLIB


### PR DESCRIPTION
In the more recent versions, Melange modified the way its libraries are provided, so they get all wrapped (see https://github.com/melange-re/melange/pull/624/).

This PR adapts the way Dune generates merlin configs so that it can find the artifacts for the library `melange.dom`.

Remaining questions:
- The test relies on the latest version of `melange` to be available in Dune, but we don't pin `melange` anymore, should we re-add the pinning?
- Should we do something similar with `melange.node`?