### PR TITLE
refactor: move more [Action_builder] functions to rules

### DIFF
--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -215,8 +215,6 @@ let memoize ?cutoff name t =
   { f = (fun mode -> force_lazy_or_eager mode lazy_ eager) }
 ;;
 
-let ignore x = map x ~f:ignore
-
 let map2 x y ~f =
   let+ x = x
   and+ y = y in
@@ -230,11 +228,6 @@ let push_stack_frame ~human_readable_description f =
   }
 ;;
 
-let delayed f =
-  let+ () = return () in
-  f ()
-;;
-
 let all_unit (xs : unit t list) =
   { f =
       (fun mode ->
@@ -243,13 +236,6 @@ let all_unit (xs : unit t list) =
         let deps = List.map res ~f:snd in
         (), Deps_or_facts.union_all mode deps)
   }
-;;
-
-type fail = { fail : 'a. unit -> 'a }
-
-let fail x =
-  let+ () = return () in
-  x.fail ()
 ;;
 
 type ('input, 'output) memo =
@@ -293,15 +279,6 @@ let goal t =
         let open Memo.O in
         let+ a, _facts_are_irrelevant_for_goals = t.f mode in
         a, Deps_or_facts.empty mode)
-  }
-;;
-
-let of_memo_join f =
-  { f =
-      (fun mode ->
-        let open Memo.O in
-        let* t = f in
-        t.f mode)
   }
 ;;
 

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -17,7 +17,6 @@ val bind : 'a t -> f:('a -> 'b t) -> 'b t
 val map : 'a t -> f:('a -> 'b) -> 'b t
 val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 val both : 'a t -> 'b t -> ('a * 'b) t
-val ignore : 'a t -> unit t
 val all : 'a t list -> 'a list t
 val all_unit : unit t list -> unit t
 
@@ -27,15 +26,6 @@ val push_stack_frame
   :  human_readable_description:(unit -> User_message.Style.t Pp.t)
   -> (unit -> 'a t)
   -> 'a t
-
-(** Delay a static computation until the description is evaluated *)
-val delayed : (unit -> 'a) -> 'a t
-
-type fail = { fail : 'a. unit -> 'a }
-
-(** Always fail when executed. We pass a function rather than an exception to
-    get a proper backtrace *)
-val fail : fail -> _ t
 
 (** [memoize ?cutoff name t] is an action builder that behaves like [t] except
     that its result is computed only once.
@@ -72,9 +62,6 @@ val goal : 'a t -> 'a t
     fact need [Command.run], and that (ii) [Process.run] only reads the declared
     build rule dependencies. *)
 val of_memo : 'a Memo.t -> 'a t
-
-(** Like [of_memo] but collapses the two levels of [t]. *)
-val of_memo_join : 'a t Memo.t -> 'a t
 
 (** {1 Execution} *)
 

--- a/src/dune_rules/action_builder.ml
+++ b/src/dune_rules/action_builder.ml
@@ -3,6 +3,20 @@ include Dune_engine.Action_builder
 open O
 module With_targets = With_targets
 
+type fail = { fail : 'a. unit -> 'a }
+
+let fail x =
+  let+ () = return () in
+  x.fail ()
+;;
+
+let delayed f =
+  let+ () = return () in
+  f ()
+;;
+
+let of_memo_join f = of_memo f >>= Fun.id
+
 let dyn_memo_deps deps =
   let* deps, a = of_memo deps in
   let+ () = Build_system.record_deps deps in
@@ -121,6 +135,7 @@ let paths_matching : type a. File_selector.t -> a eval_mode -> (Filename_set.t *
     filenames, Dep.Set.singleton (Dep.file_selector g)
 ;;
 
+let ignore x = map x ~f:ignore
 let paths_matching ~loc:_ g = of_thunk { f = (fun mode -> paths_matching g mode) }
 let paths_matching_unit ~loc g = ignore (paths_matching ~loc g)
 let env_var s = deps (Dep.Set.singleton (Dep.env s))

--- a/src/dune_rules/action_builder.mli
+++ b/src/dune_rules/action_builder.mli
@@ -4,6 +4,20 @@ include
   module type of Dune_engine.Action_builder
   with type 'a t = 'a Dune_engine.Action_builder.t
 
+(** Like [of_memo] but collapses the two levels of [t]. *)
+val of_memo_join : 'a t Memo.t -> 'a t
+
+(** Delay a static computation until the description is evaluated *)
+val delayed : (unit -> 'a) -> 'a t
+
+val ignore : 'a t -> unit t
+
+type fail = { fail : 'a. unit -> 'a }
+
+(** Always fail when executed. We pass a function rather than an exception to
+    get a proper backtrace *)
+val fail : fail -> _ t
+
 module With_targets : module type of With_targets with type 'a t = 'a With_targets.t
 
 (** [path p] records [p] as a file that is read by the action produced by the


### PR DESCRIPTION
Continuation of the splitting of https://github.com/ocaml/dune/pull/9132

This PR includes more trivial definitions that can be moved to the rules without much modification