### PR TITLE
revert #7263

### DIFF
--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -655,12 +655,6 @@ let coqdoc_directory ~mode ~obj_dir ~name =
 ;;
 
 let coqdoc_directory_targets ~dir:obj_dir (theory : Coq_stanza.Theory.t) =
-  let+ (_ : Coq_lib.DB.t) =
-    (* We force the creation of the coq_lib db here so that errors there can
-       appear before any errors to do with directory targets from coqdoc. *)
-    let* scope = Scope.DB.find_by_dir obj_dir in
-    Scope.coq_libs scope
-  in
   let loc = theory.buildable.loc in
   let name = snd theory.name in
   Path.Build.Map.of_list_exn

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -21,7 +21,7 @@ val deps_of
 val coqdoc_directory_targets
   :  dir:Path.Build.t
   -> Coq_stanza.Theory.t
-  -> Loc.t Path.Build.Map.t Memo.t
+  -> Loc.t Path.Build.Map.t
 
 (** ** Rules for Coq stanzas *)
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -301,14 +301,14 @@ let gen_rules_for_stanzas
 
 let collect_directory_targets ~init ~dir =
   Only_packages.stanzas_in_dir dir
-  >>= function
-  | None -> Memo.return init
+  >>| function
+  | None -> init
   | Some d ->
-    Memo.List.fold_left d.stanzas ~init ~f:(fun acc stanza ->
+    List.fold_left d.stanzas ~init ~f:(fun acc stanza ->
       match stanza with
       | Coq_stanza.Theory.T m ->
         Coq_rules.coqdoc_directory_targets ~dir m
-        >>| Path.Build.Map.union acc ~f:(fun path loc1 loc2 ->
+        |> Path.Build.Map.union acc ~f:(fun path loc1 loc2 ->
           User_error.raise
             ~loc:loc1
             [ Pp.textf
@@ -316,7 +316,7 @@ let collect_directory_targets ~init ~dir =
                 (Path.Build.to_string path)
             ; Pp.enumerate ~f:Loc.pp_file_colon_line [ loc1; loc2 ]
             ])
-      | _ -> Memo.return acc)
+      | _ -> acc)
 ;;
 
 let gen_rules sctx dir_contents cctxs ~source_dir ~dir

--- a/test/blackbox-tests/test-cases/coq/duplicate-theory-project.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/duplicate-theory-project.t/run.t
@@ -17,5 +17,7 @@ Duplicate theories in the same project should be caught by Dune:
   Error: Coq theory foo is defined twice:
   - theory foo in B/dune:2
   - theory foo in A/dune:2
+  -> required by _build/default/A/.foo.theory.d
+  -> required by alias A/all
   -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/coq/duplicate-theory.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/duplicate-theory.t/run.t
@@ -11,7 +11,8 @@ Duplicate theories should be caught by Dune:
 BUG The directory target is found before the theory
 
   $ dune build
-  Error: Coq theory foo is defined twice:
-  - theory foo in dune:5
-  - theory foo in dune:2
-  [1]
+  File "dune", line 1, characters 0-24:
+  1 | (coq.theory
+  2 |  (name foo))
+  Error: The following both define the same directory target:
+  _build/default/foo.tex


### PR DESCRIPTION
We aren't allowed to load the coq scope in projects where coq isn't
enabled.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 67645c04-cf78-43d2-9ad1-521569ffa523 -->