### PR TITLE
refactor(pkg): split local and repo packages

### DIFF
--- a/bin/pkg.ml
+++ b/bin/pkg.ml
@@ -368,7 +368,7 @@ module Lock = struct
         | Generated | Exists false -> Dune_project.file project
         | Exists true -> pkg.opam_file
       in
-      Opam_repo.With_file.local file opam_file)
+      { Dune_pkg.Opam_solver.opam_file; file })
   ;;
 
   let pp_packages packages =

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -236,13 +236,12 @@ module With_file = struct
   type nonrec t =
     { opam_file : OpamFile.OPAM.t
     ; file : Path.t
-    ; repo : t option
+    ; repo : t
     }
 
   let file t = t.file
   let opam_file t = t.opam_file
   let repo t = t.repo
-  let local file opam_file = { file; opam_file; repo = None }
 end
 
 (* Reads an opam package definition from an "opam" file in this repository
@@ -258,7 +257,7 @@ let load_opam_package t opam_package =
         |> OpamFile.make
         |> OpamFile.OPAM.read
       in
-      { With_file.opam_file; file = opam_file_path; repo = Some t })
+      { With_file.opam_file; file = opam_file_path; repo = t })
     |> Fiber.return
   | Repo at_rev ->
     let expected_path =
@@ -277,10 +276,7 @@ let load_opam_package t opam_package =
         OpamFile.OPAM.read_from_string ~filename content
       in
       (* TODO the [file] here is made up *)
-      { With_file.opam_file
-      ; file = Path.source @@ Path.Source.of_local file
-      ; repo = Some t
-      })
+      { With_file.opam_file; file = Path.source @@ Path.Source.of_local file; repo = t })
 ;;
 
 let load_packages_from_git rev_store opam_packages =
@@ -295,10 +291,7 @@ let load_packages_from_git rev_store opam_packages =
       OpamFile.OPAM.read_from_string ~filename opam_file_contents
     in
     (* TODO the [file] here is made up *)
-    { With_file.opam_file
-    ; file = Path.source @@ Path.Source.of_local path
-    ; repo = Some repo
-    })
+    { With_file.opam_file; file = Path.source @@ Path.Source.of_local path; repo })
 ;;
 
 let get_opam_package_version_dir_path packages_dir_path opam_package_name =

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -34,8 +34,7 @@ module With_file : sig
 
   val opam_file : t -> OpamFile.OPAM.t
   val file : t -> Path.t
-  val local : Path.t -> OpamFile.OPAM.t -> t
-  val repo : t -> repo option
+  val repo : t -> repo
 end
 
 (** Load package metadata for a single package *)

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -7,10 +7,15 @@ module Solver_result : sig
     }
 end
 
+type local_package =
+  { opam_file : OpamFile.OPAM.t
+  ; file : Path.t
+  }
+
 val solve_lock_dir
   :  Solver_env.t
   -> Version_preference.t
   -> Opam_repo.t list
-  -> local_packages:Opam_repo.With_file.t Package_name.Map.t
+  -> local_packages:local_package Package_name.Map.t
   -> experimental_translate_opam_filters:bool
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/src/dune_pkg_outdated/dune_pkg_outdated.ml
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.ml
@@ -83,15 +83,14 @@ let explain_results_to_user results ~transitive ~lock_dir_path =
 
 let better_candidate
   ~repos
-  ~(local_packages : Opam_repo.With_file.t Package_name.Map.t)
+  ~(local_packages : Dune_pkg.Opam_solver.local_package Package_name.Map.t)
   (pkg : Lock_dir.Pkg.t)
   =
   let open Fiber.O in
   let pkg_name = pkg.info.name |> Package_name.to_string |> OpamPackage.Name.of_string in
   let is_immediate_dep_of_local_package =
-    Package_name.Map.exists local_packages ~f:(fun with_file ->
-      Opam_repo.With_file.opam_file with_file
-      |> OpamFile.OPAM.depends
+    Package_name.Map.exists local_packages ~f:(fun local_package ->
+      OpamFile.OPAM.depends local_package.opam_file
       |> OpamFilter.filter_deps
            ~build:true
            ~post:false

--- a/src/dune_pkg_outdated/dune_pkg_outdated.mli
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.mli
@@ -9,7 +9,7 @@ type t
     collection of [packages] by consulting the [repos] and [local_packages].*)
 val find
   :  repos:Opam_repo.t list
-  -> local_packages:Opam_repo.With_file.t Package_name.Map.t
+  -> local_packages:Dune_pkg.Opam_solver.local_package Package_name.Map.t
   -> Lock_dir.Pkg.t Package_name.Map.t
   -> t Fiber.t
 


### PR DESCRIPTION
introduce separate types for them because they have different properties

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 963d83e9-5c78-4e77-9e2e-08acf95056db -->