### PR TITLE
chore: update vendored opam

### DIFF
--- a/vendor/update-opam.sh
+++ b/vendor/update-opam.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=dcb5165badc5fe87f7f34518c13b7d8e69a79f6f
+version=0984de6a2def6ddf2b3beab7857c062db7e0319d
 
 set -e -o pipefail
 


### PR DESCRIPTION
I've also modified the vendor script slightly so that we do a more efficient "git clone" by simply `fetch`ing the commit we want straight from the remote and checking it out locally. Downloading opam takes a long time, so I think this is a good idea.

We can eventually consolidate a lot of the common functions in the vendor update scripts and do the same everywhere.