### PR TITLE
ci: only push to docker on push events

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -244,6 +244,6 @@ jobs:
         with:
           image_name: monorepobenchmark
           dockerfile: bench/monorepo/bench.Dockerfile
-          push_image_and_stages: true
+          push_image_and_stages: on:push
           username: ocamldune
           password: "${{ secrets.DOCKER_HUB_PASSWORD }}"


### PR DESCRIPTION
`pull_request` events do not have access to secrets, so can't push.
