### PR TITLE
fix: [build_dir_only_sub_dirs] sanity check

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -16,6 +16,10 @@ module Rules = struct
   module Build_only_sub_dirs = struct
     type t = Subdir_set.t Path.Build.Map.t
 
+    let iter_dirs_containing_sub_dirs t ~f =
+      Path.Build.Map.iteri t ~f:(fun dir _ -> f dir)
+    ;;
+
     let empty = Path.Build.Map.empty
     let singleton ~dir sub_dirs = Path.Build.Map.singleton dir sub_dirs
     let find t dir = Path.Build.Map.find t dir |> Option.value ~default:Subdir_set.empty

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -25,6 +25,7 @@ module Rules : sig
     type t
 
     val empty : t
+    val iter_dirs_containing_sub_dirs : t -> f:(Path.Build.t -> unit) -> unit
     val singleton : dir:Path.Build.t -> Subdir_set.t -> t
     val find : t -> Path.Build.t -> Subdir_set.t
     val union : t -> t -> t

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -552,13 +552,15 @@ end = struct
     ;;
 
     let check_all_sub_dirs_rule_dirs_are_descendant ~of_:dir build_dir_only_sub_dirs =
-      Path.Build.Map.iteri build_dir_only_sub_dirs ~f:(fun p _sub_dirs ->
-        if not (Path.Build.is_descendant p ~of_:dir)
-        then
-          Code_error.raise
-            "[gen_rules] returned sub-directories in a directory that is not a \
-             descendant of the directory it was called for"
-            [ "dir", Path.Build.to_dyn dir; "example", Path.Build.to_dyn p ])
+      Build_config.Rules.Build_only_sub_dirs.iter_dirs_containing_sub_dirs
+        build_dir_only_sub_dirs
+        ~f:(fun p ->
+          if not (Path.Build.is_descendant p ~of_:dir)
+          then
+            Code_error.raise
+              "[gen_rules] returned sub-directories in a directory that is not a \
+               descendant of the directory it was called for"
+              [ "dir", Path.Build.to_dyn dir; "example", Path.Build.to_dyn p ])
     ;;
 
     let check_all_rules_are_descendant ~of_:dir rules =
@@ -596,7 +598,7 @@ end = struct
       { Build_config.Rules.build_dir_only_sub_dirs; directory_targets; rules }
       =
       check_all_directory_targets_are_descendant ~of_ directory_targets;
-      check_all_sub_dirs_rule_dirs_are_descendant ~of_ directory_targets;
+      check_all_sub_dirs_rule_dirs_are_descendant ~of_ build_dir_only_sub_dirs;
       let rules =
         Memo.lazy_ (fun () ->
           let+ rules = rules in


### PR DESCRIPTION
[build_dir_only_sub_dirs] should not be allowed to escape the directory
we're producing in and we have a check in the code to verify this.

The current check was buggy and was checking the directory
targets map instead. The declared directory targets indeed have this
limitation, but it's already checked elsewhere.

The fix is to correctly check the right directory set. This requires
adding an api to iterate over the sub directories.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 61f4e39b-dc39-4027-b46e-b0a2e75ee93b -->