### PR TITLE
refactor: remove [sites] from [Expander]

### DIFF
--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -156,8 +156,10 @@ let rec dep expander = function
        let+ () =
          let pkg = Package.Name.of_string pkg in
          let context = Expander.context expander in
-         let sites = Expander.sites expander in
-         Action_builder.of_memo (Sites.find_package sites pkg)
+         Action_builder.of_memo
+           (let open Memo.O in
+            let* sites = Sites.create context in
+            Sites.find_package sites pkg)
          >>= function
          | Some (Local pkg) ->
            Action_builder.alias

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -59,7 +59,6 @@ type t =
   ; lookup_artifacts : (dir:Path.Build.t -> Ml_sources.Artifacts.t Memo.t) option
   ; foreign_flags :
       dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t
-  ; sites : Sites.t
   ; expanding_what : Expanding_what.t
   }
 
@@ -747,8 +746,6 @@ let make
   ~lib_artifacts_host
   ~bin_artifacts_host
   =
-  let open Memo.O in
-  let+ sites = Sites.create context in
   { dir = context.build_dir
   ; env = context.env
   ; local_env = Env.Var.Map.empty
@@ -766,7 +763,6 @@ let make
         Code_error.raise
           "foreign flags expander is not set"
           [ "dir", Path.Build.to_dyn dir ])
-  ; sites
   ; expanding_what = Nothing_special
   }
 ;;
@@ -921,5 +917,3 @@ let expand_lock ~base expander (Locks.Lock sw) =
 let expand_locks ~base expander locks =
   Memo.List.map locks ~f:(expand_lock ~base expander)
 ;;
-
-let sites t = t.sites

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -15,7 +15,7 @@ val make
   -> lib_artifacts:Artifacts.Public_libs.t
   -> lib_artifacts_host:Artifacts.Public_libs.t
   -> bin_artifacts_host:Artifacts.Bin.t
-  -> t Memo.t
+  -> t
 
 val set_foreign_flags
   :  t
@@ -129,5 +129,3 @@ val expand_locks
   -> t
   -> Locks.t
   -> Path.t list Memo.t
-
-val sites : t -> Sites.t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -435,7 +435,7 @@ let create ~(context : Context.t) ~host ~packages ~stanzas =
         artifacts, host
     in
     let* scope = Scope.DB.find_by_dir context.build_dir in
-    let* scope_host = Scope.DB.find_by_dir context_host.build_dir in
+    let+ scope_host = Scope.DB.find_by_dir context_host.build_dir in
     Expander.make
       ~scope
       ~scope_host


### PR DESCRIPTION
This requires [Findlib], so we get to avoid initializing it in the
common case.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ea734f47-d28e-453f-9cff-da9b0d0c0135 -->