### PR TITLE
fix: executing processes

### DIFF
--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_jobs.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_jobs.ml
@@ -80,5 +80,6 @@ let%expect_test "rpc jobs after rebuild" =
     Background process is running, let's interrupt it...
     Start 1 _build/default/foo
     Background process is running, let's interrupt it...
+    Stop 1
     Start 2 _build/default/foo |}]
 ;;


### PR DESCRIPTION
* in dune exec, the running process is already being killed by the
  polling loop. There's no need to do it twice.

* the action runner process shouldn't be restarted when the input
  changes

