### PR TITLE
pkg: remove constructor for Variable_value.t

### DIFF
--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -11,33 +11,12 @@ open! Import
    be needed for full compatibility with the [OpamTypes.variable_contents]
    type.
 *)
-type t = String of string
+type t = string
 
-let string string = String string
-
-let equal a b =
-  match a, b with
-  | String a, String b -> String.equal a b
-;;
-
-let to_dyn = function
-  | String string -> Dyn.variant "String" [ Dyn.string string ]
-;;
-
-let to_string = function
-  | String string -> string
-;;
-
-let decode =
-  let open Decoder in
-  let+ string = string in
-  String string
-;;
-
-let encode = function
-  | String string -> Encoder.string string
-;;
-
-let to_opam_filter = function
-  | String string -> OpamTypes.FString string
-;;
+let string = Fun.id
+let equal = String.equal
+let to_dyn = Dyn.string
+let to_string = Fun.id
+let decode = Decoder.string
+let encode = Encoder.string
+let to_opam_filter t = OpamTypes.FString t

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -124,7 +124,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     ; ocaml = Some ("simple_lock_dir/lock.dune:3", "ocaml")
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
-        { variable_values = [ ("os", String "linux") ]
+        { variable_values = [ ("os", "linux") ]
         ; unset_variables = [ "os-family" ]
         }
     } |}]


### PR DESCRIPTION
There was only one constructor so it's not necessary. If this type gets support for other value types (e.g. booleans) we'll add it back.