### PR TITLE
refactor: Improve [Findlib] handling

### DIFF
--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -21,9 +21,7 @@ let term =
        let open Memo.O in
        let* ctxs = Context.DB.all () in
        let ctx = List.hd ctxs in
-       let* findlib =
-         Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.ocaml.lib_config
-       in
+       let* findlib = Findlib.create ctx.name in
        let* all_packages = Findlib.all_packages findlib in
        if na
        then (

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -711,6 +711,21 @@ module DB = struct
     Memo.exec memo
   ;;
 
+  let create_db ~name f =
+    let map =
+      Memo.lazy_ ~name (fun () ->
+        let+ map = all () in
+        Context_name.Map.of_list_map_exn map ~f:(fun context ->
+          context.name, Memo.lazy_ (fun () -> f context)))
+    in
+    Staged.stage (fun context ->
+      let* map = Memo.Lazy.force map in
+      match Context_name.Map.find map context with
+      | Some v -> Memo.Lazy.force v
+      | None ->
+        Code_error.raise "invalid context" [ "context", Context_name.to_dyn context ])
+  ;;
+
   let by_dir dir =
     let context =
       match Dune_engine.Dpath.analyse_dir (Path.build dir) with

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -105,4 +105,9 @@ module DB : sig
   val get : Context_name.t -> t Memo.t
   val all : unit -> t list Memo.t
   val by_dir : Path.Build.t -> t Memo.t
+
+  val create_db
+    :  name:string
+    -> (t -> 'a Memo.t)
+    -> (Context_name.t -> 'a Memo.t) Staged.t
 end

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -158,7 +158,7 @@ let rec dep expander = function
          let context = Expander.context expander in
          Action_builder.of_memo
            (let open Memo.O in
-            let* sites = Sites.create context in
+            let* sites = Sites.create context.name in
             Sites.find_package sites pkg)
          >>= function
          | Some (Local pkg) ->

--- a/src/dune_rules/findlib.mli
+++ b/src/dune_rules/findlib.mli
@@ -5,7 +5,6 @@ open Import
 (** Findlib database *)
 type t
 
-val create : paths:Path.t list -> lib_config:Lib_config.t -> t Memo.t
 val lib_config : t -> Lib_config.t
 val findlib_predicates_set_by_dune : Variant.Set.t
 
@@ -33,3 +32,9 @@ val all_packages : t -> Dune_package.Entry.t list Memo.t
 
 (** List all the packages that have broken [dune-package] files *)
 val all_broken_packages : t -> (Package.Name.t * User_message.t) list Memo.t
+
+val create : Context_name.t -> t Memo.t
+
+module For_tests : sig
+  val create : paths:Path.t list -> lib_config:Lib_config.t -> t Memo.t
+end

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -505,7 +505,7 @@ end = struct
               Install.Entry.Sourced.create entry :: acc)
             else acc))
     and+ l =
-      let* sites = Sites.create ctx in
+      let* sites = Sites.create ctx.name in
       Dune_file.fold_stanzas stanzas ~init:[] ~f:(fun dune_file stanza acc ->
         let dir = Path.Build.append_source ctx.build_dir dune_file.dir in
         let named_entries =

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1799,9 +1799,7 @@ module DB = struct
 
   let installed (context : Context.t) =
     let open Memo.O in
-    let+ findlib =
-      Findlib.create ~paths:context.findlib_paths ~lib_config:context.ocaml.lib_config
-    in
+    let+ findlib = Findlib.create context.name in
     create_from_findlib findlib ~instrument_with:context.instrument_with
   ;;
 

--- a/src/dune_rules/sites.mli
+++ b/src/dune_rules/sites.mli
@@ -6,7 +6,7 @@ type any_package =
   | Local of Package.t
   | Installed of Dune_package.t
 
-val create : Context.t -> t Memo.t
+val create : Context_name.t -> t Memo.t
 val find_package : t -> Package.Name.t -> any_package option Memo.t
 
 val section_of_site

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -454,7 +454,7 @@ let create ~(context : Context.t) ~host ~packages ~stanzas =
           | Some s -> Some (Section.Set.add s section))
       in
       let+ package_sections =
-        let* sites = Sites.create context in
+        let* sites = Sites.create context.name in
         Dune_file.Memo_fold.fold_stanzas
           stanzas
           ~init:Package.Name.Map.empty

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -41,7 +41,7 @@ let findlib =
     }
   in
   Memo.lazy_ (fun () ->
-    Findlib.create ~paths:[ Path.outside_build_dir db_path ] ~lib_config)
+    Findlib.For_tests.create ~paths:[ Path.outside_build_dir db_path ] ~lib_config)
 ;;
 
 let resolve_pkg s =


### PR DESCRIPTION
Switch to memoizing the current [Findlib] instance per context.

This allows us to do even less work for [Sites.create] which is a
sparsely used feature.

replace [Lib_config] with [ext_lib] in findlib

remove [Findlib.DB] Just an unnecessary module without a purpose

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cba6f3b1-d03f-408a-8184-759cbaa1969b -->