### PR TITLE
fix(pkg): workaround the ocaml configure script not accepting relative paths

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -8,17 +8,17 @@ Install actions should have the switch directory prepared:
   > EOF
 
   $ build_pkg test
-  ../target
-  ../target/bin
-  ../target/doc
-  ../target/doc/test
-  ../target/etc
-  ../target/etc/test
-  ../target/lib
-  ../target/lib/stublibs
-  ../target/lib/test
-  ../target/lib/toplevel
-  ../target/man
-  ../target/sbin
-  ../target/share
-  ../target/share/test
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/doc
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/doc/test
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/etc
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/etc/test
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/lib
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/lib/stublibs
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/lib/test
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/lib/toplevel
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/man
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/sbin
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/share
+  $TESTCASE_ROOT/_build/_private/default/.pkg/test/target/share/test

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -14,11 +14,8 @@ This should give us a proper error that myfile wasn't generated
 
   $ lockfile "myfile"
   $ build_pkg test 2>&1 | sed 's#_build.*_private#$ROOT/_private#'
-  Error: entry
-  $ROOT/_private/default/.pkg/test/source/myfile
-  in
-  $ROOT/_private/default/.pkg/test/source/test.install
-  does not exist
+  Error: entry $ROOT/_private/default/.pkg/test/source/myfile in
+  $ROOT/_private/default/.pkg/test/source/test.install does not exist
   -> required by $ROOT/_private/default/.pkg/test/target/cookie
 
 This on the other hand shouldn't error because myfile is optional

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -51,14 +51,14 @@ opam-var-unsupported.t
   $ build_pkg testpkg
   dune
   .
-  ../target
-  ../target/lib
-  ../target/lib
-  ../target/bin
-  ../target/sbin
-  ../target/share
-  ../target/doc
-  ../target/etc
-  ../target/man
-  ../target/lib/toplevel
-  ../target/lib/stublibs
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/lib
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/lib
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/sbin
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/share
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/doc
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/etc
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/man
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/lib/toplevel
+  $TESTCASE_ROOT/_build/_private/default/.pkg/testpkg/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -29,5 +29,4 @@ Applying patches
 Demonstrate that the original source shouldn't be modified:
 
   $ cat _build/_private/default/.pkg/test/source/foo.ml
-  cat: _build/_private/default/.pkg/test/source/foo.ml: No such file or directory
-  [1]
+  Hello World

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -14,6 +14,7 @@ Test that we run the build command
 
   $ show_pkg test
   
+  /source
   /target
   /target/bin
   /target/bin/foo

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -23,7 +23,7 @@ This should take the `foo.ml.in`, do the substitutions and create `foo.ml`:
 Demonstrate that the original sources aren't modified:
 
   $ src=_build/_private/default/.pkg/test/source/foo.ml; [ -e $src ] && cat $src
-  [1]
+  This file will be fed to the substitution mechanism
 
 This should also work with any other filename combination:
 


### PR DESCRIPTION
Absolutize the %{prefix} and package section paths for now.

This requires us to disable sandboxing, because the absolute paths
always point outside the sandbox.

This also makes the dune cache kind of useless for packages, but this
isn't an issue as it doesn't work anyway.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 78bf7be5-ac66-485a-91c7-fbec8cb147a0 -->