### PR TITLE
refactor: move some opam logic into dune_pkg

### DIFF
--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -5,6 +5,7 @@ module Opam_file = Opam_file
 module Opam_repo = Opam_repo
 module Opam_solver = Opam_solver
 module Package_variable = Package_variable
+module Package_dependency = Package_dependency
 module Repository_id = Repository_id
 module Solver_env = Solver_env
 module Solver_stats = Solver_stats

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -13,7 +13,6 @@ end
 
 include struct
   open Dune_lang
-  module Package_name = Package_name
   module Action = Action
   module String_with_vars = String_with_vars
   module Pform = Pform

--- a/src/dune_pkg/package_dependency.ml
+++ b/src/dune_pkg/package_dependency.ml
@@ -1,0 +1,129 @@
+open! Stdune
+include Dune_lang.Package_dependency
+
+let nopos pelem = { OpamParserTypes.FullPos.pelem; pos = Opam_file.nopos }
+
+module Constraint = struct
+  include Dune_lang.Package_constraint
+
+  module Op = struct
+    include Op
+
+    let to_relop = function
+      | Eq -> nopos `Eq
+      | Gte -> nopos `Geq
+      | Lte -> nopos `Leq
+      | Gt -> nopos `Gt
+      | Lt -> nopos `Lt
+      | Neq -> nopos `Neq
+    ;;
+
+    let to_relop_pelem op =
+      let ({ pelem; _ } : OpamParserTypes.FullPos.relop) = to_relop op in
+      pelem
+    ;;
+  end
+
+  module Variable = struct
+    include Variable
+
+    let to_opam { name } = nopos (OpamParserTypes.FullPos.Ident name)
+    let to_opam_filter { name } = OpamTypes.FIdent ([], OpamVariable.of_string name, None)
+  end
+
+  module Value = struct
+    include Value
+
+    let to_opam v =
+      match v with
+      | String_literal x -> nopos (OpamParserTypes.FullPos.String x)
+      | Variable variable -> Variable.to_opam variable
+    ;;
+
+    let to_opam_filter = function
+      | String_literal literal -> OpamTypes.FString literal
+      | Variable variable -> Variable.to_opam_filter variable
+    ;;
+  end
+
+  let rec to_opam_condition = function
+    | Bvar variable ->
+      OpamTypes.Atom (OpamTypes.Filter (Variable.to_opam_filter variable))
+    | Uop (op, value) ->
+      OpamTypes.Atom
+        (OpamTypes.Constraint (Op.to_relop_pelem op, Value.to_opam_filter value))
+    | Bop (op, lhs, rhs) ->
+      OpamTypes.Atom
+        (OpamTypes.Filter
+           (OpamTypes.FOp
+              (Value.to_opam_filter lhs, Op.to_relop_pelem op, Value.to_opam_filter rhs)))
+    | And conjunction -> OpamFormula.ands (List.map conjunction ~f:to_opam_condition)
+    | Or disjunction -> OpamFormula.ors (List.map disjunction ~f:to_opam_condition)
+  ;;
+end
+
+type context =
+  | Root
+  | Ctx_and
+  | Ctx_or
+
+(* The printer in opam-file-format does not insert parentheses on its own,
+   but it is possible to use the [Group] constructor with a singleton to
+   force insertion of parentheses. *)
+let group e = nopos (Group (nopos [ e ]) : OpamParserTypes.FullPos.value_kind)
+let group_if b e = if b then group e else e
+
+let op_list op = function
+  | [] ->
+    User_error.raise [ Pp.textf "logical operations with no arguments are not supported" ]
+  | v :: vs ->
+    List.fold_left ~init:v vs ~f:(fun a b ->
+      nopos (OpamParserTypes.FullPos.Logop (nopos op, a, b)))
+;;
+
+let opam_constraint t : OpamParserTypes.FullPos.value =
+  let open OpamParserTypes.FullPos in
+  let rec opam_constraint context = function
+    | Constraint.Bvar v -> Constraint.Variable.to_opam v
+    | Uop (op, x) ->
+      nopos (Prefix_relop (Constraint.Op.to_relop op, Constraint.Value.to_opam x))
+    | Bop (op, x, y) ->
+      nopos
+        (Relop
+           ( Constraint.Op.to_relop op
+           , Constraint.Value.to_opam x
+           , Constraint.Value.to_opam y ))
+    | And cs -> logical_op `And cs ~inner_ctx:Ctx_and ~group_needed:false
+    | Or cs ->
+      let group_needed =
+        match context with
+        | Root -> false
+        | Ctx_and -> true
+        | Ctx_or -> false
+      in
+      logical_op `Or cs ~inner_ctx:Ctx_or ~group_needed
+  and logical_op op cs ~inner_ctx ~group_needed =
+    List.map cs ~f:(opam_constraint inner_ctx) |> op_list op |> group_if group_needed
+  in
+  opam_constraint Root t
+;;
+
+let opam_depend { name; constraint_ } =
+  let constraint_ = Option.map ~f:opam_constraint constraint_ in
+  let pkg = nopos (OpamParserTypes.FullPos.String (Package_name.to_string name)) in
+  match constraint_ with
+  | None -> pkg
+  | Some c -> nopos (OpamParserTypes.FullPos.Option (pkg, nopos [ c ]))
+;;
+
+let list_to_opam_filtered_formula ts =
+  List.map ts ~f:(fun { name; constraint_ } ->
+    let opam_package_name = Package_name.to_opam_package_name name in
+    let condition =
+      match constraint_ with
+      | None -> OpamTypes.Empty
+      | Some constraint_ -> Constraint.to_opam_condition constraint_
+    in
+    OpamFormula.Atom (opam_package_name, condition))
+  |> OpamFormula.ands
+;;

--- a/src/dune_pkg/package_dependency.mli
+++ b/src/dune_pkg/package_dependency.mli
@@ -1,0 +1,27 @@
+open! Stdune
+
+module Constraint : sig
+  module Op : sig
+    type t = Dune_lang.Package_constraint.Op.t
+
+    val to_relop : t -> OpamParserTypes.FullPos.relop
+  end
+
+  module Value : sig
+    type t = Dune_lang.Package_constraint.Value.t
+  end
+
+  type t = Dune_lang.Package_constraint.t
+
+  val to_dyn : t -> Dyn.t
+end
+
+type t = Dune_lang.Package_dependency.t =
+  { name : Package_name.t
+  ; constraint_ : Constraint.t option
+  }
+
+include module type of Dune_lang.Package_dependency with type t := t
+
+val opam_depend : t -> OpamParserTypes.FullPos.value
+val list_to_opam_filtered_formula : t list -> OpamTypes.filtered_formula

--- a/src/dune_pkg/package_name.ml
+++ b/src/dune_pkg/package_name.ml
@@ -1,0 +1,8 @@
+open! Stdune
+include Dune_lang.Package_name
+
+let of_opam_package_name opam_package_name =
+  OpamPackage.Name.to_string opam_package_name |> of_string
+;;
+
+let to_opam_package_name t = to_string t |> OpamPackage.Name.of_string

--- a/src/dune_pkg/package_name.mli
+++ b/src/dune_pkg/package_name.mli
@@ -1,0 +1,8 @@
+open! Stdune
+
+type t = Dune_lang.Package_name.t
+
+include module type of Dune_lang.Package_name with type t := t
+
+val of_opam_package_name : OpamTypes.name -> t
+val to_opam_package_name : t -> OpamTypes.name

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -112,9 +112,7 @@ let formula_to_package_names version_by_package_name opam_formula =
       (* check if each conjunction can be satisfied and if they can't, produce a hint indicating why it wasn't satisfied *)
       List.map dnf ~f:(fun conjunction ->
         List.map conjunction ~f:(fun (opam_package_name, version_constraint_opt) ->
-          let package_name =
-            Package_name.of_string (OpamPackage.Name.to_string opam_package_name)
-          in
+          let package_name = Package_name.of_opam_package_name opam_package_name in
           match Package_name.Map.find version_by_package_name package_name with
           | None ->
             (* this package wasn't part of the solution so the current
@@ -151,7 +149,7 @@ let formula_to_package_names version_by_package_name opam_formula =
     | Some satisfied_conjunction ->
       Ok
         (List.map satisfied_conjunction ~f:(fun (opam_package_name, _) ->
-           Package_name.of_string (OpamPackage.Name.to_string opam_package_name))))
+           Package_name.of_opam_package_name opam_package_name)))
 ;;
 
 let filtered_formula_to_package_names

--- a/src/dune_pkg/substs.ml
+++ b/src/dune_pkg/substs.ml
@@ -39,8 +39,7 @@ let subst env self ~src ~dst =
     let variable = OpamVariable.Full.variable full_variable in
     let package =
       OpamVariable.Full.package ~self:self' full_variable
-      |> Option.map ~f:(fun package ->
-        package |> OpamPackage.Name.to_string |> Package_name.of_string)
+      |> Option.map ~f:Package_name.of_opam_package_name
     in
     let key = { Var.T.package; variable } in
     match Map.find env key with

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -1,6 +1,7 @@
 open! Import
 module Stanza = Dune_lang.Stanza
 module Opam_file = Dune_pkg.Opam_file
+module Dependency = Dune_pkg.Package_dependency
 
 let opam_ext = ".opam"
 let is_opam_file path = String.is_suffix (Path.to_string path) ~suffix:opam_ext
@@ -60,141 +61,6 @@ module Id = struct
   module C = Comparable.Make (T)
   module Set = C.Set
   module Map = C.Map
-end
-
-module Dependency = struct
-  include Dune_lang.Package_dependency
-
-  let nopos pelem = { OpamParserTypes.FullPos.pelem; pos = Opam_file.nopos }
-
-  module Constraint = struct
-    include Dune_lang.Package_constraint
-
-    module Op = struct
-      include Op
-
-      let to_relop = function
-        | Eq -> nopos `Eq
-        | Gte -> nopos `Geq
-        | Lte -> nopos `Leq
-        | Gt -> nopos `Gt
-        | Lt -> nopos `Lt
-        | Neq -> nopos `Neq
-      ;;
-
-      let to_relop_pelem op =
-        let ({ pelem; _ } : OpamParserTypes.FullPos.relop) = to_relop op in
-        pelem
-      ;;
-    end
-
-    module Variable = struct
-      include Variable
-
-      let to_opam { name } = nopos (OpamParserTypes.FullPos.Ident name)
-
-      let to_opam_filter { name } =
-        OpamTypes.FIdent ([], OpamVariable.of_string name, None)
-      ;;
-    end
-
-    module Value = struct
-      include Value
-
-      let to_opam v =
-        match v with
-        | String_literal x -> nopos (OpamParserTypes.FullPos.String x)
-        | Variable variable -> Variable.to_opam variable
-      ;;
-
-      let to_opam_filter = function
-        | String_literal literal -> OpamTypes.FString literal
-        | Variable variable -> Variable.to_opam_filter variable
-      ;;
-    end
-
-    let rec to_opam_condition = function
-      | Bvar variable ->
-        OpamTypes.Atom (OpamTypes.Filter (Variable.to_opam_filter variable))
-      | Uop (op, value) ->
-        OpamTypes.Atom
-          (OpamTypes.Constraint (Op.to_relop_pelem op, Value.to_opam_filter value))
-      | Bop (op, lhs, rhs) ->
-        OpamTypes.Atom
-          (OpamTypes.Filter
-             (OpamTypes.FOp
-                (Value.to_opam_filter lhs, Op.to_relop_pelem op, Value.to_opam_filter rhs)))
-      | And conjunction -> OpamFormula.ands (List.map conjunction ~f:to_opam_condition)
-      | Or disjunction -> OpamFormula.ors (List.map disjunction ~f:to_opam_condition)
-    ;;
-  end
-
-  type context =
-    | Root
-    | Ctx_and
-    | Ctx_or
-
-  (* The printer in opam-file-format does not insert parentheses on its own,
-     but it is possible to use the [Group] constructor with a singleton to
-     force insertion of parentheses. *)
-  let group e = nopos (Group (nopos [ e ]) : OpamParserTypes.FullPos.value_kind)
-  let group_if b e = if b then group e else e
-
-  let op_list op = function
-    | [] ->
-      User_error.raise
-        [ Pp.textf "logical operations with no arguments are not supported" ]
-    | v :: vs ->
-      List.fold_left ~init:v vs ~f:(fun a b ->
-        nopos (OpamParserTypes.FullPos.Logop (nopos op, a, b)))
-  ;;
-
-  let opam_constraint t : OpamParserTypes.FullPos.value =
-    let open OpamParserTypes.FullPos in
-    let rec opam_constraint context = function
-      | Constraint.Bvar v -> Constraint.Variable.to_opam v
-      | Uop (op, x) ->
-        nopos (Prefix_relop (Constraint.Op.to_relop op, Constraint.Value.to_opam x))
-      | Bop (op, x, y) ->
-        nopos
-          (Relop
-             ( Constraint.Op.to_relop op
-             , Constraint.Value.to_opam x
-             , Constraint.Value.to_opam y ))
-      | And cs -> logical_op `And cs ~inner_ctx:Ctx_and ~group_needed:false
-      | Or cs ->
-        let group_needed =
-          match context with
-          | Root -> false
-          | Ctx_and -> true
-          | Ctx_or -> false
-        in
-        logical_op `Or cs ~inner_ctx:Ctx_or ~group_needed
-    and logical_op op cs ~inner_ctx ~group_needed =
-      List.map cs ~f:(opam_constraint inner_ctx) |> op_list op |> group_if group_needed
-    in
-    opam_constraint Root t
-  ;;
-
-  let opam_depend { name; constraint_ } =
-    let constraint_ = Option.map ~f:opam_constraint constraint_ in
-    let pkg = nopos (OpamParserTypes.FullPos.String (Name.to_string name)) in
-    match constraint_ with
-    | None -> pkg
-    | Some c -> nopos (OpamParserTypes.FullPos.Option (pkg, nopos [ c ]))
-  ;;
-
-  let list_to_opam_filtered_formula ts =
-    List.map ts ~f:(fun { name; constraint_ } ->
-      let opam_package_name = Name.to_opam_package_name name in
-      let condition =
-        match constraint_ with
-        | None -> OpamTypes.Empty
-        | Some constraint_ -> Constraint.to_opam_condition constraint_
-      in
-      OpamFormula.Atom (opam_package_name, condition))
-    |> OpamFormula.ands
-  ;;
 end
 
 module Source_kind = struct

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -28,32 +28,7 @@ module Id : sig
   include Comparable_intf.S with type key := t
 end
 
-module Dependency : sig
-  module Constraint : sig
-    module Op : sig
-      type t = Dune_lang.Package_constraint.Op.t
-
-      val to_relop : t -> OpamParserTypes.FullPos.relop
-    end
-
-    module Value : sig
-      type t = Dune_lang.Package_constraint.Value.t
-    end
-
-    type t = Dune_lang.Package_constraint.t
-
-    val to_dyn : t -> Dyn.t
-  end
-
-  type t = Dune_lang.Package_dependency.t =
-    { name : Name.t
-    ; constraint_ : Constraint.t option
-    }
-
-  val opam_depend : t -> OpamParserTypes.FullPos.value
-  val to_dyn : t -> Dyn.t
-  val decode : t Dune_lang.Decoder.t
-end
+module Dependency : module type of Dune_pkg.Package_dependency
 
 module Source_kind : sig
   module Host : sig


### PR DESCRIPTION
Previously some logic for translating package metadata to/from opam was in the `dune_rules` library but it would be useful to have access to this logic in `dune_pkg` so this change moves it there.