### PR TITLE
doc: have the 'OCaml flags' documentation point to complete examples

### DIFF
--- a/doc/concepts/ocaml-flags.rst
+++ b/doc/concepts/ocaml-flags.rst
@@ -20,3 +20,8 @@ follows:
 .. code:: dune
 
     (flags (:standard <my options>))
+
+For complete usage examples, see
+:ref:`Setting the OCaml Compilation Flags Globally`,
+:ref:`How to Make Warnings Non-Fatal` and
+:ref:`How to Turn Specific Errors into Warnings`.


### PR DESCRIPTION
I had forgotten how to disable a warning with Dune, unfortunately the "OCaml flags" documentation does not actually contain any reusable code snippet doing this. In fact, the information is in the doc, hidden in the "Quickstart" and the "FAQ" pages.

This commit adds references from the "OCaml flags" reference section to those usage examples.