### PR TITLE
refactor: make all stanzas define comparisons/hashing

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -148,7 +148,7 @@ let libs db (context : Context.t) (build_system : Dune_rules.Main.build_system) 
   Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_rules.Dune_file.t) ->
     Memo.parallel_map dune_file.stanzas ~f:(fun stanza ->
       let dir = dune_file.dir in
-      match stanza with
+      match Stanza.repr stanza with
       | Dune_rules.Dune_file.Executables.T exes ->
         let* ocaml = Context.ocaml context in
         resolve_libs

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -61,7 +61,7 @@ let get_pped_file super_context file =
          Option.bind dune_file ~f:(fun dune_file ->
            dune_file.stanzas
            |> List.fold_left ~init:None ~f:(fun acc stanza ->
-             match stanza with
+             match Stanza.repr stanza with
              | Dune_rules.Dune_file.Library.T lib ->
                let preprocess =
                  Dune_rules.Preprocess.Per_module.(

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -536,7 +536,7 @@ module Crawl = struct
       Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_file.t) ->
         Memo.parallel_map dune_file.stanzas ~f:(fun stanza ->
           let dir = Path.Build.append_source (Context.build_dir context) dune_file.dir in
-          match stanza with
+          match Stanza.repr stanza with
           | Dune_file.Executables.T exes ->
             executables sctx ~options ~project:dune_file.project ~dir exes
           | _ -> Memo.return None)

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -53,7 +53,7 @@ module File = struct
 
     let stanzas_conflict (a : Stanza.t) (b : Stanza.t) =
       let open Dune_file in
-      match a, b with
+      match Stanza.repr a, Stanza.repr b with
       | Executables.T a, Executables.T b -> executables_conflict a b
       | Library.T a, Library.T b -> libraries_conflict a b
       | Tests.T a, Tests.T b -> tests_conflict a b

--- a/src/dune_lang/stanza.ml
+++ b/src/dune_lang/stanza.ml
@@ -1,14 +1,63 @@
 open! Stdune
 open Dune_sexp
+module Id = Id.Make ()
 
-type t = ..
+type repr = ..
+type _ witness = ..
+
+module type T = sig
+  type t
+  type _ witness += W : t witness
+
+  val repr : t -> repr
+  val id : Id.t
+  val compare : t -> t -> Ordering.t
+  val hash : t -> int
+end
+
+type t = E : 'a * (module T with type t = 'a) -> t
+
+module type S = sig
+  type stanza := t
+  type t
+  type repr += T of t
+
+  val make_stanza : t -> stanza
+end
+
+let repr (E (a, (module T))) = T.repr a
 
 module Make (S : sig
     type t
+
+    val compare : t -> t -> Ordering.t
+    val hash : t -> int
   end) =
 struct
-  type t += T of S.t
+  type repr += T of S.t
+
+  module T = struct
+    include S
+
+    let id = Id.gen ()
+    let repr x = T x
+
+    type _ witness += W : t witness
+  end
+
+  include T
+
+  let make_stanza (a : S.t) = E (a, (module T))
 end
+
+let compare (E (x, (module X))) (E (y, (module Y))) =
+  match X.W with
+  | Y.W -> X.compare x y
+  | _ -> Id.compare X.id Y.id
+;;
+
+let hash (E (t, (module T))) = Tuple.T2.hash Id.hash T.hash (T.id, t)
+let equal x y = Ordering.is_eq (compare x y)
 
 module Parser = struct
   type nonrec t = string * t list Decoder.t

--- a/src/dune_lang/stanza.mli
+++ b/src/dune_lang/stanza.mli
@@ -3,14 +3,28 @@
 open! Stdune
 open Dune_sexp
 
-type t = private ..
+type repr = ..
+type t
+
+val repr : t -> repr
+
+module type S = sig
+  type stanza := t
+  type t
+  type repr += T of t
+
+  val make_stanza : t -> stanza
+end
 
 module Make (S : sig
     type t
-  end) : sig
-  type t += T of S.t
-end
 
+    val hash : t -> int
+    val compare : t -> t -> Ordering.t
+  end) : S with type t := S.t
+
+val equal : t -> t -> bool
+val hash : t -> int
 val latest_version : Syntax.Version.t
 
 module Parser : sig

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -51,7 +51,8 @@ include Action_builder.Alias_rec (struct
           | Some stanzas ->
             let+ in_melange_target_dirs =
               let melange_target_dirs =
-                List.filter_map stanzas.stanzas ~f:(function
+                List.filter_map stanzas.stanzas ~f:(fun stanza ->
+                  match Stanza.repr stanza with
                   | Melange_stanzas.Emit.T mel ->
                     Some (Melange_stanzas.Emit.target_dir ~dir:build_path mel)
                   | _ -> None)

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -66,7 +66,7 @@ let get_installed_binaries ~(context : Context.t) stanzas =
       >>| Path.Build.Set.of_list
     in
     Memo.List.map d.stanzas ~f:(fun stanza ->
-      match (stanza : Stanza.t) with
+      match Stanza.repr stanza with
       | Dune_file.Install_conf.T { section = Section Bin; files; _ } ->
         binaries_from_install files
       | Dune_file.Executables.T

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -17,6 +17,8 @@ let cinaps_alias = Alias.Name.of_string name
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)
 
 let syntax =
@@ -65,7 +67,7 @@ let () =
   let open Dune_lang.Decoder in
   Dune_project.Extension.register_simple
     syntax
-    (return [ (name, decode >>| fun x -> [ T x ]) ])
+    (return [ (name, decode >>| fun x -> [ make_stanza x ]) ])
 ;;
 
 let gen_rules sctx t ~dir ~scope =

--- a/src/dune_rules/cinaps.mli
+++ b/src/dune_rules/cinaps.mli
@@ -11,7 +11,7 @@
 open Import
 
 type t
-type Stanza.t += T of t
+type Stanza.repr += T of t
 
 (** Generate the rules to handle this cinaps stanza *)
 val gen_rules : Super_context.t -> t -> dir:Path.Build.t -> scope:Scope.t -> unit Memo.t

--- a/src/dune_rules/coq/coq_sources.ml
+++ b/src/dune_rules/coq/coq_sources.ml
@@ -60,48 +60,46 @@ let extract t (stanza : Extraction.t) = Loc.Map.find_exn t.extract stanza.builda
 let of_dir stanzas ~dir ~include_subdirs ~dirs =
   check_no_unqualified include_subdirs;
   let modules = coq_modules_of_files ~dirs in
-  List.fold_left stanzas ~init:empty ~f:(fun acc ->
-      function
-      | Theory.T coq ->
-        let modules = Coq_module.eval ~dir coq.modules ~standard:modules in
-        let directories =
-          Coq_lib_name.Map.add_exn
-            acc.directories
-            (snd coq.name)
-            (List.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir))
-        in
-        let libraries = Coq_lib_name.Map.add_exn acc.libraries (snd coq.name) modules in
-        let rev_map =
-          List.fold_left modules ~init:acc.rev_map ~f:(fun acc m ->
-            Coq_module.Map.add acc m (`Theory coq)
-            |> function
-            | Ok acc -> acc
-            | Error _ ->
-              User_error.raise
-                ~loc:coq.buildable.loc
-                [ Pp.textf
-                    "Duplicate Coq module %S."
-                    (Coq_module.name m |> Coq_module.Name.to_string)
-                ])
-        in
-        { acc with directories; libraries; rev_map }
-      | Extraction.T extr ->
-        let loc, prelude = extr.prelude in
-        let m =
-          match
-            List.find modules ~f:(fun m ->
-              Coq_module.Name.equal (Coq_module.name m) prelude)
-          with
-          | Some m -> m
-          | None ->
+  List.fold_left stanzas ~init:empty ~f:(fun acc stanza ->
+    match Stanza.repr stanza with
+    | Theory.T coq ->
+      let modules = Coq_module.eval ~dir coq.modules ~standard:modules in
+      let directories =
+        Coq_lib_name.Map.add_exn
+          acc.directories
+          (snd coq.name)
+          (List.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir))
+      in
+      let libraries = Coq_lib_name.Map.add_exn acc.libraries (snd coq.name) modules in
+      let rev_map =
+        List.fold_left modules ~init:acc.rev_map ~f:(fun acc m ->
+          Coq_module.Map.add acc m (`Theory coq)
+          |> function
+          | Ok acc -> acc
+          | Error _ ->
             User_error.raise
-              ~loc
-              [ Pp.text "no coq source corresponding to prelude field" ]
-        in
-        let extract = Loc.Map.add_exn acc.extract extr.buildable.loc m in
-        let rev_map = Coq_module.Map.add_exn acc.rev_map m (`Extraction extr) in
-        { acc with extract; rev_map }
-      | _ -> acc)
+              ~loc:coq.buildable.loc
+              [ Pp.textf
+                  "Duplicate Coq module %S."
+                  (Coq_module.name m |> Coq_module.Name.to_string)
+              ])
+      in
+      { acc with directories; libraries; rev_map }
+    | Extraction.T extr ->
+      let loc, prelude = extr.prelude in
+      let m =
+        match
+          List.find modules ~f:(fun m ->
+            Coq_module.Name.equal (Coq_module.name m) prelude)
+        with
+        | Some m -> m
+        | None ->
+          User_error.raise ~loc [ Pp.text "no coq source corresponding to prelude field" ]
+      in
+      let extract = Loc.Map.add_exn acc.extract extr.buildable.loc m in
+      let rev_map = Coq_module.Map.add_exn acc.rev_map m (`Extraction extr) in
+      { acc with extract; rev_map }
+    | _ -> acc)
 ;;
 
 let lookup_module t m = Coq_module.Map.find t.rev_map m

--- a/src/dune_rules/coq/coq_stanza.ml
+++ b/src/dune_rules/coq/coq_stanza.ml
@@ -46,9 +46,11 @@ module Coqpp = struct
 
   include Stanza.Make (struct
       type nonrec t = t
+
+      include Poly
     end)
 
-  let p = "coq.pp", decode >>| fun x -> [ T x ]
+  let p = "coq.pp", decode >>| fun x -> [ make_stanza x ]
 end
 
 module Buildable = struct
@@ -133,9 +135,11 @@ module Extraction = struct
 
   include Stanza.Make (struct
       type nonrec t = t
+
+      include Poly
     end)
 
-  let p = "coq.extraction", decode >>| fun x -> [ T x ]
+  let p = "coq.extraction", decode >>| fun x -> [ make_stanza x ]
 end
 
 module Theory = struct
@@ -236,6 +240,8 @@ module Theory = struct
 
   include Stanza.Make (struct
       type nonrec t = t
+
+      include Poly
     end)
 
   let coqlib_warn x =
@@ -248,8 +254,8 @@ module Theory = struct
     x
   ;;
 
-  let coqlib_p = "coqlib", decode >>| fun x -> [ T (coqlib_warn x) ]
-  let p = "coq.theory", decode >>| fun x -> [ T x ]
+  let coqlib_p = "coqlib", decode >>| fun x -> [ make_stanza (coqlib_warn x) ]
+  let p = "coq.theory", decode >>| fun x -> [ make_stanza x ]
 end
 
 let unit_stanzas =

--- a/src/dune_rules/coq/coq_stanza.mli
+++ b/src/dune_rules/coq/coq_stanza.mli
@@ -21,7 +21,7 @@ module Extraction : sig
 
   val ml_target_fnames : t -> string list
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Theory : sig
@@ -37,7 +37,7 @@ module Theory : sig
     ; coqdoc_flags : Ordered_set_lang.Unexpanded.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Coqpp : sig
@@ -46,7 +46,7 @@ module Coqpp : sig
     ; loc : Loc.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 val key : unit Dune_project.Extension.t

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -101,7 +101,8 @@ let collect_stanzas =
     match stanzas with
     | None -> []
     | Some (d : Dune_file.t) ->
-      List.filter_map d.stanzas ~f:(function
+      List.filter_map d.stanzas ~f:(fun x ->
+        match Stanza.repr x with
         | Cram_stanza.T c -> Option.some_if (f c) (dir, c)
         | _ -> None)
   in

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -33,6 +33,8 @@ type t =
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)
 
 let decode =

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -15,6 +15,6 @@ type t =
   ; runtest_alias : (Loc.t * bool) option
   }
 
-type Stanza.t += T of t
+include Stanza.S with type t := t
 
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/ctypes/ctypes_field.ml
+++ b/src/dune_rules/ctypes/ctypes_field.ml
@@ -151,6 +151,8 @@ type t =
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)
 
 let decode =
@@ -200,7 +202,7 @@ let () =
   let open Dune_lang.Decoder in
   Dune_project.Extension.register_simple
     syntax
-    (return [ (name, decode >>| fun x -> [ T x ]) ])
+    (return [ (name, decode >>| fun x -> [ make_stanza x ]) ])
 ;;
 
 let type_gen_script ctypes =

--- a/src/dune_rules/ctypes/ctypes_field.mli
+++ b/src/dune_rules/ctypes/ctypes_field.mli
@@ -61,7 +61,7 @@ type t =
   ; version : Syntax.Version.t
   }
 
-type Stanza.t += T of t
+type Stanza.repr += T of t
 
 val decode : t Dune_lang.Decoder.t
 val syntax : Dune_lang.Syntax.t

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -128,7 +128,8 @@ let build_mlds_map stanzas ~dir ~files =
         | _ -> acc)
       |> Memo.return)
   in
-  Memo.parallel_map stanzas ~f:(function
+  Memo.parallel_map stanzas ~f:(fun x ->
+    match Stanza.repr x with
     | Documentation.T doc ->
       let+ mlds =
         let+ mlds = Memo.Lazy.force mlds in
@@ -186,7 +187,7 @@ end = struct
           Super_context.expander sctx ~dir >>| add_sources_to_expander sctx
         in
         Memo.parallel_map stanzas ~f:(fun stanza ->
-          match (stanza : Stanza.t) with
+          match Stanza.repr stanza with
           | Coq_stanza.Coqpp.T { modules; _ } ->
             Coq_sources.mlg_files ~sctx ~dir ~modules
             >>| List.rev_map ~f:(fun mlg_file ->

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -55,7 +55,7 @@ let current_group dir = function
 
 let get_include_subdirs stanzas =
   List.fold_left stanzas ~init:None ~f:(fun acc stanza ->
-    match stanza with
+    match Stanza.repr stanza with
     | Include_subdirs.T (loc, x) ->
       if Option.is_some acc
       then
@@ -68,7 +68,7 @@ let get_include_subdirs stanzas =
 
 let find_module_stanza stanzas =
   List.find_map stanzas ~f:(fun stanza ->
-    match stanza with
+    match Stanza.repr stanza with
     | Melange_stanzas.Emit.T { loc; _ }
     | Library.T { buildable = { loc; _ }; _ }
     | Executables.T { buildable = { loc; _ }; _ }
@@ -91,7 +91,7 @@ let error_no_module_consumer ~loc (qualification : Include_subdirs.qualification
 
 let extract_directory_targets ~dir stanzas =
   Memo.List.fold_left stanzas ~init:Path.Build.Map.empty ~f:(fun acc stanza ->
-    match stanza with
+    match Stanza.repr stanza with
     | Rule.T { targets = Static { targets = l; _ }; loc = rule_loc; _ } ->
       List.fold_left l ~init:acc ~f:(fun acc (target, kind) ->
         let loc = String_with_vars.loc target in

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -324,4 +324,6 @@ let fire_hooks t ~profile =
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)

--- a/src/dune_rules/dune_env.mli
+++ b/src/dune_rules/dune_env.mli
@@ -62,4 +62,4 @@ val add_error : t -> message:User_message.t -> t
 val add_warning : t -> message:User_message.t -> t
 val fire_hooks : t -> profile:Profile.t -> unit
 
-type Stanza.t += T of t
+include Stanza.S with type t := t

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -171,7 +171,7 @@ module Library : sig
     ; melange_runtime_deps : Loc.t * Dep_conf.t list
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 
   val sub_dir : t -> string option
   val package : t -> Package.t option
@@ -224,7 +224,7 @@ module Plugin : sig
     ; optional : bool
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Install_conf : sig
@@ -237,7 +237,7 @@ module Install_conf : sig
     ; enabled_if : Blang.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Executables : sig
@@ -287,7 +287,7 @@ module Executables : sig
     ; dune_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 
   (** Check if the executables have any foreign stubs or archives. *)
   val has_foreign : t -> bool
@@ -308,7 +308,7 @@ module Copy_files : sig
     ; syntax_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Rule : sig
@@ -325,7 +325,7 @@ module Rule : sig
     ; package : Package.t option
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Alias_conf : sig
@@ -339,7 +339,7 @@ module Alias_conf : sig
     ; loc : Loc.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Documentation : sig
@@ -349,7 +349,7 @@ module Documentation : sig
     ; mld_files : Ordered_set_lang.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Tests : sig
@@ -363,7 +363,7 @@ module Tests : sig
     ; action : Dune_lang.Action.t option
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Toplevel : sig
@@ -374,7 +374,7 @@ module Toplevel : sig
     ; pps : Preprocess.Without_instrumentation.t Preprocess.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 end
 
 module Include_subdirs : sig
@@ -387,7 +387,7 @@ module Include_subdirs : sig
     | Include of qualification
 
   type stanza = Loc.t * t
-  type Stanza.t += T of stanza
+  type Stanza.repr += T of stanza
 end
 
 (** The purpose of [Library_redirect] stanza is to create a redirection from an
@@ -411,7 +411,8 @@ module Library_redirect : sig
 
   module Local : sig
     type nonrec t = (Loc.t * Lib_name.Local.t) t
-    type Stanza.t += T of t
+
+    include Stanza.S with type t := t
 
     val of_private_lib : Library.t -> t option
   end
@@ -427,7 +428,7 @@ module Deprecated_library_name : sig
   end
 
   type t = Old_name.t Library_redirect.t
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 
   val old_public_name : t -> Lib_name.t
 end

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -26,7 +26,8 @@ module Node = struct
     >>| function
     | None -> None
     | Some stanzas ->
-      List.find_map stanzas.stanzas ~f:(function
+      List.find_map stanzas.stanzas ~f:(fun stanza ->
+        match Stanza.repr stanza with
         | Dune_env.T config -> Some config
         | _ -> None)
   ;;

--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -266,6 +266,8 @@ module Library = struct
 
   include Stanza.Make (struct
       type nonrec t = t
+
+      include Poly
     end)
 end
 

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -161,7 +161,7 @@ module Library : sig
 
   val decode : t Dune_lang.Decoder.t
 
-  type Stanza.t += T of t
+  include Stanza.S with type t := t
 end
 
 (** A foreign source file that has a [path] and all information of the

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -174,7 +174,7 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version =
         stanzas
         ~init:([], [], [])
         ~f:(fun ((libs, foreign_libs, exes) as acc) stanza ->
-          match (stanza : Stanza.t) with
+          match Stanza.repr stanza with
           | Library.T lib ->
             let all =
               eval_foreign_stubs

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -108,7 +108,7 @@ end = struct
     let dir = ctx_dir in
     let toplevel_setup = Toplevel.Stanza.setup in
     let open Dune_file in
-    match stanza with
+    match Stanza.repr stanza with
     | Toplevel.T toplevel ->
       let+ () = toplevel_setup ~sctx ~dir ~toplevel in
       empty_none
@@ -238,7 +238,7 @@ let gen_rules_for_stanzas
       ~f:(Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~expander)
   and+ () =
     Memo.parallel_iter stanzas ~f:(fun stanza ->
-      match (stanza : Stanza.t) with
+      match Stanza.repr stanza with
       | Menhir_stanza.T m ->
         Expander.eval_blang expander m.enabled_if
         >>= (function

--- a/src/dune_rules/generate_sites_module/generate_sites_module_stanza.ml
+++ b/src/dune_rules/generate_sites_module/generate_sites_module_stanza.ml
@@ -28,4 +28,6 @@ let decode =
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)

--- a/src/dune_rules/generate_sites_module/generate_sites_module_stanza.mli
+++ b/src/dune_rules/generate_sites_module/generate_sites_module_stanza.mli
@@ -16,4 +16,4 @@ type t =
 
 val decode : t Dune_sexp.Decoder.t
 
-type Stanza.t += T of t
+include Stanza.S with type t := t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -328,7 +328,7 @@ end = struct
   let keep_if expander ~scope stanza =
     let+ keep =
       let open Dune_file in
-      match (stanza : Stanza.t) with
+      match Stanza.repr stanza with
       | Library.T lib ->
         let* enabled_if = Expander.eval_blang expander lib.enabled_if in
         if enabled_if
@@ -454,7 +454,7 @@ end = struct
     | Some (stanza, package) ->
       let new_entries =
         let open Dune_file in
-        match (stanza : Stanza.t) with
+        match Stanza.repr stanza with
         | Install_conf.T i | Executables.T { install_conf = Some i; _ } ->
           entries_of_install_stanza ~dir ~expander ~package_db i
         | Library.T lib ->

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -194,6 +194,8 @@ let enabled_if t = t.enabled_if
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)
 
 let syntax =
@@ -268,7 +270,7 @@ let () =
   let decode = Dune_lang.Syntax.since Stanza.syntax (2, 4) >>> decode in
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("mdx", decode >>| fun x -> [ T x ]) ])
+    (return [ ("mdx", decode >>| fun x -> [ make_stanza x ]) ])
 ;;
 
 (** Returns the list of files (in _build) to be passed to mdx for the given

--- a/src/dune_rules/mdx.mli
+++ b/src/dune_rules/mdx.mli
@@ -6,7 +6,7 @@ type t
 
 val enabled_if : t -> Blang.t
 
-type Stanza.t += T of t
+type Stanza.repr += T of t
 
 (** Generates the rules to handle the given mdx stanza *)
 val gen_rules

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -577,7 +577,8 @@ let rec under_melange_emit_target ~dir =
      | None -> under_melange_emit_target ~dir:parent
      | Some stanzas ->
        (match
-          List.find_map stanzas.stanzas ~f:(function
+          List.find_map stanzas.stanzas ~f:(fun stanza ->
+            match Stanza.repr stanza with
             | Melange_stanzas.Emit.T mel ->
               let target_dir = Melange_stanzas.Emit.target_dir ~dir:parent mel in
               Option.some_if (Path.Build.equal target_dir dir) mel
@@ -643,7 +644,8 @@ let setup_emit_js_rules sctx ~dir =
      | None -> Gen_rules.no_rules
      | Some dune_file ->
        let build_dir_only_sub_dirs =
-         List.filter_map dune_file.stanzas ~f:(function
+         List.filter_map dune_file.stanzas ~f:(fun stanza ->
+           match Stanza.repr stanza with
            | Melange_stanzas.Emit.T mel -> Some mel.target
            | _ -> None)
          |> Subdir_set.of_list

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -23,6 +23,8 @@ module Emit = struct
 
   include Stanza.Make (struct
       type nonrec t = t
+
+      include Poly
     end)
 
   let implicit_alias = Alias.Name.of_string "melange"
@@ -162,5 +164,5 @@ let syntax =
 let () =
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("melange.emit", Emit.decode >>| fun x -> [ Emit.T x ]) ])
+    (return [ ("melange.emit", Emit.decode >>| fun x -> [ Emit.make_stanza x ]) ])
 ;;

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -21,7 +21,7 @@ module Emit : sig
     ; dune_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.t += T of t
+  type Stanza.repr += T of t
 
   val implicit_alias : Alias.Name.t
   val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/menhir/menhir_stanza.ml
+++ b/src/dune_rules/menhir/menhir_stanza.ml
@@ -43,12 +43,14 @@ let decode =
 
 include Stanza.Make (struct
     type nonrec t = t
+
+    include Poly
   end)
 
 let () =
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("menhir", decode >>| fun x -> [ T x ]) ])
+    (return [ ("menhir", decode >>| fun x -> [ make_stanza x ]) ])
 ;;
 
 let modules (stanza : t) : string list =

--- a/src/dune_rules/menhir/menhir_stanza.mli
+++ b/src/dune_rules/menhir/menhir_stanza.mli
@@ -19,4 +19,4 @@ val modules : t -> string list
     directory. *)
 val targets : t -> string list
 
-type Stanza.t += T of t
+type Stanza.repr += T of t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -427,7 +427,7 @@ let modules_of_stanzas =
   in
   fun stanzas ~project ~dir ~libs ~lookup_vlib ~modules ~include_subdirs ->
     Memo.parallel_map stanzas ~f:(fun stanza ->
-      match (stanza : Stanza.t) with
+      match Stanza.repr stanza with
       | Library.T lib ->
         (* jeremiedimino: this [Resolve.get] means that if the user writes an
            invalid [implements] field, we will get an error immediately even if

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -92,11 +92,11 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
     if include_stanza
     then Some stanza
     else (
-      match stanza with
+      match Stanza.repr stanza with
       | Dune_file.Library.T l ->
         let open Option.O in
         let+ redirect = Dune_file.Library_redirect.Local.of_private_lib l in
-        Dune_file.Library_redirect.Local.T redirect
+        Dune_file.Library_redirect.Local.make_stanza redirect
       | _ -> None))
 ;;
 

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -13,7 +13,8 @@ let mlds_by_package_def =
       let ctx = Super_context.context sctx in
       let* dune_files = Context.name ctx |> Only_packages.filtered_stanzas in
       Memo.parallel_map dune_files ~f:(fun dune_file ->
-        Memo.parallel_map dune_file.stanzas ~f:(function
+        Memo.parallel_map dune_file.stanzas ~f:(fun stanza ->
+          match Stanza.repr stanza with
           | Documentation.T d ->
             let dir = Path.Build.append_source (Context.build_dir ctx) dune_file.dir in
             let* dc = Dir_contents.get sctx ~dir in

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -343,7 +343,7 @@ module DB = struct
         ~init:([], [])
         ~f:(fun dune_file stanza (acc, coq_acc) ->
           let build_dir = Context.build_dir context in
-          match stanza with
+          match Stanza.repr stanza with
           | Dune_file.Library.T lib ->
             let ctx_dir = Path.Build.append_source build_dir dune_file.dir in
             Library_related_stanza.Library (ctx_dir, lib) :: acc, coq_acc
@@ -416,7 +416,7 @@ module DB = struct
     let make_map (build_dir, public_libs, stanzas) =
       let+ libs =
         Dune_file.Memo_fold.fold_stanzas stanzas ~init:[] ~f:(fun d stanza acc ->
-          match stanza with
+          match Stanza.repr stanza with
           | Dune_file.Library.T ({ visibility = Private (Some pkg); _ } as lib) ->
             let+ lib =
               let* scope = find_by_dir (Path.Build.append_source build_dir d.dir) in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -129,7 +129,8 @@ end = struct
     @@
     let open Option.O in
     let* stanzas = stanzas in
-    List.find_map stanzas.stanzas ~f:(function
+    List.find_map stanzas.stanzas ~f:(fun stanza ->
+      match Stanza.repr stanza with
       | Dune_env.T config -> Some config
       | _ -> None)
   ;;
@@ -327,7 +328,7 @@ let add_packages_env context ~base stanzas packages =
                 in
                 add_in_package_section acc pkg_name section
             in
-            match stanza with
+            match Stanza.repr stanza with
             | Dune_file.Install_conf.T { section = Site { pkg; site; loc }; _ } ->
               add_in_package_sites pkg site loc
             | Dune_file.Plugin.T { site = loc, (pkg, site); _ } ->

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -52,8 +52,11 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
           >>= function
           | None -> Memo.return Libs_and_ppxs.empty
           | Some (d : Dune_file.t) ->
-            Memo.List.fold_left d.stanzas ~init:Libs_and_ppxs.empty ~f:(fun (acc, pps) ->
-                function
+            Memo.List.fold_left
+              d.stanzas
+              ~init:Libs_and_ppxs.empty
+              ~f:(fun (acc, pps) stanza ->
+                match Stanza.repr stanza with
                 | Dune_file.Library.T l ->
                   let+ lib =
                     let open Memo.O in


### PR DESCRIPTION
We require stanzas to provide comparisons and hashing. This gets rid of physical equality. Eventually, we'll also get rid of polymorphic comparisons once we can use ppx.

@nojb could you take a brief look at stanza.ml and let me know if I'm over complicating things.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3399e548-48fa-422e-bf79-2865cfa5d668 -->