### PR TITLE
fix(nix): fix utop tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,11 @@
         let
           pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
             (self: super: {
-              ocamlPackages = self.ocaml-ng.ocamlPackages_4_14;
+              ocamlPackages = self.ocaml-ng.ocamlPackages_4_14.overrideScope' (oself: osuper: {
+                utop = osuper.utop.overrideAttrs {
+                  dontGzipMan = true;
+                };
+              });
             })
             melange.overlays.default
           ];


### PR DESCRIPTION
Nix was compressing the man pages for utop which meant the dune-package file was pointing to non-existant files. Overriding utop and disabling the compression of man pages fixes this issue.

We can also use this fix for other `(package)` dependencies that are problematic with nix.