### PR TITLE
fix: add original error to spurious error message

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -827,11 +827,6 @@ end = struct
          (match Cached_digest.build_file ~allow_dirs:true path with
           | Ok digest -> digest, Dir_target { generated_file_digests = targets }
           (* Must be a directory target *)
-          | No_such_file
-          | Broken_symlink
-          | Cyclic_symlink
-          | Unexpected_kind _
-          | Unix_error _
           | Error _ ->
             (* CR-someday amokhov: The most important reason we end up here is
                [No_such_file]. I think some of the outcomes above are impossible

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -3,14 +3,19 @@
 open Import
 
 module Digest_result : sig
-  type t =
-    | Ok of Digest.t
-    | No_such_file
-    | Broken_symlink
-    | Cyclic_symlink
-    | Unexpected_kind of File_kind.t
-    | Unix_error of Unix_error.Detailed.t (** Can't be [ENOENT]. *)
-    | Error of exn
+  module Error : sig
+    type t =
+      | No_such_file
+      | Broken_symlink
+      | Cyclic_symlink
+      | Unexpected_kind of File_kind.t
+      | Unix_error of Unix_error.Detailed.t (** Can't be [ENOENT]. *)
+      | Unrecognized of exn
+
+    val to_dyn : t -> Dyn.t
+  end
+
+  type t = (Digest.t, Error.t) result
 
   val equal : t -> t -> bool
   val to_option : t -> Digest.t option

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -283,15 +283,16 @@ let source_or_external_file_digest path =
   Fs_memo.file_digest path
   >>= function
   | Ok digest -> Memo.return digest
-  | No_such_file -> report_user_error []
-  | Broken_symlink -> report_user_error [ Pp.text "Broken symbolic link" ]
-  | Cyclic_symlink -> report_user_error [ Pp.text "Cyclic symbolic link" ]
-  | Unexpected_kind st_kind ->
+  | Error No_such_file -> report_user_error []
+  | Error Broken_symlink -> report_user_error [ Pp.text "Broken symbolic link" ]
+  | Error Cyclic_symlink -> report_user_error [ Pp.text "Cyclic symbolic link" ]
+  | Error (Unexpected_kind st_kind) ->
     report_user_error
       [ Pp.textf "This is not a regular file (%s)" (File_kind.to_string st_kind) ]
-  | Unix_error unix_error ->
+  | Error (Unix_error unix_error) ->
     report_user_error [ Unix_error.Detailed.pp ~prefix:"Reason: " unix_error ]
-  | Error exn -> report_user_error [ Pp.textf "%s" (Printexc.to_string exn) ]
+  | Error (Unrecognized exn) ->
+    report_user_error [ Pp.textf "%s" (Printexc.to_string exn) ]
 ;;
 
 let eval_source_file : type a. a Action_builder.eval_mode -> Path.Source.t -> a Memo.t =

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -107,6 +107,13 @@ module Produced : sig
     val mapi : 'a t -> f:(Path.Build.t -> 'a -> 'b option) -> 'b t option
   end
 
+  val collect_digests
+    :  'a t
+    -> f:(Path.Build.t -> 'a -> Cached_digest.Digest_result.t)
+    -> ( Digest.t t
+       , (Path.Build.t * Cached_digest.Digest_result.Error.t) Nonempty_list.t )
+       result
+
   val to_dyn : _ t -> Dyn.t
 end
 


### PR DESCRIPTION
When computing digests for the cash, the algorithm was as follows:

1. Compute the digest for every target
2. If there's a failure, recompute all the digests to find the failure

The 2nd was introducing a race because it's not necessarily the case that trying to compute the digest the second time would fail.

The new algorithm does the same thing but without trying to recompute any digests. If there's an error, it will always report it.