### PR TITLE
refactor: replace deprecated runloop in fsevents

### DIFF
--- a/src/fsevents/bin/dune_fsevents.ml
+++ b/src/fsevents/bin/dune_fsevents.ml
@@ -16,9 +16,9 @@ let fsevents =
 ;;
 
 let () =
-  let runloop = Fsevents.RunLoop.in_current_thread () in
-  Fsevents.start fsevents runloop;
-  match Fsevents.RunLoop.run_current_thread runloop with
+  let dispatch_queue = Fsevents.Dispatch_queue.create () in
+  Fsevents.start fsevents dispatch_queue;
+  match Fsevents.Dispatch_queue.wait_until_stopped dispatch_queue with
   | Ok () -> ()
   | Error e -> raise e
 ;;

--- a/src/fsevents/fsevents.mli
+++ b/src/fsevents/fsevents.mli
@@ -4,11 +4,11 @@
 
 val available : unit -> bool
 
-module RunLoop : sig
+module Dispatch_queue : sig
   type t
 
-  val in_current_thread : unit -> t
-  val run_current_thread : t -> (unit, exn) result
+  val create : unit -> t
+  val wait_until_stopped : t -> (unit, exn) result
 end
 
 module Event : sig
@@ -63,14 +63,12 @@ type t
     debouncing based on [latency]. [f] is called for every new event *)
 val create : paths:string list -> latency:float -> f:(Event.t list -> unit) -> t
 
-(** [start t] will start listening for fsevents. Note that the callback will not
-    be called until [loop t] is called. *)
-val start : t -> RunLoop.t -> unit
+(** [start t dq] will start listening for fsevents. *)
+val start : t -> Dispatch_queue.t -> unit
 
-val runloop : t -> RunLoop.t option
+val dispatch_queue : t -> Dispatch_queue.t option
 
-(** [stop t] stop listening to events. Note that this will not make [loop]
-    return until [break] is called. *)
+(** [stop t] stops listening to events. *)
 val stop : t -> unit
 
 (** [flush_sync t] flush all pending events that might be held up by debouncing.

--- a/test/expect-tests/fsevents/fsevents_tests.ml
+++ b/test/expect-tests/fsevents/fsevents_tests.ml
@@ -183,8 +183,8 @@ let test_with_multiple_fsevents ~setup ~test:f =
         res, sync)
       |> List.unzip
     in
-    let runloop = Fsevents.RunLoop.in_current_thread () in
-    List.iter fsevents ~f:(fun f -> Fsevents.start f runloop);
+    let dispatch_queue = Fsevents.Dispatch_queue.create () in
+    List.iter fsevents ~f:(fun f -> Fsevents.start f dispatch_queue);
     let (t : Thread.t) =
       Thread.create
         (fun () ->
@@ -206,7 +206,7 @@ let test_with_multiple_fsevents ~setup ~test:f =
             syncs)
         ()
     in
-    (match Fsevents.RunLoop.run_current_thread runloop with
+    (match Fsevents.Dispatch_queue.wait_until_stopped dispatch_queue with
      | Error Exit -> print_endline "[EXIT]"
      | Error _ -> assert false
      | Ok () -> ());


### PR DESCRIPTION
Replace the use of the deprecated `FSEventStreamScheduleWithRunLoop()` with `FSEventStreamSetDispatchQueue()`.

Since a dispatch queue spawns new threads, we need to call `caml_c_thread_register()` and `caml_c_thread_unregister()` for these threads. This is done indirectly via a `pthread_key_t` so that the functions only need to be called more than once if the dispatch queue switches which thread is running the callback.

We replicate the blocking nature of the existing code using a mutex and condition variable.

See git/git@b0226007f0aaf448dec1defe3e44c4e3d7513aa8 for more details about this approach.

Fixes #7352.