### PR TITLE
fix(stdune): make sure Path.drop_prefix drops path prefixes only

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -401,9 +401,13 @@ end = struct
   type t = string
 
   let drop_prefix path ~prefix =
-    String.drop_prefix path ~prefix
-    |> Option.map ~f:(fun p ->
-      String.drop_prefix_if_exists ~prefix:"/" p |> Local.of_string)
+    if prefix = path
+    then Some Local.root
+    else (
+      let prefix = prefix ^ "/" in
+      let open Option.O in
+      let+ suffix = String.drop_prefix path ~prefix in
+      Local.of_string suffix)
   ;;
 
   let to_string t = t
@@ -1347,9 +1351,13 @@ let chmod t ~mode = Unix.chmod (to_string t) mode
 let follow_symlink path = Fpath.follow_symlink (to_string path) |> Result.map ~f:of_string
 
 let drop_prefix path ~prefix =
-  String.drop_prefix (to_string path) ~prefix:(to_string prefix)
-  |> Option.map ~f:(fun p ->
-    String.drop_prefix_if_exists ~prefix:"/" p |> Local.of_string)
+  if prefix = path
+  then Some Local.root
+  else (
+    let prefix = to_string prefix ^ "/" in
+    let open Option.O in
+    let+ suffix = String.drop_prefix (to_string path) ~prefix in
+    Local.of_string suffix)
 ;;
 
 let drop_prefix_exn t ~prefix =

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -477,22 +477,20 @@ let%expect_test "drop external prefix" =
   [%expect {| Some "baz" |}]
 ;;
 
-(* CR-someday alizter: This is a bug! Should return None *)
 let%expect_test "drop prefix as substring" =
   Path.drop_prefix ~prefix:(r "foo/bar") (r "foo/barbaz")
   |> Dyn.option Path.Local.to_dyn
   |> print_dyn;
-  [%expect {| Some "baz" |}]
+  [%expect {| None |}]
 ;;
 
-(* CR-someday alizter: This is a bug! Should return None *)
 let%expect_test "drop external prefix as substring" =
   Path.External.drop_prefix
     ~prefix:(Path.External.of_filename_relative_to_initial_cwd "foo/bar")
     (Path.External.of_filename_relative_to_initial_cwd "foo/barbaz")
   |> Dyn.option Path.Local.to_dyn
   |> print_dyn;
-  [%expect {| Some "baz" |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "drop entire path" =


### PR DESCRIPTION
Fixes #8870 