### PR TITLE
[3.9] backport #8234 (sendfile fallback)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   unremovable files would make dune crash when the shared cache is enabled.
   (#8243, fixes #8228, @emillon)
 
+- Fix permission errors when `sendfile` is not available (#8234, fixes #8120,
+  @emillon)
+
 3.9.1 (2023-07-06)
 ------------------
 

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -145,10 +145,10 @@ module Copyfile = struct
       | Error `Src_missing ->
         let message = Printf.sprintf "%s: No such file or directory" src in
         raise (Sys_error message)
-      | Ok (fd_src, fd_dst, src_size) ->
-        Exn.protectx (fd_src, fd_dst, src_size)
-          ~f:(fun (src, dst, src_size) -> sendfile ~src ~dst src_size)
-          ~finally:(fun (src, dst, _) ->
+      | Ok (src, dst, src_size) ->
+        Exn.protect
+          ~f:(fun () -> sendfile ~src ~dst src_size)
+          ~finally:(fun () ->
             Unix.close src;
             Unix.close dst)
 

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -101,7 +101,7 @@ module Copyfile = struct
     | Linux -> `Sendfile
     | Windows | Other -> `Nothing
 
-  let sendfile =
+  let sendfile_with_fallback =
     let setup_copy ?(chmod = Fun.id) ~src ~dst () =
       match Unix.openfile src [ O_RDONLY ] 0 with
       | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Error `Src_missing
@@ -147,7 +147,12 @@ module Copyfile = struct
         raise (Sys_error message)
       | Ok (src, dst, src_size) ->
         Exn.protect
-          ~f:(fun () -> sendfile ~src ~dst src_size)
+          ~f:(fun () ->
+            try sendfile ~src ~dst src_size
+            with Unix.Unix_error (EINVAL, "sendfile", _) ->
+              let ic = Unix.in_channel_of_descr src in
+              let oc = Unix.out_channel_of_descr dst in
+              copy_channels ic oc)
           ~finally:(fun () ->
             Unix.close src;
             Unix.close dst)
@@ -175,11 +180,6 @@ module Copyfile = struct
   let copy_file_portable ?chmod ~src ~dst () =
     Exn.protectx (setup_copy ?chmod ~src ~dst ()) ~finally:close_both
       ~f:(fun (ic, oc) -> copy_channels ic oc)
-
-  let sendfile_with_fallback ?chmod ~src ~dst () =
-    try sendfile ?chmod ~src ~dst ()
-    with Unix.Unix_error (EINVAL, "sendfile", _) ->
-      copy_file_portable ?chmod ~src ~dst ()
 
   let copy_file_best =
     match available with

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -1,12 +1,14 @@
   $ cat > dune-project << EOF
-  > (lang dune 1.0)
+  > (lang dune 2.4)
   > (package
   >  (name p))
   > EOF
 
   $ cat > dune << EOF
+  > (rule (copy data.txt data2.txt))
+  > 
   > (install
-  >  (files data.txt)
+  >  (files data.txt data2.txt)
   >  (section share))
   > EOF
 
@@ -15,3 +17,12 @@
 If sendfile fails, we should fallback to the portable implementation.
 
   $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
+  Error: _build/default/data2.txt: Permission denied
+  -> required by _build/default/data2.txt
+  -> required by _build/install/default/share/p/data2.txt
+  -> required by _build/default/p.install
+  -> required by alias install
+  [1]
+
+#8210: data2.txt is copied from readonly-file data.txt (#3092), so it needs to
+be adequately unlinked before starting the fallback.

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -17,12 +17,6 @@
 If sendfile fails, we should fallback to the portable implementation.
 
   $ strace -e inject=sendfile:error=EINVAL -o /dev/null dune build @install
-  Error: _build/default/data2.txt: Permission denied
-  -> required by _build/default/data2.txt
-  -> required by _build/install/default/share/p/data2.txt
-  -> required by _build/default/p.install
-  -> required by alias install
-  [1]
 
 #8210: data2.txt is copied from readonly-file data.txt (#3092), so it needs to
 be adequately unlinked before starting the fallback.


### PR DESCRIPTION
- test: repro for #8210 (EACCESS if sendfile fails)
- refactor: use Exn.protect instead of protectx (#8235)
- fix(sendfile): unlink dst before fallback (#8234)
