### PR TITLE
refactor: use new names for [Action_builder.run]

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -55,7 +55,9 @@ let run_build_system ~common ~request =
       let toplevel_cell, toplevel =
         Memo.Lazy.Expert.create ~name:"toplevel" (fun () ->
           let open Memo.O in
-          let+ (), (_ : Dep.Fact.t Dep.Map.t) = Action_builder.run request Eager in
+          let+ (), (_ : Dep.Fact.t Dep.Map.t) =
+            Action_builder.evaluate_and_collect_facts request
+          in
           ())
       in
       let* res = run ~toplevel in

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -127,14 +127,14 @@ let term =
               ~coq_lang_version
               coq_module)
         in
-        Action_builder.(run deps_of) Eager
+        Action_builder.evaluate_and_collect_facts deps_of
       in
       (* Get args *)
       let* (args, _) : string list * Dep.Fact.t Dep.Map.t =
         let* args = args in
         let dir = Path.external_ Path.External.initial_cwd in
         let args = Dune_rules.Command.expand ~dir (S args) in
-        Action_builder.run args.build Eager
+        Action_builder.evaluate_and_collect_facts args.build
       in
       let* prog = Super_context.resolve_program_memo sctx ~dir ~loc:None coqtop in
       let prog = Action.Prog.ok_exn prog in

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -373,7 +373,7 @@ module Crawl = struct
       let* acc = macc in
       let deps = deps_of m in
       let+ { Ocaml.Ml_kind.Dict.intf = deps_for_intf; impl = deps_for_impl }, _ =
-        Dune_engine.Action_builder.run deps Eager
+        Dune_engine.Action_builder.evaluate_and_collect_facts deps
       in
       module_ ~obj_dir ~deps_for_intf ~deps_for_impl m :: acc)
   ;;

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -52,7 +52,8 @@ module Cmd_arg = struct
     | Terminal s -> Memo.return s
     | Expandable (sw, _) ->
       let+ path, _ =
-        Action_builder.run (Target.expand_path_from_root root sctx sw) Eager
+        Target.expand_path_from_root root sctx sw
+        |> Action_builder.evaluate_and_collect_facts
       in
       let context = Dune_rules.Super_context.context sctx in
       (* TODO Why are we stringifying this path? *)

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -138,7 +138,7 @@ module Module = struct
                   let graph =
                     Dune_rules.Dep_graph.top_closed_implementations dep_graph [ module_ ]
                   in
-                  let+ modules, _ = Action_builder.run graph Eager in
+                  let+ modules, _ = Action_builder.evaluate_and_collect_facts graph in
                   modules
                 in
                 let cmos =
@@ -166,7 +166,7 @@ module Module = struct
       let pps () =
         let module Merlin = Dune_rules.Merlin in
         let pps = Merlin.pp_config merlin ctx ~expander in
-        let+ pps, _ = Action_builder.run pps Eager in
+        let+ pps, _ = Action_builder.evaluate_and_collect_facts pps in
         let pp = Dune_rules.Module_name.Per_item.get pps module_name in
         match pp with
         | None -> None, None

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -109,7 +109,7 @@ let term =
     in
     Build_system.run_exn (fun () ->
       let open Memo.O in
-      let+ res, _facts = Action_builder.run request Eager in
+      let+ res, _facts = Action_builder.evaluate_and_collect_facts request in
       res)
     >>| function
     | [ (_, env) ] -> Format.printf "%a" (pp ~fields) env

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -247,3 +247,6 @@ let of_memo_join f =
         t.f mode)
   }
 ;;
+
+let evaluate_and_collect_deps t = t.f Lazy
+let evaluate_and_collect_facts t = t.f Eager

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -101,3 +101,12 @@ module Deps_or_facts : sig
   val union : 'a eval_mode -> 'a Dep.Map.t -> 'a Dep.Map.t -> 'a Dep.Map.t
   val union_all : 'a eval_mode -> 'a Dep.Map.t list -> 'a Dep.Map.t
 end
+
+(** Evaluate a [t] and collect the set of its dependencies. This avoids doing the build
+    work required for finding the facts about those dependencies, so you should use this
+    function if you don't need the facts. *)
+val evaluate_and_collect_deps : 'a t -> ('a * Dep.Set.t) Memo.t
+
+(** Evaluate a [t] and collect the set of its dependencies along with facts about them.
+    Note that finding [t]'s facts requires building all of [t]'s dependencies. *)
+val evaluate_and_collect_facts : 'a t -> ('a * Dep.Facts.t) Memo.t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -435,7 +435,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
           >>= (function
            | None -> toolchain `Lock
            | Some toolchain ->
-             let+ toolchain, _ = Action_builder.run toolchain Eager in
+             let+ toolchain, _ = Action_builder.evaluate_and_collect_facts toolchain in
              toolchain, `Default)
       in
       Ocaml_toolchain.register_response_file_support ocaml;

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -74,7 +74,7 @@ let eval ~loc ~expander ~paths:path_spec (deps : Dep_conf.t list) =
   Option.iter sandbox ~f:(fun _ ->
     User_error.raise ~loc [ Pp.text "sandbox settings are not allowed" ]);
   let open Memo.O in
-  let+ paths, _ = Action_builder.run runtime_deps Lazy in
+  let+ paths, _ = Action_builder.evaluate_and_collect_deps runtime_deps in
   (match path_spec with
    | Allow_all -> ()
    | Disallow_external lib_name ->

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -924,7 +924,7 @@ module Action_expander = struct
     let of_closure closure =
       Memo.parallel_map closure ~f:(fun (pkg : Pkg.t) ->
         let cookie = (Pkg_installed.of_paths pkg.paths).cookie in
-        Action_builder.run cookie Eager
+        Action_builder.evaluate_and_collect_facts cookie
         |> Memo.map ~f:(fun ((cookie : Install_cookie.t), _) -> pkg, cookie))
       |> Memo.map ~f:(fun cookies ->
         List.fold_left

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -71,7 +71,7 @@ let module_deps cctx module_ =
     Ocaml.Ml_kind.Dict.get dg Impl
   in
   let action = Dep_graph.deps_of dep_graph module_ in
-  let+ graph, _ = Action_builder.run action Eager in
+  let+ graph, _ = Action_builder.evaluate_and_collect_facts action in
   graph
 ;;
 


### PR DESCRIPTION
Use [Action_builder.evaluate_and_collect_facts] and
[Action_builder.evaluate_and_collect_deps]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0e589580-9a03-4417-a951-fc9dea8b787c -->