### PR TITLE
chore: bump ci from 4.08 to 4.10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,7 +48,7 @@ jobs:
           - ocaml-compiler: 4.13.x
             os: ubuntu-latest
             skip_test: true
-          - ocaml-compiler: 4.08.x
+          - ocaml-compiler: 4.10.x
             os: ubuntu-latest
             skip_test: true
           - ocaml-compiler: 4.04.x


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c0c29262-f457-4750-9052-a6ec28bfdf58 -->