### PR TITLE
fix(boot): make bootstrap reproducible by default

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -11,6 +11,7 @@ let _verbose, keep_generated_files, _debug =
   let verbose = ref false in
   let keep_generated_files = ref false in
   let debug = ref false in
+  let single_command = ref false in
   Arg.parse
     [ "-j", Arg.Int ignore, "JOBS Concurrency"
     ; "--verbose", Arg.Set verbose, " Set the display mode"
@@ -19,6 +20,7 @@ let _verbose, keep_generated_files, _debug =
     ; ( "--force-byte-compilation"
       , Arg.Unit ignore
       , " Force bytecode compilation even if ocamlopt is available" )
+    ; "--use-single-command", Arg.Set single_command, " Build using a single command"
     ]
     anon
     "Usage: ocaml bootstrap.ml <options>\nOptions are:";

--- a/doc/changes/boot-reproducibility.md
+++ b/doc/changes/boot-reproducibility.md
@@ -1,0 +1,3 @@
+- Make bootstrap process reproducible independenly of `-j`.
+  This can make the build slightly slower when Dune is built with `-j 1`.
+  (#9563, fixes #9507, @emillon)


### PR DESCRIPTION
Fixes #9507

In `duneboot.ml`, there are 2 strategies to build `dune.exe`:
- separate compilation (build all modules and link them together in several commands)
- single command compilation (pass all modules to the compiler driver)

Separate compilation can be executed in parallel when `-j` is set accordingly, which speeds up the build.
But when only one job can be executed at once (`-j 1`), it is faster to use a single command.

So, we would switch to single command build when `-j 1` was passed. However, this is surprising because it produces a different binary depending on the number of parallel jobs (see #9507). So this disables this optimization by default; it can be enabled by hand by passing `--use-single-command`.

(NB: this does not apply to Windows, which always uses single command compilation)
