### PR TITLE
test: formatting settings from context

### DIFF
--- a/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
+++ b/test/blackbox-tests/test-cases/formatting/disable-dune-file.t
@@ -25,3 +25,17 @@ dune file.
   File "dune", line 1, characters 0-0:
   Error: Files _build/default/dune and _build/default/.formatted/dune differ.
   [1]
+
+Disable foramtting in the root directory using context settings
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (env
+  >  (_
+  >   (formatting disabled)))
+  > EOF
+
+  $ dune build @fmt
+  File "dune", line 1, characters 0-0:
+  Error: Files _build/default/dune and _build/default/.formatted/dune differ.
+  [1]


### PR DESCRIPTION
@emillon is this behavior intentional? It seems like `env` settings for formatting in the workspace file are always ignored.