### PR TITLE
refactor: do not initialize context to load stanzas

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -142,7 +142,9 @@ let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
 let libs db (context : Context.t) (build_system : Dune_rules.Main.build_system) =
   let { Dune_rules.Main.conf; contexts = _; _ } = build_system in
   let open Memo.O in
-  let* dune_files = Dune_rules.Dune_load.Dune_files.eval conf.dune_files ~context in
+  let* dune_files =
+    Dune_rules.Dune_load.Dune_files.eval conf.dune_files ~context:(Context.name context)
+  in
   Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_rules.Dune_file.t) ->
     Memo.parallel_map dune_file.stanzas ~f:(fun stanza ->
       let dir = dune_file.dir in

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -518,10 +518,11 @@ module Crawl = struct
     dirs
     : Descr.Workspace.t Memo.t
     =
-    let sctx = Context_name.Map.find_exn scontexts (Context.name context) in
+    let context_name = Context.name context in
+    let sctx = Context_name.Map.find_exn scontexts context_name in
     let open Memo.O in
     let* dune_files =
-      Dune_load.Dune_files.eval conf.dune_files ~context
+      Dune_load.Dune_files.eval conf.dune_files ~context:context_name
       >>| List.filter ~f:(dune_file_is_in_dirs dirs)
     in
     let* exes, exe_libs =

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -9,7 +9,7 @@ module Dune_files : sig
       dune files in ocaml syntax *)
   type t
 
-  val eval : t -> context:Context.t -> Dune_file.t list Memo.t
+  val eval : t -> context:Context_name.t -> Dune_file.t list Memo.t
   val in_dir : Path.Build.t -> Dune_file.t option Memo.t
 end
 

--- a/src/dune_rules/per_context.ml
+++ b/src/dune_rules/per_context.ml
@@ -43,6 +43,16 @@ let or_invalid ctx = function
   | None -> Code_error.raise "invalid context" [ "context", Context_name.to_dyn ctx ]
 ;;
 
+let create_by_name ~name f =
+  let f =
+    Staged.unstage
+    @@ create_db ~name (function
+      | `Native ctx -> f (Workspace.Context.name ctx)
+      | `Target (_ctx, name) -> f name)
+  in
+  Staged.stage (fun name -> f name >>= or_invalid name)
+;;
+
 let profile =
   let profile =
     create_db ~cutoff:Profile.equal ~name:"profile" (function

--- a/src/dune_rules/per_context.mli
+++ b/src/dune_rules/per_context.mli
@@ -2,6 +2,11 @@
 
 open Import
 
+val create_by_name
+  :  name:string
+  -> (Context_name.t -> 'a Memo.t)
+  -> (Context_name.t -> 'a Memo.t) Staged.t
+
 val profile : Context_name.t -> Profile.t Memo.t
 val valid : Context_name.t -> bool Memo.t
 val list : unit -> Context_name.t list Memo.t


### PR DESCRIPTION
When this isn't necessary, we stop initializing the context to get all
the stanzas.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6d751c24-6496-4039-830c-8b411e912247 -->