### PR TITLE
Remove a confusing/unnecessary comment

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -385,7 +385,6 @@ end = struct
         match sandbox with
         | Some sandbox -> Sandbox.destroy sandbox
         | None ->
-          (* All went well, these targets are no longer pending. *)
           Pending_targets.remove targets;
           Fiber.return ())
       (fun () ->


### PR DESCRIPTION
The "all went well" part is confusing. The action might have failed actually, so it's unclear what is meant. After removing this bit, the comment becomes trivial, so I think we can just delete the whole thing.

As discussed here: https://github.com/ocaml/dune/pull/8791#discussion_r1342189364