### PR TITLE
ci: increase bench thresholds

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -72,7 +72,7 @@ jobs:
           auto-push: true
           # Ratio indicating how worse the current benchmark result is.
           # 175% means if last build took 40s and current takes >70s, it will trigger an alert
-          alert-threshold: "175%"
+          alert-threshold: "225%"
           fail-on-alert: true
           # Enable alert commit comment
           comment-on-alert: true
@@ -113,7 +113,7 @@ jobs:
           auto-push: true
           # Ratio indicating how worse the current benchmark result is.
           # 150% means if last build took 40s and current takes >60s, it will trigger an alert
-          alert-threshold: "150%"
+          alert-threshold: "225%"
           fail-on-alert: true
           # Enable alert commit comment
           comment-on-alert: true
@@ -144,7 +144,7 @@ jobs:
           auto-push: true
           # Ratio indicating how worse the current benchmark result is.
           # 150% means if last build took 40s and current takes >60s, it will trigger an alert
-          alert-threshold: "150%"
+          alert-threshold: "225%"
           fail-on-alert: true
           # Enable alert commit comment
           comment-on-alert: true
@@ -171,7 +171,7 @@ jobs:
           auto-push: true
           # Ratio indicating how worse the current benchmark result is.
           # 150% means if last build took 40s and current takes >60s, it will trigger an alert
-          alert-threshold: "150%"
+          alert-threshold: "225%"
           fail-on-alert: true
           # Enable alert commit comment
           comment-on-alert: true


### PR DESCRIPTION
It seems GitHub changed around the 1st of Nov their runners, and now the time difference between builds has increased. The effect can be seen very clearly in https://ocaml.github.io/dune/dev/bench/.

This has caused a lot of false positive alerts to be triggered, which causes me to receive email alerts, and commits to get commented with alerts as well.

This PR increases the threshold in to hopefully reduce noise.