### PR TITLE
[3.9] backport #8288 (sendfile buffer fix)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+3.9.3 (unreleased)
+------------------
+
+- Fix flushing when using `sendfile` fallback (#8288, @alan-j-hu)
+
 3.9.2 (2023-07-25)
 ------------------
 

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -136,4 +136,4 @@
  (applies_to github8041)
  (enabled_if
   (= %{system} linux))
- (deps %{bin:strace}))
+ (deps %{bin:strace} %{bin:head}))

--- a/test/blackbox-tests/test-cases/github8041.t
+++ b/test/blackbox-tests/test-cases/github8041.t
@@ -8,11 +8,12 @@
   > (rule (copy data.txt data2.txt))
   > 
   > (install
-  >  (files data.txt data2.txt)
+  >  (files data.txt data2.txt data3.txt)
   >  (section share))
   > EOF
 
   $ echo contents > data.txt
+  $ head -c 100000 /dev/zero > data3.txt
 
 If sendfile fails, we should fallback to the portable implementation.
 
@@ -20,3 +21,13 @@ If sendfile fails, we should fallback to the portable implementation.
 
 #8210: data2.txt is copied from readonly-file data.txt (#3092), so it needs to
 be adequately unlinked before starting the fallback.
+
+#8284: the buffer needs to be flushed, or there will be incomplete data in
+larger files.
+
+  $ if cmp -s data3.txt _build/default/data3.txt ; then
+  >   echo "File copied correctly"
+  > else
+  >   echo "File copied incorrectly"
+  > fi
+  File copied correctly


### PR DESCRIPTION
- test: add a repro for #8284 (#8292)
- fix(sendfile): Flush the out_channel used in the fallback path (#8288)
