### PR TITLE
odoc: add test for `stdlib` stanza

### DIFF
--- a/test/blackbox-tests/test-cases/odoc/stdlib-stanza.t
+++ b/test/blackbox-tests/test-cases/odoc/stdlib-stanza.t
@@ -1,0 +1,42 @@
+Demonstrate how odoc interops with the `stdlib` stanza
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.9)
+  > (using experimental_building_ocaml_compiler_with_dune 0.1)
+  > (package (name l))
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (public_name l)
+  >  (stdlib))
+  > EOF
+
+  $ cat > l.ml << EOF
+  > module Bar = Bar
+  > (** this module is bar *)
+  > EOF
+
+  $ cat > bar.ml << EOF
+  > type 'a t = 'a array
+  > EOF
+
+  $ dune build @doc
+
+Bar is compiled
+  $ find _build/default -name '*.odoc' | sort -n
+  _build/default/.l.objs/byte/l.odoc
+  _build/default/.l.objs/byte/l__Bar.odoc
+  _build/default/_doc/_odoc/pkg/l/page-index.odoc
+
+Bar is not linked
+  $ find _build/default -name '*.odocl' | sort -n
+  _build/default/_doc/_odocls/l/l.odocl
+  _build/default/_doc/_odocls/l/page-index.odocl
+
+No html is generated for Bar
+
+  $ find _build/default -name '*.html' | sort -n
+  _build/default/_doc/_html/index.html
+  _build/default/_doc/_html/l/L/index.html
+  _build/default/_doc/_html/l/index.html


### PR DESCRIPTION
I am trying to reproduce some issue with the odoc generated html from Melange stdlib producing broken links (for example, the generated page for the [Lazy module](https://melange.re/v1.0.0/api/ml/melange/Stdlib/Lazy/index.html) has a broken link at the top to `CamlinternalLazy.t`).

When trying to reproduce with dune, I am not being able to do so, because when I add `stdlib` stanza to a library, no html is generated for any of the modules contained in the library.

Is this the expected behavior?