### PR TITLE
pkg: convert opam command filters to dune blangs

### DIFF
--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -56,6 +56,7 @@ type t =
   | Compare of Op.t * String_with_vars.t * String_with_vars.t
 
 let true_ = Const true
+let false_ = Const false
 
 let rec to_dyn =
   let open Dyn in

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -22,6 +22,7 @@ type t =
   | Compare of Op.t * String_with_vars.t * String_with_vars.t
 
 val true_ : t
+val false_ : t
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t
 val encode : t Encoder.t

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -17,4 +17,5 @@ include struct
   module Action = Action
   module String_with_vars = String_with_vars
   module Pform = Pform
+  module Blang = Dune_lang.Blang
 end

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -28,6 +28,8 @@ val of_macro_invocation
   -> Pform.Macro_invocation.t
   -> (t, [ `Unexpected_macro ]) result
 
+val to_pform : t -> Pform.t
+
 (** Parse an opam variable name. Identifiers beginning with "<package>:" are
     treated as package-scoped variables unless <package> is "_" in which case
     they are treated as self-scoped. Identifiers without the "<package>:"

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -11,6 +11,7 @@ Helper shell function to generate a dune-project file and generate lockdir:
   >   dune pkg lock --opam-repository-path=mock-opam-repository
   > }
 
+
 Generate a mock opam repository
   $ mkdir -p mock-opam-repository
   $ cat >mock-opam-repository/repo <<EOF
@@ -70,6 +71,43 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   > ]
   > EOF
 
+Package for exercising opam filters on commands:
+  $ mkpkg exercise-filters <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >   [ "echo" "a" ] { foo  }
+  >   [ "echo" "b" ] { foo & bar }
+  >   [ "echo" "c" ] { foo & bar & baz }
+  >   [ "echo" "d" ] { foo | bar }
+  >   [ "echo" "e" ] { foo | bar & baz }
+  >   [ "echo" "f" ] { (foo | bar) & baz }
+  >   [ "echo" "b" ] { foo = bar }
+  >   [ "echo" "g" ] { version < "1.0" }
+  >   [ "echo" "h" ] { with-test & ocaml:version < "5.0.0" }
+  >   [ "echo" "i" ] { true }
+  >   [ "echo" "j" ] { ! false }
+  >   [ "echo" "k" ] { foo:installed }
+  >   [ "echo" "l" ] { foo:version < "0.4" }
+  >   [ "echo" "m" ] { foo+bar+baz:installed }
+  > ]
+  > EOF
+
+Package with incorrect package variable conjunction where string was expected:
+  $ mkpkg filter-error-invalid-conjunction <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >   [ "echo" "a" ] { foo+bar+baz:version < "0.4" }
+  > ]
+  > EOF
+
+Package which has boolean where string was expected. This should be caught while parsing:
+  $ mkpkg filter-error-bool-where-string-expected <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >   [ "echo" "a" ] { foo:version < (foo = bar) }
+  > ]
+  > EOF
+
   $ solve_project <<EOF
   > (lang dune 3.8)
   > (package
@@ -95,7 +133,9 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   
   (build
    (progn
-    (run dune subst)
+    (when
+     %{pkg-self:dev}
+     (run dune subst))
     (run dune build -p %{pkg-self:name} -j %{jobs} @install @runtest @doc)))
 
   $ cat dune.lock/with-interpolation.pkg
@@ -138,3 +178,96 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   The full command:
   "./configure" "--prefix=%{prefix"
   [1]
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (depends exercise-filters))
+  > EOF
+  Solution for dune.lock:
+  exercise-filters.0.0.1
+  
+
+  $ cat dune.lock/exercise-filters.pkg
+  (version 0.0.1)
+  
+  (build
+   (progn
+    (when
+     %{pkg-self:foo}
+     (run echo a))
+    (when
+     (and %{pkg-self:foo} %{pkg-self:bar})
+     (run echo b))
+    (when
+     (and
+      (and %{pkg-self:foo} %{pkg-self:bar})
+      %{pkg-self:baz})
+     (run echo c))
+    (when
+     (or %{pkg-self:foo} %{pkg-self:bar})
+     (run echo d))
+    (when
+     (or
+      %{pkg-self:foo}
+      (and %{pkg-self:bar} %{pkg-self:baz}))
+     (run echo e))
+    (when
+     (and
+      (or %{pkg-self:foo} %{pkg-self:bar})
+      %{pkg-self:baz})
+     (run echo f))
+    (when
+     (= %{pkg-self:foo} %{pkg-self:bar})
+     (run echo b))
+    (when
+     (< %{pkg-self:version} 1.0)
+     (run echo g))
+    (when
+     (and
+      %{pkg-self:with-test}
+      (< %{pkg:version:ocaml} 5.0.0))
+     (run echo h))
+    (when
+     true
+     (run echo i))
+    (when
+     (not false)
+     (run echo j))
+    (when
+     %{pkg:installed:foo}
+     (run echo k))
+    (when
+     (< %{pkg:version:foo} 0.4)
+     (run echo l))
+    (when
+     (and %{pkg:installed:foo} %{pkg:installed:bar} %{pkg:installed:baz})
+     (run echo m))))
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (depends filter-error-invalid-conjunction))
+  > EOF
+  Error: Expected string or identifier but found conjunction of identifiers:
+  foo+bar+baz:version
+  ...while processing commands for package:
+  filter-error-invalid-conjunction.0.0.1
+  Full filter: foo+bar+baz:version
+  Note that name1+name2+name3:var is the conjunction of var for each of name1,
+  name2 and name3, i.e it is equivalent to name1:var & name2:var & name3:var.
+  [1]
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (depends filter-error-bool-where-string-expected))
+  > EOF
+  Error: At
+  $TESTCASE_ROOT/mock-opam-repository/packages/filter-error-bool-where-string-expected/filter-error-bool-where-string-expected.0.0.1/opam:3:33-3:34::
+  Parse error
+  [1]
+


### PR DESCRIPTION
This just implements conversion of filters on entire commands using dune's `when` action. Currently it raises a code error if it a `?` unary operator is encountered (opam syntax for checking whether a variable is defined). This may be added in a later change though it's less trivial to convert than the rest of the opam filter dsl and no packages in opam-repository currently use this feature.