### PR TITLE
doc: add reference info for cram tests

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,6 +52,7 @@ Welcome to Dune's Documentation!
    reference/packages
    reference/findlib
    reference/aliases
+   reference/cram
    concepts/scopes
    concepts/variables
    concepts/dependency-spec

--- a/doc/reference/cram.rst
+++ b/doc/reference/cram.rst
@@ -1,0 +1,97 @@
+Cram Tests
+==========
+
+Syntax
+------
+
+Cram tests are interpreted line by line, depending on the first characters of
+each line:
+
+- if a line starts with two spaces, it is part of a command or its output.
+
+  - if the next two characters are a dollar sign ``$`` and a space character,
+    the rest is a command.
+
+  - if the next two characters are a greater-than sign ``>`` and a space
+    character, the rest is the continuation of a command.
+
+  - otherwise (line starts with two spaces and something else), this is the
+    expected output of the command just before.
+
+- otherwise (line does not start with two spaces), this is a comment.
+
+Ignoring comments, a cram test is composed of a list of commands (1 line), with
+optional continuation lines, and with optional output lines.
+
+.. code:: cram
+
+   Plain paragraphs that do not start with spaces are ignored by cram tests.
+   They are often used to introduce commands. For example, this is a command:
+
+     $ touch this-file.txt
+
+   The above is the simplest command: it has no continuation lines and no output.
+   Some commands have an expected output:
+
+     $ ls
+     this-file.txt
+
+   There can be several output lines if the command is expected to print
+   several lines.
+   Also, note that if a command has no output, the next one can come in the
+   next line.
+
+     $ touch other-file.txt
+     $ ls
+     other-file.txt
+     this-file.txt
+
+   Continuation lines are used when a command fits on several lines. This can
+   happen in all the cases where pressing Enter would not run the command. For
+   example, when passing a backslash character to escape the line ending.
+   In that case, all the continuation lines are grouped together as a single
+   command.
+   This syntax mimics the PS2 prompt in shells - the ">" character is not
+   passed to the command.
+
+     $ echo \
+     >   a \
+     >   b \
+     >   d \
+     >   c
+     a b c d
+
+Semantics
+---------
+
+Execution and Promotion
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When a cram test is executed, the commands it contains are executed, and a
+corrected file is created where the outputs of the commands are inserted after
+each command. This corrected file is then offered for
+:doc:`promotion <../concepts/promotion>` by Dune.
+
+Concretely, this means that ``dune runtest`` will display the difference
+between the current contents of the cram test, and the output of the latest
+run. This diff can be applied by running ``dune promote``, as usual.
+
+.. code:: diff
+
+   $ touch changed-name.txt
+   $ ls
+  -other-file.txt
+  +changed-name.txt
+   this-file.txt
+
+File and Directory Tests
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are two types of cram tests: file tests and directory tests. File tests
+are files with a ``.t`` extension. Directory tests are files named ``run.t``
+within a directory with a name that ends with ``.t``.
+
+A cram test begins its execution in a temporary directory where its
+dependencies (as listed in the corresponding :ref:`cram stanzas <cram-stanza>`,
+if any) are available. In the case of a directory test, the contents of the
+directory are also available.

--- a/doc/reference/cram.rst
+++ b/doc/reference/cram.rst
@@ -73,7 +73,7 @@ each command. This corrected file is then offered for
 :doc:`promotion <../concepts/promotion>` by Dune.
 
 Concretely, this means that ``dune runtest`` will display the difference
-between the current contents of the Cram test, and the output of the latest
+between the current contents of the Cram test and the output of the latest
 run. This diff can be applied by running ``dune promote``, as usual.
 
 .. code:: diff

--- a/doc/reference/cram.rst
+++ b/doc/reference/cram.rst
@@ -7,30 +7,30 @@ Syntax
 Cram tests are interpreted line by line, depending on the first characters of
 each line:
 
-- if a line starts with two spaces, it is part of a command or its output.
+- If a line starts with two spaces, it is part of a command or its output.
 
-  - if the next two characters are a dollar sign ``$`` and a space character,
+  - If the next two characters are a dollar sign ``$`` and a space character,
     the rest is a command.
 
-  - if the next two characters are a greater-than sign ``>`` and a space
+  - If the next two characters are a greater-than sign ``>`` and a space
     character, the rest is the continuation of a command.
 
-  - otherwise (line starts with two spaces and something else), this is the
+  - Otherwise (line starts with two spaces and something else), this is the
     expected output of the command just before.
 
-- otherwise (line does not start with two spaces), this is a comment.
+- Otherwise (line does not start with two spaces), this is a comment.
 
-Ignoring comments, a cram test is composed of a list of commands (1 line), with
+Ignoring comments, a Cram test is composed of a list of commands (1 line), with
 optional continuation lines, and with optional output lines.
 
 .. code:: cram
 
-   Plain paragraphs that do not start with spaces are ignored by cram tests.
+   Plain paragraphs that do not start with spaces are ignored by Cram tests.
    They are often used to introduce commands. For example, this is a command:
 
      $ touch this-file.txt
 
-   The above is the simplest command: it has no continuation lines and no output.
+   The above is the simplest command; it has no continuation lines and no output.
    Some commands have an expected output:
 
      $ ls
@@ -67,13 +67,13 @@ Semantics
 Execution and Promotion
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-When a cram test is executed, the commands it contains are executed, and a
+When a Cram test is executed, the commands it contains are executed, and a
 corrected file is created where the outputs of the commands are inserted after
 each command. This corrected file is then offered for
 :doc:`promotion <../concepts/promotion>` by Dune.
 
 Concretely, this means that ``dune runtest`` will display the difference
-between the current contents of the cram test, and the output of the latest
+between the current contents of the Cram test, and the output of the latest
 run. This diff can be applied by running ``dune promote``, as usual.
 
 .. code:: diff
@@ -87,11 +87,11 @@ run. This diff can be applied by running ``dune promote``, as usual.
 File and Directory Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are two types of cram tests: file tests and directory tests. File tests
+There are two types of Cram tests: file tests and directory tests. File tests
 are files with a ``.t`` extension. Directory tests are files named ``run.t``
 within a directory with a name that ends with ``.t``.
 
-A cram test begins its execution in a temporary directory where its
+A Cram test begins its execution in a temporary directory where its
 dependencies (as listed in the corresponding :ref:`cram stanzas <cram-stanza>`,
 if any) are available. In the case of a directory test, the contents of the
 directory are also available.

--- a/doc/reference/cram.rst
+++ b/doc/reference/cram.rst
@@ -31,7 +31,7 @@ Here is an example showing how ``echo``, ``cat``, and ``rm`` interact.
      rm: cannot remove 'data.txt': No such file or directory
      [1]
 
-The syntax mimics a shell session: there are comments, and shell commands with
+The syntax mimics a shell session: there are comments and shell commands with
 their output.
 
 Examples
@@ -41,7 +41,7 @@ Simple Commands
 ^^^^^^^^^^^^^^^
 
 This is the simplest test case: it executes the command ``touch
-this-file.txt``, and expects that the command has no output.
+this-file.txt`` and expects that the command has no output.
 
 .. code:: console
 
@@ -145,7 +145,7 @@ each line:
 - If a line starts with ``␣␣$␣`` (``␣`` denoting a space character), the rest
   is a command.
 - If it starts with ``␣␣>␣``, the rest is the continuation of a command
-  (continuation lines must immediately follow a command)
+  (continuation lines must immediately follow a command).
 - If it start with ``␣␣`` and something else, the rest is the expected output
   or exit code of the previous command.
 - Everything else is a comment.
@@ -167,30 +167,30 @@ happens in a single file. This is handy because it does not make a deep file
 hierarchy in a project. But if the test requires some files, these need to be
 created using ``cat`` and heredocs. Directory tests, on the other hand, allow
 creating these test fixtures as normal files. This can be more comfortable
-because it makes the usual tooling (syntax highlighting, completion, etc)
+because it makes the usual tooling (syntax highlighting, completion, etc.)
 available.
 
 Executing Cram Tests
 --------------------
 
-Every cram test has a name: for file tests, the name of ``something.t`` is
+Every Cram test has a name. For file tests, the name of ``something.t`` is
 ``something``, and for directory tests, the name of ``something.t/run.t`` is
 ``something``.
 
-There are several ways to execute cram tests:
+There are several ways to execute Cram tests:
 
-- all cram tests are attached to the ``@runtest`` alias. So ``dune runtest``
-  will run all cram tests.
-- every cram test creates an alias after its name. So, ``dune build
+- All Cram tests are attached to the ``@runtest`` alias. So ``dune runtest``
+  will run all Cram tests.
+- Every Cram test creates an alias after its name. So, ``dune build
   @something`` will run tests named ``something``.
 
 When a Cram test is executed, the commands it contains are executed, and a
-corrected file is created where the outputs of the commands are inserted after
+corrected file is created where the command outputs are inserted after
 each command. This corrected file is then offered for :doc:`promotion
 <../concepts/promotion>` by Dune.
 
 Concretely, this means that Dune will display the difference between the
-current contents of the Cram test and the output of the latest run. This diff
+Cram test's current contents and the latest run's output. This diff
 can be applied by running ``dune promote``, as usual.
 
 .. code:: diff

--- a/doc/stanzas/cram.rst
+++ b/doc/stanzas/cram.rst
@@ -11,6 +11,8 @@ Cram
    cases, the values from all applicable ``cram`` stanzas are merged together
    to get the final values for all the fields.
 
+   .. seealso:: :doc:`reference/cram`
+
    .. dune:field:: deps
       :param: <dep-spec>
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -550,12 +550,8 @@ To define a standalone test, we create a ``.t`` file. For example, ``foo.t``:
    Simplest possible Cram test
      $ echo "testing"
 
-This simple example demonstrates two components of Cram tests:
-
-* Comments - Anything that doesn't start with a 2 space indentation is a comment
-* Commands - A command starts with 2 spaces followed by a ``$``. It's executed
-  in the shell and the output is diffed against the output below. In this
-  example, there's no output yet.
+This simple example demonstrates two components of Cram tests: comments and
+commands. See :doc:`reference/cram` for a description of the syntax.
 
 To run the test and promote the results:
 


### PR DESCRIPTION
This document explains cram tests themselves, not only the stanza and how to set them up.
