### PR TITLE
fix(pkg): prevent blang/slang infinite recursion

### DIFF
--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -26,6 +26,16 @@ module Ast : sig
   val true_ : 'string t
   val false_ : 'string t
   val to_dyn : 'string Dyn.builder -> 'string t -> Dyn.t
-  val decode : 'string Decoder.t -> 'string t Decoder.t
+
+  (** The [override_decode_bare_literal] argument is an alternative parser that
+      if provided, will be used to parse string literals for the [Expr _]
+      constructor. This is intended to prevent infinite recursion when parsing
+      blangs whose ['string] type is another DSL which is mutually recursive
+      with blang (e.g. slang). *)
+  val decode
+    :  override_decode_bare_literal:'string Decoder.t option
+    -> 'string Decoder.t
+    -> 'string t Decoder.t
+
   val encode : 'string Encoder.t -> 'string t Encoder.t
 end

--- a/src/dune_rules/enabled_if.ml
+++ b/src/dune_rules/enabled_if.ml
@@ -52,6 +52,7 @@ let decode_value ~allowed_vars ?(is_error = true) () =
   | Any -> Blang.decode
   | Only allowed_vars ->
     Blang.Ast.decode
+      ~override_decode_bare_literal:None
       (String_with_vars.decode_manually (fun env var ->
          match Dune_lang.Template.Pform.payload var with
          | Some _ ->

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -96,6 +96,12 @@ Tests for has_undefined_var:
   $ test_action '(run echo (if (has_undefined_var (when %{pkg-self:not_a_variable} foo)) foo bar))'
   foo
 
+Test conversion from blang to string:
+  $ test_action '(run echo (and (= (concat foo bar) foobar)))'
+  true
+  $ test_action '(run echo (and true false))'
+  false
+
 Test the error message when the program doesn't exist:
   $ test_action '(run madeup)'
   File "dune.lock/test.pkg", line 2, characters 14-20:
@@ -119,4 +125,24 @@ Test the error message when the program doesn't exist:
                     ^^^^^^^^^^^^^^^^^^^^^
   Error: Program madeup not found in the tree or in PATH
    (context: default)
+  [1]
+
+Test for the error message when a slang expression fails to parse:
+  $ test_action '(run echo (concat ()))'
+  File "dune.lock/test.pkg", line 2, characters 27-29:
+  2 | (install (run echo (concat ())))
+                                 ^^
+  Error: Unexpected list
+  [1]
+  $ test_action '(run echo (if true))'
+  File "dune.lock/test.pkg", line 2, characters 19-28:
+  2 | (install (run echo (if true)))
+                         ^^^^^^^^^
+  Error: Not enough arguments for if
+  [1]
+  $ test_action '(run echo (if (= a) () ()))'
+  File "dune.lock/test.pkg", line 2, characters 23-28:
+  2 | (install (run echo (if (= a) () ())))
+                             ^^^^^
+  Error: Not enough arguments for =
   [1]


### PR DESCRIPTION
Each of the parsers for the blang and slang DSLs attempt to invoke the other when encountering a form they can't interpret. Blang invokes slang as a slang expression may return a blang literal (a string "true" or "false"), and slang invokes blang to convert the result of a blang expression into a string "true" or "false". When a form couldn't be interpreted by either parser each parser would continuously invoke the other leading to infinite recursion. This fixes the problem by checking the parser's location in the file and making sure that progress has been made before recurring.