### PR TITLE
refactor: re-implement [Appendable_list]

### DIFF
--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -1,13 +1,67 @@
-type 'a t = 'a list -> 'a list
+type 'a t =
+  | Empty
+  | Singleton of 'a
+  | Cons of 'a * 'a t
+  | List of 'a * 'a * 'a list
+  | Append of 'a t * 'a t
+  | Concat of 'a t list
 
-let empty k = k
-let singleton x k = x :: k
-let to_list l = l []
-let ( @ ) a b k = a (b k)
-let cons x xs = singleton x @ xs
+let empty = Empty
+let singleton x = Singleton x
 
-let rec concat l k =
-  match l with
-  | [] -> k
-  | t :: l -> t (concat l k)
+let ( @ ) a b =
+  match a, b with
+  | Empty, _ -> b
+  | _, Empty -> a
+  | Singleton a, Singleton b -> List (a, b, [])
+  | Singleton a, _ -> Cons (a, b)
+  | _, _ -> Append (a, b)
+;;
+
+let cons x xs =
+  match xs with
+  | Empty -> Singleton x
+  | List (y, z, rest) -> List (x, y, z :: rest)
+  | _ -> Cons (x, xs)
+;;
+
+let to_list_rev =
+  let rec loop acc stack =
+    match stack with
+    | [] -> acc
+    | t :: stack ->
+      (match t with
+       | Empty -> loop acc stack
+       | Singleton x -> loop (x :: acc) stack
+       | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
+       | List (x, y, xs) -> loop (List.rev_append xs (y :: x :: acc)) stack
+       | Append (xs, ys) -> loop acc (xs :: ys :: stack)
+       | Concat [] -> loop acc stack
+       | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
+  in
+  fun t -> loop [] [ t ]
+;;
+
+let to_list xs = List.rev (to_list_rev xs)
+
+let is_empty = function
+  | Empty -> true
+  | _ -> false
+;;
+
+let rec concat = function
+  | [] -> Empty
+  | [ x ] -> if is_empty x then Empty else x
+  | x :: xs as list -> if is_empty x then concat xs else Concat list
+;;
+
+let of_list = function
+  | [] -> Empty
+  | [ x ] -> Singleton x
+  | x :: y :: xs -> List (x, y, xs)
+;;
+
+let rec of_list_concat = function
+  | [] -> Empty
+  | x :: xs as list -> if is_empty x then of_list_concat xs else Concat list
 ;;

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -20,20 +20,21 @@ let ( @ ) a b =
 let cons x xs = Cons (x, xs)
 
 let to_list_rev =
-  let rec loop acc stack =
+  let rec loop1 acc t stack =
+    match t with
+    | Empty -> loop0 acc stack
+    | Singleton x -> loop0 (x :: acc) stack
+    | Cons (x, xs) -> loop1 (x :: acc) xs stack
+    | List xs -> loop0 (List.rev_append xs acc) stack
+    | Append (xs, ys) -> loop1 acc xs (ys :: stack)
+    | Concat [] -> loop0 acc stack
+    | Concat (x :: xs) -> loop1 acc x (Concat xs :: stack)
+  and loop0 acc stack =
     match stack with
     | [] -> acc
-    | t :: stack ->
-      (match t with
-       | Empty -> loop acc stack
-       | Singleton x -> loop (x :: acc) stack
-       | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
-       | List xs -> loop (List.rev_append xs acc) stack
-       | Append (xs, ys) -> loop acc (xs :: ys :: stack)
-       | Concat [] -> loop acc stack
-       | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
+    | t :: stack -> loop1 acc t stack
   in
-  fun t -> loop [] [ t ]
+  fun t -> loop1 [] t []
 ;;
 
 let to_list xs = List.rev (to_list_rev xs)

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -2,7 +2,7 @@ type 'a t =
   | Empty
   | Singleton of 'a
   | Cons of 'a * 'a t
-  | List of 'a * 'a * 'a list
+  | List of 'a list
   | Append of 'a t * 'a t
   | Concat of 'a t list
 
@@ -13,17 +13,11 @@ let ( @ ) a b =
   match a, b with
   | Empty, _ -> b
   | _, Empty -> a
-  | Singleton a, Singleton b -> List (a, b, [])
   | Singleton a, _ -> Cons (a, b)
   | _, _ -> Append (a, b)
 ;;
 
-let cons x xs =
-  match xs with
-  | Empty -> Singleton x
-  | List (y, z, rest) -> List (x, y, z :: rest)
-  | _ -> Cons (x, xs)
-;;
+let cons x xs = Cons (x, xs)
 
 let to_list_rev =
   let rec loop acc stack =
@@ -34,7 +28,7 @@ let to_list_rev =
        | Empty -> loop acc stack
        | Singleton x -> loop (x :: acc) stack
        | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
-       | List (x, y, xs) -> loop (List.rev_append xs (y :: x :: acc)) stack
+       | List xs -> loop (List.rev_append xs acc) stack
        | Append (xs, ys) -> loop acc (xs :: ys :: stack)
        | Concat [] -> loop acc stack
        | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
@@ -44,24 +38,16 @@ let to_list_rev =
 
 let to_list xs = List.rev (to_list_rev xs)
 
-let is_empty = function
-  | Empty -> true
-  | _ -> false
+let rec is_empty = function
+  | List (_ :: _) | Singleton _ | Cons _ -> false
+  | Append (x, y) -> is_empty x && is_empty y
+  | Concat xs -> is_empty_list xs
+  | List [] | Empty -> true
+
+and is_empty_list = function
+  | [] -> true
+  | x :: xs -> is_empty x && is_empty_list xs
 ;;
 
-let rec concat = function
-  | [] -> Empty
-  | [ x ] -> if is_empty x then Empty else x
-  | x :: xs as list -> if is_empty x then concat xs else Concat list
-;;
-
-let of_list = function
-  | [] -> Empty
-  | [ x ] -> Singleton x
-  | x :: y :: xs -> List (x, y, xs)
-;;
-
-let rec of_list_concat = function
-  | [] -> Empty
-  | x :: xs as list -> if is_empty x then of_list_concat xs else Concat list
-;;
+let concat list = Concat list
+let of_list x = List x

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -9,3 +9,7 @@ val ( @ ) : 'a t -> 'a t -> 'a t
 val cons : 'a -> 'a t -> 'a t
 val concat : 'a t list -> 'a t
 val to_list : 'a t -> 'a list
+val to_list_rev : 'a t -> 'a list
+val of_list : 'a list -> 'a t
+val is_empty : _ t -> bool
+val of_list_concat : 'a t list -> 'a t

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -7,9 +7,8 @@ val empty : 'a t
 val singleton : 'a -> 'a t
 val ( @ ) : 'a t -> 'a t -> 'a t
 val cons : 'a -> 'a t -> 'a t
-val concat : 'a t list -> 'a t
 val to_list : 'a t -> 'a list
 val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
 val is_empty : _ t -> bool
-val of_list_concat : 'a t list -> 'a t
+val concat : 'a t list -> 'a t

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -10,5 +10,7 @@ val cons : 'a -> 'a t -> 'a t
 val to_list : 'a t -> 'a list
 val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
-val is_empty : _ t -> bool
 val concat : 'a t list -> 'a t
+
+(** The current implementation is slow, don't use it on a hot path. *)
+val is_empty : _ t -> bool

--- a/otherlibs/stdune/test/appendable_list_tests.ml
+++ b/otherlibs/stdune/test/appendable_list_tests.ml
@@ -55,3 +55,17 @@ let%expect_test "concat" =
     8
     9 |}]
 ;;
+
+let%expect_test "is_empty" =
+  let assert_empty l = assert (Al.is_empty l) in
+  assert_empty Al.empty;
+  [%expect {||}];
+  assert_empty @@ Al.concat [];
+  [%expect {||}];
+  assert_empty @@ Al.concat [ Al.empty ];
+  [%expect {||}];
+  assert_empty @@ Al.concat [ Al.empty; Al.empty ];
+  [%expect {||}];
+  assert_empty @@ Al.of_list [];
+  [%expect {||}]
+;;

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -398,6 +398,8 @@ end = struct
             }
     in
     Alias.Name.Map.map aliases ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
+      (* CR-soon rgrinberg: hide this reversal behind the interface from
+         [Alias_spec] *)
       Appendable_list.to_list_rev expansions)
   ;;
 

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -392,10 +392,13 @@ end = struct
           Alias.Name.Map.set
             aliases
             Alias.Name.default
-            (Rules.Dir_rules.Alias_spec.singleton
-               (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion))
+            { expansions =
+                Appendable_list.singleton
+                  (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion)
+            }
     in
-    Alias.Name.Map.map aliases ~f:Rules.Dir_rules.Alias_spec.to_list
+    Alias.Name.Map.map aliases ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
+      Appendable_list.to_list_rev expansions)
   ;;
 
   let add_non_fallback_rules ~init ~source_files rules =

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -399,7 +399,8 @@ end = struct
     in
     Alias.Name.Map.map aliases ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
       (* CR-soon rgrinberg: hide this reversal behind the interface from
-         [Alias_spec] *)
+         [Alias_spec]. The order doesn't really matter, as we're just
+         collecting the dependencies that are attached to the alias *)
       Appendable_list.to_list_rev expansions)
   ;;
 

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -380,8 +380,8 @@ end = struct
   ;;
 
   let compute_alias_expansions ~(collected : Rules.Dir_rules.ready) ~dir =
-    let aliases = collected.aliases in
     let+ aliases =
+      let aliases = collected.aliases in
       if Alias.Name.Map.mem aliases Alias.Name.default
       then Memo.return aliases
       else
@@ -392,13 +392,10 @@ end = struct
           Alias.Name.Map.set
             aliases
             Alias.Name.default
-            { expansions =
-                Appendable_list.singleton
-                  (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion)
-            }
+            (Rules.Dir_rules.Alias_spec.singleton
+               (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion))
     in
-    Alias.Name.Map.map aliases ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
-      Appendable_list.to_list expansions)
+    Alias.Name.Map.map aliases ~f:Rules.Dir_rules.Alias_spec.to_list
   ;;
 
   let add_non_fallback_rules ~init ~source_files rules =

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -11,8 +11,6 @@ module Dir_rules = struct
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
 
     let union x y = { expansions = Appendable_list.( @ ) x.expansions y.expansions }
-    let singleton x = { expansions = Appendable_list.singleton x }
-    let to_list { expansions } = Appendable_list.to_list_rev expansions
   end
 
   type alias =
@@ -143,7 +141,10 @@ module Produce = struct
     ;;
 
     let add_deps t ?(loc = Loc.none) expansion =
-      alias t (Dir_rules.Alias_spec.singleton (loc, Dir_rules.Alias_spec.Deps expansion))
+      alias
+        t
+        { expansions = Appendable_list.singleton (loc, Dir_rules.Alias_spec.Deps expansion)
+        }
     ;;
 
     let add_action t ~loc action =
@@ -156,7 +157,10 @@ module Produce = struct
         ; alias = Some (Alias.name t)
         }
       in
-      alias t (Dir_rules.Alias_spec.singleton (loc, Dir_rules.Alias_spec.Action action))
+      alias
+        t
+        { expansions = Appendable_list.singleton (loc, Dir_rules.Alias_spec.Action action)
+        }
     ;;
   end
 end

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -50,6 +50,10 @@ module Dir_rules = struct
         | None -> Some what
         | Some base -> Some (Alias_spec.union what base)
       in
+      (* This accumulates the aliases in reverse order, but there's another
+         reversal whenever the expansion is inspected. The order doesn't really
+         matter, but it does change the tests. So it's nice to maintain it if
+         possible *)
       List.fold_left aliases ~init:Alias.Name.Map.empty ~f:(fun acc (name, item) ->
         Alias.Name.Map.update acc name ~f:(add_item item))
     in

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -21,7 +21,7 @@ module Dir_rules = struct
     type t = (Loc.t * item) Appendable_list.t
 
     let singleton = Appendable_list.singleton
-    let union_all all = Appendable_list.of_list_concat all
+    let union_all all = Appendable_list.concat all
     let to_list = Appendable_list.to_list_rev
   end
 

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -29,7 +29,10 @@ module Dir_rules : sig
         Action of
           Rule.Anonymous_action.t Action_builder.t
 
-    type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
+    type t
+
+    val singleton : Loc.t * item -> t
+    val to_list : t -> (Loc.t * item) list
   end
 
   (** A ready to process view of the rules of a directory *)

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -29,10 +29,7 @@ module Dir_rules : sig
         Action of
           Rule.Anonymous_action.t Action_builder.t
 
-    type t
-
-    val singleton : Loc.t * item -> t
-    val to_list : t -> (Loc.t * item) list
+    type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
   end
 
   (** A ready to process view of the rules of a directory *)


### PR DESCRIPTION
This is the same as https://github.com/ocaml/dune/pull/9033 without any additional book-keeping for empty checks or using the most compact constructors. Performance is looking better now.