### PR TITLE
feature(pkg): additional package constraints

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -57,6 +57,7 @@ let solve
            ; repos
            ; solver_env = solver_env_from_context
            ; context_common = { name = context_name; _ }
+           ; constraints
            ; repositories
            }
          ->
@@ -87,7 +88,8 @@ let solve
                  (Package_name.Map.map
                     local_packages
                     ~f:Dune_pkg.Local_package.for_solver)
-               ~experimental_translate_opam_filters)
+               ~experimental_translate_opam_filters
+               ~constraints)
          >>| function
          | Error (`Diagnostic_message message) -> Error (context_name, message)
          | Ok { lock_dir; files; _ } ->

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -23,6 +23,7 @@ let find_outdated_packages
               ; solver_env = _
               ; context_common = _
               ; repositories
+              ; constraints = _
               }
             ->
             (* updating makes sense when checking for outdated packages *)

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -50,6 +50,7 @@ module Per_context = struct
     ; context_common : Dune_rules.Workspace.Context.Common.t
     ; repos :
         Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
+    ; constraints : Dune_lang.Package_dependency.t list
     }
 
   let repositories_of_workspace (workspace : Workspace.t) =
@@ -70,6 +71,11 @@ module Per_context = struct
       |> Option.value
            ~default:[ Dune_pkg.Pkg_workspace.Repository.Name.of_string "default" ]
     in
+    let constraints =
+      match lock_dir with
+      | None -> []
+      | Some lock_dir -> lock_dir.constraints
+    in
     { lock_dir_path
     ; version_preference =
         Version_preference.choose
@@ -79,6 +85,7 @@ module Per_context = struct
     ; solver_env
     ; repositories
     ; repos = repositories_of_workspace workspace
+    ; constraints
     }
   ;;
 

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -24,6 +24,7 @@ module Per_context : sig
     ; context_common : Workspace.Context.Common.t
     ; repos :
         Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
+    ; constraints : Dune_lang.Package_dependency.t list
     }
 
   val choose

--- a/src/dune_lang/package_constraint.ml
+++ b/src/dune_lang/package_constraint.ml
@@ -207,3 +207,5 @@ let decode =
       Bvar (Variable.of_name (String.drop s 1))
     | _ -> sum (ops @ logops))
 ;;
+
+let equal x y = Ordering.is_eq (compare x y)

--- a/src/dune_lang/package_constraint.mli
+++ b/src/dune_lang/package_constraint.mli
@@ -43,5 +43,6 @@ type t =
 val encode : t Dune_sexp.Encoder.t
 val decode : t Dune_sexp.Decoder.t
 val to_dyn : t -> Dyn.t
+val equal : t -> t -> bool
 
 include Comparable_intf.S with type key := t

--- a/src/dune_lang/package_dependency.ml
+++ b/src/dune_lang/package_dependency.ml
@@ -31,3 +31,8 @@ let to_dyn { name; constraint_ } =
     ; "constr", Dyn.Option (Option.map ~f:Package_constraint.to_dyn constraint_)
     ]
 ;;
+
+let equal { name; constraint_ } t =
+  Package_name.equal name t.name
+  && Option.equal Package_constraint.equal constraint_ t.constraint_
+;;

--- a/src/dune_lang/package_dependency.mli
+++ b/src/dune_lang/package_dependency.mli
@@ -8,3 +8,4 @@ type t =
 val encode : t Dune_sexp.Encoder.t
 val decode : t Dune_sexp.Decoder.t
 val to_dyn : t -> Dyn.t
+val equal : t -> t -> bool

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -13,4 +13,5 @@ val solve_lock_dir
   -> Opam_repo.t list
   -> local_packages:Local_package.For_solver.t Package_name.Map.t
   -> experimental_translate_opam_filters:bool
+  -> constraints:Dune_lang.Package_dependency.t list
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -8,9 +8,10 @@ module Lock_dir = struct
     ; version_preference : Dune_pkg.Version_preference.t option
     ; solver_env : Dune_pkg.Solver_env.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
+    ; constraints : Dune_lang.Package_dependency.t list
     }
 
-  let to_dyn { path; version_preference; solver_env; repositories } =
+  let to_dyn { path; version_preference; solver_env; repositories; constraints } =
     Dyn.record
       [ "path", Path.Source.to_dyn path
       ; ( "version_preference"
@@ -18,14 +19,15 @@ module Lock_dir = struct
       ; "solver_env", Dyn.option Dune_pkg.Solver_env.to_dyn solver_env
       ; ( "repositories"
         , Dyn.list Dune_pkg.Pkg_workspace.Repository.Name.to_dyn repositories )
+      ; "constraints", Dyn.list Dune_lang.Package_dependency.to_dyn constraints
       ]
   ;;
 
-  let hash { path; version_preference; solver_env; repositories } =
-    Poly.hash (path, version_preference, solver_env, repositories)
+  let hash { path; version_preference; solver_env; repositories; constraints } =
+    Poly.hash (path, version_preference, solver_env, repositories, constraints)
   ;;
 
-  let equal { path; version_preference; solver_env; repositories } t =
+  let equal { path; version_preference; solver_env; repositories; constraints } t =
     Path.Source.equal path t.path
     && Option.equal
          Dune_pkg.Version_preference.equal
@@ -33,6 +35,7 @@ module Lock_dir = struct
          t.version_preference
     && Option.equal Dune_pkg.Solver_env.equal solver_env t.solver_env
     && List.equal Dune_pkg.Pkg_workspace.Repository.Name.equal repositories t.repositories
+    && List.equal Dune_lang.Package_dependency.equal constraints t.constraints
   ;;
 
   let decode =
@@ -53,11 +56,15 @@ module Lock_dir = struct
       and+ solver_env = field_o "solver_env" Dune_pkg.Solver_env.decode
       and+ version_preference =
         field_o "version_preference" Dune_pkg.Version_preference.decode
-      and+ repositories = Dune_lang.Ordered_set_lang.field "repositories" in
+      and+ repositories = Dune_lang.Ordered_set_lang.field "repositories"
+      and+ constraints =
+        field ~default:[] "constraints" (repeat Dune_lang.Package_dependency.decode)
+      in
       { path
       ; solver_env
       ; version_preference
       ; repositories = repositories_of_ordered_set repositories
+      ; constraints
       }
     in
     fields decode

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -8,6 +8,7 @@ module Lock_dir : sig
     ; version_preference : Dune_pkg.Version_preference.t option
     ; solver_env : Dune_pkg.Solver_env.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
+    ; constraints : Dune_lang.Package_dependency.t list
     }
 
   val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints.t
@@ -1,0 +1,28 @@
+It's possible to include additional packages or constraints in workspace files:
+
+  $ . ./helpers.sh
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.11)
+  > (lock_dir
+  >  (constraints doesnotexist foo (bar (= 1.0.0))))
+  > EOF
+
+  $ mkrepo
+
+  $ mkpkg foo 1.0.0
+  $ mkpkg bar 1.0.0
+  $ mkpkg bar 1.9.1
+
+Notice that the constraints field doesn't introduce additional packages. The
+"doesnotexist" package isn't being pulled.
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (depends foo bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.1.0.0
+  - foo.1.0.0


### PR DESCRIPTION
It's often useful to add additional constraints when solving lock
directories. The additional constraints can be usde to force different
configuration for testing.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c3d946b9-258f-49ef-9eaa-9ae34de40044 -->