### PR TITLE
refactor: simplify diagnostic event type

### DIFF
--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -142,7 +142,7 @@ end = struct
           ~init:(`Add_only [], state.diagnostics)
           ~f:(fun (mode, acc) diag_event ->
             match (diag_event : Diagnostic.Event.t) with
-            | Remove diag -> `Remove, Diagnostic_id_map.remove acc diag.id
+            | Remove id -> `Remove, Diagnostic_id_map.remove acc id
             | Add diag ->
               ( (match mode with
                  | `Add_only diags -> `Add_only (diag :: diags)

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -148,7 +148,7 @@ module V1 : sig
     module Event : sig
       type nonrec t =
         | Add of t
-        | Remove of t
+        | Remove of Id.t
     end
   end
 

--- a/otherlibs/dune-rpc/private/exported_types.ml
+++ b/otherlibs/dune-rpc/private/exported_types.ml
@@ -290,13 +290,13 @@ module Diagnostic = struct
   module Event = struct
     type nonrec t =
       | Add of t
-      | Remove of t
+      | Remove of Id.t
 
     let sexp =
       let diagnostic = sexp in
       let open Conv in
       let add = constr "Add" diagnostic (fun a -> Add a) in
-      let remove = constr "Remove" diagnostic (fun a -> Remove a) in
+      let remove = constr "Remove" Id.sexp (fun a -> Remove a) in
       sum
         [ econstr add; econstr remove ]
         (function

--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -94,7 +94,7 @@ module Diagnostic : sig
   module Event : sig
     type nonrec t =
       | Add of t
-      | Remove of t
+      | Remove of Id.t
 
     val to_dyn : t -> Dyn.t
     val sexp : (t, Conv.values) Conv.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -44,7 +44,7 @@ module Error = struct
   module Event = struct
     type nonrec t =
       | Add of t
-      | Remove of t
+      | Remove of Id.t
   end
 
   let of_exn (exn : Exn_with_backtrace.t) =
@@ -129,7 +129,7 @@ module Error = struct
         (match x, y with
          | Add x, Add y -> Id.equal (id x) (id y)
          | Add _, _ -> false
-         | Remove x, Remove y -> Id.equal (id x) (id y)
+         | Remove id_x, Remove id_y -> Id.equal id_x id_y
          | Remove _, _ -> false)
       | Some _, None | None, Some _ -> false
     ;;

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -111,7 +111,7 @@ module Error : sig
   module Event : sig
     type nonrec t =
       | Add of t
-      | Remove of t
+      | Remove of Id.t
   end
 
   module Set : sig

--- a/src/dune_rpc_impl/diagnostics.ml
+++ b/src/dune_rpc_impl/diagnostics.ml
@@ -14,6 +14,10 @@ let absolutize_paths ~dir (loc : Loc.t) =
   |> Loc.to_lexbuf_loc
 ;;
 
+let diagnostic_id_of_error_id : Build_system.Error.Id.t -> Diagnostic.Id.t =
+  fun id -> Diagnostic.Id.create (Build_system.Error.Id.to_int id)
+;;
+
 let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t =
   fun m ->
   let dir =
@@ -33,9 +37,7 @@ let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t 
   in
   let loc = Option.map message.loc ~f:make_loc in
   let make_message pars = Pp.map_tags (Pp.concat pars) ~f:(fun _ -> ()) in
-  let id =
-    Build_system.Error.id m |> Build_system.Error.Id.to_int |> Diagnostic.Id.create
-  in
+  let id = Build_system.Error.id m |> diagnostic_id_of_error_id in
   let promotion =
     match Build_system.Error.promotion m with
     | None -> []
@@ -65,6 +67,6 @@ let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t 
 
 let diagnostic_event_of_error_event (e : Build_system.Error.Event.t) : Diagnostic.Event.t =
   match e with
-  | Remove e -> Remove (diagnostic_of_error e)
+  | Remove e -> Remove (diagnostic_id_of_error_id e)
   | Add e -> Add (diagnostic_of_error e)
 ;;

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -248,7 +248,8 @@ let handler (t : _ t Fdecl.t) action_runner_server handle : 'a Dune_rpc_server.H
                match prev, now with
                | None, None -> assert false
                | Some prev, None ->
-                 Some (Diagnostics.diagnostic_event_of_error_event (Remove prev))
+                 Some
+                   (Diagnostics.diagnostic_event_of_error_event (Remove (Error.id prev)))
                | _, Some next ->
                  Some (Diagnostics.diagnostic_event_of_error_event (Add next)))
            |> Error.Id.Map.values)

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -917,7 +917,10 @@ let%expect_test "print digests for all public RPCs" =
     {|
     Version 1:
       Request: Sexp
-      Response: 443627a52ab5595206164d020ff01c56 |}];
+      Response: 443627a52ab5595206164d020ff01c56
+    Version 2:
+      Request: Sexp
+      Response: 942b884c59dc2c0c5e8fb9768e3b9633 |}];
   Decl.Request.print_generations (Procedures.Poll.poll Procedures.Poll.running_jobs);
   [%expect
     {|

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -42,7 +42,7 @@ let on_diagnostic_event diagnostics =
   (* function to remove remove pp tags and hide junk from paths *)
   let map_event (d : Diagnostic.Event.t) f : Diagnostic.Event.t =
     match d with
-    | Remove e -> Remove (f e)
+    | Remove e -> Remove e
     | Add e -> Add (f e)
   in
   let sanitize (d : Diagnostic.t) =
@@ -536,41 +536,8 @@ let%expect_test "create and fix error" =
         Building ./foo.exe
         Build ./foo.exe succeeded |}];
     let+ () = print_diagnostics poll in
-    [%expect
-      {|
-        [ "Remove"
-        ; [ [ "directory"; "$CWD" ]
-          ; [ "id"; "0" ]
-          ; [ "loc"
-            ; [ [ "start"
-                ; [ [ "pos_bol"; "0" ]
-                  ; [ "pos_cnum"; "23" ]
-                  ; [ "pos_fname"; "$CWD/foo.ml" ]
-                  ; [ "pos_lnum"; "1" ]
-                  ]
-                ]
-              ; [ "stop"
-                ; [ [ "pos_bol"; "0" ]
-                  ; [ "pos_cnum"; "26" ]
-                  ; [ "pos_fname"; "$CWD/foo.ml" ]
-                  ; [ "pos_lnum"; "1" ]
-                  ]
-                ]
-              ]
-            ]
-          ; [ "message"
-            ; [ "Verbatim"
-              ; "This expression has type int but an expression was expected of type\n\
-                \  string\n\
-                 "
-              ]
-            ]
-          ; [ "promotion"; [] ]
-          ; [ "related"; [] ]
-          ; [ "severity"; "error" ]
-          ; [ "targets"; [] ]
-          ]
-        ] |}]);
+    [%expect {|
+        [ "Remove"; "0" ] |}]);
   [%expect {| |}]
 ;;
 


### PR DESCRIPTION
Before we were using
```
type t =
  | Add of Diagnostic.t
  | Remove of Diagnostic.t
```
now we use
```
type t =
  | Add of Diagnostic.t
  | Remove of Diagnostic.Id.t
```

We bump the RPC version for the diagnostic procedure to account for this new type.