### PR TITLE
Create flakehub-publish-tagged.yml

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          visibility: "public"


### PR DESCRIPTION
We can publish our Nix flake to flakehub when there is a release.

https://flakehub.com/docs

Basically people who are interested can update their nix flake from flake hub. We just have to add this action and never think about it again.