### PR TITLE
Forbid empty directory targets

### DIFF
--- a/test/blackbox-tests/test-cases/coq/coqdoc-flags.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-flags.t
@@ -13,11 +13,14 @@ Testing the coqdoc flags field of the env stanza.
   > (coq.theory
   >  (name a))
   > EOF
+  $ cat > foo.v <<EOF
+  > Definition a := 42.
+  > EOF
 
   $ dune build @doc
 
   $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*coq/coq/' 
   coqdoc
   coq/theories Coq
-  -R . a --toc -toc-depth 2 --html -d
-  a.html
+  -R . a --toc -toc-depth 2 --html -d a.html
+  foo.v

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -42,7 +42,7 @@ Ensure directory targets are produced.
   Error: Rule failed to produce directory "output"
   [1]
 
-Error message when the matching directory target doesn't contain a requested path.
+Error message when the matching directory target is empty.
 
   $ cat > dune <<EOF
   > (rule
@@ -57,6 +57,25 @@ Error message when the matching directory target doesn't contain a requested pat
   2 |   (deps (sandbox always))
   3 |   (targets (dir output))
   4 |   (action (bash "mkdir output")))
+  Error: Rule produced directory "output" that contains no files nor non-empty
+  subdirectories
+  [1]
+
+Error message when the matching directory target doesn't contain a requested path.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps (sandbox always))
+  >   (targets (dir output))
+  >   (action (bash "mkdir output && touch output/y")))
+  > EOF
+
+  $ dune build output/x
+  File "dune", line 1, characters 0-108:
+  1 | (rule
+  2 |   (deps (sandbox always))
+  3 |   (targets (dir output))
+  4 |   (action (bash "mkdir output && touch output/y")))
   Error: This rule defines a directory target "output" that matches the
   requested path "output/x" but the rule's action didn't produce it
   [1]


### PR DESCRIPTION
We no longer allow directory targets to be empty. This wasn't well supported before and interferes with the upcoming caching support.