### PR TITLE
pkg: copy files from opam repository to lock dir

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -391,14 +391,16 @@ module Lock = struct
                ~local_packages:opam_file_map
            with
            | Error (`Diagnostic_message message) -> Error (context_name, message)
-           | Ok (summary, lock_dir) ->
+           | Ok (summary, lock_dir, files) ->
              let summary_message =
                Dune_pkg.Opam_solver.Summary.selected_packages_message
                  summary
                  ~lock_dir_path
                |> User_message.pp
              in
-             Ok (Lock_dir.Write_disk.prepare ~lock_dir_path lock_dir, summary_message))
+             Ok
+               ( Lock_dir.Write_disk.prepare ~lock_dir_path ~files lock_dir
+               , summary_message ))
        |> Result.List.all)
       >>| function
       | Error (context_name, message) ->

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -71,7 +71,19 @@ module Write_disk : sig
   type lock_dir := t
   type t
 
-  val prepare : lock_dir_path:Path.Source.t -> lock_dir -> t
+  module Files_entry : sig
+    type t =
+      { original_file : Path.t
+      ; local_file : Path.Local.t
+      }
+  end
+
+  val prepare
+    :  lock_dir_path:Path.Source.t
+    -> files:Files_entry.t Package_name.Map.Multi.t
+    -> lock_dir
+    -> t
+
   val commit : t -> unit
 end
 

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -90,6 +90,12 @@ let get_opam_file_path t opam_package =
   / "opam"
 ;;
 
+let get_opam_package_files_path t opam_package =
+  get_opam_package_version_dir_path t (OpamPackage.name opam_package)
+  / OpamPackage.to_string opam_package
+  / "files"
+;;
+
 (* Returns a list containing all versions of a package with a given name *)
 let all_package_versions t opam_package_name =
   let version_dir_path = get_opam_package_version_dir_path t opam_package_name in

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -14,3 +14,5 @@ val load_all_versions
   :  t
   -> OpamPackage.Name.t
   -> (OpamFile.OPAM.t list, [ `Package_not_found ]) result
+
+val get_opam_package_files_path : t -> OpamPackage.t -> Path.t

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Import
 
 module Summary : sig
   (** Some intermediate state from the solve exposed for logging purposes *)
@@ -13,4 +13,6 @@ val solve_lock_dir
   -> Version_preference.t
   -> Opam_repo.t * (Loc.t * Repository_id.t) option
   -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
-  -> (Summary.t * Lock_dir.t, [ `Diagnostic_message of _ Pp.t ]) result
+  -> ( Summary.t * Lock_dir.t * Lock_dir.Write_disk.Files_entry.t Package_name.Map.Multi.t
+     , [ `Diagnostic_message of _ Pp.t ] )
+     result

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -1,7 +1,6 @@
 This test checks that the files in the files/ directory inside a package in an opam
 repository are copied correctly to the dune.lock file.
 
-
   $ . ./helpers.sh
 
 Generate a mock opam repository
@@ -43,6 +42,6 @@ lock file.
 
   $ lock_dir="dune.lock/with-patch.files"
   $ [ -d $lock_dir ] && cat $lock_dir/$fname1
-  [1]
+  foo
   $ [ -d $lock_dir ] && cat $lock_dir/$fname2
-  [1]
+  bar

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -1,0 +1,49 @@
+This test demonstrates the behaviour when a Unix error is encountered when copying the
+files/ directory from a package directory inside an opam repostory.
+
+  $ . ./helpers.sh
+
+Generate a mock opam repository
+  $ mkdir -p mock-opam-repository
+  $ cat >mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+
+Make a package with a patch
+  $ mkpkg with-patch <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+  $ fname1="foo.patch"
+  $ fname2="dir/bar.patch"
+  $ opam_repo="mock-opam-repository/packages/with-patch/with-patch.0.0.1"
+  $ mkdir -p $opam_repo/files/dir
+  $ cat >$opam_repo/files/$fname1 <<EOF
+  > foo
+  > EOF
+  $ cat >$opam_repo/files/$fname2 <<EOF
+  > bar
+  > EOF
+We remove the read permissions for dir/
+
+  $ chmod -r $opam_repo/files/dir
+
+The error message should have a location for the opam repository.
+
+This does not currently seem to be the case.
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-patch))
+  > EOF
+  Error: Unable to read file in opam repository:
+  opendir($TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/dir): Permission denied
+  [1]
+ 
+Make sure to set permissions back so the sandbox can be cleaned up.
+
+  $ chmod +r $opam_repo/files/dir

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -170,7 +170,8 @@ let%expect_test "downloading, without any checksum" =
 
 let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
   let lock_dir_path = Path.Source.of_string lock_dir_path in
-  Lock_dir.Write_disk.(prepare ~lock_dir_path lock_dir |> commit);
+  Lock_dir.Write_disk.(
+    prepare ~lock_dir_path ~files:Package_name.Map.empty lock_dir |> commit);
   let lock_dir_round_tripped = Lock_dir.read_disk lock_dir_path in
   if Lock_dir.equal
        (Lock_dir.remove_locs lock_dir_round_tripped)


### PR DESCRIPTION
The opam solver now copies any files in the `files` directory inside a package directory in an opam repository.