### PR TITLE
Pkg: Merge PATHs from user and package envs

### DIFF
--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -1,3 +1,6 @@
+(* Note that operations relating to the PATH environment variable are defined
+   in a separate module [Env_path]. *)
+
 module Var : sig
   type t = string
 
@@ -25,8 +28,15 @@ val initial : t
 val to_unix : t -> string list
 val of_unix : string array -> t
 val get : t -> Var.t -> string option
+
+(** [extend env ~vars] adds all variables from [vars] to [env] overwriting any
+    existing values of those variables in [env] *)
 val extend : t -> vars:string Map.t -> t
+
+(** [extend_env a b] adds all variables from [b] to [a] overwriting any
+    existing values of those variables in [a]. *)
 val extend_env : t -> t -> t
+
 val add : t -> var:Var.t -> value:string -> t
 val mem : t -> var:Var.t -> bool
 val remove : t -> var:Var.t -> t

--- a/otherlibs/stdune/src/env_path.ml
+++ b/otherlibs/stdune/src/env_path.ml
@@ -1,8 +1,21 @@
 let var = "PATH"
 let cons env ~dir = Env.update env ~var ~f:(fun _PATH -> Some (Bin.cons_path dir ~_PATH))
 
+(* [cons_multi env ~dirs] adds each path in [dirs] to the start of the PATH
+   variable in [env], preserving their order *)
+let cons_multi env ~dirs =
+  Env.update env ~var ~f:(fun init ->
+    List.fold_right dirs ~init ~f:(fun dir acc -> Some (Bin.cons_path dir ~_PATH:acc)))
+;;
+
 let path env =
   match Env.get env var with
   | None -> []
   | Some s -> Bin.parse_path s
+;;
+
+let extend_env_concat_path a b =
+  let a_including_b's_path = cons_multi a ~dirs:(path b) in
+  let b_without_path = Env.remove b ~var in
+  Env.extend_env a_including_b's_path b_without_path
 ;;

--- a/otherlibs/stdune/src/env_path.mli
+++ b/otherlibs/stdune/src/env_path.mli
@@ -3,5 +3,14 @@
 (* this isn't in [Env] to avoid cycles *)
 
 val var : Env.Var.t
+
+(** [cons env ~dir] adds [dir] to the start of the PATH variable in [env] *)
 val cons : Env.t -> dir:Path.t -> Env.t
+
 val path : Env.t -> Path.t list
+
+(** [extend_env_concat_path a b] adds all variables from [b] to [a]
+    overwritting any existing values of those variables in [a] except for PATH
+    which is set to the concatenation of the PATH variables from [a] and [b]
+    with the PATH entries from [b] preceeding the PATH entries from [a] *)
+val extend_env_concat_path : Env.t -> Env.t -> Env.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -329,7 +329,14 @@ module Pkg = struct
         ; "OPAMCLI", "2.0"
         ]
     in
-    let env = build_env t |> Env.Map.map ~f:Env_update.string_of_env_values in
+    let package_env =
+      let vars =
+        build_env t
+        |> Env.Map.map ~f:Env_update.string_of_env_values
+        |> Env.Map.superpose base
+      in
+      Env.extend Env.empty ~vars
+    in
     (* TODO: Run actions in a constrained environment. [Env.initial] is the
        environment from which dune was executed, and some of the environment
        variables may affect builds in unintended ways and make builds less
@@ -337,7 +344,7 @@ module Pkg = struct
        for build actions to run successfully, such as $PATH on systems where the
        shell's default $PATH variable doesn't include the location of standard
        programs or build tools (e.g. NixOS). *)
-    Env.extend Env.initial ~vars:(Env.Map.superpose base env)
+    Env_path.extend_env_concat_path Env.initial package_env
   ;;
 end
 

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -27,4 +27,4 @@ Some environment variables are automatically exported by packages:
   OCAMLPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib
   CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/stublibs
   OCAMLTOP_INCLUDE_PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/toplevel
-  PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/bin
+  PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/bin:$TESTCASE_ROOT/.bin

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -32,4 +32,3 @@ Now it fails since adding the dependency modified PATH.
   >  (system "command -v cat > /dev/null 2>&1 || echo no cat"))
   > EOF
   $ dune build .pkg/test/target/
-  no cat


### PR DESCRIPTION
The user PATH is needed so system executables (like `cat`) can be found and the package PATH is needed to execute binaries from packages.