### PR TITLE
Refactor solver workspace fields

### DIFF
--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -25,6 +25,9 @@ module Variable : sig
       (** A mapping from system environment variables to their values *)
       type t
 
+      val to_dyn : t -> Dyn.t
+      val decode : t Dune_sexp.Decoder.t
+      val equal : t -> t -> bool
       val empty : t
       val set : t -> sys_var -> string -> t
       val get : t -> sys_var -> string option
@@ -57,15 +60,13 @@ end
     environment as dune does not give users access to those variables.. *)
 type t
 
+val create : sys:Variable.Sys.Bindings.t -> t
 val default : t
 val decode : t Dune_sexp.Decoder.t
 val to_dyn : t -> Dyn.t
 val equal : t -> t -> bool
 val sys : t -> Variable.Sys.Bindings.t
 val set_sys : t -> Variable.Sys.Bindings.t -> t
-
-(** [repos t] returns the selected repository names in priority order *)
-val repos : t -> Workspace.Repository.Name.t list
 
 (** A human-readible summary of the variable environment *)
 val pp : t -> 'a Pp.t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -584,7 +584,8 @@ module Group = struct
       match context with
       | Opam { base; switch } ->
         create_for_opam builder ~switch ~loc:base.loc ~targets:base.targets
-      | Default { lock; version_preference = _; solver_env = _; base } ->
+      | Default
+          { lock; version_preference = _; solver_sys_vars = _; repositories = _; base } ->
         let builder =
           match builder.findlib_toolchain with
           | Some _ -> builder

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -48,7 +48,8 @@ module Context : sig
       { base : Common.t
       ; lock : Path.Source.t option
       ; version_preference : Dune_pkg.Version_preference.t option
-      ; solver_env : Dune_pkg.Solver_env.t option
+      ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+      ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
       }
   end
 

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -33,16 +33,14 @@ Create a workspace config that defines separate build contexts for macos and lin
   >  (default
   >   (name linux)
   >   (lock dune.linux.lock)
-  >   (solver_env
-  >    (sys
-  >     (os linux)))))
+  >   (solver_sys_vars
+  >    (os linux))))
   > (context
   >  (default
   >   (name macos)
   >   (lock dune.macos.lock)
-  >   (solver_env
-  >    (sys
-  >     (os macos)))))
+  >   (solver_sys_vars
+  >    (os macos))))
   > EOF
 
 Now the os-specific dependencies are included on their respective systems.

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -9,8 +9,6 @@ Print the solver env when no dune-workspace is present
     - os-family (unset)
   - Constants
     - opam-version = 2.2.0~alpha-vendored
-  - Repositories
-       default
 
 Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
@@ -19,20 +17,18 @@ Add some build contexts with different environments
   >  (default
   >   (name linux)
   >   (lock dune.linux.lock)
-  >   (solver_env
-  >    (sys
-  >     (os linux)))))
+  >   (solver_sys_vars
+  >    (os linux))))
   > (context
   >  (default
   >   (name no-doc)
   >   (lock dune.linux.lock)
-  >   (solver_env
-  >    (sys
-  >     (arch x86_64)
-  >     (os linux)
-  >     (os-family ubuntu)
-  >     (os-distribution ubuntu)
-  >     (os-version 22.04)))))
+  >   (solver_sys_vars
+  >    (arch x86_64)
+  >    (os linux)
+  >    (os-family ubuntu)
+  >    (os-distribution ubuntu)
+  >    (os-version 22.04))))
   > EOF
 
   $ dune pkg print-solver-env --all-contexts --dont-poll-system-solver-variables
@@ -45,8 +41,6 @@ Add some build contexts with different environments
     - os-family = ubuntu
   - Constants
     - opam-version = 2.2.0~alpha-vendored
-  - Repositories
-       default
   Solver environment for context linux:
   - System Environment Variables
     - arch (unset)
@@ -56,5 +50,3 @@ Add some build contexts with different environments
     - os-family (unset)
   - Constants
     - opam-version = 2.2.0~alpha-vendored
-  - Repositories
-       default

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -38,8 +38,7 @@ We have to define both repositories in the workspace, but will only use `new`.
   > (context
   >  (default
   >   (name default)
-  >   (solver_env
-  >    (repositories new))))
+  >   (repositories new)))
   > EOF
 
   $ cat > dune-project <<EOF
@@ -73,8 +72,7 @@ solution:
   > (context
   >  (default
   >   (name default)
-  >   (solver_env
-  >    (repositories old))))
+  >   (repositories old)))
   > EOF
  
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
@@ -96,8 +94,7 @@ package:
   > (context
   >  (default
   >   (name default)
-  >   (solver_env
-  >    (repositories new old))))
+  >   (repositories new old)))
   > EOF
 
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
@@ -120,8 +117,7 @@ older version of foo:
   > (context
   >  (default
   >   (name default)
-  >   (solver_env
-  >    (repositories new old \ new))))
+  >   (repositories new old \ new)))
   > EOF
 
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -137,8 +137,7 @@ The repository can also be injected via the dune-workspace file
   > (context
   >  (default
   >   (name default)
-  >   (solver_env
-  >    (repositories foo))))
+  >   (repositories foo)))
   > EOF
   $ mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -5,16 +5,14 @@ Set up two build contexts: a default one for linux and another for macos.
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (context (default
-  >   (solver_env
-  >    (sys
-  >     (os linux)))))
+  >  (solver_sys_vars
+  >   (os linux))))
   > (context
   >  (default
   >   (name macos)
   >   (lock dune.macos.lock)
-  >   (solver_env
-  >    (sys
-  >     (os macos)))))
+  >   (solver_sys_vars
+  >    (os macos))))
   > EOF
 
 !! Do not delete this one for the one in helpers.sh as it passes --context !!


### PR DESCRIPTION
    This renames the fields in the workspace config that affect the solver
    environment. Namely, "sys" is renamed to "override_solver_sys_vars" to
    reflect the fact that they override the sys vars obtained by polling the
    system, and "repositories" is renamed to "default_repositories" to
    reflect the fact that those repositories are only used if no other repos
    were specified.