### PR TITLE
pkg: remove dev field from lockfile

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -17,7 +17,6 @@ module Pkg_info : sig
   type t =
     { name : Package_name.t
     ; version : Package_version.t
-    ; dev : bool
     ; source : Source.t option
     ; extra_sources : (Path.Local.t * Source.t) list
     }

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -513,7 +513,6 @@ let opam_package_to_lock_file_pkg
     in
     { Lock_dir.Pkg_info.name = Package_name.of_string (OpamPackage.Name.to_string name)
     ; version
-    ; dev = false
     ; source
     ; extra_sources
     }

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -57,7 +57,6 @@ module Pkg_info = struct
     String.Map.of_list_exn
       [ "name", Variable.S (Package.Name.to_string t.name)
       ; "version", S (Package_version.to_string t.version)
-      ; "dev", B t.dev
       ]
   ;;
 end
@@ -538,6 +537,7 @@ module Action_expander = struct
          | "enable" ->
            Memo.return @@ Ok [ Value.String (if present then "enable" else "disable") ]
          | "installed" -> Memo.return @@ Ok [ Value.String (Bool.to_string present) ]
+         | "dev" -> Memo.return @@ Ok [ Value.false_ ]
          | _ ->
            (match paths with
             | None -> Memo.return (Error (`Undefined_pkg_var variable_name))

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -57,8 +57,7 @@ let empty_package name ~version =
   { Lock_dir.Pkg.build_command = None
   ; install_command = None
   ; deps = []
-  ; info =
-      { Lock_dir.Pkg_info.name; version; dev = false; source = None; extra_sources = [] }
+  ; info = { Lock_dir.Pkg_info.name; version; source = None; extra_sources = [] }
   ; exported_env = []
   }
 ;;
@@ -95,7 +94,6 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               ; info =
                   { name = "bar"
                   ; version = "0.2.0"
-                  ; dev = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -108,7 +106,6 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
               ; info =
                   { name = "foo"
                   ; version = "0.1.0"
-                  ; dev = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -149,8 +146,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                     (String_with_vars.make_text ~quoted:true Loc.none "echo 'world'"))
            ; info =
                { pkg.info with
-                 dev = false
-               ; source = Some extra_source
+                 source = Some extra_source
                ; extra_sources =
                    [ Path.Local.of_string "one", extra_source
                    ; ( Path.Local.of_string "two"
@@ -174,8 +170,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
            ; deps = [ Loc.none, fst pkg_a ]
            ; info =
                { pkg.info with
-                 dev = true
-               ; source =
+                 source =
                    Some
                      (Fetch
                         { url = Loc.none, "https://github.com/foo/b"
@@ -197,8 +192,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
              deps = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
            ; info =
                { pkg.info with
-                 dev = false
-               ; source =
+                 source =
                    Some
                      (Fetch
                         { url = Loc.none, "https://github.com/foo/c"; checksum = None })
@@ -227,7 +221,6 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; info =
                   { name = "a"
                   ; version = "0.1.0"
-                  ; dev = false
                   ; source = Some External_copy External "/tmp/a"
                   ; extra_sources =
                       [ ("one", External_copy External "/tmp/a")
@@ -243,7 +236,6 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; info =
                   { name = "b"
                   ; version = "dev"
-                  ; dev = true
                   ; source =
                       Some
                         Fetch
@@ -264,7 +256,6 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; info =
                   { name = "c"
                   ; version = "0.2"
-                  ; dev = false
                   ; source = Some Fetch "https://github.com/foo/c", None
                   ; extra_sources = []
                   }


### PR DESCRIPTION
In opam the "dev" package variable is true for packages that weren't build from a release archive. Currently we only have support for building released packages so removing it to simplify the code.