### PR TITLE
fix(init): correct behavior of PATH argument for `dune init project`

### DIFF
--- a/bin/init.ml
+++ b/bin/init.ml
@@ -218,8 +218,12 @@ let project =
        let name = Dune_lang.Atom.to_string common.name in
        let root =
          match path with
+         (* If a path is given, we use that for the root during project
+            initialization, creating the path to it if needed. *)
+         | Some path -> path
+         (* Otherwise we will use the project's given name, and create a
+            directory accordingly. *)
          | None -> name
-         | Some path -> Filename.concat path name
        in
        let builder = Builder.set_root common_builder root in
        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p root in
@@ -252,8 +256,10 @@ let group =
     ; `P
         {|Run a subcommand with $(b, --help) for for details on it's supported arguments|}
     ; `P
-        {|If the optional $(b,PATH) is provided, the component will be created
-        there. Otherwise, it is created in the current working directory.|}
+        {|If the optional $(b,PATH) is provided, it must be a path to a directory, and
+        the component will be created there. Otherwise, it is created in a child of the
+        current working directory, called $(b, NAME). To initialize a component in the
+        current working directory, use `.` as the $(b,PATH).|}
     ; `P
         {|Any prefix of a $(b,COMMAND)'s name can be supplied in place of
         full name (as illustrated in the synopsis).|}

--- a/doc/changes/9447_fix_dune_init_proj_with_path.md
+++ b/doc/changes/9447_fix_dune_init_proj_with_path.md
@@ -1,0 +1,4 @@
+- Fix handling of the `PATH` argument to `dune init proj NAME PATH`. An
+  intermediate directory called `NAME` is no longer created if `PATH` is
+  supplied, so `dune init proj my_project .` will now initialize a project in
+  the current working directory. (#9447, fixes #9209, @shonfeder)

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -77,7 +77,31 @@ the file and directory, if necessary):
      (preprocess
       (pps ppx_inline_tests)))
 
-Consult the manual page using the ``dune init --help`` command for more details.
+Initializing Components in a Specified Directory
+------------------------------------------------
+
+All ``init`` subcommands take an optional ``PATH`` argument, which should be a
+path to a directory. When supplied, the component will be created in the
+specified directory. E.g., to initialize a project in the current working
+directory, run
+
+.. code:: console
+
+    $ dune init proj my_proj .
+
+To initialize a project in a directory in some nested path, run
+
+.. code:: console
+
+    $ dune init proj my_proj path/to/my/project
+
+If the specified directory does not already exist, it will be created.
+
+Learning More About the ``init`` Commands
+-----------------------------------------
+
+Consult the manual page using the ```dune init --help`` command for more
+details.
 
 .. _finding-root:
 
@@ -309,8 +333,8 @@ must be prefixed by the shortest one.
 
 .. _dune-subst:
 
-dune subst
-==========
+``dune subst``
+==============
 
 One of the features ``dune-release`` provides is watermarking; it replaces
 various strings of the form ``%%ID%%`` in all your project files

--- a/test/blackbox-tests/test-cases/dune-init-proj-no-spurious-build-dir.t
+++ b/test/blackbox-tests/test-cases/dune-init-proj-no-spurious-build-dir.t
@@ -16,15 +16,13 @@ directory in the current directory.
   test
 
   $ dune init proj foo bar
-  Entering directory 'bar/foo'
+  Entering directory 'bar'
   Success: initialized project component named foo
-  Leaving directory 'bar/foo'
+  Leaving directory 'bar'
   $ ls
   bar
   foo
   $ ls bar
-  foo
-  $ ls bar/foo
   _build
   bar
   bin
@@ -35,16 +33,14 @@ directory in the current directory.
 
   $ mkdir baz
   $ dune init proj foo baz
-  Entering directory 'baz/foo'
+  Entering directory 'baz'
   Success: initialized project component named foo
-  Leaving directory 'baz/foo'
+  Leaving directory 'baz'
   $ ls
   bar
   baz
   foo
   $ ls baz
-  foo
-  $ ls baz/foo
   _build
   baz
   bin

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -9,7 +9,7 @@ Setup mutable files
   >   (name test_lib))
   > EOF
 
-Adding a library
+Adding a Library
 ----------------
 
 Can init a public library
@@ -61,7 +61,7 @@ Clean up library with inlines tests
 
   $ rm -rf ./_inline_tests_lib
 
-Adding an executable
+Adding an Executable
 --------------------
 
 Can init a public executable
@@ -90,7 +90,7 @@ Clean up the executable tests
 
   $ rm -rf ./_test_bin_dir
 
-Adding tests
+Adding Tests
 ------------
 
 Can init tests
@@ -109,7 +109,7 @@ Clean up the test tests
 
   $ rm -rf ./_test_tests_dir
 
-Adding components to default and non-standard places
+Adding Components to Default and Non-Standard Places
 ---------------------------------------------------
 
 Add a library in the current working directory
@@ -124,27 +124,37 @@ Clean the library creation
 
   $ rm ./dune
 
-Add a library to a dune file in a specified directory
+Add a library to a `dune` file in a specified directory
 
   $ dune init lib test_lib ./_test_dir
   Success: initialized library component named test_lib
   $ test -f ./_test_dir/dune
 
-Clean up from the dune file created in ./_test_dir
+Clean up from the `dune` file created in ./_test_dir
 
   $ rm -rf ./_test_dir
 
-Add a library to a dune file in a directory specified with an absolute path
+Add a library to a `dune` file in a directory specified with an absolute path
 
   $ dune init lib test_lib $PWD/_test_dir
   Success: initialized library component named test_lib
   $ test -f $PWD/_test_dir/dune
 
-Clean up from the dune file created at an absolute path
+Clean up from the `dune` file created at an absolute path
 
   $ rm -rf $PWD/_test_dir
 
-Adding a library and an executable dependent on that library
+Add a library in the current working directory
+
+  $ dune init lib test_cwd_lib .
+  Success: initialized library component named test_cwd_lib
+  $ test -f dune
+
+Clean up from the `dune` file created in the current workding dir
+
+  $ rm dune
+
+Adding a Library and an Executable Dependent on that Library
 ------------------------------------------------------------
 
 Can init a library and dependent executable in a combo project
@@ -175,7 +185,7 @@ Clean up the combo project
 
   $ rm -rf ./_test_lib_exe_dir
 
-Adding libraries in a single directory
+Adding Libraries in a Single Directory
 --------------------------------------
 
 Can add multiple libraries in the same directory
@@ -204,7 +214,7 @@ Clan up the multiple library project
 
   $ rm -rf ./_test_lib
 
-Multiple ppxs and library dependencies
+Multiple PPXs and Library Dependencies
 --------------------------------------
 
 Can add multiple library dependencies in one command
@@ -234,7 +244,7 @@ Will not overwrite existing files
   $ cat ./existing_project/bin/main.ml
   () = print_endline "Goodbye"
 
-Comments in dune files are preserved
+Comments in `dune` files are preserved
 
   $ dune init lib test_lib2 ./existing_project/src
   Success: initialized library component named test_lib2
@@ -261,7 +271,7 @@ Will not create components with invalid names
   $ test -f ./_test_lib
   [1]
 
-Adding fields to existing stanzas
+Adding Fields to Existing Stanzas
 ---------------------------------
 
 # TODO(shonfeder)
@@ -284,10 +294,10 @@ Adding fields to existing stanzas is currently not supported
    (name test_bin)
    (libraries test_lib1))
 
-Creating projects
+Creating Projects
 -----------------
 
-Initializing executable projects
+Initializing Executable Projects
 ================================
 
 We can init a new executable project:
@@ -297,7 +307,7 @@ We can init a new executable project:
   Success: initialized project component named new_exec_proj
   Leaving directory 'new_exec_proj'
 
-The generated project contains all expected sub-components:
+The generated project contains all expected subcomponents:
 
   $ ls new_exec_proj/**
   new_exec_proj/dune-project
@@ -317,7 +327,7 @@ The generated project contains all expected sub-components:
   dune
   test_new_exec_proj.ml
 
-In particular, the dune-project file has the expected content:
+In particular, the `dune-project` file has the expected content:
 
   $ cat new_exec_proj/dune-project | sed 's/dune [0-9].[0-9]*/dune $version/g'
   (lang dune $version)
@@ -401,7 +411,7 @@ We can build and run the project's tests:
   Entering directory 'new_exec_proj'
   Leaving directory 'new_exec_proj'
 
-Initializing library projects
+Initializing Library Projects
 ================================
 
 We can init a new library project:
@@ -411,7 +421,7 @@ We can init a new library project:
   Success: initialized project component named new_lib_proj
   Leaving directory 'new_lib_proj'
 
-The generated project contains all expected sub-components:
+The generated project contains all expected subcomponents:
 
   $ ls new_lib_proj/**
   new_lib_proj/dune-project
@@ -427,7 +437,7 @@ The generated project contains all expected sub-components:
   dune
   test_new_lib_proj.ml
 
-In particular, the dune-project file has the expected content:
+In particular, the `dune-project` file has the expected content:
 
   $ cat new_lib_proj/dune-project | sed 's/dune [0-9].[0-9]*/dune $version/g'
   (lang dune $version)
@@ -508,7 +518,28 @@ And we we can run the tests:
   test_new_lib_proj alias test/runtest
   Leaving directory 'new_lib_proj'
 
-Initializing projects using Esy
+
+Initializing Projects Using the PATH Argument
+=============================================
+
+We can init a project in a specified directory:
+
+  $ dune init proj proj_at_path path/to/project
+  Entering directory 'path/to/project'
+  Success: initialized project component named proj_at_path
+  Leaving directory 'path/to/project'
+  $ test -f path/to/project/dune-project
+
+A project can be initialized in the current directory (addressing
+https://github.com/ocaml/dune/issues/9209):
+
+  $ mkdir a-new-dir
+  $ cd a-new-dir
+  $ dune init proj project_in_cwd .
+  Success: initialized project component named project_in_cwd
+  $ test -f dune-project
+
+Initializing Projects Using Esy
 ===============================
 
 We can init a project using Esy:
@@ -518,7 +549,7 @@ We can init a project using Esy:
   Success: initialized project component named new_esy_proj
   Leaving directory 'new_esy_proj'
 
-The esy project contains all expected sub-components:
+The `esy` project contains all expected subcomponents:
 
   $ ls new_esy_proj/**
   new_esy_proj/dune-project
@@ -538,7 +569,7 @@ The esy project contains all expected sub-components:
   dune
   test_new_esy_proj.ml
 
-And the dune-project file does NOT specify generation of an opam file:
+And the `dune-project` file does NOT specify generation of an opam file:
 
   $ cat new_esy_proj/dune-project | grep "generate_opam_files"
   (generate_opam_files false)

--- a/test/blackbox-tests/test-cases/github7806.t
+++ b/test/blackbox-tests/test-cases/github7806.t
@@ -1,5 +1,4 @@
   $ dune init project name $PWD 2>&1 | head -n 8
-  Entering directory 'name'
   Internal error, please report upstream including the contents of _build/log.
   Description:
     ("[as_in_source_tree_exn] called on something not in source tree",
@@ -7,3 +6,4 @@
         External
           "$TESTCASE_ROOT"
     })
+  Raised at Stdune__Code_error.raise in file


### PR DESCRIPTION
Fixes #9209

The logic around the `PATH` argument for the `dune init project` subcommand was incorrect. This was creating an unnecessary limitation on the behavior of the sub command, leading to #9209, and inconsistent behavior, diagnosed in https://github.com/ocaml/dune/issues/9209#issuecomment-1817510486.

This was the error: when the `PATH` argument was give to `dune init project`, the `NAME` argument was being appended as the final part of the path. As a result, instead of initializing the project in the specified directory, we were initializing it in a subdirectory of the given directory, bearing `NAME`. As an illustrative example, this led to the confusing behavior that both `dune init proj foo` and `dune init proj foo .` initialized projects in a newly created directory `./foo/`.

This error went undetected for so long in part because it was not being exercised in test coverage and in part because the intended behavior was underspecified in the documentation. I have tried to fix both of these oversights.