### PR TITLE
refactor: move automatic subdirs to toplevel

### DIFF
--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -2,7 +2,11 @@ open Import
 open Memo.O
 
 let bin_dir_basename = ".bin"
-let local_bin p = Path.Build.relative p bin_dir_basename
+
+let local_bin p =
+  let ctx, src = Path.Build.extract_build_context_dir_exn p in
+  Path.Build.append_source (Path.Build.relative ctx bin_dir_basename) src
+;;
 
 type t =
   { context : Context.t


### PR DESCRIPTION
this simplifies the rules

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a1130f9e-1cdd-49e6-ba7b-59a84341fcfa -->