### PR TITLE
pkg: detect test-only dependencies in lockdir

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -75,8 +75,135 @@ module Dependency_hash = struct
   let command = Cmd.v info term
 end
 
+module List_locked_dependencies = struct
+  module Package_universe = Dune_pkg.Package_universe
+  module Lock_dir = Dune_pkg.Lock_dir
+  module Opam_repo = Dune_pkg.Opam_repo
+  module Package_version = Dune_pkg.Package_version
+  module Opam_solver = Dune_pkg.Opam_solver
+
+  let info =
+    let doc = "List the dependencies locked by a lockdir" in
+    let man = [ `S "DESCRIPTION"; `P "List the dependencies locked by a lockdir" ] in
+    Cmd.info "list-locked-dependencies" ~doc ~man
+  ;;
+
+  let package_deps_in_lock_dir_pp package_universe package_name ~transitive =
+    let traverse, traverse_word =
+      if transitive then `Transitive, "Transitive" else `Immediate, "Immediate"
+    in
+    let opam_package =
+      Package_universe.opam_package_of_package package_universe package_name
+    in
+    let list_dependencies which =
+      Package_universe.opam_package_dependencies_of_package
+        package_universe
+        package_name
+        ~which
+        ~traverse
+    in
+    Pp.concat
+      ~sep:Pp.cut
+      [ Pp.hbox
+          (Pp.textf
+             "%s dependencies of local package %s"
+             traverse_word
+             (OpamPackage.to_string opam_package))
+      ; Pp.enumerate (list_dependencies `Non_test) ~f:(fun opam_package ->
+          Pp.text (OpamPackage.to_string opam_package))
+      ; Pp.enumerate (list_dependencies `Test_only) ~f:(fun opam_package ->
+          Pp.textf "%s (test only)" (OpamPackage.to_string opam_package))
+      ]
+    |> Pp.vbox
+  ;;
+
+  let enumerate_lock_dirs_by_path ~context_name_arg ~all_contexts_arg =
+    let open Fiber.O in
+    let+ per_contexts =
+      Pkg_common.Per_context.choose
+        ~context_name_arg
+        ~all_contexts_arg
+        ~version_preference_arg:None
+    in
+    List.filter_map per_contexts ~f:(fun { Pkg_common.Per_context.lock_dir_path; _ } ->
+      if Path.exists (Path.source lock_dir_path)
+      then (
+        try Some (lock_dir_path, Lock_dir.read_disk lock_dir_path) with
+        | User_error.E e ->
+          User_warning.emit
+            [ Pp.textf
+                "Failed to parse lockdir %s:"
+                (Path.Source.to_string_maybe_quoted lock_dir_path)
+            ; User_message.pp e
+            ];
+          None)
+      else None)
+  ;;
+
+  let list_locked_dependencies ~context_name_arg ~all_contexts_arg ~transitive =
+    let open Fiber.O in
+    let+ lock_dirs_by_path =
+      enumerate_lock_dirs_by_path ~context_name_arg ~all_contexts_arg
+    and+ local_packages = Pkg_common.find_local_packages in
+    let pp =
+      Pp.concat
+        ~sep:Pp.cut
+        (List.map lock_dirs_by_path ~f:(fun (lock_dir_path, lock_dir) ->
+           match Package_universe.create local_packages lock_dir with
+           | Error e -> raise (User_error.E e)
+           | Ok package_universe ->
+             Pp.vbox
+               (Pp.concat
+                  ~sep:Pp.cut
+                  [ Pp.hbox
+                      (Pp.textf
+                         "Dependencies of local packages locked in %s"
+                         (Path.Source.to_string_maybe_quoted lock_dir_path))
+                  ; Pp.enumerate
+                      (Package_name.Map.keys local_packages)
+                      ~f:(package_deps_in_lock_dir_pp package_universe ~transitive)
+                    |> Pp.box
+                  ])))
+      |> Pp.vbox
+    in
+    Console.print [ pp ]
+  ;;
+
+  let term =
+    let+ builder = Common.Builder.term
+    and+ context_name =
+      Pkg_common.context_term
+        ~doc:"Print information about the lockdir associated with this context"
+    and+ all_contexts =
+      Arg.(
+        value & flag & info [ "all-contexts" ] ~doc:"Print information about all lockdirs")
+    and+ transitive =
+      Arg.(
+        value
+        & flag
+        & info
+            [ "transitive" ]
+            ~doc:
+              "Display transitive dependencies (by default only immediate dependencies \
+               are displayed)")
+    in
+    let builder = Common.Builder.forbid_builds builder in
+    let common, config = Common.init builder in
+    Scheduler.go ~common ~config
+    @@ fun () ->
+    list_locked_dependencies
+      ~context_name_arg:context_name
+      ~all_contexts_arg:all_contexts
+      ~transitive
+  ;;
+
+  let command = Cmd.v info term
+end
+
 let command =
   let doc = "Subcommands related to package management" in
   let info = Cmd.info ~doc "pkg" in
-  Cmd.group info [ Lock.command; Dependency_hash.command ]
+  Cmd.group
+    info
+    [ Lock.command; List_locked_dependencies.command; Dependency_hash.command ]
 ;;

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -3,6 +3,8 @@ open! Import
 type t =
   { local_packages : Local_package.t Package_name.Map.t
   ; lock_dir : Lock_dir.t
+  ; version_by_package_name : Package_version.t Package_name.Map.t
+  ; solver_env : Solver_env.t
   }
 
 let lockdir_regenerate_hints =
@@ -16,13 +18,13 @@ let lockdir_regenerate_hints =
   ]
 ;;
 
-let version_by_package_name t =
+let version_by_package_name local_packages (lock_dir : Lock_dir.t) =
   let from_local_packages =
-    Package_name.Map.map t.local_packages ~f:(fun local_package ->
+    Package_name.Map.map local_packages ~f:(fun (local_package : Local_package.t) ->
       Option.value local_package.version ~default:Lock_dir.Pkg_info.default_version)
   in
   let from_lock_dir =
-    Package_name.Map.map t.lock_dir.packages ~f:(fun pkg -> pkg.info.version)
+    Package_name.Map.map lock_dir.packages ~f:(fun pkg -> pkg.info.version)
   in
   let exception Duplicate_package of Package_name.t in
   try
@@ -34,9 +36,7 @@ let version_by_package_name t =
            raise (Duplicate_package duplicate_package_name)))
   with
   | Duplicate_package duplicate_package_name ->
-    let local_package =
-      Package_name.Map.find_exn t.local_packages duplicate_package_name
-    in
+    let local_package = Package_name.Map.find_exn local_packages duplicate_package_name in
     Error
       (User_message.make
          ~hints:lockdir_regenerate_hints
@@ -47,35 +47,33 @@ let version_by_package_name t =
          ])
 ;;
 
-let all_non_local_dependencies_of_local_packages t version_by_package_name =
+let concrete_dependencies_of_local_package_with_test t local_package_name =
+  let local_package = Package_name.Map.find_exn t.local_packages local_package_name in
+  Local_package.(for_solver local_package |> For_solver.opam_filtered_dependency_formula)
+  |> Resolve_opam_formula.filtered_formula_to_package_names
+       ~stats_updater:None
+       ~with_test:true
+       t.solver_env
+       t.version_by_package_name
+  |> Result.map_error ~f:(function
+    | `Formula_could_not_be_satisfied unsatisfied_formula_hints ->
+    User_message.make
+      ~hints:lockdir_regenerate_hints
+      ~loc:local_package.loc
+      (Pp.textf
+         "The dependencies of local package %S could not be satisfied from the lockdir:"
+         (Package_name.to_string local_package.name)
+       :: List.map
+            unsatisfied_formula_hints
+            ~f:Resolve_opam_formula.Unsatisfied_formula_hint.pp))
+  |> Result.map ~f:Package_name.Set.of_list
+;;
+
+let all_non_local_dependencies_of_local_packages t =
   let open Result.O in
-  let solver_env =
-    Solver_stats.Expanded_variable_bindings.to_solver_env
-      t.lock_dir.expanded_solver_variable_bindings
-  in
   let+ all_dependencies_of_local_packages =
-    Package_name.Map.values t.local_packages
-    |> List.map ~f:(fun (local_package : Local_package.t) ->
-      Local_package.(
-        for_solver local_package |> For_solver.opam_filtered_dependency_formula)
-      |> Resolve_opam_formula.filtered_formula_to_package_names
-           ~stats_updater:None
-           ~with_test:true
-           solver_env
-           version_by_package_name
-      |> Result.map_error ~f:(function
-        | `Formula_could_not_be_satisfied unsatisfied_formula_hints ->
-        User_message.make
-          ~hints:lockdir_regenerate_hints
-          ~loc:local_package.loc
-          (Pp.textf
-             "The dependencies of local package %S could not be satisfied from the \
-              lockdir:"
-             (Package_name.to_string local_package.name)
-           :: List.map
-                unsatisfied_formula_hints
-                ~f:Resolve_opam_formula.Unsatisfied_formula_hint.pp))
-      |> Result.map ~f:Package_name.Set.of_list)
+    Package_name.Map.keys t.local_packages
+    |> List.map ~f:(concrete_dependencies_of_local_package_with_test t)
     |> Result.List.all
     |> Result.map ~f:Package_name.Set.union_all
   in
@@ -128,7 +126,7 @@ let check_for_unnecessary_packges_in_lock_dir
          ]))
 ;;
 
-let validate_dependency_hash { local_packages; lock_dir } =
+let validate_dependency_hash { local_packages; lock_dir; _ } =
   let local_packages =
     Package_name.Map.values local_packages |> List.map ~f:Local_package.for_solver
   in
@@ -193,14 +191,166 @@ let validate_dependency_hash { local_packages; lock_dir } =
 let validate t =
   let open Result.O in
   let* () = validate_dependency_hash t in
-  version_by_package_name t
-  >>= all_non_local_dependencies_of_local_packages t
+  all_non_local_dependencies_of_local_packages t
   >>= check_for_unnecessary_packges_in_lock_dir t
 ;;
 
 let create local_packages lock_dir =
   let open Result.O in
-  let t = { local_packages; lock_dir } in
+  let* version_by_package_name = version_by_package_name local_packages lock_dir in
+  let solver_env =
+    Solver_stats.Expanded_variable_bindings.to_solver_env
+      lock_dir.expanded_solver_variable_bindings
+  in
+  let t = { local_packages; lock_dir; version_by_package_name; solver_env } in
   let+ () = validate t in
   t
+;;
+
+let concrete_dependencies_of_local_package_with_test t local_package_name =
+  match concrete_dependencies_of_local_package_with_test t local_package_name with
+  | Ok x -> x
+  | Error e ->
+    Code_error.raise
+      "Invalid package universe which should have already been validated"
+      [ "error", Dyn.string (User_message.to_string e) ]
+;;
+
+let concrete_dependencies_of_local_package_without_test t local_package_name =
+  let local_package = Package_name.Map.find_exn t.local_packages local_package_name in
+  Local_package.(for_solver local_package |> For_solver.opam_filtered_dependency_formula)
+  |> Resolve_opam_formula.filtered_formula_to_package_names
+       ~stats_updater:None
+       ~with_test:false
+       t.solver_env
+       t.version_by_package_name
+  |> function
+  | Ok x -> Package_name.Set.of_list x
+  | Error (`Formula_could_not_be_satisfied hints) ->
+    User_error.raise
+      (Pp.textf
+         "Unable to find dependencies of package %S in lockdir when the solver variable \
+          'with_test' is set to 'false':"
+         (Package_name.to_string local_package.name)
+       :: List.map hints ~f:Resolve_opam_formula.Unsatisfied_formula_hint.pp)
+;;
+
+let local_transitive_dependency_closure_without_test t start =
+  let to_visit = Queue.create () in
+  let push_set = Package_name.Set.iter ~f:(Queue.push to_visit) in
+  push_set start;
+  let rec loop seen =
+    match Queue.pop to_visit with
+    | None -> seen
+    | Some node ->
+      let deps = concrete_dependencies_of_local_package_without_test t node in
+      let local_unseen_deps =
+        Package_name.Set.(
+          diff deps seen |> filter ~f:(Package_name.Map.mem t.local_packages))
+      in
+      push_set local_unseen_deps;
+      loop (Package_name.Set.union seen local_unseen_deps)
+  in
+  loop start
+;;
+
+let transitive_dependency_closure_without_test t start =
+  let local_package_names = Package_name.Set.of_keys t.local_packages in
+  let local_transitive_dependency_closure =
+    local_transitive_dependency_closure_without_test
+      t
+      (Package_name.Set.inter local_package_names start)
+  in
+  let non_local_transitive_dependency_closure =
+    let non_local_immediate_dependencies_of_local_transitive_dependency_closure =
+      Package_name.Set.to_list local_transitive_dependency_closure
+      |> Package_name.Set.union_map ~f:(fun name ->
+        let all_deps = concrete_dependencies_of_local_package_without_test t name in
+        Package_name.Set.diff all_deps local_package_names)
+    in
+    Lock_dir.transitive_dependency_closure
+      t.lock_dir
+      Package_name.Set.(
+        union
+          non_local_immediate_dependencies_of_local_transitive_dependency_closure
+          (diff start local_package_names))
+    |> function
+    | Ok x -> x
+    | Error (`Missing_packages missing_packages) ->
+      Code_error.raise
+        "Attempted to find non-existent packages in lockdir after validation which \
+         should not be possible"
+        (Package_name.Set.to_list missing_packages
+         |> List.map ~f:(fun p -> "missing package", Package_name.to_dyn p))
+  in
+  Package_name.Set.union
+    local_transitive_dependency_closure
+    non_local_transitive_dependency_closure
+;;
+
+let contains_package t package_name =
+  let in_local_packages = Package_name.Map.mem t.local_packages package_name in
+  let in_lock_dir = Package_name.Map.mem t.lock_dir.packages package_name in
+  in_local_packages || in_lock_dir
+;;
+
+let check_contains_package t package_name =
+  if not (contains_package t package_name)
+  then
+    User_error.raise
+      [ Pp.textf
+          "Package %S is neither a local package nor present in the lockdir."
+          (Package_name.to_string package_name)
+      ]
+;;
+
+let all_dependencies t package ~traverse =
+  check_contains_package t package;
+  let immediate_deps = concrete_dependencies_of_local_package_with_test t package in
+  match traverse with
+  | `Immediate -> immediate_deps
+  | `Transitive ->
+    let closure = transitive_dependency_closure_without_test t immediate_deps in
+    Package_name.Set.remove closure package
+;;
+
+let non_test_dependencies t package ~traverse =
+  check_contains_package t package;
+  match traverse with
+  | `Immediate -> concrete_dependencies_of_local_package_without_test t package
+  | `Transitive ->
+    let closure =
+      transitive_dependency_closure_without_test t (Package_name.Set.singleton package)
+    in
+    Package_name.Set.remove closure package
+;;
+
+let test_only_dependencies t package ~traverse =
+  Package_name.Set.diff
+    (all_dependencies t package ~traverse)
+    (non_test_dependencies t package ~traverse)
+;;
+
+let opam_package_dependencies_of_package t package ~which ~traverse =
+  let get_deps =
+    match which with
+    | `All -> all_dependencies
+    | `Non_test -> non_test_dependencies
+    | `Test_only -> test_only_dependencies
+  in
+  get_deps t package ~traverse
+  |> Package_name.Set.to_list
+  |> List.map ~f:(fun package_name ->
+    OpamPackage.create
+      (Package_name.to_opam_package_name package_name)
+      (Package_name.Map.find_exn t.version_by_package_name package_name
+       |> Package_version.to_opam_package_version))
+;;
+
+let opam_package_of_package t package_name =
+  check_contains_package t package_name;
+  OpamPackage.create
+    (Package_name.to_opam_package_name package_name)
+    (Package_name.Map.find_exn t.version_by_package_name package_name
+     |> Package_version.to_opam_package_version)
 ;;

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -3,12 +3,22 @@ open! Import
 (** All of the packages in a dune project including local packages and packages
     in a lockdir. The lockdir is guaranteed to contain a valid dependency
     solution for the local packages. *)
-type t = private
-  { local_packages : Local_package.t Package_name.Map.t
-  ; lock_dir : Lock_dir.t
-  }
+type t
 
 val create
   :  Local_package.t Package_name.Map.t
   -> Lock_dir.t
   -> (t, User_message.t) result
+
+(** Returns the dependencies of the specified package within teh package
+    universe *)
+val opam_package_dependencies_of_package
+  :  t
+  -> Package_name.t
+  -> which:[ `All | `Non_test | `Test_only ]
+  -> traverse:[ `Immediate | `Transitive ]
+  -> OpamPackage.t list
+
+(** Returns the opam package whose name is the given package name and whose
+    version is the version of that package within the package universe *)
+val opam_package_of_package : t -> Package_name.t -> OpamPackage.t

--- a/test/blackbox-tests/test-cases/pkg/test-only-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/test-only-deps.t
@@ -1,0 +1,119 @@
+Test that we can identify the test-only locked dependencies of a package
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg a 0.0.1 <<EOF
+  > EOF
+  $ mkpkg a 0.0.2 <<EOF
+  > EOF
+  $ mkpkg b <<EOF
+  > EOF
+  $ mkpkg c <<EOF
+  > EOF
+  $ mkpkg d <<EOF
+  > EOF
+  $ mkpkg foo <<EOF
+  > depends: [ "a" "b" ]
+  > EOF
+  $ mkpkg bar <<EOF
+  > depends: [ "b" "c"]
+  > EOF
+  $ mkpkg baz <<EOF
+  > depends: [ "bar" ]
+  > EOF
+  $ mkpkg qux <<EOF
+  > depends: [ "a" "b" "c" "d" ]
+  > EOF
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name local_1)
+  >  (depends
+  >   local_2))
+  > (package
+  >  (name local_2)
+  >  (depends
+  >   baz
+  >   (qux :with-test)))
+  > EOF
+  Solution for dune.lock:
+  - a.0.0.2
+  - b.0.0.1
+  - bar.0.0.1
+  - baz.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - qux.0.0.1
+List immediate dependencies in the lockdir. This should mirror the information in dune-project.
+  $ dune describe pkg list-locked-dependencies
+  Dependencies of local packages locked in dune.lock
+  - Immediate dependencies of local package local_1.dev
+    - local_2.dev
+    
+  - Immediate dependencies of local package local_2.dev
+    - baz.0.0.1
+    - qux.0.0.1 (test only)
+List transitive dependencies. Note that only immediate test-only dependencies
+and their dependencies are included (not test-only dependencies of test-only
+dependencies).
+  $ dune describe pkg list-locked-dependencies --transitive
+  Dependencies of local packages locked in dune.lock
+  - Transitive dependencies of local package local_1.dev
+    - b.0.0.1
+    - bar.0.0.1
+    - baz.0.0.1
+    - c.0.0.1
+    - local_2.dev
+    
+  - Transitive dependencies of local package local_2.dev
+    - b.0.0.1
+    - bar.0.0.1
+    - baz.0.0.1
+    - c.0.0.1
+    - a.0.0.2 (test only)
+    - d.0.0.1 (test only)
+    - qux.0.0.1 (test only)
+Test that we can detect the case where a local package depends on some package
+only when with-test is false. This will result in an error because the solver
+is run with with-test=true so the dependency won't even be in the lockdir.
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name local_1)
+  >  (depends
+  >   (foo (= :with-test false))
+  >   bar))
+  > EOF
+  Solution for dune.lock:
+  - b.0.0.1
+  - bar.0.0.1
+  - c.0.0.1
+  $ dune describe pkg list-locked-dependencies
+  Error: Unable to find dependencies of package "local_1" in lockdir when the
+  solver variable 'with_test' is set to 'false':
+  Package "foo" is missing
+  [1]
+Test that we can detect the case where a local package depends on some package
+with version constraints that differ depending on :with-test. This will result
+in an error because the solver is ruw with with-test=true which means an
+incompatible version of the dependency will be in the lockdir.
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name local_1)
+  >  (depends
+  >   (a (or (= 0.0.1) (and :with-test (= 0.0.2))))
+  >   bar))
+  > EOF
+  Solution for dune.lock:
+  - a.0.0.2
+  - b.0.0.1
+  - bar.0.0.1
+  - c.0.0.1
+  $ dune describe pkg list-locked-dependencies
+  Error: Unable to find dependencies of package "local_1" in lockdir when the
+  solver variable 'with_test' is set to 'false':
+  Found version "0.0.2" of package "a" which doesn't satisfy the required
+  version constraint "= 0.0.1"
+  [1]


### PR DESCRIPTION
Adds a new command `dune pkg list-locked-dependencies` which lists the locked dependencies of local packages, identifying which dependencies will only be included if tests are enabled.