### PR TITLE
Refactor Memo: move Counters and Deps into a separate module

### DIFF
--- a/src/memo/counters.ml
+++ b/src/memo/counters.ml
@@ -1,0 +1,17 @@
+(* CR-soon amokhov: Move conditionals checking [enabled] from [memo.ml] to this module. *)
+let enabled = ref false
+let nodes_restored = ref 0
+let nodes_computed = ref 0
+let edges_traversed = ref 0
+let nodes_in_cycle_detection_graph = ref 0
+let edges_in_cycle_detection_graph = ref 0
+let paths_in_cycle_detection_graph = ref 0
+
+let reset () =
+  nodes_restored := 0;
+  nodes_computed := 0;
+  edges_traversed := 0;
+  nodes_in_cycle_detection_graph := 0;
+  edges_in_cycle_detection_graph := 0;
+  paths_in_cycle_detection_graph := 0
+;;

--- a/src/memo/counters.mli
+++ b/src/memo/counters.mli
@@ -1,0 +1,12 @@
+(** Various performance counters. *)
+
+val enabled : bool ref
+val nodes_restored : int ref
+val nodes_computed : int ref
+val edges_traversed : int ref
+val nodes_in_cycle_detection_graph : int ref
+val edges_in_cycle_detection_graph : int ref
+val paths_in_cycle_detection_graph : int ref
+
+(** Reset all counters to zero. *)
+val reset : unit -> unit

--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -1,0 +1,39 @@
+open! Stdune
+open Fiber.O
+
+(* The array is stored reversed to avoid reversing the list in [create]. We need to be
+   careful about traversing the array in the right order in the functions [to_list] and
+   [changed_or_not]. *)
+type 'node t = 'node array
+
+let empty = [||]
+let create ~deps_rev = Array.of_list deps_rev
+let length = Array.length
+let to_list t = Array.fold_left t ~init:[] ~f:(fun acc x -> x :: acc)
+
+module Changed_or_not = struct
+  type 'cycle t =
+    | Unchanged
+    | Changed
+    | Cancelled of { dependency_cycle : 'cycle }
+end
+
+let changed_or_not t ~f =
+  let rec go index =
+    if index < 0
+    then (
+      if !Counters.enabled
+      then Counters.edges_traversed := !Counters.edges_traversed + Array.length t;
+      Fiber.return Changed_or_not.Unchanged)
+    else
+      f t.(index)
+      >>= function
+      | Changed_or_not.Unchanged -> go (index - 1)
+      | (Changed | Cancelled _) as res ->
+        if !Counters.enabled
+        then
+          Counters.edges_traversed := !Counters.edges_traversed + (Array.length t - index);
+        Fiber.return res
+  in
+  go (Array.length t - 1)
+;;

--- a/src/memo/deps.mli
+++ b/src/memo/deps.mli
@@ -1,0 +1,34 @@
+(** Dependencies of a Memo node. *)
+
+type 'node t
+
+val empty : 'node t
+
+(* CR-soon amokhov: Push accumulation of dependencies inside this module to avoid dealing
+   with reversed lists in [memo.ml]. *)
+val create : deps_rev:'node list -> 'node t
+val length : 'node t -> int
+val to_list : 'node t -> 'node list
+
+(** Checking dependencies of a node can lead to one of these outcomes:
+
+    - [Unchanged]: All dependencies of the node are up to date. We can therefore skip
+      recomputing the node and can reuse the value computed in the previous run.
+
+    - [Changed]: One of the dependencies has changed since the previous run and the node
+      should therefore be recomputed.
+
+    - [Cancelled _]: One of the dependencies leads to a dependency cycle. In this case,
+      there is no point in recomputing the current node: it's impossible to bring its
+      dependencies up to date! *)
+module Changed_or_not : sig
+  type 'cycle t =
+    | Unchanged
+    | Changed
+    | Cancelled of { dependency_cycle : 'cycle }
+end
+
+val changed_or_not
+  :  'node t
+  -> f:('node -> 'cycle Changed_or_not.t Fiber.t)
+  -> 'cycle Changed_or_not.t Fiber.t


### PR DESCRIPTION
Move `Deps` into a separate module `Memo.Deps`.

As part of working on fixing the loss of parallelism in the presence of cutoffs, I plan to make the implementation of `Deps` more interesting. Let's keep it in a separate module to avoid cluttering `memo.ml`.

Moving `Deps` required moving `Counters` into a separate module too.

Also added a couple of CR-soons.

----

This has been reviewed and used internally for weeks with no issues, so merging without additional review.