### PR TITLE
fix: use [O_CLOEXEC] when digesting files

### DIFF
--- a/src/dune_digest/dune_digest.ml
+++ b/src/dune_digest/dune_digest.ml
@@ -21,7 +21,7 @@ module Direct_impl : Digest_impl = struct
        [O_SHARE_DELETE] ensures that the main thread can delete it even if it
        is still open. See #8243. *)
     let fd =
-      match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE ] 0 with
+      match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE; O_CLOEXEC ] 0 with
       | fd -> fd
       | exception Unix.Unix_error (Unix.EACCES, _, _) ->
         raise (Sys_error (sprintf "%s: Permission denied" file))


### PR DESCRIPTION
@snowleopard AFAIK, you don't use this code upstream. But you might still want to make a similar change there.