### PR TITLE
`dune cache trim`: also print number of files removed

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -58,9 +58,14 @@ let trim =
        Dune_cache.Trimmer.trim ~goal
      with
      | Error s -> User_error.raise [ Pp.text s ]
-     | Ok { trimmed_bytes } ->
+     | Ok { trimmed_bytes; number_of_files_removed } ->
        User_message.print
-         (User_message.make [ Pp.textf "Freed %s" (Bytes_unit.pp trimmed_bytes) ])
+         (User_message.make
+            [ Pp.textf
+                "Freed %s (%d files removed)"
+                (Bytes_unit.pp trimmed_bytes)
+                number_of_files_removed
+            ])
 ;;
 
 let size =

--- a/src/dune_cache/trimmer.ml
+++ b/src/dune_cache/trimmer.ml
@@ -2,16 +2,21 @@ open Stdune
 open Dune_cache_storage
 
 module Trimming_result = struct
-  type t = { trimmed_bytes : int64 }
+  type t =
+    { trimmed_bytes : int64
+    ; number_of_files_removed : int
+    }
 
-  let empty = { trimmed_bytes = 0L }
+  let empty = { trimmed_bytes = 0L; number_of_files_removed = 0 }
 
   (* CR-someday amokhov: Right now Dune doesn't support large (>1Gb) files on
      32-bit platforms due to the pervasive use of [int] for representing
      individual file sizes. It's not fundamentally difficult to switch to
      [int64], so we should do it if it becomes a real issue. *)
   let add t ~(bytes : int) =
-    { trimmed_bytes = Int64.add t.trimmed_bytes (Int64.of_int bytes) }
+    { trimmed_bytes = Int64.add t.trimmed_bytes (Int64.of_int bytes)
+    ; number_of_files_removed = t.number_of_files_removed + 1
+    }
   ;;
 end
 

--- a/src/dune_cache/trimmer.mli
+++ b/src/dune_cache/trimmer.mli
@@ -4,7 +4,10 @@
    from Jenga's trimmer. *)
 
 module Trimming_result : sig
-  type t = { trimmed_bytes : int64 }
+  type t =
+    { trimmed_bytes : int64
+    ; number_of_files_removed : int
+    }
 end
 
 (** Trim the cache by removing a set of unused files so that the total freed

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -34,7 +34,7 @@ Function to reset build tree and cache.
 Check that trimming does not crash when the cache directory does not exist.
 
   $ dune cache trim --size 0B
-  Freed 0B
+  Freed 0B (0 files removed)
 
 Check that the digest scheme for executable and non-executable digests hasn't
 changed. If it has, make sure to increment the version of the cache. Note that
@@ -94,7 +94,7 @@ all metadata entries in [meta/v4] since they are broken: remember, we moved all
   $ find "$PWD/.xdg-cache/dune/db/meta/v4" -mindepth 2 -maxdepth 2 -type f | dune_cmd count-lines
   4
   $ dune cache trim --trimmed-size 1B
-  Freed 287B
+  Freed 287B (4 files removed)
   $ dune_cmd stat hardlinks _build/default/target_a
   2
   $ dune_cmd stat hardlinks _build/default/target_b
@@ -107,7 +107,7 @@ trimmed.
 
   $ rm -f _build/default/target_a _build/default/beacon_a _build/default/beacon_b
   $ dune cache trim --trimmed-size 1B
-  Freed 79B
+  Freed 79B (2 files removed)
   $ dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -153,7 +153,7 @@ by the existence of [beacon_b].
   $ dune_cmd wait-for-fs-clock-to-advance
   $ rm -f _build/default/beacon_a _build/default/target_a
   $ dune cache trim --trimmed-size 1B
-  Freed 79B
+  Freed 79B (2 files removed)
   $ dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -173,7 +173,7 @@ thus making the trimmer delete [target_a] instead of [target_b] as above.
   $ dune_cmd wait-for-fs-clock-to-advance
   $ rm -f _build/default/beacon_b _build/default/target_b
   $ dune cache trim --trimmed-size 1B
-  Freed 79B
+  Freed 79B (2 files removed)
   $ dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -191,7 +191,7 @@ are part of the same rule.
   $ dune build multi_a multi_b
   $ rm -f _build/default/multi_a _build/default/multi_b
   $ dune cache trim --trimmed-size 1B
-  Freed 123B
+  Freed 123B (2 files removed)
 
 TODO: Test trimming priority in the [copy] mode. In PR #4497 we added a test but
 it turned out to be flaky so we subsequently deleted it in #4511.


### PR DESCRIPTION
What it says on the tin. May be useful to get some more insight when `dune cache trim` takes a long time. cc @snowleopard