### PR TITLE
refactor: use [Unix.rename] over [Sys.rename]

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1342,7 +1342,7 @@ let set_of_build_paths_list =
 ;;
 
 let set_of_external_paths set = External.Set.to_list set |> Set.of_list_map ~f:external_
-let rename old_path new_path = Sys.rename (to_string old_path) (to_string new_path)
+let rename old_path new_path = Unix.rename (to_string old_path) (to_string new_path)
 let chmod t ~mode = Unix.chmod (to_string t) mode
 let follow_symlink path = Fpath.follow_symlink (to_string path) |> Result.map ~f:of_string
 

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -3,7 +3,7 @@ open Stdune
 module Optimistically = struct
   let rename ~src ~dst =
     try Path.rename src dst with
-    | Sys_error _ ->
+    | Unix.Unix_error _ ->
       Path.mkdir_p (Path.parent_exn dst);
       Path.rename src dst
   ;;

--- a/test/blackbox-tests/test-cases/sandbox-remove-write-permissions.t
+++ b/test/blackbox-tests/test-cases/sandbox-remove-write-permissions.t
@@ -12,8 +12,6 @@ Remove write permissions from a sandbox directory and observe the error we get
   > EOF
 
   $ dune build ./foo --sandbox=copy 2>&1 | sed -E 's#/.*.sandbox/[^/]+#/.sandbox/$SANDBOX#g'
-  Error: Permission denied
-  -> required by _build/default/foo
   File "dune", line 1, characters 0-90:
   1 | (rule
   2 |  (target (dir foo))
@@ -22,6 +20,9 @@ Remove write permissions from a sandbox directory and observe the error we get
   _build/.sandbox/$SANDBOX
   Reason:
   rmdir(_build/.sandbox/$SANDBOX/default/foo): Directory not empty
+  Error:
+  rename(_build/.sandbox/$SANDBOX/default/foo): Permission denied
+  -> required by _build/default/foo
 
 Manual cleaning step so the dune executing the test suite doesn't croak trying
 to delete the readonly dir


### PR DESCRIPTION
It gives better errors

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 84d9fbc8-e63e-4157-8d96-5eeb55118b01 -->