### PR TITLE
Add `when` action available in lockfiles

### DIFF
--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -118,6 +118,7 @@ type t =
   | Patch of String_with_vars.t
   | Substitute of String_with_vars.t * String_with_vars.t
   | Withenv of String_with_vars.t Env_update.t list * t
+  | When of Blang.t * t
 
 val encode : t Encoder.t
 val decode_dune_file : t Decoder.t

--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -26,6 +26,25 @@ module Op = struct
     | Lt -> string "Lt"
     | Neq -> string "Neq"
   ;;
+
+  let equal a b =
+    match a, b with
+    | Eq, Eq -> true
+    | Gt, Gt -> true
+    | Gte, Gte -> true
+    | Lte, Lte -> true
+    | Lt, Lt -> true
+    | Neq, Neq -> true
+    | _ -> false
+  ;;
+
+  let by_string = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
+  let to_string t = fst (List.find_exn by_string ~f:(fun (_, op) -> equal op t))
+
+  let encode t =
+    let open Encoder in
+    string (to_string t)
+  ;;
 end
 
 type t =
@@ -52,12 +71,10 @@ let rec to_dyn =
       [ Op.to_dyn o; String_with_vars.to_dyn s1; String_with_vars.to_dyn s2 ]
 ;;
 
-let ops = [ "=", Op.Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
-
 let decode_gen decode_string =
   let open Decoder in
   let ops =
-    List.map ops ~f:(fun (name, op) ->
+    List.map Op.by_string ~f:(fun (name, op) ->
       ( name
       , let+ x = decode_string
         and+ y = decode_string in
@@ -81,3 +98,16 @@ let decode_gen decode_string =
 
 let decode = decode_gen String_with_vars.decode
 let decode_manually f = decode_gen (String_with_vars.decode_manually f)
+
+let rec encode t =
+  let open Encoder in
+  match t with
+  | Const true -> string "true"
+  | Const false -> string "false"
+  | Not t -> List [ string "not"; encode t ]
+  | Expr e -> String_with_vars.encode e
+  | And ts -> List (string "and" :: List.map ts ~f:encode)
+  | Or ts -> List (string "or" :: List.map ts ~f:encode)
+  | Compare (o, s1, s2) ->
+    List [ Op.encode o; String_with_vars.encode s1; String_with_vars.encode s2 ]
+;;

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -24,6 +24,7 @@ type t =
 val true_ : t
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t
+val encode : t Encoder.t
 
 (** Resolve variables manually. For complex cases such as [enabled_if] *)
 val decode_manually : (Pform.Env.t -> Template.Pform.t -> Pform.t) -> t Decoder.t

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -547,7 +547,7 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
   | Cram script ->
     let+ script = E.dep script in
     Cram_exec.action script
-  | Withenv _ | Substitute _ | Patch _ ->
+  | Withenv _ | Substitute _ | Patch _ | When _ ->
     (* these can only be provided by the package language which isn't expanded here *)
     assert false
 ;;

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
@@ -1,0 +1,27 @@
+Testing the when action in lockfiles
+
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+
+Case with a mix of uncoditional and conditional actions in a progn action
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (install
+  >  (progn
+  >   (when (= foo foo)
+  >    (run echo a))
+  >   (when (<> foo foo)
+  >    (run echo b))
+  >   (when (<> foo bar)
+  >    (run echo c))
+  >   (when (< 1 2)
+  >    (run echo d))
+  >   (when (< 2 1)
+  >    (run echo e))))
+  > EOF
+
+  $ dune build .pkg/test/target/
+  a
+  c
+  d

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
@@ -1,5 +1,7 @@
 Testing the when action in lockfiles
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -21,7 +23,7 @@ Case with a mix of uncoditional and conditional actions in a progn action
   >    (run echo e))))
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   a
   c
   d


### PR DESCRIPTION
The `when` action will be used in package management to implement build commands which are conditional on some filter (this is a feature of opam we need to copy). The `nothing` action does nothing and is used internally to handle the case when `when`'s condition is false. The `nothing` action is exposed as it can be handy when writing dune files to be able to temporarily create an action which does nothing when you're not sure which action to use but you need the file to parse correctly to test some other stanza (currently it's possible to get the same effect by using `(progn)` with no arguments but this is a hack).