### PR TITLE
Improve [Action_builder.memoize]

### DIFF
--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -213,6 +213,7 @@ end
 module Facts = struct
   type t = Fact.t Map.t
 
+  let equal x y = Map.equal ~equal:Fact.equal x y
   let empty = Map.empty
 
   let union a b =

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -68,6 +68,7 @@ module Facts : sig
      keys. For example, we can't have [Map.find (File f) = File_selector _]. *)
   type t = Fact.t Map.t
 
+  val equal : t -> t -> bool
   val empty : t
   val union : t -> t -> t
   val union_all : t list -> t


### PR DESCRIPTION
Improve `Action_builder.memoize`:

* Remove one of the `Lazy.t` cells. Most `Eager` parts of `Action_builder.t`s end up being forced in every build, so the `Lazy.t` wrapper is unnecessary.

* Add the "(lazy)" suffix to the names of `Lazy` parts to be able to distinguish `Eager` and `Lazy` parts in profiling.

Our internal benchmarks show a consistent improvement across all scenarios, both in terms of time (1-2%) and memory allocations (a tiny improvement but still: 0-0.2%).

Note that I also benchmarked a similar change where I also remove the `Lazy.t` cell in the `Lazy` part of `Action_builder.t`s. That was a clear regression both in terms of time and memory. 

@rgrinberg I'm assuming this is a good change externally as well. We use `Action_builder.run Eager` in all `Action_builder.run` call sites in `build_system.ml`: `execute_rule_impl`, `build_alias_impl` and `dep_on_anonymous_action`, which is the main place where `Action_builder`s are evaluated. One notable (and the only, internally) user of `Action_builder.run Lazy` is `reflection.ml`, and I don't think we should worry about slightly increasing allocations here (because we usually combine reflection checks with building the actual targets). There is only one other call site with `Lazy` externally (`src/dune_rules/lib_file_deps.ml`) and I think it contributes much less to the overall memory usage compared to the big stuff in `build_system.ml`. Please let me know if you agree. If not, we can make this change internal-only.