### PR TITLE
fix: use [O_CLOEXEC] instead of [Unix.set_close_on_exec]

### DIFF
--- a/src/dune_util/global_lock.ml
+++ b/src/dune_util/global_lock.ml
@@ -31,10 +31,9 @@ module Lock = struct
        let fd =
          Unix.openfile
            (Path.Build.to_string lock_file)
-           [ Unix.O_CREAT; O_WRONLY; O_SHARE_DELETE ]
+           [ Unix.O_CREAT; O_WRONLY; O_SHARE_DELETE; O_CLOEXEC ]
            0o600
        in
-       Unix.set_close_on_exec fd;
        Flock.create fd)
   ;;
 


### PR DESCRIPTION
Removes a potential race condition

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: dca71241-6a70-49fa-9807-7f06cd21da1b -->