### PR TITLE
Tidy up solver env

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -1,200 +1,284 @@
 open! Stdune
 
-module Flag = struct
-  module T = struct
-    type t =
-      [ `With_test
-      | `With_doc
-      ]
-
-    let to_string = function
-      | `With_test -> "with-test"
-      | `With_doc -> "with-doc"
-    ;;
-
-    let compare a b = String.compare (to_string a) (to_string b)
-    let equal a b = Ordering.is_eq (compare a b)
-    let to_dyn t = Dyn.variant (to_string t) []
-    let all = [ `With_test; `With_doc ]
-  end
-
-  include T
-
-  let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
-
-  let encode t =
-    let open Dune_lang.Encoder in
-    string (to_string t)
-  ;;
-
-  module Set = struct
-    include Set.Of_map (T) (Map.Make (T))
-
-    let all : t = of_list all
-
-    let of_ordered_set ordered_set =
-      Dune_lang.Ordered_set_lang.eval
-        ordered_set
-        ~parse:(fun ~loc string ->
-          match of_string_opt string with
-          | Some flag -> flag
-          | None ->
-            User_error.raise
-              ~loc
-              [ Pp.textf "No such flag: %s" (String.maybe_quoted string)
-              ; Pp.textf
-                  "Valid flags: %s"
-                  (String.enumerate_and
-                     (List.map T.all ~f:(fun v -> String.maybe_quoted @@ to_string v)))
-              ])
-        ~eq:T.equal
-        ~standard:T.all
-      |> of_list
-    ;;
-
-    let decode =
-      let open Dune_lang.Decoder in
-      let+ ordered_set = Dune_lang.Ordered_set_lang.decode in
-      of_ordered_set ordered_set
-    ;;
-
-    let encode t =
-      let open Dune_lang.Encoder in
-      list encode (to_list t)
-    ;;
-  end
-end
-
-module Sys_var = struct
-  module T = struct
-    type t =
-      [ `Arch
-      | `Os
-      | `Os_version
-      | `Os_distribution
-      | `Os_family
-      | `Opam_version
-      ]
-
-    let to_string = function
-      | `Arch -> "arch"
-      | `Os -> "os"
-      | `Os_version -> "os-version"
-      | `Os_distribution -> "os-distribution"
-      | `Os_family -> "os-family"
-      | `Opam_version -> "opam-version"
-    ;;
-
-    let compare a b = String.compare (to_string a) (to_string b)
-    let to_dyn t = Dyn.string (to_string t)
-    let all = [ `Arch; `Os; `Os_version; `Os_distribution; `Os_family; `Opam_version ]
-  end
-
-  include T
-
-  let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
-
-  let decode =
-    let open Dune_lang.Decoder in
-    let+ loc, name = located string in
-    match of_string_opt name with
-    | Some t -> t
-    | None ->
-      User_error.raise
-        ~loc
-        [ Pp.textf "No such sys variable: %s" (String.maybe_quoted name)
-        ; Pp.textf
-            "Valid variables: %s"
-            (String.enumerate_and
-               (List.map T.all ~f:(fun v -> String.maybe_quoted @@ to_string v)))
+module Variable = struct
+  module Flag = struct
+    module T = struct
+      type t =
+        [ `With_test
+        | `With_doc
         ]
-  ;;
 
-  let encode t =
-    let open Dune_lang.Encoder in
-    string (to_string t)
-  ;;
+      let to_string = function
+        | `With_test -> "with-test"
+        | `With_doc -> "with-doc"
+      ;;
 
-  module Map = Map.Make (T)
+      let compare a b = String.compare (to_string a) (to_string b)
+      let equal a b = Ordering.is_eq (compare a b)
+      let to_dyn t = Dyn.variant (to_string t) []
+      let all = [ `With_test; `With_doc ]
+    end
 
-  module Bindings = struct
-    type t = string Map.t
+    include T
 
-    let empty = Map.empty
-    let to_dyn = Map.to_dyn Dyn.string
-    let equal = Map.equal ~equal:String.equal
-    let set = Map.set
-    let get = Map.find
+    let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
+
+    module Set = struct
+      include Set.Of_map (T) (Map.Make (T))
+
+      let all : t = of_list all
+
+      let of_ordered_set ordered_set =
+        Dune_lang.Ordered_set_lang.eval
+          ordered_set
+          ~parse:(fun ~loc string ->
+            match of_string_opt string with
+            | Some flag -> flag
+            | None ->
+              User_error.raise
+                ~loc
+                [ Pp.textf "No such flag: %s" (String.maybe_quoted string)
+                ; Pp.textf
+                    "Valid flags: %s"
+                    (String.enumerate_and
+                       (List.map T.all ~f:(fun v -> String.maybe_quoted @@ to_string v)))
+                ])
+          ~eq:T.equal
+          ~standard:T.all
+        |> of_list
+      ;;
+
+      let decode =
+        let open Dune_lang.Decoder in
+        let+ ordered_set = Dune_lang.Ordered_set_lang.decode in
+        of_ordered_set ordered_set
+      ;;
+
+      let pp t =
+        to_list all
+        |> Pp.enumerate ~f:(fun flag -> Pp.textf "%s = %b" (to_string flag) (mem t flag))
+      ;;
+    end
+  end
+
+  module Sys = struct
+    module T = struct
+      type t =
+        [ `Arch
+        | `Os
+        | `Os_version
+        | `Os_distribution
+        | `Os_family
+        ]
+
+      let to_string = function
+        | `Arch -> "arch"
+        | `Os -> "os"
+        | `Os_version -> "os-version"
+        | `Os_distribution -> "os-distribution"
+        | `Os_family -> "os-family"
+      ;;
+
+      let compare a b = String.compare (to_string a) (to_string b)
+      let to_dyn t = Dyn.string (to_string t)
+      let all = [ `Arch; `Os; `Os_version; `Os_distribution; `Os_family ]
+    end
+
+    include T
+
+    let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
 
     let decode =
       let open Dune_lang.Decoder in
-      let+ loc, bindings = located (repeat (pair decode string)) in
-      match Map.of_list bindings with
-      | Ok t -> t
-      | Error (duplicate_key, a, b) ->
+      let+ loc, name = located string in
+      match of_string_opt name with
+      | Some t -> t
+      | None ->
         User_error.raise
           ~loc
-          [ Pp.textf
-              "Duplicate entries for sys variable %s (%s, %s)"
-              (String.maybe_quoted (to_string duplicate_key))
-              (String.maybe_quoted a)
-              (String.maybe_quoted b)
+          [ Pp.textf "No such sys variable: %s" (String.maybe_quoted name)
+          ; Pp.textf
+              "Valid variables: %s"
+              (String.enumerate_and
+                 (List.map T.all ~f:(fun v -> String.maybe_quoted @@ to_string v)))
           ]
     ;;
 
-    let encode t =
-      let open Dune_lang.Encoder in
-      list (pair encode string) (Map.to_list t)
-    ;;
+    module Map = Map.Make (T)
 
-    type union_error = [ `Var_in_both_with_different_values of T.t * string * string ]
+    module Bindings = struct
+      type t = string Map.t
 
-    exception E of union_error
+      let empty = Map.empty
+      let to_dyn = Map.to_dyn Dyn.string
+      let equal = Map.equal ~equal:String.equal
+      let set = Map.set
+      let get = Map.find
 
-    let union a b =
-      try
-        Map.union a b ~f:(fun common_key a_value b_value ->
-          if String.equal a_value b_value
-          then Some a_value
-          else
-            raise (E (`Var_in_both_with_different_values (common_key, a_value, b_value))))
-        |> Result.ok
-      with
-      | E union_error -> Error union_error
-    ;;
+      let decode =
+        let open Dune_lang.Decoder in
+        let+ loc, bindings = located (repeat (pair decode string)) in
+        match Map.of_list bindings with
+        | Ok t -> t
+        | Error (duplicate_key, a, b) ->
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Duplicate entries for sys variable %s (%s, %s)"
+                (String.maybe_quoted (to_string duplicate_key))
+                (String.maybe_quoted a)
+                (String.maybe_quoted b)
+            ]
+      ;;
+
+      type union_error = [ `Var_in_both_with_different_values of T.t * string * string ]
+
+      exception E of union_error
+
+      let union a b =
+        try
+          Map.union a b ~f:(fun common_key a_value b_value ->
+            if String.equal a_value b_value
+            then Some a_value
+            else
+              raise
+                (E (`Var_in_both_with_different_values (common_key, a_value, b_value))))
+          |> Result.ok
+        with
+        | E union_error -> Error union_error
+      ;;
+
+      let pp t =
+        Pp.enumerate all ~f:(fun variable ->
+          match Map.find t variable with
+          | Some value ->
+            Pp.textf "%s = %s" (to_string variable) (String.maybe_quoted value)
+          | None -> Pp.textf "%s (unset)" (to_string variable))
+      ;;
+    end
   end
+
+  module Const = struct
+    type t = [ `Opam_version ]
+
+    let to_string = function
+      | `Opam_version -> "opam-version"
+    ;;
+
+    let all = [ `Opam_version ]
+    let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
+
+    module Bindings = struct
+      type t = { opam_version : string }
+
+      let to_dyn { opam_version } = Dyn.(record [ "opam_version", string opam_version ])
+      let equal { opam_version } t = String.equal opam_version t.opam_version
+
+      let get { opam_version } = function
+        | `Opam_version -> opam_version
+      ;;
+
+      let pp { opam_version } =
+        Pp.enumerate
+          [ `Opam_version, opam_version ]
+          ~f:(fun (variable, value) -> Pp.textf "%s = %s" (to_string variable) value)
+      ;;
+    end
+
+    let bindings = { Bindings.opam_version = OpamVersion.to_string OpamVersion.current }
+  end
+
+  type t =
+    | Flag of Flag.t
+    | Sys of Sys.t
+    | Const of Const.t
+
+  let of_string_opt string =
+    match Flag.of_string_opt string with
+    | Some flag -> Some (Flag flag)
+    | None ->
+      (match Sys.of_string_opt string with
+       | Some sys -> Some (Sys sys)
+       | None ->
+         (match Const.of_string_opt string with
+          | Some const -> Some (Const const)
+          | None -> None))
+  ;;
 end
 
 type t =
-  { flags : Flag.Set.t
-  ; sys : Sys_var.Bindings.t
+  { flags : Variable.Flag.Set.t
+  ; sys : Variable.Sys.Bindings.t
+  ; const : Variable.Const.Bindings.t
   }
-
-let default = { flags = Flag.Set.all; sys = Sys_var.Bindings.empty }
 
 module Fields = struct
   let flags = "flags"
   let sys = "sys"
+  let const = "const"
 end
+
+let default =
+  { flags = Variable.Flag.Set.all
+  ; sys = Variable.Sys.Bindings.empty
+  ; const = Variable.Const.bindings
+  }
+;;
 
 let decode =
   let open Dune_lang.Decoder in
   fields
-  @@ let+ flags = field Fields.flags ~default:Flag.Set.all Flag.Set.decode
-     and+ sys = field Fields.sys ~default:default.sys Sys_var.Bindings.decode in
-     { flags; sys }
+  @@ let+ flags = field Fields.flags ~default:default.flags Variable.Flag.Set.decode
+     and+ sys = field Fields.sys ~default:default.sys Variable.Sys.Bindings.decode in
+     let const = default.const in
+     { flags; sys; const }
 ;;
 
-let encode { flags; sys } =
-  let open Dune_lang.Encoder in
-  record [ Fields.flags, Flag.Set.encode flags; Fields.sys, Sys_var.Bindings.encode sys ]
-;;
-
-let to_dyn { flags; sys } =
+let to_dyn { flags; sys; const } =
   Dyn.record
-    [ Fields.flags, Flag.Set.to_dyn flags; Fields.sys, Sys_var.Bindings.to_dyn sys ]
+    [ Fields.flags, Variable.Flag.Set.to_dyn flags
+    ; Fields.sys, Variable.Sys.Bindings.to_dyn sys
+    ; Fields.const, Variable.Const.Bindings.to_dyn const
+    ]
 ;;
 
-let equal { flags; sys } t =
-  Flag.Set.equal flags t.flags && Sys_var.Bindings.equal sys t.sys
+let equal { flags; sys; const } t =
+  Variable.Flag.Set.equal flags t.flags
+  && Variable.Sys.Bindings.equal sys t.sys
+  && Variable.Const.Bindings.equal const t.const
+;;
+
+let sys { sys; _ } = sys
+let set_sys t sys = { t with sys }
+let clear_flags t = { t with flags = Variable.Flag.Set.empty }
+
+let pp { flags; sys; const } =
+  let pp_section heading pp_section =
+    (* The hbox is to prevent long values in [pp_section] from causing the heading to wrap. *)
+    let pp_heading = Pp.hbox (Pp.text heading) in
+    Pp.concat ~sep:Pp.newline [ pp_heading; pp_section ]
+  in
+  Pp.enumerate
+    ~f:Fun.id
+    [ pp_section "Flags" (Variable.Flag.Set.pp flags)
+    ; pp_section "System Environment Variables" (Variable.Sys.Bindings.pp sys)
+    ; pp_section "Constants" (Variable.Const.Bindings.pp const)
+    ]
+;;
+
+module Variable_value = struct
+  type t =
+    | Bool of bool
+    | String of string
+    | Unset_sys
+end
+
+let get t variable =
+  match (variable : Variable.t) with
+  | Flag flag -> Variable_value.Bool (Variable.Flag.Set.mem t.flags flag)
+  | Sys sys ->
+    (match Variable.Sys.Bindings.get t.sys sys with
+     | Some value -> String value
+     | None -> Unset_sys)
+  | Const const -> String (Variable.Const.Bindings.get t.const const)
 ;;

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -1,74 +1,89 @@
 open! Stdune
 
+module Variable : sig
+  module Flag : sig
+    (** A boolean variable *)
+    type t =
+      [ `With_test
+      | `With_doc
+      ]
+  end
+
+  module Sys : sig
+    (** Variables describing a system environment. These can be polled from the
+        current system and assigned specific values in dune-workspace but there
+        is no notion of a default value. During solving unset variables are
+        treated as wildcards so a solution can be built that works on a range of
+        systems. During building unset variables are treated as undefined
+        variables. *)
+    type t =
+      [ `Arch
+      | `Os
+      | `Os_version
+      | `Os_distribution
+      | `Os_family
+      ]
+
+    val to_string : t -> string
+    val of_string_opt : string -> t option
+
+    module Bindings : sig
+      type sys_var := t
+
+      (** A mapping from system environment variables to their values *)
+      type t
+
+      val empty : t
+      val set : t -> sys_var -> string -> t
+      val get : t -> sys_var -> string option
+
+      type union_error =
+        [ `Var_in_both_with_different_values of sys_var * string * string ]
+
+      (** Merge two environments returning an error if they both contain a
+          binding of the same variable to different values. *)
+      val union : t -> t -> (t, union_error) result
+    end
+  end
+
+  module Const : sig
+    (** Constant variables whose value can't be configured. These can be read
+        while solving and evaluating packages. *)
+    type t = [ `Opam_version ]
+  end
+
+  type t =
+    | Flag of Flag.t
+    | Sys of Sys.t
+    | Const of Const.t
+
+  val of_string_opt : string -> t option
+end
+
 (** A typed variable environment used by the dependency solver to evaluate
     package filters. Opam packages can declare conditional dependencies on other
     packages using a language made up of boolean operators and comparisons of
     strings. Variables in this language can represent booleans and strings. *)
+type t
 
-module Flag : sig
-  (** A boolean variable *)
-  type t =
-    [ `With_test
-    | `With_doc
-    ]
-
-  val to_string : t -> string
-  val of_string_opt : string -> t option
-
-  module Set : sig
-    type flag := t
-
-    (** A set flags. The presence of a flag in the set indicates that the flag
-        is set to true. *)
-    type t
-
-    val fold : t -> init:'a -> f:(flag -> 'a -> 'a) -> 'a
-    val mem : t -> flag -> bool
-  end
-end
-
-module Sys_var : sig
-  (** A system environment variable. Each of these variables may be assigned a
-      string value. If system environment variable has a value then that
-      variable binding will be used when evaluating opam dependency filters.
-      Unset variables are treated as wildcards. *)
-  type t =
-    [ `Arch
-    | `Os
-    | `Os_version
-    | `Os_distribution
-    | `Os_family
-    | `Opam_version
-    ]
-
-  val to_string : t -> string
-  val of_string_opt : string -> t option
-
-  module Bindings : sig
-    type sys_var := t
-
-    (** A mapping from system environment variables to their values *)
-    type t
-
-    val empty : t
-    val set : t -> sys_var -> string -> t
-    val get : t -> sys_var -> string option
-
-    type union_error = [ `Var_in_both_with_different_values of sys_var * string * string ]
-
-    (** Merge two environments returning an error if they both contain a binding
-        of the same variable to different values. *)
-    val union : t -> t -> (t, union_error) result
-  end
-end
-
-type t =
-  { flags : Flag.Set.t
-  ; sys : Sys_var.Bindings.t
-  }
-
+val default : t
 val decode : t Dune_lang.Decoder.t
-val encode : t Dune_lang.Encoder.t
 val to_dyn : t -> Dyn.t
 val equal : t -> t -> bool
-val default : t
+val sys : t -> Variable.Sys.Bindings.t
+val set_sys : t -> Variable.Sys.Bindings.t -> t
+
+(** Set all the flags to false *)
+val clear_flags : t -> t
+
+(** A human-readible summary of the variable environment *)
+val pp : t -> 'a Pp.t
+
+module Variable_value : sig
+  type t =
+    | Bool of bool
+    | String of string
+    | Unset_sys
+end
+
+val get : t -> Variable.t -> Variable_value.t

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -216,10 +216,10 @@ let sys_bindings ~path =
       ]
   in
   List.fold_left
-    ~init:Solver_env.Sys_var.Bindings.empty
+    ~init:Solver_env.Variable.Sys.Bindings.empty
     ~f:(fun sys_bindings (var, data) ->
       match data with
-      | Some value -> Solver_env.Sys_var.Bindings.set sys_bindings var value
+      | Some value -> Solver_env.Variable.Sys.Bindings.set sys_bindings var value
       | None -> sys_bindings)
     mappings
 ;;

--- a/src/dune_pkg/sys_poll.mli
+++ b/src/dune_pkg/sys_poll.mli
@@ -19,4 +19,5 @@ val os_family : path:Path.t list -> string option Fiber.t
 
 (** Returns system variable bindings where all the system-dependent values that
     could be retrieved are set *)
-val sys_bindings : path:Path.t list -> Solver_env.Sys_var.Bindings.t Fiber.t
+val sys_bindings :
+  path:Path.t list -> Solver_env.Variable.Sys.Bindings.t Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -1,7 +1,17 @@
 Print the solver env when no dune-workspace is present
   $ dune pkg lock --just-print-solver-env
   Solver environment for context default:
-  ((flags (with-doc with-test)) (sys ((opam-version 2.2.0~alpha-vendored))))
+  - Flags
+    - with-doc = true
+    - with-test = true
+  - System Environment Variables
+    - arch (unset)
+    - os (unset)
+    - os-version (unset)
+    - os-distribution (unset)
+    - os-family (unset)
+  - Constants
+    - opam-version = 2.2.0~alpha-vendored
 
 Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
@@ -23,22 +33,26 @@ Add some build contexts with different environments
 
   $ dune pkg lock --all-contexts --just-print-solver-env
   Solver environment for context no-doc:
-  ((flags (with-test)) (sys ((opam-version 2.2.0~alpha-vendored))))
+  - Flags
+    - with-doc = false
+    - with-test = true
+  - System Environment Variables
+    - arch (unset)
+    - os (unset)
+    - os-version (unset)
+    - os-distribution (unset)
+    - os-family (unset)
+  - Constants
+    - opam-version = 2.2.0~alpha-vendored
   Solver environment for context linux:
-  ((flags (with-doc with-test)) (sys ((opam-version 2.2.0~alpha-vendored) (os linux))))
-
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
-  > (context
-  >  (default
-  >   (name attempt-to-override-opam-version)
-  >   (lock dune.linux.lock)
-  >   (solver_env
-  >    (sys
-  >     (opam-version foo)))))
-  > EOF
-
-  $ dune pkg lock --all-contexts --just-print-solver-env
-  Error: Context attempt-to-override-opam-version would override solver
-  variable opam-version. This variable may not be overriden.
-  [1]
+  - Flags
+    - with-doc = true
+    - with-test = true
+  - System Environment Variables
+    - arch (unset)
+    - os = linux
+    - os-version (unset)
+    - os-distribution (unset)
+    - os-family (unset)
+  - Constants
+    - opam-version = 2.2.0~alpha-vendored


### PR DESCRIPTION
This makes it possible to configure the `make` and `jobs` opam variables through a workspace file and also to derive the `make` variable (the path to the `make` executable) from `$PATH` using the same machinery as the `%{exe:make}` pform macro. As the semantics of setting and reading build config variables differs from other types of opam variable I've taken this opportunity to refactor the solver env to reflect the different types of opam variable. This unifies the way variables are accessed which allows simplifications to the solver, also included in this change.

Also since the size of the solver environment is growing large, this change modifies the way that the environment is printed when the `--just-print-solver-env` flag is passed. The output is now more verbose and formats the variables as a nested bulleted list rather than a sexp.