### PR TITLE
fix: make copying sandbox files writeable

### DIFF
--- a/doc/changes/8920.md
+++ b/doc/changes/8920.md
@@ -1,0 +1,1 @@
+- Dependencies in the copying sandbox are now writeable (#8920, @rgrinberg)

--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -60,13 +60,13 @@ mode:
   permissions of output/
   755
   permissions of output/y
-  444
+  644
   permissions of output/x
-  444
+  644
   permissions of output/subdir
-  755
+  754
   permissions of output/subdir/z
-  444
+  644
   
 
   $ ( cd _build/default && ../../print-permissions.sh )

--- a/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
+++ b/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
@@ -16,7 +16,7 @@ A faulty test escapes the sandbox by creating its target outside the sandbox
   1 | (rule
   2 |  (target (dir foo))
   3 |  (action (system "mkdir $TESTCASE_ROOT/_build/default/foo && mkdir foo")))
-  Error: Target _build/default/foo of kind directory already exists in the
+  Error: Target _build/default/foo of kind "directory" already exists in the
   build directory
   Hint: delete this file manually or check the permissions of the parent
   directory of this file


### PR DESCRIPTION
Currently, the `copy` sandbox just uses whatever permissions are set in the workspace local cache.

With this PR, it will now make all files and directories writeable.