### PR TITLE
feature: allow custom actions to be dynamic

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -322,8 +322,8 @@ let bash_exn =
 (* When passing these to an extension, they shouldn't need to know about any
    kind of dynamic build dependency functions or prepped dependencies, etc,
    which should be handled here instead. *)
-let restrict_ctx { targets; context; metadata; rule_loc; build_deps = _ } =
-  { Action.Ext.targets; context; purpose = metadata.purpose; rule_loc }
+let restrict_ctx { targets; context; metadata; rule_loc; build_deps } =
+  { Action.Ext.targets; context; purpose = metadata.purpose; rule_loc; build_deps }
 ;;
 
 let restrict_env

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -95,6 +95,7 @@ module Ext = struct
     ; context : Build_context.t option
     ; purpose : Process.purpose
     ; rule_loc : Loc.t
+    ; build_deps : Dep.Set.t -> Dep.Facts.t Fiber.t
     }
 
   type env =


### PR DESCRIPTION
Currently, custom actions are less powerful than normal actions in one specific way:

They aren't allowed to build dependencies as part of their execution. In particular, a custom action cannot implement `dynamic-run`.

Fortunately, extending custom actions with this ability ends up being quite simple.