### PR TITLE
fix: position in error for invalid char in pform

### DIFF
--- a/src/dune_sexp/lexer.mll
+++ b/src/dune_sexp/lexer.mll
@@ -352,7 +352,14 @@ and template_variable = parse
   }
   | '}' | eof
     { error lexbuf "%{...} forms cannot be empty" }
-  | _ { error lexbuf "This character is not allowed inside %{...} forms" }
+  | (varname_char* as skip) (_ as other)
+  | (varname_char+ ':' ((':' | varname_char)*) as skip) (_ as other)
+  {
+    error
+      ~delta:(String.length skip)
+      lexbuf
+      (Printf.sprintf "The character %C is not allowed inside %%{...} forms" other)
+  }
 
 {
   let token ~with_comments lexbuf = token with_comments lexbuf

--- a/test/blackbox-tests/test-cases/pform-space-error-message.t
+++ b/test/blackbox-tests/test-cases/pform-space-error-message.t
@@ -1,0 +1,50 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (action
+  >    (run %{bi{n:echo})))
+  > EOF
+
+  $ dune build out.txt
+  File "dune", line 3, characters 12-13:
+  3 |    (run %{bi{n:echo})))
+                  ^
+  Error: The character '{' is not allowed inside %{...} forms
+  [1]
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (action
+  >    (run %{bin:ec(ho})))
+  > EOF
+
+  $ dune build out.txt
+  File "dune", line 3, characters 16-17:
+  3 |    (run %{bin:ec(ho})))
+                      ^
+  Error: The character '(' is not allowed inside %{...} forms
+  [1]
+
+  $ dune build out.txt
+  File "dune", line 3, characters 16-17:
+  3 |    (run %{bin:ec(ho})))
+                      ^
+  Error: The character '(' is not allowed inside %{...} forms
+  [1]
+  $ cat >dune <<EOF
+  > (rule
+  >  (action
+  >    (run %{bin : echo})))
+  > EOF
+
+  $ dune build out.txt
+  File "dune", line 3, characters 13-14:
+  3 |    (run %{bin : echo})))
+                   ^
+  Error: The character ' ' is not allowed inside %{...} forms
+  [1]
+

--- a/test/blackbox-tests/test-cases/quoting/filename-space.t/run.t
+++ b/test/blackbox-tests/test-cases/quoting/filename-space.t/run.t
@@ -1,6 +1,6 @@
   $ dune build @quoted
-  File "dune", line 4, characters 17-18:
+  File "dune", line 4, characters 25-26:
   4 |  (action (echo %{read:foo bar.txt})))
-                       ^
-  Error: This character is not allowed inside %{...} forms
+                               ^
+  Error: The character ' ' is not allowed inside %{...} forms
   [1]


### PR DESCRIPTION
Previously the error message would refer to the incorrect part of the source when reporting errors about invalid characters in pform templates, such as this error which refers to the invalid space character:
```
4 |  (action (echo %{read:foo bar.txt})))
                     ^
Error: This character is not allowed inside %{...} forms
```

This change corrects the position of the arrow indicating the invalid character and also adds the character to the error message itself:
```
4 |  (action (echo %{read:foo bar.txt})))
                             ^
Error: The character ' ' is not allowed inside %{...} forms
```