### PR TITLE
fix: ignoring promotion rules

### DIFF
--- a/doc/changes/8512.md
+++ b/doc/changes/8512.md
@@ -1,0 +1,2 @@
+- Respect the `--ignore-promote-rules` flag regardless of the version in the
+  `dune-project` file (#8512)

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2464,19 +2464,16 @@ type t =
   }
 
 let is_promoted_rule =
-  let is_promoted_mode version = function
+  let is_promoted_mode = function
     | Rule.Mode.Promote { only = None; lifetime; _ } ->
-      if version >= (3, 5)
-      then (
-        match lifetime with
-        | Unlimited -> true
-        | Until_clean -> false)
-      else true
+      (match lifetime with
+       | Unlimited -> true
+       | Until_clean -> false)
     | _ -> false
   in
-  fun version rule ->
+  fun rule ->
     match rule with
-    | Rule { mode; _ } | Menhir_stanza.T { mode; _ } -> is_promoted_mode version mode
+    | Rule { mode; _ } | Menhir_stanza.T { mode; _ } -> is_promoted_mode mode
     | _ -> false
 ;;
 
@@ -2485,9 +2482,7 @@ let parse sexps ~dir ~file ~project =
   let+ stanzas = Stanzas.parse ~file ~dir project sexps in
   let stanzas =
     if !Clflags.ignore_promoted_rules
-    then (
-      let version = Dune_project.dune_version project in
-      List.filter stanzas ~f:(fun s -> not (is_promoted_rule version s)))
+    then List.filter stanzas ~f:(fun s -> not (is_promoted_rule s))
     else stanzas
   in
   { dir; project; stanzas }

--- a/test/blackbox-tests/test-cases/github4401.t
+++ b/test/blackbox-tests/test-cases/github4401.t
@@ -18,9 +18,6 @@ are ignored. See #4401.
   > EOF
 
   $ dune runtest --ignore-promoted-rules
-  Error: No rule found for test
-  -> required by alias runtest in dune:5
-  [1]
 
 This is correctly ignored if `dune-lang` is bumped to 3.5.
 


### PR DESCRIPTION
Bug #4401 was `(promote until-clean)` rules being incorrectly ignored by
`--ignore-promoted-rules`. PR #5956 fixed it but only made the fix
available to newer projects.

This means that projects must update their dune versions before users
can actually build this project without being affected by this bug.
Since this bug fix doesn't have much the potential to break anything, we
make the fix available to all versions.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 82b639c6-a417-4ae8-8cd2-fae02849ea83 -->