### PR TITLE
test(pkg): building with empty dune.lock/

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/empty-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/empty-lock.t
@@ -1,0 +1,11 @@
+An empty dune.lock directory should prevent dune from building. We should also
+give a nice error message telling the user what is wrong and how it can be
+fixed.
+
+  $ mkdir dune.lock
+  $ cat > dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  $ dune build
+  Error: dune.lock/lock.dune: No such file or directory
+  [1]


### PR DESCRIPTION
Having an empty dune.lock directory should not prevent a regular dune build.

This can happen if a lock file was created and then the git changes discarded for example.