### PR TITLE
pkg: add local packages hash to lockdir

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -81,7 +81,10 @@ let solve
                solver_env
                version_preference
                repos
-               ~local_packages
+               ~local_packages:
+                 (Package_name.Map.map
+                    local_packages
+                    ~f:Dune_pkg.Local_package.for_solver)
                ~experimental_translate_opam_filters)
          >>| function
          | Error (`Diagnostic_message message) -> Error (context_name, message)

--- a/src/dune_lang/package_constraint.ml
+++ b/src/dune_lang/package_constraint.ml
@@ -9,12 +9,30 @@ module Op = struct
     | Lt
     | Neq
 
-  let equal a b =
+  (* Define an arbitrary ordering on [t] to allow a package constraint to be
+     used as the key of a map or set. The order from lowest to highest is:
+     [Eq, Gte, Lte, Gt, Lt, Neq] *)
+  let compare a b =
     match a, b with
-    | Eq, Eq | Gte, Gte | Lte, Lte | Gt, Gt | Lt, Lt | Neq, Neq -> true
-    | _ -> false
+    | Eq, Eq -> Ordering.Eq
+    | Eq, _ -> Lt
+    | _, Eq -> Gt
+    | Gte, Gte -> Eq
+    | Gte, _ -> Lt
+    | _, Gte -> Gt
+    | Lte, Lte -> Eq
+    | Lte, _ -> Lt
+    | _, Lte -> Gt
+    | Gt, Gt -> Eq
+    | Gt, _ -> Lt
+    | _, Gt -> Gt
+    | Lt, Lt -> Eq
+    | Lt, _ -> Lt
+    | _, Lt -> Gt
+    | Neq, Neq -> Eq
   ;;
 
+  let equal a b = Ordering.is_eq (compare a b)
   let map = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
   let to_dyn t = Dyn.variant (fst (List.find_exn ~f:(fun (_, op) -> equal t op) map)) []
 
@@ -24,7 +42,7 @@ module Op = struct
     List.find_exn ~f map |> fst
   ;;
 
-  let encode x = Dune_sexp.Encoder.string (to_string x)
+  let encode x = to_string x |> Dune_sexp.Encoder.string
 end
 
 module Variable = struct
@@ -38,6 +56,8 @@ module Variable = struct
     Dune_sexp.Decoder.atom_matching ~desc:"variable" (fun s ->
       if String.is_prefix s ~prefix:":" then Some (of_name (String.drop s 1)) else None)
   ;;
+
+  let compare { name } t = String.compare name t.name
 end
 
 module Value = struct
@@ -48,6 +68,14 @@ module Value = struct
   let to_dyn = function
     | String_literal s -> Dyn.variant "String_literal" [ Dyn.string s ]
     | Variable v -> Dyn.variant "Variable" [ Variable.to_dyn v ]
+  ;;
+
+  let compare a b =
+    match a, b with
+    | String_literal a, String_literal b -> String.compare a b
+    | String_literal _, _ -> Lt
+    | _, String_literal _ -> Gt
+    | Variable a, Variable b -> Variable.compare a b
   ;;
 
   let encode = function
@@ -64,12 +92,50 @@ module Value = struct
   ;;
 end
 
-type t =
-  | Bvar of Variable.t
-  | Uop of Op.t * Value.t
-  | Bop of Op.t * Value.t * Value.t
-  | And of t list
-  | Or of t list
+module T = struct
+  type t =
+    | Bvar of Variable.t
+    | Uop of Op.t * Value.t
+    | Bop of Op.t * Value.t * Value.t
+    | And of t list
+    | Or of t list
+
+  let rec to_dyn =
+    let open Dyn in
+    function
+    | Bvar v -> variant "Bvar" [ Variable.to_dyn v ]
+    | Uop (b, x) -> variant "Uop" [ Op.to_dyn b; Value.to_dyn x ]
+    | Bop (b, x, y) -> variant "Bop" [ Op.to_dyn b; Value.to_dyn x; Value.to_dyn y ]
+    | And t -> variant "And" (List.map ~f:to_dyn t)
+    | Or t -> variant "Or" (List.map ~f:to_dyn t)
+  ;;
+
+  let rec compare a b =
+    let open Ordering.O in
+    match a, b with
+    | Bvar a, Bvar b -> Variable.compare a b
+    | Bvar _, _ -> Lt
+    | _, Bvar _ -> Gt
+    | Uop (a_op, a_value), Uop (b_op, b_value) ->
+      let= () = Op.compare a_op b_op in
+      Value.compare a_value b_value
+    | Uop _, _ -> Lt
+    | _, Uop _ -> Gt
+    | Bop (a_op, a_lhs, a_rhs), Bop (b_op, b_lhs, b_rhs) ->
+      let= () = Op.compare a_op b_op in
+      let= () = Value.compare a_lhs b_lhs in
+      Value.compare a_rhs b_rhs
+    | Bop _, _ -> Lt
+    | _, Bop _ -> Gt
+    | And a, And b -> List.compare a b ~compare
+    | And _, _ -> Lt
+    | _, And _ -> Gt
+    | Or a, Or b -> List.compare a b ~compare
+  ;;
+end
+
+include T
+include Comparable.Make (T)
 
 let rec encode c =
   let open Dune_sexp.Encoder in
@@ -140,14 +206,4 @@ let decode =
       let+ () = junk in
       Bvar (Variable.of_name (String.drop s 1))
     | _ -> sum (ops @ logops))
-;;
-
-let rec to_dyn =
-  let open Dyn in
-  function
-  | Bvar v -> variant "Bvar" [ Variable.to_dyn v ]
-  | Uop (b, x) -> variant "Uop" [ Op.to_dyn b; Value.to_dyn x ]
-  | Bop (b, x, y) -> variant "Bop" [ Op.to_dyn b; Value.to_dyn x; Value.to_dyn y ]
-  | And t -> variant "And" (List.map ~f:to_dyn t)
-  | Or t -> variant "Or" (List.map ~f:to_dyn t)
 ;;

--- a/src/dune_lang/package_constraint.mli
+++ b/src/dune_lang/package_constraint.mli
@@ -43,3 +43,5 @@ type t =
 val encode : t Dune_sexp.Encoder.t
 val decode : t Dune_sexp.Decoder.t
 val to_dyn : t -> Dyn.t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -1,4 +1,5 @@
 open! Import
+module Package_constraint = Dune_lang.Package_constraint
 
 type t =
   { name : Package_name.t
@@ -7,15 +8,115 @@ type t =
   ; loc : Loc.t
   }
 
-let to_opam_file { name; version; dependencies; loc = _ } =
-  OpamFile.OPAM.empty
-  |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
-  |> OpamFile.OPAM.with_version_opt
-       (Option.map version ~f:Package_version.to_opam_package_version)
-  |> OpamFile.OPAM.with_depends
-       (Package_dependency.list_to_opam_filtered_formula dependencies)
-;;
+module Dependency_hash = struct
+  type t = Digest.t
 
-let opam_filtered_dependency_formula { dependencies; _ } =
-  Package_dependency.list_to_opam_filtered_formula dependencies
+  let hash_string = Digest.string
+  let label = "md5"
+  let to_string t = sprintf "%s=%s" label (Digest.to_hex t)
+  let equal = Digest.equal
+  let to_dyn t = Dyn.string (to_string t)
+  let encode t = to_string t |> Encoder.string
+
+  let decode =
+    let open Decoder in
+    let+ loc, string = located string in
+    match String.lsplit2 string ~on:'=' with
+    | Some (found_label, hash) ->
+      if String.equal found_label label
+      then (
+        try Digest.from_hex hash with
+        | Invalid_argument _ ->
+          User_error.raise
+            ~loc
+            [ Pp.textf "Dependency hash is not a valid md5 hash: %s" hash ])
+      else
+        User_error.raise
+          ~loc
+          [ Pp.textf
+              "Dependency hash has unexpected label %S (expected %S)"
+              found_label
+              label
+          ]
+    | None ->
+      User_error.raise
+        ~loc
+        [ Pp.textf
+            "Expected dependency hash to be encoded as \"md5=<hash>\" but found %S"
+            string
+        ]
+  ;;
+end
+
+module Dependency_set = struct
+  type t = Package_constraint.Set.t Package_name.Map.t
+
+  let empty = Package_name.Map.empty
+
+  let of_list =
+    List.fold_left ~init:empty ~f:(fun acc { Package_dependency.name; constraint_ } ->
+      Package_name.Map.update acc name ~f:(fun existing ->
+        match existing, constraint_ with
+        | None, None -> Some Package_constraint.Set.empty
+        | None, Some constraint_ -> Some (Package_constraint.Set.singleton constraint_)
+        | Some existing, None -> Some existing
+        | Some existing, Some constraint_ ->
+          Some (Package_constraint.Set.add existing constraint_)))
+  ;;
+
+  let union =
+    Package_name.Map.union ~f:(fun _name a b -> Some (Package_constraint.Set.union a b))
+  ;;
+
+  let union_all = List.fold_left ~init:empty ~f:union
+
+  let package_dependencies =
+    Package_name.Map.to_list_map ~f:(fun name constraints ->
+      let constraint_ =
+        if Package_constraint.Set.is_empty constraints
+        then None
+        else Some (Package_constraint.And (Package_constraint.Set.to_list constraints))
+      in
+      { Package_dependency.name; constraint_ })
+  ;;
+
+  let encode_for_hash t =
+    package_dependencies t |> Dune_lang.Encoder.list Package_dependency.encode
+  ;;
+
+  let hash t =
+    if Package_name.Map.is_empty t
+    then None
+    else Some (encode_for_hash t |> Dune_sexp.to_string |> Dependency_hash.hash_string)
+  ;;
+end
+
+module For_solver = struct
+  type t =
+    { name : Package_name.t
+    ; dependencies : Package_dependency.t list
+    }
+
+  let to_opam_file { name; dependencies } =
+    OpamFile.OPAM.empty
+    |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
+    |> OpamFile.OPAM.with_depends
+         (Package_dependency.list_to_opam_filtered_formula dependencies)
+  ;;
+
+  let opam_filtered_dependency_formula { dependencies; _ } =
+    Package_dependency.list_to_opam_filtered_formula dependencies
+  ;;
+
+  let dependency_set { dependencies; _ } = Dependency_set.of_list dependencies
+  let list_dependency_set ts = List.map ts ~f:dependency_set |> Dependency_set.union_all
+
+  let list_non_local_dependency_set ts =
+    List.fold_left ts ~init:(list_dependency_set ts) ~f:(fun acc { name; _ } ->
+      Package_name.Map.remove acc name)
+  ;;
+end
+
+let for_solver { name; version = _; dependencies; loc = _ } =
+  { For_solver.name; dependencies }
 ;;

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -1,6 +1,12 @@
 open! Import
 
-(** Information about a package that's relevant for solving dependencies *)
+(** Information about a local package that's relevant for package management.
+    This is intended to represent local packages defined in a dune-project file
+    (rather than packages in a lockdir). This is distinct from a
+    [Dune_rules.Package.t] in that it's only intended to represent local
+    packages. The "dune_pkg" library can't depend on "dune_rules" to avoid a
+    circular dependency so this type is defined here so "dune_pkg" has a type
+    it can use to represent local packages. *)
 type t =
   { name : Package_name.t
   ; version : Package_version.t option
@@ -8,10 +14,55 @@ type t =
   ; loc : Loc.t
   }
 
-(** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the
-    fields of [t]. Note that this does not actually create a corresponding file
-    on disk. *)
-val to_opam_file : t -> OpamFile.OPAM.t
+module Dependency_hash : sig
+  type t
 
-(** Returns an opam dependency formula for this package *)
-val opam_filtered_dependency_formula : t -> OpamTypes.filtered_formula
+  val equal : t -> t -> bool
+  val to_dyn : t -> Dyn.t
+  val to_string : t -> string
+  val encode : t Encoder.t
+  val decode : t Decoder.t
+end
+
+module Dependency_set : sig
+  (** A set of dependencies belonging to one or more local packages. Two
+      different local packages may depend on the same packages with different
+      version constraints provided that the two constraints intersect
+      (otherwise there will be no solution). In this case the conjunction of
+      both constraints will form the constraint associated with that
+      dependency. Package constraints are de-duplicated by comparing them only
+      on their syntax. *)
+  type t
+
+  (** Returns a hash of all dependencies in the set or [None] if the set is
+      empty. The reason for behaving differently when the set is empty is so
+      that callers are forced to explicitly handle the case where there are no
+      dependencies which will likely lead to better user experience. *)
+  val hash : t -> Dependency_hash.t option
+
+  val package_dependencies : t -> Package_dependency.t list
+end
+
+module For_solver : sig
+  (** The minimum set of fields about a package needed by the solver. *)
+  type t =
+    { name : Package_name.t
+    ; dependencies : Package_dependency.t list
+    }
+
+  (** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the
+      fields of [t]. Note that this does not actually create a corresponding file
+      on disk. *)
+  val to_opam_file : t -> OpamFile.OPAM.t
+
+  (** Returns an opam dependency formula for this package *)
+  val opam_filtered_dependency_formula : t -> OpamTypes.filtered_formula
+
+  (** Returns the set of dependencies of all given local packages excluding
+      dependencies which are packages in the provided list. Pass this the list
+      of all local package in a project to get a set of all non-local
+      dependencies of the project. *)
+  val list_non_local_dependency_set : t list -> Dependency_set.t
+end
+
+val for_solver : t -> For_solver.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -44,6 +44,7 @@ end
 
 type t = private
   { version : Syntax.Version.t
+  ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
   ; packages : Pkg.t Package_name.Map.t
   (** It's guaranteed that this map will contain an entry for all dependencies
       of all packages in this map. That is, the set of packages is closed under
@@ -67,6 +68,7 @@ val to_dyn : t -> Dyn.t
     entry in [packages]. *)
 val create_latest_version
   :  Pkg.t Package_name.Map.t
+  -> local_packages:Local_package.For_solver.t list
   -> ocaml:(Loc.t * Package_name.t) option
   -> repos:Opam_repo.t list option
   -> expanded_solver_variable_bindings:Solver_stats.Expanded_variable_bindings.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -613,7 +613,7 @@ let solve_lock_dir
         ~repos
         ~version_preference
         ~local_packages:
-          (Package_name.Map.map local_packages ~f:Local_package.to_opam_file)
+          (Package_name.Map.map local_packages ~f:Local_package.For_solver.to_opam_file)
         ~stats_updater
     in
     solve_package_list
@@ -683,6 +683,7 @@ let solve_lock_dir
           in
           Lock_dir.create_latest_version
             pkgs_by_name
+            ~local_packages:(Package_name.Map.values local_packages)
             ~ocaml
             ~repos:(Some repos)
             ~expanded_solver_variable_bindings

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -11,6 +11,6 @@ val solve_lock_dir
   :  Solver_env.t
   -> Version_preference.t
   -> Opam_repo.t list
-  -> local_packages:Local_package.t Package_name.Map.t
+  -> local_packages:Local_package.For_solver.t Package_name.Map.t
   -> experimental_translate_opam_filters:bool
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/src/dune_pkg_outdated/dune_pkg_outdated.ml
+++ b/src/dune_pkg_outdated/dune_pkg_outdated.ml
@@ -90,7 +90,8 @@ let better_candidate
   let pkg_name = pkg.info.name |> Package_name.to_string |> OpamPackage.Name.of_string in
   let is_immediate_dep_of_local_package =
     Package_name.Map.exists local_packages ~f:(fun local_package ->
-      OpamFile.OPAM.depends (Dune_pkg.Local_package.to_opam_file local_package)
+      Dune_pkg.Local_package.(
+        for_solver local_package |> For_solver.opam_filtered_dependency_formula)
       |> OpamFilter.filter_deps
            ~build:true
            ~post:false

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -1,0 +1,142 @@
+Tests that changing the dependencies of a project cause lockdir validation to
+fail due to the dependency hash not matching the hash stored in the lockdir.
+
+Dummy opam repo so we can generate lockdirs
+  $ . ./helpers.sh
+  $ mkrepo
+  $ mkpkg a <<EOF
+  > EOF
+
+Start with a project with a single package with no dependencies:
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+  $ cat dune.lock/lock.dune
+  (lang package 0.1)
+  
+  (repositories
+   (complete false)
+   (used))
+  $ dune pkg validate-lockdir
+
+Add a dependency to the project:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo)
+  >  (depends a))
+  > EOF
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  Error: This project has at least one non-local dependency but the lockdir
+  doesn't contain a dependency hash.
+  An example of a non-local dependency of this project is: a
+  Hint: Regenerate the lockdir by running 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Add a non-local dependency to the package:
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo)
+  >  (depends a))
+  > EOF
+  Solution for dune.lock:
+  - a.0.0.1
+  $ cat dune.lock/lock.dune
+  (lang package 0.1)
+  
+  (dependency_hash md5=69dfdf4e6a7c8489262f9d8b9958c9b3)
+  
+  (repositories
+   (complete false)
+   (used))
+  $ dune pkg validate-lockdir
+
+Add a second dependency to the project:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo)
+  >  (depends a b))
+  > EOF
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune.lock/lock.dune", line 3, characters 17-53:
+  Error: Dependency hash in lockdir does not match the hash of non-local
+  dependencies of this project. The lockdir expects the the non-local
+  dependencies to hash to:
+  md5=69dfdf4e6a7c8489262f9d8b9958c9b3
+  ...but the non-local dependencies of this project hash to:
+  md5=0cd7f9253f917ae8182c904fac99c3d9
+  Hint: Regenerate the lockdir by running 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Remove all dependencies from the project:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name foo))
+  > EOF
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune.lock/lock.dune", line 3, characters 17-53:
+  Error: This project has no non-local dependencies yet the lockfile contains a
+  dependency hash: md5=69dfdf4e6a7c8489262f9d8b9958c9b3
+  Hint: Regenerate the lockdir by running 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Exercise handling invalid dependency hashes.
+  $ make_lock_metadata_with_hash() {
+  >   cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > (dependency_hash $1)
+  > (repositories
+  >  (complete false)
+  >  (used))
+  > EOF
+  > }
+
+Case where the label ("md5") is missing:
+  $ make_lock_metadata_with_hash badhash
+  $ dune pkg validate-lockdir
+  Failed to parse lockdir dune.lock:
+  File "dune.lock/lock.dune", line 2, characters 17-24:
+  Error: Expected dependency hash to be encoded as "md5=<hash>" but found
+  "badhash"
+  
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Case where the label is not "md5":
+  $ make_lock_metadata_with_hash foo=badhash
+  $ dune pkg validate-lockdir
+  Failed to parse lockdir dune.lock:
+  File "dune.lock/lock.dune", line 2, characters 17-28:
+  Error: Dependency hash has unexpected label "foo" (expected "md5")
+  
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Case where the the hash is not a valid md5 hash:
+  $ make_lock_metadata_with_hash md5=badhash
+  $ dune pkg validate-lockdir
+  Failed to parse lockdir dune.lock:
+  File "dune.lock/lock.dune", line 2, characters 17-28:
+  Error: Dependency hash is not a valid md5 hash: badhash
+  
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-hash.t
@@ -1,0 +1,123 @@
+Tests for the `dune describe pkg dependency-hash` command.
+
+The case where there are no local packages:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  $ dune describe pkg dependency-hash
+  Error: No non-local dependencies
+  [1]
+
+The case where there are local packages but no dependencies:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name a))
+  > (package (name b))
+  > EOF
+  $ dune describe pkg dependency-hash
+  Error: No non-local dependencies
+  [1]
+
+The case where there are local packages with dependencies but no non-local
+dependencies:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name a))
+  > (package
+  >  (name b)
+  >  (depends a))
+  > EOF
+  $ dune describe pkg dependency-hash
+  Error: No non-local dependencies
+  [1]
+
+A single package with a single non-local dependency:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name a)
+  >  (depends
+  >   foo))
+  > EOF
+  $ dune describe pkg dependency-hash | tee hash1.txt
+  md5=9f76a6d656fe14d54ba74f864e736dc3
+
+Adding another dependency causes the hash to change:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name a)
+  >  (depends
+  >   foo
+  >   bar))
+  > EOF
+  $ dune describe pkg dependency-hash | tee hash2.txt
+  md5=142f33129a06ccbebd65a0bad3d94857
+  $ diff hash1.txt hash2.txt
+  1c1
+  < md5=9f76a6d656fe14d54ba74f864e736dc3
+  ---
+  > md5=142f33129a06ccbebd65a0bad3d94857
+  [1]
+
+Adding a new local package which depends on one of the existing dependencies
+doesn't change the hash:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name a)
+  >  (depends
+  >   foo
+  >   bar))
+  > (package
+  >  (name b)
+  >  (depends
+  >   foo))
+  > EOF
+  $ dune describe pkg dependency-hash | tee hash3.txt
+  md5=142f33129a06ccbebd65a0bad3d94857
+  $ diff hash2.txt hash3.txt
+
+Adding a constraint to one of the dependencies causes the hash to change:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name a)
+  >  (depends
+  >   foo
+  >   bar))
+  > (package
+  >  (name b)
+  >  (depends
+  >   (foo (and :with-test (> 0.1)))))
+  > EOF
+  $ dune describe pkg dependency-hash | tee hash4.txt
+  md5=ecad1d0d60084711169be48b130c9c52
+  $ diff hash3.txt hash4.txt
+  1c1
+  < md5=142f33129a06ccbebd65a0bad3d94857
+  ---
+  > md5=ecad1d0d60084711169be48b130c9c52
+  [1]
+
+Adding another local package with the same dependency and constraint doesn't
+change the hash:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name a)
+  >  (depends
+  >   foo
+  >   bar))
+  > (package
+  >  (name b)
+  >  (depends
+  >   (foo (and :with-test (> 0.1)))))
+  > (package
+  >  (name c)
+  >  (depends
+  >   (foo (and :with-test (> 0.1)))))
+  > EOF
+  $ dune describe pkg dependency-hash | tee hash5.txt
+  md5=ecad1d0d60084711169be48b130c9c52
+  $ diff hash4.txt hash5.txt

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -70,6 +70,8 @@ Print the contents of each file in the lockdir:
   
   (lang package 0.1)
   
+  (dependency_hash md5=ca83e32ab35d71d20fa075b395046c29)
+  
   (repositories
    (complete false)
    (used))
@@ -112,6 +114,8 @@ Run the solver again preferring oldest versions of dependencies:
   dune.lock/lock.dune:
   
   (lang package 0.1)
+  
+  (dependency_hash md5=ca83e32ab35d71d20fa075b395046c29)
   
   (repositories
    (complete false)

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -55,12 +55,16 @@ Solve packages with no variables set.
   - static-deps.1.0
   (lang package 0.1)
   
+  (dependency_hash md5=aea7daa72b636fa3a44973ec5e29d225)
+  
   (repositories
    (complete false)
    (used))
   Solution for dune.lock:
   - dynamic-deps.1.0
   (lang package 0.1)
+  
+  (dependency_hash md5=6957fba0128609ffc98fac2561c329cb)
   
   (repositories
    (complete false)
@@ -71,6 +75,8 @@ Solve packages with no variables set.
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
   (lang package 0.1)
+  
+  (dependency_hash md5=9675a3014e7e2db0f946b3ad2a95c037)
   
   (repositories
    (complete false)
@@ -98,12 +104,16 @@ Solve the packages again, this time with the variables set.
   - static-deps.1.0
   (lang package 0.1)
   
+  (dependency_hash md5=aea7daa72b636fa3a44973ec5e29d225)
+  
   (repositories
    (complete false)
    (used))
   Solution for dune.lock:
   - dynamic-deps.1.0
   (lang package 0.1)
+  
+  (dependency_hash md5=6957fba0128609ffc98fac2561c329cb)
   
   (repositories
    (complete false)
@@ -116,6 +126,8 @@ Solve the packages again, this time with the variables set.
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
   (lang package 0.1)
+  
+  (dependency_hash md5=9675a3014e7e2db0f946b3ad2a95c037)
   
   (repositories
    (complete false)

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -38,6 +38,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ~lock_dir:
       (Lock_dir.create_latest_version
          Package_name.Map.empty
+         ~local_packages:[]
          ~ocaml:None
          ~repos:None
          ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty);
@@ -45,6 +46,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     {|
     lockdir matches after roundtrip:
     { version = (0, 1)
+    ; dependency_hash = None
     ; packages = map {}
     ; ocaml = None
     ; repos = { complete = true; used = None }
@@ -72,6 +74,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
          name, empty_package name ~version
        in
        Lock_dir.create_latest_version
+         ~local_packages:[]
          ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
          ~repos:None
          ~expanded_solver_variable_bindings:
@@ -86,6 +89,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     {|
     lockdir matches after roundtrip:
     { version = (0, 1)
+    ; dependency_hash = None
     ; packages =
         map
           { "bar" :
@@ -210,6 +214,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
          Dune_pkg.Opam_repo.Private.create ~source:(Some "well-known-repo") ~repo_id
        in
        Lock_dir.create_latest_version
+         ~local_packages:[]
          ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
          ~repos:(Some [ opam_repo ])
          ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
@@ -218,6 +223,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     {|
     lockdir matches after roundtrip:
     { version = (0, 1)
+    ; dependency_hash = None
     ; packages =
         map
           { "a" :


### PR DESCRIPTION
If the package definitions in dune-project are changed after a lockdir is generated then the lockdir may no longer contain a valid solution for the local packages in the project. To help detect when this has happened this change adds a new field to the lockdir containing a hash of all the local package metadata used for generating it. When the local package metadata would change in a way that may affect the solution we can detect this by computing a new hash of the local packages and comparing it against the one stored in the lockdir.