### PR TITLE
test(dune_console): add escaping for clearer tests

### DIFF
--- a/test/expect-tests/dune_console/dune
+++ b/test/expect-tests/dune_console/dune
@@ -5,6 +5,8 @@
   (pps ppx_expect))
  (libraries
   stdune
+  dune_re
+  dune_sexp
   dune_console
   dune_tests_common
   ;; This is because of the (implicit_transitive_deps false)

--- a/test/expect-tests/dune_console/dune_console_tests.ml
+++ b/test/expect-tests/dune_console/dune_console_tests.ml
@@ -1,14 +1,18 @@
-(** Creation of Dune_console is stateful so we introduce a new module for each test. *)
+open Stdune
+module Re = Dune_re
+
+let escape str =
+  str |> String.split_lines |> List.map ~f:String.escaped |> List.iter ~f:prerr_endline
+;;
+
+(* Creation of Dune_console is stateful so we introduce a new module for each test. *)
 module New () = Dune_console
 
 module type New_console = module type of Dune_console
 
-(** Throughout this file we use regular [" "] strings rather than [{| |}] because we want
-    to observe the escape sequences.
-
-    In order to keep tests accross different backends consistent, we create some generic
-    test scripts here that take the created [Console]. We then test these for each
-    backend. *)
+(* In order to keep tests accross different backends consistent, we create some generic
+   test scripts here that take the created [Console]. We then test these for each
+   backend. *)
 
 let test_basic_usage (module Console : New_console) =
   Console.printf "Hello World!";
@@ -30,63 +34,77 @@ let test_status_line_clearing_with_wrapping (module Console : New_console) =
   let open Console in
   Status_line.set
     (Status_line.Constant
-       (Pp.text
-          "This status line is a problem because of the fact that it is especially long \
-           and therefore will not be cleared properly."));
+       (Pp.hovbox
+        @@ Pp.text
+             "This status line is a problem because of the fact that it is especially \
+              long and therefore will not be cleared properly."));
   Status_line.set (Status_line.Constant (Pp.text "Here is another"));
   Status_line.clear ()
 ;;
 
-(** Dumb backend *)
+(* Dumb backend *)
 
 let%expect_test "basic usage" =
   let module Console = New () in
   Console.Backend.set Console.Backend.dumb;
   test_basic_usage (module Console);
+  escape [%expect.output];
   [%expect
     {|
-    Hello World!
-    Hello this is a very long sentence that will probably wrap the console by the
-    time that this is over. |}]
+Hello World!
+Hello this is a very long sentence that will probably wrap the console by the
+time that this is over.
+  |}]
 ;;
 
 let%expect_test "Status line clearing." =
   let module Console = New () in
   Console.Backend.set Console.Backend.dumb;
   test_status_line_clearing (module Console);
-  [%expect "\nHere is a status line\nHere is another"]
+  escape [%expect.output];
+  [%expect {|
+Here is a status line
+Here is another
+  |}]
 ;;
 
 let%expect_test "Status line clearing with wrapping." =
   let module Console = New () in
   Console.Backend.set Console.Backend.dumb;
   test_status_line_clearing_with_wrapping (module Console);
+  escape [%expect.output];
   [%expect
-    "\n\
-     This status line is a problem because of the fact that it is especially long\n\
-     and therefore will not be cleared properly.\n\
-     Here is another "]
+    {|
+This status line is a problem because of the fact that it is especially long
+and therefore will not be cleared properly.
+Here is another
+  |}]
 ;;
 
-(** Progress backend *)
+(* Progress backend *)
 
 let%expect_test "basic usage" =
   let module Console = New () in
   Console.Backend.set Console.Backend.progress;
   test_basic_usage (module Console);
+  escape [%expect.output];
   [%expect
     {|
-    Hello World!
-    Hello this is a very long sentence that will probably wrap the console by the
-    time that this is over. |}]
+Hello World!
+Hello this is a very long sentence that will probably wrap the console by the
+time that this is over.
+  |}]
 ;;
 
 let%expect_test "Status line clearing." =
   let module Console = New () in
   Console.Backend.set Console.Backend.progress;
   test_status_line_clearing (module Console);
+  escape [%expect.output];
   [%expect
-    "Here is a status line\r                     \rHere is another\r               \r"]
+    {| 
+Here is a status line\r                     \rHere is another\r               \r
+ |}]
 ;;
 
 (* CR-someday alizter: this should insert the appropriate number of "\r"s in order to
@@ -95,10 +113,10 @@ let%expect_test "Status line clearing with wrapping." =
   let module Console = New () in
   Console.Backend.set Console.Backend.progress;
   test_status_line_clearing_with_wrapping (module Console);
+  escape [%expect.output];
   [%expect
-    "\n\
-     This status line is a problem because of the fact that it is especially long and \
-     therefore will not be cleared \
-     properly.\r                                                                                                                        \
-     \rHere is another\r               \r "]
+    {| 
+This status line is a problem because of the fact that it is especially long
+and therefore will not be cleared properly.\r                                                                                                                        \rHere is another\r               \r
+ |}]
 ;;

--- a/test/expect-tests/dune_console/dune_console_tests.ml
+++ b/test/expect-tests/dune_console/dune_console_tests.ml
@@ -103,12 +103,10 @@ let%expect_test "Status line clearing." =
   escape [%expect.output];
   [%expect
     {| 
-Here is a status line\r                     \rHere is another\r               \r
+Here is a status line\r\027[2K\027M\r\027[2KHere is another\r\027[2K\027M\r\027[2K
  |}]
 ;;
 
-(* CR-someday alizter: this should insert the appropriate number of "\r"s in order to
-   fully clear the previous lines when wrapped. *)
 let%expect_test "Status line clearing with wrapping." =
   let module Console = New () in
   Console.Backend.set Console.Backend.progress;
@@ -117,6 +115,6 @@ let%expect_test "Status line clearing with wrapping." =
   [%expect
     {| 
 This status line is a problem because of the fact that it is especially long
-and therefore will not be cleared properly.\r                                                                                                                        \rHere is another\r               \r
+and therefore will not be cleared properly.\r\027[2K\027M\r\027[2K\027M\r\027[2KHere is another\r\027[2K\027M\r\027[2K
  |}]
 ;;


### PR DESCRIPTION
We add some custom escaping functions that remove `\r` and replace it with `\\r\n` so that we can see how it is used by the console.