### PR TITLE
fix(pkg): Test the rev store lock on all platforms

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -15,7 +15,7 @@
  (applies_to :whole_subtree))
 
 (cram
- (applies_to rev-store-lock)
+ (applies_to rev-store-lock-linux)
  (enabled_if
   (= %{system} linux))
  (deps %{bin:strace}))


### PR DESCRIPTION
This reduces the Linux-only part to just the part where `strace` is used to make flock(2) fail.