### PR TITLE
fix(init): check that module names are valid

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -195,6 +195,14 @@ module Init_context = struct
   ;;
 end
 
+let check_module_name name =
+  let s = Dune_lang.Atom.to_string name in
+  let (_ : Dune_rules.Module_name.t) =
+    Dune_rules.Module_name.of_string_user_error (Loc.none, s) |> User_error.ok_exn
+  in
+  ()
+;;
+
 module Public_name = struct
   include Lib_name
   module Pkg = Dune_lang.Package_name.Opam_compatible
@@ -346,6 +354,7 @@ module Component = struct
     ;;
 
     let library (common : Options.Common.t) { Options.Library.inline_tests; public } =
+      check_module_name common.name;
       let common =
         if inline_tests
         then (

--- a/doc/changes/init-module-names.md
+++ b/doc/changes/init-module-names.md
@@ -1,0 +1,1 @@
+- init: check that module names are valid (#8644, fixes #8252, @emillon)

--- a/test/blackbox-tests/test-cases/dune-init/github8252.t
+++ b/test/blackbox-tests/test-cases/dune-init/github8252.t
@@ -2,5 +2,9 @@
 
   $ dune init project 01_module
   Entering directory '01_module'
-  Success: initialized project component named 01_module
+  Error: "01_module" is an invalid module name.
+  Module names must be non-empty, start with a letter, and composed only of the
+  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Hint: M01_module would be a correct module name
   Leaving directory '01_module'
+  [1]


### PR DESCRIPTION
Fixes #8252

When creating a library (directly or indirectly, through a project), the component name should be a valid module name.

This restriction does not apply to executable names.
