### PR TITLE
pkg: unset variables in workspace file

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -49,13 +49,17 @@ let solve per_context ~update_opam_repositories ~solver_env_from_current_system 
            ; version_preference
            ; repos
            ; solver_env = solver_env_from_context
+           ; unset_solver_vars = unset_solver_vars_from_context
            ; context_common = { name = context_name; _ }
            ; constraints
            ; repositories
            }
          ->
          let solver_env =
-           solver_env ~solver_env_from_context ~solver_env_from_current_system
+           solver_env
+             ~solver_env_from_context
+             ~solver_env_from_current_system
+             ~unset_solver_vars_from_context
          in
          let* repos = get_repos repos ~repositories ~update_opam_repositories in
          let overlay =

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -14,6 +14,7 @@ let find_outdated_packages ~context_name_arg ~all_contexts_arg ~transitive () =
               ; version_preference = _
               ; repos
               ; solver_env = _
+              ; unset_solver_vars = _
               ; context_common = _
               ; repositories
               ; constraints = _

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -11,6 +11,7 @@ val context_term : doc:string -> Context_name.t option Term.t
 val solver_env
   :  solver_env_from_current_system:Dune_pkg.Solver_env.t option
   -> solver_env_from_context:Dune_pkg.Solver_env.t option
+  -> unset_solver_vars_from_context:Dune_pkg.Variable_name.Set.t option
   -> Dune_pkg.Solver_env.t
 
 module Version_preference : sig
@@ -22,6 +23,7 @@ module Per_context : sig
     { lock_dir_path : Path.Source.t
     ; version_preference : Dune_pkg.Version_preference.t
     ; solver_env : Dune_pkg.Solver_env.t option
+    ; unset_solver_vars : Dune_pkg.Variable_name.Set.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; context_common : Workspace.Context.Common.t
     ; repos :

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -4,11 +4,17 @@ open Pkg_common
 let print_solver_env_for_one_context
   ~solver_env_from_current_system
   { Per_context.solver_env = solver_env_from_context
+  ; unset_solver_vars = unset_solver_vars_from_context
   ; context_common = { name = context_name; _ }
   ; _
   }
   =
-  let solver_env = solver_env ~solver_env_from_current_system ~solver_env_from_context in
+  let solver_env =
+    solver_env
+      ~solver_env_from_current_system
+      ~solver_env_from_context
+      ~unset_solver_vars_from_context
+  in
   Console.print
     [ Pp.textf
         "Solver environment for context %s:"

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -67,3 +67,10 @@ let pp t =
         (Variable_name.to_string variable)
         (String.maybe_quoted (Variable_value.to_string value)))
 ;;
+
+let unset = Variable_name.Map.remove
+
+let unset_multi t variable_names =
+  Variable_name.Set.fold variable_names ~init:t ~f:(fun variable_name t ->
+    unset t variable_name)
+;;

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -20,3 +20,4 @@ val extend : t -> t -> t
 val with_defaults : t
 
 val pp : t -> 'a Pp.t
+val unset_multi : t -> Variable_name.Set.t -> t

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -7,6 +7,7 @@ module Lock_dir : sig
     { path : Path.Source.t
     ; version_preference : Dune_pkg.Version_preference.t option
     ; solver_env : Dune_pkg.Solver_env.t option
+    ; unset_solver_vars : Dune_pkg.Variable_name.Set.t option
     ; repositories : Dune_pkg.Pkg_workspace.Repository.Name.t list
     ; constraints : Dune_lang.Package_dependency.t list
     }

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -1,16 +1,10 @@
-Print the solver env when no dune-workspace is present
-  $ dune pkg print-solver-env --dont-poll-system-solver-variables
-  Solver environment for context default:
-  - opam-version = 2.2.0~alpha-vendored
-  - with-doc = false
-
-Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
   >  (path dune.linux.lock)
   >  (solver_env
-  >   (os linux)))
+  >   (os linux))
+  >  (unset_solver_vars arch os-distribution os-family os-version sys-ocaml-version))
   > (lock_dir
   >  (path dune.linux.no-doc.lock)
   >  (solver_env
@@ -18,11 +12,13 @@ Add some build contexts with different environments
   >   (os linux)
   >   (os-family ubuntu)
   >   (os-distribution ubuntu)
-  >   (os-version 22.04)))
+  >   (os-version 22.04)
+  >   (sys-ocaml-version 5.0)))
   > (lock_dir
   >  (path change-opam-version.lock)
   >  (solver_env
-  >   (opam-version 42)))
+  >   (opam-version 42))
+  >  (unset_solver_vars arch os os-distribution os-family os-version sys-ocaml-version))
   > (context
   >  (default
   >   (name linux)
@@ -37,7 +33,7 @@ Add some build contexts with different environments
   >   (lock_dir change-opam-version.lock)))
   > EOF
 
-  $ dune pkg print-solver-env --all-contexts --dont-poll-system-solver-variables
+  $ dune pkg print-solver-env --all-contexts
   Solver environment for context change-opam-version:
   - opam-version = 42
   - with-doc = false
@@ -48,6 +44,7 @@ Add some build contexts with different environments
   - os-distribution = ubuntu
   - os-family = ubuntu
   - os-version = 22.04
+  - sys-ocaml-version = 5.0
   - with-doc = false
   Solver environment for context linux:
   - opam-version = 2.2.0~alpha-vendored


### PR DESCRIPTION
Adds a field "unset_solver_vars" to dune-workspace to unset variables that were set to initial values by interogating the current system.