### PR TITLE
pkg: allow user to set arbitrary solver variables

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -56,6 +56,7 @@ let solve
            ; version_preference
            ; repos
            ; solver_sys_vars = solver_sys_vars_from_context
+           ; solver_user_vars
            ; context_common = { name = context_name; _ }
            ; repositories
            }
@@ -66,6 +67,10 @@ let solve
                (solver_env_variables
                   ~solver_sys_vars_from_context
                   ~sys_bindings_from_current_system)
+             ~user:
+               (Option.value
+                  solver_user_vars
+                  ~default:Dune_pkg.Solver_env.Variable.User.Bindings.empty)
          in
          let* repos =
            get_repos

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -21,6 +21,7 @@ let find_outdated_packages
               ; version_preference = _
               ; repos
               ; solver_sys_vars = _
+              ; solver_user_vars = _
               ; context_common = _
               ; repositories
               }

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -48,6 +48,7 @@ module Per_context = struct
     { lock_dir_path : Path.Source.t
     ; version_preference : Version_preference.t
     ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+    ; solver_user_vars : Dune_pkg.Solver_env.Variable.User.Bindings.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; context_common : Dune_rules.Workspace.Context.Common.t
     ; repos :
@@ -87,6 +88,7 @@ module Per_context = struct
              { lock
              ; version_preference = version_preference_context
              ; solver_sys_vars
+             ; solver_user_vars
              ; repositories
              ; base = context_common
              ; _
@@ -97,6 +99,7 @@ module Per_context = struct
                  ~from_arg:version_preference_arg
                  ~from_context:version_preference_context
            ; solver_sys_vars
+           ; solver_user_vars
            ; repositories
            ; context_common
            ; repos = repositories_of_workspace workspace
@@ -116,6 +119,7 @@ module Per_context = struct
             ; version_preference = version_preference_context
             ; base = context_common
             ; solver_sys_vars
+            ; solver_user_vars
             ; repositories
             } ->
           let lock_dir_path = Option.value lock ~default:Dune_pkg.Lock_dir.default_path in
@@ -127,6 +131,7 @@ module Per_context = struct
                   ~from_context:version_preference_context
             ; context_common
             ; solver_sys_vars
+            ; solver_user_vars
             ; repositories
             ; repos = repositories_of_workspace workspace
             }

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -16,6 +16,7 @@ module Per_context : sig
     { lock_dir_path : Path.Source.t
     ; version_preference : Dune_pkg.Version_preference.t
     ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+    ; solver_user_vars : Dune_pkg.Solver_env.Variable.User.Bindings.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; context_common : Workspace.Context.Common.t
     ; repos :

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -4,6 +4,7 @@ open Pkg_common
 let print_solver_env_for_one_context
   ~sys_bindings_from_current_system
   { Per_context.solver_sys_vars = solver_sys_vars_from_context
+  ; solver_user_vars
   ; context_common = { name = context_name; _ }
   ; _
   }
@@ -14,6 +15,10 @@ let print_solver_env_for_one_context
         (solver_env_variables
            ~solver_sys_vars_from_context
            ~sys_bindings_from_current_system)
+      ~user:
+        (Option.value
+           solver_user_vars
+           ~default:Dune_pkg.Solver_env.Variable.User.Bindings.empty)
   in
   Console.print
     [ Pp.textf

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -7,7 +7,8 @@ module Name : sig
   val of_opam : OpamVariable.t -> t
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t
-  val encode : t -> Dune_sexp.t
+  val encode : t Dune_lang.Encoder.t
+  val decode : t Dune_lang.Decoder.t
 
   module Map : Map.S with type key = t
 

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -16,7 +16,7 @@ let substitute_variables_in_filter
            Option.iter stats_updater ~f:(fun stats_updater ->
              Solver_stats.Updater.expand_variable stats_updater variable);
            (match Solver_env.get solver_env variable with
-            | Unset_sys -> filter
+            | Unset -> filter
             | String string -> FString string))
       | other -> other)
     opam_filter

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -38,6 +38,24 @@ module Variable : sig
     end
   end
 
+  module User : sig
+    (** A custom variable that can be configured by a user *)
+    type t = Package_variable.Name.t
+
+    module Bindings : sig
+      type user_var := t
+
+      (** A mapping from user variables to their values *)
+      type t
+
+      val to_dyn : t -> Dyn.t
+      val decode : t Decoder.t
+      val equal : t -> t -> bool
+      val empty : t
+      val set : t -> user_var -> string -> t
+    end
+  end
+
   module Const : sig
     (** Constant variables whose value can't be configured. These can be read
         while solving and evaluating packages. *)
@@ -46,6 +64,7 @@ module Variable : sig
 
   type t =
     | Sys of Sys.t
+    | User of User.t
     | Const of Const.t
 
   val to_string : t -> string
@@ -68,7 +87,7 @@ end
     environment as dune does not give users access to those variables.. *)
 type t
 
-val create : sys:Variable.Sys.Bindings.t -> t
+val create : sys:Variable.Sys.Bindings.t -> user:Variable.User.Bindings.t -> t
 val default : t
 val decode : t Decoder.t
 val to_dyn : t -> Dyn.t
@@ -82,7 +101,7 @@ val pp : t -> 'a Pp.t
 module Variable_value : sig
   type t =
     | String of string
-    | Unset_sys
+    | Unset
 end
 
 val get : t -> Variable.t -> Variable_value.t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -600,7 +600,13 @@ module Group = struct
       | Opam { base; switch } ->
         create_for_opam builder ~switch ~loc:base.loc ~targets:base.targets
       | Default
-          { lock; version_preference = _; solver_sys_vars = _; repositories = _; base } ->
+          { lock
+          ; version_preference = _
+          ; solver_sys_vars = _
+          ; solver_user_vars = _
+          ; repositories = _
+          ; base
+          } ->
         let builder =
           match builder.findlib_toolchain with
           | Some _ -> builder

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -49,6 +49,7 @@ module Context : sig
       ; lock : Path.Source.t option
       ; version_preference : Dune_pkg.Version_preference.t option
       ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+      ; solver_user_vars : Dune_pkg.Solver_env.Variable.User.Bindings.t option
       ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
       }
   end

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -7,6 +7,8 @@ Print the solver env when no dune-workspace is present
     - os-version (unset)
     - os-distribution (unset)
     - os-family (unset)
+  - User
+    (none)
   - Constants
     - opam-version = 2.2.0~alpha-vendored
 
@@ -28,7 +30,9 @@ Add some build contexts with different environments
   >    (os linux)
   >    (os-family ubuntu)
   >    (os-distribution ubuntu)
-  >    (os-version 22.04))))
+  >    (os-version 22.04))
+  >   (solver_user_vars
+  >    (foo bar))))
   > EOF
 
   $ dune pkg print-solver-env --all-contexts --dont-poll-system-solver-variables
@@ -39,6 +43,8 @@ Add some build contexts with different environments
     - os-version = 22.04
     - os-distribution = ubuntu
     - os-family = ubuntu
+  - User
+    - foo = bar
   - Constants
     - opam-version = 2.2.0~alpha-vendored
   Solver environment for context linux:
@@ -48,5 +54,7 @@ Add some build contexts with different environments
     - os-version (unset)
     - os-distribution (unset)
     - os-family (unset)
+  - User
+    (none)
   - Constants
     - opam-version = 2.2.0~alpha-vendored

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -19,8 +19,8 @@ A package which doesn't use variables to determine its dependencies
 A packgae which uses variables to determine its dependencies
   $ mkpkg dynamic-deps 1.0 <<EOF
   > depends: [
-  >   "no-deps-a" { os = linux }
-  >   "no-deps-b" { arch = arm }
+  >   "no-deps-a" { os = "linux" }
+  >   "no-deps-b" { arch = "arm" }
   > ]
   > EOF
 
@@ -30,8 +30,8 @@ them to be ignored under lazy evaluation. This is to clarify the behaviour of
 the logic which stores solver vars in lockdir metadata in this case.
   $ mkpkg dynamic-deps-lazy 1.0 <<EOF
   > depends: [
-  >   "no-deps-a" { os = linux | os-family = ubuntu }
-  >   "no-deps-b" { arch = arm | os-version = "22.04" }
+  >   "no-deps-a" { os = "linux" | os-family = "ubuntu" }
+  >   "no-deps-b" { arch = "arm" | os-version = "22.04" }
   > ]
   > EOF
 
@@ -111,6 +111,8 @@ Solve the packages again, this time with the variables set.
    (used))
   Solution for dune.lock:
   - dynamic-deps.1.0
+  - no-deps-a.1.0
+  - no-deps-b.1.0
   (lang package 0.1)
   
   (dependency_hash 6957fba0128609ffc98fac2561c329cb)
@@ -125,6 +127,8 @@ Solve the packages again, this time with the variables set.
     (arch arm)))
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
+  - no-deps-a.1.0
+  - no-deps-b.1.0
   (lang package 0.1)
   
   (dependency_hash 9675a3014e7e2db0f946b3ad2a95c037)

--- a/test/blackbox-tests/test-cases/pkg/user-variable-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/user-variable-conditional-dependencies.t
@@ -1,0 +1,54 @@
+Tests for setting arbitrary solver variables.
+
+  $ . ./helpers.sh
+  $ mkrepo
+ 
+  $ mkpkg a <<EOF
+  > depends: [
+  >  "b" {custom_flag}
+  >  "c" {custom_string = "foo"}
+  >  "d" {custom_string = "bar"}
+  > ]
+  > EOF
+  $ mkpkg b <<EOF
+  > EOF
+  $ mkpkg c <<EOF
+  > EOF
+  $ mkpkg d <<EOF
+  > EOF
+
+Initial solve with no user variables set.
+  $ solve a
+  Solution for dune.lock:
+  - a.0.0.1
+
+Set some user variables and solve again.
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (context
+  >  (default
+  >   (solver_user_vars
+  >    (custom_flag true)
+  >    (custom_string foo))))
+  > EOF
+
+  $ solve a
+  Solution for dune.lock:
+  - a.0.0.1
+  - b.0.0.1
+  - c.0.0.1
+
+Set some user variables to different values and solve again.
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (context
+  >  (default
+  >   (solver_user_vars
+  >    (custom_flag false)
+  >    (custom_string bar))))
+  > EOF
+
+  $ solve a
+  Solution for dune.lock:
+  - a.0.0.1
+  - d.0.0.1


### PR DESCRIPTION
First attempt at adding user-controlled solver variables. Fixes https://github.com/ocaml/dune/issues/8969. I intend to add checks that prevent the user from setting user variables whose names are the same as system variables or constants and also prevent the user from setting the `with-test` variable but opening this for review now to get early feedback.