### PR TITLE
feature: add Haiku, Serenity, Solaris detection

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -107,8 +107,8 @@ module Copyfile = struct
 
   let available =
     match Platform.OS.value with
-    | Darwin -> `Copyfile
-    | Linux -> `Sendfile
+    | `Darwin -> `Copyfile
+    | `Linux -> `Sendfile
     | _ -> `Nothing
   ;;
 

--- a/otherlibs/stdune/src/platform.ml
+++ b/otherlibs/stdune/src/platform.ml
@@ -1,13 +1,44 @@
 module OS = struct
   (* CR-someday alizter: Include mingw32, mongw64, cygwin *)
   type t =
-    | Darwin
-    | Linux
-    | Windows
-    | FreeBSD
-    | NetBSD
-    | OpenBSD
-    | Other
+    [ `Darwin
+    | `Linux
+    | `Windows
+    | `FreeBSD
+    | `NetBSD
+    | `OpenBSD
+    | `DragonFly
+    | `Haiku
+    | `Serenity
+    | `Solaris
+    | `Other
+    ]
+
+  (* Include all constructors here. *)
+  let all =
+    [ `Darwin
+    ; `Linux
+    ; `Windows
+    ; `FreeBSD
+    ; `NetBSD
+    ; `OpenBSD
+    ; `DragonFly
+    ; `Haiku
+    ; `Serenity
+    ; `Solaris
+    ; `Other
+    ]
+  ;;
+
+  type fswatch_support =
+    [ `Darwin
+    | `Linux
+    | `FreeBSD
+    | `NetBSD
+    | `OpenBSD
+    | `DragonFly
+    | `Solaris
+    ]
 
   let equal = Poly.equal
 
@@ -15,15 +46,23 @@ module OS = struct
   external is_freebsd : unit -> bool = "stdune_is_freebsd"
   external is_netbsd : unit -> bool = "stdune_is_netbsd"
   external is_openbsd : unit -> bool = "stdune_is_openbsd"
+  external is_dragonfly : unit -> bool = "stdune_is_dragonfly"
+  external is_haiku : unit -> bool = "stdune_is_haiku"
+  external is_serenity : unit -> bool = "stdune_is_serenity"
+  external is_solaris : unit -> bool = "stdune_is_solaris"
 
   let to_dyn : t -> Dyn.t = function
-    | Windows -> Dyn.variant "Windows" []
-    | Darwin -> Dyn.variant "Darwin" []
-    | Linux -> Dyn.variant "Linux" []
-    | FreeBSD -> Dyn.variant "FreeBSD" []
-    | NetBSD -> Dyn.variant "NetBSD" []
-    | OpenBSD -> Dyn.variant "OpenBSD" []
-    | Other -> Dyn.variant "Other" []
+    | `Windows -> Dyn.variant "Windows" []
+    | `Darwin -> Dyn.variant "Darwin" []
+    | `Linux -> Dyn.variant "Linux" []
+    | `FreeBSD -> Dyn.variant "FreeBSD" []
+    | `NetBSD -> Dyn.variant "NetBSD" []
+    | `OpenBSD -> Dyn.variant "OpenBSD" []
+    | `DragonFly -> Dyn.variant "DragonFly" []
+    | `Haiku -> Dyn.variant "Haiku" []
+    | `Serenity -> Dyn.variant "Serenity" []
+    | `Solaris -> Dyn.variant "Solaris" []
+    | `Other -> Dyn.variant "Other" []
   ;;
 
   let is_linux () =
@@ -39,20 +78,24 @@ module OS = struct
     | _ -> false
   ;;
 
+  let detect = function
+    | `Windows -> Stdlib.Sys.win32
+    | `Darwin -> is_darwin ()
+    | `Linux -> is_linux ()
+    | `FreeBSD -> is_freebsd ()
+    | `NetBSD -> is_netbsd ()
+    | `OpenBSD -> is_openbsd ()
+    | `DragonFly -> is_dragonfly ()
+    | `Haiku -> is_haiku ()
+    | `Serenity -> is_serenity ()
+    | `Solaris -> is_solaris ()
+    | `Other -> false
+  ;;
+
   let value =
-    if Stdlib.Sys.win32
-    then Windows
-    else if is_darwin ()
-    then Darwin
-    else if is_linux ()
-    then Linux
-    else if is_freebsd ()
-    then FreeBSD
-    else if is_netbsd ()
-    then NetBSD
-    else if is_openbsd ()
-    then OpenBSD
-    else Other
+    match List.find all ~f:detect with
+    | Some os -> os
+    | None -> `Other
   ;;
 end
 

--- a/otherlibs/stdune/src/platform.mli
+++ b/otherlibs/stdune/src/platform.mli
@@ -2,15 +2,29 @@
 
 module OS : sig
   (** Detect the operating system. *)
-
   type t =
-    | Darwin
-    | Linux
-    | Windows
-    | FreeBSD
-    | NetBSD
-    | OpenBSD
-    | Other
+    [ `Darwin
+    | `Linux
+    | `Windows
+    | `FreeBSD
+    | `NetBSD
+    | `OpenBSD
+    | `DragonFly
+    | `Haiku
+    | `Serenity
+    | `Solaris
+    | `Other
+    ]
+
+  type fswatch_support =
+    [ `Darwin
+    | `Linux
+    | `FreeBSD
+    | `NetBSD
+    | `OpenBSD
+    | `DragonFly
+    | `Solaris
+    ]
 
   (** [value] is the current os we're running on. *)
   val value : t

--- a/otherlibs/stdune/src/platform_stubs.c
+++ b/otherlibs/stdune/src/platform_stubs.c
@@ -1,6 +1,7 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 
+// MacOS
 CAMLprim value stdune_is_darwin(value v_unit) {
   CAMLparam1(v_unit);
 #if defined(__APPLE__)
@@ -10,8 +11,9 @@ CAMLprim value stdune_is_darwin(value v_unit) {
 #endif
 }
 
+// FreeBSD
 CAMLprim value stdune_is_freebsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__FreeBSD__)
   CAMLreturn(Val_true);
 #else
@@ -19,8 +21,9 @@ CAMLprim value stdune_is_freebsd(value v_unit) {
 #endif
 }
 
+// OpenBSD
 CAMLprim value stdune_is_openbsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__OpenBSD__)
   CAMLreturn(Val_true);
 #else
@@ -28,9 +31,50 @@ CAMLprim value stdune_is_openbsd(value v_unit) {
 #endif
 }
 
+// NetBSD
 CAMLprim value stdune_is_netbsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__NetBSD__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+// DragonFly BSD
+CAMLprim value stdune_is_dragonfly(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__DragonFly__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+// Haiku
+CAMLprim value stdune_is_haiku(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__HAIKU__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+// Serenity
+CAMLprim value stdune_is_serenity(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__serenity__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+// Solaris
+CAMLprim value stdune_is_solaris(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__sun)
   CAMLreturn(Val_true);
 #else
   CAMLreturn(Val_false);

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -238,7 +238,7 @@ module Session = struct
 
   let write =
     match Platform.OS.value with
-    | Linux -> send
+    | `Linux -> send
     | _ -> Unix.single_write
   ;;
 

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -113,7 +113,7 @@ let copy_file =
 
 let background_default =
   match Platform.OS.value with
-  | Linux | Windows | Darwin -> `Enabled
+  | `Linux | `Windows | `Darwin -> `Enabled
   | _ -> `Disabled
 ;;
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -363,7 +363,7 @@ let handle_fs_event ({ kind; path } : Dune_file_watcher.Fs_memo_event.t)
   match Path.destruct_build_dir path with
   | `Inside _ ->
     (* This can occur on MacOS when [PATH=.:$PATH] for example *)
-    Platform.assert_os Darwin;
+    Platform.assert_os `Darwin;
     Memo.Invalidation.empty
   | `Outside path ->
     (match kind with

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -148,7 +148,7 @@ let create ~mode ~dune_stats ~rule_loc ~deps ~rule_dir ~rule_digest ~expand_alia
        when a file changes. This doesn't work on OSX for instance as the file
        system granularity is 1s, which is too coarse. *)
     (match Platform.OS.value with
-     | Linux -> ()
+     | `Linux -> ()
      | _ ->
        User_error.raise
          ~loc:rule_loc

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -365,8 +365,12 @@ let select_watcher_backend () =
   then `Inotify_lib
   else (
     match Platform.OS.value with
-    | Windows -> `Fswatch_win
-    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Other -> fswatch_backend ())
+    | `Windows -> `Fswatch_win
+    | #Platform.OS.fswatch_support -> fswatch_backend ()
+    | _ ->
+      (* CR-someday alizter: For platforms which we know there isn't fswatch support we
+         should give a better error message. *)
+      fswatch_backend ())
 ;;
 
 let prepare_sync () =


### PR DESCRIPTION
We also change the Platform.OS.t type to a polymorphic variant. The reason for doing this is it allows us to define subtypes such as `fswatch_supported` allowing us to pattern match elsewhere.

This will be useful for `posix` compliant OSes etc. later on.

We also add the following OS detection:
- Haiku
- Serenity
- Solaris
- DragonFly