### PR TITLE
tests: Conv digest

### DIFF
--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -119,3 +119,4 @@ val dyn_of_error : error -> Dyn.t
 val to_sexp : ('a, values) t -> 'a -> Sexp.t
 val of_sexp : ('a, values) t -> version:int * int -> Sexp.t -> ('a, error) result
 val fdecl : ('a, 'k) t Fdecl.t -> ('a, 'k) t
+val sexp_for_digest : ('a, 'k) t -> Sexp.t

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -118,5 +118,5 @@ val error : error -> 'a
 val dyn_of_error : error -> Dyn.t
 val to_sexp : ('a, values) t -> 'a -> Sexp.t
 val of_sexp : ('a, values) t -> version:int * int -> Sexp.t -> ('a, error) result
-val fdecl : ('a, 'k) t Fdecl.t -> ('a, 'k) t
+val fixpoint : (('a, 'k) t -> ('a, 'k) t) -> ('a, 'k) t
 val sexp_for_digest : ('a, 'k) t -> Sexp.t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -155,6 +155,8 @@ module Decl : sig
       -> generations:('req, 'resp) gen list
       -> ('req, 'resp) t
 
+    val print_generations : ('req, 'resp) t -> unit
+
     type ('a, 'b) witness
 
     val witness : ('a, 'b) t -> ('a, 'b) witness
@@ -175,6 +177,7 @@ module Decl : sig
     type 'a t
 
     val make : method_:Method.Name.t -> generations:'payload gen list -> 'payload t
+    val print_generations : 'payload t -> unit
 
     type 'a witness
 

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -456,7 +456,10 @@ module Decl = struct
     let print_generation_list ~include_response generations =
       List.iter generations ~f:(fun (version, Generation.T conv) ->
         let conv_to_digest conv =
-          Digest.to_hex (Digest.string (Sexp.to_string (Conv.sexp_for_digest conv)))
+          let sexp_string = Sexp.to_string (Conv.sexp_for_digest conv) in
+          if String.length sexp_string < 32
+          then sexp_string
+          else Digest.to_hex (Digest.string sexp_string)
         in
         let req = conv_to_digest conv.req in
         let resp = conv_to_digest conv.resp in

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -453,6 +453,19 @@ module Decl = struct
       }
     ;;
 
+    let print_generation_list ~include_response generations =
+      List.iter generations ~f:(fun (version, Generation.T conv) ->
+        let conv_to_digest conv =
+          Digest.to_hex (Digest.string (Sexp.to_string (Conv.sexp_for_digest conv)))
+        in
+        let req = conv_to_digest conv.req in
+        let resp = conv_to_digest conv.resp in
+        if include_response
+        then Printf.printf "Version %d:\n  Request: %s\n  Response: %s\n" version req resp
+        else Printf.printf "Version %d: %s\n" version req)
+    ;;
+
+    let print_generations t = print_generation_list ~include_response:true t.generations
     let witness t = t.decl
   end
 
@@ -496,6 +509,10 @@ module Decl = struct
       ; decl =
           { method_; key = Univ_map.Key.create ~name:method_ (Int.Map.to_dyn gen_to_dyn) }
       }
+    ;;
+
+    let print_generations t =
+      Request.print_generation_list ~include_response:false t.generations
     ;;
 
     let witness t = t.decl

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -222,6 +222,7 @@ module Decl : sig
       -> generations:('req, 'resp) gen list
       -> ('req, 'resp) t
 
+    val print_generations : ('req, 'resp) t -> unit
     val witness : ('a, 'b) t -> ('a, 'b) witness
   end
 
@@ -248,6 +249,7 @@ module Decl : sig
       }
 
     val make : method_:Method.Name.t -> generations:'payload gen list -> 'payload t
+    val print_generations : 'payload t -> unit
     val witness : 'a t -> 'a witness
   end
 

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -814,51 +814,51 @@ let%expect_test _ =
   Decl.Request.print_generations Procedures.Public.ping;
   [%expect {|
     Version 1:
-      Request: (Iso Sexp)
-      Response: (Iso Sexp) |}];
+      Request: Unit
+      Response: Unit |}];
   Decl.Request.print_generations Procedures.Public.diagnostics;
   [%expect
     {|
     Version 1:
-      Request: (Iso Sexp)
-      Response: edf854370d5dfa545fb938f0decc9b4a |}];
+      Request: Unit
+      Response: bc16efad38b17b9f18ff457cd1e08610 |}];
   Decl.Notification.print_generations Procedures.Public.shutdown;
-  [%expect {| Version 1: (Iso Sexp) |}];
+  [%expect {| Version 1: Unit |}];
   Decl.Request.print_generations Procedures.Public.format_dune_file;
   [%expect
     {|
     Version 1:
-      Request: 385d03c35294f29d1120b609433c81d9
-      Response: (Iso Sexp) |}];
+      Request: 15eae4b546faf05a0fc3b6d03aed0c63
+      Response: String |}];
   Decl.Request.print_generations Procedures.Public.promote;
   [%expect {|
     Version 1:
-      Request: (Iso Sexp)
-      Response: (Iso Sexp) |}];
+      Request: String
+      Response: Unit |}];
   Decl.Request.print_generations Procedures.Public.build_dir;
   [%expect {|
     Version 1:
-      Request: (Iso Sexp)
-      Response: (Iso Sexp) |}];
+      Request: Unit
+      Response: String |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.progress);
   [%expect
     {|
     Version 1:
       Request: Sexp
-      Response: 6cab728f4e6c77947bb4082f3d5b1984
+      Response: 889aa68f4ad3fc68ef5dfffbb7282c18
     Version 2:
       Request: Sexp
-      Response: c10fb0e0a088186b904acb072906cd23 |}];
+      Response: 929074caab98360dc7116b6f27c2b9ad |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.diagnostic);
   [%expect
     {|
     Version 1:
       Request: Sexp
-      Response: a2365e51e13e7807a04abc32c91b68e1 |}];
+      Response: c91ffa13987876c4ed47304707f9db5a |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.running_jobs);
   [%expect
     {|
     Version 1:
       Request: Sexp
-      Response: 21ffd99ccccf76f795e0139a1f7a4ae2 |}]
+      Response: c6f1b15280c98f2ba94ba70001f6a63d |}]
 ;;

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -808,3 +808,60 @@ let%test_module "finalization" =
     ;;
   end)
 ;;
+
+let%expect_test _ =
+  let open Dune_rpc_private in
+  Decl.Request.print_generations Procedures.Public.ping;
+  [%expect
+    {|
+    Version 1:
+      Request: 3809995ca81082c9846344c2fc507a3d
+      Response: 3809995ca81082c9846344c2fc507a3d |}];
+  Decl.Request.print_generations Procedures.Public.diagnostics;
+  [%expect
+    {|
+    Version 1:
+      Request: 3809995ca81082c9846344c2fc507a3d
+      Response: edf854370d5dfa545fb938f0decc9b4a |}];
+  Decl.Notification.print_generations Procedures.Public.shutdown;
+  [%expect {| Version 1: 3809995ca81082c9846344c2fc507a3d |}];
+  Decl.Request.print_generations Procedures.Public.format_dune_file;
+  [%expect
+    {|
+    Version 1:
+      Request: 385d03c35294f29d1120b609433c81d9
+      Response: 3809995ca81082c9846344c2fc507a3d |}];
+  Decl.Request.print_generations Procedures.Public.promote;
+  [%expect
+    {|
+    Version 1:
+      Request: 3809995ca81082c9846344c2fc507a3d
+      Response: 3809995ca81082c9846344c2fc507a3d |}];
+  Decl.Request.print_generations Procedures.Public.build_dir;
+  [%expect
+    {|
+    Version 1:
+      Request: 3809995ca81082c9846344c2fc507a3d
+      Response: 3809995ca81082c9846344c2fc507a3d |}];
+  Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.progress);
+  [%expect
+    {|
+    Version 1:
+      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Response: 6cab728f4e6c77947bb4082f3d5b1984
+    Version 2:
+      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Response: c10fb0e0a088186b904acb072906cd23 |}];
+  Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.diagnostic);
+  [%expect
+    {|
+    Version 1:
+      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Response: a2365e51e13e7807a04abc32c91b68e1 |}];
+  Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.running_jobs);
+  [%expect
+    {|
+    Version 1:
+      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Response: 21ffd99ccccf76f795e0139a1f7a4ae2 |}]
+;;

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -840,6 +840,10 @@ let%expect_test _ =
     Version 1:
       Request: Unit
       Response: String |}];
+  Decl.Notification.print_generations Procedures.Server_side.abort;
+  [%expect {| Version 1: 0e9dfd1099101769896cf0bb06f891c6 |}];
+  Decl.Notification.print_generations Procedures.Server_side.log;
+  [%expect {| Version 1: 0e9dfd1099101769896cf0bb06f891c6 |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.progress);
   [%expect
     {|

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -809,7 +809,7 @@ let%test_module "finalization" =
   end)
 ;;
 
-let%expect_test _ =
+let%expect_test "print digests for all public RPCs" =
   let open Dune_rpc_private in
   Decl.Request.print_generations Procedures.Public.ping;
   [%expect {|

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -812,56 +812,53 @@ let%test_module "finalization" =
 let%expect_test _ =
   let open Dune_rpc_private in
   Decl.Request.print_generations Procedures.Public.ping;
-  [%expect
-    {|
+  [%expect {|
     Version 1:
-      Request: 3809995ca81082c9846344c2fc507a3d
-      Response: 3809995ca81082c9846344c2fc507a3d |}];
+      Request: (Iso Sexp)
+      Response: (Iso Sexp) |}];
   Decl.Request.print_generations Procedures.Public.diagnostics;
   [%expect
     {|
     Version 1:
-      Request: 3809995ca81082c9846344c2fc507a3d
+      Request: (Iso Sexp)
       Response: edf854370d5dfa545fb938f0decc9b4a |}];
   Decl.Notification.print_generations Procedures.Public.shutdown;
-  [%expect {| Version 1: 3809995ca81082c9846344c2fc507a3d |}];
+  [%expect {| Version 1: (Iso Sexp) |}];
   Decl.Request.print_generations Procedures.Public.format_dune_file;
   [%expect
     {|
     Version 1:
       Request: 385d03c35294f29d1120b609433c81d9
-      Response: 3809995ca81082c9846344c2fc507a3d |}];
+      Response: (Iso Sexp) |}];
   Decl.Request.print_generations Procedures.Public.promote;
-  [%expect
-    {|
+  [%expect {|
     Version 1:
-      Request: 3809995ca81082c9846344c2fc507a3d
-      Response: 3809995ca81082c9846344c2fc507a3d |}];
+      Request: (Iso Sexp)
+      Response: (Iso Sexp) |}];
   Decl.Request.print_generations Procedures.Public.build_dir;
-  [%expect
-    {|
+  [%expect {|
     Version 1:
-      Request: 3809995ca81082c9846344c2fc507a3d
-      Response: 3809995ca81082c9846344c2fc507a3d |}];
+      Request: (Iso Sexp)
+      Response: (Iso Sexp) |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.progress);
   [%expect
     {|
     Version 1:
-      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Request: Sexp
       Response: 6cab728f4e6c77947bb4082f3d5b1984
     Version 2:
-      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Request: Sexp
       Response: c10fb0e0a088186b904acb072906cd23 |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.diagnostic);
   [%expect
     {|
     Version 1:
-      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Request: Sexp
       Response: a2365e51e13e7807a04abc32c91b68e1 |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.running_jobs);
   [%expect
     {|
     Version 1:
-      Request: bf530f6aef3b26e6f85213c11d6a2c6d
+      Request: Sexp
       Response: 21ffd99ccccf76f795e0139a1f7a4ae2 |}]
 ;;


### PR DESCRIPTION
This is inspired by something that https://github.com/janestreet/bin_prot does; the idea is to ensure we don't accidentally break old versions of an RPC by cementing in tests some artifact of the serialization format. While this PR has some non-test changes, they should just be refactors and shouldn't change any behavior at all.

I personally think this PR is a good idea, but I will not be offended if others disagree and think it should not be merged at all.