### PR TITLE
fix: use [O_CLOEXEC] when creating temp files

### DIFF
--- a/otherlibs/stdune/src/temp.ml
+++ b/otherlibs/stdune/src/temp.ml
@@ -28,7 +28,10 @@ let tmp_dirs = ref Path.Set.empty
 
 let create_temp_file ?(perms = 0o600) path =
   let file = Path.to_string path in
-  match Unix.close (Unix.openfile file [ O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] perms) with
+  match
+    Unix.close
+      (Unix.openfile file [ O_WRONLY; Unix.O_CREAT; Unix.O_EXCL; Unix.O_CLOEXEC ] perms)
+  with
   | () -> Ok ()
   | exception Unix.Unix_error (EEXIST, _, _) -> Error `Retry
 ;;


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 538ad2da-ceae-4b54-933a-4273db56364b -->