### PR TITLE
fix: correctly check if (binaries) is set in workspace file

### DIFF
--- a/doc/changes/9309.md
+++ b/doc/changes/9309.md
@@ -1,0 +1,2 @@
+- Forbid the empty `(binaries ..)` field in the `env` stanza in the workspace
+  file unless language version is at least 3.2.

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -77,7 +77,7 @@ module Stanza = struct
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign_language.Dict.t
     ; link_flags : Link_flags.Spec.t
     ; env_vars : Env.t
-    ; binaries : File_binding.Unexpanded.t list
+    ; binaries : File_binding.Unexpanded.t list option
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t option
     ; odoc : Odoc.t
@@ -119,7 +119,7 @@ module Stanza = struct
          t.foreign_flags
     && Link_flags.Spec.equal link_flags t.link_flags
     && Env.equal env_vars t.env_vars
-    && List.equal File_binding.Unexpanded.equal binaries t.binaries
+    && Option.equal (List.equal File_binding.Unexpanded.equal) binaries t.binaries
     && Option.equal Inline_tests.equal inline_tests t.inline_tests
     && Option.equal Ordered_set_lang.Unexpanded.equal menhir_flags t.menhir_flags
     && Odoc.equal odoc t.odoc
@@ -138,7 +138,7 @@ module Stanza = struct
     ; foreign_flags = Foreign_language.Dict.make_both Ordered_set_lang.Unexpanded.standard
     ; link_flags = Link_flags.Spec.standard
     ; env_vars = Env.empty
-    ; binaries = []
+    ; binaries = None
     ; inline_tests = None
     ; menhir_flags = None
     ; odoc = Odoc.empty
@@ -231,8 +231,7 @@ module Stanza = struct
       Link_flags.Spec.decode ~check:(Some (Dune_lang.Syntax.since Stanza.syntax (3, 0)))
     and+ env_vars = env_vars_field
     and+ binaries =
-      field
-        ~default:[]
+      field_o
         "binaries"
         (Dune_lang.Syntax.since Stanza.syntax (1, 6) >>> File_binding.Unexpanded.L.decode)
     and+ inline_tests = inline_tests_field

--- a/src/dune_rules/dune_env.mli
+++ b/src/dune_rules/dune_env.mli
@@ -28,7 +28,7 @@ module Stanza : sig
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign_language.Dict.t
     ; link_flags : Link_flags.Spec.t
     ; env_vars : Env.t
-    ; binaries : File_binding.Unexpanded.t list
+    ; binaries : File_binding.Unexpanded.t list option
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t option
     ; odoc : Odoc.t

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -88,10 +88,11 @@ let make
            let* field = Memo.Lazy.force t >>= field in
            f_absent (Some field)))
   in
+  let config_binaries = Option.value config.binaries ~default:[] in
   let local_binaries =
     Memo.lazy_ (fun () ->
       Memo.parallel_map
-        config.binaries
+        config_binaries
         ~f:
           (File_binding.Unexpanded.expand
              ~dir
@@ -101,7 +102,7 @@ let make
     inherited ~field:external_env ~root:default_env (fun env ->
       let env =
         let env = Env.extend_env env config.env_vars in
-        match config.binaries with
+        match config_binaries with
         | [] -> env
         | _ :: _ ->
           let dir = Artifacts.local_bin dir |> Path.build in

--- a/test/blackbox-tests/test-cases/github5555.t
+++ b/test/blackbox-tests/test-cases/github5555.t
@@ -87,3 +87,10 @@ And for another profile:
 Version checking is supposed to work even if (binaries) is empty.
 
   $ t 3.1 _ ""
+  File "dune-workspace", line 2, characters 0-21:
+  2 | (env (_ (binaries )))
+      ^^^^^^^^^^^^^^^^^^^^^
+  Error: "binaries" in an "env" stanza in a dune-workspace file is only
+  available since version 3.2 of the dune language. Please update your
+  dune-project file to have (lang dune 3.2).
+  [1]


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1ab2aacb-01cd-41ef-922a-6c951abec004 -->