### PR TITLE
refactor: delay source loading

### DIFF
--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -55,8 +55,9 @@ val include_subdirs : t -> Dune_file.Include_subdirs.t
 val make
   :  Stanza.t list
   -> dir:Path.Build.t
-  -> scope:Scope.t
-  -> lib_config:Lib_config.t
+  -> libs:Lib.DB.t Memo.t
+  -> project:Dune_project.t
+  -> lib_config:Lib_config.t Memo.t
   -> loc:Loc.t
   -> lookup_vlib:(loc:Loc.t -> dir:Path.Build.t -> t Memo.t)
   -> include_subdirs:Loc.t * Dune_file.Include_subdirs.t


### PR DESCRIPTION
do not require loading the OCaml compiler or the library scope just to
resolve some modules

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e62c1616-0582-4dbc-a8ef-f5602593b3d0 -->