### PR TITLE
Validate lockdir against local packages

### DIFF
--- a/bin/pkg/pkg.ml
+++ b/bin/pkg/pkg.ml
@@ -11,4 +11,12 @@ let info =
   Cmd.info "pkg" ~doc ~man
 ;;
 
-let group = Cmd.group info [ Lock.command; Print_solver_env.command; Outdated.command ]
+let group =
+  Cmd.group
+    info
+    [ Lock.command
+    ; Print_solver_env.command
+    ; Outdated.command
+    ; Validate_lock_dir.command
+    ]
+;;

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -1,0 +1,84 @@
+open! Import
+module Package_universe = Dune_pkg.Package_universe
+module Lock_dir = Dune_pkg.Lock_dir
+module Opam_repo = Dune_pkg.Opam_repo
+module Package_version = Dune_pkg.Package_version
+module Opam_solver = Dune_pkg.Opam_solver
+
+let info =
+  let doc = "Validate that a lockdir contains a solution for local packages" in
+  let man = [ `S "DESCRIPTION"; `P doc ] in
+  Cmd.info "validate-lockdir" ~doc ~man
+;;
+
+let enumerate_lock_dirs_by_path ~context_name_arg ~all_contexts_arg =
+  let open Fiber.O in
+  let+ per_contexts =
+    Pkg_common.Per_context.choose
+      ~context_name_arg
+      ~all_contexts_arg
+      ~version_preference_arg:None
+  in
+  List.filter_map per_contexts ~f:(fun { Pkg_common.Per_context.lock_dir_path; _ } ->
+    if Path.exists (Path.source lock_dir_path)
+    then (
+      try Some (Ok (lock_dir_path, Lock_dir.read_disk lock_dir_path)) with
+      | User_error.E e -> Some (Error (lock_dir_path, `Parse_error e)))
+    else None)
+;;
+
+let validate_lock_dirs ~context_name_arg ~all_contexts_arg =
+  let open Fiber.O in
+  let+ lock_dirs_by_path = enumerate_lock_dirs_by_path ~context_name_arg ~all_contexts_arg
+  and+ local_packages = Pkg_common.find_local_packages in
+  if List.is_empty lock_dirs_by_path then print_endline "No lockdirs to validate.";
+  let errors_by_path =
+    List.filter_map lock_dirs_by_path ~f:(function
+      | Error e -> Some e
+      | Ok (path, lock_dir) ->
+        (match Package_universe.create local_packages lock_dir with
+         | Ok _ -> None
+         | Error e -> Some (path, `Lock_dir_out_of_sync e)))
+  in
+  if not (List.is_empty errors_by_path)
+  then (
+    List.iter errors_by_path ~f:(fun (path, error) ->
+      match error with
+      | `Parse_error error ->
+        User_message.prerr
+          (User_message.make
+             [ Pp.textf
+                 "Failed to parse lockdir %s:"
+                 (Path.Source.to_string_maybe_quoted path)
+             ; User_message.pp error
+             ])
+      | `Lock_dir_out_of_sync error ->
+        User_message.prerr
+          (User_message.make
+             [ Pp.textf
+                 "Lockdir %s does not contain a solution for local packages:"
+                 (Path.Source.to_string path)
+             ]);
+        User_message.prerr error);
+    User_error.raise
+      [ Pp.text "Some lockdirs do not contain solutions for local packages:"
+      ; Pp.enumerate errors_by_path ~f:(fun (path, _) ->
+          Pp.text (Path.Source.to_string path))
+      ])
+;;
+
+let term =
+  let+ builder = Common.Builder.term
+  and+ context_name =
+    Pkg_common.context_term ~doc:"Validate the lockdir associated with this context"
+  and+ all_contexts =
+    Arg.(value & flag & info [ "all-contexts" ] ~doc:"Validate all lockdirs")
+  in
+  let builder = Common.Builder.forbid_builds builder in
+  let common, config = Common.init builder in
+  Scheduler.go ~common ~config
+  @@ fun () ->
+  validate_lock_dirs ~context_name_arg:context_name ~all_contexts_arg:all_contexts
+;;
+
+let command = Cmd.v info term

--- a/bin/pkg/validate_lock_dir.mli
+++ b/bin/pkg/validate_lock_dir.mli
@@ -1,0 +1,4 @@
+open Import
+
+(** Command to check if local packages and lockdir agree *)
+val command : unit Cmd.t

--- a/src/dune_lang/package_constraint.ml
+++ b/src/dune_lang/package_constraint.ml
@@ -18,11 +18,13 @@ module Op = struct
   let map = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
   let to_dyn t = Dyn.variant (fst (List.find_exn ~f:(fun (_, op) -> equal t op) map)) []
 
-  let encode x =
+  let to_string x =
     let f (_, op) = equal x op in
     (* Assumes the [map] is complete, so exception is impossible *)
-    List.find_exn ~f map |> fst |> Dune_sexp.Encoder.string
+    List.find_exn ~f map |> fst
   ;;
+
+  let encode x = Dune_sexp.Encoder.string (to_string x)
 end
 
 module Variable = struct

--- a/src/dune_lang/package_constraint.mli
+++ b/src/dune_lang/package_constraint.mli
@@ -10,6 +10,7 @@ module Op : sig
     | Neq
 
   val to_dyn : t -> Dyn.t
+  val to_string : t -> string
 end
 
 module Variable : sig

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -16,3 +16,4 @@ module Version_preference = Version_preference
 module Package_version = Package_version
 module Pkg_workspace = Workspace
 module Local_package = Local_package
+module Package_universe = Package_universe

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -4,13 +4,18 @@ type t =
   { name : Package_name.t
   ; version : Package_version.t option
   ; dependencies : Package_dependency.t list
+  ; loc : Loc.t
   }
 
-let to_opam_file { name; version; dependencies } =
+let to_opam_file { name; version; dependencies; loc = _ } =
   OpamFile.OPAM.empty
   |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
   |> OpamFile.OPAM.with_version_opt
        (Option.map version ~f:Package_version.to_opam_package_version)
   |> OpamFile.OPAM.with_depends
        (Package_dependency.list_to_opam_filtered_formula dependencies)
+;;
+
+let opam_filtered_dependency_formula { dependencies; _ } =
+  Package_dependency.list_to_opam_filtered_formula dependencies
 ;;

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -5,9 +5,13 @@ type t =
   { name : Package_name.t
   ; version : Package_version.t option
   ; dependencies : Package_dependency.t list
+  ; loc : Loc.t
   }
 
 (** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the
     fields of [t]. Note that this does not actually create a corresponding file
     on disk. *)
 val to_opam_file : t -> OpamFile.OPAM.t
+
+(** Returns an opam dependency formula for this package *)
+val opam_filtered_dependency_formula : t -> OpamTypes.filtered_formula

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -103,3 +103,13 @@ module Make_load (Io : sig
   end) : sig
   val load : Path.Source.t -> t Io.t
 end
+
+(** [transitive_dependency_closure t names] returns the set of package names
+    making up the transitive closure of dependencies of the set [names], or
+    [Error (`Missing_packages missing_packages)] if if any element of [names]
+    is not found in the lockdir. [missing_packages] is a subset of [names]
+    not present in the lockdir. *)
+val transitive_dependency_closure
+  :  t
+  -> Package_name.Set.t
+  -> (Package_name.Set.t, [ `Missing_packages of Package_name.Set.t ]) result

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -1,0 +1,142 @@
+open! Import
+
+type t =
+  { local_packages : Local_package.t Package_name.Map.t
+  ; lock_dir : Lock_dir.t
+  }
+
+let lockdir_regenerate_hints =
+  [ Pp.concat
+      ~sep:Pp.space
+      [ Pp.text
+          "The lockdir no longer contains a solution for the local packages in this \
+           project. Regenerate the lockdir by running:"
+      ; User_message.command "dune pkg lock"
+      ]
+  ]
+;;
+
+let version_by_package_name t =
+  let from_local_packages =
+    Package_name.Map.map t.local_packages ~f:(fun local_package ->
+      Option.value local_package.version ~default:Lock_dir.Pkg_info.default_version)
+  in
+  let from_lock_dir =
+    Package_name.Map.map t.lock_dir.packages ~f:(fun pkg -> pkg.info.version)
+  in
+  let exception Duplicate_package of Package_name.t in
+  try
+    Ok
+      (Package_name.Map.union
+         from_local_packages
+         from_lock_dir
+         ~f:(fun duplicate_package_name _ _ ->
+           raise (Duplicate_package duplicate_package_name)))
+  with
+  | Duplicate_package duplicate_package_name ->
+    let local_package =
+      Package_name.Map.find_exn t.local_packages duplicate_package_name
+    in
+    Error
+      (User_message.make
+         ~hints:lockdir_regenerate_hints
+         ~loc:local_package.loc
+         [ Pp.textf
+             "A package named %S is defined locally but is also present in the lockdir"
+             (Package_name.to_string local_package.name)
+         ])
+;;
+
+let all_non_local_dependencies_of_local_packages t version_by_package_name =
+  let open Result.O in
+  let solver_env =
+    Solver_stats.Expanded_variable_bindings.to_solver_env
+      t.lock_dir.expanded_solver_variable_bindings
+  in
+  let+ all_dependencies_of_local_packages =
+    Package_name.Map.values t.local_packages
+    |> List.map ~f:(fun (local_package : Local_package.t) ->
+      Local_package.opam_filtered_dependency_formula local_package
+      |> Resolve_opam_formula.filtered_formula_to_package_names
+           ~stats_updater:None
+           ~with_test:true
+           solver_env
+           version_by_package_name
+      |> Result.map_error ~f:(function
+        | `Formula_could_not_be_satisfied unsatisfied_formula_hints ->
+        User_message.make
+          ~hints:lockdir_regenerate_hints
+          ~loc:local_package.loc
+          (Pp.textf
+             "The dependencies of local package %S could not be satisfied from the \
+              lockdir:"
+             (Package_name.to_string local_package.name)
+           :: List.map
+                unsatisfied_formula_hints
+                ~f:Resolve_opam_formula.Unsatisfied_formula_hint.pp))
+      |> Result.map ~f:Package_name.Set.of_list)
+    |> Result.List.all
+    |> Result.map ~f:Package_name.Set.union_all
+  in
+  Package_name.Set.diff
+    all_dependencies_of_local_packages
+    (Package_name.Set.of_keys t.local_packages)
+;;
+
+let check_for_unnecessary_packges_in_lock_dir
+  t
+  all_non_local_dependencies_of_local_packages
+  =
+  let locked_transitive_closure_of_local_package_dependencies =
+    match
+      Lock_dir.transitive_dependency_closure
+        t.lock_dir
+        all_non_local_dependencies_of_local_packages
+    with
+    | Ok x -> x
+    | Error (`Missing_packages missing_packages) ->
+      (* Resolving the dependency formulae would have failed if there were any missing packages in the lockdir. *)
+      Code_error.raise
+        "Missing packages from lockdir after confirming no missing packages in lockdir"
+        [ "missing package", Package_name.Set.to_dyn missing_packages ]
+  in
+  let all_locked_packages = Package_name.Set.of_keys t.lock_dir.packages in
+  let unneeded_packages_in_lock_dir =
+    Package_name.Set.diff
+      all_locked_packages
+      locked_transitive_closure_of_local_package_dependencies
+  in
+  if Package_name.Set.is_empty unneeded_packages_in_lock_dir
+  then Ok ()
+  else (
+    let packages =
+      Package_name.Set.to_list unneeded_packages_in_lock_dir
+      |> List.map ~f:(Package_name.Map.find_exn t.lock_dir.packages)
+    in
+    Error
+      (User_message.make
+         ~hints:lockdir_regenerate_hints
+         [ Pp.text
+             "The lockdir contains packages which are not among the transitive \
+              dependencies of any local package:"
+         ; Pp.enumerate packages ~f:(fun (package : Lock_dir.Pkg.t) ->
+             Pp.textf
+               "%s.%s"
+               (Package_name.to_string package.info.name)
+               (Package_version.to_string package.info.version))
+         ]))
+;;
+
+let validate t =
+  let open Result.O in
+  version_by_package_name t
+  >>= all_non_local_dependencies_of_local_packages t
+  >>= check_for_unnecessary_packges_in_lock_dir t
+;;
+
+let create local_packages lock_dir =
+  let open Result.O in
+  let t = { local_packages; lock_dir } in
+  let+ () = validate t in
+  t
+;;

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -1,0 +1,14 @@
+open! Import
+
+(** All of the packages in a dune project including local packages and packages
+    in a lockdir. The lockdir is guaranteed to contain a valid dependency
+    solution for the local packages. *)
+type t = private
+  { local_packages : Local_package.t Package_name.Map.t
+  ; lock_dir : Lock_dir.t
+  }
+
+val create
+  :  Local_package.t Package_name.Map.t
+  -> Lock_dir.t
+  -> (t, User_message.t) result

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -67,6 +67,10 @@ module Version_constraint = struct
   let to_dyn (op, package_version) =
     Dyn.Tuple [ Op.to_dyn op; Package_version.to_dyn package_version ]
   ;;
+
+  let to_string (op, package_version) =
+    sprintf "%s %s" (Op.to_string op) (Package_version.to_string package_version)
+  ;;
 end
 
 module Unsatisfied_formula_hint = struct
@@ -91,6 +95,19 @@ module Unsatisfied_formula_hint = struct
             ; "version_constraint", Version_constraint.to_dyn version_constraint
             ]
         ]
+  ;;
+
+  let pp = function
+    | Missing_package missing_package ->
+      Pp.textf "Package %S is missing" (Package_name.to_string missing_package)
+    | Unsatisfied_version_constraint { package_name; found_version; version_constraint }
+      ->
+      Pp.textf
+        "Found version %S of package %S which doesn't satisfy the required version \
+         constraint %S"
+        (Package_version.to_string found_version)
+        (Package_name.to_string package_name)
+        (Version_constraint.to_string version_constraint)
   ;;
 end
 

--- a/src/dune_pkg/resolve_opam_formula.mli
+++ b/src/dune_pkg/resolve_opam_formula.mli
@@ -29,6 +29,7 @@ module Unsatisfied_formula_hint : sig
         }
 
   val to_dyn : t -> Dyn.t
+  val pp : t -> 'a Pp.t
 end
 
 (** An unsatisfied formula is accompanied by a list of hints rather than a

--- a/src/dune_pkg/solver_stats.ml
+++ b/src/dune_pkg/solver_stats.ml
@@ -87,4 +87,20 @@ module Expanded_variable_bindings = struct
       ; "unset_variables", Dyn.list Solver_env.Variable.to_dyn unset_variables
       ]
   ;;
+
+  let to_solver_env { variable_values; unset_variables = _ } =
+    (* TODO currently this only supports system variables but this will be
+       generalized when the solver gains support for arbitrary variables *)
+    let sys =
+      List.fold_left
+        variable_values
+        ~init:Solver_env.Variable.Sys.Bindings.empty
+        ~f:(fun acc (variable, value) ->
+          match variable with
+          | Solver_env.Variable.Sys sys ->
+            Solver_env.Variable.Sys.Bindings.set acc sys value
+          | Const _ -> acc)
+    in
+    Solver_env.create ~sys
+  ;;
 end

--- a/src/dune_pkg/solver_stats.mli
+++ b/src/dune_pkg/solver_stats.mli
@@ -24,4 +24,5 @@ module Expanded_variable_bindings : sig
   val encode : t -> Dune_lang.t list
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
+  val to_solver_env : t -> Solver_env.t
 end

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -646,5 +646,9 @@ let missing_deps (t : t) ~effective_deps =
 ;;
 
 let to_local_package t =
-  { Dune_pkg.Local_package.name = name t; version = t.version; dependencies = t.depends }
+  { Dune_pkg.Local_package.name = name t
+  ; version = t.version
+  ; dependencies = t.depends
+  ; loc = t.loc
+  }
 ;;

--- a/test/blackbox-tests/test-cases/pkg/lock-dir-local-package-sync.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-dir-local-package-sync.t
@@ -1,0 +1,199 @@
+Tests that dune can detect when the lockdir no longer contains a valid solution
+to local packges
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ mkpkg a <<EOF
+  > depends: [ "c" "d" ]
+  > EOF
+  $ mkpkg b <<EOF
+  > EOF
+  $ mkpkg c <<EOF
+  > depends: [ "e" ]
+  > EOF
+  $ mkpkg d <<EOF
+  > EOF
+  $ mkpkg e <<EOF
+  > EOF
+  $ mkpkg f 0.0.1 <<EOF
+  > EOF
+  $ mkpkg f 0.0.2 <<EOF
+  > EOF
+
+Define some local packages.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name foo) (depends a b))
+  > (package (name bar) (depends foo c))
+  > EOF
+
+Without a lockdir this command prints a hint but exits successfully.
+  $ dune pkg validate-lockdir
+  No lockdirs to validate.
+
+Make the lockdir.
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+
+Initially the lockdir will be valid.
+  $ dune pkg validate-lockdir
+
+Add a file to the lockdir to cause the parser to fail.
+  $ echo foo > dune.lock/bar.pkg
+  $ dune pkg validate-lockdir
+  Failed to parse lockdir dune.lock:
+  File "dune.lock/bar.pkg", line 1, characters 0-3:
+  Error: S-expression of the form (<name> <values>...) expected
+  
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Remove the file but corrupt the lockdir metadata file.
+  $ rm dune.lock/bar.pkg
+  $ echo foo >> dune.lock/lock.dune
+  $ dune pkg validate-lockdir
+  Failed to parse lockdir dune.lock:
+  File "dune.lock/lock.dune", line 6, characters 0-3:
+  Error: S-expression of the form (<name> <values>...) expected
+  
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Regenerate the lockdir and validate the result.
+  $ rm -r dune.lock
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+  $ dune pkg validate-lockdir
+
+Add a dependency that's not present in the lockdir.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name foo) (depends a b))
+  > (package (name bar) (depends foo c f))
+  > EOF
+
+This results in an invalid lockdir due to the missing package.
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", line 3, characters 0-38:
+  The dependencies of local package "bar" could not be satisfied from the
+  lockdir:
+  Package "f" is missing
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Regenerate the lockdir and validate the result.
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+  - f.0.0.2
+  $ dune pkg validate-lockdir
+
+Change the version of a dependency to one which isn't in the lockdir.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name foo) (depends a b))
+  > (package (name bar) (depends foo c (f (< 0.0.2))))
+  > EOF
+
+Now the lockdir is invalid as it doesn't contain the right version of "f".
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", line 3, characters 0-50:
+  The dependencies of local package "bar" could not be satisfied from the
+  lockdir:
+  Found version "0.0.2" of package "f" which doesn't satisfy the required
+  version constraint "< 0.0.2"
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Regenerate the lockdir and validate the result.
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+  - f.0.0.1
+  $ dune pkg validate-lockdir
+
+Add a new local package with the same name as a locked package.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name foo) (depends a b))
+  > (package (name bar) (depends foo c (f (< 0.0.2))))
+  > (package (name b))
+  > EOF
+
+The lockdir is invalid as the package "b" is now defined both locally and in the lockdir.
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", line 4, characters 0-18:
+  A package named "b" is defined locally but is also present in the lockdir
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Regenerate the lockdir and validate the result.
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - a.0.0.1
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+  - f.0.0.1
+  $ dune pkg validate-lockdir
+
+Remove a dependency from a local package so that the lockdir contains an unneeded package.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > (package (name foo) (depends b))
+  > (package (name bar) (depends foo c (f (< 0.0.2))))
+  > (package (name b))
+  > EOF
+
+The lockdir is invalid as it contains unnecessary packages.
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  The lockdir contains packages which are not among the transitive dependencies
+  of any local package:
+  - a.0.0.1
+  - d.0.0.1
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]
+
+Regenerate the lockdir and validate the result.
+  $ dune pkg lock --dont-poll-system-solver-variables --opam-repository-path=mock-opam-repository
+  Solution for dune.lock:
+  - c.0.0.1
+  - e.0.0.1
+  - f.0.0.1
+  $ dune pkg validate-lockdir


### PR DESCRIPTION
This adds a type `Dune_pkg.Package_universe.t` made up of the set of local packages in a project and a lockdir whose constructor validates that the lockdir contains a valid solution for the dependencies of local packages. As we add more pkg operations we'll need a way of talking about the set of packages that makes up a project, both local and not.

Also this adds a command `dune pkg validate-lockdir` which validates lockdirs against local packages in order to test this feature.