### PR TITLE
fix(memo): delay implicit output collector

### DIFF
--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -104,21 +104,22 @@ let produce_opt t v =
 ;;
 
 let collect (type o) (type_ : o t) f =
-  (* If we don't delay the computation here, [output] becomes shared between future runs
-     of the resulting fiber, causing the collected output to be duplicated. *)
-  let* () = Fiber.return () in
-  let output = ref None in
-  Fiber.map
-    (Fiber.Var.set
-       current_handler
-       (module struct
-         type nonrec o = o
+  (* If we don't delay the computation here, [output] becomes shared between
+     future runs of the resulting fiber, causing the collected output to be
+     duplicated. *)
+  Fiber.of_thunk (fun () ->
+    let output = ref None in
+    Fiber.map
+      (Fiber.Var.set
+         current_handler
+         (module struct
+           type nonrec o = o
 
-         let type_ = type_
-         let so_far = output
-       end)
-       f)
-    ~f:(fun res -> res, !output)
+           let type_ = type_
+           let so_far = output
+         end)
+         f)
+      ~f:(fun res -> res, !output))
 ;;
 
 let forbid f = Fiber.Var.unset current_handler f

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -104,6 +104,8 @@ let produce_opt t v =
 ;;
 
 let collect (type o) (type_ : o t) f =
+  (* If we don't delay the computation here, [output] becomes shared between future runs
+     of the resulting fiber, causing the collected output to be duplicated. *)
   let* () = Fiber.return () in
   let output = ref None in
   Fiber.map

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -104,6 +104,7 @@ let produce_opt t v =
 ;;
 
 let collect (type o) (type_ : o t) f =
+  let* () = Fiber.return () in
   let output = ref None in
   Fiber.map
     (Fiber.Var.set

--- a/test/blackbox-tests/test-cases/watching/github9225.t
+++ b/test/blackbox-tests/test-cases/watching/github9225.t
@@ -30,18 +30,8 @@ rebuilds.
   $ cat > src/a
 
   $ build .
-  Failure
+  Success
 
   $ stop_dune
   Success, waiting for filesystem changes...
-  Error: Multiple rules generated for _build/default/.dune/ccomp/ccomp:
-  - <internal location>
-  - <internal location>
-  -> required by _build/default/src/stub.o
-  -> required by _build/default/src/dlldune_rpc_lwt_tests_stubs.so
-  -> required by alias src/all
-  -> required by alias src/default
-  Error: Multiple rules generated for _build/default/test.opam:
-  - <internal location>
-  - <internal location>
-  Had 2 errors, waiting for filesystem changes...
+  Success, waiting for filesystem changes...

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2138,7 +2138,7 @@ let%expect_test "variables - cutoff" =
   [%expect {| var: 202 |}]
 ;;
 
-let%expect_test "implicit output bug. storage cell is reused between runs" =
+let%expect_test "Ensure that implicit output storage cell is not reused between runs" =
   let var = Memo.Var.create ~name:"var" () in
   let output =
     Memo.Implicit_output.add

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -2164,5 +2164,5 @@ let%expect_test "implicit output bug. storage cell is reused between runs" =
   set_invalidate_print_run ();
   [%expect {| Some [ "x" ] |}];
   set_invalidate_print_run ();
-  [%expect {| Some [ "x"; "x" ] |}]
+  [%expect {| Some [ "x" ] |}]
 ;;


### PR DESCRIPTION
When doing:

```
let x = Memo.Implicit_output.collect (fun () -> ..) in
let* _ = x in
let* _ = x in
```

Would share the collecting cell between the binds. That's inconsistent
with delaying the side effects until binds.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7829e529-690d-4f62-b046-849783409ee8 -->