### PR TITLE
Add link flags ocamlmklib when using ctypes stubs.

### DIFF
--- a/doc/changes/8784.md
+++ b/doc/changes/8784.md
@@ -1,0 +1,1 @@
+- Add link flags to to ocamlmklib for ctypes stubs (#8784, @frejsoya)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -328,7 +328,14 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
       | _ -> Action_builder.return []
     in
     let c_library_flags =
-      Expander.expand_and_eval_set expander lib.c_library_flags ~standard
+      let open Action_builder.O in
+      let+ c_lib = Expander.expand_and_eval_set expander lib.c_library_flags ~standard
+      and+ ctypes_lib =
+        (* CR rgrinberg: Should we add these flags to :standard? to make
+           it possible for users to remove these *)
+        Ctypes_rules.ctypes_cclib_flags sctx ~expander ~buildable:lib.buildable
+      in
+      c_lib @ ctypes_lib
     in
     let lib_o_files_for_all_modes = Mode.Map.Multi.for_all_modes o_files in
     let for_all_modes = List.rev_append vlib_stubs_o_files lib_o_files_for_all_modes in

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune
@@ -1,0 +1,4 @@
+(executable
+ (name example)
+ (modes byte)
+ (libraries examplelib))

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-project
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.10)
+
+(using ctypes 0.3)

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/example.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/example.ml
@@ -1,0 +1,2 @@
+let () =
+  Printf.printf "%d\n" (Examplelib.C.Functions.add2 2)

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
@@ -11,10 +11,7 @@ Explictly set {DYLD,LD}_LIBRARY_PATH at runtime for this testcase, otherwise
 dlopen cannot find libexample, after loading dllexamplelib_stub.so
 
   $  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$LIBEX" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBEX" CAML_LD_LIBRARY_PATH="$CAML_LD_LIBRARY_PATH:$PWD/_build/default/stubgen" dune exec ./example.bc
-  Fatal error: cannot load shared library dllexamplelib_stubs
-  Reason: $TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so: undefined symbol: example_add2
-  Aborted
-  [134]
+  4
 
 Utop works with ctypes pkg-config external library.
 
@@ -23,7 +20,4 @@ Utop works with ctypes pkg-config external library.
     pkg-config stubgen/.pkg-config/libexample.libs
         ocamlc .utop/.utop.eobjs/byte/dune__exe__Utop.{cmi,cmo,cmt}
         ocamlc .utop/utop.bc
-  Fatal error: cannot load shared library dllexamplelib_stubs
-  Reason: $TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so: undefined symbol: example_add2
-  Aborted
-  [134]
+  4

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
@@ -1,0 +1,29 @@
+Build an example library as a DLL and set up the environment so that it looks
+like a system/distro library that can be probed with pkg-config and dynamically
+loaded.
+
+  $ LIBEX=$(realpath "$PWD/../libexample")
+
+ocamlrun + requires CAML_LD_LIBRARY_PATH such that dlopen system call can find
+dllexamplelib_stub.so
+
+Explictly set {DYLD,LD}_LIBRARY_PATH at runtime for this testcase, otherwise
+dlopen cannot find libexample, after loading dllexamplelib_stub.so
+
+  $  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$LIBEX" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBEX" CAML_LD_LIBRARY_PATH="$CAML_LD_LIBRARY_PATH:$PWD/_build/default/stubgen" dune exec ./example.bc
+  Fatal error: cannot load shared library dllexamplelib_stubs
+  Reason: $TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so: undefined symbol: example_add2
+  Aborted
+  [134]
+
+Utop works with ctypes pkg-config external library.
+
+  $   DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$LIBEX" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBEX"  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune utop --display=short ./ -- example.ml
+    pkg-config stubgen/.pkg-config/libexample.cflags
+    pkg-config stubgen/.pkg-config/libexample.libs
+        ocamlc .utop/.utop.eobjs/byte/dune__exe__Utop.{cmi,cmo,cmt}
+        ocamlc .utop/utop.bc
+  Fatal error: cannot load shared library dllexamplelib_stubs
+  Reason: $TESTCASE_ROOT/_build/default/stubgen/dllexamplelib_stubs.so: undefined symbol: example_add2
+  Aborted
+  [134]

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/dune
@@ -1,0 +1,14 @@
+(library
+  (name examplelib)
+  (flags (:standard -w -9-27))
+  (ctypes
+    (external_library_name libexample)
+    (build_flags_resolver pkg_config)
+    (headers (include "example.h"))
+    (type_description
+      (instance Types)
+      (functor Type_description))
+    (function_description
+      (instance Functions)
+      (functor Function_description))
+    (generated_entry_point C)))

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/function_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/function_description.ml
@@ -1,0 +1,8 @@
+open Ctypes
+
+module Types = Types_generated
+
+module Functions (F : Ctypes.FOREIGN) = struct
+  open F
+  let add2 = foreign "example_add2" (int @-> returning int)
+end

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/type_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/type_description.ml
@@ -1,0 +1,3 @@
+module Types (F : Ctypes.TYPE) = struct
+
+end

--- a/test/blackbox-tests/test-cases/ctypes/dune
+++ b/test/blackbox-tests/test-cases/ctypes/dune
@@ -27,6 +27,7 @@
 
 (cram
  (applies_to
+  bytecode-stubs-external-lib
   lib-pkg_config
   lib-pkg_config-multiple-fd
   lib-external-name-need-mangling


### PR DESCRIPTION

  Add link flags for external dependencies when using ctypes.

  Required when the external lib is not statically linked, in which case
  linker needs to be aware at runtime what libs to call. This is the case
  for

  - dune exec <file>.bc
  - dune utop
  - mdx tests

  That is add to ocamlmklib, link flags such as -l<libname> -L<libdir>
  from ctypes if info is available.

  If dependent library are not installed in expected locations, env
  variable such as LD_LIBRARY_PATH must be extended when required program
  is run, depending on os. This may be fixed by adding relocatable paths to
  link flags.