### PR TITLE
Communicate READER to merlin for configured dialects

### DIFF
--- a/doc/changes/8567.md
+++ b/doc/changes/8567.md
@@ -1,0 +1,3 @@
+- merlin: add optional `(merlin_reader CMD)` construct to `(dialect)` stanza to
+  configure a merlin reader (#8567, @andreypopp)
+

--- a/src/dune_rules/dialect.ml
+++ b/src/dune_rules/dialect.ml
@@ -91,7 +91,7 @@ let decode =
     and+ merlin_reader =
       field_o
         "merlin_reader"
-        (Dune_lang.Syntax.since Stanza.syntax (3, 11) >>> located (repeat1 string))
+        (Dune_lang.Syntax.since Stanza.syntax (3, 16) >>> located (repeat1 string))
     and+ syntax_ver = Syntax.get_exn Stanza.syntax in
     let ver = 3, 9 in
     if syntax_ver < ver && Option.is_some (String.index_from extension 1 '.')
@@ -152,8 +152,8 @@ let print_ast { file_kinds; _ } ml_kind =
 
 let merlin_reader { file_kinds; _ } ml_kind =
   let open Option.O in
-  let* x = Ml_kind.Dict.get file_kinds ml_kind in
-  let+ _, merlin_reader = x.merlin_reader in
+  let* dialect = Ml_kind.Dict.get file_kinds ml_kind in
+  let+ _, merlin_reader = dialect.merlin_reader in
   merlin_reader
 ;;
 

--- a/src/dune_rules/dialect.ml
+++ b/src/dune_rules/dialect.ml
@@ -292,8 +292,8 @@ module DB = struct
     }
 
   and for_merlin =
-    { extensions : string option Ml_kind.Dict.t list
-    ; readers : string list String.Map.t
+    { extensions : Filename.Extension.t option Ml_kind.Dict.t list
+    ; readers : Filename.Extension.t list String.Map.t
     }
 
   let fold { by_name; _ } = String.Map.fold by_name

--- a/src/dune_rules/dialect.mli
+++ b/src/dune_rules/dialect.mli
@@ -43,8 +43,14 @@ module DB : sig
   val find_by_name : t -> string -> dialect option
   val find_by_extension : t -> Filename.Extension.t -> (dialect * Ml_kind.t) option
   val fold : t -> init:'a -> f:(dialect -> 'a -> 'a) -> 'a
-  val extensions_for_merlin : t -> Filename.Extension.t option Ml_kind.Dict.t list
   val to_dyn : t -> Dyn.t
   val builtin : t
   val is_default : t -> bool
+
+  type for_merlin =
+    { extensions : string option Ml_kind.Dict.t list
+    ; readers : string list String.Map.t
+    }
+
+  val for_merlin : t -> for_merlin
 end

--- a/src/dune_rules/dialect.mli
+++ b/src/dune_rules/dialect.mli
@@ -49,7 +49,7 @@ module DB : sig
 
   type for_merlin =
     { extensions : string option Ml_kind.Dict.t list
-    ; readers : string list String.Map.t
+    ; readers : Filename.Extension.t list String.Map.t
     }
 
   val for_merlin : t -> for_merlin

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -589,13 +589,13 @@ module Unprocessed = struct
       (* And copy for each module the resulting pp flags *)
       modules
       |> Modules.With_vlib.drop_vlib
-      |> Modules.fold_no_vlib modules ~init:[] ~f:(fun m init ->
-        Module.orig_sources m
+      |> Modules.fold ~init:[] ~f:(fun m init ->
+        Module.sources_without_pp m
         |> Path.Build.Set.of_list_map ~f:(fun src -> Path.as_in_build_dir_exn src)
         |> Path.Build.Set.fold ~init ~f:(fun src acc ->
           let config =
             { Processed.module_ = Module.set_pp m None
-            ; opens = Modules.local_open modules m
+            ; opens = Modules.With_vlib.local_open modules m
             ; reader = String.Map.find readers (Path.Build.extension src)
             }
           in

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -600,7 +600,7 @@ module Unprocessed = struct
             }
           in
           (* we add the config with and without the extension, the latter is
-             needed for a fallback in get *)
+             needed for a fallback in this file's [get] function. *)
           let src_without_extension = remove_extension src in
           (src, config) :: (src_without_extension, config) :: acc))
       |> Path.Build.Map.of_list_reduce ~f:(fun existing _ -> existing)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -68,25 +68,30 @@ module Processed = struct
   type module_config =
     { opens : Module_name.t list
     ; module_ : Module.t
+    ; reader : string list option
     }
 
-  let dyn_of_module_config { opens; module_ } =
+  let dyn_of_module_config { opens; module_; reader } =
     let open Dyn in
-    record [ "opens", list Module_name.to_dyn opens; "module_", Module.to_dyn module_ ]
+    record
+      [ "opens", list Module_name.to_dyn opens
+      ; "module_", Module.to_dyn module_
+      ; "reader", option (list string) reader
+      ]
   ;;
 
   (* ...but modules can have different preprocessing specifications*)
   type t =
     { config : config
-    ; per_module_config : module_config Path.Build.Map.t
+    ; per_file_config : module_config Path.Build.Map.t
     ; pp_config : pp_flag option Module_name.Per_item.t
     }
 
-  let to_dyn { config; per_module_config; pp_config } =
+  let to_dyn { config; per_file_config; pp_config } =
     let open Dyn in
     record
       [ "config", dyn_of_config config
-      ; "per_module_config", Path.Build.Map.to_dyn dyn_of_module_config per_module_config
+      ; "per_file_config", Path.Build.Map.to_dyn dyn_of_module_config per_file_config
       ; "pp_config", Module_name.Per_item.to_dyn (option dyn_of_pp_flag) pp_config
       ]
   ;;
@@ -106,7 +111,7 @@ module Processed = struct
           ; flags = [ "-x" ]
           ; extensions = [ { Ml_kind.Dict.intf = None; impl = Some "ext" } ]
           }
-      ; per_module_config = Path.Build.Map.empty
+      ; per_file_config = Path.Build.Map.empty
       ; pp_config =
           (match
              Module_name.Per_item.of_mapping
@@ -144,7 +149,7 @@ module Processed = struct
     | None, None -> None
   ;;
 
-  let to_sexp ~opens ~pp { stdlib_dir; obj_dirs; src_dirs; flags; extensions } =
+  let to_sexp ~opens ~pp ~reader { stdlib_dir; obj_dirs; src_dirs; flags; extensions } =
     let make_directive tag value = Sexp.List [ Atom tag; value ] in
     let make_directive_of_path tag path =
       make_directive tag (Sexp.Atom (serialize_path path))
@@ -185,8 +190,16 @@ module Processed = struct
         let+ impl, intf = get_ext x in
         make_directive "SUFFIX" (Sexp.Atom (Printf.sprintf "%s %s" impl intf)))
     in
+    let reader =
+      match reader with
+      | Some reader ->
+        [ make_directive "READER" (Sexp.List (List.map ~f:(fun r -> Sexp.Atom r) reader))
+        ]
+      | None -> []
+    in
     Sexp.List
-      (List.concat [ stdlib_dir; exclude_query_dir; obj_dirs; src_dirs; flags; suffixes ])
+      (List.concat
+         [ stdlib_dir; exclude_query_dir; obj_dirs; src_dirs; flags; suffixes; reader ])
   ;;
 
   let quote_for_dot_merlin s =
@@ -231,39 +244,50 @@ module Processed = struct
     Buffer.contents b
   ;;
 
-  let get { per_module_config; pp_config; config } ~file =
-    (* We only match the first part of the filename : foo.ml -> foo foo.cppo.ml
-       -> foo *)
+  let get { per_file_config; pp_config; config } ~file =
     let open Option.O in
-    let+ { module_; opens } =
-      let find file =
-        let file_without_ext = remove_extension file in
-        Path.Build.Map.find per_module_config file_without_ext
-      in
+    let+ { module_; opens; reader } =
+      let find file = Path.Build.Map.find per_file_config file in
       match find file with
       | Some _ as s -> s
-      | None -> Copy_line_directive.DB.follow_while file ~f:find
+      | None ->
+        (match Copy_line_directive.DB.follow_while file ~f:find with
+         | Some _ as s -> s
+         | None ->
+           (* Fallback to handle preprocessed files (where the preprocessor has
+              the file extensison changed).
+
+              We choose to fallback by a lookup with file_without_ext.ml e.g.
+              stripping all possible file extensions prefixes.
+
+              This is too rough but, really, preprocessors should emit copy
+              line directives instead and then Dune should have the database
+              similar to Copy_line_directive to handle this. *)
+           let file_without_ext = remove_extension file in
+           Path.Build.Map.find
+             per_file_config
+             (Path.Build.set_extension file_without_ext ~ext:".ml"))
     in
     let pp = Module_name.Per_item.get pp_config (Module.name module_) in
-    to_sexp ~opens ~pp config
+    to_sexp ~opens ~pp ~reader config
   ;;
 
   let print_file path =
     match load_file path with
     | Error msg -> Printf.eprintf "%s\n" msg
-    | Ok { per_module_config; pp_config; config } ->
-      let pp_one (source, { module_; opens }) =
+    | Ok { per_file_config; pp_config; config } ->
+      let pp_one (source, { module_; opens; reader }) =
         let open Pp.O in
         let name = Module.name module_ in
         let pp = Module_name.Per_item.get pp_config name in
-        let sexp = to_sexp ~opens ~pp config in
+        let sexp = to_sexp ~reader ~opens ~pp config in
         Pp.hvbox
           (Pp.textf "%s: %s" (Module_name.to_string name) (Path.Build.to_string source))
         ++ Pp.newline
         ++ Pp.vbox (Sexp.pp sexp)
       in
       let pp =
-        Path.Build.Map.to_list per_module_config
+        Path.Build.Map.to_list per_file_config
         |> Pp.concat_map ~sep:Pp.cut ~f:pp_one
         |> Pp.vbox
       in
@@ -288,7 +312,7 @@ module Processed = struct
           ~f:
             (fun
               (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
-              { per_module_config = _
+              { per_file_config = _
               ; pp_config
               ; config = { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
               }
@@ -335,6 +359,7 @@ module Unprocessed = struct
     ; source_dirs : Path.Source.Set.t
     ; objs_dirs : Path.Set.t
     ; extensions : string option Ml_kind.Dict.t list
+    ; readers : string list String.Map.t
     ; mode : Lib_mode.t
     }
 
@@ -373,7 +398,7 @@ module Unprocessed = struct
       Path.Set.singleton @@ obj_dir_of_lib `Private mode (Obj_dir.of_local obj_dir)
     in
     let flags = Ocaml_flags.get flags mode in
-    let extensions = Dialect.DB.extensions_for_merlin dialects in
+    let { Dialect.DB.extensions; readers } = Dialect.DB.for_merlin dialects in
     let config =
       { stdlib_dir
       ; mode
@@ -384,6 +409,7 @@ module Unprocessed = struct
       ; source_dirs
       ; objs_dirs
       ; extensions
+      ; readers
       }
     in
     { ident; config; modules }
@@ -488,6 +514,7 @@ module Unprocessed = struct
      ; config =
          { stdlib_dir
          ; extensions
+         ; readers
          ; flags
          ; objs_dirs
          ; source_dirs
@@ -562,24 +589,24 @@ module Unprocessed = struct
       in
       { Processed.stdlib_dir; src_dirs; obj_dirs; flags; extensions }
     and+ pp_config = pp_config t (Super_context.context sctx) ~expander in
-    let per_module_config =
+    let per_file_config =
       (* And copy for each module the resulting pp flags *)
       modules
       |> Modules.With_vlib.drop_vlib
-      |> Modules.fold ~init:[] ~f:(fun m init ->
-        Module.sources m
-        |> Path.Build.Set.of_list_map ~f:(fun src ->
-          Path.as_in_build_dir_exn src |> remove_extension)
+      |> Modules.fold_no_vlib modules ~init:[] ~f:(fun m init ->
+        Module.orig_sources m
+        |> Path.Build.Set.of_list_map ~f:(fun src -> Path.as_in_build_dir_exn src)
         |> Path.Build.Set.fold ~init ~f:(fun src acc ->
           let config =
             { Processed.module_ = Module.set_pp m None
-            ; opens = Modules.With_vlib.local_open modules m
+            ; opens = Modules.local_open modules m
+            ; reader = String.Map.find readers (Path.Build.extension src)
             }
           in
           (src, config) :: acc))
       |> Path.Build.Map.of_list_exn
     in
-    { Processed.pp_config; config; per_module_config }
+    { Processed.pp_config; config; per_file_config }
   ;;
 end
 

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -3,9 +3,9 @@ open Import
 module File = struct
   type t =
     { path : Path.t
-    ; orig_path : Path.t
+    ; original_path : Path.t
         (* while path can be changed for a module (when it is being pp'ed), the
-           orig_path stays the same and points to an original source file *)
+           original_path stays the same and points to an original source file *)
     ; dialect : Dialect.t
     }
 
@@ -14,17 +14,17 @@ module File = struct
     fields
     @@ let+ path = field "path" (Dune_lang.Path.Local.decode ~dir) in
        (* TODO do not just assume the dialect is OCaml *)
-       { path; orig_path = path; dialect = Dialect.ocaml }
+       { path; original_path = path; dialect = Dialect.ocaml }
   ;;
 
-  let encode { path; orig_path = _; dialect = _ } ~dir =
+  let encode { path; original_path = _; dialect = _ } ~dir =
     let open Dune_lang.Encoder in
     record_fields [ field "path" (Dune_lang.Path.Local.encode ~dir) path ]
   ;;
 
   let dialect t = t.dialect
   let path t = t.path
-  let orig_path t = t.orig_path
+  let original_path t = t.original_path
 
   let version_installed t ~src_root ~install_dir =
     let path =
@@ -36,13 +36,13 @@ module File = struct
     { t with path }
   ;;
 
-  let make dialect path = { dialect; path; orig_path = path }
+  let make dialect path = { dialect; path; original_path = path }
 
-  let to_dyn { path; orig_path; dialect } =
+  let to_dyn { path; original_path; dialect } =
     let open Dyn in
     record
       [ "path", Path.to_dyn path
-      ; "orig_path", Path.to_dyn orig_path
+      ; "original_path", Path.to_dyn original_path
       ; "dialect", Dyn.string @@ Dialect.name dialect
       ]
   ;;
@@ -323,7 +323,7 @@ let wrapped_compat t =
           (src_dir t)
           [ ".wrapped_compat"; Module_name.Path.to_string t.source.path ^ ml_gen ]
       in
-      Some { File.dialect = Dialect.ocaml; path; orig_path = path }
+      Some { File.dialect = Dialect.ocaml; path; original_path = path }
     in
     { t.source with files = { intf = None; impl } }
   in
@@ -338,10 +338,10 @@ let sources t =
     ~f:(Option.map ~f:(fun (x : File.t) -> x.path))
 ;;
 
-let orig_sources t =
+let sources_without_pp t =
   List.filter_map
     [ t.source.files.intf; t.source.files.impl ]
-    ~f:(Option.map ~f:(fun (x : File.t) -> x.orig_path))
+    ~f:(Option.map ~f:(fun (x : File.t) -> x.original_path))
 ;;
 
 module Obj_map = struct

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -12,18 +12,14 @@ module File = struct
   let decode ~dir =
     let open Dune_lang.Decoder in
     fields
-    @@ let+ path = field "path" (Dune_lang.Path.Local.decode ~dir)
-       and+ orig_path = field "orig_path" (Dune_lang.Path.Local.decode ~dir) in
+    @@ let+ path = field "path" (Dune_lang.Path.Local.decode ~dir) in
        (* TODO do not just assume the dialect is OCaml *)
-       { path; orig_path; dialect = Dialect.ocaml }
+       { path; orig_path = path; dialect = Dialect.ocaml }
   ;;
 
-  let encode { path; orig_path; dialect = _ } ~dir =
+  let encode { path; orig_path = _; dialect = _ } ~dir =
     let open Dune_lang.Encoder in
-    record_fields
-      [ field "path" (Dune_lang.Path.Local.encode ~dir) path
-      ; field "orig_path" (Dune_lang.Path.Local.encode ~dir) orig_path
-      ]
+    record_fields [ field "path" (Dune_lang.Path.Local.encode ~dir) path ]
   ;;
 
   let dialect t = t.dialect

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -5,7 +5,7 @@ module File = struct
     { path : Path.t
     ; orig_path : Path.t
         (* while path can be changed for a module (when it is being pp'ed), the
-           orig_path stays the same and point to an original source file *)
+           orig_path stays the same and points to an original source file *)
     ; dialect : Dialect.t
     }
 

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -7,7 +7,7 @@ module File : sig
 
   val dialect : t -> Dialect.t
   val path : t -> Path.t
-  val orig_path : t -> Path.t
+  val original_path : t -> Path.t
   val make : Dialect.t -> Path.t -> t
 end
 
@@ -88,7 +88,7 @@ module Obj_map : sig
 end
 
 val sources : t -> Path.t list
-val orig_sources : t -> Path.t list
+val sources_without_pp : t -> Path.t list
 val visibility : t -> Visibility.t
 val encode : t -> src_dir:Path.t -> Dune_lang.t list
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -7,6 +7,7 @@ module File : sig
 
   val dialect : t -> Dialect.t
   val path : t -> Path.t
+  val orig_path : t -> Path.t
   val make : Dialect.t -> Path.t -> t
 end
 
@@ -61,7 +62,6 @@ val set_obj_name : t -> Module_name.Unique.t -> t
 val set_path : t -> Module_name.Path.t -> t
 val add_file : t -> Ml_kind.t -> File.t -> t
 val set_source : t -> Ml_kind.t -> File.t option -> t
-val map_files : t -> f:(Ml_kind.t -> File.t -> File.t) -> t
 
 (** Set preprocessing flags *)
 val set_pp : t -> (string list Action_builder.t * Sandbox_config.t) option -> t
@@ -88,6 +88,7 @@ module Obj_map : sig
 end
 
 val sources : t -> Path.t list
+val orig_sources : t -> Path.t list
 val visibility : t -> Visibility.t
 val encode : t -> src_dir:Path.t -> Dune_lang.t list
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t

--- a/test/blackbox-tests/test-cases/github2206.t/run.t
+++ b/test/blackbox-tests/test-cases/github2206.t/run.t
@@ -5,3 +5,7 @@ copy_files would break the generation of the preprocessing flags
    (FLG
     (-pp
      $TESTCASE_ROOT/_build/default/pp.exe))
+  --
+   (FLG
+    (-pp
+     $TESTCASE_ROOT/_build/default/pp.exe))

--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -21,6 +21,9 @@ Show that the merlin config knows about melange.compile_flags
      +42)))
      +42)))
      +42)))
+     +42)))
+     +42)))
+     +42)))
 
   $ cat >dune <<EOF
   > (melange.emit
@@ -32,6 +35,9 @@ Show that the merlin config knows about melange.compile_flags
   $ dune build @check
 
   $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
+     +42)))
+     +42)))
+     +42)))
      +42)))
      +42)))
      +42)))

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -25,10 +25,10 @@
   $ dune ocaml merlin dump-config "$PWD" | grep -i "$lib"
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
-  Foo__: _build/default/foo__
+  Foo__: _build/default/foo__.ml-gen
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
 
 Paths to Melange stdlib appear in B and S entries without melange.emit stanza
@@ -102,7 +102,7 @@ Check for flag directives ordering when another preprocessor is defined
 User ppx flags should appear in merlin config
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
-  Bar: _build/default/bar
+  Bar: _build/default/bar.ml
   ((STDLIB /MELC_STDLIB/melange)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -124,7 +124,7 @@ User ppx flags should appear in merlin config
      -short-paths
      -keep-locs
      -g)))
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml-gen
   ((STDLIB /MELC_STDLIB/melange)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -145,7 +145,7 @@ User ppx flags should appear in merlin config
      -short-paths
      -keep-locs
      -g)))
-  Fooppx: _build/default/fooppx
+  Fooppx: _build/default/fooppx.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -25,9 +25,16 @@
   $ dune ocaml merlin dump-config "$PWD" | grep -i "$lib"
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (FLG (-open Foo__))
+  Foo: _build/default/foo
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (FLG (-open Foo__))
   Foo: _build/default/foo.ml
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
+  Foo__: _build/default/foo__
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
   Foo__: _build/default/foo__.ml-gen
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
 
@@ -53,6 +60,7 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   $ touch main.ml
   $ dune build @check
   $ dune ocaml merlin dump-config $PWD | grep -i "$target"
+    $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
     $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
 
 Dump-dot-merlin includes the melange flags
@@ -102,6 +110,28 @@ Check for flag directives ordering when another preprocessor is defined
 User ppx flags should appear in merlin config
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
+  Bar: _build/default/bar
+  ((STDLIB /MELC_STDLIB/melange)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-open Foo))
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Bar: _build/default/bar.ml
   ((STDLIB /MELC_STDLIB/melange)
    (EXCLUDE_QUERY_DIR)
@@ -110,6 +140,27 @@ User ppx flags should appear in merlin config
    (S
     $TESTCASE_ROOT)
    (FLG (-open Foo))
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Foo: _build/default/foo
+  ((STDLIB /MELC_STDLIB/melange)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (S
+    $TESTCASE_ROOT)
    (FLG
     (-ppx
      "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
@@ -137,6 +188,21 @@ User ppx flags should appear in merlin config
      --as-ppx
      --cookie
      'library-name="foo"'"))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Fooppx: _build/default/fooppx
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.fooppx.objs/byte)
+   (S
+    $TESTCASE_ROOT)
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -22,7 +22,7 @@ If Merlin field is absent, default context is chosen
   lib-foo
 
   $ dune ocaml merlin dump-config "$PWD"
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -60,7 +60,7 @@ If Merlin field is present, this context is chosen
   No config in default
 
   $ dune ocaml merlin dump-config "$PWD"
-  Foo: _build/cross/foo
+  Foo: _build/cross/foo.ml
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -22,6 +22,21 @@ If Merlin field is absent, default context is chosen
   lib-foo
 
   $ dune ocaml merlin dump-config "$PWD"
+  Foo: _build/default/foo
+  ((STDLIB OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Foo: _build/default/foo.ml
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
@@ -60,6 +75,21 @@ If Merlin field is present, this context is chosen
   No config in default
 
   $ dune ocaml merlin dump-config "$PWD"
+  Foo: _build/cross/foo
+  ((STDLIB OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Foo: _build/cross/foo.ml
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/dune-project
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/dune-project
@@ -1,0 +1,10 @@
+(lang dune 3.11)
+
+(using melange 0.1)
+
+(dialect
+ (name mlx)
+ (implementation
+  (extension mlx)
+  (preprocess (run cat %{input-file}))
+  (merlin_reader mlx)))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/dune-project
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.16)
 
 (using melange 0.1)
 

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/exe/dune
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/exe/dune
@@ -1,0 +1,2 @@
+(executable
+ (name x))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/lib/dune
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/lib/dune
@@ -1,0 +1,2 @@
+(library
+ (name x))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/melange/dune
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/melange/dune
@@ -1,0 +1,3 @@
+(library
+ (modes melange)
+ (name x_mel))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -1,0 +1,61 @@
+  $ ocamlc_where="$(ocamlc -where)"
+  $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ ocamlfind_libs="$(ocamlfind printconf path | while read line; do printf lib=${line}:; done)"
+  $ export BUILD_PATH_PREFIX_MAP="$ocamlfind_libs:$BUILD_PATH_PREFIX_MAP"
+  $ melc_compiler="$(which melc)"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
+
+CRAM sanitization
+  $ dune build ./exe/.merlin-conf/exe-x --profile release
+  $ dune ocaml merlin dump-config $PWD/exe
+  X: _build/default/exe/x.mlx
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/exe)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mlx")
+   (READER (mlx)))
+  X: _build/default/exe/x.mlx.mli
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/exe)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mlx"))
+
+CRAM sanitization
+  $ dune build ./lib/.merlin-conf/lib-x --profile release
+  $ dune ocaml merlin dump-config $PWD/lib
+  X: _build/default/lib/x.mlx
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mlx")
+   (READER (mlx)))
+
+CRAM sanitization
+  $ dune build ./melange/.merlin-conf/lib-x_mel --profile release
+  $ dune ocaml merlin dump-config $PWD/melange
+  X_mel: _build/default/melange/x_mel.mlx
+  ((STDLIB lib/melange/melange)
+   (EXCLUDE_QUERY_DIR)
+   (B lib/melange/js/melange)
+   (B lib/melange/melange)
+   (B
+    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
+   (S lib/melange)
+   (S lib/melange/js)
+   (S
+    $TESTCASE_ROOT/melange)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mlx")
+   (READER (mlx)))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -8,6 +8,15 @@
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml merlin dump-config $PWD/exe
+  X: _build/default/exe/x
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/exe)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mli"))
   X: _build/default/exe/x.mlx
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -31,6 +40,16 @@ CRAM sanitization
 CRAM sanitization
   $ dune build ./lib/.merlin-conf/lib-x --profile release
   $ dune ocaml merlin dump-config $PWD/lib
+  X: _build/default/lib/x
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mli")
+   (READER (mlx)))
   X: _build/default/lib/x.mlx
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -45,6 +64,20 @@ CRAM sanitization
 CRAM sanitization
   $ dune build ./melange/.merlin-conf/lib-x_mel --profile release
   $ dune ocaml merlin dump-config $PWD/melange
+  X_mel: _build/default/melange/x_mel
+  ((STDLIB lib/melange/melange)
+   (EXCLUDE_QUERY_DIR)
+   (B lib/melange/js/melange)
+   (B lib/melange/melange)
+   (B
+    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
+   (S lib/melange)
+   (S lib/melange/js)
+   (S
+    $TESTCASE_ROOT/melange)
+   (FLG (-w -40 -g))
+   (SUFFIX ".mlx .mli")
+   (READER (mlx)))
   X_mel: _build/default/melange/x_mel.mlx
   ((STDLIB lib/melange/melange)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -16,7 +16,7 @@ CRAM sanitization
    (S
     $TESTCASE_ROOT/exe)
    (FLG (-w -40 -g))
-   (SUFFIX ".mlx .mli"))
+   (SUFFIX ".mlx .mlx"))
   X: _build/default/exe/x.mlx
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -48,7 +48,7 @@ CRAM sanitization
    (S
     $TESTCASE_ROOT/lib)
    (FLG (-w -40 -g))
-   (SUFFIX ".mlx .mli")
+   (SUFFIX ".mlx .mlx")
    (READER (mlx)))
   X: _build/default/lib/x.mlx
   ((STDLIB /OCAMLC_WHERE)
@@ -76,7 +76,7 @@ CRAM sanitization
    (S
     $TESTCASE_ROOT/melange)
    (FLG (-w -40 -g))
-   (SUFFIX ".mlx .mli")
+   (SUFFIX ".mlx .mlx")
    (READER (mlx)))
   X_mel: _build/default/melange/x_mel.mlx
   ((STDLIB lib/melange/melange)

--- a/test/blackbox-tests/test-cases/merlin/future-syntax.t
+++ b/test/blackbox-tests/test-cases/merlin/future-syntax.t
@@ -17,6 +17,14 @@
 
   $ dune build ./.merlin-conf/exe-pp_future_syntax --profile release
   $ dune ocaml merlin dump-config .
+  Pp_future_syntax: _build/default/pp_future_syntax
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-w -40 -g)))
   Pp_future_syntax: _build/default/pp_future_syntax.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/future-syntax.t
+++ b/test/blackbox-tests/test-cases/merlin/future-syntax.t
@@ -17,7 +17,15 @@
 
   $ dune build ./.merlin-conf/exe-pp_future_syntax --profile release
   $ dune ocaml merlin dump-config .
-  Pp_future_syntax: _build/default/pp_future_syntax
+  Pp_future_syntax: _build/default/pp_future_syntax.ml
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-w -40 -g)))
+  Pp_future_syntax: _build/default/pp_future_syntax.mli
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
@@ -6,7 +6,7 @@ in the same dune file, but require different ppx specifications
 
   $ dune build @all --profile release
   $ dune ocaml merlin dump-config $PWD
-  Usesppx1: _build/default/usesppx1
+  Usesppx1: _build/default/usesppx1.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -20,7 +20,7 @@ in the same dune file, but require different ppx specifications
      --cookie
      'library-name="usesppx1"'"))
    (FLG (-w -40 -g)))
-  Usesppx2: _build/default/usesppx2
+  Usesppx2: _build/default/usesppx2.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
@@ -6,6 +6,20 @@ in the same dune file, but require different ppx specifications
 
   $ dune build @all --profile release
   $ dune ocaml merlin dump-config $PWD
+  Usesppx1: _build/default/usesppx1
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/c152d6ca3c7e1d83471ffdf48bf729ae/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="usesppx1"'"))
+   (FLG (-w -40 -g)))
   Usesppx1: _build/default/usesppx1.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -19,6 +33,20 @@ in the same dune file, but require different ppx specifications
      --as-ppx
      --cookie
      'library-name="usesppx1"'"))
+   (FLG (-w -40 -g)))
+  Usesppx2: _build/default/usesppx2
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/d7394c27c5e0f7ad7ab1110d6b092c05/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="usesppx2"'"))
    (FLG (-w -40 -g)))
   Usesppx2: _build/default/usesppx2.ml-gen
   ((STDLIB /OCAMLC_WHERE)

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -22,7 +22,7 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   lib-foo
 
   $ dune ocaml merlin dump-config "$PWD"
-  Foo: _build/cross/foo
+  Foo: _build/cross/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -22,6 +22,21 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   lib-foo
 
   $ dune ocaml merlin dump-config "$PWD"
+  Foo: _build/cross/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Foo: _build/cross/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github759.t/run.t
@@ -3,6 +3,14 @@
 
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-w -40 -g)))
   Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -15,6 +23,14 @@
   $ rm -f .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-w -40 -g)))
   Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -27,6 +43,14 @@
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-w -40 -g)))
   Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github759.t/run.t
@@ -3,7 +3,7 @@
 
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -15,7 +15,7 @@
   $ rm -f .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -27,7 +27,7 @@
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -1,3 +1,6 @@
+  $ ocamlc_where="$(ocamlc -where)"
+  $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+
 # A utility to query merlin configuration for a file:
   $ cat >merlin_conf.sh <<EOF
   > #!/bin/sh
@@ -103,7 +106,7 @@ locate to work correctly.
 
 Is it expected that the suffix for implementation and interface is the same ?
   $ ./merlin_conf.sh pped.ml | tee pped.out
-  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  ((?:STDLIB?:/OCAMLC_WHERE
   (?:EXCLUDE_QUERY_DIR
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
@@ -118,7 +121,7 @@ Is it expected that the suffix for implementation and interface is the same ?
 
 As expected, the reader is not communicated for the standard mli
   $ ./merlin_conf.sh mel.mli | tee mel.out
-  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  ((?:STDLIB?:/OCAMLC_WHERE
   (?:EXCLUDE_QUERY_DIR
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
@@ -140,11 +143,14 @@ The reader is set for the mlx file
 ## Unconventionnal file names:
 
 Users might have preprocessing steps that start with a non-conventionnal
-filename like `mymodule.cppo.ml`. Dune makes the assumption that the module name
-is always the first segment of a filename delimited by dots.
+filename like `mymodule.cppo.ml`. 
+
+While Dune first tries to match by the exact filename requested, if nothing is
+found, then it'll make a guess that the file was preprocessed into a file with
+.ml extension:
 
   $ ./merlin_conf.sh cppomod.cppo.ml | tee cppomod.out
-  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  ((?:STDLIB?:/OCAMLC_WHERE
   (?:EXCLUDE_QUERY_DIR
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
@@ -158,11 +164,15 @@ Note that this means unreleated files might be given the same configuration:
 
   $ ./merlin_conf.sh cppomod.tralala.ml | diff cppomod.out -
 
-TODO: this heuristic might not be needed, we could match the filename directly
-
 And with unconventionnal extension: 
 (note that without appropriate suffix configuration Merlin will never jump to
 such files) 
 We could expect dune to get the wrongext module configuration
   $ ./merlin_conf.sh wrongext.cppo.cml | tee wrongext.out
-  ((?:ERROR?:No config found for file wrongext.cppo.cml. Try calling `dune build`.))
+  ((?:STDLIB?:/OCAMLC_WHERE
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx))

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -1,7 +1,7 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
-# A utility to query merlin configuration for a file:
+A utility to query merlin configuration for a file:
   $ cat >merlin_conf.sh <<EOF
   > #!/bin/sh
   > FILE=\$1
@@ -11,10 +11,10 @@
 
   $ chmod a+x merlin_conf.sh
 
-# Project sources
+Project sources
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.11)
+  > (lang dune 3.16)
   > (using melange 0.1)
   > 
   > (dialect
@@ -89,7 +89,7 @@ A pped file with unconventionnal filename
   44
   45
 
-# We now query Merlin configuration for the various source files:
+We now query Merlin configuration for the various source files:
 
 Some configuration fields are common to all the modules of a same stanza. This
 is the case for the stdlib, build and sources directories, flags and suffixes.
@@ -99,10 +99,9 @@ Some configuration can be specific to a module like preprocessing.
 Dialects are specified by extensions so are specific to a file. This means a
 different reader might be used for the signature and the implementation.
 
-Note that suffixes provided by dialect should always be told to Merlin for
-locate to work correctly. 
+Note that Merlin should always be told about dialect-provided suffixes, to make `MerlinLocate` work correctly.
 
-## Preprocessing:
+Preprocessing:
 
 Is it expected that the suffix for implementation and interface is the same ?
   $ ./merlin_conf.sh pped.ml | tee pped.out
@@ -117,7 +116,7 @@ Is it expected that the suffix for implementation and interface is the same ?
 
   $ ./merlin_conf.sh pped.mli | diff pped.out -
 
-## Melange:
+Melange:
 
 As expected, the reader is not communicated for the standard mli
   $ ./merlin_conf.sh mel.mli | tee mel.out
@@ -140,9 +139,9 @@ The reader is set for the mlx file
   \ No newline at end of file
   [1]
 
-## Unconventionnal file names:
+Unconventional file names:
 
-Users might have preprocessing steps that start with a non-conventionnal
+Users might have preprocessing steps that start with a non-conventional
 filename like `mymodule.cppo.ml`. 
 
 While Dune first tries to match by the exact filename requested, if nothing is
@@ -160,11 +159,11 @@ found, then it'll make a guess that the file was preprocessed into a file with
 
   $ ./merlin_conf.sh cppomod.ml | diff cppomod.out -
 
-Note that this means unreleated files might be given the same configuration:
+Note that this means unrelated files might be given the same configuration:
 
   $ ./merlin_conf.sh cppomod.tralala.ml | diff cppomod.out -
 
-And with unconventionnal extension: 
+And with unconventional extension: 
 (note that without appropriate suffix configuration Merlin will never jump to
 such files) 
 We could expect dune to get the wrongext module configuration

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -45,6 +45,16 @@ Project sources
   > 
   > (rule
   >  (action  (copy wrongext.cppo.cml wrongext.ml)))
+  > 
+  > (rule
+  >  (target generatedx.mlx)
+  >  (mode promote)
+  >  (action  (with-stdout-to %{target} (echo "let x = \"Generatedx!\""))))
+  > 
+  > (rule
+  >  (target generated.ml)
+  >  (mode promote)
+  >  (action  (with-stdout-to %{target} (echo "let x = \"Generated!\""))))
   > EOF
 
   $ cat >test.ml <<EOF
@@ -52,6 +62,7 @@ Project sources
   > print_endline Mel.x;;
   > print_endline Cppomod.x;;
   > print_endline Wrongext.x;;
+  > print_endline Generated.x;;
   > EOF
 
 Both Pped's ml and mli files will be preprocessed
@@ -88,6 +99,7 @@ A pped file with unconventionnal filename
   43
   44
   45
+  Generated!
 
 We now query Merlin configuration for the various source files:
 
@@ -175,3 +187,27 @@ We could expect dune to get the wrongext module configuration
   (?:FLG(?:-open?:Dune__exe)
   (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
   (?:SUFFIX?:.mlx .mlx))
+
+We also have generated.ml and generatedx.mlx promoted:
+  $ ls -1 . | grep generated
+  generated.ml
+  generatedx.mlx
+
+It should be possible to get its merlin configuration as well:
+  $ ./merlin_conf.sh generated.ml
+  ((?:STDLIB?:/OCAMLC_WHERE
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx))
+  $ ./merlin_conf.sh generatedx.mlx
+  ((?:STDLIB?:/OCAMLC_WHERE
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx
+  (?:READER(?:mlx)))

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -1,0 +1,168 @@
+# A utility to query merlin configuration for a file:
+  $ cat >merlin_conf.sh <<EOF
+  > #!/bin/sh
+  > FILE=\$1
+  > printf "(4:File%d:%s)" \${#FILE} \$FILE | dune ocaml-merlin \
+  >   | sed -E "s/[[:digit:]]+:/\?:/g" | sed -E "s/\)(\(+)/\n\1/g"
+  > EOF
+
+  $ chmod a+x merlin_conf.sh
+
+# Project sources
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (using melange 0.1)
+  > 
+  > (dialect
+  >  (name mlx)
+  >  (implementation
+  >   (extension mlx)
+  >   (preprocess (run cat %{input-file}))
+  >   (merlin_reader mlx)))
+  > EOF
+
+  $ cat >pp.sh <<EOF
+  > #!/bin/sh
+  > sed 's/%INT%/42/g' \$1
+  > EOF
+
+  $ chmod a+x pp.sh
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name test)
+  >  (flags :standard -no-strict-formats)
+  >  (preprocess
+  >   (per_module
+  >    ((action (run ./pp.sh %{input-file})) pped))))
+  > 
+  > (rule
+  >  (action  (copy cppomod.cppo.ml cppomod.ml)))
+  > 
+  > (rule
+  >  (action  (copy wrongext.cppo.cml wrongext.ml)))
+  > EOF
+
+  $ cat >test.ml <<EOF
+  > print_endline Pped.x_42;;
+  > print_endline Mel.x;;
+  > print_endline Cppomod.x;;
+  > print_endline Wrongext.x;;
+  > EOF
+
+Both Pped's ml and mli files will be preprocessed
+  $ cat >pped.mli <<EOF
+  > val x_%INT% : string
+  > EOF
+
+  $ cat >pped.ml <<EOF
+  > let x_42 = "%INT%"
+  > EOF
+
+Melange module signature
+  $ cat >mel.mli <<EOF
+  > val x : string
+  > EOF
+
+Melange module implementation in Melange syntax
+  $ cat >mel.mlx <<EOF
+  > let x = "43"
+  > EOF
+
+A pped file with unconventionnal filename
+  $ cat >cppomod.cppo.ml <<EOF
+  > let x = "44"
+  > EOF
+
+  $ cat >wrongext.cppo.cml <<EOF
+  > let x = "45"
+  > EOF
+
+  $ dune build @check
+  $ dune exec ./test.exe
+  42
+  43
+  44
+  45
+
+# We now query Merlin configuration for the various source files:
+
+Some configuration fields are common to all the modules of a same stanza. This
+is the case for the stdlib, build and sources directories, flags and suffixes.
+
+Some configuration can be specific to a module like preprocessing.
+
+Dialects are specified by extensions so are specific to a file. This means a
+different reader might be used for the signature and the implementation.
+
+Note that suffixes provided by dialect should always be told to Merlin for
+locate to work correctly. 
+
+## Preprocessing:
+
+Is it expected that the suffix for implementation and interface is the same ?
+  $ ./merlin_conf.sh pped.ml | tee pped.out
+  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-pp?:$TESTCASE_ROOT/_build/default/pp.sh)
+  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx))
+
+  $ ./merlin_conf.sh pped.mli | diff pped.out -
+
+## Melange:
+
+As expected, the reader is not communicated for the standard mli
+  $ ./merlin_conf.sh mel.mli | tee mel.out
+  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx))
+
+The reader is set for the mlx file
+  $ ./merlin_conf.sh mel.mlx | diff mel.out -
+  7c7,8
+  < (?:SUFFIX?:.mlx .mlx))
+  \ No newline at end of file
+  ---
+  > (?:SUFFIX?:.mlx .mlx
+  > (?:READER(?:mlx)))
+  \ No newline at end of file
+  [1]
+
+## Unconventionnal file names:
+
+Users might have preprocessing steps that start with a non-conventionnal
+filename like `mymodule.cppo.ml`. Dune makes the assumption that the module name
+is always the first segment of a filename delimited by dots.
+
+  $ ./merlin_conf.sh cppomod.cppo.ml | tee cppomod.out
+  ((?:STDLIB?:/Users/ulysse/.opam/5.1.0+trunk/lib/ocaml
+  (?:EXCLUDE_QUERY_DIR
+  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
+  (?:S?:$TESTCASE_ROOT
+  (?:FLG(?:-open?:Dune__exe)
+  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:SUFFIX?:.mlx .mlx))
+
+  $ ./merlin_conf.sh cppomod.ml | diff cppomod.out -
+
+Note that this means unreleated files might be given the same configuration:
+
+  $ ./merlin_conf.sh cppomod.tralala.ml | diff cppomod.out -
+
+TODO: this heuristic might not be needed, we could match the filename directly
+
+And with unconventionnal extension: 
+(note that without appropriate suffix configuration Merlin will never jump to
+such files) 
+We could expect dune to get the wrongext module configuration
+  $ ./merlin_conf.sh wrongext.cppo.cml | tee wrongext.out
+  ((?:ERROR?:No config found for file wrongext.cppo.cml. Try calling `dune build`.))

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -111,7 +111,7 @@ Is it expected that the suffix for implementation and interface is the same ?
   (?:S?:$TESTCASE_ROOT
   (?:FLG(?:-open?:Dune__exe)
   (?:FLG(?:-pp?:$TESTCASE_ROOT/_build/default/pp.sh)
-  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
   (?:SUFFIX?:.mlx .mlx))
 
   $ ./merlin_conf.sh pped.mli | diff pped.out -
@@ -125,7 +125,7 @@ As expected, the reader is not communicated for the standard mli
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
   (?:FLG(?:-open?:Dune__exe)
-  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
   (?:SUFFIX?:.mlx .mlx))
 
 The reader is set for the mlx file
@@ -154,7 +154,7 @@ found, then it'll make a guess that the file was preprocessed into a file with
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
   (?:FLG(?:-open?:Dune__exe)
-  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
   (?:SUFFIX?:.mlx .mlx))
 
   $ ./merlin_conf.sh cppomod.ml | diff cppomod.out -
@@ -173,5 +173,5 @@ We could expect dune to get the wrongext module configuration
   (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
   (?:S?:$TESTCASE_ROOT
   (?:FLG(?:-open?:Dune__exe)
-  (?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
+  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
   (?:SUFFIX?:.mlx .mlx))

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -21,7 +21,7 @@
 
   $ dune build .merlin-conf/lib-foo
   $ dune ocaml merlin dump-config .
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -40,7 +40,7 @@
      -short-paths
      -keep-locs
      -g)))
-  Foo__Groupintf__: _build/default/foo__Groupintf__
+  Foo__Groupintf__: _build/default/foo__Groupintf__.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -59,7 +59,7 @@
      -short-paths
      -keep-locs
      -g)))
-  Utils: _build/default/foo__Utils
+  Utils: _build/default/foo__Utils.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -78,27 +78,7 @@
      -short-paths
      -keep-locs
      -g)))
-  Calc: _build/default/groupintf/calc
-  ((STDLIB /OPAM_PREFIX)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG (-open Foo__Groupintf__ -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g)))
-  Groupintf: _build/default/groupintf/groupintf
+  Calc: _build/default/groupintf/calc.ml
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -118,7 +98,27 @@
      -short-paths
      -keep-locs
      -g)))
-  Main: _build/default/main
+  Groupintf: _build/default/groupintf/groupintf.ml
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Main: _build/default/main.ml
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -138,7 +138,7 @@
      -short-paths
      -keep-locs
      -g)))
-  Calc: _build/default/utils/calc
+  Calc: _build/default/utils/calc.ml
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -21,7 +21,45 @@
 
   $ dune build .merlin-conf/lib-foo
   $ dune ocaml merlin dump-config .
+  Foo: _build/default/foo
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Foo: _build/default/foo.ml-gen
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Foo__Groupintf__: _build/default/foo__Groupintf__
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -59,6 +97,25 @@
      -short-paths
      -keep-locs
      -g)))
+  Utils: _build/default/foo__Utils
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Utils: _build/default/foo__Utils.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
@@ -78,7 +135,47 @@
      -short-paths
      -keep-locs
      -g)))
+  Calc: _build/default/groupintf/calc
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Calc: _build/default/groupintf/calc.ml
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Groupintf: _build/default/groupintf/groupintf
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -118,6 +215,26 @@
      -short-paths
      -keep-locs
      -g)))
+  Main: _build/default/main
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG (-open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Main: _build/default/main.ml
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
@@ -130,6 +247,26 @@
    (S
     $TESTCASE_ROOT/utils)
    (FLG (-open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Calc: _build/default/utils/calc
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/groupintf)
+   (S
+    $TESTCASE_ROOT/utils)
+   (FLG (-open Foo__Utils -open Foo))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -8,7 +8,7 @@ up a project with instrumentation and testing checking the merlin config.
 
   $ dune build --instrument-with hello ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
-  Bar: _build/default/lib/bar
+  Bar: _build/default/lib/bar.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -22,7 +22,7 @@ up a project with instrumentation and testing checking the merlin config.
    (S
     $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g)))
-  File: _build/default/lib/subdir/file
+  File: _build/default/lib/subdir/file.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -37,7 +37,7 @@ up a project with instrumentation and testing checking the merlin config.
     $TESTCASE_ROOT/ppx)
    (FLG (-open Bar))
    (FLG (-w -40 -g)))
-  Foo: _build/default/lib/foo
+  Foo: _build/default/lib/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -51,7 +51,7 @@ up a project with instrumentation and testing checking the merlin config.
    (S
     $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g)))
-  Privmod: _build/default/lib/privmod
+  Privmod: _build/default/lib/privmod.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -8,6 +8,20 @@ up a project with instrumentation and testing checking the merlin config.
 
   $ dune build --instrument-with hello ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
+  Bar: _build/default/lib/bar
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (S
+    $TESTCASE_ROOT/ppx)
+   (FLG (-w -40 -g)))
   Bar: _build/default/lib/bar.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -21,6 +35,21 @@ up a project with instrumentation and testing checking the merlin config.
     $TESTCASE_ROOT/lib/subdir)
    (S
     $TESTCASE_ROOT/ppx)
+   (FLG (-w -40 -g)))
+  File: _build/default/lib/subdir/file
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (S
+    $TESTCASE_ROOT/ppx)
+   (FLG (-open Bar))
    (FLG (-w -40 -g)))
   File: _build/default/lib/subdir/file.ml
   ((STDLIB /OCAMLC_WHERE)
@@ -37,6 +66,20 @@ up a project with instrumentation and testing checking the merlin config.
     $TESTCASE_ROOT/ppx)
    (FLG (-open Bar))
    (FLG (-w -40 -g)))
+  Foo: _build/default/lib/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (S
+    $TESTCASE_ROOT/ppx)
+   (FLG (-w -40 -g)))
   Foo: _build/default/lib/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -50,6 +93,21 @@ up a project with instrumentation and testing checking the merlin config.
     $TESTCASE_ROOT/lib/subdir)
    (S
     $TESTCASE_ROOT/ppx)
+   (FLG (-w -40 -g)))
+  Privmod: _build/default/lib/privmod
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (S
+    $TESTCASE_ROOT/ppx)
+   (FLG (-open Foo))
    (FLG (-w -40 -g)))
   Privmod: _build/default/lib/privmod.ml
   ((STDLIB /OCAMLC_WHERE)

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -7,7 +7,7 @@ We build the project
 
 Verify that merlin configuration was generated...
   $ dune ocaml merlin dump-config $PWD
-  Test: _build/default/test
+  Test: _build/default/test.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -26,7 +26,7 @@ Verify that merlin configuration was generated...
      -short-paths
      -keep-locs
      -g)))
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -7,6 +7,25 @@ We build the project
 
 Verify that merlin configuration was generated...
   $ dune ocaml merlin dump-config $PWD
+  Test: _build/default/test
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/411)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Test: _build/default/test.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -14,6 +33,23 @@ Verify that merlin configuration was generated...
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (B
     $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/411)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
     $TESTCASE_ROOT)
    (S

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -13,6 +13,25 @@ We're going create a fake findlib library for use:
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml merlin dump-config $PWD/exe
+  X: _build/default/exe/x
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (B
+    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
+   (S
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (S
+    $TESTCASE_ROOT/exe)
+   (S
+    $TESTCASE_ROOT/lib)
+   (FLG
+    (-pp
+     $TESTCASE_ROOT/_build/default/pp/pp.exe))
+   (FLG (-w -40 -g)))
   X: _build/default/exe/x.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -35,6 +54,22 @@ CRAM sanitization
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
+  Bar: _build/default/lib/bar
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="bar"'"))
+   (FLG (-w -40 -g)))
   Bar: _build/default/lib/bar.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -44,6 +79,23 @@ CRAM sanitization
     $TESTCASE_ROOT/lib)
    (S
     $TESTCASE_ROOT/lib/subdir)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="bar"'"))
+   (FLG (-w -40 -g)))
+  File: _build/default/lib/subdir/file
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (FLG (-open Bar))
    (FLG
     (-ppx
      "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
@@ -68,6 +120,26 @@ CRAM sanitization
      --cookie
      'library-name="bar"'"))
    (FLG (-w -40 -g)))
+  Foo: _build/default/lib/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG (-w -40 -g)))
   Foo: _build/default/lib/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -81,6 +153,27 @@ CRAM sanitization
     $TESTCASE_ROOT/lib)
    (S
     $TESTCASE_ROOT/lib/subdir)
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG (-w -40 -g)))
+  Privmod: _build/default/lib/privmod
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (B
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT/_findlib/publicfoo)
+   (S
+    $TESTCASE_ROOT/lib)
+   (S
+    $TESTCASE_ROOT/lib/subdir)
+   (FLG (-open Foo))
    (FLG
     (-ppx
      "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
@@ -117,6 +210,18 @@ Make sure pp flag is correct and variables are expanded
 
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
   $ dune ocaml merlin dump-config $PWD/pp-with-expand
+  Foobar: _build/default/pp-with-expand/foobar
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/pp-with-expand)
+   (FLG
+    (-pp
+     "$TESTCASE_ROOT/_build/default/pp/pp.exe
+     -nothing"))
+   (FLG (-w -40 -g)))
   Foobar: _build/default/pp-with-expand/foobar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -133,7 +238,37 @@ Make sure pp flag is correct and variables are expanded
 Check hash of executables names if more than one
   $ dune build ./exes/.merlin-conf/exe-x-6562915302827c6dce0630390bfa68b7
   $ dune ocaml merlin dump-config $PWD/exes
+  X: _build/default/exes/x
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/exes)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   X: _build/default/exes/x.ml
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S
+    $TESTCASE_ROOT/exes)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Y: _build/default/exes/y
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -13,7 +13,7 @@ We're going create a fake findlib library for use:
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml merlin dump-config $PWD/exe
-  X: _build/default/exe/x
+  X: _build/default/exe/x.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -35,7 +35,7 @@ CRAM sanitization
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
-  Bar: _build/default/lib/bar
+  Bar: _build/default/lib/bar.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -51,7 +51,7 @@ CRAM sanitization
      --cookie
      'library-name="bar"'"))
    (FLG (-w -40 -g)))
-  File: _build/default/lib/subdir/file
+  File: _build/default/lib/subdir/file.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -68,7 +68,7 @@ CRAM sanitization
      --cookie
      'library-name="bar"'"))
    (FLG (-w -40 -g)))
-  Foo: _build/default/lib/foo
+  Foo: _build/default/lib/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -88,7 +88,7 @@ CRAM sanitization
      --cookie
      'library-name="foo"'"))
    (FLG (-w -40 -g)))
-  Privmod: _build/default/lib/privmod
+  Privmod: _build/default/lib/privmod.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -117,7 +117,7 @@ Make sure pp flag is correct and variables are expanded
 
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
   $ dune ocaml merlin dump-config $PWD/pp-with-expand
-  Foobar: _build/default/pp-with-expand/foobar
+  Foobar: _build/default/pp-with-expand/foobar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -133,7 +133,7 @@ Make sure pp flag is correct and variables are expanded
 Check hash of executables names if more than one
   $ dune build ./exes/.merlin-conf/exe-x-6562915302827c6dce0630390bfa68b7
   $ dune ocaml merlin dump-config $PWD/exes
-  X: _build/default/exes/x
+  X: _build/default/exes/x.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -148,7 +148,7 @@ Check hash of executables names if more than one
      -short-paths
      -keep-locs
      -g)))
-  Y: _build/default/exes/y
+  Y: _build/default/exes/y.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -7,6 +7,21 @@ We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
   $ dune ocaml merlin dump-config $PWD
+  Bar: _build/default/bar
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Bar: _build/default/bar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -14,6 +29,24 @@ should appear only once since only Foo is using it.
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
     $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-pp
+     $TESTCASE_ROOT/_build/default/pp/pp.exe))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62-40

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -7,7 +7,7 @@ We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
   $ dune ocaml merlin dump-config $PWD
-  Bar: _build/default/bar
+  Bar: _build/default/bar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -22,7 +22,7 @@ should appear only once since only Foo is using it.
      -short-paths
      -keep-locs
      -g)))
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -22,6 +22,27 @@ library also has more than one src dir.
 
   $ dune build lib2/.merlin-conf/lib-lib2
   $ dune ocaml merlin dump-config $PWD/lib2
+  Lib2: _build/default/lib2/lib2
+  ((STDLIB /OPAM_PREFIX)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
+   (S
+    $TESTCASE_ROOT/lib1)
+   (S
+    $TESTCASE_ROOT/lib1/sub)
+   (S
+    $TESTCASE_ROOT/lib2)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Lib2: _build/default/lib2/lib2.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -22,7 +22,7 @@ library also has more than one src dir.
 
   $ dune build lib2/.merlin-conf/lib-lib2
   $ dune ocaml merlin dump-config $PWD/lib2
-  Lib2: _build/default/lib2/lib2
+  Lib2: _build/default/lib2/lib2.ml-gen
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
    (B

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -3,3 +3,5 @@
   $ dune ocaml merlin dump-config $PWD | grep SUFFIX
    (SUFFIX ".aml .amli")
    (SUFFIX ".baml .bamli"))
+   (SUFFIX ".aml .amli")
+   (SUFFIX ".baml .bamli"))

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -17,12 +17,12 @@ Absolute path with resolved symlinks will match with Dune's root path:
   $ dune ocaml merlin \
   > dump-config "$(pwd | sed 's/linkroot/realroot/')/realsrc" \
   > --root="." | head -n 1
-  Foo: _build/default/realsrc/foo
+  Foo: _build/default/realsrc/foo.ml
 
 
 Dune ocaml-merlin also accepts paths relative to the current directory
   $ dune ocaml merlin dump-config "realsrc" --root="." | head -n 1
-  Foo: _build/default/realsrc/foo
+  Foo: _build/default/realsrc/foo.ml
 
   $ cd realsrc
 
@@ -30,5 +30,5 @@ Dune ocaml-merlin also accepts paths relative to the current directory
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune ocaml merlin dump-config "." --root=".." | head -n 2
-  Foo: _build/default/realsrc/foo
+  Foo: _build/default/realsrc/foo.ml
   ((STDLIB /OCAMLC_WHERE)

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -17,12 +17,12 @@ Absolute path with resolved symlinks will match with Dune's root path:
   $ dune ocaml merlin \
   > dump-config "$(pwd | sed 's/linkroot/realroot/')/realsrc" \
   > --root="." | head -n 1
-  Foo: _build/default/realsrc/foo.ml
+  Foo: _build/default/realsrc/foo
 
 
 Dune ocaml-merlin also accepts paths relative to the current directory
   $ dune ocaml merlin dump-config "realsrc" --root="." | head -n 1
-  Foo: _build/default/realsrc/foo.ml
+  Foo: _build/default/realsrc/foo
 
   $ cd realsrc
 
@@ -30,5 +30,5 @@ Dune ocaml-merlin also accepts paths relative to the current directory
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune ocaml merlin dump-config "." --root=".." | head -n 2
-  Foo: _build/default/realsrc/foo.ml
+  Foo: _build/default/realsrc/foo
   ((STDLIB /OCAMLC_WHERE)

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -5,6 +5,25 @@
   42
 
   $ dune ocaml merlin dump-config $PWD
+  Foo: _build/default/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
+   (B
+    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (S
+    $TESTCASE_ROOT/foo)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Foo: _build/default/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -26,6 +45,22 @@
      -g)))
 
   $ dune ocaml merlin dump-config $PWD/foo
+  Bar: _build/default/foo/bar
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT/foo)
+   (FLG (-open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
   Bar: _build/default/foo/bar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -34,6 +69,21 @@
    (S
     $TESTCASE_ROOT/foo)
    (FLG (-open Foo))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g)))
+  Foo: _build/default/foo/foo
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S
+    $TESTCASE_ROOT/foo)
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62-40

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -5,7 +5,7 @@
   42
 
   $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
+  Foo: _build/default/foo.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -26,7 +26,7 @@
      -g)))
 
   $ dune ocaml merlin dump-config $PWD/foo
-  Bar: _build/default/foo/bar
+  Bar: _build/default/foo/bar.ml
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B
@@ -42,7 +42,7 @@
      -short-paths
      -keep-locs
      -g)))
-  Foo: _build/default/foo/foo
+  Foo: _build/default/foo/foo.ml-gen
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
    (B


### PR DESCRIPTION
Communicate `READER` to merlin for configured dialects.

The user visible change is the `(merlin_reader ...)` is now allowed in `dune-project` in `(dialect ...)` configuration:
```
(dialect
 (name mlx)
 (implementation
  (extension mlx)
  (merlin_reader mlx)
  (preprocess
   (run ./mlx/pp.exe %{input-file}))))
```