### PR TITLE
test: translation of depopts field

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
@@ -1,0 +1,38 @@
+We test how opam files with depopts fields are translated into dune.lock files:
+
+  $ . ../helpers.sh
+  $ mkrepo
+
+Make a package with a depopts field
+  $ mkpkg with-depopts <<'EOF'
+  > depopts: [ "foo" ]
+  > EOF
+  $ mkpkg foo
+
+  $ solve with-depopts
+  Solution for dune.lock:
+  - with-depopts.0.0.1
+
+When depopts are supported and selected, the above lock should change and we
+should also be able to see a deps field in the lock file:
+
+  $ cat dune.lock/with-depopts.pkg
+  (version 0.0.1)
+
+We should also be able to validate the lock directory:
+
+  $ dune pkg validate-lockdir
+
+Depopts should not be selected if they conflict with other constraints:
+
+  $ mkpkg no-foo <<'EOF'
+  > depends: [ "with-depopts" ]
+  > conflicts: [ "foo" ]
+  > EOF
+
+  $ solve no-foo
+  Solution for dune.lock:
+  - no-foo.0.0.1
+  - with-depopts.0.0.1
+
+  $ dune pkg validate-lockdir


### PR DESCRIPTION
This tests the translation of the depopts field. Importantly it outputs the translated lock file for a package using depopts to make sure it correctly gets added as a `deps` field.

We also validate the lock directory at the end. This will become important when we implement depopts to make sure we are creating valid build plans.

Finally, we make sure that the depopt is ommited and check the lock directory is setup correctly in that case.