### PR TITLE
test: conflicting depopts

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
@@ -1,0 +1,23 @@
+We test depopts with conflicting constraints to see which one the solver will
+prefer if any:
+
+  $ . ../helpers.sh
+  $ mkpkg foo 1
+  $ mkpkg foo 2
+
+  $ mkpkg bar <<'EOF'
+  > depopts: [ "foo" {= "1"} ]
+  > EOF
+
+  $ mkpkg baz <<'EOF'
+  > depopts: [ "foo" {= "2"} ]
+  > EOF
+
+We don't currently support depopts so they are both omitted.
+
+  $ solve bar baz
+  Solution for dune.lock:
+  - bar.0.0.1
+  - baz.0.0.1
+
+It's possible to find a solution by satisfying one (but not both) depopts.


### PR DESCRIPTION
@rgrinberg This test demonstrates the behaviour of depopts when there is a conflict between them. It appears that 0install eagerly discards them after #9430. There are <s>3</s> 2 situations that could come out of this test:

1. We choose no depopts, as is currently (after #9430) the behaviour.
2. We choose 1 depopt, probably the latest version. This behaviour seems the most sensible, but would require changes in 0install.
3. <s>We choose both depopts by allowing for "local dependencies". This would make the depopts as only being visible to the package being built, allowing multiple versions to be installed at once. This would be a separate feature, and probably has some of its own difficulties.</s> This won't work.