### PR TITLE
feat: add a way to mark extensions as deleted

### DIFF
--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -71,7 +71,7 @@ val create :
      ?experimental:bool
   -> name:string
   -> desc:string
-  -> (Version.t * [ `Since of Version.t ]) list
+  -> (Version.t * [ `Since of Version.t | `Deleted_in of Version.t ]) list
   -> t
 
 (** Return the name of the syntax. *)


### PR DESCRIPTION
Our extension mechanism is versioned, but we only support adding new versions.
However, for experimental extensions or 0.x versions we've always said that
these could be removed. This PR adds such a mechanism.
