### PR TITLE
test: easier to read permissions from dune_cmd

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -8,16 +8,7 @@ mode:
 
   $ cat >print-permissions.sh <<EOF
   > /usr/bin/env sh
-  > echo permissions of output/
-  > dune_cmd stat permissions output
-  > echo permissions of output/y
-  > dune_cmd stat permissions output/y
-  > echo permissions of output/x
-  > dune_cmd stat permissions output/x
-  > echo permissions of output/subdir
-  > dune_cmd stat permissions output/subdir
-  > echo permissions of output/subdir/z
-  > dune_cmd stat permissions output/subdir/z
+  > dune_cmd ls -d output output/y output/x output/subdir output/subdir/z
   > echo ""
   > EOF
 
@@ -46,38 +37,23 @@ mode:
 
   $ dune build foo --sandbox=copy
   building output/
-  permissions of output/
-  777
-  permissions of output/y
-  444
-  permissions of output/x
-  644
-  permissions of output/subdir
-  776
-  permissions of output/subdir/z
-  666
+  drwxrwxrwx output
+  -r--r--r-- output/y
+  -rw-r--r-- output/x
+  drwxrwxrw- output/subdir
+  -rw-rw-rw- output/subdir/z
   
-  permissions of output/
-  755
-  permissions of output/y
-  444
-  permissions of output/x
-  444
-  permissions of output/subdir
-  755
-  permissions of output/subdir/z
-  444
+  drwxr-xr-x output
+  -r--r--r-- output/y
+  -r--r--r-- output/x
+  drwxr-xr-x output/subdir
+  -r--r--r-- output/subdir/z
   
 
   $ ( cd _build/default && ../../print-permissions.sh )
-  permissions of output/
-  777
-  permissions of output/y
-  444
-  permissions of output/x
-  444
-  permissions of output/subdir
-  776
-  permissions of output/subdir/z
-  444
+  drwxrwxrwx output
+  -r--r--r-- output/y
+  -r--r--r-- output/x
+  drwxrwxrw- output/subdir
+  -r--r--r-- output/subdir/z
   

--- a/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
+++ b/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
@@ -13,9 +13,9 @@ Write permissions on directory targets.
 
   $ dune build ./foo
   $ dir=_build/default/foo
-  $ dune_cmd stat permissions $dir
-  755
-  $ dune_cmd stat permissions $dir/foo2
-  755
-  $ dune_cmd stat permissions $dir/foo2/bar
-  444
+  $ dune_cmd ls -d $dir
+  drwxr-xr-x _build/default/foo
+  $ dune_cmd ls -d $dir/foo2
+  drwxr-xr-x _build/default/foo/foo2
+  $ dune_cmd ls -d $dir/foo2/bar
+  -r--r--r-- _build/default/foo/foo2/bar

--- a/test/blackbox-tests/test-cases/write-permissions.t
+++ b/test/blackbox-tests/test-cases/write-permissions.t
@@ -16,8 +16,8 @@ Check that dune <= 2.3 leaves write permissions alone.
   $ dune build --root 2.3 target | head -c1
   Entering directory '2.3'
   Leaving directory '2.3'
-  $ dune_cmd stat permissions 2.3/_build/default/target | head -c1
-  6
+  $ dune_cmd ls 2.3/_build/default/target 
+  -rw-r--r-- 2.3/_build/default/target
 
 Check that dune >= 2.4 removes target write permissions.
 
@@ -49,15 +49,15 @@ Check that dune >= 2.4 removes target write permissions.
   $ dune build --root 2.4 foo.exe @install
   Entering directory '2.4'
   Leaving directory '2.4'
-  $ dune_cmd stat permissions 2.4/_build/default/foo.exe | head -c1
-  5
+  $ dune_cmd ls 2.4/_build/default/foo.exe 
+  -r-xr-xr-x 2.4/_build/default/foo.exe
   $ dune install --root 2.4 --prefix ./ --display short
   Installing lib/foo/META
   Installing lib/foo/dune-package
   Installing bin/foo
   Installing bin/foo.exe
   Installing share/foo/target
-  $ dune_cmd stat permissions 2.4/bin/foo.exe | head -c1
-  7
-  $ dune_cmd stat permissions 2.4/share/foo/target | head -c1
-  6
+  $ dune_cmd ls 2.4/bin/foo.exe 
+  -rwxr-xr-x 2.4/bin/foo.exe
+  $ dune_cmd ls 2.4/share/foo/target 
+  -rw-r--r-- 2.4/share/foo/target


### PR DESCRIPTION
This adds a `dune_cmd ls` command that prints output like this:
```
-rw-r--r-- README.md
drwxr-xr-x _boot
drwxr-xr-x _build
```

This is more portable than using `ls` which can have some subtle differences in implementation across platforms. It also allows us to inspect the permissions of files in a more readable way.

@rgrinberg This might be useful for #8908 