### PR TITLE
improve "install fswatch" error for FreeBSD

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -355,7 +355,13 @@ let fswatch_backend () =
   in
   match try_fswatch () with
   | Some res -> res
-  | None -> User_error.raise [ Pp.text "Please install fswatch to enable watch mode." ]
+  | None ->
+    let hints =
+      match Platform.OS.value with
+      | FreeBSD -> [ Pp.text "pkg install fswatch-mon" ]
+      | _ -> []
+    in
+    User_error.raise ~hints [ Pp.text "Please install fswatch to enable watch mode." ]
 ;;
 
 let select_watcher_backend () =


### PR DESCRIPTION
On FreeBSD fswatch is packaged under fswatch-mon and fswatch is a completely unrelated package. This might save some users some time.

We can also give hints for other platforms too, but I am unsure what the best hints might be.