### PR TITLE
fix: resolve installed binaries to local paths

### DIFF
--- a/doc/changes/9496.md
+++ b/doc/changes/9496.md
@@ -1,0 +1,3 @@
+- Resolve various public binaries to their build location, rather than to where
+  they're copied in the `_build/install` directory (#9496, fixes #7908,
+  @rgrinberg).

--- a/otherlibs/stdune/src/map.ml
+++ b/otherlibs/stdune/src/map.ml
@@ -44,6 +44,12 @@ module Make (Key : Key) : S with type key = Key.t = struct
   let merge a b ~f = merge a b ~f
   let union a b ~f = union a b ~f
 
+  let union_all maps ~f =
+    match maps with
+    | [] -> empty
+    | init :: maps -> List.fold_left maps ~init ~f:(fun acc map -> union acc map ~f)
+  ;;
+
   let union_exn a b =
     union a b ~f:(fun key _ _ ->
       Code_error.raise

--- a/otherlibs/stdune/src/map_intf.ml
+++ b/otherlibs/stdune/src/map_intf.ml
@@ -20,6 +20,7 @@ module type S = sig
   val add_multi : 'a list t -> key -> 'a -> 'a list t
   val merge : 'a t -> 'b t -> f:(key -> 'a option -> 'b option -> 'c option) -> 'c t
   val union : 'a t -> 'a t -> f:(key -> 'a -> 'a -> 'a option) -> 'a t
+  val union_all : 'a t list -> f:(key -> 'a -> 'a -> 'a option) -> 'a t
 
   (** Like [union] but raises a code error if a key appears in both maps. *)
   val union_exn : 'a t -> 'a t -> 'a t

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -2,6 +2,16 @@ open Import
 
 type t
 
+type origin =
+  { binding : File_binding.Unexpanded.t
+  ; dir : Path.Build.t
+  ; dst : Path.Local.t
+  }
+
+type where =
+  | Install_dir
+  | Original_path
+
 (** Force the computation of the internal list of binaries. This is exposed as
     some error checking is only performed during this computation and some
     errors will go unreported unless this computation takes place. *)
@@ -15,8 +25,17 @@ val local_bin : Path.Build.t -> Path.Build.t
 
 (** A named artifact that is looked up in the PATH if not found in the tree If
     the name is an absolute path, it is used as it. *)
-val binary : t -> ?hint:string -> loc:Loc.t option -> string -> Action.Prog.t Memo.t
+val binary
+  :  t
+  -> ?hint:string
+  -> ?where:where
+  -> loc:Loc.t option
+  -> Filename.t
+  -> Action.Prog.t Memo.t
 
 val binary_available : t -> string -> bool Memo.t
 val add_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list -> t
-val create : Context.t -> local_bins:Path.Build.Set.t Memo.Lazy.t -> t
+val create : Context.t -> local_bins:origin Filename.Map.t Memo.Lazy.t -> t
+
+val expand
+  : (context:Context.t -> dir:Path.Build.t -> String_with_vars.t -> string Memo.t) Fdecl.t

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -127,6 +127,7 @@ let gen_rules sctx t ~dir ~scope =
          Super_context.resolve_program
            sctx
            ~dir
+           ~where:Original_path
            ~loc:(Some loc)
            name
            ~hint:"opam install cinaps"

--- a/src/dune_rules/coq/coq_config.ml
+++ b/src/dune_rules/coq/coq_config.ml
@@ -269,7 +269,7 @@ let by_name { version_info; coqlib; coqcorelib; coq_native_compiler_default } na
 let expand source macro artifacts_host =
   let s = Pform.Macro_invocation.Args.whole macro in
   let open Memo.O in
-  let* coqc = Artifacts.binary artifacts_host ~loc:None "coqc" in
+  let* coqc = Artifacts.binary artifacts_host ~where:Original_path ~loc:None "coqc" in
   let+ t = make ~coqc in
   match t with
   | Error msg ->

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -95,6 +95,7 @@ let coqc ~loc ~dir ~sctx =
   Super_context.resolve_program_memo
     sctx
     "coqc"
+    ~where:Original_path
     ~dir
     ~loc:(Some loc)
     ~hint:"opam install coq"
@@ -488,6 +489,7 @@ let setup_coqdep_for_theory_rule
       sctx
       "coqdep"
       ~dir
+      ~where:Original_path
       ~loc:(Some loc)
       ~hint:"opam install coq"
   in
@@ -746,6 +748,7 @@ let setup_coqdoc_rules ~sctx ~dir ~theories_deps (s : Coq_stanza.Theory.t) coq_m
             sctx
             "coqdoc"
             ~dir
+            ~where:Original_path
             ~loc:(Some loc)
             ~hint:"opam install coq"
         in
@@ -1075,6 +1078,7 @@ let setup_coqpp_rules ~sctx ~dir ({ loc; modules } : Coq_stanza.Coqpp.t) =
     Super_context.resolve_program_memo
       sctx
       "coqpp"
+      ~where:Original_path
       ~dir
       ~loc:(Some loc)
       ~hint:"opam install coq"

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -925,3 +925,8 @@ let expand_lock ~base expander (Locks.Lock sw) =
 let expand_locks ~base expander locks =
   Memo.List.map locks ~f:(expand_lock ~base expander) |> Action_builder.of_memo
 ;;
+
+let () =
+  Fdecl.set Artifacts.expand (fun ~context ~dir sw ->
+    With_reduced_var_set.expand_str ~context ~dir sw)
+;;

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -35,6 +35,7 @@ let ocamlfdo_binary sctx dir =
   Super_context.resolve_program
     sctx
     ~dir
+    ~where:Original_path
     ~loc:None
     "ocamlfdo"
     ~hint:"opam install ocamlfdo"

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -263,7 +263,13 @@ include Sub_system.Register_end_point (struct
             let+ flags = flags in
             Action.run (Ok exe) flags
           | Some runner ->
-            let* prog = Super_context.resolve_program ~dir sctx ~loc:(Some loc) runner
+            let* prog =
+              Super_context.resolve_program
+                ~dir
+                sctx
+                ~where:Original_path
+                ~loc:(Some loc)
+                runner
             and* flags = flags in
             let action =
               Action.run prog (Path.reach exe ~from:(Path.build dir) :: flags)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -185,7 +185,13 @@ let in_obj_dir' ~obj_dir ~config args =
 ;;
 
 let jsoo ~dir sctx =
-  Super_context.resolve_program sctx ~dir ~loc:None ~hint:install_jsoo_hint "js_of_ocaml"
+  Super_context.resolve_program
+    sctx
+    ~dir
+    ~loc:None
+    ~where:Original_path
+    ~hint:install_jsoo_hint
+    "js_of_ocaml"
 ;;
 
 type sub_command =

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -509,6 +509,7 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
     let mdx_prog =
       Super_context.resolve_program
         sctx
+        ~where:Original_path
         ~dir
         ~loc:(Some t.loc)
         ~hint:"opam install mdx"

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -1,7 +1,13 @@
 open Import
 
 let melc sctx ~loc ~dir =
-  Super_context.resolve_program_memo sctx ~loc ~dir ~hint:"opam install melange" "melc"
+  Super_context.resolve_program_memo
+    sctx
+    ~loc
+    ~dir
+    ~where:Original_path
+    ~hint:"opam install melange"
+    "melc"
 ;;
 
 let where =

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -119,7 +119,13 @@ module Run (P : PARAMS) = struct
   (* Rule generation. *)
 
   let menhir_binary =
-    Super_context.resolve_program sctx ~dir "menhir" ~loc:None ~hint:"opam install menhir"
+    Super_context.resolve_program
+      sctx
+      ~dir
+      ~where:Original_path
+      "menhir"
+      ~loc:None
+      ~hint:"opam install menhir"
   ;;
 
   (* Reminder (from command.mli):

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -247,7 +247,13 @@ let odoc_base_flags quiet build_dir =
 ;;
 
 let odoc_program sctx dir =
-  Super_context.resolve_program sctx ~dir "odoc" ~loc:None ~hint:"opam install odoc"
+  Super_context.resolve_program
+    sctx
+    ~dir
+    ~where:Original_path
+    "odoc"
+    ~loc:None
+    ~hint:"opam install odoc"
 ;;
 
 let run_odoc sctx ~dir command ~quiet ~flags_for args =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -231,13 +231,13 @@ let add_alias_action t alias ~dir ~loc action =
 
 let env_node = Env_tree.get_node
 
-let resolve_program_memo t ~dir ?hint ~loc bin =
+let resolve_program_memo t ~dir ?where ?hint ~loc bin =
   let* artifacts = Env_tree.artifacts_host t ~dir in
-  Artifacts.binary ?hint ~loc artifacts bin
+  Artifacts.binary ?hint ?where ~loc artifacts bin
 ;;
 
-let resolve_program t ~dir ?hint ~loc bin =
-  Action_builder.of_memo @@ resolve_program_memo t ~dir ?hint ~loc bin
+let resolve_program t ~dir ?where ?hint ~loc bin =
+  Action_builder.of_memo @@ resolve_program_memo t ~dir ?where ?hint ~loc bin
 ;;
 
 let make_default_env_node

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -69,6 +69,7 @@ val add_alias_action
 val resolve_program
   :  t
   -> dir:Path.Build.t
+  -> ?where:Artifacts.where
   -> ?hint:string
   -> loc:Loc.t option
   -> string
@@ -78,6 +79,7 @@ val resolve_program
 val resolve_program_memo
   :  t
   -> dir:Path.Build.t
+  -> ?where:Artifacts.where
   -> ?hint:string
   -> loc:Loc.t option
   -> string


### PR DESCRIPTION
Previously, we'd always binaries from the install context
(_build/install/$context/bin). This would unnecessarily load the install
rules.

Now, we add an argument that allows us to resolve to the original paths.
Reducing the amount of rules that need to be loaded.

We use this argument in a few cases where we don't need to build the
path in _build/install

Ideally, we'd use this everywhere as it's basically strictly superior. The only issue is that it doesn't preserve backward compat in cases like:

```
(rule
 (dep %{bin:foo})
 (action (run which foo)))
```

Resolving it in _build/install/default will make the `which` above succeed because we add the bin path in the install directory to the PATH when executing actions. There's a way to get around that of course, but it's not trivial.