### PR TITLE
refactor: centralize workaround for OCaml bug

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -491,10 +491,9 @@ let portable_hardlink ~src ~dst =
           filter out the duplicates first. *)
        Path.unlink dst;
        Path.link src dst
-     | Unix.Unix_error (Unix.EMLINK, _, _)
-     | Unix.Unix_error (Unix.EUNKNOWNERR -1142, _, _) (* Needed for OCaml < 5.1 *) ->
+     | Unix.Unix_error (Unix.EMLINK, _, _) ->
        (* If we can't make a new hard link because we reached the limit on the
-          number of hard links per file, we fall back to copying. We expect that
-          this happens very rarely (probably only for empty files). *)
+          number of hard links per file, we fall back to copying. We expect
+          that this happens very rarely (probably only for empty files). *)
        copy_file ~src ~dst ())
 ;;

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1130,7 +1130,16 @@ let is_directory t =
 
 let rmdir t = Unix.rmdir (to_string t)
 let unlink t = Fpath.unlink (to_string t)
-let link x y = Unix.link (to_string x) (to_string y)
+
+let link src dst =
+  match Unix.link (to_string src) (to_string dst) with
+  | exception Unix.Unix_error (Unix.EUNKNOWNERR -1142, syscall, arg)
+  (* Needed for OCaml < 5.1 on windows *) ->
+    Exn.reraise (Unix.Unix_error (Unix.EMLINK, syscall, arg))
+  | s -> s
+  | exception e -> Exn.reraise e
+;;
+
 let unlink_no_err t = Fpath.unlink_no_err (to_string t)
 let build_dir_exists () = is_directory build_dir
 

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -61,8 +61,7 @@ end
    hard links on [$file] will be allowed, triggering the [EMLINK] code path. *)
 let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst with
-  | Unix.Unix_error (Unix.EMLINK, _, _)
-  | Unix.Unix_error (Unix.EUNKNOWNERR -1142, _, _) (* Needed for OCaml < 5.1 *) ->
+  | Unix.Unix_error (Unix.EMLINK, _, _) ->
     Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e
       | Ok temp_file ->


### PR DESCRIPTION
OCaml older than 5.1 will not correctly raise EMLINK. We make
[Path.link] transalte the error correctly and remove the two other cases
where it was done.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 48c637bc-55f6-422e-b1d8-dd0cd9cdb0a4 -->