### PR TITLE
Concise pkg macro

### DIFF
--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -265,6 +265,7 @@ module Macro = struct
     | Env
     | Artifact of Artifact.t
     | Pkg
+    | Pkg_self
 
   let compare x y =
     match x, y with
@@ -316,6 +317,9 @@ module Macro = struct
     | Pkg, Pkg -> Eq
     | Pkg, _ -> Lt
     | _, Pkg -> Gt
+    | Pkg_self, Pkg_self -> Eq
+    | Pkg_self, _ -> Lt
+    | _, Pkg_self -> Gt
     | Artifact x, Artifact y -> Artifact.compare x y
   ;;
 
@@ -341,6 +345,7 @@ module Macro = struct
     | Env -> string "Env"
     | Artifact ext -> variant "Artifact" [ Artifact.to_dyn ext ]
     | Pkg -> variant "Pkg" []
+    | Pkg_self -> variant "Pkg_self" []
   ;;
 
   let encode = function
@@ -362,6 +367,7 @@ module Macro = struct
     | Coq_config -> Ok "coq"
     | Env -> Ok "env"
     | Pkg -> Ok "pkg"
+    | Pkg_self -> Ok "pkg-self"
     | Artifact a -> Ok (String.drop (Artifact.ext a) 1)
   ;;
 end

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -127,6 +127,7 @@ module Macro : sig
     | Env
     | Artifact of Artifact.t
     | Pkg
+    | Pkg_self
 
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -4,6 +4,7 @@ module Lock_dir = Lock_dir
 module Opam_file = Opam_file
 module Opam_repo = Opam_repo
 module Opam_solver = Opam_solver
+module Package_variable = Package_variable
 module Solver_env = Solver_env
 module Substs = Substs
 module Sys_poll = Sys_poll

--- a/src/dune_pkg/package_variable.ml
+++ b/src/dune_pkg/package_variable.ml
@@ -1,0 +1,79 @@
+open Stdune
+open Dune_lang
+
+module Name = struct
+  include String
+
+  include (
+    Dune_util.Stringlike.Make (struct
+      type t = string
+
+      let to_string x = x
+      let module_ = "Package_variable.Name"
+      let description = "package variable name"
+      let description_of_valid_string = None
+      let hint_valid = None
+      let of_string_opt s = if s = "" then None else Some s
+    end) :
+      Dune_util.Stringlike with type t := t)
+end
+
+module Scope = struct
+  type t =
+    | Self
+    | Package of Package_name.t
+
+  let of_string = function
+    | "_" -> Self
+    | package -> Package (Package_name.of_string package)
+  ;;
+
+  let to_string = function
+    | Self -> "_"
+    | Package package_name -> Package_name.to_string package_name
+  ;;
+end
+
+type t =
+  { name : Name.t
+  ; scope : Scope.t
+  }
+
+let self_scoped name = { name; scope = Self }
+let package_scoped name package_name = { name; scope = Package package_name }
+let var_tag = "var"
+
+let to_payload { name; scope } =
+  Pform.Payload.of_args [ var_tag; Scope.to_string scope; Name.to_string name ]
+;;
+
+let of_macro_invocation ({ Pform.Macro_invocation.macro; _ } as macro_invocation) =
+  match macro with
+  | Pkg ->
+    (match Pform.Macro_invocation.Args.split macro_invocation with
+     | [ tag; scope_arg; variable_name ] when String.equal tag var_tag ->
+       Some { name = Name.of_string variable_name; scope = Scope.of_string scope_arg }
+     | _ -> None)
+  | _ -> None
+;;
+
+let to_macro_invocation t = { Pform.Macro_invocation.macro = Pkg; payload = to_payload t }
+let to_pform t = Pform.Macro (to_macro_invocation t)
+
+let of_opam_ident ident =
+  match String.lsplit2 ident ~on:':' with
+  | Some ("_", variable) -> `Package_variable (self_scoped (Name.of_string variable))
+  | Some (package, variable) ->
+    `Package_variable
+      (package_scoped (Name.of_string variable) (Package_name.of_string package))
+  | None ->
+    (match Pform.Var.of_opam_global_variable_name ident with
+     | Some var -> `Global_variable var
+     | None -> `Package_variable (self_scoped (Name.of_string ident)))
+;;
+
+let pform_of_opam_ident ident =
+  match of_opam_ident ident with
+  | `Package_variable t -> to_pform t
+  | `Global_variable var -> Pform.Var var
+;;

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -1,0 +1,30 @@
+open! Stdune
+open Dune_lang
+
+module Name : sig
+  type t
+
+  val of_string : string -> t
+  val to_string : t -> string
+end
+
+module Scope : sig
+  type t =
+    | Self
+    | Package of Package_name.t
+end
+
+type t =
+  { name : Name.t
+  ; scope : Scope.t
+  }
+
+val of_macro_invocation : Pform.Macro_invocation.t -> t option
+
+(** Parse an opam variable name. Identifiers begining with "<package>:" are
+    treated as package-scoped variables unless <package> is "_" in which case
+    they are treated as self-scoped. Identifiers without the "<package>:"
+    prefix are treated as self-scoped unless they are the name of an opam
+    global variable. Global variables are encoded as pform variables while all
+    other variables are encoded as pform macros with the [Macro.Pkg] macro. *)
+val pform_of_opam_ident : string -> Pform.t

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -19,9 +19,16 @@ type t =
   ; scope : Scope.t
   }
 
-val of_macro_invocation : Pform.Macro_invocation.t -> t option
+(** [of_macro_invocation ~loc macro_invocation] interprets a macro invocation
+    as a package variable. It's assumed that the macro invocation was created
+    using the [pform_of_opam_ident] function. This function expects the macro
+    to be [Pkg] or [Pkg_self] or an error is returned. *)
+val of_macro_invocation
+  :  loc:Loc.t
+  -> Pform.Macro_invocation.t
+  -> (t, [ `Unexpected_macro ]) result
 
-(** Parse an opam variable name. Identifiers begining with "<package>:" are
+(** Parse an opam variable name. Identifiers beginning with "<package>:" are
     treated as package-scoped variables unless <package> is "_" in which case
     they are treated as self-scoped. Identifiers without the "<package>:"
     prefix are treated as self-scoped unless they are the name of an opam

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -545,6 +545,7 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source (pform : Pfor
        let s = Pform.Macro_invocation.Args.whole macro_invocation in
        (match macro_invocation.macro with
         | Pkg -> Code_error.raise "pkg forms aren't possible here" []
+        | Pkg_self -> Code_error.raise "pkg-self forms aren't possible here" []
         | Ocaml_config ->
           static
           @@

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -508,35 +508,43 @@ module Action_expander = struct
         let roots = Paths.install_roots paths in
         let dir = section_dir_of_root roots section in
         Memo.return [ Value.Dir dir ]
-      | Macro macro_invocation ->
-        (match Pform.Macro_invocation.Args.split macro_invocation with
-         | [ "var"; name; var ] ->
-           let variables, paths =
-             let name = if name = "_" then paths.name else Package.Name.of_string name in
-             match Package.Name.Map.find deps name with
-             | None -> String.Map.empty, None
-             | Some (var, paths) -> var, Some paths
-           in
-           let present = Option.is_some paths in
-           (match String.Map.find variables var with
-            | Some v -> Memo.return @@ Variable.dune_value v
-            | None ->
-              (match var with
-               | "pinned" -> Memo.return [ Value.String "false" ]
-               | "enable" ->
-                 Memo.return [ Value.String (if present then "enable" else "disable") ]
-               | "installed" -> Memo.return [ Value.String (Bool.to_string present) ]
-               | _ ->
-                 (match paths with
-                  | None -> assert false
-                  | Some paths ->
-                    (match Pform.Var.Pkg.Section.of_string var with
-                     | None -> User_error.raise ~loc [ Pp.textf "invalid section %S" var ]
-                     | Some section ->
-                       let section = dune_section_of_pform section in
-                       let install_paths = Paths.install_paths paths in
-                       Memo.return [ Value.Dir (Install.Paths.get install_paths section) ]))))
-         | _ -> assert false)
+      | Macro ({ macro = Pkg; _ } as macro_invocation) ->
+        let { Package_variable.name = variable_name; scope } =
+          match Package_variable.of_macro_invocation macro_invocation with
+          | Some package_variable -> package_variable
+          | None -> assert false
+        in
+        let package_name =
+          match scope with
+          | Self -> paths.name
+          | Package package_name -> package_name
+        in
+        let variables, paths =
+          match Package.Name.Map.find deps package_name with
+          | None -> String.Map.empty, None
+          | Some (var, paths) -> var, Some paths
+        in
+        let present = Option.is_some paths in
+        let variable_name = Package_variable.Name.to_string variable_name in
+        (match String.Map.find variables variable_name with
+         | Some v -> Memo.return @@ Variable.dune_value v
+         | None ->
+           (match variable_name with
+            | "pinned" -> Memo.return [ Value.String "false" ]
+            | "enable" ->
+              Memo.return [ Value.String (if present then "enable" else "disable") ]
+            | "installed" -> Memo.return [ Value.String (Bool.to_string present) ]
+            | _ ->
+              (match paths with
+               | None -> assert false
+               | Some paths ->
+                 (match Pform.Var.Pkg.Section.of_string variable_name with
+                  | None ->
+                    User_error.raise ~loc [ Pp.textf "invalid section %S" variable_name ]
+                  | Some section ->
+                    let section = dune_section_of_pform section in
+                    let install_paths = Paths.install_paths paths in
+                    Memo.return [ Value.Dir (Install.Paths.get install_paths section) ]))))
       | Var Context_name -> Memo.return [ Value.String (Context_name.to_string context) ]
       | _ -> Expander0.isn't_allowed_in_this_position ~source
     ;;

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -60,6 +60,16 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   > build: [ "./configure" "--prefix=%{prefix" ]
   > EOF
 
+  $ mkpkg variable-types <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >   ["echo" local_var]
+  >   ["echo" _:explicit_local_var]
+  >   ["echo" foo:package_var]
+  >   ["echo" os-family]
+  > ]
+  > EOF
+
   $ solve_project <<EOF
   > (lang dune 3.8)
   > (package
@@ -67,10 +77,12 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   >  (depends
   >   standard-dune
   >   with-interpolation
-  >   with-percent-sign))
+  >   with-percent-sign
+  >   variable-types))
   > EOF
   Solution for dune.lock:
   standard-dune.0.0.1
+  variable-types.0.0.1
   with-interpolation.0.0.1
   with-percent-sign.0.0.1
   
@@ -78,7 +90,7 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   $ cat dune.lock/standard-dune.pkg
   (version 0.0.1)
   (install (run %{make} install))
-  (build (progn (run dune subst) (run dune build -p %{pkg:var:_:name} -j %{jobs} @install @runtest @doc)))
+  (build (progn (run dune subst) (run dune build -p %{pkg-self:name} -j %{jobs} @install @runtest @doc)))
 
   $ cat dune.lock/with-interpolation.pkg
   (version 0.0.1)
@@ -88,6 +100,10 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   $ cat dune.lock/with-percent-sign.pkg
   (version 0.0.1)
   (build (run printf %d 42))
+
+  $ cat dune.lock/variable-types.pkg
+  (version 0.0.1)
+  (build (progn (run echo %{pkg-self:local_var}) (run echo %{pkg-self:explicit_local_var}) (run echo %{pkg:package_var:foo}) (run echo %{os_family})))
 
   $ solve_project <<EOF
   > (lang dune 3.8)

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -21,9 +21,9 @@ Test that we can set variables
   > (deps test)
   > (build
   >  (progn
-  >   (system "\| echo %{pkg:var:test:abool}
-  >           "\| echo %{pkg:var:test:astring}
-  >           "\| echo %{pkg:var:test:somestrings}
+  >   (system "\| echo %{pkg:test:abool}
+  >           "\| echo %{pkg:test:astring}
+  >           "\| echo %{pkg:test:somestrings}
   >   )
   >   (run mkdir -p %{prefix})))
   > EOF


### PR DESCRIPTION
This change adds a small library for encoding and decoding package variables as pforms so we can change the way they are formatted without needing to touch multiple parts of the code. It then changes the format of the `pkg` macro to be more concise in an attempt to make it more ergonomic to use.