### PR TITLE
refactor: introduce [Fpath.traverse_files]

### DIFF
--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -41,3 +41,9 @@ val clear_dir : string -> clear_dir_result
 val rm_rf : string -> unit
 
 val is_root : string -> bool
+
+val traverse_files
+  :  dir:string
+  -> init:'acc
+  -> f:(dir:string -> Filename.t -> 'acc -> 'acc)
+  -> 'acc

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -27,7 +27,7 @@ The error message should have a location for the opam repository.
 This does not currently seem to be the case.
 
   $ solve with-patch
-  File "$TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/dir", line 1, characters 0-0:
+  File "$TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files", line 1, characters 0-0:
   Error: Unable to read file in opam repository:
   opendir($TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/dir): Permission denied
   [1]


### PR DESCRIPTION
To remove duplication between the various traversal functions we have.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a7b7d573-5c4a-44d2-841c-e71126525ea3 -->