### PR TITLE
test: (expand_aliases_in_sandbox) should re-run actions

### DIFF
--- a/test/blackbox-tests/test-cases/depend-on/expand-aliases-rerun.t
+++ b/test/blackbox-tests/test-cases/depend-on/expand-aliases-rerun.t
@@ -1,0 +1,27 @@
+Setting (expand_aliases_in_sandbox) should re-run the action
+
+First, we create an action and make it depend on an alias
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  $ export DUNE_SANDBOX=symlink
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias bar)
+  >  (action (with-stdout-to alias-dep (echo ""))))
+  > (rule
+  >  (alias foo)
+  >  (deps (alias bar))
+  >  (action (system "find . | sort")))
+  > EOF
+  $ dune build @foo
+  .
+
+Now we set (expand_aliases_in_sandbox), and re-run the action.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (expand_aliases_in_sandbox)
+  > EOF
+  $ dune build @foo


### PR DESCRIPTION
The bug is demonstrated as follows:

1. Create a rule that depends on an alias
2. Execute the rule
3. Modify its `(expand_aliases_in_sandbox)` value
4. Try executing the rule again.
5. Observe that that this doesn't re-run it.