### PR TITLE
refactor(pkg): remove [let open Fiber.O in]

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -1,6 +1,7 @@
 open Stdune
 module Process = Dune_engine.Process
 module Display = Dune_engine.Display
+open Fiber.O
 
 module Curl = struct
   let bin = lazy (Bin.which ~path:(Env_path.path Env.initial) "curl")
@@ -33,7 +34,6 @@ module Curl = struct
       ; url
       ]
     in
-    let open Fiber.O in
     let stderr = Path.relative temp_dir "curl.stderr" in
     let+ http_code, exit_code =
       let stderr_to = Process.Io.file stderr Out in
@@ -73,7 +73,6 @@ end
 
 module Fiber_job = struct
   let run (command : OpamProcess.command) =
-    let open Fiber.O in
     let prefix = "dune-source-fetch" in
     let stderr_file = Temp.create File ~prefix ~suffix:"stderr" in
     let stdout_file =
@@ -129,7 +128,6 @@ module Fiber_job = struct
   ;;
 
   let run =
-    let open Fiber.O in
     let rec run1 = function
       | OpamProcess.Job.Op.Done x -> Fiber.return x
       | Run (cmd, cont) ->
@@ -151,7 +149,6 @@ let fetch_curl ~unpack ~checksum ~target (url : OpamUrl.t) =
   let url = OpamUrl.to_string url in
   let temp_dir = Temp.create Dir ~prefix:"dune" ~suffix:(Filename.basename url) in
   let output = Path.relative temp_dir "download" in
-  let open Fiber.O in
   Fiber.finalize ~finally:(fun () ->
     Temp.destroy Dir temp_dir;
     Fiber.return ())
@@ -193,7 +190,6 @@ let fetch_curl ~unpack ~checksum ~target (url : OpamUrl.t) =
 ;;
 
 let fetch_others ~unpack ~checksum ~target (url : OpamUrl.t) =
-  let open Fiber.O in
   let path = Path.to_string target in
   let+ downloaded =
     Fiber_job.run
@@ -284,7 +280,6 @@ module Opam_repository = struct
     }
 
   let path =
-    let open Fiber.O in
     let ( / ) = Filename.concat in
     fun repo ->
       let url = Workspace.Repository.opam_url repo in

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -1,6 +1,7 @@
 open! Stdune
 module Encoder = Dune_lang.Encoder
 module Decoder = Dune_lang.Decoder
+open Fiber.O
 
 let ( / ) = Path.relative
 
@@ -154,7 +155,6 @@ let xdg_repo_location =
 ;;
 
 let of_git_repo ~repo_id ~source =
-  let open Fiber.O in
   let dir = Lazy.force xdg_repo_location in
   let* repo = Rev_store.load_or_create ~dir in
   let* remote = Rev_store.add_repo repo ~source in
@@ -235,7 +235,6 @@ let scan_files_entries path =
 ;;
 
 let get_opam_package_files t opam_package =
-  let open Fiber.O in
   let name = opam_package |> OpamPackage.name |> OpamPackage.Name.to_string in
   match t.source with
   | Directory path ->
@@ -297,7 +296,6 @@ let load_opam_package t opam_package =
        in
        Fiber.return (Some { With_file.opam_file; file = opam_file_path }))
   | Repo at_rev ->
-    let open Fiber.O in
     let package_name = opam_package |> OpamPackage.name |> OpamPackage.Name.to_string in
     let package_version =
       opam_package |> OpamPackage.version |> OpamPackage.Version.to_string
@@ -324,7 +322,6 @@ let get_opam_package_version_dir_path packages_dir_path opam_package_name =
 ;;
 
 let all_package_versions t opam_package_name =
-  let open Fiber.O in
   match t.source with
   | Directory d ->
     (match get_opam_package_version_dir_path d opam_package_name with
@@ -364,7 +361,6 @@ let all_package_versions t opam_package_name =
 ;;
 
 let load_all_versions ts opam_package_name =
-  let open Fiber.O in
   let* versions =
     List.map ts ~f:(fun t -> all_package_versions t opam_package_name) |> Fiber.all
   in

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -125,7 +125,6 @@ module Context_for_dune = struct
   ;;
 
   let candidates t name =
-    let open Fiber.O in
     match OpamPackage.Name.Map.find_opt name t.local_packages with
     | Some opam_file ->
       let version =
@@ -441,7 +440,6 @@ let opam_package_to_lock_file_pkg
   ~experimental_translate_opam_filters
   opam_package
   =
-  let open Fiber.O in
   let name = OpamPackage.name opam_package in
   let version = OpamPackage.version opam_package |> OpamPackage.Version.to_string in
   let dev = OpamPackage.Name.Map.mem name local_packages in
@@ -612,7 +610,6 @@ let solve_lock_dir
   ~local_packages
   ~experimental_translate_opam_filters
   =
-  let open Fiber.O in
   let local_packages = opam_file_map_of_dune_package_map local_packages in
   let is_local_package package =
     OpamPackage.Name.Map.mem (OpamPackage.name package) local_packages

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -1,6 +1,7 @@
 open Stdune
 module Process = Dune_engine.Process
 module Display = Dune_engine.Display
+open Fiber.O
 
 let norm = function
   | "" -> None
@@ -36,7 +37,6 @@ let run_capture_line ~path ~prog ~args =
   match prog with
   | None -> Fiber.return None
   | Some prog ->
-    let open Fiber.O in
     let+ res = Process.run_capture_line ~display:Quiet Strict prog args in
     norm res
 ;;
@@ -45,7 +45,6 @@ let uname ~path args = run_capture_line ~path ~prog:"uname" ~args
 let lsb_release ~path args = run_capture_line ~path ~prog:"lsb_release" ~args
 
 let arch ~path =
-  let open Fiber.O in
   let+ raw =
     match Sys.os_type with
     | "Unix" | "Cygwin" -> uname ~path [ "-m" ]
@@ -67,7 +66,6 @@ let arch ~path =
 ;;
 
 let os ~path =
-  let open Fiber.O in
   let+ raw =
     match Sys.os_type with
     | "Unix" -> uname ~path [ "-s" ]
@@ -83,7 +81,6 @@ let android_release ~path =
 ;;
 
 let is_android ~path =
-  let open Fiber.O in
   let+ prop = android_release ~path in
   prop <> None
 ;;
@@ -109,7 +106,6 @@ let os_release_field field =
 ;;
 
 let os_version ~path =
-  let open Fiber.O in
   let* os = os ~path in
   match os with
   | Some "linux" ->
@@ -144,7 +140,6 @@ let os_version ~path =
 ;;
 
 let os_distribution ~path =
-  let open Fiber.O in
   let* os = os ~path in
   match os with
   | Some "macos" as macos ->
@@ -187,7 +182,6 @@ let os_distribution ~path =
 ;;
 
 let os_family ~path =
-  let open Fiber.O in
   let* os = os ~path in
   match os with
   | Some "linux" ->
@@ -205,7 +199,6 @@ let os_family ~path =
 ;;
 
 let sys_bindings ~path =
-  let open Fiber.O in
   let entry k f =
     let+ v = f ~path in
     k, v


### PR DESCRIPTION
this is the only monad we need in dune_pkg, so just open it once per
module

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f7280e4f-d57d-4132-90af-5a9d3b4c8829 -->