### PR TITLE
refactor(pkg): simplify package loading

### DIFF
--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -39,10 +39,7 @@ end
 val load_opam_package : t -> OpamPackage.t -> With_file.t option Fiber.t
 
 (** Load package metadata for all versions of a package with a given name *)
-val load_all_versions
-  :  t list
-  -> OpamPackage.Name.t
-  -> (OpamFile.OPAM.t list, [ `Package_not_found ]) result Fiber.t
+val load_all_versions : t list -> OpamPackage.Name.t -> OpamFile.OPAM.t list Fiber.t
 
 val get_opam_package_files : t -> OpamPackage.t -> File_entry.t list Fiber.t
 

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -132,24 +132,20 @@ module Context_for_dune = struct
       in
       Fiber.return [ version, Ok opam_file ]
     | None ->
-      let+ all_versions = Opam_repo.load_all_versions t.repos name in
-      (match all_versions with
-       | Error `Package_not_found ->
-         (* The CONTEXT interface doesn't give us a way to report this type of
-            error and there's not enough context to give a helpful error message
-            so just tell opam_0install that there are no versions of this
-            package available (technically true) and let it produce the error
-            message. *)
-         []
-       | Ok opam_files ->
-         let opam_files_in_priority_order =
-           List.sort opam_files ~compare:(opam_version_compare t)
-         in
-         List.map opam_files_in_priority_order ~f:(fun opam_file ->
-           let opam_file_result =
-             if is_opam_available t opam_file then Ok opam_file else Error Unavailable
-           in
-           OpamFile.OPAM.version opam_file, opam_file_result))
+      let+ opam_files = Opam_repo.load_all_versions t.repos name in
+      (* The CONTEXT interface doesn't give us a way to report this type of
+         error and there's not enough context to give a helpful error message
+         so just tell opam_0install that there are no versions of this
+         package available (technically true) and let it produce the error
+         message. *)
+      let opam_files_in_priority_order =
+        List.sort opam_files ~compare:(opam_version_compare t)
+      in
+      List.map opam_files_in_priority_order ~f:(fun opam_file ->
+        let opam_file_result =
+          if is_opam_available t opam_file then Ok opam_file else Error Unavailable
+        in
+        OpamFile.OPAM.version opam_file, opam_file_result)
   ;;
 
   let user_restrictions : t -> OpamPackage.Name.t -> OpamFormula.version_constraint option


### PR DESCRIPTION
There's no difference between Ok [] and Error `Package_not_found. So we
just use the empty list to represent that we haven't found any packages.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 580cd379-ad02-472d-abba-ebba2fbfe8bc -->