### PR TITLE
test(pkg): copying opam repository files

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -1,0 +1,50 @@
+This test checks that the files in the files/ directory inside a package in an opam
+repository are copied correctly to the dune.lock file.
+
+
+  $ . ./helpers.sh
+
+Generate a mock opam repository
+  $ mkdir -p mock-opam-repository
+  $ cat >mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+
+Make a package with a patch
+  $ mkpkg with-patch <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+  $ fname1="foo.patch"
+  $ fname2="dir/bar.patch"
+  $ opam_repo="mock-opam-repository/packages/with-patch/with-patch.0.0.1"
+  $ mkdir -p $opam_repo/files/dir
+  $ cat >$opam_repo/files/$fname1 <<EOF
+  > foo
+  > EOF
+  $ cat >$opam_repo/files/$fname2 <<EOF
+  > bar
+  > EOF
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-patch))
+  > EOF
+  Solution for dune.lock:
+  with-patch.0.0.1
+  
+
+We expect that the files in the files directory of the opam repository get copied to the
+lock file. 
+
+  $ lock_dir="dune.lock/with-patch.files"
+  $ ls $lock_dir && cat $lock_dir/$fname1
+  ls: cannot access 'dune.lock/with-patch.files': No such file or directory
+  [2]
+  $ ls $lock_dir && cat $lock_dir/$fname2
+  ls: cannot access 'dune.lock/with-patch.files': No such file or directory
+  [2]


### PR DESCRIPTION
This test demonstrates that we don't currently copy the files folder in the opam repository to the lock file.