### PR TITLE
fix: stop using Pp.newline

### DIFF
--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -75,10 +75,11 @@ let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
         (* If we are printing multiple directories, we print the directory
            name as a header. *)
         (if header then [ Pp.textf "%s:" (Path.to_string dir) ] else [])
-        @ [ Pp.concat_map targets ~f:Pp.text ~sep:Pp.newline ]
-        |> Pp.concat ~sep:Pp.newline)
+        @ [ Pp.concat_map targets ~f:Pp.text ~sep:Pp.space ]
+        |> Pp.concat ~sep:Pp.space)
     in
-    Console.print [ Pp.concat paragraphs ~sep:(Pp.seq Pp.newline Pp.newline) ]
+    Console.print
+      [ Pp.vbox @@ Pp.concat_map ~f:Pp.vbox paragraphs ~sep:(Pp.seq Pp.space Pp.space) ]
   in
   Scheduler.go ~common ~config
   @@ fun () ->

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -217,15 +217,13 @@ module Public_name = struct
     if is_opam_compatible l
     then Ok l
     else
-      let open Pp.O in
-      let descr =
-        Pp.text
-          "Public names are composed of an opam package name and optional dot-separated \
-           string suffixes."
-        ++ Pp.newline
-        ++ Pkg.description_of_valid_string
-      in
-      Error (User_error.make [ descr ])
+      Error
+        (User_error.make
+           [ Pp.text
+               "Public names are composed of an opam package name and optional \
+                dot-separated string suffixes."
+           ; Pkg.description_of_valid_string
+           ])
   ;;
 
   let of_name_exn name =

--- a/bin/rpc/status.ml
+++ b/bin/rpc/status.ml
@@ -72,9 +72,9 @@ let get_status (dune : Dune_rpc.Registry.Dune.t) =
 (** Print a list of statuses to the console *)
 let print_statuses statuses =
   List.sort statuses ~compare:(fun x y -> String.compare x.root y.root)
-  |> Pp.concat_map ~sep:Pp.newline ~f:(fun { root; pid; result } ->
+  |> Pp.concat_map ~sep:Pp.space ~f:(fun { root; pid; result } ->
     Pp.concat
-      ~sep:Pp.newline
+      ~sep:Pp.space
       [ Pp.textf "root: %s" root
       ; Pp.enumerate
           ~f:Fun.id
@@ -86,6 +86,7 @@ let print_statuses statuses =
                | Error e -> e)
           ]
       ])
+  |> Pp.vbox
   |> List.singleton
   |> Console.print
 ;;
@@ -129,10 +130,10 @@ let term =
               [ Pp.textf "Client [%s], conducting version negotiation" id ]
           | Menu menu ->
             User_message.make
-              [ Pp.box
+              [ Pp.vbox
                   ~indent:2
                   (Pp.concat
-                     ~sep:Pp.newline
+                     ~sep:Pp.space
                      (Pp.textf "Client [%s] with the following RPC versions:" id
                       :: List.map menu ~f:(fun (method_, version) ->
                         Pp.textf "%s: %d" method_ version)))

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -166,7 +166,7 @@ let do_promote db files_to_promote =
       List.iter others ~f:(fun (path, _staging) ->
         Console.print
           [ Pp.textf " -> ignored %s." (Path.to_string_maybe_quoted (Path.build path))
-          ; Pp.newline
+          ; Pp.space
           ])
   in
   match files_to_promote with

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -254,7 +254,7 @@ let pp =
   let pp_section heading pp_section =
     (* The hbox is to prevent long values in [pp_section] from causing the heading to wrap. *)
     let pp_heading = Pp.hbox (Pp.text heading) in
-    Pp.concat ~sep:Pp.newline [ pp_heading; pp_section ]
+    Pp.concat ~sep:Pp.space [ pp_heading; pp_section ] |> Pp.vbox
   in
   fun { flags; sys; const; repos } ->
     Pp.enumerate

--- a/src/dune_pkg_outdated/dune_pkg_outdated.ml
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.ml
@@ -111,6 +111,7 @@ let better_candidate
               (OpamFile.OPAM.version x)
               (OpamFile.OPAM.version y)))
      with
+     | None -> Package_not_found pkg.info.name
      | Some newest_opam_file ->
        let version = OpamFile.OPAM.version newest_opam_file in
        (match
@@ -125,8 +126,7 @@ let better_candidate
             ; name = pkg.info.name
             ; newer_version = version |> OpamPackage.Version.to_string
             ; outdated_version = pkg.info.version
-            })
-     | None -> Package_not_found pkg.info.name)
+            }))
 ;;
 
 let pp results ~transitive ~lock_dir_path =
@@ -163,8 +163,8 @@ let pp results ~transitive ~lock_dir_path =
     | outdated_packages -> [ Pp.enumerate ~f:Fun.id outdated_packages ]
   in
   explain_results_to_user ~transitive ~lock_dir_path results @ outdated_packages
-  |> Pp.concat_map ~sep:Pp.newline ~f:Pp.box
-  |> Pp.hovbox
+  |> Pp.concat_map ~sep:Pp.space ~f:Pp.box
+  |> Pp.vbox
 ;;
 
 let find ~repos ~local_packages packages =

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -191,16 +191,14 @@ let rules ~sctx ~expander ~dir tests =
                    | None -> Some (loc, set)
                    | Some (loc', _) ->
                      let main_message =
-                       Pp.concat
-                         ~sep:Pp.newline
-                         [ Pp.text
-                             "enabling or disabling the runtest alias for a cram test \
-                              may only be set once."
-                         ; Pp.textf "It's already set for the test %S" name
-                         ]
+                       [ Pp.text
+                           "enabling or disabling the runtest alias for a cram test may \
+                            only be set once."
+                       ; Pp.textf "It's already set for the test %S" name
+                       ]
                      in
                      let annots =
-                       let main = User_message.make ~loc:loc' [ main_message ] in
+                       let main = User_message.make ~loc:loc' main_message in
                        let related =
                          [ User_message.make ~loc [ Pp.text "Already set here" ] ]
                        in
@@ -211,10 +209,10 @@ let rules ~sctx ~expander ~dir tests =
                      User_error.raise
                        ~annots
                        ~loc
-                       [ main_message
-                       ; Pp.text "The first definition is at:"
-                       ; Pp.text (Loc.to_file_colon_line loc')
-                       ])
+                       (main_message
+                        @ [ Pp.text "The first definition is at:"
+                          ; Pp.text (Loc.to_file_colon_line loc')
+                          ]))
               in
               let enabled_if = stanza.enabled_if :: acc.enabled_if in
               let alias =

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
@@ -24,7 +24,6 @@ Solver finds the invalid solution as it doesn't check cycles.
 
   $ solve c
   Solution for dune.lock:
-  a.0.0.1
-  b.0.0.1
-  c.0.0.1
-  
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
@@ -17,19 +17,16 @@ Solver doesn't complain about cycles.
 
   $ solve a
   Solution for dune.lock:
-  a.0.0.1
-  b.0.0.1
-  c.0.0.1
-  
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
   $ solve b
   Solution for dune.lock:
-  a.0.0.1
-  b.0.0.1
-  c.0.0.1
-  
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
   $ solve c
   Solution for dune.lock:
-  a.0.0.1
-  b.0.0.1
-  c.0.0.1
-  
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -90,7 +90,8 @@ If we remove packages from the repository then we should get a nice error.
   $ outdated 
   1/2 packages in dune.lock are outdated.
   Showing immediate dependencies, use --transitive to see the rest.
-  Error: When checking dune.lock, the following packages:
+  Error: Some packages could not be found.
+  When checking dune.lock, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -100,7 +101,8 @@ When printing both successes and failures, any errors should appear afterwards.
   $ outdated --transitive
   1/2 packages in dune.lock are outdated.
   - foo 0.0.1 < 0.0.2
-  Error: When checking dune.lock, the following packages:
+  Error: Some packages could not be found.
+  When checking dune.lock, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -113,14 +115,14 @@ Similarly for all contexts.
   - 1/2 packages in dune.lock are outdated.
     - foo 0.0.1 < 0.0.2
   Error: Some packages could not be found.
-  - When checking dune.workspace.lock, the following packages:
-    - bar
-    were not found in the following opam repositories:
-    - None
-  - When checking dune.lock, the following packages:
-    - bar
-    were not found in the following opam repositories:
-    - None
+  When checking dune.workspace.lock, the following packages:
+  - bar
+  were not found in the following opam repositories:
+  - None
+  When checking dune.lock, the following packages:
+  - bar
+  were not found in the following opam repositories:
+  - None
   [1]
 
 If multiple packages are missing, the error should enumerate them. The errors should
@@ -128,7 +130,8 @@ appear irrespective of being a transitive dependency.
   $ rm -r mock-opam-repository/packages/foo
   $ outdated --transitive 
   dune.lock is up to date.
-  Error: When checking dune.lock, the following packages:
+  Error: Some packages could not be found.
+  When checking dune.lock, the following packages:
   - bar
   - foo
   were not found in the following opam repositories:
@@ -140,14 +143,14 @@ With multiple contexts, the errors should also be printed for each context.
   - dune.workspace.lock is up to date.
   - dune.lock is up to date.
   Error: Some packages could not be found.
-  - When checking dune.workspace.lock, the following packages:
-    - bar
-    - foo
-    were not found in the following opam repositories:
-    - None
-  - When checking dune.lock, the following packages:
-    - bar
-    - foo
-    were not found in the following opam repositories:
-    - None
+  When checking dune.workspace.lock, the following packages:
+  - bar
+  - foo
+  were not found in the following opam repositories:
+  - None
+  When checking dune.lock, the following packages:
+  - bar
+  - foo
+  were not found in the following opam repositories:
+  - None
   [1]


### PR DESCRIPTION
If we want vertical spacing, we can create a vbox.

This also makes the output of $ dune pkg outdated more uniform. It was
possible to preserve the old output, but it would require even more
special casing. So I just get rid of it all at once.