### PR TITLE
fix: correctly handle absolute paths in dune ocaml top-module

### DIFF
--- a/doc/changes/8249.md
+++ b/doc/changes/8249.md
@@ -1,0 +1,2 @@
+- Fix `dune ocaml top-module` to correctly handle absolute paths. (#8249, fixes
+  #7370, @Alizter)

--- a/test/blackbox-tests/test-cases/top-module/load-from-lib.t
+++ b/test/blackbox-tests/test-cases/top-module/load-from-lib.t
@@ -57,11 +57,12 @@ We try to load a module defined in a library with a dependnecy
   $ ls _build/default/mydummylib/*.cma
   _build/default/mydummylib/mydummylib.cma
 
-  $ dune ocaml top-module $PWD/foo/foo.ml 2>&1 | head -n7
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Local.relative: received absolute path",
-    { t = "."
-    ; path =
-        "$TESTCASE_ROOT/foo/foo.ml"
-    })
+  $ dune ocaml top-module $PWD/foo/foo.ml
+  #directory "$TESTCASE_ROOT/_build/default/.topmod/foo/foo.ml";;
+  #directory "$TESTCASE_ROOT/_build/default/mydummylib/.mydummylib.objs/byte";;
+  #load "$TESTCASE_ROOT/_build/default/mydummylib/mydummylib.cma";;
+  #load "$TESTCASE_ROOT/_build/default/foo/.foo.objs/byte/foo__.cmo";;
+  #load "$TESTCASE_ROOT/_build/default/foo/.foo.objs/byte/foo__Bar.cmo";;
+  #load "$TESTCASE_ROOT/_build/default/.topmod/foo/foo.ml/foo.cmo";;
+  open Foo__
+  ;;


### PR DESCRIPTION
- fix #7370