### PR TITLE
Set the opam-version variable during solving

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -68,6 +68,7 @@ module Sys_var = struct
       | `Os_version
       | `Os_distribution
       | `Os_family
+      | `Opam_version
       ]
 
     let to_string = function
@@ -76,12 +77,14 @@ module Sys_var = struct
       | `Os_version -> "os-version"
       | `Os_distribution -> "os-distribution"
       | `Os_family -> "os-family"
+      | `Opam_version -> "opam-version"
 
     let compare a b = String.compare (to_string a) (to_string b)
 
     let to_dyn t = Dyn.string (to_string t)
 
-    let all = [ `Arch; `Os; `Os_version; `Os_distribution; `Os_family ]
+    let all =
+      [ `Arch; `Os; `Os_version; `Os_distribution; `Os_family; `Opam_version ]
   end
 
   include T

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -40,6 +40,7 @@ module Sys_var : sig
     | `Os_version
     | `Os_distribution
     | `Os_family
+    | `Opam_version
     ]
 
   val to_string : t -> string

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -1,7 +1,7 @@
 Print the solver env when no dune-workspace is present
   $ dune pkg lock --just-print-solver-env
   Solver environment for context default:
-  ((flags (with-doc with-test)) (sys ()))
+  ((flags (with-doc with-test)) (sys ((opam-version 2.2.0~alpha-vendored))))
 
 Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
@@ -23,6 +23,22 @@ Add some build contexts with different environments
 
   $ dune pkg lock --all-contexts --just-print-solver-env
   Solver environment for context no-doc:
-  ((flags (with-test)) (sys ()))
+  ((flags (with-test)) (sys ((opam-version 2.2.0~alpha-vendored))))
   Solver environment for context linux:
-  ((flags (with-doc with-test)) (sys ((os linux))))
+  ((flags (with-doc with-test)) (sys ((opam-version 2.2.0~alpha-vendored) (os linux))))
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (context
+  >  (default
+  >   (name attempt-to-override-opam-version)
+  >   (lock dune.linux.lock)
+  >   (solver_env
+  >    (sys
+  >     (opam-version foo)))))
+  > EOF
+
+  $ dune pkg lock --all-contexts --just-print-solver-env
+  Error: Context attempt-to-override-opam-version would override solver
+  variable opam-version. This variable may not be overriden.
+  [1]


### PR DESCRIPTION
The variable is always set to the version of opam vendored inside dune.