### PR TITLE
fix(pkg): respect [flags] field in opam packages

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -1,19 +1,17 @@
+The ocaml compiler needs to be marked inside the lock dir:
 
   $ . ./helpers.sh
   $ mkrepo
 
-  $ mkpkg ocaml <<EOF
+To mark it, we use flags: compiler:
+
+  $ mkpkg foocaml <<EOF
+  > flags: compiler
   > EOF
 
-  $ solve ocaml
+  $ solve foocaml
   Solution for dune.lock:
-  - ocaml.0.0.1
+  - foocaml.0.0.1
 
-  $ cat dune.lock/lock.dune
-  (lang package 0.1)
-  
-  (ocaml ocaml)
-  
-  (repositories
-   (complete false)
-   (used))
+  $ grep ocaml dune.lock/lock.dune
+  (ocaml foocaml)


### PR DESCRIPTION
Use `flags: compiler` to detect which package is the compiler rather than guessing from the package name.