### PR TITLE
fix: ignore [bigarray] correctly

### DIFF
--- a/doc/changes/8902.md
+++ b/doc/changes/8902.md
@@ -1,0 +1,2 @@
+- Do not ignore libraries named `bigarray` when they are defined in conjunction
+  with OCaml 5.0 (#8902, fixes #8901, @rgrinberg)


### PR DESCRIPTION
The way it was ignored previously, it would completely ignore locally
named libraries named bigarray.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 781df074-c1dd-4beb-82bd-71b1f25d53ff -->