### PR TITLE
feature: private packages

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1316,6 +1316,11 @@ module Executables = struct
                     project
                     (pluralize "executable" ~multi)
               }
+        | Some (_loc, package), None when package.private_ ->
+          Some
+            { package
+            ; public_names = List.map names ~f:(fun (loc, name) -> loc, Some name)
+            }
         | Some (loc, _), None ->
           User_error.raise
             ~loc

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1353,6 +1353,9 @@ let gen_project_rules sctx project =
   let* () = meta_and_dune_package_rules sctx project in
   let* packages = Only_packages.packages_of_project project in
   Package.Name.Map_traversals.parallel_iter packages ~f:(fun _name package ->
-    let* () = gen_package_install_file_rules sctx package in
-    gen_install_alias sctx package)
+    if package.private_
+    then Memo.return ()
+    else
+      let* () = gen_package_install_file_rules sctx package in
+      gen_install_alias sctx package)
 ;;

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -124,6 +124,7 @@ let package_fields
   ; sites = _
   ; opam_file = _
   ; allow_empty = _
+  ; private_ = _
   }
   ~project
   =

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -356,6 +356,7 @@ type t =
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Site.Map.t
   ; allow_empty : bool
+  ; private_ : bool
   }
 
 (* Package name are globally unique, so we can reasonably expect that there will
@@ -385,6 +386,7 @@ let encode
   ; deprecated_package_names
   ; sites
   ; allow_empty
+  ; private_ = _
   ; opam_file = _
   }
   =
@@ -464,6 +466,8 @@ let decode =
            "Site location name"
        and+ allow_empty =
          field_b "allow_empty" ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
+       and+ private_ =
+         field_b "private" ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 13))
        and+ lang_version = Dune_lang.Syntax.get_exn Stanza.syntax in
        let allow_empty = lang_version < (3, 0) || allow_empty in
        let id = { Id.name; dir } in
@@ -482,6 +486,7 @@ let decode =
        ; deprecated_package_names
        ; sites
        ; allow_empty
+       ; private_
        ; opam_file
        }
 ;;
@@ -508,6 +513,7 @@ let to_dyn
   ; deprecated_package_names
   ; sites
   ; allow_empty
+  ; private_
   ; opam_file = _
   }
   =
@@ -526,6 +532,7 @@ let to_dyn
     ; "deprecated_package_names", Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names
     ; "sites", Site.Map.to_dyn Section.to_dyn sites
     ; "allow_empty", Bool allow_empty
+    ; "private", Bool private_
     ]
 ;;
 
@@ -556,6 +563,7 @@ let default name dir =
   ; sites = Site.Map.empty
   ; allow_empty = false
   ; opam_file = Id.default_opam_file id
+  ; private_ = false
   }
 ;;
 
@@ -632,6 +640,7 @@ let load_opam_file file name =
   ; deprecated_package_names = Name.Map.empty
   ; sites = Site.Map.empty
   ; allow_empty = true
+  ; private_ = false
   ; opam_file = Id.default_opam_file id
   }
 ;;

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -102,6 +102,7 @@ type t =
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Install.Section.t Site.Map.t
   ; allow_empty : bool
+  ; private_ : bool
   }
 
 val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/package-private.t
+++ b/test/blackbox-tests/test-cases/package-private.t
@@ -1,0 +1,47 @@
+Private packages are packages that don't generate install rules. This allows private
+libraries and executables to be assodicated with them, without having to install them.
+
+This allows for private libraries to have their dependencies resolved without having to
+associate them to a public library.
+
+First we declare a package named "hidden" as (private).
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.13)
+  > 
+  > (package
+  >  (name hidden)
+  >  (private))
+  > EOF
+
+Next we make a private executable and private library.
+
+  $ cat > dune << EOF
+  > (library
+  >  (name other_secret)
+  >  (modules other_secret)
+  >  (package hidden))
+  > (executable
+  >  (name secret)
+  >  (modules secret)
+  >  (package hidden))
+  > EOF
+
+  $ cat > secret.ml
+  $ cat > other_secret.ml
+
+We build the install layout.
+
+  $ dune build @install
+
+The executable is not in the install layout.
+
+  $ ! [ -e _build/install/default/bin ]
+
+The library is not in the install layout.
+
+  $ ! [ -e _build/install/default/lib/other_secret.cmi ]
+
+The install layout isn't even created since there are no install rules.
+
+  $ ! [ -e _build/install ]

--- a/test/blackbox-tests/test-cases/private-package-depends.t
+++ b/test/blackbox-tests/test-cases/private-package-depends.t
@@ -1,0 +1,49 @@
+We test how Dune handles dependencies on private packages.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (private))
+  > (package
+  >  (name bar)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (deps
+  >   (package foo))
+  >  (action
+  >   (echo "foo")))
+  > (rule
+  >  (alias bar)
+  >  (deps
+  >   (package bar))
+  >  (action
+  >   (echo "bar")))
+  > EOF
+
+You cannot use (package) to depend on a private package since it will not have an install
+layout. Perhaps in the future a virtual one could be constructed. Dune should give an
+error message indicating that.
+
+  $ dune build @foo
+  File "dune", line 4, characters 11-14:
+  4 |   (package foo))
+                 ^^^
+  Error: Only non-private packages are accepted in (package) dependencies.
+  [1]
+
+The public package bar cannot depend on the private package foo and Dune should give an
+error message indicating that.
+
+For now Dune does not validate the depends field of (package) stanzas. So the following
+builds when it shouldn't.
+
+  $ dune build @bar 
+  bar
+


### PR DESCRIPTION
We add a (private) field to the (package) stanza allowing for packages to be declared that do not generate any install rules. This is useful for adding private executables and libraries to a package so that their package dependencies can be resolved without generating install rules.

Private executables and libraries can be added to private libraries without needing to make them public.

grants #8772 

- [x] update versioning
- [ ] add documentation
- [ ] changelog
- [x] Add test of public package depending on private package.
- [x] https://github.com/ocaml/dune/pull/9250