### PR TITLE
pkg: include lockdirs with no context

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -160,13 +160,11 @@ module Lock_dirs_arg = struct
 
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
     let workspace_lock_dirs =
-      List.filter_map workspace.contexts ~f:(function
-        | Workspace.Context.Default { lock_dir; base = _ } ->
-          let lock_dir_path =
-            Option.value lock_dir ~default:Dune_pkg.Lock_dir.default_path
-          in
-          Some lock_dir_path
-        | Opam _ -> None)
+      Lock_dir.default_path
+      :: List.map workspace.lock_dirs ~f:(fun (lock_dir : Workspace.Lock_dir.t) ->
+        lock_dir.path)
+      |> Path.Source.Set.of_list
+      |> Path.Source.Set.to_list
     in
     match t with
     | All -> workspace_lock_dirs

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -37,13 +37,13 @@ Here is the output of solving for multiple contexts:
   >  (name x)
   >  (depends A B C))
   > EOF
-  Solution for foo.lock:
+  Solution for dune.lock:
   - A.1.2.0
   - B.2.1+rc1
   - C.81.0.4044.138
   - D.0.4.0.beta1
   - E.3.0~alpha1
-  Solution for dune.lock:
+  Solution for foo.lock:
   - A.1.2.0
   - B.2.1+rc1
   - C.81.0.4044.138

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -53,7 +53,11 @@ Create a workspace config that defines separate build contexts for macos and lin
 
 Now the os-specific dependencies are included on their respective systems.
   $ dune pkg lock --all
+  Solution for dune.linux.lock:
+  (no dependencies to lock)
+  Solution for dune.lock:
+  (no dependencies to lock)
   Solution for dune.macos.lock:
   (no dependencies to lock)
-  Solution for dune.linux.lock:
+  Solution for dune.no-os.lock:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -2,6 +2,9 @@ Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
+  >  (path dune.lock)
+  >  (unset_solver_vars arch os-distribution os os-family os-version sys-ocaml-version))
+  > (lock_dir
   >  (path dune.linux.lock)
   >  (solver_env
   >   (os linux))
@@ -38,6 +41,10 @@ Add some build contexts with different environments
   Solver environment for lock directory change-opam-version.lock:
   - opam-version = 42
   - with-doc = false
+  Solver environment for lock directory dune.linux.lock:
+  - opam-version = 2.2.0~alpha-vendored
+  - os = linux
+  - with-doc = false
   Solver environment for lock directory dune.linux.no-doc.lock:
   - arch = x86_64
   - opam-version = 2.2.0~alpha-vendored
@@ -47,7 +54,6 @@ Add some build contexts with different environments
   - os-version = 22.04
   - sys-ocaml-version = 5.0
   - with-doc = false
-  Solver environment for lock directory dune.linux.lock:
+  Solver environment for lock directory dune.lock:
   - opam-version = 2.2.0~alpha-vendored
-  - os = linux
   - with-doc = false

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -33,10 +33,10 @@
   >  (name baz)
   >  (depends bar))
   > EOF
-  Solution for dune.workspace.lock:
+  Solution for dune.lock:
   - bar.0.0.1
   - foo.0.0.1
-  Solution for dune.lock:
+  Solution for dune.workspace.lock:
   - bar.0.0.1
   - foo.0.0.1
 
@@ -48,8 +48,8 @@ Default behaviour is to check the default lock file.
 
 All lock file can be check by passing --all
   $ outdated --all
-  - dune.workspace.lock is up to date.
   - dune.lock is up to date.
+  - dune.workspace.lock is up to date.
 
 Specific lock files can be given as positional arguments.
   $ outdated dune.lock
@@ -60,8 +60,8 @@ Invalid lock files give an error
   Error: The following directories are not lock directories in this workspace:
   - invalid_lock
   This workspace contains the following lock directories:
-  - dune.workspace.lock
   - dune.lock
+  - dune.workspace.lock
   [1]
 
 Multiple lock files can be given.
@@ -78,9 +78,9 @@ Adding a new version of the bar package to the repository.
 Dune should report the new version of bar as available.
 
   $ outdated --all
-  - 1/2 packages in dune.workspace.lock are outdated.
-    - bar 0.0.1 < 0.0.2
   - 1/2 packages in dune.lock are outdated.
+    - bar 0.0.1 < 0.0.2
+  - 1/2 packages in dune.workspace.lock are outdated.
     - bar 0.0.1 < 0.0.2
 
 Now we add a new version of the foo package to the repository.
@@ -88,10 +88,10 @@ Dune should only report the bar package as it is an immediate dependency.
 
   $ mkpkg foo 0.0.2 
   $ outdated --all
-  - 2/2 packages in dune.workspace.lock are outdated.
+  - 2/2 packages in dune.lock are outdated.
     Showing immediate dependencies, use --transitive to see them all.
     - bar 0.0.1 < 0.0.2
-  - 2/2 packages in dune.lock are outdated.
+  - 2/2 packages in dune.workspace.lock are outdated.
     Showing immediate dependencies, use --transitive to see them all.
     - bar 0.0.1 < 0.0.2
 
@@ -130,16 +130,16 @@ When printing both successes and failures, any errors should appear afterwards.
 Similarly for multiple lock files.
 
   $ outdated --transitive --all
-  - 1/2 packages in dune.workspace.lock are outdated.
-    - foo 0.0.1 < 0.0.2
   - 1/2 packages in dune.lock are outdated.
     - foo 0.0.1 < 0.0.2
+  - 1/2 packages in dune.workspace.lock are outdated.
+    - foo 0.0.1 < 0.0.2
   Error: Some packages could not be found.
-  When checking dune.workspace.lock, the following packages:
+  When checking dune.lock, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
-  When checking dune.lock, the following packages:
+  When checking dune.workspace.lock, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -162,15 +162,15 @@ appear irrespective of being a transitive dependency.
 With multiple lock files, the errors should also be printed for each of them.
 
   $ outdated --all 
-  - dune.workspace.lock is up to date.
   - dune.lock is up to date.
+  - dune.workspace.lock is up to date.
   Error: Some packages could not be found.
-  When checking dune.workspace.lock, the following packages:
+  When checking dune.lock, the following packages:
   - bar
   - foo
   were not found in the following opam repositories:
   - None
-  When checking dune.lock, the following packages:
+  When checking dune.workspace.lock, the following packages:
   - bar
   - foo
   were not found in the following opam repositories:

--- a/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
@@ -1,0 +1,31 @@
+  $ . ./helpers.sh
+
+  $ mkrepo
+
+  $ mkpkg a <<EOF
+  > EOF
+
+  $ mkpkg b <<EOF
+  > EOF
+
+  $  cat > dune-workspace <<EOF
+  > (lang dune 3.12)
+  > (lock_dir
+  >  (path foo.lock)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (source "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.12)
+  > (package
+  >  (name foo)
+  >  (depends a b))
+  > EOF
+
+  $ dune pkg lock foo.lock
+  Solution for foo.lock:
+  - a.0.0.1
+  - b.0.0.1


### PR DESCRIPTION
Previously dune acted as though lockdirs associated with no context did not exist. This change allows such lockdirs to be solved and includes them in other information about lockdirs.