### PR TITLE
test: reproduce #8630

### DIFF
--- a/test/blackbox-tests/test-cases/eager-package-lookup.t
+++ b/test/blackbox-tests/test-cases/eager-package-lookup.t
@@ -1,0 +1,24 @@
+When a package fails to resolve, it shouldn't prevent rules from loading in a
+directory.
+
+Github issue #8630
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (using dune_site 0.1)
+  > (package (name a))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section (site (foobarpkg baz)))
+  >  (files foo))
+  > (rule (with-stdout-to foo (echo bar)))
+  > EOF
+
+  $ dune build foo
+  File "dune", line 2, characters 16-31:
+  2 |  (section (site (foobarpkg baz)))
+                      ^^^^^^^^^^^^^^^
+  Error: The package foobarpkg is not found
+  [1]


### PR DESCRIPTION
Demonstrate that looking up a package breaks rule loading in the entire
directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3acfde16-8547-4bc4-9aa5-bef4926acdae -->