### PR TITLE
refactor: move switch to a separate module

### DIFF
--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -22,16 +22,9 @@
 open Import
 
 module Kind : sig
-  module Opam : sig
-    type t =
-      { root : string option
-      ; switch : string
-      }
-  end
-
   type t =
     | Default
-    | Opam of Opam.t
+    | Opam of Opam_switch.t
 end
 
 module Env_nodes : sig

--- a/src/dune_rules/opam_switch.ml
+++ b/src/dune_rules/opam_switch.ml
@@ -1,0 +1,18 @@
+open Import
+
+type t =
+  { root : string option
+  ; switch : string
+  }
+
+let to_dyn { root; switch } =
+  Dyn.(record [ "root", option string root; "switch", string switch ])
+;;
+
+let equal { root; switch } t =
+  Option.equal String.equal root t.root && String.equal switch t.switch
+;;
+
+let hash { root; switch } =
+  Tuple.T2.hash (Option.hash String.hash) String.hash (root, switch)
+;;

--- a/src/dune_rules/opam_switch.mli
+++ b/src/dune_rules/opam_switch.mli
@@ -1,0 +1,8 @@
+type t =
+  { root : string option
+  ; switch : string
+  }
+
+val equal : t -> t -> bool
+val hash : t -> int
+val to_dyn : t -> Dyn.t

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -233,23 +233,16 @@ module Context = struct
   module Opam = struct
     type t =
       { base : Common.t
-      ; switch : string
-      ; root : string option
+      ; switch : Opam_switch.t
       }
 
-    let to_dyn { base; switch; root } =
+    let to_dyn { base; switch } =
       let open Dyn in
-      record
-        [ "base", Common.to_dyn base
-        ; "switch", string switch
-        ; "root", option string root
-        ]
+      record [ "base", Common.to_dyn base; "switch", Opam_switch.to_dyn switch ]
     ;;
 
-    let equal { base; switch; root } t =
-      Common.equal base t.base
-      && String.equal switch t.switch
-      && Option.equal String.equal root t.root
+    let equal { base; switch } t =
+      Common.equal base t.base && Opam_switch.equal switch t.switch
     ;;
 
     let decode =
@@ -275,7 +268,8 @@ module Context = struct
                  ])
         in
         let base = { base with targets = Target.add base.targets x; name } in
-        { base; switch; root }
+        let switch = { Opam_switch.switch; root } in
+        { base; switch }
     ;;
   end
 

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -39,8 +39,7 @@ module Context : sig
       { base : Common.t
           (** Either a switch name or a path to a local switch. This argument
               is left opaque as we leave to opam to interpret it. *)
-      ; switch : string
-      ; root : string option
+      ; switch : Opam_switch.t
       }
   end
 


### PR DESCRIPTION
So that it can be used both in [Workspace] and [Context]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 92253b5b-92c9-4597-9958-f21196522301 -->