### PR TITLE
fix(rpc): stop erroring on closed channels

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -284,10 +284,7 @@ module Session = struct
         ; Pp.text ">>"
         ];
     match t.state with
-    | Closed ->
-      Code_error.raise
-        "attempting to write to a closed channel"
-        [ "sexp", Dyn.(list Sexp.to_dyn) sexps ]
+    | Closed -> Fiber.return (Error `Closed)
     | Open { fd; out_buf; write_mutex; _ } ->
       let* res =
         Fiber.Mutex.with_lock write_mutex ~f:(fun () ->


### PR DESCRIPTION
We have a concrete error value for this now

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 38904564-ee69-4772-a845-b32e048aba83 -->