### PR TITLE
test(pkg): remove useless helper

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -85,7 +85,7 @@ Package which has boolean where string was expected. This should be caught while
   > ]
   > EOF
 
-  $ solve_translate_opam_filters standard-dune with-interpolation with-percent-sign variable-types
+  $ solve standard-dune with-interpolation with-percent-sign variable-types
   Solution for dune.lock:
   - standard-dune.0.0.1
   - variable-types.0.0.1
@@ -132,7 +132,7 @@ Package which has boolean where string was expected. This should be caught while
     (run echo %{pkg:foo:package_var})
     (run echo %{os_family})))
 
-  $ solve_translate_opam_filters with-malformed-interpolation
+  $ solve with-malformed-interpolation
   File "$TESTCASE_ROOT/mock-opam-repository/packages/with-malformed-interpolation/with-malformed-interpolation.0.0.1/opam", line 1, characters 0-0:
   Error: Encountered malformed variable interpolation while processing commands
   for package with-malformed-interpolation.0.0.1.
@@ -140,7 +140,7 @@ Package which has boolean where string was expected. This should be caught while
   %{prefix
   [1]
 
-  $ solve_translate_opam_filters exercise-filters
+  $ solve exercise-filters
   Solution for dune.lock:
   - exercise-filters.0.0.1
 
@@ -238,7 +238,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
      (and %{pkg:foo:installed} %{pkg:bar:installed} %{pkg:baz:installed})
      (run echo m))))
 
-  $ solve_translate_opam_filters exercise-term-filters
+  $ solve exercise-term-filters
   Solution for dune.lock:
   - exercise-term-filters.0.0.1
   $ cat dune.lock/exercise-term-filters.pkg
@@ -253,7 +253,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
      (and_absorb_undefined_var %{pkg-self:bar} %{pkg-self:baz})
      c)))
 
-  $ solve_translate_opam_filters filter-error-bool-where-string-expected
+  $ solve filter-error-bool-where-string-expected
   Error: At
   $TESTCASE_ROOT/mock-opam-repository/packages/filter-error-bool-where-string-expected/filter-error-bool-where-string-expected.0.0.1/opam:3:33-3:34::
   Parse error
@@ -276,7 +276,7 @@ Package with package conjunction and string selections inside variable interpola
   > ]
   > EOF
 
-  $ solve_project_translate_opam_filters <<EOF
+  $ solve_project <<EOF
   > (lang dune 3.8)
   > (package (name x) (depends package-conjunction-and-string-selection))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -81,12 +81,6 @@ solve_project() {
   dune pkg lock --dont-poll-system-solver-variables $@
 }
 
-solve_project_translate_opam_filters() {
-  cat >dune-project
-  add_mock_repo_if_needed
-  dune pkg lock --dont-poll-system-solver-variables
-}
-
 make_lockdir() {
   mkdir dune.lock
   cat >dune.lock/lock.dune <<EOF
@@ -107,8 +101,4 @@ EOF
 
 solve() {
   make_project $@ | solve_project
-}
-
-solve_translate_opam_filters() {
-  make_project $@ | solve_project_translate_opam_filters
 }

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -24,7 +24,7 @@ Declare a package which refers to some variables:
   > EOF
 
 Solve the package using the default solver env:
-  $ solve_translate_opam_filters a
+  $ solve a
   Solution for dune.lock:
   - a.0.0.1
   $ cat dune.lock/a.pkg
@@ -67,7 +67,7 @@ Make a custom solver env:
   > EOF
 
 Run the solver using the new env:
-  $ solve_translate_opam_filters a
+  $ solve a
   Solution for dune.lock:
   - a.0.0.1
   $ cat dune.lock/a.pkg

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -68,7 +68,7 @@ Generate a mock opam repository
   > EOF
 
   $ build_single_package() {
-  > solve_project_translate_opam_filters <<EOF
+  > solve_project <<EOF
   > (lang dune 3.11)
   > (package
   >  (name x)


### PR DESCRIPTION
filters are always translated one so we don't need a special function

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5091bc2d-035e-40a7-8725-ae1705af147c -->