### PR TITLE
feature(pkg): add implicit constraint on dune

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -15,10 +15,15 @@ module Context_for_dune = struct
     ; version_preference : Version_preference.t
     ; local_packages : OpamFile.OPAM.t OpamPackage.Name.Map.t
     ; solver_env : Solver_env.t
+    ; dune_version : OpamPackage.Version.t
     }
 
   let create ~solver_env ~repos ~local_packages ~version_preference =
-    { repos; version_preference; local_packages; solver_env }
+    let dune_version =
+      let major, minor = Dune_lang.Stanza.latest_version in
+      OpamPackage.Version.of_string @@ sprintf "%d.%d" major minor
+    in
+    { repos; version_preference; local_packages; solver_env; dune_version }
   ;;
 
   type rejection = Unavailable
@@ -122,7 +127,12 @@ module Context_for_dune = struct
            OpamFile.OPAM.version opam_file, opam_file_result))
   ;;
 
-  let user_restrictions _ _ = None
+  let user_restrictions : t -> OpamPackage.Name.t -> OpamFormula.version_constraint option
+    =
+    let dune = OpamPackage.Name.of_string "dune" in
+    fun t pkg ->
+      if OpamPackage.Name.equal dune pkg then Some (`Eq, t.dune_version) else None
+  ;;
 
   let map_filters ~(f : filter -> filter) : filtered_formula -> filtered_formula =
     OpamFilter.gen_filter_formula

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -845,12 +845,13 @@ module DB = struct
   let get context =
     let+ all = Lock_dir.get context in
     let system_provided =
-      if Env.mem Env.initial ~var:"DUNE_PKG_OVERRIDE_OCAML"
-      then (
-        match all.ocaml with
-        | None -> Package.Name.Set.singleton ocaml_package_name
-        | Some (_, name) -> Package.Name.Set.singleton name)
-      else Package.Name.Set.empty
+      let base = Package.Name.Set.singleton (Package.Name.of_string "dune") in
+      match Env.mem Env.initial ~var:"DUNE_PKG_OVERRIDE_OCAML" with
+      | false -> base
+      | true ->
+        (match all.ocaml with
+         | None -> Package.Name.Set.add base ocaml_package_name
+         | Some (_, name) -> Package.Name.Set.singleton name)
     in
     { all = all.packages; system_provided }
   ;;

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -1,0 +1,31 @@
+By default, we introduce a constraint on in the build plan that will require
+the dune version to match the version of dune being used to generate the
+constraint.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg dune 3.11.0 <<EOF
+  > EOF
+
+  $ test() {
+  > mkpkg foo <<EOF
+  > depends: [ "dune" {<= "$1"} ]
+  > EOF
+  > solve foo
+  > }
+
+  $ test "2.0.0"
+  Error: Unable to solve dependencies in build context: default
+  Can't find all required versions.
+  Selected: foo.0.0.1 x.dev
+  - dune -> (problem)
+      User requested = 3.11
+      Rejected candidates:
+        dune.3.11.0: Incompatible with restriction: = 3.11
+  [1]
+  $ test "4.0.0"
+  Solution for dune.lock:
+  dune.3.11.0
+  foo.0.0.1
+  


### PR DESCRIPTION
This constraint is almost always what the user wants if they are
planning to use the same dune that generated the build plan to build it.

There will be a need to override this, but for now it's hard coded.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0d650828-dc2f-444a-b89a-993cb1fb5e90 -->