### PR TITLE
fix(pkg): stop using physical equality

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -844,7 +844,7 @@ end = struct
     let module Input = struct
       type t = db * Context_name.t * Package.Name.t
 
-      let equal = ( == )
+      let equal = Tuple.T3.equal ( == ) Context_name.equal Package.Name.equal
       let hash = Tuple.T3.hash Poly.hash Context_name.hash Package.Name.hash
       let to_dyn = Dyn.opaque
     end


### PR DESCRIPTION
Makes memo go into an infinite loop

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 82ed4151-bf3f-4640-b9bf-458466913bfa -->