### PR TITLE
refactor: move [supports_shared_libraries] outside of context

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -97,7 +97,6 @@ type t =
   ; findlib_paths : Path.t list
   ; findlib_toolchain : Context_name.t option
   ; default_ocamlpath : Path.t list
-  ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; build_context : Build_context.t
   ; instrument_with : Lib_name.t list
   }
@@ -130,10 +129,6 @@ let to_dyn t : Dyn.t =
     ; "ocamlmklib", Action.Prog.to_dyn t.ocaml.ocamlmklib
     ; "installed_env", Env.to_dyn (Env.diff t.installed_env Env.initial)
     ; "findlib_paths", list path t.findlib_paths
-    ; ( "natdynlink_supported"
-      , Bool (Dynlink_supported.By_the_os.get t.ocaml.lib_config.natdynlink_supported) )
-    ; ( "supports_shared_libraries"
-      , Bool (Dynlink_supported.By_the_os.get t.supports_shared_libraries) )
     ; "ocaml_config", Ocaml_config.to_dyn t.ocaml.ocaml_config
     ; "instrument_with", (list Lib_name.to_dyn) t.instrument_with
     ]
@@ -358,11 +353,9 @@ let create
   in
   let installed_env = installed_env env name findlib env_nodes ocaml.version profile in
   if Option.is_some fdo_target_exe then Ocaml_toolchain.check_fdo_support ocaml name;
-  let supports_shared_libraries =
-    Ocaml_config.supports_shared_libraries ocaml.ocaml_config
-  in
   let dynamically_linked_foreign_archives =
-    supports_shared_libraries && dynamically_linked_foreign_archives
+    Ocaml_config.supports_shared_libraries ocaml.ocaml_config
+    && dynamically_linked_foreign_archives
   in
   Ocaml_toolchain.register_response_file_support ocaml;
   Memo.return
@@ -382,8 +375,6 @@ let create
     ; findlib_paths = ocamlpath @ default_ocamlpath
     ; findlib_toolchain
     ; default_ocamlpath
-    ; supports_shared_libraries =
-        Dynlink_supported.By_the_os.of_bool supports_shared_libraries
     ; build_context = Build_context.create ~name
     ; instrument_with
     }

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -71,7 +71,6 @@ type t = private
   ; findlib_paths : Path.t list
   ; findlib_toolchain : Context_name.t option (** Misc *)
   ; default_ocamlpath : Path.t list
-  ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; build_context : Build_context.t
   ; instrument_with : Lib_name.t list
   }

--- a/src/dune_rules/dynlink_supported.ml
+++ b/src/dune_rules/dynlink_supported.ml
@@ -9,3 +9,7 @@ type t = bool
 
 let of_bool t = t
 let get x y = x && y
+
+let get_ocaml_config t ocaml_config =
+  get t (Ocaml_config.supports_shared_libraries ocaml_config)
+;;

--- a/src/dune_rules/dynlink_supported.mli
+++ b/src/dune_rules/dynlink_supported.mli
@@ -11,3 +11,4 @@ type t
 
 val of_bool : bool -> t
 val get : t -> By_the_os.t -> bool
+val get_ocaml_config : t -> Ocaml_config.t -> bool

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -111,7 +111,7 @@ end = struct
   let dll_files ~(modes : Mode.Dict.Set.t) ~dynlink ~(ctx : Context.t) lib =
     if_
       (modes.byte
-       && Dynlink_supported.get dynlink ctx.supports_shared_libraries
+       && Dynlink_supported.get_ocaml_config dynlink ctx.ocaml.ocaml_config
        && ctx.dynamically_linked_foreign_archives)
       (Lib_info.foreign_dll_files lib)
   ;;

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -318,7 +318,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
     let build_targets_together =
       modes.ocaml.native
       && modes.ocaml.byte
-      && Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries
+      && Dynlink_supported.get_ocaml_config lib.dynlink ctx.ocaml.ocaml_config
     in
     let* standard =
       let+ project = Scope.DB.find_by_dir dir >>| Scope.project in


### PR DESCRIPTION
it's computed from the ocaml config

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 359c840a-5ea8-4e77-88de-f7ea8ac00db1 -->