### PR TITLE
pkg: improve dune pkg lock message

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -26,7 +26,8 @@ module Lock = struct
         ~sep:Pp.space
         [ Pp.hovbox
           @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
-        ; Pkg.Lock.pp_packages lock_dir.packages
+        ; Pkg.Lock.pp_packages
+            (Package_name.Map.to_list_map ~f:(fun _ pkg -> pkg) lock_dir.packages)
         ]
       |> Pp.vbox)
   ;;

--- a/bin/pkg.mli
+++ b/bin/pkg.mli
@@ -3,7 +3,7 @@ open Import
 module Lock : sig
   (** [pp_packages lock_dir] returns a list of pretty-printed packages
       occuring in [lock_dir]. *)
-  val pp_packages : Dune_pkg.Lock_dir.Pkg.t Package_name.Map.t -> 'a Pp.t
+  val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> 'a Pp.t
 end
 
 val group : unit Cmd.t

--- a/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
@@ -17,7 +17,6 @@ included.
 
   $ solve "(test :with-test) (doc :with-doc) (dev :with-dev) (build :build) (post :post)"
   Solution for dune.lock:
-  build.0.0.1
-  doc.0.0.1
-  test.0.0.1
-  
+  - build.0.0.1
+  - doc.0.0.1
+  - test.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -87,11 +87,10 @@ Package which has boolean where string was expected. This should be caught while
 
   $ solve_translate_opam_filters standard-dune with-interpolation with-percent-sign variable-types
   Solution for dune.lock:
-  standard-dune.0.0.1
-  variable-types.0.0.1
-  with-interpolation.0.0.1
-  with-percent-sign.0.0.1
-  
+  - standard-dune.0.0.1
+  - variable-types.0.0.1
+  - with-interpolation.0.0.1
+  - with-percent-sign.0.0.1
 
   $ cat dune.lock/standard-dune.pkg
   (version 0.0.1)
@@ -152,8 +151,7 @@ Package which has boolean where string was expected. This should be caught while
 
   $ solve_translate_opam_filters exercise-filters
   Solution for dune.lock:
-  exercise-filters.0.0.1
-  
+  - exercise-filters.0.0.1
 
   $ cat dune.lock/exercise-filters.pkg
   (version 0.0.1)
@@ -222,8 +220,7 @@ Package which has boolean where string was expected. This should be caught while
 Test that if opam filter translation is disabled the output doesn't contain any translated filters:
   $ solve exercise-filters
   Solution for dune.lock:
-  exercise-filters.0.0.1
-  
+  - exercise-filters.0.0.1
   $ cat dune.lock/exercise-filters.pkg
   (version 0.0.1)
   
@@ -248,8 +245,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
 
   $ solve_translate_opam_filters exercise-term-filters
   Solution for dune.lock:
-  exercise-term-filters.0.0.1
-  
+  - exercise-term-filters.0.0.1
   $ cat dune.lock/exercise-term-filters.pkg
   (version 0.0.1)
   
@@ -290,8 +286,7 @@ Package with package conjunction and string selections inside variable interpola
   > (package (name x) (depends package-conjunction-and-string-selection))
   > EOF
   Solution for dune.lock:
-  package-conjunction-and-string-selection.0.0.1
-  
+  - package-conjunction-and-string-selection.0.0.1
 Note that "enable" is not a true opam variable. Opam desugars occurances of
 "pkg:enable" into "pkg:enable?enable:disable" but if the explicit package scope
 is omitted then it's treated like a regular variable. That explains why the

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -30,39 +30,37 @@ Here is the output of solving for multiple contexts:
   >  (depends A B C))
   > EOF
   Solution for foo.lock:
-  A.1.2.0
-  B.2.1+rc1
-  C.81.0.4044.138
-  D.0.4.0.beta1
-  E.3.0~alpha1
-  
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
   Solution for dune.lock:
-  A.1.2.0
-  B.2.1+rc1
-  C.81.0.4044.138
-  D.0.4.0.beta1
-  E.3.0~alpha1
-  
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
 Here is the output of dune describe pkg lock:
   $ dune describe pkg lock
   Contents of dune.lock:
-  A.1.2.0
-  B.2.1+rc1
-  C.81.0.4044.138
-  D.0.4.0.beta1
-  E.3.0~alpha1
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
 
 The names of the lockfiles can also be provided:
   $ dune describe pkg lock dune.lock foo.lock 
   Contents of dune.lock:
-  A.1.2.0
-  B.2.1+rc1
-  C.81.0.4044.138
-  D.0.4.0.beta1
-  E.3.0~alpha1
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1
   Contents of foo.lock:
-  A.1.2.0
-  B.2.1+rc1
-  C.81.0.4044.138
-  D.0.4.0.beta1
-  E.3.0~alpha1
+  - A.1.2.0
+  - B.2.1+rc1
+  - C.81.0.4044.138
+  - D.0.4.0.beta1
+  - E.3.0~alpha1

--- a/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
+++ b/test/blackbox-tests/test-cases/pkg/detect-duplicate-lock-dir-paths.t
@@ -18,15 +18,12 @@ Check that we can still generate lockdirs for individual contexts:
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
-  
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=default
   Solution for dune.lock:
   (no dependencies to lock)
-  
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=custom-context-with-default-lock-dir
   Solution for dune.lock:
   (no dependencies to lock)
-  
 
 It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
   $ dune pkg lock --opam-repository-path=mock-opam-repository --all-contexts
@@ -57,11 +54,9 @@ Check that we can still generate lockdirs for individual contexts:
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=a
   Solution for foo.lock:
   (no dependencies to lock)
-  
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=b
   Solution for foo.lock:
   (no dependencies to lock)
-  
 
 It's an error to use --all-contexts when there are multiple contexts with the same lockdir:
   $ dune pkg lock --opam-repository-path=mock-opam-repository --all-contexts

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -24,8 +24,7 @@ With no "os" variable set in the workspace, none of the os-specific
 dependencies are included.
   $ solve foo
   Solution for dune.lock:
-  foo.0.0.1
-  
+  - foo.0.0.1
 
 Create a workspace config that defines separate build contexts for macos and linux.
   $ cat >dune-workspace <<EOF
@@ -49,10 +48,8 @@ Create a workspace config that defines separate build contexts for macos and lin
 Now the os-specific dependencies are included on their respective systems.
   $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository --all-contexts
   Solution for dune.macos.lock:
-  foo.0.0.1
-  foo-macos.0.0.1
-  
+  - foo.0.0.1
+  - foo-macos.0.0.1
   Solution for dune.linux.lock:
-  foo.0.0.1
-  foo-linux.0.0.1
-  
+  - foo.0.0.1
+  - foo-linux.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -26,6 +26,5 @@ constraint.
   [1]
   $ test "4.0.0"
   Solution for dune.lock:
-  dune.3.11.0
-  foo.0.0.1
-  
+  - dune.3.11.0
+  - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -2,7 +2,6 @@ Create a lock directory that didn't originally exist
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
-  
   $ cat dune.lock/lock.dune
   (lang package 0.1)
   
@@ -14,7 +13,6 @@ Re-create a lock directory in the newly created lock dir
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
   (no dependencies to lock)
-  
   $ cat dune.lock/lock.dune
   (lang package 0.1)
   

--- a/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-per-context.t/run.t
@@ -49,10 +49,9 @@ Test that we get an error if an opam context is specified.
 Generate the lockdir for the default context.
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for foo.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Only foo.lock (the default context's lockdir) was generated.
   $ find *.lock | sort
@@ -66,10 +65,9 @@ Only foo.lock (the default context's lockdir) was generated.
 Generate the lockdir with the default context explicitly specified.
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=default
   Solution for foo.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Again, only foo.lock (the default context's lockdir) was generated.
   $ find *.lock | sort
@@ -83,10 +81,9 @@ Again, only foo.lock (the default context's lockdir) was generated.
 Generate the lockdir for the non-default context.
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=foo
   Solution for bar.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Now only bar.lock was generated.
   $ find *.lock | sort
@@ -100,37 +97,32 @@ Now only bar.lock was generated.
 Generate the lockdir for a context which prefers oldest package versions.
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=prefers_oldest
   Solution for prefers_oldest.lock:
-  bar.0.4.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.4.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Re-generate the lockdir for a context which prefers oldest package versions,
 but override it to prefer newest with a command line argument.
   $ dune pkg lock --opam-repository-path=mock-opam-repository --context=prefers_oldest --version-preference=newest
   Solution for prefers_oldest.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Generate the lockdir for all (non-opam) contexts.
   $ dune pkg lock --opam-repository-path=mock-opam-repository --all-contexts
   Solution for prefers_oldest.lock:
-  bar.0.4.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.4.0
+  - baz.0.1.0
+  - foo.0.0.1
   Solution for bar.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
   Solution for foo.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Now both lockdirs were generated.
   $ find *.lock | sort

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -33,10 +33,9 @@ Run the solver and generate a lock directory.
 
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  bar.0.5.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - foo.0.0.1
 
 Helper to the name and contents of each file in the lock directory separated by
 "---", sorting by filename for consistency.
@@ -82,10 +81,9 @@ Print the contents of each file in the lockdir:
 Run the solver again preferring oldest versions of dependencies:
   $ dune pkg lock --version-preference=oldest --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  bar.0.4.0
-  baz.0.1.0
-  foo.0.0.1
-  
+  - bar.0.4.0
+  - baz.0.1.0
+  - foo.0.0.1
 
   $ print_all
   dune.lock/bar.pkg:
@@ -166,9 +164,8 @@ both.
 
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  bar.0.5.0
-  bar-or-baz.0.0.1
-  
+  - bar.0.5.0
+  - bar-or-baz.0.0.1
 Top level or is simple, but does nested or work? nested-r defines nested or
 patterns that can't be simplified
 
@@ -191,11 +188,10 @@ well as bar or qux.
 
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  bar.0.5.0
-  baz.0.1.0
-  nested-or.0.0.1
-  quux.0.0.1
-  
+  - bar.0.5.0
+  - baz.0.1.0
+  - nested-or.0.0.1
+  - quux.0.0.1
 In the dependency formulas, & should bind stronger than | so if we depend on
 bar and quux or baz, it should pick the first two or the last one, but nothing
 in between.
@@ -212,10 +208,9 @@ in between.
 
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  bar.0.5.0
-  priorities.0.0.1
-  quux.0.0.1
-  
+  - bar.0.5.0
+  - priorities.0.0.1
+  - quux.0.0.1
  
 We also want to make sure nested negation in versions work fine. For this we
 have the same package with version 1-4 and we want to negate the choice of
@@ -240,6 +235,5 @@ we'd expect version 2 to be chosen:
 
   $ dune pkg lock --opam-repository-path=mock-opam-repository
   Solution for dune.lock:
-  negation.0.0.1
-  pkg.2
-  
+  - negation.0.0.1
+  - pkg.2

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -57,8 +57,7 @@ Locking should produce the newest package from `new`
   $ mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
   Solution for dune.lock:
-  foo.2.0
-  
+  - foo.2.0
 
 If we just use `old` we should get the older `foo` package in our lockfile
 solution:
@@ -81,8 +80,7 @@ solution:
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
   Solution for dune.lock:
-  foo.1.0
-  
+  - foo.1.0
 
 If we specify both repositories to be used, we should still get the new foo
 package:
@@ -105,8 +103,7 @@ package:
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
   Solution for dune.lock:
-  foo.2.0
-  
+  - foo.2.0
 
 If we use the ordered set language format and try to exclude `new` from the
 set, we should get a solution that only has `old` and will thus include the
@@ -130,5 +127,4 @@ older version of foo:
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
   Solution for dune.lock:
-  foo.1.0
-  
+  - foo.1.0

--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -7,8 +7,7 @@
 
   $ solve ocaml
   Solution for dune.lock:
-  ocaml.0.0.1
-  
+  - ocaml.0.0.1
 
   $ cat dune.lock/lock.dune
   (lang package 0.1)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -21,8 +21,7 @@ Make a package with a patch
 
   $ solve with-patch
   Solution for dune.lock:
-  with-patch.0.0.1
-  
+  - with-patch.0.0.1
 
 We expect that the files in the files directory of the opam repository get copied to the
 lock file. 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
@@ -12,8 +12,7 @@ Make a package with only an install step
 
   $ solve install-no-build
   Solution for dune.lock:
-  install-no-build.0.0.1
-  
+  - install-no-build.0.0.1
 The lockfile should only contain an install step.
 
   $ cat dune.lock/install-no-build.pkg 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -16,8 +16,7 @@ Make a package with a substs and patches field field
 
   $ solve with-substs-and-patches
   Solution for dune.lock:
-  with-substs-and-patches.0.0.1
-  
+  - with-substs-and-patches.0.0.1
   $ cat >>dune.lock/with-substs-and-patches.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
@@ -11,8 +11,7 @@ Make a package with a build-env field and no build or install step
 
   $ solve with-build-env
   Solution for dune.lock:
-  with-build-env.0.0.1
-  
+  - with-build-env.0.0.1
 
 When there is no build or install step the build environment does not appear in the lock
 file.

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
@@ -13,8 +13,7 @@ Make a package with a build-env field
 
   $ solve with-build-env
   Solution for dune.lock:
-  with-build-env.0.0.1
-  
+  - with-build-env.0.0.1
 The lockfile should contain a setenv action.
 
   $ cat dune.lock/with-build-env.pkg 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
@@ -14,8 +14,7 @@ In this test we demonstrate that we don't currently do anything special with tho
 
   $ solve with-build-test-doc
   Solution for dune.lock:
-  with-build-test-doc.0.0.1
-  
+  - with-build-test-doc.0.0.1
 The lockfile should contain the `build-test` and `build-doc` fields inside the build
 action.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
@@ -32,10 +32,9 @@ Make a package with an extra-source field and multiple checksums
 
   $ solve with-extra-source with-extra-source-md5 with-extra-source-multiple-checksums
   Solution for dune.lock:
-  with-extra-source.0.0.1
-  with-extra-source-md5.0.0.1
-  with-extra-source-multiple-checksums.0.0.1
-  
+  - with-extra-source.0.0.1
+  - with-extra-source-md5.0.0.1
+  - with-extra-source-multiple-checksums.0.0.1
   $ cat >>dune.lock/with-extra-source.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -23,8 +23,7 @@ Make a package with a patch behind a filter
 
   $ solve with-patch-filter
   Solution for dune.lock:
-  with-patch-filter.0.0.1
-  
+  - with-patch-filter.0.0.1
   $ cat >>dune.lock/with-patch-filter.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -47,8 +47,7 @@ file and the second patches two, one of the files is in a subdirectory.:w
 
   $ solve with-patch
   Solution for dune.lock:
-  with-patch.0.0.1
-  
+  - with-patch.0.0.1
   $ cat >>dune.lock/with-patch.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -24,8 +24,7 @@ Make a package with a patch
 
   $ solve with-patch
   Solution for dune.lock:
-  with-patch.0.0.1
-  
+  - with-patch.0.0.1
   $ cat >>dune.lock/with-patch.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -28,9 +28,8 @@ Make another package that depends on that and outputs the exported env vars
   > EOF
   > solve deps-on-with-setenv
   Solution for dune.lock:
-  deps-on-with-setenv.0.0.1
-  with-setenv.0.0.1
-  
+  - deps-on-with-setenv.0.0.1
+  - with-setenv.0.0.1
 The exported env from the first package should be in the lock dir.
 
   $ cat dune.lock/with-setenv.pkg
@@ -95,10 +94,9 @@ difference between a propagated export_env versus the initial env.
   > EOF
   > solve deps-on-with-setenv-2
   Solution for dune.lock:
-  deps-on-with-setenv-2.0.0.1
-  with-setenv.0.0.1
-  with-setenv-2.0.0.1
-  
+  - deps-on-with-setenv-2.0.0.1
+  - with-setenv.0.0.1
+  - with-setenv-2.0.0.1
 We can now observe how the environment updates are applied a second time.
 
 We currently have the following issues:

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -11,8 +11,7 @@ Make a package with a substs field
 
   $ solve with-substs
   Solution for dune.lock:
-  with-substs.0.0.1
-  
+  - with-substs.0.0.1
   $ cat >>dune.lock/with-substs.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -72,9 +72,8 @@ Run Dune and tell it to cache into our custom cache folder.
   $ mkdir fake-xdg-cache
   $ XDG_CACHE_HOME=$(pwd)/fake-xdg-cache dune pkg lock --opam-repository-url=http://localhost:$PORT/index.tar.gz
   Solution for dune.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
 
 Our custom cache folder should be populated with the unpacked tarball
 containing the repository:
@@ -110,9 +109,8 @@ reproducible)
   $ mkdir fake-xdg-cache-with-git
   $ XDG_CACHE_HOME=$(pwd)/fake-xdg-cache-with-git dune pkg lock --opam-repository-url=git+file://$(pwd)/mock-opam-repository
   Solution for dune.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
 
   $ grep "git_hash $REPO_HASH" dune.lock/lock.dune > /dev/null
 
@@ -122,9 +120,8 @@ Now try it with an existing cached dir, which given it is not reproducible shoul
   $ FOLDER=$(ls $(pwd)/fake-xdg-cache-with-git/dune/opam-repositories/)
   $ dune pkg lock --opam-repository-path=$(pwd)/fake-xdg-cache-with-git/dune/opam-repositories/$FOLDER
   Solution for dune.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
 
   $ grep "git_hash $REPO_HASH" dune.lock/lock.dune > /dev/null || echo "not found"
   not found
@@ -146,8 +143,7 @@ The repository can also be injected via the dune-workspace file
   $ mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
   Solution for dune.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
 
   $ grep "git_hash $REPO_HASH" dune.lock/lock.dune > /dev/null

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -16,9 +16,8 @@ Demonstrate the generation of the lock directory in the presence of "|"
 
   $ solve b
   Solution for dune.lock:
-  a1.0.0.1
-  b.0.0.1
-  
+  - a1.0.0.1
+  - b.0.0.1
 Only a1 or a2 should appear but not both.
 
   $ cat dune.lock/b.pkg

--- a/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
@@ -13,8 +13,7 @@ Test conversion of opam sources into lock dir package specifications
 
   $ solve testpkg
   Solution for dune.lock:
-  testpkg.0.0.1
-  
+  - testpkg.0.0.1
  
   $ cat dune.lock/testpkg.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
@@ -14,8 +14,7 @@ variables can be found in `opam-var-os.t`.
   > EOF
   > solve testpkg
   Solution for dune.lock:
-  testpkg.0.0.1
-  
+  - testpkg.0.0.1
   $ cat dune.lock/testpkg.pkg
   (version 0.0.1)
   
@@ -40,8 +39,7 @@ Therefore we modify the lockfile here to remove these from the opam file:
   > EOF
   > solve testpkg
   Solution for dune.lock:
-  testpkg.0.0.1
-  
+  - testpkg.0.0.1
 The value for "jobs" should always be 1.
 
   $ GROUP="$(id -gn)"

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -19,8 +19,7 @@ to compare their values.
   > EOF
   > solve testpkg
   Solution for dune.lock:
-  testpkg.0.0.1
-  
+  - testpkg.0.0.1
   $ cat dune.lock/testpkg.pkg 
   (version 0.0.1)
   

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -50,9 +50,8 @@ We echo each package variable.
   > EOF
   > solve testpkg
   Solution for dune.lock:
-  foo.0.0.1
-  testpkg.0.0.1
-  
+  - foo.0.0.1
+  - testpkg.0.0.1
 Inspecting the lockfile we can see how each opam package variable was translated into a
 corresponding Dune version.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -27,8 +27,7 @@ opam-var-unsupported.t
   > EOF
   > solve testpkg
   Solution for dune.lock:
-  testpkg.0.0.1
-  
+  - testpkg.0.0.1
   $ cat dune.lock/testpkg.pkg
   (version 0.0.1)
   

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -26,13 +26,11 @@
   >  (depends bar))
   > EOF
   Solution for dune.workspace.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
   Solution for dune.lock:
-  bar.0.0.1
-  foo.0.0.1
-  
+  - bar.0.0.1
+  - foo.0.0.1
 No package should be outdated after a fresh lock.
   $ outdated
   dune.lock is up to date.

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -80,8 +80,7 @@ Generate a mock opam repository
 
   $ build_single_package foo
   Solution for dune.lock:
-  foo.0.0.1
-  
+  - foo.0.0.1
   package: foo.0.0.1
   enable: enable
   installed: true
@@ -90,8 +89,7 @@ Generate a mock opam repository
   package conjunction string selection: bar
   $ build_single_package bar
   Solution for dune.lock:
-  bar.0.0.1
-  
+  - bar.0.0.1
   installed
   installed or pinned
   version greater than 0 (version is 0.0.1)
@@ -100,16 +98,14 @@ Generate a mock opam repository
   check if variable 'installed' is defined
   $ build_single_package baz
   Solution for dune.lock:
-  baz.0.0.1
-  
+  - baz.0.0.1
   installed
   not madeup:installed
   hello
   installed-defined
   $ build_single_package error1
   Solution for dune.lock:
-  error1.0.0.1
-  
+  - error1.0.0.1
   File "dune.lock/error1.pkg", line 8, characters 30-43:
   8 |      (or_absorb_undefined_var %{pkg-self:a} %{pkg-self:b})
                                     ^^^^^^^^^^^^^
@@ -117,8 +113,7 @@ Generate a mock opam repository
   [1]
   $ build_single_package error2
   Solution for dune.lock:
-  error2.0.0.1
-  
+  - error2.0.0.1
   File "dune.lock/error2.pkg", line 8, characters 31-44:
   8 |      (and_absorb_undefined_var %{pkg-self:a} %{pkg-self:b})
                                      ^^^^^^^^^^^^^
@@ -126,8 +121,7 @@ Generate a mock opam repository
   [1]
   $ build_single_package error3
   Solution for dune.lock:
-  error3.0.0.1
-  
+  - error3.0.0.1
   File "dune.lock/error3.pkg", line 5, characters 2-46:
   5 |   (when
   6 |    (not
@@ -138,8 +132,7 @@ Generate a mock opam repository
   [1]
   $ build_single_package error4
   Solution for dune.lock:
-  error4.0.0.1
-  
+  - error4.0.0.1
   File "dune.lock/error4.pkg", line 5, characters 2-63:
   5 |   (when
   6 |    (not

--- a/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-flags-per-context.t
@@ -66,38 +66,30 @@ Create a workspace file with some contexts with different combinations of with-t
 
   $ solve regular-package "(test-package :with-test)" "(doc-package :with-doc)"
   Solution for with-standard-flags.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
+  - test-package.0.0.1
   Solution for with-doc-and-with-test.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
+  - test-package.0.0.1
   Solution for with-doc-only.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
   Solution for with-test-only.lock:
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - regular-package.0.0.1
+  - test-package.0.0.1
   Solution for empty-solver-flags.lock:
-  regular-package.0.0.1
-  
+  - regular-package.0.0.1
   Solution for default-solver-flags.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
+  - test-package.0.0.1
   Solution for default-solver-env.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
+  - test-package.0.0.1
   Solution for dune.lock:
-  doc-package.0.0.1
-  regular-package.0.0.1
-  test-package.0.0.1
-  
+  - doc-package.0.0.1
+  - regular-package.0.0.1
+  - test-package.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -74,8 +74,7 @@ No solution will be available on macos as all versions of this package are only
 available on linux.
   $ solve linux-only
   Solution for dune.lock:
-  linux-only.0.0.2
-  
+  - linux-only.0.0.2
   Error: Unable to solve dependencies in build context: macos
   Can't find all required versions.
   Selected: x.dev
@@ -89,19 +88,16 @@ The latest version of the package will be chosen on linux but the middle
 version will be chosen on macos as that's the only version available on macos.
   $ solve macos-sometimes
   Solution for dune.lock:
-  macos-sometimes.0.0.3
-  
+  - macos-sometimes.0.0.3
   Solution for dune.macos.lock:
-  macos-sometimes.0.0.2
-  
+  - macos-sometimes.0.0.2
 
 A warning will be printed as the undefined-var.0.0.1 package has an undefined
 variable in its `available` filter. The undefined-var.0.0.2 package has a valid
 `available` filter but is only available on linux.
   $ solve undefined-var
   Solution for dune.lock:
-  undefined-var.0.0.2
-  
+  - undefined-var.0.0.2
   Error: Unable to solve dependencies in build context: macos
   Can't find all required versions.
   Selected: x.dev
@@ -135,8 +131,6 @@ with-test is set. This exercises that we can handle flags in the available
 filter.
   $ solve with-test-check
   Solution for dune.lock:
-  with-test-check.0.0.2
-  
+  - with-test-check.0.0.2
   Solution for dune.macos.lock:
-  with-test-check.0.0.2
-  
+  - with-test-check.0.0.2

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -33,29 +33,25 @@ Test variable filters on dependencies
 Regular dependencies are resolved transitively:
   $ solve depends-on-foo
   Solution for dune.lock:
-  depends-on-foo.0.0.1
-  foo.0.0.1
-  foo-dependency.0.0.1
-  
+  - depends-on-foo.0.0.1
+  - foo.0.0.1
+  - foo-dependency.0.0.1
 
 Transitive test dependencies are not included:
   $ solve depends-on-foo-with-test
   Solution for dune.lock:
-  depends-on-foo-with-test.0.0.1
-  
+  - depends-on-foo-with-test.0.0.1
 
 Test dependencies of the project are included:
   $ solve "(foo :with-test)"
   Solution for dune.lock:
-  foo.0.0.1
-  foo-dependency.0.0.1
-  
+  - foo.0.0.1
+  - foo-dependency.0.0.1
 
 Test dependencies of test dependencies are excluded:
   $ solve "(depends-on-foo-with-test :with-test)"
   Solution for dune.lock:
-  depends-on-foo-with-test.0.0.1
-  
+  - depends-on-foo-with-test.0.0.1
 
 Conflicting packages can't be co-installed:
   $ solve foo conflicts-with-foo
@@ -80,7 +76,6 @@ Conflicting packages in transitive dependencies can't be co-installed:
 Conflicts with transitive test dependencies don't affect the solution:
   $ solve depends-on-foo-with-test conflicts-with-foo
   Solution for dune.lock:
-  conflicts-with-foo.0.0.1
-  depends-on-foo-with-test.0.0.1
-  
+  - conflicts-with-foo.0.0.1
+  - depends-on-foo-with-test.0.0.1
 


### PR DESCRIPTION
We use `Pp.enumerate` when printing packages in a lock file. Affecting the output of `dune pkg lock` and `dune describe pkg lock`. Additionally:
- The "Contents of dune.lock" message is given the Success tag.
- The extra space after `dune pkg lock` is removed.