### PR TITLE
fix(pkg): Avoid IO when determining the default branch

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -150,23 +150,7 @@ let of_git_repo ~repo_id ~source =
       at_rev, Some repo_id
     | None ->
       let+ at_rev =
-        let* name =
-          Rev_store.Remote.default_branch remote
-          >>| function
-          | Some name -> name
-          | None ->
-            User_error.raise
-              ~hints:
-                [ Pp.text
-                    "Specify a different repository with a default branch or an exiting \
-                     revision"
-                ]
-              [ Pp.textf
-                  "No revision given and default branch could not be determined in \
-                   repository %s"
-                  source
-              ]
-        in
+        let name = Rev_store.Remote.default_branch remote in
         Rev_store.Remote.rev_of_name remote ~name
       in
       let repo_id = Option.map at_rev ~f:Rev_store.At_rev.repository_id in

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -25,7 +25,7 @@ module Remote : sig
 
   val equal : t -> t -> bool
   val update : t -> unit Fiber.t
-  val default_branch : t -> string option Fiber.t
+  val default_branch : t -> string
   val rev_of_name : t -> name:string -> At_rev.t option Fiber.t
   val rev_of_repository_id : t -> Repository_id.t -> At_rev.t option Fiber.t
 end


### PR DESCRIPTION
This moves the default branch determination to when the remote is first added, it determines the HEAD branch and uses this sole branch as a tracking branch.

When loading a repo, it determines the default branch from the list of tracking branches (of which there is now only one, thus it must be the default).

This approach that we came up with @Alizter makes it possible to avoid network I/O when loading remotes so if we make the `update` optional (future PR) we can lock without any network IO, only using the cached git revisions.