### PR TITLE
refactor: remove [Dpath.Build.is_dev_null]

### DIFF
--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -173,7 +173,6 @@ module Build = struct
     Path.Build.(relative root) base
   ;;
 
-  let is_dev_null = Fun.const false
   let install_dir = install_dir
   let anonymous_actions_dir = anonymous_actions_dir
 end

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -49,7 +49,6 @@ end
 module Build : sig
   include Dune_sexp.Conv.S with type t = Path.Build.t
 
-  val is_dev_null : t -> bool
   val install_dir : t
   val anonymous_actions_dir : t
 end


### PR DESCRIPTION
This function doesn't seem to be used and its implementation shows us
that it's not very useful.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 05df91d3-20e7-480d-974c-f6b9ae5552cb -->