### PR TITLE
test(pkg): show precedence of make and gmake

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/make-over-gmake.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/make-over-gmake.t
@@ -1,0 +1,24 @@
+  $ . ./opam-var-helpers.sh 
+
+If both make and gmake are available, we should prefer make.
+
+opam doesn't resolve make but rather runs make literally so it is up to whatever is in
+PATH to resolve it. This does mean that make is preferred over gmake so we should
+replicate that behaviour.
+
+We create a dummy package that will output the value of the opam make variable:
+  $ mkrepo
+  > mkpkg testpkg << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" make ]
+  > EOF
+  > solve testpkg 2> /dev/null
+
+We now create dummy versions of make and gmake.
+  $ cat > make; cat > gmake
+We add the current directory to PATH. Dune will expand %{make} and should prefer make over
+gmake.
+  $ PATH=.:$PATH
+  > build_pkg testpkg
+  $TESTCASE_ROOT/gmake
+


### PR DESCRIPTION
This test demonstrates that we currently prefer `gmake` over `make` when resolving `%{make}`.

opam won't resolve make in the PATH but rather just use `make` literally. This means that `make` will always be preferred over `gmake`.

Typically if `make` and `gmake` are both present, `make` is just a symlink to `gmake` anyway.

---

#### Idea how to fix:

The correct thing to do here IMO would be to replicate opams behaviour and choose `make` over `gmake` in this situation. This test would therefore be update to prefer `make` at the end.

Here is how we choose make in our implementation:
```ocaml
let which loc context ~path =
  (let which = Which.which ~path in
   match Sys.unix with
   | false -> which "make"
   | true ->
     which "gmake"
     >>= (function
     | None -> which "make"
     | Some _ as s -> Memo.return s))
  >>| function
  | Some p -> p
  | None -> Utils.program_not_found ~context ~loc:(Some loc) "make"
;;
```

If we are on a unix-like system we immediately prefer `gmake`. We should therefore swap the order and prefer `make` over `gmake` using `gmake` as a fallback instead.