### PR TITLE
fix: add fake opam switch to opam-var tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/dune
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/dune
@@ -4,12 +4,19 @@
 
 (data_only_dirs fake_opam_root)
 
+; Without this, no copying rules will be setup for the .opam-switch directory
+
+(subdir
+ fake_opam_root/default
+ (dirs :standard .opam-switch))
+
 ; We trick opam into thinking it has a config file with fake_opam_root so that we can
 ; access the os variables without having to do opam init
 
 (rule
  (target opam-vars)
- (deps fake_opam_root/config)
+ (deps
+  (source_tree fake_opam_root))
  (action
   (with-stdout-to
    %{target}

--- a/test/blackbox-tests/test-cases/pkg/opam-var/fake_opam_root/config
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/fake_opam_root/config
@@ -1,1 +1,3 @@
 opam-version: "2.0"
+switch: "default"
+installed-switches: ["default"]

--- a/test/blackbox-tests/test-cases/pkg/opam-var/fake_opam_root/default/.opam-switch/switch-config
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/fake_opam_root/default/.opam-switch/switch-config
@@ -1,0 +1,1 @@
+opam-version: "2.0"


### PR DESCRIPTION
Prior to this change the tests in pkg/opam-var would fail on older versions of opam with the error:
```
[ERROR] No switch is currently set. Please use 'opam switch' to set or
install a switch
```

This change adds an opam switch to the fake opam root used by these tests.