### PR TITLE
fix: failing coq --config

### DIFF
--- a/doc/changes/coq_config_fix.md
+++ b/doc/changes/coq_config_fix.md
@@ -1,0 +1,6 @@
+- [coq rules] Be more tolerant when coqc --print-version / --config
+  don't work properly, and fallback to a reasonable default. This
+  fixes problems when building Coq projects with `(stdlib no)` and
+  likely other cases. (#8966, fix #8958, @Alizter, reported by Lasse
+  Blaauwbroek)
+

--- a/src/dune_rules/coq/coq_config.mli
+++ b/src/dune_rules/coq/coq_config.mli
@@ -1,10 +1,23 @@
 open Import
 
+(** Data of a Coq configuration. *)
 type t
 
-val version : coqc:Action.Prog.t -> (string, User_message.Style.t Pp.t) Result.t Memo.t
-val make : coqc:Action.Prog.t -> t Memo.t
-val make_opt : coqc:Action.Prog.t -> t Option.t Memo.t
+(** [version ~coqc] runs coqc --print-version and returns the version of Coq as a string
+    without having to run coqc --config. Exceptionally, one of the following will happen:
+
+    - Return [Error message] if coqc --print-version exits with a non-zero code.
+    - Throw a user error if coqc --print-version is not parsable.
+    - Throw an [Action.Prog.Not_found] exception if the coqc binary is not found. *)
+val version : coqc:Action.Prog.t -> (string, User_message.Style.t Pp.t) result Memo.t
+
+(** [make ~coqc] runs coqc --config and returns the configuration data. Exceptionally, one
+    of the following will happen:
+
+    - Return [Error message] if coqc --config exits with a non-zero code.
+    - Throw a user error if coqc --config is not parsable.
+    - Throw an [Action.Prog.Not_found] exception if the coqc binary is not found. *)
+val make : coqc:Action.Prog.t -> (t, User_message.Style.t Pp.t) result Memo.t
 
 module Value : sig
   type t = private

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -111,10 +111,10 @@ let select_native_mode ~sctx ~dir (buildable : Coq_stanza.Buildable.t) =
     then Memo.return Coq_mode.VoOnly
     else
       let* coqc = coqc ~sctx ~dir ~loc:buildable.loc in
-      let+ config = Coq_config.make_opt ~coqc in
+      let+ config = Coq_config.make ~coqc in
       (match config with
-       | None -> Coq_mode.VoOnly
-       | Some config ->
+       | Error _ -> Coq_mode.VoOnly
+       | Ok config ->
          (match Coq_config.by_name config "coq_native_compiler_default" with
           | Some (String "yes") | Some (String "ondemand") -> Coq_mode.Native
           | _ -> Coq_mode.VoOnly))

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -656,16 +656,29 @@ let expand_pform_macro
           (let open Memo.O in
            let* coqc = Artifacts.binary t.artifacts_host ~loc:None "coqc" in
            let+ t = Coq_config.make ~coqc in
-           match Coq_config.by_name t s with
-           | None ->
+           match t with
+           | Error msg ->
              User_error.raise
                ~loc:(Dune_lang.Template.Pform.loc source)
-               [ Pp.textf "Unknown Coq configuration variable %S" s ]
-           | Some v ->
-             (match v with
-              | Int x -> string (string_of_int x)
-              | String x -> string x
-              | Path x -> Value.L.paths [ x ])))
+               [ Pp.textf "Could not expand %%{coq:%s} as running coqc --config failed." s
+               ; msg
+               ]
+               ~hints:
+                 [ Pp.textf
+                     "coqc --config requires the coq-stdlib package in order to function \
+                      properly."
+                 ]
+           | Ok t ->
+             (match Coq_config.by_name t s with
+              | None ->
+                User_error.raise
+                  ~loc:(Dune_lang.Template.Pform.loc source)
+                  [ Pp.textf "Unknown Coq configuration variable %S" s ]
+              | Some v ->
+                (match v with
+                 | Int x -> string (string_of_int x)
+                 | String x -> string x
+                 | Path x -> Value.L.paths [ x ]))))
 ;;
 
 let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source (pform : Pform.t)

--- a/test/blackbox-tests/test-cases/coq/failed-config.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/failed-config.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.11)
+
+(using coq 0.8)

--- a/test/blackbox-tests/test-cases/coq/failed-config.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/failed-config.t/run.t
@@ -1,0 +1,138 @@
+Here we test what happens when coq --config or --print-version fails in an unexpected way
+and how dune reacts to this failure.
+
+First we create a wrapper around coqc so we can make it fail. It should only fail on
+--config and --print-version.
+  $ mkdir bin
+  $ cat > bin/coqc <<'EOF'
+  > #!/bin/sh
+  > if    [ $1 = --config ]        && [ -n "$FAIL_CONFIG" ]; then
+  >   echo "coqc --config has failed for some reason" >&2
+  >   exit 1
+  > elif  [ $1 = --print-version ] && [ -n "$FAIL_VERSION" ]; then
+  >   echo "coqc --print-version has failed for some reason" >&2
+  >   exit 1
+  > fi
+  > EOF
+  > echo "$(which coqc) \$@" >> bin/coqc
+  > chmod +x bin/coqc
+
+  $ export PATH=$PWD/bin:$PATH
+
+To make sure these are working correctly we test them.
+
+These should succeed.
+  $ coqc --print-version > /dev/null
+  $ coqc --config > /dev/null
+These should fail.
+  $ FAIL_VERSION=1 \
+  > coqc --print-version 2> /dev/null
+  [1]
+  $ FAIL_CONFIG=1 \
+  > coqc --config 2> /dev/null
+  [1]
+
+Now we create a simple project that uses this coqc wrapper.
+
+  $ cat > dune <<EOF
+  > (coq.theory
+  >  (flags -noinit)
+  >  (name foo))
+  > 
+  > (rule
+  >  (deps
+  >   (env_var FAIL_VERSION)
+  >   (env_var FAIL_CONFIG))
+  >  (action
+  >   (write-file a.v "")))
+  > EOF
+
+Here we build a simple Coq project. Neither a failing --config or --print-version should
+block this.
+
+Should succeed, but should warn that installed theories are being skipped due to the
+failure.
+  $ FAIL_CONFIG=1 \
+  > dune build
+  coqc --config has failed for some reason
+  Error: Error while running
+  $TESTCASE_ROOT/bin/coqc
+  --config
+  Exit code: 1
+  Output:
+  
+  [1]
+
+  $ FAIL_VERSION=1 \
+  > dune build
+  coqc --print-version has failed for some reason
+  [1]
+
+  $ dune build
+
+Here we query the version of Coq. Due to the expansion of %{coq:_} macros we need coq
+--config. A failing --print-version or --config will block this value from being realised.
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias version)
+  >  (action
+  >   (echo %{coq:version})))
+  > EOF
+
+Fails for now, but could be improved in the future.
+  $ FAIL_CONFIG=1 \
+  > dune build @version
+  coqc --config has failed for some reason
+  Error: Error while running
+  $TESTCASE_ROOT/bin/coqc
+  --config
+  Exit code: 1
+  Output:
+  
+  -> required by %{coq:version} at dune:4
+  -> required by alias version in dune:1
+  [1]
+
+Should fail.
+  $ FAIL_VERSION=1 \
+  > dune build @version
+  coqc --print-version has failed for some reason
+  -> required by %{coq:version} at dune:4
+  -> required by alias version in dune:1
+  [1]
+
+Here we query the config. A failing --config will block this value from being realised
+however a failing --print-version will not.
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias config)
+  >  (action
+  >   (echo %{coq:coqlib})))
+  > EOF
+
+Should fail.
+  $ export coqlib="$(coqc -config | grep COQLIB | sed 's/COQLIB=//')"
+  $ FAIL_CONFIG=1 \
+  > dune build @config 
+  coqc --config has failed for some reason
+  Error: Error while running
+  $TESTCASE_ROOT/bin/coqc
+  --config
+  Exit code: 1
+  Output:
+  
+  -> required by %{coq:coqlib} at dune:4
+  -> required by alias config in dune:1
+  [1]
+
+Should succeed.
+  $ FAIL_VERSION=1 \
+  > dune build @config | sed "s,$coqlib,COQLIB," > /dev/null
+  coqc --print-version has failed for some reason
+  -> required by %{coq:coqlib} at dune:4
+  -> required by alias config in dune:1
+
+Should succeed.
+  $ dune build @config | sed "s,$coqlib,COQLIB," > /dev/null

--- a/test/blackbox-tests/test-cases/coq/failed-config.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/failed-config.t/run.t
@@ -54,19 +54,12 @@ Should succeed, but should warn that installed theories are being skipped due to
 failure.
   $ FAIL_CONFIG=1 \
   > dune build
-  coqc --config has failed for some reason
-  Error: Error while running
-  $TESTCASE_ROOT/bin/coqc
-  --config
-  Exit code: 1
-  Output:
-  
-  [1]
+  Warning: Skipping installed theories due to coqc --config failure:
+  - $TESTCASE_ROOT/bin/coqc --config failed with exit code 1.
+  Hint: Try running `coqc --config` manually to see the error.
 
   $ FAIL_VERSION=1 \
   > dune build
-  coqc --print-version has failed for some reason
-  [1]
 
   $ dune build
 
@@ -83,21 +76,20 @@ Here we query the version of Coq. Due to the expansion of %{coq:_} macros we nee
 Fails for now, but could be improved in the future.
   $ FAIL_CONFIG=1 \
   > dune build @version
-  coqc --config has failed for some reason
-  Error: Error while running
-  $TESTCASE_ROOT/bin/coqc
-  --config
-  Exit code: 1
-  Output:
-  
-  -> required by %{coq:version} at dune:4
-  -> required by alias version in dune:1
+  File "dune", line 4, characters 8-22:
+  4 |   (echo %{coq:version})))
+              ^^^^^^^^^^^^^^
+  Error: Could not expand %{coq:version} as running coqc --config failed.
+  $TESTCASE_ROOT/bin/coqc --config failed with exit code 1.
+  Hint: coqc --config requires the coq-stdlib package in order to function
+  properly.
   [1]
 
 Should fail.
   $ FAIL_VERSION=1 \
   > dune build @version
-  coqc --print-version has failed for some reason
+  Error: Could not parse coqc version: 
+  $TESTCASE_ROOT/bin/coqc --print-version failed with exit code 1.
   -> required by %{coq:version} at dune:4
   -> required by alias version in dune:1
   [1]
@@ -116,23 +108,18 @@ Should fail.
   $ export coqlib="$(coqc -config | grep COQLIB | sed 's/COQLIB=//')"
   $ FAIL_CONFIG=1 \
   > dune build @config 
-  coqc --config has failed for some reason
-  Error: Error while running
-  $TESTCASE_ROOT/bin/coqc
-  --config
-  Exit code: 1
-  Output:
-  
-  -> required by %{coq:coqlib} at dune:4
-  -> required by alias config in dune:1
+  File "dune", line 4, characters 8-21:
+  4 |   (echo %{coq:coqlib})))
+              ^^^^^^^^^^^^^
+  Error: Could not expand %{coq:coqlib} as running coqc --config failed.
+  $TESTCASE_ROOT/bin/coqc --config failed with exit code 1.
+  Hint: coqc --config requires the coq-stdlib package in order to function
+  properly.
   [1]
 
 Should succeed.
   $ FAIL_VERSION=1 \
   > dune build @config | sed "s,$coqlib,COQLIB," > /dev/null
-  coqc --print-version has failed for some reason
-  -> required by %{coq:coqlib} at dune:4
-  -> required by alias config in dune:1
 
 Should succeed.
   $ dune build @config | sed "s,$coqlib,COQLIB," > /dev/null


### PR DESCRIPTION
The first commit adds a test detailing how Dune reacts to `coqc --version` and `coqc --config` failing. We write down what we expect to happen in each situation.

The second commit does a few things:
- Cleans up how `coq_config` is handled, shares more code, streamlines the API (removing `make_exn`).
- We start passing `-boot` to `coqc --print-version` to make it work when only `coq-core` is around.
- We make sure that the failure of `coqc --config` does not inhibit the build. There is a check for the config in the installed theories composition for example. We emit a warning if config fails and do a best effort without any installed theories.
- We improve error messages elsewhere where config or version are requested but could fail.

I don't think this needs a version bump as it affects a very small minority of users who build with only `coq-core`.

- [x] changelog
- Fixes #8958 