### PR TITLE
Use `%{pkg:...}` macro for package vars

### DIFF
--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -55,8 +55,6 @@ module Var = struct
       | Jobs
       | Arch
       | Section_dir of Section.t
-      | Name
-      | Version
 
     let compare = Poly.compare
 
@@ -75,8 +73,6 @@ module Var = struct
       | Arch -> variant "Arch" []
       | Section_dir section ->
         variant "Section_dir" [ string (Section.to_string section) ]
-      | Name -> variant "Name" []
-      | Version -> variant "Version" []
     ;;
 
     let encode_to_latest_dune_lang_version = function
@@ -91,8 +87,6 @@ module Var = struct
       | Jobs -> "jobs"
       | Arch -> "arch"
       | Section_dir section -> Section.to_string section
-      | Name -> "name"
-      | Version -> "version"
     ;;
   end
 
@@ -213,8 +207,6 @@ module Var = struct
        | "group" -> Some (Pkg Group)
        | "jobs" -> Some (Pkg Jobs)
        | "arch" -> Some (Pkg Arch)
-       | "name" -> Some (Pkg Name)
-       | "version" -> Some (Pkg Version)
        | _ -> None)
   ;;
 end

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -33,8 +33,6 @@ module Var : sig
       | Jobs
       | Arch
       | Section_dir of Section.t
-      | Name
-      | Version
 
     val compare : t -> t -> Ordering.t
     val to_dyn : t -> Dyn.t

--- a/src/dune_sexp/template.ml
+++ b/src/dune_sexp/template.ml
@@ -30,6 +30,8 @@ module Pform = struct
 
       let split t = String.split t ~on:sep
     end
+
+    let of_args = String.concat ~sep:(String.make 1 Args.sep)
   end
 
   type t =

--- a/src/dune_sexp/template.mli
+++ b/src/dune_sexp/template.mli
@@ -8,6 +8,7 @@ module Pform : sig
     val to_string : t -> string
     val to_dyn : t -> Dyn.t
     val compare : t -> t -> Ordering.t
+    val of_args : string list -> t
 
     module Args : sig
       (** Treat the entire payload as a single string argument. *)

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -36,11 +36,6 @@ Generate a mock opam repository
   > install: [ make "install" ]
   > EOF
 
-  $ mkpkg with-unknown-variable <<EOF
-  > opam-version: "2.0"
-  > build: [ fake "install" ]
-  > EOF
-
   $ solve_project <<EOF
   > (lang dune 3.8)
   > (package
@@ -54,16 +49,4 @@ Generate a mock opam repository
   $ cat dune.lock/standard-dune.pkg
   (version 0.0.1)
   (install (run %{make} install))
-  (build (progn (run dune subst) (run dune build -p %{name} -j %{jobs} @install @runtest @doc)))
-
-  $ solve_project <<EOF
-  > (lang dune 3.8)
-  > (package
-  >  (name x)
-  >  (depends with-unknown-variable))
-  > EOF
-  Error: Encountered unknown variable "fake" while processing commands for
-  package with-unknown-variable.0.0.1.
-  The full command:
-  fake "install"
-  [1]
+  (build (progn (run dune subst) (run dune build -p %{pkg:var:_:name} -j %{jobs} @install @runtest @doc)))


### PR DESCRIPTION
This removes the `Name` and `Version` pkg pform variables as these variables are always package scoped (possibly implicitly). This plus the fact that opam allows custom package variables means we can get rid of handling unknown variables when converting commands. It also makes it trivial to support explicitly package-scoped variables when converting commands so that's included in this change too.