### PR TITLE
refactor: introduce simpler env stanza db

### DIFF
--- a/doc/changes/8447.md
+++ b/doc/changes/8447.md
@@ -1,0 +1,2 @@
+- Do not ignore `(formatting ..)` settings in context or workspace files
+  (#8447, @rgrinberg)

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -180,7 +180,7 @@ let create
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b
-    | None -> Super_context.bin_annot super_context ~dir:(Obj_dir.dir obj_dir)
+    | None -> Env_stanza_db.bin_annot ~dir:(Obj_dir.dir obj_dir)
   in
   { super_context
   ; scope

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -2,14 +2,6 @@
 
 open Import
 
-module Odoc : sig
-  type warnings = Dune_env.Odoc.warnings =
-    | Fatal
-    | Nonfatal
-
-  type t = { warnings : warnings }
-end
-
 type t
 
 val make
@@ -24,13 +16,11 @@ val make
   -> default_context_flags:string list Action_builder.t Foreign_language.Dict.t
   -> default_env:Env.t
   -> default_artifacts:Artifacts.t
-  -> default_bin_annot:bool
   -> t
 
 val scope : t -> Scope.t
 val external_env : t -> Env.t Memo.t
 val ocaml_flags : t -> Ocaml_flags.t Memo.t
-val inline_tests : t -> Dune_env.Inline_tests.t Memo.t
 val js_of_ocaml : t -> string list Action_builder.t Js_of_ocaml.Env.t Memo.t
 val foreign_flags : t -> string list Action_builder.t Foreign_language.Dict.t
 val link_flags : t -> Link_flags.t Memo.t
@@ -40,9 +30,5 @@ val link_flags : t -> Link_flags.t Memo.t
 val local_binaries : t -> File_binding.Expanded.t list Memo.t
 
 val artifacts : t -> Artifacts.t Memo.t
-val odoc : t -> Odoc.t Action_builder.t
 val coq_flags : t -> Coq_flags.t Action_builder.t Memo.t
 val menhir_flags : t -> string list Action_builder.t
-val format_config : t -> Format_config.t Memo.t
-val set_format_config : t -> Format_config.t -> t
-val bin_annot : t -> bool Memo.t

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -1,0 +1,99 @@
+open Import
+open Memo.O
+
+module Node = struct
+  type t =
+    { value : Dune_env.t
+    ; parent : t option Memo.t
+    }
+
+  let by_context dir =
+    let open Memo.O in
+    let+ context = Context.DB.by_dir dir in
+    let { Context.Env_nodes.context; workspace } = Context.env_nodes context in
+    match context, workspace with
+    | None, None -> None
+    | Some value, None | None, Some value -> Some { value; parent = Memo.return None }
+    | Some context, Some workspace ->
+      Some
+        { value = context
+        ; parent = Memo.return (Some { value = workspace; parent = Memo.return None })
+        }
+  ;;
+
+  let in_dir ~dir =
+    Only_packages.stanzas_in_dir dir
+    >>| function
+    | None -> None
+    | Some stanzas ->
+      List.find_map stanzas.stanzas ~f:(function
+        | Dune_env.T config -> Some config
+        | _ -> None)
+  ;;
+
+  let rec by_dir dir =
+    let parent =
+      let* scope = Scope.DB.find_by_dir dir in
+      if Path.Build.equal dir (Scope.root scope)
+      then by_context dir
+      else (
+        match Path.Build.parent dir with
+        | None -> by_context dir
+        | Some parent -> by_dir parent)
+    in
+    in_dir ~dir
+    >>= function
+    | Some value -> Memo.return (Some { value; parent })
+    | None -> parent
+  ;;
+end
+
+let value ~default ~f =
+  let rec loop = function
+    | None -> Memo.return default
+    | Some { Node.value; parent } ->
+      let* next =
+        f value
+        >>| function
+        | Some x -> `Ok x
+        | None -> `Parent
+      in
+      (match next with
+       | `Ok x -> Memo.return x
+       | `Parent -> parent >>= loop)
+  in
+  fun ~dir -> Node.by_dir dir >>= loop
+;;
+
+let profile ~dir =
+  let name, _ = Path.Build.extract_build_context_exn dir in
+  let context = Context_name.of_string name in
+  Per_context.profile context
+;;
+
+let value ~default ~dir ~f =
+  let profile = lazy (profile ~dir) in
+  value ~default ~dir ~f:(fun stanza ->
+    let* profile = Lazy.force profile in
+    match Dune_env.find_opt stanza ~profile with
+    | None -> Memo.return None
+    | Some stanza -> f stanza)
+;;
+
+let bin_annot ~dir =
+  value ~default:true ~dir ~f:(fun (t : Dune_env.config) -> Memo.return t.bin_annot)
+;;
+
+let inline_tests ~dir =
+  value ~default:None ~dir ~f:(fun (t : Dune_env.config) ->
+    Memo.return
+    @@
+    match t.inline_tests with
+    | None -> None
+    | Some s -> Some (Some s))
+  >>= function
+  | Some s -> Memo.return s
+  | None ->
+    let+ profile = profile ~dir in
+    if Profile.is_inline_test profile then Dune_env.Inline_tests.Enabled else Disabled
+;;

--- a/src/dune_rules/env_stanza_db.mli
+++ b/src/dune_rules/env_stanza_db.mli
@@ -1,0 +1,10 @@
+open Import
+
+val value
+  :  default:'a
+  -> dir:Path.Build.t
+  -> f:(Dune_env.config -> 'a option Memo.t)
+  -> 'a Memo.t
+
+val bin_annot : dir:Path.Build.t -> bool Memo.t
+val inline_tests : dir:Path.Build.t -> Dune_env.Inline_tests.t Memo.t

--- a/src/dune_rules/format_rules.mli
+++ b/src/dune_rules/format_rules.mli
@@ -9,6 +9,6 @@ val gen_rules : Super_context.t -> output_dir:Path.Build.t -> unit Memo.t
 
 (** This must be called from the main directory, i.e. the ones containing the
     source files and the the [formatted_dir_basename] sub-directory. *)
-val setup_alias : Super_context.t -> dir:Path.Build.t -> unit Memo.t
+val setup_alias : dir:Path.Build.t -> unit Memo.t
 
 val formatted_dir_basename : Filename.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -300,7 +300,7 @@ let gen_rules_for_stanzas
 ;;
 
 let gen_format_and_cram_rules sctx ~expander ~dir source_dir =
-  let+ () = Format_rules.setup_alias sctx ~dir
+  let+ () = Format_rules.setup_alias ~dir
   and+ () =
     Source_tree.Dir.cram_tests source_dir >>= Cram_rules.rules ~sctx ~expander ~dir
   in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -279,7 +279,7 @@ end = struct
       in
       let set_dir m = List.map ~f:(fun (cm_kind, p) -> cm_dir m cm_kind, p) in
       let+ modules_impl =
-        let+ bin_annot = Super_context.bin_annot sctx ~dir in
+        let+ bin_annot = Env_stanza_db.bin_annot ~dir in
         List.concat_map installable_modules.impl ~f:(fun m ->
           let cmt_files =
             match bin_annot with

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -27,7 +27,6 @@ val context : t -> Context.t
 val context_env : t -> Env.t
 
 val env_node : t -> dir:Path.Build.t -> Env_node.t Memo.t
-val bin_annot : t -> dir:Path.Build.t -> bool Memo.t
 
 val add_rule
   :  t

--- a/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
+++ b/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
@@ -36,6 +36,3 @@ Disable foramtting in the root directory using context settings
   > EOF
 
   $ dune build @fmt
-  File "dune", line 1, characters 0-0:
-  Error: Files _build/default/dune and _build/default/.formatted/dune differ.
-  [1]


### PR DESCRIPTION
This is an experiment to replace the `Env_tree`. The goal is to reduce the possibility of cycles, remove unnecessary memoization, and make it easy to introduce new values that depend on the `env` stanza without shoving everything in one module.