### PR TITLE
feature: Haiku support

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -110,4 +110,5 @@ let link_flags =
     [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
   ; ("mingw64",
     [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
+  ; ("beos", [ "-cclib"; "-lbsd" ])
   ]

--- a/doc/changes/haiku.md
+++ b/doc/changes/haiku.md
@@ -1,0 +1,1 @@
+- Dune can now be built and installed on Haiku (#8795, fix #8551, @Alizter)

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -10,6 +10,8 @@
   (re_export dyn)
   (re_export pp)
   (re_export dune_filesystem_stubs))
+ (library_flags
+  (:include flags/sexp))
  (foreign_stubs
   (language c)
   (names wait4_stubs platform_stubs copyfile_stubs signal_stubs))

--- a/otherlibs/stdune/src/flags/dune
+++ b/otherlibs/stdune/src/flags/dune
@@ -1,0 +1,10 @@
+(executable
+ (name gen_flags))
+
+(rule
+ (deps
+  (:script gen_flags.ml))
+ (action
+  (with-stdout-to
+   sexp
+   (run ./gen_flags.exe %{system}))))

--- a/otherlibs/stdune/src/flags/gen_flags.ml
+++ b/otherlibs/stdune/src/flags/gen_flags.ml
@@ -1,0 +1,1 @@
+let () = Printf.printf @@ if Sys.argv.(1) = "beos" then {|(-cclib -lbsd)|} else "()"

--- a/otherlibs/stdune/src/platform.ml
+++ b/otherlibs/stdune/src/platform.ml
@@ -7,6 +7,7 @@ module OS = struct
     | FreeBSD
     | NetBSD
     | OpenBSD
+    | Haiku
     | Other
 
   let equal = Poly.equal
@@ -15,6 +16,7 @@ module OS = struct
   external is_freebsd : unit -> bool = "stdune_is_freebsd"
   external is_netbsd : unit -> bool = "stdune_is_netbsd"
   external is_openbsd : unit -> bool = "stdune_is_openbsd"
+  external is_haiku : unit -> bool = "stdune_is_haiku"
 
   let to_dyn : t -> Dyn.t = function
     | Windows -> Dyn.variant "Windows" []
@@ -23,6 +25,7 @@ module OS = struct
     | FreeBSD -> Dyn.variant "FreeBSD" []
     | NetBSD -> Dyn.variant "NetBSD" []
     | OpenBSD -> Dyn.variant "OpenBSD" []
+    | Haiku -> Dyn.variant "Haiku" []
     | Other -> Dyn.variant "Other" []
   ;;
 
@@ -52,6 +55,8 @@ module OS = struct
     then NetBSD
     else if is_openbsd ()
     then OpenBSD
+    else if is_haiku ()
+    then Haiku
     else Other
   ;;
 end

--- a/otherlibs/stdune/src/platform.mli
+++ b/otherlibs/stdune/src/platform.mli
@@ -10,6 +10,7 @@ module OS : sig
     | FreeBSD
     | NetBSD
     | OpenBSD
+    | Haiku
     | Other
 
   (** [value] is the current os we're running on. *)

--- a/otherlibs/stdune/src/platform_stubs.c
+++ b/otherlibs/stdune/src/platform_stubs.c
@@ -11,7 +11,7 @@ CAMLprim value stdune_is_darwin(value v_unit) {
 }
 
 CAMLprim value stdune_is_freebsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__FreeBSD__)
   CAMLreturn(Val_true);
 #else
@@ -20,7 +20,7 @@ CAMLprim value stdune_is_freebsd(value v_unit) {
 }
 
 CAMLprim value stdune_is_openbsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__OpenBSD__)
   CAMLreturn(Val_true);
 #else
@@ -29,8 +29,17 @@ CAMLprim value stdune_is_openbsd(value v_unit) {
 }
 
 CAMLprim value stdune_is_netbsd(value v_unit) {
-   CAMLparam1(v_unit);
+  CAMLparam1(v_unit);
 #if defined(__NetBSD__)
+  CAMLreturn(Val_true);
+#else
+  CAMLreturn(Val_false);
+#endif
+}
+
+CAMLprim value stdune_is_haiku(value v_unit) {
+  CAMLparam1(v_unit);
+#if defined(__HAIKU__)
   CAMLreturn(Val_true);
 #else
   CAMLreturn(Val_false);

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -602,7 +602,11 @@ end = struct
     Process_table.remove t proc_info
   ;;
 
-  let wait = if Sys.win32 then wait_win32 else wait_unix
+  let wait =
+    match Platform.OS.value with
+    | Windows -> wait_win32
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Haiku | Other -> wait_unix
+  ;;
 
   let run t =
     Mutex.lock t.mutex;

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -358,6 +358,7 @@ let fswatch_backend () =
   | None ->
     let hints =
       match Platform.OS.value with
+      | Haiku -> [ Pp.text "fswatch is available on HaikuPorts" ]
       | FreeBSD -> [ Pp.text "pkg install fswatch-mon" ]
       | _ -> []
     in
@@ -372,7 +373,7 @@ let select_watcher_backend () =
   else (
     match Platform.OS.value with
     | Windows -> `Fswatch_win
-    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Other -> fswatch_backend ())
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Haiku | Other -> fswatch_backend ())
 ;;
 
 let prepare_sync () =

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -26,6 +26,7 @@ let rule sctx ~requires_link (exes : Dune_file.Executables.t) =
     ; "win64", win_link_flags
     ; "mingw", win_link_flags
     ; "mingw64", win_link_flags
+    ; "beos", [ "-cclib"; "-lbsd" ] (* flags for Haiku *)
     ]
   in
   let+ locals =

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -382,5 +382,5 @@ let backend =
   fun () ->
     match (Platform.OS.value : Platform.OS.t) with
     | Windows -> User_error.raise [ Pp.text "TUI is currently not supported on Windows." ]
-    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Other -> Lazy.force t
+    | Linux | Darwin | FreeBSD | OpenBSD | NetBSD | Haiku | Other -> Lazy.force t
 ;;

--- a/vendor/notty/src-unix/native/winsize.c
+++ b/vendor/notty/src-unix/native/winsize.c
@@ -7,6 +7,11 @@
 #include <signal.h>
 #endif
 
+#ifdef __HAIKU__
+/* On some platforms, ioctl() is declared in <unistd.h>. */
+#include <unistd.h>
+#endif
+
 CAMLprim value caml_notty_winsize (value vfd) {
 #ifdef _WIN32
   (void) vfd;

--- a/vendor/update-notty.sh
+++ b/vendor/update-notty.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=7a95a8c8c39ed0742284d42216106cb9559fe34e
+version=cb7221c73f8009a904fa249fdeb5558c83043b8f
 
 set -e -o pipefail
 


### PR DESCRIPTION
This patch adds Haiku detection to our platform stubs letting us give a better hint for `fswatch` when compiling on Haiku.

It also introduces a linking flag for `dune` that allows `wait4` to be linked correctly Haiku. 

- fixes #8551 
- [x] bootstraps on Haiku
- [x] builds on Haiku
- [x] update notty fork (noctl has different location, fixed in https://github.com/ocaml-dune/notty/pull/5)
- [x] changelog

Here is TUI:
![image](https://github.com/ocaml/dune/assets/8614547/44ce224e-a4df-4bcb-be7e-03d0f58b32d3)
