### PR TITLE
refactor(engine): remove install paths

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -29,7 +29,8 @@ let in_dir ~name ~recursive ~contexts dir =
     User_error.raise
       [ Pp.textf
           "Invalid alias: %s."
-          (Path.to_string_maybe_quoted (Path.build Dune_engine.Dpath.Build.install_dir))
+          (Path.to_string_maybe_quoted
+             (Path.build Install.Context.install_context.build_dir))
       ; Pp.textf "There are no aliases in %s." (Path.to_string_maybe_quoted dir)
       ]
   | In_build_dir (ctx, dir) ->

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -47,7 +47,12 @@ let all_direct_targets dir =
     | None -> Source_tree.root ()
     | Some dir -> Source_tree.nearest_dir dir
   and* contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-  Memo.parallel_map (Context_name.Map.values contexts) ~f:(fun ctx ->
+  Context_name.Map.values contexts
+  |> List.filter_map ~f:(fun (ctx, (ctx_type : Build_config.Gen_rules.Context_type.t)) ->
+    match ctx_type with
+    | Empty -> None
+    | With_sources -> Some ctx)
+  |> Memo.parallel_map ~f:(fun (ctx : Dune_engine.Build_context.t) ->
     Source_tree_map_reduce.map_reduce
       root
       ~traverse:Sub_dirs.Status.Set.all

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -41,6 +41,9 @@ let check_path contexts =
        | Other _ -> internal_path ()
        | Alias (_, _) -> internal_path ()
        | Anonymous_action _ -> internal_path ()
-       | Install (name, src) -> In_install_dir (context_exn name, src)
-       | Regular (name, src) -> In_build_dir (context_exn name, src))
+       | Regular (name, src) ->
+         (match Install.Context.analyze_path name src with
+          | Invalid -> internal_path ()
+          | Install (ctx, path) -> In_install_dir (context_exn ctx, path)
+          | Normal (ctx, path) -> In_build_dir (context_exn ctx, path)))
 ;;

--- a/src/dune_engine/context_name.ml
+++ b/src/dune_engine/context_name.ml
@@ -19,7 +19,6 @@ include (
       if name = ""
          || String.is_prefix name ~prefix:"."
          || name = "log"
-         || name = "install"
          || String.contains name '/'
          || String.contains name '\\'
       then None

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -8,7 +8,6 @@ module Target_dir : sig
   val build_dir : context_related -> Path.Build.t
 
   type t =
-    | Install of context_related
     | Anonymous_action of context_related
     | Regular of context_related
     | Invalid of Path.Build.t
@@ -20,7 +19,6 @@ type target_kind =
   | Regular of Context_name.t * Path.Source.t
   | Alias of Context_name.t * Path.Source.t
   | Anonymous_action of Context_name.t
-  | Install of Context_name.t * Path.Source.t
   | Other of Path.Build.t
 
 type 'build path_kind =
@@ -46,6 +44,6 @@ val encode : Path.t Dune_sexp.Encoder.t
 module Build : sig
   type t = Path.Build.t
 
-  val install_dir : t
   val anonymous_actions_dir : t
+  val anonymous_actions_dir_basename : Filename.t
 end

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -2,7 +2,7 @@ open Import
 open Memo.O
 module Action_builder = Action_builder0
 module Gen_rules = Build_config.Gen_rules
-module Context_or_install = Gen_rules.Context_or_install
+module Context_type = Gen_rules.Context_type
 module Build_only_sub_dirs = Gen_rules.Build_only_sub_dirs
 
 module type Rule_generator = Gen_rules.Rule_generator
@@ -46,10 +46,11 @@ end
 
 module Dir_triage = struct
   module Build_directory = struct
-    (* invariant: [dir = context_or_install / sub_dir] *)
+    (* invariant: [dir = context_name / sub_dir] *)
     type t =
       { dir : Path.Build.t
-      ; context_or_install : Context_or_install.t
+      ; context_name : Context_name.t
+      ; context_type : Context_type.t
       ; sub_dir : Path.Source.t
       }
 
@@ -61,10 +62,7 @@ module Dir_triage = struct
 
     let parent t =
       Option.map (Path.Source.parent t.sub_dir) ~f:(fun sub_dir ->
-        { dir = Path.Build.parent_exn t.dir
-        ; context_or_install = t.context_or_install
-        ; sub_dir
-        })
+        { t with dir = Path.Build.parent_exn t.dir; sub_dir })
     ;;
   end
 
@@ -73,6 +71,7 @@ module Dir_triage = struct
     | Build_directory of Build_directory.t
 
   let empty_source = Known (Source { files = Path.Source.Set.empty })
+  let no_rules = Known (Loaded.no_rules ~allowed_subdirs:Dir_set.empty)
 end
 
 let get_dir_triage ~dir =
@@ -110,18 +109,8 @@ let get_dir_triage ~dir =
   | Build (Regular Root) ->
     let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
     let allowed_subdirs =
-      Subdir_set.to_dir_set
-        (Subdir_set.of_list
-           (([ Dpath.Build.anonymous_actions_dir; Dpath.Build.install_dir ]
-             |> List.map ~f:Path.Build.basename)
-            @ (Context_name.Map.keys contexts |> List.map ~f:Context_name.to_string)))
-    in
-    Dir_triage.Known (Loaded.no_rules ~allowed_subdirs)
-  | Build (Install Root) ->
-    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-    let allowed_subdirs =
-      Context_name.Map.keys contexts
-      |> List.map ~f:Context_name.to_string
+      [ Path.Build.basename Dpath.Build.anonymous_actions_dir ]
+      @ (Context_name.Map.keys contexts |> List.map ~f:Context_name.to_string)
       |> Subdir_set.of_list
       |> Subdir_set.to_dir_set
     in
@@ -133,16 +122,14 @@ let get_dir_triage ~dir =
       [ "dir", Path.Build.to_dyn build_dir ]
   | Build (Invalid _) ->
     Memo.return @@ Dir_triage.Known (Loaded.no_rules ~allowed_subdirs:Dir_set.empty)
-  | Build (Install (With_context (context_name, sub_dir))) ->
-    (* In this branch, [dir] is in the build directory. *)
-    let dir = Path.as_in_build_dir_exn dir in
-    let context_or_install = Context_or_install.Install context_name in
-    Memo.return (Dir_triage.Build_directory { dir; context_or_install; sub_dir })
   | Build (Regular (With_context (context_name, sub_dir))) ->
-    (* In this branch, [dir] is in the build directory. *)
-    let dir = Path.as_in_build_dir_exn dir in
-    let context_or_install = Context_or_install.Context context_name in
-    Memo.return (Dir_triage.Build_directory { dir; context_or_install; sub_dir })
+    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
+    (match Context_name.Map.find contexts context_name with
+     | None -> Dir_triage.no_rules
+     | Some ((_ : Build_context.t), context_type) ->
+       (* In this branch, [dir] is in the build directory. *)
+       let dir = Path.as_in_build_dir_exn dir in
+       Dir_triage.Build_directory { dir; context_name; context_type; sub_dir })
 ;;
 
 let describe_rule (rule : Rule.t) =
@@ -257,17 +244,6 @@ let no_rule_found ~loc fn =
       User_error.raise
         [ Pp.textf
             "Trying to build %s but build context %s doesn't exist."
-            (Path.Build.to_string_maybe_quoted fn)
-            (Context_name.to_string ctx)
-        ]
-        ~hints:(hints ctx)
-  | Install (ctx, _) ->
-    if Context_name.Map.mem contexts ctx
-    then fail fn ~loc
-    else
-      User_error.raise
-        [ Pp.textf
-            "Trying to build %s for install but build context %s doesn't exist."
             (Path.Build.to_string_maybe_quoted fn)
             (Context_name.to_string ctx)
         ]
@@ -497,7 +473,7 @@ end = struct
       let module Source_tree = (val (Build_config.get ()).source_tree) in
       let corresponding_source_dir =
         match Dpath.analyse_target dir with
-        | Install _ | Alias _ | Anonymous_action _ | Other _ -> Memo.return None
+        | Alias _ | Anonymous_action _ | Other _ -> Memo.return None
         | Regular (_ctx, sub_dir) -> Source_tree.find_dir sub_dir
       in
       corresponding_source_dir
@@ -630,23 +606,23 @@ end = struct
     ;;
 
     let call_rules_generator
-      ({ Dir_triage.Build_directory.dir; context_or_install; sub_dir } as d)
+      ({ Dir_triage.Build_directory.dir; context_name; context_type = _; sub_dir } as d)
       =
       let (module RG : Rule_generator) = (Build_config.get ()).rule_generator in
       let sub_dir_components = Path.Source.explode sub_dir in
-      RG.gen_rules context_or_install ~dir sub_dir_components
+      RG.gen_rules context_name ~dir sub_dir_components
       >>= function
       | Rules rules -> Memo.return @@ Normal (Normal.make_rules_gen_result ~of_:dir rules)
-      | Unknown_context_or_install ->
+      | Unknown_context ->
         Code_error.raise
           "[gen_rules] did not specify rules for the context"
-          [ "context_or_install", Context_or_install.to_dyn context_or_install ]
+          [ "context_name", Context_name.to_dyn context_name ]
       | Redirect_to_parent child ->
         (match Dir_triage.Build_directory.parent d with
          | None ->
            Code_error.raise
              "[gen_rules] returned Redirect_to_parent on a root directory"
-             [ "context_or_install", Context_or_install.to_dyn context_or_install ]
+             [ "context_name", Context_name.to_dyn context_name ]
          | Some parent ->
            let child = Normal.make_rules_gen_result ~of_:dir child in
            let+ parent = Gen_rules.gen_rules parent in
@@ -734,64 +710,62 @@ end = struct
           })
   ;;
 
-  type source_rules =
-    { source_files : Path.Source.Set.t
-    ; source_dirs : Filename.Set.t
-    ; copy_rules : Rule.t list
-    }
+  module Source_rules = struct
+    type t =
+      { source_files : Path.Source.Set.t
+      ; source_dirs : Filename.Set.t
+      ; copy_rules : Rule.t list
+      }
+
+    let empty =
+      { source_files = Path.Source.Set.empty
+      ; source_dirs = Filename.Set.empty
+      ; copy_rules = []
+      }
+    ;;
+  end
 
   (* Compute all the copying rules from the source directory. *)
-  let rules_from_source_dir
-    source_paths_to_ignore
-    (context_or_install : Context_or_install.t)
-    sub_dir
+  let rules_from_source_dir source_paths_to_ignore (context_name : Context_name.t) sub_dir
     =
-    match context_or_install with
-    | Install _ ->
-      Memo.return
-        { source_files = Path.Source.Set.empty
-        ; source_dirs = Filename.Set.empty
-        ; copy_rules = []
-        }
-    | Context context_name ->
-      (* Take into account the source files *)
-      let+ source_files, source_dirs =
-        let+ files, subdirs =
-          let module Source_tree = (val (Build_config.get ()).source_tree) in
-          Source_tree.find_dir sub_dir
-          >>| function
-          | None -> Path.Source.Set.empty, Filename.Set.empty
-          | Some dir -> Source_tree.Dir.file_paths dir, Source_tree.Dir.sub_dir_names dir
-        in
-        let files =
-          let source_files_to_ignore =
-            Path.Build.Set.to_list_map
-              ~f:Path.Build.drop_build_context_exn
-              source_paths_to_ignore.files
-            |> Path.Source.Set.of_list
-          in
-          Path.Source.Set.diff files source_files_to_ignore
-        in
-        let subdirs = Filename.Set.diff subdirs source_paths_to_ignore.dirnames in
-        files, subdirs
+    (* Take into account the source files *)
+    let+ source_files, source_dirs =
+      let+ files, subdirs =
+        let module Source_tree = (val (Build_config.get ()).source_tree) in
+        Source_tree.find_dir sub_dir
+        >>| function
+        | None -> Path.Source.Set.empty, Filename.Set.empty
+        | Some dir -> Source_tree.Dir.file_paths dir, Source_tree.Dir.sub_dir_names dir
       in
-      (* Compile the rules and cleanup stale artifacts *)
-      let copy_rules =
-        let ctx_dir = Context_name.build_dir context_name in
-        create_copy_rules ~ctx_dir ~non_target_source_files:source_files
+      let files =
+        let source_files_to_ignore =
+          Path.Build.Set.to_list_map
+            ~f:Path.Build.drop_build_context_exn
+            source_paths_to_ignore.files
+          |> Path.Source.Set.of_list
+        in
+        Path.Source.Set.diff files source_files_to_ignore
       in
-      { source_files; source_dirs; copy_rules }
+      let subdirs = Filename.Set.diff subdirs source_paths_to_ignore.dirnames in
+      files, subdirs
+    in
+    (* Compile the rules and cleanup stale artifacts *)
+    let copy_rules =
+      let ctx_dir = Context_name.build_dir context_name in
+      create_copy_rules ~ctx_dir ~non_target_source_files:source_files
+    in
+    { Source_rules.source_files; source_dirs; copy_rules }
   ;;
 
   let descendants_to_keep
-    { Dir_triage.Build_directory.dir; context_or_install; sub_dir }
+    { Dir_triage.Build_directory.dir; context_name = _; context_type; sub_dir }
     (build_dir_only_sub_dirs : Subdir_set.t)
     ~source_dirs
     rules_produced
     =
     let* allowed_by_parent =
-      match context_or_install, Path.Source.to_string sub_dir with
-      | Context _, ".dune" ->
+      match context_type, Path.Source.to_string sub_dir with
+      | With_sources, ".dune" ->
         (* GROSS HACK: this is to avoid a cycle as the rules for all
            directories force the generation of ".dune/configurator". We need a
            better way to deal with such cases. *)
@@ -872,7 +846,7 @@ end = struct
   ;;
 
   let load_build_directory_exn
-    ({ Dir_triage.Build_directory.dir; context_or_install; sub_dir } as build_dir)
+    ({ Dir_triage.Build_directory.dir; context_name; context_type; sub_dir } as build_dir)
     =
     (* Load all the rules *)
     Gen_rules.gen_rules build_dir
@@ -898,11 +872,14 @@ end = struct
       (* Compute the set of sources and targets promoted to the source tree that
          must not be copied to the build directory. *)
       (* Take into account the source files *)
-      let* { source_files; source_dirs; copy_rules } =
-        let source_paths_to_ignore =
-          source_paths_to_ignore ~dir build_dir_only_sub_dirs rules
-        in
-        rules_from_source_dir source_paths_to_ignore context_or_install sub_dir
+      let* { Source_rules.source_files; source_dirs; copy_rules } =
+        match context_type with
+        | Empty -> Memo.return Source_rules.empty
+        | With_sources ->
+          let source_paths_to_ignore =
+            source_paths_to_ignore ~dir build_dir_only_sub_dirs rules
+          in
+          rules_from_source_dir source_paths_to_ignore context_name sub_dir
       in
       (* Compile the rules and cleanup stale artifacts *)
       let rules =
@@ -934,10 +911,10 @@ end = struct
               (Path.Build.local dir))
          ~subdirs_to_keep);
       let+ aliases =
-        match context_or_install with
-        | Context _ -> compute_alias_expansions ~collected ~dir
-        | Install _ ->
-          (* There are no aliases in the [_build/install] directory *)
+        match context_type with
+        | With_sources -> compute_alias_expansions ~collected ~dir
+        | Empty ->
+          (* There are no aliases in contexts without sources *)
           Memo.return Alias.Name.Map.empty
       in
       Loaded.Build { Loaded.allowed_subdirs = descendants_to_keep; rules_here; aliases }

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -386,11 +386,6 @@ end = struct
                (("alias " ^ Path.Source.to_string name) :: targets_acc)
                (add_ctx ctx ctxs_acc)
                rest
-           | Install (ctx, name) ->
-             split_paths
-               (("install " ^ Path.Source.to_string name) :: targets_acc)
-               (add_ctx ctx ctxs_acc)
-               rest
            | Anonymous_action ctx ->
              split_paths ("(internal)" :: targets_acc) (add_ctx ctx ctxs_acc) rest)
       in

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -97,7 +97,6 @@ module Build_config = struct
   module Gen_rules = struct
     open Build_config.Gen_rules
     module Build_only_sub_dirs = Build_only_sub_dirs
-    module Context_or_install = Context_or_install
     module Rules = Rules
 
     let make

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -83,7 +83,10 @@ let init
     ~contexts:
       (Memo.lazy_ (fun () ->
          let open Memo.O in
-         Workspace.workspace () >>| Workspace.build_contexts))
+         let+ contexts = Workspace.workspace () >>| Workspace.build_contexts in
+         let open Dune_engine.Build_config.Gen_rules.Context_type in
+         (Install.Context.install_context, Empty)
+         :: List.map contexts ~f:(fun ctx -> ctx, With_sources)))
     ~cache_config
     ~cache_debug_flags
     ~rule_generator:(module Gen_rules)

--- a/src/install/context.ml
+++ b/src/install/context.ml
@@ -1,8 +1,13 @@
 open Import
 
+let install_context =
+  let name = Context_name.of_string "install" in
+  Dune_engine.Build_context.create ~name
+;;
+
 let dir ~context =
   let context = Context_name.to_string context in
-  Path.Build.relative Dpath.Build.install_dir context
+  Path.Build.relative (Context_name.build_dir install_context.name) context
 ;;
 
 let lib_root ~context = Path.Build.relative (dir ~context) "lib"
@@ -15,9 +20,25 @@ let lib_dir ~context ~package =
 
 let of_path path =
   match Dune_engine.Dpath.analyse_dir (Path.build path) with
-  | Build
-      ( Install (With_context (name, _))
-      | Regular (With_context (name, _))
-      | Anonymous_action (With_context (name, _)) ) -> Some name
+  | Build (Regular (With_context (name, src))) ->
+    Some
+      (if Context_name.equal name install_context.name
+       then Context_name.of_string (Path.Source.basename src)
+       else name)
+  | Build (Anonymous_action (With_context (name, _))) -> Some name
   | _ -> None
+;;
+
+type analyze_path =
+  | Invalid
+  | Install of Context_name.t * Path.Source.t
+  | Normal of Context_name.t * Path.Source.t
+
+let analyze_path ctx_name source =
+  match Context_name.equal ctx_name install_context.name with
+  | false -> Normal (ctx_name, source)
+  | true ->
+    (match Path.Source.split_first_component source with
+     | None -> Invalid
+     | Some (ctx, path) -> Install (Context_name.of_string ctx, Path.Source.of_local path))
 ;;

--- a/src/install/context.mli
+++ b/src/install/context.mli
@@ -6,6 +6,8 @@
 
 open! Import
 
+val install_context : Dune_engine.Build_context.t
+
 (** Local installation directory: [<build-dir>/install/<context-name>]. *)
 val dir : context:Context_name.t -> Path.Build.t
 
@@ -14,3 +16,10 @@ val bin_dir : context:Context_name.t -> Path.Build.t
 val man_dir : context:Context_name.t -> Path.Build.t
 val lib_dir : context:Context_name.t -> package:Package_name.t -> Path.Build.t
 val of_path : Path.Build.t -> Context_name.t option
+
+type analyze_path =
+  | Invalid
+  | Install of Context_name.t * Path.Source.t
+  | Normal of Context_name.t * Path.Source.t
+
+val analyze_path : Context_name.t -> Path.Source.t -> analyze_path


### PR DESCRIPTION
This PR moves the special "install" context from the engine to the rules. This context is used solely by the dune rules to copy the directory structure that is used by opam packages, therefore it should be moved to the rules.

Implementation wise, the only relevant difference between the install context and other contexts is that the install context has no source copying rules. To reflect this, I've added a new context configuration option to `Build_config` to reflect this possibility. As a consequence, the rules now have the ability to configure every context with or without source copying rules.