### PR TITLE
fix: stop passing -j jobs in opam file to ocaml

### DIFF
--- a/dune.opam
+++ b/dune.opam
@@ -37,7 +37,7 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["ocaml" "boot/bootstrap.ml"]
   ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -1,5 +1,5 @@
 build: [
-  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["ocaml" "boot/bootstrap.ml"]
   ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [


### PR DESCRIPTION
This seems to be ignored, but it definitely isn't correct.