### PR TITLE
test: make sure depopts are optional

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depopts-optional.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts-optional.t
@@ -1,0 +1,21 @@
+This tests that depopts are considered optional by the solver.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ mkpkg foo
+  $ mkpkg bar
+
+We create a package that depends on foo and has an optional dependency on bar
+but also a conflict with bar. This should ensure that bar is never selected by
+the solver.
+
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (depends foo)
+  >  (depopts bar)
+  >  (conflicts bar))
+  > EOF
+  Solution for dune.lock:
+  - foo.0.0.1


### PR DESCRIPTION
This adds a simple test that ensures we are treating depopts optionally in the solver. When we support depopts in #9430, this test shouldn't change. (And it doesn't)