### PR TITLE
fix: define COPYFILE_CLONE if not available.

### DIFF
--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -15,6 +15,10 @@
 #include <string.h>
 #include <sys/syslimits.h>
 
+#ifndef COPYFILE_CLONE
+#define COPYFILE_CLONE (1<<24)
+#endif
+
 CAMLprim value stdune_copyfile(value v_from, value v_to) {
   CAMLparam2(v_from, v_to);
   caml_unix_check_path(v_from, "copyfile");


### PR DESCRIPTION
On older versions of macos the copyfile.c header is missing the COPYFILE_CLONE macro. We explicitly redeine it here when it is missing. This should allow Dune to be run on older versions of macos.