### PR TITLE
fix: replace obsolete wait3 with wait4

### DIFF
--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -12,6 +12,6 @@
   (re_export dune_filesystem_stubs))
  (foreign_stubs
   (language c)
-  (names wait3_stubs platform_stubs copyfile_stubs signal_stubs))
+  (names wait4_stubs platform_stubs copyfile_stubs signal_stubs))
  (instrumentation
   (backend bisect_ppx)))

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -47,15 +47,25 @@ module Process_info = struct
 end
 
 external stub_wait4
-  :  int -> Unix.wait_flag list
+  :  int
+  -> Unix.wait_flag list
   -> int * Unix.process_status * float * Resource_usage.t
   = "dune_wait4"
 
-let wait pid flags =
+type wait =
+  | Any
+  | Pid of Pid.t
+
+let wait wait flags =
   if Sys.win32
   then Code_error.raise "wait4 not available on windows" []
   else (
-    let pid, status, end_time, resource_usage = stub_wait4 (Pid.to_int pid) flags in
+    let pid =
+      match wait with
+      | Any -> -1
+      | Pid pid -> Pid.to_int pid
+    in
+    let pid, status, end_time, resource_usage = stub_wait4 pid flags in
     { Process_info.pid = Pid.of_int pid
     ; status
     ; end_time

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -47,15 +47,15 @@ module Process_info = struct
 end
 
 external stub_wait4
-  :  Unix.wait_flag list
+  :  int -> Unix.wait_flag list
   -> int * Unix.process_status * float * Resource_usage.t
   = "dune_wait4"
 
-let wait flags =
+let wait pid flags =
   if Sys.win32
   then Code_error.raise "wait4 not available on windows" []
   else (
-    let pid, status, end_time, resource_usage = stub_wait4 flags in
+    let pid, status, end_time, resource_usage = stub_wait4 (Pid.to_int pid) flags in
     { Process_info.pid = Pid.of_int pid
     ; status
     ; end_time

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -46,16 +46,16 @@ module Process_info = struct
     }
 end
 
-external stub_wait3
+external stub_wait4
   :  Unix.wait_flag list
   -> int * Unix.process_status * float * Resource_usage.t
-  = "dune_wait3"
+  = "dune_wait4"
 
 let wait flags =
   if Sys.win32
-  then Code_error.raise "wait3 not available on windows" []
+  then Code_error.raise "wait4 not available on windows" []
   else (
-    let pid, status, end_time, resource_usage = stub_wait3 flags in
+    let pid, status, end_time, resource_usage = stub_wait4 flags in
     { Process_info.pid = Pid.of_int pid
     ; status
     ; end_time

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -24,4 +24,4 @@ module Process_info : sig
 end
 
 (** This function is not implemented on Windows *)
-val wait : Unix.wait_flag list -> Process_info.t
+val wait : Pid.t -> Unix.wait_flag list -> Process_info.t

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -23,5 +23,9 @@ module Process_info : sig
     }
 end
 
+type wait =
+  | Any
+  | Pid of Pid.t
+
 (** This function is not implemented on Windows *)
-val wait : Pid.t -> Unix.wait_flag list -> Process_info.t
+val wait : wait -> Unix.wait_flag list -> Process_info.t

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -3,9 +3,9 @@
 #ifdef _WIN32
 #include <caml/fail.h>
 
-void dune_wait3(value flags) {
+void dune_wait4(value flags) {
   (void)flags;
-  caml_failwith("wait3: not supported on windows");
+  caml_failwith("wait4: not supported on windows");
 }
 
 #else
@@ -45,7 +45,7 @@ static value alloc_process_status(int status) {
 
 static int wait_flag_table[] = {WNOHANG, WUNTRACED};
 
-value dune_wait3(value flags) {
+value dune_wait4(value flags) {
   CAMLparam1(flags);
   CAMLlocal2(times, res);
 
@@ -56,11 +56,11 @@ value dune_wait3(value flags) {
   struct rusage ru;
 
   caml_enter_blocking_section();
-  pid = wait3(&status, cv_flags, &ru);
+  pid = wait4(-1, &status, cv_flags, &ru);
   gettimeofday(&tp, NULL);
   caml_leave_blocking_section();
   if (pid == -1)
-    uerror("wait3", Nothing);
+    uerror("wait4", Nothing);
 
   times = caml_alloc_small(2 * Double_wosize, Double_array_tag);
   Store_double_field(times, 0, ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -45,8 +45,10 @@ static value alloc_process_status(int status) {
 
 static int wait_flag_table[] = {WNOHANG, WUNTRACED};
 
-value dune_wait4(value flags) {
-  CAMLparam1(flags);
+// see https://man7.org/linux/man-pages/man2/waitpid.2.html for a description of possible i_pid values
+// -1 is the one we typically use, which means wait for any child process
+value dune_wait4(value i_pid, value flags) {
+  CAMLparam2(i_pid, flags);
   CAMLlocal2(times, res);
 
   int pid, status, cv_flags;
@@ -56,7 +58,8 @@ value dune_wait4(value flags) {
   struct rusage ru;
 
   caml_enter_blocking_section();
-  pid = wait4(-1, &status, cv_flags, &ru);
+  // returns the pid of the terminated process, or -1 on error
+  pid = wait4(Int_val(i_pid), &status, cv_flags, &ru);
   gettimeofday(&tp, NULL);
   caml_leave_blocking_section();
   if (pid == -1)

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -597,7 +597,8 @@ end = struct
 
   let wait_unix t =
     Mutex.unlock t.mutex;
-    let proc_info = Proc.wait [] in
+    (* -1 means wait for any child process *)
+    let proc_info = Proc.wait (Pid.of_int (-1)) [] in
     Mutex.lock t.mutex;
     Process_table.remove t proc_info
   ;;

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -597,8 +597,7 @@ end = struct
 
   let wait_unix t =
     Mutex.unlock t.mutex;
-    (* -1 means wait for any child process *)
-    let proc_info = Proc.wait (Pid.of_int (-1)) [] in
+    let proc_info = Proc.wait Any [] in
     Mutex.lock t.mutex;
     Process_table.remove t proc_info
   ;;


### PR DESCRIPTION
Related: https://github.com/ocaml/dune/issues/8676

`wait3` is the predecessor to `wait4`: https://www.gnu.org/software/libc/manual/html_node/BSD-Wait-Functions.html

When `-1` is passed as the first argument to `wait4`, it behaves the same as `wait3`

main reason for switching is that `wait3` is not declared on android, but `wait4` is

Testing on termux: `Linux localhost 4.19.269-g8728c337137c-ab10161573 #1 SMP PREEMPT Thu May 18 11:19:41 UTC 2023 aarch64 Android`

```
git clone https://github.com/seanbreckenridge/dune
cd dune
[ /data/data/com.termux/files/usr/tmp/Cx3VGdysNf/dune | main ] $ make release
ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
./.duneboot.exe
Done: 143/1349 (jobs: 8)cd _boot && /data/data/com.termux/files/home/.opam/5.1.0/bin/ocamlopt.opt -c -g -I +unix -I +threads wait3_stubs.c
otherlibs/stdune/src/wait3_stubs.c:59:9: error: call to undeclared function 'wait3'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  pid = wait3(&status, cv_flags, &ru);
        ^
1 error generated.
[ /data/data/com.termux/files/usr/tmp/Cx3VGdysNf/dune | main ] $ git checkout replace-wait3-wait4
Switched to branch 'replace-wait3-wait4'
[ /data/data/com.termux/files/usr/tmp/Cx3VGdysNf/dune | replace-wait3-wait4 ] $ git branch --set-upstream-to=origin/replace-wait3-wait4 replace-wait3-wait4 && git pull -q
branch 'replace-wait3-wait4' set up to track 'origin/replace-wait3-wait4'.
[ /data/data/com.termux/files/usr/tmp/Cx3VGdysNf/dune | replace-wait3-wait4 ] $ make release
ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
./.duneboot.exe
Done: 146/1349 (jobs: 8)cd _boot && /data/data/com.termux/files/home/.opam/5.1.0/bin/ocamlopt.opt -c -g -I +unix -I +threads spawn_stubs.c
vendor/spawn/src/spawn_stubs.c:706:3: error: call to undeclared function 'pthread_setcancelstate'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancel_state);
  ^
vendor/spawn/src/spawn_stubs.c:706:26: error: use of undeclared identifier 'PTHREAD_CANCEL_DISABLE'
```

Ends up with a different error (solved by https://github.com/janestreet/spawn/pull/52), but point is the 'undeclared function wait3' error is gone

No more references to `wait3`:

```
[ ~/Repos/dune | replace-wait3-wait4 ] $ rg 'wait3'    
[ ~/Repos/dune | replace-wait3-wait4 ] $
```