### PR TITLE
refactor: declare directory targets without loading rules

### DIFF
--- a/src/dune_rules/coq/coq_doc.ml
+++ b/src/dune_rules/coq/coq_doc.ml
@@ -1,0 +1,27 @@
+open Import
+open Memo.O
+
+let coqdoc_directory ~mode ~obj_dir ~name =
+  Path.Build.relative
+    obj_dir
+    (Coq_lib_name.to_string name
+     ^
+     match mode with
+     | `Html -> ".html"
+     | `Latex -> ".tex")
+;;
+
+let coqdoc_directory_targets ~dir:obj_dir (theory : Coq_stanza.Theory.t) =
+  let+ (_ : Coq_lib.DB.t) =
+    (* We force the creation of the coq_lib db here so that errors there can
+       appear before any errors to do with directory targets from coqdoc. *)
+    let* scope = Scope.DB.find_by_dir obj_dir in
+    Scope.coq_libs scope
+  in
+  let loc = theory.buildable.loc in
+  let name = snd theory.name in
+  Path.Build.Map.of_list_exn
+    [ coqdoc_directory ~mode:`Html ~obj_dir ~name, loc
+    ; coqdoc_directory ~mode:`Latex ~obj_dir ~name, loc
+    ]
+;;

--- a/src/dune_rules/coq/coq_doc.mli
+++ b/src/dune_rules/coq/coq_doc.mli
@@ -1,0 +1,15 @@
+open Import
+
+(* This code lives in its own module so that it's usable in [Dir_status]
+   without creating dependency cycles *)
+
+val coqdoc_directory
+  :  mode:[< `Html | `Latex ]
+  -> obj_dir:Path.Build.t
+  -> name:Coq_lib_name.t
+  -> Path.Build.t
+
+val coqdoc_directory_targets
+  :  dir:Path.Build.t
+  -> Coq_stanza.Theory.t
+  -> Loc.t Path.Build.Map.t Memo.t

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -18,11 +18,6 @@ val deps_of
   -> Coq_module.t
   -> unit Dune_engine.Action_builder.t
 
-val coqdoc_directory_targets
-  :  dir:Path.Build.t
-  -> Coq_stanza.Theory.t
-  -> Loc.t Path.Build.Map.t Memo.t
-
 (** ** Rules for Coq stanzas *)
 
 (**coq.theory stanza rules *)

--- a/src/dune_rules/dir_contents.mli
+++ b/src/dune_rules/dir_contents.mli
@@ -44,7 +44,6 @@ module Standalone_or_root : sig
   type dir_contents := t
   type t
 
-  val directory_targets : t -> Loc.t Path.Build.Map.t
   val rules : t -> Rules.t Memo.t
   val root : t -> dir_contents Memo.t
   val subdirs : t -> dir_contents list Memo.t

--- a/src/dune_rules/dir_status.mli
+++ b/src/dune_rules/dir_status.mli
@@ -40,3 +40,5 @@ type t =
 module DB : sig
   val get : dir:Path.Build.t -> t Memo.t
 end
+
+val directory_targets : dir:Path.Build.t -> Loc.t Path.Build.Map.t Memo.t


### PR DESCRIPTION
Now we only need to consult the directory status to determine whether a directory is a target of a rule.

@ejgallego @Alizter I (minimally) shuffled around some coq stuff to avoid dependency cycles. Feel free to re-shuffle as you see fit.