### PR TITLE
Add Dyn.result

### DIFF
--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -150,3 +150,8 @@ let variant s args = Variant (s, args)
 let hash = Stdlib.Hashtbl.hash
 let compare x y = Ordering.of_int (compare x y)
 let equal x y = x = y
+
+let result ok err = function
+  | Ok e -> variant "Ok" [ ok e ]
+  | Error e -> variant "Error" [ err e ]
+;;

--- a/otherlibs/dyn/dyn.mli
+++ b/otherlibs/dyn/dyn.mli
@@ -50,3 +50,4 @@ val option : 'a builder -> 'a option builder
 val opaque : _ builder
 val record : (string * t) list -> t
 val variant : string -> t list -> t
+val result : 'a builder -> 'error builder -> ('a, 'error) result builder


### PR DESCRIPTION
As `result` can be considered a base type it seems to make sense to have it as a basic Dyn.builder shipped with the `dyn` library. This would prove quite convenient for `ppx_deriving_dyn` as well but it's not strictly necessary as any occurrence of `result` can be replaced with `Result.t` for it to work. We could even inline it in the generated code for occurrences of `result` but having a `Dyn.result` felt more natural.

I'm opening this PR directly rather than an issue as, as you can see, the code is short and straightforward. If you don't think this is a good idea please feel free to close this PR.

If you do think this makes sense, I'm also happy to remove `Result.to_dyn` and replace it with `Dyn.result` elsewhere in the code as part of this PR.