### PR TITLE
refactor: remove uses of [Dpath] in the rules

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -735,12 +735,9 @@ module DB = struct
 
   let by_dir dir =
     let context =
-      match Dune_engine.Dpath.analyse_dir (Path.build dir) with
-      | Build
-          ( Install (With_context (name, _))
-          | Regular (With_context (name, _))
-          | Anonymous_action (With_context (name, _)) ) -> name
-      | _ ->
+      match Install.Context.of_path dir with
+      | Some name -> name
+      | None ->
         Code_error.raise
           "directory does not have an associated context"
           [ "dir", Path.Build.to_dyn dir ]

--- a/src/install/context.ml
+++ b/src/install/context.ml
@@ -12,3 +12,12 @@ let man_dir ~context = Path.Build.relative (dir ~context) "man"
 let lib_dir ~context ~package =
   Path.Build.relative (lib_root ~context) (Package_name.to_string package)
 ;;
+
+let of_path path =
+  match Dune_engine.Dpath.analyse_dir (Path.build path) with
+  | Build
+      ( Install (With_context (name, _))
+      | Regular (With_context (name, _))
+      | Anonymous_action (With_context (name, _)) ) -> Some name
+  | _ -> None
+;;

--- a/src/install/context.mli
+++ b/src/install/context.mli
@@ -13,3 +13,4 @@ val lib_root : context:Context_name.t -> Path.Build.t
 val bin_dir : context:Context_name.t -> Path.Build.t
 val man_dir : context:Context_name.t -> Path.Build.t
 val lib_dir : context:Context_name.t -> package:Package_name.t -> Path.Build.t
+val of_path : Path.Build.t -> Context_name.t option


### PR DESCRIPTION
The install context is something that should come from our own code
rather than the engine. Therefore we move this to the [install] library
which already defines some specifics of the install context already.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 495555c2-7841-41e3-8050-66b08e47df53 -->