### PR TITLE
fix(pkg): improve invalid substitute error

### DIFF
--- a/src/dune_rules/expander0.ml
+++ b/src/dune_rules/expander0.ml
@@ -11,3 +11,16 @@ let isn't_allowed_in_this_position ~(source : Dune_lang.Template.Pform.t) =
   in
   raise (User_error.E exn)
 ;;
+
+let as_in_build_dir ~what ~loc p =
+  match Path.as_in_build_dir p with
+  | Some p -> p
+  | None ->
+    User_error.raise
+      ~loc
+      [ Pp.textf
+          "%s %s is outside the build directory. This is not allowed."
+          what
+          (Path.to_string_maybe_quoted p)
+      ]
+;;

--- a/src/dune_rules/expander0.mli
+++ b/src/dune_rules/expander0.mli
@@ -1,1 +1,4 @@
+open Import
+
 val isn't_allowed_in_this_position : source:Dune_lang.Template.Pform.t -> 'a
+val as_in_build_dir : what:string -> loc:Loc.t -> Path.t -> Path.Build.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -716,9 +716,9 @@ module Action_expander = struct
       let+ input =
         Expander.expand_pform_gen ~mode:Single expander input >>| Value.to_path ~dir
       and+ output =
-        let+ output = Expander.expand_pform_gen ~mode:Single expander output in
-        Value.to_path ~dir output
-        |> (* TODO this needs proper error handling *) Path.as_in_build_dir_exn
+        Expander.expand_pform_gen ~mode:Single expander output
+        >>| Value.to_path ~dir
+        >>| Expander0.as_in_build_dir ~what:"subsitute" ~loc:(String_with_vars.loc output)
       in
       let env = substitute_env expander in
       Substitute.action ~env ~name:expander.paths.name ~input ~output


### PR DESCRIPTION
When substitute tries to escape the build directory, give the user a
proper error.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9914e87b-0692-4856-9b8a-7ce005dbd00d -->