### PR TITLE
fix(pkg): delay expansion of paths

### DIFF
--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -24,8 +24,32 @@ end
 
 include T
 
+let to_list_map =
+  let rec loop arr i f acc =
+    if i < 0
+    then acc
+    else (
+      let acc = f (get arr i) :: acc in
+      loop arr (i - 1) f acc)
+  in
+  fun arr ~f -> loop arr (length arr - 1) f []
+;;
+
+let of_list_map l ~f =
+  let len = List.length l in
+  let l = ref l in
+  init len ~f:(fun _ ->
+    match !l with
+    | [] -> assert false
+    | x :: xs ->
+      l := xs;
+      f x)
+;;
+
 module Immutable = struct
   include T
 
   let of_array a = copy a
+  let to_list_map t ~f = to_list_map t ~f
+  let of_list_map t ~f = of_list_map t ~f
 end

--- a/otherlibs/stdune/src/array.mli
+++ b/otherlibs/stdune/src/array.mli
@@ -18,4 +18,6 @@ module Immutable : sig
   val fold_right : 'a t -> f:('a -> 'acc -> 'acc) -> init:'acc -> 'acc
   val exists : 'a t -> f:('a -> bool) -> bool
   val length : _ t -> int
+  val to_list_map : 'a t -> f:('a -> 'b) -> 'b list
+  val of_list_map : 'a list -> f:('a -> 'b) -> 'b t
 end

--- a/src/dune_rules/slang_expand.mli
+++ b/src/dune_rules/slang_expand.mli
@@ -6,17 +6,10 @@ type expander =
   -> dir:Path.t
   -> (Value.t list, [ `Undefined_pkg_var of Dune_pkg.Variable_name.t ]) result Memo.t
 
-(** Evaluate a [Slang.t] expression. Expressions in the unfollowed branches of
-    if-statements are not followed and boolean expressions are evaluated
-    lazily. Undefined package variables or invalid strings in the conditions of
-    if and when statements do not result in errors if they occur in unevaluated
-    portions of an expression. *)
-val eval : Slang.t -> dir:Path.t -> f:expander -> Value.t list Memo.t
-
 val eval_multi_located
   :  Slang.t list
   -> dir:Path.t
   -> f:expander
-  -> (Loc.t * Value.t) list Memo.t
+  -> (Loc.t * [ `Concat of Value.t list ]) list Memo.t
 
 val eval_blang : Slang.blang -> dir:Path.t -> f:expander -> bool Memo.t

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -47,17 +47,17 @@ opam-var-unsupported.t
     (run echo %{toplevel})
     (run echo %{stublibs})))
 
-  $ build_pkg testpkg
+  $ build_pkg testpkg 2>&1 | sed -E 's#.*.sandbox/[^/]+#.sandbox/$SANDBOX#g'
   dune
-  .
-  ../target
-  ../target/lib
-  ../target/lib
-  ../target/bin
-  ../target/sbin
-  ../target/share
-  ../target/doc
-  ../target/etc
-  ../target/man
-  ../target/lib/toplevel
-  ../target/lib/stublibs
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/source
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/bin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/sbin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/share
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/doc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/etc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/man
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/lib/toplevel
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg/target/lib/stublibs


### PR DESCRIPTION
Delay expansion of paths until action execution time

This is needed to delay the conversion of paths to absolute paths when executing the rules. In particular, to address the issue in #8861