### PR TITLE
test: directory targets + globs + sandboxing

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/glob-inside-directory-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/glob-inside-directory-target.t
@@ -1,0 +1,19 @@
+This test makes sure that whenever we evaluate a glob inside a directory target
+that matches nothing, we still copy the directory and make it empty.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir output))
+  >  (action (system "mkdir output && touch output/foo.txt")))
+  > (rule
+  >  (targets x)
+  >  (deps (glob_files output/*.baz))
+  >  (action (system "ls output/ && touch x")))
+  > EOF
+
+  $ DUNE_SANDBOX=copy dune build x


### PR DESCRIPTION
We test the following scenario:

A rule depends on a glob inside a directory target. The glob matches
nothing. The rule runs in a sandbox.

The directory target should be copied to sandbox, even if it's empty.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: db58c054-cebb-489d-b613-566bc688bff4 -->