### PR TITLE
refactor: move file contents memoization to [Build_system]

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1164,9 +1164,20 @@ let build_file p =
   ()
 ;;
 
-let read_file p ~f =
+let with_file p ~f =
   let+ () = build_file p in
   f p
+;;
+
+(* CR-someday amokhov: Try running [Io.read_file] in a separate thread. *)
+let read_file =
+  Memo.exec
+    (Memo.create_with_store
+       "Build_system.read_file"
+       ~store:(module Path.Table)
+       ~input:(module Path)
+       ~cutoff:String.equal
+       (fun path -> with_file path ~f:Io.read_file))
 ;;
 
 let state = State.t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -5,8 +5,12 @@ open Import
 (** Build a file. *)
 val build_file : Path.t -> unit Memo.t
 
-(** Build a file and access its contents with [f]. *)
-val read_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.t
+(** Build a file and read its contents with [f]. The execution of [f] is not memoized, so
+    call sites should be careful to avoid duplicating [f]'s work. *)
+val with_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.t
+
+(** Build a file and read its contents. Like [with_file ~f:Io.read_file] but memoized. *)
+val read_file : Path.t -> string Memo.t
 
 (** Return [true] if a file exists or is buildable *)
 val file_exists : Path.t -> bool Memo.t

--- a/src/dune_rules/action_builder.ml
+++ b/src/dune_rules/action_builder.ml
@@ -41,24 +41,14 @@ let path_set ps = deps (Dep.Set.of_files_set ps)
 let dyn_paths paths = dyn_deps (paths >>| fun (x, paths) -> x, Dep.Set.of_files paths)
 let dyn_paths_unit paths = dyn_deps (paths >>| fun paths -> (), Dep.Set.of_files paths)
 
-let contents =
-  let read_file =
-    Memo.exec
-      (Memo.create_with_store
-         "Action_builder_fs.contents"
-         ~store:(module Path.Table)
-         ~input:(module Path)
-         ~cutoff:String.equal
-         (fun p -> Build_system.read_file p ~f:Io.read_file))
-  in
-  fun p ->
-    of_thunk
-      { f =
-          (fun _mode ->
-            let open Memo.O in
-            let+ x = read_file p in
-            x, Dep.Map.empty)
-      }
+let contents p =
+  of_thunk
+    { f =
+        (fun _mode ->
+          let open Memo.O in
+          let+ x = Build_system.read_file p in
+          x, Dep.Map.empty)
+    }
 ;;
 
 let lines_of p = contents p >>| String.split_lines

--- a/src/dune_rules/recursive_include.ml
+++ b/src/dune_rules/recursive_include.ml
@@ -63,7 +63,7 @@ let decode ~base_term ~include_keyword ~include_allowed_in_versions ~non_sexp_be
 
 let load_included_file config path ~context =
   let open Memo.O in
-  let+ contents = Build_system.read_file (Path.build path) ~f:Io.read_file in
+  let+ contents = Build_system.read_file (Path.build path) in
   let ast =
     Dune_lang.Parser.parse_string contents ~mode:Single ~fname:(Path.Build.to_string path)
   in


### PR DESCRIPTION
and remove it from the rules

Continuation of the splitting of https://github.com/ocaml/dune/pull/9132