### PR TITLE
fix: copy sandboxes should copy symlinks as well

### DIFF
--- a/doc/changes/9282.md
+++ b/doc/changes/9282.md
@@ -1,0 +1,1 @@
+- Copying mode for sandboxes will now follow symbolic links (#9282, @rgrinberg)

--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -103,15 +103,7 @@ Now we demonstrate that symlinks aren't supported:
   > }
 
   $ runtest "touch foo && ln -s foo bar"
-  File "dune", line 1, characters 0-63:
-  1 | (rule
-  2 |  (alias foo)
-  3 |  (action (echo test))
-  4 |  (deps sub/targetdir))
-  Error: Failed to copy file _build/default/sub/targetdir/bar of kind "symbolic
-  link" while creating a copy sandbox
-  Hint: Re-run Dune to delete the stale artifact, or manually delete this file
-  [1]
+  test
 
   $ runtest "mkdir bar && touch bar/somefileinbar && ln -s bar symlinktobar"
   File "sub/dune", line 1, characters 0-151:


### PR DESCRIPTION
Add support for copying sandboxes with symlinks. We do this just by copying whatever the symlink is pointing to. We also copy broken symlinks.