### PR TITLE
refactor: introduce inherited fields in stanza db

### DIFF
--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -4,7 +4,7 @@ open Memo.O
 let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
   let* expander = Super_context.expander t ~dir in
   let* flags =
-    let+ ocaml_flags = Super_context.env_node t ~dir >>= Env_node.ocaml_flags in
+    let+ ocaml_flags = Ocaml_flags_db.ocaml_flags_env ~dir in
     Ocaml_flags.make
       ~spec
       ~default:ocaml_flags

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -64,3 +64,5 @@ val install_rules
   -> dir:Path.Build.t
   -> Coq_stanza.Theory.t
   -> Install.Entry.Sourced.t list Memo.t
+
+val coq_env : dir:Path.Build.t -> Coq_flags.t Action_builder.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -7,8 +7,12 @@ module Context = Context
 module Env_node = Env_node
 module Link_flags = Link_flags
 module Ocaml_flags = Ocaml_flags
+module Ocaml_flags_db = Ocaml_flags_db
 module Js_of_ocaml = Js_of_ocaml
 module Menhir_env = Menhir_env
+module Menhir_rules = Menhir_rules
+module Foreign_rules = Foreign_rules
+module Jsoo_rules = Jsoo_rules
 module Super_context = Super_context
 module Compilation_context = Compilation_context
 module Colors = Colors
@@ -68,7 +72,6 @@ module For_tests = struct
   module Dynlink_supported = Dynlink_supported
   module Ocamlobjinfo = Ocamlobjinfo
   module Action_unexpanded = Action_unexpanded
-  module Jsoo_rules = Jsoo_rules
 end
 
 module Coq = struct

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -3,26 +3,14 @@ open Import
 type t =
   { scope : Scope.t
   ; local_binaries : File_binding.Expanded.t list Memo.Lazy.t
-  ; ocaml_flags : Ocaml_flags.t Memo.Lazy.t
-  ; foreign_flags : string list Action_builder.t Foreign_language.Dict.t
-  ; link_flags : Link_flags.t Memo.Lazy.t
   ; external_env : Env.t Memo.Lazy.t
   ; artifacts : Artifacts.t Memo.Lazy.t
-  ; menhir : string list Action_builder.t Menhir_env.t Memo.Lazy.t
-  ; js_of_ocaml : string list Action_builder.t Js_of_ocaml.Env.t Memo.Lazy.t
-  ; coq_flags : Coq_flags.t Action_builder.t Memo.Lazy.t
   }
 
 let scope t = t.scope
 let local_binaries t = Memo.Lazy.force t.local_binaries
-let ocaml_flags t = Memo.Lazy.force t.ocaml_flags
-let foreign_flags t = t.foreign_flags
-let link_flags t = Memo.Lazy.force t.link_flags
 let external_env t = Memo.Lazy.force t.external_env
 let artifacts t = Memo.Lazy.force t.artifacts
-let js_of_ocaml t = Memo.Lazy.force t.js_of_ocaml
-let menhir t = Memo.Lazy.force t.menhir
-let coq_flags t = Memo.Lazy.force t.coq_flags
 
 let expand_str_lazy expander sw =
   match String_with_vars.text_only sw with
@@ -34,15 +22,12 @@ let expand_str_lazy expander sw =
 ;;
 
 let make
-  build_context
   ~dir
   ~inherit_from
   ~scope
   ~config_stanza
   ~profile
-  ~expander
   ~expander_for_artifacts
-  ~default_context_flags
   ~default_env
   ~default_artifacts
   =
@@ -82,104 +67,5 @@ let make
       let+ local_binaries = Memo.Lazy.force local_binaries in
       Artifacts.add_binaries binaries ~dir local_binaries)
   in
-  let ocaml_flags =
-    let default_ocaml_flags =
-      let project = Scope.project scope in
-      let dune_version = Dune_project.dune_version project in
-      Ocaml_flags.default ~profile ~dune_version
-    in
-    inherited ~field:ocaml_flags ~root:default_ocaml_flags (fun flags ->
-      let+ expander = Memo.Lazy.force expander in
-      Ocaml_flags.make
-        ~spec:config.flags
-        ~default:flags
-        ~eval:(Expander.expand_and_eval_set expander))
-  in
-  let js_of_ocaml =
-    inherited
-      ~field:(fun t -> js_of_ocaml t)
-      ~root:Js_of_ocaml.Env.(map ~f:Action_builder.return (default ~profile))
-      (fun (jsoo : _ Action_builder.t Js_of_ocaml.Env.t) ->
-        let local = config.js_of_ocaml in
-        let+ expander = Memo.Lazy.force expander in
-        { Js_of_ocaml.Env.compilation_mode =
-            Option.first_some local.compilation_mode jsoo.compilation_mode
-        ; runtest_alias = Option.first_some local.runtest_alias jsoo.runtest_alias
-        ; flags =
-            Js_of_ocaml.Flags.make
-              ~spec:local.flags
-              ~default:jsoo.flags
-              ~eval:(Expander.expand_and_eval_set expander)
-        })
-  in
-  let foreign_flags lang =
-    let field t = Memo.return (Foreign_language.Dict.get t.foreign_flags lang) in
-    Action_builder.of_memo_join
-      (Memo.Lazy.force
-         (inherited
-            ~field
-            ~root:(Foreign_language.Dict.get default_context_flags lang)
-            (fun flags ->
-               let+ expander = Memo.Lazy.force expander in
-               let f = Foreign_language.Dict.get config.foreign_flags lang in
-               Expander.expand_and_eval_set expander f ~standard:flags)))
-  in
-  let foreign_flags =
-    Foreign_language.Dict.make ~c:(foreign_flags C) ~cxx:(foreign_flags Cxx)
-  in
-  let link_flags =
-    let default_link_flags =
-      let default_cxx_link_flags = Cxx_flags.get_flags ~for_:Link build_context in
-      Link_flags.default ~default_cxx_link_flags
-    in
-    inherited ~field:link_flags ~root:default_link_flags (fun link_flags ->
-      let+ expander = Memo.Lazy.force expander in
-      Link_flags.make
-        ~spec:config.link_flags
-        ~default:link_flags
-        ~eval:(Expander.expand_and_eval_set expander))
-  in
-  let menhir =
-    inherited
-      ~field:menhir
-      ~root:(Menhir_env.map ~f:Action_builder.return Menhir_env.default)
-      (fun (menhir : _ Action_builder.t Menhir_env.t) ->
-         let local = config.menhir in
-         let+ expander = Memo.Lazy.force expander in
-         let flags =
-           Expander.expand_and_eval_set expander local.flags ~standard:menhir.flags
-         in
-         { Menhir_env.flags; explain = Option.first_some local.explain menhir.explain })
-  in
-  let coq_flags : Coq_flags.t Action_builder.t Memo.Lazy.t =
-    inherited
-      ~field:coq_flags
-      ~root:(Action_builder.return Coq_flags.default)
-      (fun coq_flags ->
-         let+ expander = Memo.Lazy.force expander in
-         let open Action_builder.O in
-         let* { coq_flags; coqdoc_flags } = coq_flags in
-         let+ coq_flags =
-           let standard = Action_builder.return coq_flags in
-           Expander.expand_and_eval_set expander (Coq_env.flags config.coq) ~standard
-         and+ coqdoc_flags =
-           let standard = Action_builder.return coqdoc_flags in
-           Expander.expand_and_eval_set
-             expander
-             (Coq_env.coqdoc_flags config.coq)
-             ~standard
-         in
-         { Coq_flags.coq_flags; coqdoc_flags })
-  in
-  { scope
-  ; ocaml_flags
-  ; foreign_flags
-  ; link_flags
-  ; external_env
-  ; artifacts
-  ; local_binaries
-  ; js_of_ocaml
-  ; menhir
-  ; coq_flags
-  }
+  { scope; external_env; artifacts; local_binaries }
 ;;

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -5,30 +5,21 @@ open Import
 type t
 
 val make
-  :  Build_context.t
-  -> dir:Path.Build.t
+  :  dir:Path.Build.t
   -> inherit_from:t Memo.Lazy.t option
   -> scope:Scope.t
   -> config_stanza:Dune_env.t
   -> profile:Profile.t
-  -> expander:Expander.t Memo.Lazy.t
   -> expander_for_artifacts:Expander.t Memo.Lazy.t
-  -> default_context_flags:string list Action_builder.t Foreign_language.Dict.t
   -> default_env:Env.t
   -> default_artifacts:Artifacts.t
   -> t
 
 val scope : t -> Scope.t
 val external_env : t -> Env.t Memo.t
-val ocaml_flags : t -> Ocaml_flags.t Memo.t
-val js_of_ocaml : t -> string list Action_builder.t Js_of_ocaml.Env.t Memo.t
-val foreign_flags : t -> string list Action_builder.t Foreign_language.Dict.t
-val link_flags : t -> Link_flags.t Memo.t
 
 (** Binaries that are symlinked in the associated .bin directory of [dir]. This
     associated directory is *)
 val local_binaries : t -> File_binding.Expanded.t list Memo.t
 
 val artifacts : t -> Artifacts.t Memo.t
-val coq_flags : t -> Coq_flags.t Action_builder.t Memo.t
-val menhir : t -> string list Action_builder.t Menhir_env.t Memo.t

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -100,3 +100,92 @@ let inline_tests ~dir =
     let+ profile = profile ~dir in
     if Profile.is_inline_test profile then Dune_env.Inline_tests.Enabled else Disabled
 ;;
+
+module Inherit = struct
+  let for_context
+    (type a)
+    ~name
+    ~(root : Context_name.t -> Dune_project.t -> a Memo.t)
+    (context : Context_name.t)
+    ~(f : parent:a Memo.t -> dir:Path.Build.t -> Dune_env.config -> a Memo.t)
+    =
+    let for_context =
+      Memo.Lazy.create (fun () ->
+        let+ context = Context.DB.get context in
+        let profile = Context.profile context in
+        let { Context.Env_nodes.context; workspace } = Context.env_nodes context in
+        let make env = Option.bind env ~f:(Dune_env.find_opt ~profile) in
+        [ make workspace; make context ] |> List.filter_opt)
+    in
+    let root =
+      Memo.create
+        (sprintf "%s-root" name)
+        ~input:(module Path.Source)
+        (fun dir ->
+          let* { Dune_load.projects_by_root; _ } = Dune_load.load ()
+          and* envs = Memo.Lazy.force for_context in
+          let project = Path.Source.Map.find_exn projects_by_root dir in
+          let root = root context project in
+          let dir = Path.Build.append_source (Context_name.build_dir context) dir in
+          List.fold_left envs ~init:root ~f:(fun acc env -> f ~parent:acc ~dir env))
+      |> Memo.exec
+    in
+    let module Non_rec = struct
+      module rec Rec : sig
+        val memo : Path.Build.t -> a Memo.t
+      end = struct
+        let f path =
+          let* env =
+            Node.in_dir ~dir:path
+            >>= function
+            | None -> Memo.return None
+            | Some stanza ->
+              let+ profile = Context.DB.get context >>| Context.profile in
+              Dune_env.find_opt stanza ~profile
+          in
+          let parent =
+            let* parent_path =
+              match Path.Build.parent path with
+              | None -> Code_error.raise "invalid path" []
+              | Some parent ->
+                let+ project = Dune_load.find_project ~dir:path in
+                let without_context = Path.Build.drop_build_context_exn path in
+                if Path.Source.equal (Dune_project.root project) without_context
+                then `Root without_context
+                else `Parent parent
+            in
+            match parent_path with
+            | `Root without_context -> root without_context
+            | `Parent p -> Rec.memo p
+          in
+          match env with
+          | None -> parent
+          | Some stanza -> f ~parent ~dir:path stanza
+        ;;
+
+        let memo = Memo.exec (Memo.create name ~input:(module Path.Build) f)
+      end
+    end
+    in
+    Staged.stage Non_rec.Rec.memo
+  ;;
+
+  let inherited ~name ~root ~f =
+    let by_context =
+      Per_context.create_by_name ~name:(sprintf "inherited-%s" name) (fun ctx ->
+        Memo.return (for_context ~name ~root ctx ~f))
+      |> Staged.unstage
+    in
+    Staged.stage (fun path ->
+      match Install.Context.of_path path with
+      | None ->
+        Code_error.raise
+          "path is not allowed inherited nodes"
+          [ "path", Path.Build.to_dyn path ]
+      | Some ctx ->
+        let* for_ctx = by_context ctx in
+        Staged.unstage for_ctx path)
+  ;;
+end
+
+include Inherit

--- a/src/dune_rules/env_stanza_db.mli
+++ b/src/dune_rules/env_stanza_db.mli
@@ -1,5 +1,7 @@
 open Import
 
+(** Define a value that is computed from the env stanza. This function is not
+    memoized, so it's best used when the computation is simple. *)
 val value
   :  default:'a
   -> dir:Path.Build.t
@@ -8,3 +10,15 @@ val value
 
 val bin_annot : dir:Path.Build.t -> bool Memo.t
 val inline_tests : dir:Path.Build.t -> Dune_env.Inline_tests.t Memo.t
+
+(** [inherited ~name ~root ~f] create a function that computes a value derived
+    from the env stanza for every directory.
+
+    [root] is used to set the top level value for every project.
+
+    [f] is used to compute the value for every single env stanza definition. *)
+val inherited
+  :  name:string
+  -> root:(Context_name.t -> Dune_project.t -> 'a Memo.t)
+  -> f:(parent:'a Memo.t -> dir:Path.Build.t -> Dune_env.config -> 'a Memo.t)
+  -> (Path.Build.t -> 'a Memo.t) Staged.t

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -17,11 +17,6 @@ val make_root
   -> artifacts_host:Artifacts.t
   -> t
 
-val set_foreign_flags
-  :  t
-  -> f:(dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)
-  -> t
-
 val set_local_env_var : t -> var:string -> value:string Action_builder.t -> t
 val set_dir : t -> dir:Path.Build.t -> t
 val set_scope : t -> scope:Scope.t -> scope_host:Scope.t -> t
@@ -134,3 +129,7 @@ val expand_locks
   -> t
   -> Locks.t
   -> Path.t list Action_builder.t
+
+val foreign_flags
+  : (dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)
+      Fdecl.t

--- a/src/dune_rules/foreign_rules.mli
+++ b/src/dune_rules/foreign_rules.mli
@@ -16,3 +16,7 @@ val build_o_files
   -> requires:Lib.t list Resolve.t
   -> dir_contents:Dir_contents.t
   -> Path.t Mode.Map.Multi.t Memo.t
+
+val foreign_flags_env
+  :  dir:Path.Build.t
+  -> string list Action_builder.t Foreign_language.Dict.t Memo.t

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -324,7 +324,7 @@ include Sub_system.Register_end_point (struct
           let* runtest_alias =
             match mode with
             | Native | Best | Byte -> Memo.return Alias0.runtest
-            | Javascript -> Jsoo_rules.js_of_ocaml_runtest_alias sctx ~dir
+            | Javascript -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir
           in
           Super_context.add_alias_action
             sctx

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -38,4 +38,5 @@ val build_exe
 
 val setup_separate_compilation_rules : Super_context.t -> string list -> unit Memo.t
 val runner : string
-val js_of_ocaml_runtest_alias : Super_context.t -> dir:Path.Build.t -> Alias.Name.t Memo.t
+val js_of_ocaml_runtest_alias : dir:Path.Build.t -> Alias.Name.t Memo.t
+val jsoo_env : dir:Path.Build.t -> string list Action_builder.t Js_of_ocaml.Env.t Memo.t

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -44,6 +44,32 @@ end
 
 (* This functor is where [(menhir ...)] stanzas are desugared. *)
 
+let menhir_env =
+  let f =
+    Env_stanza_db.inherited
+      ~name:"jsoo-env"
+      ~root:(fun _ _ ->
+        Menhir_env.map ~f:Action_builder.return Menhir_env.default |> Memo.return)
+      ~f:(fun ~parent ~dir (local : Dune_env.config) ->
+        let local = local.menhir in
+        let open Memo.O in
+        let* parent = parent in
+        let+ expander =
+          let* context = Context.DB.by_dir dir in
+          let* sctx = Super_context.find_exn (Context.name context) in
+          Super_context.expander sctx ~dir
+        in
+        let flags =
+          Expander.expand_and_eval_set expander local.flags ~standard:parent.flags
+        in
+        { Menhir_env.flags; explain = Option.first_some local.explain parent.explain })
+  in
+  fun ~dir ->
+    let open Memo.O in
+    let* () = Memo.return () in
+    (Staged.unstage f) dir
+;;
+
 module Run (P : PARAMS) = struct
   open P
 
@@ -56,12 +82,7 @@ module Run (P : PARAMS) = struct
      directory to we get correct error paths. *)
   let build_dir = Super_context.context sctx |> Context.build_dir
   let expander = Super_context.expander ~dir sctx
-
-  let env =
-    let open Memo.O in
-    let* env = Super_context.env_node ~dir sctx in
-    Env_node.menhir env
-  ;;
+  let env = menhir_env ~dir
 
   let sandbox =
     let scope = Compilation_context.scope cctx in

--- a/src/dune_rules/menhir/menhir_rules.mli
+++ b/src/dune_rules/menhir/menhir_rules.mli
@@ -11,3 +11,5 @@ val gen_rules
   -> Compilation_context.t
   -> Menhir_stanza.t
   -> unit Memo.t
+
+val menhir_env : dir:Path.Build.t -> string list Action_builder.t Menhir_env.t Memo.t

--- a/src/dune_rules/ocaml_flags_db.ml
+++ b/src/dune_rules/ocaml_flags_db.ml
@@ -1,10 +1,35 @@
 open Import
 open Memo.O
 
+let ocaml_flags_env =
+  let f =
+    Env_stanza_db.inherited
+      ~name:"ocaml-flags-env"
+      ~root:(fun ctx project ->
+        let+ profile = Context.DB.get ctx >>| Context.profile in
+        let dune_version = Dune_project.dune_version project in
+        Ocaml_flags.default ~profile ~dune_version)
+      ~f:(fun ~parent ~dir (env : Dune_env.config) ->
+        let* parent = parent in
+        let+ expander =
+          let* context = Context.DB.by_dir dir in
+          let* sctx = Super_context.find_exn (Context.name context) in
+          Super_context.expander sctx ~dir
+        in
+        Ocaml_flags.make
+          ~spec:env.flags
+          ~default:parent
+          ~eval:(Expander.expand_and_eval_set expander))
+  in
+  fun ~dir ->
+    let* () = Memo.return () in
+    (Staged.unstage f) dir
+;;
+
 let ocaml_flags sctx ~dir (spec : Ocaml_flags.Spec.t) =
   let* flags =
     let* expander = Super_context.expander sctx ~dir in
-    let+ ocaml_flags = Super_context.env_node sctx ~dir >>= Env_node.ocaml_flags in
+    let+ ocaml_flags = ocaml_flags_env ~dir in
     Ocaml_flags.make
       ~spec
       ~default:ocaml_flags
@@ -21,8 +46,34 @@ let ocaml_flags sctx ~dir (spec : Ocaml_flags.Spec.t) =
     Ocaml_flags.with_vendored_flags ~ocaml_version flags
 ;;
 
+let link_env =
+  let f =
+    Env_stanza_db.inherited
+      ~name:"link-env"
+      ~root:(fun ctx _ ->
+        let default_cxx_link_flags =
+          Cxx_flags.get_flags ~for_:Link (Build_context.create ~name:ctx)
+        in
+        Link_flags.default ~default_cxx_link_flags |> Memo.return)
+      ~f:(fun ~parent ~dir (env : Dune_env.config) ->
+        let* parent = parent in
+        let+ expander =
+          let* context = Context.DB.by_dir dir in
+          let* sctx = Super_context.find_exn (Context.name context) in
+          Super_context.expander sctx ~dir
+        in
+        Link_flags.make
+          ~spec:env.link_flags
+          ~default:parent
+          ~eval:(Expander.expand_and_eval_set expander))
+  in
+  fun ~dir ->
+    let* () = Memo.return () in
+    (Staged.unstage f) dir
+;;
+
 let link_flags sctx ~dir (spec : Link_flags.Spec.t) =
   let* expander = Super_context.expander sctx ~dir in
-  let+ link_flags = Super_context.env_node sctx ~dir >>= Env_node.link_flags in
+  let+ link_flags = link_env ~dir in
   Link_flags.make ~spec ~default:link_flags ~eval:(Expander.expand_and_eval_set expander)
 ;;

--- a/src/dune_rules/ocaml_flags_db.mli
+++ b/src/dune_rules/ocaml_flags_db.mli
@@ -13,3 +13,6 @@ val link_flags
   -> dir:Path.Build.t
   -> Link_flags.Spec.t
   -> Link_flags.t Memo.t
+
+val link_env : dir:Path.Build.t -> Link_flags.t Memo.t
+val ocaml_flags_env : dir:Path.Build.t -> Ocaml_flags.t Memo.t

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -67,7 +67,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
         in
         let* runtest_alias =
           match runtest_mode with
-          | `js -> Jsoo_rules.js_of_ocaml_runtest_alias sctx ~dir
+          | `js -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir
           | `exe | `bc -> Memo.return Alias0.runtest
         in
         let add_alias ~loc ~action ~locks =

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -106,23 +106,16 @@ But when lang dune is 3.3 or higher the warning becomes an error:
     -short-paths
     -keep-locs))
   Leaving directory 'outer'
+
   $ dune build --root=outer
   Entering directory 'outer'
-  File "vendored/inner/inner.ml", line 6, characters 11-18:
-  6 | type t = { x : int }
-                 ^^^^^^^
-  Error (warning 69 [unused-field]): unused record field x.
   Leaving directory 'outer'
-  [1]
   $ pat="\-o [./a-zA-Z_]\{1,\}.cmx"
   $ log=outer/_build/log
   $ grep -o "$pat" $log | sort
   -o .outer.eobjs/native/dune__exe__Outer.cmx
-  -o vendored/inner/.inner.objs/native/inner.cmx
   $ grep "$pat" $log | sort | grep -n -E -o "\-w [^ ]+"
   1:-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-  2:-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-  2:-w -a
 
 This is unexpected as vendored projects should be built according to their
 declared dune-project rather than the dune-project of the outer project.

--- a/test/expect-tests/jsoo_tests.ml
+++ b/test/expect-tests/jsoo_tests.ml
@@ -1,5 +1,5 @@
 open Stdune
-module Jsoo_rules = Dune_rules.For_tests.Jsoo_rules
+module Jsoo_rules = Dune_rules.Jsoo_rules
 
 let%expect_test _ =
   let test s l =


### PR DESCRIPTION
This allows us to define the constituents of `Env_node` separately. The goals are as follows:

1. Make it possible for rules to define their own handling of their `env` fields individually. This allows for better isolation of subsystem specific parts to their own part of the rules. E.g. the coq stuff now lives separate from everything else.

2. Remove the manual shuffling of scope/artifacts that's required when creating the env node. Getting rid of this also fixes a bug with the vendored flags as we can see from the test. Also this PR doesn't completely get rid of this.

3. Improve the performance of incremental compilation. Now, we don't recompute all the effective values derived from `env` when a single one changes. The recomputation is reserved to only what needs to be recomputed. Although no cutoffs have been added yet.