### PR TITLE
refactor: arrays instead of lists for arguments

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -55,7 +55,10 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
   let path = Encoder.string in
   let target = Encoder.string in
   function
-  | Run (a, xs) -> List (atom "run" :: program a :: List.map xs ~f:string)
+  | Run (a, xs) ->
+    List
+      (atom "run" :: program a
+      :: List.map (Array.Immutable.to_list xs) ~f:string)
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"

--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -11,3 +11,15 @@ let equal f x y =
       done;
       true
     with Exit -> false
+
+module Immutable = struct
+  type 'a t = 'a array
+
+  let of_array a = copy a
+
+  let to_list a = to_list a
+
+  let of_list a = of_list a
+
+  let map t ~f = map t ~f
+end

--- a/otherlibs/stdune/src/array.mli
+++ b/otherlibs/stdune/src/array.mli
@@ -1,0 +1,15 @@
+include module type of Stdlib.ArrayLabels with type 'a t = 'a array
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+module Immutable : sig
+  type 'a t
+
+  val of_array : 'a array -> 'a t
+
+  val to_list : 'a t -> 'a list
+
+  val of_list : 'a list -> 'a t
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+end

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -21,7 +21,7 @@ module Make
 struct
   include Ast
 
-  let run prog args = Run (prog, args)
+  let run prog args = Run (prog, Array.Immutable.of_list args)
 
   let chdir path t = Chdir (path, t)
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -226,7 +226,9 @@ let rec exec t ~display ~ectx ~eenv =
   match (t : Action.t) with
   | Run (Error e, _) -> Action.Prog.Not_found.raise e
   | Run (Ok prog, args) ->
-    let+ () = exec_run ~display ~ectx ~eenv prog args in
+    let+ () =
+      exec_run ~display ~ectx ~eenv prog (Array.Immutable.to_list args)
+    in
     Done
   | With_accepted_exit_codes (exit_codes, t) ->
     let eenv =

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -30,7 +30,7 @@ module type Ast = sig
   type ext
 
   type t =
-    | Run of program * string list
+    | Run of program * string Array.Immutable.t
     | With_accepted_exit_codes of int Predicate_lang.t * t
     | Dynamic_run of program * string list
     | Chdir of path * t
@@ -71,6 +71,7 @@ module type Helpers = sig
 
   type t
 
+  (* TODO consider changing this to a [string array] to save some conversion *)
   val run : program -> string list -> t
 
   val chdir : path -> t -> t

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -16,7 +16,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     let f t ~dir = f t ~dir ~f_program ~f_string ~f_path ~f_target ~f_ext in
     match t with
     | Run (prog, args) ->
-      Run (f_program ~dir prog, List.map args ~f:(f_string ~dir))
+      Run (f_program ~dir prog, Array.Immutable.map args ~f:(f_string ~dir))
     | With_accepted_exit_codes (pred, t) ->
       With_accepted_exit_codes (pred, f t ~dir)
     | Dynamic_run (prog, args) ->

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -44,7 +44,7 @@ let interpret_perm (perm : Action.File_perm.t) fn acc =
 let simplify act =
   let rec loop (act : Action.For_shell.t) acc =
     match act with
-    | Run (prog, args) -> Run (prog, args) :: acc
+    | Run (prog, args) -> Run (prog, Array.Immutable.to_list args) :: acc
     | With_accepted_exit_codes (_, t) -> loop t acc
     | Dynamic_run (prog, args) -> Run (prog, args) :: acc
     | Chdir (p, act) -> loop act (Chdir p :: mkdir p :: acc)

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -404,7 +404,7 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
   match t with
   | Run (prog, args) ->
     let+ prog, args = expand_run prog args in
-    O.Run (prog, args)
+    O.Run (prog, Array.Immutable.of_list args)
   | With_accepted_exit_codes (pred, t) ->
     let+ t = expand t in
     O.With_accepted_exit_codes (pred, t)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -429,7 +429,10 @@ module Unprocessed = struct
           match exe with
           | Error _ -> None
           | Ok bin ->
-            let args = encode_command ~bin ~args in
+            let args =
+              let args = Array.Immutable.to_list args in
+              encode_command ~bin ~args
+            in
             Some { Processed.flag = Processed.Pp_kind.Pp; args }
         in
         Action_builder.map action ~f:(fun act ->

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -550,7 +550,7 @@ module Action_expander = struct
       let* exe, more_args = Expander.expand_exe expander exe in
       let+ args = Memo.parallel_map args ~f:(Expander.expand_pform expander) in
       let args = more_args @ List.concat args |> Value.L.to_strings ~dir in
-      Action.Run (exe, args)
+      Action.Run (exe, Array.Immutable.of_list args)
     | Progn t ->
       let+ args = Memo.parallel_map t ~f:(expand ~expander) in
       Action.Progn args
@@ -573,7 +573,7 @@ module Action_expander = struct
                ~loc ())
       in
       (* TODO opam has a preprocessing step that we should probably apply *)
-      Action.Run (patch, [ "-p1"; "-i"; input ])
+      Action.Run (patch, Array.Immutable.of_array [| "-p1"; "-i"; input |])
     | Substitute (input, output) ->
       let* input = Expander.expand_pform_gen ~mode:Single expander input in
       let input = input |> Value.to_path ~dir in

--- a/test/expect-tests/dune_engine/action_to_sh_tests.ml
+++ b/test/expect-tests/dune_engine/action_to_sh_tests.ml
@@ -1,3 +1,4 @@
+open Stdune
 open Dune_engine
 open Action.For_shell
 module Action = Dune_engine.Action
@@ -5,7 +6,7 @@ module Action = Dune_engine.Action
 let print x = x |> Action_to_sh.pp |> Dune_tests_common.print
 
 let%expect_test "run" =
-  Run ("my_program", [ "my"; "-I"; "args" ]) |> print;
+  Run ("my_program", Array.Immutable.of_array [| "my"; "-I"; "args" |]) |> print;
   [%expect {|
     my_program my -I args |}]
 


### PR DESCRIPTION
Should cost us about half the storage

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fcda7237-dfbe-4b7a-9b75-d167db9472b5 -->