### PR TITLE
refactor(engine): simplify rule loading

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1164,7 +1164,7 @@ end = struct
             (Memo.Stack_frame.as_instance_of
                frame
                ~of_:execute_action_generic_stage2_memo)
-            ~f:(fun x -> x.action.Rule.Anonymous_action.loc)))
+            ~f:(fun (x : Anonymous_action.t) -> x.action.loc)))
   ;;
 end
 

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -109,10 +109,15 @@ let promote_target_if_not_up_to_date
    file promotions. Another approach is to make restarts really cheap, so that
    we don't care any more, for example, by introducing reverse dependencies in
    Memo (and/or by having smarter cancellations). *)
-let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
+let promote
+  ~dir
+  ~(targets : _ Targets.Produced.t)
+  ~(promote : Rule.Promote.t)
+  ~promote_source
+  =
   (* Select targets taking into account the (promote (only <glob>)) field. *)
   let selected_for_promotion : Path.Build.t -> bool =
-    match promote.Rule.Promote.only with
+    match promote.only with
     | None -> fun (_ : Path.Build.t) -> true
     | Some pred ->
       fun target ->


### PR DESCRIPTION
The function [load_build_directory_exn] is quite large. This PR splits
it into a few logical parts:

* Computing which source paths to ignore
* Computing the copying rules for source files
* Validating the directory targets
* Computing the descendants that artifact deletion should leave alone

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9c5a6c80-b0aa-40d5-a606-e201deab4cfd -->