### PR TITLE
fix: set lower bound macOS version to 101000

### DIFF
--- a/src/fsevents/fsevents_stubs.c
+++ b/src/fsevents/fsevents_stubs.c
@@ -10,7 +10,7 @@
 #include <AvailabilityMacros.h>
 #endif
 
-#if defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 100700
+#if defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreServices/CoreServices.h>


### PR DESCRIPTION
macOS 10.7 actually has a version number of 1007, and it isn't until macOS 10.10 that version numbers start using 6 digits:

https://opensource.apple.com/source/xnu/xnu-3247.10.11/EXTERNAL_HEADERS/AvailabilityMacros.h.auto.html

This version "bump" actually preserves the existing behavior but makes it more clear.