### PR TITLE
doc: add how-to for bundling text resources

### DIFF
--- a/doc/howto/bundle.rst
+++ b/doc/howto/bundle.rst
@@ -4,7 +4,7 @@ How to Bundle Resources
 This guide will show you how to configure Dune to generate modules with string resources
 from other files in your project.
 
-Folder structure
+Folder Structure
 ----------------
 
 .. code:: bash
@@ -17,7 +17,7 @@ Folder structure
             └── resources
                 └── site.css
 
-Dune configuration
+Dune Configuration
 ------------------
 
 See the section on :doc:`../reference/actions` for more details on ``progn`` and ``with-stdout-to``.
@@ -32,7 +32,7 @@ See the section on :doc:`../reference/actions` for more details on ``progn`` and
        (cat resources/site.css)
        (echo "|}"))))
 
-Using the bundled resource
+Using the Bundled Resource
 --------------------------
 
 .. code:: ocaml

--- a/doc/howto/bundle.rst
+++ b/doc/howto/bundle.rst
@@ -9,7 +9,7 @@ Folder Structure
 
 .. code:: bash
 
-    ❯ tree src
+    $ tree src
     src
     └── lib
         └── my_lib
@@ -20,7 +20,7 @@ Folder Structure
 Dune Configuration
 ------------------
 
-See the section on :doc:`../reference/actions` for more details on ``progn`` and ``with-stdout-to``.
+See the section on :doc:`../reference/actions` for more details on :dune:ref:`action-progn` and :dune:ref:`action-with-<outputs>-to`.
 
 .. code:: dune
 

--- a/doc/howto/bundle.rst
+++ b/doc/howto/bundle.rst
@@ -1,0 +1,40 @@
+How to Bundle Resources
+=======================
+
+This guide will show you how to configure Dune to generate modules with string resources
+from other files in your project.
+
+Folder structure
+----------------
+
+.. code:: bash
+
+    ❯ tree src
+    src
+    └── lib
+        └── my_lib
+            ├── dune
+            └── resources
+                └── site.css
+
+Dune configuration
+------------------
+
+See the section on :doc:`../reference/actions` for more details on ``progn`` and ``with-stdout-to``.
+
+.. code:: dune
+
+    (rule
+     (with-stdout-to
+      css.ml
+      (progn
+       (echo "let css = {|")
+       (cat resources/site.css)
+       (echo "|}"))))
+
+Using the bundled resource
+--------------------------
+
+.. code:: ocaml
+
+   let () = Printf.printf "%s" Css.css

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@ Welcome to Dune's Documentation!
    toplevel-integration
    variants
    tests
+   howto/bundle
 
 .. toctree::
    :caption: Reference Guides


### PR DESCRIPTION
I found myself looking for information on how to do this and ended up getting pointers to #4358 and [an example in the wild](https://github.com/ocaml/ocaml-lsp/blob/f2303a7e3e516a36ec09b182d06003ee845e8e38/lsp/bin/dune#L5-L11) on Discord.

