### PR TITLE
refactor: remove markdown from terminal output

### DIFF
--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -293,3 +293,13 @@ let is_loc_none loc =
 let has_embedded_location msg = Annots.mem msg.annots Annots.has_embedded_location
 let has_location msg = (not (is_loc_none msg.loc)) || has_embedded_location msg
 let needs_stack_trace msg = Annots.mem msg.annots Annots.needs_stack_trace
+
+let command cmd =
+  (* CR-someday rgrinberg: this should be its own tag, but that might bring
+     some backward compat issues with rpc. *)
+  Pp.concat
+    [ Pp.verbatim "'"
+    ; Pp.tag (Style.Ansi_styles [ `Underline ]) @@ Pp.verbatim cmd
+    ; Pp.verbatim "'"
+    ]
+;;

--- a/otherlibs/stdune/src/user_message.mli
+++ b/otherlibs/stdune/src/user_message.mli
@@ -117,3 +117,6 @@ val has_embedded_location : t -> bool
 (** Returns [true] if the message's annotations contains
     [Annot.Needs_stack_trace]. *)
 val needs_stack_trace : t -> bool
+
+(** Formatting of shell commands *)
+val command : string -> Style.t Pp.t

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -565,7 +565,15 @@ struct
     match Path.exists (Path.source lock_dir_path) with
     | false ->
       User_error.raise
-        ~hints:[ Pp.text "Run `dune pkg lock` to generate it." ]
+        ~hints:
+          [ Pp.concat
+              ~sep:Pp.space
+              [ Pp.text "Run"
+              ; User_message.command "dune pkg lock"
+              ; Pp.text "to generate it."
+              ]
+            |> Pp.hovbox
+          ]
         [ Pp.textf "%s does not exist." (Path.Source.to_string lock_dir_path) ]
     | true ->
       (match Path.is_directory (Path.source lock_dir_path) with


### PR DESCRIPTION
No terminal renders it. It has its own meaning in shell commands
(command substitution). I've added `$` to signify that it's a shell
command plus an underline for visual distinction.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8c5508fb-ded3-44e0-81c0-65bc5ceb2d73 -->