### PR TITLE
[coq] Correctly handle composed stdlib after coq lang 0.8

### DIFF
--- a/doc/changes/9347_fix_coq_boot_bug.md
+++ b/doc/changes/9347_fix_coq_boot_bug.md
@@ -1,0 +1,2 @@
+- [coq] Fix bug in computation of flags when composed with boot theories.
+  (#9347, fixes #7909, @ejgallego)

--- a/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
@@ -15,7 +15,7 @@ Testing coqdoc when composed with a boot library
 Dune should be passing '--coqlib' to coqdoc, but it doesn't. This is a bug.
 
   $ cat _build/log | sed 's/$ (cd .*coqc/coqc/' | sed 's/$ (cd .*coqdoc/coqdoc/' | sed '/# /d' | sed '/> /d' | sort
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R Coq Coq Coq/mytheory.v)
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -R Coq Coq -R A A A/a.v)
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -R Coq Coq Coq/Init/Prelude.v)
+  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -boot -R Coq Coq Coq/mytheory.v)
+  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Coq -R A A A/a.v)
+  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Coq Coq/Init/Prelude.v)
   coqdoc -R ../Coq Coq -R . A --toc --html -d A.html a.v)

--- a/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
@@ -1,11 +1,17 @@
 Test that when `(stdlib no)` is provided, the standard library is not bound to `Coq`
-and the prelude is not imported
+and the prelude is not imported; we expect the below two tests to fail.
 
   $ dune build --display=short foo.vo
   Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
   3.8 and will be removed in an upcoming Dune version.
         coqdep .basic.theory.d
-          coqc foo.{glob,vo}
+  *** Warning: in file foo.v, library Prelude is required from root Coq and has not been found in the loadpath!
+          coqc foo.{glob,vo} (exit 1)
+  File "./foo.v", line 1, characters 0-32:
+  Error: Cannot find a physical path bound to logical path
+  Prelude with prefix Coq.
+  
+  [1]
 
   $ dune build --display=short bar.vo
   Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune


### PR DESCRIPTION
Indeed the logic is a bit more complex than what we had. Current setup should work well now.

Fixes #7909 , replaces #7942

This also reverts most of d92cb2e4fb8500aaaabd0d08b4959bf44eaa6157