### PR TITLE
chore(pkg): cleanup imports

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -1,6 +1,4 @@
-open Stdune
-module Process = Dune_engine.Process
-module Display = Dune_engine.Display
+open Import
 open Fiber.O
 
 module Curl = struct

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -1,4 +1,4 @@
-open Stdune
+open Import
 
 type failure =
   | Checksum_mismatch of Checksum.t

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -17,6 +17,12 @@ include struct
   module Action = Action
   module String_with_vars = String_with_vars
   module Pform = Pform
-  module Blang = Dune_lang.Blang
-  module Slang = Dune_lang.Slang
+  module Blang = Blang
+  module Slang = Slang
+end
+
+include struct
+  open Dune_engine
+  module Process = Process
+  module Display = Display
 end

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -35,7 +35,7 @@ module Pkg : sig
     }
 
   val equal : t -> t -> bool
-  val decode : (lock_dir:Path.Source.t -> Package_name.t -> t) Dune_sexp.Decoder.t
+  val decode : (lock_dir:Path.Source.t -> Package_name.t -> t) Decoder.t
 end
 
 module Repositories : sig

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -1,6 +1,4 @@
-open! Stdune
-module Encoder = Dune_lang.Encoder
-module Decoder = Dune_lang.Decoder
+open Import
 open Fiber.O
 
 let ( / ) = Path.relative

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Import
 
 type t
 
@@ -6,7 +6,7 @@ module Serializable : sig
   type t
 
   val encode : t -> Dune_lang.t list
-  val decode : t Dune_lang.Decoder.t
+  val decode : t Decoder.t
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
 end

--- a/src/dune_pkg/package_variable.ml
+++ b/src/dune_pkg/package_variable.ml
@@ -1,5 +1,4 @@
-open Stdune
-open Dune_lang
+open Import
 
 module Name = struct
   include String

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -1,5 +1,4 @@
-open! Stdune
-open Dune_lang
+open Import
 
 module Name : sig
   type t

--- a/src/dune_pkg/repository_id.ml
+++ b/src/dune_pkg/repository_id.ml
@@ -7,7 +7,7 @@ let equal a b =
   | Git_hash a, Git_hash b -> String.equal a b
 ;;
 
-let encode : t -> Dune_sexp.t = function
+let encode : t Encoder.t = function
   | Git_hash commitish ->
     List
       [ Dune_lang.atom_or_quoted_string "git_hash"
@@ -16,7 +16,7 @@ let encode : t -> Dune_sexp.t = function
 ;;
 
 let decode =
-  let open Dune_sexp.Decoder in
+  let open Decoder in
   let+ constr, stamp = pair string string in
   match constr with
   | "git_hash" -> Git_hash stamp

--- a/src/dune_pkg/repository_id.mli
+++ b/src/dune_pkg/repository_id.mli
@@ -4,8 +4,8 @@ open Import
     potentially be used to reproduce the lock dir/lock file exactly. *)
 type t
 
-val encode : t -> Dune_sexp.t
-val decode : t Dune_sexp.Decoder.t
+val encode : t Encoder.t
+val decode : t Decoder.t
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val of_path : Path.t -> t option

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -139,7 +139,7 @@ module Variable = struct
     let equal a b = String.equal (to_string a) (to_string b)
 
     let decode =
-      let open Dune_lang.Decoder in
+      let open Decoder in
       let+ loc, string = located string in
       match of_string_opt string with
       | Some t -> t

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Import
 
 module Variable : sig
   module Sys : sig
@@ -26,7 +26,7 @@ module Variable : sig
       type t
 
       val to_dyn : t -> Dyn.t
-      val decode : t Dune_sexp.Decoder.t
+      val decode : t Decoder.t
       val equal : t -> t -> bool
       val empty : t
       val set : t -> sys_var -> string -> t
@@ -55,8 +55,8 @@ module Variable : sig
 
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
-  val decode : t Dune_lang.Decoder.t
-  val encode : t Dune_lang.Encoder.t
+  val decode : t Decoder.t
+  val encode : t Encoder.t
 end
 
 (** A variable environment used by the dependency solver to evaluate package
@@ -70,7 +70,7 @@ type t
 
 val create : sys:Variable.Sys.Bindings.t -> t
 val default : t
-val decode : t Dune_sexp.Decoder.t
+val decode : t Decoder.t
 val to_dyn : t -> Dyn.t
 val equal : t -> t -> bool
 val sys : t -> Variable.Sys.Bindings.t

--- a/src/dune_pkg/solver_stats.ml
+++ b/src/dune_pkg/solver_stats.ml
@@ -1,5 +1,4 @@
-open! Import
-open! Stdune
+open Import
 
 type t = { expanded_variables : Solver_env.Variable.Set.t }
 
@@ -40,7 +39,7 @@ module Expanded_variable_bindings = struct
   ;;
 
   let decode =
-    let open Dune_lang.Decoder in
+    let open Decoder in
     fields
       (let+ variable_values =
          field

--- a/src/dune_pkg/solver_stats.mli
+++ b/src/dune_pkg/solver_stats.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type t = { expanded_variables : Solver_env.Variable.Set.t }
 
@@ -20,7 +20,7 @@ module Expanded_variable_bindings : sig
   val empty : t
   val is_empty : t -> bool
   val of_variable_set : Solver_env.Variable.Set.t -> Solver_env.t -> t
-  val decode : t Dune_lang.Decoder.t
+  val decode : t Decoder.t
   val encode : t -> Dune_lang.t list
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/substs.ml
+++ b/src/dune_pkg/substs.ml
@@ -1,4 +1,4 @@
-open Stdune
+open Import
 
 module Variable = struct
   type t = OpamVariable.t
@@ -12,21 +12,18 @@ end
 module Var = struct
   module T = struct
     type t =
-      { package : Dune_lang.Package_name.t option
+      { package : Package_name.t option
       ; variable : Variable.t
       }
 
     let compare a b =
-      match Option.compare Dune_lang.Package_name.compare a.package b.package with
+      match Option.compare Package_name.compare a.package b.package with
       | Eq -> Ordering.of_int @@ OpamVariable.compare a.variable b.variable
       | otherwise -> otherwise
     ;;
 
     let to_dyn { package; variable } =
-      Dyn.pair
-        (Dyn.option Dune_lang.Package_name.to_dyn)
-        Variable.to_dyn
-        (package, variable)
+      Dyn.pair (Dyn.option Package_name.to_dyn) Variable.to_dyn (package, variable)
     ;;
   end
 
@@ -37,13 +34,13 @@ end
 module Map = Var.Map
 
 let subst env self ~src ~dst =
-  let self' = self |> Dune_lang.Package_name.to_string |> OpamPackage.Name.of_string in
+  let self' = self |> Package_name.to_string |> OpamPackage.Name.of_string in
   let env full_variable =
     let variable = OpamVariable.Full.variable full_variable in
     let package =
       OpamVariable.Full.package ~self:self' full_variable
       |> Option.map ~f:(fun package ->
-        package |> OpamPackage.Name.to_string |> Dune_lang.Package_name.of_string)
+        package |> OpamPackage.Name.to_string |> Package_name.of_string)
     in
     let key = { Var.T.package; variable } in
     match Map.find env key with

--- a/src/dune_pkg/substs.mli
+++ b/src/dune_pkg/substs.mli
@@ -1,17 +1,17 @@
-open Stdune
+open Import
 
 module Variable : sig
   type t
 
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t
-  val encode : t -> Dune_sexp.t
+  val encode : t Encoder.t
   val of_string : string -> t
 end
 
 module Var : sig
   type t =
-    { package : Dune_lang.Package_name.t option
+    { package : Package_name.t option
     ; variable : Variable.t
     }
 
@@ -24,7 +24,7 @@ end
 
 val subst
   :  OpamVariable.variable_contents Var.Map.t
-  -> Dune_lang.Package_name.t
+  -> Package_name.t
   -> src:Path.t
   -> dst:Path.Build.t
   -> unit

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -1,6 +1,4 @@
-open Stdune
-module Process = Dune_engine.Process
-module Display = Dune_engine.Display
+open Import
 open Fiber.O
 
 let norm = function

--- a/src/dune_pkg/sys_poll.mli
+++ b/src/dune_pkg/sys_poll.mli
@@ -1,6 +1,6 @@
 (** Functions to retrieve the values of system-dependent OPAM values like "arch"
     or "os". *)
-open Stdune
+open Import
 
 (** Returns the value of [arch] *)
 val arch : path:Path.t list -> string option Fiber.t

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -37,7 +37,7 @@ module Repository = struct
   let default = { name = "default"; source = "https://opam.ocaml.org/index.tar.gz" }
 
   let decode =
-    let open Dune_lang.Decoder in
+    let open Decoder in
     fields
       (let+ name = field "name" Name.decode
        and+ source = field "source" string in


### PR DESCRIPTION
- Use `open Import` everywhere in `dune_pkg`
- Replace Dune_lang with Dune_sexp where appropriate
- Use `Dune_sexp.Encoder/Decoder` where appropriate
- Remove unnecessary module qualifiers