### PR TITLE
Refactor Common.init

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -143,9 +143,9 @@ let runtest_info =
 
 let runtest_term =
   let name_ = Arg.info [] ~docv:"DIR" in
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ dirs = Arg.(value & pos_all string [ "." ] name_) in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let request (setup : Import.Main.build_system) =
     Action_builder.all_unit
       (List.map dirs ~f:(fun dir ->
@@ -180,14 +180,14 @@ let build =
   in
   let name_ = Arg.info [] ~docv:"TARGET" in
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ targets = Arg.(value & pos_all dep [] name_) in
     let targets =
       match targets with
-      | [] -> [ Common.default_target common ]
+      | [] -> [ Common.Builder.default_target builder ]
       | _ :: _ -> targets
     in
-    let config = Common.init common in
+    let common, config = Common.init builder in
     let request setup =
       Target.interpret_targets (Common.root common) config setup targets
     in
@@ -209,7 +209,7 @@ let fmt =
     ]
   in
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ no_promote =
       Arg.(
         value
@@ -221,10 +221,10 @@ let fmt =
                This takes precedence over auto-promote as that flag is assumed for this \
                command.")
     in
-    let common =
-      Common.set_promote common (if no_promote then Never else Automatically)
+    let builder =
+      Common.Builder.set_promote builder (if no_promote then Never else Automatically)
     in
-    let config = Common.init common in
+    let common, config = Common.init builder in
     let request (setup : Import.Main.build_system) =
       let dir = Path.(relative root) (Common.prefix_target common ".") in
       Alias.in_dir ~name:Dune_rules.Alias.fmt ~recursive:true ~contexts:setup.contexts dir

--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -9,13 +9,13 @@ let command =
     ]
   in
   let term =
-    let+ common = Common.term in
-    (* Pass [No_log_file] to prevent the log file from being created. Indeed, we
-       are going to delete the whole build directory right after and that
-       includes deleting the log file. Not only creating the log file would be
-       useless but with some FS this also causes [dune clean] to fail (cf
+    let+ builder = Common.Builder.term in
+    (* Disable log file creation. Indeed, we are going to delete the whole build directory
+       right after and that includes deleting the log file. Not only would creating the
+       log file be useless but with some FS this also causes [dune clean] to fail (cf
        https://github.com/ocaml/dune/issues/2964). *)
-    let _config = Common.init common ~log_file:No_log_file in
+    let builder = Common.Builder.disable_log_file builder in
+    let _common, _config = Common.init builder in
     Dune_util.Global_lock.lock_exn ~timeout:None;
     Dune_engine.Target_promotion.files_in_source_tree_to_delete ()
     |> Path.Source.Set.iter ~f:(fun p -> Path.unlink_no_err (Path.source p));

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -14,7 +14,6 @@ val rpc
      | `Forbid_builds (** Promise not to build anything. For now, this isn't checked *)
      ]
 
-val forbid_builds : t -> t
 val signal_watcher : t -> [ `Yes | `No ]
 val watch_exclusions : t -> string list
 val stats : t -> Dune_stats.t option
@@ -24,23 +23,41 @@ val dump_memo_graph_format : t -> Dune_graph.Graph.File_format.t
 val dump_memo_graph_with_timing : t -> bool
 val watch : t -> Dune_rpc_impl.Watch_mode_config.t
 val file_watcher : t -> Dune_engine.Scheduler.Run.file_watcher
-val default_target : t -> Arg.Dep.t
 val prefix_target : t -> string -> string
 val insignificant_changes : t -> [ `React | `Ignore ]
 
-(** [init] executes sequence of side-effecting actions to initialize Dune's
-    working environment based on the options determined in a [Common.t]
-    record.contents.
+module Action_runner : sig
+  type t =
+    | No
+    | Yes of
+        (Dune_lang.Dep_conf.t Dune_rpc_impl.Server.t
+         -> (Dune_engine.Action_exec.input -> Dune_engine.Action_runner.t option) Staged.t)
+end
 
-    Return the final configuration, which is the same as the one returned in the
-    [config] field of [Dune_rules.Workspace.workspace ()]) *)
-val init
-  :  ?action_runner:
-       (Dune_lang.Dep_conf.t Dune_rpc_impl.Server.t
-        -> (Dune_engine.Action_exec.input -> Dune_engine.Action_runner.t option) Staged.t)
-  -> ?log_file:Dune_util.Log.File.t
-  -> t
-  -> Dune_config.t
+(** [Builder] describes how to initialize Dune. *)
+module Builder : sig
+  type t
+
+  val set_root : t -> string -> t
+  val forbid_builds : t -> t
+  val set_default_root_is_cwd : t -> bool -> t
+  val set_action_runner : t -> Action_runner.t -> t
+  val set_log_file : t -> Dune_util.Log.File.t -> t
+  val disable_log_file : t -> t
+  val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
+  val default_target : t -> Arg.Dep.t
+  val term : t Cmdliner.Term.t
+end
+
+val build : Builder.t -> t
+
+(** [init] creates a [Common.t] by executing a sequence of side-effecting actions to
+    initialize Dune's working environment based on the options determined in the\
+    [Builder.t].
+
+    Return the [Common.t] and the final configuration, which is the same as the one
+    returned in the [config] field of [Dune_rules.Workspace.workspace ()]) *)
+val init : Builder.t -> t * Dune_config_file.Dune_config.t
 
 (** [examples [("description", "dune cmd foo"); ...]] is an [EXAMPLES] manpage
     section of enumerated examples illustrating how to run the documented
@@ -54,10 +71,7 @@ val command_synopsis : string list -> Cmdliner.Manpage.block list
 
 val help_secs : Cmdliner.Manpage.block list
 val footer : Cmdliner.Manpage.block
-val term : t Cmdliner.Term.t
-val term_with_default_root_is_cwd : t Cmdliner.Term.t
 val envs : Cmdliner.Cmd.Env.info list
-val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
 val debug_backtraces : bool Cmdliner.Term.t
 val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 val display_term : Dune_config.Display.t option Cmdliner.Term.t
@@ -73,12 +87,3 @@ module Let_syntax : sig
   val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
   val ( and+ ) : 'a Cmdliner.Term.t -> 'b Cmdliner.Term.t -> ('a * 'b) Cmdliner.Term.t
 end
-
-module Builder : sig
-  type t
-
-  val set_root : t -> string -> t
-  val term : t Cmdliner.Term.t
-end
-
-val build : Builder.t -> t

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -18,7 +18,7 @@ let man =
 let info = Cmd.info "top" ~doc ~man
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ context =
     let doc = "Run the Coq toplevel in this build context." in
     Common.context_arg ~doc
@@ -34,7 +34,7 @@ let term =
       & flag
       & info [ "no-build" ] ~doc:"Don't rebuild dependencies before executing.")
   in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let coq_file_arg = Common.prefix_target common coq_file_arg |> Path.Local.of_string in
   let coqtop, argv, env =
     Scheduler.go ~common ~config

--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -1,12 +1,12 @@
 open Import
 
 let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ paths = Arg.(value & pos_all string [ "." ] & info [] ~docv:"DIR")
   and+ context =
     Common.context_arg ~doc:"The context to look in. Defaults to the default context."
   in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let request (_ : Dune_rules.Main.build_system) =
     let header = List.length paths > 1 in
     let open Action_builder.O in

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -204,11 +204,11 @@ let to_dyn context_name external_resolved_libs =
 ;;
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ _ = Describe_lang_compat.arg
   and+ format = Describe_format.arg in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config
   @@ fun () ->
   let open Fiber.O in

--- a/bin/describe/describe_opam_files.ml
+++ b/bin/describe/describe_opam_files.ml
@@ -1,10 +1,10 @@
 open Import
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ format = Describe_format.arg
   and+ _ = Describe_lang_compat.arg in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config
   @@ fun () ->
   Build_system.run_exn

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -84,11 +84,11 @@ let get_pped_file super_context file =
 ;;
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ _ = Describe_lang_compat.arg
   and+ file = Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"FILE")) in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config
   @@ fun () ->
   let open Fiber.O in

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -583,7 +583,7 @@ let find_dir common dir =
 ;;
 
 let term : unit Term.t =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ what =
     Arg.(
       value
@@ -598,7 +598,7 @@ let term : unit Term.t =
   and+ format = Describe_format.arg
   and+ lang = Lang.arg
   and+ options = Options.arg in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let dirs =
     let args = "workspace" :: what in
     let parse =

--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -1,10 +1,10 @@
 open Import
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ format = Describe_format.arg in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config
   @@ fun () ->
   let open Fiber.O in

--- a/bin/diagnostics.ml
+++ b/bin/diagnostics.ml
@@ -31,8 +31,8 @@ let info =
 ;;
 
 let term =
-  let+ (common : Common.t) = Common.term in
-  Rpc_common.client_term common exec
+  let+ (builder : Common.Builder.t) = Common.Builder.term in
+  Rpc_common.client_term builder exec
 ;;
 
 let command = Cmd.v info term

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -315,7 +315,7 @@ module Exec_context = struct
 end
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ context = Common.context_arg ~doc:{|Run the command in this build context.|}
   and+ prog = Arg.(required & pos 0 (some Cmd_arg.conv) None (Arg.info [] ~docv:"PROG"))
   and+ no_rebuild =
@@ -324,7 +324,7 @@ let term =
   (* TODO we should make sure to finalize the current backend before exiting dune.
      For watch mode, we should finalize the backend and then restart it in between
      runs. *)
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let exec_context = Exec_context.init ~common ~context ~no_rebuild ~prog ~args in
   let f =
     match Common.watch common with

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -17,7 +17,7 @@ let info = Cmd.info "external-lib-deps" ~doc ~man
 
 let term =
   Term.ret
-  @@ let+ _ = Common.term
+  @@ let+ _ = Common.Builder.term
      and+ _ = Arg.(value & flag & info [ "missing" ] ~doc:{|unused|})
      and+ _ = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET")
      and+ _ = Arg.(value & flag & info [ "unstable-by-dir" ] ~doc:{|unused|})

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -70,10 +70,11 @@ let path =
 ;;
 
 let context_cwd : Init_context.t Term.t =
-  let+ common_term = Common.term_with_default_root_is_cwd
+  let+ builder = Common.Builder.term
   and+ path = path in
-  let config = Common.init common_term in
-  Scheduler.go ~common:common_term ~config (fun () -> Memo.run (Init_context.make path))
+  let builder = Common.Builder.set_default_root_is_cwd builder true in
+  let common, config = Common.init builder in
+  Scheduler.go ~common ~config (fun () -> Memo.run (Init_context.make path))
 ;;
 
 module Public_name = struct
@@ -220,9 +221,8 @@ let project =
          | None -> name
          | Some path -> Filename.concat path name
        in
-       let common = Builder.set_root common_builder root |> Common.build in
+       let common, config = Builder.set_root common_builder root |> Common.init in
        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p root in
-       let config = Common.init common in
        Scheduler.go ~common ~config (fun () -> Memo.run init_context)
      in
      Component.init

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -221,8 +221,9 @@ let project =
          | None -> name
          | Some path -> Filename.concat path name
        in
-       let common, config = Builder.set_root common_builder root |> Common.init in
+       let builder = Builder.set_root common_builder root in
        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p root in
+       let common, config = Common.init builder in
        Scheduler.go ~common ~config (fun () -> Memo.run init_context)
      in
      Component.init

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -462,7 +462,7 @@ let install_uninstall ~what =
       , Arg.conv_printer Arg.string )
   in
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ prefix_from_command_line =
       Arg.(
         value
@@ -574,8 +574,9 @@ let install_uninstall ~what =
               "Select context to install from. By default, install files from all \
                defined contexts.")
     and+ sections = Sections.term in
-    let common = Common.forbid_builds common in
-    let config = Common.init ~log_file:No_log_file common in
+    let builder = Common.Builder.forbid_builds builder in
+    let builder = Common.Builder.disable_log_file builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* workspace = Workspace.get () in

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -4,7 +4,7 @@ let doc = "Print out libraries installed on the system."
 let info = Cmd.info "installed-libraries" ~doc
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ na =
     Arg.(
       value
@@ -13,7 +13,7 @@ let term =
           [ "na"; "not-available" ]
           ~doc:"List libraries that are not available and explain why")
   in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go
     ~common
     ~config

--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -14,9 +14,9 @@ let man =
 let info = Cmd.info "dump" ~doc ~man
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ file = Arg.(required & pos 0 (some Arg.path) None & Arg.info [] ~docv:"FILE") in
-  let _config = Common.init common in
+  let _common, _config = Common.init builder in
   let (Persistent.T ((module D), data)) = Persistent.load_exn (Arg.Path.path file) in
   Console.print [ Dyn.pp (D.to_dyn data) ]
 ;;

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -265,7 +265,7 @@ let command =
     Cmd.info "monitor" ~doc ~man
   and term =
     let open Import in
-    let+ (common : Common.t) = Common.term
+    let+ builder = Common.Builder.term
     and+ quit_on_disconnect =
       Arg.(
         value
@@ -274,8 +274,9 @@ let command =
             [ "quit-on-disconnect" ]
             ~doc:"Quit if the connection to the server is lost.")
     in
-    let common = Common.forbid_builds common in
-    let config = Common.init ~log_file:No_log_file common in
+    let builder = Common.Builder.forbid_builds builder in
+    let builder = Common.Builder.disable_log_file builder in
+    let common, config = Common.init builder in
     let stats = Common.stats common in
     let config =
       Dune_config.for_scheduler

--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -193,10 +193,11 @@ module Dump_config = struct
   ;;
 
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH") in
-    let common = Common.forbid_builds common in
-    let config = Common.init ~log_file:No_log_file common in
+    let builder = Common.Builder.forbid_builds builder in
+    let builder = Common.Builder.disable_log_file builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () -> Server.dump dir)
   ;;
 
@@ -219,9 +220,10 @@ let man =
 let start_session_info name = Cmd.info name ~doc ~man
 
 let start_session_term =
-  let+ common = Common.term in
-  let common = Common.forbid_builds common in
-  let config = Common.init common ~log_file:No_log_file in
+  let+ builder = Common.Builder.term in
+  let builder = Common.Builder.forbid_builds builder in
+  let builder = Common.Builder.disable_log_file builder in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config Server.start
 ;;
 
@@ -245,7 +247,7 @@ module Dump_dot_merlin = struct
   let info = Cmd.info "dump-dot-merlin" ~doc ~man
 
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ path =
       Arg.(
         value
@@ -257,8 +259,9 @@ module Dump_dot_merlin = struct
               "The path to the folder of which the configuration should be printed. \
                Defaults to the current directory.")
     in
-    let common = Common.forbid_builds common in
-    let config = Common.init common ~log_file:No_log_file in
+    let builder = Common.Builder.forbid_builds builder in
+    let builder = Common.Builder.disable_log_file builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () ->
       match path with
       | Some s -> Server.dump_dot_merlin s

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -34,10 +34,10 @@ let files_to_load_of_requires sctx requires =
 ;;
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
   and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in
@@ -187,11 +187,11 @@ module Module = struct
   ;;
 
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ module_path =
       Arg.(required & pos 0 (some string) None & Arg.info [] ~docv:"MODULE")
     and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
-    let config = Common.init common in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -13,11 +13,11 @@ let man =
 let info = Cmd.info "utop" ~doc ~man
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
   and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|}
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let dir = Common.prefix_target common dir in
   if not (Path.is_directory (Path.of_string dir))
   then User_error.raise [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];

--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -206,7 +206,7 @@ module Print_solver_env = struct
   ;;
 
   let term =
-    let+ (common : Common.t) = Common.term
+    let+ builder = Common.Builder.term
     and+ context_name =
       context_term
         ~doc:
@@ -232,8 +232,8 @@ module Print_solver_env = struct
                a filter `{os = \"linux\"}` and the variable \"os\" is unset, the \
                dependency will be excluded. ")
     in
-    let common = Common.forbid_builds common in
-    let config = Common.init common in
+    let builder = Common.Builder.forbid_builds builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () ->
       print_solver_env
         ~context_name
@@ -472,7 +472,7 @@ module Lock = struct
   ;;
 
   let term =
-    let+ (common : Common.t) = Common.term
+    let+ builder = Common.Builder.term
     and+ opam_repository_path = Opam_repository_path.term
     and+ opam_repository_url = Opam_repository_url.term
     and+ context_name =
@@ -511,8 +511,8 @@ module Lock = struct
                changes to it in the future. Without this flag all conditional commands \
                and terms in Opam files are included unconditionally.")
     in
-    let common = Common.forbid_builds common in
-    let config = Common.init common in
+    let builder = Common.Builder.forbid_builds builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config (fun () ->
       lock
         ~context_name
@@ -606,7 +606,7 @@ module Outdated = struct
   ;;
 
   let term =
-    let+ (common : Common.t) = Common.term
+    let+ builder = Common.Builder.term
     and+ context_name_arg =
       context_term ~doc:"Check for outdated packages in this context"
     and+ all_contexts_arg =
@@ -624,8 +624,8 @@ module Outdated = struct
             [ "transitive" ]
             ~doc:"Check for outdated packages in transitive dependencies")
     in
-    let common = Common.forbid_builds common in
-    let config = Common.init common in
+    let builder = Common.Builder.forbid_builds builder in
+    let common, config = Common.init builder in
     Scheduler.go ~common ~config
     @@ find_outdated_packages
          ~context_name_arg

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -162,7 +162,7 @@ module Syntax = struct
 end
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ out =
     Arg.(
       value
@@ -179,7 +179,7 @@ let term =
              targets.")
   and+ syntax = Syntax.term
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go ~common ~config (fun () ->
     let open Fiber.O in

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -27,7 +27,7 @@ let pp ppf ~fields sexps =
 ;;
 
 let term =
-  let+ common = Common.term
+  let+ builder = Common.Builder.term
   and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH")
   and+ fields =
     Arg.(
@@ -40,7 +40,7 @@ let term =
             "Only print this field. This option can be repeated multiple times to print \
              multiple fields.")
   in
-  let config = Common.init common in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -35,9 +35,9 @@ module Apply = struct
   ;;
 
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
-    let _config = Common.init common in
+    let common, _config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
     Diff_promotion.promote_files_registered_in_last_run files_to_promote
   ;;
@@ -49,9 +49,9 @@ module Diff = struct
   let info = Cmd.info ~doc:"List promotions to be applied" "diff"
 
   let term =
-    let+ common = Common.term
+    let+ builder = Common.Builder.term
     and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
-    let config = Common.init common in
+    let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
     Scheduler.go ~common ~config (fun () -> Diff_promotion.display files_to_promote)
   ;;

--- a/bin/rpc/build.ml
+++ b/bin/rpc/build.ml
@@ -48,10 +48,10 @@ let establish_client_session ~wait =
 
 let term =
   let name_ = Arg.info [] ~docv:"TARGET" in
-  let+ (common : Common.t) = Common.term
+  let+ (builder : Common.Builder.t) = Common.Builder.term
   and+ wait = Rpc_common.wait_term
   and+ targets = Arg.(value & pos_all string [] name_) in
-  Rpc_common.client_term common
+  Rpc_common.client_term builder
   @@ fun _common ->
   let open Fiber.O in
   let* conn = establish_client_session ~wait in

--- a/bin/rpc/ping.ml
+++ b/bin/rpc/ping.ml
@@ -26,8 +26,8 @@ let info =
 ;;
 
 let term =
-  let+ (common : Common.t) = Common.term in
-  Rpc_common.client_term common exec
+  let+ (builder : Common.Builder.t) = Common.Builder.term in
+  Rpc_common.client_term builder exec
 ;;
 
 let cmd = Cmd.v info term

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -29,9 +29,10 @@ let request_exn client witness n =
   | Ok decl -> Client.request client decl n
 ;;
 
-let client_term common f =
-  let common = Common.forbid_builds common in
-  let config = Common.init ~log_file:No_log_file common in
+let client_term builder f =
+  let builder = Common.Builder.forbid_builds builder in
+  let builder = Common.Builder.disable_log_file builder in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config f
 ;;
 

--- a/bin/rpc/rpc_common.mli
+++ b/bin/rpc/rpc_common.mli
@@ -13,7 +13,7 @@ val request_exn
   -> ('b, Dune_rpc_private.Response.Error.t) result Fiber.t
 
 (** Cmdliner term for a generic RPC client. *)
-val client_term : Common.t -> (unit -> 'a Fiber.t) -> 'a
+val client_term : Common.Builder.t -> (unit -> 'a Fiber.t) -> 'a
 
 (** Cmdliner argument for a wait flag. *)
 val wait_term : bool Cmdliner.Term.t

--- a/bin/rpc/status.ml
+++ b/bin/rpc/status.ml
@@ -91,7 +91,7 @@ let print_statuses statuses =
 ;;
 
 let term =
-  let+ (common : Common.t) = Common.term
+  let+ builder = Common.Builder.term
   and+ all =
     Arg.(
       value
@@ -102,7 +102,7 @@ let term =
             "Show all running Dune instances together with their root, pids and number \
              of clients.")
   in
-  Rpc_common.client_term common
+  Rpc_common.client_term builder
   @@ fun () ->
   let open Fiber.O in
   if all

--- a/bin/shutdown.ml
+++ b/bin/shutdown.ml
@@ -30,8 +30,8 @@ let info =
 ;;
 
 let term =
-  let+ (common : Common.t) = Common.term in
-  Rpc_common.client_term common exec
+  let+ builder = Common.Builder.term in
+  Rpc_common.client_term builder exec
 ;;
 
 let command = Cmd.v info term

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -14,8 +14,8 @@ let man =
 let info = Cmd.info "upgrade" ~doc ~man
 
 let term =
-  let+ common = Common.term in
-  let config = Common.init common in
+  let+ builder = Common.Builder.term in
+  let common, config = Common.init builder in
   Scheduler.go ~common ~config (fun () -> Dune_upgrader.upgrade ())
 ;;
 


### PR DESCRIPTION
Previously, we would obtain a [Common.t] from [Common.term] but it would be only partially initialised, until we called [Common.init] on it. This seemed unnecessarily unsafe and also made some upcoming changes to tracing harder than they should be.

This PR refactors things such that [Common.init] now takes a [Builder.t] (which was partially exposed but not really used externally before) and produces a [Common.t]. [Builder.t] encapsulates how Dune should be initialised and [Common.t] is the result of that initialisation. This seems cleaner.

This also allows us to move some config settings into [Builder.t] which were previously sprinkled through the code. The upcoming tracing settings will be able to go in the same spot.