### PR TITLE
Add test for parse error when using run action

### DIFF
--- a/test/blackbox-tests/test-cases/run-parse-error.t
+++ b/test/blackbox-tests/test-cases/run-parse-error.t
@@ -1,0 +1,16 @@
+Test that parse errors in the run error produce the expected error message.
+
+  $ echo "(lang dune 3.11)" > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (target foo.txt)
+  >  (action
+  >   (run ())))
+  > EOF
+
+  $ dune build foo.txt
+  File "dune", line 4, characters 7-9:
+  4 |   (run ())))
+             ^^
+  Error: Unexpected list
+  [1]


### PR DESCRIPTION
Repro for https://github.com/ocaml/dune/issues/9529