### PR TITLE
chore: add lang dune 3.12

### DIFF
--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -417,7 +417,7 @@ Let us start with a simple project. First, make sure we have a
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using coq 0.8)
 
 Next we need a :ref:`dune<dune-files>` file with a :ref:`coq-theory` stanza:
@@ -647,7 +647,7 @@ otherwise Coq will not be able to find it.
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using coq 0.8)
 
   (package

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -14,7 +14,7 @@ contents of all configuration files read by Dune and looks like:
 
 .. code:: dune
 
-   (lang dune 3.11)
+   (lang dune 3.12)
 
 Additionally, they can contains the following stanzas.
 
@@ -785,7 +785,7 @@ The ``dune-workspace`` file uses the S-expression syntax. This is what a typical
 
 .. code:: dune
 
-    (lang dune 3.11)
+    (lang dune 3.12)
     (context (opam (switch 4.07.1)))
     (context (opam (switch 4.08.1)))
     (context (opam (switch 4.11.1)))

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -92,7 +92,7 @@ file:
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using ctypes 0.3)
 
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -282,7 +282,7 @@ Such languages must be enabled in the ``dune`` project file separately:
 
 .. code:: dune
 
-   (lang dune 3.11)
+   (lang dune 3.12)
    (using coq 0.8)
 
 If such extensions are experimental, it's recommended that they pass

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -88,14 +88,14 @@ To enable an instrumentation backend globally, type the following in your
 
 .. code:: dune
 
-   (lang dune 3.11)
+   (lang dune 3.12)
    (instrument_with bisect_ppx)
 
 or for each context individually:
 
 .. code:: dune
 
-   (lang dune 3.11)
+   (lang dune 3.12)
    (context default)
    (context (default (name coverage) (instrument_with bisect_ppx)))
    (context (default (name profiling) (instrument_with landmarks)))

--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -41,7 +41,7 @@ version 3.8 of the dune language and the Melange extension is enabled:
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using melange 0.1)
 
 Next, write a :ref:`dune<dune-files>` file with a :ref:`melange-emit` stanza:

--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -26,7 +26,7 @@ consists of a name and a :ref:`section<install>` (e.g ``lib``, ``share``,
 
 .. code:: dune
 
-   (lang dune 3.11)
+   (lang dune 3.12)
    (using dune_site 0.1)
    (name mygui)
 
@@ -225,7 +225,7 @@ Main Executable (C)
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using dune_site 0.1)
   (name app)
 
@@ -285,7 +285,7 @@ The Plugin "plugin1"
 
 .. code:: dune
 
-  (lang dune 3.11)
+  (lang dune 3.12)
   (using dune_site 0.1)
 
   (generate_opam_files true)

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -27,7 +27,7 @@ end
 module Version = struct
   type t = int * int
 
-  let latest = 3, 11
+  let latest = 3, 12
 
   let sexp : t Conv.value =
     let open Conv in

--- a/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
+++ b/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
@@ -25,7 +25,7 @@ Allow directories to be installable
   Leaving directory 'a'
 
   $ cat a/_build/install/default/lib/foo/dune-package
-  (lang dune 3.11)
+  (lang dune 3.12)
   (name foo)
   (sections (lib .) (share ../../share/foo))
   (files (lib (META dune-package)) (share ((dir bar) x y)))

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -369,7 +369,7 @@ And the opam file will be generated as expected
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
     "ocaml"
-    $dune {>= "3.11"}
+    $dune {>= "3.12"}
     "odoc" {with-doc}
   ]
   build: [
@@ -479,7 +479,7 @@ And the opam file will be generated as expected
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
     "ocaml"
-    "dune" {>= "3.11"}
+    "dune" {>= "3.12"}
     "odoc" {with-doc}
   ]
   build: [

--- a/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
@@ -32,7 +32,7 @@ Begin by installing a library with C stubs.
   Installing install/lib/libA/libA.cmxs
   Installing install/lib/stublibs/dlllibA_stubs.so
   $ cat ./install/lib/libA/dune-package
-  (lang dune 3.11)
+  (lang dune 3.12)
   (name libA)
   (sections
    (lib

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -27,7 +27,7 @@ Test that we can install melange mode libraries
   ]
 
   $ cat ./_build/install/default/lib/foo/dune-package
-  (lang dune 3.11)
+  (lang dune 3.12)
   (name foo)
   (sections (lib .))
   (files

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -20,9 +20,9 @@ constraint.
   Can't find all required versions.
   Selected: foo.0.0.1 x.dev
   - dune -> (problem)
-      User requested = 3.11
+      User requested = 3.12
       Rejected candidates:
-        dune.3.11.0: Incompatible with restriction: = 3.11
+        dune.3.11.0: Incompatible with restriction: = 3.12
   [1]
   $ test "4.0.0"
   Solution for dune.lock:


### PR DESCRIPTION
Nothing is attached to it, but this ensures that we are future proof:
Assuming we do not do that in 3.12.0, (lang dune 3.12) will be implicitly be created when bumping to 3.13. Then `(lang dune 3.12)` would incorrectly create a `>= 3.12.0` opam bound.
