### PR TITLE
feature: allow installing source trees

### DIFF
--- a/doc/changes/8349.md
+++ b/doc/changes/8349.md
@@ -1,0 +1,2 @@
+- Introduce `(source_trees ..)` to the install stanza to allow installing
+  entire source trees. (#8349, @rgrinberg)

--- a/doc/stanzas/install.rst
+++ b/doc/stanzas/install.rst
@@ -7,7 +7,7 @@ Dune supports installing packages on the system, i.e., copying freshly built
 artifacts from the workspace to the system. The ``install`` stanza takes three
 pieces of information:
 
-- The list of files to install.
+- The list of files or directories to install.
 - The package to attach these files. This field is optional if your project
   contains a single package.
 - The section in which the files will be installed.
@@ -177,3 +177,14 @@ to ensure that executables are always installed with this extension on Windows.
 More precisely, when installing a file via an ``(install ...)`` stanza, Dune
 implicitly adds the ``.exe`` extension to the destination, if the source file
 has extension ``.exe`` or ``.bc`` and if it's not already present
+
+Installing Source Directories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install entire source directories, the ``source_tree`` field can be used:
+
+.. code:: dune
+
+   (install
+    (section doc)
+    (source_trees doc))

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -228,6 +228,7 @@ module Install_conf : sig
     { section : Section_with_site.t
     ; files : Install_entry.File.t list
     ; dirs : Install_entry.Dir.t list
+    ; source_trees : Install_entry.Dir.t list
     ; package : Package.t
     ; enabled_if : Blang.t
     }

--- a/src/dune_rules/install_entry_with_site.mli
+++ b/src/dune_rules/install_entry_with_site.mli
@@ -6,7 +6,7 @@ val make_with_site
   :  Section_with_site.t
   -> ?dst:string
   -> (loc:Loc.t -> pkg:Package.Name.t -> site:Site.t -> Section.t Memo.t)
-  -> kind:[ `File | `Directory ]
+  -> kind:Install.Entry.kind
   -> Path.Build.t
   -> Path.Build.t Install.Entry.t Memo.t
 

--- a/src/install/entry.mli
+++ b/src/install/entry.mli
@@ -7,6 +7,7 @@ module Dst : sig
 
   val to_string : t -> string
   val add_prefix : string -> t -> t
+  val add_suffix : t -> string -> t
   val concat_all : t -> string list -> t
 
   include Dune_lang.Conv.S with type t := t
@@ -15,9 +16,15 @@ module Dst : sig
   val install_path : Paths.t -> Section.t -> t -> Path.t
 end
 
+type kind =
+  [ `File
+  | `Directory
+  | `Source_tree
+  ]
+
 type 'src t = private
   { src : 'src
-  ; kind : [ `File | `Directory ]
+  ; kind : kind
   ; dst : Dst.t
   ; section : Section.t
   ; optional : bool
@@ -45,22 +52,10 @@ val adjust_dst
   -> section:Section.t
   -> Dst.t
 
+val set_kind : 'src t -> kind -> 'src t
 val adjust_dst' : src:Path.Build.t -> dst:string option -> section:Section.t -> Dst.t
-
-val make
-  :  Section.t
-  -> ?dst:string
-  -> kind:[ `File | `Directory ]
-  -> Path.Build.t
-  -> Path.Build.t t
-
-val make_with_dst
-  :  Section.t
-  -> Dst.t
-  -> kind:[ `File | `Directory ]
-  -> src:Path.Build.t
-  -> Path.Build.t t
-
+val make : Section.t -> ?dst:string -> kind:kind -> Path.Build.t -> Path.Build.t t
+val make_with_dst : Section.t -> Dst.t -> kind:kind -> src:Path.Build.t -> Path.Build.t t
 val set_src : _ t -> 'src -> 'src t
 val map_dst : 'a t -> f:(Dst.t -> Dst.t) -> 'a t
 val relative_installed_path : _ t -> paths:Paths.t -> Path.t

--- a/test/blackbox-tests/test-cases/install/install-source-tree.t
+++ b/test/blackbox-tests/test-cases/install/install-source-tree.t
@@ -1,0 +1,75 @@
+Testing the source_trees field which is used to entire source_trees
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (allow_empty)
+  >  (name mypkg))
+  > EOF
+
+  $ test() {
+  > cat >dune <<EOF
+  > (install
+  >  (section doc)
+  >  (source_trees $1))
+  > EOF
+  > dune build mypkg.install && cat _build/default/mypkg.install
+  > }
+
+Try to build a source directory that doesn't exist:
+
+  $ test "mydocs"
+  File "dune", line 3, characters 15-21:
+  3 |  (source_trees mydocs))
+                     ^^^^^^
+  Error: This source directory does not exist
+  [1]
+
+Create the source directory and fill it up with some dummy stuff for the test:
+
+  $ mkdir -p mydocs/foo
+  $ touch mydocs/foo.md mydocs/baz.md mydocs/foo/bar.md
+
+  $ test "mydocs"
+  lib: [
+    "_build/install/default/lib/mypkg/META"
+    "_build/install/default/lib/mypkg/dune-package"
+  ]
+  doc: [
+    "_build/install/default/doc/mypkg/mydocs/baz.md" {"mydocs/baz.md"}
+    "_build/install/default/doc/mypkg/mydocs/foo.md" {"mydocs/foo.md"}
+    "_build/install/default/doc/mypkg/mydocs/foo/bar.md" {"mydocs/foo/bar.md"}
+  ]
+
+  $ test "(mydocs as yourdocs)"
+  lib: [
+    "_build/install/default/lib/mypkg/META"
+    "_build/install/default/lib/mypkg/dune-package"
+  ]
+  doc: [
+    "_build/install/default/doc/mypkg/yourdocs/baz.md" {"yourdocs/baz.md"}
+    "_build/install/default/doc/mypkg/yourdocs/foo.md" {"yourdocs/foo.md"}
+    "_build/install/default/doc/mypkg/yourdocs/foo/bar.md" {"yourdocs/foo/bar.md"}
+  ]
+
+  $ test "(mydocs as your/docs)"
+  lib: [
+    "_build/install/default/lib/mypkg/META"
+    "_build/install/default/lib/mypkg/dune-package"
+  ]
+  doc: [
+    "_build/install/default/doc/mypkg/your/docs/baz.md" {"your/docs/baz.md"}
+    "_build/install/default/doc/mypkg/your/docs/foo.md" {"your/docs/foo.md"}
+    "_build/install/default/doc/mypkg/your/docs/foo/bar.md" {"your/docs/foo/bar.md"}
+  ]
+
+  $ test "(mydocs as ../)"
+  lib: [
+    "_build/install/default/lib/mypkg/META"
+    "_build/install/default/lib/mypkg/dune-package"
+  ]
+  doc: [
+    "_build/install/default/doc/baz.md" {"../baz.md"}
+    "_build/install/default/doc/foo.md" {"../foo.md"}
+    "_build/install/default/doc/foo/bar.md" {"../foo/bar.md"}
+  ]


### PR DESCRIPTION
This PR allows us to install source trees with the following field in the install stanza:

```
(install
 (section doc)
 (source_tree dir))
```