### PR TITLE
refactor(rules): add [Import.Build_config]

### DIFF
--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -1,2 +1,1 @@
-open Import
-include Build_config.Rule_generator
+include Import.Build_config.Gen_rules.Generator

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -80,3 +80,46 @@ include struct
 end
 
 include Dune_engine.No_io
+
+module Build_config = struct
+  module Gen_rules = struct
+    module Build_only_sub_dirs = Build_config.Rules.Build_only_sub_dirs
+    module Context_or_install = Build_config.Context_or_install
+
+    module Rules = struct
+      include Build_config.Rules
+
+      let create
+        ?(build_dir_only_sub_dirs = empty.build_dir_only_sub_dirs)
+        ?(directory_targets = empty.directory_targets)
+        rules
+        =
+        { rules; build_dir_only_sub_dirs; directory_targets }
+      ;;
+    end
+
+    let make
+      ?(build_dir_only_sub_dirs = Rules.empty.build_dir_only_sub_dirs)
+      ?(directory_targets = Rules.empty.directory_targets)
+      rules
+      =
+      let rules =
+        { Build_config.Rules.build_dir_only_sub_dirs; directory_targets; rules }
+      in
+      Build_config.Rules rules
+    ;;
+
+    let redirect_to_parent rules = Build_config.Redirect_to_parent rules
+    let rules_here rules = Build_config.Rules rules
+    let unknown_context_or_install = Build_config.Unknown_context_or_install
+    let no_rules = make (Memo.return Dune_engine.Rules.empty)
+
+    type result = Build_config.gen_rules_result
+
+    module type Generator = Build_config.Rule_generator
+
+    let set = Build_config.set
+  end
+
+  let set = Build_config.set
+end

--- a/src/dune_rules/odoc.mli
+++ b/src/dune_rules/odoc.mli
@@ -16,4 +16,4 @@ val gen_rules
   :  Super_context.t
   -> dir:Path.Build.t
   -> string list
-  -> Build_config.gen_rules_result Memo.t
+  -> Build_config.Gen_rules.result Memo.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1370,29 +1370,30 @@ let gen_rules context_name (pkg : Pkg.t) =
     |> Action_builder.With_targets.add_directories
          ~directory_targets:[ pkg.paths.target_dir ]
   in
-  rule build_rule
+  rule ~loc:Loc.none (* TODO *) build_rule
 ;;
 
-let setup_package_rules context ~dir ~pkg_name : Build_config.gen_rules_result Memo.t =
+module Gen_rules = Build_config.Gen_rules
+
+let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
   match Package.Name.of_string_user_error (Loc.none, pkg_name) with
   | Error m -> raise (User_error.E m)
   | Ok name ->
     let* db = Lock_dir.get context in
     let+ pkg = resolve db.packages context (Loc.none, name) in
     let paths = Paths.make name context in
-    let rules =
-      { Build_config.Rules.directory_targets =
-          (let target_dir = paths.target_dir in
-           let map = Path.Build.Map.singleton target_dir Loc.none in
-           match pkg.info.source with
-           | Some (Fetch f) -> Path.Build.Map.add_exn map paths.source_dir (fst f.url)
-           | _ -> map)
-      ; build_dir_only_sub_dirs =
-          Build_config.Rules.Build_only_sub_dirs.singleton ~dir Subdir_set.empty
-      ; rules = Rules.collect_unit (fun () -> gen_rules context pkg)
-      }
+    let directory_targets =
+      let target_dir = paths.target_dir in
+      let map = Path.Build.Map.singleton target_dir Loc.none in
+      match pkg.info.source with
+      | Some (Fetch f) -> Path.Build.Map.add_exn map paths.source_dir (fst f.url)
+      | _ -> map
     in
-    Build_config.Rules rules
+    let build_dir_only_sub_dirs =
+      Gen_rules.Build_only_sub_dirs.singleton ~dir Subdir_set.empty
+    in
+    let rules = Rules.collect_unit (fun () -> gen_rules context pkg) in
+    Gen_rules.make ~directory_targets ~build_dir_only_sub_dirs rules
 ;;
 
 let ocaml_toolchain context =

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -13,7 +13,7 @@ val setup_package_rules
   :  Context_name.t
   -> dir:Path.Build.t
   -> pkg_name:string
-  -> Build_config.gen_rules_result Memo.t
+  -> Build_config.Gen_rules.result Memo.t
 
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t Memo.t
 val which : Context_name.t -> Filename.t -> Path.t option Memo.t


### PR DESCRIPTION
This simplifies our interface to [Dune_engine.Build_config] while it's
going some changes. Eventually, we'll get rid of this completely.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4fdcbfaf-62a7-4565-8a07-2c4a9ac567c0 -->