### PR TITLE
test: duplicate rules being loaded on rebuild

### DIFF
--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -398,6 +398,7 @@ let gen_project_rules =
     ()
   in
   fun sctx source_dir ->
+    let* () = Memo.return () in
     let project = Source_tree.Dir.project source_dir in
     match
       Path.Source.equal (Source_tree.Dir.path source_dir) (Dune_project.root project)

--- a/test/blackbox-tests/test-cases/watching/github9213.t
+++ b/test/blackbox-tests/test-cases/watching/github9213.t
@@ -1,0 +1,28 @@
+  $ . ./helpers.sh
+
+This test demonstrates a bug where rules are being duplicated between rebuilds.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (allow_empty)
+  >  (name test))
+  > EOF
+
+  $ mkdir src
+
+  $ start_dune
+  $ build .
+  Success
+
+  $ cat > src/a
+
+  $ build .
+  Failure
+
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Error: Multiple rules generated for _build/default/test.install:
+  - <internal location>
+  - <internal location>
+  Had 1 error, waiting for filesystem changes...

--- a/test/blackbox-tests/test-cases/watching/github9213.t
+++ b/test/blackbox-tests/test-cases/watching/github9213.t
@@ -18,11 +18,8 @@ This test demonstrates a bug where rules are being duplicated between rebuilds.
   $ cat > src/a
 
   $ build .
-  Failure
+  Success
 
   $ stop_dune
   Success, waiting for filesystem changes...
-  Error: Multiple rules generated for _build/default/test.install:
-  - <internal location>
-  - <internal location>
-  Had 1 error, waiting for filesystem changes...
+  Success, waiting for filesystem changes...


### PR DESCRIPTION
Here is a minimal test case for a bug that occurs when using watch mode.

@emillon I would suggest that this is blocking for 3.12 as it renders watch mode unusable.