### PR TITLE
fix: sandboxing anonymous actions

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -328,10 +328,15 @@ end = struct
       match sandbox_mode with
       | Some mode ->
         let+ sandbox =
+          let rule_dir =
+            match rule_kind with
+            | Anonymous_action _ -> None
+            | Normal_rule -> Some dir
+          in
           Sandbox.create
             ~mode
             ~deps
-            ~rule_dir:dir
+            ~rule_dir
             ~rule_loc:loc
             ~rule_digest
             ~dune_stats

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -98,8 +98,13 @@ let copy_recursively =
 ;;
 
 let create_dirs t ~deps ~rule_dir =
-  Path.Build.Set.add (Dep.Facts.necessary_dirs_for_sandboxing deps) rule_dir
-  |> Path.Build.Set.iter ~f:(fun path -> Path.mkdir_p (Path.build (map_path t path)))
+  let dirs =
+    let base = Dep.Facts.necessary_dirs_for_sandboxing deps in
+    match rule_dir with
+    | None -> base
+    | Some rule_dir -> Path.Build.Set.add base rule_dir
+  in
+  Path.Build.Set.iter dirs ~f:(fun path -> Path.mkdir_p (Path.build (map_path t path)))
 ;;
 
 let link_function ~(mode : Sandbox_mode.some) =

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -15,7 +15,7 @@ val create
   -> dune_stats:Dune_stats.t option
   -> rule_loc:Loc.t
   -> deps:Dep.Facts.t
-  -> rule_dir:Path.Build.t
+  -> rule_dir:Path.Build.t option
   -> rule_digest:Digest.t
   -> expand_aliases:bool
   -> t Fiber.t


### PR DESCRIPTION
Stop creating the rule directories when sandboxing. They aren't
necessary as we write the stamp files outside the sandbox.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cb983e3b-b857-45ef-a68f-3b3d115c7a99 -->