### PR TITLE
fix(pkg): interpret install entries correctly

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -422,6 +422,8 @@ val drop_prefix_exn : t -> prefix:t -> Local.t
     leftover `/` prefix. Returns [None] if the prefix wasn't found. *)
 val drop_prefix : t -> prefix:t -> Local.t option
 
+val make_local_path : Local.t -> t
+
 module Expert : sig
   (** Attempt to convert external paths to source/build paths. Don't use this
       function unless strictly necessary. It's not completely reliable and we

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1034,12 +1034,14 @@ module Install_action = struct
           | false -> Section.Map.empty
           | true ->
             let map =
-              let install_dir = Path.parent_exn install_file in
-              let install_entries = Install.Entry.load_install_file install_file in
+              let install_entries =
+                let dir = Path.parent_exn install_file in
+                Install.Entry.load_install_file install_file (fun local ->
+                  Path.append_local dir local)
+              in
               let by_src =
                 List.rev_map install_entries ~f:(fun (entry : _ Install.Entry.t) ->
-                  ( Path.as_in_source_tree_exn entry.src |> Path.append_source install_dir
-                  , entry ))
+                  entry.src, entry)
                 |> Path.Map.of_list_multi
               in
               let install_entries =

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -271,7 +271,7 @@ let gen_install_file entries =
   Buffer.contents buf
 ;;
 
-let load_install_file path =
+let load_install_file path local =
   let open OpamParserTypes.FullPos in
   let file = Io.with_lexbuf_from_file path ~f:Dune_pkg.Opam_file.parse in
   let fail { filename = pos_fname; start; stop } msg =
@@ -296,7 +296,11 @@ let load_install_file path =
                 | None -> false, src
                 | Some src -> true, src
               in
-              let src = Path.of_string src in
+              let src =
+                if Filename.is_relative src
+                then local (Path.Local.of_string src)
+                else Path.external_ (Path.External.of_string src)
+              in
               of_install_file ~optional ~src ~dst ~section
             in
             List.map l.pelem ~f:(function

--- a/src/install/entry.mli
+++ b/src/install/entry.mli
@@ -63,4 +63,4 @@ val add_install_prefix : 'a t -> paths:Paths.t -> prefix:Path.t -> 'a t
 val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
 val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
 val gen_install_file : Path.t t list -> string
-val load_install_file : Path.t -> Path.t t list
+val load_install_file : Path.t -> (Path.Local.t -> Path.t) -> Path.t t list

--- a/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
@@ -1,0 +1,15 @@
+Use build paths in the install entries of a package
+
+  $ . ./helpers.sh
+
+  $ make_lockdir
+
+  $ cat >dune.lock/test.pkg <<EOF
+  > (build
+  >  (system "\| cat >test.install <<EOF
+  >          "\| bin: [ "?_build/install/default/bin/foo" ]
+  >          "\| EOF
+  >  ))
+  > EOF
+
+  $ build_pkg test


### PR DESCRIPTION
Interpret all entries relative to the path of the install file

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0cbe7fec-d721-4685-a829-0eba6eaa91e9 -->