### PR TITLE
test(pkg): demonstrate that lockfiles in workspace are not ignored

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-release.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-release.t
@@ -18,3 +18,24 @@ When building a project in release mode we should ignore the lock directory.
   > EOF
 
   $ dune build @install --release
+
+Similarly for lockfiles in other contexts
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (context
+  >  (default))
+  > (context
+  >  (default
+  >   (name workspace-context)
+  >   (lock dune.workspace.lock)))
+  > EOF
+
+  $ cp -r dune.lock dune.workspace.lock 
+  $ cat > dune.workspace.lock/test.pkg <<EOF
+  > (build
+  >  (run echo "I have not been ignored from the workspace context."))
+  > EOF
+
+  $ dune build @install --release 2>&1 | tail -n1
+  I have not been ignored from the workspace context.


### PR DESCRIPTION
Following up from #8684, it appears that lockfiles in the workspace are not ignored. This could be solved by just ignoring the workspace.