### PR TITLE
rpc status: fix for Win32

### DIFF
--- a/doc/changes/8806.md
+++ b/doc/changes/8806.md
@@ -1,1 +1,1 @@
-- Fix `dune rpc status` on Windows (#8806, fixes #8799, @nojb)
+- Fix `dune rpc` commands on Windows (#8806, fixes #8799, @nojb)

--- a/doc/changes/8806.md
+++ b/doc/changes/8806.md
@@ -1,0 +1,1 @@
+- Fix `dune rpc status` on Windows (#8806, fixes #8799, @nojb)

--- a/otherlibs/dune-rpc/private/where.ml
+++ b/otherlibs/dune-rpc/private/where.ml
@@ -151,22 +151,20 @@ module Make
          | Ok s -> Ok (Some s)
          | Error exn -> Error exn)
     | None ->
-      (match default ~build_dir () with
-       | `Ip _ as x -> Fiber.return (Ok (Some x))
-       | `Unix file as x ->
-         let of_file f =
-           let+ contents = IO.read_file f in
-           match contents with
+      let of_file f =
+        let+ contents = IO.read_file f in
+        match contents with
+        | Error e -> Error e
+        | Ok contents ->
+          (match of_string contents with
            | Error e -> Error e
-           | Ok contents ->
-             (match of_string contents with
-              | Error e -> Error e
-              | Ok s -> Ok (Some s))
-         in
-         let** analyze = IO.analyze_path file in
-         (match analyze with
-          | `Other -> Fiber.return (Ok None)
-          | `Normal_file -> of_file file
-          | `Unix_socket -> Fiber.return (Ok (Some x))))
+           | Ok s -> Ok (Some s))
+      in
+      let file = Filename.concat build_dir rpc_socket_relative_to_build_dir in
+      let** analyze = IO.analyze_path file in
+      (match analyze with
+       | `Other -> Fiber.return (Ok None)
+       | `Normal_file -> of_file file
+       | `Unix_socket -> Fiber.return (Ok (Some (`Unix file))))
   ;;
 end

--- a/src/dune_rpc_client/where.ml
+++ b/src/dune_rpc_client/where.ml
@@ -47,10 +47,7 @@ let to_socket = function
   | `Ip (`Host host, `Port port) -> Unix.ADDR_INET (Unix.inet_addr_of_string host, port)
 ;;
 
-let to_string = function
-  | `Unix p -> sprintf "unix://%s" p
-  | `Ip (`Host host, `Port port) -> sprintf "%s:%d" host port
-;;
+let to_string t = Dune_rpc_private.Where.to_string t
 
 let rpc_socket_file =
   let f =

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -433,6 +433,9 @@ let create
        Path.mkdir_p (Path.build (Path.Build.parent_exn socket_file));
        match Csexp_rpc.Server.create [ Where.to_socket where ] ~backlog:10 with
        | Ok s ->
+         (match where with
+          | `Ip _ -> Io.write_file (Path.build socket_file) (Where.to_string where)
+          | `Unix _ -> ());
          at_exit (fun () -> Path.Build.unlink_no_err socket_file);
          s
        | Error `Already_in_use ->

--- a/test/blackbox-tests/test-cases/action-runner/worker.t
+++ b/test/blackbox-tests/test-cases/action-runner/worker.t
@@ -1,6 +1,6 @@
 Connecting without server should fail
 
   $ DUNE_RPC="unix:path=foo" dune internal action-runner start foobar 2>&1 | sed -n '/^Error/,/backtrace:/p'
-  Error: failed to connect to RPC server unix://foo
+  Error: failed to connect to RPC server unix:path=foo
   Unix.Unix_error(Unix.ENOENT, "connect", "")
   backtrace:


### PR DESCRIPTION
Beginning of a fix for #8799, but not complete because `dune rpc status` does not seem to be fully working:

![image](https://github.com/ocaml/dune/assets/113560/95600708-8cf5-4ad1-aabd-c6efe19e3f31)

(no data is reported for the connected client)

cc @Alizter 