### PR TITLE
fix(pkg): remove the [DUNE_PKG_OVERRIDE_OCAML] hack

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -1,5 +1,3 @@
-export DUNE_PKG_OVERRIDE_OCAML=1
-
 dune="dune"
 
 pkg_root="_build/_private/default/.pkg"

--- a/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
@@ -77,7 +77,7 @@ Now we finally make the OCaml package for testing through the lock file:
   > (lang package 0.1)
   > (ocaml mycaml)
   > EOF
-  $ cat >dune.lock/mycaml.dune <<EOF
+  $ cat >dune.lock/mycaml.pkg <<EOF
   > (source (copy $PWD/mycamlsources))
   > (build
   >  (system "\| cat >mycaml.install <<EOF
@@ -107,4 +107,4 @@ Now we finally make the OCaml package for testing through the lock file:
 This should display the ocaml from the lock file rather than shadowsystemocaml
 
   $ dune build @foo
-  $TESTCASE_ROOT/shadowsystemocaml/ocamlc
+  $TESTCASE_ROOT/_build/_private/default/.pkg/mycaml/target/bin/ocamlc


### PR DESCRIPTION
This hack can be replaced by forcing the solver to use `ocaml-system`. This can be done by amending the constraints in the workspace file.