### PR TITLE
fix: use correct hash for id's in hashtable

### DIFF
--- a/otherlibs/stdune/src/id.ml
+++ b/otherlibs/stdune/src/id.ml
@@ -23,7 +23,6 @@ end
 module Make () : S = struct
   module Set = Int.Set
   module Map = Int.Map
-  module Table = Hashtbl.Make (Int)
 
   type t = int
 
@@ -45,4 +44,14 @@ module Make () : S = struct
   let hash (t : t) = t
 
   let to_dyn t = Dyn.Int t
+
+  module Table = Hashtbl.Make (struct
+    type nonrec t = t
+
+    let equal = equal
+
+    let hash t = t
+
+    let to_dyn = to_dyn
+  end)
 end


### PR DESCRIPTION
We were using [Int.hash] rather than the specialized [hash] for id's.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ed38e143-5eba-4292-8d17-a8060634a341 -->