### PR TITLE
refactor: pass less contexts

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -188,7 +188,8 @@ let gen_rules sctx t ~dir ~scope =
       cctx
       ~link_args
       ~program:{ name; main_module_name; loc }
-      ~linkages:[ Exe.Linkage.native_or_custom (Super_context.context sctx) ]
+      ~linkages:
+        [ Exe.Linkage.native_or_custom (Super_context.context sctx |> Context.ocaml) ]
       ~promote:None
   in
   let action =

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -29,19 +29,18 @@ module Linkage = struct
   let is_js x = x.mode = Byte && x.ext = Js_of_ocaml.Ext.exe
   let is_byte x = x.mode = Byte && not (is_js x)
 
-  let custom_with_ext ~ext (context : Context.t) =
+  let custom_with_ext ~ext ocaml_version =
     { mode = Byte_with_stubs_statically_linked_in
     ; ext
-    ; flags =
-        [ Ocaml.Version.custom_or_output_complete_exe (Context.ocaml context).version ]
+    ; flags = [ Ocaml.Version.custom_or_output_complete_exe ocaml_version ]
     }
   ;;
 
   let custom = custom_with_ext ~ext:".exe"
 
-  let native_or_custom (context : Context.t) =
-    match (Context.ocaml context).ocamlopt with
-    | Error _ -> custom context
+  let native_or_custom (ocaml : Ocaml_toolchain.t) =
+    match ocaml.ocamlopt with
+    | Error _ -> custom ocaml.version
     | Ok _ -> native
   ;;
 
@@ -58,7 +57,12 @@ module Linkage = struct
   let cmxs_flags = [ "-shared" ]
   let cma_flags = [ "-a" ]
 
-  let of_user_config (ctx : Context.t) ~loc (m : Dune_file.Executables.Link_mode.t) =
+  let of_user_config
+    (ocaml : Ocaml_toolchain.t)
+    ~dynamically_linked_foreign_archives
+    ~loc
+    (m : Dune_file.Executables.Link_mode.t)
+    =
     match m with
     | Other { mode = Byte; kind = Js } -> js
     | _ ->
@@ -68,7 +72,7 @@ module Linkage = struct
         | Other { mode; _ } ->
           (match mode with
            | Byte ->
-             if Context.dynamically_linked_foreign_archives ctx
+             if dynamically_linked_foreign_archives
              then Byte
              else
                (* When [dynamically_linked_foreign_archives] is set to [false] in
@@ -77,12 +81,12 @@ module Linkage = struct
                Byte_with_stubs_statically_linked_in
            | Native -> Native
            | Best ->
-             if Result.is_ok (Context.ocaml ctx).ocamlopt
+             if Result.is_ok ocaml.ocamlopt
              then Native
              else Byte_with_stubs_statically_linked_in)
       in
       let ext =
-        let lib_config = (Context.ocaml ctx).lib_config in
+        let lib_config = ocaml.lib_config in
         Dune_file.Executables.Link_mode.extension
           m
           ~loc
@@ -91,8 +95,7 @@ module Linkage = struct
       in
       let flags =
         match m with
-        | Byte_complete ->
-          [ Ocaml.Version.custom_or_output_complete_exe (Context.ocaml ctx).version ]
+        | Byte_complete -> [ Ocaml.Version.custom_or_output_complete_exe ocaml.version ]
         | Other { kind; _ } ->
           (match kind with
            | C -> c_flags
@@ -100,8 +103,7 @@ module Linkage = struct
            | Exe ->
              (match link_mode with
               | Byte_with_stubs_statically_linked_in ->
-                [ Ocaml.Version.custom_or_output_complete_exe (Context.ocaml ctx).version
-                ]
+                [ Ocaml.Version.custom_or_output_complete_exe ocaml.version ]
               | _ -> [])
            | Object -> o_flags
            | Plugin ->
@@ -110,7 +112,7 @@ module Linkage = struct
               | _ -> cma_flags)
            | Shared_object ->
              let so_flags =
-               let os_type = Ocaml_config.os_type (Context.ocaml ctx).ocaml_config in
+               let os_type = Ocaml_config.os_type ocaml.ocaml_config in
                if os_type = Win32 then so_flags_windows else so_flags_unix
              in
              (match link_mode with
@@ -118,7 +120,7 @@ module Linkage = struct
                 (* The compiler doesn't pass these flags in native mode. This
                    looks like a bug in the compiler. *)
                 let native_c_libraries =
-                  Ocaml_config.native_c_libraries (Context.ocaml ctx).ocaml_config
+                  Ocaml_config.native_c_libraries ocaml.ocaml_config
                 in
                 List.concat_map native_c_libraries ~f:(fun flag -> [ "-cclib"; flag ])
                 @ so_flags

--- a/src/dune_rules/exe.mli
+++ b/src/dune_rules/exe.mli
@@ -22,13 +22,13 @@ module Linkage : sig
   val native : t
 
   (** like [custom] but allows for a custom extension *)
-  val custom_with_ext : ext:string -> Context.t -> t
+  val custom_with_ext : ext:string -> Ocaml.Version.t -> t
 
   (** Byte compilation with stubs statically linked in, extension [.exe] *)
-  val custom : Context.t -> t
+  val custom : Ocaml.Version.t -> t
 
   (** [native] if supported, [custom] if not *)
-  val native_or_custom : Context.t -> t
+  val native_or_custom : Ocaml_toolchain.t -> t
 
   (** Javascript compilation, extension [.bc.js] *)
   val js : t
@@ -36,7 +36,13 @@ module Linkage : sig
   val is_native : t -> bool
   val is_js : t -> bool
   val is_byte : t -> bool
-  val of_user_config : Context.t -> loc:Loc.t -> Dune_file.Executables.Link_mode.t -> t
+
+  val of_user_config
+    :  Ocaml_toolchain.t
+    -> dynamically_linked_foreign_archives:bool
+    -> loc:Loc.t
+    -> Dune_file.Executables.Link_mode.t
+    -> t
 end
 
 type dep_graphs = { for_exes : Module.t list Action_builder.t list }

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -180,9 +180,13 @@ include Sub_system.Register_end_point (struct
         List.concat_map (Mode_conf.Set.to_list modes) ~f:(fun (mode : Mode_conf.t) ->
           match mode with
           | Native -> [ Exe.Linkage.native ]
-          | Best -> [ Exe.Linkage.native_or_custom (Super_context.context sctx) ]
+          | Best ->
+            [ Exe.Linkage.native_or_custom (Super_context.context sctx |> Context.ocaml) ]
           | Byte ->
-            [ Exe.Linkage.custom_with_ext ~ext:".bc" (Super_context.context sctx) ]
+            [ Exe.Linkage.custom_with_ext
+                ~ext:".bc"
+                (Super_context.context sctx |> Context.ocaml).version
+            ]
           | Javascript -> [ Exe.Linkage.js; Exe.Linkage.byte_for_jsoo ])
       in
       let* (_ : Exe.dep_graphs) =

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -323,7 +323,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
              let+ driver, _ = driver_and_libs in
              sprintf "let () = %s ()\n" driver.info.main)))
   in
-  let linkages = [ Exe.Linkage.native_or_custom ctx ] in
+  let linkages = [ Exe.Linkage.native_or_custom (Context.ocaml ctx) ] in
   let program : Exe.Program.t =
     { name = Filename.remove_extension (Path.Build.basename target)
     ; main_module_name

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -243,9 +243,10 @@ module Stanza = struct
     in
     let resolved = make ~cctx ~source ~preprocess:toplevel.pps expander in
     let* exe =
-      setup_rules_and_return_exe_path
-        resolved
-        ~linkage:(Exe.Linkage.custom (Compilation_context.context cctx))
+      let linkage =
+        Exe.Linkage.custom (Compilation_context.context cctx |> Context.ocaml).version
+      in
+      setup_rules_and_return_exe_path resolved ~linkage
     in
     let symlink = Path.Build.relative dir (Path.Build.basename exe) in
     Super_context.add_rule


### PR DESCRIPTION
Pass whatever is needed directly instead of passing the entire context

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1abc0d73-3598-42ed-8ec9-523060a0b3ed -->