### PR TITLE
test(pkg): add a shell script helper

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -1,5 +1,7 @@
 Make sure we can run exes from the user's PATH variable.
 
+  $ . ./helpers.sh
+
 Create a directory containing a shell script and add the directory to PATH.
   $ mkdir bin
   $ cat > bin/hello <<EOF
@@ -19,5 +21,5 @@ Create a lockdir with a lockfile that runs the shell script in a build command.
   > EOF
 
 The build command is run from an environment including the custom PATH variable.
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   Hello, World!

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -1,5 +1,7 @@
 Some environment variables are automatically exported by packages:
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -22,7 +24,7 @@ Some environment variables are automatically exported by packages:
   $ ln -s $(which ocamlc) .bin/ocamlc
   $ ln -s $(which sh) .bin/sh
   $ dune=$(which dune)
-  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" $dune build .pkg/usetest/target/
+  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest
   MANPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/man
   OCAMLPATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib
   CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/default/.pkg/test/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -1,3 +1,7 @@
 (cram
+ (deps helpers.sh)
+ (applies_to :whole_subtree))
+
+(cram
  (deps %{bin:patch})
  (applies_to patch))

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -1,5 +1,7 @@
 Packages can export environment variables
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -25,7 +27,7 @@ Packages can export environment variables
   >   (run mkdir -p %{prefix})))
   > EOF
 
-  $ dune build .pkg/usetest/target/
+  $ build_pkg usetest
   FOO=bar
   BAR=zzz:yyy:xxx
   OPAM_PACKAGE_NAME=usetest

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -1,5 +1,7 @@
 Test that can fetch the sources from an external dir
 
+  $ . ./helpers.sh
+
   $ mkdir foo
   $ echo "y" > foo/x
 
@@ -12,16 +14,16 @@ Test that can fetch the sources from an external dir
   > (build
   >  (progn
   >   (run mkdir -p %{prefix}/bin)
-  >   (run cp x %{prefix}/bin/x )))
+  >   (run cp x %{prefix}/bin/x)))
   > EOF
 
-  $ dune build .pkg/test/target/bin/x
+  $ build_pkg test
 
-  $ find _build/default/.pkg/test | sort
-  _build/default/.pkg/test
-  _build/default/.pkg/test/source
-  _build/default/.pkg/test/source/x
-  _build/default/.pkg/test/target
-  _build/default/.pkg/test/target/bin
-  _build/default/.pkg/test/target/bin/x
-  _build/default/.pkg/test/target/cookie
+  $ show_pkg test
+  
+  /source
+  /source/x
+  /target
+  /target/bin
+  /target/bin/x
+  /target/cookie

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -1,5 +1,7 @@
 Fetch from more than one source
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -21,7 +23,7 @@ Fetch from more than one source
   >  (system "find . | sort -u"))
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   .
   ./bar
   ./mybaz

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -1,5 +1,7 @@
 Things should be the same whether dependencies are specified or not.
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -20,7 +22,7 @@ And we have a package we want to build
   > (build
   >  (system "command -v cat > /dev/null 2>&1 || echo no cat"))
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test
 
 Now it fails since adding the dependency modified PATH.
 
@@ -31,4 +33,4 @@ Now it fails since adding the dependency modified PATH.
   > (build
   >  (system "command -v cat > /dev/null 2>&1 || echo no cat"))
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -1,5 +1,7 @@
 Test fetching from git
 
+  $ . ./helpers.sh
+
   $ mkdir somerepo
   $ cd somerepo
   $ git init --quiet
@@ -20,5 +22,5 @@ Test fetching from git
   > (build (run cat foo))
   > EOF
 
-  $ dune build _build/default/.pkg/test/target
+  $ build_pkg test
   hello world

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -1,0 +1,19 @@
+dune="dune"
+
+pkg_root="_build/default/.pkg"
+
+build_pkg() {
+  $dune build .pkg/$1/target/
+}
+
+show_pkg() {
+  find $pkg_root/$1 | sort | sed "s#$pkg_root/$1##"
+}
+
+show_pkg_targets() {
+  find $pkg_root/$1/target | sort | sed "s#$pkg_root/$1/target##"
+}
+
+show_pkg_cookie() {
+  $dune internal dump $pkg_root/$1/target/cookie
+}

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -1,5 +1,7 @@
 Install actions should have the switch directory prepared:
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -8,7 +10,7 @@ Install actions should have the switch directory prepared:
   > (install (system "find %{prefix} | sort"))
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   ../target
   ../target/bin
   ../target/doc

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -1,5 +1,7 @@
 Testing install actions
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -8,28 +10,30 @@ Testing install actions
   > (install (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   foobar
 
-  $ find _build/default/.pkg/test/target | sort
-  _build/default/.pkg/test/target
-  _build/default/.pkg/test/target/bin
-  _build/default/.pkg/test/target/cookie
-  _build/default/.pkg/test/target/doc
-  _build/default/.pkg/test/target/doc/test
-  _build/default/.pkg/test/target/etc
-  _build/default/.pkg/test/target/etc/test
-  _build/default/.pkg/test/target/lib
-  _build/default/.pkg/test/target/lib/stublibs
-  _build/default/.pkg/test/target/lib/test
-  _build/default/.pkg/test/target/lib/toplevel
-  _build/default/.pkg/test/target/lib/xxx
-  _build/default/.pkg/test/target/man
-  _build/default/.pkg/test/target/sbin
-  _build/default/.pkg/test/target/share
-  _build/default/.pkg/test/target/share/test
+  $ export BUILD_PATH_PREFIX_MAP="/PKG_ROOT=test/target:$BUILD_PATH_PREFIX_MAP"
 
-  $ dune internal dump _build/default/.pkg/test/target/cookie
+  $ show_pkg_targets test
+  
+  /bin
+  /cookie
+  /doc
+  /doc/test
+  /etc
+  /etc/test
+  /lib
+  /lib/stublibs
+  /lib/test
+  /lib/toplevel
+  /lib/xxx
+  /man
+  /sbin
+  /share
+  /share/test
+
+  $ show_pkg_cookie test
   { files =
       map { LIB_ROOT : [ In_build_dir "default/.pkg/test/target/lib/xxx" ] }
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -1,5 +1,7 @@
 Test missing entries in the .install file
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -14,7 +16,7 @@ Test missing entries in the .install file
 This should give us a proper error that myfile wasn't generated
 
   $ lockfile "myfile"
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   Error: No such file or directory
   -> required by _build/default/.pkg/test/target
   [1]
@@ -22,4 +24,4 @@ This should give us a proper error that myfile wasn't generated
 This on the other hand shouldn't error because myfile is optional
 
   $ lockfile "?myfile"
-  $ dune build .pkg/test/target/
+  $ build_pkg test

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -1,5 +1,7 @@
 Test that installed binaries are visible in dependent packages
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -26,21 +28,21 @@ Test that installed binaries are visible in dependent packages
   >   (run mkdir -p %{prefix})))
   > EOF
 
-  $ dune build .pkg/usetest/target/
+  $ build_pkg usetest
   from test package
 
-  $ find _build/default/.pkg/test/target | sort
-  _build/default/.pkg/test/target
-  _build/default/.pkg/test/target/bin
-  _build/default/.pkg/test/target/bin/foo
-  _build/default/.pkg/test/target/cookie
-  _build/default/.pkg/test/target/lib
-  _build/default/.pkg/test/target/lib/lib_rootxxx
-  _build/default/.pkg/test/target/lib/test
-  _build/default/.pkg/test/target/lib/test/libxxx
-  _build/default/.pkg/test/target/share
-  _build/default/.pkg/test/target/share/lib_rootxxx
-  $ dune internal dump _build/default/.pkg/test/target/cookie
+  $ show_pkg_targets test
+  
+  /bin
+  /bin/foo
+  /cookie
+  /lib
+  /lib/lib_rootxxx
+  /lib/test
+  /lib/test/libxxx
+  /share
+  /share/lib_rootxxx
+  $ show_pkg_cookie test
   { files =
       map
         { LIB : [ In_build_dir "default/.pkg/test/target/lib/test/libxxx" ]

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -1,6 +1,8 @@
 Additional files overlaid on top of the source can be found in the
 %pkg.files/ directory:
 
+  $ . ./helpers.sh
+
   $ mkdir test-source
   $ touch test-source/foo
 
@@ -23,7 +25,7 @@ Additional files overlaid on top of the source can be found in the
   > bar from test.files
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   foo:
   foo from test.files
   bar:

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -1,5 +1,7 @@
 Applying patches
 
+  $ . ./helpers.sh
+
   $ mkdir test-source
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
@@ -24,6 +26,6 @@ Applying patches
   > +Hello World
   > EOF
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   patching file foo.ml
   Hello World

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -2,6 +2,8 @@ Set lock file per context.
 
 TODO: versioning will be added once this feature is stable
 
+  $ . ./helpers.sh
+
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (context
@@ -23,6 +25,6 @@ TODO: versioning will be added once this feature is stable
   > EOF
   $ ln -s foo.lock bar.lock
 
-  $ dune build .pkg/test/target
+  $ build_pkg test
   building from foo
   building from default

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -1,5 +1,7 @@
 Test that we run the build command
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -11,11 +13,11 @@ Test that we run the build command
   >   (run touch %{prefix}/bin/foo)))
   > EOF
 
-  $ dune build .pkg/test/target/bin/foo
+  $ build_pkg test
 
-  $ find _build/default/.pkg/test | sort
-  _build/default/.pkg/test
-  _build/default/.pkg/test/target
-  _build/default/.pkg/test/target/bin
-  _build/default/.pkg/test/target/bin/foo
-  _build/default/.pkg/test/target/cookie
+  $ show_pkg test
+  
+  /target
+  /target/bin
+  /target/bin/foo
+  /target/cookie

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -1,5 +1,7 @@
 The test-source folder has a file to use substitution on.
 
+  $ . ./helpers.sh
+
   $ mkdir test-source
   $ cat >test-source/foo.ml.in <<EOF
   > This file will be fed to the substitution mechanism
@@ -18,7 +20,7 @@ The test-source folder has a file to use substitution on.
 
 This should take the `foo.ml.in`, do the substitutions and create `foo.ml`:
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   This file will be fed to the substitution mechanism
 
 This should also work with any other filename combination:
@@ -37,7 +39,7 @@ This should also work with any other filename combination:
 This should take the `foo.ml.template`, do the substitution and create
 `foo.ml`, thus be more flexible that the OPAM `substs` field:
 
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   This is using a different file suffix
 
 Undefined variables, how do they substitute?
@@ -52,7 +54,7 @@ Undefined variables, how do they substitute?
   >   (substitute variables.ml.in variables.ml)
   >   (system "cat variables.ml")))
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   We substitute this '%{var}%' into ''
 
 Now with variables set
@@ -85,7 +87,7 @@ Now with variables set
   >    (substitute defined.ml.in defined.ml))
   >   (system "cat defined.ml")))
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   We substitute '%{name}%' into 'test' and '%{_:name}%' into 'test'
   And '%{version}%' is set to 'dev'
   There is also some paths set:
@@ -123,6 +125,6 @@ It is also possible to use variables of your dependencies:
   > There is also some paths set:
   > '%%{dependency:lib}%%' is '%{dependency:lib}%'
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   There is also some paths set:
   '%{dependency:lib}%' is '_build/default/.pkg/test/target/lib/test'

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -1,5 +1,7 @@
 Test that we can set variables
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -28,12 +30,12 @@ Test that we can set variables
   >   (run mkdir -p %{prefix})))
   > EOF
 
-  $ dune build .pkg/usetest/target/
+  $ build_pkg usetest
   true
   foobar
   foo bar
 
-  $ dune internal dump _build/default/.pkg/test/target/cookie
+  $ show_pkg_cookie test
   { files = map {}
   ; variables =
       [ ("abool", Bool true)

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -1,5 +1,7 @@
 Setting environment variables in actions
 
+  $ . ./helpers.sh
+
   $ mkdir dune.lock
   $ cat >dune.lock/lock.dune <<EOF
   > (lang package 0.1)
@@ -16,7 +18,7 @@ Setting environment variables in actions
   >    (+= BAR ""))
   >   (system "echo XYZ=$XYZ; echo FOO=$FOO; echo BAR=$BAR")))
   > EOF
-  $ dune build .pkg/test/target/
+  $ build_pkg test
   XYZ=111:000
   FOO=myfoo
   BAR=yyy:xxx


### PR DESCRIPTION
With some simple functions to build/print packages.

The test suite is growing quite fast, so it will pay off to maintain some common subset all the tests can use.