### PR TITLE
refactor(engine): simplify file/dir conflict checking

### DIFF
--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -702,17 +702,12 @@ end = struct
            don't check directory targets as these are already checked
            earlier. *)
         (match
-           let target_filenames =
-             Path.Build.Set.to_list_map ~f:Path.Build.basename targets.files
-             |> Filename.Set.of_list
-           in
-           Filename.Set.choose
-             (* TODO it's unnecessary to compute the entire intersection to
-                just check if there's an overlap between the two sets *)
-             (Subdir_set.inter_set build_dir_only_sub_dirs target_filenames)
+           Path.Build.Set.find targets.files ~f:(fun file ->
+             Subdir_set.mem build_dir_only_sub_dirs (Path.Build.basename file))
          with
          | None -> ()
-         | Some target_name -> report_rule_internal_dir_conflict target_name loc);
+         | Some target_name ->
+           report_rule_internal_dir_conflict (Path.Build.basename target_name) loc);
         match mode with
         | Standard | Fallback -> acc
         | Ignore_source_files ->

--- a/src/dune_engine/subdir_set.ml
+++ b/src/dune_engine/subdir_set.ml
@@ -38,9 +38,4 @@ let union a b =
   | These a, These b -> These (Filename.Set.union a b)
 ;;
 
-let inter_set = function
-  | All -> Fun.id
-  | These t -> Filename.Set.inter t
-;;
-
 let union_all = List.fold_left ~init:empty ~f:union

--- a/src/dune_engine/subdir_set.mli
+++ b/src/dune_engine/subdir_set.mli
@@ -13,5 +13,4 @@ val empty : t
 val is_empty : t -> bool
 val mem : t -> Filename.t -> bool
 val union : t -> t -> t
-val inter_set : t -> Filename.Set.t -> Filename.Set.t
 val union_all : t list -> t


### PR DESCRIPTION
* Remove the [Subdir_set.inter_set] function. It's quite specialized and
  is used only in one place (inappropriately)

* Simplify the conflict check for build_dir_only_sub_dirs and file
  targets. We don't need to build an intermediate set. If we're going to
  traverse the files, we might as well do the check directly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5623644e-6ec4-4c18-87eb-9333684bdbb5 -->