### PR TITLE
refactor(tui): encapsulate terminal functionality in dune_tui

### DIFF
--- a/src/dune_tui/import.ml
+++ b/src/dune_tui/import.ml
@@ -1,6 +1,5 @@
 include Stdune
 module Ui = Nottui.Ui
-module Term = Notty_unix.Term
 module A = Notty.A
 module I = Notty.I
 module Renderer = Nottui.Renderer


### PR DESCRIPTION
We encapsulate the basic terminal functionality we use for dune_tui. This will help us understand what exactly we need to implement for a future windows backend. The idea with the API is that it should be completely hide the lower level details of the terminal.

Keeping as a draft for now as I think about it. 