### PR TITLE
feature: FreeBSD, OpenBSD, NetBSD platform detection

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -109,7 +109,7 @@ module Copyfile = struct
     match Platform.OS.value with
     | Darwin -> `Copyfile
     | Linux -> `Sendfile
-    | Windows | Other -> `Nothing
+    | _ -> `Nothing
   ;;
 
   let sendfile_with_fallback =

--- a/otherlibs/stdune/src/platform.ml
+++ b/otherlibs/stdune/src/platform.ml
@@ -1,22 +1,32 @@
 module OS = struct
+  (* CR-someday alizter: Include mingw32, mongw64, cygwin *)
   type t =
     | Darwin
     | Linux
     | Windows
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
     | Other
 
   let equal = Poly.equal
 
   external is_darwin : unit -> bool = "stdune_is_darwin"
+  external is_freebsd : unit -> bool = "stdune_is_freebsd"
+  external is_netbsd : unit -> bool = "stdune_is_netbsd"
+  external is_openbsd : unit -> bool = "stdune_is_openbsd"
 
-  let to_dyn = function
+  let to_dyn : t -> Dyn.t = function
     | Windows -> Dyn.variant "Windows" []
     | Darwin -> Dyn.variant "Darwin" []
     | Linux -> Dyn.variant "Linux" []
+    | FreeBSD -> Dyn.variant "FreeBSD" []
+    | NetBSD -> Dyn.variant "NetBSD" []
+    | OpenBSD -> Dyn.variant "OpenBSD" []
     | Other -> Dyn.variant "Other" []
   ;;
 
-  let linux () =
+  let is_linux () =
     try
       let chan = open_in_bin "/proc/sys/kernel/ostype" in
       Exn.protect
@@ -34,8 +44,14 @@ module OS = struct
     then Windows
     else if is_darwin ()
     then Darwin
-    else if linux ()
+    else if is_linux ()
     then Linux
+    else if is_freebsd ()
+    then FreeBSD
+    else if is_netbsd ()
+    then NetBSD
+    else if is_openbsd ()
+    then OpenBSD
     else Other
   ;;
 end

--- a/otherlibs/stdune/src/platform.mli
+++ b/otherlibs/stdune/src/platform.mli
@@ -7,6 +7,9 @@ module OS : sig
     | Darwin
     | Linux
     | Windows
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
     | Other
 
   (** [value] is the current os we're running on. *)

--- a/otherlibs/stdune/src/platform_stubs.c
+++ b/otherlibs/stdune/src/platform_stubs.c
@@ -9,3 +9,30 @@ CAMLprim value stdune_is_darwin(value v_unit) {
   CAMLreturn(Val_false);
 #endif
 }
+
+CAMLprim value stdune_is_freebsd(value v_unit) {
+   CAMLparam1(v_unit);
+#if defined(__FreeBSD__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+CAMLprim value stdune_is_openbsd(value v_unit) {
+   CAMLparam1(v_unit);
+#if defined(__OpenBSD__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+CAMLprim value stdune_is_netbsd(value v_unit) {
+   CAMLparam1(v_unit);
+#if defined(__NetBSD__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -362,7 +362,7 @@ let select_watcher_backend () =
   else (
     match Platform.OS.value with
     | Windows -> `Fswatch_win
-    | Linux | Darwin | Other -> fswatch_backend ())
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Other -> fswatch_backend ())
 ;;
 
 let prepare_sync () =


### PR DESCRIPTION
We add platform detection for FreeBSD, OpenBSD and NetBSD in order to refine the `Other` constructor for Platform.OS.t. This allows us to exclude Other when we want to be more sure a feature is supported.

I could have put these all into the same constructor, however there are subtle differences which may become relevant. It would also make the C stubs a little trickier to use.