### PR TITLE
feature(pkg): add filtering to opam patches field translation

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -43,7 +43,9 @@ The lockfile should contain the patch action with the appropriate filter.
   
   (build
    (progn
-    (patch foo.patch)
+    (when
+     (= %{switch} foobar)
+     (patch foo.patch))
     (run cat foo.ml)))
   (source (copy $TESTCASE_ROOT/source))
 
@@ -53,4 +55,4 @@ The lockfile should contain the patch action with the appropriate filter.
   > EOF
 
   $ build_pkg with-patch-filter 
-  This is wrong; this patch should have been filtered out.
+  This is right; the patch should never be applied.


### PR DESCRIPTION
Filters in the opam files in the patches field are now translated to the lock file.

This highlights an unrelated bug with the `pkg-self` macro however.