### PR TITLE
Command.run: remove comment about API

### DIFF
--- a/src/dune_rules/command.mli
+++ b/src/dune_rules/command.mli
@@ -71,8 +71,6 @@ module Args : sig
   val as_any : without_targets t -> any t
 end
 
-(* TODO: Using list in [with_targets t list] complicates the API unnecessarily:
-   we can use the constructor [S] to concatenate lists instead. *)
 val run
   :  dir:Path.t
   -> ?sandbox:Sandbox_config.t


### PR DESCRIPTION
After trying to change the type, it turns out that adding `S` everywhere is not going in the right direction.