### PR TITLE
pkg: redirect output of build step

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -535,6 +535,12 @@ let opam_package_to_lock_file_pkg
     in
     List.concat [ subst_step; patch_step; build_step ]
     |> make_action
+    |> Option.map ~f:(fun action ->
+      Action.Redirect_out
+        ( Action.Outputs.Outputs
+        , String_with_vars.make_text Loc.none (OpamPackage.Name.to_string name ^ ".build")
+        , Action.File_perm.Normal
+        , action ))
     |> Option.map ~f:build_env
   in
   let install_command =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -786,6 +786,16 @@ module Action_expander = struct
       >>= (function
        | true -> expand action ~expander
        | false -> Memo.return (Action.progn []))
+    | Redirect_out (outputs, file, file_perm, action) ->
+      let+ action = expand action ~expander
+      and+ file =
+        Expander.expand_pform_gen ~mode:Single expander file
+        >>| Value.to_path ~dir
+        >>| Expander0.as_in_build_dir
+              ~what:"redirect_out"
+              ~loc:(String_with_vars.loc file)
+      in
+      Action.Redirect_out (outputs, file, file_perm, action)
     | _ ->
       (* TODO *)
       assert false


### PR DESCRIPTION
This adds a `with-outputs-to` action around the build action allowing us to inspect the build log after the fact and not have a noisy build.

- fixes https://github.com/ocaml/dune/issues/9281