### PR TITLE
Delete Build_system.build_pred

### DIFF
--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -128,8 +128,8 @@ module Module = struct
                     ~dir:(Path.build (Obj_dir.byte_dir private_obj_dir))
                     (Dune_lang.Glob.of_string_exn Loc.none "*.cmi")
                 in
-                let+ (_ : Dep.Fact.Files.t) = Build_system.build_pred glob in
-                ()
+                let* files = Build_system.eval_pred glob in
+                Memo.parallel_iter (Filename_set.to_list files) ~f:Build_system.build_file
               in
               let cmos () =
                 let obj_dir = Compilation_context.obj_dir cctx in

--- a/otherlibs/dune-action-plugin/test/depends-on-its-target-by-read-dir/run.t
+++ b/otherlibs/dune-action-plugin/test/depends-on-its-target-by-read-dir/run.t
@@ -12,10 +12,10 @@
 
   $ cp ./bin/foo.exe ./
 
-  $ dune build some_file 2>&1 | awk '/Internal error/,/unable to serialize/'
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("unable to serialize exception",
+  $ dune build some_file
+  Error: Dependency cycle between:
+     _build/default/some_file
+  [1]
 
 ^ This is not great. There is no actual dependency cycle, dune is just
 interpreting glob dependency too coarsely (it builds all files instead

--- a/otherlibs/stdune/src/filename_set.ml
+++ b/otherlibs/stdune/src/filename_set.ml
@@ -11,6 +11,7 @@ let equal t { dir; filenames } =
 let dir { dir; filenames = _ } = dir
 let filenames { dir = _; filenames } = filenames
 let empty ~dir = { dir; filenames = String.Set.empty }
+let is_empty { dir = _; filenames } = Filename.Set.is_empty filenames
 
 let create ?filter ~dir filenames =
   match filter with

--- a/otherlibs/stdune/src/filename_set.mli
+++ b/otherlibs/stdune/src/filename_set.mli
@@ -13,6 +13,7 @@ val dir : t -> Path.t
 val filenames : t -> Filename.Set.t
 
 val empty : dir:Path.t -> t
+val is_empty : t -> bool
 
 (* CR-soon amokhov: Decouple [create] from [filter]. *)
 val create : ?filter:(basename:string -> bool) -> dir:Path.t -> Filename.Set.t -> t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -22,19 +22,15 @@ val build_deps : Dep.Set.t -> Dep.Facts.t Memo.t
 val record_deps : Dep.Set.t -> unit Action_builder.t
 
 (** [eval_pred glob] returns the set of filenames in [File_selector.dir glob] that matches
-    [File_selector.predicate glob], including both sources and generated files. *)
+    [File_selector.predicate glob], including both sources and generated files.
+
+    This function does the minimum amount of work necessary to produce the result, and may
+    do some building (e.g., if [glob] points inside a directory target). To force building
+    the files you need, use [build_file]. *)
 val eval_pred : File_selector.t -> Filename_set.t Memo.t
 
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
 val files_of : dir:Path.t -> Filename_set.t Memo.t
-
-(* CR-someday amokhov: Make [build_pred] return something like [Dep.Fact.Filename_set.t]
-   which is anchored to the [File_selector]'s directory. *)
-
-(** Like [eval_pred] but also builds the resulting set of files. This function
-    doesn't have [eval_pred]'s limitation about directory targets and takes them
-    into account. *)
-val build_pred : File_selector.t -> Dep.Fact.Files.t Memo.t
 
 (** Execute an action. The execution is cached. *)
 val execute_action : observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> unit Memo.t

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -44,16 +44,13 @@ module Fact : sig
     (** A group of files for which we cache the digest of the whole group. *)
     type t
 
-    (** Record an observed path-digest mapping. If a [dir] is specified, record it as
-        existing, so that it can be created in the sandbox when the mapping is empty. *)
-    val create : ?dir:Path.Build.t -> Digest.t Path.Map.t -> t
+    (** Record a file-digest mapping for a given [Filename_set.t]. If the set is empty,
+        record the parent directory as existing, so that it can be created in the sandbox
+        even when the mapping is empty. *)
+    val create : Filename_set.t -> build_file:(Path.t -> Digest.t Memo.t) -> t Memo.t
 
     val to_dyn : t -> Dyn.t
     val equal : t -> t -> bool
-
-    (** Like [paths] but asserts that all paths are relative to the [expected_parent] and
-        returns their basenames instead. *)
-    val filenames_exn : t -> expected_parent:Path.t -> Filename_set.t
   end
 
   (** [digest] is assumed to be the [digest_paths expansion]. *)


### PR DESCRIPTION
The functions `build_pred` and `eval_pred` partially duplicate each other. We don't really need `build_pred`, since it's decomposable into `eval_pred` followed by building the files via `build_file`, so let's get rid of it.

Reviewed, tested and benchmarked internally.