### PR TITLE
refactor: simplify lock_dir interface

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -385,8 +385,6 @@ let decode_metadata =
 ;;
 
 module Package_filename = struct
-  type t = Filename.t
-
   let file_extension = ".pkg"
   let of_package_name package_name = Package_name.to_string package_name ^ file_extension
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -60,16 +60,8 @@ val create_latest_version
   -> t
 
 val default_path : Path.Source.t
-val metadata : Filename.t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
-
-module Package_filename : sig
-  type t = Filename.t
-
-  val of_package_name : Package_name.t -> t
-  val to_package_name : t -> (Package_name.t, [ `Bad_extension ]) result
-end
 
 module Write_disk : sig
   type lock_dir := t


### PR DESCRIPTION
remove some functions from the public api that aren't used

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0fd4a8d0-d781-4b30-88b7-55d9b1884847 -->