### PR TITLE
docs: fix the `dune cache trim` documentation

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -11,11 +11,11 @@ let trim =
       ; `Pre
           {|Trimming the Dune cache to 1 GB.
 
-           \$ dune cache trim --trimmed-size=1GB |}
+           \$ dune cache trim --size=1GB |}
       ; `Pre
           {|Trimming 500 MB from the Dune cache.
 
-           \$ dune cache trim --size=500MB |}
+           \$ dune cache trim --trimmed-size=500MB |}
       ]
     in
     Cmd.info "trim" ~doc ~man

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -117,11 +117,11 @@ Testing the output of dune cache trim.
   EXAMPLES
          Trimming the Dune cache to 1 GB.
          
-                    $ dune cache trim --trimmed-size=1GB 
+                    $ dune cache trim --size=1GB 
   
          Trimming 500 MB from the Dune cache.
          
-                    $ dune cache trim --size=500MB 
+                    $ dune cache trim --trimmed-size=500MB 
   
   SEE ALSO
          dune(1)


### PR DESCRIPTION
- `--size` is the final size
- `--trimmed-size` is how many bytes to remove

cc @ygrek