### PR TITLE
fix(pkg): Check that git repo dir is accessible

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -48,15 +48,17 @@ let show { dir } (Rev rev) path =
 
 let load_or_create ~dir =
   let t = { dir } in
-  (match Path.mkdir_p dir with
-   | () -> ()
-   | exception Unix.Unix_error (e, x, y) ->
-     User_error.raise
-       [ Pp.textf "%s isn't a directory" (Path.to_string_maybe_quoted dir)
-       ; Pp.textf "reason: %s" (Unix_error.Detailed.to_string_hum (e, x, y))
-       ]
-       ~hints:[ Pp.text "delete this file or check its permissions" ]);
-  let+ () = run t [ "init"; "--bare" ] in
+  let+ () =
+    match Fpath.mkdir_p (Path.to_string dir) with
+    | Already_exists -> Fiber.return ()
+    | Created -> run t [ "init"; "--bare" ]
+    | exception Unix.Unix_error (e, x, y) ->
+      User_error.raise
+        [ Pp.textf "%s isn't a directory" (Path.to_string_maybe_quoted dir)
+        ; Pp.textf "reason: %s" (Unix_error.Detailed.to_string_hum (e, x, y))
+        ]
+        ~hints:[ Pp.text "delete this file or check its permissions" ]
+  in
   t
 ;;
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -46,10 +46,21 @@ let show { dir } (Rev rev) path =
   >>| Result.to_option
 ;;
 
+let dir_exists dir =
+  match Path.exists dir with
+  | false -> false
+  | true ->
+    (match Path.stat dir with
+     | Ok stats ->
+       (match stats.st_kind with
+        | S_DIR -> true
+        | _ -> false)
+     | Error issue -> Dune_filesystem_stubs.Unix_error.Detailed.raise issue)
+;;
+
 let load_or_create ~dir =
   let t = { dir } in
-  (* TODO might as well double check it's a directory *)
-  match Path.exists dir with
+  match dir_exists dir with
   | true -> Fiber.return t
   | false ->
     Path.mkdir_p dir;

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -48,6 +48,7 @@ let show { dir } (Rev rev) path =
 
 let load_or_create ~dir =
   let t = { dir } in
+  let* () = Fiber.return () in
   let+ () =
     match Fpath.mkdir_p (Path.to_string dir) with
     | Already_exists -> Fiber.return ()


### PR DESCRIPTION
Instead of going ahead and running git against something that is not an accessible directory, this will at least raise an exception.

Are there better ways to solve it? Except for showing a possibly better error message, not really - if someone has replaced the folder with something we can't access there is no other option than to fail in some way or other.