### PR TITLE
chore: add missing unix dependencies

### DIFF
--- a/otherlibs/dune-rpc/private/dune
+++ b/otherlibs/dune-rpc/private/dune
@@ -1,7 +1,7 @@
 (library
  (name dune_rpc_private)
  (public_name dune-rpc.private)
- (libraries stdune ordering pp csexp dyn xdg)
+ (libraries stdune ordering pp csexp dyn xdg unix)
  (synopsis "for internal use only")
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_digest)
- (libraries dune_metrics stdune)
+ (libraries dune_metrics stdune unix)
  (foreign_stubs
   (names dune_digest_stubs)
   (language c))

--- a/src/dune_findlib/config.ml
+++ b/src/dune_findlib/config.ml
@@ -29,7 +29,7 @@ module File = struct
       let config_dir = Path.Outside_build_dir.extend_basename config_file ~suffix:".d" in
       Fs_memo.is_directory config_dir
       >>= function
-      | Ok false | Error _ -> Memo.return vars
+      | Ok false | Error (_ : Unix.error * _ * _) -> Memo.return vars
       | Ok true ->
         Fs_memo.dir_contents config_dir
         >>= (function
@@ -43,7 +43,7 @@ module File = struct
           in
           List.fold_left all_vars ~init:vars ~f:(fun acc vars ->
             Vars.union acc vars ~f:(fun _ x y -> Some (Rules.union x y)))
-        | Error _ -> Memo.return vars)
+        | Error (_ : Unix.error * _ * _) -> Memo.return vars)
     in
     { vars; preds = Ps.empty }
   ;;

--- a/src/dune_findlib/dune
+++ b/src/dune_findlib/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_findlib)
- (libraries stdune dune_lang dune_engine memo ocaml dune_meta_parser))
+ (libraries stdune dune_lang dune_engine memo ocaml dune_meta_parser unix))

--- a/src/dune_metrics/dune
+++ b/src/dune_metrics/dune
@@ -1,5 +1,5 @@
 (library
  (name dune_metrics)
- (libraries stdune)
+ (libraries stdune unix)
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
This suppresses warnings with ocaml >= 5.
