### PR TITLE
refactor: use precise path types

### DIFF
--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -58,7 +58,7 @@ module Glob_dir = struct
      base dir (typically the directory containing the dune file which contains
      the glob) or absolute. *)
   type t =
-    | Absolute of string
+    | Absolute of Path.External.t
     | Relative of
         { relative_dir : string
         ; base_dir : Path.Build.t
@@ -104,7 +104,9 @@ module Without_vars = struct
           [ Pp.textf "Absolute paths in recursive globs are not supported." ]
       else
         Memo.return
-          [ (File_selector.of_glob ~dir:(Path.of_string dir) glob, dir) ]
+          [ ( File_selector.of_glob ~dir:(Path.external_ dir) glob
+            , Path.External.to_string dir )
+          ]
 end
 
 module Expand
@@ -123,7 +125,7 @@ struct
     let dir : Glob_dir.t =
       if Filename.is_relative parent_str then
         Relative { relative_dir = parent_str; base_dir }
-      else Absolute parent_str
+      else Absolute (Path.External.of_string parent_str)
     in
     { Without_vars.glob; dir; recursive }
 


### PR DESCRIPTION
Use [Path.External.t] instead of string in [Glob_files_expand]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 22e7dea6-268f-4be5-a201-8b716d182b44 -->