### PR TITLE
bench: update version of monorepo benchmark

### DIFF
--- a/bench/monorepo/Makefile
+++ b/bench/monorepo/Makefile
@@ -15,6 +15,7 @@ DUNIVERSE_MOUNT_POINT = /home/opam/bench-dir/current-bench-data/duniverse
 duniverse:
 	sudo cp -a $(DUNIVERSE_MOUNT_POINT) .
 	sudo chown -hR $(USER_GROUP) duniverse
+	./apply-patches.sh || true # TODO(steve): remove the "|| true" once the monorepo is reassembled without patches applied
 
 # Run the dune benchmark runner. To reduce noise, short benchmarks are run 5
 # times each, and the max and min results of each benchmark are discarded. The

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -136,7 +136,7 @@ RUN opam switch create prepare 4.14.1
 RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-08-23.0
+ENV MONOREPO_BENCHMARK_TAG=2023-12-25.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
   tar xf ocaml-monorepo-benchmark.tar.gz && \
   mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark && \


### PR DESCRIPTION
This adds patches to some packages which contain syntax errors that went undetected until recently.

More info is here: https://github.com/ocaml-dune/ocaml-monorepo-benchmark/pull/1.

cc @ElectreAAS 