### PR TITLE
chore(pkg): Remove obsoleted private function

### DIFF
--- a/src/dune_pkg/repository_id.ml
+++ b/src/dune_pkg/repository_id.ml
@@ -68,7 +68,3 @@ let of_path dir =
   | Ok { st_kind = S_DIR; _ } -> repo_id_of_git dir
   | Ok _ | Error _ -> None
 ;;
-
-module Private = struct
-  let git_hash = of_git_hash
-end

--- a/src/dune_pkg/repository_id.mli
+++ b/src/dune_pkg/repository_id.mli
@@ -11,7 +11,3 @@ val to_dyn : t -> Dyn.t
 val of_path : Path.t -> t option
 val git_hash : t -> string option
 val of_git_hash : string -> t
-
-module Private : sig
-  val git_hash : string -> t
-end

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -205,7 +205,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
            } )
        in
        let opam_repo =
-         let repo_id = Some (Dune_pkg.Repository_id.Private.git_hash "95cf548dc") in
+         let repo_id = Some (Dune_pkg.Repository_id.of_git_hash "95cf548dc") in
          Dune_pkg.Opam_repo.Private.create ~source:(Some "well-known-repo") ~repo_id
        in
        Lock_dir.create_latest_version


### PR DESCRIPTION
This isn't used anymore since a `string -> Repo_id.t` function had to be exposed anyway.