### PR TITLE
fix: only sign executables

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -340,7 +340,8 @@ module File_ops_real (W : sig
             | Dune_package -> process_dune_package ~get_location:conf.get_location
           in
           copy_special_file ~src ~package ~ic ~oc ~f)
-    | None -> Dune_rules.Artifact_substitution.copy_file ~conf ~src ~dst ~chmod ()
+    | None ->
+      Dune_rules.Artifact_substitution.copy_file ~conf ~executable ~src ~dst ~chmod ()
   ;;
 
   let remove_file_if_exists dst =

--- a/doc/changes/8361.md
+++ b/doc/changes/8361.md
@@ -1,0 +1,2 @@
+- Stop signing source files with substitutions. Sign only binaries instead
+  (#8361, fixes #8360, @anmonteiro)

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -57,6 +57,7 @@ val decode : string -> t option
     and then atomically renamed to [dst]. *)
 val copy_file
   :  conf:conf
+  -> ?executable:bool
   -> ?chmod:(int -> int)
   -> ?delete_dst_if_it_is_a_directory:bool
   -> src:Path.t


### PR DESCRIPTION
- It looks like macOS's `codesign` tool is a lot more lenient than Nix's `sigtool`, and skips signing files altogether if they're not binaries.
- This PR fixes the Nix part by only signing binaries and not regular files (e.g. sites modules produced by `dune-site`)

fixes https://github.com/ocaml/dune/issues/8360