### PR TITLE
chore: disable windows cygwin job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          #- windows-latest # renable once https://github.com/ocaml/setup-ocaml/issues/731 is fixed
         # Please keep the list in sync with the minimal version of OCaml in
         # dune-project, opam/dune.opam.template and bootstrap.ml
         #


### PR DESCRIPTION
Until https://github.com/ocaml/setup-ocaml/issues/731 is fixed, there is little we can do to allow this CI job to succeed.

The issue is that opam on Windows (cygwin) is stuck on version 2.0.10 which incorrectly pins opam files in an opam/ subdirectory. The fix exists in 2.1.x so setup-ocaml needs to update their opam version. However this is not any easy task, as it requires maintaining a no longer maintained cygwin opam repo. Therefore a fix won't happen soon.

We already run windows tests, of which there is only a single test, in the MSVC jobs. Therefore I think it is OK to disable this job for now.

Edit: The original issue I reported got moved, here is the new ticket:
- https://github.com/ocaml/setup-ocaml/issues/733