### PR TITLE
feature(engine): allow customizing execution parameters per context

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -77,7 +77,7 @@ type t =
   ; cache_config : Dune_cache.Config.t
   ; cache_debug_flags : Cache_debug_flags.t
   ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
-  ; execution_parameters : dir:Path.Source.t -> Execution_parameters.t Memo.t
+  ; execution_parameters : dir:Path.Build.t -> Execution_parameters.t Memo.t
   ; source_tree : (module Source_tree)
   ; action_runner : Action_exec.input -> Action_runner.t option
   ; action_runners : unit -> Action_runner.t list

--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -136,7 +136,7 @@ module type Build_config = sig
     -> sandboxing_preference:Sandbox_mode.t list
     -> rule_generator:(module Gen_rules.Rule_generator)
     -> implicit_default_alias:(Path.Build.t -> unit Action_builder.t option Memo.t)
-    -> execution_parameters:(dir:Path.Source.t -> Execution_parameters.t Memo.t)
+    -> execution_parameters:(dir:Path.Build.t -> Execution_parameters.t Memo.t)
     -> source_tree:(module Source_tree)
     -> shared_cache:(module Shared_cache_intf.S)
     -> write_error_summary:(Build_system_error.Set.t -> unit Fiber.t)
@@ -157,7 +157,7 @@ module type Build_config = sig
     ; cache_config : Dune_cache.Config.t
     ; cache_debug_flags : Cache_debug_flags.t
     ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
-    ; execution_parameters : dir:Path.Source.t -> Execution_parameters.t Memo.t
+    ; execution_parameters : dir:Path.Build.t -> Execution_parameters.t Memo.t
     ; source_tree : (module Source_tree)
     ; action_runner : Action_exec.input -> Action_runner.t option
     ; action_runners : unit -> Action_runner.t list

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -440,7 +440,7 @@ end = struct
     let head_target = Targets.Validated.head targets in
     let* execution_parameters =
       match Dpath.Target_dir.of_target dir with
-      | Regular (With_context (_, dir)) | Anonymous_action (With_context (_, dir)) ->
+      | Regular (With_context (_, _)) | Anonymous_action (With_context (_, _)) ->
         (Build_config.get ()).execution_parameters ~dir
       | Anonymous_action Root | Regular Root | Invalid _ ->
         Code_error.raise "invalid dir for rule execution" [ "dir", Path.Build.to_dyn dir ]

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -26,15 +26,18 @@ let implicit_default_alias dir =
 
 let execution_parameters =
   let f path =
-    let open Memo.O in
-    let+ dir = Source_tree.nearest_dir path
-    and+ ep = Execution_parameters.default in
-    Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep
+    match Path.Build.drop_build_context path with
+    | None -> Dune_engine.Execution_parameters.default
+    | Some path ->
+      let open Memo.O in
+      let+ dir = Source_tree.nearest_dir path
+      and+ ep = Execution_parameters.default in
+      Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep
   in
   let memo =
     Memo.create
       "execution-parameters-of-dir"
-      ~input:(module Path.Source)
+      ~input:(module Path.Build)
       ~cutoff:Execution_parameters.equal
       f
   in


### PR DESCRIPTION
Contexts are a way for users to customize the rules in a workspace and build all these workspaces concurrently. This PR makes it possible to customize the execution parameters per context, giving us additional customization possibilities for free.

In addition, it's also good to make the engine as agnostic to contexts as possible. It gives the rules more flexibility and makes the engine assume less about the rules.

Here's a related ticket that describes the motivation more: https://github.com/ocaml/dune/issues/7049
