### PR TITLE
chore: update ppx_expect to 0.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ menhir \
 ocamlfind \
 ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat) \
 "odoc>=2.0.1" \
-"ppx_expect.v0.15.0" \
+"ppx_expect>=v0.16.0" \
 ppx_inline_test \
 ppxlib \
 ctypes \


### PR DESCRIPTION
This is a prerequisite of moving the test suite to 5.1.
