### PR TITLE
fix: dune describe pp no longer dumps into source root

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -18,15 +18,21 @@ let pp_with_ocamlc sctx project pp_file =
   let+ () =
     Process.run
       ~display:!Clflags.display
+      ~dir:(Path.build (Super_context.context sctx).build_dir)
       ~env:(Super_context.context_env sctx)
       Strict
       (Super_context.context sctx).ocaml.ocamlc
-      [ "-stop-after"; "parsing"; "-dsource"; Path.to_string pp_file; "-dump-into-file" ]
+      [ "-stop-after"
+      ; "parsing"
+      ; "-dsource"
+      ; Path.to_string (Path.drop_optional_build_context_maybe_sandboxed pp_file)
+      ; "-dump-into-file"
+      ]
   in
   match Path.stat dump_file with
   | Ok { st_kind = S_REG; _ } ->
     Io.cat dump_file;
-    Path.unlink_no_err dump_file
+    Path.unlink dump_file
   | _ ->
     User_error.raise [ Pp.textf "cannot find a dump file: %s" (Path.to_string dump_file) ]
 ;;

--- a/doc/changes/8340.md
+++ b/doc/changes/8340.md
@@ -1,0 +1,2 @@
+- Fix `dune describe pp` from leaving behind a dump file. (#8222, fixes #7430,
+  @Alizter)

--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
@@ -11,4 +11,4 @@ We can also show the original source if it is not preprocessed
 We also make sure that the dump file is not present
 
   $ dune_cmd exists profile.dump
-  true
+  false


### PR DESCRIPTION
We also fix this by running ocamlc in the _build directory and cleaning up the dump file afterwards.

- fix #7430
- [x] changelog