### PR TITLE
refactor: move ocaml flags to [Ocaml_flags_db]

### DIFF
--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -38,3 +38,11 @@ val modules_rules
   -> Scope.t
   -> Modules.t
   -> (Modules.t * Pp_spec.t) Memo.t
+
+(** Compute the ocaml flags based on the directory environment and a buildable
+    stanza *)
+val ocaml_flags
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Ocaml_flags.Spec.t
+  -> Ocaml_flags.t Memo.t

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -177,7 +177,7 @@ let gen_rules sctx t ~dir ~scope =
     let link_args =
       let open Action_builder.O in
       let* link_flags =
-        Action_builder.of_memo (Super_context.link_flags sctx ~dir t.link_flags)
+        Action_builder.of_memo (Ocaml_flags_db.link_flags sctx ~dir t.link_flags)
       in
       let+ link_args = Link_flags.get ~use_standard_cxx_flags:false link_flags in
       Command.Args.As link_args

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -128,7 +128,7 @@ let executables_rules
   let programs = programs ~modules ~exes in
   let explicit_js_mode = Dune_project.explicit_js_mode project in
   let linkages = linkages ctx ~exes ~explicit_js_mode in
-  let* flags = Super_context.ocaml_flags sctx ~dir exes.buildable.flags in
+  let* flags = Buildable_rules.ocaml_flags sctx ~dir exes.buildable.flags in
   let* modules, pp =
     Buildable_rules.modules_rules
       sctx
@@ -179,7 +179,7 @@ let executables_rules
       let link_flags =
         let* () = link_deps in
         let* link_flags =
-          Action_builder.of_memo (Super_context.link_flags sctx ~dir exes.link_flags)
+          Action_builder.of_memo (Ocaml_flags_db.link_flags sctx ~dir exes.link_flags)
         in
         Link_flags.get ~use_standard_cxx_flags link_flags
       in

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -150,7 +150,7 @@ include Sub_system.Register_end_point (struct
       and* cctx =
         let package = Dune_file.Library.package lib in
         let* ocaml_flags =
-          Super_context.ocaml_flags sctx ~dir info.executable_ocaml_flags
+          Buildable_rules.ocaml_flags sctx ~dir info.executable_ocaml_flags
         in
         let flags = Ocaml_flags.append_common ocaml_flags [ "-w"; "-24"; "-g" ] in
         let js_of_ocaml =

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -501,7 +501,7 @@ let setup_build_archives
 ;;
 
 let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_info =
-  let* flags = Super_context.ocaml_flags sctx ~dir lib.buildable.flags
+  let* flags = Buildable_rules.ocaml_flags sctx ~dir lib.buildable.flags
   and* vimpl = Virtual_rules.impl sctx ~lib ~scope in
   let obj_dir = Library.obj_dir ~dir lib in
   let ctx = Super_context.context sctx in

--- a/src/dune_rules/ocaml_flags_db.ml
+++ b/src/dune_rules/ocaml_flags_db.ml
@@ -1,0 +1,25 @@
+open Import
+open Memo.O
+
+let ocaml_flags sctx ~dir (spec : Ocaml_flags.Spec.t) =
+  let* flags =
+    let* expander = Super_context.expander sctx ~dir in
+    let+ ocaml_flags = Super_context.env_node sctx ~dir >>= Env_node.ocaml_flags in
+    Ocaml_flags.make
+      ~spec
+      ~default:ocaml_flags
+      ~eval:(Expander.expand_and_eval_set expander)
+  in
+  Source_tree.is_vendored (Path.Build.drop_build_context_exn dir)
+  >>| function
+  | false -> flags
+  | true ->
+    let ocaml_version = (Super_context.context sctx).ocaml.version in
+    Ocaml_flags.with_vendored_flags ~ocaml_version flags
+;;
+
+let link_flags sctx ~dir (spec : Link_flags.Spec.t) =
+  let* expander = Super_context.expander sctx ~dir in
+  let+ link_flags = Super_context.env_node sctx ~dir >>= Env_node.link_flags in
+  Link_flags.make ~spec ~default:link_flags ~eval:(Expander.expand_and_eval_set expander)
+;;

--- a/src/dune_rules/ocaml_flags_db.mli
+++ b/src/dune_rules/ocaml_flags_db.mli
@@ -1,0 +1,15 @@
+open Import
+
+(** Compute the ocaml flags based on the directory environment and a buildable
+    stanza *)
+val ocaml_flags
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Ocaml_flags.Spec.t
+  -> Ocaml_flags.t Memo.t
+
+val link_flags
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Link_flags.Spec.t
+  -> Link_flags.t Memo.t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -294,29 +294,6 @@ let add_alias_action t alias ~dir ~loc action =
     build
 ;;
 
-let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
-  let* expander = Env_tree.expander t ~dir in
-  let* flags =
-    let+ ocaml_flags = Env_tree.get_node t ~dir >>= Env_node.ocaml_flags in
-    Ocaml_flags.make
-      ~spec
-      ~default:ocaml_flags
-      ~eval:(Expander.expand_and_eval_set expander)
-  in
-  Source_tree.is_vendored (Path.Build.drop_build_context_exn dir)
-  >>| function
-  | false -> flags
-  | true ->
-    let ocaml_version = (Env_tree.context t).ocaml.version in
-    Ocaml_flags.with_vendored_flags ~ocaml_version flags
-;;
-
-let link_flags t ~dir (spec : Link_flags.Spec.t) =
-  let* expander = Env_tree.expander t ~dir in
-  let+ link_flags = Env_tree.get_node t ~dir >>= Env_node.link_flags in
-  Link_flags.make ~spec ~default:link_flags ~eval:(Expander.expand_and_eval_set expander)
-;;
-
 let local_binaries t ~dir = Env_tree.get_node t ~dir >>= Env_node.local_binaries
 let env_node = Env_tree.get_node
 let bin_annot t ~dir = Env_tree.get_node t ~dir >>= Env_node.bin_annot

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -23,12 +23,6 @@ val context : t -> Context.t
 (** Context env with additional variables computed from packages *)
 val context_env : t -> Env.t
 
-(** Compute the ocaml flags based on the directory environment and a buildable
-    stanza *)
-val ocaml_flags : t -> dir:Path.Build.t -> Ocaml_flags.Spec.t -> Ocaml_flags.t Memo.t
-
-val link_flags : t -> dir:Path.Build.t -> Link_flags.Spec.t -> Link_flags.t Memo.t
-
 (** Binaries that are symlinked in the associated .bin directory of [dir]. This
     associated directory is [Path.relative dir ".bin"] *)
 val local_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list Memo.t


### PR DESCRIPTION
Removes the last unrelated thing in [Super_context]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d8fa030d-a834-4a69-9572-a613ebf9303c -->