### PR TITLE
chore: post 3.12 changelog merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+3.12.1 (2023-11-29)
+-------------------
+
+- Revert unintended inclusion of #9250 and #9280 (@emillon)
+
 3.12.0 (2023-11-28)
 -------------------
 
@@ -39,9 +44,6 @@
 
 - Add `test_` prefix to default test name in `dune init project` (#9257, fixes
   #9131, @9sako6)
-
-- Add `coqdoc_flags` field to `coq` field of `env` stanza allowing the setting
-  of workspace-wide defaults for `coqdoc_flags`. (#9280, fixes #9139, @Alizter)
 
 - [coq rules] Be more tolerant when coqc --print-version / --config don't work
   properly, and fallback to a reasonable default. This fixes problems when

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+If you're a contributor, please include your CHANGES entry in a file
+`doc/changes/$PR_NAME.md`. At release time, it will be incoporated into the
+changelog properly.  
+
 3.12.1 (2023-11-29)
 -------------------
 

--- a/doc/changes/coqdoc-flags.md
+++ b/doc/changes/coqdoc-flags.md
@@ -1,0 +1,2 @@
+- Add `coqdoc_flags` field to `coq` field of `env` stanza allowing the setting
+  of workspace-wide defaults for `coqdoc_flags`. (#9280, fixes #9139, @Alizter)


### PR DESCRIPTION
- Add 3.12.1 changelog
- #9280 was reverted; move it off the main changelog
