### PR TITLE
refactor: delay cxx compiler rules

### DIFF
--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -19,28 +19,38 @@ CCOMP
 
 let rules ~sctx ~dir =
   let file = Path.Build.relative dir Cxx_flags.preprocessed_filename in
-  let* ocfg =
+  let ocfg =
+    Action_builder.of_memo
+    @@
     let+ ocaml = Super_context.context sctx |> Context.ocaml in
     ocaml.ocaml_config
-  in
-  let open Memo.O in
-  let* prog =
-    Super_context.resolve_program sctx ~dir ~loc:None (Ocaml_config.c_compiler ocfg)
   in
   (* let tmp = Path.External.of_string (Filename.get_temp_dir_name ()) in *)
   let header_file = Path.Build.relative dir "header_check.h" in
   let write_test_file = Action.write_file header_file header_file_content in
   let args =
-    let open Command.Args in
-    [ (match Ocaml_config.ccomp_type ocfg with
-       | Msvc -> A "/EP"
-       | Other _ -> As [ "-E"; "-P" ])
-    ; Path (Path.build header_file)
-    ]
+    let open Action_builder.O in
+    Command.Args.Dyn
+      (let+ ocfg = ocfg in
+       let open Command.Args in
+       S
+         [ (match Ocaml_config.ccomp_type ocfg with
+            | Msvc -> A "/EP"
+            | Other _ -> As [ "-E"; "-P" ])
+         ; Path (Path.build header_file)
+         ])
   in
   let action =
+    let prog =
+      let open Action_builder.O in
+      let* ocfg = ocfg in
+      Super_context.resolve_program sctx ~dir ~loc:None (Ocaml_config.c_compiler ocfg)
+      |> Action_builder.of_memo
+    in
     let open Action_builder.With_targets.O in
-    let+ run_preprocessor = Command.run ~dir:(Path.build dir) ~stdout_to:file prog args in
+    let+ run_preprocessor =
+      Command.run_dyn_prog ~dir:(Path.build dir) ~stdout_to:file prog [ args ]
+    in
     Action.Full.reduce [ Action.Full.make write_test_file; run_preprocessor ]
   in
   Super_context.add_rule sctx ~dir action


### PR DESCRIPTION
delay resolving the cxx detection action until we need to run it

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: eaec5c2a-0509-4e70-9953-60627ddab27c -->