### PR TITLE
Collect rules with Appendable_list.t instead of Id.Map.t

### DIFF
--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -1,13 +1,67 @@
-type 'a t = 'a list -> 'a list
+type 'a t =
+  | Empty
+  | Singleton of 'a
+  | Cons of 'a * 'a t
+  | List of 'a * 'a * 'a list
+  | Append of 'a t * 'a t
+  | Concat of 'a t list
 
-let empty k = k
-let singleton x k = x :: k
-let to_list l = l []
-let ( @ ) a b k = a (b k)
-let cons x xs = singleton x @ xs
+let empty = Empty
+let singleton x = Singleton x
 
-let rec concat l k =
-  match l with
-  | [] -> k
-  | t :: l -> t (concat l k)
+let ( @ ) a b =
+  match a, b with
+  | Empty, _ -> b
+  | _, Empty -> a
+  | Singleton a, Singleton b -> List (a, b, [])
+  | Singleton a, _ -> Cons (a, b)
+  | _, _ -> Append (a, b)
+;;
+
+let cons x xs =
+  match xs with
+  | Empty -> Singleton x
+  | List (y, z, rest) -> List (x, y, z :: rest)
+  | _ -> Cons (x, xs)
+;;
+
+let to_list_rev =
+  let rec loop acc stack =
+    match stack with
+    | [] -> acc
+    | t :: stack ->
+      (match t with
+       | Empty -> loop acc stack
+       | Singleton x -> loop (x :: acc) stack
+       | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
+       | List (x, y, xs) -> loop (List.rev_append xs (y :: x :: acc)) stack
+       | Append (xs, ys) -> loop acc (xs :: ys :: stack)
+       | Concat [] -> loop acc stack
+       | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
+  in
+  fun t -> loop [] [ t ]
+;;
+
+let to_list xs = List.rev (to_list_rev xs)
+
+let is_empty = function
+  | Empty -> true
+  | _ -> false
+;;
+
+let rec concat = function
+  | [] -> Empty
+  | [ x ] -> if is_empty x then Empty else x
+  | x :: xs as list -> if is_empty x then concat xs else Concat list
+;;
+
+let of_list = function
+  | [] -> Empty
+  | [ x ] -> Singleton x
+  | x :: y :: xs -> List (x, y, xs)
+;;
+
+let rec of_list_concat = function
+  | [] -> Empty
+  | x :: xs as list -> if is_empty x then of_list_concat xs else Concat list
 ;;

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -52,3 +52,4 @@ and is_empty_list = function
 
 let concat list = Concat list
 let of_list x = List x
+let map t ~f = to_list_rev t |> List.rev_map ~f |> of_list

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -52,4 +52,27 @@ and is_empty_list = function
 
 let concat list = Concat list
 let of_list x = List x
-let map t ~f = to_list_rev t |> List.rev_map ~f |> of_list
+
+let rec rev_append_map xs ys ~f =
+  match xs with
+  | [] -> ys
+  | x :: xs -> rev_append_map xs (f x :: ys) ~f
+;;
+
+let rev_map =
+  let rec loop1 acc t stack ~f =
+    match t with
+    | Empty -> loop0 acc stack ~f
+    | Singleton x -> loop0 (f x :: acc) stack ~f
+    | Cons (x, xs) -> loop1 (f x :: acc) xs stack ~f
+    | List xs -> loop0 (rev_append_map xs acc ~f) stack ~f
+    | Append (xs, ys) -> loop1 acc xs (ys :: stack) ~f
+    | Concat [] -> loop0 acc stack ~f
+    | Concat (x :: xs) -> loop1 acc x (Concat xs :: stack) ~f
+  and loop0 acc stack ~f =
+    match stack with
+    | [] -> acc
+    | t :: stack -> loop1 acc t stack ~f
+  in
+  fun t ~f -> List (loop1 [] t [] ~f)
+;;

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -20,20 +20,21 @@ let ( @ ) a b =
 let cons x xs = Cons (x, xs)
 
 let to_list_rev =
-  let rec loop acc stack =
+  let rec loop1 acc t stack =
+    match t with
+    | Empty -> loop0 acc stack
+    | Singleton x -> loop0 (x :: acc) stack
+    | Cons (x, xs) -> loop1 (x :: acc) xs stack
+    | List xs -> loop0 (List.rev_append xs acc) stack
+    | Append (xs, ys) -> loop1 acc xs (ys :: stack)
+    | Concat [] -> loop0 acc stack
+    | Concat (x :: xs) -> loop1 acc x (Concat xs :: stack)
+  and loop0 acc stack =
     match stack with
     | [] -> acc
-    | t :: stack ->
-      (match t with
-       | Empty -> loop acc stack
-       | Singleton x -> loop (x :: acc) stack
-       | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
-       | List xs -> loop (List.rev_append xs acc) stack
-       | Append (xs, ys) -> loop acc (xs :: ys :: stack)
-       | Concat [] -> loop acc stack
-       | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
+    | t :: stack -> loop1 acc t stack
   in
-  fun t -> loop [] [ t ]
+  fun t -> loop1 [] t []
 ;;
 
 let to_list xs = List.rev (to_list_rev xs)

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -2,7 +2,7 @@ type 'a t =
   | Empty
   | Singleton of 'a
   | Cons of 'a * 'a t
-  | List of 'a * 'a * 'a list
+  | List of 'a list
   | Append of 'a t * 'a t
   | Concat of 'a t list
 
@@ -13,17 +13,11 @@ let ( @ ) a b =
   match a, b with
   | Empty, _ -> b
   | _, Empty -> a
-  | Singleton a, Singleton b -> List (a, b, [])
   | Singleton a, _ -> Cons (a, b)
   | _, _ -> Append (a, b)
 ;;
 
-let cons x xs =
-  match xs with
-  | Empty -> Singleton x
-  | List (y, z, rest) -> List (x, y, z :: rest)
-  | _ -> Cons (x, xs)
-;;
+let cons x xs = Cons (x, xs)
 
 let to_list_rev =
   let rec loop acc stack =
@@ -34,7 +28,7 @@ let to_list_rev =
        | Empty -> loop acc stack
        | Singleton x -> loop (x :: acc) stack
        | Cons (x, xs) -> loop (x :: acc) (xs :: stack)
-       | List (x, y, xs) -> loop (List.rev_append xs (y :: x :: acc)) stack
+       | List xs -> loop (List.rev_append xs acc) stack
        | Append (xs, ys) -> loop acc (xs :: ys :: stack)
        | Concat [] -> loop acc stack
        | Concat (x :: xs) -> loop acc (x :: Concat xs :: stack))
@@ -44,24 +38,16 @@ let to_list_rev =
 
 let to_list xs = List.rev (to_list_rev xs)
 
-let is_empty = function
-  | Empty -> true
-  | _ -> false
+let rec is_empty = function
+  | List (_ :: _) | Singleton _ | Cons _ -> false
+  | Append (x, y) -> is_empty x && is_empty y
+  | Concat xs -> is_empty_list xs
+  | List [] | Empty -> true
+
+and is_empty_list = function
+  | [] -> true
+  | x :: xs -> is_empty x && is_empty_list xs
 ;;
 
-let rec concat = function
-  | [] -> Empty
-  | [ x ] -> if is_empty x then Empty else x
-  | x :: xs as list -> if is_empty x then concat xs else Concat list
-;;
-
-let of_list = function
-  | [] -> Empty
-  | [ x ] -> Singleton x
-  | x :: y :: xs -> List (x, y, xs)
-;;
-
-let rec of_list_concat = function
-  | [] -> Empty
-  | x :: xs as list -> if is_empty x then of_list_concat xs else Concat list
-;;
+let concat list = Concat list
+let of_list x = List x

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -9,3 +9,7 @@ val ( @ ) : 'a t -> 'a t -> 'a t
 val cons : 'a -> 'a t -> 'a t
 val concat : 'a t list -> 'a t
 val to_list : 'a t -> 'a list
+val to_list_rev : 'a t -> 'a list
+val of_list : 'a list -> 'a t
+val is_empty : _ t -> bool
+val of_list_concat : 'a t list -> 'a t

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -7,9 +7,8 @@ val empty : 'a t
 val singleton : 'a -> 'a t
 val ( @ ) : 'a t -> 'a t -> 'a t
 val cons : 'a -> 'a t -> 'a t
-val concat : 'a t list -> 'a t
 val to_list : 'a t -> 'a list
 val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
 val is_empty : _ t -> bool
-val of_list_concat : 'a t list -> 'a t
+val concat : 'a t list -> 'a t

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -12,4 +12,4 @@ val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
 val is_empty : _ t -> bool
 val concat : 'a t list -> 'a t
-val map : 'a t -> f:('a -> 'b) -> 'b t
+val rev_map : 'a t -> f:('a -> 'b) -> 'b t

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -12,3 +12,4 @@ val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
 val is_empty : _ t -> bool
 val concat : 'a t list -> 'a t
+val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/otherlibs/stdune/test/appendable_list_tests.ml
+++ b/otherlibs/stdune/test/appendable_list_tests.ml
@@ -55,3 +55,17 @@ let%expect_test "concat" =
     8
     9 |}]
 ;;
+
+let%expect_test "is_empty" =
+  let assert_empty l = assert (Al.is_empty l) in
+  assert_empty Al.empty;
+  [%expect {||}];
+  assert_empty @@ Al.concat [];
+  [%expect {||}];
+  assert_empty @@ Al.concat [ Al.empty ];
+  [%expect {||}];
+  assert_empty @@ Al.concat [ Al.empty; Al.empty ];
+  [%expect {||}];
+  assert_empty @@ Al.of_list [];
+  [%expect {||}]
+;;

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -380,8 +380,8 @@ end = struct
   ;;
 
   let compute_alias_expansions ~(collected : Rules.Dir_rules.ready) ~dir =
-    let aliases = collected.aliases in
     let+ aliases =
+      let aliases = collected.aliases in
       if Alias.Name.Map.mem aliases Alias.Name.default
       then Memo.return aliases
       else
@@ -392,13 +392,10 @@ end = struct
           Alias.Name.Map.set
             aliases
             Alias.Name.default
-            { expansions =
-                Appendable_list.singleton
-                  (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion)
-            }
+            (Rules.Dir_rules.Alias_spec.singleton
+               (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion))
     in
-    Alias.Name.Map.map aliases ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
-      Appendable_list.to_list expansions)
+    Alias.Name.Map.map aliases ~f:Rules.Dir_rules.Alias_spec.to_list
   ;;
 
   let add_non_fallback_rules ~init ~source_files rules =

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -85,7 +85,6 @@ module Dir_rules = struct
     Id.Map.set t id data
   ;;
 
-  let is_subset t ~of_ = Id.Map.is_subset t ~of_ ~f:(fun _ ~of_:_ -> true)
   let is_empty = Id.Map.is_empty
 
   module Nonempty : sig
@@ -219,10 +218,6 @@ let map t ~f =
       | `Changed data -> Id.gen (), data)
     |> Dir_rules.Nonempty.create
     |> Option.value_exn)
-;;
-
-let is_subset t ~of_ =
-  Path.Build.Map.is_subset (to_map t) ~of_:(to_map of_) ~f:Dir_rules.is_subset
 ;;
 
 let map_rules t ~f =

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -197,7 +197,7 @@ let to_map x = (x : t :> Dir_rules.t Path.Build.Map.t)
 let map t ~f =
   Path.Build.Map.map t ~f:(fun m ->
     (m : Dir_rules.Nonempty.t :> Dir_rules.t)
-    |> Appendable_list.map ~f:(fun data ->
+    |> Appendable_list.rev_map ~f:(fun data ->
       match f data with
       | `No_change -> data
       | `Changed data -> data)

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -21,7 +21,7 @@ module Dir_rules = struct
     type t = (Loc.t * item) Appendable_list.t
 
     let singleton = Appendable_list.singleton
-    let union_all all = Appendable_list.of_list_concat all
+    let union_all all = Appendable_list.concat all
     let to_list = Appendable_list.to_list_rev
   end
 

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -29,7 +29,10 @@ module Dir_rules : sig
         Action of
           Rule.Anonymous_action.t Action_builder.t
 
-    type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
+    type t
+
+    val singleton : Loc.t * item -> t
+    val to_list : t -> (Loc.t * item) list
   end
 
   (** A ready to process view of the rules of a directory *)

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -42,8 +42,6 @@ module Dir_rules : sig
     }
 
   val consume : t -> ready
-  val is_subset : t -> of_:t -> bool
-  val is_empty : t -> bool
   val to_dyn : t -> Dyn.t
 end
 
@@ -90,7 +88,6 @@ val union : t -> t -> t
 val of_dir_rules : dir:Path.Build.t -> Dir_rules.t -> t
 val of_rules : Rule.t list -> t
 val produce : t -> unit Memo.t
-val is_subset : t -> of_:t -> bool
 val map_rules : t -> f:(Rule.t -> Rule.t) -> t
 val collect : (unit -> 'a Memo.t) -> ('a * t) Memo.t
 val collect_unit : (unit -> unit Memo.t) -> t Memo.t


### PR DESCRIPTION
Based on #9050, the main goal is to replace the unioning of a bunch of maps with what I expect to be a cheaper operation. I've benchmarked a similar patch on Jane Street's code base and saw enough improvement to think that this is a worthwhile refactor. My thinking was to have review done first here on GitHub; once it is able to be merged I'll import it, run benchmark it again and report back with a summary of the results.