### PR TITLE
refactor: warning system

### DIFF
--- a/doc/changes/8448.md
+++ b/doc/changes/8448.md
@@ -1,0 +1,2 @@
+- Add a `warnings` field to `dune-project` files as a unified mechanism to
+  enable or disable dune warnings (@rgrinberg, 8448)

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -689,6 +689,22 @@ map_workspace_root
    .. versionchanged:: 3.7
         Add a way to disable the mapping.
 
+.. _warnings:
+
+warnings
+--------
+
+.. dune:stanza:: warnings
+
+   .. versionadded:: 3.11
+
+   Configure Dune warnings for the project.
+
+   .. dune:field:: <name>
+      :param: <enabled | disabled>
+
+      Enable or disable the warning <name> for the current project.
+
 .. _dune-files:
 
 dune

--- a/otherlibs/stdune/src/user_warning.ml
+++ b/otherlibs/stdune/src/user_warning.ml
@@ -1,17 +1,23 @@
 let reporter = ref (fun msg -> User_message.prerr msg)
 let set_reporter f = reporter := f
 
+let prefix =
+  Pp.seq (Pp.tag User_message.Style.Warning (Pp.verbatim "Warning")) (Pp.char ':')
+;;
+
+let prefix_paragraphs paragraphs =
+  match paragraphs with
+  | [] -> [ prefix ]
+  | x :: l -> Pp.concat ~sep:Pp.space [ prefix; x ] :: l
+;;
+
+let emit_message (message : User_message.t) =
+  let paragraphs = prefix_paragraphs message.paragraphs in
+  !reporter { message with paragraphs }
+;;
+
 let emit ?loc ?hints ?(is_error = false) paragraphs =
   if is_error
   then User_error.raise ?loc ?hints paragraphs
-  else
-    !reporter
-      (User_message.make
-         paragraphs
-         ?loc
-         ?hints
-         ~prefix:
-           (Pp.seq
-              (Pp.tag User_message.Style.Warning (Pp.verbatim "Warning"))
-              (Pp.char ':')))
+  else !reporter (User_message.make paragraphs ?loc ?hints ~prefix)
 ;;

--- a/otherlibs/stdune/src/user_warning.mli
+++ b/otherlibs/stdune/src/user_warning.mli
@@ -16,5 +16,9 @@ val emit
   -> User_message.Style.t Pp.t list
   -> unit
 
+(** [emit_message m] is like [emit], but allow you to provide the message as
+    [m] instead of the arguments to construct the messagee. *)
+val emit_message : User_message.t -> unit
+
 (** Set the warning reporter. The default one is [User_message.prerr]. *)
 val set_reporter : (User_message.t -> unit) -> unit

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -142,6 +142,7 @@ val default_dune_language_version : Dune_lang.Syntax.Version.t ref
 val set : t -> ('a, 'k) Dune_lang.Decoder.parser -> ('a, 'k) Dune_lang.Decoder.parser
 
 val get_exn : unit -> (t, 'k) Dune_lang.Decoder.parser
+val get : unit -> (t option, 'k) Dune_lang.Decoder.parser
 
 (** Find arguments passed to (using). [None] means that the extension was not
     written in dune-project. *)
@@ -158,6 +159,7 @@ val accept_alternative_dune_file_name : t -> bool
 val strict_package_deps : t -> bool
 val cram : t -> bool
 val info : t -> Package.Info.t
+val warnings : t -> Warning.Settings.t
 
 (** Update the execution parameters according to what is written in the
     [dune-project] file. *)

--- a/src/dune_rules/file_binding.ml
+++ b/src/dune_rules/file_binding.ml
@@ -7,21 +7,24 @@ type ('src, 'dst) t =
       (* The [dune_syntax] field is used for validation which has different
          behaviour depending on the version of dune syntax in use. *)
   ; dune_syntax : Syntax.Version.t
+  ; dir : Path.Source.t option
   }
 
-let to_dyn f g { src; dst; dune_syntax } =
+let to_dyn f g { src; dst; dune_syntax; dir } =
   let open Dyn in
   record
     [ "src", f src
     ; "dst", option g dst
     ; "dune_syntax", Syntax.Version.to_dyn dune_syntax
+    ; "dir", option Path.Source.to_dyn dir
     ]
 ;;
 
-let equal f g { src; dst; dune_syntax } t =
+let equal f g { src; dst; dune_syntax; dir } t =
   f src t.src
   && Option.equal g dst t.dst
   && Syntax.Version.equal dune_syntax t.dune_syntax
+  && Option.equal Path.Source.equal dir t.dir
 ;;
 
 let relative_path_starts_with_parent relative_path =
@@ -33,38 +36,41 @@ let relative_path_starts_with_parent relative_path =
 let validate_dst_for_install_stanza
   ~relative_dst_path_starts_with_parent_error_when
   ~loc
-  dst
-  dune_syntax
+  ~dst
+  ~dir
   =
-  if relative_path_starts_with_parent dst
-  then (
-    match relative_dst_path_starts_with_parent_error_when with
-    | `Deprecation_warning_from_3_11 ->
-      let open Syntax.Version.Infix in
-      if dune_syntax >= (3, 11)
-      then
-        User_warning.emit
-          ~loc
-          [ Pp.textf
-              "The destination path %s begins with %s which will become an error in a \
-               future version of Dune. Destinations of files in install stanzas \
-               beginning with %s will be disallowed to prevent a package's installed \
-               files from escaping that package's install directories."
-              (String.maybe_quoted dst)
-              (String.maybe_quoted Filename.parent_dir_name)
-              (String.maybe_quoted Filename.parent_dir_name)
-          ]
-    | `Always_error ->
-      User_error.raise
-        ~loc
-        [ Pp.textf
-            "The destination path %s begins with %s which is not allowed. Destinations \
-             in install stanzas may not begin with %s to prevent a package's installed \
-             files from escaping that package's install directories."
-            (String.maybe_quoted dst)
-            (String.maybe_quoted Filename.parent_dir_name)
-            (String.maybe_quoted Filename.parent_dir_name)
-        ])
+  match relative_path_starts_with_parent dst with
+  | false -> Memo.return ()
+  | true ->
+    (match relative_dst_path_starts_with_parent_error_when with
+     | `Deprecation_warning_from_3_11 ->
+       Warning_emit.emit
+         Warning.escaping_paths_in_install_stanza
+         (Warning_emit.Context.source_dir_or_enable dir)
+         (fun () ->
+           User_message.make
+             ~loc
+             [ Pp.textf
+                 "The destination path %s begins with %s which will become an error in a \
+                  future version of Dune. Destinations of files in install stanzas \
+                  beginning with %s will be disallowed to prevent a package's installed \
+                  files from escaping that package's install directories."
+                 (String.maybe_quoted dst)
+                 (String.maybe_quoted Filename.parent_dir_name)
+                 (String.maybe_quoted Filename.parent_dir_name)
+             ]
+           |> Memo.return)
+     | `Always_error ->
+       User_error.raise
+         ~loc
+         [ Pp.textf
+             "The destination path %s begins with %s which is not allowed. Destinations \
+              in install stanzas may not begin with %s to prevent a package's installed \
+              files from escaping that package's install directories."
+             (String.maybe_quoted dst)
+             (String.maybe_quoted Filename.parent_dir_name)
+             (String.maybe_quoted Filename.parent_dir_name)
+         ])
 ;;
 
 module Expanded = struct
@@ -79,7 +85,7 @@ module Expanded = struct
   let dst t = Option.map ~f:snd t.dst
   let src_loc t = fst t.src
 
-  let dst_basename { src = _, src; dst; dune_syntax = _ } =
+  let dst_basename { src = _, src; dst; dune_syntax = _; dir = _ } =
     match dst with
     | Some (_, dst) -> dst
     | None ->
@@ -90,12 +96,12 @@ module Expanded = struct
   let dst_path t ~dir = Path.Build.relative dir (dst_basename t)
 
   let validate_for_install_stanza t ~relative_dst_path_starts_with_parent_error_when =
-    Option.iter t.dst ~f:(fun (loc, dst) ->
+    Memo.Option.iter t.dst ~f:(fun (loc, dst) ->
       validate_dst_for_install_stanza
         ~relative_dst_path_starts_with_parent_error_when
         ~loc
-        dst
-        t.dune_syntax)
+        ~dst
+        ~dir:t.dir)
   ;;
 end
 
@@ -105,29 +111,32 @@ module Unexpanded = struct
   let to_dyn = to_dyn String_with_vars.to_dyn String_with_vars.to_dyn
   let equal = equal String_with_vars.equal_no_loc String_with_vars.equal_no_loc
 
-  let make ~src:(locs, src) ~dst:(locd, dst) ~dune_syntax =
+  let make ~src:(locs, src) ~dst:(locd, dst) ~dune_syntax ~dir =
     { src = String_with_vars.make_text locs src
     ; dst = Some (String_with_vars.make_text locd dst)
     ; dune_syntax
+    ; dir
     }
   ;;
 
   let expand_src t ~dir ~f = f t.src >>| Path.Build.relative dir
 
   let destination_relative_to_install_path t ~section ~expand ~expand_partial =
-    let+ src = expand_partial t.src
+    let* src = expand_partial t.src
     and+ dst_loc_opt =
       Memo.Option.map t.dst ~f:(fun dst ->
         let loc = String_with_vars.loc dst in
         let+ dst = expand dst in
         dst, loc)
     in
-    Option.iter dst_loc_opt ~f:(fun (dst, loc) ->
-      validate_dst_for_install_stanza
-        ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
-        ~loc
-        dst
-        t.dune_syntax);
+    let+ () =
+      Memo.Option.iter dst_loc_opt ~f:(fun (dst, loc) ->
+        validate_dst_for_install_stanza
+          ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
+          ~loc
+          ~dst
+          ~dir:t.dir)
+    in
     Install.Entry.adjust_dst ~section ~src ~dst:(Option.map dst_loc_opt ~f:fst)
   ;;
 
@@ -147,7 +156,11 @@ module Unexpanded = struct
         let+ loc, p = f dst in
         Some (loc, p)
     in
-    { src; dst; dune_syntax = t.dune_syntax }
+    { src
+    ; dst
+    ; dune_syntax = t.dune_syntax
+    ; dir = Some (Path.Build.drop_build_context_exn dir)
+    }
   ;;
 
   let decode =
@@ -169,16 +182,20 @@ module Unexpanded = struct
         Dune_lang.Syntax.Error.since (String_with_vars.loc s) Stanza.syntax (1, 6) ~what)
       else s, dune_syntax
     in
+    let dir = Dune_project.get () >>| Option.map ~f:Dune_project.root in
     peek_exn
     >>= function
     | Atom _ | Quoted_string _ | Template _ ->
-      decode >>| fun (src, dune_syntax) -> { src; dst = None; dune_syntax }
+      let+ src, dune_syntax = decode
+      and+ dir = dir in
+      { src; dst = None; dune_syntax; dir }
     | List (_, [ _; Atom (_, A "as"); _ ]) ->
       enter
         (let* src, dune_syntax = decode in
          keyword "as"
-         >>> let* dst, _ = decode in
-             return { src; dst = Some dst; dune_syntax })
+         >>> let* dst, _ = decode
+             and+ dir = dir in
+             return { src; dst = Some dst; dune_syntax; dir })
     | sexp ->
       User_error.raise
         ~loc:(Dune_lang.Ast.loc sexp)
@@ -189,7 +206,10 @@ module Unexpanded = struct
 
   module L = struct
     let decode = Dune_lang.Decoder.repeat decode
-    let strings_with_vars { src; dst; dune_syntax = _ } = src :: Option.to_list dst
+
+    let strings_with_vars { src; dst; dune_syntax = _; dir = _ } =
+      src :: Option.to_list dst
+    ;;
 
     let find_pform fbs =
       List.find_map fbs ~f:(fun fb ->

--- a/src/dune_rules/file_binding.mli
+++ b/src/dune_rules/file_binding.mli
@@ -13,7 +13,7 @@ module Expanded : sig
     :  t
     -> relative_dst_path_starts_with_parent_error_when:
          [ `Deprecation_warning_from_3_11 | `Always_error ]
-    -> unit
+    -> unit Memo.t
 end
 
 module Unexpanded : sig
@@ -21,7 +21,14 @@ module Unexpanded : sig
 
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
-  val make : src:Loc.t * string -> dst:Loc.t * string -> dune_syntax:Syntax.Version.t -> t
+
+  val make
+    :  src:Loc.t * string
+    -> dst:Loc.t * string
+    -> dune_syntax:Syntax.Version.t
+    -> dir:Path.Source.t option
+    -> t
+
   val decode : t Dune_lang.Decoder.t
   val dune_syntax : t -> Syntax.Version.t
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -368,17 +368,19 @@ let gen_project_rules sctx project : unit Memo.t =
        with
        | false -> Memo.return ()
        | true ->
-         let+ vendored = Source_tree.is_vendored (Dune_project.root project) in
-         if not vendored
-         then (
-           let loc = Loc.in_file (Path.source (Dune_project.file project)) in
-           User_warning.emit
-             ~loc
-             [ Pp.text
-                 "Project name is not specified. Add a (name <project-name>) field to \
-                  your dune-project file to make sure that $ dune subst works in release \
-                  or pinned builds"
-             ]))
+         Warning_emit.emit
+           Warning.missing_project_name
+           (Warning_emit.Context.project project)
+           (fun () ->
+             let+ () = Memo.return () in
+             let loc = Loc.in_file (Path.source (Dune_project.file project)) in
+             User_message.make
+               ~loc
+               [ Pp.text
+                   "Project name is not specified. Add a (name <project-name>) field to \
+                    your dune-project file to make sure that $ dune subst works in \
+                    release or pinned builds"
+               ]))
   in
   ()
 ;;

--- a/src/dune_rules/warning.ml
+++ b/src/dune_rules/warning.ml
@@ -1,0 +1,97 @@
+open Import
+
+module Name = struct
+  include String
+
+  include Stringlike.Make (struct
+      type t = string
+
+      let module_ = "Warning.Name"
+      let description = "Warning name"
+      let description_of_valid_string = None
+      let hint_valid = None
+      let of_string_opt x = if Dune_sexp.Atom.is_valid x then Some x else None
+      let to_string x = x
+    end)
+end
+
+type t =
+  { name : Name.t
+  ; since : Syntax.Version.t (* The version where this warning was introduced. *)
+  ; default : Syntax.Version.t -> Config.Toggle.t
+      (* Decide the version where this warning should be enabled. This is
+         needed because some warnings were introduced before this module
+         existed *)
+  }
+
+let name t = Name.to_string t.name
+let frozen = ref false
+let all : (Name.t, t) Table.t = Table.create (module Name) 12
+
+let create ~default ~name ~since =
+  if !frozen
+  then
+    Code_error.raise
+      "Warning.create may not be called after warning settings have been parsed. \
+       Warnings should be created at the top level (not inside function definitions) in \
+       the file src/dune_rules/warnings.ml"
+      [ "name", Name.to_dyn name ];
+  let name = Name.of_string name in
+  let t = { name; since; default } in
+  Table.add_exn all name t;
+  t
+;;
+
+module Settings = struct
+  type nonrec t = (t * Config.Toggle.t) list
+
+  let empty = []
+  let to_dyn = Dyn.opaque
+
+  let decode : t Dune_sexp.Decoder.t =
+    let all_warnings =
+      lazy
+        (frozen := true;
+         Table.values all)
+    in
+    let open Dune_sexp.Decoder in
+    let warning w =
+      Dune_lang.Syntax.since Stanza.syntax w.since
+      >>> string
+      |> map_validate ~f:(fun s ->
+        match Config.Toggle.of_string s with
+        | Ok s -> Ok (w, s)
+        | Error s -> Error (User_message.make [ Pp.text s ]))
+    in
+    let* () = return () in
+    Lazy.force all_warnings
+    |> List.map ~f:(fun w -> Name.to_string w.name, warning w)
+    |> leftover_fields_as_sums
+    |> fields
+  ;;
+
+  let active t warn version =
+    match
+      List.find_map t ~f:(fun (warn', value) ->
+        Option.some_if (Name.equal warn.name warn'.name) value)
+    with
+    | Some w -> w
+    | None -> warn.default version
+  ;;
+end
+
+let missing_project_name =
+  create
+    ~default:(fun version -> if version >= (2, 8) then `Enabled else `Disabled)
+    ~name:"missing_project_name"
+    ~since:(3, 11)
+;;
+
+let escaping_paths_in_install_stanza =
+  create
+    ~default:(fun version -> if version >= (3, 11) then `Enabled else `Disabled)
+    ~name:"escaping_paths_in_install_stanza"
+    ~since:(3, 11)
+;;
+
+let no_keep_locs = create ~default:(fun _ -> `Enabled) ~name:"no_keep_locs" ~since:(3, 11)

--- a/src/dune_rules/warning.mli
+++ b/src/dune_rules/warning.mli
@@ -1,0 +1,25 @@
+(** General warning mechanism for dune rules *)
+
+open Import
+
+type t
+
+module Settings : sig
+  (** Settings to disable/enable specific warnings in a project *)
+
+  type warning := t
+  type t
+
+  val to_dyn : t -> Dyn.t
+  val empty : t
+  val decode : t Dune_sexp.Decoder.t
+  val active : t -> warning -> Syntax.Version.t -> Config.Toggle.t
+end
+
+val name : t -> string
+
+(** Warn whenever [(name <name>)]) is missing from the [dune-project] file *)
+val missing_project_name : t
+
+val escaping_paths_in_install_stanza : t
+val no_keep_locs : t

--- a/src/dune_rules/warning_emit.ml
+++ b/src/dune_rules/warning_emit.ml
@@ -1,0 +1,111 @@
+open Import
+open Memo.O
+
+module Context = struct
+  type t =
+    | Source_dir_or_enable of Path.Source.t option
+    | Project of Dune_project.t
+
+  let project p = Project p
+  let source_dir_or_enable p = Source_dir_or_enable p
+end
+
+let check_project warning project =
+  let warnings = Dune_project.warnings project in
+  let version = Dune_project.dune_version project in
+  Warning.Settings.active warnings warning version
+;;
+
+let maybe_emit warning f = function
+  | `Disabled -> Memo.return ()
+  | `Enabled ->
+    let+ message =
+      let+ message = f () in
+      let hints =
+        [ Pp.concat
+            ~sep:Pp.space
+            [ Pp.text
+                "To disable this warning, add the following to your dune-project file:"
+            ; Pp.verbatim (sprintf "(%s disabled)" (Warning.name warning))
+            ]
+        ]
+      in
+      { message with User_message.hints }
+    in
+    User_warning.emit_message message
+;;
+
+let emit t context f =
+  (let+ dir =
+     match
+       match (context : Context.t) with
+       | Source_dir_or_enable dir -> dir
+       | Project project -> Some (Dune_project.root project)
+     with
+     | None -> Memo.return None
+     | Some dir -> Source_tree.nearest_dir dir >>| Option.some
+   in
+   match dir with
+   | None -> `Enabled
+   | Some dir ->
+     (match Source_tree.Dir.status dir with
+      | Vendored -> `Disabled
+      | _ -> check_project t (Source_tree.Dir.project dir)))
+  >>= maybe_emit t f
+;;
+
+module Bag = struct
+  type decode =
+    { active : Config.Toggle.t
+    ; warning : Warning.t
+    ; project_root : Path.Source.t option
+    ; produce : unit -> User_message.t Memo.t
+    }
+
+  let decode warning produce =
+    let open Dune_sexp.Decoder in
+    Dune_project.get ()
+    >>| function
+    | None -> { warning; active = `Enabled; project_root = None; produce }
+    | Some project ->
+      { active = check_project warning project
+      ; project_root = Some (Dune_project.root project)
+      ; produce
+      ; warning
+      }
+  ;;
+
+  let emit_decode { warning; active; project_root; produce } =
+    (match project_root with
+     | None -> Memo.return active
+     | Some project_root ->
+       Source_tree.nearest_dir project_root
+       >>| Source_tree.Dir.status
+       >>| (function
+       | Vendored -> `Disabled
+       | _ -> active))
+    >>= maybe_emit warning produce
+  ;;
+
+  type t = decode list ref
+
+  let create () = ref []
+  let key = Univ_map.Key.create ~name:"warning-bag" Dyn.opaque
+
+  let decode w produce =
+    let open Dune_sexp.Decoder in
+    let* decode = decode w produce in
+    Dune_sexp.Decoder.get key
+    >>| function
+    | None -> Code_error.raise "no warning bag in context" []
+    | Some p -> p := decode :: !p
+  ;;
+
+  let emit_all t =
+    let all = !t in
+    t := [];
+    Memo.parallel_iter all ~f:emit_decode
+  ;;
+
+  let set t decoder = Dune_sexp.Decoder.set key t decoder
+end

--- a/src/dune_rules/warning_emit.mli
+++ b/src/dune_rules/warning_emit.mli
@@ -1,0 +1,30 @@
+(** Emit warnings that respect dune's conventions *)
+
+open Import
+
+module Context : sig
+  (** a context decides whether a warning should be emitted based on the
+      settings inside the project and if the directory we're in is vendored *)
+  type t
+
+  val project : Dune_project.t -> t
+  val source_dir_or_enable : Path.Source.t option -> t
+end
+
+(** [emit w ctx f] will call [f] if [w] is enabled in [ctx]. [f] should
+    generate the warning corresponding to [w] *)
+val emit : Warning.t -> Context.t -> (unit -> User_message.t Memo.t) -> unit Memo.t
+
+module Bag : sig
+  (** A set of warnings collected while parsing the dune language *)
+  type t
+
+  val create : unit -> t
+  val decode : Warning.t -> (unit -> User_message.t Memo.t) -> unit Dune_sexp.Decoder.t
+
+  (**  [set t decoder] make [decoder] record warnings by adding them to [t] *)
+  val set : t -> 'a Dune_sexp.Decoder.t -> 'a Dune_sexp.Decoder.t
+
+  (** [emit_all t] returns all the warnings collected in [decode] *)
+  val emit_all : t -> unit Memo.t
+end

--- a/test/blackbox-tests/test-cases/disable-warning.t
+++ b/test/blackbox-tests/test-cases/disable-warning.t
@@ -1,0 +1,29 @@
+Demonstrate dune's system for enabling/disabling warnings
+
+  $ cat >dune-project <<EOF
+  > (lang dune 1.5)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (no_keep_locs))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 1-15:
+  3 |  (no_keep_locs))
+       ^^^^^^^^^^^^^^
+  Warning: no_keep_locs is a no-op. Please delete it.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (no_keep_locs disabled)
+
+Now we demonstrate how this warning can be deleted:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (warnings
+  >  (no_keep_locs disabled))
+  > EOF
+
+  $ dune build

--- a/test/blackbox-tests/test-cases/install/install-glob/install-glob-relative.t
+++ b/test/blackbox-tests/test-cases/install/install-glob/install-glob-relative.t
@@ -35,6 +35,8 @@ Incorrect install stanza that would place files outside the package's install di
   become an error in a future version of Dune. Destinations of files in install
   stanzas beginning with .. will be disallowed to prevent a package's installed
   files from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   File "stanza/dune", line 2, characters 24-38:
   2 |  (files (glob_files_rec ../stuff/*.txt))
                               ^^^^^^^^^^^^^^
@@ -42,7 +44,17 @@ Incorrect install stanza that would place files outside the package's install di
   become an error in a future version of Dune. Destinations of files in install
   stanzas beginning with .. will be disallowed to prevent a package's installed
   files from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
 
+Test that we can disable the warning:
+  $ cat >>dune-project <<EOF
+  > (warnings (escaping_paths_in_install_stanza disabled))
+  > EOF
+  $ dune build foo.install
+
+Now we remove disabling the warning
+  $ sed -i.bak '$d' dune-project
 
 Correction to the above which uses `with_prefix` to change the install destination:
   $ cat >stanza/dune <<EOF

--- a/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
+++ b/test/blackbox-tests/test-cases/start-install-dst-with-parent-error.t
@@ -27,6 +27,8 @@ Test that we get a warning if `(files ...)` has a dst starting with "..":
   in a future version of Dune. Destinations of files in install stanzas
   beginning with .. will be disallowed to prevent a package's installed files
   from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"
@@ -53,6 +55,8 @@ Test that we get a warning if `(dirs ...)` has a dst starting with "..":
   error in a future version of Dune. Destinations of files in install stanzas
   beginning with .. will be disallowed to prevent a package's installed files
   from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"
@@ -79,6 +83,8 @@ Test that we get a warning if `(dirs ...)` has a dst that is exactly "..":
   a future version of Dune. Destinations of files in install stanzas beginning
   with .. will be disallowed to prevent a package's installed files from
   escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"
@@ -102,6 +108,8 @@ Test that we get get a warning if the ".." is the result of variable expansion:
   in a future version of Dune. Destinations of files in install stanzas
   beginning with .. will be disallowed to prevent a package's installed files
   from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"
@@ -156,6 +164,8 @@ Test that we get a warning if the ".." comes from the prefix of a glob:
   an error in a future version of Dune. Destinations of files in install
   stanzas beginning with .. will be disallowed to prevent a package's installed
   files from escaping that package's install directories.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (escaping_paths_in_install_stanza disabled)
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"

--- a/test/blackbox-tests/test-cases/syntax-versioning.t
+++ b/test/blackbox-tests/test-cases/syntax-versioning.t
@@ -49,4 +49,6 @@ Since 3.0.0, jbuild files are plain ignored:
   3 |  (no_keep_locs))
        ^^^^^^^^^^^^^^
   Warning: no_keep_locs is a no-op. Please delete it.
+  Hint: To disable this warning, add the following to your dune-project file:
+  (no_keep_locs disabled)
   $ rm -f dune


### PR DESCRIPTION
Add a [Warning] module to handle warnings in a consistent way in dune.

We'd like dune warnings to have the following two properties:

* Muted while in the vendored directory
* Possible to disable

This PR adds a warning mechanism that makes it easy to handle these two concerns.

I've converted a couple of trivial warnings we currently have to this mechanism. More can be done, but this is a start.