### PR TITLE
fix(pkg): dune.lock is ignored in --release

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -102,6 +102,7 @@ module Options_implied_by_dash_p = struct
     ; always_show_command_line : bool
     ; promote_install_files : bool
     ; require_dune_project_file : bool
+    ; ignore_lock_directory : bool
     }
 
   let docs = copts_sect
@@ -215,6 +216,9 @@ module Options_implied_by_dash_p = struct
         last
         & opt_all ~vopt:true bool [ false ]
         & info [ "require-dune-project-file" ] ~docs ~doc)
+    and+ ignore_lock_directory =
+      let doc = "Ignore dune.lock/ directory." in
+      Arg.(value & flag & info [ "ignore-lock-directory" ] ~docs ~doc)
     in
     { root
     ; only_packages = No_restriction
@@ -225,6 +229,7 @@ module Options_implied_by_dash_p = struct
     ; always_show_command_line
     ; promote_install_files
     ; require_dune_project_file
+    ; ignore_lock_directory
     }
   ;;
 
@@ -239,6 +244,7 @@ module Options_implied_by_dash_p = struct
       ; "--always-show-command-line"
       ; "--promote-install-files"
       ; "--require-dune-project-file"
+      ; "--ignore-lock-directory"
       ; "--default-target"
       ; "@install"
       ]
@@ -563,6 +569,7 @@ module Builder = struct
     ; ignore_promoted_rules : bool
     ; force : bool
     ; no_print_directory : bool
+    ; ignore_lock_directory : bool
     ; store_orig_src_dir : bool
     ; default_target : Arg.Dep.t (* For build & runtest only *)
     ; watch : Dune_rpc_impl.Watch_mode_config.t
@@ -794,6 +801,7 @@ module Builder = struct
          ; always_show_command_line
          ; promote_install_files
          ; require_dune_project_file
+         ; ignore_lock_directory
          }
       =
       Options_implied_by_dash_p.term
@@ -977,6 +985,7 @@ module Builder = struct
     ; ignore_promoted_rules
     ; force
     ; no_print_directory
+    ; ignore_lock_directory
     ; store_orig_src_dir
     ; default_target
     ; watch
@@ -1202,6 +1211,7 @@ let init ?action_runner ?log_file c =
   Dune_rules.Clflags.promote_install_files := c.builder.promote_install_files;
   Dune_engine.Clflags.always_show_command_line := c.builder.always_show_command_line;
   Dune_rules.Clflags.ignore_promoted_rules := c.builder.ignore_promoted_rules;
+  Dune_rules.Clflags.ignore_lock_directory := c.builder.ignore_lock_directory;
   Dune_rules.Clflags.on_missing_dune_project_file
     := if c.builder.require_dune_project_file then Error else Warn;
   Log.info

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -4,6 +4,7 @@ let promote_install_files = ref false
 let display = Dune_engine.Clflags.display
 let capture_outputs = Dune_engine.Clflags.capture_outputs
 let debug_artifact_substitution = ref false
+let ignore_lock_directory = ref false
 
 type on_missing_dune_project_file =
   | Error

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -16,6 +16,9 @@ val capture_outputs : bool ref
 (** Print debug info about artifact substitution *)
 val debug_artifact_substitution : bool ref
 
+(** Wether we are ignoring "dune.lock/". *)
+val ignore_lock_directory : bool ref
+
 type on_missing_dune_project_file =
   | Error
   | Warn

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -98,8 +98,11 @@ module Lock_dir = struct
   let get (ctx : Context_name.t) : t Memo.t = get_path ctx >>= Load.load
 
   let has_lock ctx =
-    let* path = get_path ctx in
-    Fs_memo.dir_exists (In_source_dir path)
+    if !Clflags.ignore_lock_directory
+    then Memo.return false
+    else
+      let* path = get_path ctx in
+      Fs_memo.dir_exists (In_source_dir path)
   ;;
 end
 

--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-release.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-release.t
@@ -17,5 +17,4 @@ When building a project in release mode we should ignore the lock directory.
   >  (depends test))
   > EOF
 
-  $ dune build @install --release 2>&1 | tail -n1 
-  I have not been ignored.
+  $ dune build @install --release


### PR DESCRIPTION
We add a new --ignore-lock-directory option that will always skip the lockfile. We also add this to --release (and -p).

- fix #8684 
