### PR TITLE
fix(coq): unescape \: to :

### DIFF
--- a/doc/changes/9231_coq.md
+++ b/doc/changes/9231_coq.md
@@ -1,0 +1,2 @@
+- Fixed a bug where Dune was incorrectly parsing the output of coqdep when it was escaped,
+  as is the case on Windows. (#9231, fixes #9218, @Alizter)


### PR DESCRIPTION
coqdep outputs escaped paths for makefile which means on Windows that `C:\foo\bar` gets escaped to `C\:\\foo\\bar` causing Dune to interpret escaped absolute Windows directories as relative ones.

This patch searches for `\:` in the deps output of coqdep and replaces it with `:` allowing the paths to be interpreted correctly.

I couldn't write any tests for this since we don't run Coq tests on Windows and I don't plan to.

fix #9218 