### PR TITLE
refactor(findlib): functorize lookup

### DIFF
--- a/src/dune_findlib/meta.mli
+++ b/src/dune_findlib/meta.mli
@@ -58,6 +58,7 @@ end
 val complexify : Simplified.t -> t
 val of_string : string -> name:Package.Name.t option -> Simplified.t
 val load : Path.Outside_build_dir.t -> name:Package.Name.t option -> Simplified.t Memo.t
+val of_lex : Lexing.lexbuf -> name:Package.Name.t option -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when
     ocamlfind is not installed. *)

--- a/src/dune_findlib/package0.mli
+++ b/src/dune_findlib/package0.mli
@@ -16,7 +16,23 @@ val ppx_runtime_deps : t -> Lib_name.t list
 val kind : t -> Lib_kind.t
 val archives : t -> Path.t list Mode.Dict.t
 val plugins : t -> Path.t list Mode.Dict.t
-val exists : t -> is_builtin:bool -> bool Memo.t
+
+module Exists
+    (Monad : sig
+       type 'a t
+
+       val return : 'a -> 'a t
+
+       module List : sig
+         val for_all : 'a list -> f:('a -> bool t) -> bool t
+         val exists : 'a list -> f:('a -> bool t) -> bool t
+       end
+     end)
+    (_ : sig
+       val file_exists : Path.t -> bool Monad.t
+     end) : sig
+  val exists : t -> is_builtin:bool -> bool Monad.t
+end
 
 val candidates
   :  dir:Path.Outside_build_dir.t

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -496,34 +496,40 @@ module Or_meta = struct
          Dune_package package)
   ;;
 
-  let load file =
-    let dir = Path.parent_exn file in
-    let file_path = Path.as_outside_build_dir_exn file in
-    Fs_memo.with_lexbuf_from_file file_path ~f:(fun lexbuf ->
-      match
-        Vfile.parse_contents lexbuf ~f:(fun lang ->
-          String_with_vars.set_decoding_env
-            (Pform.Env.initial lang.version)
-            (decode ~lang ~dir))
-      with
-      | contents -> Ok contents
-      | exception User_error.E message -> Error message
-      | exception Sys_error msg ->
-        Error
-          (User_message.make
-             [ Pp.textf
-                 "Failed to read %s:"
-                 (Path.Outside_build_dir.to_string_maybe_quoted file_path)
-             ; Pp.text msg
-             ])
-      | exception End_of_file ->
-        Error
-          (User_message.make
-             [ Pp.textf
-                 "Unexpected end of file when reading %s."
-                 (Path.Outside_build_dir.to_string_maybe_quoted file_path)
-             ]))
-  ;;
+  module Load
+      (Monad : sig
+         type 'a t
+       end)
+      (Fs : sig
+         val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Monad.t
+       end) =
+  struct
+    let load file =
+      let dir = Path.parent_exn file in
+      Fs.with_lexbuf_from_file file ~f:(fun lexbuf ->
+        match
+          Vfile.parse_contents lexbuf ~f:(fun lang ->
+            String_with_vars.set_decoding_env
+              (Pform.Env.initial lang.version)
+              (decode ~lang ~dir))
+        with
+        | contents -> Ok contents
+        | exception User_error.E message -> Error message
+        | exception Sys_error msg ->
+          Error
+            (User_message.make
+               [ Pp.textf "Failed to read %s:" (Path.to_string_maybe_quoted file)
+               ; Pp.text msg
+               ])
+        | exception End_of_file ->
+          Error
+            (User_message.make
+               [ Pp.textf
+                   "Unexpected end of file when reading %s."
+                   (Path.to_string_maybe_quoted file)
+               ]))
+    ;;
+  end
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -64,6 +64,16 @@ module Or_meta : sig
     | Dune_package of t
 
   val pp : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
-  val load : Dpath.t -> (t, User_message.t) result Memo.t
+
+  module Load
+      (Monad : sig
+         type 'a t
+       end)
+      (_ : sig
+         val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Monad.t
+       end) : sig
+    val load : Path.t -> (t, User_message.t) result Monad.t
+  end
+
   val to_dyn : t Dyn.builder
 end


### PR DESCRIPTION
The file system operations will need to be done without [Fs_memo] to
avoid adding watches.

The monad will be [Identity.t] because we'll already be inside
[Action_builder]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ef0bd325-2e28-4a52-b108-4a5eed2001fb -->