### PR TITLE
fix: Prevent relative install destinations leaking outside package install dir

### DIFF
--- a/doc/changes/8350.md
+++ b/doc/changes/8350.md
@@ -1,0 +1,2 @@
+- Deprecate install destination paths beginning with ".." to prevent packages
+  escaping their designated installation directories. (#8350, @gridbugs)

--- a/doc/stanzas/install.rst
+++ b/doc/stanzas/install.rst
@@ -106,6 +106,16 @@ installed with mode ``0o644`` (``rw-r--r--``).
 Note that all files in the install stanza must be specified by relative paths
 only. It is an error to specify files by absolute paths.
 
+Also note that as of dune-lang 3.11 (ie. ``(lang dune 3.11)`` in
+``dune-project``) it is deprecated to use the ``as`` keyword to specify a
+destination beginning with ``..``. Dune intends for files associated with a
+package to only be installed under specific directories in the file system
+implied by the installation section (e.g. ``share``, ``bin``, ``doc``, etc.)
+and the package name. Starting destination paths with ``..`` allows packages to
+install files to arbitrary locations on the file system. In 3.11 this behaviour
+is still supported (as some projects may depend on it) but will generate a
+warning and will be removed in a future version of Dune.
+
 Including Files in the Install Stanza
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1179,6 +1179,7 @@ module Executables = struct
     type t =
       { names : (Loc.t * string) list
       ; public : public option
+      ; dune_syntax : Syntax.Version.t
       }
 
     let names t = t.names
@@ -1319,7 +1320,7 @@ module Executables = struct
                 (pluralize "public_name" ~multi)
             ]
       in
-      { names; public }
+      { names; public; dune_syntax }
     ;;
 
     let install_conf t ~ext ~enabled_if =
@@ -1328,7 +1329,10 @@ module Executables = struct
           List.map2 t.names public_names ~f:(fun (locn, name) (locp, pub) ->
             Option.map pub ~f:(fun pub ->
               Install_entry.File.of_file_binding
-                (File_binding.Unexpanded.make ~src:(locn, name ^ ext) ~dst:(locp, pub))))
+                (File_binding.Unexpanded.make
+                   ~src:(locn, name ^ ext)
+                   ~dst:(locp, pub)
+                   ~dune_syntax:t.dune_syntax)))
           |> List.filter_opt
         in
         { Install_conf.section = Section Bin

--- a/src/dune_rules/file_binding.mli
+++ b/src/dune_rules/file_binding.mli
@@ -8,6 +8,12 @@ module Expanded : sig
   val dst : t -> string option
   val src_loc : t -> Loc.t
   val dst_path : t -> dir:Path.Build.t -> Path.Build.t
+
+  val validate_for_install_stanza
+    :  relative_dst_path_starts_with_parent_error_when:
+         [ `Deprecation_warning_from_3_11 | `Always_error ]
+    -> t
+    -> unit
 end
 
 module Unexpanded : sig
@@ -15,8 +21,9 @@ module Unexpanded : sig
 
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
-  val make : src:Loc.t * string -> dst:Loc.t * string -> t
+  val make : src:Loc.t * string -> dst:Loc.t * string -> dune_syntax:Syntax.Version.t -> t
   val decode : t Dune_lang.Decoder.t
+  val dune_syntax : t -> Syntax.Version.t
 
   val expand
     :  t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -236,6 +236,7 @@ let gen_rules
           install_conf.dirs
           ~expand_str
           ~dir:ctx_dir
+          ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
       in
       List.map (files_expanded @ dirs_expanded) ~f:(fun fb ->
         File_binding.Expanded.src fb |> Path.build)

--- a/src/dune_rules/install_entry.mli
+++ b/src/dune_rules/install_entry.mli
@@ -36,5 +36,7 @@ module Dir : sig
     :  t list
     -> expand_str:(String_with_vars.t -> string Memo.t)
     -> dir:Path.Build.t
+    -> relative_dst_path_starts_with_parent_error_when:
+         [ `Deprecation_warning_from_3_11 | `Always_error ]
     -> File_binding.Expanded.t list Memo.t
 end

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -391,14 +391,26 @@ end = struct
         Install.Entry.Sourced.create ~loc entry)
     and+ files_from_dirs =
       let* dirs_expanded =
-        Install_entry.Dir.to_file_bindings_expanded i.dirs ~expand_str ~dir
+        Install_entry.Dir.to_file_bindings_expanded
+          i.dirs
+          ~expand_str
+          ~dir
+          ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
       in
       Memo.List.map dirs_expanded ~f:(fun fb ->
         let loc = File_binding.Expanded.src_loc fb in
         let+ entry = make_entry ~kind:`Directory fb in
         Install.Entry.Sourced.create ~loc entry)
     and+ source_trees =
-      Install_entry.Dir.to_file_bindings_expanded i.source_trees ~expand_str ~dir
+      (* There's no deprecation warning when a relative destination path
+         starts with a parent in this feature. It's safe to raise an error in
+         this case as installing source trees was added in the same dune version
+         that we deprecated starting a destination install path with "..". *)
+      Install_entry.Dir.to_file_bindings_expanded
+        i.source_trees
+        ~expand_str
+        ~dir
+        ~relative_dst_path_starts_with_parent_error_when:`Always_error
       >>= Memo.List.map ~f:(fun fb ->
         let loc = File_binding.Expanded.src_loc fb in
         let* entry = make_entry ~kind:`Source_tree fb in

--- a/test/blackbox-tests/test-cases/install/install-source-tree.t
+++ b/test/blackbox-tests/test-cases/install/install-source-tree.t
@@ -96,3 +96,13 @@ Install zero source trees:
     "_build/install/default/lib/mypkg/META"
     "_build/install/default/lib/mypkg/dune-package"
   ]
+
+It is an error for the destination path to start with "..".
+  $ test "(mydocs as ../)"
+  File "dune", line 3, characters 26-29:
+  3 |  (source_trees (mydocs as ../)))
+                                ^^^
+  Error: The destination path ../ begins with .. which is not allowed.
+  Destinations in install stanzas may not begin with .. to prevent a package's
+  installed files from escaping that package's install directories.
+  [1]

--- a/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
+++ b/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
@@ -1,0 +1,232 @@
+Test for the case where the destination of an install stanza entry would place a
+file outside of the directories associated with the package. This behaviour was
+deprecated in 3.11.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo))
+  > (using directory-targets 0.1)
+  > EOF
+
+Create a file to install
+  $ mkdir a
+  $ touch a/b.txt
+
+Test that we get a warning if `(files ...)` has a dst starting with "..":
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (files (a/b.txt as ../b)))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 3, characters 20-24:
+  3 |  (files (a/b.txt as ../b)))
+                          ^^^^
+  Warning: The destination path ../b begins with .. which will become an error
+  in a future version of Dune. Destinations of files in install stanzas
+  beginning with .. will be disallowed to prevent a package's installed files
+  from escaping that package's install directories.
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  etc: [
+    "_build/install/default/etc/b" {"../b"}
+  ]
+
+Test that we get a warning if `(dirs ...)` has a dst starting with "..":
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir bar))
+  >  (action (progn (run mkdir bar) (run touch bar/baz.txt))))
+  > 
+  > (install
+  >  (section etc)
+  >  (dirs (bar as ../baz)))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 7, characters 15-21:
+  7 |  (dirs (bar as ../baz)))
+                     ^^^^^^
+  Warning: The destination path ../baz begins with .. which will become an
+  error in a future version of Dune. Destinations of files in install stanzas
+  beginning with .. will be disallowed to prevent a package's installed files
+  from escaping that package's install directories.
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  etc: [
+    "_build/install/default/etc/baz/baz.txt" {"../baz/baz.txt"}
+  ]
+
+Test that we get a warning if `(dirs ...)` has a dst that is exactly "..":
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir bar))
+  >  (action (progn (run mkdir bar) (run touch bar/baz.txt))))
+  > 
+  > (install
+  >  (section etc)
+  >  (dirs (bar as ..)))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 7, characters 15-17:
+  7 |  (dirs (bar as ..)))
+                     ^^
+  Warning: The destination path .. begins with .. which will become an error in
+  a future version of Dune. Destinations of files in install stanzas beginning
+  with .. will be disallowed to prevent a package's installed files from
+  escaping that package's install directories.
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  etc: [
+    "_build/install/default/etc/baz.txt" {"../baz.txt"}
+  ]
+
+Test that we get get a warning if the ".." is the result of variable expansion:
+  $ printf ".." > prefix.txt
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (files (a/b.txt as %{read:prefix.txt}/b)))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 3, characters 20-40:
+  3 |  (files (a/b.txt as %{read:prefix.txt}/b)))
+                          ^^^^^^^^^^^^^^^^^^^^
+  Warning: The destination path ../b begins with .. which will become an error
+  in a future version of Dune. Destinations of files in install stanzas
+  beginning with .. will be disallowed to prevent a package's installed files
+  from escaping that package's install directories.
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  etc: [
+    "_build/install/default/etc/b" {"../b"}
+  ]
+
+Test that we get an error if `(source_tree ...)` has a dst starting with "..".
+This is an error rather than a warning as installing source trees is added in
+the same version of dune as starting a dest with ".." was deprecated.
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (source_trees (a as ../b)))
+  > EOF
+  $ dune build foo.install
+  File "dune", line 3, characters 21-25:
+  3 |  (source_trees (a as ../b)))
+                           ^^^^
+  Error: The destination path ../b begins with .. which is not allowed.
+  Destinations in install stanzas may not begin with .. to prevent a package's
+  installed files from escaping that package's install directories.
+  [1]
+
+Test that we get an error if `(source_tree ...)` has a dst that is exactly "..":
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (source_trees (a as ..)))
+  > EOF
+  $ dune build foo.install
+  File "dune", line 3, characters 21-23:
+  3 |  (source_trees (a as ..)))
+                           ^^
+  Error: The destination path .. begins with .. which is not allowed.
+  Destinations in install stanzas may not begin with .. to prevent a package's
+  installed files from escaping that package's install directories.
+  [1]
+
+Test that on older versions of dune we don't get warnings in this case:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.10)
+  > (package
+  >  (name foo))
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (files (a/b.txt as ../b)))
+  > 
+  > (rule
+  >  (target (dir bar))
+  >  (action (progn (run mkdir bar) (run touch bar/baz.txt))))
+  > 
+  > (install
+  >  (section etc)
+  >  (dirs (bar as ../baz)))
+  > 
+  > (install
+  >  (section share)
+  >  (dirs (bar as ..)))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/baz.txt" {"../baz.txt"}
+  ]
+  etc: [
+    "_build/install/default/etc/b" {"../b"}
+    "_build/install/default/etc/baz/baz.txt" {"../baz/baz.txt"}
+  ]
+
+Test that we don't get the warning if a vendored project starts an install dst
+with "..". This is so that if a project vendors another project which would
+produce warnings, the first project doesn't get spammed with those warnings.
+
+  $ mkdir -p vendor/bar
+
+  $ cat >vendor/dune <<EOF
+  > (vendored_dirs *)
+  > EOF
+
+  $ cat >vendor/bar/dune-project <<EOF
+  > (lang dune 3.10)
+  > (package
+  >  (name bar))
+  > EOF
+
+  $ touch vendor/bar/a.txt
+
+  $ cat >vendor/bar/bar.ml <<EOF
+  > let bar = "bar"
+  > EOF
+
+  $ cat >vendor/bar/dune <<EOF
+  > (library
+  >  (public_name bar))
+  > 
+  > (install
+  >  (section etc)
+  >  (files (a.txt as ../a.txt)))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (public_name foo)
+  >  (libraries bar))
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  bin: [
+    "_build/install/default/bin/foo"
+  ]
+


### PR DESCRIPTION
This disallows install dst paths from begining with ".." to prevent them referencing a directory outside the install directories of the package.

This new constraint would prevent globs from being able to refer to files outside the current directory and its descendants, so this also adds a new keyword which changes the prefix of paths matched by a glob in the install stanza. It's similar to the `(files (foo as bar))` syntax in that it allows installed files to be placed in a location other than the one implied by their position in the source tree. It's now possible to write:
`(files (glob_files (some/path/* with_prefix new/path)))` ...which takes all the paths matched by the glob and replaces the `some/path` component with `new/path`.

I haven't yet updated the docs or changelog or written any tests beside modifying the one defined in https://github.com/ocaml/dune/pull/8265 to demonstrate how the feature gets used to give us a chance to discuss and change things about this solution before taking the time to write docs/tests, etc.

Also note that this breaks the test `github2123`. I followed the rabbit hole starting from https://github.com/ocaml/dune/issues/2123 to understand why this is necessary but I still don't understand. The test uses this dune file:
```
(install
 (section lib)
 (files (mirage-xen.pc as ../pkgconfig/mirage-xen.pc)))
```
That file ends up in `_build/install/default/lib/pkgconfig/mirage-xen.pc` which seems like it's escaping the package's install directory by design. @rgrinberg is that right? That issue was made in 2019. Do we know if mirage still needs this feature?