### PR TITLE
test: improving copying sandbox

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -9,14 +9,14 @@ mode:
   $ cat >dune <<EOF
   > (rule
   >  (targets (dir output))
-  >  (action (bash "mkdir -p output/; echo x > output/x; echo y > output/y")))
+  >  (action (system "\| mkdir -p output/;
+  >                  "\| echo x > output/x;
+  >                  "\| echo y > output/y
+  >          )))
   > (rule
   >  (target foo)
   >  (deps (sandbox always) output/)
-  >  (action
-  >   (progn
-  >    (bash "ls output | sort")
-  >    (run touch foo))))
+  >  (action (system "ls output | sort; touch foo")))
   > EOF
 
   $ dune build foo --sandbox=copy


### PR DESCRIPTION
* use multiline strings
* remove unnnecessary proccess
* do not use bash

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c7fb0cfa-e7f7-48cb-8d25-676191d3134d -->