### PR TITLE
pkg: add hint to "dune.lock does not exist" error

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -549,12 +549,13 @@ struct
     match Path.exists (Path.source lock_dir_path) with
     | false ->
       User_error.raise
-        [ Pp.textf "%s does not exist" (Path.Source.to_string lock_dir_path) ]
+        ~hints:[ Pp.text "Run dune pkg lock to generate it." ]
+        [ Pp.textf "%s does not exist." (Path.Source.to_string lock_dir_path) ]
     | true ->
       (match Path.is_directory (Path.source lock_dir_path) with
        | false ->
          User_error.raise
-           [ Pp.textf "%s is not a directory" (Path.Source.to_string lock_dir_path) ]
+           [ Pp.textf "%s is not a directory." (Path.Source.to_string lock_dir_path) ]
        | true -> ())
   ;;
 


### PR DESCRIPTION
![image](https://github.com/ocaml/dune/assets/8614547/bedfabf8-c9c2-4c71-b288-a2ec393eb219)
