### PR TITLE
refactor: add [Per_context]

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1005,8 +1005,9 @@ module Library = struct
               let context, _ = Path.Build.extract_build_context_exn dir in
               Memo.return context
             | Var Profile ->
-              let+ context = Context.DB.by_dir dir in
-              Profile.to_string context.profile
+              let context, _ = Path.Build.extract_build_context_exn dir in
+              let+ profile = Per_context.profile (Context_name.of_string context) in
+              Profile.to_string profile
             | _ -> Memo.return @@ Lib_config.get_for_enabled_if lib_config pform
           in
           [ Value.String value ])

--- a/src/dune_rules/per_context.ml
+++ b/src/dune_rules/per_context.ml
@@ -1,0 +1,46 @@
+open Import
+open Memo.O
+
+let all =
+  Memo.lazy_ ~name:"context-db"
+  @@ fun () ->
+  let+ workspace = Workspace.workspace () in
+  let contexts =
+    List.concat_map workspace.contexts ~f:(fun (context : Workspace.Context.t) ->
+      let native, targets =
+        match context with
+        | Default default -> default.base.name, default.base.targets
+        | Opam opam -> opam.base.name, opam.base.targets
+      in
+      let targets =
+        List.filter_map targets ~f:(function
+          | Native -> None
+          | Named toolchain ->
+            let name = Context_name.target native ~toolchain in
+            Some (name, `Target (context, toolchain)))
+      in
+      (native, `Native context) :: targets)
+  in
+  Context_name.Map.of_list_exn contexts
+;;
+
+let create_db ?cutoff ~name f =
+  let cutoff = Option.map cutoff ~f:(fun equal -> Context_name.Map.equal ~equal) in
+  let map =
+    Memo.lazy_ ~name ?cutoff (fun () ->
+      let+ map = Memo.Lazy.force all in
+      Context_name.Map.map map ~f)
+  in
+  Staged.stage (fun context ->
+    let+ map = Memo.Lazy.force map in
+    match Context_name.Map.find map context with
+    | Some v -> v
+    | None ->
+      Code_error.raise "invalid context" [ "context", Context_name.to_dyn context ])
+;;
+
+let profile =
+  create_db ~cutoff:Profile.equal ~name:"profile" (function
+    | `Native ctx | `Target (ctx, _) -> (Workspace.Context.base ctx).profile)
+  |> Staged.unstage
+;;

--- a/src/dune_rules/per_context.mli
+++ b/src/dune_rules/per_context.mli
@@ -1,0 +1,3 @@
+open Import
+
+val profile : Context_name.t -> Profile.t Memo.t

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -62,6 +62,7 @@ module Context : sig
   val env : t -> Dune_env.Stanza.t
   val host_context : t -> Context_name.t option
   val to_dyn : t -> Dyn.t
+  val base : t -> Common.t
 end
 
 (** Representation of a workspace. The list of context is topologically sorted,


### PR DESCRIPTION
This allows us to access the profile with cutoff and without
initializing the context.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 33db7a47-6411-4c30-abad-c087f1f01d86 -->