### PR TITLE
pkg: add quotes to command in error message

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -564,7 +564,7 @@ struct
     match Path.exists (Path.source lock_dir_path) with
     | false ->
       User_error.raise
-        ~hints:[ Pp.text "Run dune pkg lock to generate it." ]
+        ~hints:[ Pp.text "Run `dune pkg lock` to generate it." ]
         [ Pp.textf "%s does not exist." (Path.Source.to_string lock_dir_path) ]
     | true ->
       (match Path.is_directory (Path.source lock_dir_path) with


### PR DESCRIPTION
Without the quotes it's harder than it needs to be to tell which part of the sentence is the command it's hinting you to run.