### PR TITLE
fix(pkg): Read the main branch correctly even if tags exist

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -275,5 +275,10 @@ We should be able to successfully solve the project with `foo` and `bar`,
 however due to some issues this currently fails:
 
   $ rm -r dune.lock
-  $ dune pkg lock 2> /dev/null
+  $ dune pkg lock
+  Error: Unable to solve dependencies for dune.lock:
+  Can't find all required versions.
+  Selected: baz.dev
+  - bar -> (problem)
+      No known implementations at all
   [1]

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -405,7 +405,8 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
   run (fun () ->
     let cwd = Path.External.cwd () |> Path.external_ in
     let dir = Path.relative cwd "git-repo" in
-    let* git_hash = Rev_store_tests.create_repo_at dir in
+    let other_dir = Path.relative cwd "random-git-repo" in
+    let* git_hash = Rev_store_tests.create_repo_at other_dir in
     let* rev_store = Rev_store.load_or_create ~dir in
     let+ lock_dir =
       let pkg_a =


### PR DESCRIPTION
The issue was that `git remote show -n <handle>` will return tags as branches, so if a repo has tags, it will fail to determine the default branch. This has been possible since #9471.

`git remote show` is problematic in many ways (e.g. it localizes output, thus already having lead to issues, see #9390), so instead this code reads the branch from the fetch `refspec`, which is locale-independent.

This does not fix the issue that submodules are not supported yet, but it will determine the branch correctly on the way to determining submodules and not fail with an unrelated error.