### PR TITLE
feature(cram): allow overriding default alias

### DIFF
--- a/doc/changes/8887.md
+++ b/doc/changes/8887.md
@@ -1,0 +1,2 @@
+- Introduce the `runtest_alias` field to the `cram` stanza. This allows
+  removing default `runtest` alias from tests. (@rgrinberg, #8887)

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -674,6 +674,9 @@ The ``cram`` stanza accepts the following fields:
 - ``deps`` - dependencies of the test
 - ``(package <package-name>)`` - attach the tests selected by this stanza to the
   specified package
+- ``(runtest_alias <true|false>)`` - when set to ``false``, do not add the
+  tests to the ``runtest`` alias. The default is to add every cram test to
+  ``runtest``, but this is not always desired.
 
 A single test may be configured by more than one ``cram`` stanza. In such cases,
 the values from all applicable ``cram`` stanzas are merged together to get the

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -28,6 +28,7 @@ type t =
   ; enabled_if : Blang.t
   ; locks : Locks.t
   ; package : Package.t option
+  ; runtest_alias : (Loc.t * bool) option
   }
 
 type Stanza.t += T of t
@@ -42,6 +43,10 @@ let decode =
      and+ locks = Locks.field ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 9)) ()
      and+ package =
        Stanza_common.Pkg.field_opt ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8)) ()
+     and+ runtest_alias =
+       field_o
+         "runtest_alias"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 11) >>> located bool)
      in
-     { loc; alias; deps; enabled_if; locks; applies_to; package })
+     { loc; alias; deps; enabled_if; locks; applies_to; package; runtest_alias })
 ;;

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -12,6 +12,7 @@ type t =
   ; enabled_if : Blang.t
   ; locks : Locks.t
   ; package : Package.t option
+  ; runtest_alias : (Loc.t * bool) option
   }
 
 type Stanza.t += T of t

--- a/test/blackbox-tests/test-cases/cram/runtest_alias.t
+++ b/test/blackbox-tests/test-cases/cram/runtest_alias.t
@@ -1,0 +1,44 @@
+Control the default runtest alias for cram tests
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (cram
+  >  (runtest_alias false)
+  >  (alias this))
+  > EOF
+
+  $ cat >foo.t <<EOF
+  >   $ echo foo
+  > EOF
+
+This shouldn't run the test
+
+  $ dune runtest
+
+This should run the test
+
+  $ dune build @this
+  File "foo.t", line 1, characters 0-0:
+  Error: Files _build/default/foo.t and _build/default/foo.t.corrected differ.
+  [1]
+
+Now we try setting runtest alias default twice. This should be impossible:
+
+  $ cat >dune <<EOF
+  > (cram (runtest_alias false))
+  > (cram (runtest_alias true))
+  > EOF
+
+  $ dune build @a
+  File "dune", line 2, characters 21-25:
+  2 | (cram (runtest_alias true))
+                           ^^^^
+  Error: enabling or disabling the runtest alias for a cram test may only be
+  set once.
+  It's already set for the test "foo"
+  The first definition is at:
+  dune:1
+  [1]


### PR DESCRIPTION
Introduce a [(default_aliases ..)] that allows to set the default alias
for a cram test.

Unlike, the existing [alias] field, we're only allowed to set the
default once. If the default isn't set, it's just [runtest].

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 23568b34-517f-464d-93e2-ac2c0f05f885 -->