### PR TITLE
Add `dune cache clear` command

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -80,16 +80,25 @@ let size =
     Cmd.info "size" ~doc ~man
   in
   Cmd.v info
-  @@ let+ machine_readble =
+  @@ let+ machine_readable =
        Arg.(
          value
          & flag
          & info [ "machine-readable" ] ~doc:"Outputs size as a plain number of bytes.")
      in
      let size = Dune_cache.Trimmer.overhead_size () in
-     if machine_readble
+     if machine_readable
      then User_message.print (User_message.make [ Pp.textf "%Ld" size ])
      else User_message.print (User_message.make [ Pp.textf "%s" (Bytes_unit.pp size) ])
+;;
+
+let clear =
+  let info =
+    let doc = "Clear the Dune cache." in
+    let man = [ `P "Remove any traces of the Dune cache." ] in
+    Cmd.info "clear" ~doc ~man
+  in
+  Cmd.v info @@ Term.(const Dune_cache_storage.clear $ const ())
 ;;
 
 let command =
@@ -104,5 +113,5 @@ let command =
     in
     Cmd.info "cache" ~doc ~man
   in
-  Cmd.group info [ trim; size ]
+  Cmd.group info [ trim; size; clear ]
 ;;

--- a/doc/changes/8975.md
+++ b/doc/changes/8975.md
@@ -1,0 +1,2 @@
+- Add command `dune cache clear` to completely delete all traces of the Dune
+  cache. (#8975, @nojb)

--- a/src/dune_cache_storage/dune_cache_storage.mli
+++ b/src/dune_cache_storage/dune_cache_storage.mli
@@ -138,3 +138,5 @@ module Raw_value : sig
     -> content_digest:Digest.t
     -> Util.Write_result.t
 end
+
+val clear : unit -> unit

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -13,6 +13,9 @@ Here we observe the documentation for the dune cache commands.
          functionality soon.
   
   COMMANDS
+         clear [OPTION]…
+             Clear the Dune cache.
+  
          size [--machine-readable] [OPTION]…
              Query the size of the Dune cache.
   

--- a/test/blackbox-tests/test-cases/dune-cache/clear.t
+++ b/test/blackbox-tests/test-cases/dune-cache/clear.t
@@ -1,0 +1,50 @@
+Test for the "dune cache clear" command.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/dune-cache
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.10)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule (with-stdout-to foo (progn)))
+  > EOF
+
+  $ dune build
+
+  $ find $DUNE_CACHE_ROOT -type d | sort -u
+  $TESTCASE_ROOT/dune-cache
+  $TESTCASE_ROOT/dune-cache/files
+  $TESTCASE_ROOT/dune-cache/files/v4
+  $TESTCASE_ROOT/dune-cache/files/v4/11
+  $TESTCASE_ROOT/dune-cache/files/v4/4d
+  $TESTCASE_ROOT/dune-cache/files/v4/b8
+  $TESTCASE_ROOT/dune-cache/meta
+  $TESTCASE_ROOT/dune-cache/meta/v5
+  $TESTCASE_ROOT/dune-cache/meta/v5/2f
+  $TESTCASE_ROOT/dune-cache/meta/v5/39
+  $TESTCASE_ROOT/dune-cache/meta/v5/4d
+  $TESTCASE_ROOT/dune-cache/temp
+  $TESTCASE_ROOT/dune-cache/values
+  $TESTCASE_ROOT/dune-cache/values/v3
+
+  $ dune cache clear
+
+  $ ! test -d $DUNE_CACHE_ROOT
+
+Next let us add some extra directories/files and check that they are not deleted
+by mistake.
+
+  $ dune build
+
+  $ mkdir -p $DUNE_CACHE_ROOT/extra; touch $DUNE_CACHE_ROOT/extra1 $DUNE_CACHE_ROOT/extra/extra2
+
+  $ dune cache clear
+  Error:
+  rmdir($TESTCASE_ROOT/dune-cache): Directory not empty
+  [1]
+
+  $ find $DUNE_CACHE_ROOT -type f | sort -u
+  $TESTCASE_ROOT/dune-cache/extra/extra2
+  $TESTCASE_ROOT/dune-cache/extra1

--- a/test/blackbox-tests/test-cases/dune-cache/clear.t
+++ b/test/blackbox-tests/test-cases/dune-cache/clear.t
@@ -13,21 +13,11 @@ Test for the "dune cache clear" command.
 
   $ dune build
 
-  $ find $DUNE_CACHE_ROOT -type d | sort -u
-  $TESTCASE_ROOT/dune-cache
-  $TESTCASE_ROOT/dune-cache/files
-  $TESTCASE_ROOT/dune-cache/files/v4
-  $TESTCASE_ROOT/dune-cache/files/v4/11
-  $TESTCASE_ROOT/dune-cache/files/v4/4d
-  $TESTCASE_ROOT/dune-cache/files/v4/b8
-  $TESTCASE_ROOT/dune-cache/meta
-  $TESTCASE_ROOT/dune-cache/meta/v5
-  $TESTCASE_ROOT/dune-cache/meta/v5/2f
-  $TESTCASE_ROOT/dune-cache/meta/v5/39
-  $TESTCASE_ROOT/dune-cache/meta/v5/4d
-  $TESTCASE_ROOT/dune-cache/temp
-  $TESTCASE_ROOT/dune-cache/values
-  $TESTCASE_ROOT/dune-cache/values/v3
+  $ ls $DUNE_CACHE_ROOT | sort -u
+  files
+  meta
+  temp
+  values
 
   $ dune cache clear
 


### PR DESCRIPTION
Fixes #8971

Of course, if someone does `DUNE_CACHE_ROOT=/ dune cache clear` or similar they will zap their whole system...