### PR TITLE
fix: add break hints to Dyn.pp

### DIFF
--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -112,7 +112,11 @@ let rec pp =
   | Variant (v, xs) ->
     Pp.hvbox
       ~indent:2
-      (Pp.concat [ Pp.verbatim v; Pp.space; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp ])
+      (Pp.concat
+         [ Pp.verbatim v
+         ; Pp.space
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ',') Pp.space) xs ~f:pp
+         ])
 ;;
 
 let to_string t = Format.asprintf "%a" Pp.to_fmt (pp t)

--- a/otherlibs/ocamlc-loc/test/ocamlc_loc_tests.ml
+++ b/otherlibs/ocamlc-loc/test/ocamlc_loc_tests.ml
@@ -169,7 +169,7 @@ Error: Signature mismatch:
   [%expect
     {|
     >> error 0
-    { loc = { path = "test.ml"; line = Range 3,5; chars = Some (6, 3) }
+    { loc = { path = "test.ml"; line = Range 3, 5; chars = Some (6, 3) }
     ; message =
         "Signature mismatch:\n\
          Modules do not match:\n\
@@ -316,7 +316,7 @@ Error: Some record fields are undefined: signal_watcher
     >> error 0
     { loc =
         { path = "test/expect-tests/timer_tests.ml"
-        ; line = Range 6,10
+        ; line = Range 6, 10
         ; chars = Some (2, 3)
         }
     ; message = "Some record fields are undefined: signal_watcher"
@@ -573,7 +573,7 @@ Case
     >> error 0
     { loc =
         { path = "src/dune_engine/action.ml"
-        ; line = Range 34,96
+        ; line = Range 34, 96
         ; chars = Some (4, 64)
         }
     ; message =
@@ -586,7 +586,7 @@ Case
     >> error 1
     { loc =
         { path = "src/dune_engine/action.ml"
-        ; line = Range 291,315
+        ; line = Range 291, 315
         ; chars = Some (2, 22)
         }
     ; message =
@@ -599,7 +599,7 @@ Case
     >> error 2
     { loc =
         { path = "src/dune_engine/action.ml"
-        ; line = Range 339,363
+        ; line = Range 339, 363
         ; chars = Some (21, 24)
         }
     ; message =
@@ -612,7 +612,7 @@ Case
     >> error 3
     { loc =
         { path = "src/dune_engine/action.ml"
-        ; line = Range 391,414
+        ; line = Range 391, 414
         ; chars = Some (4, 70)
         }
     ; message =

--- a/otherlibs/stdune/test/ansi_color_tests.ml
+++ b/otherlibs/stdune/test/ansi_color_tests.ml
@@ -53,7 +53,9 @@ let%expect_test "reproduce #2664" =
   [%expect
     {|
     Vbox
-      0,Seq
+      0,
+      Seq
+        Seq
           Seq
             Seq
               Seq
@@ -72,46 +74,27 @@ let%expect_test "reproduce #2664" =
                                         Seq
                                           Seq
                                             Seq
-                                              Seq
-                                                Nop,Tag [ Fg_blue ],Verbatim "1",
-                                              Tag
-                                                [ Fg_blue ],Verbatim "2",
-                                            Tag
-                                              [ Fg_blue ],Verbatim "3",Tag
-                                                                        [ Fg_blue
-                                                                        ],
-                                                                        Verbatim
-                                                                        "4",
-                                        Tag
-                                          [ Fg_blue ],Verbatim "5",Tag
-                                                                     [ Fg_blue ],
-                                                                     Verbatim
-                                                                       "6",
-                                    Tag
-                                      [ Fg_blue ],Verbatim "7",Tag
-                                                                 [ Fg_blue ],
-                                                                 Verbatim
-                                                                   "8",Tag
-                                                                        [ Fg_blue
-                                                                        ],
-                                                                        Verbatim
-                                                                        "9",
-                              Tag
-                                [ Fg_blue ],Verbatim "10",Tag
-                                                            [ Fg_blue ],Verbatim
-                                                                        "11",
-                          Tag
-                            [ Fg_blue ],Verbatim "12",Tag
-                                                        [ Fg_blue ],Verbatim "13",
-                      Tag
-                        [ Fg_blue ],Verbatim "14",Tag [ Fg_blue ],Verbatim "15",
-                  Tag
-                    [ Fg_blue ],Verbatim "16",Tag [ Fg_blue ],Verbatim "17",
-              Tag
-                [ Fg_blue ],Verbatim "18",Tag [ Fg_blue ],Verbatim "19",Tag
-                                                                        [ Fg_blue
-                                                                        ],Verbatim
-                                                                        "20" |}]
+                                              Nop,
+                                              Tag [ Fg_blue ], Verbatim "1",
+                                            Tag [ Fg_blue ], Verbatim "2",
+                                          Tag [ Fg_blue ], Verbatim "3",
+                                        Tag [ Fg_blue ], Verbatim "4",
+                                      Tag [ Fg_blue ], Verbatim "5",
+                                    Tag [ Fg_blue ], Verbatim "6",
+                                  Tag [ Fg_blue ], Verbatim "7",
+                                Tag [ Fg_blue ], Verbatim "8",
+                              Tag [ Fg_blue ], Verbatim "9",
+                            Tag [ Fg_blue ], Verbatim "10",
+                          Tag [ Fg_blue ], Verbatim "11",
+                        Tag [ Fg_blue ], Verbatim "12",
+                      Tag [ Fg_blue ], Verbatim "13",
+                    Tag [ Fg_blue ], Verbatim "14",
+                  Tag [ Fg_blue ], Verbatim "15",
+                Tag [ Fg_blue ], Verbatim "16",
+              Tag [ Fg_blue ], Verbatim "17",
+            Tag [ Fg_blue ], Verbatim "18",
+          Tag [ Fg_blue ], Verbatim "19",
+        Tag [ Fg_blue ], Verbatim "20" |}]
 ;;
 
 let%expect_test "Ansi_color.strip" =
@@ -146,7 +129,9 @@ let%expect_test "parse fg and bg colors" =
   [%expect
     {|
 Vbox
-  0,Seq
+  0,
+  Seq
+    Seq
       Seq
         Seq
           Seq
@@ -156,27 +141,18 @@ Vbox
                   Seq
                     Seq
                       Seq
-                        Seq
-                          Seq Nop,Verbatim "This is a ",Tag
-                                                          [ Fg_blue ],
-                                                          Verbatim
-                                                            "blue",Verbatim
-                                                                    " string with ",
-                      Tag
-                        [ Fg_red ],Verbatim "red",Verbatim " and ",Tag
-                                                                    [ Fg_green
-                                                                    ],
-                                                                    Verbatim
-                                                                    "green",
-                Verbatim
-                  " together with strings of a ",Tag
-                                                   [ Bg_blue ],Verbatim
-                                                                 "blue blackground",
-            Verbatim
-              " and ",Tag [ Bg_red ],Verbatim "red background",Verbatim
-                                                                 " and ",
-      Tag
-        [ Bg_green ],Verbatim "green background" |}]
+                        Seq Nop, Verbatim "This is a ",
+                        Tag [ Fg_blue ], Verbatim "blue",
+                      Verbatim " string with ",
+                    Tag [ Fg_red ], Verbatim "red",
+                  Verbatim " and ",
+                Tag [ Fg_green ], Verbatim "green",
+              Verbatim " together with strings of a ",
+            Tag [ Bg_blue ], Verbatim "blue blackground",
+          Verbatim " and ",
+        Tag [ Bg_red ], Verbatim "red background",
+      Verbatim " and ",
+    Tag [ Bg_green ], Verbatim "green background" |}]
 ;;
 
 let%expect_test "parse multiple fg and bg colors" =
@@ -191,16 +167,14 @@ let%expect_test "parse multiple fg and bg colors" =
   [%expect
     {|
 Vbox
-  0,Seq
+  0,
+  Seq
+    Seq
       Seq
-        Seq
-          Seq Nop,Verbatim "This text is ",Tag
-                                             [ Fg_blue; Bg_red ],Verbatim
-                                                                   "blue string with a red background",
-        Verbatim
-          " and ",Tag
-                    [ Fg_green; Bg_blue ],Verbatim
-                                            "green string with a blue background" |}]
+        Seq Nop, Verbatim "This text is ",
+        Tag [ Fg_blue; Bg_red ], Verbatim "blue string with a red background",
+      Verbatim " and ",
+    Tag [ Fg_green; Bg_blue ], Verbatim "green string with a blue background" |}]
 ;;
 
 let%expect_test "fg default overrides" =
@@ -215,15 +189,14 @@ let%expect_test "fg default overrides" =
   [%expect
     {|
   Vbox
-    0,Seq
+    0,
+    Seq
+      Seq
         Seq
-          Seq
-            Seq Nop,Verbatim "This text has a ",Tag
-                                                  [ Fg_blue ],Verbatim
-                                                                "blue foreground",
-          Verbatim
-            " but here it becomes the default foreground,",Verbatim
-                                                             " even together with another foreground modifier." |}]
+          Seq Nop, Verbatim "This text has a ",
+          Tag [ Fg_blue ], Verbatim "blue foreground",
+        Verbatim " but here it becomes the default foreground,",
+      Verbatim " even together with another foreground modifier." |}]
 ;;
 
 let%expect_test "bg default overrides" =
@@ -238,15 +211,14 @@ let%expect_test "bg default overrides" =
   [%expect
     {|
 Vbox
-  0,Seq
+  0,
+  Seq
+    Seq
       Seq
-        Seq
-          Seq Nop,Verbatim "This text has a ",Tag
-                                                [ Bg_blue ],Verbatim
-                                                              "blue background",
-        Verbatim
-          " but here it becomes the default background,",Verbatim
-                                                           " even together with another background modifier." |}]
+        Seq Nop, Verbatim "This text has a ",
+        Tag [ Bg_blue ], Verbatim "blue background",
+      Verbatim " but here it becomes the default background,",
+    Verbatim " even together with another background modifier." |}]
 ;;
 
 let%expect_test "parse 8-bit colors" =
@@ -263,7 +235,9 @@ let%expect_test "parse 8-bit colors" =
   [%expect
     {|
 Vbox
-  0,Seq
+  0,
+  Seq
+    Seq
       Seq
         Seq
           Seq
@@ -273,25 +247,18 @@ Vbox
                   Seq
                     Seq
                       Seq
-                        Seq
-                          Seq Nop,Verbatim "This is a ",Tag
-                                                          [ Fg_8_bit_color 33
-                                                          ],Verbatim "blue",
-                        Verbatim
-                          " string with ",Tag
-                                            [ Fg_8_bit_color 196 ],Verbatim
-                                                                    "red",
-                    Verbatim
-                      " and ",Tag [ Fg_8_bit_color 46 ],Verbatim "green",
-                Verbatim
-                  " together with strings of a ",Tag
-                                                   [ Bg_8_bit_color 33 ],
-                                                   Verbatim
-                                                     "blue blackground",
-            Verbatim
-              " and ",Tag [ Bg_8_bit_color 196 ],Verbatim "red background",
-        Verbatim
-          " and ",Tag [ Bg_8_bit_color 46 ],Verbatim "green background" |}]
+                        Seq Nop, Verbatim "This is a ",
+                        Tag [ Fg_8_bit_color 33 ], Verbatim "blue",
+                      Verbatim " string with ",
+                    Tag [ Fg_8_bit_color 196 ], Verbatim "red",
+                  Verbatim " and ",
+                Tag [ Fg_8_bit_color 46 ], Verbatim "green",
+              Verbatim " together with strings of a ",
+            Tag [ Bg_8_bit_color 33 ], Verbatim "blue blackground",
+          Verbatim " and ",
+        Tag [ Bg_8_bit_color 196 ], Verbatim "red background",
+      Verbatim " and ",
+    Tag [ Bg_8_bit_color 46 ], Verbatim "green background" |}]
 ;;
 
 let%expect_test "parse 24-bit colors" =
@@ -308,7 +275,9 @@ let%expect_test "parse 24-bit colors" =
   [%expect
     {|
     Vbox
-      0,Seq
+      0,
+      Seq
+        Seq
           Seq
             Seq
               Seq
@@ -318,31 +287,21 @@ let%expect_test "parse 24-bit colors" =
                       Seq
                         Seq
                           Seq
-                            Seq
-                              Seq Nop,Verbatim "This is a ",Tag
-                                                              [ Fg_24_bit_color
-                                                                  [ 255; 0; 0 ]
-                                                              ],Verbatim "blue",
-                            Verbatim
-                              " string with ",Tag
-                                                [ Fg_24_bit_color [ 0; 255; 0 ] ],
-                                                Verbatim
-                                                  "red",Verbatim " and ",
-                      Tag
-                        [ Fg_24_bit_color [ 0; 0; 255 ] ],Verbatim "green",
-                    Verbatim
-                      " together with strings of a ",Tag
-                                                       [ Bg_24_bit_color
-                                                           [ 255; 0; 0 ]
-                                                       ],Verbatim
-                                                           "blue blackground",
-                Verbatim
-                  " and ",Tag
-                            [ Bg_24_bit_color [ 0; 255; 0 ] ],Verbatim
-                                                                "red background",
-            Verbatim
-              " and ",Tag
-                        [ Bg_24_bit_color [ 0; 0; 255 ] ],Verbatim
-                                                            "green background"
+                            Seq Nop, Verbatim "This is a ",
+                            Tag
+                              [ Fg_24_bit_color [ 255; 0; 0 ] ],
+                              Verbatim "blue",
+                          Verbatim " string with ",
+                        Tag [ Fg_24_bit_color [ 0; 255; 0 ] ], Verbatim "red",
+                      Verbatim " and ",
+                    Tag [ Fg_24_bit_color [ 0; 0; 255 ] ], Verbatim "green",
+                  Verbatim " together with strings of a ",
+                Tag
+                  [ Bg_24_bit_color [ 255; 0; 0 ] ],
+                  Verbatim "blue blackground",
+              Verbatim " and ",
+            Tag [ Bg_24_bit_color [ 0; 255; 0 ] ], Verbatim "red background",
+          Verbatim " and ",
+        Tag [ Bg_24_bit_color [ 0; 0; 255 ] ], Verbatim "green background"
 |}]
 ;;

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -202,7 +202,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; source = Some External_copy External "/tmp/a"
                   ; extra_sources =
                       [ ("one", External_copy External "/tmp/a")
-                      ; ("two", Fetch "randomurl",None)
+                      ; ("two", Fetch "randomurl", None)
                       ]
                   }
               ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
@@ -218,8 +218,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; source =
                       Some
                         Fetch
-                          "https://github.com/foo/b",Some
-                                                       "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                          "https://github.com/foo/b",
+                          Some
+                            "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
                   ; extra_sources = []
                   }
               ; exported_env = []
@@ -235,7 +236,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "c"
                   ; version = "0.2"
                   ; dev = false
-                  ; source = Some Fetch "https://github.com/foo/c",None
+                  ; source = Some Fetch "https://github.com/foo/c", None
                   ; extra_sources = []
                   }
               ; exported_env = []
@@ -247,7 +248,8 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
         ; used =
             Some
               [ opam_repo_serializable
-                  Some Git_hash "95cf548dc","well-known-repo"
+                  Some Git_hash "95cf548dc",
+                  "well-known-repo"
               ]
         }
     } |}]

--- a/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
+++ b/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
@@ -51,31 +51,28 @@ let%expect_test "serialize and deserialize error message" =
     Error: Oh no!
     ---- Original ----
     Vbox
-      0,Seq
-          Box
-            0,Concat
-                Break ("", 1, ""),("", 0, ""),[ Seq
-                                                  Tag Error,Verbatim "Error",
-                                                  Char
-                                                    :
-                                              ; Verbatim "Oh no!"
-                                              ],Break ("", 0, ""),("", 0, "")
+      0,
+      Seq
+        Box
+          0,
+          Concat
+            Break ("", 1, ""), ("", 0, ""),
+            [ Seq Tag Error, Verbatim "Error", Char :; Verbatim "Oh no!" ],
+        Break ("", 0, ""), ("", 0, "")
     ------- RPC ------
     Vbox
-      0,Seq
-          Box
-            0,Vbox
-                0,Box
-                    0,Concat
-                        Break ("", 1, ""),("", 0, ""),[ Seq
-                                                          Tag
-                                                            Error,Verbatim
-                                                                    "Error",
-                                                          Char
-                                                            :
-                                                      ; Verbatim "Oh no!"
-                                                      ],Break
-                                                          ("", 0, ""),("", 0, "") |}]
+      0,
+      Seq
+        Box
+          0,
+          Vbox
+            0,
+            Box
+              0,
+              Concat
+                Break ("", 1, ""), ("", 0, ""),
+                [ Seq Tag Error, Verbatim "Error", Char :; Verbatim "Oh no!" ],
+        Break ("", 0, ""), ("", 0, "") |}]
 ;;
 
 let%expect_test "serialize and deserialize error message with location" =
@@ -94,50 +91,44 @@ let%expect_test "serialize and deserialize error message with location" =
     Error: An error with location!
     ---- Original ----
     Vbox
-      0,Concat
-          Nop,[ Seq
-                  Box 0,Tag Loc,Text "File \"Bar\", line 1, characters 2-3:",
-                  Break
-                    ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Concat
-                        Break ("", 1, ""),("", 0, ""),[ Seq
-                                                          Tag
-                                                            Error,Verbatim
-                                                                    "Error",
-                                                          Char
-                                                            :
-                                                      ; Verbatim
-                                                          "An error with location!"
-                                                      ],Break
-                                                          ("", 0, ""),("", 0, "")
-              ]
+      0,
+      Concat
+        Nop,
+        [ Seq
+            Box 0, Tag Loc, Text "File \"Bar\", line 1, characters 2-3:",
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Concat
+                Break ("", 1, ""), ("", 0, ""),
+                [ Seq Tag Error, Verbatim "Error", Char :
+                ; Verbatim "An error with location!"
+                ],
+            Break ("", 0, ""), ("", 0, "")
+        ]
     ------- RPC ------
     Vbox
-      0,Concat
-          Nop,[ Seq
-                  Box 0,Tag Loc,Text "File \"/Foo/Bar\", line 1, characters 2-3:",
-                  Break
-                    ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Vbox
-                        0,Box
-                            0,Concat
-                                Break ("", 1, ""),("", 0, ""),[ Seq
-                                                                  Tag
-                                                                    Error,
-                                                                    Verbatim
-                                                                      "Error",
-                                                                  Char
-                                                                    :
-                                                              ; Verbatim
-                                                                  "An error with location!"
-                                                              ],Break
-                                                                  ("", 0, ""),
-                                                                  ("", 0, "")
-              ] |}]
+      0,
+      Concat
+        Nop,
+        [ Seq
+            Box 0, Tag Loc, Text "File \"/Foo/Bar\", line 1, characters 2-3:",
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Vbox
+                0,
+                Box
+                  0,
+                  Concat
+                    Break ("", 1, ""), ("", 0, ""),
+                    [ Seq Tag Error, Verbatim "Error", Char :
+                    ; Verbatim "An error with location!"
+                    ],
+            Break ("", 0, ""), ("", 0, "")
+        ] |}]
 ;;
 
 let%expect_test "serialize and deserialize error with location exerpt and hint" =
@@ -167,94 +158,78 @@ let%expect_test "serialize and deserialize error with location exerpt and hint" 
     Hint: Hint 2
     ---- Original ----
     Vbox
-      0,Concat
-          Nop,[ Seq
-                  Box 0,Tag Loc,Text "File \"foo.ml\", line 1, characters 2-3:",
-                  Break
-                    ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Concat
-                        Break ("", 1, ""),("", 0, ""),[ Seq
-                                                          Tag
-                                                            Error,Verbatim
-                                                                    "Error",
-                                                          Char
-                                                            :
-                                                      ; Verbatim
-                                                          "An error with location!"
-                                                      ],Break
-                                                          ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Seq
-                        Seq
-                          Tag Hint,Verbatim "Hint:",Break ("", 1, ""),("", 0, ""),
-                        Verbatim
-                          "Hint 1",Break ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Seq
-                        Seq
-                          Tag Hint,Verbatim "Hint:",Break ("", 1, ""),("", 0, ""),
-                        Verbatim
-                          "Hint 2",Break ("", 0, ""),("", 0, "")
-              ]
+      0,
+      Concat
+        Nop,
+        [ Seq
+            Box 0, Tag Loc, Text "File \"foo.ml\", line 1, characters 2-3:",
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Concat
+                Break ("", 1, ""), ("", 0, ""),
+                [ Seq Tag Error, Verbatim "Error", Char :
+                ; Verbatim "An error with location!"
+                ],
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Seq
+                Seq Tag Hint, Verbatim "Hint:", Break ("", 1, ""), ("", 0, ""),
+                Verbatim "Hint 1",
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Seq
+                Seq Tag Hint, Verbatim "Hint:", Break ("", 1, ""), ("", 0, ""),
+                Verbatim "Hint 2",
+            Break ("", 0, ""), ("", 0, "")
+        ]
     ------- RPC ------
     Vbox
-      0,Concat
-          Nop,[ Seq
-                  Box
-                    0,Tag
-                        Loc,Text
-                              "File \"TEST/foo.ml\", line 1, characters 2-3:",
-                  Break
-                    ("", 0, ""),("", 0, "")
-              ; Seq
-                  Box
-                    0,Vbox
-                        0,Concat
-                            Break ("", 0, ""),("", 0, ""),[ Box
-                                                              0,Concat
-                                                                  Break
-                                                                    ("", 1, ""),
-                                                                    ("", 0, ""),
-                                                                  [ Seq
-                                                                      Tag
-                                                                        Error,
-                                                                        Verbatim
-                                                                        "Error",
-                                                                      Char
-                                                                        :
-                                                                  ; Verbatim
-                                                                      "An error with location!"
-                                                                  ]
-                                                          ; Box
-                                                              0,Seq
-                                                                  Seq
-                                                                    Tag
-                                                                      Hint,
-                                                                      Verbatim
-                                                                        "Hint:",
-                                                                    Break
-                                                                      ("", 1, ""),
-                                                                      ("", 0, ""),
-                                                                  Verbatim
-                                                                    "Hint 1"
-                                                          ; Box
-                                                              0,Seq
-                                                                  Seq
-                                                                    Tag
-                                                                      Hint,
-                                                                      Verbatim
-                                                                        "Hint:",
-                                                                    Break
-                                                                      ("", 1, ""),
-                                                                      ("", 0, ""),
-                                                                  Verbatim
-                                                                    "Hint 2"
-                                                          ],Break
-                                                              ("", 0, ""),
-                                                              ("", 0, "")
-              ] |}]
+      0,
+      Concat
+        Nop,
+        [ Seq
+            Box
+              0,
+              Tag
+                Loc,
+                Text
+                  "File \"TEST/foo.ml\", line 1, characters 2-3:",
+            Break ("", 0, ""), ("", 0, "")
+        ; Seq
+            Box
+              0,
+              Vbox
+                0,
+                Concat
+                  Break ("", 0, ""), ("", 0, ""),
+                  [ Box
+                      0,
+                      Concat
+                        Break ("", 1, ""), ("", 0, ""),
+                        [ Seq Tag Error, Verbatim "Error", Char :
+                        ; Verbatim "An error with location!"
+                        ]
+                  ; Box
+                      0,
+                      Seq
+                        Seq
+                          Tag Hint, Verbatim "Hint:",
+                          Break ("", 1, ""), ("", 0, ""),
+                        Verbatim "Hint 1"
+                  ; Box
+                      0,
+                      Seq
+                        Seq
+                          Tag Hint, Verbatim "Hint:",
+                          Break ("", 1, ""), ("", 0, ""),
+                        Verbatim "Hint 2"
+                  ],
+            Break ("", 0, ""), ("", 0, "")
+        ] |}]
 ;;


### PR DESCRIPTION
When working on another feature I noticed that Dyn.pp behaved very poorly when pretty printing variant constructor arguments. Turns out a Pp.char ',' separator was being used however there was no break hint. This patch adds a Pp.space afterwards which seems to make the output much more pleasant.
