### PR TITLE
fix(nix): fix melange build and update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,46 +1,15 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -60,33 +29,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1685563568,
-        "narHash": "sha256-nbdH3TKhgCfofhRxOyl5pv4nz9EiuOqZM4ExFkwTgAw=",
-        "owner": "melange-re",
+        "lastModified": 1700157818,
+        "narHash": "sha256-BAT0/885I7dRrGtpxp2WMB3rubkC06CGx/tj73A2J08=",
+        "owner": "alizter",
         "repo": "melange",
-        "rev": "c989a91761a9b1bcc8af80fb9653eab897360325",
+        "rev": "15ea670d97ec5a235e84a0a3832761d987990c23",
         "type": "github"
       },
       "original": {
-        "owner": "melange-re",
-        "ref": "1.0.0",
+        "owner": "alizter",
+        "ref": "melange-1.0-without-failing-test",
         "repo": "melange",
-        "type": "github"
-      }
-    },
-    "mirage-opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661959605,
-        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
-        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
         "type": "github"
       }
     },
@@ -107,32 +60,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699343069,
-        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "lastModified": 1700108881,
+        "narHash": "sha256-+Lqybl8kj0+nD/IlAWPPG/RDTa47gff9nbei0u7BntE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "rev": "7414e9ee0b3e9903c24d3379f577a417f0aae5f1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1682362401,
-        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -144,105 +81,22 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "opam-nix": "opam-nix",
-        "opam-repository": "opam-repository"
-      },
-      "locked": {
-        "lastModified": 1692785055,
-        "narHash": "sha256-Bilj0xK7BYPvE+e/wq3QEUjjAvxYtDxOvBh1ycSsXhg=",
-        "ref": "refs/heads/master",
-        "rev": "2fc7f0a0d165519ef6e5b1b2d4b89c408818e08d",
-        "revCount": 2037,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/ocaml/ocaml-lsp"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/ocaml/ocaml-lsp"
-      }
-    },
-    "opam-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
-        "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs_2",
-        "opam-overlays": "opam-overlays",
-        "opam-repository": [
-          "ocamllsp",
-          "opam-repository"
-        ],
-        "opam2json": "opam2json"
-      },
-      "locked": {
-        "lastModified": 1686742877,
-        "narHash": "sha256-HOWgC19NkL4+7DCbXgocRE9MZUxT5lhBWv3YF5z7LL8=",
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "rev": "06bd670789748155195083ddabd8a383bac4cc5c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "type": "github"
-      }
-    },
-    "opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "type": "github"
-      }
-    },
-    "opam-repository": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1686747547,
-        "narHash": "sha256-cQtSgqdoc3zfdmLdv5hcoGSUpw44js6zWavKmYCPKGU=",
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "rev": "6ed4e23f2cefb96b2e2fce1c99e5cd85d7c4ee04",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "type": "github"
-      }
-    },
-    "opam2json": {
-      "inputs": {
-        "nixpkgs": [
-          "ocamllsp",
-          "opam-nix",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
-        "owner": "tweag",
-        "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
-        "type": "github"
+        "lastModified": 1697959944,
+        "narHash": "sha256-i77VXRk3w9X4dPG/U+vqMo9rQNFqr8XKtHB8P25YpE0=",
+        "ref": "refs/heads/master",
+        "rev": "c6eafd83d40c89f0832503c9509b1bcc01acc54d",
+        "revCount": 2052,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/ocaml/ocaml-lsp"
       },
       "original": {
-        "owner": "tweag",
-        "repo": "opam2json",
-        "type": "github"
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/ocaml/ocaml-lsp"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,9 @@
       inputs.flake-utils.follows = "flake-utils";
     };
     melange = {
-      url = "github:melange-re/melange/1.0.0";
+      # We use melange 1.0 because later versions do not work on OCaml < 5.0.
+      # melange 1.0 has a non-reproducible test causing issues. This branch removes that test.
+      url = "github:alizter/melange/melange-1.0-without-failing-test";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
@@ -19,7 +21,7 @@
     , nixpkgs
     , ocamllsp
     , melange
-    }@inputs:
+    }:
     let package = "dune";
     in flake-utils.lib.eachDefaultSystem (system:
     let


### PR DESCRIPTION
We need to use melange 1.0 because later versions don't work with OCaml 4.14. Annoyingly, this version of melange has a test that is run by the flake which is non reproducible between differing versions of Dune due to the order of execution. This leads to the failure observed in https://github.com/ocaml/dune/issues/9154.

Updating melange is not an option, so I've gone ahead and forked melange 1.0 and manually removed the offending test. This lets `nix develop` work again which was broken for a while. 