### PR TITLE
refactor(engine): remove unused encoders/decoders

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -113,7 +113,11 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
 
 let print_rule_sexp ppf (rule : Dune_engine.Reflection.Rule.t) =
   let sexp_of_action action = Action.for_shell action |> encode in
-  let paths ps = Dune_lang.Encoder.list Dpath.Build.encode (Path.Build.Set.to_list ps) in
+  let paths ps =
+    Dune_lang.Encoder.list
+      (fun p -> Dune_sexp.atom_or_quoted_string (Path.Build.to_string p))
+      (Path.Build.Set.to_list ps)
+  in
   let sexp =
     Dune_lang.Encoder.record
       (List.concat

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -104,7 +104,10 @@ module Prog = struct
 end
 
 module Encode_ext = struct
-  type t = (module Ext.Instance with type target = Dpath.Build.t and type path = Dpath.t)
+  type t =
+    (module Ext.Instance
+       with type target = Stdune.Path.Build.t
+        and type path = Stdune.Path.t)
 end
 
 module type Ast =
@@ -116,7 +119,7 @@ module type Ast =
      and type ext = Encode_ext.t
 
 module rec Ast : Ast = Ast
-include Make (Prog) (Dpath) (Dpath.Build) (String) (Encode_ext) (Ast)
+include Make (Prog) (Stdune.Path) (Stdune.Path.Build) (String) (Encode_ext) (Ast)
 
 include Monoid.Make (struct
     type nonrec t = t

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -39,21 +39,13 @@ val describe_target : Path.Build.t -> string
 
 val describe_path : Path.t -> string
 
-include Dune_sexp.Conv.S with type t = Path.t
+type t = Path.t
 
-module Local : sig
-  val encode : dir:Path.t -> Path.t Dune_sexp.Encoder.t
-  val decode : dir:Path.t -> Path.t Dune_sexp.Decoder.t
-end
+val encode : Path.t Dune_sexp.Encoder.t
 
 module Build : sig
-  include Dune_sexp.Conv.S with type t = Path.Build.t
+  type t = Path.Build.t
 
   val install_dir : t
   val anonymous_actions_dir : t
-end
-
-module External : sig
-  val encode : Path.External.t Dune_sexp.Encoder.t
-  val decode : Path.External.t Dune_sexp.Decoder.t
 end

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -8,6 +8,7 @@ module String_with_vars = String_with_vars
 module Pform = Pform
 module Action = Action
 module Dune_file_script = Dune_file_script
+module Path = Path
 module Value = Value
 module Blang = Blang
 module Binary_kind = Binary_kind

--- a/src/dune_lang/path.ml
+++ b/src/dune_lang/path.ml
@@ -1,0 +1,17 @@
+open Stdune
+
+(* to trick ocamldep *)
+module Path = Path
+
+module Local = struct
+  let encode ~dir:from p =
+    let open Dune_sexp.Encoder in
+    string (Path.reach ~from p)
+  ;;
+
+  let decode ~dir =
+    let open Dune_sexp.Decoder in
+    let+ error_loc, path = located string in
+    Path.relative ~error_loc dir path
+  ;;
+end

--- a/src/dune_lang/path.mli
+++ b/src/dune_lang/path.mli
@@ -1,0 +1,8 @@
+open Stdune
+
+module Local : sig
+  type t := Path.t
+
+  val encode : dir:Path.t -> t Dune_sexp.Encoder.t
+  val decode : dir:Path.t -> t Dune_sexp.Decoder.t
+end

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -33,7 +33,7 @@ module Lib = struct
   let encode ~package_root ~stublibs { info; main_module_name } =
     let open Dune_lang.Encoder in
     let no_loc f (_loc, x) = f x in
-    let path = Dpath.Local.encode ~dir:package_root in
+    let path = Dune_lang.Path.Local.encode ~dir:package_root in
     let paths name f = field_l name path f in
     let mode_paths name (xs : Path.t Mode.Dict.List.t) =
       field_l name sexp (Mode.Dict.List.encode path xs)
@@ -135,7 +135,7 @@ module Lib = struct
 
   let decode ~(lang : Vfile.Lang.Instance.t) ~base =
     let open Dune_lang.Decoder in
-    let path = Dpath.Local.decode ~dir:base in
+    let path = Dune_lang.Path.Local.decode ~dir:base in
     let field_l s x = field ~default:[] s (repeat x) in
     let libs s = field_l s (located Lib_name.decode) in
     let paths s = field_l s path in
@@ -375,7 +375,7 @@ let decode ~lang ~dir =
     field
       ~default:[]
       "sections"
-      (repeat (pair (located Section.decode) (Dpath.Local.decode ~dir)))
+      (repeat (pair (located Section.decode) (Dune_lang.Path.Local.decode ~dir)))
   and+ sites =
     field ~default:[] "sites" (repeat (pair (located Site.decode) Section.decode))
   and+ files =
@@ -439,7 +439,7 @@ let encode ~dune_version { entries; name; version; dir; sections; sites; files }
       ; field_o "version" string version
       ; field_l
           "sections"
-          (pair Section.encode (Dpath.Local.encode ~dir))
+          (pair Section.encode (Dune_lang.Path.Local.encode ~dir))
           (Section.Map.to_list sections)
       ; field_l "sites" (pair Site.encode Section.encode) sites
       ; field_l "files" (pair Section.encode (list Install.Entry.Dst.encode)) files

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -9,14 +9,14 @@ module File = struct
   let decode ~dir =
     let open Dune_lang.Decoder in
     fields
-    @@ let+ path = field "path" (Dpath.Local.decode ~dir) in
+    @@ let+ path = field "path" (Dune_lang.Path.Local.decode ~dir) in
        (* TODO do not just assume the dialect is OCaml *)
        { path; dialect = Dialect.ocaml }
   ;;
 
   let encode { path; dialect = _ } ~dir =
     let open Dune_lang.Encoder in
-    record_fields [ field "path" (Dpath.Local.encode ~dir) path ]
+    record_fields [ field "path" (Dune_lang.Path.Local.encode ~dir) path ]
   ;;
 
   let dialect t = t.dialect

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -306,7 +306,7 @@ module Context = struct
            1. guard before version check before releasing
            2. allow external paths
         *)
-        field_o "lock" (Dpath.Local.decode ~dir:(Path.source Path.Source.root))
+        field_o "lock" (Dune_lang.Path.Local.decode ~dir:(Path.source Path.Source.root))
       and+ version_preference =
         field_o "version_preference" Dune_pkg.Version_preference.decode
       and+ solver_env = field_o "solver_env" Dune_pkg.Solver_env.decode in

--- a/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
@@ -45,7 +45,7 @@ Now we try loading the rules in output/a and make sure that nothing is deleted:
   Loading build directory _build/default/.dune
   Loading build directory _build
   ((deps ())
-   (targets ((files ()) (directories (default/output))))
+   (targets ((files ()) (directories (_build/default/output))))
    (context default)
    (action
     (chdir

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -123,7 +123,7 @@ Print rules:
 
   $ dune rules output
   ((deps ((File (In_build_dir _build/default/src_x))))
-   (targets ((files ()) (directories (default/output))))
+   (targets ((files ()) (directories (_build/default/output))))
    (context default)
    (action
     (chdir

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
@@ -32,7 +32,7 @@ Rules created for the assets in the output directory
 
   $ dune rules @mel | grep file.txt
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-   (targets ((files (default/a/output/a/assets/file.txt)) (directories ())))
+    ((files (_build/default/a/output/a/assets/file.txt)) (directories ())))
     (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
 
   $ dune build @mel
@@ -115,10 +115,10 @@ Need to create the source dir first for the alias to be picked up
 
   $ dune rules @mel | grep .txt
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-   (targets ((files (default/a/output/a/assets/file.txt)) (directories ())))
+    ((files (_build/default/a/output/a/assets/file.txt)) (directories ())))
     (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-    ((files (default/another/another-output/a/assets/file.txt))
+    ((files (_build/default/another/another-output/a/assets/file.txt))
      (copy a/assets/file.txt another/another-output/a/assets/file.txt))))
 
   $ dune build @mel

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -42,14 +42,14 @@ Alias is found even if source dir "output" isn't present
 
   $ dune rules @mel | grep file.txt
   ((deps ((File (In_build_dir _build/default/assets/file.txt))))
-   (targets ((files (default/output/assets/file.txt)) (directories ())))
+   (targets ((files (_build/default/output/assets/file.txt)) (directories ())))
    (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
 
 Creating the source directory makes it appear in the alias
 
   $ dune rules @mel | grep file.txt
   ((deps ((File (In_build_dir _build/default/assets/file.txt))))
-   (targets ((files (default/output/assets/file.txt)) (directories ())))
+   (targets ((files (_build/default/output/assets/file.txt)) (directories ())))
    (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
 
   $ dune build @mel


### PR DESCRIPTION
All of these are either:

* completely unused
* only used in the rules
* trivially inlined in into the rules printer

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 916471b4-a96e-4013-b9a1-aa09edfa2808 -->