### PR TITLE
feature(pkg): Implement offline mode for Rev Store

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -37,6 +37,7 @@ let solve
   per_context
   ~opam_repository_path
   ~opam_repository_url
+  ~update_opam_repositories
   ~sys_bindings_from_current_system
   ~experimental_translate_opam_filters
   =
@@ -67,7 +68,12 @@ let solve
                   ~sys_bindings_from_current_system)
          in
          let* repos =
-           get_repos repos ~opam_repository_path ~opam_repository_url ~repositories
+           get_repos
+             repos
+             ~opam_repository_path
+             ~opam_repository_url
+             ~repositories
+             ~update_opam_repositories
          in
          let overlay =
            Console.Status_line.add_overlay (Constant (Pp.text "Solving for Build Plan"))
@@ -128,6 +134,7 @@ let lock
   ~version_preference
   ~opam_repository_path
   ~opam_repository_url
+  ~update_opam_repositories
   ~experimental_translate_opam_filters
   =
   let open Fiber.O in
@@ -145,6 +152,7 @@ let lock
     per_context
     ~opam_repository_path
     ~opam_repository_url
+    ~update_opam_repositories
     ~sys_bindings_from_current_system
     ~experimental_translate_opam_filters
 ;;
@@ -186,6 +194,15 @@ let term =
              enabled by default but is currently opt-in as we expect to make major \
              changes to it in the future. Without this flag all conditional commands and \
              terms in Opam files are included unconditionally.")
+  and+ skip_update =
+    Arg.(
+      value
+      & flag
+      & info
+          [ "skip-update" ]
+          ~doc:
+            "Do not fetch updates of opam repositories, will use the cached opam \
+             metadata. This allows offline use if the repositories are cached locally.")
   in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
@@ -197,6 +214,7 @@ let term =
       ~version_preference
       ~opam_repository_path
       ~opam_repository_url
+      ~update_opam_repositories:(not skip_update)
       ~experimental_translate_opam_filters)
 ;;
 

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -25,8 +25,14 @@ let find_outdated_packages
               ; repositories
               }
             ->
+            (* updating makes sense when checking for outdated packages *)
             let* repos =
-              get_repos repos ~opam_repository_path ~opam_repository_url ~repositories
+              get_repos
+                repos
+                ~opam_repository_path
+                ~opam_repository_url
+                ~repositories
+                ~update_opam_repositories:true
             and+ local_packages = find_local_packages in
             let lock_dir = Lock_dir.read_disk lock_dir_path in
             let+ results =

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -34,6 +34,7 @@ val get_repos
   -> opam_repository_path:Path.t option
   -> opam_repository_url:OpamUrl.t option
   -> repositories:Dune_pkg.Pkg_workspace.Repository.Name.t list
+  -> update_opam_repositories:bool
   -> Dune_pkg.Opam_repo.t list Fiber.t
 
 val find_local_packages : Dune_pkg.Local_package.t Package_name.Map.t Fiber.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -138,11 +138,14 @@ let of_opam_repo_dir_path ~source ~repo_id opam_repo_dir_path =
   { source = Directory opam_repo_dir_path; serializable }
 ;;
 
-let of_git_repo ~repo_id ~source =
+let of_git_repo ~repo_id ~update ~source =
   let+ at_rev, computed_repo_id =
     let* remote =
       let* repo = rev_store in
-      Rev_store.add_repo repo ~source
+      let* remote = Rev_store.add_repo repo ~source in
+      match update with
+      | true -> Rev_store.Remote.update remote
+      | false -> Fiber.return @@ Rev_store.Remote.don't_update remote
     in
     match repo_id with
     | Some repo_id ->

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -21,8 +21,16 @@ val of_opam_repo_dir_path
   -> Path.t
   -> t
 
-(** [of_git_repo git source] loads the data through git *)
-val of_git_repo : repo_id:Repository_id.t option -> source:string -> t Fiber.t
+(** [of_git_repo git ~repo_id ~update ~source] loads the opam repository located at [source] from git.
+    [source] can be any URL that [git remote add] supports.
+
+    Set [update] to true to update the source to the newest revision, otherwise it will use the latest
+    data available in the cache (if any). *)
+val of_git_repo
+  :  repo_id:Repository_id.t option
+  -> update:bool
+  -> source:string
+  -> t Fiber.t
 
 val repo_id : t -> Repository_id.t option
 val source : t -> string option

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -21,10 +21,21 @@ module At_rev : sig
 end
 
 module Remote : sig
+  (** [uninit] represents an uninitialized remote. Use [update] or
+      [don't_update] to get a remote [t] *)
+  type uninit
+
+  (** handle representing a particular git repository *)
   type t
 
   val equal : t -> t -> bool
-  val update : t -> unit Fiber.t
+
+  (** [update remote] will fetch the most current revisions from the remote *)
+  val update : uninit -> t Fiber.t
+
+  (** [don't_update] signals that the remote should not be updated *)
+  val don't_update : uninit -> t
+
   val default_branch : t -> string
   val rev_of_name : t -> name:string -> At_rev.t option Fiber.t
   val rev_of_repository_id : t -> Repository_id.t -> At_rev.t option Fiber.t
@@ -32,4 +43,12 @@ end
 
 val content_of_files : t -> File.t list -> string list Fiber.t
 val load_or_create : dir:Path.t -> t Fiber.t
-val add_repo : t -> source:string -> Remote.t Fiber.t
+
+(** [add_repo t ~source] idempotently registers a git repo to the rev store.
+    [source] is any URL that is supported by [git remote add].
+
+    This only adds the remote metadata, to get a remote you need to either
+    use [Remote.update] if you want to fetch from the remote (thus potentially
+    triggering network IO) or if you are sure the [t] already contains all
+    required revisions (e.g. from a previous run) then use [don't_update]. *)
+val add_repo : t -> source:string -> Remote.uninit Fiber.t

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -50,13 +50,22 @@ let%expect_test "adding remotes" =
     let remote_path = Path.relative cwd "git-remote" in
     let* () = create_repo_at remote_path in
     let source = Path.to_string remote_path in
-    let* _remote = Rev_store.add_repo rev_store ~source in
+    let* remote = Rev_store.add_repo rev_store ~source in
+    let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote in
     print_endline "Creating first remote succeeded";
-    let* _remote' = Rev_store.add_repo rev_store ~source in
-    print_endline "Adding same remote succeeded";
-    Fiber.return ());
-  [%expect {|
+    [%expect {|
     Creating first remote succeeded
-    Adding same remote succeeded
-    |}]
+    |}];
+    let* (_remote' : Rev_store.Remote.uninit) = Rev_store.add_repo rev_store ~source in
+    print_endline "Adding same remote without update succeeded";
+    [%expect {|
+    Adding same remote without update succeeded
+    |}];
+    let* remote'' = Rev_store.add_repo rev_store ~source in
+    let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote'' in
+    print_endline "Adding same remote with update succeeded";
+    [%expect {|
+    Adding same remote with update succeeded
+    |}];
+    Fiber.return ())
 ;;


### PR DESCRIPTION
This allows the rev store to be loaded without doing a `git fetch` thus allowing offline functionality as long as the cache is populated.

The behavior is opt-in to not lead to people accidentally locking old versions.