### PR TITLE
chore: remove stale comment

### DIFF
--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -99,10 +99,7 @@ let copy_recursively =
 
 let create_dirs t ~deps ~rule_dir =
   Path.Build.Set.add (Dep.Facts.necessary_dirs_for_sandboxing deps) rule_dir
-  |> Path.Build.Set.iter ~f:(fun path ->
-    (* There is no point in using the memoized version [Fs.mkdir_p] since
-       these directories are not shared between actions. *)
-    Path.mkdir_p (Path.build (map_path t path)))
+  |> Path.Build.Set.iter ~f:(fun path -> Path.mkdir_p (Path.build (map_path t path)))
 ;;
 
 let link_function ~(mode : Sandbox_mode.some) =


### PR DESCRIPTION
[Fs.mkdir_p] doesn't exist, so there's no need to comment about it

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c9daca9b-2fda-48b1-8a4a-51b106594021 -->