### PR TITLE
fix(pkg): remove post deps

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -166,7 +166,7 @@ module Context_for_dune = struct
       ~f:(Filter.resolve_solver_env solver_env)
     |> OpamFilter.filter_deps
          ~build:true
-         ~post:true
+         ~post:false
          ~dev:false
          ~default:false
          ~test:false

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
@@ -29,4 +29,4 @@ Demonstrate the translation of filtered dependencies
   $ cat dune.lock/bar.pkg
   (version 0.0.1)
   
-  (deps pkg-post pkg-build)
+  (deps pkg-build)


### PR DESCRIPTION
those aren't real dependencies so there's no need to include them

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 768e3697-584a-46f7-9b27-79889d006b65 -->