### PR TITLE
Set the right flags when `Shared` is selected.

### DIFF
--- a/src/dune_util/dune_flock.c
+++ b/src/dune_util/dune_flock.c
@@ -52,6 +52,8 @@ CAMLprim value dune_flock_lock(value v_fd, value v_block, value v_exclusive) {
   int flags = 0;
   if (Bool_val(v_exclusive)) {
     flags |= LOCK_EX;
+  } else {
+    flags |= LOCK_SH;
   }
   if (!Bool_val(v_block)) {
     flags |= LOCK_NB;


### PR DESCRIPTION
`exclusive` selects between `LOCK_EX` and `LOCK_SH` but if it is `false` `LOCK_SH` is never set on the flags. This could've worked if `LOCK_SH` is `0` but at least on GNU/Linux on amd64 with glibc, `LOCK_SH` is `1`.

We never use `Shared` in the Dune codebase but in case we would, it better works otherwise it would create issues that are hard to debug.

Discovered by @emillon as we were investigating the semantics of write locks.