### PR TITLE
fix(pkg): fix to allow seq to build

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
@@ -10,8 +10,5 @@ file copying step rather than the build step.
 
   $ touch dune.lock/foo.files/foo.install dune.lock/foo.pkg
 
-The foo.install file in files/ should have been copied over.
-  $ build_pkg foo 2>&1 | sed 's/copyfile/open/'
-  Error:
-  open(_build/_private/default/.pkg/foo/source/foo.install): No such file or directory
-  -> required by _build/_private/default/.pkg/foo/target/cookie
+The foo.install file in files/ has been copied over allowing the build to succeed.
+  $ build_pkg foo


### PR DESCRIPTION
Here is a way of fixing #9017. It seems that the `expand` step is necessary for the copied `.install` file to be available. I'm not entirely sure why. In order to allow the `expand` step to always work, I needed to use the empty action rather than not calling `expand` at all. Unfortunately due to strict requirements with sandboxing (see #8854) we need a workaround to disable the sandbox in that case.

@rgrinberg would you be able to lend a hand and explain how to fix this properly? 