### PR TITLE
refactor(init): move Use_name handling to parsing

### DIFF
--- a/bin/dune_init.mli
+++ b/bin/dune_init.mli
@@ -26,21 +26,15 @@ module Component : sig
         }
     end
 
-    type public_name =
-      | Use_name
-      | Public_name of Dune_lang.Atom.t
-
-    val public_name_to_string : public_name -> string
-
     (** Options for executable components *)
     module Executable : sig
-      type t = { public : public_name option }
+      type t = { public : Dune_lang.Atom.t option }
     end
 
     (** Options for library components *)
     module Library : sig
       type t =
-        { public : public_name option
+        { public : Dune_lang.Atom.t option
         ; inline_tests : bool
         }
     end


### PR DESCRIPTION
`dune init` supports the following pattern:

- `--public pub` will use `pub` as public name
- no `--public` argument means no public name
- `--public` with no argument will reuse the name as the public name

The third case is replaced later, requiring a custom type and some
parameter passing. Instead, we just set the right public name at parse
time.

Signed-off-by: Etienne Millon <me@emillon.org>
