### PR TITLE
feature(pkg): include local test deps

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
@@ -1,0 +1,23 @@
+Demonstrate that local dependencies that are marked as {with-test} can be
+included.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg post <<EOF
+  > EOF
+  $ mkpkg build <<EOF
+  > EOF
+  $ mkpkg dev <<EOF
+  > EOF
+  $ mkpkg test <<EOF
+  > EOF
+  $ mkpkg doc <<EOF
+  > EOF
+
+  $ solve "(test :with-test) (doc :with-doc) (dev :with-dev) (build :build) (post :post)"
+  Solution for dune.lock:
+  build.0.0.1
+  doc.0.0.1
+  test.0.0.1
+  


### PR DESCRIPTION
This will include all the dependencies marked with `:with-test` from the packages inside the workspace.

For now, there's no way to turn this off, but at least this is the better default.