### PR TITLE
Use precise ranges in patches in pkg tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -41,7 +41,7 @@ The lockfile should contain the substitute and patch actions.
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml
   > +++ b/foo.ml
-  > @@ -1,2 +1,2 @@
+  > @@ -1,1 +1,1 @@
   > -This is wrong
   > +This is right
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -21,7 +21,7 @@ file and the second patches two, one of the files is in a subdirectory.:w
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml
   > +++ b/foo.ml
-  > @@ -1,2 +1,2 @@
+  > @@ -1,1 +1,1 @@
   > -This is wrong
   > +This is right
   > EOF
@@ -31,7 +31,7 @@ file and the second patches two, one of the files is in a subdirectory.:w
   > index b69a69a5a..ea988f6bd 100644
   > --- a/bar.ml
   > +++ b/bar.ml
-  > @@ -1,2 +1,2 @@
+  > @@ -1,1 +1,1 @@
   > -This is wrong
   > +This is right
   > 
@@ -40,7 +40,7 @@ file and the second patches two, one of the files is in a subdirectory.:w
   > index b69a69a5a..ea988f6bd 100644
   > --- a/dir/baz.ml
   > +++ b/dir/baz.ml
-  > @@ -1,2 +1,2 @@
+  > @@ -1,1 +1,1 @@
   > -This is wrong
   > +This is right
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -17,7 +17,7 @@ Make a package with a patch
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml
   > +++ b/foo.ml
-  > @@ -1,2 +1,2 @@
+  > @@ -1,1 +1,1 @@
   > -This is wrong
   > +This is right
   > EOF


### PR DESCRIPTION
The patches specified a length that put the diff past the end of the file. This caused the patches to not apply when using the `patch` command on MacOS Sonoma.