### PR TITLE
doc: Fix wrapped_executables documentation

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -651,18 +651,18 @@ wrapped_executables
 
    .. versionadded:: 1.11
 
-      Control wrapping of modules in executables.
+   Control wrapping of modules in executables.
 
-      Executables are made of compilation units whose names may collide with
-      libraries' compilation units. To avoid this possibility, Dune prefixes
-      these compilation unit names with ``Dune__exe__``. This is entirely
-      transparent to users except when such executables are debugged. In which
-      case, the mangled names will be visible in the debugger.
+   Executables are made of compilation units whose names may collide with
+   libraries' compilation units. To avoid this possibility, Dune prefixes
+   these compilation unit names with ``Dune__exe__``. This is entirely
+   transparent to users except when such executables are debugged. In which
+   case, the mangled names will be visible in the debugger.
 
-      - with ``(wrapped_executables false)``, the original names are used.
-      - with ``(wrapped_executables true)``, the names are mangled.
+   - with ``(wrapped_executables false)``, the original names are used.
+   - with ``(wrapped_executables true)``, the names are mangled.
 
-      Starting in language version 2.0, the default value is ``true``.
+   Starting in language version 2.0, the default value is ``true``.
 
 .. _map-workspace-root:
 


### PR DESCRIPTION
Incorrect indentation grouped the first line of `wrapped_executables` description with versionadded.

![image](https://github.com/ocaml/dune/assets/1518025/6a2a8af6-0491-4ee2-89a5-eb8cbafe74aa)

Trivial patch to fix it.
