### PR TITLE
test(pkg): test env updates in opam-package-with-setenv

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -3,19 +3,30 @@ Testing the translation of the setenv field of an opam file into the dune lock d
   $ . ./helpers.sh
   $ mkrepo
 
-Make a package with a setenv 
+Make a package with a setenv. We also test all the kinds of env updates here expcept for
+=+= which isn't used at all in the wild. 
   $ mkpkg with-setenv <<EOF
   > opam-version: "2.0"
   > setenv: [
   >  [EXPORTED_ENV_VAR = "Hello from the other package!"]
+  >  [prepend_with_trailing_sep := "Prepended with trailing sep"]
+  >  [prepend_without_trailing_sep += "Prepended without trailing sep"]
+  >  [append_without_leading_sep =+ "Appended without leading sep"]
+  >  [append_with_leading_sep =: "Appended with leading sep"]
   > ]
   > EOF
 
-Make another package that depends on that and outputs the exported env var
+Make another package that depends on that and outputs the exported env vars
   $ mkpkg deps-on-with-setenv <<'EOF'
   > opam-version: "2.0"
   > depends: [ "with-setenv" ]
-  > build: [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
+  > build: [
+  >  [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
+  >  [ "sh" "-c" "echo $prepend_without_trailing_sep" ]
+  >  [ "sh" "-c" "echo $prepend_with_trailing_sep" ]
+  >  [ "sh" "-c" "echo $append_without_leading_sep" ]
+  >  [ "sh" "-c" "echo $append_with_leading_sep" ]
+  > ]
   > EOF
 
   $ mkdir -p $mock_packages/with-setenv/with-setenv.0.0.1
@@ -40,12 +51,26 @@ The exported env from the first package should be in the lock dir.
   (version 0.0.1)
   
   (build
-   (run sh -c "echo $EXPORTED_ENV_VAR"))
+   (progn
+    (run sh -c "echo $EXPORTED_ENV_VAR")
+    (run sh -c "echo $prepend_without_trailing_sep")
+    (run sh -c "echo $prepend_with_trailing_sep")
+    (run sh -c "echo $append_without_leading_sep")
+    (run sh -c "echo $append_with_leading_sep")))
   
   (deps with-setenv)
 
-When building the second package the exported env var from the first package should be
-available.
+When building the second package the exported env vars from the first package should be
+available and all the env updates should be applied correctly.
 
-  $ EXPORTED_ENV_VAR="I have not been exported yet." build_pkg deps-on-with-setenv 
+  $ EXPORTED_ENV_VAR="I have not been exported yet." \
+  > prepend_without_trailing_sep="foo:bar" \
+  > prepend_with_trailing_sep="foo:bar" \
+  > append_without_leading_sep="foo:bar" \
+  > append_with_leading_sep="foo:bar" \
+  > build_pkg deps-on-with-setenv 
   I have not been exported yet.
+  foo:bar
+  foo:bar
+  foo:bar
+  foo:bar


### PR DESCRIPTION
We add all the kinds of env var updates that we care about to the setenv test in order to test how they are applied.