### PR TITLE
fix(pkg): remove build warning

### DIFF
--- a/vendor/opam/src/core/custom_opamStubs.c
+++ b/vendor/opam/src/core/custom_opamStubs.c
@@ -80,20 +80,20 @@ CAMLprim value OPAMW_GetArchitecture(value unit)
 
 #else
 
-static void fail ()
-{
-  caml_failwith("Windows stubs are only allowed to be called on Windows.");
-}
+static char * unavailable_message =
+  "Windows stubs are only allowed to be called on Windows.";
 
 
 CAMLprim value OPAMW_GetWindowsVersion(value unit)
 {
-  fail ();
+  (void)unit;
+  caml_failwith(unavailable_message);
 }
 
 CAMLprim value OPAMW_GetArchitecture(value unit)
 {
-  fail ();
+  (void)unit;
+  caml_failwith(unavailable_message);
 }
 
 #endif


### PR DESCRIPTION
Removes the following warning:

```
custom_opamStubs.c:92:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
custom_opamStubs.c:97:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
```

@Alizter can you upstream these?