### PR TITLE
fix(pkg): use system instead of run when translating build action

### DIFF
--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -375,3 +375,16 @@ let remove_locs { quoted; loc = _; parts } =
         | Pform (source, p) -> Pform ({ source with loc = Loc.none }, p))
   }
 ;;
+
+(* CR-someday alizter: Somehow preserve the location information, perhaps as a union of
+   all the locations. *)
+let concat ts =
+  List.fold_left
+    ts
+    ~init:{ quoted = false; parts = []; loc = Loc.none }
+    ~f:(fun { quoted = _; parts; loc = _ } t ->
+      { quoted = true
+      ; parts = parts @ (if parts = [] then [] else [ Text " " ]) @ t.parts
+      ; loc = Loc.none
+      })
+;;

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -43,6 +43,13 @@ val make_text : ?quoted:bool -> Loc.t -> string -> t
 (** Concatenate a list of parts. *)
 val make : ?quoted:bool -> Loc.t -> [ `Text of string | `Pform of Pform.t ] list -> t
 
+(** [concat l] concatenates the list of [String_with_vars.t] named [l] with the following
+    caveats:
+    - The [Loc.t]s are discarded.
+    - The [String_with_vars.t] is always quoted.
+    - They are all separated by a space [" "]. *)
+val concat : t list -> t
+
 (** [is_pform v p] holds when [v] is just the Pform [p] *)
 val is_pform : t -> Pform.t -> bool
 

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -375,15 +375,13 @@ let opam_commands_to_actions package (commands : OpamTypes.command list) =
             (Package_variable.pform_of_opam_ident ident))
     in
     match terms with
-    | program :: args ->
-      let action = Action.run program args in
-      let action =
-        match filter with
-        | Some filter -> Action.When (filter_to_blang package filter, action)
-        | None -> action
-      in
-      Some action
-    | [] -> None)
+    | [] -> None
+    | terms ->
+      let action = Action.System (String_with_vars.concat terms) in
+      Some
+        (match filter with
+         | Some filter -> Action.When (filter_to_blang package filter, action)
+         | None -> action))
 ;;
 
 (* returns:

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -117,41 +117,41 @@ Package which has boolean where string was expected. This should be caught while
   (version 0.0.1)
   
   (install
-   (run %{make} install))
+   (system "%{make} install"))
   
   (build
    (progn
     (when
      %{pkg-self:dev}
-     (run dune subst))
-    (run dune build -p %{pkg-self:name} -j %{jobs} @install @runtest @doc)))
+     (system "dune subst"))
+    (system "dune build -p %{pkg-self:name} -j %{jobs} @install @runtest @doc")))
 
   $ cat dune.lock/with-interpolation.pkg
   (version 0.0.1)
   
   (install
-   (run %{make} install))
+   (system "%{make} install"))
   
   (build
    (progn
-    (run ./configure --prefix=%{prefix} --docdir=%{doc}/ocaml)
-    (run %{make} -j%{jobs})))
+    (system "./configure --prefix=%{prefix} --docdir=%{doc}/ocaml")
+    (system "%{make} -j%{jobs}")))
 
   $ cat dune.lock/with-percent-sign.pkg
   (version 0.0.1)
   
   (build
-   (run printf %d 42))
+   (system "printf %d 42"))
 
   $ cat dune.lock/variable-types.pkg
   (version 0.0.1)
   
   (build
    (progn
-    (run echo %{pkg-self:local_var})
-    (run echo %{pkg-self:explicit_local_var})
-    (run echo %{pkg:package_var:foo})
-    (run echo %{os_family})))
+    (system "echo %{pkg-self:local_var}")
+    (system "echo %{pkg-self:explicit_local_var}")
+    (system "echo %{pkg:package_var:foo}")
+    (system "echo %{os_family}")))
 
   $ solve_project <<EOF
   > (lang dune 3.8)
@@ -184,54 +184,54 @@ Package which has boolean where string was expected. This should be caught while
    (progn
     (when
      %{pkg-self:foo}
-     (run echo a))
+     (system "echo a"))
     (when
      (and %{pkg-self:foo} %{pkg-self:bar})
-     (run echo b))
+     (system "echo b"))
     (when
      (and
       (and %{pkg-self:foo} %{pkg-self:bar})
       %{pkg-self:baz})
-     (run echo c))
+     (system "echo c"))
     (when
      (or %{pkg-self:foo} %{pkg-self:bar})
-     (run echo d))
+     (system "echo d"))
     (when
      (or
       %{pkg-self:foo}
       (and %{pkg-self:bar} %{pkg-self:baz}))
-     (run echo e))
+     (system "echo e"))
     (when
      (and
       (or %{pkg-self:foo} %{pkg-self:bar})
       %{pkg-self:baz})
-     (run echo f))
+     (system "echo f"))
     (when
      (= %{pkg-self:foo} %{pkg-self:bar})
-     (run echo b))
+     (system "echo b"))
     (when
      (< %{pkg-self:version} 1.0)
-     (run echo g))
+     (system "echo g"))
     (when
      (and
       %{pkg-self:with-test}
       (< %{pkg:version:ocaml} 5.0.0))
-     (run echo h))
+     (system "echo h"))
     (when
      true
-     (run echo i))
+     (system "echo i"))
     (when
      (not false)
-     (run echo j))
+     (system "echo j"))
     (when
      %{pkg:installed:foo}
-     (run echo k))
+     (system "echo k"))
     (when
      (< %{pkg:version:foo} 0.4)
-     (run echo l))
+     (system "echo l"))
     (when
      (and %{pkg:installed:foo} %{pkg:installed:bar} %{pkg:installed:baz})
-     (run echo m))))
+     (system "echo m"))))
 
   $ solve_project <<EOF
   > (lang dune 3.8)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -54,7 +54,7 @@ this in.
   (version 0.0.1)
   
   (build
-   (run cat foo.ml))
+   (system "cat foo.ml"))
   (source (copy $TESTCASE_ROOT/source))
 
   $ mkdir source


### PR DESCRIPTION
We were using the `run` action to run arbitrary shell commands in the opam build step. This is wrong because it doesn't allow us to run certain commands. We therefore change back to `system` which is more correct, however in the future we might want to refine this depending on the kind of command.

For context, it was noticed in #8656 that this was incorrect.