### PR TITLE
change: never ignore promote until-clean under -p

### DIFF
--- a/doc/changes/promote-fallback-always.md
+++ b/doc/changes/promote-fallback-always.md
@@ -1,0 +1,3 @@
+- If `--ignore-promoted-rules` is set, do not change `(promote (until-clean))`
+  rules and make affected rules fallback instead of removing them. This was
+  previously done depending on `(lang dune)`. (#8721, @emillon)

--- a/promote-until-clean-always.md
+++ b/promote-until-clean-always.md
@@ -1,3 +1,0 @@
-- Never ignore `(promote (until-clean))` if `--ignore-promoted-rules` is
-  passed. This was previously done depending on `(lang dune)`. (#8721,
-  @emillon)

--- a/promote-until-clean-always.md
+++ b/promote-until-clean-always.md
@@ -1,0 +1,3 @@
+- Never ignore `(promote (until-clean))` if `--ignore-promoted-rules` is
+  passed. This was previously done depending on `(lang dune)`. (#8721,
+  @emillon)

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2472,27 +2472,21 @@ type t =
   ; stanzas : Stanzas.t
   }
 
-let filter_map_stanza_mode ~f =
-  let open Option.O in
-  function
-  | Rule r ->
-    let+ mode = f r.mode in
-    Rule { r with mode }
-  | Menhir_stanza.T m ->
-    let+ mode = f m.mode in
-    Menhir_stanza.T { m with mode }
-  | s -> Some s
+let map_stanza_mode ~f = function
+  | Rule r -> Rule { r with mode = f r.mode }
+  | Menhir_stanza.T m -> Menhir_stanza.T { m with mode = f m.mode }
+  | s -> s
 ;;
 
-let change_stanza s =
-  filter_map_stanza_mode s ~f:(fun mode ->
-    if Rule_mode_decoder.is_ignored mode then Some Fallback else Some mode)
+let change_stanza =
+  map_stanza_mode ~f:(fun mode ->
+    if Rule_mode_decoder.is_ignored mode then Fallback else mode)
 ;;
 
 let parse sexps ~dir ~file ~project =
   let open Memo.O in
   let+ stanzas = Stanzas.parse ~file ~dir project sexps in
-  let stanzas = List.filter_map stanzas ~f:change_stanza in
+  let stanzas = List.map stanzas ~f:change_stanza in
   { dir; project; stanzas }
 ;;
 

--- a/src/dune_rules/rule_mode_decoder.ml
+++ b/src/dune_rules/rule_mode_decoder.ml
@@ -100,14 +100,10 @@ end
 let decode = sum mode_decoders
 let field = field "mode" decode ~default:Rule.Mode.Standard
 
-let is_ignored (mode : Rule.Mode.t) ~until_clean =
+let is_ignored (mode : Rule.Mode.t) =
   !Clflags.ignore_promoted_rules
   &&
   match mode with
   | Promote { only = None; lifetime = Unlimited; _ } -> true
-  | Promote { only = None; lifetime = Until_clean; _ } ->
-    (match until_clean with
-     | `Ignore -> true
-     | `Keep -> false)
   | _ -> false
 ;;

--- a/src/dune_rules/rule_mode_decoder.mli
+++ b/src/dune_rules/rule_mode_decoder.mli
@@ -16,10 +16,6 @@ end
 val decode : Rule.Mode.t Dune_lang.Decoder.t
 val field : Rule.Mode.t Dune_lang.Decoder.fields_parser
 
-(** [is_ignored mode ~until_clean] will return if a rule with [mode] should be
-    ignored whenever [--ignored-promoted-rules] is set.
-
-    [until_clean] is used to set if [(promote (until-clean))] is ignored as
-    considered by this function. Old versions of dune would incorrectly ignore
-    this, so we need to maintain the old behavior for now. *)
-val is_ignored : Rule.Mode.t -> until_clean:[ `Ignore | `Keep ] -> bool
+(** [is_ignored mode] will return if a rule with [mode] should be
+    ignored, considering whether [--ignored-promoted-rules] is set. *)
+val is_ignored : Rule.Mode.t -> bool

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -260,7 +260,7 @@ let extend_action t ~dir action =
 
 let make_rule t ?mode ?loc ~dir { Action_builder.With_targets.build; targets } =
   match mode with
-  | Some mode when Rule_mode_decoder.is_ignored mode ~until_clean:`Keep -> None
+  | Some mode when Rule_mode_decoder.is_ignored mode -> None
   | _ ->
     let build = extend_action t build ~dir in
     Some

--- a/test/blackbox-tests/test-cases/github4401.t
+++ b/test/blackbox-tests/test-cases/github4401.t
@@ -1,5 +1,5 @@
 When --ignore-promoted-rules is passed, rules marked `(promote (until-clean))`
-are ignored. See #4401.
+are not ignored, independently of dune-lang. See #4401.
 
   $ cat > dune-project << EOF
   > (lang dune 3.4)
@@ -17,16 +17,4 @@ are ignored. See #4401.
   >  (action (diff reference test)))
   > EOF
 
-  $ dune runtest --ignore-promoted-rules
-  Error: No rule found for test
-  -> required by alias runtest in dune:5
-  [1]
-
-This is correctly ignored if `dune-lang` is bumped to 3.5.
-
-  $ cat > dune-project << EOF
-  > (lang dune 3.5)
-  > EOF
-
-  $ dune clean
   $ dune runtest --ignore-promoted-rules

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -139,8 +139,13 @@ Test for (promote (into ...)) + (enabled_if %{ignoring_promoted_rules}
 
   $ dune clean
   $ dune build into+ignoring --ignore-promoted-rules
+  Error: Multiple rules generated for _build/default/into+ignoring:
+  - dune:30
+  - dune:35
+  [1]
   $ ls -1 _build/default/into*
-  _build/default/into+ignoring
+  ls: cannot access '_build/default/into*': No such file or directory
+  [2]
 
 Reproduction case for #3069
 ---------------------------


### PR DESCRIPTION
This extends #5956 to all versions of `(lang dune)`, since this is a property of the CLI.
