### PR TITLE
test(pkg): lock file generation from opam file with patch

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -4,7 +4,7 @@
 
 (cram
  (deps %{bin:patch})
- (applies_to patch))
+ (applies_to patch opam-package-with-patch))
 
 (cram
  (deps %{bin:git})

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -1,0 +1,70 @@
+  $ . ./helpers.sh
+
+Generate a mock opam repository
+  $ mkdir -p mock-opam-repository
+  $ cat >mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+
+Make a package with a patch
+  $ mkpkg with-patch <<EOF
+  > opam-version: "2.0"
+  > patches: ["foo.patch"]
+  > build: ["cat" "foo.ml"]
+  > EOF
+
+
+  $ mkdir -p mock-opam-repository/packages/with-patch/with-patch.0.0.1/files
+  $ cat >mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/foo.patch <<EOF
+  > diff --git a/foo.ml b/foo.ml
+  > index b69a69a5a..ea988f6bd 100644
+  > --- a/foo.ml
+  > +++ b/foo.ml
+  > @@ -1,2 +1,2 @@
+  > -This is wrong
+  > +This is right
+  > EOF
+
+  $ cat>mock-opam-repository/packages/with-patch/with-patch.0.0.1/foo.ml
+
+  $ ls mock-opam-repository/packages/with-patch/with-patch.0.0.1
+  files
+  foo.ml
+  opam
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-patch))
+  > EOF
+  Solution for dune.lock:
+  with-patch.0.0.1
+  
+  $ cat >>dune.lock/with-patch.pkg <<EOF
+  > (source (copy $PWD/source))
+  > EOF
+
+The lockfile should contain the patch action. The generation step currently doesn't add
+this in.
+
+  $ cat dune.lock/with-patch.pkg 
+  (version 0.0.1)
+  
+  (build
+   (run cat foo.ml))
+  (source (copy $TESTCASE_ROOT/source))
+
+  $ mkdir source
+  $ cat > source/foo.ml <<EOF
+  > This is wrong
+  > EOF
+
+  $ build_pkg with-patch 
+  This is wrong
+
+  $ (cd source && patch -p1  < ../mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/foo.patch)
+  patching file foo.ml
+  Hunk #1 succeeded at 1 with fuzz 1.


### PR DESCRIPTION
We show that the generation of lock files does not take into account the patch step in an opam file.