### PR TITLE
fix(pkg): Only parse `blob` objects into files

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -134,4 +134,4 @@ With this set up in place, locking should still work as the commit is not
 relevant
 
   $ XDG_CACHE_HOME=$PWD/dune-cache dune pkg lock 2> /dev/null && echo "Solution found"
-  [1]
+  Solution found


### PR DESCRIPTION
While investigating #9328 it turns out that the tree has an object that's of type `commit`. I originally thought that this was a symlink to nowhere (since the revision it points to does not exist) but it turns out it is something different as symlinks are represented as blobs after all.

The code should discard these non-blob objects. However I don't yet know how to create a `commit` object for the repro case so for now it only tests broken symlinks. Any git-fu appreciated!

Fixes #9328