### PR TITLE
refactor(memo): remove unnecessary tupling of a constructor

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1627,7 +1627,7 @@ struct
   end
 
   module Value = struct
-    type t = T : ('a Type_eq.Id.t * 'a output) -> t
+    type t = T : 'a Type_eq.Id.t * 'a output -> t
 
     let get (type a) ~(input_with_matching_id : a input) value : a output =
       match value with


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 63264ceb-3253-4faa-8627-18098fd5199a -->