### PR TITLE
refactor: remove [Expander] from [Compilation_context]

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -163,7 +163,6 @@ let gen_rules sctx t ~dir ~scope =
     Compilation_context.create
       ()
       ~super_context:sctx
-      ~expander
       ~scope
       ~obj_dir
       ~modules

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -71,7 +71,6 @@ let singleton_modules m =
 type t =
   { super_context : Super_context.t
   ; scope : Scope.t
-  ; expander : Expander.t
   ; obj_dir : Path.Build.t Obj_dir.t
   ; modules : modules
   ; flags : Ocaml_flags.t
@@ -95,7 +94,6 @@ type t =
 let loc t = t.loc
 let super_context t = t.super_context
 let scope t = t.scope
-let expander t = t.expander
 let dir t = Obj_dir.dir t.obj_dir
 let obj_dir t = t.obj_dir
 let modules t = t.modules.modules
@@ -121,7 +119,6 @@ let dep_graphs t = t.modules.dep_graphs
 let create
   ~super_context
   ~scope
-  ~expander
   ~obj_dir
   ~modules
   ~flags
@@ -181,7 +178,6 @@ let create
   in
   { super_context
   ; scope
-  ; expander
   ; obj_dir
   ; modules = { modules; dep_graphs }
   ; flags

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -22,7 +22,6 @@ type opaque =
 val create
   :  super_context:Super_context.t
   -> scope:Scope.t
-  -> expander:Expander.t
   -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.t
   -> flags:Ocaml_flags.t
@@ -45,7 +44,6 @@ val create
 val for_alias_module : t -> Module.t -> t
 
 val super_context : t -> Super_context.t
-val expander : t -> Expander.t
 val context : t -> Context.t
 val scope : t -> Scope.t
 

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -151,7 +151,6 @@ let executables_rules
       ()
       ~loc:exes.buildable.loc
       ~super_context:sctx
-      ~expander
       ~scope
       ~obj_dir
       ~modules

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -161,7 +161,6 @@ include Sub_system.Register_end_point (struct
         Compilation_context.create
           ()
           ~super_context:sctx
-          ~expander
           ~scope
           ~obj_dir
           ~modules

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -535,7 +535,6 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_
   Compilation_context.create
     ()
     ~super_context:sctx
-    ~expander
     ~scope
     ~obj_dir
     ~modules

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -397,7 +397,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
 
 let name = "mdx_gen"
 
-let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
+let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
   let loc = t.loc in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let file = Path.Build.relative dir "mdx_gen.ml-gen" in
@@ -463,7 +463,6 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
     Compilation_context.create
       ~super_context:sctx
       ~scope
-      ~expander
       ~obj_dir
       ~modules
       ~flags
@@ -500,8 +499,7 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
     in
     let* mdx_prog_gen =
       if Dune_lang.Syntax.Version.Infix.(t.version >= (0, 2))
-      then
-        Memo.Option.map (Some t) ~f:(mdx_prog_gen ~sctx ~dir ~scope ~expander ~mdx_prog)
+      then Memo.Option.map (Some t) ~f:(mdx_prog_gen ~sctx ~dir ~scope ~mdx_prog)
       else Memo.return None
     in
     Memo.parallel_iter

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -240,7 +240,6 @@ let setup_emit_cmj_rules
         ()
         ~loc:mel.loc
         ~super_context:sctx
-        ~expander
         ~scope
         ~obj_dir
         ~modules

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -55,7 +55,7 @@ module Run (P : PARAMS) = struct
   (* [build_dir] is the base directory of the context; we run menhir from this
      directory to we get correct error paths. *)
   let build_dir = (Super_context.context sctx).build_dir
-  let expander = Compilation_context.expander cctx
+  let expander = Super_context.expander ~dir sctx
 
   let sandbox =
     let scope = Compilation_context.scope cctx in
@@ -128,7 +128,8 @@ module Run (P : PARAMS) = struct
     Action_builder.memoize
       ~cutoff:(List.equal String.equal)
       "menhir flags"
-      (Expander.expand_and_eval_set expander flags ~standard)
+      (let* expander = Action_builder.of_memo expander in
+       Expander.expand_and_eval_set expander flags ~standard)
   ;;
 
   (* ------------------------------------------------------------------------ *)

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -332,7 +332,6 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
   in
   let obj_dir = Obj_dir.for_pp ~dir in
   let* cctx =
-    let* expander = Super_context.expander sctx ~dir in
     let requires_compile = Resolve.map driver_and_libs ~f:snd in
     let requires_link = Memo.lazy_ (fun () -> Memo.return requires_compile) in
     let flags = Ocaml_flags.of_list [ "-g"; "-w"; "-24" ] in
@@ -341,7 +340,6 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
     Compilation_context.create
       ~super_context:sctx
       ~scope
-      ~expander
       ~obj_dir
       ~modules
       ~flags

--- a/src/dune_rules/toplevel.mli
+++ b/src/dune_rules/toplevel.mli
@@ -17,6 +17,7 @@ val make
   :  cctx:Compilation_context.t
   -> source:Source.t
   -> preprocess:Preprocess.Without_instrumentation.t Preprocess.t
+  -> Expander.t
   -> t
 
 type directives =

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -183,7 +183,6 @@ let setup sctx ~dir =
     Compilation_context.create
       ()
       ~super_context:sctx
-      ~expander
       ~scope
       ~obj_dir
       ~modules
@@ -195,6 +194,6 @@ let setup sctx ~dir =
       ~package:None
       ~preprocessing
   in
-  let toplevel = Toplevel.make ~cctx ~source ~preprocess:pps in
+  let toplevel = Toplevel.make ~cctx ~source ~preprocess:pps expander in
   Toplevel.setup_rules toplevel
 ;;


### PR DESCRIPTION
It's only passed through in a few instances where it's not even needed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7cbcd89b-72e1-4a54-bf45-1c18c51ded36 -->