### PR TITLE
fix: pass O_SHARE_DELETE when digesting files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ Unreleased
 - Improve `dune describe external-lib-deps` by adding the internal dependencies
   for more information. (#7478, @moyodiallo)
 
+- Re-enable background file digests on Windows. The files are now open in a way
+  that prevents race condition around deletion. (#8262, fixes #8268, @emillon)
+
 3.9.2 (2023-07-25)
 ------------------
 

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -116,10 +116,7 @@ let background_digests =
   let t =
     { name = "background_digests"
     ; of_string = Toggle.of_string
-    ; value =
-        (match Platform.OS.value with
-        | Linux -> `Enabled
-        | _ -> `Disabled)
+    ; value = background_default
     }
   in
   register t;

--- a/src/dune_digest/dune_digest.ml
+++ b/src/dune_digest/dune_digest.ml
@@ -17,8 +17,12 @@ end
 
 module Direct_impl : Digest_impl = struct
   let file file =
+    (* On Windows, if this function is invoked in a background thread,
+       if can happen that the file is not properly closed.
+       [O_SHARE_DELETE] ensures that the main thread can delete it even if it
+       is still open. See #8243. *)
     let fd =
-      match Unix.openfile file [ Unix.O_RDONLY ] 0 with
+      match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE ] 0 with
       | fd -> fd
       | exception Unix.Unix_error (Unix.EACCES, _, _) ->
         raise (Sys_error (sprintf "%s: Permission denied" file))


### PR DESCRIPTION
Fixes #8268

This flag corresponds to what `Stdlib.open_in` does. When passed, the files can be removed while they are still open. This condition can happen when background digests are enabled. This is a no-op everywhere else.

This allows enabling background digests on Windows.