### PR TITLE
fix(tests): adjust to setup-ocaml passing OPAMCONFIRMLEVEL

### DIFF
--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -9,7 +9,7 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   > (context
   > (opam
   >  (name cross)
-  >  (switch $(opam switch show))
+  >  (switch $(opam --cli 2.1 switch show))
   >  (merlin)))
   > EOF
 

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -1,5 +1,6 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ unset OPAMCONFIRMLEVEL
 
 We call `$(opam switch show)` so that this test always uses an existing switch
 
@@ -9,7 +10,7 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   > (context
   > (opam
   >  (name cross)
-  >  (switch $(opam --cli 2.1 switch show))
+  >  (switch $(opam switch show))
   >  (merlin)))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-var/dune
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/dune
@@ -21,8 +21,8 @@
   (with-stdout-to
    %{target}
    (progn
-    (run %{bin:opam} var --root fake_opam_root arch)
-    (run %{bin:opam} var --root fake_opam_root os)
-    (run %{bin:opam} var --root fake_opam_root os-distribution)
-    (run %{bin:opam} var --root fake_opam_root os-family)
-    (run %{bin:opam} var --root fake_opam_root os-version)))))
+    (run %{bin:opam} --cli 2.1 var --root fake_opam_root arch)
+    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os)
+    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-distribution)
+    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-family)
+    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-version)))))


### PR DESCRIPTION
This ensures our test suite is more future proof wrt opam CLI.

As an immediate benefit, this allows the test suite to run with setup-ocaml 2.1.5: it sets `OPAMCONFIRMLEVEL=unsafe-yes`, which emits a warning if the cli version is 2.0.

See ocaml/setup-ocaml#728.
