### PR TITLE
refactor(pkg): remove copying hacks

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -412,7 +412,7 @@ end = struct
     >>= function
     | Is_component_of_a_group_but_not_the_root { group_root; stanzas = _ } ->
       Memo.return @@ Group_part group_root
-    | Generated | Source_only _ ->
+    | Lock_dir | Generated | Source_only _ ->
       Memo.return @@ Standalone_or_root (Standalone_or_root.empty ~dir)
     | Standalone (st_dir, d) ->
       Memo.return @@ Standalone_or_root (make_standalone sctx st_dir ~dir d)

--- a/src/dune_rules/dir_status.mli
+++ b/src/dune_rules/dir_status.mli
@@ -26,6 +26,7 @@ module Group_root : sig
 end
 
 type t =
+  | Lock_dir
   | Generated
   | Source_only of Source_tree.Dir.t
   | Standalone of Source_tree.Dir.t * Dune_file.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -95,19 +95,23 @@ module Lock_dir = struct
         | false -> None
         | true -> Some ctx')
     with
-    | None -> default_path
-    | Some (Default { lock; _ }) -> Option.value lock ~default:default_path
-    | Some (Opam _) -> assert false
+    | None -> Some default_path
+    | Some (Default { lock; _ }) -> Some (Option.value lock ~default:default_path)
+    | Some (Opam _) -> None
   ;;
 
-  let get (ctx : Context_name.t) : t Memo.t = get_path ctx >>= Load.load
+  let get (ctx : Context_name.t) : t Memo.t =
+    get_path ctx >>| Option.value_exn >>= Load.load
+  ;;
 
   let lock_dir_active ctx =
     if !Clflags.ignore_lock_directory
     then Memo.return false
     else
-      let* path = get_path ctx in
-      Fs_memo.dir_exists (In_source_dir path)
+      get_path ctx
+      >>= function
+      | None -> Memo.return false
+      | Some path -> Fs_memo.dir_exists (In_source_dir path)
   ;;
 end
 
@@ -249,7 +253,7 @@ module Pkg = struct
     ; deps : t list
     ; info : Pkg_info.t
     ; paths : Paths.t
-    ; files_dir : Path.Source.t
+    ; files_dir : Path.Build.t
     ; mutable exported_env : string Env_update.t list
     }
 
@@ -891,10 +895,12 @@ end = struct
           | `System_provided -> None)
         >>| List.filter_opt
       and+ files_dir =
-        let+ lock_dir = Lock_dir.get_path ctx in
-        Path.Source.relative
-          lock_dir
-          (sprintf "%s.files" (Package.Name.to_string info.name))
+        let+ lock_dir = Lock_dir.get_path ctx >>| Option.value_exn in
+        Path.Build.append_source
+          (Context_name.build_dir ctx)
+          (Path.Source.relative
+             lock_dir
+             (sprintf "%s.files" (Package.Name.to_string info.name)))
       in
       let id = Pkg.Id.gen () in
       let paths = Paths.make name ctx in
@@ -1301,56 +1307,6 @@ module Fetch = struct
   ;;
 end
 
-module Copy_tree = struct
-  module Spec = struct
-    type ('path, 'target) t = 'path * 'target
-
-    let name = "copy-tree"
-    let version = 1
-    let bimap (src, dst) f g = f src, g dst
-    let is_useful_to ~memoize = memoize
-
-    let encode (src, dst) dep target : Dune_lang.t =
-      List [ Dune_lang.atom_or_quoted_string name; dep src; target dst ]
-    ;;
-
-    let action (root, dst) ~ectx:_ ~eenv:_ =
-      let open Fiber.O in
-      let+ () = Fiber.return () in
-      Install_action.Spec.collect [ root ] []
-      |> List.iter ~f:(fun src ->
-        let dst =
-          Path.append_local (Path.build dst) (Path.drop_prefix_exn src ~prefix:root)
-        in
-        let old_permissions =
-          match Path.Untracked.stat dst with
-          | Error _ -> None
-          | Ok s ->
-            Path.unlink dst;
-            Some s.st_perm
-        in
-        Io.copy_file
-          ~chmod:(fun default -> Option.value old_permissions ~default)
-          ~src
-          ~dst
-          ())
-    ;;
-  end
-
-  let action ~src ~dst =
-    let module M = struct
-      type path = Path.t
-      type target = Path.Build.t
-
-      module Spec = Spec
-
-      let v = src, dst
-    end
-    in
-    Action.Extension (module M)
-  ;;
-end
-
 let add_env env action =
   Action_builder.With_targets.map action ~f:(Action.Full.add_env env)
 ;;
@@ -1415,13 +1371,29 @@ let build_rule context_name ~source_deps (pkg : Pkg.t) =
     let+ build_and_install =
       let+ copy_action =
         let+ copy_action =
-          Fs_memo.dir_exists (In_source_dir pkg.files_dir)
-          >>| function
-          | false -> []
+          Fs_memo.dir_exists
+            (In_source_dir (Path.Build.drop_build_context_exn pkg.files_dir))
+          >>= function
+          | false -> Memo.return []
           | true ->
-            [ Copy_tree.action ~src:(Path.source pkg.files_dir) ~dst:pkg.paths.source_dir
-              |> Action.Full.make
-              |> Action_builder.With_targets.return
+            let+ deps, source_deps = Source_deps.files (Path.build pkg.files_dir) in
+            let open Action_builder.O in
+            [ Action_builder.with_no_targets
+              @@ (Action_builder.deps deps
+                  >>> (Path.Set.to_list_map source_deps ~f:(fun src ->
+                         let dst =
+                           let local_path =
+                             Path.drop_prefix_exn src ~prefix:(Path.build pkg.files_dir)
+                           in
+                           Path.Build.append_local pkg.paths.source_dir local_path
+                         in
+                         Action.progn
+                           [ Action.mkdir (Path.Build.parent_exn dst)
+                           ; Action.copy src dst
+                           ])
+                       |> Action.concurrent
+                       |> Action.Full.make
+                       |> Action_builder.return))
             ]
         in
         copy_action
@@ -1585,6 +1557,7 @@ let which context =
 ;;
 
 let lock_dir_active = Lock_dir.lock_dir_active
+let lock_dir_path = Lock_dir.get_path
 
 let exported_env context =
   let+ all_packages = all_packages context in

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -15,6 +15,7 @@ val setup_rules
   -> Context_name.t
   -> Build_config.Gen_rules.t Memo.t
 
+val lock_dir_path : Context_name.t -> Path.Source.t option Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
@@ -12,6 +12,3 @@ file copying step rather than the build step.
 
 The foo.install file in files/ should have been copied over.
   $ build_pkg foo 2>&1 | sed 's/copyfile/open/'
-  Error:
-  open(_build/_private/default/.pkg/foo/source/foo.install): No such file or directory
-  -> required by _build/_private/default/.pkg/foo/target/cookie


### PR DESCRIPTION
Replace them with regular copying rules. The cycle that follows is
broken by not initializing the context for the rules in dune.lock
directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5dc5e6e1-5a5c-4b7c-beee-8243f7e0d207 -->