### PR TITLE
fix: always use "portable" hardlinks

### DIFF
--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -98,14 +98,16 @@ module Artifacts = struct
      the result is [Error] with the corresponding exception. Otherwise, the
      result is [Ok ()]. *)
   let store_targets_to ~temp_dir ~targets ~mode : unit Or_exn.t =
+    let portable_hard_link_or_copy =
+      match (mode : Dune_cache_storage.Mode.t) with
+      | Hardlink -> Io.portable_hardlink
+      | Copy -> fun ~src ~dst -> Io.copy_file ~src ~dst ()
+    in
     Result.List.iter targets ~f:(fun { Target.path; _ } ->
       let path_in_build_dir = Path.build path in
       let path_in_temp_dir = Path.relative temp_dir (Path.basename path_in_build_dir) in
       Result.try_with (fun () ->
-        Dune_cache_storage.Util.link_or_copy
-          ~mode
-          ~src:path_in_build_dir
-          ~dst:path_in_temp_dir))
+        portable_hard_link_or_copy ~src:path_in_build_dir ~dst:path_in_temp_dir))
   ;;
 
   (* Step II of [store_skipping_metadata].

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -16,12 +16,6 @@ module Optimistically = struct
   ;;
 end
 
-let link_or_copy ~mode ~src ~dst =
-  match (mode : Mode.t) with
-  | Hardlink -> Path.link src dst
-  | Copy -> Io.copy_file ~src ~dst ()
-;;
-
 module Write_result = struct
   type t =
     | Ok
@@ -41,6 +35,8 @@ end
 let add_atomically ~mode ~src ~dst : Write_result.t =
   match (mode : Mode.t) with
   | Hardlink ->
+    (* The [src] comes from a fresh temporary file, so we should never get
+       [EMLINK] *)
     (match Optimistically.link ~src ~dst with
      | () -> Ok
      | exception Unix.Unix_error (Unix.EEXIST, _, _) -> Already_present

--- a/src/dune_cache_storage/util.mli
+++ b/src/dune_cache_storage/util.mli
@@ -17,9 +17,6 @@ end
     function returns [Ok] instead of [Already_present]. *)
 val write_atomically : mode:Mode.t -> content:string -> Path.t -> Write_result.t
 
-(** Create a hard link or copy depending on the [mode]. *)
-val link_or_copy : mode:Mode.t -> src:Path.t -> dst:Path.t -> unit
-
 (** The functions in this module are bare wrappers that assume that the "target
     directory" (whatever that means for a given function) already exists. If the
     wrapped function fails, then the "target directory" is created, and the


### PR DESCRIPTION
Our portable_hardlink fallbacks to copying whenever hardlinking fails
for whatever reason (too many links, windows, etc)

We now use it consistently when sandboxing & caching.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: df63af45-aa89-4539-89c4-553820d99d74 -->