### PR TITLE
fix: include expand aliases in digest

### DIFF
--- a/doc/changes/8990.md
+++ b/doc/changes/8990.md
@@ -1,0 +1,2 @@
+- Re-run actions whenever `(expand_aliases_in_sandbox)` changes (#8990,
+  @rgrinberg)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -235,7 +235,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 17
+  let rule_digest_version = 18
 
   let compute_rule_digest
     (rule : Rule.t)
@@ -270,7 +270,7 @@ end = struct
       , Execution_parameters.action_stdout_on_success execution_parameters
       , Execution_parameters.action_stderr_on_success execution_parameters
       , Execution_parameters.workspace_root_to_build_path_prefix_map execution_parameters
-      )
+      , Execution_parameters.expand_aliases_in_sandbox execution_parameters )
     in
     Digest.generic trace
   ;;

--- a/test/blackbox-tests/test-cases/depend-on/expand-aliases-rerun.t
+++ b/test/blackbox-tests/test-cases/depend-on/expand-aliases-rerun.t
@@ -25,3 +25,8 @@ Now we set (expand_aliases_in_sandbox), and re-run the action.
   > (expand_aliases_in_sandbox)
   > EOF
   $ dune build @foo
+  .
+  ./alias-dep
+
+The above output should include the files that we depend on via the alias
+expansion.

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [d008bb41344a7d0d53972220079cbb8c] (_build/default/source): not found in cache
+  Shared cache miss [43284c58c2079faf9e5421c4d82a28c2] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [b13d2ba64fcb9361d4fe1b3b094f2f82] (_build/default/target1): not found in cache
+  Shared cache miss [d92cafbd0f0c19a3a6c99407b959dc72] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [26bdf30e58f853b22578ed89686d983f] (_build/default/source): not found in cache
+  Shared cache miss [afae5cd4afe24e40e88a52ffd372da14] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [b12a77bbe2d67c323ef28eaaebdcfb34] (_build/default/target1): not found in cache
+  Shared cache miss [8dd10495c1458bf12c3c55807797879c] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
+  Warning: cache store error [f533fad74b151f0d6cbf8c3f5a91fa30]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
+  Warning: cache store error [f533fad74b151f0d6cbf8c3f5a91fa30]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [ea838ee96c7527baca974c6516345e68]: ((in_cache
+  Warning: cache store error [f533fad74b151f0d6cbf8c3f5a91fa30]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./c7/c7dd3e91adf65ae3cd721eef06904b93:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./d7/d74e8e6eb3d6cf509b6d3b7cbfeee223:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./8c/8c4aba72abad331531e3af2fb9f9cfaa:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./df/df307ded076980fa7dc2f5dbd563dbc1:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 


### PR DESCRIPTION
Action digests should depend on whether the aliases have been expanded in the sandbox.

Technically, this value should only matter if the action is sandboxed and there are alias dependencies, but it's likely not worth the effort to make the digest this precise.

cc @jchavarri who discovered this issue