### PR TITLE
refactor(engine): remove host from [Build_context]

### DIFF
--- a/src/dune_engine/build_context.ml
+++ b/src/dune_engine/build_context.ml
@@ -3,10 +3,9 @@ open Import
 type t =
   { name : Context_name.t
   ; build_dir : Path.Build.t
-  ; host : Context_name.t option
   }
 
-let create ~name ~host =
+let create ~name =
   let build_dir = Path.Build.of_string (Context_name.to_string name) in
-  { name; build_dir; host }
+  { name; build_dir }
 ;;

--- a/src/dune_engine/build_context.mli
+++ b/src/dune_engine/build_context.mli
@@ -8,7 +8,6 @@ open Import
 type t = private
   { name : Context_name.t
   ; build_dir : Path.Build.t
-  ; host : Context_name.t option
   }
 
-val create : name:Context_name.t -> host:Context_name.t option -> t
+val create : name:Context_name.t -> t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -422,9 +422,7 @@ let create
       supports_shared_libraries && dynamically_linked_foreign_archives
     in
     let t =
-      let build_context =
-        Build_context.create ~name ~host:(Option.map host ~f:(fun c -> c.name))
-      in
+      let build_context = Build_context.create ~name in
       { name
       ; implicit
       ; kind

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -415,13 +415,13 @@ module Context = struct
 
   let build_contexts t =
     let name = name t in
-    let native = Build_context.create ~name ~host:(host_context t) in
+    let native = Build_context.create ~name in
     native
     :: List.filter_map (targets t) ~f:(function
       | Native -> None
       | Named toolchain ->
         let name = Context_name.target name ~toolchain in
-        Some (Build_context.create ~name ~host:(Some native.name)))
+        Some (Build_context.create ~name))
   ;;
 end
 


### PR DESCRIPTION
This was needed for some sanity checks during cross compilation.

Cross compilation is working well enough and is entirely self contained
in the the rules. If this sanity check is needed, it can be implemented
in the rules directly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 83cafb79-3d9d-47a7-af80-ef69b108b593 -->