### PR TITLE
chore(ci): switch to OCaml 5.2 trunk and intro 5.1 jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,14 +34,14 @@ jobs:
           - 4.14.x
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.1.0+trunk
+          - ocaml-compiler: ocaml-variants.5.2.0+trunk
             os: ubuntu-latest
             skip_test: true
           # OCaml 5:
-          - ocaml-compiler: 5.0.x
+          - ocaml-compiler: 5.1.x
             os: ubuntu-latest
             skip_test: true
-          - ocaml-compiler: 5.0.x
+          - ocaml-compiler: 5.1.x
             os: macos-latest
             skip_test: true
           # OCaml 4:


### PR DESCRIPTION
Not sure if we want so many jobs. @rgrinberg WDYT?

I think that dropping OCaml 5.0 might be better than not adding 5.1.