### PR TITLE
tests: use [tail] instead of [wait] to block on a process finishing

### DIFF
--- a/test/blackbox-tests/test-cases/watching/helpers.sh
+++ b/test/blackbox-tests/test-cases/watching/helpers.sh
@@ -22,7 +22,7 @@ with_timeout () {
 
 stop_dune () {
     with_timeout dune shutdown;
-    wait $DUNE_PID;
+    tail --pid=$DUNE_PID -f /dev/null;
     cat .#dune-output;
 }
 


### PR DESCRIPTION
I'm not entirely sure why, but when I run `dune runtest` on the repository, I get the following error:

```
./helpers.sh: line 25: wait: pid 123456 is not a child of this shell
```

My hypothesis is that the command that starts dune is run from within a different sub-shell than the command that stops it. What confuses me is that this error doesn't show up in CI jobs; maybe it's because of differences in the version of bash on my machine and the CI machine? In any case, I think using `tail` is more robust to changes in the structure of the scripts, so even if I could fix my environment to make the tests pass, I think this is a good change.

Signed-off-by: Philip White <code@trailingwhite.space>