### PR TITLE
refactor: allow config values to be defined anywhere

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -79,36 +79,29 @@ let init values =
   initialized := true
 ;;
 
-let global_lock =
-  let t = { name = "global_lock"; of_string = Toggle.of_string; value = `Enabled } in
+let make ~name ~of_string ~default =
+  let t = { name; of_string; value = default } in
   register t;
   t
 ;;
 
+let global_lock = make ~name:"global_lock" ~of_string:Toggle.of_string ~default:`Enabled
+
 let cutoffs_that_reduce_concurrency_in_watch_mode =
-  let t =
-    { name = "cutoffs_that_reduce_concurrency_in_watch_mode"
-    ; of_string = Toggle.of_string
-    ; value = `Disabled
-    }
-  in
-  register t;
-  t
+  make
+    ~name:"cutoffs_that_reduce_concurrency_in_watch_mode"
+    ~of_string:Toggle.of_string
+    ~default:`Disabled
 ;;
 
 let copy_file =
-  let t =
-    { name = "copy_file"
-    ; of_string =
-        (function
-          | "portable" -> Ok `Portable
-          | "fast" -> Ok `Best
-          | _ -> Error (sprintf "only %S and %S are allowed" "fast" "portable"))
-    ; value = `Best
-    }
-  in
-  register t;
-  t
+  make
+    ~name:"copy_file"
+    ~of_string:(function
+      | "portable" -> Ok `Portable
+      | "fast" -> Ok `Best
+      | _ -> Error (sprintf "only %S and %S are allowed" "fast" "portable"))
+    ~default:`Best
 ;;
 
 let background_default =
@@ -118,77 +111,38 @@ let background_default =
 ;;
 
 let background_actions =
-  let t =
-    { name = "background_actions"; of_string = Toggle.of_string; value = `Disabled }
-  in
-  register t;
-  t
+  make ~name:"background_actions" ~of_string:Toggle.of_string ~default:`Disabled
 ;;
 
 let background_digests =
-  let t =
-    { name = "background_digests"
-    ; of_string = Toggle.of_string
-    ; value = background_default
-    }
-  in
-  register t;
-  t
+  make ~name:"background_digests" ~of_string:Toggle.of_string ~default:background_default
 ;;
 
 let background_sandboxes =
-  let t =
-    { name = "background_sandboxes"
-    ; of_string = Toggle.of_string
-    ; value = background_default
-    }
-  in
-  register t;
-  t
-;;
-
-let background_dune_rules =
-  let t =
-    { name = "background_dune_rules"; of_string = Toggle.of_string; value = `Disabled }
-  in
-  register t;
-  t
+  make
+    ~name:"background_sandboxes"
+    ~of_string:Toggle.of_string
+    ~default:background_default
 ;;
 
 let background_file_system_operations_in_rule_execution =
-  let t =
-    { name = "background_file_system_operations_in_rule_execution"
-    ; of_string = Toggle.of_string
-    ; value = `Disabled
-    }
-  in
-  register t;
-  t
+  make
+    ~name:"background_file_system_operations_in_rule_execution"
+    ~of_string:Toggle.of_string
+    ~default:`Disabled
 ;;
 
 let threaded_console =
-  let t =
-    { name = "threaded_console"
-    ; of_string = Toggle.of_string
-    ; value = background_default
-    }
-  in
-  register t;
-  t
+  make ~name:"threaded_console" ~of_string:Toggle.of_string ~default:background_default
 ;;
 
 let threaded_console_frames_per_second =
-  let t =
-    { name = "threaded_console_frames_per_second"
-    ; of_string =
-        (fun x ->
-          match Int.of_string x with
-          | Some x when x > 0 && x <= 1000 -> Ok (`Custom x)
-          | Some _ -> Error (sprintf "value must be between 1 and 1000")
-          | None -> Error (sprintf "could not parse %S as an integer" x))
-    ; value = `Default
-    }
-  in
-  register t;
-  t
+  make
+    ~name:"threaded_console_frames_per_second"
+    ~of_string:(fun x ->
+      match Int.of_string x with
+      | Some x when x > 0 && x <= 1000 -> Ok (`Custom x)
+      | Some _ -> Error (sprintf "value must be between 1 and 1000")
+      | None -> Error (sprintf "could not parse %S as an integer" x))
+    ~default:`Default
 ;;

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -22,6 +22,10 @@ module Toggle : sig
   val to_dyn : t -> Dyn.t
 end
 
+(** [make ~name ~of_string ~default] registers a config value called [name],
+    parsed using [of_string], defaulting to [default]. *)
+val make : name:string -> of_string:(string -> ('a, string) result) -> default:'a -> 'a t
+
 (** [get t] return the value of the configuration for [t] *)
 val get : 'a t -> 'a
 
@@ -53,9 +57,6 @@ val threaded_console : Toggle.t t
 
 (** The number of frames per second for the threaded console. *)
 val threaded_console_frames_per_second : [ `Default | `Custom of int ] t
-
-(** Controls whether we use background threads in the dune rules *)
-val background_dune_rules : Toggle.t t
 
 (** Before any configuration value is accessed, this function must be called
     with all the configuration values from the relevant config file

--- a/src/dune_rules/async.ml
+++ b/src/dune_rules/async.ml
@@ -1,7 +1,7 @@
 open Import
 
 let async f =
-  match Config.(get background_dune_rules) with
+  match Config.get background_dune_rules with
   | `Enabled -> Dune_engine.Scheduler.async_exn f
   | `Disabled -> Fiber.return (f ())
 ;;

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -149,3 +149,11 @@ end
 
 let phys_equal x y = x == y
 let ( == ) = `Use_phys_equal
+
+(** Controls whether we use background threads in the dune rules *)
+let background_dune_rules =
+  Config.make
+    ~name:"background_dune_rules"
+    ~of_string:Config.Toggle.of_string
+    ~default:`Disabled
+;;


### PR DESCRIPTION
Expose a [Config.make] function to allow settings to be defined
anywhere.

Move dune rules specific configuration to [Dune_rules].

@snowleopard this should reduce some potential for syncing by allowing internal/external dune to keep private config options outside of the main module.