### PR TITLE
Remove warning 30 from the standard set.

### DIFF
--- a/doc/changes/9568.md
+++ b/doc/changes/9568.md
@@ -1,0 +1,2 @@
+- Remove warning 30 from default set for projects where dune lang is at least
+  3.13 (#9568, @gasche)

--- a/test/blackbox-tests/test-cases/default-ocaml-flags-3-13.t
+++ b/test/blackbox-tests/test-cases/default-ocaml-flags-3-13.t
@@ -1,0 +1,25 @@
+  $ cat >dune <<EOF
+  > (library
+  >  (modes byte)
+  >  (name foo))
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > type a = { a : int }
+  > and b = { a : int ; b : bool }
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.12)
+  > EOF
+  $ dune build foo.cma
+  File "foo.ml", line 2, characters 10-19:
+  2 | and b = { a : int ; b : bool }
+                ^^^^^^^^^
+  Error (warning 30 [duplicate-definitions]): the label a is defined in both types a and b.
+  [1]
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > EOF
+  $ dune build foo.cma


### PR DESCRIPTION
Warning 30 (same constructor/label name used in two mutually-recursive declarations) is an annoying warning that makes no sense since we introduced type-based disambiguation of fields and constructors. It was disabled by default in OCaml 4.10

  https://github.com/ocaml/ocaml/pull/9046

and there is no reason to keep it in Dune.

Note: I wasn't sure how warning changes are supposed to be versioned (or not). 3eff8102d299bc6f408736ad641b0392957a4ac1 implements versioning for the new warnings 67, 69, but then c967d8a4880732f2f7cba39d4f283154c5ef914e earlier removed a bunch of warning without any specific versioning code. I went with the simplest approach of the two, but happy to take feedback. (This could benefit from a comment in the source besides `(* New warnings should be introduced here *)`.