### PR TITLE
fix: attr_of_ansi_color_rgb24

### DIFF
--- a/src/dune_tui/drawing.ml
+++ b/src/dune_tui/drawing.ml
@@ -29,7 +29,7 @@ let attr_of_ansi_color_rgb8 (c : Ansi_color.RGB8.t) =
 ;;
 
 let attr_of_ansi_color_rgb24 (c : Ansi_color.RGB24.t) =
-  A.rgb
+  A.rgb_888
     ~r:(Ansi_color.RGB24.red c)
     ~g:(Ansi_color.RGB24.green c)
     ~b:(Ansi_color.RGB24.blue c)


### PR DESCRIPTION
This was a subtle mistake. A.rgb and A.rgb_888 are for 8 bit and 24 bit RGB color values respectively. This would of meant that any 24 bit color could have raised an Invalid_argument exception in TUI.

I don't see a good way of enforcing these invariants via typing. We could add a few asserts however that might be slow.