### PR TITLE
pkg: validate dependencies of packages in lockdir

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -42,9 +42,12 @@ module Repositories : sig
   type t
 end
 
-type t =
+type t = private
   { version : Syntax.Version.t
   ; packages : Pkg.t Package_name.Map.t
+  (** It's guaranteed that this map will contain an entry for all dependencies
+      of all packages in this map. That is, the set of packages is closed under
+      the "depends on" relationship between packages. *)
   ; ocaml : (Loc.t * Package_name.t) option
   ; repos : Repositories.t
   ; expanded_solver_variable_bindings : Solver_stats.Expanded_variable_bindings.t
@@ -57,6 +60,11 @@ val remove_locs : t -> t
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 
+(** [create_latest_version packages ~ocaml ~repos
+    ~expanded_solver_variable_bindings] raises a [Code_error] if [packages] is
+    not closed under the "depends on" relationship between packages. Every
+    dependency of every package in [packages] must itself have a corresponding
+    entry in [packages]. *)
 val create_latest_version
   :  Pkg.t Package_name.Map.t
   -> ocaml:(Loc.t * Package_name.t) option

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -1,0 +1,52 @@
+Check that if the user tampers with the lockdir in a way that invalidates the
+package graph then it's caught when loading the lockdir.
+
+  $ . ./helpers.sh
+
+
+  $ make_lockdir
+
+  $ cat >dune.lock/a.pkg <<EOF
+  > (deps b)
+  > EOF
+  $ cat >dune.lock/b.pkg <<EOF
+  > (deps c)
+  > EOF
+  $ cat >dune.lock/c.pkg <<EOF
+  > (deps a)
+  > EOF
+
+  $ dune describe pkg lock
+  Contents of dune.lock:
+  - a.dev
+  - b.dev
+  - c.dev
+
+  $ cat >dune.lock/c.pkg <<EOF
+  > (deps a d)
+  > EOF
+
+  $ dune describe pkg lock
+  File "dune.lock/c.pkg", line 1, characters 8-9:
+  The package "c" depends on the package "d", but "d" does not appear in the
+  lockdir dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]
+
+  $ rm dune.lock/a.pkg
+
+  $ dune describe pkg lock
+  File "dune.lock/c.pkg", line 1, characters 6-7:
+  The package "c" depends on the package "a", but "a" does not appear in the
+  lockdir dune.lock.
+  File "dune.lock/c.pkg", line 1, characters 8-9:
+  The package "c" depends on the package "d", but "d" does not appear in the
+  lockdir dune.lock.
+  Error: At least one package dependency is itself not present as a package in
+  the lockdir dune.lock.
+  Hint: This could indicate that the lockdir is corrupted. Delete it and then
+  regenerate it by running: 'dune pkg lock'
+  [1]


### PR DESCRIPTION
When loading or creating a lockdir, check that the dependencies of each locked package are also present in the lockdir.