### PR TITLE
refactor: unify relational operators

### DIFF
--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -1,59 +1,13 @@
 open Stdune
 open Dune_sexp
 
-module Op = struct
-  type t =
-    | Eq
-    | Gt
-    | Gte
-    | Lte
-    | Lt
-    | Neq
-
-  let eval t (x : Ordering.t) =
-    match t, x with
-    | (Eq | Gte | Lte), Eq | (Neq | Lt | Lte), Lt | (Neq | Gt | Gte), Gt -> true
-    | _, _ -> false
-  ;;
-
-  let to_dyn =
-    let open Dyn in
-    function
-    | Eq -> string "Eq"
-    | Gt -> string "Gt"
-    | Gte -> string "Gte"
-    | Lte -> string "Lte"
-    | Lt -> string "Lt"
-    | Neq -> string "Neq"
-  ;;
-
-  let equal a b =
-    match a, b with
-    | Eq, Eq -> true
-    | Gt, Gt -> true
-    | Gte, Gte -> true
-    | Lte, Lte -> true
-    | Lt, Lt -> true
-    | Neq, Neq -> true
-    | _ -> false
-  ;;
-
-  let by_string = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
-  let to_string t = fst (List.find_exn by_string ~f:(fun (_, op) -> equal op t))
-
-  let encode t =
-    let open Encoder in
-    string (to_string t)
-  ;;
-end
-
 type 'string ast =
   | Const of bool
   | Not of 'string ast
   | Expr of 'string
   | And of 'string ast list
   | Or of 'string ast list
-  | Compare of Op.t * 'string * 'string
+  | Compare of Relop.t * 'string * 'string
 
 module Ast = struct
   type 'string t = 'string ast
@@ -70,13 +24,13 @@ module Ast = struct
     | And t -> variant "And" (List.map ~f:(to_dyn string_to_dyn) t)
     | Or t -> variant "Or" (List.map ~f:(to_dyn string_to_dyn) t)
     | Compare (o, s1, s2) ->
-      variant "Compare" [ Op.to_dyn o; string_to_dyn s1; string_to_dyn s2 ]
+      variant "Compare" [ Relop.to_dyn o; string_to_dyn s1; string_to_dyn s2 ]
   ;;
 
   let decode decode_string =
     let open Decoder in
     let ops =
-      List.map Op.by_string ~f:(fun (name, op) ->
+      List.map Relop.map ~f:(fun (name, op) ->
         ( name
         , let+ x = decode_string
           and+ y = decode_string in
@@ -107,7 +61,7 @@ module Ast = struct
     | Expr e -> encode_string e
     | And ts -> List (string "and" :: List.map ts ~f:(encode encode_string))
     | Or ts -> List (string "or" :: List.map ts ~f:(encode encode_string))
-    | Compare (o, s1, s2) -> List [ Op.encode o; encode_string s1; encode_string s2 ]
+    | Compare (o, s1, s2) -> List [ Relop.encode o; encode_string s1; encode_string s2 ]
   ;;
 end
 

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -1,17 +1,4 @@
-open Stdune
 open Dune_sexp
-
-module Op : sig
-  type t =
-    | Eq
-    | Gt
-    | Gte
-    | Lte
-    | Lt
-    | Neq
-
-  val eval : t -> Ordering.t -> bool
-end
 
 (* Note that this type is defined separately from [_ Ast.t] so that its
    constructors are scoped within the [Blang] module, allowing us to construct
@@ -22,7 +9,7 @@ type 'string ast =
   | Expr of 'string
   | And of 'string ast list
   | Or of 'string ast list
-  | Compare of Op.t * 'string * 'string
+  | Compare of Relop.t * 'string * 'string
 
 type t = String_with_vars.t ast
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -30,3 +30,4 @@ module Targets_spec = Targets_spec
 module Wrapped = Wrapped
 module Visibility = Visibility
 module Dep_conf = Dep_conf
+module Relop = Relop

--- a/src/dune_lang/package_constraint.mli
+++ b/src/dune_lang/package_constraint.mli
@@ -1,18 +1,5 @@
 open! Stdune
 
-module Op : sig
-  type t =
-    | Eq
-    | Gte
-    | Lte
-    | Gt
-    | Lt
-    | Neq
-
-  val to_dyn : t -> Dyn.t
-  val to_string : t -> string
-end
-
 module Variable : sig
   type t = { name : string }
 end
@@ -31,12 +18,13 @@ end
     boolean is expected it will be assumed to represent a boolean. *)
 type t =
   | Bvar of Variable.t (** A boolean variable *)
-  | Uop of Op.t * Value.t
+  | Uop of Relop.t * Value.t
   (** A unary operator applied to a value. Unary operators are operators
       whose LHS is implied by context. E.g. when placing version constraints
       on dependencies of a package the implied LHS is the version of the
       dependency: `(dependency (>= version))` *)
-  | Bop of Op.t * Value.t * Value.t (** A binary operator applied to LHS and RHS values *)
+  | Bop of Relop.t * Value.t * Value.t
+  (** A binary operator applied to LHS and RHS values *)
   | And of t list (** The conjunction of a list of boolean expressions *)
   | Or of t list (** The disjunction of a list of boolean expressions *)
 

--- a/src/dune_lang/relop.ml
+++ b/src/dune_lang/relop.ml
@@ -1,0 +1,50 @@
+open Stdune
+
+type t =
+  | Eq
+  | Gte
+  | Lte
+  | Gt
+  | Lt
+  | Neq
+
+(* Define an arbitrary ordering on [t] to allow a package constraint to be
+   used as the key of a map or set. The order from lowest to highest is:
+   [Eq, Gte, Lte, Gt, Lt, Neq] *)
+let compare a b : Ordering.t =
+  match a, b with
+  | Eq, Eq -> Eq
+  | Eq, _ -> Lt
+  | _, Eq -> Gt
+  | Gte, Gte -> Eq
+  | Gte, _ -> Lt
+  | _, Gte -> Gt
+  | Lte, Lte -> Eq
+  | Lte, _ -> Lt
+  | _, Lte -> Gt
+  | Gt, Gt -> Eq
+  | Gt, _ -> Lt
+  | _, Gt -> Gt
+  | Lt, Lt -> Eq
+  | Lt, _ -> Lt
+  | _, Lt -> Gt
+  | Neq, Neq -> Eq
+;;
+
+let equal a b = Ordering.is_eq (compare a b)
+let map = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
+let to_dyn t = Dyn.variant (fst (List.find_exn ~f:(fun (_, op) -> equal t op) map)) []
+
+let to_string x =
+  let f (_, op) = equal x op in
+  (* Assumes the [map] is complete, so exception is impossible *)
+  List.find_exn ~f map |> fst
+;;
+
+let encode x = to_string x |> Dune_sexp.Encoder.string
+
+let eval t (x : Ordering.t) =
+  match t, x with
+  | (Eq | Gte | Lte), Eq | (Neq | Lt | Lte), Lt | (Neq | Gt | Gte), Gt -> true
+  | _, _ -> false
+;;

--- a/src/dune_lang/relop.mli
+++ b/src/dune_lang/relop.mli
@@ -1,0 +1,15 @@
+type t =
+  | Eq
+  | Gte
+  | Lte
+  | Gt
+  | Lt
+  | Neq
+
+val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t
+val to_string : t -> string
+val map : (string * t) list
+val encode : t -> Dune_sexp.t
+val eval : t -> Ordering.t -> bool

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -320,15 +320,7 @@ let filter_to_blang ~package ~loc filter =
     | FBool false -> Blang.Ast.false_
     | (FString _ | FIdent _) as slangable -> Blang.Expr (filter_to_slang slangable)
     | FOp (lhs, op, rhs) ->
-      let op =
-        match op with
-        | `Eq -> Blang.Op.Eq
-        | `Neq -> Neq
-        | `Geq -> Gte
-        | `Gt -> Gt
-        | `Leq -> Lte
-        | `Lt -> Lt
-      in
+      let op = Package_dependency.Constraint.Op.of_opam op in
       Blang.Compare (op, filter_to_slang lhs, filter_to_slang rhs)
     | FAnd (lhs, rhs) ->
       Blang.Expr

--- a/src/dune_pkg/package_dependency.mli
+++ b/src/dune_pkg/package_dependency.mli
@@ -2,9 +2,10 @@ open! Stdune
 
 module Constraint : sig
   module Op : sig
-    type t = Dune_lang.Package_constraint.Op.t
+    type t = Dune_lang.Relop.t
 
-    val to_relop : t -> OpamParserTypes.FullPos.relop
+    val to_opam : t -> OpamParserTypes.relop
+    val of_opam : OpamParserTypes.relop -> t
   end
 
   module Value : sig

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -1,5 +1,5 @@
 open! Import
-module Op = Dune_lang.Package_constraint.Op
+module Relop = Dune_lang.Relop
 
 let substitute_variables_in_filter
   ~stats_updater
@@ -46,28 +46,19 @@ let apply_filter
 ;;
 
 module Version_constraint = struct
-  type t = Op.t * Package_version.t
+  type t = Relop.t * Package_version.t
 
   let of_opam ((relop, version) : OpamFormula.version_constraint) =
-    let op =
-      match relop with
-      | `Eq -> Op.Eq
-      | `Neq -> Neq
-      | `Geq -> Gte
-      | `Gt -> Gt
-      | `Leq -> Lte
-      | `Lt -> Lt
-    in
     let package_version = Package_version.of_opam_package_version version in
-    op, package_version
+    Package_dependency.Constraint.Op.of_opam relop, package_version
   ;;
 
   let to_dyn (op, package_version) =
-    Dyn.Tuple [ Op.to_dyn op; Package_version.to_dyn package_version ]
+    Dyn.Tuple [ Relop.to_dyn op; Package_version.to_dyn package_version ]
   ;;
 
   let to_string (op, package_version) =
-    sprintf "%s %s" (Op.to_string op) (Package_version.to_string package_version)
+    sprintf "%s %s" (Relop.to_string op) (Package_version.to_string package_version)
   ;;
 end
 

--- a/src/dune_pkg/resolve_opam_formula.mli
+++ b/src/dune_pkg/resolve_opam_formula.mli
@@ -16,7 +16,7 @@ val apply_filter
   -> OpamTypes.formula
 
 module Version_constraint : sig
-  type t = Dune_lang.Package_constraint.Op.t * Package_version.t
+  type t = Dune_lang.Relop.t * Package_version.t
 end
 
 module Unsatisfied_formula_hint : sig

--- a/src/dune_rules/blang_expand.ml
+++ b/src/dune_rules/blang_expand.ml
@@ -18,5 +18,5 @@ let rec eval (t : Blang.t) ~dir ~f =
   | Compare (op, x, y) ->
     let+ x = String_expander.Memo.expand x ~mode:Many ~dir ~f
     and+ y = String_expander.Memo.expand y ~mode:Many ~dir ~f in
-    Blang.Op.eval op (Value.L.compare_vals ~dir x y)
+    Relop.eval op (Value.L.compare_vals ~dir x y)
 ;;

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -91,6 +91,7 @@ include struct
   module Visibility = Visibility
   module Dep_conf = Dep_conf
   module Package_version = Package_version
+  module Relop = Relop
 end
 
 include Dune_engine.No_io

--- a/src/dune_rules/slang_expand.ml
+++ b/src/dune_rules/slang_expand.ml
@@ -165,7 +165,7 @@ and eval_blang_rec (t : Slang.blang) ~dir ~f =
     let+ x = eval_rec x ~dir ~f
     and+ y = eval_rec y ~dir ~f in
     Result.bind x ~f:(fun x ->
-      Result.map y ~f:(fun y -> Blang.Op.eval op (Value.L.compare_vals ~dir x y)))
+      Result.map y ~f:(fun y -> Relop.eval op (Value.L.compare_vals ~dir x y)))
 ;;
 
 let eval t ~dir ~f =


### PR DESCRIPTION
Relational operators for blang and package constraints are equivalent.
We don't need two types.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9492dc28-e701-4236-8781-6f78fbee0e95 -->