### PR TITLE
refactor: use let+ instead of >>| where we introduce a name for the binding

### DIFF
--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -102,7 +102,12 @@ module Parse = struct
   let with_include ~elt =
     generic
       ~elt
-      ~inc:(sum [ (":include", String_with_vars.decode >>| fun s -> Include s) ])
+      ~inc:
+        (sum
+           [ ( ":include"
+             , let+ s = String_with_vars.decode in
+               Include s )
+           ])
   ;;
 
   let without_include ~elt =
@@ -240,7 +245,10 @@ module Unexpanded = struct
     let+ context = get_all
     and+ loc, ast =
       located
-        (Parse.with_include ~elt:(String_with_vars.decode >>| fun s -> Ast.Element s))
+        (Parse.with_include
+           ~elt:
+             (let+ s = String_with_vars.decode in
+              Ast.Element s))
     in
     { ast; loc = Some loc; context }
   ;;

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -67,7 +67,11 @@ let () =
   let open Dune_lang.Decoder in
   Dune_project.Extension.register_simple
     syntax
-    (return [ (name, decode >>| fun x -> [ make_stanza x ]) ])
+    (return
+       [ ( name
+         , let+ stanza = decode in
+           [ make_stanza stanza ] )
+       ])
 ;;
 
 let gen_rules sctx t ~dir ~scope =

--- a/src/dune_rules/ctypes/ctypes_field.ml
+++ b/src/dune_rules/ctypes/ctypes_field.ml
@@ -202,7 +202,11 @@ let () =
   let open Dune_lang.Decoder in
   Dune_project.Extension.register_simple
     syntax
-    (return [ (name, decode >>| fun x -> [ make_stanza x ]) ])
+    (return
+       [ ( name
+         , let+ stanza = decode in
+           [ make_stanza stanza ] )
+       ])
 ;;
 
 let type_gen_script ctypes =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -568,8 +568,7 @@ module Library = struct
            parsing the ordered set language succeeds, ask the user to upgrade to
            a supported version *)
         try_ Mode_conf.Lib.Set.decode (fun _exn ->
-          Mode_conf.Lib.Set.decode_osl ~stanza_loc project
-          >>| fun _modes ->
+          let+ _modes = Mode_conf.Lib.Set.decode_osl ~stanza_loc project in
           Syntax.Error.since
             stanza_loc
             Stanza.syntax
@@ -1183,8 +1182,7 @@ module Executables = struct
     let has_public_name t = Option.is_some t.public
 
     let public_name ~dash_is_none =
-      located string
-      >>| fun (loc, s) ->
+      let+ loc, s = located string in
       ( loc
       , match s with
         | "-" -> if dash_is_none then None else Some s
@@ -1465,8 +1463,7 @@ module Executables = struct
       include O.Map
 
       let decode =
-        located (repeat (located decode))
-        >>| fun (loc, l) ->
+        let+ loc, l = located (repeat (located decode)) in
         match l with
         | [] -> User_error.raise ~loc [ Pp.textf "No linking mode defined" ]
         | l ->

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -393,7 +393,9 @@ let expand_lib_variable t source ~lib ~file ~lib_exec ~lib_private =
             Resolve.Memo.lift_memo (Lib.DB.available (Scope.libs scope) lib)
           in
           match available with
-          | false -> p >>| fun _ -> assert false
+          | false ->
+            let+ _ = p in
+            assert false
           | true ->
             Resolve.Memo.fail
               (User_error.make

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -270,7 +270,11 @@ let () =
   let decode = Dune_lang.Syntax.since Stanza.syntax (2, 4) >>> decode in
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("mdx", decode >>| fun x -> [ make_stanza x ]) ])
+    (return
+       [ ( "mdx"
+         , let+ stanza = decode in
+           [ make_stanza stanza ] )
+       ])
 ;;
 
 (** Returns the list of files (in _build) to be passed to mdx for the given

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -164,5 +164,9 @@ let syntax =
 let () =
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("melange.emit", Emit.decode >>| fun x -> [ Emit.make_stanza x ]) ])
+    (return
+       [ ( "melange.emit"
+         , let+ stanza = Emit.decode in
+           [ Emit.make_stanza stanza ] )
+       ])
 ;;

--- a/src/dune_rules/menhir/menhir_stanza.ml
+++ b/src/dune_rules/menhir/menhir_stanza.ml
@@ -50,7 +50,11 @@ include Stanza.Make (struct
 let () =
   Dune_project.Extension.register_simple
     syntax
-    (return [ ("menhir", decode >>| fun x -> [ make_stanza x ]) ])
+    (return
+       [ ( "menhir"
+         , let+ stanza = decode in
+           [ make_stanza stanza ] )
+       ])
 ;;
 
 let modules (stanza : t) : string list =

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -193,7 +193,11 @@ module Source_kind = struct
 
   let decode =
     let open Dune_lang.Decoder in
-    sum (("uri", string >>| fun s -> Url s) :: Host.enum (fun x -> Host x))
+    sum
+      (( "uri"
+       , let+ s = string in
+         Url s )
+       :: Host.enum (fun x -> Host x))
   ;;
 end
 


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4e229025-e2dc-4c0c-b126-83ecf8b4b52c -->