### PR TITLE
fix: handle errors in threaded console correctly

### DIFF
--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -79,8 +79,8 @@ let make (module Base : S) : (module Dune_console.Backend) =
          | Error exn ->
            (* we can't log to console because we are cleaning it up and we
               borked it *)
-           Dune_util.Log.info
-             [ Pp.text "Error cleaning up console"; Exn_with_backtrace.pp exn ]);
+           Dune_util.Log.log (fun () ->
+             [ Pp.text "Error cleaning up console"; Exn_with_backtrace.pp exn ]));
         Condition.broadcast finish_cv;
         Mutex.unlock mutex
       in

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -40,16 +40,26 @@ let init ?(file = File.Default) () =
 let init_disabled () = Fdecl.set t None
 let t () = Fdecl.get t
 
+let log_oc oc msg =
+  let s = Format.asprintf "%a@?" Pp.to_fmt (User_message.pp msg) in
+  List.iter (String.split_lines s) ~f:(function
+    | "" -> output_string oc "#\n"
+    | s -> Printf.fprintf oc "# %s\n" s);
+  flush oc
+;;
+
+let log msg =
+  match t () with
+  | None -> ()
+  | Some { oc; _ } ->
+    Option.iter oc ~f:(fun oc -> User_message.make (msg ()) |> log_oc oc)
+;;
+
 let info_user_message msg =
   match t () with
   | None -> ()
   | Some { oc; _ } ->
-    Option.iter oc ~f:(fun oc ->
-      let s = Format.asprintf "%a@?" Pp.to_fmt (User_message.pp msg) in
-      List.iter (String.split_lines s) ~f:(function
-        | "" -> output_string oc "#\n"
-        | s -> Printf.fprintf oc "# %s\n" s);
-      flush oc);
+    Option.iter oc ~f:(fun oc -> log_oc oc msg);
     if !verbose then Console.print_user_message msg
 ;;
 

--- a/src/dune_util/log.mli
+++ b/src/dune_util/log.mli
@@ -16,6 +16,9 @@ val init : ?file:File.t -> unit -> unit
     messages. *)
 val init_disabled : unit -> unit
 
+(** Print the message only the log file (despite verbose mode) if it's set *)
+val log : (unit -> User_message.Style.t Pp.t list) -> unit
+
 (** Print an informative message in the log *)
 val info_user_message : User_message.t -> unit
 


### PR DESCRIPTION
don't try to write errors to the console when the console is dead

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cb3ac130-a6bd-4f43-9625-16efb495a301 -->