### PR TITLE
pkg: simplify representation of solver variables

### DIFF
--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -20,7 +20,7 @@ let find_outdated_packages
               { Per_context.lock_dir_path
               ; version_preference = _
               ; repos
-              ; solver_sys_vars = _
+              ; solver_env = _
               ; context_common = _
               ; repositories
               }

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -1,19 +1,17 @@
 open Import
 module Lock_dir = Dune_pkg.Lock_dir
+module Solver_env = Dune_pkg.Solver_env
+module Variable_name = Dune_pkg.Variable_name
+module Variable_value = Dune_pkg.Variable_value
 
 let context_term ~doc =
   Arg.(value & opt (some Arg.context_name) None & info [ "context" ] ~docv:"CONTEXT" ~doc)
 ;;
 
-(* The system environment variables used by the solver are taken from the
-   current system by default but can be overridden by the build context. *)
-let solver_env_variables ~solver_sys_vars_from_context ~sys_bindings_from_current_system =
-  match solver_sys_vars_from_context with
-  | None -> sys_bindings_from_current_system
-  | Some solver_env_variables ->
-    Dune_pkg.Solver_env.Variable.Sys.Bindings.extend
-      sys_bindings_from_current_system
-      solver_env_variables
+let solver_env ~solver_env_from_current_system ~solver_env_from_context =
+  [ solver_env_from_current_system; solver_env_from_context ]
+  |> List.filter_opt
+  |> List.fold_left ~init:Solver_env.with_opam_version_set_to_current ~f:Solver_env.extend
 ;;
 
 module Version_preference = struct
@@ -47,7 +45,7 @@ module Per_context = struct
   type t =
     { lock_dir_path : Path.Source.t
     ; version_preference : Version_preference.t
-    ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+    ; solver_env : Dune_pkg.Solver_env.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; context_common : Dune_rules.Workspace.Context.Common.t
     ; repos :
@@ -63,9 +61,7 @@ module Per_context = struct
   let make_solver workspace context_common ~version_preference_arg ~lock =
     let lock_dir_path = Option.value lock ~default:Dune_pkg.Lock_dir.default_path in
     let lock_dir = Workspace.find_lock_dir workspace lock_dir_path in
-    let solver_sys_vars =
-      Option.bind lock_dir ~f:(fun lock_dir -> lock_dir.solver_sys_vars)
-    in
+    let solver_env = Option.bind lock_dir ~f:(fun lock_dir -> lock_dir.solver_env) in
     let version_preference_context =
       Option.bind lock_dir ~f:(fun lock_dir -> lock_dir.version_preference)
     in
@@ -80,7 +76,7 @@ module Per_context = struct
           ~from_arg:version_preference_arg
           ~from_context:version_preference_context
     ; context_common
-    ; solver_sys_vars
+    ; solver_env
     ; repositories
     ; repos = repositories_of_workspace workspace
     }

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -2,10 +2,14 @@ open Import
 
 val context_term : doc:string -> Context_name.t option Term.t
 
-val solver_env_variables
-  :  solver_sys_vars_from_context:Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
-  -> sys_bindings_from_current_system:Dune_pkg.Solver_env.Variable.Sys.Bindings.t
-  -> Dune_pkg.Solver_env.Variable.Sys.Bindings.t
+(** Create a [Dune_pkg.Solver_env.t] by combining variables taken from the
+    current system and variables taken from the current context, with priority
+    being given to the latter. Also adds a binding from the variable
+    "opam-version" to the version of opam vendored by dune. *)
+val solver_env
+  :  solver_env_from_current_system:Dune_pkg.Solver_env.t option
+  -> solver_env_from_context:Dune_pkg.Solver_env.t option
+  -> Dune_pkg.Solver_env.t
 
 module Version_preference : sig
   val term : Dune_pkg.Version_preference.t option Term.t
@@ -15,7 +19,7 @@ module Per_context : sig
   type t =
     { lock_dir_path : Path.Source.t
     ; version_preference : Dune_pkg.Version_preference.t
-    ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+    ; solver_env : Dune_pkg.Solver_env.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; context_common : Workspace.Context.Common.t
     ; repos :

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -17,3 +17,5 @@ module Package_version = Package_version
 module Pkg_workspace = Workspace
 module Local_package = Local_package
 module Package_universe = Package_universe
+module Variable_name = Variable_name
+module Variable_value = Variable_value

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -208,7 +208,7 @@ let opam_variable_to_slang ~loc packages variable =
     if not (is_valid_package_variable_name variable_string)
     then invalid_variable_error ~loc variable;
     let pform =
-      let name = Package_variable.Name.of_string variable_string in
+      let name = Variable_name.of_string variable_string in
       let scope : Package_variable.Scope.t =
         match package_name with
         | None -> Self

--- a/src/dune_pkg/package_variable.ml
+++ b/src/dune_pkg/package_variable.ml
@@ -1,35 +1,5 @@
 open Import
 
-module Name = struct
-  module T = struct
-    type t = OpamVariable.t
-
-    let to_dyn s = Dyn.string (OpamVariable.to_string s)
-    let compare x y = Ordering.of_int (OpamVariable.compare x y)
-  end
-
-  module Map = Map.Make (T)
-  include T
-
-  let to_opam = Fun.id
-  let of_opam = Fun.id
-
-  include (
-    Dune_util.Stringlike.Make (struct
-      type t = OpamVariable.t
-
-      let to_string x = OpamVariable.to_string x
-      let module_ = "Package_variable.Name"
-      let description = "package variable name"
-      let description_of_valid_string = None
-      let hint_valid = None
-      let of_string_opt s = if s = "" then None else Some (OpamVariable.of_string s)
-    end) :
-      Dune_util.Stringlike with type t := t)
-
-  let encode t = Dune_sexp.Encoder.string (to_string t)
-end
-
 module Scope = struct
   type t =
     | Self
@@ -51,19 +21,19 @@ end
 
 module T = struct
   type t =
-    { name : Name.t
+    { name : Variable_name.t
     ; scope : Scope.t
     }
 
   let compare t { name; scope } =
     match Scope.compare t.scope scope with
-    | Eq -> Name.compare t.name name
+    | Eq -> Variable_name.compare t.name name
     | x -> x
   ;;
 
   let to_dyn { name; scope } =
     let open Dyn in
-    record [ "name", Name.to_dyn name; "scope", Scope.to_dyn scope ]
+    record [ "name", Variable_name.to_dyn name; "scope", Scope.to_dyn scope ]
   ;;
 end
 
@@ -78,14 +48,14 @@ let of_macro_invocation ~loc ({ Pform.Macro_invocation.macro; _ } as macro_invoc
   match macro with
   | Pkg_self ->
     let variable_name = Pform.Macro_invocation.Args.whole macro_invocation in
-    Ok (self_scoped (Name.of_string variable_name))
+    Ok (self_scoped (Variable_name.of_string variable_name))
   | Pkg ->
     let package_name, variable_name =
       Pform.Macro_invocation.Args.lsplit2_exn macro_invocation loc
     in
     Ok
       (package_scoped
-         (Name.of_string variable_name)
+         (Variable_name.of_string variable_name)
          (Package_name.of_string package_name))
   | _ -> Error `Unexpected_macro
 ;;
@@ -94,12 +64,13 @@ let to_macro_invocation { name; scope } =
   match scope with
   | Self ->
     { Pform.Macro_invocation.macro = Pkg_self
-    ; payload = Pform.Payload.of_args [ Name.to_string name ]
+    ; payload = Pform.Payload.of_args [ Variable_name.to_string name ]
     }
   | Package package_name ->
     { Pform.Macro_invocation.macro = Pkg
     ; payload =
-        Pform.Payload.of_args [ Package_name.to_string package_name; Name.to_string name ]
+        Pform.Payload.of_args
+          [ Package_name.to_string package_name; Variable_name.to_string name ]
     }
 ;;
 

--- a/src/dune_pkg/package_variable.mli
+++ b/src/dune_pkg/package_variable.mli
@@ -1,20 +1,5 @@
 open Import
 
-module Name : sig
-  type t
-
-  val to_opam : t -> OpamVariable.t
-  val of_opam : OpamVariable.t -> t
-  val compare : t -> t -> Ordering.t
-  val to_dyn : t -> Dyn.t
-  val encode : t -> Dune_sexp.t
-
-  module Map : Map.S with type key = t
-
-  val of_string : string -> t
-  val to_string : t -> string
-end
-
 module Scope : sig
   type t =
     | Self
@@ -22,7 +7,7 @@ module Scope : sig
 end
 
 type t =
-  { name : Name.t
+  { name : Variable_name.t
   ; scope : Scope.t
   }
 

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -10,14 +10,12 @@ let substitute_variables_in_filter
   OpamFilter.map_up
     (function
       | FIdent ([], variable, None) as filter ->
-        (match Solver_env.Variable.of_string_opt (OpamVariable.to_string variable) with
+        let variable_name = Variable_name.of_opam variable in
+        Option.iter stats_updater ~f:(fun stats_updater ->
+          Solver_stats.Updater.expand_variable stats_updater variable_name);
+        (match Solver_env.get solver_env variable_name with
          | None -> filter
-         | Some variable ->
-           Option.iter stats_updater ~f:(fun stats_updater ->
-             Solver_stats.Updater.expand_variable stats_updater variable);
-           (match Solver_env.get solver_env variable with
-            | Unset_sys -> filter
-            | String string -> FString string))
+         | Some value -> Variable_value.to_opam_filter value)
       | other -> other)
     opam_filter
 ;;

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -1,222 +1,48 @@
 open Import
 
-module Variable = struct
-  module Sys = struct
-    module T = struct
-      type t =
-        [ `Arch
-        | `Os
-        | `Os_version
-        | `Os_distribution
-        | `Os_family
-        ]
+type t = Variable_value.t Variable_name.Map.t
 
-      let to_string = function
-        | `Arch -> "arch"
-        | `Os -> "os"
-        | `Os_version -> "os-version"
-        | `Os_distribution -> "os-distribution"
-        | `Os_family -> "os-family"
-      ;;
-
-      let compare a b = String.compare (to_string a) (to_string b)
-      let to_dyn t = Dyn.string (to_string t)
-      let all = [ `Arch; `Os; `Os_version; `Os_distribution; `Os_family ]
-    end
-
-    include T
-
-    let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
-
-    let decode =
-      let open Decoder in
-      let+ loc, name = located string in
-      match of_string_opt name with
-      | Some t -> t
-      | None ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "No such sys variable: %s" (String.maybe_quoted name)
-          ; Pp.textf
-              "Valid variables: %s"
-              (String.enumerate_and
-                 (List.map T.all ~f:(fun v -> String.maybe_quoted @@ to_string v)))
-          ]
-    ;;
-
-    module Map = Map.Make (T)
-
-    module Bindings = struct
-      type t = string Map.t
-
-      let empty = Map.empty
-      let to_dyn = Map.to_dyn Dyn.string
-      let equal = Map.equal ~equal:String.equal
-      let set = Map.set
-      let get = Map.find
-
-      let decode =
-        let open Decoder in
-        let+ loc, bindings = located (repeat (pair decode string)) in
-        match Map.of_list bindings with
-        | Ok t -> t
-        | Error (duplicate_key, a, b) ->
-          User_error.raise
-            ~loc
-            [ Pp.textf
-                "Duplicate entries for sys variable %s (%s, %s)"
-                (String.maybe_quoted (to_string duplicate_key))
-                (String.maybe_quoted a)
-                (String.maybe_quoted b)
-            ]
-      ;;
-
-      let extend t t' = Map.superpose t' t
-
-      let pp t =
-        Pp.enumerate all ~f:(fun variable ->
-          match Map.find t variable with
-          | Some value ->
-            Pp.textf "%s = %s" (to_string variable) (String.maybe_quoted value)
-          | None -> Pp.textf "%s (unset)" (to_string variable))
-      ;;
-    end
-  end
-
-  module Const = struct
-    type t = [ `Opam_version ]
-
-    let to_string = function
-      | `Opam_version -> "opam-version"
-    ;;
-
-    let to_dyn t = Dyn.string (to_string t)
-    let all = [ `Opam_version ]
-    let of_string_opt s = List.find all ~f:(fun t -> String.equal s (to_string t))
-
-    module Bindings = struct
-      type t = { opam_version : string }
-
-      let to_dyn { opam_version } = Dyn.(record [ "opam_version", string opam_version ])
-      let equal { opam_version } t = String.equal opam_version t.opam_version
-
-      let get { opam_version } = function
-        | `Opam_version -> opam_version
-      ;;
-
-      let pp { opam_version } =
-        Pp.enumerate
-          [ `Opam_version, opam_version ]
-          ~f:(fun (variable, value) -> Pp.textf "%s = %s" (to_string variable) value)
-      ;;
-    end
-
-    let bindings = { Bindings.opam_version = OpamVersion.to_string OpamVersion.current }
-  end
-
-  module T = struct
-    type t =
-      | Sys of Sys.t
-      | Const of Const.t
-
-    let to_dyn = function
-      | Sys sys -> Dyn.variant "Sys" [ Sys.to_dyn sys ]
-      | Const const -> Dyn.variant "Const" [ Const.to_dyn const ]
-    ;;
-
-    let of_string_opt string =
-      match Sys.of_string_opt string with
-      | Some sys -> Some (Sys sys)
-      | None -> Const.of_string_opt string |> Option.map ~f:(fun const -> Const const)
-    ;;
-
-    let to_string = function
-      | Sys sys -> Sys.to_string sys
-      | Const const -> Const.to_string const
-    ;;
-
-    let compare a b = String.compare (to_string a) (to_string b)
-    let equal a b = String.equal (to_string a) (to_string b)
-
-    let decode =
-      let open Decoder in
-      let+ loc, string = located string in
-      match of_string_opt string with
-      | Some t -> t
-      | None ->
-        User_error.raise
-          ~loc
-          [ Pp.textf "No such variable: %s" (String.maybe_quoted string) ]
-    ;;
-
-    let encode t = Encoder.string (to_string t)
-  end
-
-  include Comparable.Make (T)
-  include T
-end
-
-type t =
-  { sys : Variable.Sys.Bindings.t
-  ; const : Variable.Const.Bindings.t
-  }
-
-module Fields = struct
-  let sys = "sys"
-  let const = "const"
-end
-
-let create ~sys = { sys; const = Variable.Const.bindings }
-let default = create ~sys:Variable.Sys.Bindings.empty
+let empty = Variable_name.Map.empty
+let equal = Variable_name.Map.equal ~equal:Variable_value.equal
+let to_dyn = Variable_name.Map.to_dyn Variable_value.to_dyn
+let is_empty = Variable_name.Map.is_empty
 
 let decode =
   let open Decoder in
-  fields
-  @@
-  let+ sys = field Fields.sys ~default:default.sys Variable.Sys.Bindings.decode in
-  let const = default.const in
-  { sys; const }
-;;
-
-let to_dyn { sys; const } =
-  Dyn.record
-    [ Fields.sys, Variable.Sys.Bindings.to_dyn sys
-    ; Fields.const, Variable.Const.Bindings.to_dyn const
-    ]
-;;
-
-let equal { sys; const } t =
-  Variable.Sys.Bindings.equal sys t.sys && Variable.Const.Bindings.equal const t.const
-;;
-
-let sys { sys; _ } = sys
-let set_sys t sys = { t with sys }
-
-let pp =
-  let pp_section heading pp_section =
-    (* The hbox is to prevent long values in [pp_section] from causing the heading to wrap. *)
-    let pp_heading = Pp.hbox (Pp.text heading) in
-    Pp.concat ~sep:Pp.space [ pp_heading; pp_section ] |> Pp.vbox
+  let+ loc, bindings =
+    located (repeat (pair Variable_name.decode Variable_value.decode))
   in
-  fun { sys; const } ->
-    Pp.enumerate
-      ~f:Fun.id
-      [ pp_section "System Environment Variables" (Variable.Sys.Bindings.pp sys)
-      ; pp_section "Constants" (Variable.Const.Bindings.pp const)
+  match Variable_name.Map.of_list bindings with
+  | Ok t -> t
+  | Error (duplicate_key, a, b) ->
+    User_error.raise
+      ~loc
+      [ Pp.textf
+          "Duplicate entries for user variable %s (%s, %s)"
+          (String.maybe_quoted (Variable_name.to_string duplicate_key))
+          (String.maybe_quoted (Variable_value.to_string a))
+          (String.maybe_quoted (Variable_value.to_string b))
       ]
 ;;
 
-module Variable_value = struct
-  type t =
-    | String of string
-    | Unset_sys
-end
+let set = Variable_name.Map.set
+let get = Variable_name.Map.find
+let extend = Variable_name.Map.superpose
 
-let get t variable =
-  match (variable : Variable.t) with
-  | Const const -> Variable_value.String (Variable.Const.Bindings.get t.const const)
-  | Sys sys ->
-    (match Variable.Sys.Bindings.get t.sys sys with
-     | Some value -> String value
-     | None -> Unset_sys)
+let with_opam_version_set_to_current =
+  set
+    empty
+    Variable_name.opam_version
+    (OpamVersion.to_string OpamVersion.current |> Variable_value.string)
+;;
+
+let pp t =
+  if Variable_name.Map.is_empty t
+  then Pp.text "(empty)"
+  else
+    Pp.enumerate (Variable_name.Map.to_list t) ~f:(fun (variable, value) ->
+      Pp.textf
+        "%s = %s"
+        (Variable_name.to_string variable)
+        (String.maybe_quoted (Variable_value.to_string value)))
 ;;

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -1,88 +1,21 @@
 open Import
 
-module Variable : sig
-  module Sys : sig
-    (** Variables describing a system environment. These can be polled from the
-        current system and assigned specific values in dune-workspace but there
-        is no notion of a default value. During solving unset variables are
-        treated as wildcards so a solution can be built that works on a range of
-        systems. During building unset variables are treated as undefined
-        variables. *)
-    type t =
-      [ `Arch
-      | `Os
-      | `Os_version
-      | `Os_distribution
-      | `Os_family
-      ]
-
-    val to_string : t -> string
-    val of_string_opt : string -> t option
-
-    module Bindings : sig
-      type sys_var := t
-
-      (** A mapping from system environment variables to their values *)
-      type t
-
-      val to_dyn : t -> Dyn.t
-      val decode : t Decoder.t
-      val equal : t -> t -> bool
-      val empty : t
-      val set : t -> sys_var -> string -> t
-      val get : t -> sys_var -> string option
-
-      (** [extend a b] adds all variables from [b] to [a] overwriting any
-          existing values of those variables in [a]. *)
-      val extend : t -> t -> t
-    end
-  end
-
-  module Const : sig
-    (** Constant variables whose value can't be configured. These can be read
-        while solving and evaluating packages. *)
-    type t = [ `Opam_version ]
-  end
-
-  type t =
-    | Sys of Sys.t
-    | Const of Const.t
-
-  val to_string : t -> string
-  val of_string_opt : string -> t option
-
-  include Comparable_intf.S with type key := t
-
-  val equal : t -> t -> bool
-  val to_dyn : t -> Dyn.t
-  val decode : t Decoder.t
-  val encode : t Encoder.t
-end
-
-(** A variable environment used by the dependency solver to evaluate package
-    dependency filters. Opam packages can declare conditional dependencies on
-    other packages using a language made up of boolean operators and comparisons
-    of strings. Note that the variables in this environment are those that dune
-    allows users to configure or derive from their environment. Other variables,
-    such as the flags "with-test" and "with-doc" are not part of this
-    environment as dune does not give users access to those variables.. *)
 type t
 
-val create : sys:Variable.Sys.Bindings.t -> t
-val default : t
-val decode : t Decoder.t
-val to_dyn : t -> Dyn.t
+val empty : t
 val equal : t -> t -> bool
-val sys : t -> Variable.Sys.Bindings.t
-val set_sys : t -> Variable.Sys.Bindings.t -> t
+val to_dyn : t -> Dyn.t
+val is_empty : t -> bool
+val decode : t Decoder.t
+val set : t -> Variable_name.t -> Variable_value.t -> t
+val get : t -> Variable_name.t -> Variable_value.t option
 
-(** A human-readible summary of the variable environment *)
+(** [extend a b] adds all variables from [b] to [a] overwriting any
+    existing values of those variables in [a]. *)
+val extend : t -> t -> t
+
+(** A [t] with a single variable "opam-version" set to the version of the opam
+    library dependen on by dune *)
+val with_opam_version_set_to_current : t
+
 val pp : t -> 'a Pp.t
-
-module Variable_value : sig
-  type t =
-    | String of string
-    | Unset_sys
-end
-
-val get : t -> Variable.t -> Variable_value.t

--- a/src/dune_pkg/solver_stats.ml
+++ b/src/dune_pkg/solver_stats.ml
@@ -1,8 +1,8 @@
 open Import
 
-type t = { expanded_variables : Solver_env.Variable.Set.t }
+type t = { expanded_variables : Variable_name.Set.t }
 
-let empty = { expanded_variables = Solver_env.Variable.Set.empty }
+let empty = { expanded_variables = Variable_name.Set.empty }
 
 module Updater = struct
   type stats = t
@@ -13,14 +13,14 @@ module Updater = struct
 
   let expand_variable t variable =
     let { expanded_variables } = !t in
-    t := { expanded_variables = Solver_env.Variable.Set.add expanded_variables variable }
+    t := { expanded_variables = Variable_name.Set.add expanded_variables variable }
   ;;
 end
 
 module Expanded_variable_bindings = struct
   type t =
-    { variable_values : (Solver_env.Variable.t * string) list
-    ; unset_variables : Solver_env.Variable.t list
+    { variable_values : (Variable_name.t * Variable_value.t) list
+    ; unset_variables : Variable_name.t list
     }
 
   let empty = { variable_values = []; unset_variables = [] }
@@ -30,12 +30,12 @@ module Expanded_variable_bindings = struct
   ;;
 
   let of_variable_set variables solver_env =
-    Solver_env.Variable.Set.to_list variables
+    Variable_name.Set.to_list variables
     |> List.fold_left ~init:empty ~f:(fun acc variable ->
       match Solver_env.get solver_env variable with
-      | String string ->
-        { acc with variable_values = (variable, string) :: acc.variable_values }
-      | Unset_sys -> { acc with unset_variables = variable :: acc.unset_variables })
+      | Some value ->
+        { acc with variable_values = (variable, value) :: acc.variable_values }
+      | None -> { acc with unset_variables = variable :: acc.unset_variables })
   ;;
 
   let decode =
@@ -45,9 +45,9 @@ module Expanded_variable_bindings = struct
          field
            "variable_values"
            ~default:[]
-           (repeat (pair Solver_env.Variable.decode string))
+           (repeat (pair Variable_name.decode Variable_value.decode))
        and+ unset_variables =
-         field "unset_variables" ~default:[] (repeat Solver_env.Variable.decode)
+         field "unset_variables" ~default:[] (repeat Variable_name.decode)
        in
        { variable_values; unset_variables })
   ;;
@@ -59,48 +59,39 @@ module Expanded_variable_bindings = struct
      else
        [ Dune_sexp.List
            (string "variable_values"
-            :: List.map ~f:(pair Solver_env.Variable.encode string) variable_values)
+            :: List.map
+                 ~f:(pair Variable_name.encode Variable_value.encode)
+                 variable_values)
        ])
     @
     if List.is_empty unset_variables
     then []
     else
       [ Dune_sexp.List
-          (string "unset_variables"
-           :: List.map ~f:Solver_env.Variable.encode unset_variables)
+          (string "unset_variables" :: List.map ~f:Variable_name.encode unset_variables)
       ]
   ;;
 
   let equal { variable_values; unset_variables } t =
     List.equal
-      (Tuple.T2.equal Solver_env.Variable.equal String.equal)
+      (Tuple.T2.equal Variable_name.equal Variable_value.equal)
       variable_values
       t.variable_values
-    && List.equal Solver_env.Variable.equal unset_variables t.unset_variables
+    && List.equal Variable_name.equal unset_variables t.unset_variables
   ;;
 
   let to_dyn { variable_values; unset_variables } =
     Dyn.record
       [ ( "variable_values"
-        , Dyn.list (Tuple.T2.to_dyn Solver_env.Variable.to_dyn Dyn.string) variable_values
-        )
-      ; "unset_variables", Dyn.list Solver_env.Variable.to_dyn unset_variables
+        , Dyn.list
+            (Tuple.T2.to_dyn Variable_name.to_dyn Variable_value.to_dyn)
+            variable_values )
+      ; "unset_variables", Dyn.list Variable_name.to_dyn unset_variables
       ]
   ;;
 
   let to_solver_env { variable_values; unset_variables = _ } =
-    (* TODO currently this only supports system variables but this will be
-       generalized when the solver gains support for arbitrary variables *)
-    let sys =
-      List.fold_left
-        variable_values
-        ~init:Solver_env.Variable.Sys.Bindings.empty
-        ~f:(fun acc (variable, value) ->
-          match variable with
-          | Solver_env.Variable.Sys sys ->
-            Solver_env.Variable.Sys.Bindings.set acc sys value
-          | Const _ -> acc)
-    in
-    Solver_env.create ~sys
+    List.fold_left variable_values ~init:Solver_env.empty ~f:(fun acc (variable, value) ->
+      Solver_env.set acc variable value)
   ;;
 end

--- a/src/dune_pkg/solver_stats.mli
+++ b/src/dune_pkg/solver_stats.mli
@@ -1,6 +1,6 @@
 open Import
 
-type t = { expanded_variables : Solver_env.Variable.Set.t }
+type t = { expanded_variables : Variable_name.Set.t }
 
 module Updater : sig
   type stats = t
@@ -8,18 +8,18 @@ module Updater : sig
 
   val init : unit -> t
   val snapshot : t -> stats
-  val expand_variable : t -> Solver_env.Variable.t -> unit
+  val expand_variable : t -> Variable_name.t -> unit
 end
 
 module Expanded_variable_bindings : sig
   type t =
-    { variable_values : (Solver_env.Variable.t * string) list
-    ; unset_variables : Solver_env.Variable.t list
+    { variable_values : (Variable_name.t * Variable_value.t) list
+    ; unset_variables : Variable_name.t list
     }
 
   val empty : t
   val is_empty : t -> bool
-  val of_variable_set : Solver_env.Variable.Set.t -> Solver_env.t -> t
+  val of_variable_set : Variable_name.Set.t -> Solver_env.t -> t
   val decode : t Decoder.t
   val encode : t -> Dune_lang.t list
   val equal : t -> t -> bool

--- a/src/dune_pkg/substs.ml
+++ b/src/dune_pkg/substs.ml
@@ -72,9 +72,7 @@ struct
     let env =
       let self' = self |> Package_name.to_string |> OpamPackage.Name.of_string in
       fun full_variable ->
-        let name =
-          OpamVariable.Full.variable full_variable |> Package_variable.Name.of_opam
-        in
+        let name = OpamVariable.Full.variable full_variable |> Variable_name.of_opam in
         let scope : Package_variable.Scope.t =
           match
             OpamVariable.Full.package ~self:self' full_variable

--- a/src/dune_pkg/sys_poll.mli
+++ b/src/dune_pkg/sys_poll.mli
@@ -17,6 +17,6 @@ val os_distribution : path:Path.t list -> string option Fiber.t
 (** Returns the value of [os-family] *)
 val os_family : path:Path.t list -> string option Fiber.t
 
-(** Returns system variable bindings where all the system-dependent values that
+(** Returns a solver environment where all the system-dependent values that
     could be retrieved are set *)
-val sys_bindings : path:Path.t list -> Solver_env.Variable.Sys.Bindings.t Fiber.t
+val solver_env_from_current_system : path:Path.t list -> Solver_env.t Fiber.t

--- a/src/dune_pkg/variable_name.ml
+++ b/src/dune_pkg/variable_name.ml
@@ -1,0 +1,43 @@
+open Import
+
+module T = struct
+  type t = OpamVariable.t
+
+  let to_dyn s = Dyn.string (OpamVariable.to_string s)
+  let compare x y = Ordering.of_int (OpamVariable.compare x y)
+end
+
+module Map = Map.Make (T)
+module Set = Set.Make (T) (Map)
+include T
+
+let to_opam = Fun.id
+let of_opam = Fun.id
+let equal = OpamVariable.equal
+
+include (
+  Dune_util.Stringlike.Make (struct
+    type t = OpamVariable.t
+
+    let to_string x = OpamVariable.to_string x
+    let module_ = "Variable_name"
+    let description = "variable name"
+    let description_of_valid_string = None
+    let hint_valid = None
+    let of_string_opt s = if s = "" then None else Some (OpamVariable.of_string s)
+  end) :
+    Dune_util.Stringlike with type t := t)
+
+let encode t = Encoder.string (to_string t)
+
+let decode =
+  let open Decoder in
+  string >>| of_string
+;;
+
+let arch = of_string "arch"
+let os = of_string "os"
+let os_version = of_string "os-version"
+let os_distribution = of_string "os-distribution"
+let os_family = of_string "os-family"
+let opam_version = of_string "opam-version"

--- a/src/dune_pkg/variable_name.mli
+++ b/src/dune_pkg/variable_name.mli
@@ -1,0 +1,23 @@
+open! Import
+
+type t
+
+val to_opam : t -> OpamVariable.t
+val of_opam : OpamVariable.t -> t
+val compare : t -> t -> Ordering.t
+val to_dyn : t -> Dyn.t
+val encode : t Encoder.t
+val decode : t Decoder.t
+val equal : t -> t -> bool
+
+module Map : Map.S with type key = t
+module Set : Set.S with type elt = t and type 'a map = 'a Map.t
+
+val of_string : string -> t
+val to_string : t -> string
+val arch : t
+val os : t
+val os_version : t
+val os_distribution : t
+val os_family : t
+val opam_version : t

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -1,0 +1,43 @@
+open! Import
+
+(* Currently only string values can be represented. Opam silently converts
+   between strings to booleans when appropriate so this doesn't prevent boolean
+   values from being used in formulae. Since string values in dune syntax don't
+   require quotes, representing boolean literals requires extra syntax which we
+   don't yet have. When such a syntax exists we can add boolean values to this
+   type.
+
+   We also don't yet support setting variables to lists of strings which would
+   be needed for full compatibility with the [OpamTypes.variable_contents]
+   type.
+*)
+type t = String of string
+
+let string string = String string
+
+let equal a b =
+  match a, b with
+  | String a, String b -> String.equal a b
+;;
+
+let to_dyn = function
+  | String string -> Dyn.variant "String" [ Dyn.string string ]
+;;
+
+let to_string = function
+  | String string -> string
+;;
+
+let decode =
+  let open Decoder in
+  let+ string = string in
+  String string
+;;
+
+let encode = function
+  | String string -> Encoder.string string
+;;
+
+let to_opam_filter = function
+  | String string -> OpamTypes.FString string
+;;

--- a/src/dune_pkg/variable_value.mli
+++ b/src/dune_pkg/variable_value.mli
@@ -1,0 +1,13 @@
+open! Import
+
+type t
+
+(** Construct a value of type string *)
+val string : string -> t
+
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t
+val decode : t Decoder.t
+val encode : t Encoder.t
+val to_string : t -> string
+val to_opam_filter : t -> OpamTypes.filter

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -31,7 +31,7 @@ module Variable = struct
     | S of string
     | L of string list
 
-  type t = Package_variable.Name.t * value
+  type t = Variable_name.t * value
 
   let dyn_of_value : value -> Dyn.t =
     let open Dyn in
@@ -47,21 +47,19 @@ module Variable = struct
     | L s -> List.map s ~f:(fun x -> Value.String x)
   ;;
 
-  let to_dyn (name, value) =
-    Dyn.(pair Package_variable.Name.to_dyn dyn_of_value (name, value))
-  ;;
+  let to_dyn (name, value) = Dyn.(pair Variable_name.to_dyn dyn_of_value (name, value))
 end
 
 module Pkg_info = struct
   include Dune_pkg.Lock_dir.Pkg_info
 
   let variables t =
-    Package_variable.Name.Map.of_list_map_exn
+    Variable_name.Map.of_list_map_exn
       [ "name", Variable.S (Package.Name.to_string t.name)
       ; "version", S (Package_version.to_string t.version)
       ; "dev", B t.dev
       ]
-      ~f:(fun (name, value) -> Package_variable.Name.of_string name, value)
+      ~f:(fun (name, value) -> Variable_name.of_string name, value)
   ;;
 end
 
@@ -425,7 +423,7 @@ module Substitute = struct
                 | Self -> Dune_sexp.List []
                 | Package p -> Dune_lang.Package_name.encode p
               in
-              Dune_sexp.List [ package; Package_variable.Name.encode name ]
+              Dune_sexp.List [ package; Variable_name.encode name ]
             in
             let v =
               Dune_lang.atom_or_quoted_string (OpamVariable.string_of_variable_contents v)
@@ -470,7 +468,7 @@ module Action_expander = struct
     type t =
       { paths : Paths.t
       ; artifacts : Path.t Filename.Map.t
-      ; deps : (Variable.value Package_variable.Name.Map.t * Paths.t) Package.Name.Map.t
+      ; deps : (Variable.value Variable_name.Map.t * Paths.t) Package.Name.Map.t
       ; context : Context_name.t
       ; version : Package_version.t
       ; env : Value.t list Env.Map.t
@@ -561,15 +559,15 @@ module Action_expander = struct
           | Package package_name -> package_name
         in
         match Package.Name.Map.find deps package_name with
-        | None -> Package_variable.Name.Map.empty, None
+        | None -> Variable_name.Map.empty, None
         | Some (var, paths) -> var, Some paths
       in
-      match Package_variable.Name.Map.find variables variable_name with
+      match Variable_name.Map.find variables variable_name with
       | Some v -> Memo.return @@ Ok (Variable.dune_value v)
       | None ->
         let present = Option.is_some paths in
         (* TODO we should be looking it up in all packages now *)
-        (match Package_variable.Name.to_string variable_name with
+        (match Variable_name.to_string variable_name with
          | "pinned" -> Memo.return @@ Ok [ Value.false_ ]
          | "enable" ->
            Memo.return @@ Ok [ Value.String (if present then "enable" else "disable") ]
@@ -579,8 +577,7 @@ module Action_expander = struct
             | None -> Memo.return (Error (`Undefined_pkg_var variable_name))
             | Some paths ->
               (match
-                 Pform.Var.Pkg.Section.of_string
-                   (Package_variable.Name.to_string variable_name)
+                 Pform.Var.Pkg.Section.of_string (Variable_name.to_string variable_name)
                with
                | None -> Memo.return (Error (`Undefined_pkg_var variable_name))
                | Some section ->
@@ -593,7 +590,7 @@ module Action_expander = struct
       { env = _; paths; artifacts = _; context; deps; version = _ }
       ~source
       (pform : Pform.t)
-      : (Value.t list, [ `Undefined_pkg_var of Package_variable.Name.t ]) result Memo.t
+      : (Value.t list, [ `Undefined_pkg_var of Variable_name.t ]) result Memo.t
       =
       let loc = Dune_sexp.Template.Pform.loc source in
       match pform with
@@ -623,7 +620,7 @@ module Action_expander = struct
               ~loc:(Dune_sexp.Template.Pform.loc source)
               [ Pp.textf
                   "Undefined package variable: %s"
-                  (Package_variable.Name.to_string variable_name)
+                  (Variable_name.to_string variable_name)
               ])
     ;;
 
@@ -688,9 +685,7 @@ module Action_expander = struct
       (* values set with withenv *)
       Env.Map.map expander.env ~f:Env_update.string_of_env_values
       |> Env.Map.to_list_map ~f:(fun variable value ->
-        ( { Package_variable.scope = Self
-          ; name = Package_variable.Name.of_string variable
-          }
+        ( { Package_variable.scope = Self; name = Variable_name.of_string variable }
         , OpamVariable.S value ))
       |> Package_variable.Map.of_list_exn
     in
@@ -699,14 +694,14 @@ module Action_expander = struct
       ~init:env
       ~f:(fun name (var_conts, paths) env ->
         let env =
-          Package_variable.Name.Map.foldi var_conts ~init:env ~f:(fun key value env ->
+          Variable_name.Map.foldi var_conts ~init:env ~f:(fun key value env ->
             setenv name key value env)
         in
         let install_paths = Paths.install_paths paths in
         List.fold_left
           ~init:env
           ~f:(fun env (var_name, section) ->
-            let key = Package_variable.Name.of_string var_name in
+            let key = Variable_name.of_string var_name in
             let section =
               OpamVariable.S (Path.to_string (Install.Paths.get install_paths section))
             in
@@ -829,7 +824,7 @@ module Action_expander = struct
     type artifacts_and_deps =
       { binaries : Path.t Filename.Map.t
       ; dep_info :
-          (OpamVariable.variable_contents Package_variable.Name.Map.t * Paths.t)
+          (OpamVariable.variable_contents Variable_name.Map.t * Paths.t)
             Package.Name.Map.t
       }
 
@@ -852,8 +847,8 @@ module Action_expander = struct
             in
             let dep_info =
               let variables =
-                Package_variable.Name.Map.superpose
-                  (Package_variable.Name.Map.of_list_exn cookie.variables)
+                Variable_name.Map.superpose
+                  (Variable_name.Map.of_list_exn cookie.variables)
                   (Pkg_info.variables pkg.info)
               in
               Package.Name.Map.add_exn dep_info pkg.info.name (variables, pkg.paths)
@@ -1223,7 +1218,7 @@ module Install_action = struct
               [ message_with_loc; Pp.seq (Pp.text "Reason: ") (Pp.text message) ]
         in
         OpamFile.Dot_config.bindings config
-        |> List.map ~f:(fun (name, value) -> Package_variable.Name.of_opam name, value)
+        |> List.map ~f:(fun (name, value) -> Variable_name.of_opam name, value)
     ;;
 
     let install_entry ~src ~install_file ~target_dir (entry : Path.t Install.Entry.t) =

--- a/src/dune_rules/slang_expand.ml
+++ b/src/dune_rules/slang_expand.ml
@@ -1,16 +1,15 @@
 open! Stdune
 open Import
-module Package_variable = Dune_pkg.Package_variable
 
 type expander =
   String_with_vars.t
   -> dir:Path.t
-  -> (Value.t list, [ `Undefined_pkg_var of Package_variable.Name.t ]) result Memo.t
+  -> (Value.t list, [ `Undefined_pkg_var of Dune_pkg.Variable_name.t ]) result Memo.t
 
 type error =
   | Undefined_pkg_var of
       { literal : String_with_vars.t
-      ; variable_name : Package_variable.Name.t
+      ; variable_name : Dune_pkg.Variable_name.t
       }
 
 let rec eval_rec (t : Slang.t) ~dir ~f =
@@ -179,7 +178,7 @@ let eval t ~dir ~f =
       ~loc:(String_with_vars.loc literal)
       [ Pp.textf
           "Undefined package variable %S"
-          (Package_variable.Name.to_string variable_name)
+          (Dune_pkg.Variable_name.to_string variable_name)
       ]
 ;;
 
@@ -200,6 +199,6 @@ let eval_blang blang ~dir ~f =
       ~loc:(String_with_vars.loc literal)
       [ Pp.textf
           "Undefined package variable %S"
-          (Package_variable.Name.to_string variable_name)
+          (Dune_pkg.Variable_name.to_string variable_name)
       ]
 ;;

--- a/src/dune_rules/slang_expand.mli
+++ b/src/dune_rules/slang_expand.mli
@@ -4,8 +4,7 @@ open Import
 type expander =
   String_with_vars.t
   -> dir:Path.t
-  -> (Value.t list, [ `Undefined_pkg_var of Dune_pkg.Package_variable.Name.t ]) result
-       Memo.t
+  -> (Value.t list, [ `Undefined_pkg_var of Dune_pkg.Variable_name.t ]) result Memo.t
 
 (** Evaluate a [Slang.t] expression. Expressions in the unfollowed branches of
     if-statements are not followed and boolean expressions are evaluated

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -6,7 +6,7 @@ module Lock_dir : sig
   type t =
     { path : Path.Source.t
     ; version_preference : Dune_pkg.Version_preference.t option
-    ; solver_sys_vars : Dune_pkg.Solver_env.Variable.Sys.Bindings.t option
+    ; solver_env : Dune_pkg.Solver_env.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     }
 

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -31,11 +31,11 @@ Create a workspace config that defines separate build contexts for macos and lin
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.linux.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os linux)))
   > (lock_dir
   >  (path dune.macos.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os macos)))
   > (context
   >  (default

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -1,25 +1,18 @@
 Print the solver env when no dune-workspace is present
   $ dune pkg print-solver-env --dont-poll-system-solver-variables
   Solver environment for context default:
-  - System Environment Variables
-    - arch (unset)
-    - os (unset)
-    - os-version (unset)
-    - os-distribution (unset)
-    - os-family (unset)
-  - Constants
-    - opam-version = 2.2.0~alpha-vendored
+  - opam-version = 2.2.0~alpha-vendored
 
 Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.linux.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os linux)))
   > (lock_dir
   >  (path dune.linux.no-doc.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (arch x86_64)
   >   (os linux)
   >   (os-family ubuntu)
@@ -37,20 +30,12 @@ Add some build contexts with different environments
 
   $ dune pkg print-solver-env --all-contexts --dont-poll-system-solver-variables
   Solver environment for context no-doc:
-  - System Environment Variables
-    - arch = x86_64
-    - os = linux
-    - os-version = 22.04
-    - os-distribution = ubuntu
-    - os-family = ubuntu
-  - Constants
-    - opam-version = 2.2.0~alpha-vendored
+  - arch = x86_64
+  - opam-version = 2.2.0~alpha-vendored
+  - os = linux
+  - os-distribution = ubuntu
+  - os-family = ubuntu
+  - os-version = 22.04
   Solver environment for context linux:
-  - System Environment Variables
-    - arch (unset)
-    - os = linux
-    - os-version (unset)
-    - os-distribution (unset)
-    - os-family (unset)
-  - Constants
-    - opam-version = 2.2.0~alpha-vendored
+  - opam-version = 2.2.0~alpha-vendored
+  - os = linux

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -19,8 +19,8 @@ A package which doesn't use variables to determine its dependencies
 A packgae which uses variables to determine its dependencies
   $ mkpkg dynamic-deps 1.0 <<EOF
   > depends: [
-  >   "no-deps-a" { os = linux }
-  >   "no-deps-b" { arch = arm }
+  >   "no-deps-a" { os = "linux" }
+  >   "no-deps-b" { arch = "arm" }
   > ]
   > EOF
 
@@ -30,8 +30,8 @@ them to be ignored under lazy evaluation. This is to clarify the behaviour of
 the logic which stores solver vars in lockdir metadata in this case.
   $ mkpkg dynamic-deps-lazy 1.0 <<EOF
   > depends: [
-  >   "no-deps-a" { os = linux | os-family = ubuntu }
-  >   "no-deps-b" { arch = arm | os-version = "22.04" }
+  >   "no-deps-a" { os = "linux" | os-family = "ubuntu" }
+  >   "no-deps-b" { arch = "arm" | os-version = "22.04" }
   > ]
   > EOF
 
@@ -90,7 +90,7 @@ Make a workspace file which sets some of the variables.
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os linux)
   >   (arch arm)))
   > (context
@@ -113,6 +113,8 @@ Solve the packages again, this time with the variables set.
    (used))
   Solution for dune.lock:
   - dynamic-deps.1.0
+  - no-deps-a.1.0
+  - no-deps-b.1.0
   (lang package 0.1)
   
   (dependency_hash 6957fba0128609ffc98fac2561c329cb)
@@ -127,6 +129,8 @@ Solve the packages again, this time with the variables set.
     (arch arm)))
   Solution for dune.lock:
   - dynamic-deps-lazy.1.0
+  - no-deps-a.1.0
+  - no-deps-b.1.0
   (lang package 0.1)
   
   (dependency_hash 9675a3014e7e2db0f946b3ad2a95c037)

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -6,11 +6,11 @@ Set up two build contexts: a default one for linux and another for macos.
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os linux)))
   > (lock_dir
   >  (path dune.macos.lock)
-  >  (solver_sys_vars
+  >  (solver_env
   >   (os macos)))
   > (context (default))
   > (context

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -2,7 +2,8 @@ open Stdune
 module Checksum = Dune_pkg.Checksum
 module Lock_dir = Dune_pkg.Lock_dir
 module Expanded_variable_bindings = Dune_pkg.Solver_stats.Expanded_variable_bindings
-module Variable = Dune_pkg.Solver_env.Variable
+module Variable_name = Dune_pkg.Variable_name
+module Variable_value = Dune_pkg.Variable_value
 module Package_version = Dune_pkg.Package_version
 module Package_name = Dune_lang.Package_name
 
@@ -78,8 +79,9 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
          ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
          ~repos:None
          ~expanded_solver_variable_bindings:
-           { Expanded_variable_bindings.variable_values = [ Variable.Sys `Os, "linux" ]
-           ; unset_variables = [ Variable.Sys `Os_family ]
+           { Expanded_variable_bindings.variable_values =
+               [ Variable_name.os, Variable_value.string "linux" ]
+           ; unset_variables = [ Variable_name.os_family ]
            }
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
@@ -122,8 +124,8 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     ; ocaml = Some ("simple_lock_dir/lock.dune:3", "ocaml")
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
-        { variable_values = [ (Sys "os", "linux") ]
-        ; unset_variables = [ Sys "os-family" ]
+        { variable_values = [ ("os", String "linux") ]
+        ; unset_variables = [ "os-family" ]
         }
     } |}]
 ;;


### PR DESCRIPTION
This removes the distinctions between system solver variables and constants and switches to using a single map to store all solver variables. This also allows users to set arbitrary variables in the workspace context.

This was originally meant as fixes to https://github.com/ocaml/dune/pull/9256 but I ended up rewriting most of it so I'm opening a new PR.