### PR TITLE
Add delay to address flaky fsevent test

### DIFF
--- a/test/expect-tests/fsevents/fsevents_tests.ml
+++ b/test/expect-tests/fsevents/fsevents_tests.ml
@@ -258,7 +258,10 @@ let%expect_test "raise inside callback" =
       raise Exit)
     (fun () ->
       Io.String_path.write_file "old" "foobar";
-      Io.String_path.write_file "old" "foobar");
+      Io.String_path.write_file "old" "foobar";
+      (* Delay to allow the event handler callback to catch the exception
+         before stopping the watcher. *)
+      Unix.sleepf 1.0);
   [%expect {|
     [EXIT]
     exiting. |}]


### PR DESCRIPTION
The test checks that exceptions raised in in event handlers cause the watcher to terminate and the exception is passed to the thread waiting on the watcher. The test is flaky because the watcher is stopped directly after some period of time and there's a race between this and the exception being raised. This change delays stopping the watcher directly so it's practically guaranteed that there will be time for the exception to be raised.

Fixes https://github.com/ocaml/dune/issues/9299