### PR TITLE
refactor: simplify some stanza signatures

### DIFF
--- a/src/dune_rules/cinaps.mli
+++ b/src/dune_rules/cinaps.mli
@@ -11,7 +11,8 @@
 open Import
 
 type t
-type Stanza.repr += T of t
+
+include Stanza.S with type t := t
 
 (** Generate the rules to handle this cinaps stanza *)
 val gen_rules : Super_context.t -> t -> dir:Path.Build.t -> scope:Scope.t -> unit Memo.t

--- a/src/dune_rules/coq/coq_stanza.mli
+++ b/src/dune_rules/coq/coq_stanza.mli
@@ -21,7 +21,7 @@ module Extraction : sig
 
   val ml_target_fnames : t -> string list
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Theory : sig
@@ -37,7 +37,7 @@ module Theory : sig
     ; coqdoc_flags : Ordered_set_lang.Unexpanded.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Coqpp : sig
@@ -46,7 +46,7 @@ module Coqpp : sig
     ; loc : Loc.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 val key : unit Dune_project.Extension.t

--- a/src/dune_rules/ctypes/ctypes_field.mli
+++ b/src/dune_rules/ctypes/ctypes_field.mli
@@ -61,7 +61,7 @@ type t =
   ; version : Syntax.Version.t
   }
 
-type Stanza.repr += T of t
+include Stanza.S with type t := t
 
 val decode : t Dune_lang.Decoder.t
 val syntax : Dune_lang.Syntax.t

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -171,7 +171,7 @@ module Library : sig
     ; melange_runtime_deps : Loc.t * Dep_conf.t list
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 
   val sub_dir : t -> string option
   val package : t -> Package.t option
@@ -224,7 +224,7 @@ module Plugin : sig
     ; optional : bool
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Install_conf : sig
@@ -237,7 +237,7 @@ module Install_conf : sig
     ; enabled_if : Blang.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Executables : sig
@@ -287,7 +287,7 @@ module Executables : sig
     ; dune_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 
   (** Check if the executables have any foreign stubs or archives. *)
   val has_foreign : t -> bool
@@ -308,7 +308,7 @@ module Copy_files : sig
     ; syntax_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Rule : sig
@@ -325,7 +325,7 @@ module Rule : sig
     ; package : Package.t option
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Alias_conf : sig
@@ -339,7 +339,7 @@ module Alias_conf : sig
     ; loc : Loc.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Documentation : sig
@@ -349,7 +349,7 @@ module Documentation : sig
     ; mld_files : Ordered_set_lang.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Tests : sig
@@ -363,7 +363,7 @@ module Tests : sig
     ; action : Dune_lang.Action.t option
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Toplevel : sig
@@ -374,7 +374,7 @@ module Toplevel : sig
     ; pps : Preprocess.Without_instrumentation.t Preprocess.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 end
 
 module Include_subdirs : sig
@@ -387,7 +387,8 @@ module Include_subdirs : sig
     | Include of qualification
 
   type stanza = Loc.t * t
-  type Stanza.repr += T of stanza
+
+  include Stanza.S with type t := stanza
 end
 
 (** The purpose of [Library_redirect] stanza is to create a redirection from an
@@ -428,7 +429,8 @@ module Deprecated_library_name : sig
   end
 
   type t = Old_name.t Library_redirect.t
-  type Stanza.repr += T of t
+
+  include Stanza.S with type t := t
 
   val old_public_name : t -> Lib_name.t
 end

--- a/src/dune_rules/mdx.mli
+++ b/src/dune_rules/mdx.mli
@@ -6,7 +6,7 @@ type t
 
 val enabled_if : t -> Blang.t
 
-type Stanza.repr += T of t
+include Stanza.S with type t := t
 
 (** Generates the rules to handle the given mdx stanza *)
 val gen_rules

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -21,7 +21,7 @@ module Emit : sig
     ; dune_version : Dune_lang.Syntax.Version.t
     }
 
-  type Stanza.repr += T of t
+  include Stanza.S with type t := t
 
   val implicit_alias : Alias.Name.t
   val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/menhir/menhir_stanza.mli
+++ b/src/dune_rules/menhir/menhir_stanza.mli
@@ -19,4 +19,4 @@ val modules : t -> string list
     directory. *)
 val targets : t -> string list
 
-type Stanza.repr += T of t
+include Stanza.S with type t := t


### PR DESCRIPTION
Use [Stanza.S] everywhere for consistency

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3bb43769-2cff-41fc-a524-cfe485b19392 -->