### PR TITLE
fix: properly ignore bigarray if it shouldn't exist

### DIFF
--- a/doc/changes/9076.md
+++ b/doc/changes/9076.md
@@ -1,0 +1,1 @@
+- Correctly ignore `bigarray` on recent version of OCaml (#9076, @rgrinberg)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1815,7 +1815,12 @@ module DB = struct
           | Error e ->
             (match e with
              | Invalid_dune_package why -> Invalid why
-             | Not_found when has_bigarray_library && Lib_name.equal name bigarray ->
+             | Not_found when (not has_bigarray_library) && Lib_name.equal name bigarray
+               ->
+               (* Recent versions of OCaml already include a [bigrray] library,
+                  so we just silently ignore dependencies on it. The more
+                  correct thing to do would be to redirect it to the stdlib,
+                  but the stdlib isn't first class. *)
                Ignore
              | Not_found -> Not_found))
         ~all:(fun () ->


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7d481f45-e899-449e-8bb0-23c2b4195ded -->