### PR TITLE
refactor: unify toggling in cache/config

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Dune_config
 open Dune_config_file
 module Console = Dune_console
 module Graph = Dune_graph.Graph
@@ -406,12 +407,12 @@ let shared_with_config_file =
     let doc =
       Printf.sprintf
         "Enable or disable Dune cache (%s). Default is `%s'."
-        (Arg.doc_alts_enum Dune_config.Cache.Enabled.all)
-        (Dune_config.Cache.Enabled.to_string Dune_config.default.cache_enabled)
+        (Arg.doc_alts_enum Config.Toggle.all)
+        (Config.Toggle.to_string Dune_config.default.cache_enabled)
     in
     Arg.(
       value
-      & opt (some (enum Dune_config.Cache.Enabled.all)) None
+      & opt (some (enum Config.Toggle.all)) None
       & info [ "cache" ] ~docs ~env:(Cmd.Env.info ~doc "DUNE_CACHE") ~doc)
   and+ cache_storage_mode =
     let doc =
@@ -1160,18 +1161,14 @@ let init ?action_runner ?log_file c =
   Dune_rules.Global.init ~capture_outputs:c.builder.capture_outputs;
   let cache_config =
     match config.cache_enabled with
-    | Disabled -> Dune_cache.Config.Disabled
-    | Enabled ->
+    | `Disabled -> Dune_cache.Config.Disabled
+    | `Enabled ->
       Enabled
         { storage_mode = Option.value config.cache_storage_mode ~default:Hardlink
         ; reproducibility_check = config.cache_reproducibility_check
         }
   in
-  Log.info
-    [ Pp.textf
-        "Shared cache: %s"
-        (Dune_config.Cache.Enabled.to_string config.cache_enabled)
-    ];
+  Log.info [ Pp.textf "Shared cache: %s" (Config.Toggle.to_string config.cache_enabled) ];
   let action_runner =
     match action_runner with
     | None -> None

--- a/bin/dune
+++ b/bin/dune
@@ -34,6 +34,7 @@
   ; Kept to keep implicit_transitive_deps false working in 4.x
   threads.posix
   build_info
+  dune_config
   dune_config_file
   chrome_trace
   dune_stats

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -27,10 +27,24 @@ module Toggle = struct
     | `Disabled
     ]
 
-  let of_string = function
-    | "enabled" -> Ok `Enabled
-    | "disabled" -> Ok `Disabled
-    | _ -> Error (sprintf "only %S and %S are allowed" "enabled" "disabled")
+  let all : (string * t) list = [ "enabled", `Enabled; "disabled", `Disabled ]
+
+  let to_string t =
+    List.find_map all ~f:(fun (k, v) -> if Poly.equal v t then Some k else None)
+    |> Option.value_exn
+  ;;
+
+  let of_string s =
+    match List.assoc all s with
+    | Some s -> Ok s
+    | None -> Error (sprintf "only %S and %S are allowed" "enabled" "disabled")
+  ;;
+
+  let to_dyn =
+    let open Dyn in
+    function
+    | `Enabled -> variant "Enabled" []
+    | `Disabled -> variant "Disabled" []
   ;;
 end
 

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -15,6 +15,11 @@ module Toggle : sig
     [ `Enabled
     | `Disabled
     ]
+
+  val all : (string * t) list
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val to_dyn : t -> Dyn.t
 end
 
 (** [get t] return the value of the configuration for [t] *)

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -79,26 +79,6 @@ module Dune_config = struct
   end
 
   module Cache = struct
-    module Enabled = struct
-      type t =
-        | Enabled
-        | Disabled
-
-      let all = [ "enabled", Enabled; "disabled", Disabled ]
-
-      let to_string = function
-        | Enabled -> "enabled"
-        | Disabled -> "disabled"
-      ;;
-
-      let to_dyn = function
-        | Enabled -> Dyn.Variant ("Enabled", [])
-        | Disabled -> Dyn.Variant ("Disabled", [])
-      ;;
-
-      let decode = enum all
-    end
-
     module Transport_deprecated = struct
       type t =
         | Daemon
@@ -141,7 +121,7 @@ module Dune_config = struct
       ; concurrency : Concurrency.t field
       ; terminal_persistence : Terminal_persistence.t field
       ; sandboxing_preference : Sandboxing_preference.t field
-      ; cache_enabled : Cache.Enabled.t field
+      ; cache_enabled : Config.Toggle.t field
       ; cache_reproducibility_check : Dune_cache.Config.Reproducibility_check.t field
       ; cache_storage_mode : Cache.Storage_mode.t field
       ; action_stdout_on_success : Action_output_on_success.t field
@@ -205,7 +185,7 @@ module Dune_config = struct
         ; "terminal_persistence", field Terminal_persistence.to_dyn terminal_persistence
         ; ( "sandboxing_preference"
           , field (Dyn.list Sandbox_mode.to_dyn) sandboxing_preference )
-        ; "cache_enabled", field Cache.Enabled.to_dyn cache_enabled
+        ; "cache_enabled", field Config.Toggle.to_dyn cache_enabled
         ; ( "cache_reproducibility_check"
           , field
               Dune_cache.Config.Reproducibility_check.to_dyn
@@ -299,7 +279,7 @@ module Dune_config = struct
     ; concurrency = (if Execution_env.inside_dune then Fixed 1 else Auto)
     ; terminal_persistence = Clear_on_rebuild
     ; sandboxing_preference = []
-    ; cache_enabled = Disabled
+    ; cache_enabled = `Disabled
     ; cache_reproducibility_check = Skip
     ; cache_storage_mode = None
     ; action_stdout_on_success = Print
@@ -320,7 +300,7 @@ module Dune_config = struct
       field_o "terminal-persistence" (1, 0) Terminal_persistence.decode
     and+ sandboxing_preference =
       field_o "sandboxing_preference" (1, 0) Sandboxing_preference.decode
-    and+ cache_enabled = field_o "cache" (2, 0) Cache.Enabled.decode
+    and+ cache_enabled = field_o "cache" (2, 0) (enum Config.Toggle.all)
     and+ _cache_transport_unused_since_3_0 =
       field_o
         "cache-transport"

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -2,6 +2,7 @@ module Dune_config : sig
   (** Dune configuration (visible to the user) *)
 
   open Stdune
+  open Dune_config
   module Display : module type of Display
 
   module Concurrency : sig
@@ -18,16 +19,6 @@ module Dune_config : sig
   end
 
   module Cache : sig
-    module Enabled : sig
-      type t =
-        | Enabled
-        | Disabled
-
-      val all : (string * t) list
-      val decode : t Dune_lang.Decoder.t
-      val to_string : t -> string
-    end
-
     module Storage_mode : sig
       type t = Dune_cache_storage.Mode.t option
 
@@ -60,7 +51,7 @@ module Dune_config : sig
       ; concurrency : Concurrency.t field
       ; terminal_persistence : Terminal_persistence.t field
       ; sandboxing_preference : Sandboxing_preference.t field
-      ; cache_enabled : Cache.Enabled.t field
+      ; cache_enabled : Config.Toggle.t field
       ; cache_reproducibility_check : Dune_cache.Config.Reproducibility_check.t field
       ; cache_storage_mode : Cache.Storage_mode.t field
       ; action_stdout_on_success : Action_output_on_success.t field


### PR DESCRIPTION
Use the same type and decoders in both places

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fa30e4d3-991a-4e82-98e2-4b7fe645abd1 -->