### PR TITLE
refactor: delay context creation up in configurator rules

### DIFF
--- a/src/dune_rules/configurator_rules.mli
+++ b/src/dune_rules/configurator_rules.mli
@@ -1,7 +1,9 @@
 (** configurator rules *)
 
+open Import
+
 (** Generate the rules for producing the files needed by configurator. *)
-val gen_rules : Context.t -> unit Memo.t
+val gen_rules : Context_name.t -> unit Memo.t
 
 (** Force the files required by configurator at runtime to be produced. *)
 val force_files : unit Memo.Lazy.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -605,7 +605,7 @@ let gen_rules ctx sctx ~dir components : Gen_rules.result Memo.t =
     has_rules
       ~dir
       (Subdir_set.of_set (Filename.Set.of_list [ "ccomp" ]))
-      (fun () -> Context.DB.get ctx >>= Configurator_rules.gen_rules)
+      (fun () -> Configurator_rules.gen_rules ctx)
   | _ -> gen_rules_regular_directory sctx ~components ~dir
 ;;
 


### PR DESCRIPTION
allow loading rules in for configurator without initializing context

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 70e40ebb-dc79-497d-af6f-0591bbfa8578 -->