### PR TITLE
feature(pkg): translate setenv from opam file into dune lock dir

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -504,7 +504,10 @@ let opam_package_to_lock_file_pkg ~repos ~local_packages opam_package =
     |> make_action
     |> Option.map ~f:build_env
   in
-  { Lock_dir.Pkg.build_command; install_command; deps; info; exported_env = [] }
+  let exported_env =
+    OpamFile.OPAM.env opam_file |> List.map ~f:opam_env_update_to_env_update
+  in
+  { Lock_dir.Pkg.build_command; install_command; deps; info; exported_env }
 ;;
 
 let solve_package_list local_packages context =

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -47,6 +47,13 @@ The exported env from the first package should be in the lock dir.
 
   $ cat dune.lock/with-setenv.pkg
   (version 0.0.1)
+  
+  (exported_env
+   (= EXPORTED_ENV_VAR "Hello from the other package!")
+   (:= prepend_with_trailing_sep "Prepended with trailing sep")
+   (+= prepend_without_trailing_sep "Prepended without trailing sep")
+   (=+ append_without_leading_sep "Appended without leading sep")
+   (=: append_with_leading_sep "Appended with leading sep"))
   $ cat dune.lock/deps-on-with-setenv.pkg
   (version 0.0.1)
   
@@ -69,8 +76,8 @@ available and all the env updates should be applied correctly.
   > append_without_leading_sep="foo:bar" \
   > append_with_leading_sep="foo:bar" \
   > build_pkg deps-on-with-setenv 
-  I have not been exported yet.
-  foo:bar
-  foo:bar
-  foo:bar
-  foo:bar
+  Hello from the other package!
+  Prepended without trailing sep
+  Prepended with trailing sep
+  Appended without leading sep
+  Appended with leading sep


### PR DESCRIPTION
- fixes #8641 

This highlights an issue with env updates that we have but that is separate from supporting setenv.