### PR TITLE
feature(pkg): Write identifier of repository into metadata

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -348,7 +348,10 @@ val readdir_unsorted_with_kinds
      Result.t
 
 val is_dir_sep : char -> bool
+
+(** [is_dir t] checks if [t] is a directory. It swallows permission errors so the preferred way is to use [stat] instead *)
 val is_directory : t -> bool
+
 val rmdir : t -> unit
 val unlink : t -> unit
 val unlink_no_err : t -> unit

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -16,6 +16,7 @@
   opam_format
   opam_state
   opam_0install
-  fmt)
+  fmt
+  xdg)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -5,6 +5,7 @@ module Opam_file = Opam_file
 module Opam_repo = Opam_repo
 module Opam_solver = Opam_solver
 module Package_variable = Package_variable
+module Repository_id = Repository_id
 module Solver_env = Solver_env
 module Substs = Substs
 module Sys_poll = Sys_poll

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -18,3 +18,16 @@ val fetch
   -> target:Path.t
   -> OpamUrl.t
   -> (unit, failure) result Fiber.t
+
+module Opam_repository : sig
+  type t
+
+  type success =
+    { path : Path.t
+    ; repo_id : Repository_id.t option
+    }
+
+  val of_url : OpamUrl.t -> t
+  val default : t
+  val path : t -> (success, failure) result Fiber.t
+end

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -42,6 +42,7 @@ type t =
   { version : Syntax.Version.t
   ; packages : Pkg.t Package_name.Map.t
   ; ocaml : (Loc.t * Package_name.t) option
+  ; repo_id : (Loc.t * Repository_id.t) option
   }
 
 val remove_locs : t -> t
@@ -51,6 +52,7 @@ val to_dyn : t -> Dyn.t
 val create_latest_version
   :  Pkg.t Package_name.Map.t
   -> ocaml:(Loc.t * Package_name.t) option
+  -> repo_id:(Loc.t * Repository_id.t) option
   -> t
 
 val default_path : Path.Source.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -349,7 +349,7 @@ let solve_package_list local_packages context =
   | Ok packages -> Ok (Solver.packages_of_result packages)
 ;;
 
-let solve_lock_dir solver_env version_preference repo ~local_packages =
+let solve_lock_dir solver_env version_preference (repo, repo_id) ~local_packages =
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in
@@ -373,7 +373,8 @@ let solve_lock_dir solver_env version_preference repo ~local_packages =
              "Solver selected multiple packages named \"%s\""
              (Package_name.to_string name))
           []
-      | Ok pkgs_by_name -> Lock_dir.create_latest_version pkgs_by_name ~ocaml:None
+      | Ok pkgs_by_name ->
+        Lock_dir.create_latest_version pkgs_by_name ~ocaml:None ~repo_id
     in
     summary, lock_dir)
 ;;

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -11,6 +11,6 @@ end
 val solve_lock_dir
   :  Solver_env.t
   -> Version_preference.t
-  -> Opam_repo.t
+  -> Opam_repo.t * (Loc.t * Repository_id.t) option
   -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
   -> (Summary.t * Lock_dir.t, [ `Diagnostic_message of _ Pp.t ]) result

--- a/src/dune_pkg/repository_id.ml
+++ b/src/dune_pkg/repository_id.ml
@@ -1,0 +1,68 @@
+open Import
+
+type t = Git_hash of string
+
+let equal a b =
+  match a, b with
+  | Git_hash a, Git_hash b -> String.equal a b
+;;
+
+let encode : t -> Dune_sexp.t = function
+  | Git_hash commitish ->
+    List
+      [ Dune_lang.atom_or_quoted_string "git_hash"
+      ; Dune_lang.atom_or_quoted_string commitish
+      ]
+;;
+
+let decode =
+  let open Dune_sexp.Decoder in
+  let+ constr, stamp = pair string string in
+  match constr with
+  | "git_hash" -> Git_hash stamp
+  | _ -> failwith "TODO: parsing failure"
+;;
+
+let to_dyn = function
+  | Git_hash commitish -> Dyn.Variant ("Git_hash", [ String commitish ])
+;;
+
+let attempt_repo_id ~dir =
+  let head_path = Path.append_local dir (Path.Local.of_string "HEAD") in
+  match Path.lstat head_path with
+  | Ok { st_kind = S_REG; _ } ->
+    let head = Io.file_line head_path 0 in
+    (match String.lsplit2 head ~on:' ' with
+     | None ->
+       (* when checking out a commit *)
+       Some (Git_hash head)
+     | Some ("ref:", reference) ->
+       (* when a reference is checked out (e.g. a branch) *)
+       let reference = Path.Local.of_string reference in
+       let rev_path = Path.append_local dir reference in
+       let commit_id = Io.file_line rev_path 0 in
+       Some (Git_hash commit_id)
+     | Some _ -> None)
+  | Ok _ | Error _ -> None
+;;
+
+let repo_id_of_git dir =
+  let res = attempt_repo_id ~dir in
+  match res with
+  | Some _ as v -> v
+  | None ->
+    (* if it is not a bare repo the repo is in .git, try again here *)
+    let git_dir = Path.Local.of_string ".git" in
+    let dir = Path.append_local dir git_dir in
+    attempt_repo_id ~dir
+;;
+
+let of_path dir =
+  match Path.stat dir with
+  | Ok { st_kind = S_DIR; _ } -> repo_id_of_git dir
+  | Ok _ | Error _ -> None
+;;
+
+module Private = struct
+  let git_hash s = Git_hash s
+end

--- a/src/dune_pkg/repository_id.mli
+++ b/src/dune_pkg/repository_id.mli
@@ -1,0 +1,15 @@
+open Import
+
+(** [t] represents an identifier of the state of an opam repository that can
+    potentially be used to reproduce the lock dir/lock file exactly. *)
+type t
+
+val encode : t -> Dune_sexp.t
+val decode : t Dune_sexp.Decoder.t
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t
+val of_path : Path.t -> t option
+
+module Private : sig
+  val git_hash : string -> t
+end

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -183,11 +183,12 @@ let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
 let%expect_test "encode/decode round trip test for lockdir with no deps" =
   lock_dir_encode_decode_round_trip_test
     ~lock_dir_path:"empty_lock_dir"
-    ~lock_dir:(Lock_dir.create_latest_version Package_name.Map.empty ~ocaml:None);
+    ~lock_dir:
+      (Lock_dir.create_latest_version Package_name.Map.empty ~ocaml:None ~repo_id:None);
   [%expect
     {|
     lockdir matches after roundtrip:
-    { version = (0, 1); packages = map {}; ocaml = None } |}]
+    { version = (0, 1); packages = map {}; ocaml = None; repo_id = None } |}]
 ;;
 
 let%expect_test "encode/decode round trip test for lockdir with simple deps" =
@@ -212,6 +213,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
        in
        Lock_dir.create_latest_version
          ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
+         ~repo_id:None
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:"0.1.0"
             ; mk_pkg_basic ~name:"bar" ~version:"0.2.0"
@@ -250,6 +252,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               }
           }
     ; ocaml = Some ("simple_lock_dir/lock.dune:2", "ocaml")
+    ; repo_id = None
     } |}]
 ;;
 
@@ -341,6 +344,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
        in
        Lock_dir.create_latest_version
          ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
+         ~repo_id:(Some (Loc.none, Dune_pkg.Repository_id.Private.git_hash "95cf548dc"))
          (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ]));
   [%expect
     {|
@@ -399,5 +403,6 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               }
           }
     ; ocaml = Some ("complex_lock_dir/lock.dune:2", "ocaml")
+    ; repo_id = Some ("complex_lock_dir/lock.dune:3", Git_hash "95cf548dc")
     } |}]
 ;;


### PR DESCRIPTION
This PR adds an identifier of the repo that was passed in to the metadata so it is potentially feasible to recreate the lock with the exact same versions.

Currently supported identifiers are

1. Git commit hashes, if `git` was found and the repo is a `git` repo
2. ~~OPAM `stamp` values, if the repo has them set (opam-repository tarballs do)~~