### PR TITLE
pkg: add Dune_pkg.Local_package module

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -185,17 +185,7 @@ let find_local_packages =
     let+ source_dir = Memo.run (Source_tree.root ()) in
     Source_tree.Dir.project source_dir
   in
-  Dune_project.packages project
-  |> Package.Name.Map.map ~f:(fun pkg ->
-    let opam_file = Package.to_opam_file pkg in
-    let file =
-      Path.source
-      @@
-      match pkg.has_opam_file with
-      | Generated | Exists false -> Dune_project.file project
-      | Exists true -> pkg.opam_file
-    in
-    { Dune_pkg.Opam_solver.opam_file; file })
+  Dune_project.packages project |> Package.Name.Map.map ~f:Package.to_local_package
 ;;
 
 module Opam_repository_path = struct

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -36,7 +36,7 @@ val get_repos
   -> repositories:Dune_pkg.Pkg_workspace.Repository.Name.t list
   -> Dune_pkg.Opam_repo.t list Fiber.t
 
-val find_local_packages : Dune_pkg.Opam_solver.local_package Package_name.Map.t Fiber.t
+val find_local_packages : Dune_pkg.Local_package.t Package_name.Map.t Fiber.t
 
 module Opam_repository_path : sig
   val term : Path.t option Term.t

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -14,3 +14,4 @@ module Sys_poll = Sys_poll
 module Version_preference = Version_preference
 module Package_version = Package_version
 module Pkg_workspace = Workspace
+module Local_package = Local_package

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -1,0 +1,16 @@
+open! Import
+
+type t =
+  { name : Package_name.t
+  ; version : Package_version.t option
+  ; dependencies : Package_dependency.t list
+  }
+
+let to_opam_file { name; version; dependencies } =
+  OpamFile.OPAM.empty
+  |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
+  |> OpamFile.OPAM.with_version_opt
+       (Option.map version ~f:Package_version.to_opam_package_version)
+  |> OpamFile.OPAM.with_depends
+       (Package_dependency.list_to_opam_filtered_formula dependencies)
+;;

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -1,0 +1,13 @@
+open! Import
+
+(** Information about a package that's relevant for solving dependencies *)
+type t =
+  { name : Package_name.t
+  ; version : Package_version.t option
+  ; dependencies : Package_dependency.t list
+  }
+
+(** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the
+    fields of [t]. Note that this does not actually create a corresponding file
+    on disk. *)
+val to_opam_file : t -> OpamFile.OPAM.t

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -7,15 +7,10 @@ module Solver_result : sig
     }
 end
 
-type local_package =
-  { opam_file : OpamFile.OPAM.t
-  ; file : Path.t
-  }
-
 val solve_lock_dir
   :  Solver_env.t
   -> Version_preference.t
   -> Opam_repo.t list
-  -> local_packages:local_package Package_name.Map.t
+  -> local_packages:Local_package.t Package_name.Map.t
   -> experimental_translate_opam_filters:bool
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/src/dune_pkg/package_version.ml
+++ b/src/dune_pkg/package_version.ml
@@ -1,5 +1,8 @@
 open! Stdune
 include Dune_lang.Package_version
 
-let of_opam opam_version = OpamPackage.Version.to_string opam_version |> of_string
-let to_opam t = to_string t |> OpamPackage.Version.of_string
+let of_opam_package_version opam_version =
+  OpamPackage.Version.to_string opam_version |> of_string
+;;
+
+let to_opam_package_version t = to_string t |> OpamPackage.Version.of_string

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -8,5 +8,5 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val encode : t Dune_lang.Encoder.t
 val decode : t Dune_lang.Decoder.t
-val of_opam : OpamPackage.Version.t -> t
-val to_opam : t -> OpamPackage.Version.t
+val of_opam_package_version : OpamPackage.Version.t -> t
+val to_opam_package_version : t -> OpamPackage.Version.t

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -60,7 +60,7 @@ module Version_constraint = struct
       | `Leq -> Lte
       | `Lt -> Lt
     in
-    let package_version = Package_version.of_opam version in
+    let package_version = Package_version.of_opam_package_version version in
     op, package_version
   ;;
 
@@ -124,7 +124,7 @@ let formula_to_package_names version_by_package_name opam_formula =
                (* no constraint so any version will satisfy *)
                Ok ()
              | Some (constraint_ : OpamFormula.version_constraint) ->
-               let opam_version = Package_version.to_opam version in
+               let opam_version = Package_version.to_opam_package_version version in
                let version_formula = OpamFormula.Atom constraint_ in
                if OpamFormula.check_version_formula version_formula opam_version
                then Ok ()

--- a/src/dune_pkg_outdated/dune_pkg_outdated.ml
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.ml
@@ -83,14 +83,14 @@ let explain_results_to_user results ~transitive ~lock_dir_path =
 
 let better_candidate
   ~repos
-  ~(local_packages : Dune_pkg.Opam_solver.local_package Package_name.Map.t)
+  ~(local_packages : Dune_pkg.Local_package.t Package_name.Map.t)
   (pkg : Lock_dir.Pkg.t)
   =
   let open Fiber.O in
   let pkg_name = pkg.info.name |> Package_name.to_string |> OpamPackage.Name.of_string in
   let is_immediate_dep_of_local_package =
     Package_name.Map.exists local_packages ~f:(fun local_package ->
-      OpamFile.OPAM.depends local_package.opam_file
+      OpamFile.OPAM.depends (Dune_pkg.Local_package.to_opam_file local_package)
       |> OpamFilter.filter_deps
            ~build:true
            ~post:false
@@ -115,7 +115,7 @@ let better_candidate
   | Some newest_opam_file ->
     let version = OpamFile.OPAM.version newest_opam_file in
     (match
-       Package_version.to_opam pkg.info.version
+       Package_version.to_opam_package_version pkg.info.version
        |> OpamPackage.Version.compare version
        |> Ordering.of_int
      with
@@ -124,7 +124,7 @@ let better_candidate
        Better_candidate
          { is_immediate_dep_of_local_package
          ; name = pkg.info.name
-         ; newer_version = version |> Package_version.of_opam
+         ; newer_version = version |> Package_version.of_opam_package_version
          ; outdated_version = pkg.info.version
          })
 ;;

--- a/src/dune_pkg_outdated/dune_pkg_outdated.mli
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.mli
@@ -9,7 +9,7 @@ type t
     collection of [packages] by consulting the [repos] and [local_packages].*)
 val find
   :  repos:Opam_repo.t list
-  -> local_packages:Dune_pkg.Opam_solver.local_package Package_name.Map.t
+  -> local_packages:Dune_pkg.Local_package.t Package_name.Map.t
   -> Lock_dir.Pkg.t Package_name.Map.t
   -> t Fiber.t
 

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -645,13 +645,6 @@ let missing_deps (t : t) ~effective_deps =
   Name.Set.diff effective_deps specified_deps
 ;;
 
-let to_opam_file t =
-  let opam_package_name = name t |> Name.to_opam_package_name in
-  let depends = Dependency.list_to_opam_filtered_formula t.depends in
-  (* Currently this just creates an opam file with fields needed for dependency
-     solving with opam_0install but could easily be extended with more fields.
-  *)
-  OpamFile.OPAM.empty
-  |> OpamFile.OPAM.with_name opam_package_name
-  |> OpamFile.OPAM.with_depends depends
+let to_local_package t =
+  { Dune_pkg.Local_package.name = name t; version = t.version; dependencies = t.depends }
 ;;

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -125,8 +125,4 @@ val default : Name.t -> Path.Source.t -> t
 val load_opam_file : Path.Source.t -> Name.t -> t Memo.t
 
 val missing_deps : t -> effective_deps:Name.Set.t -> Name.Set.t
-
-(** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the
-    fields of [t]. Note that this does not actually create a corresponding file
-    on disk. *)
-val to_opam_file : t -> OpamFile.OPAM.t
+val to_local_package : t -> Dune_pkg.Local_package.t


### PR DESCRIPTION
Thus far we've been using `OpamFile.OPAM.t` to represent local packages in our package management code, mainly because dune's `Package.t` type is in the `dune_rules` library which `dune_pkg` can't depend on (to avoid a dependency cycle). This change adds a minimal `Dune_pkg.Local_package.t` type containing the information about a local package that is relevant to package management from which a `OpamFile.OPAM.t` can be derived. This also replaces the `OpamSolver.local_package` type which was opam-specific and contained an unused `file` field (removed in this change).

Having our own local package type rather than depending on opam's will help clarify the intent of code through types and reduce the degree to which pkg's api is opam-specific. It also means we can easily implement `to_dyn` and other helpful functions without having to worry about how to represent values of `OpamFile.OPAM.t`.

Also in this change the `Package_version.*_opam` conversion functions are renamed to `Package_version.*_opam_package_version` to clarify that they convert between `Package_version.t` and `OpamPackage.Version.t` (rather than `OpamVersion.t`) and for consistency with the `Package_name.*_opam_package_version` functions.