### PR TITLE
test: dune-workspace and --release

### DIFF
--- a/test/blackbox-tests/test-cases/workspace-release.t
+++ b/test/blackbox-tests/test-cases/workspace-release.t
@@ -1,0 +1,44 @@
+Here we test how workspace files modify the enviornment when building a package in and out
+of --release mode.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (action
+  >   (with-outputs-to foo.out
+  >    (echo %{env:FOO_VAR=default}))))
+  > (install
+  >  (files foo.out)
+  >  (section share)
+  >  (package foo))
+  > EOF
+
+Without a workspace file we get the default value.
+  $ dune build @install
+  $ cat _build/install/default/share/foo/foo.out 
+  default
+
+With a workspace file present, we get the value of FOO_VAR set in the workspace file.
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (env
+  >  (_
+  >   (env-vars
+  >    (FOO_VAR workspace))))
+  > EOF
+
+  $ dune build @install
+  $ cat _build/install/default/share/foo/foo.out 
+  workspace
+ 
+In --release mode the current behaviour is not to ignore the dune-workspace value.
+
+  $ dune build @install --release
+  $ cat _build/install/default/share/foo/foo.out
+  workspace


### PR DESCRIPTION
We test the interaction of dune-workspace files and --release. The current behaviour appears to be to not ignore them in --release mode.