### PR TITLE
feature(pkg): add our package overlay to default repos

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -68,7 +68,10 @@ module Per_context = struct
     let repositories =
       Option.map lock_dir ~f:(fun lock_dir -> lock_dir.repositories)
       |> Option.value
-           ~default:[ Dune_pkg.Pkg_workspace.Repository.Name.of_string "default" ]
+           ~default:
+             (List.map
+                Workspace.default_repositories
+                ~f:Dune_pkg.Pkg_workspace.Repository.name)
     in
     { lock_dir_path
     ; version_preference =

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -35,8 +35,12 @@ module Repository = struct
   let equal { name; source } t = Name.equal name t.name && String.equal source t.source
   let hash { name; source } = Tuple.T2.hash Name.hash String.hash (name, source)
 
-  let default =
-    { name = "default"; source = "git+https://github.com/ocaml/opam-repository.git" }
+  let upstream =
+    { name = "upstream"; source = "git+https://github.com/ocaml/opam-repository.git" }
+  ;;
+
+  let overlay =
+    { name = "overlay"; source = "git+https://github.com/ocaml-dune/opam-overlays.git" }
   ;;
 
   let decode =

--- a/src/dune_pkg/workspace.mli
+++ b/src/dune_pkg/workspace.mli
@@ -7,7 +7,8 @@ module Repository : sig
   val hash : t -> int
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
-  val default : t
+  val upstream : t
+  val overlay : t
   val decode : t Decoder.t
 
   module Name : sig

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -2,6 +2,8 @@ open Import
 open Dune_lang.Decoder
 module Repository = Dune_pkg.Pkg_workspace.Repository
 
+let default_repositories = [ Repository.overlay; Repository.upstream ]
+
 module Lock_dir = struct
   type t =
     { path : Path.Source.t
@@ -42,7 +44,7 @@ module Lock_dir = struct
         ~parse:(fun ~loc string ->
           Dune_pkg.Pkg_workspace.Repository.Name.parse_string_exn (loc, string))
         ~eq:Dune_pkg.Pkg_workspace.Repository.Name.equal
-        ~standard:[ Dune_pkg.Pkg_workspace.Repository.Name.of_string "default" ]
+        ~standard:(List.map default_repositories ~f:Repository.name)
     in
     let decode =
       let+ path =
@@ -693,7 +695,7 @@ let step1 clflags =
        in
        let defined_names = ref Context_name.Set.empty in
        let env = Lazy.force env in
-       let repos = Repository.default :: List.map ~f:Lazy.force repos in
+       let repos = default_repositories @ List.map ~f:Lazy.force repos in
        let merlin_context =
          List.fold_left contexts ~init:None ~f:(fun acc ctx ->
            let name = Context.name ctx in
@@ -772,7 +774,7 @@ let default clflags =
   ; contexts = [ Context.default ~x ~profile ~instrument_with ]
   ; env = None
   ; config
-  ; repos = [ Repository.default ]
+  ; repos = default_repositories
   ; lock_dirs = []
   }
 ;;

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -97,6 +97,7 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val hash : t -> int
 val find_lock_dir : t -> Path.Source.t -> Lock_dir.t option
+val default_repositories : Dune_pkg.Pkg_workspace.Repository.t list
 
 module Clflags : sig
   type t =


### PR DESCRIPTION
Our newly created overlay repository (https://github.com/ocaml-dune/opam-overlays) is added to the list of repos. I've also renamed the repos to clarify things:

* `upstream` is ocaml/opam-repository
* `overlay` is our overlay