### PR TITLE
Fix stdune -> pp bound

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -190,7 +190,7 @@ understood by dune language."))
   base-unix
   (dyn (= :version))
   (ordering (= :version))
-  (pp (>= 1.1.0))
+  (pp (>= 1.2.0))
   (csexp (>= 1.5.0)))
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 

--- a/stdune.opam
+++ b/stdune.opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "dyn" {= version}
   "ordering" {= version}
-  "pp" {>= "1.1.0"}
+  "pp" {>= "1.2.0"}
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
It uses `Pp.compare`, introduced in `pp.1.2.0`.

Fixes #8657
