### PR TITLE
feature(pkg): dune describe pkg lock

### DIFF
--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -18,6 +18,7 @@ let subcommands =
   ; Aliases_targets.Targets_cmd.command
   ; Aliases_targets.Aliases_cmd.command
   ; Package_entries.command
+  ; Describe_pkg.command
   ]
 ;;
 

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -24,7 +24,7 @@ module Lock = struct
       let lock_dir = Lock_dir.read_disk lock_dir_path in
       Pp.concat
         ~sep:Pp.space
-        [ Pp.hbox
+        [ Pp.hovbox
           @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
         ; Pkg.Lock.pp_packages lock_dir.packages
         ]

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -27,7 +27,8 @@ module Lock = struct
         [ Pp.hbox
           @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
         ; Pkg.Lock.pp_packages lock_dir.packages
-        ])
+        ]
+      |> Pp.vbox)
   ;;
 
   let command =

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -23,10 +23,10 @@ module Lock = struct
     @@ List.map lock_dir_paths ~f:(fun lock_dir_path ->
       let lock_dir = Lock_dir.read_disk lock_dir_path in
       Pp.concat
-        ~sep:Pp.newline
+        ~sep:Pp.space
         [ Pp.hbox
           @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
-        ; Pkg.Lock.pp_packages lock_dir |> Pp.enumerate ~f:Fun.id
+        ; Pkg.Lock.pp_packages lock_dir.packages
         ])
   ;;
 

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -1,0 +1,44 @@
+open Import
+module Lock_dir = Dune_pkg.Lock_dir
+
+module Lock = struct
+  let term =
+    let+ lock_dir_paths =
+      Arg.(
+        value
+        & pos_all string []
+        & info
+            ~doc:
+              "The paths of the the lock directories to be inspected. Defaults to the \
+               lock directory specified in the default context."
+            ~docv:"LOCKDIRS"
+            [])
+    in
+    let lock_dir_paths =
+      match List.map lock_dir_paths ~f:Path.Source.of_string with
+      | [] -> [ Lock_dir.default_path ]
+      | lock_dir_paths -> lock_dir_paths
+    in
+    Console.print
+    @@ List.map lock_dir_paths ~f:(fun lock_dir_path ->
+      let lock_dir = Lock_dir.read_disk lock_dir_path in
+      Pp.concat
+        ~sep:Pp.newline
+        [ Pp.hbox
+          @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
+        ; Pkg.Lock.pp_packages lock_dir |> Pp.enumerate ~f:Fun.id
+        ])
+  ;;
+
+  let command =
+    let doc = "Display packages in a lock file" in
+    let info = Cmd.info ~doc "lock" in
+    Cmd.v info term
+  ;;
+end
+
+let command =
+  let doc = "Subcommands related to package management" in
+  let info = Cmd.info ~doc "pkg" in
+  Cmd.group info [ Lock.command ]
+;;

--- a/bin/describe/describe_pkg.mli
+++ b/bin/describe/describe_pkg.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -371,6 +371,15 @@ module Lock = struct
       { Opam_repo.With_file.opam_file; file })
   ;;
 
+  (* CR-someday alizter: change this to return ['a Pp.t] rather than ['a Pp.t list] likely
+     using Pp.enumerate. It will also require changing the output of dune pkg lock. *)
+  let pp_packages (t : Lock_dir.t) =
+    Package_name.Map.to_list_map
+      t.packages
+      ~f:(fun _ { Lock_dir.Pkg.info = { Lock_dir.Pkg_info.name; version; _ }; _ } ->
+        Pp.text (Package_name.to_string name ^ "." ^ version))
+  ;;
+
   let solve
     per_context
     ~opam_repository_path
@@ -416,16 +425,24 @@ module Lock = struct
                    ~experimental_translate_opam_filters)
            with
            | Error (`Diagnostic_message message) -> Error (context_name, message)
-           | Ok { Dune_pkg.Opam_solver.Solver_result.summary; lock_dir; files } ->
+           | Ok { lock_dir; files } ->
              let summary_message =
-               Dune_pkg.Opam_solver.Summary.selected_packages_message
-                 summary
-                 ~lock_dir_path
-               |> User_message.pp
+               (Pp.textf
+                  "Solution for %s:"
+                  (Path.Source.to_string_maybe_quoted lock_dir_path)
+                (* CR-someday alizter: use Pp.enumerate to print the list here. *)
+                ::
+                (match pp_packages lock_dir with
+                 | [] -> [ Pp.text "(no dependencies to lock)" ]
+                 | packages -> packages))
+               (* CR-someday alizter: Don't print a newline after the last context.
+                  However a newline between any error messages will still need to be
+                  printed. For now we always print one. *)
+               @ [ Pp.nop ]
              in
              Ok
                ( Lock_dir.Write_disk.prepare ~lock_dir_path ~files lock_dir
-               , summary_message ))
+               , User_message.make summary_message ))
      in
      Result.List.all solutions)
     >>| function
@@ -437,8 +454,8 @@ module Lock = struct
         ; message
         ]
     | Ok write_disks_with_summaries ->
-      let write_disk_list, summary_pps = List.split write_disks_with_summaries in
-      Dune_console.print summary_pps;
+      let write_disk_list, summary_messages = List.split write_disks_with_summaries in
+      List.iter summary_messages ~f:Console.print_user_message;
       (* All the file IO side effects happen here: *)
       List.iter write_disk_list ~f:Lock_dir.Write_disk.commit
   ;;

--- a/bin/pkg.mli
+++ b/bin/pkg.mli
@@ -3,7 +3,7 @@ open Import
 module Lock : sig
   (** [pp_packages lock_dir] returns a list of pretty-printed packages
       occuring in [lock_dir]. *)
-  val pp_packages : Dune_pkg.Lock_dir.t -> 'a Pp.t list
+  val pp_packages : Dune_pkg.Lock_dir.Pkg.t Package_name.Map.t -> 'a Pp.t
 end
 
 val group : unit Cmd.t

--- a/bin/pkg.mli
+++ b/bin/pkg.mli
@@ -1,3 +1,9 @@
 open Import
 
+module Lock : sig
+  (** [pp_packages lock_dir] returns a list of pretty-printed packages
+      occuring in [lock_dir]. *)
+  val pp_packages : Dune_pkg.Lock_dir.t -> 'a Pp.t list
+end
+
 val group : unit Cmd.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -166,23 +166,6 @@ end
 
 module Solver = Opam_0install.Solver.Make (Context_for_dune)
 
-module Summary = struct
-  type t = { opam_packages_to_lock : OpamPackage.t list }
-
-  let selected_packages_message t ~lock_dir_path =
-    let parts =
-      match t.opam_packages_to_lock with
-      | [] -> [ Pp.tag User_message.Style.Success (Pp.text "(no dependencies to lock)") ]
-      | opam_packages_to_lock ->
-        List.map opam_packages_to_lock ~f:(fun package ->
-          Pp.text (OpamPackage.to_string package))
-    in
-    User_message.make
-      (Pp.textf "Solution for %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
-       :: parts)
-  ;;
-end
-
 let is_valid_global_variable_name = function
   | "root" -> false
   | _ -> true
@@ -614,8 +597,7 @@ let scan_files_entries path =
 
 module Solver_result = struct
   type t =
-    { summary : Summary.t
-    ; lock_dir : Lock_dir.t
+    { lock_dir : Lock_dir.t
     ; files : Lock_dir.Write_disk.Files_entry.t Package_name.Map.Multi.t
     }
 end
@@ -646,7 +628,6 @@ let solve_lock_dir
       List.map solution ~f:OpamPackage.name |> OpamPackage.Name.Set.of_list
     in
     let opam_packages_to_lock = List.filter solution ~f:(Fun.negate is_local_package) in
-    let summary = { Summary.opam_packages_to_lock } in
     let lock_dir =
       match
         Package_name.Map.of_list_map opam_packages_to_lock ~f:(fun opam_package ->
@@ -689,5 +670,5 @@ let solve_lock_dir
             , files ))
       |> Package_name.Map.of_list_exn
     in
-    { Solver_result.summary; lock_dir; files })
+    { Solver_result.lock_dir; files })
 ;;

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -1,17 +1,8 @@
 open Import
 
-module Summary : sig
-  (** Some intermediate state from the solve exposed for logging purposes *)
-  type t
-
-  (** A message listing selected packages *)
-  val selected_packages_message : t -> lock_dir_path:Path.Source.t -> User_message.t
-end
-
 module Solver_result : sig
   type t =
-    { summary : Summary.t
-    ; lock_dir : Lock_dir.t
+    { lock_dir : Lock_dir.t
     ; files : Lock_dir.Write_disk.Files_entry.t Package_name.Map.Multi.t
     }
 end

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -1,0 +1,68 @@
+  $ . ./helpers.sh
+  $ mkrepo
+
+Testing the output of the dune describe pkg lock command.
+
+First we setup a repo.
+  $ mkpkg A 1.2.0
+  > mkpkg B 2.1+rc1
+  > mkpkg C 81.0.4044.138 <<EOF
+  > depends: [ "D" "E" ]
+  > EOF
+  > mkpkg D 0.4.0.beta1
+  > mkpkg E 3.0~alpha1
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (context
+  >  (default))
+  > (context
+  >  (default
+  >   (name "foo")
+  >   (lock foo.lock)))
+  > EOF
+
+Here is the output of solving for multiple contexts:
+  $ solve_project --all-contexts <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (depends A B C))
+  > EOF
+  Solution for foo.lock:
+  A.1.2.0
+  B.2.1+rc1
+  C.81.0.4044.138
+  D.0.4.0.beta1
+  E.3.0~alpha1
+  
+  Solution for dune.lock:
+  A.1.2.0
+  B.2.1+rc1
+  C.81.0.4044.138
+  D.0.4.0.beta1
+  E.3.0~alpha1
+  
+Here is the output of dune describe pkg lock:
+  $ dune describe pkg lock
+  Contents of dune.lock:
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
+
+The names of the lockfiles can also be provided:
+  $ dune describe pkg lock dune.lock foo.lock 
+  Contents of dune.lock:
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
+  Contents of foo.lock:
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -46,23 +46,23 @@ Here is the output of solving for multiple contexts:
 Here is the output of dune describe pkg lock:
   $ dune describe pkg lock
   Contents of dune.lock:
-  - A.1.2.0
-  - B.2.1+rc1
-  - C.81.0.4044.138
-  - D.0.4.0.beta1
-  - E.3.0~alpha1
+  A.1.2.0
+  B.2.1+rc1
+  C.81.0.4044.138
+  D.0.4.0.beta1
+  E.3.0~alpha1
 
 The names of the lockfiles can also be provided:
   $ dune describe pkg lock dune.lock foo.lock 
   Contents of dune.lock:
-  - A.1.2.0
-  - B.2.1+rc1
-  - C.81.0.4044.138
-  - D.0.4.0.beta1
-  - E.3.0~alpha1
+  A.1.2.0
+  B.2.1+rc1
+  C.81.0.4044.138
+  D.0.4.0.beta1
+  E.3.0~alpha1
   Contents of foo.lock:
-  - A.1.2.0
-  - B.2.1+rc1
-  - C.81.0.4044.138
-  - D.0.4.0.beta1
-  - E.3.0~alpha1
+  A.1.2.0
+  B.2.1+rc1
+  C.81.0.4044.138
+  D.0.4.0.beta1
+  E.3.0~alpha1


### PR DESCRIPTION
We add a new `dune describe` command that displays the packages in a lock file. In order to do this, we refactored pkg.ml to share its printing function.

- fix https://github.com/ocaml/dune/issues/8833