### PR TITLE
fix(pkg): expand with-test into %{with-test}

### DIFF
--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -53,6 +53,8 @@ module Var = struct
       | Group
       | Jobs
       | Arch
+      | With_test
+      | With_doc
       | Section_dir of Section.t
 
     let compare = Poly.compare
@@ -71,6 +73,8 @@ module Var = struct
       | Group -> variant "Group" []
       | Jobs -> variant "Jobs" []
       | Arch -> variant "Arch" []
+      | With_test -> variant "With_test" []
+      | With_doc -> variant "With_doc" []
       | Section_dir section ->
         variant "Section_dir" [ string (Section.to_string section) ]
     ;;
@@ -87,6 +91,8 @@ module Var = struct
       | Group -> "group"
       | Jobs -> "jobs"
       | Arch -> "arch"
+      | With_test -> "with-test"
+      | With_doc -> "with-doc"
       | Section_dir section -> Section.to_string section
     ;;
   end
@@ -209,6 +215,8 @@ module Var = struct
        | "group" -> Some (Pkg Group)
        | "jobs" -> Some (Pkg Jobs)
        | "arch" -> Some (Pkg Arch)
+       | "with-test" -> Some (Pkg With_test)
+       | "with-doc" -> Some (Pkg With_doc)
        | _ -> None)
   ;;
 end

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -32,6 +32,8 @@ module Var : sig
       | Group
       | Jobs
       | Arch
+      | With_test
+      | With_doc
       | Section_dir of Section.t
 
     val compare : t -> t -> Ordering.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -502,6 +502,10 @@ module Action_expander = struct
         let roots = Paths.install_roots paths in
         let dir = section_dir_of_root roots section in
         Memo.return [ Value.Dir dir ]
+      (* CR-someday alizter: We are always passing with-test here. *)
+      | With_test -> Memo.return [ Value.String "true" ]
+      (* CR-someday alizter: We are always passing with-doc here. *)
+      | With_doc -> Memo.return [ Value.String "true" ]
     ;;
 
     let expand_pform

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -209,7 +209,7 @@ Package which has boolean where string was expected. This should be caught while
      (run echo g))
     (when
      (and
-      %{pkg-self:with-test}
+      %{with-test}
       (< %{pkg:ocaml:version} 5.0.0))
      (run echo h))
     (when

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -103,10 +103,10 @@ corresponding Dune version.
     (run echo 32 %{pkg:foo:dev})
     (run echo 33 %{pkg-self:opamfile})
     (run echo 34 %{pkg:foo:opamfile})
-    (run echo 35 %{pkg-self:with-test})
+    (run echo 35 %{with-test})
     (run echo 36 %{pkg-self:with-test})
     (run echo 37 %{pkg:foo:with-test})
-    (run echo 38 %{pkg-self:with-doc})
+    (run echo 38 %{with-doc})
     (run echo 39 %{pkg-self:with-doc})
     (run echo 40 %{pkg:foo:with-doc})
     (run echo 41 %{pkg-self:with-dev-setup})
@@ -201,10 +201,10 @@ The values here are not important, but Dune should be able to interpret the vari
   38 |   (run echo 34 %{pkg:foo:opamfile})
                       ^^^^^^^^^^^^^^^^^^^
   Error: invalid section "opamfile"
-  File "dune.lock/testpkg.pkg", line 39, characters 15-36:
-  39 |   (run echo 35 %{pkg-self:with-test})
-                      ^^^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{pkg-self:..}
+  File "dune.lock/testpkg.pkg", line 39, characters 15-27:
+  39 |   (run echo 35 %{with-test})
+                      ^^^^^^^^^^^^
+  Error: Unknown variable %{with-test}
   File "dune.lock/testpkg.pkg", line 40, characters 15-36:
   40 |   (run echo 36 %{pkg-self:with-test})
                       ^^^^^^^^^^^^^^^^^^^^^
@@ -213,10 +213,10 @@ The values here are not important, but Dune should be able to interpret the vari
   41 |   (run echo 37 %{pkg:foo:with-test})
                       ^^^^^^^^^^^^^^^^^^^^
   Error: invalid section "with-test"
-  File "dune.lock/testpkg.pkg", line 42, characters 15-35:
-  42 |   (run echo 38 %{pkg-self:with-doc})
-                      ^^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{pkg-self:..}
+  File "dune.lock/testpkg.pkg", line 42, characters 15-26:
+  42 |   (run echo 38 %{with-doc})
+                      ^^^^^^^^^^^
+  Error: Unknown variable %{with-doc}
   File "dune.lock/testpkg.pkg", line 43, characters 15-35:
   43 |   (run echo 39 %{pkg-self:with-doc})
                       ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
We fix the expansion of {with-test} in an opam file to %{with-test} as a pfrom. For now this is always set to be true.

I've left some CRs mentioning that this temporary default should be changed to something more appropriate.