### PR TITLE
pkg: add `run-with-conditional-terms` action

### DIFF
--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -118,6 +118,7 @@ type t =
   | Patch of String_with_vars.t
   | Substitute of String_with_vars.t * String_with_vars.t
   | Withenv of String_with_vars.t Env_update.t list * t
+  | Run_with_conditional_terms of (Blang.t option * String_with_vars.t) list
 
 val encode : t Encoder.t
 val decode_dune_file : t Decoder.t

--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -26,6 +26,25 @@ module Op = struct
     | Lt -> string "Lt"
     | Neq -> string "Neq"
   ;;
+
+  let equal a b =
+    match a, b with
+    | Eq, Eq -> true
+    | Gt, Gt -> true
+    | Gte, Gte -> true
+    | Lte, Lte -> true
+    | Lt, Lt -> true
+    | Neq, Neq -> true
+    | _ -> false
+  ;;
+
+  let by_string = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
+  let to_string t = fst (List.find_exn by_string ~f:(fun (_, op) -> equal op t))
+
+  let encode t =
+    let open Encoder in
+    string (to_string t)
+  ;;
 end
 
 type t =
@@ -52,12 +71,10 @@ let rec to_dyn =
       [ Op.to_dyn o; String_with_vars.to_dyn s1; String_with_vars.to_dyn s2 ]
 ;;
 
-let ops = [ "=", Op.Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
-
 let decode_gen decode_string =
   let open Decoder in
   let ops =
-    List.map ops ~f:(fun (name, op) ->
+    List.map Op.by_string ~f:(fun (name, op) ->
       ( name
       , let+ x = decode_string
         and+ y = decode_string in
@@ -81,3 +98,16 @@ let decode_gen decode_string =
 
 let decode = decode_gen String_with_vars.decode
 let decode_manually f = decode_gen (String_with_vars.decode_manually f)
+
+let rec encode t =
+  let open Encoder in
+  match t with
+  | Const true -> string "true"
+  | Const false -> string "false"
+  | Not t -> List [ string "not"; encode t ]
+  | Expr e -> String_with_vars.encode e
+  | And ts -> List (string "and" :: List.map ts ~f:encode)
+  | Or ts -> List (string "or" :: List.map ts ~f:encode)
+  | Compare (o, s1, s2) ->
+    List [ Op.encode o; String_with_vars.encode s1; String_with_vars.encode s2 ]
+;;

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -24,6 +24,7 @@ type t =
 val true_ : t
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t
+val encode : t Encoder.t
 
 (** Resolve variables manually. For complex cases such as [enabled_if] *)
 val decode_manually : (Pform.Env.t -> Template.Pform.t -> Pform.t) -> t Decoder.t

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -543,7 +543,7 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
   | Cram script ->
     let+ script = E.dep script in
     Cram_exec.action script
-  | Withenv _ | Substitute _ | Patch _ ->
+  | Withenv _ | Substitute _ | Patch _ | Run_with_conditional_terms _ ->
     (* these can only be provided by the package language which isn't expanded here *)
     assert false
 ;;

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-run-with-conditional-terms.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-run-with-conditional-terms.t
@@ -1,0 +1,70 @@
+Testing the run-with-conditional-terms action
+
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+
+Case with no conditional terms
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms echo Hello, World!))
+  > EOF
+  $ dune build .pkg/foo/target/
+  Hello, World!
+
+Case with mix of conditional and unconditional terms in the program's arguments
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms echo (true foo) bar (false baz) ((= 2 3) qux)))
+  > EOF
+  $ dune build .pkg/foo/target/
+  foo bar
+
+Case where the first term is conditional and included
+  $ mkdir dune.lock/foo.files
+  $ cat >dune.lock/foo.files/hello.txt <<EOF
+  > Hello, World!
+  > EOF
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms (true echo) (false cat) hello.txt))
+  > EOF
+  $ dune build .pkg/foo/target/
+  hello.txt
+
+Case where the first term is conditional and excluded
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms (false echo) (true cat) hello.txt))
+  > EOF
+  $ dune build .pkg/foo/target/
+  Hello, World!
+
+Case where the first non-filtered term is not a program
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms (false echo) (false cat) (true hello.txt)))
+  > EOF
+  $ dune build .pkg/foo/target/
+  File "dune.lock/foo.pkg", line 2, characters 60-69:
+  2 |  (run-with-conditional-terms (false echo) (false cat) (true hello.txt)))
+                                                                  ^^^^^^^^^
+  Error: When using the run-with-conditional-terms action the first term which
+  is either non-conditional or whose condition is true must be a program.
+  In this case the first term was "hello.txt" which is not a valid program.
+  [1]
+
+Case where the first non-filtered term is computed from a variable
+  $ cat >dune.lock/foo.pkg <<EOF
+  > (install
+  >  (run-with-conditional-terms (false echo) (false cat) (true %{context_name})))
+  > EOF
+  $ dune build .pkg/foo/target/
+  File "dune.lock/foo.pkg", line 2, characters 60-75:
+  2 |  (run-with-conditional-terms (false echo) (false cat) (true %{context_name})))
+                                                                  ^^^^^^^^^^^^^^^
+  Error: When using the run-with-conditional-terms action the first term which
+  is either non-conditional or whose condition is true must be a program.
+  In this case the first term was "default" which is not a valid program.
+  [1]


### PR DESCRIPTION
This adds an action tha is similar to `run` except that each term (including the first one) has an optional predicate which can filter out terms. This is added to match the behaviour of opam commands where each term can be optional based on a filter.