### PR TITLE
Add with_prefix keyword for installing globs

### DIFF
--- a/doc/changes/8416.md
+++ b/doc/changes/8416.md
@@ -1,0 +1,2 @@
+- Add `with_prefix` keyword for changing the prefix of the destination of
+  installed files matched by globs. (#8416, @gridbugs)

--- a/doc/stanzas/install.rst
+++ b/doc/stanzas/install.rst
@@ -7,10 +7,10 @@ Dune supports installing packages on the system, i.e., copying freshly built
 artifacts from the workspace to the system. The ``install`` stanza takes three
 pieces of information:
 
-- The list of files or directories to install.
+- The list of files or directories to install
 - The package to attach these files. This field is optional if your project
   contains a single package.
-- The section in which the files will be installed.
+- The section in which the files will be installed
 
 For instance:
 
@@ -106,13 +106,13 @@ installed with mode ``0o644`` (``rw-r--r--``).
 Note that all files in the install stanza must be specified by relative paths
 only. It is an error to specify files by absolute paths.
 
-Also note that as of dune-lang 3.11 (ie. ``(lang dune 3.11)`` in
+Also note that as of dune-lang 3.11 (i.e., ``(lang dune 3.11)`` in
 ``dune-project``) it is deprecated to use the ``as`` keyword to specify a
 destination beginning with ``..``. Dune intends for files associated with a
 package to only be installed under specific directories in the file system
-implied by the installation section (e.g. ``share``, ``bin``, ``doc``, etc.)
+implied by the installation section (e.g., ``share``, ``bin``, ``doc``, etc.)
 and the package name. Starting destination paths with ``..`` allows packages to
-install files to arbitrary locations on the file system. In 3.11 this behaviour
+install files to arbitrary locations on the file system. In 3.11, this behaviour
 is still supported (as some projects may depend on it) but will generate a
 warning and will be removed in a future version of Dune.
 
@@ -218,7 +218,7 @@ example writing:
 
 ...would cause Dune to attempt to install the matching files to
 ``share/<package>/../``, ie. ``share`` where ``<package>`` is the name of the
-package (ie. ``dune-project`` would contain ``(package (name <package>))``).
+package (i.e., ``dune-project`` would contain ``(package (name <package>))``).
 This is probably not what the user intends, and installing files to relative
 paths beginning with ``..`` is deprecated from version 3.11 of Dune and will
 become an error in a future version.

--- a/doc/stanzas/install.rst
+++ b/doc/stanzas/install.rst
@@ -162,7 +162,9 @@ For example:
 .. code:: dune
 
     (install
-     (files (glob_files style/*.css) (glob_files_rec content/*.html))
+     (files
+      (glob_files style/*.css)
+      (glob_files_rec content/*.html))
      (section share))
 
 This example will install:
@@ -176,7 +178,61 @@ Note that the paths to files are preserved after installation. Suppose the
 source directory contained the files ``style/foo.css`` and
 ``content/bar/baz.html``. The example above will place these files in
 ``share/<package>/style/foo.css`` and ``share/<package>/content/bar/baz.html``
-respectively.
+respectively where ``<package>`` is the name of the package (ie.
+``dune-project`` would contain ``(package (name <package>))``).
+
+The ``with_prefix`` keyword can be used to change the destination path of files
+matched by a glob, similar to the ``as`` keyword in the ``(files ...)`` field.
+``with_prefix`` changes the prefix of a path before the component matched by the
+``*`` to some new value. For example:
+
+.. code:: dune
+
+    (install
+     (files
+      (glob_files (style/*.css with_prefix web/stylesheets))
+      (glob_files_rec (content/*.html with_prefix web/documents)))
+     (section share))
+
+Continuing the example above, this would result in the source file at
+``style/foo.css`` being installed to ``share/<package>/web/stylesheets/foo.css``
+and ``content/bar/baz.html`` being installed to
+``share/<package>/web/documents/bar/baz.html``. Note in the latter case
+``with_prefix`` only replaced the ``content`` component of the path and not the
+``bar`` component since since it replaces the prefix of the glob - not the
+prefix of paths matching the glob.
+
+Installing Globs from Parent Directories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default treatment of paths in globs creates a complication where referring
+to globs in a parent directory such as ``(glob_files ../*.txt)`` would attempt
+to install the matched files outside the designated install directory. For
+example writing:
+
+.. code:: dune
+
+    (install
+     (files (glob_files ../*.txt))
+     (section share))
+
+...would cause Dune to attempt to install the matching files to
+``share/<package>/../``, ie. ``share`` where ``<package>`` is the name of the
+package (ie. ``dune-project`` would contain ``(package (name <package>))``).
+This is probably not what the user intends, and installing files to relative
+paths beginning with ``..`` is deprecated from version 3.11 of Dune and will
+become an error in a future version.
+
+The solution is to use ``with_prefix`` to replace the ``..`` with some other
+path. For example:
+
+.. code:: dune
+
+    (install
+     (files (glob_files (../*.txt with_prefix .)))
+     (section share))
+
+...would install the matched files to ``share/<package>/`` instead.
 
 Handling of the .exe Extension on Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/dune_rules/dep_conf.ml
+++ b/src/dune_rules/dep_conf.ml
@@ -6,6 +6,10 @@ module Glob_files = struct
     { glob : String_with_vars.t
     ; recursive : bool
     }
+
+  let to_dyn { glob; recursive } =
+    Dyn.record [ "glob", String_with_vars.to_dyn glob; "recursive", Dyn.bool recursive ]
+  ;;
 end
 
 type t =

--- a/src/dune_rules/dep_conf.mli
+++ b/src/dune_rules/dep_conf.mli
@@ -12,6 +12,8 @@ module Glob_files : sig
     { glob : String_with_vars.t
     ; recursive : bool
     }
+
+  val to_dyn : t -> Dyn.t
 end
 
 type t =

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -141,6 +141,7 @@ let rec dep expander = function
          glob_files
          ~f:(Expander.expand_str expander)
          ~base_dir:(Expander.dir expander)
+       >>| Glob_files_expand.Expanded.matches
        >>| List.map ~f:(fun path ->
          if Filename.is_relative path
          then Path.Build.relative (Expander.dir expander) path |> Path.build

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -64,13 +64,20 @@ module Glob_dir = struct
         { relative_dir : string
         ; base_dir : Path.Build.t
         }
+
+  let to_dyn = function
+    | Absolute external_path ->
+      Dyn.variant "Absolute" [ Path.External.to_dyn external_path ]
+    | Relative { relative_dir; base_dir } ->
+      Dyn.variant "Relative" [ Dyn.string relative_dir; Path.Build.to_dyn base_dir ]
+  ;;
 end
 
 module Without_vars = struct
   (* A glob whose [String_with_vars.t] has been expanded. A [Glob.t] is a
-     wildcard for matching filenames only, not entire paths. The [relative_dir]
-     field holds the directory component of the original glob. E.g. for the glob
-     "foo/bar/*.txt", [relative_dir] would be "foo/bar". *)
+     wildcard for matching filenames only, not entire paths. The [dir] field
+     holds the directory component of the original glob. E.g. for the glob
+     "foo/bar/*.txt", [dir] would be "foo/bar". *)
   type t =
     { glob : Glob.t
     ; dir : Glob_dir.t
@@ -113,6 +120,25 @@ module Without_vars = struct
   ;;
 end
 
+module Expanded = struct
+  type t =
+    { matches : string list
+    ; dir : Glob_dir.t
+    }
+
+  let to_dyn { matches; dir } =
+    Dyn.record [ "matches", Dyn.list Dyn.string matches; "dir", Glob_dir.to_dyn dir ]
+  ;;
+
+  let matches { matches; _ } = matches
+
+  let prefix { dir; _ } =
+    match dir with
+    | Glob_dir.Absolute path -> Path.External.to_string path
+    | Relative { relative_dir; _ } -> relative_dir
+  ;;
+end
+
 module Expand
     (M : Memo.S)
     (C : sig
@@ -137,12 +163,15 @@ struct
     let open M.O in
     let loc = String_with_vars.loc t.glob in
     let* without_vars = expand_vars t ~f ~base_dir in
-    Without_vars.file_selectors_with_relative_dirs without_vars ~loc
-    |> M.of_memo
-    >>= M.List.concat_map ~f:(fun (file_selector, relative_dir) ->
-      C.collect_files ~loc file_selector
-      >>| Path.Set.to_list_map ~f:(replace_path_dir relative_dir))
-    >>| List.sort ~compare:String.compare
+    let+ matches =
+      Without_vars.file_selectors_with_relative_dirs without_vars ~loc
+      |> M.of_memo
+      >>= M.List.concat_map ~f:(fun (file_selector, relative_dir) ->
+        C.collect_files ~loc file_selector
+        >>| Path.Set.to_list_map ~f:(replace_path_dir relative_dir))
+      >>| List.sort ~compare:String.compare
+    in
+    { Expanded.matches; dir = without_vars.dir }
   ;;
 end
 

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -76,7 +76,7 @@ end
 module Without_vars = struct
   (* A glob whose [String_with_vars.t] has been expanded. A [Glob.t] is a
      wildcard for matching filenames only, not entire paths. The [dir] field
-     holds the directory component of the original glob. E.g. for the glob
+     holds the directory component of the original glob. E.g., for the glob
      "foo/bar/*.txt", [dir] would be "foo/bar". *)
   type t =
     { glob : Glob.t

--- a/src/dune_rules/glob_files_expand.mli
+++ b/src/dune_rules/glob_files_expand.mli
@@ -1,5 +1,16 @@
 open! Import
 
+module Expanded : sig
+  type t
+
+  val to_dyn : t -> Dyn.t
+  val matches : t -> string list
+
+  (** The component of the glob before the final "/". This is guaranteed to be
+      a common prefix of all matches patchs. *)
+  val prefix : t -> string
+end
+
 (** There are different contexts within which globs can be expanded, and this
     signature generalizes the [expand] function over them. These contexts affect
     the expressive power available in [f] when expanding [String_with_vars.t]s
@@ -12,7 +23,7 @@ val memo
   :  Dep_conf.Glob_files.t
   -> f:(String_with_vars.t -> string Memo.t)
   -> base_dir:Path.Build.t
-  -> string list Memo.t
+  -> Expanded.t Memo.t
 
 (** Expand a glob inside the [Action_builder] context. The result of calling
     [Glob_files.Action_builder.expand] is an action builder which will resolve
@@ -22,4 +33,4 @@ val action_builder
   :  Dep_conf.Glob_files.t
   -> f:(String_with_vars.t -> string Action_builder.t)
   -> base_dir:Path.Build.t
-  -> string list Action_builder.t
+  -> Expanded.t Action_builder.t

--- a/test/blackbox-tests/test-cases/install/install-glob/install-glob-relative.t
+++ b/test/blackbox-tests/test-cases/install/install-glob/install-glob-relative.t
@@ -43,3 +43,24 @@ Incorrect install stanza that would place files outside the package's install di
   stanzas beginning with .. will be disallowed to prevent a package's installed
   files from escaping that package's install directories.
 
+
+Correction to the above which uses `with_prefix` to change the install destination:
+  $ cat >stanza/dune <<EOF
+  > (install
+  >  (files (glob_files_rec (../stuff/*.txt with_prefix stuff)))
+  >  (section share))
+  > EOF
+
+  $ dune build foo.install
+
+
+  $ grep txt _build/default/foo.install
+    "_build/install/default/share/foo/foo.txt"
+    "_build/install/default/share/foo/stuff/foo.txt" {"stuff/foo.txt"}
+    "_build/install/default/share/foo/stuff/xy/bar.txt" {"stuff/xy/bar.txt"}
+
+  $ dune install foo --prefix _foo
+  $ find _foo | sort | grep txt
+  _foo/share/foo/foo.txt
+  _foo/share/foo/stuff/foo.txt
+  _foo/share/foo/stuff/xy/bar.txt

--- a/test/blackbox-tests/test-cases/install/install-glob/install-glob-with-prefix.t
+++ b/test/blackbox-tests/test-cases/install/install-glob/install-glob-with-prefix.t
@@ -1,0 +1,186 @@
+Examples of the with-prefix feature
+
+  $ touch a.txt b.txt c.txt d.md e.md
+
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files (*.txt with_prefix bar)))
+  >  (section share))
+  > EOF
+
+Test that the feature is unavailable before 3.11
+  $ cat >dune-project <<EOF
+  > (lang dune 3.10)
+  > (package
+  >  (name foo))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 2, characters 20-43:
+  2 |  (files (glob_files (*.txt with_prefix bar)))
+                          ^^^^^^^^^^^^^^^^^^^^^^^
+  Error: This syntax is only available since version 3.11 of the dune language.
+  Please update your dune-project file to have (lang dune 3.11).
+  [1]
+
+Basic example of using this feature:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/bar/a.txt" {"bar/a.txt"}
+    "_build/install/default/share/foo/bar/b.txt" {"bar/b.txt"}
+    "_build/install/default/share/foo/bar/c.txt" {"bar/c.txt"}
+  ]
+
+Test with multiple with_prefix blocks in a single files entry:
+  $ cat >dune <<EOF
+  > (install
+  >  (files
+  >   (glob_files (*.txt with_prefix txt))
+  >   (glob_files (*.md with_prefix md)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/md/d.md" {"md/d.md"}
+    "_build/install/default/share/foo/md/e.md" {"md/e.md"}
+    "_build/install/default/share/foo/txt/a.txt" {"txt/a.txt"}
+    "_build/install/default/share/foo/txt/b.txt" {"txt/b.txt"}
+    "_build/install/default/share/foo/txt/c.txt" {"txt/c.txt"}
+  ]
+
+Use "." as the prefix:
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files (*.txt with_prefix .)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/a.txt" {"./a.txt"}
+    "_build/install/default/share/foo/b.txt" {"./b.txt"}
+    "_build/install/default/share/foo/c.txt" {"./c.txt"}
+  ]
+
+Use a pform in the prefix:
+  $ printf baz > prefix
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files (*.txt with_prefix %{read:prefix})))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/baz/a.txt" {"baz/a.txt"}
+    "_build/install/default/share/foo/baz/b.txt" {"baz/b.txt"}
+    "_build/install/default/share/foo/baz/c.txt" {"baz/c.txt"}
+  ]
+
+Use a prefix with a recursive glob:
+  $ mkdir -p a/b/c
+  $ touch a/x.txt a/b/y.txt a/b/c/z.txt
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files_rec (*.txt with_prefix qux)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/qux/a.txt" {"qux/a.txt"}
+    "_build/install/default/share/foo/qux/a/b/c/z.txt" {"qux/a/b/c/z.txt"}
+    "_build/install/default/share/foo/qux/a/b/y.txt" {"qux/a/b/y.txt"}
+    "_build/install/default/share/foo/qux/a/x.txt" {"qux/a/x.txt"}
+    "_build/install/default/share/foo/qux/b.txt" {"qux/b.txt"}
+    "_build/install/default/share/foo/qux/c.txt" {"qux/c.txt"}
+  ]
+
+Demonstrating behaviour of `with_prefix` on globs with a prefix:
+  $ mkdir -p path/to/files
+  $ touch path/to/files/foo.txt path/to/files/bar.txt path/to/files/baz.txt
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files (path/to/files/*.txt with_prefix some/new/path/)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/some/new/path/bar.txt" {"some/new/path/bar.txt"}
+    "_build/install/default/share/foo/some/new/path/baz.txt" {"some/new/path/baz.txt"}
+    "_build/install/default/share/foo/some/new/path/foo.txt" {"some/new/path/foo.txt"}
+  ]
+
+Replacing the prefix with the empty string works the same as with ".".
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files_rec (*.txt with_prefix "")))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/a.txt"
+    "_build/install/default/share/foo/a/b/c/z.txt" {"a/b/c/z.txt"}
+    "_build/install/default/share/foo/a/b/y.txt" {"a/b/y.txt"}
+    "_build/install/default/share/foo/a/x.txt" {"a/x.txt"}
+    "_build/install/default/share/foo/b.txt"
+    "_build/install/default/share/foo/c.txt"
+    "_build/install/default/share/foo/path/to/files/bar.txt" {"path/to/files/bar.txt"}
+    "_build/install/default/share/foo/path/to/files/baz.txt" {"path/to/files/baz.txt"}
+    "_build/install/default/share/foo/path/to/files/foo.txt" {"path/to/files/foo.txt"}
+  ]
+
+It's an error to use an absolute path as the prefix.
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files_rec (*.txt with_prefix /some/absolute/path)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 2, characters 43-62:
+  2 |  (files (glob_files_rec (*.txt with_prefix /some/absolute/path)))
+                                                 ^^^^^^^^^^^^^^^^^^^
+  Error: Absolute paths are not allowed in the install stanza.
+  [1]
+
+The root directory is treated like an absolute path (ie. it's an error).
+  $ cat >dune <<EOF
+  > (install
+  >  (files (glob_files_rec (*.txt with_prefix /)))
+  >  (section share))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 2, characters 43-44:
+  2 |  (files (glob_files_rec (*.txt with_prefix /)))
+                                                 ^
+  Error: Absolute paths are not allowed in the install stanza.
+  [1]

--- a/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
+++ b/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
@@ -142,6 +142,28 @@ Test that we get an error if `(source_tree ...)` has a dst that is exactly "..":
   installed files from escaping that package's install directories.
   [1]
 
+Test that we get a warning if the ".." comes from the prefix of a glob:
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc)
+  >  (files (glob_files_rec (a/*.txt with_prefix ../baz))))
+  > EOF
+  $ dune build foo.install && cat _build/default/foo.install
+  File "dune", line 3, characters 45-51:
+  3 |  (files (glob_files_rec (a/*.txt with_prefix ../baz))))
+                                                   ^^^^^^
+  Warning: The destination path ../baz/b.txt begins with .. which will become
+  an error in a future version of Dune. Destinations of files in install
+  stanzas beginning with .. will be disallowed to prevent a package's installed
+  files from escaping that package's install directories.
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  etc: [
+    "_build/install/default/etc/baz/b.txt" {"../baz/b.txt"}
+  ]
+
 Test that on older versions of dune we don't get warnings in this case:
   $ cat >dune-project <<EOF
   > (lang dune 3.10)


### PR DESCRIPTION
This allows the `(glob_files[_rec] ...)` construct to specify an alternative prefix for destinations when installing files. Previously the prefix of the glob (the part before the `*`) would be used but this proved too inflexible in some cases such as when the glob starts with "..".