### PR TITLE
Add a cram alias for the pkg tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -1,4 +1,8 @@
 (cram
+ (alias pkg)
+ (applies_to :whole_subtree))
+
+(cram
  (deps helpers.sh)
  (applies_to :whole_subtree))
 

--- a/test/expect-tests/dune_pkg/dune
+++ b/test/expect-tests/dune_pkg/dune
@@ -28,3 +28,8 @@
  (deps plaintext.md)
  (action
   (run tar -czf %{target} %{deps})))
+
+(alias
+ (name pkg)
+ (deps
+  (alias runtest)))


### PR DESCRIPTION
This allows all the tests defined in test/blackbox-tests/test-cases/pkg to be run with a single command (the command is `dune build @test/pkg`).