### PR TITLE
Add dkml-workflows to TEST_DEPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ ppxlib \
 ctypes \
 "utop>=2.6.0" \
 "melange>=1.0.0" \
-"rescript-syntax"
+"rescript-syntax" \
+"dkml-workflows"
 # Dependencies recommended for developing dune locally,
 # but not wanted in CI
 DEV_DEPS := \


### PR DESCRIPTION
When setting up the dune codebase on a new machine it's recommended to run `make dev-deps` to install development dependencies but you also need to install the `dkml-workflows` package in order to run (say) `dune build` in the root of this project. This change adds `dkml-workflows` to the packages installed with `make dev-deps` to remove the need to manually install it.