### PR TITLE
fix: disable background digests on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ Unreleased
 - Fix permission errors when `sendfile` is not available (#8234, fixes #8120,
   @emillon)
 
+- Disable background digests on Windows. This prevents an issue where
+  unremovable files would make dune crash when the shared cache is enabled.
+  (#8243, fixes #8228, @emillon)
+
 3.9.1 (2023-07-06)
 ------------------
 

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -116,7 +116,10 @@ let background_digests =
   let t =
     { name = "background_digests"
     ; of_string = Toggle.of_string
-    ; value = background_default
+    ; value =
+        (match Platform.OS.value with
+        | Linux -> `Enabled
+        | _ -> `Disabled)
     }
   in
   register t;


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/8228

In some cases when the shared cache is enabled, some temporary directories cannot be removed.