### PR TITLE
refactor: move [Lib_config] to [Ocaml_toolchain]

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -134,8 +134,8 @@ let exes_extensions (ctx : Context.t) modes =
     Dune_rules.Dune_file.Executables.Link_mode.extension
       m
       ~loc
-      ~ext_obj:ctx.lib_config.ext_obj
-      ~ext_dll:ctx.lib_config.ext_dll)
+      ~ext_obj:ctx.ocaml.lib_config.ext_obj
+      ~ext_dll:ctx.ocaml.lib_config.ext_dll)
 ;;
 
 let libs db (context : Context.t) (build_system : Dune_rules.Main.build_system) =

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -22,7 +22,7 @@ let term =
        let* ctxs = Context.DB.all () in
        let ctx = List.hd ctxs in
        let* findlib =
-         Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config
+         Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.ocaml.lib_config
        in
        let* all_packages = Findlib.all_packages findlib in
        if na

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -96,7 +96,7 @@ let conf_of_context (context : Context.t option) =
     let get_location = Install.Paths.get_local_location context.name in
     let get_config_path = function
       | Sourceroot -> Some (Path.source Path.Source.root)
-      | Stdlib -> Some context.lib_config.stdlib_dir
+      | Stdlib -> Some context.ocaml.lib_config.stdlib_dir
     in
     let hardcoded_ocaml_path =
       let install_dir = Install.Context.dir ~context:context.name in
@@ -120,7 +120,7 @@ let conf_for_install ~relocatable ~roots ~(context : Context.t) =
   in
   let get_config_path = function
     | Sourceroot -> None
-    | Stdlib -> Some context.lib_config.stdlib_dir
+    | Stdlib -> Some context.ocaml.lib_config.stdlib_dir
   in
   let sign_hook = lazy (sign_hook_of_context context) in
   { get_location; get_vcs; get_config_path; hardcoded_ocaml_path; sign_hook }

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -72,7 +72,6 @@ type t = private
   ; findlib_toolchain : Context_name.t option (** Misc *)
   ; default_ocamlpath : Path.t list
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
-  ; lib_config : Lib_config.t
   ; build_context : Build_context.t
   ; instrument_with : Lib_name.t list
   }
@@ -87,7 +86,6 @@ val to_dyn_concise : t -> Dyn.t
 val compare : t -> t -> Ordering.t
 
 val name : t -> Context_name.t
-val lib_config : t -> Lib_config.t
 
 (** [map_exe t exe] returns a version of [exe] that is suitable for being
     executed on the current machine. For instance, if [t] is a cross-compilation

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -214,7 +214,7 @@ let build_c_program
     Command.Args.S [ base_flags; As foreign_flags ]
   in
   let include_args =
-    let ocaml_where = ctx.lib_config.stdlib_dir in
+    let ocaml_where = ctx.ocaml.lib_config.stdlib_dir in
     (* XXX: need glob dependency *)
     let open Action_builder.O in
     let ctypes = Lib_name.of_string "ctypes" in
@@ -323,8 +323,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx ~version =
   let open Memo.O in
   let foreign_archives_deps =
     let ctx = Super_context.context sctx in
-    let ext_lib = ctx.lib_config.ext_lib in
-    let ext_dll = ctx.lib_config.ext_dll in
+    let { Lib_config.ext_lib; ext_dll; _ } = ctx.ocaml.lib_config in
     List.concat_map buildable.foreign_archives ~f:(fun (_loc, archive) ->
       let mode = Mode.Select.All in
       [ Foreign.Archive.lib_file ~mode ~archive ~dir ~ext_lib

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -290,7 +290,7 @@ end = struct
 
   let get0_impl (sctx, dir) : result0 Memo.t =
     let ctx = Super_context.context sctx in
-    let lib_config = (Super_context.context sctx).lib_config in
+    let lib_config = (Super_context.context sctx).ocaml.lib_config in
     let* status = Dir_status.DB.get ~dir in
     let human_readable_description () =
       Pp.textf
@@ -352,7 +352,7 @@ end = struct
                            Foreign_sources.make
                              d.stanzas
                              ~dune_version
-                             ~lib_config:ctx.lib_config
+                             ~lib_config:ctx.ocaml.lib_config
                              ~dirs
                            |> Memo.return)
                      ; coq =
@@ -419,7 +419,7 @@ end = struct
               Foreign_sources.make
                 d.stanzas
                 ~dune_version
-                ~lib_config:ctx.lib_config
+                ~lib_config:ctx.ocaml.lib_config
                 ~dirs
               |> Memo.return)
           in

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -82,11 +82,12 @@ module Linkage = struct
              else Byte_with_stubs_statically_linked_in)
       in
       let ext =
+        let lib_config = ctx.ocaml.lib_config in
         Dune_file.Executables.Link_mode.extension
           m
           ~loc
-          ~ext_obj:ctx.lib_config.ext_obj
-          ~ext_dll:ctx.lib_config.ext_dll
+          ~ext_obj:lib_config.ext_obj
+          ~ext_dll:lib_config.ext_dll
       in
       let flags =
         match m with
@@ -193,7 +194,7 @@ let link_exe
                  ; Lib_flags.Lib_and_module.L.link_flags
                      sctx
                      to_link
-                     ~lib_config:ctx.lib_config
+                     ~lib_config:ctx.ocaml.lib_config
                      ~mode:linkage.mode
                  ])
           ; Deps o_files
@@ -289,7 +290,7 @@ let link_many
           ~obj_dir
           ~modules
           ~top_sorted_modules
-          ~ext_obj:ctx.lib_config.ext_obj
+          ~ext_obj:ctx.ocaml.lib_config.ext_obj
           ()
       in
       let+ () =

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -89,7 +89,7 @@ let o_files
       Foreign_sources.for_exes foreign_sources ~first_exe
     in
     let foreign_o_files =
-      let { Lib_config.ext_obj; _ } = (Super_context.context sctx).lib_config in
+      let { Lib_config.ext_obj; _ } = (Super_context.context sctx).ocaml.lib_config in
       Foreign.Objects.build_paths exes.buildable.extra_objects ~ext_obj ~dir
     in
     let+ o_files =
@@ -163,7 +163,8 @@ let executables_rules
       ~opaque:Inherit_from_settings
       ~package:exes.package
   in
-  let stdlib_dir = ctx.lib_config.stdlib_dir in
+  let lib_config = ctx.ocaml.lib_config in
+  let stdlib_dir = lib_config.stdlib_dir in
   let* requires_compile = Compilation_context.requires_compile cctx in
   let* dep_graphs =
     (* Building an archive for foreign stubs, we link the corresponding object
@@ -190,7 +191,7 @@ let executables_rules
       Command.Args.S
         [ As flags
         ; S
-            (let ext_lib = ctx.lib_config.ext_lib in
+            (let ext_lib = lib_config.ext_lib in
              let foreign_archives = exes.buildable.foreign_archives |> List.map ~f:snd in
              (* XXX: don't these need the msvc hack being done in lib_rules? *)
              (* XXX: also the Command.quote_args being done in lib_rules? *)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -430,6 +430,7 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source (pform : Pfor
   | None ->
     (match pform with
      | Var var ->
+       let lib_config = context.ocaml.lib_config in
        (match var with
         | Pkg _ -> assert false
         | Nothing -> static []
@@ -485,13 +486,12 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source (pform : Pfor
         | Ocaml_bin_dir -> static [ Dir context.ocaml.bin_dir ]
         | Ocaml_version ->
           static (string (Ocaml_config.version_string context.ocaml.ocaml_config))
-        | Ocaml_stdlib_dir ->
-          static (string (Path.to_string context.lib_config.stdlib_dir))
+        | Ocaml_stdlib_dir -> static (string (Path.to_string lib_config.stdlib_dir))
         | Dev_null -> static (string (Path.to_string Dev_null.path))
-        | Ext_obj -> static (string context.lib_config.ext_obj)
+        | Ext_obj -> static (string lib_config.ext_obj)
         | Ext_asm -> static (string (Ocaml_config.ext_asm context.ocaml.ocaml_config))
-        | Ext_lib -> static (string context.lib_config.ext_lib)
-        | Ext_dll -> static (string context.lib_config.ext_dll)
+        | Ext_lib -> static (string lib_config.ext_lib)
+        | Ext_dll -> static (string lib_config.ext_dll)
         | Ext_exe -> static (string (Ocaml_config.ext_exe context.ocaml.ocaml_config))
         | Ext_plugin ->
           (if Ocaml_config.natdynlink_supported context.ocaml.ocaml_config
@@ -531,9 +531,7 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source (pform : Pfor
                 (let* cc = Action_builder.of_memo (cc t) in
                  cc.cxx))
         | Ccomp_type ->
-          static
-          @@ string
-          @@ Ocaml_config.Ccomp_type.to_string context.lib_config.ccomp_type
+          static @@ string @@ Ocaml_config.Ccomp_type.to_string lib_config.ccomp_type
         | Toolchain ->
           static
           @@ string

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -198,7 +198,7 @@ let build_c
       (Ocaml_config.c_compiler ctx.ocaml.ocaml_config)
   in
   let output_param =
-    match ctx.lib_config.ccomp_type with
+    match ctx.ocaml.lib_config.ccomp_type with
     | Msvc -> [ Command.Args.Concat ("", [ A "/Fo"; Target dst ]) ]
     | Other _ -> [ A "-o"; Target dst ]
   in
@@ -214,7 +214,7 @@ let build_c
        ~dir:(Path.build dir)
        c_compiler
        ([ Command.Args.dyn with_user_and_std_flags
-        ; S [ A "-I"; Path ctx.lib_config.stdlib_dir ]
+        ; S [ A "-I"; Path ctx.ocaml.lib_config.stdlib_dir ]
         ; include_flags
         ]
         @ output_param
@@ -283,7 +283,7 @@ let build_o_files
       in
       let dst =
         let ctx = Super_context.context sctx in
-        Path.Build.relative dir (obj ^ ctx.lib_config.ext_obj)
+        Path.Build.relative dir (obj ^ ctx.ocaml.lib_config.ext_obj)
       in
       let+ () =
         build_c

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -126,7 +126,7 @@ end = struct
     =
     let loc = lib.buildable.loc in
     let ctx = Super_context.context sctx in
-    let lib_config = ctx.lib_config in
+    let lib_config = ctx.ocaml.lib_config in
     let* info = Dune_file.Library.to_lib_info lib ~dir ~lib_config in
     let make_entry =
       let in_sub_dir = function
@@ -616,7 +616,7 @@ end = struct
             let dir = Obj_dir.obj_dir obj_dir in
             let+ foreign_sources = Dir_contents.foreign_sources dir_contents in
             Foreign_sources.for_lib ~name foreign_sources
-            |> Foreign.Sources.object_files ~dir ~ext_obj:ctx.lib_config.ext_obj
+            |> Foreign.Sources.object_files ~dir ~ext_obj:ctx.ocaml.lib_config.ext_obj
             |> List.map ~f:Path.build
           and* modules =
             Dir_contents.ocaml dir_contents >>| Ml_sources.modules ~for_:(Library name)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1800,7 +1800,7 @@ module DB = struct
   let installed (context : Context.t) =
     let open Memo.O in
     let+ findlib =
-      Findlib.create ~paths:context.findlib_paths ~lib_config:context.lib_config
+      Findlib.create ~paths:context.findlib_paths ~lib_config:context.ocaml.lib_config
     in
     create_from_findlib findlib ~instrument_with:context.instrument_with
   ;;

--- a/src/dune_rules/lib_config.ml
+++ b/src/dune_rules/lib_config.ml
@@ -55,3 +55,22 @@ let cc_g t =
   | Msvc -> []
   | Other _ -> [ "-g" ]
 ;;
+
+let create ocaml_config ~ocamlopt =
+  { has_native = Result.is_ok ocamlopt
+  ; ext_obj = Ocaml_config.ext_obj ocaml_config
+  ; ext_lib = Ocaml_config.ext_lib ocaml_config
+  ; os_type = Ocaml_config.os_type ocaml_config
+  ; architecture = Ocaml_config.architecture ocaml_config
+  ; system = Ocaml_config.system ocaml_config
+  ; model = Ocaml_config.model ocaml_config
+  ; ext_dll = Ocaml_config.ext_dll ocaml_config
+  ; natdynlink_supported =
+      (let natdynlink_supported = Ocaml_config.natdynlink_supported ocaml_config in
+       Dynlink_supported.By_the_os.of_bool natdynlink_supported)
+  ; stdlib_dir = Path.of_string (Ocaml_config.standard_library ocaml_config)
+  ; ccomp_type = Ocaml_config.ccomp_type ocaml_config
+  ; ocaml_version_string = Ocaml_config.version_string ocaml_config
+  ; ocaml_version = Ocaml.Version.of_ocaml_config ocaml_config
+  }
+;;

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -25,3 +25,5 @@ val to_dyn : t -> Dyn.t
 
 (** [["-g"]] if [!Clflags.g] and [[]] otherwise *)
 val cc_g : t -> string list
+
+val create : Ocaml_config.t -> ocamlopt:(_, _) result -> t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -57,7 +57,7 @@ let build_lib
     in
     let map_cclibs =
       (* https://github.com/ocaml/dune/issues/119 *)
-      match ctx.lib_config.ccomp_type with
+      match ctx.ocaml.lib_config.ccomp_type with
       | Msvc -> msvc_hack_cclibs
       | Other _ -> Fun.id
     in
@@ -115,7 +115,7 @@ let build_lib
              ; Deps
                  (Foreign.Objects.build_paths
                     lib.buildable.extra_objects
-                    ~ext_obj:ctx.lib_config.ext_obj
+                    ~ext_obj:ctx.ocaml.lib_config.ext_obj
                     ~dir)
              ]))
 ;;
@@ -164,7 +164,7 @@ let ocamlmklib
   ~build_targets_together
   =
   let ctx = Super_context.context sctx in
-  let { Lib_config.ext_lib; ext_dll; _ } = ctx.lib_config in
+  let { Lib_config.ext_lib; ext_dll; _ } = ctx.ocaml.lib_config in
   let static_target =
     Foreign.Archive.Name.lib_file archive_name ~dir ~ext_lib ~mode:stubs_mode
   in
@@ -172,7 +172,7 @@ let ocamlmklib
     Action_builder.map c_library_flags ~f:(fun cclibs ->
       (* https://github.com/ocaml/dune/issues/119 *)
       let cclibs =
-        match ctx.lib_config.ccomp_type with
+        match ctx.ocaml.lib_config.ccomp_type with
         | Msvc -> msvc_hack_cclibs cclibs
         | Other _ -> cclibs
       in
@@ -292,7 +292,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
   in
   let* o_files =
     let lib_foreign_o_files =
-      let { Lib_config.ext_obj; _ } = (Super_context.context sctx).lib_config in
+      let { Lib_config.ext_obj; _ } = (Super_context.context sctx).ocaml.lib_config in
       Foreign.Objects.build_paths lib.buildable.extra_objects ~ext_obj ~dir
     in
     let+ tbl =
@@ -369,7 +369,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
 let build_shared lib ~native_archives ~sctx ~dir ~flags =
   let ctx = Super_context.context sctx in
   Memo.Result.iter ctx.ocaml.ocamlopt ~f:(fun ocamlopt ->
-    let ext_lib = ctx.lib_config.ext_lib in
+    let ext_lib = ctx.ocaml.lib_config.ext_lib in
     let src =
       let ext = Mode.compiled_lib_ext Native in
       Path.build (Library.archive lib ~dir ~ext)
@@ -434,7 +434,7 @@ let setup_build_archives
   let js_of_ocaml = Js_of_ocaml.In_context.make ~dir lib.buildable.js_of_ocaml in
   let sctx = Compilation_context.super_context cctx in
   let ctx = Compilation_context.context cctx in
-  let { Lib_config.ext_obj; natdynlink_supported; _ } = ctx.lib_config in
+  let { Lib_config.ext_obj; natdynlink_supported; _ } = ctx.ocaml.lib_config in
   let open Memo.O in
   let* () =
     Modules.exit_module modules
@@ -518,7 +518,7 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_
   let requires_compile = Lib.Compile.direct_requires compile_info in
   let requires_link = Lib.Compile.requires_link compile_info in
   let modes =
-    let { Lib_config.has_native; _ } = ctx.lib_config in
+    let { Lib_config.has_native; _ } = ctx.ocaml.lib_config in
     Dune_file.Mode_conf.Lib.Set.eval_detailed lib.modes ~has_native
   in
   let package = Dune_file.Library.package lib in
@@ -571,7 +571,7 @@ let library_rules
   let dir = Compilation_context.dir cctx in
   let scope = Compilation_context.scope cctx in
   let* requires_compile = Compilation_context.requires_compile cctx in
-  let stdlib_dir = (Compilation_context.context cctx).lib_config.stdlib_dir in
+  let stdlib_dir = (Compilation_context.context cctx).ocaml.lib_config.stdlib_dir in
   let top_sorted_modules =
     let impl_only = Modules.impl_only modules in
     Dep_graph.top_closed_implementations
@@ -586,7 +586,7 @@ let library_rules
   and* () = Module_compilation.build_all cctx
   and* expander = Super_context.expander sctx ~dir
   and* lib_info =
-    let lib_config = (Super_context.context sctx).lib_config in
+    let lib_config = (Super_context.context sctx).ocaml.lib_config in
     let* info = Library.to_lib_info lib ~dir ~lib_config in
     let mode = Lib_mode.Map.Set.for_merlin (Lib_info.modes info) in
     let+ () = Check_rules.add_obj_dir sctx ~obj_dir mode in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -256,7 +256,7 @@ let setup_emit_cmj_rules
     in
     let* () = Module_compilation.build_all cctx in
     let* requires_compile = Compilation_context.requires_compile cctx in
-    let stdlib_dir = ctx.lib_config.stdlib_dir in
+    let stdlib_dir = ctx.ocaml.lib_config.stdlib_dir in
     let+ () =
       let emit_and_libs_deps =
         let target_dir = Path.Build.relative dir mel.target in

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -131,7 +131,7 @@ let build_cm
    let+ src = Module.file m ~ml_kind in
    let dst = Obj_dir.Module.cm_file_exn obj_dir m ~kind:cm_kind in
    let obj =
-     Obj_dir.Module.obj_file obj_dir m ~kind:(Ocaml Cmx) ~ext:ctx.lib_config.ext_obj
+     Obj_dir.Module.obj_file obj_dir m ~kind:(Ocaml Cmx) ~ext:ctx.ocaml.lib_config.ext_obj
    in
    let open Memo.O in
    let* extra_args, extra_deps, other_targets =

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -13,6 +13,7 @@ type t =
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml.Version.t
   ; builtins : Meta.Simplified.t Package.Name.Map.t Memo.t
+  ; lib_config : Lib_config.t
   }
 
 let make_builtins ~ocaml_config ~version =
@@ -99,6 +100,7 @@ let of_env_with_findlib name env findlib_config ~which =
     ; ocaml_config
     ; ocaml_config_vars
     ; version
+    ; lib_config = Lib_config.create ocaml_config ~ocamlopt
     ; builtins = Memo.Lazy.force builtins
     }
 ;;
@@ -195,5 +197,6 @@ let of_binaries name env binaries =
   ; ocaml_config_vars
   ; version
   ; builtins = Memo.Lazy.force builtins
+  ; lib_config = Lib_config.create ocaml_config ~ocamlopt
   }
 ;;

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -14,6 +14,7 @@ type t =
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml.Version.t
   ; builtins : Meta.Simplified.t Package.Name.Map.t Memo.t
+  ; lib_config : Lib_config.t
   }
 
 val of_env_with_findlib

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -300,7 +300,7 @@ module DB = struct
     let open Memo.O in
     let t = Fdecl.create Dyn.opaque in
     let build_dir = context.build_dir in
-    let lib_config = Context.lib_config context in
+    let lib_config = context.ocaml.lib_config in
     let instrument_with = context.instrument_with in
     let* public_libs =
       let+ installed_libs = Lib.DB.installed context in

--- a/src/dune_rules/sites.ml
+++ b/src/dune_rules/sites.ml
@@ -26,7 +26,7 @@ let find_package t pkg =
 let create (context : Context.t) =
   let* packages = Only_packages.get () in
   let+ findlib =
-    Findlib.create ~paths:context.findlib_paths ~lib_config:context.lib_config
+    Findlib.create ~paths:context.findlib_paths ~lib_config:context.ocaml.lib_config
   in
   { packages; findlib }
 ;;

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -351,7 +351,7 @@ let default_foreign_flags t ~dir ~language =
 ;;
 
 let foreign_flags t ~dir ~expander ~flags ~language =
-  let ccg = Lib_config.cc_g (Env_tree.context t).lib_config in
+  let ccg = Lib_config.cc_g (Env_tree.context t).ocaml.lib_config in
   let default = default_foreign_flags t ~dir ~language in
   let open Action_builder.O in
   let name = Foreign_language.proper_name language in

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -10,7 +10,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
   let copy_to_obj_dir ~src ~dst =
     add_rule ~loc:(Loc.of_pos __POS__) (Action_builder.symlink ~src ~dst)
   in
-  let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
+  let { Lib_config.has_native; ext_obj; _ } = ctx.ocaml.lib_config in
   let { Lib_mode.Map.ocaml = { byte; native }; melange } =
     Dune_file.Mode_conf.Lib.Set.eval impl.modes ~has_native
   in
@@ -109,7 +109,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
             >>= Modules.map_user_written ~f:(fun m -> Memo.return (pp_spec m))
           in
           let+ foreign_objects =
-            let ext_obj = (Super_context.context sctx).lib_config.ext_obj in
+            let ext_obj = (Super_context.context sctx).ocaml.lib_config.ext_obj in
             let dir = Obj_dir.obj_dir (Lib.Local.obj_dir vlib) in
             let+ foreign_sources = Dir_contents.foreign_sources dir_contents in
             foreign_sources


### PR DESCRIPTION
This vaule can be completely constructed from the toolchain so we move
it there.

Eventually, we'll be able to access the toolchain directly without the
context, so this value will also be available that way.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a21997b9-c9a6-40f6-9c1d-c98e10e6abb0 -->