### PR TITLE
doc: move reference info about cram test stanza

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -735,6 +735,7 @@ The following sections describe the available stanzas and their meanings.
 .. include:: stanzas/cinaps.rst
 .. include:: stanzas/copy_files.rst
 .. include:: stanzas/coq_theory.rst
+.. include:: stanzas/cram.rst
 .. include:: stanzas/data_only_dirs.rst
 .. include:: stanzas/deprecated_library_name.rst
 .. include:: stanzas/dirs.rst

--- a/doc/stanzas/cram.rst
+++ b/doc/stanzas/cram.rst
@@ -11,8 +11,6 @@ cram
    cases, the values from all applicable ``cram`` stanzas are merged together
    to get the final values for all the fields.
 
-   .. seealso:: :doc:`reference/cram`
-
    .. dune:field:: deps
       :param: <dep-spec>
 

--- a/doc/stanzas/cram.rst
+++ b/doc/stanzas/cram.rst
@@ -1,11 +1,11 @@
 .. _cram-stanza:
 
-cram
+Cram
 ----
 
 .. dune:stanza:: cram
 
-   Configure cram tests in the current directory (and subdirectories).
+   Configure Cram tests in the current directory (and subdirectories).
 
    A single test may be configured by more than one ``cram`` stanza. In such
    cases, the values from all applicable ``cram`` stanzas are merged together
@@ -23,7 +23,7 @@ cram
       - The dependencies must be specified to guarantee that they're visible to
         the test when running it.
 
-      The following introduces a dependency on ``foo.exe`` on all cram tests in
+      The following introduces a dependency on ``foo.exe`` on all Cram tests in
       this directory:
 
       .. code:: dune
@@ -36,8 +36,8 @@ cram
    .. dune:field:: applies_to
       :param: <predicate-lang>
 
-      Specify the scope of this cram stanza. By default it applies to all the
-      cram tests in the current directory. The special ``:whole_subtree`` value
+      Specify the scope of this ``cram`` stanza. By default it applies to all the
+      Cram tests in the current directory. The special ``:whole_subtree`` value
       will apply the options to all tests in all subdirectories (recursively).
       This is useful to apply common options to an entire test suite.
 
@@ -84,5 +84,5 @@ cram
       .. versionadded:: 3.12
 
       When set to ``false``, do not add the tests to the ``runtest`` alias.
-      The default is to add every cram test to ``runtest``, but this is not
+      The default is to add every Cram test to ``runtest``, but this is not
       always desired.

--- a/doc/stanzas/cram.rst
+++ b/doc/stanzas/cram.rst
@@ -1,0 +1,90 @@
+.. _cram-stanza:
+
+cram
+----
+
+.. dune:stanza:: cram
+
+   Configure cram tests in the current directory (and subdirectories).
+
+   A single test may be configured by more than one ``cram`` stanza. In such
+   cases, the values from all applicable ``cram`` stanzas are merged together
+   to get the final values for all the fields.
+
+   .. seealso:: :doc:`reference/cram`
+
+   .. dune:field:: deps
+      :param: <dep-spec>
+
+      Specify the dependencies of the test.
+
+      When testing binaries, it's important to to specify a dependency on the
+      binary for two reasons:
+
+      - Dune must know to re-run the test when a dependency changes
+      - The dependencies must be specified to guarantee that they're visible to
+        the test when running it.
+
+      The following introduces a dependency on ``foo.exe`` on all cram tests in
+      this directory:
+
+      .. code:: dune
+
+         (cram
+          (deps ../foo.exe))
+
+      .. seealso:: :doc:`concepts/dependency-spec`.
+
+   .. dune:field:: applies_to
+      :param: <predicate-lang>
+
+      Specify the scope of this cram stanza. By default it applies to all the
+      cram tests in the current directory. The special ``:whole_subtree`` value
+      will apply the options to all tests in all subdirectories (recursively).
+      This is useful to apply common options to an entire test suite.
+
+      The following will apply the stanza to all tests in this directory,
+      except for ``foo.t`` and ``bar.t``:
+
+      .. code:: dune
+
+         (cram
+          (applies_to * \ foo bar)
+          (deps ../foo.exe))
+
+      .. seealso:: :doc:`reference/predicate-language`
+
+   .. dune:field:: enabled_if
+      :param: <blang>
+
+      Control whether the tests are enabled.
+
+      .. seealso:: :doc:`reference/boolean-language`, :doc:`concepts/variables`
+
+   .. dune:field:: alias
+      :param: <name>
+
+      Alias that can be used to run the test. In addition to the user alias,
+      every test ``foo.t`` is attached to the ``@runtest`` alias and gets its
+      own ``@foo`` alias to make it convenient to run individually.
+
+   .. dune:field:: locks
+      :param: <lock-names>
+
+      Specify that the tests must be run while holding the following locks.
+
+      .. seealso:: :doc:`concepts/locks`
+
+   .. dune:field:: package
+      :param: <name>
+
+      Attach the tests selected by this stanza to the specified package.
+
+   .. dune:field:: runtest_alias
+      :param: <true|false>
+
+      .. versionadded:: 3.12
+
+      When set to ``false``, do not add the tests to the ``runtest`` alias.
+      The default is to add every cram test to ``runtest``, but this is not
+      always desired.

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -628,59 +628,7 @@ access their contents in the test script ``run.t``:
      $ wc -l $(ls bar) | awk '{ print $1 }'
      1231
 
-
-Test Options
-------------
-
-When testing binaries, it's important to to specify a dependency on the binary
-for two reasons:
-
-- Dune must know to re-run the test when a dependency changes
-- The dependencies must be specified to guarantee that they're visible to the
-  test when running it.
-
-We can specify dependencies using the ``deps`` field using the usual syntax:
-
-.. code:: dune
-
-   (cram
-    (deps ../foo.exe))
-    
-This introduces a dependency on ``foo.exe`` on all Cram tests in this directory.
-To apply the stanza to a particular test, it's possible to use ``applies_to``
-field:
-
-.. code:: dune
-
-   (cram
-    (applies_to * \ foo bar)
-    (deps ../foo.exe))
-
-We use the :doc:`reference/predicate-language` to apply this stanza to all tests
-in this directory, except for ``foo.t`` and ``bar.t``. The ``applies_to`` field
-also accepts the special value ``:whole_subtree`` in order to apply the options
-to all tests in all subdirectories (recursively). This is useful to apply
-common options to an entire test suite.
-
-The ``cram`` stanza accepts the following fields:
-
-- ``enabled_if`` - controls whether the tests are enabled
-- ``alias`` - alias that can be used to run the test. In addition to the user
-  alias, every test ``foo.t`` is attached to the ``@runtest`` alias and gets its
-  own ``@foo`` alias to make it convenient to run individually.
-- ``(locks (<lock-names>))`` specify that the tests must be run while
-  holding the following locks. See :doc:`concepts/locks` for more details.
-- ``deps`` - dependencies of the test
-- ``(package <package-name>)`` - attach the tests selected by this stanza to the
-  specified package
-- ``(runtest_alias <true|false>)`` - when set to ``false``, do not add the
-  tests to the ``runtest`` alias. The default is to add every cram test to
-  ``runtest``, but this is not always desired.
-
-A single test may be configured by more than one ``cram`` stanza. In such cases,
-the values from all applicable ``cram`` stanzas are merged together to get the
-final values for all the fields.
-
+.. seealso:: :ref:`(cram) stanza reference <cram-stanza>`
 
 Testing an OCaml Program
 ------------------------


### PR DESCRIPTION
It goes with the rest of the stanza documentation and we can use the domain.

Fixes #9211
