### PR TITLE
test(pkg): reproduce #9145

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
@@ -1,0 +1,21 @@
+Test the %{pkg:intsalled}% form inside file substitution:
+
+  $ . ./helpers.sh
+
+  $ make_lockdir
+  $ mkdir source
+  $ cat >source/foo.in <<EOF
+  > foo: %{somepkg:installed}%
+  > EOF
+  $ cat >dune.lock/test.pkg <<EOF
+  > (source (copy $PWD/source))
+  > (build
+  >  (progn
+  >   (system "echo somepkg installation %{pkg:somepkg:installed}")
+  >   (substitute foo.in foo)
+  >   (system "cat foo")))
+  > EOF
+
+  $ build_pkg test
+  somepkg installation false
+  foo: 


### PR DESCRIPTION
%{pkg:foo:installed} isn't interpreted correctly inside substitutions

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3c51b354-f97c-40aa-8574-a95bace10be1 -->