### PR TITLE
refactor: move Dependency.t into Dune_lang

### DIFF
--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -14,6 +14,7 @@ module Blang = Blang
 module Binary_kind = Binary_kind
 module Package_constraint = Package_constraint
 module Package_name = Package_name
+module Package_dependency = Package_dependency
 module Lib_kind = Lib_kind
 module Lib_dep = Lib_dep
 module Pkg = Pkg

--- a/src/dune_lang/package_dependency.ml
+++ b/src/dune_lang/package_dependency.ml
@@ -1,0 +1,33 @@
+open! Stdune
+
+type t =
+  { name : Package_name.t
+  ; constraint_ : Package_constraint.t option
+  }
+
+let encode { name; constraint_ } =
+  let open Dune_sexp.Encoder in
+  match constraint_ with
+  | None -> Package_name.encode name
+  | Some c -> pair Package_name.encode Package_constraint.encode (name, c)
+;;
+
+let decode =
+  let open Dune_sexp.Decoder in
+  let constrained =
+    let+ name = Package_name.decode
+    and+ expr = Package_constraint.decode in
+    { name; constraint_ = Some expr }
+  in
+  enter constrained
+  <|> let+ name = Package_name.decode in
+      { name; constraint_ = None }
+;;
+
+let to_dyn { name; constraint_ } =
+  let open Dyn in
+  record
+    [ "name", Package_name.to_dyn name
+    ; "constr", Dyn.Option (Option.map ~f:Package_constraint.to_dyn constraint_)
+    ]
+;;

--- a/src/dune_lang/package_dependency.mli
+++ b/src/dune_lang/package_dependency.mli
@@ -1,0 +1,10 @@
+open! Stdune
+
+type t =
+  { name : Package_name.t
+  ; constraint_ : Package_constraint.t option
+  }
+
+val encode : t Dune_sexp.Encoder.t
+val decode : t Dune_sexp.Decoder.t
+val to_dyn : t -> Dyn.t

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -63,6 +63,8 @@ module Id = struct
 end
 
 module Dependency = struct
+  include Dune_lang.Package_dependency
+
   let nopos pelem = { OpamParserTypes.FullPos.pelem; pos = Opam_file.nopos }
 
   module Constraint = struct
@@ -126,38 +128,6 @@ module Dependency = struct
       | Or disjunction -> OpamFormula.ors (List.map disjunction ~f:to_opam_condition)
     ;;
   end
-
-  type t =
-    { name : Name.t
-    ; constraint_ : Constraint.t option
-    }
-
-  let encode { name; constraint_ } =
-    let open Dune_sexp.Encoder in
-    match constraint_ with
-    | None -> Name.encode name
-    | Some c -> pair Name.encode Constraint.encode (name, c)
-  ;;
-
-  let decode =
-    let open Dune_sexp.Decoder in
-    let constrained =
-      let+ name = Name.decode
-      and+ expr = Constraint.decode in
-      { name; constraint_ = Some expr }
-    in
-    enter constrained
-    <|> let+ name = Name.decode in
-        { name; constraint_ = None }
-  ;;
-
-  let to_dyn { name; constraint_ } =
-    let open Dyn in
-    record
-      [ "name", Name.to_dyn name
-      ; "constr", Dyn.Option (Option.map ~f:Constraint.to_dyn constraint_)
-      ]
-  ;;
 
   type context =
     | Root

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -45,7 +45,7 @@ module Dependency : sig
     val to_dyn : t -> Dyn.t
   end
 
-  type t =
+  type t = Dune_lang.Package_dependency.t =
     { name : Name.t
     ; constraint_ : Constraint.t option
     }


### PR DESCRIPTION
I want to use `Dependency.t` in some upcoming pkg changes so it needs to be moved out of `dune_rules`.