### PR TITLE
fix(pkg): filter partial evaluation

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -103,16 +103,7 @@ Package which has boolean where string was expected. This should be caught while
     (when
      %{pkg-self:dev}
      (run dune subst))
-    (run
-     dune
-     build
-     -p
-     %{pkg-self:name}
-     -j
-     %{jobs}
-     @install
-     (when %{pkg-self:with-test} @runtest)
-     (when %{pkg-self:with-doc} @doc))))
+    (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
 
   $ cat dune.lock/with-interpolation.pkg
   (version 0.0.1)
@@ -189,15 +180,10 @@ Package which has boolean where string was expected. This should be caught while
      (< %{pkg-self:version} 1.0)
      (run echo g))
     (when
-     (and_absorb_undefined_var
-      %{pkg-self:with-test}
-      (< %{pkg:ocaml:version} 5.0.0))
-     (run echo h))
-    (when
      true
      (run echo i))
     (when
-     (not false)
+     true
      (run echo j))
     (when
      %{pkg:foo:installed}
@@ -207,15 +193,7 @@ Package which has boolean where string was expected. This should be caught while
      (run echo l))
     (when
      (and %{pkg:foo:installed} %{pkg:bar:installed} %{pkg:baz:installed})
-     (run echo m))
-    (when
-     (not
-      (has_undefined_var %{pkg-self:madeup}))
-     (run echo n))
-    (when
-     (not
-      (has_undefined_var %{pkg-self:installed}))
-     (run echo o))))
+     (run echo m))))
 
 Test that if opam filter translation is disabled the output doesn't contain any translated filters:
   $ solve exercise-filters

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -95,14 +95,13 @@ Generate a mock opam repository
   version greater than 0 (version is 0.0.1)
   disjunction with some undefined vars
   conjunction with some undefined vars
-  check if variable 'installed' is defined
   $ build_single_package baz
   Solution for dune.lock:
   - baz.0.0.1
   installed
   not madeup:installed
   hello
-  installed-defined
+  
   $ build_single_package error1
   Solution for dune.lock:
   - error1.0.0.1
@@ -122,22 +121,18 @@ Generate a mock opam repository
   $ build_single_package error3
   Solution for dune.lock:
   - error3.0.0.1
-  File "dune.lock/error3.pkg", line 5, characters 2-46:
-  5 |   (when
-  6 |    (not
-  7 |     (< 2 1))
-  8 |    not-a-program)
+  File "dune.lock/error3.pkg", line 5, characters 2-27:
+  5 |   (when true not-a-program)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Program not-a-program not found in the tree or in PATH
    (context: default)
   [1]
   $ build_single_package error4
   Solution for dune.lock:
   - error4.0.0.1
-  File "dune.lock/error4.pkg", line 5, characters 2-63:
-  5 |   (when
-  6 |    (not
-  7 |     (< 2 1))
-  8 |    not-a-program-%{pkg-self:name})
+  File "dune.lock/error4.pkg", line 5, characters 2-44:
+  5 |   (when true not-a-program-%{pkg-self:name})
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Program not-a-program-error4 not found in the tree or in PATH
    (context: default)
   [1]


### PR DESCRIPTION
with-test and with-doc are variables that are used in the solving stage,
therefore, they should just be eliminated by the solving step and not
appear in the build plan.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b5a53d59-76c0-4655-bac6-1adc6fede499 -->