### PR TITLE
feature(pkg): Enable checking out tags

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -243,7 +243,9 @@ let of_git_repo ~repo_id ~update (source : Source.t) =
       let+ at_rev =
         match source.commit with
         | Some (Commit ref) -> Rev_store.Remote.rev_of_ref remote ~ref
-        | _ ->
+        | Some (Branch name) | Some (Tag name) ->
+          Rev_store.Remote.rev_of_name remote ~name
+        | None ->
           let name = Rev_store.Remote.default_branch remote in
           Rev_store.Remote.rev_of_name remote ~name
       in

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -324,7 +324,7 @@ module Remote = struct
   type uninit = t
 
   let update ({ repo; handle; default_branch = _ } as t) =
-    let+ () = run repo [ "fetch"; handle; "--no-tags" ] in
+    let+ () = run repo [ "fetch"; handle ] in
     t
   ;;
 
@@ -422,7 +422,15 @@ let read_head_branch =
 ;;
 
 let remote_add t ~branch ~handle ~source =
-  run t [ "remote"; "add"; "--track"; branch; handle; source ]
+  let* () = run t [ "remote"; "add"; "--track"; branch; handle; source ] in
+  (* add a refspec to fetch the remotes' tags into <handle>/<tag> namespace *)
+  run
+    t
+    [ "config"
+    ; "--add"
+    ; sprintf "remote.%s.fetch" handle
+    ; sprintf "+refs/tags/*:refs/tags/%s/*" handle
+    ]
 ;;
 
 let add_repo ({ dir } as t) ~source ~branch =

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -188,7 +188,39 @@ sure that the default branch differs from `bar-2`).
 Locking that branch should work and pick `bar.2.0.0`:
 
   $ rm -r dune.lock
-  $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
+  $ dune pkg lock
   Solution for dune.lock:
   - bar.2.0.0
+  - foo.0.1.0
+
+We want to make sure tagging a specific tag works as well, so we tag the
+current state as `1.0`, add a new package (that `1.0` does not include) on top
+of the main branch.
+
+  $ mkpkg bar 3.0.0 <<EOF
+  > depends: [ "foo" ]
+  > EOF
+  $ cd mock-opam-repository
+  $ git tag 1.0
+  $ git add -A
+  $ git commit -m "bar.3.0.0" --quiet
+  $ cd ..
+
+The repo should be using the `1.0` tag, as we don't want `bar.3.0.0`.
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (repository
+  >  (name mock)
+  >  (source "git+file://$(pwd)/mock-opam-repository#1.0"))
+  > (lock_dir
+  >  (repositories mock))
+  > EOF
+
+So we should get `bar.1.0.0` when locking.
+
+  $ rm -r dune.lock
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.1.0.0
   - foo.0.1.0


### PR DESCRIPTION
This implements the feature to check out tags. By default all remote tags get dumped into a common namespace, which is not what we want so we add an additional refspec in the config to map the tags fetched under the handle name.

Thanks to @Alizter for pointing me to [this Stack Overflow post](https://stackoverflow.com/questions/20663394/what-to-do-about-tag-collisions-when-merging-repositories-in-git) on how to deal with tag collisions (the reason why we used `--no-tags` to avoid collisions). It turns out we can map the tags into `<remote-handle>/<tag>` to match the default format of branches and conveniently `git rev-parse` will resolve this into a commit hash without any fuss.