### PR TITLE
add option to keep sandboxes after use

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -192,3 +192,9 @@ let threaded_console_frames_per_second =
   register t;
   t
 ;;
+
+let clear_sandboxes =
+  let t = { name = "clear_sandboxes"; of_string = Toggle.of_string; value = `Enabled } in
+  register t;
+  t
+;;

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -57,6 +57,9 @@ val threaded_console_frames_per_second : [ `Default | `Custom of int ] t
 (** Controls whether we use background threads in the dune rules *)
 val background_dune_rules : Toggle.t t
 
+(** Whether to destroy sandboxes after use. Enabled by default. *)
+val clear_sandboxes : Toggle.t t
+
 (** Before any configuration value is accessed, this function must be called
     with all the configuration values from the relevant config file
     ([dune-workspace], or [dune-config]).

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -382,7 +382,10 @@ end = struct
     Fiber.finalize
       ~finally:(fun () ->
         match sandbox with
-        | Some sandbox -> Sandbox.destroy sandbox
+        | Some sandbox ->
+          (match Config.(get clear_sandboxes) with
+           | `Enabled -> Sandbox.destroy sandbox
+           | `Disabled -> Fiber.return ())
         | None ->
           Pending_targets.remove targets;
           Fiber.return ())


### PR DESCRIPTION
### Problem

When running into errors or unexpected outputs in our rules it can be helpful to inspect the _build directory to see what has happened. Unfortunately if these actions are sandboxed, we do not retain the sandbox after execution which makes debugging them difficult.

### Solution

We add a hidden developer option `DUNE_CONFIG__CLEAR_SANDBOXES` that defaults to `enabled` which when `disabled` will skip the cleanup step of the sandboxing mechanism. This allows for manual inspection of a _build directory and allows us to better rerun command line output for sandboxed actions.

This was useful in debugging #9374 for example.