### PR TITLE
test(pkg): make make test more repro

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
@@ -27,14 +27,16 @@ variables can be found in `opam-var-os.t`.
     (run echo %{user})
     (run echo %{group})))
 
-The implementation of %{user} uses Unix.getlogin which doesn't work in our Linux CI job.
-Therefore we modify the lockfile here to remove that from the opam file:
+
+- The implementation of %{user} uses Unix.getlogin which doesn't work in our Linux CI job.
+- The implementation of %{make} prefers gmake over make and is tested in `make.t`.
+
+Therefore we modify the lockfile here to remove these from the opam file:
 
   $ mkpkg testpkg << EOF
   > opam-version: "2.0"
   > build: [
   >   [ "echo" jobs ]
-  >   [ "echo" make ]
   >   [ "echo" group ]
   > ]
   > EOF
@@ -42,14 +44,10 @@ Therefore we modify the lockfile here to remove that from the opam file:
   Solution for dune.lock:
   testpkg.0.0.1
   
-If this is fixed, we should use $(whoami) to compare the output.
-
 The value for "jobs" should always be 1.
 
-  $ MAKE="$(which make)"
-  > GROUP="$(id -gn)"
-  > build_pkg testpkg 2>&1 \
-  > | sed "s/$GROUP/GROUP/g" | sed "s#$MAKE#MAKE#g"
+  $ GROUP="$(id -gn)"
+  > build_pkg testpkg 2>&1 | sed "s/$GROUP/GROUP/g"
   File "dune.lock/testpkg.pkg", line 5, characters 12-19:
   5 |   (run echo %{jobs})
                   ^^^^^^^


### PR DESCRIPTION
We stop outputing the expansion of make and rely on it being tested in make.t.