### PR TITLE
refactor: remove findlib from link time code gen

### DIFF
--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -67,7 +67,6 @@ end
 
 type t = DB.t
 
-let builtins (db : DB.t) = db.builtins
 let findlib_predicates_set_by_dune = Ps.of_list [ P.ppx_driver; P.mt; P.mt_posix ]
 
 module Loader : sig

--- a/src/dune_rules/findlib.mli
+++ b/src/dune_rules/findlib.mli
@@ -7,10 +7,6 @@ type t
 
 val create : paths:Path.t list -> lib_config:Lib_config.t -> t Memo.t
 val lib_config : t -> Lib_config.t
-
-(** The builtins packages *)
-val builtins : t -> Meta.Simplified.t Package.Name.Map.t
-
 val findlib_predicates_set_by_dune : Variant.Set.t
 
 module Unavailable_reason : sig

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -235,10 +235,9 @@ let handle_special_libs cctx =
   in
   let open Memo.O in
   let dune_site_plugin_code =
-    Memo.lazy_ (fun () ->
-      let+ findlib = Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config in
-      let builtins = Findlib.builtins findlib in
-      dune_site_plugins_code ~libs:all_libs ~builtins)
+    let* () = Memo.return () in
+    let+ builtins = ctx.ocaml.builtins in
+    dune_site_plugins_code ~libs:all_libs ~builtins
   in
   let rec process_libs ~to_link_rev ~force_linkall libs =
     match libs with
@@ -309,9 +308,7 @@ let handle_special_libs cctx =
               Action_builder.of_memo
               @@ Memo.of_thunk
               @@ fun () ->
-              if plugins
-              then Memo.Lazy.force dune_site_plugin_code
-              else Memo.return (dune_site_code ())
+              if plugins then dune_site_plugin_code else Memo.return (dune_site_code ())
             in
             let& module_ =
               generate_and_compile_module

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -13,6 +13,7 @@ type t =
   ; ocaml_config : Ocaml_config.t
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml.Version.t
+  ; builtins : Meta.Simplified.t Package.Name.Map.t Memo.t
   }
 
 val of_env_with_findlib


### PR DESCRIPTION
Getting the builtins doesn't require initializing findlib

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 98d72caa-1ac4-45f8-b605-36bae1c041bc -->