### PR TITLE
chore: update spawn

### DIFF
--- a/vendor/update-spawn.sh
+++ b/vendor/update-spawn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=posix_spawn
+version=e184beb298d9abe0c524a4839bb0bec3d2571282
 
 set -e -o pipefail
 
@@ -12,7 +12,7 @@ mkdir -p spawn/src
 
 (
     cd $TMP
-    git clone https://github.com/rgrinberg/spawn.git
+    git clone https://github.com/ocaml-dune/spawn.git
     cd spawn
     git checkout $version
 )


### PR DESCRIPTION
- pull some upstream changes including janestreet/spawn#51 (Haiku) and janestreet/spawn#52 (Android)
- point to `ocaml-dune/spawn`
- point to a commit instead of a branch name
