### PR TITLE
refactor: project lookup without scope

### DIFF
--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -366,3 +366,8 @@ let load =
   let memo = Memo.lazy_ ~name:"dune_load" load in
   fun () -> Memo.Lazy.force memo
 ;;
+
+let find_project ~dir =
+  let+ { projects_by_root; _ } = load () in
+  Find_closest_source_dir.find_by_dir projects_by_root ~dir
+;;

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -22,3 +22,5 @@ type conf = private
 
 (** Load all dune files. This function is memoized. *)
 val load : unit -> conf Memo.t
+
+val find_project : dir:Path.Build.t -> Dune_project.t Memo.t

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -34,8 +34,10 @@ module Node = struct
 
   let rec by_dir dir =
     let parent =
-      let* scope = Scope.DB.find_by_dir dir in
-      if Path.Build.equal dir (Scope.root scope)
+      let* project = Dune_load.find_project ~dir in
+      if Path.Source.equal
+           (Path.Build.drop_build_context_exn dir)
+           (Dune_project.root project)
       then by_context dir
       else (
         match Path.Build.parent dir with

--- a/src/dune_rules/find_closest_source_dir.ml
+++ b/src/dune_rules/find_closest_source_dir.ml
@@ -1,0 +1,34 @@
+open Import
+
+let find_by_dir map (dir : Path.Source.t) =
+  let rec loop d =
+    match Path.Source.Map.find map d with
+    | Some s -> s
+    | None ->
+      (match Path.Source.parent d with
+       | Some d -> loop d
+       | None ->
+         Code_error.raise
+           "find_by_dir: invalid directory"
+           [ "d", Path.Source.to_dyn d; "dir", Path.Source.to_dyn dir ])
+  in
+  loop dir
+;;
+
+let invalid_path dir =
+  Code_error.raise
+    "path doesn't belong to any source dir"
+    [ "dir", Path.Build.to_dyn dir ]
+;;
+
+let find_by_dir map ~dir =
+  if Path.Build.is_root dir
+  then invalid_path dir
+  else (
+    match Dune_engine.Dpath.analyse_target dir with
+    | Regular (name, src) ->
+      (match Install.Context.analyze_path name src with
+       | Normal (_, path) -> find_by_dir map path
+       | _ -> invalid_path dir)
+    | _ -> invalid_path dir)
+;;

--- a/src/dune_rules/find_closest_source_dir.mli
+++ b/src/dune_rules/find_closest_source_dir.mli
@@ -1,0 +1,3 @@
+open Import
+
+val find_by_dir : 'a Path.Source.Map.t -> dir:Path.Build.t -> 'a

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -148,7 +148,7 @@ let build_c
   (loc, (src : Foreign.Source.t), dst)
   =
   let ctx = Super_context.context sctx in
-  let* project = Scope.DB.find_by_dir dir >>| Scope.project in
+  let* project = Dune_load.find_project ~dir in
   let use_standard_flags = Dune_project.use_standard_c_and_cxx_flags project in
   let* ocaml = Context.ocaml ctx in
   let base_flags =

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -193,9 +193,7 @@ let gen_rules sctx ~output_dir =
   let dir = Path.Build.parent_exn output_dir in
   with_config ~dir (fun config ->
     let* expander = Super_context.expander sctx ~dir in
-    (* CR-rgrinberg: initializing the library database seems unnecessary here *)
-    let* scope = Scope.DB.find_by_dir output_dir in
-    let project = Scope.project scope in
+    let* project = Dune_load.find_project ~dir in
     let dialects = Dune_project.dialects project in
     let version = Dune_project.dune_version project in
     gen_rules_output sctx config ~version ~dialects ~expander ~output_dir)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1165,10 +1165,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
       entries
       ~f:(List.map ~f:(fun (e : Install.Entry.Sourced.t) -> e.entry.src))
   in
-  let* dune_project =
-    let+ scope = Scope.DB.find_by_dir pkg_build_dir in
-    Scope.project scope
-  in
+  let* dune_project = Dune_load.find_project ~dir:pkg_build_dir in
   let strict_package_deps = Dune_project.strict_package_deps dune_project in
   let packages =
     let open Action_builder.O in

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -68,7 +68,7 @@ let build_lib
     in
     let ocaml_flags = Ocaml_flags.get flags (Ocaml mode) in
     let* standard =
-      let+ project = Scope.DB.find_by_dir dir |> Memo.map ~f:Scope.project in
+      let+ project = Dune_load.find_project ~dir in
       match Dune_project.use_standard_c_and_cxx_flags project with
       | Some true when Buildable.has_foreign_cxx lib.buildable ->
         Cxx_flags.get_flags ~for_:Link (Context.build_context ctx)
@@ -263,13 +263,10 @@ let foreign_rules (library : Foreign.Library.t) ~sctx ~expander ~dir ~dir_conten
   in
   let* () = Check_rules.add_files sctx ~dir o_files in
   let* standard =
-    let+ project =
-      let+ scope = Scope.DB.find_by_dir dir in
-      Scope.project scope
-    in
-    let ctx = Super_context.context sctx in
+    let+ project = Dune_load.find_project ~dir in
     match Dune_project.use_standard_c_and_cxx_flags project with
     | Some true when Foreign.Sources.has_cxx_sources foreign_sources ->
+      let ctx = Super_context.context sctx in
       Cxx_flags.get_flags ~for_:Link (Context.build_context ctx)
     | _ -> Action_builder.return []
   in
@@ -328,7 +325,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
            (Compilation_context.ocaml cctx).ocaml_config
     in
     let* standard =
-      let+ project = Scope.DB.find_by_dir dir >>| Scope.project in
+      let+ project = Dune_load.find_project ~dir in
       match Dune_project.use_standard_c_and_cxx_flags project with
       | Some true when Foreign.Sources.has_cxx_sources foreign_sources ->
         Cxx_flags.get_flags ~for_:Link (Context.build_context ctx)

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -69,10 +69,7 @@ let gen_rule sctx ~loc ~dir query =
   | Ok _ as bin ->
     let* command =
       let+ env =
-        let* dune_version =
-          let+ expander = Super_context.expander sctx ~dir in
-          expander |> Expander.scope |> Scope.project |> Dune_project.dune_version
-        in
+        let* dune_version = Dune_load.find_project ~dir >>| Dune_project.dune_version in
         let* env_node = Super_context.env_node sctx ~dir in
         if dune_version >= (3, 8)
         then Env_node.external_env env_node


### PR DESCRIPTION
Looking up the project can be done without constructing the scope db. This has the advantages of doing less work and preventing some possible memo cycles in the future.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>