### PR TITLE
fix(pkg): respect filters for dependency list

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
@@ -35,4 +35,4 @@ Demonstrate the translation of filtered dependencies
   $ cat dune.lock/bar.pkg
   (version 0.0.1)
   
-  (deps pkg-post pkg-dev pkg-test pkg-doc pkg-build)
+  (deps pkg-post pkg-build)


### PR DESCRIPTION
When converting the dependencies from opam to dune, we need to filter
them according to the effective set of dependencies.

This is needed to avoid downloading & building unnecessary packages for
the current build plan.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f8e91443-5c21-43fb-9076-36d1ca648b22 -->