### PR TITLE
refactor: move package map conversion to Lock_dir

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -78,20 +78,6 @@ module Lock = struct
     ;;
   end
 
-  (* Converts the package table found inside a [Dune_project.t] into the
-     package table expected by the dependency solver *)
-  let opam_file_map_of_dune_package_map (dune_package_map : Package.t Package.Name.Map.t)
-    : OpamFile.OPAM.t OpamTypes.name_map
-    =
-    Package.Name.Map.to_list_map
-      dune_package_map
-      ~f:(fun dune_package_name dune_package ->
-        let opam_package_name = Package.Name.to_opam_package_name dune_package_name in
-        let opam_file = Package.to_opam_file dune_package in
-        opam_package_name, opam_file)
-    |> OpamPackage.Name.Map.of_list
-  ;;
-
   module Per_context = struct
     type t =
       { lock_dir_path : Path.Source.t
@@ -320,7 +306,7 @@ module Lock = struct
          let project = Source_tree.Dir.project source_dir in
          Dune_project.packages project
        in
-       opam_file_map_of_dune_package_map dune_package_map
+       Package.Name.Map.map dune_package_map ~f:Package.to_opam_file
      in
      let+ solutions =
        Fiber.parallel_map

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -417,6 +417,15 @@ let make_action = function
   | actions -> Some (Action.Progn actions)
 ;;
 
+let opam_file_map_of_dune_package_map dune_package_map =
+  Package_name.Map.to_list_map dune_package_map ~f:(fun dune_package_name opam_file ->
+    let opam_package_name =
+      Package_name.to_string dune_package_name |> OpamPackage.Name.of_string
+    in
+    opam_package_name, opam_file)
+  |> OpamPackage.Name.Map.of_list
+;;
+
 let opam_package_to_lock_file_pkg context_for_dune ~repos ~local_packages opam_package =
   let name = OpamPackage.name opam_package in
   let version = OpamPackage.version opam_package |> OpamPackage.Version.to_string in
@@ -570,6 +579,7 @@ module Solver_result = struct
 end
 
 let solve_lock_dir solver_env version_preference repos ~local_packages =
+  let local_packages = opam_file_map_of_dune_package_map local_packages in
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages
   in

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -20,5 +20,5 @@ val solve_lock_dir
   :  Solver_env.t
   -> Version_preference.t
   -> Opam_repo.t list
-  -> local_packages:OpamFile.OPAM.t OpamTypes.name_map
+  -> local_packages:OpamFile.OPAM.t Package_name.Map.t
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result


### PR DESCRIPTION
Ideally, dune_pkg should wrap opam related implementation details

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d93a6c59-99bf-4cd7-bdb9-fa5d6b94033d -->