### PR TITLE
refactor: rename [Expander.make]

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -740,16 +740,17 @@ let expand t ~mode template =
     ~f:(expand_pform t)
 ;;
 
-let make
+let make_root
   ~scope
   ~scope_host
   ~(context : Context.t)
+  ~env
   ~lib_artifacts
   ~lib_artifacts_host
   ~bin_artifacts_host
   =
   { dir = context.build_dir
-  ; env = context.env
+  ; env
   ; local_env = Env.Var.Map.empty
   ; bindings = Pform.Map.empty
   ; scope

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -8,10 +8,11 @@ val scope : t -> Scope.t
 val dir : t -> Path.Build.t
 val context : t -> Context.t
 
-val make
+val make_root
   :  scope:Scope.t
   -> scope_host:Scope.t
   -> context:Context.t
+  -> env:Env.t
   -> lib_artifacts:Artifacts.Public_libs.t
   -> lib_artifacts_host:Artifacts.Public_libs.t
   -> bin_artifacts_host:Artifacts.Bin.t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -399,10 +399,11 @@ let create ~(context : Context.t) ~host ~packages ~stanzas =
     in
     let+ scope = Scope.DB.find_by_dir context.build_dir
     and+ scope_host = Scope.DB.find_by_dir context_host.build_dir in
-    Expander.make
+    Expander.make_root
       ~scope
       ~scope_host
       ~context
+      ~env:context.env
       ~lib_artifacts:artifacts.public_libs
       ~bin_artifacts_host:artifacts_host.bin
       ~lib_artifacts_host:artifacts_host.public_libs


### PR DESCRIPTION
Rename to [Expander.make_root] to reflect where it can be used correctly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9db2be48-fb78-4f6e-b747-c90db636a150 -->