### PR TITLE
Updated error message to indicate that modules must start with a letter

### DIFF
--- a/src/dune_rules/site.ml
+++ b/src/dune_rules/site.ml
@@ -2,8 +2,8 @@ open Import
 
 let valid_format_doc =
   Pp.text
-    "Module names must be non-empty and composed only of the following characters: \
-     'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'."
+    "Module names must be non-empty, start with a letter, and composed only of the \
+     following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'."
 ;;
 
 module Modulelike (S : sig

--- a/test/blackbox-tests/test-cases/github5273.t
+++ b/test/blackbox-tests/test-cases/github5273.t
@@ -9,7 +9,7 @@
   1 | (library (name 03))
                      ^^
   Error: "03" is an invalid module name.
-  Module names must be non-empty and composed only of the following characters:
-  'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Module names must be non-empty, start with a letter, and composed only of the
+  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
   Hint: M03 would be a correct module name
   [1]

--- a/test/blackbox-tests/test-cases/github7600.t
+++ b/test/blackbox-tests/test-cases/github7600.t
@@ -22,7 +22,7 @@ directories too.
   $ dune build @install
   File "src/baz-bar", line 1, characters 0-0:
   Error: "baz-bar" is an invalid module name.
-  Module names must be non-empty and composed only of the following characters:
-  'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Module names must be non-empty, start with a letter, and composed only of the
+  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
   Hint: baz_bar would be a correct module name
   [1]

--- a/test/blackbox-tests/test-cases/include-qualified/pp.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/pp.t/run.t
@@ -4,7 +4,7 @@ We can set preprocessing options for nested modules
   8 |      (run cat %{input-file})) bar/ppme))))
                                     ^^^^^^^^
   Error: "bar/ppme" is an invalid module name.
-  Module names must be non-empty and composed only of the following characters:
-  'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Module names must be non-empty, start with a letter, and composed only of the
+  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
   Hint: barppme would be a correct module name
   [1]


### PR DESCRIPTION
This partially addresses #8252 by ensuring that the produced error message indicates that a module name must start with a letter.