### PR TITLE
fix: remove code error in copying sandbox

### DIFF
--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -52,9 +52,15 @@ let rec copy_recursively (src_kind : Unix.file_kind) ~src ~dst =
        List.iter contents ~f:(fun (name, kind) ->
          copy_recursively kind ~src:(Path.relative src name) ~dst:(Path.relative dst name)))
   | _ ->
-    Code_error.raise
-      "Can not copy file of this kind"
-      [ "src_kind", File_kind.to_dyn src_kind; "src", Path.to_dyn src ]
+    User_error.raise
+      ~hints:
+        [ Pp.text "re-run dune to delete the stale artifact, or manually delete this file"
+        ]
+      [ Pp.textf
+          "Failed to copy file %s of kind %s while creating a copy sandbox"
+          (Path.to_string_maybe_quoted src)
+          (File_kind.to_string_hum src_kind)
+      ]
 ;;
 
 let create_dirs t ~deps ~rule_dir =


### PR DESCRIPTION
When there's a type of file we can't copy, do not raise a code error.
This situation is possible if the user sneaks in a socket file in the
build directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d9abb9e6-b15a-40bd-9eb1-a704a9002794 -->