### PR TITLE
Optimise Dep.Fact.Files.t

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -130,7 +130,7 @@ module type Rec = sig
   val build_alias : Alias.t -> Dep.Fact.Files.t Memo.t
 
   val build_file : Path.t -> Digest.t Memo.t
-  val build_dir : Path.t -> (Digest.t * Digest.t Targets.Produced.t) Memo.t
+  val build_dir : Path.t -> Digest.t Targets.Produced.t Memo.t
   val build_dep : Dep.t -> Dep.Fact.t Memo.t
   val build_deps : Dep.Set.t -> Dep.Facts.t Memo.t
   val execute_rule : Rule.t -> rule_execution_result Memo.t
@@ -227,7 +227,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 20
+  let rule_digest_version = 21
 
   let compute_rule_digest
     (rule : Rule.t)
@@ -681,6 +681,10 @@ end = struct
       execute_action_generic_stage2_impl
   ;;
 
+  (* The current version of the action digest scheme. We should increment it when
+     making any changes to the scheme, to avoid collisions. *)
+  let action_digest_version = 1
+
   let execute_action_generic
     ~observing_facts
     (act : Rule.Anonymous_action.t)
@@ -737,7 +741,8 @@ end = struct
         |> Env.Map.to_list
       in
       Digest.generic
-        ( env
+        ( action_digest_version
+        , env
         , Dep.Set.digest deps
         , Action.for_shell action
         , List.map locks ~f:Path.to_string
@@ -768,6 +773,10 @@ end = struct
     Io.read_file (Path.build target)
   ;;
 
+  (* CR-soon amokhov: Instead of wrapping the result into a variant, [build_file_impl]
+     could always return [targets : Digest.t Targets.Produced.t], and the latter could
+     provide a way to conveniently check if a specific [path] is a file or a directory,
+     as well as extract its digest when needed. *)
   type target_kind =
     | File_target
     | Dir_target of
@@ -800,6 +809,13 @@ end = struct
       (match Targets.Produced.find targets path with
        | Some digest -> digest, File_target
        | None ->
+         (* CR-soon amokhov: Here we expect [path] to be a directory target. It seems odd
+            to compute its digest here by calling to [Cached_digest.build_file]. Shouldn't
+            we do that in [execute_rule], like we do for file targets?
+
+            rleshchinskiy: Is this digest ever used? [build_dir] discards it and do we
+            (or should we) ever use [build_file] to build directories? Perhaps this could
+            be split in two memo tables, one for files and one for directories. *)
          (match Cached_digest.build_file ~allow_dirs:true path with
           | Ok digest -> digest, Dir_target { targets }
           (* Must be a directory target *)
@@ -883,9 +899,9 @@ end = struct
             let+ digest = build_file path in
             path, digest)
         in
-        Dep.Fact.Files.make ~files:(Path.Map.of_list_exn files) ~dirs:Path.Map.empty
-      | Build_under_directory_target _ ->
-        let* digest, path_map = build_dir dir in
+        Dep.Fact.Files.make ~files:(Path.Map.of_list_exn files)
+      | Build_under_directory_target { directory_target_ancestor = _ } ->
+        let+ path_map = build_dir dir in
         let files =
           let dir = Path.as_in_build_dir_exn dir in
           match Targets.Produced.find_dir path_map dir with
@@ -896,8 +912,7 @@ end = struct
             |> Path.Map.of_list_exn
           | None -> Path.Map.empty
         in
-        let dirs = Path.Map.singleton dir digest in
-        Memo.return (Dep.Fact.Files.make ~files ~dirs)
+        Dep.Fact.Files.make ~files
     ;;
 
     let eval_impl g =
@@ -925,7 +940,7 @@ end = struct
         |> Filename.Set.of_list
         |> Filename_set.create ~dir
         |> Memo.return
-      | Build_under_directory_target _ ->
+      | Build_under_directory_target { directory_target_ancestor = _ } ->
         (* To evaluate a glob in a generated directory, we have no choice but to build the
            whole directory, so we might as well build the predicate. *)
         let+ facts = Pred.build g in
@@ -976,9 +991,9 @@ end = struct
   let build_file path = Memo.exec (Lazy.force build_file_memo) path >>| fst
 
   let build_dir path =
-    let+ digest, kind = Memo.exec (Lazy.force build_file_memo) path in
+    let+ (_ : Digest.t), kind = Memo.exec (Lazy.force build_file_memo) path in
     match kind with
-    | Dir_target { targets } -> digest, targets
+    | Dir_target { targets } -> targets
     | File_target ->
       Code_error.raise "build_dir called on a file target" [ "path", Path.to_dyn path ]
   ;;
@@ -1041,7 +1056,7 @@ let file_exists fn =
     Memo.return
       (Path.Build.Map.mem rules_here.by_file_targets (Path.as_in_build_dir_exn fn))
   | Build_under_directory_target { directory_target_ancestor } ->
-    let+ _digest, path_map = build_dir (Path.build directory_target_ancestor) in
+    let+ path_map = build_dir (Path.build directory_target_ancestor) in
     Targets.Produced.mem path_map (Path.as_in_build_dir_exn fn)
 ;;
 
@@ -1056,7 +1071,7 @@ let files_of ~dir =
     |> Filename_set.create ~dir
     |> Memo.return
   | Build_under_directory_target { directory_target_ancestor } ->
-    let+ _digest, path_map = build_dir (Path.build directory_target_ancestor) in
+    let+ path_map = build_dir (Path.build directory_target_ancestor) in
     let filenames =
       let dir = Path.as_in_build_dir_exn dir in
       match Targets.Produced.find_dir path_map dir with

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -89,7 +89,6 @@ module Fact = struct
     let is_empty t = Path.Set.is_empty t.files
     let compare a b = Digest.compare a.digest b.digest
     let equal a b = Digest.equal a.digest b.digest
-    let paths t = t.files
 
     let filenames_exn t ~expected_parent =
       let filenames =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -288,8 +288,9 @@ module Facts = struct
       match (fact : Fact.t) with
       | Nothing -> acc
       | File (path, _digest) -> Path.Set.add acc path
-      | File_selector { file_selector_digest = _; facts } | Alias facts ->
-        if expand_aliases then Path.Set.union acc facts.files else acc)
+      | File_selector { file_selector_digest = _; facts } ->
+        Path.Set.union acc facts.files
+      | Alias facts -> if expand_aliases then Path.Set.union acc facts.files else acc)
   ;;
 
   let group_paths_as_fact_files ts =

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -44,20 +44,17 @@ module Fact : sig
     (** A group of files for which we cache the digest of the whole group. *)
     type t
 
-    val make : files:Digest.t Path.Map.t -> dirs:Digest.t Path.Map.t -> t
+    val make : files:Digest.t Path.Map.t -> t
     val to_dyn : t -> Dyn.t
     val equal : t -> t -> bool
     val compare : t -> t -> Ordering.t
 
     (** Return all file paths in this file group. *)
-    val paths : t -> Digest.t Path.Map.t
+    val paths : t -> Path.Set.t
 
     (** Like [paths] but asserts that all paths are relative to the [expected_parent] and
         returns their basenames instead. *)
     val filenames_exn : t -> expected_parent:Path.t -> Filename_set.t
-
-    (** Create a new [t] from a list of [t] and a list of files. *)
-    val group : t list -> Digest.t Path.Map.t -> t
   end
 
   (** [digest] is assumed to be the [digest_paths expansion]. *)
@@ -99,10 +96,8 @@ module Facts : sig
   val union_all : t list -> t
   val record_facts : Set.t -> f:(dep -> Fact.t Memo.t) -> t Memo.t
 
-  (** Return all file paths, expanding aliases. *)
-  val paths : t -> Digest.t Path.Map.t
-
-  val paths_without_expanding_aliases : t -> Digest.t Path.Map.t
+  (** Return all file paths, expanding aliases if [expand_aliases = true]. *)
+  val paths : t -> expand_aliases:bool -> Path.Set.t
 
   (** Create a single [Fact.Files.t] from all the paths contained in a list of
       fact maps. Does so while preserving as much sharing as possible with the

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -47,10 +47,6 @@ module Fact : sig
     val make : files:Digest.t Path.Map.t -> t
     val to_dyn : t -> Dyn.t
     val equal : t -> t -> bool
-    val compare : t -> t -> Ordering.t
-
-    (** Return all file paths in this file group. *)
-    val paths : t -> Path.Set.t
 
     (** Like [paths] but asserts that all paths are relative to the [expected_parent] and
         returns their basenames instead. *)

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -44,7 +44,10 @@ module Fact : sig
     (** A group of files for which we cache the digest of the whole group. *)
     type t
 
-    val make : files:Digest.t Path.Map.t -> t
+    (** Record an observed path-digest mapping. If a [dir] is specified, record it as
+        existing, so that it can be created in the sandbox when the mapping is empty. *)
+    val create : ?dir:Path.Build.t -> Digest.t Path.Map.t -> t
+
     val to_dyn : t -> Dyn.t
     val equal : t -> t -> bool
 

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -12,6 +12,10 @@ type t =
 let dir t = t.dir
 let only_generated_files t = t.only_generated_files
 
+let digest_exn { dir; predicate; only_generated_files } =
+  Digest.generic (dir, Predicate_lang.Glob.digest_exn predicate, only_generated_files)
+;;
+
 let compare { dir; predicate; only_generated_files } t =
   let open Ordering.O in
   let= () = Path.compare dir t.dir in

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -26,3 +26,6 @@ val to_dyn : t -> Dyn.t
 
 val test : t -> Path.t -> bool
 val test_basename : t -> basename:string -> bool
+
+(** Raises on non-serialisable globs, just like most other functions above. *)
+val digest_exn : t -> Digest.t

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -145,7 +145,7 @@ let link_function ~(mode : Sandbox_mode.some) =
 
 let link_deps t ~mode ~deps =
   let link = Staged.unstage (link_function ~mode) in
-  Path.Map.iteri deps ~f:(fun path (_ : Digest.t) ->
+  Path.Set.iter deps ~f:(fun path ->
     match Path.as_in_build_dir path with
     | None ->
       (* This can actually raise if we try to sandbox the "copy from source
@@ -199,11 +199,7 @@ let create ~mode ~dune_stats ~rule_loc ~deps ~rule_dir ~rule_digest ~expand_alia
       create_dirs t ~deps ~rule_dir;
       (* CR-someday amokhov: Note that this doesn't link dynamic dependencies, so
          targets produced dynamically will be unavailable. *)
-      let deps =
-        if expand_aliases
-        then Dep.Facts.paths deps
-        else Dep.Facts.paths_without_expanding_aliases deps
-      in
+      let deps = Dep.Facts.paths deps ~expand_aliases in
       link_deps t ~mode ~deps)
   in
   Dune_stats.finish event;

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1046,7 +1046,7 @@ let package_deps (pkg : Package.t) files =
         let* res = Dune_engine.Build_system.execute_rule rule in
         loop_files
           rules_seen
-          (Dep.Facts.paths ~expand_aliases:false res.deps
+          (Dep.Facts.paths ~expand_aliases:true res.deps
            |> Path.Set.to_list
            |> (* if this file isn't in the build dir, it doesn't belong to any
                  package and it doesn't have dependencies that do *)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1046,8 +1046,8 @@ let package_deps (pkg : Package.t) files =
         let* res = Dune_engine.Build_system.execute_rule rule in
         loop_files
           rules_seen
-          (Dep.Facts.paths res.deps
-           |> Path.Map.keys
+          (Dep.Facts.paths ~expand_aliases:false res.deps
+           |> Path.Set.to_list
            |> (* if this file isn't in the build dir, it doesn't belong to any
                  package and it doesn't have dependencies that do *)
            List.filter_map ~f:Path.as_in_build_dir))

--- a/src/predicate_lang/dune
+++ b/src/predicate_lang/dune
@@ -1,3 +1,3 @@
 (library
  (name predicate_lang)
- (libraries stdune dune_glob dune_sexp dyn))
+ (libraries stdune dune_glob dune_digest dune_sexp dyn))

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -47,4 +47,7 @@ module Glob : sig
   val hash : t -> int
   val decode : t Dune_sexp.Decoder.t
   val encode : t -> Dune_sexp.t
+
+  (** Raises on non-serialisable globs, just like most other functions above. *)
+  val digest_exn : t -> Dune_digest.t
 end

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [790009feab9e691c98ad47625fd7047a] (_build/default/source): not found in cache
+  Shared cache miss [336d1a8283f1097557c047e6a3f440e4] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [3aa5494f9cb89c79b5f41e9c6123a666] (_build/default/target1): not found in cache
+  Shared cache miss [cf6246e80dbc827c134803daf7b6dc45] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [336d1a8283f1097557c047e6a3f440e4] (_build/default/source): not found in cache
+  Shared cache miss [13c77218604dc994750d09a29ee8afbc] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [cf6246e80dbc827c134803daf7b6dc45] (_build/default/target1): not found in cache
+  Shared cache miss [20702b179e0171aac33d40d83f666fc2] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [1b443618b766306bf5c4846b19349675] (_build/default/source): not found in cache
+  Shared cache miss [731ad27774db51b36ac167bd02a2d64e] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [44158ca8448d6bb0366c050c668a168c] (_build/default/target1): not found in cache
+  Shared cache miss [9eb3ddc684318ff4f7ac759ca0c2ed46] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [731ad27774db51b36ac167bd02a2d64e] (_build/default/source): not found in cache
+  Shared cache miss [3ad1761950da90e34e52b4c065db1504] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [9eb3ddc684318ff4f7ac759ca0c2ed46] (_build/default/target1): not found in cache
+  Shared cache miss [b5096eeda3d7be4e9a631c563907399e] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [016cbdcbd1b45ba2125d3738c441dd87]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
+  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
+  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
+  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./57/572f0d07f15fafa10217f0f78d2d4f39:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./5a/5a512ee6d64f5d7a29d7863269566506:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./4e/4e86d96c474b2bf21f00736e524add20:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./da/dadf48eff6efc0cc0eced61607e4c673:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./4e/4e86d96c474b2bf21f00736e524add20:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./da/dadf48eff6efc0cc0eced61607e4c673:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./c2/c2ad4d4223dc4899614b496fe575ab08:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./d9/d9253f5d1695e3bee65f4e6e63b4dc5e:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-61c2a19beb7c9447302b9348604599d6
+  _build/.actions/default/blah-98b715ceb840414fcdd2546357b09ca0
 
 And we check that it isn't copied in the source tree:
 


### PR DESCRIPTION
Importing some internal optimisations (already reviewed, tested and benchmarked).

This PR optimises `Dep.Fact.Files.t` in two ways:
* Stop storing per-file digests: they are not needed -- the aggregate `t.digest` is sufficient.
* Stop storing `dirs`: it makes no sense to record the facts about the whole directory target when depending only on a subset of files inside via a `File_selector`.
* Stop using `File_selector.to_dyn` when computing digests of file selectors.

I also import a few comments with future suggestions, turn some tuples into records (for clarity), and add `action_digest_version` to force rerunning the actions after the digesting scheme changes (not sure why it was missing).