### PR TITLE
fix(menhir): include_subdirs qualified

### DIFF
--- a/doc/changes/8949.md
+++ b/doc/changes/8949.md
@@ -1,0 +1,2 @@
+- Correctly determine the stanza of menhir modules when `(include_subdirs
+  qualified)` is enabled (@rgrinberg, #8949, fixes #7610)

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -12,6 +12,7 @@ module Origin : sig
     | Melange of Melange_stanzas.Emit.t
 
   val loc : t -> Loc.t
+  val to_dyn : t -> Dyn.t
 end
 
 module Artifacts : sig
@@ -38,7 +39,7 @@ val modules_and_obj_dir : t -> for_:for_ -> Modules.t * Path.Build.t Obj_dir.t
 val modules : t -> for_:for_ -> Modules.t
 
 (** Find out the origin of the stanza for a given module *)
-val find_origin : t -> Module_name.t -> Origin.t option
+val find_origin : t -> Module_name.Path.t -> Origin.t option
 
 val empty : t
 
@@ -48,6 +49,8 @@ val empty : t
     We need to know the contents of the virtual library to: - verify conditions
     all virtual modules are implemented - make sure that we construct [Module.t]
     with the correct [kind] *)
+
+val include_subdirs : t -> Dune_file.Include_subdirs.t
 
 val make
   :  Dune_file.t

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -33,7 +33,7 @@ let find_module sctx src =
     let* dir_contents = drop_rules @@ fun () -> Dir_contents.get sctx ~dir in
     let* ocaml = Dir_contents.ocaml dir_contents in
     let stanza =
-      match Ml_sources.find_origin ocaml module_name with
+      match Ml_sources.find_origin ocaml [ module_name ] with
       | Some (Executables exes) -> Some (`Executables exes)
       | Some (Library lib) -> Some (`Library lib)
       | None | Some (Melange _) -> None

--- a/test/blackbox-tests/test-cases/menhir/menhir-include-subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/menhir/menhir-include-subdirs.t/run.t
@@ -17,9 +17,3 @@ Menhir in other places than the root of the file hierarchy.
   Hint: Did you mean Baz?
   [1]
   $ test qualified
-  File "bar/dune", line 1, characters 0-23:
-  1 | (menhir
-  2 |  (modules baz))
-  Error: I can't determine what library/executable the files produced by this
-  stanza are part of.
-  [1]


### PR DESCRIPTION
menhir stanzas wouldn't know how to attach themselves to executables or
libraries with (include_subdirs qualified) because the module path
wouldn't be computed. Now we compute the module path and it works.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e4746ac6-cc95-4844-9fb9-25e9472b6fa0 -->