### PR TITLE
melange: show test depending on alias

### DIFF
--- a/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
@@ -1,0 +1,36 @@
+Test the case where a test that depends on a melange emit alias
+
+  $ cat <<EOF > dune-project
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ mkdir test
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target app)
+  >  (alias app-alias))
+  > EOF
+
+  $ cat > a.ml <<EOF
+  > let () = Js.log "foo"
+  > EOF
+
+  $ cat > test/dune <<EOF
+  > (cram
+  >  (deps (alias_rec %{workspace_root}/app-alias)))
+  > EOF
+
+The expected behavior would be that all .js artifacts are copied over to the
+test folder, but only the empty folders structured is copied.
+
+  $ cat > test/foo.t <<EOF
+  >   $ ls ..
+  >   app
+  >   test
+  >   $ ls ../app
+  >   node_modules
+  > EOF
+
+  $ dune build @foo

--- a/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
@@ -23,7 +23,7 @@ Test the case where a test that depends on a melange emit alias
   > EOF
 
 The expected behavior would be that all .js artifacts are copied over to the
-test folder, but only the empty folders structured is copied.
+test folder, but only the empty folders layout is copied.
 
   $ cat > test/foo.t <<EOF
   >   $ ls ..
@@ -35,7 +35,7 @@ test folder, but only the empty folders structured is copied.
 
   $ dune build @foo
 
-Adding (expand_aliases_in_sandbox) does not affect it
+Adding (expand_aliases_in_sandbox) fixes it (needs to clean first)
 
   $ cat <<EOF > dune-project
   > (lang dune 3.8)
@@ -43,5 +43,15 @@ Adding (expand_aliases_in_sandbox) does not affect it
   > (expand_aliases_in_sandbox)
   > EOF
 
-  $ dune build @foo
+  $ cat > test/foo.t <<EOF
+  >   $ ls ..
+  >   app
+  >   test
+  >   $ ls ../app
+  >   a.js
+  >   node_modules
+  > EOF
 
+  $ dune clean
+
+  $ dune build @foo

--- a/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-alias-in-test.t
@@ -34,3 +34,14 @@ test folder, but only the empty folders structured is copied.
   > EOF
 
   $ dune build @foo
+
+Adding (expand_aliases_in_sandbox) does not affect it
+
+  $ cat <<EOF > dune-project
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > (expand_aliases_in_sandbox)
+  > EOF
+
+  $ dune build @foo
+


### PR DESCRIPTION
Demonstrates issue #8977, when trying to depend on the alias of a `melange.emit` stanza.