### PR TITLE
Avoid a warning of the C compiler on Windows

### DIFF
--- a/src/fswatch_win/fswatch_win_stubs.c
+++ b/src/fswatch_win/fswatch_win_stubs.c
@@ -79,6 +79,10 @@ struct watch {
   LPVOID buffer;
 };
 
+#ifdef unix_error
+#undef unix_error
+#endif
+
 #define unix_error(s, err) \
   do { \
     caml_win32_maperr(err); \


### PR DESCRIPTION
The macro `unix_error` is also defined in `caml/unixsupport.h` (at least when `CAML_BUILDING_UNIX` is not set with ≥ 5.x compiler) so the C compiler generates a warning when it is redefined in `fswatch_win_stubs`.
This PR simply avoids this unnecessary warning.