### PR TITLE
fix(pkg): unbreak ocaml-system

### DIFF
--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -128,14 +128,16 @@ let of_env_with_findlib name env findlib_config ~which =
   make name ~env ~get_ocaml_tool ~which
 ;;
 
-let of_binaries name env binaries =
+let of_binaries ~path name env binaries =
   let which =
     let map =
       Path.Set.to_list binaries
       |> Filename.Map.of_list_map_exn ~f:(fun binary -> Path.basename binary, binary)
     in
     fun basename ->
-      Which.candidates basename |> List.find_map ~f:(Filename.Map.find map) |> Memo.return
+      match Which.candidates basename |> List.find_map ~f:(Filename.Map.find map) with
+      | Some s -> Memo.return (Some s)
+      | None -> Which.which ~path basename
   in
   let get_ocaml_tool ~dir:_ prog = which prog in
   make name ~env ~get_ocaml_tool ~which

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -24,7 +24,7 @@ val of_env_with_findlib
   -> which:(Filename.t -> Path.t option Memo.t)
   -> t Memo.t
 
-val of_binaries : Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
+val of_binaries : path:Path.t list -> Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
 
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Ocaml.Mode.t -> Action.Prog.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1616,11 +1616,13 @@ let ocaml_toolchain context =
       let cookie = (Pkg_installed.of_paths pkg.paths).cookie in
       let open Action_builder.O in
       let* cookie = cookie in
+      (* TODO we should use the closure of [pkg] *)
       let binaries =
         Section.Map.find cookie.files Bin |> Option.value ~default:[] |> Path.Set.of_list
       in
-      let env = Pkg.exported_env pkg in
-      Action_builder.of_memo @@ Ocaml_toolchain.of_binaries context env binaries
+      let env = Env.extend_env (Global.env ()) (Pkg.exported_env pkg) in
+      let path = Env_path.path (Global.env ()) in
+      Action_builder.of_memo @@ Ocaml_toolchain.of_binaries ~path context env binaries
     in
     Some (Action_builder.memoize "ocaml_toolchain" toolchain)
 ;;


### PR DESCRIPTION
allow ocaml-system binaries to come from the inherited environment

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d9d1f1ce-e506-404f-a01a-43c37f2941c1 -->