### PR TITLE
pkg: use new type instead of string for versions

### DIFF
--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -58,16 +58,16 @@ let term =
              Lib_name.to_string (Dune_package.Entry.name e))
          in
          List.iter pkgs ~f:(fun e ->
-           let ver =
+           let ver_string =
              match Dune_package.Entry.version e with
-             | Some v -> v
+             | Some v -> Dune_pkg.Package_version.to_string v
              | _ -> "n/a"
            in
            Printf.printf
              "%-*s (version: %s)\n"
              max_len
              (Lib_name.to_string (Dune_package.Entry.name e))
-             ver);
+             ver_string);
          Memo.return ())
      in
      fun () -> Memo.run (run ()))

--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -3,6 +3,7 @@ module Lock_dir = Dune_pkg.Lock_dir
 module Fetch = Dune_pkg.Fetch
 module Opam_repo = Dune_pkg.Opam_repo
 module Repository_id = Dune_pkg.Repository_id
+module Package_version = Dune_pkg.Package_version
 
 let context_term ~doc =
   Arg.(value & opt (some Arg.context_name) None & info [ "context" ] ~docv:"CONTEXT" ~doc)
@@ -374,7 +375,7 @@ module Lock = struct
     Pp.enumerate
       packages
       ~f:(fun { Lock_dir.Pkg.info = { Lock_dir.Pkg_info.name; version; _ }; _ } ->
-        Pp.verbatim (Package_name.to_string name ^ "." ^ version))
+        Pp.verbatim (Package_name.to_string name ^ "." ^ Package_version.to_string version))
   ;;
 
   let solve

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -11,4 +11,5 @@ module Solver_stats = Solver_stats
 module Substs = Substs
 module Sys_poll = Sys_poll
 module Version_preference = Version_preference
+module Package_version = Package_version
 module Pkg_workspace = Workspace

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -16,13 +16,13 @@ end
 module Pkg_info : sig
   type t =
     { name : Package_name.t
-    ; version : string
+    ; version : Package_version.t
     ; dev : bool
     ; source : Source.t option
     ; extra_sources : (Path.Local.t * Source.t) list
     }
 
-  val default_version : string
+  val default_version : Package_version.t
 end
 
 module Pkg : sig

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -27,7 +27,7 @@ module Context_for_dune = struct
   type rejection = Unavailable
 
   let local_package_default_version =
-    OpamPackage.Version.of_string Lock_dir.Pkg_info.default_version
+    Package_version.to_opam Lock_dir.Pkg_info.default_version
   ;;
 
   type t =
@@ -455,7 +455,7 @@ let opam_package_to_lock_file_pkg
   opam_package
   =
   let name = OpamPackage.name opam_package in
-  let version = OpamPackage.version opam_package |> OpamPackage.Version.to_string in
+  let version = OpamPackage.version opam_package |> Package_version.of_opam in
   let dev = OpamPackage.Name.Map.mem name local_packages in
   let+ opam_file, loc =
     let+ { Opam_repo.With_file.opam_file = opam_file_with_filters; file } =

--- a/src/dune_pkg/package_version.ml
+++ b/src/dune_pkg/package_version.ml
@@ -1,0 +1,18 @@
+open Stdune
+include String
+
+include (
+  Dune_util.Stringlike.Make (struct
+    type t = string
+
+    let to_string x = x
+    let module_ = "Package_version.Name"
+    let description = "package version name"
+    let description_of_valid_string = None
+    let hint_valid = None
+    let of_string_opt s = if s = "" then None else Some s
+  end) :
+    Dune_util.Stringlike with type t := t)
+
+let of_opam = OpamPackage.Version.to_string
+let to_opam = OpamPackage.Version.of_string

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -1,0 +1,12 @@
+open! Stdune
+
+type t
+
+val of_string : string -> t
+val to_string : t -> string
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t
+val encode : t Dune_lang.Encoder.t
+val decode : t Dune_lang.Decoder.t
+val of_opam : OpamPackage.Version.t -> t
+val to_opam : t -> OpamPackage.Version.t

--- a/src/dune_pkg_outdated/dune_pkg_outdated.ml
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.ml
@@ -3,8 +3,8 @@ open Import
 type candidate =
   { is_immediate_dep_of_local_package : bool
   ; name : Package_name.t
-  ; outdated_version : string
-  ; newer_version : string
+  ; outdated_version : Package_version.t
+  ; newer_version : Package_version.t
   }
 
 type result =
@@ -111,7 +111,7 @@ let better_candidate
   | Some newest_opam_file ->
     let version = OpamFile.OPAM.version newest_opam_file in
     (match
-       OpamPackage.Version.of_string pkg.info.version
+       Package_version.to_opam pkg.info.version
        |> OpamPackage.Version.compare version
        |> Ordering.of_int
      with
@@ -120,7 +120,7 @@ let better_candidate
        Better_candidate
          { is_immediate_dep_of_local_package
          ; name = pkg.info.name
-         ; newer_version = version |> OpamPackage.Version.to_string
+         ; newer_version = version |> Package_version.of_opam
          ; outdated_version = pkg.info.version
          })
 ;;
@@ -147,11 +147,11 @@ let pp results ~transitive ~lock_dir_path =
                  ; Pp.space
                  ; Pp.tag
                      (User_message.Style.Ansi_styles [ `Fg_bright_red ])
-                     (Pp.verbatim outdated_version)
+                     (Pp.verbatim (Package_version.to_string outdated_version))
                  ; Pp.text " < "
                  ; Pp.tag
                      (User_message.Style.Ansi_styles [ `Fg_bright_green ])
-                     (Pp.verbatim newer_version)
+                     (Pp.verbatim (Package_version.to_string newer_version))
                  ])
           else None)
     with

--- a/src/dune_pkg_outdated/dune_pkg_outdated.mli
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.mli
@@ -36,8 +36,8 @@ module For_tests : sig
   val better_candidate
     :  is_immediate_dep_of_local_package:bool
     -> name:string
-    -> newer_version:string
-    -> outdated_version:string
+    -> newer_version:Package_version.t
+    -> outdated_version:Package_version.t
     -> result
 
   val explain_results

--- a/src/dune_pkg_outdated/import.ml
+++ b/src/dune_pkg_outdated/import.ml
@@ -4,6 +4,7 @@ include struct
   open Dune_pkg
   module Lock_dir = Lock_dir
   module Opam_repo = Opam_repo
+  module Package_version = Package_version
 end
 
 include struct

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -385,7 +385,7 @@ let path_to_dyn = function
 type t =
   { name : Package.Name.t
   ; entries : Entry.t Lib_name.Map.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; sections : Path.t Section.Map.t
   ; sites : Section.t Site.Map.t
   ; dir : Path.t
@@ -395,7 +395,7 @@ type t =
 let decode ~lang ~dir =
   let open Dune_lang.Decoder in
   let+ name = field "name" Package.Name.decode
-  and+ version = field_o "version" string
+  and+ version = field_o "version" Dune_pkg.Package_version.decode
   and+ sections =
     field
       ~default:[]
@@ -458,7 +458,7 @@ let encode ~dune_version { entries; name; version; dir; sections; sites; files }
   let sexp =
     record_fields
       [ field "name" Package.Name.encode name
-      ; field_o "version" string version
+      ; field_o "version" Dune_pkg.Package_version.encode version
       ; field_l
           "sections"
           (pair Section.encode (Dune_lang.Path.Local.encode ~dir))
@@ -489,7 +489,7 @@ let to_dyn { entries; name; version; dir; sections; sites; files } =
   record
     [ "entries", list Entry.to_dyn (Lib_name.Map.values entries)
     ; "name", Package.Name.to_dyn name
-    ; "version", option string version
+    ; "version", option Dune_pkg.Package_version.to_dyn version
     ; "dir", Path.to_dyn dir
     ; "sections", Section.Map.to_dyn Path.to_dyn sections
     ; "sites", Site.Map.to_dyn Section.to_dyn sites

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -41,7 +41,7 @@ module Entry : sig
             Dune itself never produces hidden libraries. *)
 
   val name : t -> Lib_name.t
-  val version : t -> string option
+  val version : t -> Dune_pkg.Package_version.t option
   val loc : t -> Loc.t
   val to_dyn : t Dyn.builder
 end
@@ -51,7 +51,7 @@ type path = [ `File | `Dir ] * Install.Entry.Dst.t
 type t =
   { name : Package.Name.t
   ; entries : Entry.t Lib_name.Map.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; sections : Path.t Section.Map.t
   ; sites : Section.t Site.Map.t
   ; dir : Path.t

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -129,7 +129,7 @@ end
 type t =
   { name : Name.t
   ; root : Path.Source.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; dune_version : Dune_lang.Syntax.Version.t
   ; info : Package.Info.t
   ; packages : Package.t Package.Name.Map.t
@@ -209,7 +209,7 @@ let to_dyn
   record
     [ "name", Name.to_dyn name
     ; "root", Path.Source.to_dyn root
-    ; "version", (option string) version
+    ; "version", (option Dune_pkg.Package_version.to_dyn) version
     ; "dune_version", Dune_lang.Syntax.Version.to_dyn dune_version
     ; "info", Package.Info.to_dyn info
     ; "project_file", Path.Source.to_dyn project_file
@@ -708,7 +708,10 @@ let encode : t -> Dune_lang.t list =
     |> Option.to_list
   in
   let name = constr "name" Name.encode name in
-  let version = Option.map ~f:(constr "version" string) version |> Option.to_list in
+  let version =
+    Option.map ~f:(constr "version" Dune_pkg.Package_version.encode) version
+    |> Option.to_list
+  in
   [ lang_stanza; name ]
   @ flags
   @ version
@@ -853,7 +856,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
   String_with_vars.set_decoding_env (Pform.Env.initial lang.version)
   @@ fields
   @@ let+ name = field_o "name" Name.decode
-     and+ version = field_o "version" string
+     and+ version = field_o "version" Dune_pkg.Package_version.decode
      and+ info = Package.Info.decode ()
      and+ packages = multi_field "package" (Package.decode ~dir)
      and+ explicit_extensions =

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -114,7 +114,7 @@ let dep p =
 let expand_version { scope; _ } ~(source : Dune_lang.Template.Pform.t) s =
   let value_from_version = function
     | None -> [ Value.String "" ]
-    | Some s -> [ String s ]
+    | Some s -> [ String (Dune_pkg.Package_version.to_string s) ]
   in
   let project = Scope.project scope in
   match

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -124,7 +124,9 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib =
       | Public (_, _) -> Lib_info.Status.Installed
     in
     let src_dir = Obj_dir.dir obj_dir in
-    let version = Findlib.Package.version t in
+    let version =
+      Findlib.Package.version t |> Option.map ~f:Dune_pkg.Package_version.of_string
+    in
     let dune_version = None in
     let virtual_deps = [] in
     let implements = None in

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -158,7 +158,7 @@ let gen ~(package : Package.t) ~add_directory_entry entries =
   let version =
     match package.version with
     | None -> []
-    | Some s -> [ rule "version" [] Set s ]
+    | Some s -> [ rule "version" [] Set (Dune_pkg.Package_version.to_string s) ]
   in
   let+ pkgs =
     Memo.parallel_map entries ~f:(fun (e : Scope.DB.Lib_entry.t) ->

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -356,7 +356,7 @@ type 'path t =
   ; src_dir : 'path
   ; orig_src_dir : 'path option
   ; obj_dir : 'path Obj_dir.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; synopsis : string option
   ; archives : 'path list Mode.Dict.t
   ; plugins : 'path list Mode.Dict.t
@@ -442,7 +442,7 @@ let equal
   && path_equal src_dir t.src_dir
   && Option.equal path_equal orig_src_dir t.orig_src_dir
   && Obj_dir.equal obj_dir t.obj_dir
-  && Option.equal String.equal version t.version
+  && Option.equal Dune_pkg.Package_version.equal version t.version
   && Option.equal String.equal synopsis t.synopsis
   && Mode.Dict.equal (List.equal path_equal) archives t.archives
   && Mode.Dict.equal (List.equal path_equal) plugins t.plugins
@@ -769,7 +769,7 @@ let to_dyn
     ; "src_dir", path src_dir
     ; "orig_src_dir", option path orig_src_dir
     ; "obj_dir", Obj_dir.to_dyn obj_dir
-    ; "version", option string version
+    ; "version", option Dune_pkg.Package_version.to_dyn version
     ; "synopsis", option string synopsis
     ; "archives", Mode.Dict.to_dyn (list path) archives
     ; "plugins", Mode.Dict.to_dyn (list path) plugins

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -151,7 +151,7 @@ val preprocess : _ t -> Preprocess.With_instrumentation.t Preprocess.Per_module.
 val sub_systems : _ t -> Sub_system_info.t Sub_system_name.Map.t
 val enabled : _ t -> Enabled_status.t
 val orig_src_dir : 'path t -> 'path option
-val version : _ t -> string option
+val version : _ t -> Dune_pkg.Package_version.t option
 val dune_version : _ t -> Dune_lang.Syntax.Version.t option
 
 (** Directory where the source files for the library are located. Returns the
@@ -164,7 +164,7 @@ type local = Path.Build.t t
 val user_written_deps : _ t -> Lib_dep.t list
 val of_local : local -> external_
 val as_local_exn : external_ -> local
-val set_version : 'a t -> string option -> 'a t
+val set_version : 'a t -> Dune_pkg.Package_version.t option -> 'a t
 
 val for_dune_package
   :  Path.t t
@@ -196,7 +196,7 @@ val create
   -> src_dir:'a
   -> orig_src_dir:'a option
   -> obj_dir:'a Obj_dir.t
-  -> version:string option
+  -> version:Dune_pkg.Package_version.t option
   -> synopsis:string option
   -> main_module_name:Main_module_name.t
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -122,7 +122,8 @@ let build_info_code cctx ~libs ~api_version =
   in
   let version_of_package placeholders (p : Package.t) =
     match p.version with
-    | Some v -> Memo.return (sprintf "Some %S" v, placeholders)
+    | Some v ->
+      Memo.return (sprintf "Some %S" (Dune_pkg.Package_version.to_string v), placeholders)
     | None -> placeholder placeholders (Package.dir p)
   in
   let* version, placeholders =
@@ -137,7 +138,9 @@ let build_info_code cctx ~libs ~api_version =
     Memo.List.fold_left ~init:([], placeholders) libs ~f:(fun (libs, placeholders) lib ->
       let+ v, placeholders =
         match Lib_info.version (Lib.info lib) with
-        | Some v -> Memo.return (sprintf "Some %S" v, placeholders)
+        | Some v ->
+          Memo.return
+            (sprintf "Some %S" (Dune_pkg.Package_version.to_string v), placeholders)
         | None ->
           (match Lib_info.status (Lib.info lib) with
            | Installed_private | Installed -> Memo.return ("None", placeholders)

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -458,7 +458,7 @@ let sp = Printf.sprintf
 module Toplevel_index = struct
   type item =
     { name : string
-    ; version : string option
+    ; version : Dune_pkg.Package_version.t option
     ; link : string
     }
 
@@ -474,7 +474,8 @@ module Toplevel_index = struct
       let version_suffix =
         match version with
         | None -> ""
-        | Some v -> sp {| <span class="version">%s</span>|} v
+        | Some v ->
+          sp {| <span class="version">%s</span>|} (Dune_pkg.Package_version.to_string v)
       in
       sp "<li>%s%s</li>" link version_suffix)
     |> String.concat ~sep:"\n      "
@@ -516,7 +517,9 @@ module Toplevel_index = struct
   let item_to_json { name; version; link } =
     `Assoc
       [ "name", string_to_json name
-      ; "version", option_to_json ~f:string_to_json version
+      ; ( "version"
+        , Option.map ~f:Dune_pkg.Package_version.to_string version
+          |> option_to_json ~f:string_to_json )
       ; "link", string_to_json link
       ]
   ;;

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -232,7 +232,7 @@ let opam_fields project (package : Package.t) =
       , match Package.Info.license info with
         | Some [ x ] -> Some x
         | _ -> None )
-    ; "version", package.version
+    ; "version", Option.map ~f:Dune_pkg.Package_version.to_string package.version
     ; "dev-repo", Option.map ~f:Package.Source_kind.to_string (Package.Info.source info)
     ]
     |> List.filter_map ~f:(fun (k, v) -> Option.map v ~f:(fun v -> k, string v))

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -514,7 +514,7 @@ type t =
   ; conflicts : Dependency.t list
   ; depopts : Dependency.t list
   ; info : Info.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; has_opam_file : opam_file
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
@@ -562,7 +562,7 @@ let encode
         ; field_l "depends" Dependency.encode depends
         ; field_l "conflicts" Dependency.encode conflicts
         ; field_l "depopts" Dependency.encode depopts
-        ; field_o "version" string version
+        ; field_o "version" Dune_pkg.Package_version.encode version
         ; field "tags" (list string) ~default:[] tags
         ; field_l
             "deprecated_package_names"
@@ -600,7 +600,10 @@ let decode =
        and+ synopsis = field_o "synopsis" string
        and+ description = field_o "description" string
        and+ version =
-         field_o "version" (Dune_lang.Syntax.since Stanza.syntax (2, 5) >>> string)
+         field_o
+           "version"
+           (Dune_lang.Syntax.since Stanza.syntax (2, 5)
+            >>> Dune_pkg.Package_version.decode)
        and+ depends = field ~default:[] "depends" (repeat Dependency.decode)
        and+ conflicts = field ~default:[] "conflicts" (repeat Dependency.decode)
        and+ depopts = field ~default:[] "depopts" (repeat Dependency.decode)
@@ -684,7 +687,7 @@ let to_dyn
     ; "info", Info.to_dyn info
     ; "has_opam_file", dyn_of_opam_file has_opam_file
     ; "tags", list string tags
-    ; "version", option string version
+    ; "version", option Dune_pkg.Package_version.to_dyn version
     ; "deprecated_package_names", Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names
     ; "sites", Site.Map.to_dyn Section.to_dyn sites
     ; "allow_empty", Bool allow_empty
@@ -772,7 +775,7 @@ let load_opam_file file name =
   let id = { Id.name; dir = Path.Source.parent_exn file } in
   { id
   ; loc
-  ; version = get_one "version"
+  ; version = get_one "version" |> Option.map ~f:Dune_pkg.Package_version.of_string
   ; conflicts = []
   ; depends = []
   ; depopts = []

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -121,7 +121,7 @@ type t =
   ; conflicts : Dependency.t list
   ; depopts : Dependency.t list
   ; info : Info.t
-  ; version : string option
+  ; version : Dune_pkg.Package_version.t option
   ; has_opam_file : opam_file
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -56,7 +56,7 @@ module Pkg_info = struct
   let variables t =
     String.Map.of_list_exn
       [ "name", Variable.S (Package.Name.to_string t.name)
-      ; "version", S t.version
+      ; "version", S (Package_version.to_string t.version)
       ; "dev", B t.dev
       ]
   ;;
@@ -332,7 +332,7 @@ module Pkg = struct
         ; "CDPATH", ""
         ; "MAKELEVEL", ""
         ; "OPAM_PACKAGE_NAME", Package.Name.to_string t.info.name
-        ; "OPAM_PACKAGE_VERSION", t.info.version
+        ; "OPAM_PACKAGE_VERSION", Package_version.to_string t.info.version
         ; "OPAMCLI", "2.0"
         ]
     in
@@ -435,7 +435,7 @@ module Action_expander = struct
       ; artifacts : Path.t Filename.Map.t
       ; deps : (Variable.value String.Map.t * Paths.t) Package.Name.Map.t
       ; context : Context_name.t
-      ; version : string
+      ; version : Package_version.t
       ; env : Value.t list Env.Map.t
       }
 

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -3,6 +3,7 @@ module Checksum = Dune_pkg.Checksum
 module Lock_dir = Dune_pkg.Lock_dir
 module Expanded_variable_bindings = Dune_pkg.Solver_stats.Expanded_variable_bindings
 module Variable = Dune_pkg.Solver_env.Variable
+module Package_version = Dune_pkg.Package_version
 module Package_name = Dune_lang.Package_name
 
 let () = Dune_tests_common.init ()
@@ -78,8 +79,8 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
            ; unset_variables = [ Variable.Sys `Os_family ]
            }
          (Package_name.Map.of_list_exn
-            [ mk_pkg_basic ~name:"foo" ~version:"0.1.0"
-            ; mk_pkg_basic ~name:"bar" ~version:"0.2.0"
+            [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
+            ; mk_pkg_basic ~name:"bar" ~version:(Package_version.of_string "0.2.0")
             ]));
   [%expect
     {|
@@ -135,7 +136,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
            External_copy (Loc.none, Path.External.of_string "/tmp/a")
          in
          ( name
-         , let pkg = empty_package name ~version:"0.1.0" in
+         , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
            { pkg with
              build_command =
                Some
@@ -167,7 +168,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
        let pkg_b =
          let name = Package_name.of_string "b" in
          ( name
-         , let pkg = empty_package name ~version:"dev" in
+         , let pkg = empty_package name ~version:(Package_version.of_string "dev") in
            { pkg with
              install_command = None
            ; deps = [ Loc.none, fst pkg_a ]
@@ -191,7 +192,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
        let pkg_c =
          let name = Package_name.of_string "c" in
          ( name
-         , let pkg = empty_package name ~version:"0.2" in
+         , let pkg = empty_package name ~version:(Package_version.of_string "0.2") in
            { pkg with
              deps = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
            ; info =

--- a/test/expect-tests/dune_pkg_outdated/dune
+++ b/test/expect-tests/dune_pkg_outdated/dune
@@ -5,6 +5,7 @@
   dune_tests_common
   stdune
   dune_pkg_outdated
+  dune_pkg
   dune_console
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
+++ b/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
@@ -16,16 +16,16 @@ let dummy_results
     Dune_pkg_outdated.For_tests.better_candidate
       ~is_immediate_dep_of_local_package:true
       ~name:(sprintf "foo%d" i)
-      ~newer_version:"2.0.0"
-      ~outdated_version:"1.0.0")
+      ~newer_version:(Dune_pkg.Package_version.of_string "2.0.0")
+      ~outdated_version:(Dune_pkg.Package_version.of_string "1.0.0"))
   @ List.init (total_number_of_transitive - number_of_transitive) ~f:(fun _ ->
     Dune_pkg_outdated.For_tests.package_is_best_candidate)
   @ List.init number_of_transitive ~f:(fun i ->
     Dune_pkg_outdated.For_tests.better_candidate
       ~is_immediate_dep_of_local_package:false
       ~name:(sprintf "bar%d" i)
-      ~newer_version:"2.0.0"
-      ~outdated_version:"1.0.0")
+      ~newer_version:(Dune_pkg.Package_version.of_string "2.0.0")
+      ~outdated_version:(Dune_pkg.Package_version.of_string "1.0.0"))
 ;;
 
 (* This will comb through a [User_message.Style.t Pp.t] message and find the style that


### PR DESCRIPTION
This adds the `Package_version.t` type which represents the type of a version of a package. This replaces the use of `string` for this purpose.