### PR TITLE
fix: concatenate strings before comparing

### DIFF
--- a/src/dune_rules/slang_expand.ml
+++ b/src/dune_rules/slang_expand.ml
@@ -165,7 +165,13 @@ and eval_blang_rec (t : Slang.blang) ~dir ~f =
     and+ y = eval_rec y ~dir ~f in
     Result.bind x ~f:(fun x ->
       Result.map y ~f:(fun y ->
-        Relop.eval op (List.compare ~compare:(Value.L.compare_vals ~dir) x y)))
+        (* Concatenation of strings is delayed but to compare the result of a
+           slang expression we must force the concatenation first. *)
+        let concat =
+          List.map ~f:(fun s ->
+            Value.String (List.map s ~f:(Value.to_string ~dir) |> String.concat ~sep:""))
+        in
+        Relop.eval op (Value.L.compare_vals ~dir (concat x) (concat y))))
 ;;
 
 let eval t ~dir ~f : Value.t list list Memo.t =

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -28,6 +28,8 @@ Tests for concat:
   foo
   $ test_action '(run echo foo (concat) bar (concat) baz)' # two spaces between each word because (concat) is the empty string
   foo  bar  baz
+  $ test_action '(run echo (= (concat foo bar) (concat f o o b a r)))'
+  true
 
 Tests for when:
   $ test_action '(run echo (when true foo) bar (when false baz) qux)'


### PR DESCRIPTION
Fixes a bug where the argument lists to slang's `concat` operator were being compared in blang comparisons rather than comparing the result of the concatenation.