### PR TITLE
Variable interpolations in opam commands

### DIFF
--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -47,13 +47,27 @@ let compare_no_loc { quoted; parts; loc = _ } t =
 let equal_no_loc t1 t2 = Ordering.is_eq (compare_no_loc t1 t2)
 let make_text ?(quoted = false) loc s = { quoted; loc; parts = [ Text s ] }
 
-let make_pform ?(quoted = false) loc pform =
+let part_of_pform loc pform =
   let source =
     match Pform.encode_to_latest_dune_lang_version pform with
     | Success { name; payload } -> { Template.Pform.loc; name; payload }
     | Pform_was_deleted -> assert false
   in
-  { quoted; loc; parts = [ Pform (source, pform) ] }
+  Pform (source, pform)
+;;
+
+let make_pform ?(quoted = false) loc pform =
+  let part = part_of_pform loc pform in
+  { quoted; loc; parts = [ part ] }
+;;
+
+let make ?(quoted = false) loc parts =
+  let parts =
+    List.map parts ~f:(function
+      | `Text s -> Text s
+      | `Pform p -> part_of_pform loc p)
+  in
+  { quoted; loc; parts }
 ;;
 
 let literal ~quoted ~loc s = { parts = [ Text s ]; quoted; loc }

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -39,6 +39,10 @@ val virt_pform : ?quoted:bool -> string * int * int * int -> Pform.t -> t
 val virt_text : string * int * int * int -> string -> t
 val make_pform : ?quoted:bool -> Loc.t -> Pform.t -> t
 val make_text : ?quoted:bool -> Loc.t -> string -> t
+
+(** Concatenate a list of parts. *)
+val make : ?quoted:bool -> Loc.t -> [ `Text of string | `Pform of Pform.t ] list -> t
+
 val is_pform : t -> Pform.t -> bool
 val has_pforms : t -> bool
 

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -10,6 +10,7 @@
   dune_stats
   dune_lang
   dune_console
+  dune_re
   opam_core
   opam_repository
   opam_format

--- a/vendor/opam/src/format/opamFilter.mli
+++ b/vendor/opam/src/format/opamFilter.mli
@@ -8,6 +8,7 @@
 (*  exception on linking described in the file LICENSE.                   *)
 (*                                                                        *)
 (**************************************************************************)
+module Re = Dune_re
 
 (** Formulas on variables, as used in opam files build scripts
 
@@ -49,6 +50,10 @@ val fold_down_left: ('a -> filter -> 'a) -> 'a -> filter -> 'a
 
 (** Maps on all nodes of a filter, bottom-up *)
 val map_up: (filter -> filter) -> filter -> filter
+
+(** Regex matching string interpolation syntax (["%%"], ["%{xxx}%"], or
+    ["%{xxx"] if unclosed) *)
+val string_interp_regex : Re.re
 
 (** Returns all the variables appearing in a filter (including the ones within
     string interpolations *)

--- a/vendor/update-opam.sh
+++ b/vendor/update-opam.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=7d5c4217c11c18f1405d58702409ed7290668135
+version=d3c96a02c4747b2ae4c8648a1f15d13c0efde832
 
 set -e -o pipefail
 
@@ -173,6 +173,19 @@ index 2857654a9..53f11d870 100644
  let log fmt = OpamConsole.log "XSYS" fmt
  
  (* Run commands *)
+
+diff --git a/vendor/opam/src/format/opamFilter.mli b/vendor/opam/src/format/opamFilter.mli
+index a2f01d179..1787b24b1 100644
+--- a/vendor/opam/src/format/opamFilter.mli
++++ b/vendor/opam/src/format/opamFilter.mli
+@@ -8,6 +8,7 @@
+ (*  exception on linking described in the file LICENSE.                   *)
+ (*                                                                        *)
+ (**************************************************************************)
++module Re = Dune_re
+
+ (** Formulas on variables, as used in opam files build scripts
+
 EOF
 
 for subpackage in core repository format state


### PR DESCRIPTION
Adds support for replacing opam variable interpolations with dune pforms while converting opam build/install commands to dune actions.