### PR TITLE
Switch to Filename.Set in various places

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -183,10 +183,11 @@ let not_found ~dir ~prog =
        matching executable, they would be located in a subdirectory of
        [dir], so it's unclear if that's what the user wanted. *)
     let+ candidates =
-      Build_system.files_of ~dir:(Path.build dir)
-      >>| Path.Set.to_list
-      >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
-      >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
+      let+ filename_set = Build_system.files_of ~dir:(Path.build dir) in
+      Filename_set.filenames filename_set
+      |> Filename.Set.to_list
+      |> List.filter ~f:(fun filename -> Filename.extension filename = ".exe")
+      |> List.map ~f:(fun filename -> "./" ^ filename)
     in
     User_message.did_you_mean prog ~candidates
   in

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -12,6 +12,7 @@ module Either = Either
 module Exn = Exn
 module Exn_with_backtrace = Exn_with_backtrace
 module Filename = Filename
+module Filename_set = Filename_set
 module Hashtbl = Hashtbl
 module Table = Table
 module Int = Int

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -43,7 +43,7 @@ let paths ps = deps (Dep.Set.of_files ps)
 let path_set ps = deps (Dep.Set.of_files_set ps)
 
 let paths_matching
-  : type a. File_selector.t -> a eval_mode -> (Filename.Set.t * a Dep.Map.t) Memo.t
+  : type a. File_selector.t -> a eval_mode -> (Filename_set.t * a Dep.Map.t) Memo.t
   =
   fun g mode ->
   let open Memo.O in

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -43,18 +43,18 @@ let paths ps = deps (Dep.Set.of_files ps)
 let path_set ps = deps (Dep.Set.of_files_set ps)
 
 let paths_matching
-  : type a. File_selector.t -> a eval_mode -> (Path.Set.t * a Dep.Map.t) Memo.t
+  : type a. File_selector.t -> a eval_mode -> (Filename.Set.t * a Dep.Map.t) Memo.t
   =
   fun g mode ->
   let open Memo.O in
   match mode with
   | Eager ->
-    let+ files = Build_system.build_pred g in
-    ( Path.Map.keys (Dep.Fact.Files.paths files) |> Path.Set.of_list
-    , Dep.Map.singleton (Dep.file_selector g) (Dep.Fact.file_selector g files) )
+    let+ facts = Build_system.build_pred g in
+    ( Dep.Fact.Files.filenames_exn facts ~expected_parent:(File_selector.dir g)
+    , Dep.Map.singleton (Dep.file_selector g) (Dep.Fact.file_selector g facts) )
   | Lazy ->
-    let+ files = Build_system.eval_pred g in
-    files, Dep.Set.singleton (Dep.file_selector g)
+    let+ filenames = Build_system.eval_pred g in
+    filenames, Dep.Set.singleton (Dep.file_selector g)
 ;;
 
 let paths_matching ~loc:_ g = of_thunk { f = (fun mode -> paths_matching g mode) }

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -76,12 +76,9 @@ val dyn_deps : ('a * Dep.Set.t) t -> 'a t
 val paths : Path.t list -> unit t
 val path_set : Path.Set.t -> unit t
 
-(* CR-soon amokhov: Make [paths_matching] return a [Filename_set.t] anchored to the right
-   [dir] instead of [Filename.Set.t], once [Filename_set.t] is moved to Stdune. *)
-
 (** Evaluate a predicate against all targets and record all the matched files as
     dependencies of the action produced by the action builder. *)
-val paths_matching : loc:Loc.t -> File_selector.t -> Filename.Set.t t
+val paths_matching : loc:Loc.t -> File_selector.t -> Filename_set.t t
 
 (** Like [paths_matching], but don't return the resulting set. The action
     dependency is still registered. *)

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -76,9 +76,12 @@ val dyn_deps : ('a * Dep.Set.t) t -> 'a t
 val paths : Path.t list -> unit t
 val path_set : Path.Set.t -> unit t
 
+(* CR-soon amokhov: Make [paths_matching] return a [Filename_set.t] anchored to the right
+   [dir] instead of [Filename.Set.t], once [Filename_set.t] is moved to Stdune. *)
+
 (** Evaluate a predicate against all targets and record all the matched files as
     dependencies of the action produced by the action builder. *)
-val paths_matching : loc:Loc.t -> File_selector.t -> Path.Set.t t
+val paths_matching : loc:Loc.t -> File_selector.t -> Filename.Set.t t
 
 (** Like [paths_matching], but don't return the resulting set. The action
     dependency is still registered. *)

--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -61,7 +61,7 @@ module type Source_tree = sig
     type t
 
     val sub_dir_names : t -> Filename.Set.t
-    val file_paths : t -> Path.Source.Set.t
+    val filenames : t -> Filename.Set.t
   end
 
   val find_dir : Path.Source.t -> Dir.t option Memo.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -917,21 +917,8 @@ end = struct
          a bunch of set/list operations and reduce code duplication. *)
       Load_rules.load_dir ~dir
       >>= function
-      | Source { files } ->
-        Path.Source.Set.to_list files
-        |> List.filter_map ~f:(fun file ->
-          let basename = Path.Source.basename file in
-          Option.some_if (File_selector.test_basename g ~basename) basename)
-        |> Filename.Set.of_list
-        |> Filename_set.create ~dir
-        |> Memo.return
-      | External { files } ->
-        Path.External.Set.to_list files
-        |> List.filter_map ~f:(fun file ->
-          let basename = Path.External.basename file in
-          Option.some_if (File_selector.test_basename g ~basename) basename)
-        |> Filename.Set.of_list
-        |> Filename_set.create ~dir
+      | Source { filenames } | External { filenames } ->
+        Filename_set.create ~dir ~filter:(File_selector.test_basename g) filenames
         |> Memo.return
       | Build { rules_here; _ } ->
         let only_generated_files = File_selector.only_generated_files g in
@@ -1058,16 +1045,8 @@ let build_pred = Pred.build
 let file_exists fn =
   Load_rules.load_dir ~dir:(Path.parent_exn fn)
   >>= function
-  | Source { files } ->
-    Memo.return
-      (match Path.as_in_source_tree fn with
-       | None -> false
-       | Some file -> Path.Source.Set.mem files file)
-  | External { files } ->
-    Memo.return
-      (match Path.as_external fn with
-       | None -> false
-       | Some file -> Path.External.Set.mem files file)
+  | Source { filenames } | External { filenames } ->
+    Filename.Set.mem filenames (Path.basename fn) |> Memo.return
   | Build { rules_here; _ } ->
     Memo.return
       (Path.Build.Map.mem rules_here.by_file_targets (Path.as_in_build_dir_exn fn))
@@ -1079,20 +1058,26 @@ let file_exists fn =
 let files_of ~dir =
   Load_rules.load_dir ~dir
   >>= function
-  | Source { files } -> Memo.return (Path.set_of_source_paths files)
-  | External { files } -> Memo.return (Path.set_of_external_paths files)
+  | Source { filenames } | External { filenames } ->
+    Memo.return (Filename_set.create ~dir filenames)
   | Build { rules_here; _ } ->
-    Memo.return
-      (Path.Build.Map.keys rules_here.by_file_targets
-       |> Path.Set.of_list_map ~f:Path.build)
+    Path.Build.Map.keys rules_here.by_file_targets
+    |> Filename.Set.of_list_map ~f:Path.Build.basename
+    |> Filename_set.create ~dir
+    |> Memo.return
   | Build_under_directory_target { directory_target_ancestor } ->
     let+ _digest, path_map = build_dir (Path.build directory_target_ancestor) in
-    let dir = Path.as_in_build_dir_exn dir in
-    Path.Build.Map.foldi path_map ~init:Path.Set.empty ~f:(fun path _digest acc ->
-      let parent = Path.Build.parent_exn path in
-      match Path.Build.equal parent dir with
-      | true -> Path.Set.add acc (Path.build path)
-      | false -> acc)
+    let filenames =
+      let dir = Path.as_in_build_dir_exn dir in
+      Path.Build.Map.keys path_map
+      |> List.filter_map ~f:(fun path ->
+        let parent = Path.Build.parent_exn path in
+        match Path.Build.equal parent dir with
+        | true -> Some (Path.Build.basename path)
+        | false -> None)
+      |> Filename.Set.of_list
+    in
+    Filename_set.create ~dir filenames
 ;;
 
 let caused_by_cancellation (exn : Exn_with_backtrace.t) =

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -15,14 +15,9 @@ val file_exists : Path.t -> bool Memo.t
 (** Build a set of dependencies and return learned facts about them. *)
 val build_deps : Dep.Set.t -> Dep.Facts.t Memo.t
 
-(* CR-soon amokhov: Make [eval_pred] return a [Filename_set.t] anchored to the right [dir]
-   instead of [Filename.Set.t], once [Filename_set.t] is moved to Stdune. *)
-
-(** [eval_pred glob] returns the list of files in [File_selector.dir glob] that
-    matches [File_selector.predicate glob]. The list of files includes the list
-    of file targets. Currently, this function ignores directory targets, which
-    is a limitation we'd like to remove in future. *)
-val eval_pred : File_selector.t -> Filename.Set.t Memo.t
+(** [eval_pred glob] returns the set of filenames in [File_selector.dir glob] that matches
+    [File_selector.predicate glob], including both sources and generated files. *)
+val eval_pred : File_selector.t -> Filename_set.t Memo.t
 
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
 val files_of : dir:Path.t -> Path.Set.t Memo.t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -15,14 +15,20 @@ val file_exists : Path.t -> bool Memo.t
 (** Build a set of dependencies and return learned facts about them. *)
 val build_deps : Dep.Set.t -> Dep.Facts.t Memo.t
 
+(* CR-soon amokhov: Make [eval_pred] return a [Filename_set.t] anchored to the right [dir]
+   instead of [Filename.Set.t], once [Filename_set.t] is moved to Stdune. *)
+
 (** [eval_pred glob] returns the list of files in [File_selector.dir glob] that
     matches [File_selector.predicate glob]. The list of files includes the list
     of file targets. Currently, this function ignores directory targets, which
     is a limitation we'd like to remove in future. *)
-val eval_pred : File_selector.t -> Path.Set.t Memo.t
+val eval_pred : File_selector.t -> Filename.Set.t Memo.t
 
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
 val files_of : dir:Path.t -> Path.Set.t Memo.t
+
+(* CR-someday amokhov: Make [build_pred] return something like [Dep.Fact.Filename_set.t]
+   which is anchored to the [File_selector]'s directory. *)
 
 (** Like [eval_pred] but also builds the resulting set of files. This function
     doesn't have [eval_pred]'s limitation about directory targets and takes them

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -20,7 +20,7 @@ val build_deps : Dep.Set.t -> Dep.Facts.t Memo.t
 val eval_pred : File_selector.t -> Filename_set.t Memo.t
 
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
-val files_of : dir:Path.t -> Path.Set.t Memo.t
+val files_of : dir:Path.t -> Filename_set.t Memo.t
 
 (* CR-someday amokhov: Make [build_pred] return something like [Dep.Fact.Filename_set.t]
    which is anchored to the [File_selector]'s directory. *)

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -97,6 +97,19 @@ module Fact = struct
     let equal a b = Digest.equal a.digest b.digest
     let paths t = t.files
 
+    let filenames_exn t ~expected_parent =
+      Filename.Set.of_list_map (Path.Map.keys t.files) ~f:(fun path ->
+        match Path.parent path with
+        | Some actual_parent when Path.equal expected_parent actual_parent ->
+          Path.basename path
+        | actual_parent ->
+          Code_error.raise
+            "Unexpected parent directory in Dep.Fact.Files.filenames_exn"
+            [ "expected_parent", Path.to_dyn expected_parent
+            ; "actual_parent", Dyn.option Path.to_dyn actual_parent
+            ])
+    ;;
+
     let make ~files ~dirs =
       { files
       ; dirs

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -98,16 +98,19 @@ module Fact = struct
     let paths t = t.files
 
     let filenames_exn t ~expected_parent =
-      Filename.Set.of_list_map (Path.Map.keys t.files) ~f:(fun path ->
-        match Path.parent path with
-        | Some actual_parent when Path.equal expected_parent actual_parent ->
-          Path.basename path
-        | actual_parent ->
-          Code_error.raise
-            "Unexpected parent directory in Dep.Fact.Files.filenames_exn"
-            [ "expected_parent", Path.to_dyn expected_parent
-            ; "actual_parent", Dyn.option Path.to_dyn actual_parent
-            ])
+      let filenames =
+        Filename.Set.of_list_map (Path.Map.keys t.files) ~f:(fun path ->
+          match Path.parent path with
+          | Some actual_parent when Path.equal expected_parent actual_parent ->
+            Path.basename path
+          | actual_parent ->
+            Code_error.raise
+              "Unexpected parent directory in Dep.Fact.Files.filenames_exn"
+              [ "expected_parent", Path.to_dyn expected_parent
+              ; "actual_parent", Dyn.option Path.to_dyn actual_parent
+              ])
+      in
+      Filename_set.create ~dir:expected_parent filenames
     ;;
 
     let make ~files ~dirs =

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -52,12 +52,9 @@ module Fact : sig
     (** Return all file paths in this file group. *)
     val paths : t -> Digest.t Path.Map.t
 
-    (* CR-soon amokhov: Make [filenames_exn] return a [Filename_set.t] anchored to the
-       [expected_parent] once [Filename_set.t] is moved to Stdune. *)
-
     (** Like [paths] but asserts that all paths are relative to the [expected_parent] and
         returns their basenames instead. *)
-    val filenames_exn : t -> expected_parent:Path.t -> Filename.Set.t
+    val filenames_exn : t -> expected_parent:Path.t -> Filename_set.t
 
     (** Create a new [t] from a list of [t] and a list of files. *)
     val group : t list -> Digest.t Path.Map.t -> t

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -52,6 +52,13 @@ module Fact : sig
     (** Return all file paths in this file group. *)
     val paths : t -> Digest.t Path.Map.t
 
+    (* CR-soon amokhov: Make [filenames_exn] return a [Filename_set.t] anchored to the
+       [expected_parent] once [Filename_set.t] is moved to Stdune. *)
+
+    (** Like [paths] but asserts that all paths are relative to the [expected_parent] and
+        returns their basenames instead. *)
+    val filenames_exn : t -> expected_parent:Path.t -> Filename.Set.t
+
     (** Create a new [t] from a list of [t] and a list of files. *)
     val group : t list -> Digest.t Path.Map.t -> t
   end

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -58,3 +58,7 @@ let test t path =
     ~standard:Predicate_lang.false_
     (Path.basename path)
 ;;
+
+let test_basename t ~basename =
+  Predicate_lang.Glob.test t.predicate ~standard:Predicate_lang.false_ basename
+;;

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -25,3 +25,4 @@ val encode : t Dune_sexp.Encoder.t
 val to_dyn : t -> Dyn.t
 
 val test : t -> Path.t -> bool
+val test_basename : t -> basename:string -> bool

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -16,6 +16,9 @@ end
 let set_current_rule_loc = Current_rule_loc.set
 
 module Loaded = struct
+  (* CR-someday amokhov: Loaded rules are relative to the directory passed to [load_dir],
+     so these maps should probably be indexed by [Filename.t]s rather than [Path.t]s. We
+     could add [Filename_map.t] anchored to a specific directory like [Filename_set.t]. *)
   type rules_here =
     { by_file_targets : Rule.t Path.Build.Map.t
     ; by_directory_targets : Rule.t Path.Build.Map.t

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -37,8 +37,8 @@ module Loaded = struct
     }
 
   type t =
-    | Source of { files : Path.Source.Set.t }
-    | External of { files : Path.External.Set.t }
+    | Source of { filenames : Filename.Set.t }
+    | External of { filenames : Filename.Set.t }
     | Build of build
     | Build_under_directory_target of { directory_target_ancestor : Path.Build.t }
 
@@ -73,7 +73,7 @@ module Dir_triage = struct
     | Known of Loaded.t
     | Build_directory of Build_directory.t
 
-  let empty_source = Known (Source { files = Path.Source.Set.empty })
+  let empty_source = Known (Source { filenames = Filename.Set.empty })
   let no_rules = Known (Loaded.no_rules ~allowed_subdirs:Dir_set.empty)
 end
 
@@ -84,31 +84,27 @@ let get_dir_triage ~dir =
     Source_tree.find_dir dir
     >>| (function
      | None -> Dir_triage.empty_source
-     | Some dir ->
-       let files = Source_tree.Dir.file_paths dir in
-       Dir_triage.Known (Source { files }))
+     | Some dir -> Dir_triage.Known (Source { filenames = Source_tree.Dir.filenames dir }))
   | External dir_ext ->
-    let+ files =
+    let+ filenames =
       Fs_memo.dir_contents (External dir_ext)
       >>| function
-      | Error (Unix.ENOENT, _, _) -> Path.External.Set.empty
+      | Error (Unix.ENOENT, _, _) -> Filename.Set.empty
       | Error unix_error ->
         User_warning.emit
           [ Pp.textf "Unable to read %s" (Path.to_string_maybe_quoted dir)
           ; Unix_error.Detailed.pp ~prefix:"Reason: " unix_error
           ];
-        Path.External.Set.empty
+        Filename.Set.empty
       | Ok filenames ->
-        let filenames =
-          Fs_cache.Dir_contents.to_list filenames
-          |> List.filter_map ~f:(fun (name, kind) ->
-            match kind with
-            | Unix.S_DIR -> None
-            | _ -> Some name)
-        in
-        Path.External.Set.of_listing ~dir:dir_ext ~filenames
+        Fs_cache.Dir_contents.to_list filenames
+        |> List.filter_map ~f:(fun (filename, kind) ->
+          match kind with
+          | Unix.S_DIR -> None
+          | _ -> Some filename)
+        |> Filename.Set.of_list
     in
-    Dir_triage.Known (External { files })
+    Dir_triage.Known (External { filenames })
   | Build (Regular Root) ->
     let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
     let allowed_subdirs =
@@ -317,8 +313,9 @@ module rec Load_rules : sig
 end = struct
   open Load_rules
 
-  let create_copy_rules ~ctx_dir ~non_target_source_files =
-    Path.Source.Set.to_list_map non_target_source_files ~f:(fun path ->
+  let create_copy_rules ~dir ~ctx_dir ~non_target_source_filenames =
+    Filename.Set.to_list_map non_target_source_filenames ~f:(fun filename ->
+      let path = Path.Source.relative dir filename in
       let ctx_path = Path.Build.append_source ctx_dir path in
       let build =
         Action_builder.of_thunk
@@ -407,37 +404,33 @@ end = struct
       Appendable_list.to_list_rev expansions)
   ;;
 
-  let add_non_fallback_rules ~init ~source_files rules =
+  let add_non_fallback_rules ~init ~dir ~source_filenames rules =
     List.fold_left rules ~init ~f:(fun acc (rule : Rule.t) ->
       match rule.mode with
       | Standard | Promote _ | Ignore_source_files -> rule :: acc
       | Fallback ->
-        let source_files_for_targets =
+        let source_filenames_for_targets =
           if not (Path.Build.Set.is_empty rule.targets.dirs)
           then
             Code_error.raise
               "Unexpected directory target in a Fallback rule"
               [ "targets", Targets.Validated.to_dyn rule.targets ];
-          Path.Build.Set.to_list_map
-            rule.targets.files
-            (* All targets are in a directory of a build context since there
-               are source files to copy, so this call can't fail. *)
-            ~f:Path.Build.drop_build_context_exn
-          |> Path.Source.Set.of_list
+          Targets.Validated.filenames rule.targets ~dir
         in
-        if Path.Source.Set.is_subset source_files_for_targets ~of_:source_files
+        if Filename.Set.is_subset source_filenames_for_targets ~of_:source_filenames
         then (* All targets are present *)
           acc
-        else if Path.Source.Set.are_disjoint source_files_for_targets source_files
+        else if Filename.Set.are_disjoint source_filenames_for_targets source_filenames
         then (* No target is present *)
           rule :: acc
         else (
           let absent_targets =
-            Path.Source.Set.diff source_files_for_targets source_files
+            Filename.Set.diff source_filenames_for_targets source_filenames
           in
           let present_targets =
-            Path.Source.Set.diff source_files_for_targets absent_targets
+            Filename.Set.diff source_filenames_for_targets absent_targets
           in
+          let dir = Path.source (Path.Build.drop_build_context_exn rule.dir) in
           User_error.raise
             ~loc:(Rule.loc rule)
             [ Pp.text
@@ -448,12 +441,12 @@ end = struct
             ; Pp.text "The following targets are present:"
             ; Pp.enumerate
                 ~f:Path.pp
-                (Path.set_of_source_paths present_targets |> Path.Set.to_list)
+                (Filename.Set.to_list_map present_targets ~f:(Path.relative dir))
             ; Pp.nop
             ; Pp.text "The following targets are not:"
             ; Pp.enumerate
                 ~f:Path.pp
-                (Path.set_of_source_paths absent_targets |> Path.Set.to_list)
+                (Filename.Set.to_list_map absent_targets ~f:(Path.relative dir))
             ]))
   ;;
 
@@ -666,92 +659,80 @@ end = struct
   ;;
 
   type source_paths_to_ignore =
-    { files : Path.Build.Set.t
+    { filenames : Filename.Set.t
     ; dirnames : Filename.Set.t
     }
 
   (* Compute source paths ignored by specific rules *)
-  let source_paths_to_ignore ~dir build_dir_only_sub_dirs rules =
-    let rec iter ~files ~dirnames rules =
+  let source_paths_to_ignore ~dir build_dir_only_sub_dirs rules : source_paths_to_ignore =
+    let rec iter ~filenames ~dirnames rules =
       match rules with
-      | [] -> { files; dirnames }
+      | [] -> { filenames; dirnames }
       | { Rule.targets; mode; loc; _ } :: rules ->
-        let target_dirnames =
-          lazy
-            (Path.Build.Set.to_list_map ~f:Path.Build.basename targets.dirs
-             |> Filename.Set.of_list)
-        in
-        (* Check if this rule defines any file targets that conflict with
-           internal Dune directories listed in [build_dir_only_sub_dirs]. We
-           don't check directory targets as these are already checked
-           earlier. *)
+        let target_filenames = Targets.Validated.filenames targets ~dir in
+        let target_dirnames = lazy (Targets.Validated.dirnames targets ~dir) in
+        (* Check if this rule defines any file targets that conflict with internal Dune
+           directories listed in [build_dir_only_sub_dirs]. We don't check directory
+           targets as these are already checked earlier. *)
         (match
-           Path.Build.Set.find targets.files ~f:(fun file ->
-             Subdir_set.mem build_dir_only_sub_dirs (Path.Build.basename file))
+           Filename.Set.find target_filenames ~f:(Subdir_set.mem build_dir_only_sub_dirs)
          with
          | None -> ()
-         | Some target_name ->
-           report_rule_internal_dir_conflict (Path.Build.basename target_name) loc);
+         | Some target_name -> report_rule_internal_dir_conflict target_name loc);
         (match mode with
-         | Standard | Fallback -> iter ~files ~dirnames rules
+         | Standard | Fallback -> iter ~filenames ~dirnames rules
          | Ignore_source_files ->
            iter
-             ~files:(Path.Build.Set.union files targets.files)
+             ~filenames:(Filename.Set.union filenames target_filenames)
              ~dirnames:(Filename.Set.union dirnames (Lazy.force target_dirnames))
              rules
          | Promote { only; _ } ->
            (* Note that the [only] predicate applies to the files inside the
               directory targets rather than to directory names themselves. *)
-           let target_files =
+           let target_filenames =
              match only with
-             | None -> targets.files
+             | None -> target_filenames
              | Some pred ->
-               let is_promoted file =
+               let is_promoted filename =
+                 let file = Path.Build.relative dir filename in
                  Predicate.test pred (Path.reach (Path.build file) ~from:(Path.build dir))
                in
-               Path.Build.Set.filter targets.files ~f:is_promoted
+               Filename.Set.filter target_filenames ~f:is_promoted
            in
            iter
-             ~files:(Path.Build.Set.union files target_files)
+             ~filenames:(Filename.Set.union filenames target_filenames)
              ~dirnames:(Filename.Set.union dirnames (Lazy.force target_dirnames))
              rules)
     in
-    iter ~files:Path.Build.Set.empty ~dirnames:Filename.Set.empty rules
+    iter ~filenames:Filename.Set.empty ~dirnames:Filename.Set.empty rules
   ;;
 
   module Source_files_and_dirs = struct
     type t =
-      { source_files : Path.Source.Set.t
+      { source_filenames : Filename.Set.t
       ; source_dirs : Filename.Set.t
       }
 
-    let empty = { source_files = Path.Source.Set.empty; source_dirs = Filename.Set.empty }
+    let empty =
+      { source_filenames = Filename.Set.empty; source_dirs = Filename.Set.empty }
+    ;;
   end
 
-  let source_files_and_dirs source_paths_to_ignore sub_dir =
+  let source_files_and_dirs source_paths_to_ignore dir =
     (* Take into account the source files *)
-    let+ source_files, source_dirs =
-      let+ files, subdirs =
+    let+ source_filenames, source_dirs =
+      let+ filenames, dirnames =
         let module Source_tree = (val (Build_config.get ()).source_tree) in
-        Source_tree.find_dir sub_dir
+        Source_tree.find_dir dir
         >>| function
-        | None -> Path.Source.Set.empty, Filename.Set.empty
-        | Some dir -> Source_tree.Dir.file_paths dir, Source_tree.Dir.sub_dir_names dir
+        | None -> Filename.Set.empty, Filename.Set.empty
+        | Some dir -> Source_tree.Dir.filenames dir, Source_tree.Dir.sub_dir_names dir
       in
-      let files =
-        let source_files_to_ignore =
-          Path.Build.Set.to_list_map
-            ~f:Path.Build.drop_build_context_exn
-            source_paths_to_ignore.files
-          |> Path.Source.Set.of_list
-        in
-        Path.Source.Set.diff files source_files_to_ignore
-      in
-      let subdirs = Filename.Set.diff subdirs source_paths_to_ignore.dirnames in
-      files, subdirs
+      ( Filename.Set.diff filenames source_paths_to_ignore.filenames
+      , Filename.Set.diff dirnames source_paths_to_ignore.dirnames )
     in
     (* Compile the rules and cleanup stale artifacts *)
-    { Source_files_and_dirs.source_files; source_dirs }
+    { Source_files_and_dirs.source_filenames; source_dirs }
   ;;
 
   let descendants_to_keep
@@ -869,7 +850,7 @@ end = struct
       (* Compute the set of sources and targets promoted to the source tree that
          must not be copied to the build directory. *)
       (* Take into account the source files *)
-      let* { source_files; source_dirs } =
+      let* { source_filenames; source_dirs } =
         match context_type with
         | Empty -> Memo.return Source_files_and_dirs.empty
         | With_sources ->
@@ -880,17 +861,20 @@ end = struct
       in
       let copy_rules =
         let ctx_dir = Context_name.build_dir context_name in
-        create_copy_rules ~ctx_dir ~non_target_source_files:source_files
+        create_copy_rules
+          ~dir:sub_dir
+          ~ctx_dir
+          ~non_target_source_filenames:source_filenames
       in
       (* Compile the rules and cleanup stale artifacts *)
       let rules =
         (* Filter out fallback rules *)
-        if Path.Source.Set.is_empty source_files
+        if Filename.Set.is_empty source_filenames
         then
           (* If there are no source files to copy, fallback rules are
              automatically kept *)
           rules
-        else add_non_fallback_rules ~init:copy_rules ~source_files rules
+        else add_non_fallback_rules ~init:copy_rules ~dir ~source_filenames rules
       in
       let* descendants_to_keep =
         descendants_to_keep build_dir build_dir_only_sub_dirs ~source_dirs rules_produced

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -20,9 +20,11 @@ module Loaded : sig
     ; aliases : (Loc.t * Rules.Dir_rules.Alias_spec.item) list Alias.Name.Map.t
     }
 
+  (* CR-someday amokhov: Switch to [Filename_set.Source.t] and [Filename_set.External.t]
+     or something similar to avoid handling filename sets unanchored to their directory. *)
   type t =
-    | Source of { files : Path.Source.Set.t }
-    | External of { files : Path.External.Set.t }
+    | Source of { filenames : Filename.Set.t }
+    | External of { filenames : Filename.Set.t }
     | Build of build
     | Build_under_directory_target of { directory_target_ancestor : Path.Build.t }
 

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -46,7 +46,12 @@ end = struct
     Memo.parallel_map (Dep.Set.to_list deps) ~f:(fun (dep : Dep.t) ->
       match dep with
       | File p -> Memo.return (Path.Set.singleton p)
-      | File_selector g -> Build_system.eval_pred g
+      | File_selector g ->
+        let+ filenames = Build_system.eval_pred g in
+        (* Alas, we can't use filename sets here because we end up putting paths coming
+           from different directories together. *)
+        Filename.Set.to_list_map filenames ~f:(Path.relative (File_selector.dir g))
+        |> Path.Set.of_list
       | Alias a -> Expand.alias a
       | Env _ | Universe -> Memo.return Path.Set.empty)
     >>| Path.Set.union_all

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -50,8 +50,7 @@ end = struct
         let+ filenames = Build_system.eval_pred g in
         (* Alas, we can't use filename sets here because we end up putting paths coming
            from different directories together. *)
-        Filename.Set.to_list_map filenames ~f:(Path.relative (File_selector.dir g))
-        |> Path.Set.of_list
+        Path.Set.of_list (Filename_set.to_list filenames)
       | Alias a -> Expand.alias a
       | Env _ | Universe -> Memo.return Path.Set.empty)
     >>| Path.Set.union_all

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -176,7 +176,7 @@ end = struct
 
   (* As a side-effect, setup user rules and copy_files rules. *)
   let load_text_files sctx st_dir stanzas ~dir ~src_dir =
-    let from_source = Source_tree.Dir.files st_dir in
+    let from_source = Source_tree.Dir.filenames st_dir in
     match stanzas with
     | [] -> Memo.return from_source
     | _ :: _ ->

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -124,8 +124,12 @@ let gen_rules_output
     match source_dir with
     | None -> Memo.return ()
     | Some source_dir ->
-      Source_tree.Dir.file_paths source_dir
-      |> Memo.parallel_iter_set (module Path.Source.Set) ~f:setup_formatting
+      Source_tree.Dir.filenames source_dir
+      |> Memo.parallel_iter_set
+           (module Filename.Set)
+           ~f:(fun file ->
+             setup_formatting
+               (Path.Source.relative (Source_tree.Dir.path source_dir) file))
   and* () =
     match Format_config.includes config Dune with
     | false -> Memo.return ()

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -6,9 +6,13 @@ open! Import
    will return the list containing all descendants of the directory
    "foo/bar/baz/qux". The descendants of a directory are that directory's
    subdirectories, and each of of their subdirectories, and so on ad infinitum. *)
-let get_descendants_of_relative_dir_relative_to_base_dir_local ~base_dir ~relative_dir =
+let get_descendants_of_relative_dir_relative_to_base_dir_local
+  ~base_dir
+  ~relative_dir
+  ~prefix
+  =
   let base_dir = Path.Build.drop_build_context_exn base_dir in
-  let rec get_descendants_rec relative_dir =
+  let rec get_descendants_rec relative_dir prefix =
     let absolute_dir = Path.Source.relative base_dir relative_dir in
     let open Memo.O in
     let* children =
@@ -19,17 +23,14 @@ let get_descendants_of_relative_dir_relative_to_base_dir_local ~base_dir ~relati
     in
     let+ rest =
       Memo.List.concat_map children ~f:(fun child ->
-        get_descendants_rec (Filename.concat relative_dir child))
+        get_descendants_rec
+          (Filename.concat relative_dir child)
+          (Filename.concat prefix child))
     in
-    relative_dir :: rest
+    (relative_dir, prefix) :: rest
   in
-  get_descendants_rec relative_dir
+  get_descendants_rec relative_dir prefix
 ;;
-
-(* Takes a path to a directory [new_dir] and a path to a file [old_path] and
-   returns the path to a file of the same name as that of [old_path],
-   contained in the directory [new_dir]. *)
-let replace_path_dir new_dir old_path = Filename.concat new_dir (Path.basename old_path)
 
 let split_glob_string_into_parent_and_pattern glob_string =
   (* Extract the component of the string after the last path separator. This
@@ -41,7 +42,7 @@ let split_glob_string_into_parent_and_pattern glob_string =
      glob in the style of the original glob. For example, the globs "*" and
      "./*" will match the same files, but we want the results of the latter to
      include the "./" prefix, but not the former. *)
-  let parent_str =
+  let prefix =
     match String.drop_suffix glob_string ~suffix:pattern_str with
     | Some x -> x
     | None ->
@@ -51,7 +52,8 @@ let split_glob_string_into_parent_and_pattern glob_string =
            glob_string)
         []
   in
-  parent_str, pattern_str
+  let parent_str = Filename.dirname glob_string in
+  prefix, parent_str, pattern_str
 ;;
 
 module Glob_dir = struct
@@ -64,34 +66,29 @@ module Glob_dir = struct
         { relative_dir : string
         ; base_dir : Path.Build.t
         }
-
-  let to_dyn = function
-    | Absolute external_path ->
-      Dyn.variant "Absolute" [ Path.External.to_dyn external_path ]
-    | Relative { relative_dir; base_dir } ->
-      Dyn.variant "Relative" [ Dyn.string relative_dir; Path.Build.to_dyn base_dir ]
-  ;;
 end
 
 module Without_vars = struct
   (* A glob whose [String_with_vars.t] has been expanded. A [Glob.t] is a
      wildcard for matching filenames only, not entire paths. The [dir] field
-     holds the directory component of the original glob. E.g., for the glob
-     "foo/bar/*.txt", [dir] would be "foo/bar". *)
+     holds the directory component of the original glob whereas [prefix] holds the
+     directory prefix exactly as it was written. E.g., for the glob
+     "foo/bar/*.txt", [dir] would be "foo/bar" and [prefix] would be "foo/bar/". *)
   type t =
     { glob : Glob.t
     ; dir : Glob_dir.t
+    ; prefix : string
     ; recursive : bool
     }
 
-  (* Returns a list of pairs (file_selector, relative_path), which correspond
+  (* Returns a list of pairs (file_selector, prefix), which correspond
      to each directory that will be searched for files matching the glob. If the
      glob is not recursive, this list will be of length 1. The returned file
      selectors will expand globs relative to [base_dir], and the corresponding
-     relative paths are the paths to each directory relative to [base_dir]. The
-     relative paths are required to construct relative paths to the files found
-     by expanding the glob. *)
-  let file_selectors_with_relative_dirs { glob; dir; recursive } ~loc =
+     prefixes are the paths to each directory relative to [base_dir] exactly as writen in
+     the glob. The relative paths are required to construct relative paths to the files
+     found by expanding the glob. *)
+  let file_selectors_with_prefixes { glob; dir; prefix; recursive } ~loc =
     match (dir : Glob_dir.t) with
     | Relative { relative_dir; base_dir } ->
       let make_file_selector relative_dir =
@@ -100,63 +97,59 @@ module Without_vars = struct
       in
       if recursive
       then
-        get_descendants_of_relative_dir_relative_to_base_dir_local ~base_dir ~relative_dir
+        get_descendants_of_relative_dir_relative_to_base_dir_local
+          ~base_dir
+          ~relative_dir
+          ~prefix
         |> Memo.map
              ~f:
-               (List.map ~f:(fun relative_dir ->
-                  make_file_selector relative_dir, relative_dir))
-      else Memo.return [ make_file_selector relative_dir, relative_dir ]
+               (List.map ~f:(fun (relative_dir, prefix) ->
+                  make_file_selector relative_dir, prefix))
+      else Memo.return [ make_file_selector relative_dir, prefix ]
     | Absolute dir ->
       if recursive
       then
         User_error.raise
           ~loc
           [ Pp.textf "Absolute paths in recursive globs are not supported." ]
-      else
-        Memo.return
-          [ ( File_selector.of_glob ~dir:(Path.external_ dir) glob
-            , Path.External.to_string dir )
-          ]
+      else Memo.return [ File_selector.of_glob ~dir:(Path.external_ dir) glob, prefix ]
   ;;
 end
 
 module Expanded = struct
   type t =
     { matches : string list
-    ; dir : Glob_dir.t
+    ; prefix : string
     }
 
-  let to_dyn { matches; dir } =
-    Dyn.record [ "matches", Dyn.list Dyn.string matches; "dir", Glob_dir.to_dyn dir ]
+  let to_dyn { matches; prefix } =
+    Dyn.record [ "matches", Dyn.list Dyn.string matches; "prefix", Dyn.string prefix ]
   ;;
 
   let matches { matches; _ } = matches
-
-  let prefix { dir; _ } =
-    match dir with
-    | Glob_dir.Absolute path -> Path.External.to_string path
-    | Relative { relative_dir; _ } -> relative_dir
-  ;;
+  let prefix { prefix; _ } = prefix
 end
 
 module Expand
     (M : Memo.S)
     (C : sig
-       val collect_files : loc:Loc.t -> File_selector.t -> Path.Set.t M.t
+       val collect_files : loc:Loc.t -> File_selector.t -> Filename.Set.t M.t
      end) =
 struct
   let expand_vars { Dep_conf.Glob_files.glob; recursive } ~f ~base_dir =
     let open M.O in
     let loc = String_with_vars.loc glob in
     let+ glob_str = f glob in
-    let parent_str, pattern_str = split_glob_string_into_parent_and_pattern glob_str in
+    let prefix, parent_str, pattern_str =
+      split_glob_string_into_parent_and_pattern glob_str
+    in
     let glob = Glob.of_string_exn loc pattern_str in
     let dir : Glob_dir.t =
       if Filename.is_relative parent_str
       then Relative { relative_dir = parent_str; base_dir }
       else Absolute (Path.External.of_string parent_str)
     in
-    { Without_vars.glob; dir; recursive }
+    { Without_vars.glob; dir; prefix; recursive }
   ;;
 
   let expand (t : Dep_conf.Glob_files.t) ~f ~base_dir =
@@ -164,14 +157,14 @@ struct
     let loc = String_with_vars.loc t.glob in
     let* without_vars = expand_vars t ~f ~base_dir in
     let+ matches =
-      Without_vars.file_selectors_with_relative_dirs without_vars ~loc
+      Without_vars.file_selectors_with_prefixes without_vars ~loc
       |> M.of_memo
-      >>= M.List.concat_map ~f:(fun (file_selector, relative_dir) ->
+      >>= M.List.concat_map ~f:(fun (file_selector, prefix) ->
         C.collect_files ~loc file_selector
-        >>| Path.Set.to_list_map ~f:(replace_path_dir relative_dir))
+        >>| Filename.Set.to_list_map ~f:(Filename.concat prefix))
       >>| List.sort ~compare:String.compare
     in
-    { Expanded.matches; dir = without_vars.dir }
+    { Expanded.matches; prefix = without_vars.prefix }
   ;;
 end
 

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -133,7 +133,7 @@ end
 module Expand
     (M : Memo.S)
     (C : sig
-       val collect_files : loc:Loc.t -> File_selector.t -> Filename.Set.t M.t
+       val collect_files : loc:Loc.t -> File_selector.t -> Filename_set.t M.t
      end) =
 struct
   let expand_vars { Dep_conf.Glob_files.glob; recursive } ~f ~base_dir =
@@ -161,6 +161,7 @@ struct
       |> M.of_memo
       >>= M.List.concat_map ~f:(fun (file_selector, prefix) ->
         C.collect_files ~loc file_selector
+        >>| Filename_set.filenames
         >>| Filename.Set.to_list_map ~f:(Filename.concat prefix))
       >>| List.sort ~compare:String.compare
     in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -523,7 +523,7 @@ end = struct
         | None -> init
         | Some dir ->
           let pkg_dir = Path.Build.append_source (Context.build_dir ctx) pkg_dir in
-          Source_tree.Dir.files dir
+          Source_tree.Dir.filenames dir
           |> Filename.Set.fold ~init ~f:(fun fn acc ->
             if is_odig_doc_file fn
             then (

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -224,10 +224,10 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
      do only one traversal we need [Memo.parallel_map_set]. *)
   let* () =
     Memo.parallel_iter_set
-      (module Path.Set)
+      (module Filename.Set)
       files
-      ~f:(fun file_src ->
-        let basename = Path.basename file_src in
+      ~f:(fun basename ->
+        let file_src = Path.relative src_in_build basename in
         let file_dst = Path.Build.relative dir basename in
         let context = Super_context.context sctx in
         Super_context.add_rule
@@ -242,10 +242,10 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
              ~dst:file_dst))
   in
   let targets =
-    Path.Set.map files ~f:(fun file_src ->
-      let basename = Path.basename file_src in
+    Filename.Set.to_list_map files ~f:(fun basename ->
       let file_dst = Path.Build.relative dir basename in
       Path.build file_dst)
+    |> Path.Set.of_list
   in
   let+ () =
     Memo.Option.iter def.alias ~f:(fun alias ->

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -225,7 +225,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
   let* () =
     Memo.parallel_iter_set
       (module Filename.Set)
-      files
+      (Filename_set.filenames files)
       ~f:(fun basename ->
         let file_src = Path.relative src_in_build basename in
         let file_dst = Path.Build.relative dir basename in
@@ -242,7 +242,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
              ~dst:file_dst))
   in
   let targets =
-    Filename.Set.to_list_map files ~f:(fun basename ->
+    Filename.Set.to_list_map (Filename_set.filenames files) ~f:(fun basename ->
       let file_dst = Path.Build.relative dir basename in
       Path.build file_dst)
     |> Path.Set.of_list

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -16,7 +16,7 @@ let files dir =
       Map_reduce.map_reduce dir ~traverse:Sub_dirs.Status.Set.all ~f:(fun dir ->
         let path = Path.append_source prefix_with @@ Source_tree.Dir.path dir in
         let files =
-          Source_tree.Dir.files dir
+          Source_tree.Dir.filenames dir
           |> String.Set.to_list
           |> Path.Set.of_list_map ~f:(fun fn -> Path.relative path fn)
         in

--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -382,14 +382,10 @@ module Dir0 = struct
   let contents t = t.contents
   let path t = t.path
   let status t = t.status
-  let files t = (contents t).files
+  let filenames t = (contents t).files
   let sub_dirs t = (contents t).sub_dirs
   let dune_file t = (contents t).dune_file
   let project t = t.project
-
-  let file_paths t =
-    Path.Source.Set.of_listing ~dir:t.path ~filenames:(Filename.Set.to_list (files t))
-  ;;
 
   let sub_dir_names t =
     Filename.Map.foldi (sub_dirs t) ~init:Filename.Set.empty ~f:(fun s _ acc ->
@@ -720,7 +716,7 @@ let files_of path =
   >>| function
   | None -> Path.Source.Set.empty
   | Some dir ->
-    Dir0.files dir
+    Dir0.filenames dir
     |> Filename.Set.to_list
     |> Path.Source.Set.of_list_map ~f:(Path.Source.relative path)
 ;;

--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -25,8 +25,7 @@ module Dir : sig
 
   val cram_tests : t -> (Cram_test.t, error) result list Memo.t
   val path : t -> Path.Source.t
-  val files : t -> Filename.Set.t
-  val file_paths : t -> Path.Source.Set.t
+  val filenames : t -> Filename.Set.t
 
   type sub_dir
 

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -45,6 +45,12 @@ module Validated : sig
 
   val to_dyn : t -> Dyn.t
   val unvalidate : t -> unvalidated
+
+  (** The set of target filenames in a specified [dir]. *)
+  val filenames : t -> dir:Path.Build.t -> Filename.Set.t
+
+  (** The set of target dirnames in a specified [dir]. *)
+  val dirnames : t -> dir:Path.Build.t -> Filename.Set.t
 end
 
 module Validation_result : sig

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -256,7 +256,7 @@ module V2 = struct
   ;;
 
   let upgrade_dune_files todo dir =
-    if String.Set.mem (Source_tree.Dir.files dir) Source_tree.Dune_file.fname
+    if String.Set.mem (Source_tree.Dir.filenames dir) Source_tree.Dune_file.fname
     then (
       let path = Source_tree.Dir.path dir in
       let fn = Path.Source.relative path Source_tree.Dune_file.fname in
@@ -314,7 +314,7 @@ language. Use the (foreign_archives ...) field instead.|}
 end
 
 let detect_project_version project dir =
-  let in_tree = String.Set.mem (Source_tree.Dir.files dir) in
+  let in_tree = String.Set.mem (Source_tree.Dir.filenames dir) in
   Dune_project.default_dune_language_version := 0, 1;
   if in_tree "jbuild"
   then (


### PR DESCRIPTION
This switches various things to use `Filename.Set` and `Filename_set` instead of `Path.Set`.

Most of the code is by @snowleopard 