### PR TITLE
fix(pkg): remove experimental filter translation option

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -33,12 +33,7 @@ let check_for_dup_lock_dir_paths ts =
            (Loc.to_file_colon_line c.loc))))
 ;;
 
-let solve
-  per_context
-  ~update_opam_repositories
-  ~solver_env_from_current_system
-  ~experimental_translate_opam_filters
-  =
+let solve per_context ~update_opam_repositories ~solver_env_from_current_system =
   let open Fiber.O in
   check_for_dup_lock_dir_paths per_context;
   (* a list of thunks that will perform all the file IO side
@@ -79,7 +74,6 @@ let solve
                  (Package_name.Map.map
                     local_packages
                     ~f:Dune_pkg.Local_package.for_solver)
-               ~experimental_translate_opam_filters
                ~constraints)
          >>| function
          | Error (`Diagnostic_message message) -> Error (context_name, message)
@@ -122,7 +116,6 @@ let lock
   ~dont_poll_system_solver_variables
   ~version_preference
   ~update_opam_repositories
-  ~experimental_translate_opam_filters
   =
   let open Fiber.O in
   let* per_context =
@@ -138,11 +131,7 @@ let lock
         ~path:(Env_path.path Stdune.Env.initial)
       >>| Option.some
   in
-  solve
-    per_context
-    ~update_opam_repositories
-    ~solver_env_from_current_system
-    ~experimental_translate_opam_filters
+  solve per_context ~update_opam_repositories ~solver_env_from_current_system
 ;;
 
 let term =
@@ -169,17 +158,6 @@ let term =
              \"undefined\" which is treated as false. For example if a dependency has a \
              filter `{os = \"linux\"}` and the variable \"os\" is unset, the dependency \
              will be excluded. ")
-  and+ experimental_translate_opam_filters =
-    Arg.(
-      value
-      & flag
-      & info
-          [ "experimental-translate-opam-filters" ]
-          ~doc:
-            "Translate Opam filters into Dune's \"Slang\" DSL. This will eventually be \
-             enabled by default but is currently opt-in as we expect to make major \
-             changes to it in the future. Without this flag all conditional commands and \
-             terms in Opam files are included unconditionally.")
   and+ skip_update =
     Arg.(
       value
@@ -198,8 +176,7 @@ let term =
       ~all_contexts
       ~dont_poll_system_solver_variables
       ~version_preference
-      ~update_opam_repositories:(not skip_update)
-      ~experimental_translate_opam_filters)
+      ~update_opam_repositories:(not skip_update))
 ;;
 
 let info =

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -461,25 +461,9 @@ let make_action = function
   | actions -> Some (Action.Progn actions)
 ;;
 
-let remove_filters_from_command ((command, _filter) : OpamTypes.command)
-  : OpamTypes.command
-  =
-  let command = List.map command ~f:(fun (term, _filter) -> term, None) in
-  command, None
-;;
-
-let remove_filters_from_opam_file opam_file =
-  opam_file
-  |> OpamFile.OPAM.with_build
-       (List.map ~f:remove_filters_from_command (OpamFile.OPAM.build opam_file))
-  |> OpamFile.OPAM.with_install
-       (List.map ~f:remove_filters_from_command (OpamFile.OPAM.install opam_file))
-;;
-
 let opam_package_to_lock_file_pkg
   solver_env
   version_by_package_name
-  ~experimental_translate_opam_filters
   opam_package
   ~(candidates_cache : (Package_name.t, Context_for_dune.candidates) Table.t)
   =
@@ -494,12 +478,7 @@ let opam_package_to_lock_file_pkg
         .resolved
       |> OpamPackage.Version.Map.find (Package_version.to_opam_package_version version)
     in
-    let opam_file =
-      let opam_file_with_filters = With_file.opam_file with_file in
-      if experimental_translate_opam_filters
-      then opam_file_with_filters
-      else remove_filters_from_opam_file opam_file_with_filters
-    in
+    let opam_file = With_file.opam_file with_file in
     let loc = Loc.in_file (With_file.file with_file) in
     opam_file, loc
   in
@@ -653,14 +632,7 @@ module Solver_result = struct
     }
 end
 
-let solve_lock_dir
-  solver_env
-  version_preference
-  repos
-  ~local_packages
-  ~experimental_translate_opam_filters
-  ~constraints
-  =
+let solve_lock_dir solver_env version_preference repos ~local_packages ~constraints =
   let* solver_result =
     let stats_updater = Solver_stats.Updater.init () in
     let context =
@@ -700,7 +672,6 @@ let solve_lock_dir
             opam_package_to_lock_file_pkg
               solver_env
               version_by_package_name
-              ~experimental_translate_opam_filters
               opam_package
               ~candidates_cache:context.candidates_cache)
         in

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -12,6 +12,5 @@ val solve_lock_dir
   -> Version_preference.t
   -> Opam_repo.t list
   -> local_packages:Local_package.For_solver.t Package_name.Map.t
-  -> experimental_translate_opam_filters:bool
   -> constraints:Dune_lang.Package_dependency.t list
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -198,22 +198,45 @@ Test that if opam filter translation is disabled the output doesn't contain any 
   
   (build
    (progn
-    (run echo a)
-    (run echo b)
-    (run echo c)
-    (run echo d)
-    (run echo e)
-    (run echo f)
-    (run echo b)
-    (run echo g)
-    (run echo h)
+    (when
+     %{pkg-self:foo}
+     (run echo a))
+    (when
+     (and_absorb_undefined_var %{pkg-self:foo} %{pkg-self:bar})
+     (run echo b))
+    (when
+     (and_absorb_undefined_var %{pkg-self:foo} %{pkg-self:bar} %{pkg-self:baz})
+     (run echo c))
+    (when
+     (or_absorb_undefined_var %{pkg-self:foo} %{pkg-self:bar})
+     (run echo d))
+    (when
+     (or_absorb_undefined_var
+      %{pkg-self:foo}
+      (and_absorb_undefined_var %{pkg-self:bar} %{pkg-self:baz}))
+     (run echo e))
+    (when
+     (and_absorb_undefined_var
+      (or_absorb_undefined_var %{pkg-self:foo} %{pkg-self:bar})
+      %{pkg-self:baz})
+     (run echo f))
+    (when
+     (= %{pkg-self:foo} %{pkg-self:bar})
+     (run echo b))
+    (when
+     (< %{pkg-self:version} 1.0)
+     (run echo g))
     (run echo i)
     (run echo j)
-    (run echo k)
-    (run echo l)
-    (run echo m)
-    (run echo n)
-    (run echo o)))
+    (when
+     %{pkg:foo:installed}
+     (run echo k))
+    (when
+     (< %{pkg:foo:version} 0.4)
+     (run echo l))
+    (when
+     (and %{pkg:foo:installed} %{pkg:bar:installed} %{pkg:baz:installed})
+     (run echo m))))
 
   $ solve_translate_opam_filters exercise-term-filters
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -84,9 +84,7 @@ solve_project() {
 solve_project_translate_opam_filters() {
   cat >dune-project
   add_mock_repo_if_needed
-  dune pkg lock \
-    --dont-poll-system-solver-variables \
-    --experimental-translate-opam-filters
+  dune pkg lock --dont-poll-system-solver-variables
 }
 
 make_lockdir() {


### PR DESCRIPTION
Nothing works without this option is enabled, so we might as well make
it the default.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4dc2b1b0-0402-477b-9dab-43d1ac92c788 -->