### PR TITLE
refactor: path types in [Glob_files_expand]

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1291,6 +1291,8 @@ module Source = struct
 
   let is_in_build_dir s = is_in_build_dir (path_of_local s)
 
+  let append_local = append
+
   let to_local t = t
 end
 

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -116,6 +116,8 @@ module Source : sig
 
   val to_local : t -> Local.t
 
+  val append_local : t -> Local.t -> t
+
   module Table : Hashtbl.S with type key = t
 end
 

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -130,10 +130,13 @@ let rec dep expander = function
       (Glob_files_expand.action_builder glob_files
          ~f:(Expander.expand_str expander)
          ~base_dir:(Expander.dir expander)
-      >>| List.map ~f:(fun path ->
-              if Filename.is_relative path then
-                Path.Build.relative (Expander.dir expander) path |> Path.build
-              else Path.of_string path))
+      >>| List.map ~f:(fun (path : Path.t) ->
+              match path with
+              | External _ -> path
+              | In_build_dir _ -> assert false
+              | In_source_tree path ->
+                Path.Build.append_source (Expander.dir expander) path
+                |> Path.build))
   | Source_tree s ->
     Other
       (let* path = Expander.expand_path expander s in

--- a/src/dune_rules/glob_files_expand.mli
+++ b/src/dune_rules/glob_files_expand.mli
@@ -12,7 +12,7 @@ val memo :
      Dep_conf.Glob_files.t
   -> f:(String_with_vars.t -> string Memo.t)
   -> base_dir:Path.Build.t
-  -> string list Memo.t
+  -> Path.t list Memo.t
 
 (** Expand a glob inside the [Action_builder] context. The result of calling
     [Glob_files.Action_builder.expand] is an action builder which will resolve
@@ -22,4 +22,4 @@ val action_builder :
      Dep_conf.Glob_files.t
   -> f:(String_with_vars.t -> string Action_builder.t)
   -> base_dir:Path.Build.t
-  -> string list Action_builder.t
+  -> Path.t list Action_builder.t

--- a/src/dune_rules/install_entry.ml
+++ b/src/dune_rules/install_entry.ml
@@ -48,7 +48,14 @@ module File = struct
         in
         let glob_loc = String_with_vars.loc glob_files.glob in
         List.map paths ~f:(fun path ->
-            let src = (glob_loc, path) in
+            let src =
+              ( glob_loc
+              , match (path : Path.t) with
+                | External s -> Path.External.to_string s
+                | In_build_dir d -> Path.Local.to_string @@ Path.Build.local d
+                | In_source_tree d ->
+                  Path.Local.to_string @@ Path.Source.to_local d )
+            in
             File_binding.Unexpanded.make ~src ~dst:src)
 
     let to_file_bindings_expanded t ~expand_str ~dir =


### PR DESCRIPTION
Use [Path.Local.t] to represent instead of strings

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a02d7850-f1c5-4b13-9342-50d6a54a53b4 -->