### PR TITLE
Better message for menhir_flags in dune-workspace

### DIFF
--- a/src/dune_rules/dune_env.mli
+++ b/src/dune_rules/dune_env.mli
@@ -68,3 +68,12 @@ module Stanza : sig
 end
 
 type stanza += T of Stanza.t
+
+module Source : sig
+  type t =
+    | Workspace_file
+    | Dune_file
+
+  val to_dyn : t -> Dyn.t
+  val key : t Univ_map.Key.t
+end

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2348,7 +2348,7 @@ module Stanzas = struct
       , let+ () = Dune_lang.Syntax.deleted_in Stanza.syntax (2, 6) in
         [] )
     ; ( "env"
-      , let+ x = Dune_env.Stanza.decode in
+      , let+ x = set Dune_env.Source.key Dune_file Dune_env.Stanza.decode in
         [ Dune_env.T x ] )
     ; ( "include_subdirs"
       , let* project = Dune_project.get_exn () in

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -14,6 +14,7 @@ let env_field, env_field_lazy =
   let make f g =
     field "env" ~default:(f None)
     @@ g
+    @@ set Dune_env.Source.key Workspace_file
     @@ let+ () = Dune_lang.Syntax.since syntax (1, 1)
        and+ version = Dune_lang.Syntax.get_exn syntax
        and+ loc = loc

--- a/test/blackbox-tests/test-cases/menhir/flags-in-workspace.t
+++ b/test/blackbox-tests/test-cases/menhir/flags-in-workspace.t
@@ -12,9 +12,9 @@ See #9024.
   >  (test (menhir_flags --table)))
   > EOF
 
-  $ dune build 2>&1 | head -n 5
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Syntax identifier is unset",
-    { name = "menhir"
-    ; supported_versions =
+  $ dune build
+  File "dune-workspace", line 3, characters 7-29:
+  3 |  (test (menhir_flags --table)))
+             ^^^^^^^^^^^^^^^^^^^^^^
+  Error: (menhir_flags ...) is not supported in workspace files.
+  [1]


### PR DESCRIPTION
This adds a context variable to determine whether we are parsing a dune-workspace file or a dune file.

See #9024
