### PR TITLE
Store Targets.Validated and Produced as root dir + basenames

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -222,13 +222,15 @@ let exec_run_dynamic_client ~display ~ectx ~eenv prog args =
       match ectx.targets with
       | None -> String.Set.empty
       | Some targets ->
-        if not (Path.Build.Set.is_empty targets.dirs)
+        if not (Filename.Set.is_empty targets.dirs)
         then
           User_error.raise
             ~loc:ectx.rule_loc
             [ Pp.text "Directory targets are not compatible with dynamic actions" ];
-        Path.Build.Set.to_list_map targets.files ~f:(fun target ->
-          Path.reach (Path.build target) ~from:eenv.working_dir)
+        Filename.Set.to_list_map targets.files ~f:(fun target ->
+          Path.Build.relative targets.root target
+          |> Path.build
+          |> Path.reach ~from:eenv.working_dir)
         |> String.Set.of_list
     in
     { DAP.Run_arguments.prepared_dependencies = eenv.prepared_dependencies; targets }

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -432,12 +432,12 @@ end = struct
           | Error error -> User_error.raise ~loc (Targets.Produced.Error.message error)))
   ;;
 
-  let promote_targets ~rule_mode ~dir ~targets ~promote_source =
+  let promote_targets ~rule_mode ~targets ~promote_source =
     match rule_mode, !Clflags.promote with
     | (Rule.Mode.Standard | Fallback | Ignore_source_files), _ | Promote _, Some Never ->
       Fiber.return ()
     | Promote promote, (Some Automatically | None) ->
-      Target_promotion.promote ~dir ~targets ~promote ~promote_source
+      Target_promotion.promote ~targets ~promote ~promote_source
   ;;
 
   let execute_rule_impl ~rule_kind rule =
@@ -615,7 +615,6 @@ end = struct
       let* () =
         promote_targets
           ~rule_mode:mode
-          ~dir:targets.root
           ~targets:produced_targets
           ~promote_source:config.promote_source
       in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -41,7 +41,7 @@ val execute_action_stdout
 
 type rule_execution_result =
   { deps : Dep.Fact.t Dep.Map.t
-  ; targets : Digest.t Path.Build.Map.t
+  ; targets : Digest.t Targets.Produced.t
   }
 
 val execute_rule : Rule.t -> rule_execution_result Memo.t

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -5,7 +5,6 @@ open Memo.O
 module Rule = struct
   type t =
     { id : Rule.Id.t
-    ; dir : Path.Build.t
     ; deps : Dep.Set.t
     ; expanded_deps : Path.Set.t
     ; targets : Targets.Validated.t
@@ -67,7 +66,6 @@ let evaluate_rule =
         let* expanded_deps = Expand.deps deps in
         Memo.return
           { Rule.id = rule.id
-          ; dir = rule.dir
           ; deps
           ; expanded_deps
           ; targets = rule.targets

--- a/src/dune_engine/reflection.mli
+++ b/src/dune_engine/reflection.mli
@@ -4,7 +4,6 @@ module Non_evaluated_rule = Rule
 module Rule : sig
   type t = private
     { id : Rule.Id.t
-    ; dir : Path.Build.t
     ; deps : Dep.Set.t
     ; (* [expanded_deps] skips over non-file dependencies, such as: environment
          variables, universe, glob listings, sandbox requirements *)

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -60,7 +60,6 @@ type t = private
   ; mode : Mode.t
   ; info : Info.t
   ; loc : Loc.t
-  ; dir : Path.Build.t (** Directory where all the targets are produced. *)
   }
 
 include Comparable_intf.S with type key := t

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -218,10 +218,10 @@ module Workspace_local = struct
 end
 
 module Shared = struct
-  let lookup ~can_go_in_shared_cache ~rule_digest ~targets ~target_dir =
+  let lookup ~can_go_in_shared_cache ~rule_digest ~targets =
     let config = Build_config.get () in
     let module Shared_cache = (val config.shared_cache) in
-    Shared_cache.lookup ~can_go_in_shared_cache ~rule_digest ~targets ~target_dir
+    Shared_cache.lookup ~can_go_in_shared_cache ~rule_digest ~targets
   ;;
 
   let examine_targets_and_store

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -117,7 +117,7 @@ include T
 let to_dyn = Path.Build.Map.to_dyn Dir_rules.Nonempty.to_dyn
 
 let singleton_rule (rule : Rule.t) =
-  let dir = rule.dir in
+  let dir = rule.targets.root in
   Path.Build.Map.singleton dir (Dir_rules.Nonempty.singleton (Rule rule))
 ;;
 
@@ -177,7 +177,7 @@ let of_dir_rules ~dir rules =
 
 let of_rules rules =
   List.fold_left rules ~init:Path.Build.Map.empty ~f:(fun acc rule ->
-    Path.Build.Map.update acc rule.Rule.dir ~f:(function
+    Path.Build.Map.update acc rule.Rule.targets.root ~f:(function
       | None -> Some (Dir_rules.Nonempty.singleton (Rule rule))
       | Some acc -> Some (Dir_rules.Nonempty.add acc (Rule rule))))
 ;;
@@ -192,7 +192,8 @@ let directory_targets (rules : t) =
         match data with
         | Alias _ -> acc
         | Rule rule ->
-          Path.Build.Set.fold ~init:acc rule.targets.dirs ~f:(fun target acc ->
+          Filename.Set.fold ~init:acc rule.targets.dirs ~f:(fun target acc ->
+            let target = Path.Build.relative rule.targets.root target in
             Path.Build.Map.add_exn acc target rule.loc)))
 ;;
 

--- a/src/dune_engine/shared_cache_intf.ml
+++ b/src/dune_engine/shared_cache_intf.ml
@@ -10,7 +10,6 @@ module type S = sig
     :  can_go_in_shared_cache:bool
     -> rule_digest:Digest.t
     -> targets:Targets.Validated.t
-    -> target_dir:Path.Build.t
     -> Digest.t Targets.Produced.t option Fiber.t
 
   (** This function performs the following steps:

--- a/src/dune_engine/target_promotion.mli
+++ b/src/dune_engine/target_promotion.mli
@@ -5,8 +5,7 @@
 open Import
 
 val promote
-  :  dir:Path.Build.t
-  -> targets:Digest.t Targets.Produced.t
+  :  targets:Digest.t Targets.Produced.t
   -> promote:Rule.Promote.t
   -> promote_source:
        (chmod:(int -> int)

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -201,7 +201,7 @@ end = struct
              | None -> []
              | Some targets ->
                (* CR-someday amokhov: Do not ignore directory targets. *)
-               Path.Build.Set.to_list_map targets.files ~f:Path.Build.basename)
+               Filename.Set.to_list targets.files)
           | Copy_files.T def ->
             Simple_rules.copy_files sctx def ~src_dir ~dir ~expander
             >>| Path.Set.to_list_map ~f:Path.basename

--- a/src/dune_targets/dune
+++ b/src/dune_targets/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_targets)
- (libraries stdune fiber dyn dune_digest))
+ (libraries stdune fiber chrome_trace dyn dune_digest))

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -35,7 +35,7 @@ module Validated : sig
   (** A rule can produce a set of files whose names are known upfront, as well
       as a set of "opaque" directories whose contents is initially unknown. *)
   type t = private
-    { root : Path.Build.t
+    { root : Path.Build.t (** [files] and [dirs] are relative to [root] *)
     ; files : Filename.Set.t
     ; dirs : Filename.Set.t
     }
@@ -80,8 +80,9 @@ val all : t -> Path.Build.t list
     payload, for example, the target's digest. *)
 module Produced : sig
   type 'a t = private
-    { files : 'a Path.Build.Map.t
-    ; dirs : 'a Filename.Map.t Path.Build.Map.t
+    { root : Path.Build.t (** [files] and [dirs] are relative to [root] *)
+    ; files : 'a Filename.Map.t
+    ; dirs : 'a Filename.Map.t Path.Local.Map.t
     }
 
   module Error : sig
@@ -101,8 +102,9 @@ module Produced : sig
   (** Drop all directory targets, leaving only file targets. *)
   val drop_dirs : 'a t -> 'a t
 
-  (** Union of [t.files] and all files in [t.dirs] as [Seq.t] for efficient traversal. *)
-  val all_files_seq : 'a t -> (Path.Build.t * 'a) Seq.t
+  (** Union of [t.files] and all files in [t.dirs] as [Seq.t] for efficient traversal.
+      The resulting [Path.Local.t]s are relative to [t.root]. *)
+  val all_files_seq : 'a t -> (Path.Local.t * 'a) Seq.t
 
   (** Check if a file is present in the targets. *)
   val mem : 'a t -> Path.Build.t -> bool

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -98,15 +98,22 @@ module Produced : sig
   (** Populates only the [files] field, leaving [dirs] empty. *)
   val of_files : Path.Build.t -> 'a Filename.Map.t -> 'a t
 
-  (* Drop all directory targets, leaving only file targets. *)
+  (** Drop all directory targets, leaving only file targets. *)
   val drop_dirs : 'a t -> 'a t
 
-  (** Union of [t.files] and all files in [t.dirs]. *)
-  val all_files : 'a t -> 'a Path.Build.Map.t
-
-  (** Like [all_files] but returns a [Seq.t] for efficient traversal. *)
+  (** Union of [t.files] and all files in [t.dirs] as [Seq.t] for efficient traversal. *)
   val all_files_seq : 'a t -> (Path.Build.t * 'a) Seq.t
 
+  (** Check if a file is present in the targets. *)
+  val mem : 'a t -> Path.Build.t -> bool
+
+  (** Find the value associated with the file, if any. *)
+  val find : 'a t -> Path.Build.t -> 'a option
+
+  (** Find all files in a directory target or a subdirectory. *)
+  val find_dir : 'a t -> Path.Build.t -> 'a Filename.Map.t option
+
+  val equal : 'a t -> 'a t -> equal:('a -> 'a -> bool) -> bool
   val exists : 'a t -> f:('a -> bool) -> bool
   val foldi : 'a t -> init:'acc -> f:(Path.Build.t -> 'a -> 'acc -> 'acc) -> 'acc
   val iteri : 'a t -> f:(Path.Build.t -> 'a -> unit) -> unit

--- a/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
+++ b/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
@@ -31,7 +31,8 @@ Whenever an invalid package name is used, dune crashes when building @doc
     ; example =
         Rule
           { targets =
-              { files = set { "default/_doc/_html/x/index.html" }
+              { root = In_build_dir "default/_doc/_html/x"
+              ; files = set { "index.html" }
               ; dirs = set {}
               }
           }


### PR DESCRIPTION
These represent targets for one rule and are thus rooted in one directory. This PR changes the representation to reflect this fact and uses this to refactor a few places. The resulting code seems cleaner, is slightly more efficient and simplifies the implementation of caching for directory targets in a subsequent PR.