### PR TITLE
refactor: move [with_vendored_flags]

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -15,7 +15,7 @@ let ocaml_flags sctx ~dir melange =
   | false -> flags
   | true ->
     let ocaml_version = (Super_context.context sctx).ocaml.version in
-    Super_context.with_vendored_flags ~ocaml_version flags
+    Ocaml_flags.with_vendored_flags ~ocaml_version flags
 ;;
 
 let output_of_lib ~target_dir lib =

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -165,3 +165,10 @@ let dump t =
     ; "melange.compile_flags", melange
     ]
 ;;
+
+let with_vendored_flags flags ~ocaml_version =
+  let with_warnings = with_vendored_warnings flags in
+  if Ocaml.Version.supports_alerts ocaml_version
+  then with_vendored_alerts with_warnings
+  else with_warnings
+;;

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -35,6 +35,6 @@ val empty : t
 val of_list : string list -> t
 val get : t -> Lib_mode.t -> string list Action_builder.t
 val append_common : t -> string list -> t
-val with_vendored_warnings : t -> t
 val with_vendored_alerts : t -> t
 val dump : t -> Dune_lang.t list Action_builder.t
+val with_vendored_flags : t -> ocaml_version:Version.t -> t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -287,13 +287,6 @@ let add_alias_action t alias ~dir ~loc action =
     build
 ;;
 
-let with_vendored_flags ~ocaml_version flags =
-  let with_warnings = Ocaml_flags.with_vendored_warnings flags in
-  if Ocaml.Version.supports_alerts ocaml_version
-  then Ocaml_flags.with_vendored_alerts with_warnings
-  else with_warnings
-;;
-
 let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
   let* expander = Env_tree.expander t ~dir in
   let* flags =
@@ -305,10 +298,10 @@ let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
   in
   Source_tree.is_vendored (Path.Build.drop_build_context_exn dir)
   >>| function
+  | false -> flags
   | true ->
     let ocaml_version = (Env_tree.context t).ocaml.version in
-    with_vendored_flags ~ocaml_version flags
-  | false -> flags
+    Ocaml_flags.with_vendored_flags ~ocaml_version flags
 ;;
 
 let js_of_ocaml_runtest_alias t ~dir =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -23,8 +23,6 @@ val context : t -> Context.t
 (** Context env with additional variables computed from packages *)
 val context_env : t -> Env.t
 
-val with_vendored_flags : ocaml_version:Version.t -> Ocaml_flags.t -> Ocaml_flags.t
-
 (** Compute the ocaml flags based on the directory environment and a buildable
     stanza *)
 val ocaml_flags : t -> dir:Path.Build.t -> Ocaml_flags.Spec.t -> Ocaml_flags.t Memo.t


### PR DESCRIPTION
Make it live in [Ocaml_flags] instead. With two benefits:

* We get to hide [with_vendored_warnings]
* We remove yet another thing from [Super_context]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8e0d520b-fc64-4498-be21-422ae1429d7b -->