### PR TITLE
test(pkg): demonstrate that "|" aren't recorded correctly

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -1,0 +1,27 @@
+Demonstrate the generation of the lock directory in the presence of "|"
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg a1 <<EOF
+  > conflicts: [ "a2" ]
+  > EOF
+  $ mkpkg a2 <<EOF
+  > conflicts: [ "a1" ]
+  > EOF
+
+  $ mkpkg b <<EOF
+  > depends: [ "a1" | "a2" ]
+  > EOF
+
+  $ solve b
+  Solution for dune.lock:
+  a1.0.0.1
+  b.0.0.1
+  
+Only a1 or a2 should appear but not both.
+
+  $ cat dune.lock/b.pkg
+  (version 0.0.1)
+  
+  (deps a1 a2)


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1d467075-3d75-4e67-aa72-2925b832a4f3 -->