### PR TITLE
fix(pkg): move solver env printing to own command

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -4,197 +4,159 @@ module Fetch = Dune_pkg.Fetch
 module Opam_repo = Dune_pkg.Opam_repo
 module Repository_id = Dune_pkg.Repository_id
 
-module Lock = struct
-  module Opam_repository_path = struct
-    let term =
-      let dune_path =
-        let parser s =
-          s
-          |> Path.External.of_filename_relative_to_initial_cwd
-          |> Path.external_
-          |> Result.ok
-        in
-        let printer pf p = Pp.to_fmt pf (Path.pp p) in
-        Arg.conv (parser, printer)
+let context_term =
+  Arg.(
+    value
+    & opt (some Arg.context_name) None
+    & info
+        [ "context" ]
+        ~docv:"CONTEXT"
+        ~doc:
+          "Generate the lockdir associated with this context (the default context will \
+           be used if this is omitted)")
+;;
+
+module Version_preference = struct
+  include Dune_pkg.Version_preference
+
+  let term =
+    let all_strings = List.map all_by_string ~f:fst in
+    let doc =
+      sprintf
+        "Whether to prefer the newest compatible version of a package or the oldest \
+         compatible version of packages while solving dependencies. This overrides any \
+         setting in the current workspace. The default is %s."
+        (to_string default)
+    in
+    let docv = String.concat ~sep:"|" all_strings |> sprintf "(%s)" in
+    Arg.(
+      value
+      & opt (some (enum all_by_string)) None
+      & info [ "version-preference" ] ~doc ~docv)
+  ;;
+
+  let choose ~from_arg ~from_context =
+    match from_arg, from_context with
+    | Some from_arg, _ -> from_arg
+    | None, Some from_context -> from_context
+    | None, None -> default
+  ;;
+end
+
+module Per_context = struct
+  type t =
+    { lock_dir_path : Path.Source.t
+    ; version_preference : Version_preference.t
+    ; solver_env : Dune_pkg.Solver_env.t
+    ; context_common : Dune_rules.Workspace.Context.Common.t
+    ; repos :
+        Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
+    }
+
+  let repositories_of_workspace (workspace : Workspace.t) =
+    List.map workspace.repos ~f:(fun repo ->
+      Dune_pkg.Pkg_workspace.Repository.name repo, repo)
+    |> Dune_pkg.Pkg_workspace.Repository.Name.Map.of_list_exn
+  ;;
+
+  let choose ~context_name_arg ~all_contexts_arg ~version_preference_arg =
+    let open Fiber.O in
+    match context_name_arg, all_contexts_arg with
+    | Some _, true ->
+      User_error.raise [ Pp.text "--context and --all-contexts are mutually exclusive" ]
+    | context_name_opt, false ->
+      let+ workspace = Memo.run (Workspace.workspace ()) in
+      let context_name =
+        Option.value context_name_opt ~default:Dune_engine.Context_name.default
       in
-      Arg.(
-        value
-        & opt (some dune_path) None
-        & info
-            [ "opam-repository-path" ]
-            ~docv:"PATH"
-            ~doc:
-              "Path to a local opam repository. This should be a directory containing a \
-               valid opam repository such as the one at \
-               https://github.com/ocaml/opam-repository.")
-    ;;
-  end
-
-  module Opam_repository_url = struct
-    let term =
-      let parser s =
-        match OpamUrl.parse_opt s with
-        | Some url -> Ok url
-        | None -> Error (`Msg "URL can't be parsed")
+      let context =
+        List.find workspace.contexts ~f:(fun context ->
+          Dune_engine.Context_name.equal (Workspace.Context.name context) context_name)
       in
-      let printer pf u = Pp.to_fmt pf (Pp.text (OpamUrl.to_string u)) in
-      let opam_url = Arg.conv (parser, printer) in
-      Arg.(
-        value
-        & opt (some opam_url) None
-        & info
-            [ "opam-repository-url" ]
-            ~docv:"URL"
-            ~doc:
-              "URL of opam repository to download. Can be either a git repository or a \
-               link to the tarball of a repository.")
-    ;;
-  end
-
-  module Version_preference = struct
-    include Dune_pkg.Version_preference
-
-    let term =
-      let all_strings = List.map all_by_string ~f:fst in
-      let doc =
-        sprintf
-          "Whether to prefer the newest compatible version of a package or the oldest \
-           compatible version of packages while solving dependencies. This overrides any \
-           setting in the current workspace. The default is %s."
-          (to_string default)
-      in
-      let docv = String.concat ~sep:"|" all_strings |> sprintf "(%s)" in
-      Arg.(
-        value
-        & opt (some (enum all_by_string)) None
-        & info [ "version-preference" ] ~doc ~docv)
-    ;;
-
-    let choose ~from_arg ~from_context =
-      match from_arg, from_context with
-      | Some from_arg, _ -> from_arg
-      | None, Some from_context -> from_context
-      | None, None -> default
-    ;;
-  end
-
-  module Per_context = struct
-    type t =
-      { lock_dir_path : Path.Source.t
-      ; version_preference : Version_preference.t
-      ; solver_env : Dune_pkg.Solver_env.t
-      ; context_common : Dune_rules.Workspace.Context.Common.t
-      ; repos :
-          Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
-      }
-
-    let repositories_of_workspace (workspace : Workspace.t) =
-      List.map workspace.repos ~f:(fun repo ->
-        Dune_pkg.Pkg_workspace.Repository.name repo, repo)
-      |> Dune_pkg.Pkg_workspace.Repository.Name.Map.of_list_exn
-    ;;
-
-    let choose ~context_name_arg ~all_contexts_arg ~version_preference_arg =
-      let open Fiber.O in
-      match context_name_arg, all_contexts_arg with
-      | Some _, true ->
-        User_error.raise [ Pp.text "--context and --all-contexts are mutually exclusive" ]
-      | context_name_opt, false ->
-        let+ workspace = Memo.run (Workspace.workspace ()) in
-        let context_name =
-          Option.value context_name_opt ~default:Dune_engine.Context_name.default
-        in
-        let context =
-          List.find workspace.contexts ~f:(fun context ->
-            Dune_engine.Context_name.equal (Workspace.Context.name context) context_name)
-        in
-        (match context with
-         | None ->
-           User_error.raise
-             [ Pp.textf
-                 "Unknown build context: %s"
-                 (Dune_engine.Context_name.to_string context_name |> String.maybe_quoted)
-             ]
-         | Some
-             (Default
-               { lock
-               ; version_preference = version_preference_context
-               ; solver_env
-               ; base = context_common
-               ; _
-               }) ->
-           [ { lock_dir_path = Option.value lock ~default:Lock_dir.default_path
-             ; version_preference =
-                 Version_preference.choose
-                   ~from_arg:version_preference_arg
-                   ~from_context:version_preference_context
-             ; solver_env = Option.value solver_env ~default:Dune_pkg.Solver_env.default
-             ; context_common
-             ; repos = repositories_of_workspace workspace
-             }
+      (match context with
+       | None ->
+         User_error.raise
+           [ Pp.textf
+               "Unknown build context: %s"
+               (Dune_engine.Context_name.to_string context_name |> String.maybe_quoted)
            ]
-         | Some (Opam _) ->
-           User_error.raise
-             [ Pp.textf
-                 "Unexpected opam build context: %s"
-                 (Dune_engine.Context_name.to_string context_name |> String.maybe_quoted)
-             ])
-      | None, true ->
-        let+ workspace = Memo.run (Workspace.workspace ()) in
-        List.filter_map workspace.contexts ~f:(function
-          | Workspace.Context.Default
-              { lock
-              ; version_preference = version_preference_context
-              ; base = context_common
-              ; solver_env
-              } ->
-            let lock_dir_path =
-              Option.value lock ~default:Dune_pkg.Lock_dir.default_path
-            in
-            Some
-              { lock_dir_path
-              ; version_preference =
-                  Version_preference.choose
-                    ~from_arg:version_preference_arg
-                    ~from_context:version_preference_context
-              ; context_common
-              ; solver_env = Option.value solver_env ~default:Dune_pkg.Solver_env.default
-              ; repos = repositories_of_workspace workspace
-              }
-          | Opam _ -> None)
-    ;;
+       | Some
+           (Default
+             { lock
+             ; version_preference = version_preference_context
+             ; solver_env
+             ; base = context_common
+             ; _
+             }) ->
+         [ { lock_dir_path = Option.value lock ~default:Lock_dir.default_path
+           ; version_preference =
+               Version_preference.choose
+                 ~from_arg:version_preference_arg
+                 ~from_context:version_preference_context
+           ; solver_env = Option.value solver_env ~default:Dune_pkg.Solver_env.default
+           ; context_common
+           ; repos = repositories_of_workspace workspace
+           }
+         ]
+       | Some (Opam _) ->
+         User_error.raise
+           [ Pp.textf
+               "Unexpected opam build context: %s"
+               (Dune_engine.Context_name.to_string context_name |> String.maybe_quoted)
+           ])
+    | None, true ->
+      let+ workspace = Memo.run (Workspace.workspace ()) in
+      List.filter_map workspace.contexts ~f:(function
+        | Workspace.Context.Default
+            { lock
+            ; version_preference = version_preference_context
+            ; base = context_common
+            ; solver_env
+            } ->
+          let lock_dir_path = Option.value lock ~default:Dune_pkg.Lock_dir.default_path in
+          Some
+            { lock_dir_path
+            ; version_preference =
+                Version_preference.choose
+                  ~from_arg:version_preference_arg
+                  ~from_context:version_preference_context
+            ; context_common
+            ; solver_env = Option.value solver_env ~default:Dune_pkg.Solver_env.default
+            ; repos = repositories_of_workspace workspace
+            }
+        | Opam _ -> None)
+  ;;
 
-    let contexts_with_dup_lock_dir_paths ts =
-      List.map ts ~f:(fun { lock_dir_path; context_common; _ } ->
-        lock_dir_path, context_common)
-      |> Path.Source.Map.of_list_multi
-      |> Path.Source.Map.to_list
-      |> List.find_opt ~f:(fun (_, context_commons) -> List.length context_commons > 1)
-    ;;
+  let contexts_with_dup_lock_dir_paths ts =
+    List.map ts ~f:(fun { lock_dir_path; context_common; _ } ->
+      lock_dir_path, context_common)
+    |> Path.Source.Map.of_list_multi
+    |> Path.Source.Map.to_list
+    |> List.find_opt ~f:(fun (_, context_commons) -> List.length context_commons > 1)
+  ;;
 
-    let check_for_dup_lock_dir_paths ts =
-      contexts_with_dup_lock_dir_paths ts
-      |> Option.iter ~f:(fun (lock_dir_path, context_commons) ->
-        let loc = (List.hd context_commons : Workspace.Context.Common.t).loc in
-        User_error.raise
-          ~loc
-          ([ Pp.text
-               "Refusing to proceed as multiple selected contexts would create a lock \
-                dir at the same path."
-           ; Pp.textf
-               "These contexts all create a lock dir: %s"
-               (Path.Source.to_string_maybe_quoted lock_dir_path)
-           ]
-           @ List.map
-               context_commons
-               ~f:(fun (c : Dune_rules.Workspace.Context.Common.t) ->
-                 Pp.textf
-                   "- %s (defined at %s)"
-                   (Context_name.to_string c.name |> String.maybe_quoted)
-                   (Loc.to_file_colon_line c.loc))))
-    ;;
-  end
+  let check_for_dup_lock_dir_paths ts =
+    contexts_with_dup_lock_dir_paths ts
+    |> Option.iter ~f:(fun (lock_dir_path, context_commons) ->
+      let loc = (List.hd context_commons : Workspace.Context.Common.t).loc in
+      User_error.raise
+        ~loc
+        ([ Pp.text
+             "Refusing to proceed as multiple selected contexts would create a lock dir \
+              at the same path."
+         ; Pp.textf
+             "These contexts all create a lock dir: %s"
+             (Path.Source.to_string_maybe_quoted lock_dir_path)
+         ]
+         @ List.map context_commons ~f:(fun (c : Dune_rules.Workspace.Context.Common.t) ->
+           Pp.textf
+             "- %s (defined at %s)"
+             (Context_name.to_string c.name |> String.maybe_quoted)
+             (Loc.to_file_colon_line c.loc))))
+  ;;
+end
 
+module Print_solver_env = struct
   (* Add the opam system variables derived from the current system into a
      solver environment configured in a build context. If variables derived
      from the current system are also present in the solver environment
@@ -247,46 +209,149 @@ module Lock = struct
     Dune_pkg.Solver_env.set_sys solver_env_from_context sys
   ;;
 
-  let context_term =
-    Arg.(
-      value
-      & opt (some Arg.context_name) None
-      & info
-          [ "context" ]
-          ~docv:"CONTEXT"
-          ~doc:
-            "Generate the lockdir associated with this context (the default context will \
-             be used if this is omitted)")
+  let print_solver_env_for_one_context
+    ~sys_bindings_from_current_system
+    ~use_env_from_current_system
+    { Per_context.solver_env = solver_env_from_context
+    ; context_common = { name = context_name; _ }
+    ; _
+    }
+    =
+    let solver_env =
+      merge_current_system_bindings_into_solver_env_from_context
+        ~context_name
+        ~solver_env_from_context
+        ~sys_bindings_from_current_system
+        ~use_env_from_current_system
+    in
+    Console.print
+      [ Pp.textf
+          "Solver environment for context %s:"
+          (String.maybe_quoted @@ Dune_engine.Context_name.to_string context_name)
+      ; Dune_pkg.Solver_env.pp solver_env
+      ]
   ;;
 
   let print_solver_env
-    per_context
-    ~sys_bindings_from_current_system
+    ~context_name
+    ~all_contexts
+    ~version_preference
     ~use_env_from_current_system
     =
+    let open Fiber.O in
+    let+ per_context =
+      Per_context.choose
+        ~context_name_arg:context_name
+        ~all_contexts_arg:all_contexts
+        ~version_preference_arg:version_preference
+    and+ sys_bindings_from_current_system =
+      if use_env_from_current_system
+      then Dune_pkg.Sys_poll.sys_bindings ~path:(Env_path.path Stdune.Env.initial)
+      else Fiber.return Dune_pkg.Solver_env.Variable.Sys.Bindings.empty
+    in
     List.iter
       per_context
       ~f:
-        (fun
-          { Per_context.solver_env = solver_env_from_context
-          ; context_common = { name = context_name; _ }
-          ; _
-          }
-        ->
-        let solver_env =
-          merge_current_system_bindings_into_solver_env_from_context
-            ~context_name
-            ~solver_env_from_context
-            ~sys_bindings_from_current_system
-            ~use_env_from_current_system
-        in
-        Console.print
-          [ Pp.textf
-              "Solver environment for context %s:"
-              (String.maybe_quoted @@ Dune_engine.Context_name.to_string context_name)
-          ; Dune_pkg.Solver_env.pp solver_env
-          ])
+        (print_solver_env_for_one_context
+           ~sys_bindings_from_current_system
+           ~use_env_from_current_system)
   ;;
+
+  let term =
+    let+ (common : Common.t) = Common.term
+    and+ context_name = context_term
+    and+ all_contexts =
+      Arg.(
+        value
+        & flag
+        & info [ "all-contexts" ] ~doc:"Generate the lockdir for all contexts")
+    and+ version_preference = Version_preference.term
+    and+ use_env_from_current_system =
+      Arg.(
+        value
+        & flag
+        & info
+            [ "use-env-from-current-system" ]
+            ~doc:
+              "Set opam system environment variables based on the current system when \
+               solving dependencies. This will restrict packages to just those which can \
+               be installed on the current system. Note that this will mean that the \
+               generated lockdir may not be compatible with other systems. If the build \
+               context(s) specify system environment variables then the solver will use \
+               the union of the environment variables inferred from the current system \
+               and the environment variables set in the build context(s). If the current \
+               system and the build context(s) disagree on the value of an environment \
+               variable then an error is raised.")
+    in
+    let common = Common.forbid_builds common in
+    let config = Common.init common in
+    Scheduler.go ~common ~config (fun () ->
+      print_solver_env
+        ~context_name
+        ~all_contexts
+        ~version_preference
+        ~use_env_from_current_system)
+  ;;
+
+  let info =
+    let doc =
+      "Print an s-expression describing the environment that would be used to solve \
+       dependencies and then exit without attempting to solve the dependencies or \
+       generate the lockfile. Intended to be used to debug situations where no solution \
+       can be found to a project's dependencies."
+    in
+    Cmd.info "print-solver-env" ~doc
+  ;;
+
+  let command = Cmd.v info term
+end
+
+module Lock = struct
+  module Opam_repository_path = struct
+    let term =
+      let dune_path =
+        let parser s =
+          s
+          |> Path.External.of_filename_relative_to_initial_cwd
+          |> Path.external_
+          |> Result.ok
+        in
+        let printer pf p = Pp.to_fmt pf (Path.pp p) in
+        Arg.conv (parser, printer)
+      in
+      Arg.(
+        value
+        & opt (some dune_path) None
+        & info
+            [ "opam-repository-path" ]
+            ~docv:"PATH"
+            ~doc:
+              "Path to a local opam repository. This should be a directory containing a \
+               valid opam repository such as the one at \
+               https://github.com/ocaml/opam-repository.")
+    ;;
+  end
+
+  module Opam_repository_url = struct
+    let term =
+      let parser s =
+        match OpamUrl.parse_opt s with
+        | Some url -> Ok url
+        | None -> Error (`Msg "URL can't be parsed")
+      in
+      let printer pf u = Pp.to_fmt pf (Pp.text (OpamUrl.to_string u)) in
+      let opam_url = Arg.conv (parser, printer) in
+      Arg.(
+        value
+        & opt (some opam_url) None
+        & info
+            [ "opam-repository-url" ]
+            ~docv:"URL"
+            ~doc:
+              "URL of opam repository to download. Can be either a git repository or a \
+               link to the tarball of a repository.")
+    ;;
+  end
 
   let solve
     per_context
@@ -321,7 +386,7 @@ module Lock = struct
              }
            ->
            let solver_env =
-             merge_current_system_bindings_into_solver_env_from_context
+             Print_solver_env.merge_current_system_bindings_into_solver_env_from_context
                ~context_name
                ~solver_env_from_context
                ~sys_bindings_from_current_system
@@ -418,7 +483,6 @@ module Lock = struct
     ~all_contexts
     ~version_preference
     ~use_env_from_current_system
-    ~just_print_solver_env
     ~opam_repository_path
     ~opam_repository_url
     =
@@ -433,20 +497,12 @@ module Lock = struct
       then Dune_pkg.Sys_poll.sys_bindings ~path:(Env_path.path Stdune.Env.initial)
       else Fiber.return Dune_pkg.Solver_env.Variable.Sys.Bindings.empty
     in
-    if just_print_solver_env
-    then
-      let+ () = Fiber.return () in
-      print_solver_env
-        per_context
-        ~sys_bindings_from_current_system
-        ~use_env_from_current_system
-    else
-      solve
-        per_context
-        ~opam_repository_path
-        ~opam_repository_url
-        ~sys_bindings_from_current_system
-        ~use_env_from_current_system
+    solve
+      per_context
+      ~opam_repository_path
+      ~opam_repository_url
+      ~sys_bindings_from_current_system
+      ~use_env_from_current_system
   ;;
 
   let term =
@@ -476,17 +532,6 @@ module Lock = struct
                and the environment variables set in the build context(s). If the current \
                system and the build context(s) disagree on the value of an environment \
                variable then an error is raised.")
-    and+ just_print_solver_env =
-      Arg.(
-        value
-        & flag
-        & info
-            [ "just-print-solver-env" ]
-            ~doc:
-              "Print an s-expression describing the environment that would be used to \
-               solve dependencies and then exit without attempting to solve the \
-               dependencies or generate the lockfile. Intended to be used to debug \
-               situations where no solution can be found to a project's dependencies.")
     in
     let common = Common.forbid_builds common in
     let config = Common.init common in
@@ -496,7 +541,6 @@ module Lock = struct
         ~all_contexts
         ~version_preference
         ~use_env_from_current_system
-        ~just_print_solver_env
         ~opam_repository_path
         ~opam_repository_url)
   ;;
@@ -520,4 +564,4 @@ let info =
   Cmd.info "pkg" ~doc ~man
 ;;
 
-let group = Cmd.group info [ Lock.command ]
+let group = Cmd.group info [ Lock.command; Print_solver_env.command ]

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -1,5 +1,5 @@
 Print the solver env when no dune-workspace is present
-  $ dune pkg lock --just-print-solver-env
+  $ dune pkg print-solver-env
   Solver environment for context default:
   - Flags
     - with-doc = true
@@ -33,7 +33,7 @@ Add some build contexts with different environments
   >    (flags (:standard \ with-doc)))))
   > EOF
 
-  $ dune pkg lock --all-contexts --just-print-solver-env
+  $ dune pkg print-solver-env --all-contexts
   Solver environment for context no-doc:
   - Flags
     - with-doc = false


### PR DESCRIPTION
Instead of [--just-print-solver-env], introduce [dune pkg
just-print-solver-env]

I didn't remove some of the duplication between the two commands,
because some of these duplicated options will be removed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b02726bf-1362-48f4-85fa-cceffccf06e7 -->