### PR TITLE
melange: remove ppx flag from merlin

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -51,10 +51,9 @@ module Processed = struct
     ; src_dirs : Path.Set.t
     ; flags : string list
     ; extensions : string option Ml_kind.Dict.t list
-    ; melc_flags : string list
     }
 
-  let dyn_of_config { stdlib_dir; obj_dirs; src_dirs; flags; extensions; melc_flags } =
+  let dyn_of_config { stdlib_dir; obj_dirs; src_dirs; flags; extensions } =
     let open Dyn in
     record
       [ "stdlib_dir", option Path.to_dyn stdlib_dir
@@ -62,7 +61,6 @@ module Processed = struct
       ; "src_dirs", Path.Set.to_dyn src_dirs
       ; "flags", list string flags
       ; "extensions", list (Ml_kind.Dict.to_dyn (Dyn.option string)) extensions
-      ; "melc_flags", list string melc_flags
       ]
   ;;
 
@@ -106,7 +104,6 @@ module Processed = struct
           ; src_dirs = Path.Set.empty
           ; flags = [ "-x" ]
           ; extensions = [ { Ml_kind.Dict.intf = None; impl = Some "ext" } ]
-          ; melc_flags = [ "-y" ]
           }
       ; per_module_config = Path.Build.Map.empty
       ; pp_config =
@@ -146,7 +143,7 @@ module Processed = struct
     | None, None -> None
   ;;
 
-  let to_sexp ~opens ~pp { stdlib_dir; obj_dirs; src_dirs; flags; extensions; melc_flags }
+  let to_sexp ~opens ~pp { stdlib_dir; obj_dirs; src_dirs; flags; extensions }
     =
     let make_directive tag value = Sexp.List [ Atom tag; value ] in
     let make_directive_of_path tag path =
@@ -166,13 +163,6 @@ module Processed = struct
         | [] -> []
         | flags ->
           [ make_directive "FLG" (Sexp.List (List.map ~f:(fun s -> Sexp.Atom s) flags)) ]
-      in
-      let flags =
-        match melc_flags with
-        | [] -> flags
-        | melc_flags ->
-          make_directive "FLG" (Sexp.List (List.map ~f:(fun s -> Sexp.Atom s) melc_flags))
-          :: flags
       in
       let flags =
         match pp with
@@ -286,7 +276,7 @@ module Processed = struct
     | Error msg -> Printf.eprintf "%s\n" msg
     | Ok [] -> Printf.eprintf "No merlin configuration found.\n"
     | Ok (init :: tl) ->
-      let pp_configs, obj_dirs, src_dirs, flags, extensions, melc_flags =
+      let pp_configs, obj_dirs, src_dirs, flags, extensions =
         (* We merge what is easy to merge and ignore the rest *)
         List.fold_left
           tl
@@ -295,30 +285,21 @@ module Processed = struct
             , init.config.obj_dirs
             , init.config.src_dirs
             , [ init.config.flags ]
-            , init.config.extensions
-            , init.config.melc_flags )
+            , init.config.extensions )
           ~f:
             (fun
-              (acc_pp, acc_obj, acc_src, acc_flags, acc_ext, acc_melc_flags)
+              (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
               { per_module_config = _
               ; pp_config
               ; config =
-                  { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions; melc_flags }
+                  { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
               }
             ->
             ( pp_config :: acc_pp
             , Path.Set.union acc_obj obj_dirs
             , Path.Set.union acc_src src_dirs
             , flags :: acc_flags
-            , extensions @ acc_ext
-            , match acc_melc_flags with
-              | [] -> melc_flags
-              | acc_melc_flags -> acc_melc_flags ))
-      in
-      let flags =
-        match melc_flags with
-        | [] -> flags
-        | melc -> melc :: flags
+            , extensions @ acc_ext))
       in
       Printf.printf
         "%s\n"
@@ -564,8 +545,8 @@ module Unprocessed = struct
                Lib.Set.union requires (Lib.Set.of_list libs)
              | None -> Memo.return requires)
       in
-      let* flags = flags
-      and* src_dirs, obj_dirs =
+      let+ flags = flags
+      and+ src_dirs, obj_dirs =
         Action_builder.of_memo
           (let open Memo.O in
            Memo.parallel_map (Lib.Set.to_list requires) ~f:(fun lib ->
@@ -584,8 +565,7 @@ module Unprocessed = struct
       let src_dirs =
         Path.Set.union src_dirs (Path.Set.of_list_map ~f:Path.source more_src_dirs)
       in
-      let+melc_flags = Action_builder.return [] in
-      { Processed.stdlib_dir; src_dirs; obj_dirs; flags; extensions; melc_flags }
+      { Processed.stdlib_dir; src_dirs; obj_dirs; flags; extensions }
     and+ pp_config = pp_config t sctx ~expander in
     let per_module_config =
       (* And copy for each module the resulting pp flags *)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -143,8 +143,7 @@ module Processed = struct
     | None, None -> None
   ;;
 
-  let to_sexp ~opens ~pp { stdlib_dir; obj_dirs; src_dirs; flags; extensions }
-    =
+  let to_sexp ~opens ~pp { stdlib_dir; obj_dirs; src_dirs; flags; extensions } =
     let make_directive tag value = Sexp.List [ Atom tag; value ] in
     let make_directive_of_path tag path =
       make_directive tag (Sexp.Atom (serialize_path path))
@@ -291,15 +290,14 @@ module Processed = struct
               (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
               { per_module_config = _
               ; pp_config
-              ; config =
-                  { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
+              ; config = { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
               }
             ->
             ( pp_config :: acc_pp
             , Path.Set.union acc_obj obj_dirs
             , Path.Set.union acc_src src_dirs
             , flags :: acc_flags
-            , extensions @ acc_ext))
+            , extensions @ acc_ext ))
       in
       Printf.printf
         "%s\n"

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -584,18 +584,7 @@ module Unprocessed = struct
       let src_dirs =
         Path.Set.union src_dirs (Path.Set.of_list_map ~f:Path.source more_src_dirs)
       in
-      let+ melc_flags =
-        match t.config.mode with
-        | Ocaml _ -> Action_builder.return []
-        | Melange ->
-          let+ melc_compiler =
-            Action_builder.of_memo (Melange_binary.melc sctx ~loc:None ~dir)
-          in
-          (match melc_compiler with
-           | Error _ -> []
-           | Ok path ->
-             [ Processed.Pp_kind.to_flag Ppx; Processed.serialize_path path ^ " -as-ppx" ])
-      in
+      let+melc_flags = Action_builder.return [] in
       { Processed.stdlib_dir; src_dirs; obj_dirs; flags; extensions; melc_flags }
     and+ pp_config = pp_config t sctx ~expander in
     let per_module_config =

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -43,15 +43,11 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   S /MELC_STDLIB
   S $TESTCASE_ROOT
 
-All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
-
-  $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-  [1]
-
   $ target=output
   $ cat >dune <<EOF
   > (melange.emit
   >  (target "$target")
+  >  (compile_flags :standard -bs-D DEBUG=true )
   >  (modules main))
   > EOF
 
@@ -59,11 +55,6 @@ All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
   $ dune build @check
   $ dune ocaml merlin dump-config $PWD | grep -i "$target"
     $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
-
-The melange.emit entry contains a ppx directive
-
-  $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-  [1]
 
 Dump-dot-merlin includes the melange flags
 
@@ -78,12 +69,8 @@ Dump-dot-merlin includes the melange flags
   S /MELC_STDLIB
   S /MELC_STDLIB
   S $TESTCASE_ROOT
-  # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g
+  # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bs-D DEBUG=true
   
-
-
-
-
 Check for flag directives ordering when another preprocessor is defined
 
   $ cat >fooppx.ml <<EOF
@@ -115,8 +102,7 @@ Check for flag directives ordering when another preprocessor is defined
 
   $ dune build @check
 
-Melange ppx should appear after user ppx, so that Merlin applies the former first
-(the flags seem to be applied in reversed order)
+User ppx flags should appear in merlin config
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
   Bar

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -46,9 +46,7 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
 All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
+  [1]
 
   $ target=output
   $ cat >dune <<EOF
@@ -65,7 +63,7 @@ All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 The melange.emit entry contains a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
+  [1]
 
 Dump-dot-merlin includes the melange flags
 
@@ -80,7 +78,6 @@ Dump-dot-merlin includes the melange flags
   S /MELC_STDLIB
   S /MELC_STDLIB
   S $TESTCASE_ROOT
-  # FLG -ppx '/MELC_COMPILER -as-ppx'
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g
   
 
@@ -136,7 +133,6 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      --as-ppx
      --cookie
      'library-name="foo"'"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
@@ -158,7 +154,6 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      --as-ppx
      --cookie
      'library-name="foo"'"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -44,7 +44,7 @@ let%expect_test "persistent digests" =
     ---
 
     merlin-conf version 4
-    0a56dee94d10f6a2a2ad8558266ee877
+    782b1c9ea57a40a427f80fa24ba6d853
     ---
 
     INCREMENTAL-DB version 5


### PR DESCRIPTION
In https://github.com/melange-re/melange/pull/583 Melange moved its preprocessor outside of the compiler so that it can be invoked like any other ppx.

This PR adapts merlin config to not set this flag any longer.

Regarding backwards compatibility, the plan is to wait until a newer Dune version with this patch is released, and once it's published, add an upper bound on the `dune` dep in the `melange.1.0.0` opam so that it never uses that version.