### PR TITLE
refactor(ansi_color): rename components

### DIFF
--- a/otherlibs/stdune/src/ansi_color.ml
+++ b/otherlibs/stdune/src/ansi_color.ml
@@ -27,9 +27,9 @@ module RGB24 : sig
 
   val to_dyn : t -> Dyn.t
   val compare : t -> t -> Ordering.t
-  val red : t -> int
-  val green : t -> int
-  val blue : t -> int
+  val r : t -> int
+  val g : t -> int
+  val b : t -> int
   val create : r:int -> g:int -> b:int -> t
 
   (** This is only used internally. *)
@@ -38,19 +38,19 @@ end = struct
   type t = int
 
   let compare = Int.compare
-  let red t = Int.shift_right t 16 land 0xFF
-  let green t = Int.shift_right t 8 land 0xFF
-  let blue t = t land 0xFF
-  let to_dyn t = Dyn.list Dyn.int [ red t; green t; blue t ]
+  let r t = Int.shift_right t 16 land 0xFF
+  let g t = Int.shift_right t 8 land 0xFF
+  let b t = t land 0xFF
+  let to_dyn t = Dyn.record [ "r", Dyn.int (r t); "g", Dyn.int (g t); "b", Dyn.int (b t) ]
   let create ~r ~g ~b = ((r land 0xFF) lsl 16) lor ((g land 0xFF) lsl 8) lor (b land 0xFF)
 
   let write_to_buffer buf t =
     Buffer.add_string buf "38;2;";
-    red t |> Int.to_string |> Buffer.add_string buf;
+    r t |> Int.to_string |> Buffer.add_string buf;
     Buffer.add_char buf ';';
-    green t |> Int.to_string |> Buffer.add_string buf;
+    g t |> Int.to_string |> Buffer.add_string buf;
     Buffer.add_char buf ';';
-    blue t |> Int.to_string |> Buffer.add_string buf
+    b t |> Int.to_string |> Buffer.add_string buf
   ;;
 end
 

--- a/otherlibs/stdune/src/ansi_color.mli
+++ b/otherlibs/stdune/src/ansi_color.mli
@@ -10,14 +10,14 @@ module RGB24 : sig
   (** 24 bit RGB color *)
   type t
 
-  (** [RGB24.red t] returns the red component of [t] *)
-  val red : t -> int
+  (** [RGB24.r t] returns the red component of [t] *)
+  val r : t -> int
 
-  (** [RGB24.green t] returns the green component of [t] *)
-  val green : t -> int
+  (** [RGB24.g t] returns the green component of [t] *)
+  val g : t -> int
 
-  (** [RGB24.blue t] returns the blue component of [t] *)
-  val blue : t -> int
+  (** [RGB24.b t] returns the blue component of [t] *)
+  val b : t -> int
 end
 
 module Style : sig

--- a/src/dune_tui/drawing.ml
+++ b/src/dune_tui/drawing.ml
@@ -29,10 +29,7 @@ let attr_of_ansi_color_rgb8 (c : Ansi_color.RGB8.t) =
 ;;
 
 let attr_of_ansi_color_rgb24 (c : Ansi_color.RGB24.t) =
-  A.rgb_888
-    ~r:(Ansi_color.RGB24.red c)
-    ~g:(Ansi_color.RGB24.green c)
-    ~b:(Ansi_color.RGB24.blue c)
+  A.rgb_888 ~r:(Ansi_color.RGB24.r c) ~g:(Ansi_color.RGB24.g c) ~b:(Ansi_color.RGB24.b c)
 ;;
 
 let attr_of_ansi_color_style (s : Ansi_color.Style.t) =


### PR DESCRIPTION
The "components" of RGB24 should be consistent with our `make` constructor. This will also let us include named color constants here later on.