### PR TITLE
test(pkg): modify test to use switch instead

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -7,7 +7,7 @@ lock file.
 Make a package with a patch behind a filter
   $ mkpkg with-patch-filter <<EOF
   > opam-version: "2.0"
-  > patches: ["foo.patch" {with-test}]
+  > patches: ["foo.patch" {switch = "foobar"}]
   > build: ["cat" "foo.ml"]
   > EOF
 


### PR DESCRIPTION
<s>This makes this test more portable.</s>

This avoids `with-test` as it might be treated in a special way.