### PR TITLE
fix(pkg): do not expose hashing scheme of dependency_hash in lock dir

### DIFF
--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -12,39 +12,19 @@ module Dependency_hash = struct
   type t = Digest.t
 
   let hash_string = Digest.string
-  let label = "md5"
-  let to_string t = sprintf "%s=%s" label (Digest.to_hex t)
+  let to_string t = Digest.to_hex t
   let equal = Digest.equal
   let to_dyn t = Dyn.string (to_string t)
   let encode t = to_string t |> Encoder.string
 
   let decode =
     let open Decoder in
-    let+ loc, string = located string in
-    match String.lsplit2 string ~on:'=' with
-    | Some (found_label, hash) ->
-      if String.equal found_label label
-      then (
-        try Digest.from_hex hash with
-        | Invalid_argument _ ->
-          User_error.raise
-            ~loc
-            [ Pp.textf "Dependency hash is not a valid md5 hash: %s" hash ])
-      else
-        User_error.raise
-          ~loc
-          [ Pp.textf
-              "Dependency hash has unexpected label %S (expected %S)"
-              found_label
-              label
-          ]
-    | None ->
+    let+ loc, hash = located string in
+    try Digest.from_hex hash with
+    | Invalid_argument _ ->
       User_error.raise
         ~loc
-        [ Pp.textf
-            "Expected dependency hash to be encoded as \"md5=<hash>\" but found %S"
-            string
-        ]
+        [ Pp.textf "Dependency hash is not a valid md5 hash: %s" hash ]
   ;;
 end
 

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -52,7 +52,7 @@ Add a non-local dependency to the package:
   $ cat dune.lock/lock.dune
   (lang package 0.1)
   
-  (dependency_hash md5=69dfdf4e6a7c8489262f9d8b9958c9b3)
+  (dependency_hash 69dfdf4e6a7c8489262f9d8b9958c9b3)
   
   (repositories
    (complete false)
@@ -68,13 +68,13 @@ Add a second dependency to the project:
   > EOF
   $ dune pkg validate-lockdir
   Lockdir dune.lock does not contain a solution for local packages:
-  File "dune.lock/lock.dune", line 3, characters 17-53:
+  File "dune.lock/lock.dune", line 3, characters 17-49:
   Error: Dependency hash in lockdir does not match the hash of non-local
   dependencies of this project. The lockdir expects the the non-local
   dependencies to hash to:
-  md5=69dfdf4e6a7c8489262f9d8b9958c9b3
+  69dfdf4e6a7c8489262f9d8b9958c9b3
   ...but the non-local dependencies of this project hash to:
-  md5=0cd7f9253f917ae8182c904fac99c3d9
+  0cd7f9253f917ae8182c904fac99c3d9
   Hint: Regenerate the lockdir by running 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
   - dune.lock
@@ -88,9 +88,9 @@ Remove all dependencies from the project:
   > EOF
   $ dune pkg validate-lockdir
   Lockdir dune.lock does not contain a solution for local packages:
-  File "dune.lock/lock.dune", line 3, characters 17-53:
+  File "dune.lock/lock.dune", line 3, characters 17-49:
   Error: This project has no non-local dependencies yet the lockfile contains a
-  dependency hash: md5=69dfdf4e6a7c8489262f9d8b9958c9b3
+  dependency hash: 69dfdf4e6a7c8489262f9d8b9958c9b3
   Hint: Regenerate the lockdir by running 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
   - dune.lock
@@ -112,8 +112,7 @@ Case where the label ("md5") is missing:
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/lock.dune", line 2, characters 17-24:
-  Error: Expected dependency hash to be encoded as "md5=<hash>" but found
-  "badhash"
+  Error: Dependency hash is not a valid md5 hash: badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
   - dune.lock
@@ -124,7 +123,7 @@ Case where the label is not "md5":
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/lock.dune", line 2, characters 17-28:
-  Error: Dependency hash has unexpected label "foo" (expected "md5")
+  Error: Dependency hash is not a valid md5 hash: foo=badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
   - dune.lock
@@ -135,7 +134,7 @@ Case where the the hash is not a valid md5 hash:
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/lock.dune", line 2, characters 17-28:
-  Error: Dependency hash is not a valid md5 hash: badhash
+  Error: Dependency hash is not a valid md5 hash: md5=badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
   - dune.lock

--- a/test/blackbox-tests/test-cases/pkg/dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-hash.t
@@ -40,7 +40,7 @@ A single package with a single non-local dependency:
   >   foo))
   > EOF
   $ dune describe pkg dependency-hash | tee hash1.txt
-  md5=9f76a6d656fe14d54ba74f864e736dc3
+  9f76a6d656fe14d54ba74f864e736dc3
 
 Adding another dependency causes the hash to change:
   $ cat >dune-project <<EOF
@@ -52,12 +52,12 @@ Adding another dependency causes the hash to change:
   >   bar))
   > EOF
   $ dune describe pkg dependency-hash | tee hash2.txt
-  md5=142f33129a06ccbebd65a0bad3d94857
+  142f33129a06ccbebd65a0bad3d94857
   $ diff hash1.txt hash2.txt
   1c1
-  < md5=9f76a6d656fe14d54ba74f864e736dc3
+  < 9f76a6d656fe14d54ba74f864e736dc3
   ---
-  > md5=142f33129a06ccbebd65a0bad3d94857
+  > 142f33129a06ccbebd65a0bad3d94857
   [1]
 
 Adding a new local package which depends on one of the existing dependencies
@@ -75,7 +75,7 @@ doesn't change the hash:
   >   foo))
   > EOF
   $ dune describe pkg dependency-hash | tee hash3.txt
-  md5=142f33129a06ccbebd65a0bad3d94857
+  142f33129a06ccbebd65a0bad3d94857
   $ diff hash2.txt hash3.txt
 
 Adding a constraint to one of the dependencies causes the hash to change:
@@ -92,12 +92,12 @@ Adding a constraint to one of the dependencies causes the hash to change:
   >   (foo (and :with-test (> 0.1)))))
   > EOF
   $ dune describe pkg dependency-hash | tee hash4.txt
-  md5=ecad1d0d60084711169be48b130c9c52
+  ecad1d0d60084711169be48b130c9c52
   $ diff hash3.txt hash4.txt
   1c1
-  < md5=142f33129a06ccbebd65a0bad3d94857
+  < 142f33129a06ccbebd65a0bad3d94857
   ---
-  > md5=ecad1d0d60084711169be48b130c9c52
+  > ecad1d0d60084711169be48b130c9c52
   [1]
 
 Adding another local package with the same dependency and constraint doesn't
@@ -119,5 +119,5 @@ change the hash:
   >   (foo (and :with-test (> 0.1)))))
   > EOF
   $ dune describe pkg dependency-hash | tee hash5.txt
-  md5=ecad1d0d60084711169be48b130c9c52
+  ecad1d0d60084711169be48b130c9c52
   $ diff hash4.txt hash5.txt

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -70,7 +70,7 @@ Print the contents of each file in the lockdir:
   
   (lang package 0.1)
   
-  (dependency_hash md5=ca83e32ab35d71d20fa075b395046c29)
+  (dependency_hash ca83e32ab35d71d20fa075b395046c29)
   
   (repositories
    (complete false)
@@ -115,7 +115,7 @@ Run the solver again preferring oldest versions of dependencies:
   
   (lang package 0.1)
   
-  (dependency_hash md5=ca83e32ab35d71d20fa075b395046c29)
+  (dependency_hash ca83e32ab35d71d20fa075b395046c29)
   
   (repositories
    (complete false)

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -55,7 +55,7 @@ Solve packages with no variables set.
   - static-deps.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=aea7daa72b636fa3a44973ec5e29d225)
+  (dependency_hash aea7daa72b636fa3a44973ec5e29d225)
   
   (repositories
    (complete false)
@@ -64,7 +64,7 @@ Solve packages with no variables set.
   - dynamic-deps.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=6957fba0128609ffc98fac2561c329cb)
+  (dependency_hash 6957fba0128609ffc98fac2561c329cb)
   
   (repositories
    (complete false)
@@ -76,7 +76,7 @@ Solve packages with no variables set.
   - dynamic-deps-lazy.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=9675a3014e7e2db0f946b3ad2a95c037)
+  (dependency_hash 9675a3014e7e2db0f946b3ad2a95c037)
   
   (repositories
    (complete false)
@@ -104,7 +104,7 @@ Solve the packages again, this time with the variables set.
   - static-deps.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=aea7daa72b636fa3a44973ec5e29d225)
+  (dependency_hash aea7daa72b636fa3a44973ec5e29d225)
   
   (repositories
    (complete false)
@@ -113,7 +113,7 @@ Solve the packages again, this time with the variables set.
   - dynamic-deps.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=6957fba0128609ffc98fac2561c329cb)
+  (dependency_hash 6957fba0128609ffc98fac2561c329cb)
   
   (repositories
    (complete false)
@@ -127,7 +127,7 @@ Solve the packages again, this time with the variables set.
   - dynamic-deps-lazy.1.0
   (lang package 0.1)
   
-  (dependency_hash md5=9675a3014e7e2db0f946b3ad2a95c037)
+  (dependency_hash 9675a3014e7e2db0f946b3ad2a95c037)
   
   (repositories
    (complete false)


### PR DESCRIPTION
It's controlled by the version set in lock.dune

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a409c9fa-fe03-468c-936f-29f6a2f12e17 -->