### PR TITLE
fix: stale directory target check

### DIFF
--- a/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
+++ b/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
@@ -1,0 +1,22 @@
+A faulty test escapes the sandbox by creating its target outside the sandbox
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir foo))
+  >  (action (system "mkdir $PWD/_build/default/foo && mkdir foo")))
+  > EOF
+
+  $ dune build foo/ --sandbox=copy 2>&1 | sed -E 's/characters [0-9]+-[0-9]+/characters <REDACTED>/'
+  File "dune", line 1, characters <REDACTED>:
+  1 | (rule
+  2 |  (target (dir foo))
+  3 |  (action (system "mkdir $TESTCASE_ROOT/_build/default/foo && mkdir foo")))
+  Error: Target _build/default/foo of kind directory already exists in the
+  build directory
+  Hint: delete this file manually or check the permissions of the parent
+  directory of this file


### PR DESCRIPTION
The current directory check swallows permission and other errors and
just says the directory doesn't exist.

We improve the check to emit a correct error every time.

We should probably reimplement `Path.exists` to stop being relying on `Sys.file_exists` and use `Unix`.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5003c913-1b6c-43e6-82f9-7b63b29908d9 -->