### PR TITLE
tests: use %{cc} instead of cc

### DIFF
--- a/test/blackbox-tests/test-cases/ctypes/libexample/dune
+++ b/test/blackbox-tests/test-cases/ctypes/libexample/dune
@@ -4,7 +4,7 @@
   example.h)
  (target example.o)
  (action
-  (run cc -c -fPIC -o %{target} %{c})))
+  (run %{cc} -c -fPIC -o %{target} %{c})))
 
 (rule
  (deps example.o)
@@ -16,4 +16,4 @@
  (deps example.o)
  (target libexample.so)
  (action
-  (run cc -shared -o %{target} %{deps})))
+  (run %{cc} -shared -o %{target} %{deps})))

--- a/test/blackbox-tests/test-cases/ctypes/libneed-mangling/dune
+++ b/test/blackbox-tests/test-cases/ctypes/libneed-mangling/dune
@@ -4,7 +4,7 @@
   example.h)
  (target example.o)
  (action
-  (run cc -c -fPIC -o %{target} %{c})))
+  (run %{cc} -c -fPIC -o %{target} %{c})))
 
 (rule
  (deps example.o)
@@ -16,4 +16,4 @@
  (deps example.o)
  (target libneed-mangling.so)
  (action
-  (run cc -shared -o %{target} %{deps})))
+  (run %{cc} -shared -o %{target} %{deps})))


### PR DESCRIPTION
There is no guarantee of a `cc` executable in scope.
