### PR TITLE
Remove ref to non existing `toplevel-init-file` in doc of `dune top`

### DIFF
--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -9,7 +9,7 @@ let man =
   ; `P
       {|Print a list of toplevel directives for including directories and loading cma files.|}
   ; `P
-      {|The output of $(b,dune toplevel-init-file) should be evaluated in a toplevel
+      {|The output of $(b,dune top) should be evaluated in a toplevel
           to make a library available there.|}
   ; `Blocks Common.help_secs
   ]
@@ -80,7 +80,7 @@ module Module = struct
         "The module's source is evaluated in the toplevel without being sealed by the \
          mli."
     ; `P
-        {|The output of $(b,dune toplevel-init-file) should be evaluated in a toplevel
+        {|The output of $(b,dune top) should be evaluated in a toplevel
           to make the module available there.|}
     ; `Blocks Common.help_secs
     ]


### PR DESCRIPTION
```
$ dune toplevel-init-file
dune: unknown command 'toplevel-init-file', must be one of 'build', 'cache', 'clean', 'coq', 'describe', 'diagnostics', 'exec', 'external-lib-deps', 'fmt', 'format-dune-file', 'help', 'init', 'install', 'installed-libraries', 'internal', 'monitor', 'ocaml', 'ocaml-merlin', 'pkg', 'printenv', 'promote', 'promotion', 'rpc', 'rules', 'runtest', 'show', 'shutdown', 'subst', 'test', 'top', 'uninstall', 'upgrade' or 'utop'.
```