### PR TITLE
refactor(pkg): fetch all package extra files in a single call

### DIFF
--- a/otherlibs/stdune/src/map.ml
+++ b/otherlibs/stdune/src/map.ml
@@ -77,6 +77,14 @@ module Make (Key : Key) : S with type key = Key.t = struct
   let filter t ~f = filteri t ~f:(fun _ x -> f x)
   let partitioni t ~f = partition t ~f
   let partition t ~f = partitioni t ~f:(fun _ x -> f x)
+
+  let partition_map t ~f =
+    foldi t ~init:(empty, empty) ~f:(fun i x (l, r) ->
+      match f x with
+      | Either.Left e -> set l i e, r
+      | Right e -> l, set r i e)
+  ;;
+
   let to_list = bindings
   let to_list_map t ~f = foldi t ~init:[] ~f:(fun k v acc -> f k v :: acc) |> List.rev
 

--- a/otherlibs/stdune/src/map_intf.ml
+++ b/otherlibs/stdune/src/map_intf.ml
@@ -41,6 +41,7 @@ module type S = sig
   val filter : 'a t -> f:('a -> bool) -> 'a t
   val filteri : 'a t -> f:(key -> 'a -> bool) -> 'a t
   val partition : 'a t -> f:('a -> bool) -> 'a t * 'a t
+  val partition_map : 'a t -> f:('a -> ('x, 'y) Either.t) -> 'x t * 'y t
   val partitioni : 'a t -> f:(key -> 'a -> bool) -> 'a t * 'a t
   val cardinal : 'a t -> int
   val to_list : 'a t -> (key * 'a) list

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -32,13 +32,11 @@ module With_file : sig
   type repo := t
   type t
 
+  val package : t -> OpamPackage.t
   val opam_file : t -> OpamFile.OPAM.t
   val file : t -> Path.t
   val repo : t -> repo
 end
-
-(** Load package metadata for a single package *)
-val load_opam_package : t -> OpamPackage.t -> With_file.t option Fiber.t
 
 (** Load package metadata for all versions of a package with a given name *)
 val load_all_versions
@@ -46,7 +44,7 @@ val load_all_versions
   -> OpamPackage.Name.t
   -> With_file.t OpamPackage.Version.Map.t Fiber.t
 
-val get_opam_package_files : t -> OpamPackage.t -> File_entry.t list Fiber.t
+val get_opam_package_files : With_file.t list -> File_entry.t list list Fiber.t
 
 module Private : sig
   val create : source:string option -> repo_id:Repository_id.t option -> t


### PR DESCRIPTION
Previously, we'd call `git show` essentially for every single package to try and see if it has `pkg.files`. Now we do all this work in a single call.