### PR TITLE
test(pkg): split out and expand env update tests for setenv 

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/env-update.t/env-update-helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/env-update.t/env-update-helpers.sh
@@ -1,0 +1,55 @@
+. ../helpers.sh
+
+# [mktestpkg <package> <depends> <env_update_op>] makes an opam <package> that depends
+# on <depends> and updated "env_var" using <env_update_op>
+mktestpkg() {
+  mkpkg $1 <<EOF
+opam-version: "2.0"
+depends: [ "$2" ]
+setenv: [
+  [ override = "$1" ]
+  [ prepend_sep := "$1" ]
+  [ prepend += "$1" ]
+  [ append_sep =: "$1" ]
+  [ append =+ "$1" ]
+]
+build: [
+  [ "echo" "\n$1:" ]
+  [ "sh" "-c" "echo \"   override: \$override\"" ]
+  [ "sh" "-c" "echo \"prepend_sep: \$prepend_sep\"" ] 
+  [ "sh" "-c" "echo \"    prepend: \$prepend\"" ]
+  [ "sh" "-c" "echo \" append_sep: \$append_sep\"" ]
+  [ "sh" "-c" "echo \"     append: \$append\"" ]
+]
+EOF
+  echo $1
+  grep -A6 setenv $mock_packages/$1/$1.0.0.1/opam | tail -n6 | head -n5
+}
+
+solve() {
+  solve_project <<EOF
+(lang dune 3.11)
+ (package
+  (name x)
+  (allow_empty)
+  (depends $1))
+EOF
+}
+
+setup_test() {
+  mkrepo
+  mktestpkg package1 "" 
+  mktestpkg package2 package1 
+  mktestpkg package3 package2 
+  solve package3 2> /dev/null
+}
+
+test() {
+  setup_test
+  override="initial value" \
+  prepend_sep="initial value" \
+  prepend="initial value" \
+  append_sep="initial value" \
+  append="initial value" \
+  build_pkg package3 
+}

--- a/test/blackbox-tests/test-cases/pkg/env-update.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/env-update.t/run.t
@@ -1,0 +1,79 @@
+We have 3 opam packages depending on each other in order. We test how setenv interacts
+with the various env update operators.
+
+  $ . ./env-update-helpers.sh
+
+  $ test 
+  package1
+    [ override = "package1" ]
+    [ prepend_sep := "package1" ]
+    [ prepend += "package1" ]
+    [ append_sep =: "package1" ]
+    [ append =+ "package1" ]
+  package2
+    [ override = "package2" ]
+    [ prepend_sep := "package2" ]
+    [ prepend += "package2" ]
+    [ append_sep =: "package2" ]
+    [ append =+ "package2" ]
+  package3
+    [ override = "package3" ]
+    [ prepend_sep := "package3" ]
+    [ prepend += "package3" ]
+    [ append_sep =: "package3" ]
+    [ append =+ "package3" ]
+  
+  package1:
+     override: initial value
+  prepend_sep: initial value
+      prepend: initial value
+   append_sep: initial value
+       append: initial value
+  
+  package2:
+     override: initial value
+  prepend_sep: initial value
+      prepend: initial value
+   append_sep: initial value
+       append: initial value
+  
+  package3:
+     override: initial value
+  prepend_sep: initial value
+      prepend: initial value
+   append_sep: initial value
+       append: initial value
+
+Here are some properties the values above should have:
+
+= override
+The following should hold:
+- package1 should have the initial value
+- package(n) shuld have value package(n-1)
+This does not currently hold.
+ 
+:= prepend seperator
+The following should hold:
+- All values should have a trailing seperator :
+- package1 should have the initial value
+- package3 should output "package2:package1:initial value:"
+This does not currently hold.
+
++= prepend
+The following should hold:
+- package1 should have the initial value
+- package3 should output "package2:package1:initial value"
+This does not currently hold.
+
+=: append seperator
+The following should hold:
+- All values should have a leading seperator :
+- package1 should have the initial value
+- package3 should output ":initial value:package1:package2"
+This does not currently hold.
+
+=+ append
+The following should hold:
+- package1 should have the initial value
+- package3 should output "initial value:package1:package2"
+This does not currently hold.

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -3,30 +3,19 @@ Testing the translation of the setenv field of an opam file into the dune lock d
   $ . ./helpers.sh
   $ mkrepo
 
-Make a package with a setenv. We also test all the kinds of env updates here expcept for
-=+= which isn't used at all in the wild. 
+Make a package with a setenv 
   $ mkpkg with-setenv <<EOF
   > opam-version: "2.0"
   > setenv: [
   >  [EXPORTED_ENV_VAR = "Hello from the other package!"]
-  >  [prepend_with_trailing_sep := "Prepended with trailing sep"]
-  >  [prepend_without_trailing_sep += "Prepended without trailing sep"]
-  >  [append_without_leading_sep =+ "Appended without leading sep"]
-  >  [append_with_leading_sep =: "Appended with leading sep"]
   > ]
   > EOF
 
-Make another package that depends on that and outputs the exported env vars
+Make another package that depends on that and outputs the exported env var
   $ mkpkg deps-on-with-setenv <<'EOF'
   > opam-version: "2.0"
   > depends: [ "with-setenv" ]
-  > build: [
-  >  [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
-  >  [ "sh" "-c" "echo $prepend_without_trailing_sep" ]
-  >  [ "sh" "-c" "echo $prepend_with_trailing_sep" ]
-  >  [ "sh" "-c" "echo $append_without_leading_sep" ]
-  >  [ "sh" "-c" "echo $append_with_leading_sep" ]
-  > ]
+  > build: [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
   > EOF
 
   $ mkdir -p $mock_packages/with-setenv/with-setenv.0.0.1
@@ -51,26 +40,12 @@ The exported env from the first package should be in the lock dir.
   (version 0.0.1)
   
   (build
-   (progn
-    (run sh -c "echo $EXPORTED_ENV_VAR")
-    (run sh -c "echo $prepend_without_trailing_sep")
-    (run sh -c "echo $prepend_with_trailing_sep")
-    (run sh -c "echo $append_without_leading_sep")
-    (run sh -c "echo $append_with_leading_sep")))
+   (run sh -c "echo $EXPORTED_ENV_VAR"))
   
   (deps with-setenv)
 
-When building the second package the exported env vars from the first package should be
-available and all the env updates should be applied correctly.
+When building the second package the exported env var from the first package should be
+available.
 
-  $ EXPORTED_ENV_VAR="I have not been exported yet." \
-  > prepend_without_trailing_sep="foo:bar" \
-  > prepend_with_trailing_sep="foo:bar" \
-  > append_without_leading_sep="foo:bar" \
-  > append_with_leading_sep="foo:bar" \
-  > build_pkg deps-on-with-setenv 
+  $ EXPORTED_ENV_VAR="I have not been exported yet." build_pkg deps-on-with-setenv 
   I have not been exported yet.
-  foo:bar
-  foo:bar
-  foo:bar
-  foo:bar


### PR DESCRIPTION
This reverts commit 977a943858ae1a32e3cbd0e5708952371cccf229.

We also add in the tests for each env update operation. Together with #7742 it highlights some shortcomings of our env var handling.