### PR TITLE
refactor(pkg): use a single git call to load opam files

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -37,13 +37,50 @@ let run_capture_zero_separated_lines { dir } =
   Process.run_capture_zero_separated ~dir ~display failure_mode git
 ;;
 
-let show { dir } (Rev rev) path =
-  let git = Lazy.force Vcs.git in
-  let failure_mode = Vcs.git_accept () in
-  let command = [ "show"; sprintf "%s:%s" rev (Path.Local.to_string path) ] in
-  let stderr_to = make_stderr () in
-  Process.run_capture ~dir ~display ~stderr_to failure_mode git command
-  >>| Result.to_option
+let show =
+  let show { dir } revs_and_paths =
+    let git = Lazy.force Vcs.git in
+    let failure_mode = Vcs.git_accept () in
+    let command =
+      "show"
+      :: List.map revs_and_paths ~f:(function
+        | `Object o -> o
+        | `Path (Rev r, path) -> sprintf "%s:%s" r (Path.Local.to_string path))
+    in
+    let stderr_to = make_stderr () in
+    Process.run_capture ~dir ~display ~stderr_to failure_mode git command
+  in
+  fun t revs_and_paths ->
+    let cli_limit =
+      (if Sys.win32 then 8191 else 2097152)
+      - String.length "show"
+      - 1 (* space *)
+      - String.length (Path.to_string (Lazy.force Vcs.git))
+      - 100 (* some extra safety *)
+    in
+    let rec loop acc batch cmd_len_remaining = function
+      | [] -> List.rev batch :: acc
+      | cmd :: cmds ->
+        let cmd_len =
+          1
+          (* space separator *)
+          +
+          match cmd with
+          | `Object o -> String.length o
+          | `Path (Rev r, path) ->
+            String.length r + String.length (Path.Local.to_string path) + 1
+        in
+        let new_remaining = cmd_len_remaining - cmd_len in
+        if new_remaining >= 0
+        then loop acc (cmd :: batch) new_remaining cmds
+        else loop (List.rev batch :: acc) [ cmd ] cli_limit cmds
+    in
+    loop [] [] cli_limit revs_and_paths
+    |> List.rev
+    |> Fiber.parallel_map ~f:(show t)
+    >>| Result.List.all
+    >>| Result.map ~f:(String.concat ~sep:"")
+    >>| Result.to_option
 ;;
 
 let load_or_create ~dir =
@@ -62,6 +99,63 @@ let load_or_create ~dir =
   in
   t
 ;;
+
+module File = struct
+  module T = struct
+    type t =
+      { path : Path.Local.t
+      ; size : int
+      ; hash : string
+      }
+
+    let compare { path; size; hash } t =
+      let open Ordering.O in
+      let= () = Path.Local.compare path t.path in
+      let= () = Int.compare size t.size in
+      String.compare hash t.hash
+    ;;
+
+    let to_dyn { hash; path; size } =
+      Dyn.record
+        [ "path", Path.Local.to_dyn path; "size", Dyn.int size; "hash", Dyn.string hash ]
+    ;;
+  end
+
+  include T
+  module C = Comparable.Make (T)
+  module Set = C.Set
+
+  let parse =
+    let re =
+      let space = Re.(rep1 space) in
+      let perm = Re.(rep1 digit) in
+      let hash = Re.(rep1 alnum) in
+      let type_ = Re.(rep1 alpha) in
+      let size = Re.(rep1 digit) in
+      let path = Re.(rep1 any) in
+      [ perm
+      ; space
+      ; type_
+      ; space
+      ; Re.group hash
+      ; space
+      ; Re.group size
+      ; space
+      ; Re.group path
+      ]
+      |> Re.seq
+      |> Re.compile
+    in
+    fun line ->
+      let m = Re.exec re line in
+      { hash = Re.Group.get m 1
+      ; size = Int.of_string_exn @@ Re.Group.get m 2
+      ; path = Path.Local.of_string @@ Re.Group.get m 3
+      }
+  ;;
+
+  let path t = t.path
+end
 
 module Remote = struct
   type nonrec t =
@@ -84,27 +178,26 @@ module Remote = struct
     type nonrec t =
       { remote : t
       ; revision : rev
-      ; files_at_rev : Path.Local.Set.t
+      ; files_at_rev : File.Set.t
       }
 
     let content { remote = { repo; handle = _ }; revision; files_at_rev = _ } path =
-      show repo revision path
+      show repo [ `Path (revision, path) ]
     ;;
 
     let directory_entries { files_at_rev; remote = _; revision = _ } path =
-      (* TODO: there are much better of implementing this:
-         1. Using one [$ git show] for the entire director
-         2. using libgit or ocamlgit
-         3. using [$ git archive] *)
-      Path.Local.Set.filter files_at_rev ~f:(fun file ->
-        Path.Local.is_descendant file ~of_:path)
+      (* TODO: there are much better ways of implementing this:
+         1. using libgit or ocamlgit
+         2. possibly using [$ git archive] *)
+      File.Set.filter files_at_rev ~f:(fun (file : File.t) ->
+        Path.Local.is_descendant file.path ~of_:path)
     ;;
 
     let equal { remote; revision = Rev revision; files_at_rev } t =
       let (Rev revision') = t.revision in
       equal remote t.remote
       && String.equal revision revision'
-      && Path.Local.Set.equal files_at_rev t.files_at_rev
+      && File.Set.equal files_at_rev t.files_at_rev
     ;;
 
     let repository_id { revision = Rev rev; remote = _; files_at_rev = _ } =
@@ -113,8 +206,8 @@ module Remote = struct
   end
 
   let files_at_rev repo (Rev rev) =
-    run_capture_zero_separated_lines repo [ "ls-tree"; "-z"; "--name-only"; "-r"; rev ]
-    >>| Path.Local.Set.of_list_map ~f:Path.Local.of_string
+    run_capture_zero_separated_lines repo [ "ls-tree"; "-z"; "--long"; "-r"; rev ]
+    >>| File.Set.of_list_map ~f:File.parse
   ;;
 
   let rev_of_name ({ repo; handle } as remote) ~name =
@@ -165,4 +258,23 @@ let add_repo t ~source =
   let remote : Remote.t = { repo = t; handle } in
   let+ () = Remote.update remote in
   remote
+;;
+
+let content_of_files t files =
+  let+ out =
+    List.map files ~f:(fun (file : File.t) -> `Object file.hash)
+    |> show t
+    >>| function
+    | Some s -> s
+    | None -> Code_error.raise "content_of_files failed" []
+  in
+  let rec loop acc pos = function
+    | [] ->
+      assert (pos = String.length out);
+      acc
+    | (file : File.t) :: files ->
+      let acc = String.sub out ~pos ~len:file.size :: acc in
+      loop acc (pos + file.size) files
+  in
+  List.rev (loop [] 0 files)
 ;;

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -2,6 +2,15 @@ open Stdune
 
 type t
 
+module File : sig
+  type t
+
+  val path : t -> Path.Local.t
+  val to_dyn : t -> Dyn.t
+
+  module Set : Set.S with type elt = t
+end
+
 module Remote : sig
   type t
 
@@ -12,7 +21,7 @@ module Remote : sig
     type t
 
     val content : t -> Path.Local.t -> string option Fiber.t
-    val directory_entries : t -> Path.Local.t -> Path.Local.Set.t
+    val directory_entries : t -> Path.Local.t -> File.Set.t
     val equal : t -> t -> bool
     val repository_id : t -> Repository_id.t
   end
@@ -21,5 +30,6 @@ module Remote : sig
   val rev_of_repository_id : t -> Repository_id.t -> At_rev.t option Fiber.t
 end
 
+val content_of_files : t -> File.t list -> string list Fiber.t
 val load_or_create : dir:Path.t -> t Fiber.t
 val add_repo : t -> source:string -> Remote.t Fiber.t


### PR DESCRIPTION
Rather than calling $ git show for every file, we introduce an API that
allows us to fetch mutliple files in a single command.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6b29e72d-ce26-4b09-af07-c9d39955e7a4 -->