### PR TITLE
ci: fix bench tests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - bench/fix-melange-bench
+      - bench/fix-melange-bench-grep
 
 permissions:
   # deployments permission to deploy GitHub pages website

--- a/bench/run-synthetic-dune-watch.sh
+++ b/bench/run-synthetic-dune-watch.sh
@@ -50,7 +50,7 @@ echo Starting dune
 start_dune
 
 echo Checking for error
-until grep 'Had errors' .#dune-output > /dev/null; do sleep 0.1; done
+until grep 'error' .#dune-output > /dev/null; do sleep 0.1; done
 
 echo Found, fixing build
 echo "let f() = ()" > ./internal/m_1_1_1_1.ml


### PR DESCRIPTION
The benchmark tests for melange and other e2e measurements broke in https://github.com/ocaml/dune/pull/8408 as the output of the watch mode (which the tests were grepping) changed.

This PR should fix it.