### PR TITLE
refactor: [Super_contex.resolve_program] should return Action_builder.t

### DIFF
--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -136,7 +136,7 @@ let term =
         let args = Dune_rules.Command.expand ~dir (S args) in
         Action_builder.run args.build Eager
       in
-      let* prog = Super_context.resolve_program sctx ~dir ~loc:None coqtop in
+      let* prog = Super_context.resolve_program_memo sctx ~dir ~loc:None coqtop in
       let prog = Action.Prog.ok_exn prog in
       let+ () = Build_system.build_file prog in
       Path.to_string prog, args

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -202,7 +202,7 @@ let get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog =
   let open Memo.O in
   match Filename.analyze_program_name prog with
   | In_path ->
-    Super_context.resolve_program sctx ~dir ~loc:None prog
+    Super_context.resolve_program_memo sctx ~dir ~loc:None prog
     >>= (function
      | Error (_ : Action.Prog.Not_found.t) -> not_found ~dir ~prog
      | Ok p -> build_prog ~no_rebuild ~prog p)

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -122,7 +122,6 @@ let gen_rules sctx t ~dir ~scope =
            ~loc:(Some loc)
            name
            ~hint:"opam install cinaps"
-         |> Action_builder.of_memo
        in
        Command.run_dyn_prog
          ~dir:(Path.build dir)

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -92,7 +92,12 @@ end = struct
 end
 
 let coqc ~loc ~dir ~sctx =
-  Super_context.resolve_program sctx "coqc" ~dir ~loc:(Some loc) ~hint:"opam install coq"
+  Super_context.resolve_program_memo
+    sctx
+    "coqc"
+    ~dir
+    ~loc:(Some loc)
+    ~hint:"opam install coq"
 ;;
 
 let select_native_mode ~sctx ~dir (buildable : Coq_stanza.Buildable.t) =
@@ -404,7 +409,7 @@ let setup_coqdep_for_theory_rule
   in
   let stdout_to = dep_theory_file ~dir ~wrapper_name in
   let* coqdep =
-    Super_context.resolve_program
+    Super_context.resolve_program_memo
       sctx
       "coqdep"
       ~dir
@@ -659,7 +664,7 @@ let setup_coqdoc_rules ~sctx ~dir ~theories_deps (s : Coq_stanza.Theory.t) coq_m
     fun mode ->
       let* () =
         let* coqdoc =
-          Super_context.resolve_program
+          Super_context.resolve_program_memo
             sctx
             "coqdoc"
             ~dir
@@ -988,7 +993,7 @@ let install_rules ~sctx ~dir s =
 
 let setup_coqpp_rules ~sctx ~dir ({ loc; modules } : Coq_stanza.Coqpp.t) =
   let* coqpp =
-    Super_context.resolve_program
+    Super_context.resolve_program_memo
       sctx
       "coqpp"
       ~dir

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -179,13 +179,12 @@ let build_c_program
   ~deps
   =
   let ctx = Super_context.context sctx in
-  let open Memo.O in
   let ocaml = Context.ocaml ctx in
   let exe =
-    (let* ocaml = ocaml in
-     Ocaml_config.c_compiler ocaml.ocaml_config
-     |> Super_context.resolve_program ~loc:None ~dir sctx)
-    |> Action_builder.of_memo
+    let open Action_builder.O in
+    let* ocaml = Action_builder.of_memo ocaml in
+    Ocaml_config.c_compiler ocaml.ocaml_config
+    |> Super_context.resolve_program ~loc:None ~dir sctx
   in
   let project = Scope.project scope in
   let with_user_and_std_flags =

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -45,7 +45,6 @@ let rules ~sctx ~dir =
       let open Action_builder.O in
       let* ocfg = ocfg in
       Super_context.resolve_program sctx ~dir ~loc:None (Ocaml_config.c_compiler ocfg)
-      |> Action_builder.of_memo
     in
     let open Action_builder.With_targets.O in
     let+ run_preprocessor =

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -38,7 +38,6 @@ let ocamlfdo_binary sctx dir =
     ~loc:None
     "ocamlfdo"
     ~hint:"opam install ocamlfdo"
-  |> Action_builder.of_memo
 ;;
 
 (* FDO flags are context dependent. *)

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -236,7 +236,6 @@ let build_c
          ~dir
          sctx
          (Ocaml_config.c_compiler ocaml.ocaml_config)
-       |> Action_builder.of_memo
      in
      Command.run_dyn_prog
        ~dir:(Path.build dir)

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -263,9 +263,7 @@ include Sub_system.Register_end_point (struct
             let+ flags = flags in
             Action.run (Ok exe) flags
           | Some runner ->
-            let* prog =
-              Action_builder.of_memo
-                (Super_context.resolve_program ~dir sctx ~loc:(Some loc) runner)
+            let* prog = Super_context.resolve_program ~dir sctx ~loc:(Some loc) runner
             and* flags = flags in
             let action =
               Action.run prog (Path.reach exe ~from:(Path.build dir) :: flags)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -160,7 +160,6 @@ let in_obj_dir' ~obj_dir ~config args =
 
 let jsoo ~dir sctx =
   Super_context.resolve_program sctx ~dir ~loc:None ~hint:install_jsoo_hint "js_of_ocaml"
-  |> Action_builder.of_memo
 ;;
 
 type sub_command =

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -506,7 +506,6 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
         ~loc:(Some t.loc)
         ~hint:"opam install mdx"
         "ocaml-mdx"
-      |> Action_builder.of_memo
     in
     let* mdx_prog_gen =
       if Dune_lang.Syntax.Version.Infix.(t.version >= (0, 2))

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -1,7 +1,7 @@
 open Import
 
 let melc sctx ~loc ~dir =
-  Super_context.resolve_program sctx ~loc ~dir ~hint:"opam install melange" "melc"
+  Super_context.resolve_program_memo sctx ~loc ~dir ~hint:"opam install melange" "melc"
 ;;
 
 let where =

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -98,7 +98,6 @@ module Run (P : PARAMS) = struct
 
   let menhir_binary =
     Super_context.resolve_program sctx ~dir "menhir" ~loc:None ~hint:"opam install menhir"
-    |> Action_builder.of_memo
   ;;
 
   (* Reminder (from command.mli):

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -230,7 +230,6 @@ let odoc_base_flags sctx quiet build_dir =
 
 let odoc_program sctx dir =
   Super_context.resolve_program sctx ~dir "odoc" ~loc:None ~hint:"opam install odoc"
-  |> Action_builder.of_memo
 ;;
 
 let run_odoc sctx ~dir command ~quiet ~flags_for args =

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -44,10 +44,9 @@ module Query = struct
   let read t sctx ~dir =
     let open Action_builder.O in
     let* bin =
-      Action_builder.of_memo
-        (let open Memo.O in
-         let* pkg_config = pkg_config_binary sctx ~dir in
-         Super_context.resolve_program sctx ~loc:None ~dir pkg_config)
+      let open Action_builder.O in
+      let* pkg_config = Action_builder.of_memo @@ pkg_config_binary sctx ~dir in
+      Super_context.resolve_program sctx ~loc:None ~dir pkg_config
     in
     match bin with
     | Error _ -> Action_builder.return (default t)
@@ -63,7 +62,7 @@ let gen_rule sctx ~loc ~dir query =
   let* bin =
     let open Memo.O in
     let* pkg_config = pkg_config_binary sctx ~dir in
-    Super_context.resolve_program sctx ~loc:(Some loc) ~dir pkg_config
+    Super_context.resolve_program_memo sctx ~loc:(Some loc) ~dir pkg_config
   in
   match bin with
   | Error _ -> Memo.return @@ Error `Not_found

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -278,9 +278,13 @@ let local_binaries t ~dir = Env_tree.get_node t ~dir >>= Env_node.local_binaries
 let env_node = Env_tree.get_node
 let bin_annot t ~dir = Env_tree.get_node t ~dir >>= Env_node.bin_annot
 
-let resolve_program t ~dir ?hint ~loc bin =
+let resolve_program_memo t ~dir ?hint ~loc bin =
   let* artifacts = Env_tree.artifacts_host t ~dir in
   Artifacts.binary ?hint ~loc artifacts bin
+;;
+
+let resolve_program t ~dir ?hint ~loc bin =
+  Action_builder.of_memo @@ resolve_program_memo t ~dir ?hint ~loc bin
 ;;
 
 let add_packages_env context ~base stanzas packages =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -77,6 +77,15 @@ val resolve_program
   -> ?hint:string
   -> loc:Loc.t option
   -> string
+  -> Action.Prog.t Action_builder.t
+
+(** try not to use this as it breaks rule loading laziness *)
+val resolve_program_memo
+  :  t
+  -> dir:Path.Build.t
+  -> ?hint:string
+  -> loc:Loc.t option
+  -> string
   -> Action.Prog.t Memo.t
 
 val expander : t -> dir:Path.Build.t -> Expander.t Memo.t


### PR DESCRIPTION
It's the better default as it's lazier

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8c2f8c5d-257c-4a6f-8225-166f151b8ae6 -->