### PR TITLE
feature(pkg): Support for specifying particular branches/commits for repos

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -876,3 +876,20 @@ let compute_missing_checksums t =
   in
   { t with packages }
 ;;
+
+module Private = struct
+  let used_with_commit ~commit xs =
+    List.map xs ~f:(fun serializable ->
+      Opam_repo.Serializable.Private.with_commit ~commit serializable)
+  ;;
+
+  let repos_with_commit ~commit ({ Repositories.used; _ } as repos) =
+    let used = Option.map used ~f:(used_with_commit ~commit) in
+    { repos with used }
+  ;;
+
+  let with_commit ~commit ({ repos; _ } as lock_dir) =
+    let repos = repos_with_commit ~commit repos in
+    { lock_dir with repos }
+  ;;
+end

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -95,6 +95,10 @@ end
 
 val read_disk : Path.Source.t -> t
 
+module Private : sig
+  val with_commit : commit:string -> t -> t
+end
+
 module Make_load (Io : sig
     include Monad.S
 

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -9,11 +9,36 @@ module Serializable : sig
   val decode : t Decoder.t
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
+
+  module Private : sig
+    val with_commit : commit:string -> t -> t
+  end
 end
 
 val equal : t -> t -> bool
 
-(** [of_opam_repo_dir_path opam_repo_dir] creates a repo representedy by a local
+module Source : sig
+  type commitish =
+    | Commit of string
+    | Branch of string
+    | Tag of string
+
+  type t =
+    { url : string
+    ; commit : commitish option
+    }
+
+  val of_opam_url : OpamUrl.t -> t Fiber.t
+  val to_string : t -> string
+  val to_dyn : t -> Dyn.t
+  val equal : t -> t -> bool
+
+  module Private : sig
+    val of_opam_url : Rev_store.t -> OpamUrl.t -> t Fiber.t
+  end
+end
+
+(** [of_opam_repo_dir_path opam_repo_dir] creates a repo represented by a local
     directory in the path given by [opam_repo_dir]. *)
 val of_opam_repo_dir_path
   :  source:string option
@@ -21,19 +46,14 @@ val of_opam_repo_dir_path
   -> Path.t
   -> t
 
-(** [of_git_repo git ~repo_id ~update ~source] loads the opam repository located at [source] from git.
+(** [of_git_repo git ~repo_id ~update source] loads the opam repository located at [source] from git.
     [source] can be any URL that [git remote add] supports.
 
     Set [update] to true to update the source to the newest revision, otherwise it will use the latest
     data available in the cache (if any). *)
-val of_git_repo
-  :  repo_id:Repository_id.t option
-  -> update:bool
-  -> source:string
-  -> t Fiber.t
+val of_git_repo : repo_id:Repository_id.t option -> update:bool -> Source.t -> t Fiber.t
 
 val repo_id : t -> Repository_id.t option
-val source : t -> string option
 val serializable : t -> Serializable.t option
 
 module With_file : sig

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -38,17 +38,23 @@ module Remote : sig
 
   val default_branch : t -> string
   val rev_of_name : t -> name:string -> At_rev.t option Fiber.t
+  val rev_of_ref : t -> ref:string -> At_rev.t option Fiber.t
   val rev_of_repository_id : t -> Repository_id.t -> At_rev.t option Fiber.t
 end
 
 val content_of_files : t -> File.t list -> string list Fiber.t
 val load_or_create : dir:Path.t -> t Fiber.t
 
-(** [add_repo t ~source] idempotently registers a git repo to the rev store.
+(** [add_repo t ~source ~branch] idempotently registers a git repo to the rev store.
     [source] is any URL that is supported by [git remote add].
 
     This only adds the remote metadata, to get a remote you need to either
     use [Remote.update] if you want to fetch from the remote (thus potentially
     triggering network IO) or if you are sure the [t] already contains all
     required revisions (e.g. from a previous run) then use [don't_update]. *)
-val add_repo : t -> source:string -> Remote.uninit Fiber.t
+val add_repo : t -> source:string -> branch:string option -> Remote.uninit Fiber.t
+
+(** [mem t ~rev] returns whether the revision [rev] is part of the repository *)
+val mem : t -> rev:string -> bool Fiber.t
+
+val ref_type : t -> source:string -> ref:string -> [ `Head | `Tag ] option Fiber.t

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -1,15 +1,85 @@
 open Stdune
 module Checksum = Dune_pkg.Checksum
 module Lock_dir = Dune_pkg.Lock_dir
+module Opam_repo = Dune_pkg.Opam_repo
 module Expanded_variable_bindings = Dune_pkg.Solver_stats.Expanded_variable_bindings
 module Variable_name = Dune_pkg.Variable_name
 module Variable_value = Dune_pkg.Variable_value
+module Rev_store = Dune_pkg.Rev_store
 module Package_version = Dune_pkg.Package_version
 module Package_name = Dune_lang.Package_name
+module Scheduler = Dune_engine.Scheduler
 
 let () = Dune_tests_common.init ()
 
-let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
+module Update = struct
+  open Dyn
+
+  let update_commit ~commit = function
+    | Option (Some (Variant ("Commit", [ String s ]))) as d ->
+      (match String.equal commit s with
+       | true -> Option (Some (Variant ("Commit", [ string "MATCHES EXPECTED" ])))
+       | false -> d)
+    | otherwise -> otherwise
+  ;;
+
+  let update_source ~commit = function
+    | Record xs ->
+      let xs =
+        List.map xs ~f:(function
+          | ("commit" as u), dyn -> u, update_commit ~commit dyn
+          | otherwise -> otherwise)
+      in
+      Record xs
+    | otherwise -> otherwise
+  ;;
+
+  let update_repo_id ~commit = function
+    | Option (Some (Variant ("Git_hash", [ String s ]))) as d ->
+      (match String.equal commit s with
+       | true -> Option (Some (Variant ("Git_hash", [ string "MATCHES EXPECTED" ])))
+       | false -> d)
+    | otherwise -> otherwise
+  ;;
+
+  let update_used ~commit = function
+    | Option (Some (List xs)) ->
+      let xs =
+        List.map xs ~f:(function
+          | Variant (("opam_repo_serializable" as u), [ repo_id; source ]) ->
+            let repo_id = update_repo_id ~commit repo_id in
+            let source = update_source ~commit source in
+            Variant (u, [ repo_id; source ])
+          | otherwise -> otherwise)
+      in
+      Option (Some (List xs))
+    | otherwise -> otherwise
+  ;;
+
+  let update_repositories ~commit = function
+    | Record xs ->
+      let xs =
+        List.map xs ~f:(function
+          | ("used" as u), dyn -> u, update_used ~commit dyn
+          | otherwise -> otherwise)
+      in
+      Record xs
+    | otherwise -> otherwise
+  ;;
+
+  let update_lock_dir_dyn ~commit = function
+    | Record xs ->
+      let xs =
+        List.map xs ~f:(function
+          | ("repos" as u), dyn -> u, update_repositories ~commit dyn
+          | otherwise -> otherwise)
+      in
+      Record xs
+    | otherwise -> otherwise
+  ;;
+end
+
+let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   let lock_dir_path = Path.Source.of_string lock_dir_path in
   Lock_dir.Write_disk.(
     prepare ~lock_dir_path ~files:Package_name.Map.empty lock_dir |> commit);
@@ -25,12 +95,38 @@ let lock_dir_encode_decode_round_trip_test ~lock_dir_path ~lock_dir =
       print_endline metadata_file_contents;
       Exn.raise exn
   in
-  if Lock_dir.equal
-       (Lock_dir.remove_locs lock_dir_round_tripped)
-       (Lock_dir.remove_locs lock_dir)
+  let lock_dir_round_tripped', lock_dir' =
+    match commit with
+    | None -> Lock_dir.remove_locs lock_dir_round_tripped, Lock_dir.remove_locs lock_dir
+    | Some commit ->
+      let lock_dir_round_tripped = Lock_dir.remove_locs lock_dir_round_tripped in
+      let lock_dir = Lock_dir.remove_locs lock_dir in
+      ( Lock_dir.Private.with_commit ~commit lock_dir_round_tripped
+      , Lock_dir.Private.with_commit ~commit lock_dir )
+  in
+  if Lock_dir.equal lock_dir_round_tripped' lock_dir'
   then print_endline "lockdir matches after roundtrip:"
   else print_endline "lockdir doesn't match after roundtrip:";
-  print_endline (Lock_dir.to_dyn lock_dir_round_tripped |> Dyn.to_string)
+  let dyn_lock_dir = Lock_dir.to_dyn lock_dir_round_tripped in
+  let dyn_lock_dir =
+    match commit with
+    | None -> dyn_lock_dir
+    | Some commit -> Update.update_lock_dir_dyn ~commit dyn_lock_dir
+  in
+  print_endline (dyn_lock_dir |> Dyn.to_string)
+;;
+
+let run thunk =
+  let on_event _config _event = () in
+  let config : Scheduler.Config.t =
+    { concurrency = 1
+    ; stats = None
+    ; insignificant_changes = `Ignore
+    ; signal_watcher = `No
+    ; watch_exclusions = []
+    }
+  in
+  Scheduler.Run.go config ~on_event thunk
 ;;
 
 let%expect_test "encode/decode round trip test for lockdir with no deps" =
@@ -42,7 +138,8 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
          ~local_packages:[]
          ~ocaml:None
          ~repos:None
-         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty);
+         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty)
+    ();
   [%expect
     {|
     lockdir matches after roundtrip:
@@ -86,7 +183,8 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
             ; mk_pkg_basic ~name:"bar" ~version:(Package_version.of_string "0.2.0")
-            ]));
+            ]))
+    ();
   [%expect
     {|
     lockdir matches after roundtrip:
@@ -131,96 +229,102 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
 ;;
 
 let%expect_test "encode/decode round trip test for lockdir with complex deps" =
+  let open Fiber.O in
   let module Action = Dune_lang.Action in
   let module String_with_vars = Dune_lang.String_with_vars in
-  lock_dir_encode_decode_round_trip_test
-    ~lock_dir_path:"complex_lock_dir"
-    ~lock_dir:
-      (let pkg_a =
-         let name = Package_name.of_string "a" in
-         let extra_source : Lock_dir.Source.t =
-           External_copy (Loc.none, Path.External.of_string "/tmp/a")
-         in
-         ( name
-         , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
-           { pkg with
-             build_command =
-               Some
-                 Action.(Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ])
-           ; install_command =
-               Some
-                 (Action.System
-                    (* String_with_vars.t doesn't round trip so we have to set
-                       [quoted] if the string would be quoted *)
-                    (String_with_vars.make_text ~quoted:true Loc.none "echo 'world'"))
-           ; info =
-               { pkg.info with
-                 dev = false
-               ; source = Some extra_source
-               ; extra_sources =
-                   [ Path.Local.of_string "one", extra_source
-                   ; ( Path.Local.of_string "two"
-                     , Fetch { url = Loc.none, "randomurl"; checksum = None } )
-                   ]
-               }
-           ; exported_env =
-               [ { Action.Env_update.op = Eq
-                 ; var = "foo"
-                 ; value = String_with_vars.make_text Loc.none "bar"
-                 }
-               ]
-           } )
-       in
-       let pkg_b =
-         let name = Package_name.of_string "b" in
-         ( name
-         , let pkg = empty_package name ~version:(Package_version.of_string "dev") in
-           { pkg with
-             install_command = None
-           ; deps = [ Loc.none, fst pkg_a ]
-           ; info =
-               { pkg.info with
-                 dev = true
-               ; source =
-                   Some
-                     (Fetch
-                        { url = Loc.none, "https://github.com/foo/b"
-                        ; checksum =
-                            Some
-                              ( Loc.none
-                              , Checksum.of_string
-                                  "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
-                              )
-                        })
-               }
-           } )
-       in
-       let pkg_c =
-         let name = Package_name.of_string "c" in
-         ( name
-         , let pkg = empty_package name ~version:(Package_version.of_string "0.2") in
-           { pkg with
-             deps = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
-           ; info =
-               { pkg.info with
-                 dev = false
-               ; source =
-                   Some
-                     (Fetch
-                        { url = Loc.none, "https://github.com/foo/c"; checksum = None })
-               }
-           } )
-       in
-       let opam_repo =
-         let repo_id = Some (Dune_pkg.Repository_id.of_git_hash "95cf548dc") in
-         Dune_pkg.Opam_repo.Private.create ~source:(Some "well-known-repo") ~repo_id
-       in
-       Lock_dir.create_latest_version
-         ~local_packages:[]
-         ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
-         ~repos:(Some [ opam_repo ])
-         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
-         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ]));
+  run (fun () ->
+    let+ lock_dir =
+      let pkg_a =
+        let name = Package_name.of_string "a" in
+        let extra_source : Lock_dir.Source.t =
+          External_copy (Loc.none, Path.External.of_string "/tmp/a")
+        in
+        ( name
+        , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
+          { pkg with
+            build_command =
+              Some Action.(Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ])
+          ; install_command =
+              Some
+                (Action.System
+                   (* String_with_vars.t doesn't round trip so we have to set
+                      [quoted] if the string would be quoted *)
+                   (String_with_vars.make_text ~quoted:true Loc.none "echo 'world'"))
+          ; info =
+              { pkg.info with
+                dev = false
+              ; source = Some extra_source
+              ; extra_sources =
+                  [ Path.Local.of_string "one", extra_source
+                  ; ( Path.Local.of_string "two"
+                    , Fetch { url = Loc.none, "randomurl"; checksum = None } )
+                  ]
+              }
+          ; exported_env =
+              [ { Action.Env_update.op = Eq
+                ; var = "foo"
+                ; value = String_with_vars.make_text Loc.none "bar"
+                }
+              ]
+          } )
+      in
+      let pkg_b =
+        let name = Package_name.of_string "b" in
+        ( name
+        , let pkg = empty_package name ~version:(Package_version.of_string "dev") in
+          { pkg with
+            install_command = None
+          ; deps = [ Loc.none, fst pkg_a ]
+          ; info =
+              { pkg.info with
+                dev = true
+              ; source =
+                  Some
+                    (Fetch
+                       { url = Loc.none, "https://github.com/foo/b"
+                       ; checksum =
+                           Some
+                             ( Loc.none
+                             , Checksum.of_string
+                                 "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                             )
+                       })
+              }
+          } )
+      in
+      let pkg_c =
+        let name = Package_name.of_string "c" in
+        ( name
+        , let pkg = empty_package name ~version:(Package_version.of_string "0.2") in
+          { pkg with
+            deps = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
+          ; info =
+              { pkg.info with
+                dev = false
+              ; source =
+                  Some
+                    (Fetch { url = Loc.none, "https://github.com/foo/c"; checksum = None })
+              }
+          } )
+      in
+      let+ opam_repo =
+        let repo_id = Some (Dune_pkg.Repository_id.of_git_hash "95cf548dc") in
+        let+ source =
+          OpamUrl.parse "https://github.com/ocaml/dune"
+          |> Opam_repo.Source.of_opam_url
+          >>| (fun (src : Opam_repo.Source.t) -> src.url)
+          >>| Option.some
+        in
+        Opam_repo.Private.create ~source ~repo_id
+      in
+      Lock_dir.create_latest_version
+        ~local_packages:[]
+        ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
+        ~repos:(Some [ opam_repo ])
+        ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+        (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
+    in
+    lock_dir_encode_decode_round_trip_test ~lock_dir_path:"complex_lock_dir" ~lock_dir ());
   [%expect
     {|
     lockdir matches after roundtrip:
@@ -286,7 +390,114 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
             Some
               [ opam_repo_serializable
                   Some Git_hash "95cf548dc",
-                  "well-known-repo"
+                  "https://github.com/ocaml/dune"
+              ]
+        }
+    ; expanded_solver_variable_bindings =
+        { variable_values = []; unset_variables = [] }
+    } |}]
+;;
+
+let%expect_test "encode/decode round trip test with locked repo revision" =
+  let open Fiber.O in
+  let module Action = Dune_lang.Action in
+  let module String_with_vars = Dune_lang.String_with_vars in
+  run (fun () ->
+    let cwd = Path.External.cwd () |> Path.external_ in
+    let dir = Path.relative cwd "git-repo" in
+    let* git_hash = Rev_store_tests.create_repo_at dir in
+    let* rev_store = Rev_store.load_or_create ~dir in
+    let+ lock_dir =
+      let pkg_a =
+        let name = Package_name.of_string "a" in
+        name, empty_package name ~version:(Package_version.of_string "0.1.0")
+      in
+      let pkg_b =
+        let name = Package_name.of_string "b" in
+        name, empty_package name ~version:(Package_version.of_string "dev")
+      in
+      let pkg_c =
+        let name = Package_name.of_string "c" in
+        name, empty_package name ~version:(Package_version.of_string "0.2")
+      in
+      let+ opam_repo =
+        let repo_id = Some (Dune_pkg.Repository_id.of_git_hash git_hash) in
+        let+ source =
+          sprintf "https://github.com/ocaml/dune#%s" git_hash
+          |> OpamUrl.parse
+          |> Opam_repo.Source.Private.of_opam_url rev_store
+          >>| (fun (src : Opam_repo.Source.t) -> src.url)
+          >>| Option.some
+        in
+        Opam_repo.Private.create ~source ~repo_id
+      in
+      Lock_dir.create_latest_version
+        ~local_packages:[]
+        ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
+        ~repos:(Some [ opam_repo ])
+        ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+        (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
+    in
+    lock_dir_encode_decode_round_trip_test
+      ~commit:git_hash
+      ~lock_dir_path:"complex_lock_dir"
+      ~lock_dir
+      ());
+  [%expect
+    {|
+    lockdir matches after roundtrip:
+    { version = (0, 1)
+    ; dependency_hash = None
+    ; packages =
+        map
+          { "a" :
+              { build_command = None
+              ; install_command = None
+              ; deps = []
+              ; info =
+                  { name = "a"
+                  ; version = "0.1.0"
+                  ; dev = false
+                  ; source = None
+                  ; extra_sources = []
+                  }
+              ; exported_env = []
+              }
+          ; "b" :
+              { build_command = None
+              ; install_command = None
+              ; deps = []
+              ; info =
+                  { name = "b"
+                  ; version = "dev"
+                  ; dev = false
+                  ; source = None
+                  ; extra_sources = []
+                  }
+              ; exported_env = []
+              }
+          ; "c" :
+              { build_command = None
+              ; install_command = None
+              ; deps = []
+              ; info =
+                  { name = "c"
+                  ; version = "0.2"
+                  ; dev = false
+                  ; source = None
+                  ; extra_sources = []
+                  }
+              ; exported_env = []
+              }
+          }
+    ; ocaml = Some ("complex_lock_dir/lock.dune:3", "ocaml")
+    ; repos =
+        { complete = true
+        ; used =
+            Some
+              [ opam_repo_serializable
+                  Some Git_hash "MATCHES EXPECTED",
+                  "https://github.com/ocaml/dune"
               ]
         }
     ; expanded_solver_variable_bindings =

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -4,6 +4,7 @@ module Scheduler = Dune_engine.Scheduler
 module Process = Dune_engine.Process
 module Display = Dune_engine.Display
 module Rev_store = Dune_pkg.Rev_store
+module Opam_repo = Dune_pkg.Opam_repo
 module Vcs = Dune_vcs.Vcs
 
 let () = Dune_tests_common.init ()
@@ -27,11 +28,14 @@ let make_stdout () = Process.Io.make_stdout ~output_on_success:Swallow ~output_l
 let make_stderr () = Process.Io.make_stderr ~output_on_success:Swallow ~output_limit
 
 let create_repo_at dir =
-  let stdout_to = make_stdout () in
-  let stderr_to = make_stdout () in
-  let git =
+  let git, git_out =
+    let stdout_to = make_stdout () in
+    let stderr_to = make_stdout () in
     let git = Lazy.force Vcs.git in
-    Process.run ~dir ~display ~stdout_to ~stderr_to Process.Failure_mode.Strict git
+    let failure_mode = Process.Failure_mode.Strict in
+    ( (fun args -> Process.run ~dir ~display ~stdout_to ~stderr_to failure_mode git args)
+    , fun args -> Process.run_capture_line ~dir ~display ~stderr_to failure_mode git args
+    )
   in
   Path.mkdir_p dir;
   let* () = git [ "init" ] in
@@ -39,7 +43,8 @@ let create_repo_at dir =
   let entry = Path.relative dir entry_name in
   Io.write_lines entry [ "just some content" ];
   let* () = git [ "add"; entry_name ] in
-  git [ "commit"; "-m 'Initial commit'" ]
+  let* () = git [ "commit"; "-m 'Initial commit'" ] in
+  git_out [ "rev-parse"; "HEAD" ]
 ;;
 
 let%expect_test "adding remotes" =
@@ -48,20 +53,23 @@ let%expect_test "adding remotes" =
   run (fun () ->
     let* rev_store = Rev_store.load_or_create ~dir in
     let remote_path = Path.relative cwd "git-remote" in
-    let* () = create_repo_at remote_path in
-    let source = Path.to_string remote_path in
-    let* remote = Rev_store.add_repo rev_store ~source in
+    let* _head = create_repo_at remote_path in
+    let opam_url = remote_path |> Path.to_string |> OpamUrl.parse in
+    let* (src : Opam_repo.Source.t) = Opam_repo.Source.of_opam_url opam_url in
+    let source = src.url in
+    let* remote = Rev_store.add_repo rev_store ~source ~branch:None in
     let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote in
     print_endline "Creating first remote succeeded";
     [%expect {|
     Creating first remote succeeded
     |}];
-    let* (_remote' : Rev_store.Remote.uninit) = Rev_store.add_repo rev_store ~source in
+    let* remote' = Rev_store.add_repo rev_store ~source ~branch:None in
+    let (_ : Rev_store.Remote.t) = Rev_store.Remote.don't_update remote' in
     print_endline "Adding same remote without update succeeded";
     [%expect {|
     Adding same remote without update succeeded
     |}];
-    let* remote'' = Rev_store.add_repo rev_store ~source in
+    let* remote'' = Rev_store.add_repo rev_store ~source ~branch:None in
     let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote'' in
     print_endline "Adding same remote with update succeeded";
     [%expect {|


### PR DESCRIPTION
This adds support for checking out specific revisions that are different from the default branch. This also refactors the `source` argument which used to be a pretty nondescript string and is not a distinct type that is constructed from an `OpamUrl.t`.