### PR TITLE
feature(pkg): translate substs field of opam file into build action

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -386,17 +386,6 @@ let opam_commands_to_actions package (commands : OpamTypes.command list) =
     | [] -> None)
 ;;
 
-(* returns:
-   [None] if the command list is empty
-   [Some (Action.Run ...)] if there is a single command
-   [Some (Action.Progn [Action.Run ...; ...])] if there are multiple commands *)
-let opam_commands_to_action package (commands : OpamTypes.command list) =
-  match opam_commands_to_actions package commands with
-  | [] -> None
-  | [ action ] -> Some action
-  | actions -> Some (Action.Progn actions)
-;;
-
 let opam_package_to_lock_file_pkg ~repo ~local_packages opam_package =
   let name = OpamPackage.name opam_package in
   let version = OpamPackage.version opam_package |> OpamPackage.Version.to_string in
@@ -424,27 +413,34 @@ let opam_package_to_lock_file_pkg ~repo ~local_packages opam_package =
       Loc.none, Package_name.of_string (OpamPackage.Name.to_string name))
   in
   let build_command =
+    let subst_step =
+      OpamFile.OPAM.substs opam_file
+      |> List.map ~f:(fun x ->
+        let x = OpamFilename.Base.to_string x in
+        let input = String_with_vars.make_text Loc.none (x ^ ".in") in
+        let output = String_with_vars.make_text Loc.none x in
+        Action.Substitute (input, output))
+    in
     let patch_step =
       (* CR-someday alizter: Patches don't take into account filters that are present. For
          now we take them all. *)
-      match
-        OpamFile.OPAM.patches opam_file
-        |> List.map ~f:(fun (x, _) ->
-          Action.Patch
-            (String_with_vars.make_text Loc.none (OpamFilename.Base.to_string x)))
-      with
-      | [] -> None
-      | [ x ] -> Some x
-      | xs -> Some (Action.Progn xs)
+      OpamFile.OPAM.patches opam_file
+      |> List.map ~f:(fun (x, _) ->
+        Action.Patch (String_with_vars.make_text Loc.none (OpamFilename.Base.to_string x)))
     in
-    opam_commands_to_action opam_package (OpamFile.OPAM.build opam_file)
-    |> Option.map ~f:(fun action ->
-      match patch_step with
-      | None -> action
-      | Some patch_step -> Action.Progn [ patch_step; action ])
+    let build_step =
+      opam_commands_to_actions opam_package (OpamFile.OPAM.build opam_file)
+    in
+    match List.concat [ subst_step; patch_step; build_step ] with
+    | [] -> None
+    | [ action ] -> Some action
+    | actions -> Some (Action.Progn actions)
   in
   let install_command =
-    opam_commands_to_action opam_package (OpamFile.OPAM.install opam_file)
+    match opam_commands_to_actions opam_package (OpamFile.OPAM.install opam_file) with
+    | [] -> None
+    | [ action ] -> Some action
+    | actions -> Some (Action.Progn actions)
   in
   { Lock_dir.Pkg.build_command; install_command; deps; info; exported_env = [] }
 ;;

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -1,0 +1,68 @@
+We test how opam files with substs fields together with patches fields are translated into
+the dune.lock file. Opam allows substitution to happen before the patches phase, so we
+must do the same.
+ 
+  $ . ./helpers.sh
+
+Generate a mock opam repository
+  $ mkdir -p mock-opam-repository
+  $ cat >mock-opam-repository/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+Make a package with a substs and patches field field 
+  $ mkpkg with-substs-and-patches <<EOF
+  > opam-version: "2.0"
+  > substs: ["foo.patch"]
+  > patches: ["foo.patch"]
+  > build: [ "sh" "-c" "[ -e foo.ml ] && cat foo.ml" ]
+  > EOF
+
+  $ opam_repo=mock-opam-repository/packages/with-substs-and-patches/with-substs-and-patches.0.0.1
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-substs-and-patches)) 
+  > EOF
+  Solution for dune.lock:
+  with-substs-and-patches.0.0.1
+  
+  $ cat >>dune.lock/with-substs-and-patches.pkg <<EOF
+  > (source (copy $PWD/source))
+  > EOF
+
+The lockfile should contain the substitute and patch actions.
+
+  $ cat dune.lock/with-substs-and-patches.pkg 
+  (version 0.0.1)
+  
+  (build
+   (progn
+    (substitute foo.patch.in foo.patch)
+    (patch foo.patch)
+    (run sh -c "[ -e foo.ml ] && cat foo.ml")))
+  (source (copy $TESTCASE_ROOT/source))
+
+  $ mkdir source
+
+  $ cat > source/foo.patch.in <<EOF
+  > diff --git a/foo.ml b/foo.ml
+  > index b69a69a5a..ea988f6bd 100644
+  > --- a/foo.ml
+  > +++ b/foo.ml
+  > @@ -1,2 +1,2 @@
+  > -This is wrong
+  > +This is right
+  > EOF
+
+  $ cat > source/foo.ml <<EOF
+  > This is wrong
+  > EOF
+
+The file foo.ml should have been built:
+
+  $ build_pkg with-substs-and-patches 
+  This is right

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -81,9 +81,8 @@ this in.
   
   (build
    (progn
-    (progn
-     (patch foo.patch)
-     (patch dir/bar.patch))
+    (patch foo.patch)
+    (patch dir/bar.patch)
     (run cat foo.ml bar.ml dir/baz.ml)))
   (source (copy $TESTCASE_ROOT/source))
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -38,7 +38,9 @@ add this in.
   (version 0.0.1)
   
   (build
-   (run sh -c "[ -e foo.ml ] && cat foo.ml"))
+   (progn
+    (substitute foo.ml.in foo.ml)
+    (run sh -c "[ -e foo.ml ] && cat foo.ml")))
   (source (copy $TESTCASE_ROOT/source))
 
   $ mkdir source
@@ -49,6 +51,4 @@ add this in.
 The file foo.ml should have been built:
 
   $ build_pkg with-substs 
-  Command exited with code 1.
-  -> required by _build/_private/default/.pkg/with-substs/target
-  [1]
+  I have been substituted.


### PR DESCRIPTION
This adds support for the translation of the substs field of an opam file.
- fixes #8640 

We have two tests: one with a basic substitution and another with a substitution that modifies a patch file. This is in order to make explicit the order of substitution and patching implicitly present in opam.