### PR TITLE
fix(engine): remove context from action digest

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -128,9 +128,9 @@ let print_rule_sexp ppf (rule : Dune_engine.Reflection.Rule.t) =
                  ; "directories", paths rule.targets.dirs
                  ] )
            ]
-         ; (match rule.context with
+         ; (match Path.Build.extract_build_context rule.dir with
             | None -> []
-            | Some c -> [ "context", Dune_engine.Context_name.encode c.name ])
+            | Some (c, _) -> [ "context", Dune_sexp.atom_or_quoted_string c ])
          ; [ "action", sexp_of_action rule.action ]
          ])
   in

--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -71,7 +71,6 @@ type t =
       -> delete_dst_if_it_is_a_directory:bool
       -> src:Path.Build.t
       -> dst:Path.Source.t
-      -> Build_context.t option
       -> unit Fiber.t
   ; stats : Dune_stats.t option
   ; cache_config : Dune_cache.Config.t

--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -129,7 +129,6 @@ module type Build_config = sig
           -> delete_dst_if_it_is_a_directory:bool
           -> src:Path.Build.t
           -> dst:Path.Source.t
-          -> Build_context.t option
           -> unit Fiber.t)
     -> cache_config:Dune_cache.Config.t
     -> cache_debug_flags:Cache_debug_flags.t
@@ -151,7 +150,6 @@ module type Build_config = sig
         -> delete_dst_if_it_is_a_directory:bool
         -> src:Path.Build.t
         -> dst:Path.Source.t
-        -> Build_context.t option
         -> unit Fiber.t
     ; stats : Dune_stats.t option
     ; cache_config : Dune_cache.Config.t

--- a/src/dune_engine/build_context.ml
+++ b/src/dune_engine/build_context.ml
@@ -9,3 +9,9 @@ let create ~name =
   let build_dir = Path.Build.of_string (Context_name.to_string name) in
   { name; build_dir }
 ;;
+
+let of_build_path p =
+  match Dpath.analyse_target p with
+  | Regular (name, _) | Alias (name, _) | Anonymous_action name -> Some (create ~name)
+  | Other _ -> None
+;;

--- a/src/dune_engine/build_context.mli
+++ b/src/dune_engine/build_context.mli
@@ -11,3 +11,4 @@ type t = private
   }
 
 val create : name:Context_name.t -> t
+val of_build_path : Path.Build.t -> t option

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -332,7 +332,6 @@ end = struct
           }
       in
       Rule.make
-        ~context:None
         ~info:(Source_file_copy path)
         ~targets:(Targets.File.create ctx_path)
         build)

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -9,7 +9,6 @@ module Rule = struct
     ; deps : Dep.Set.t
     ; expanded_deps : Path.Set.t
     ; targets : Targets.Validated.t
-    ; context : Build_context.t option
     ; action : Action.t
     }
 end
@@ -68,7 +67,6 @@ let evaluate_rule =
           ; deps
           ; expanded_deps
           ; targets = rule.targets
-          ; context = rule.context
           ; action = action.action
           })
   in

--- a/src/dune_engine/reflection.mli
+++ b/src/dune_engine/reflection.mli
@@ -10,7 +10,6 @@ module Rule : sig
          variables, universe, glob listings, sandbox requirements *)
       expanded_deps : Path.Set.t
     ; targets : Targets.Validated.t
-    ; context : Build_context.t option
     ; action : Action.t
     }
 end

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -53,7 +53,6 @@ module Id = Id.Make ()
 module T = struct
   type t =
     { id : Id.t
-    ; context : Build_context.t option
     ; targets : Targets.Validated.t
     ; action : Action.Full.t Action_builder.t
     ; mode : Mode.t
@@ -72,7 +71,7 @@ end
 include T
 include Comparable.Make (T)
 
-let make ?(mode = Mode.Standard) ~context ?(info = Info.Internal) ~targets action =
+let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
   let action = Action_builder.memoize "Rule.make" action in
   let report_error ?(extra_pp = []) message =
     match info with
@@ -111,7 +110,7 @@ let make ?(mode = Mode.Standard) ~context ?(info = Info.Internal) ~targets actio
            (Path.build (Path.Build.relative dir "_unknown_")))
     | Source_file_copy p -> Loc.in_file (Path.source p)
   in
-  { id = Id.gen (); targets; context; action; mode; info; loc; dir }
+  { id = Id.gen (); targets; action; mode; info; loc; dir }
 ;;
 
 let set_action t action =
@@ -121,8 +120,7 @@ let set_action t action =
 
 module Anonymous_action = struct
   type t =
-    { context : Build_context.t option
-    ; action : Action.Full.t
+    { action : Action.Full.t
     ; loc : Loc.t
     ; dir : Path.Build.t
     ; alias : Alias.Name.t option

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -55,7 +55,6 @@ end
 
 type t = private
   { id : Id.t
-  ; context : Build_context.t option
   ; targets : Targets.Validated.t
   ; action : Action.Full.t Action_builder.t
   ; mode : Mode.t
@@ -74,7 +73,6 @@ val to_dyn : t -> Dyn.t
     [Targets.Validation_result] data type for the list of possible problems. *)
 val make
   :  ?mode:Mode.t
-  -> context:Build_context.t option
   -> ?info:Info.t
   -> targets:Targets.t
   -> Action.Full.t Action_builder.t
@@ -87,8 +85,7 @@ module Anonymous_action : sig
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should
      eventually share the code. *)
   type t =
-    { context : Build_context.t option
-    ; action : Action.Full.t
+    { action : Action.Full.t
     ; loc : Loc.t
     ; dir : Path.Build.t
         (** Directory the action is attached to. This is the directory where

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -148,12 +148,11 @@ module Produce = struct
         }
     ;;
 
-    let add_action t ~context ~loc action =
+    let add_action t ~loc action =
       let action =
         let open Action_builder.O in
         let+ action = action in
-        { Rule.Anonymous_action.context = Some context
-        ; action
+        { Rule.Anonymous_action.action
         ; loc
         ; dir = Alias.dir t
         ; alias = Some (Alias.name t)

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -74,14 +74,9 @@ module Produce : sig
         [alias]. *)
     val add_deps : t -> ?loc:Stdune.Loc.t -> unit Action_builder.t -> unit Memo.t
 
-    (** [add_action alias ~context ~loc action] arrange things so that [action]
+    (** [add_action alias ~loc action] arrange things so that [action]
         is executed as part of the build of alias [alias]. *)
-    val add_action
-      :  t
-      -> context:Build_context.t
-      -> loc:Loc.t
-      -> Action.Full.t Action_builder.t
-      -> unit Memo.t
+    val add_action : t -> loc:Loc.t -> Action.Full.t Action_builder.t -> unit Memo.t
   end
 end
 

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -24,7 +24,7 @@ module Conf : sig
   type t
 
   val get_location : t -> Section.t -> Package.Name.t -> Path.t
-  val of_context : Context.t option -> t
+  val of_context : Context.t -> t
 
   val of_install
     :  relocatable:Path.t option

--- a/src/dune_rules/configurator_rules.ml
+++ b/src/dune_rules/configurator_rules.ml
@@ -25,7 +25,7 @@ let gen_rules (ctx : Build_context.t) (ocaml : Ocaml_toolchain.t) =
      |> String.concat ~sep:""
      |> Action.write_file fn
      |> Action.Full.make)
-    |> Rule.make ~targets:(Targets.File.create fn) ~context:None
+    |> Rule.make ~targets:(Targets.File.create fn)
     |> Rules.Produce.rule
   in
   let fn = configurator_v2 ctx in
@@ -42,7 +42,7 @@ let gen_rules (ctx : Build_context.t) (ocaml : Ocaml_toolchain.t) =
    |> Csexp.to_string
    |> Action.write_file fn
    |> Action.Full.make)
-  |> Rule.make ~targets:(Targets.File.create fn) ~context:None
+  |> Rule.make ~targets:(Targets.File.create fn)
   |> Rules.Produce.rule
 ;;
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -921,7 +921,7 @@ let symlink_installed_artifacts_to_build_install
     in
     let src = Path.build entry.src in
     let rule { Action_builder.With_targets.targets; build } =
-      Rule.make ~info:(From_dune_file loc) ~context:(Some ctx) ~targets build
+      Rule.make ~info:(From_dune_file loc) ~targets build
     in
     match entry.kind with
     | `Source_tree ->

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -51,12 +51,9 @@ let init
   ()
   : unit
   =
-  let promote_source ~chmod ~delete_dst_if_it_is_a_directory ~src ~dst ctx =
+  let promote_source ~chmod ~delete_dst_if_it_is_a_directory ~src ~dst =
     let open Fiber.O in
-    let* ctx =
-      Memo.run
-        (Memo.Option.map ctx ~f:(fun (ctx : Build_context.t) -> Context.DB.get ctx.name))
-    in
+    let* ctx = Path.Build.parent_exn src |> Context.DB.by_dir |> Memo.run in
     let conf = Artifact_substitution.Conf.of_context ctx in
     let src = Path.build src in
     let dst = Path.source dst in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1349,8 +1349,7 @@ let add_env env action =
 
 let rule ?loc { Action_builder.With_targets.build; targets } =
   (* TODO this ignores the workspace file *)
-  Rule.make ~info:(Rule.Info.of_loc_opt loc) ~targets build ~context:None
-  |> Rules.Produce.rule
+  Rule.make ~info:(Rule.Info.of_loc_opt loc) ~targets build |> Rules.Produce.rule
 ;;
 
 let source_rules (pkg : Pkg.t) =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -253,12 +253,7 @@ let extend_action t ~dir action =
 
 let make_rule t ?mode ?loc ~dir { Action_builder.With_targets.build; targets } =
   let build = extend_action t build ~dir in
-  Rule.make
-    ?mode
-    ~info:(Rule.Info.of_loc_opt loc)
-    ~context:(Some (Context.build_context (Env_tree.context t)))
-    ~targets
-    build
+  Rule.make ?mode ~info:(Rule.Info.of_loc_opt loc) ~targets build
 ;;
 
 let add_rule t ?mode ?loc ~dir build =
@@ -276,11 +271,7 @@ let add_rules t ?loc ~dir builds = Memo.parallel_iter builds ~f:(add_rule ?loc t
 
 let add_alias_action t alias ~dir ~loc action =
   let build = extend_action t action ~dir in
-  Rules.Produce.Alias.add_action
-    ~context:(Context.build_context (Env_tree.context t))
-    alias
-    ~loc
-    build
+  Rules.Produce.Alias.add_action alias ~loc build
 ;;
 
 let local_binaries t ~dir = Env_tree.get_node t ~dir >>= Env_node.local_binaries

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [9acd3a08d49c004c7c4af47984604b5c] (_build/default/source): not found in cache
+  Shared cache miss [d008bb41344a7d0d53972220079cbb8c] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [c8ba5d0ce97e5b84d90b24999e54d106] (_build/default/target1): not found in cache
+  Shared cache miss [b13d2ba64fcb9361d4fe1b3b094f2f82] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [4971137801799003aa6e088963677239] (_build/default/source): not found in cache
+  Shared cache miss [26bdf30e58f853b22578ed89686d983f] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [967c475fcb42c969b0a32a612f7f8918] (_build/default/target1): not found in cache
+  Shared cache miss [b12a77bbe2d67c323ef28eaaebdcfb34] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [9c0ced5efcd85d0a6c5364bee242c3a2]: ((in_cache
+  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [9c0ced5efcd85d0a6c5364bee242c3a2]: ((in_cache
+  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [9c0ced5efcd85d0a6c5364bee242c3a2]: ((in_cache
+  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./25/259be1c0c7a2f2eab4f17969ff8486f5:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./f2/f280f0a3c487ec316e741894b164691a:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./c7/c7dd3e91adf65ae3cd721eef06904b93:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./d7/d74e8e6eb3d6cf509b6d3b7cbfeee223:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-6e90ca359837e9da9d2387e4bdfedc59
+  _build/.actions/default/blah-182327d6e04fe09497790fcdbab8ca83
 
 And we check that it isn't copied in the source tree:
 


### PR DESCRIPTION
This PR removes the context name from the rules and actions. The context can always be derived from the action directory so it's just redundant.