### PR TITLE
refactor: lazy target checking

### DIFF
--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -13,13 +13,20 @@ end
 
 type rules = Rules.t
 
+module Directory_targets = struct
+  type t =
+    { all : Loc.t Path.Build.Map.t Memo.t
+    ; mem : Path.Build.t -> bool Memo.t
+    }
+end
+
 module Rules = struct
   type t =
     { build_dir_only_sub_dirs : Build_only_sub_dirs.t
         (** Sub-directories that don't exist in the source tree but exists in
             the build directory. This is for internal directories such as
             [.dune] or [.ppx]. *)
-    ; directory_targets : Loc.t Path.Build.Map.t
+    ; directory_targets : Directory_targets.t
         (** Directories that are target of a rule. For each directory target,
             give the location of the rule that generates it. The keys in this
             map must correspond exactly to the set of directory targets that
@@ -92,12 +99,19 @@ module type Build_config = sig
       val union : t -> t -> t
     end
 
+    module Directory_targets : sig
+      type t = Directory_targets.t
+
+      val of_map : Loc.t Path.Build.Map.t -> t
+      val union_exn : t -> t -> t
+    end
+
     module Rules : sig
       include module type of Rules with type t = Rules.t
 
       val create
         :  ?build_dir_only_sub_dirs:Build_only_sub_dirs.t
-        -> ?directory_targets:Loc.t Path.Build.Map.t
+        -> ?directory_targets:Directory_targets.t
         -> rules Memo.t
         -> t
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -618,7 +618,10 @@ let gen_rules_standalone_or_root
     Rules.union rules rules'
   in
   let* build_config =
-    let+ directory_targets = collect_directory_targets ~dir ~init:directory_targets in
+    let+ directory_targets =
+      let+ directory_targets = collect_directory_targets ~dir ~init:directory_targets in
+      Gen_rules.Directory_targets.of_map directory_targets
+    in
     fun allowed_subdirs -> rules_for ~dir ~allowed_subdirs rules ~directory_targets
   in
   match under_melange_emit_target with
@@ -861,7 +864,9 @@ let gen_rules ctx ~dir components =
       let ctx = Context_name.of_string ctx in
       with_context ctx ~f:(fun sctx ->
         let+ subdirs, rules = Install_rules.symlink_rules sctx ~dir in
-        let directory_targets = Rules.directory_targets rules in
+        let directory_targets =
+          Gen_rules.Directory_targets.of_map @@ Rules.directory_targets rules
+        in
         Gen_rules.make
           ~build_dir_only_sub_dirs:(Gen_rules.Build_only_sub_dirs.singleton ~dir subdirs)
           ~directory_targets

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -99,6 +99,7 @@ module Build_config = struct
     open Build_config.Gen_rules
     module Build_only_sub_dirs = Build_only_sub_dirs
     module Rules = Rules
+    module Directory_targets = Directory_targets
 
     let make
       ?(build_dir_only_sub_dirs = Rules.empty.build_dir_only_sub_dirs)

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -923,6 +923,7 @@ let setup_private_library_doc_alias sctx ~scope ~dir (l : Dune_file.Library.t) =
 
 let has_rules ?(directory_targets = Path.Build.Map.empty) m =
   let rules = Rules.collect_unit (fun () -> m) in
+  let directory_targets = Gen_rules.Directory_targets.of_map directory_targets in
   Memo.return (Gen_rules.make ~directory_targets rules)
 ;;
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1510,6 +1510,7 @@ let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
     Gen_rules.Build_only_sub_dirs.singleton ~dir Subdir_set.empty
   in
   let rules = Rules.collect_unit (fun () -> gen_rules context pkg) in
+  let directory_targets = Gen_rules.Directory_targets.of_map directory_targets in
   Gen_rules.make ~directory_targets ~build_dir_only_sub_dirs rules
 ;;
 


### PR DESCRIPTION
Allow checking if a dierctroy is a target without generating all
directory targets.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: bcc22700-c79a-4f43-a18a-b73c28f489dd -->