### PR TITLE
test(pkg): opam package with root variable

### DIFF
--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -55,6 +55,7 @@ module Var = struct
       | Jobs
       | Arch
       | Section_dir of Section.t
+      | Root
 
     let compare = Poly.compare
 
@@ -73,6 +74,7 @@ module Var = struct
       | Arch -> variant "Arch" []
       | Section_dir section ->
         variant "Section_dir" [ string (Section.to_string section) ]
+      | Root -> variant "Root" []
     ;;
 
     let encode_to_latest_dune_lang_version = function
@@ -87,6 +89,7 @@ module Var = struct
       | Jobs -> "jobs"
       | Arch -> "arch"
       | Section_dir section -> Section.to_string section
+      | Root -> "root"
     ;;
   end
 
@@ -207,6 +210,7 @@ module Var = struct
        | "group" -> Some (Pkg Group)
        | "jobs" -> Some (Pkg Jobs)
        | "arch" -> Some (Pkg Arch)
+       | "root" -> Some (Pkg Root)
        | _ -> None)
   ;;
 end

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -33,6 +33,7 @@ module Var : sig
       | Jobs
       | Arch
       | Section_dir of Section.t
+      | Root
 
     val compare : t -> t -> Ordering.t
     val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/package_variable.ml
+++ b/src/dune_pkg/package_variable.ml
@@ -77,6 +77,9 @@ let of_opam_ident ident =
 
 let pform_of_opam_ident ident =
   match of_opam_ident ident with
-  | `Package_variable t -> to_pform t
-  | `Global_variable var -> Pform.Var var
+  | `Package_variable t -> Ok (to_pform t)
+  | `Global_variable var ->
+    (match (var : Pform.Var.t) with
+     | Pkg Root -> Error `Root_unsupported
+     | var -> Ok (Pform.Var var))
 ;;

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -30,10 +30,16 @@ val of_macro_invocation
 
 val to_pform : t -> Pform.t
 
-(** Parse an opam variable name. Identifiers beginning with "<package>:" are
-    treated as package-scoped variables unless <package> is "_" in which case
-    they are treated as self-scoped. Identifiers without the "<package>:"
-    prefix are treated as self-scoped unless they are the name of an opam
-    global variable. Global variables are encoded as pform variables while all
-    other variables are encoded as pform macros with the [Macro.Pkg] macro. *)
-val pform_of_opam_ident : string -> Pform.t
+(** Parse an opam variable name.
+
+    Identifiers beginning with "<package>:" are treated as package-scoped variables unless
+    <package> is "_" in which case they are treated as self-scoped.
+
+    Identifiers without the "<package>:" prefix are treated as self-scoped unless they are
+    the name of an opam global variable.
+
+    Global variables are encoded as pform variables while all other variables are encoded
+    as pform macros with the [Macro.Pkg] macro.
+
+    Returns an [Error] if the identifier is not a valid opam variable name. *)
+val pform_of_opam_ident : string -> (Pform.t, [ `Root_unsupported ]) result

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -489,6 +489,7 @@ module Action_expander = struct
 
     let expand_pkg (paths : Paths.t) (pform : Pform.Var.Pkg.t) =
       match pform with
+      | Root -> Code_error.raise "Root is not supported" []
       | Switch -> Memo.return [ Value.String "dune" ]
       | Os_version -> sys_poll_var (fun { os_version; _ } -> os_version)
       | Os_distribution -> sys_poll_var (fun { os_distribution; _ } -> os_distribution)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-root-var.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-root-var.t
@@ -11,6 +11,8 @@ have a good error message in that case.
 
   $ mkdir -p $mock_packages/with-root/with-root.0.0.1
 
+Dune should reject the variable during the solving stage.
+
   $ solve_project <<EOF
   > (lang dune 3.8)
   > (package
@@ -18,13 +20,6 @@ have a good error message in that case.
   >  (allow_empty)
   >  (depends with-root))
   > EOF
-  Solution for dune.lock:
-  with-root.0.0.1
-  
-Generating a lock file with this variable should give an error.
-
-  $ cat dune.lock/with-root.pkg
-  (version 0.0.1)
-  
-  (build
-   (run echo %{pkg-self:root}))
+  Error: Variable "root" occuring in opam package "with-root.0.0.1" is not
+  supported.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/opam-package-root-var.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-root-var.t
@@ -1,0 +1,30 @@
+Dune cannot handle the %{root}% opam variable in an opam file. This test makes sure we
+have a good error message in that case.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg with-root <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" root ]
+  > EOF
+
+  $ mkdir -p $mock_packages/with-root/with-root.0.0.1
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-root))
+  > EOF
+  Solution for dune.lock:
+  with-root.0.0.1
+  
+Generating a lock file with this variable should give an error.
+
+  $ cat dune.lock/with-root.pkg
+  (version 0.0.1)
+  
+  (build
+   (run echo %{pkg-self:root}))


### PR DESCRIPTION
We give a better error message when the solver encounters a package with the `root` opam variable. We can't just fail during parsing as we need more information for a good error message.