### PR TITLE
Don't warn on undefined opam variables when solving

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -287,9 +287,9 @@ let solve_package_list local_packages context =
     with
     | OpamPp.(Bad_format _ | Bad_format_list _ | Bad_version _) as bad_format ->
       User_error.raise [ Pp.text (OpamPp.string_of_bad_format bad_format) ]
-    (* | unexpected_exn ->
-       Code_error.raise "Unexpected exception raised while solving dependencies"
-         [ ("exception", Exn.to_dyn unexpected_exn) ] *)
+    | unexpected_exn ->
+      Code_error.raise "Unexpected exception raised while solving dependencies"
+        [ ("exception", Exn.to_dyn unexpected_exn) ]
   in
   match result with
   | Error e -> Error (`Diagnostic_message (Solver.diagnostics e |> Pp.text))

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -33,13 +33,7 @@ module Filter : sig
   val resolve_solver_env_treating_unset_sys_vars_as_wildcards :
     Solver_env.t -> filter -> filter
 
-  type eval_to_bool_error :=
-    [ `Not_a_bool of string
-    | `Undefined_sys_env_var of OpamVariable.t
-    | `Undefined_var of OpamVariable.t
-    ]
-
-  val eval_to_bool : filter -> (bool, eval_to_bool_error) result
+  val eval_to_bool : filter -> (bool, [ `Not_a_bool of string ]) result
 end = struct
   open OpamTypes
 
@@ -92,24 +86,9 @@ end = struct
     filter |> resolve_flags flags
     |> resolve_sys_var_treating_unset_vars_as_wildcards sys
 
-  let first_variable filter =
-    OpamFilter.fold_down_left
-      (fun acc filter ->
-        match (acc, filter) with
-        | None, FIdent (_, variable, _) -> Some variable
-        | _ -> acc)
-      None filter
-
   let eval_to_bool filter =
-    match filter with
-    | FIdent (_, variable, _) when is_variable_sys variable ->
-      Error (`Undefined_sys_env_var variable)
-    | _ -> (
-      match first_variable filter with
-      | Some variable -> Error (`Undefined_var variable)
-      | None -> (
-        try Ok (OpamFilter.eval_to_bool (Fun.const None) filter)
-        with Invalid_argument msg -> Error (`Not_a_bool msg)))
+    try Ok (OpamFilter.eval_to_bool ~default:false (Fun.const None) filter)
+    with Invalid_argument msg -> Error (`Not_a_bool msg)
 end
 
 (* Helper module for working with [OpamTypes.filtered_formula] *)
@@ -190,26 +169,6 @@ module Context_for_dune = struct
                   package_string
               ; Pp.textf "available: %s" available_string
               ; Pp.text msg
-              ]
-          | `Undefined_sys_env_var variable ->
-            User_warning.emit
-              [ Pp.textf
-                  "Ignoring package %s as its `available` filter resolves to a \
-                   system environment variable instead of a boolean."
-                  package_string
-              ; Pp.textf "available: %s" available_string
-              ; Pp.textf "%s is an system environment variable."
-                  (OpamVariable.to_string variable)
-              ]
-          | `Undefined_var variable ->
-            User_warning.emit
-              [ Pp.textf
-                  "Ignoring package %s as its `available` filter contains an \
-                   undefined variable."
-                  package_string
-              ; Pp.textf "available: %s" available_string
-              ; Pp.textf "The variable %s is undefined."
-                  (OpamVariable.to_string variable)
               ]);
         false
 

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -133,17 +133,9 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
   >  (name x)
   >  (depends undefined-var))
   > EOF
-  Warning: Ignoring package undefined-var.0.0.1 as its `available` filter
-  contains an undefined variable.
-  available: xos = "linux"
-  The variable xos is undefined.
   Solution for dune.lock:
   undefined-var.0.0.2
   
-  Warning: Ignoring package undefined-var.0.0.1 as its `available` filter
-  contains an undefined variable.
-  available: xos = "linux"
-  The variable xos is undefined.
   Error: Unable to solve dependencies in build context: macos
   Can't find all required versions.
   Selected: x.dev
@@ -161,14 +153,6 @@ filter resolves to a string instead of to a boolean.
   >  (name x)
   >  (depends availability-string))
   > EOF
-  Warning: Ignoring package availability-string.0.0.2 as its `available` filter
-  resolves to a system environment variable instead of a boolean.
-  available: os
-  os is an system environment variable.
-  Warning: Ignoring package availability-string.0.0.1 as its `available` filter
-  can't be resolved to a boolean value.
-  available: "foo"
-  value_bool: "foo"
   Error: Unable to solve dependencies in build context: default
   Can't find all required versions.
   Selected: x.dev
@@ -176,14 +160,6 @@ filter resolves to a string instead of to a boolean.
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
-  Warning: Ignoring package availability-string.0.0.2 as its `available` filter
-  can't be resolved to a boolean value.
-  available: os
-  value_bool: "macos"
-  Warning: Ignoring package availability-string.0.0.1 as its `available` filter
-  can't be resolved to a boolean value.
-  available: "foo"
-  value_bool: "foo"
   Error: Unable to solve dependencies in build context: macos
   Can't find all required versions.
   Selected: x.dev


### PR DESCRIPTION
Undefined variables don't indicate a problem and packages expect comparisons with undefined variables to resolve to false.