### PR TITLE
refactor: do not force findlib for link time code gen

### DIFF
--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -234,9 +234,11 @@ let handle_special_libs cctx =
     Super_context.context sctx
   in
   let open Memo.O in
-  let* builtins =
-    let+ findlib = Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config in
-    Findlib.builtins findlib
+  let dune_site_plugin_code =
+    Memo.lazy_ (fun () ->
+      let+ findlib = Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config in
+      let builtins = Findlib.builtins findlib in
+      dune_site_plugins_code ~libs:all_libs ~builtins)
   in
   let rec process_libs ~to_link_rev ~force_linkall libs =
     match libs with
@@ -304,11 +306,12 @@ let handle_special_libs cctx =
             process_libs libs ~to_link_rev:(Lib lib :: to_link_rev) ~force_linkall
           | Dune_site { data_module; plugins } ->
             let code =
-              Action_builder.delayed
+              Action_builder.of_memo
+              @@ Memo.of_thunk
               @@ fun () ->
               if plugins
-              then dune_site_plugins_code ~libs:all_libs ~builtins
-              else dune_site_code ()
+              then Memo.Lazy.force dune_site_plugin_code
+              else Memo.return (dune_site_code ())
             in
             let& module_ =
               generate_and_compile_module


### PR DESCRIPTION
only force findlib when we actually need it

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 402b0724-116b-40eb-8a5c-2b27394e2071 -->