### PR TITLE
feature(pkg): initialize context with packages

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -59,6 +59,7 @@ let local_libraries =
   ; ("src/dune_engine", Some "Dune_engine", false, None)
   ; ("otherlibs/dune-private-libs/meta_parser", Some "Dune_meta_parser",
     false, None)
+  ; ("src/fs", Some "Fs", false, None)
   ; ("src/dune_findlib", Some "Dune_findlib", false, None)
   ; ("vendor/sha", None, false, None)
   ; ("vendor/uutf", None, false, None)

--- a/src/dune_findlib/dune
+++ b/src/dune_findlib/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_findlib)
- (libraries stdune dune_lang dune_engine memo ocaml dune_meta_parser unix))
+ (libraries stdune dune_lang dune_engine memo ocaml dune_meta_parser unix fs))

--- a/src/dune_findlib/package0.ml
+++ b/src/dune_findlib/package0.ml
@@ -52,43 +52,27 @@ let plugins t =
     (make_archives t "plugin" preds)
 ;;
 
-module Exists
-    (Monad : sig
-       type 'a t
+let exists t ~is_builtin =
+  let exists_if = Vars.get_words t.vars "exists_if" Ps.empty in
+  match exists_if with
+  | _ :: _ ->
+    Memo.List.for_all exists_if ~f:(fun fn -> Fs.file_exists (Path.relative t.dir fn))
+  | [] ->
+    if not is_builtin
+    then Memo.return true
+    else (
+      (* The META files for installed packages are sometimes broken, i.e.
+         META files for libraries that were not installed by the compiler
+         are still present:
 
-       val return : 'a -> 'a t
+         https://github.com/ocaml/dune/issues/563
 
-       module List : sig
-         val for_all : 'a list -> f:('a -> bool t) -> bool t
-         val exists : 'a list -> f:('a -> bool t) -> bool t
-       end
-     end)
-    (Fs : sig
-       val file_exists : Path.t -> bool Monad.t
-     end) =
-struct
-  let exists t ~is_builtin =
-    let exists_if = Vars.get_words t.vars "exists_if" Ps.empty in
-    match exists_if with
-    | _ :: _ ->
-      Monad.List.for_all exists_if ~f:(fun fn -> Fs.file_exists (Path.relative t.dir fn))
-    | [] ->
-      if not is_builtin
-      then Monad.return true
-      else (
-        (* The META files for installed packages are sometimes broken, i.e.
-           META files for libraries that were not installed by the compiler
-           are still present:
-
-           https://github.com/ocaml/dune/issues/563
-
-           To workaround this problem, for builtin packages we check that at
-           least one of the archive is present. *)
-        match archives t with
-        | { byte = []; native = [] } -> Monad.return true
-        | { byte; native } -> Monad.List.exists (byte @ native) ~f:Fs.file_exists)
-  ;;
-end
+         To workaround this problem, for builtin packages we check that at
+         least one of the archive is present. *)
+      match archives t with
+      | { byte = []; native = [] } -> Memo.return true
+      | { byte; native } -> Memo.List.exists (byte @ native) ~f:Fs.file_exists)
+;;
 
 let candidates ~dir name =
   [ meta_fn ^ "." ^ Package.Name.to_string name; meta_fn ]

--- a/src/dune_findlib/package0.mli
+++ b/src/dune_findlib/package0.mli
@@ -17,23 +17,7 @@ val kind : t -> Lib_kind.t
 val archives : t -> Path.t list Mode.Dict.t
 val plugins : t -> Path.t list Mode.Dict.t
 val findlib_predicates_set_by_dune : Ocaml.Variant.Set.t
-
-module Exists
-    (Monad : sig
-       type 'a t
-
-       val return : 'a -> 'a t
-
-       module List : sig
-         val for_all : 'a list -> f:('a -> bool t) -> bool t
-         val exists : 'a list -> f:('a -> bool t) -> bool t
-       end
-     end)
-    (_ : sig
-       val file_exists : Path.t -> bool Monad.t
-     end) : sig
-  val exists : t -> is_builtin:bool -> bool Monad.t
-end
+val exists : t -> is_builtin:bool -> bool Memo.t
 
 val candidates
   :  dir:Path.Outside_build_dir.t

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -25,6 +25,7 @@ module Kind : sig
   type t =
     | Default
     | Opam of Opam_switch.t
+    | Lock of { default : bool }
 end
 
 module Env_nodes : sig

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -36,6 +36,7 @@
   dune_findlib
   dune_patch
   scheme
+  fs
   unix)
  (synopsis "Internal Dune library, do not use!")
  (instrumentation

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -496,40 +496,31 @@ module Or_meta = struct
          Dune_package package)
   ;;
 
-  module Load
-      (Monad : sig
-         type 'a t
-       end)
-      (Fs : sig
-         val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Monad.t
-       end) =
-  struct
-    let load file =
-      let dir = Path.parent_exn file in
-      Fs.with_lexbuf_from_file file ~f:(fun lexbuf ->
-        match
-          Vfile.parse_contents lexbuf ~f:(fun lang ->
-            String_with_vars.set_decoding_env
-              (Pform.Env.initial lang.version)
-              (decode ~lang ~dir))
-        with
-        | contents -> Ok contents
-        | exception User_error.E message -> Error message
-        | exception Sys_error msg ->
-          Error
-            (User_message.make
-               [ Pp.textf "Failed to read %s:" (Path.to_string_maybe_quoted file)
-               ; Pp.text msg
-               ])
-        | exception End_of_file ->
-          Error
-            (User_message.make
-               [ Pp.textf
-                   "Unexpected end of file when reading %s."
-                   (Path.to_string_maybe_quoted file)
-               ]))
-    ;;
-  end
+  let load file =
+    let dir = Path.parent_exn file in
+    Fs.with_lexbuf_from_file file ~f:(fun lexbuf ->
+      match
+        Vfile.parse_contents lexbuf ~f:(fun lang ->
+          String_with_vars.set_decoding_env
+            (Pform.Env.initial lang.version)
+            (decode ~lang ~dir))
+      with
+      | contents -> Ok contents
+      | exception User_error.E message -> Error message
+      | exception Sys_error msg ->
+        Error
+          (User_message.make
+             [ Pp.textf "Failed to read %s:" (Path.to_string_maybe_quoted file)
+             ; Pp.text msg
+             ])
+      | exception End_of_file ->
+        Error
+          (User_message.make
+             [ Pp.textf
+                 "Unexpected end of file when reading %s."
+                 (Path.to_string_maybe_quoted file)
+             ]))
+  ;;
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -64,16 +64,6 @@ module Or_meta : sig
     | Dune_package of t
 
   val pp : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
-
-  module Load
-      (Monad : sig
-         type 'a t
-       end)
-      (_ : sig
-         val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Monad.t
-       end) : sig
-    val load : Path.t -> (t, User_message.t) result Monad.t
-  end
-
+  val load : Path.t -> (t, User_message.t) result Memo.t
   val to_dyn : t Dyn.builder
 end

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -944,7 +944,7 @@ let promote_install_file (ctx : Context.t) =
   && (not (Context.implicit ctx))
   &&
   match Context.kind ctx with
-  | Default -> true
+  | Lock _ | Default -> true
   | Opam _ -> false
 ;;
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -105,6 +105,11 @@ module Lock_dir = struct
   ;;
 
   let get (ctx : Context_name.t) : t Memo.t = get_path ctx >>= Load.load
+
+  let has_lock ctx =
+    let* path = get_path ctx in
+    Fs_memo.dir_exists (In_source_dir path)
+  ;;
 end
 
 module Paths = struct
@@ -298,21 +303,21 @@ module Pkg = struct
     | Some (Fetch _) -> assert false
   ;;
 
+  let dep t = Dep.file (Path.build t.paths.target_dir)
+
   let package_deps t =
     deps_closure t
-    |> List.fold_left ~init:Dep.Set.empty ~f:(fun acc t ->
-      Path.build t.paths.target_dir |> Dep.file |> Dep.Set.add acc)
+    |> List.fold_left ~init:Dep.Set.empty ~f:(fun acc t -> dep t |> Dep.Set.add acc)
   ;;
 
-  let build_env =
+  let build_env_of_deps =
     let add_to_path env var what =
       Env.Map.update env var ~f:(fun paths ->
         let paths = Option.value paths ~default:[] in
         Some (Value.Dir (Path.build what) :: paths))
     in
-    fun t ->
-      deps_closure t
-      |> List.fold_left ~init:Env.Map.empty ~f:(fun env t ->
+    fun xs ->
+      List.fold_left xs ~init:Env.Map.empty ~f:(fun env t ->
         let env =
           let roots =
             Paths.install_roots t.paths |> Install.Roots.map ~f:Path.as_in_build_dir_exn
@@ -323,6 +328,8 @@ module Pkg = struct
         in
         List.fold_left t.exported_env ~init:env ~f:Env_update.set)
   ;;
+
+  let build_env t = build_env_of_deps @@ deps_closure t
 
   let exported_env t =
     let base =
@@ -803,23 +810,55 @@ module Action_expander = struct
   ;;
 end
 
-module DB = struct
-  type t = Lock_dir.Pkg.t Package.Name.Map.t
+let ocaml_package_name = Package.Name.of_string "ocaml"
 
-  let equal = Package.Name.Map.equal ~equal:Lock_dir.Pkg.equal
+module DB = struct
+  type t =
+    { all : Lock_dir.Pkg.t Package.Name.Map.t
+    ; system_provided : Package.Name.Set.t
+    }
+
+  let equal t { all; system_provided } =
+    Package.Name.Map.equal ~equal:Lock_dir.Pkg.equal t.all all
+    && Package.Name.Set.equal t.system_provided system_provided
+  ;;
+
+  let get context =
+    let+ all = Lock_dir.get context in
+    let system_provided =
+      if Env.mem Env.initial ~var:"DUNE_PKG_OVERRIDE_OCAML"
+      then (
+        match all.ocaml with
+        | None -> Package.Name.Set.singleton ocaml_package_name
+        | Some (_, name) -> Package.Name.Set.singleton name)
+      else Package.Name.Set.empty
+    in
+    { all = all.packages; system_provided }
+  ;;
 end
 
 module rec Resolve : sig
-  val resolve : DB.t -> Context_name.t -> Loc.t * Package.Name.t -> Pkg.t Memo.t
+  val resolve
+    :  DB.t
+    -> Context_name.t
+    -> Loc.t * Package.Name.t
+    -> [ `Inside_lock_dir of Pkg.t | `System_provided ] Memo.t
 end = struct
   open Resolve
 
   let resolve_impl ((db : DB.t), ctx, (name : Package.Name.t)) =
-    match Package.Name.Map.find db name with
+    match Package.Name.Map.find db.all name with
     | None -> Memo.return None
     | Some { Lock_dir.Pkg.build_command; install_command; deps; info; exported_env } ->
       assert (Package.Name.equal name info.name);
-      let* deps = Memo.parallel_map deps ~f:(resolve db ctx) in
+      let* deps =
+        Memo.parallel_map deps ~f:(fun name ->
+          resolve db ctx name
+          >>| function
+          | `Inside_lock_dir pkg -> Some pkg
+          | `System_provided -> None)
+        >>| List.filter_opt
+      in
       let id = Pkg.Id.gen () in
       let paths = Paths.make name ctx in
       let* lock_dir = Lock_dir.get_path ctx in
@@ -864,18 +903,19 @@ end = struct
           Pp.textf "- package %s" (Package.Name.to_string pkg))
         resolve_impl
     in
-    fun db ctx (loc, name) ->
-      Memo.exec memo (db, ctx, name)
-      >>| function
-      | Some s -> s
-      | None ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "Unknown package %S" (Package.Name.to_string name) ]
+    fun (db : DB.t) ctx (loc, name) ->
+      if Package.Name.Set.mem db.system_provided name
+      then Memo.return `System_provided
+      else
+        Memo.exec memo (db, ctx, name)
+        >>| function
+        | Some s -> `Inside_lock_dir s
+        | None ->
+          User_error.raise
+            ~loc
+            [ Pp.textf "Unknown package %S" (Package.Name.to_string name) ]
   ;;
 end
-
-open Resolve
 
 module Install_action = struct
   let installable_sections =
@@ -1415,8 +1455,18 @@ module Gen_rules = Build_config.Gen_rules
 
 let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
   let name = User_error.ok_exn (Package.Name.of_string_user_error (Loc.none, pkg_name)) in
-  let* db = Lock_dir.get context in
-  let+ pkg = resolve db.packages context (Loc.none, name) in
+  let* db = DB.get context in
+  let+ pkg =
+    Resolve.resolve db context (Loc.none, name)
+    >>| function
+    | `Inside_lock_dir pkg -> pkg
+    | `System_provided ->
+      User_error.raise
+        [ Pp.textf
+            "There are no rules for %S because it's set as provided by the system"
+            (Package.Name.to_string name)
+        ]
+  in
   let paths = Paths.make name context in
   let directory_targets =
     let target_dir = paths.target_dir in
@@ -1433,32 +1483,63 @@ let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
 ;;
 
 let ocaml_toolchain context =
-  let* db = Lock_dir.get context in
+  let* lock_dir = Lock_dir.get context in
   let+ pkg =
-    match db.ocaml with
-    | None -> User_error.raise [ Pp.text "no ocaml toolchain defined" ]
-    | Some ocaml -> resolve db.packages context ocaml
+    let* db = DB.get context in
+    match lock_dir.ocaml with
+    | None -> Resolve.resolve db context (Loc.none, ocaml_package_name)
+    | Some ocaml -> Resolve.resolve db context ocaml
   in
-  let toolchain =
-    let cookie = (Pkg_installed.of_paths pkg.paths).cookie in
-    let open Action_builder.O in
-    let* cookie = cookie in
-    let binaries =
-      Section.Map.find cookie.files Bin |> Option.value ~default:[] |> Path.Set.of_list
+  match pkg with
+  | `System_provided -> None
+  | `Inside_lock_dir pkg ->
+    let toolchain =
+      let cookie = (Pkg_installed.of_paths pkg.paths).cookie in
+      let open Action_builder.O in
+      let* cookie = cookie in
+      let binaries =
+        Section.Map.find cookie.files Bin |> Option.value ~default:[] |> Path.Set.of_list
+      in
+      let env = Pkg.exported_env pkg in
+      Action_builder.of_memo @@ Ocaml_toolchain.of_binaries context env binaries
     in
-    let env = Pkg.exported_env pkg in
-    Action_builder.of_memo @@ Ocaml_toolchain.of_binaries context env binaries
-  in
-  Action_builder.memoize "ocaml_toolchain" toolchain
+    Some (Action_builder.memoize "ocaml_toolchain" toolchain)
 ;;
 
-let which context program =
-  let* db = Lock_dir.get context in
-  let+ artifacts, _ =
-    Package.Name.Map.values db.packages
-    |> Memo.parallel_map ~f:(fun (pkg : Lock_dir.Pkg.t) ->
-      resolve db.packages context (Loc.none, pkg.info.name))
-    >>= Action_expander.artifacts_and_deps
+let all_packages context =
+  let* db = DB.get context in
+  let+ closure =
+    Dune_lang.Package_name.Map.values db.all
+    |> Memo.parallel_map ~f:(fun (package : Lock_dir.Pkg.t) ->
+      let package = package.info.name in
+      Resolve.resolve db context (Loc.none, package)
+      >>| function
+      | `Inside_lock_dir pkg -> Some pkg
+      | `System_provided -> None)
+    >>| List.filter_opt
+    >>| Pkg.top_closure
   in
-  Filename.Map.find artifacts program
+  match closure with
+  | Error _ -> assert false
+  | Ok closure -> closure
+;;
+
+let which context =
+  let artifacts_and_deps =
+    Memo.lazy_ (fun () ->
+      let+ artifacts, _ = all_packages context >>= Action_expander.artifacts_and_deps in
+      artifacts)
+  in
+  Staged.stage (fun program ->
+    let+ artifacts = Memo.Lazy.force artifacts_and_deps in
+    Filename.Map.find artifacts program)
+;;
+
+let has_lock = Lock_dir.has_lock
+
+let exported_env context =
+  let+ all_packages = all_packages context in
+  let env = Pkg.build_env_of_deps all_packages in
+  let vars = Env.Map.map env ~f:Env_update.string_of_env_values in
+  Env.extend Env.empty ~vars
 ;;

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -15,5 +15,7 @@ val setup_package_rules
   -> pkg_name:string
   -> Build_config.Gen_rules.result Memo.t
 
-val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t Memo.t
-val which : Context_name.t -> Filename.t -> Path.t option Memo.t
+val has_lock : Context_name.t -> bool Memo.t
+val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
+val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t
+val exported_env : Context_name.t -> Env.t Memo.t

--- a/src/fs/dune
+++ b/src/fs/dune
@@ -1,0 +1,3 @@
+(library
+ (name fs)
+ (libraries dune_engine stdune memo))

--- a/src/fs/fs.ml
+++ b/src/fs/fs.ml
@@ -1,0 +1,55 @@
+open Stdune
+open Memo.O
+
+open struct
+  open Dune_engine
+  module Fs_memo = Fs_memo
+  module Fs_cache = Fs_cache
+  module Build_system = Build_system
+end
+
+let dir_contents (dir : Path.t) =
+  let* () = Memo.return () in
+  match Path.destruct_build_dir dir with
+  | `Outside dir ->
+    Fs_memo.dir_contents dir
+    >>| Result.map ~f:(fun contents ->
+      Fs_cache.Dir_contents.to_list contents |> List.map ~f:fst)
+  | `Inside _ ->
+    let* () = Build_system.build_file dir in
+    Memo.return (Path.readdir_unsorted dir)
+;;
+
+let exists file kind =
+  Build_system.file_exists file
+  >>= function
+  | false -> Memo.return false
+  | true ->
+    let+ () = Build_system.build_file file in
+    (match Path.stat file with
+     | Ok { st_kind; _ } when kind = st_kind -> true
+     | _ -> false)
+;;
+
+let file_exists file =
+  let* () = Memo.return () in
+  match Path.destruct_build_dir file with
+  | `Outside file -> Fs_memo.file_exists file
+  | `Inside _ -> exists file Unix.S_REG
+;;
+
+let dir_exists dir =
+  let* () = Memo.return () in
+  match Path.destruct_build_dir dir with
+  | `Outside dir -> Fs_memo.dir_exists dir
+  | `Inside _ -> exists dir Unix.S_DIR
+;;
+
+let with_lexbuf_from_file file ~f =
+  let* () = Memo.return () in
+  match Path.destruct_build_dir file with
+  | `Outside file -> Fs_memo.with_lexbuf_from_file ~f file
+  | `Inside _ ->
+    let* () = Build_system.build_file file in
+    Memo.return @@ Io.with_lexbuf_from_file file ~f
+;;

--- a/src/fs/fs.mli
+++ b/src/fs/fs.mli
@@ -1,0 +1,9 @@
+(** These functions will either build or watch their arguments before accessing
+    them *)
+
+open Stdune
+
+val dir_contents : Path.t -> (Filename.t list, Unix_error.Detailed.t) result Memo.t
+val file_exists : Path.t -> bool Memo.t
+val dir_exists : Path.t -> bool Memo.t
+val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.t

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -1,3 +1,5 @@
+export DUNE_PKG_OVERRIDE_OCAML=1
+
 dune="dune"
 
 pkg_root="_build/_private/default/.pkg"

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -20,7 +20,7 @@ This should give us a proper error that myfile wasn't generated
   Error:
   $ROOT/_private/default/.pkg/test/source/myfile:
   No such file or directory
-  -> required by $ROOT/_private/default/.pkg/test/target
+  -> required by $ROOT/_private/default/.pkg/test/target/cookie
 
 This on the other hand shouldn't error because myfile is optional
 

--- a/test/blackbox-tests/test-cases/pkg/libraries.t
+++ b/test/blackbox-tests/test-cases/pkg/libraries.t
@@ -1,6 +1,8 @@
 This test attempts to build a library installed through a lock file and then
 use it inside dune.
 
+  $ . ./helpers.sh
+
 We set up a library that will be installed as part of the package:
 
   $ mkdir external_sources
@@ -30,7 +32,7 @@ Now we set up a lock file with this package and then attempt to use it:
 
   $ cat >dune.lock/mypkg.pkg <<EOF
   > (source (copy $PWD/external_sources))
-  > (build (run dune build @install))
+  > (build (run dune build --promote-install-file=true . @install))
   > EOF
 
   $ cat >dune <<EOF
@@ -45,11 +47,3 @@ Now we set up a lock file with this package and then attempt to use it:
   > EOF
 
   $ dune build foo.cma
-  File "dune", line 4, characters 12-21:
-  4 |  (libraries mypkg.lib))
-                  ^^^^^^^^^
-  Error: Library "mypkg.lib" not found.
-  -> required by library "foo" in _build/default
-  -> required by _build/default/.foo.objs/byte/foo.cmo
-  -> required by _build/default/foo.cma
-  [1]

--- a/test/blackbox-tests/test-cases/pkg/package-resolution-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/package-resolution-cycle.t
@@ -22,7 +22,7 @@ Dune should gracefully error when packages introduce circular dependenices
 
   $ build_pkg c
   Error: Dependency cycle between:
-     - package c
-  -> - package a
+     - package a
   -> - package c
+  -> - package a
   [1]

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -26,4 +26,5 @@ TODO: versioning will be added once this feature is stable
   $ ln -s foo.lock bar.lock
 
   $ build_pkg test
+  building from foo
   building from default

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps.t
@@ -1,13 +1,12 @@
 We should be able to specify (package ..) deps on locally built packages.
 
+  $ . ./helpers.sh
+
   $ cat >dune-project <<EOF
   > (lang dune 3.11)
   > EOF
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ make_lockdir
   $ cat >dune.lock/foo.pkg <<EOF
   > (build
   >  (progn
@@ -50,8 +49,4 @@ Now we define the external package using a dune project:
   > (build (run dune build @install --promote-install-files))
   > EOF
   $ dune build @foo
-  File "dune", line 5, characters 16-19:
-  5 |  (deps (package foo)))
-                      ^^^
-  Error: Package foo does not exist
-  [1]
+  $TESTCASE_ROOT/_build/_private/default/.pkg/foo/target/bin/foo


### PR DESCRIPTION
This PR does the following:

* Initialize the context with the OCaml toolchain from the lock dir
* Initialize the findlib database with all the packages installed from the lock dir
* Introduce the environment variable `DUNE_PKG_OVERRIDE_OCAML` to prevent dune from installing OCaml. This is useful to make sure we can run the test suite in a reasonable time.