### PR TITLE
feature: case and cond statements

### DIFF
--- a/doc/changes/8324.md
+++ b/doc/changes/8324.md
@@ -1,0 +1,3 @@
+- Added `(case ...)` and `(cond ...)` to the action language. The first allows
+  for the matching of values against a pattern and the second allows for
+  branching against blang values. (#8324, fixes #924, @Alizter)

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -284,6 +284,39 @@ The following constructions are available:
        (run ./list-tests.exe)
        (run ./exec-tests.exe))
 
+.. dune:action:: case
+   :param: <string> (<pattern1> <DSL>) (<pattern2> <DSL>) ... (_ <DSL>)
+
+   .. versionadded:: 3.11
+
+   Execute the action corresponding to the first ``<pattern>`` that matches
+   ``<string>``. The ``_`` pattern is always required and is executed if no
+   other pattern matches ``<string>``.
+
+   Example::
+
+      (case %{os_type}
+       ("unix" (copy unix_impl.ml impl.ml))
+       ("windows" (copy windows_impl.ml impl.ml))
+       (_ (echo "Unsupported system")))
+
+.. dune:action:: cond
+   :param: (<blang1> <DSL>) (<blang2> <DSL>) ... (_ <DSL>)
+
+   .. versionadded:: 3.11
+
+   Execute the action corresponding to the first ``<blang>`` expression of the
+   :doc:`boolean-language` that evaluates to ``true``. The ``_`` pattern is
+   always required and is executed if no other pattern evaluates to ``true``.
+
+   Example::
+
+      (cond
+       ((= %{os_type} "unix") (copy unix_impl.ml impl.ml))
+       ((= %{os_type} "windows") (copy windows_impl.ml impl.ml))
+       ((> %{version} "4.02") (copy new_impl.ml impl.ml))
+       (_ (echo "Unsupported system")))
+
 Note: expansion of the special ``%{<kind>:...}`` is done relative to the current
 working directory of the DSL being executed. So for instance, if you
 have this action in a ``src/foo/dune``:

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -118,6 +118,8 @@ type t =
   | Patch of String_with_vars.t
   | Substitute of String_with_vars.t * String_with_vars.t
   | Withenv of String_with_vars.t Env_update.t list * t
+  | Case of String_with_vars.t * (String_with_vars.t * t) list * t
+  | Cond of (Blang.t * t) list * t
 
 val encode : t Encoder.t
 val decode_dune_file : t Decoder.t

--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -16,6 +16,26 @@ module Op = struct
     | _, _ -> false
   ;;
 
+  let compare a b : Ordering.t =
+    match a, b with
+    | Eq, Eq -> Eq
+    | Eq, _ -> Lt
+    | _, Eq -> Gt
+    | Gt, Gt -> Eq
+    | Gt, _ -> Gt
+    | _, Gt -> Lt
+    | Gte, Gte -> Eq
+    | Gte, _ -> Gt
+    | _, Gte -> Lt
+    | Lte, Lte -> Eq
+    | Lte, _ -> Lt
+    | _, Lte -> Gt
+    | Lt, Lt -> Eq
+    | Lt, _ -> Lt
+    | _, Lt -> Gt
+    | Neq, Neq -> Eq
+  ;;
+
   let to_dyn =
     let open Dyn in
     function
@@ -26,6 +46,16 @@ module Op = struct
     | Lt -> string "Lt"
     | Neq -> string "Neq"
   ;;
+
+  let all = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
+
+  let encode x =
+    atom
+    @@
+    match List.assoc (List.map ~f:Tuple.T2.swap all) x with
+    | Some x -> x
+    | None -> Code_error.raise "Unknown op" []
+  ;;
 end
 
 type t =
@@ -35,6 +65,16 @@ type t =
   | And of t list
   | Or of t list
   | Compare of Op.t * String_with_vars.t * String_with_vars.t
+
+let rec map_string_with_vars t ~f =
+  match t with
+  | Const _ -> t
+  | Not t -> Not (map_string_with_vars t ~f)
+  | Expr e -> Expr (f e)
+  | And t -> And (List.map ~f:(map_string_with_vars ~f) t)
+  | Or t -> Or (List.map ~f:(map_string_with_vars ~f) t)
+  | Compare (o, s1, s2) -> Compare (o, f s1, f s2)
+;;
 
 let true_ = Const true
 
@@ -52,12 +92,22 @@ let rec to_dyn =
       [ Op.to_dyn o; String_with_vars.to_dyn s1; String_with_vars.to_dyn s2 ]
 ;;
 
-let ops = [ "=", Op.Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
+let rec encode =
+  let open Encoder in
+  function
+  | Const b -> bool b
+  | Not t -> List [ atom "not"; encode t ]
+  | Expr e -> String_with_vars.encode e
+  | And t -> List (atom "and" :: List.map ~f:encode t)
+  | Or t -> List (atom "or" :: List.map ~f:encode t)
+  | Compare (o, s1, s2) ->
+    List [ Op.encode o; String_with_vars.encode s1; String_with_vars.encode s2 ]
+;;
 
 let decode_gen decode_string =
   let open Decoder in
   let ops =
-    List.map ops ~f:(fun (name, op) ->
+    List.map Op.all ~f:(fun (name, op) ->
       ( name
       , let+ x = decode_string
         and+ y = decode_string in
@@ -81,3 +131,28 @@ let decode_gen decode_string =
 
 let decode = decode_gen String_with_vars.decode
 let decode_manually f = decode_gen (String_with_vars.decode_manually f)
+
+let rec compare_no_loc a b : Ordering.t =
+  let open Ordering.O in
+  match a, b with
+  | Const a, Const b -> Bool.compare a b
+  | Const _, _ -> Lt
+  | _, Const _ -> Gt
+  | Not a, Not b -> compare_no_loc a b
+  | Not _, _ -> Lt
+  | _, Not _ -> Gt
+  | Expr a, Expr b -> String_with_vars.compare_no_loc a b
+  | Expr _, _ -> Lt
+  | _, Expr _ -> Gt
+  | And a, And b | Or a, Or b -> List.compare ~compare:compare_no_loc a b
+  | And _, _ -> Lt
+  | _, And _ -> Gt
+  | Compare (o1, s1, s2), Compare (o2, s3, s4) ->
+    let= () = Op.compare o1 o2 in
+    let= () = String_with_vars.compare_no_loc s1 s3 in
+    String_with_vars.compare_no_loc s2 s4
+  | Compare _, _ -> Lt
+  | _, Compare _ -> Gt
+;;
+
+let equal_no_loc a b = Ordering.is_eq (compare_no_loc a b)

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -21,8 +21,11 @@ type t =
   | Or of t list
   | Compare of Op.t * String_with_vars.t * String_with_vars.t
 
+val equal_no_loc : t -> t -> bool
 val true_ : t
 val to_dyn : t -> Dyn.t
+val map_string_with_vars : t -> f:(String_with_vars.t -> String_with_vars.t) -> t
+val encode : t Encoder.t
 val decode : t Decoder.t
 
 (** Resolve variables manually. For complex cases such as [enabled_if] *)

--- a/test/blackbox-tests/test-cases/actions/case.t
+++ b/test/blackbox-tests/test-cases/actions/case.t
@@ -1,0 +1,170 @@
+Testing (case) action.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.11)
+  > EOF
+
+  $ cat > version << EOF
+  > 1
+  > EOF
+
+Basic usage:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (3 (echo "version is 3"))
+  >    (_ (echo "shouldn't happen, got %{read-lines:version}")))))
+  > EOF
+
+  $ dune build @foo
+  version is 1
+
+  $ cat > version << EOF
+  > 2
+  > EOF
+  $ dune build @foo
+  version is 2
+
+  $ cat > version << EOF
+  > 3
+  > EOF
+  $ dune build @foo
+  version is 3
+
+  $ cat > version << EOF
+  > 4
+  > EOF
+  $ dune build @foo
+  shouldn't happen, got 4
+
+  $ cat > version << EOF
+  > 1
+  > EOF
+
+Missing default field:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 5, characters 4-5:
+  5 |    (1 (echo "version is 1")))))
+          ^
+  Error: The final branch must be the default one.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Two default fields:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (_ (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (_ (echo "version is 3")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Multiple default cases.
+  File "dune", line 5, characters 4-5:
+  5 |    (_ (echo "version is 1"))
+          ^
+  
+  File "dune", line 7, characters 4-5:
+  7 |    (_ (echo "version is 3")))))
+          ^
+  
+  [1]
+
+Last case is not default case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (_ (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (3 (echo "version is 3")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 7, characters 4-5:
+  7 |    (3 (echo "version is 3")))))
+          ^
+  Error: The final branch must be the default one.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Empty case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version})))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 4, characters 2-30:
+  4 |   (case %{read-lines:version})))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Not enough arguments for case
+  [1]
+
+Duplicate cases:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (1 (echo "version is 1"))
+  >    (1 (echo "version is 1"))
+  >    (_ (echo "shouldn't happen")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Duplicate case.
+  File "dune", line 5, characters 4-5:
+  5 |    (1 (echo "version is 1"))
+          ^
+  
+  File "dune", line 6, characters 4-5:
+  6 |    (1 (echo "version is 1"))
+          ^
+  
+  [1]
+
+Demo what happens when "_" is used as a pattern.
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    ("_" (echo "version is _"))
+  >    (_ (echo "version is default")))))
+  > EOF
+
+  $ dune build @foo
+  version is default
+
+  $ cat > version << EOF
+  > _
+  > EOF
+
+  $ dune build @foo
+  version is _

--- a/test/blackbox-tests/test-cases/actions/cond.t
+++ b/test/blackbox-tests/test-cases/actions/cond.t
@@ -1,0 +1,134 @@
+Testing (case) action.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.11)
+  > EOF
+
+Basic usage:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond
+  >    ((= 1 2) (echo " 1 is 2"))
+  >    ((= 2 3) (echo "2 is 3"))
+  >    ((< 3 4) (echo "3 is less than 4"))
+  >    (_ (echo "shouldn't happen")))))
+  > EOF
+
+  $ dune build @foo
+  3 is less than 4
+
+Missing default field:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond
+  >    ((= 1 2) (echo " 1 is 2")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 5, characters 4-11:
+  5 |    ((= 1 2) (echo " 1 is 2")))))
+          ^^^^^^^
+  Error: The final branch must be the default one.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Two default fields:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (case %{read-lines:version}
+  >    (_ (echo "version is 1"))
+  >    (2 (echo "version is 2"))
+  >    (_ (echo "version is 3")))))
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond
+  >    (_ (echo " 1 is 2"))
+  >    ((= 2 3) (echo "2 is 3"))
+  >    (_ (echo "3 is less than 4")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Multiple default cases.
+  File "dune", line 5, characters 4-5:
+  5 |    (_ (echo " 1 is 2"))
+          ^
+  
+  File "dune", line 7, characters 4-5:
+  7 |    (_ (echo "3 is less than 4")))))
+          ^
+  
+  [1]
+
+Last case is not default case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond
+  >    ((= 1 2) (echo " 1 is 2"))
+  >    ((= 2 3) (echo "2 is 3"))
+  >    (_ (echo "shouldn't happen"))
+  >    ((< 3 4) (echo "3 is less than 4")))))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 8, characters 4-11:
+  8 |    ((< 3 4) (echo "3 is less than 4")))))
+          ^^^^^^^
+  Error: The final branch must be the default one.
+  Hint: Add a (_ (...)) case at the end.
+  [1]
+
+Empty case:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond)))
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 4, characters 2-8:
+  4 |   (cond)))
+        ^^^^^^
+  Error: Not enough arguments for cond
+  [1]
+
+Duplicate cases:
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (cond
+  >    ((= 1 1) (echo "1 is 1"))
+  >    ((= 1 1) (echo "1 is 1"))
+  >    (_ (echo "shouldn't happen")))))
+  > EOF
+
+  $ dune build @foo
+  Error: Duplicate case.
+  File "dune", line 5, characters 4-11:
+  5 |    ((= 1 1) (echo "1 is 1"))
+          ^^^^^^^
+  
+  File "dune", line 6, characters 4-11:
+  6 |    ((= 1 1) (echo "1 is 1"))
+          ^^^^^^^
+  
+  [1]


### PR DESCRIPTION
We add a `(case ...)` constructor to dune_lang for actions which when expanded will reduce down to the matching branch.

We also add a `(cond ...)` constructor for checking blang values which will reduce down to the first true branch condition.

- [x] doc
- [x] test
- [x] changelog
- fixes #924