### PR TITLE
Allow expansion in `(modules)` field

### DIFF
--- a/doc/changes/9578.md
+++ b/doc/changes/9578.md
@@ -1,0 +1,4 @@
+- It is now possible to use special forms such as `(:include)` and variables
+  `%{read-lines:}` in `(modules)` and similar fields. Note that the dependencies
+  introduced in this way (ie the files being read) must live in a different
+  directory than the stanza making use of them. (#9578, @nojb)

--- a/doc/stanzas/library.rst
+++ b/doc/stanzas/library.rst
@@ -54,7 +54,11 @@ order to declare a multi-directory library, you need to use the
   <modules>)`` field. ``<modules>`` uses the
   :doc:`reference/ordered-set-language`, where elements are module names and
   don't need to start with an uppercase letter. For instance, to exclude module
-  ``Foo``, use ``(modules (:standard \ foo))``
+  ``Foo``, use ``(modules (:standard \ foo))``.  Starting in Dune 3.13, one can
+  also use special forms ``(:include <file>)`` and variables such as
+  ``%{read-lines:<file>}`` in this field to customize the list of modules using
+  Dune rules. The dependencies introduced in this way *must live in a different
+  directory that the stanza making use of them*.
 
 - ``(libraries <library-dependencies>)`` specifies the library's dependencies.
   See :doc:`reference/library-dependencies` for more details.

--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -238,6 +238,7 @@ module Unexpanded = struct
   type ast = (String_with_vars.t, Ast.unexpanded) Ast.t
   type t = ast generic
 
+  let loc t = t.loc
   let equal x y = equal_generic (Ast.equal String_with_vars.equal_no_loc) x y
 
   let decode : t Decoder.t =

--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -411,7 +411,13 @@ module Unexpanded = struct
             let* sexp =
               let* path = expand_template fn ~mode:Single in
               let path = Value.to_path path ?error_loc:(Some loc) ~dir in
-              Action_builder.read_sexp path
+              Action_builder.push_stack_frame
+                ~human_readable_description:(fun () ->
+                  Pp.textf
+                    "(:include %s) at %s"
+                    (Path.to_string path)
+                    (Loc.to_file_colon_line loc))
+                (fun () -> Action_builder.read_sexp path)
             in
             let t = Decoder.parse decode context sexp in
             expand t.ast ~allow_include:false

--- a/src/dune_lang/ordered_set_lang.mli
+++ b/src/dune_lang/ordered_set_lang.mli
@@ -44,6 +44,7 @@ module Unexpanded : sig
   type expanded := t
   type t
 
+  val loc : t -> Loc.t option
   val equal : t -> t -> bool
 
   include Dune_sexp.Conv.S with type t := t

--- a/src/dune_lang/ordered_set_lang.mli
+++ b/src/dune_lang/ordered_set_lang.mli
@@ -53,7 +53,19 @@ module Unexpanded : sig
   val standard : t
   val of_strings : pos:string * int * int * int -> string list -> t
   val include_single : context:Univ_map.t -> pos:string * int * int * int -> string -> t
-  val field : ?check:unit Decoder.t -> string -> t Decoder.fields_parser
+
+  val field
+    :  ?check:unit Decoder.t
+    -> ?since_expanded:Syntax.Version.t
+    -> string
+    -> t Decoder.fields_parser
+
+  val field_o
+    :  ?check:unit Decoder.t
+    -> ?since_expanded:Syntax.Version.t
+    -> string
+    -> t option Decoder.fields_parser
+
   val has_special_forms : t -> bool
   val has_standard : t -> bool
 

--- a/src/dune_lang/ordered_set_lang_intf.ml
+++ b/src/dune_lang/ordered_set_lang_intf.ml
@@ -46,6 +46,11 @@ module type Action_builder = sig
   val all : 'a t list -> 'a list t
   val read_sexp : Path.t -> Dune_sexp.Ast.t t
 
+  val push_stack_frame
+    :  human_readable_description:(unit -> User_message.Style.t Pp.t)
+    -> (unit -> 'a t)
+    -> 'a t
+
   module O : sig
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
     val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -77,3 +77,40 @@ let create =
     in
     { context; local_bins }
 ;;
+
+module Objs = struct
+  type t =
+    { libraries : Lib_info.local Lib_name.Map.t
+    ; modules : (Path.Build.t Obj_dir.t * Module.t) Module_name.Map.t
+    }
+
+  let empty = { libraries = Lib_name.Map.empty; modules = Module_name.Map.empty }
+  let lookup_module { modules; libraries = _ } = Module_name.Map.find modules
+  let lookup_library { libraries; modules = _ } = Lib_name.Map.find libraries
+
+  let make ~dir ~lib_config ~libs ~exes =
+    let+ libraries =
+      Memo.List.map libs ~f:(fun ((lib : Dune_file.Library.t), _, _, _) ->
+        let* lib_config = lib_config in
+        let name = Lib_name.of_local lib.name in
+        let+ info = Dune_file.Library.to_lib_info lib ~dir ~lib_config in
+        name, info)
+      >>| Lib_name.Map.of_list_exn
+    in
+    let modules =
+      let by_name modules obj_dir =
+        Modules.fold_user_available ~init:modules ~f:(fun m modules ->
+          Module_name.Map.add_exn modules (Module.name m) (obj_dir, m))
+      in
+      let init =
+        List.fold_left
+          exes
+          ~init:Module_name.Map.empty
+          ~f:(fun modules (_, _, m, obj_dir) -> by_name modules obj_dir m)
+      in
+      List.fold_left libs ~init ~f:(fun modules (_, _, m, obj_dir) ->
+        by_name modules obj_dir m)
+    in
+    { libraries; modules }
+  ;;
+end

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -20,3 +20,19 @@ val binary : t -> ?hint:string -> loc:Loc.t option -> string -> Action.Prog.t Me
 val binary_available : t -> string -> bool Memo.t
 val add_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list -> t
 val create : Context.t -> local_bins:Path.Build.Set.t Memo.Lazy.t -> t
+
+module Objs : sig
+  type t
+
+  val empty : t
+
+  val make
+    :  dir:Path.Build.t
+    -> lib_config:Lib_config.t Memo.t
+    -> libs:(Dune_file.Library.t * _ * Modules.t * Path.Build.t Obj_dir.t) list
+    -> exes:(_ * _ * Modules.t * Path.Build.t Obj_dir.t) list
+    -> t Memo.t
+
+  val lookup_module : t -> Module_name.t -> (Path.Build.t Obj_dir.t * Module.t) option
+  val lookup_library : t -> Lib_name.t -> Lib_info.local option
+end

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -278,8 +278,10 @@ end = struct
               let lookup_vlib = lookup_vlib sctx ~current_dir:dir in
               let loc = loc_of_dune_file st_dir in
               let libs = Scope.DB.find_by_dir dir >>| Scope.libs in
+              let* expander = Super_context.expander sctx ~dir in
               Ml_sources.make
                 d.stanzas
+                ~expander
                 ~dir
                 ~libs
                 ~project:d.project
@@ -360,8 +362,10 @@ end = struct
               let lookup_vlib = lookup_vlib sctx ~current_dir:dir in
               let libs = Scope.DB.find_by_dir dir >>| Scope.libs in
               let project = dune_file.project in
+              let* expander = Super_context.expander sctx ~dir in
               Ml_sources.make
                 dune_file.stanzas
+                ~expander
                 ~dir
                 ~project
                 ~libs

--- a/src/dune_rules/dir_contents.mli
+++ b/src/dune_rules/dir_contents.mli
@@ -24,7 +24,7 @@ val foreign_sources : t -> Foreign_sources.t Memo.t
 val ocaml : t -> Ml_sources.t Memo.t
 
 (** Artifacts defined in this directory *)
-val artifacts : t -> Ml_sources.Artifacts.t Memo.t
+val artifacts : t -> Artifacts.Objs.t Memo.t
 
 (** All mld files attached to this documentation stanza *)
 val mlds : t -> Dune_file.Documentation.t -> Path.Build.t list Memo.t

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -665,10 +665,10 @@ module Library = struct
          ()
        and+ sub_systems = Sub_system_info.record_parser
        and+ virtual_modules =
-         field_o
+         Ordered_set_lang.Unexpanded.field_o
+           ~check:(Dune_lang.Syntax.since Stanza.syntax (1, 7))
+           ~since_expanded:Stanza_common.Modules_settings.since_expanded
            "virtual_modules"
-           (Dune_lang.Syntax.since Stanza.syntax (1, 7)
-            >>> Ordered_set_lang.Unexpanded.decode)
        and+ implements =
          field_o
            "implements"
@@ -678,10 +678,10 @@ module Library = struct
            "default_implementation"
            (Dune_lang.Syntax.since Stanza.syntax (2, 6) >>> located Lib_name.decode)
        and+ private_modules =
-         field_o
+         Ordered_set_lang.Unexpanded.field_o
+           ~check:(Dune_lang.Syntax.since Stanza.syntax (1, 2))
+           ~since_expanded:Stanza_common.Modules_settings.since_expanded
            "private_modules"
-           (Dune_lang.Syntax.since Stanza.syntax (1, 2)
-            >>> Ordered_set_lang.Unexpanded.decode)
        and+ stdlib =
          field_o
            "stdlib"

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -601,10 +601,10 @@ module Library = struct
     ; project : Dune_project.t
     ; sub_systems : Sub_system_info.t Sub_system_name.Map.t
     ; dune_version : Dune_lang.Syntax.Version.t
-    ; virtual_modules : Ordered_set_lang.t option
+    ; virtual_modules : Ordered_set_lang.Unexpanded.t option
     ; implements : (Loc.t * Lib_name.t) option
     ; default_implementation : (Loc.t * Lib_name.t) option
-    ; private_modules : Ordered_set_lang.t option
+    ; private_modules : Ordered_set_lang.Unexpanded.t option
     ; stdlib : Ocaml_stdlib.t option
     ; special_builtin_support : (Loc.t * Lib_info.Special_builtin_support.t) option
     ; enabled_if : Blang.t
@@ -667,7 +667,8 @@ module Library = struct
        and+ virtual_modules =
          field_o
            "virtual_modules"
-           (Dune_lang.Syntax.since Stanza.syntax (1, 7) >>> Ordered_set_lang.decode)
+           (Dune_lang.Syntax.since Stanza.syntax (1, 7)
+            >>> Ordered_set_lang.Unexpanded.decode)
        and+ implements =
          field_o
            "implements"
@@ -679,7 +680,8 @@ module Library = struct
        and+ private_modules =
          field_o
            "private_modules"
-           (Dune_lang.Syntax.since Stanza.syntax (1, 2) >>> Ordered_set_lang.decode)
+           (Dune_lang.Syntax.since Stanza.syntax (1, 2)
+            >>> Ordered_set_lang.Unexpanded.decode)
        and+ stdlib =
          field_o
            "stdlib"
@@ -766,7 +768,7 @@ module Library = struct
        Option.both virtual_modules implements
        |> Option.iter ~f:(fun (virtual_modules, (_, impl)) ->
          User_error.raise
-           ~loc:(Ordered_set_lang.loc virtual_modules |> Option.value_exn)
+           ~loc:(Ordered_set_lang.Unexpanded.loc virtual_modules |> Option.value_exn)
            [ Pp.textf
                "A library cannot be both virtual and implement %s"
                (Lib_name.to_string impl)

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -160,10 +160,10 @@ module Library : sig
     ; project : Dune_project.t
     ; sub_systems : Sub_system_info.t Sub_system_name.Map.t
     ; dune_version : Dune_lang.Syntax.Version.t
-    ; virtual_modules : Ordered_set_lang.t option
+    ; virtual_modules : Ordered_set_lang.Unexpanded.t option
     ; implements : (Loc.t * Lib_name.t) option
     ; default_implementation : (Loc.t * Lib_name.t) option
-    ; private_modules : Ordered_set_lang.t option
+    ; private_modules : Ordered_set_lang.Unexpanded.t option
     ; stdlib : Ocaml_stdlib.t option
     ; special_builtin_support : (Loc.t * Lib_info.Special_builtin_support.t) option
     ; enabled_if : Blang.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -57,7 +57,7 @@ let programs ~modules ~(exes : Executables.t) =
           [ Pp.textf "Module %S has no implementation." (Module_name.to_string mod_name) ]
     | None ->
       let msg =
-        match Ordered_set_lang.loc exes.buildable.modules.modules with
+        match Ordered_set_lang.Unexpanded.loc exes.buildable.modules.modules with
         | None -> Pp.textf "Module %S doesn't exist." (Module_name.to_string mod_name)
         | Some _ ->
           Pp.textf

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -55,7 +55,7 @@ type t =
   ; scope : Scope.t
   ; scope_host : Scope.t
   ; context : Context.t
-  ; lookup_artifacts : (dir:Path.Build.t -> Ml_sources.Artifacts.t Memo.t) option
+  ; lookup_artifacts : (dir:Path.Build.t -> Artifacts.Objs.t Memo.t) option
   ; expanding_what : Expanding_what.t
   }
 
@@ -165,7 +165,7 @@ let expand_artifact ~source t a s =
        let name =
          Module_name.of_string_allow_invalid (Dune_lang.Template.Pform.loc source, name)
        in
-       (match Ml_sources.Artifacts.lookup_module artifacts name with
+       (match Artifacts.Objs.lookup_module artifacts name with
         | None ->
           does_not_exist
             ~loc:(Dune_lang.Template.Pform.loc source)
@@ -177,7 +177,7 @@ let expand_artifact ~source t a s =
            | Some path -> dep (Path.build path)))
      | Lib mode ->
        let name = Lib_name.parse_string_exn (Dune_lang.Template.Pform.loc source, name) in
-       (match Ml_sources.Artifacts.lookup_library artifacts name with
+       (match Artifacts.Objs.lookup_library artifacts name with
         | None ->
           does_not_exist
             ~loc:(Dune_lang.Template.Pform.loc source)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -909,6 +909,16 @@ let expand_and_eval_set t set ~standard =
   Ordered_set_lang.eval set ~standard ~eq:String.equal ~parse:(fun ~loc:_ s -> s)
 ;;
 
+module Unordered (Key : Ordered_set_lang.Key) = struct
+  module Unordered = Ordered_set_lang.Unordered (Key)
+
+  let expand_and_eval t set ~parse ~key ~standard =
+    let dir = Path.build (dir t) in
+    let+ set = expand_ordered_set_lang set ~dir ~f:(expand_pform t) in
+    Unordered.eval_loc set ~parse ~key ~standard
+  ;;
+end
+
 let eval_blang t blang =
   Blang_expand.eval ~f:(No_deps.expand_pform t) ~dir:(Path.build t.dir) blang
 ;;

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -912,10 +912,18 @@ let expand_and_eval_set t set ~standard =
 module Unordered (Key : Ordered_set_lang.Key) = struct
   module Unordered = Ordered_set_lang.Unordered (Key)
 
-  let expand_and_eval t set ~parse ~key ~standard =
+  let expand_and_eval t set ~ctx ~parse ~key ~standard =
     let dir = Path.build (dir t) in
     let+ set = expand_ordered_set_lang set ~dir ~f:(expand_pform t) in
-    Unordered.eval_loc set ~parse ~key ~standard
+    let ctx = ref ctx in
+    let parse ~loc x =
+      let x, ctx' = parse ~loc ~ctx:!ctx x in
+      ctx := ctx';
+      x
+    in
+    let r = Unordered.eval_loc set ~parse ~key ~standard in
+    let ctx = !ctx in
+    r, ctx
   ;;
 end
 

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -909,24 +909,6 @@ let expand_and_eval_set t set ~standard =
   Ordered_set_lang.eval set ~standard ~eq:String.equal ~parse:(fun ~loc:_ s -> s)
 ;;
 
-module Unordered (Key : Ordered_set_lang.Key) = struct
-  module Unordered = Ordered_set_lang.Unordered (Key)
-
-  let expand_and_eval t set ~ctx ~parse ~key ~standard =
-    let dir = Path.build (dir t) in
-    let+ set = expand_ordered_set_lang set ~dir ~f:(expand_pform t) in
-    let ctx = ref ctx in
-    let parse ~loc x =
-      let x, ctx' = parse ~loc ~ctx:!ctx x in
-      ctx := ctx';
-      x
-    in
-    let r = Unordered.eval_loc set ~parse ~key ~standard in
-    let ctx = !ctx in
-    r, ctx
-  ;;
-end
-
 let eval_blang t blang =
   Blang_expand.eval ~f:(No_deps.expand_pform t) ~dir:(Path.build t.dir) blang
 ;;

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -107,6 +107,12 @@ module With_reduced_var_set : sig
   val eval_blang : context:Context.t -> dir:Path.Build.t -> Blang.t -> bool Memo.t
 end
 
+val expand_ordered_set_lang
+  :  Ordered_set_lang.Unexpanded.t
+  -> dir:Path.t
+  -> f:Value.t list Action_builder.t String_with_vars.expander
+  -> Ordered_set_lang.t Action_builder.t
+
 (** Expand forms of the form (:standard \ foo bar). Expansion is only possible
     inside [Action_builder.t] because such forms may contain the form (:include
     ..) which needs files to be built. *)
@@ -115,17 +121,6 @@ val expand_and_eval_set
   -> Ordered_set_lang.Unexpanded.t
   -> standard:string list Action_builder.t
   -> string list Action_builder.t
-
-module Unordered (Key : Ordered_set_lang.Key) : sig
-  val expand_and_eval
-    :  t
-    -> Ordered_set_lang.Unexpanded.t
-    -> ctx:'ctx
-    -> parse:(loc:Loc.t -> ctx:'ctx -> string -> 'a * 'ctx)
-    -> key:('a -> Key.t)
-    -> standard:(Loc.t * 'a) Key.Map.t
-    -> ((Loc.t * 'a) Key.Map.t * 'ctx) Action_builder.t
-end
 
 val eval_blang : t -> Blang.t -> bool Memo.t
 val map_exe : t -> Path.t -> Path.t

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -116,6 +116,16 @@ val expand_and_eval_set
   -> standard:string list Action_builder.t
   -> string list Action_builder.t
 
+module Unordered (Key : Ordered_set_lang.Key) : sig
+  val expand_and_eval
+    :  t
+    -> Ordered_set_lang.Unexpanded.t
+    -> parse:(loc:Loc.t -> string -> 'a)
+    -> key:('a -> Key.t)
+    -> standard:(Loc.t * 'a) Key.Map.t
+    -> (Loc.t * 'a) Key.Map.t Action_builder.t
+end
+
 val eval_blang : t -> Blang.t -> bool Memo.t
 val map_exe : t -> Path.t -> Path.t
 val artifacts : t -> Artifacts.t

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -120,10 +120,11 @@ module Unordered (Key : Ordered_set_lang.Key) : sig
   val expand_and_eval
     :  t
     -> Ordered_set_lang.Unexpanded.t
-    -> parse:(loc:Loc.t -> string -> 'a)
+    -> ctx:'ctx
+    -> parse:(loc:Loc.t -> ctx:'ctx -> string -> 'a * 'ctx)
     -> key:('a -> Key.t)
     -> standard:(Loc.t * 'a) Key.Map.t
-    -> (Loc.t * 'a) Key.Map.t Action_builder.t
+    -> ((Loc.t * 'a) Key.Map.t * 'ctx) Action_builder.t
 end
 
 val eval_blang : t -> Blang.t -> bool Memo.t

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -21,11 +21,7 @@ val set_local_env_var : t -> var:string -> value:string Action_builder.t -> t
 val set_dir : t -> dir:Path.Build.t -> t
 val set_scope : t -> scope:Scope.t -> scope_host:Scope.t -> t
 val set_artifacts : t -> artifacts_host:Artifacts.t -> t
-
-val set_lookup_ml_sources
-  :  t
-  -> f:(dir:Path.Build.t -> Ml_sources.Artifacts.t Memo.t)
-  -> t
+val set_lookup_ml_sources : t -> f:(dir:Path.Build.t -> Artifacts.Objs.t Memo.t) -> t
 
 module Expanding_what : sig
   type t =

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -469,6 +469,9 @@ let make
   ~include_subdirs:(loc_include_subdirs, (include_subdirs : Dune_file.Include_subdirs.t))
   ~dirs
   =
+  Memo.push_stack_frame ~human_readable_description:(fun () ->
+    Pp.textf "Finding source files in directory %s" (Path.Build.to_string dir))
+  @@ fun () ->
   let+ modules_of_stanzas =
     let modules =
       let dialects = Dune_project.dialects project in

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -469,9 +469,6 @@ let make
   ~include_subdirs:(loc_include_subdirs, (include_subdirs : Dune_file.Include_subdirs.t))
   ~dirs
   =
-  Memo.push_stack_frame ~human_readable_description:(fun () ->
-    Pp.textf "Finding source files in directory %s" (Path.Build.to_string dir))
-  @@ fun () ->
   let+ modules_of_stanzas =
     let modules =
       let dialects = Dune_project.dialects project in

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -47,6 +47,7 @@ val include_subdirs : t -> Dune_file.Include_subdirs.t
 
 val make
   :  Stanza.t list
+  -> expander:Expander.t
   -> dir:Path.Build.t
   -> libs:Lib.DB.t Memo.t
   -> project:Dune_project.t

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -15,16 +15,9 @@ module Origin : sig
   val to_dyn : t -> Dyn.t
 end
 
-module Artifacts : sig
-  type t
-
-  val lookup_module : t -> Module_name.t -> (Path.Build.t Obj_dir.t * Module.t) option
-  val lookup_library : t -> Lib_name.t -> Lib_info.local option
-end
-
 type t
 
-val artifacts : t -> Artifacts.t Memo.t
+val artifacts : t -> Artifacts.Objs.t Memo.t
 
 type for_ =
   | Library of Lib_name.t (** Library name *)

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -404,6 +404,9 @@ let eval
   (settings : Stanza_common.Modules_settings.t)
   =
   let open Memo.O in
+  Memo.push_stack_frame ~human_readable_description:(fun () ->
+    Pp.textf "Evaluating modules field in directory %s" (Path.Build.to_string src_dir))
+  @@ fun () ->
   let* modules0 =
     eval0 ~expander ~loc:stanza_loc ~all_modules ~standard:all_modules settings.modules
   in

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -405,7 +405,7 @@ let eval
   =
   let open Memo.O in
   Memo.push_stack_frame ~human_readable_description:(fun () ->
-    Pp.textf "Evaluating modules field in directory %s" (Path.Build.to_string src_dir))
+    Pp.textf "(modules) field at %s" (Loc.to_file_colon_line stanza_loc))
   @@ fun () ->
   let* modules0 =
     eval0 ~expander ~loc:stanza_loc ~all_modules ~standard:all_modules settings.modules

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -4,7 +4,7 @@
 open Import
 
 module Virtual : sig
-  type t = { virtual_modules : Ordered_set_lang.t }
+  type t = { virtual_modules : Ordered_set_lang.Unexpanded.t }
 end
 
 module Implementation : sig
@@ -20,9 +20,10 @@ type kind =
   | Exe_or_normal_lib
 
 val eval
-  :  modules:Module.Source.t Module_trie.t
+  :  expander:Expander.t
+  -> modules:Module.Source.t Module_trie.t
   -> stanza_loc:Loc.t
-  -> private_modules:Ordered_set_lang.t
+  -> private_modules:Ordered_set_lang.Unexpanded.t
   -> kind:kind
   -> src_dir:Path.Build.t
   -> version:Dune_lang.Syntax.Version.t

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -202,15 +202,15 @@ let instrumentation =
 module Modules_settings = struct
   type t =
     { root_module : (Loc.t * Module_name.t) option
-    ; modules_without_implementation : Ordered_set_lang.t
-    ; modules : Ordered_set_lang.t
+    ; modules_without_implementation : Ordered_set_lang.Unexpanded.t
+    ; modules : Ordered_set_lang.Unexpanded.t
     }
 
   let decode =
     let+ root_module = field_o "root_module" Module_name.decode_loc
     and+ modules_without_implementation =
-      Ordered_set_lang.field "modules_without_implementation"
-    and+ modules = Ordered_set_lang.field "modules" in
+      Ordered_set_lang.Unexpanded.field "modules_without_implementation"
+    and+ modules = Ordered_set_lang.Unexpanded.field "modules" in
     { root_module; modules; modules_without_implementation }
   ;;
 end

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -206,11 +206,13 @@ module Modules_settings = struct
     ; modules : Ordered_set_lang.Unexpanded.t
     }
 
+  let since_expanded = 3, 13
+
   let decode =
     let+ root_module = field_o "root_module" Module_name.decode_loc
     and+ modules_without_implementation =
-      Ordered_set_lang.Unexpanded.field "modules_without_implementation"
-    and+ modules = Ordered_set_lang.Unexpanded.field "modules" in
+      Ordered_set_lang.Unexpanded.field ~since_expanded "modules_without_implementation"
+    and+ modules = Ordered_set_lang.Unexpanded.field ~since_expanded "modules" in
     { root_module; modules; modules_without_implementation }
   ;;
 end

--- a/src/dune_rules/stanza_common.mli
+++ b/src/dune_rules/stanza_common.mli
@@ -26,5 +26,6 @@ module Modules_settings : sig
     ; modules : Ordered_set_lang.Unexpanded.t
     }
 
+  val since_expanded : Syntax.Version.t
   val decode : t Dune_lang.Decoder.fields_parser
 end

--- a/src/dune_rules/stanza_common.mli
+++ b/src/dune_rules/stanza_common.mli
@@ -22,8 +22,8 @@ val instrumentation
 module Modules_settings : sig
   type t =
     { root_module : (Loc.t * Module_name.t) option
-    ; modules_without_implementation : Ordered_set_lang.t
-    ; modules : Ordered_set_lang.t
+    ; modules_without_implementation : Ordered_set_lang.Unexpanded.t
+    ; modules : Ordered_set_lang.Unexpanded.t
     }
 
   val decode : t Dune_lang.Decoder.fields_parser

--- a/test/blackbox-tests/test-cases/modules-expansion.t
+++ b/test/blackbox-tests/test-cases/modules-expansion.t
@@ -151,10 +151,9 @@ Interaction with `(include_subdirs)` when the dependencies are in the subtree:
 
   $ dune build --display short
   Error: Dependency cycle between:
-     Finding source files in directory _build/default
+     (modules) field at dune:2
   -> %{read-lines:gen/lst} at dune:4
-  -> Evaluating modules field in directory _build/default
-  -> Finding source files in directory _build/default
+  -> (modules) field at dune:2
   [1]
 
 Let's move the gen subdirectory out of the hierarchy:
@@ -197,9 +196,9 @@ appears. We need to handle this cycle gracefully and report it to the user.
 
   $ dune exec ./mod.exe
   Error: Dependency cycle between:
-     Finding source files in directory _build/default
-  -> Evaluating modules field in directory _build/default
-  -> Finding source files in directory _build/default
+     (modules) field at dune:2
+  -> (:include _build/default/lst) at dune:2
+  -> (modules) field at dune:2
   [1]
 
 Let's do one example with a generated source file:

--- a/test/blackbox-tests/test-cases/modules-expansion.t
+++ b/test/blackbox-tests/test-cases/modules-expansion.t
@@ -1,0 +1,177 @@
+Here we test the ability of (modules) to be contain dynamic forms such as
+`(:include)` and variables such as `"%{read-lines:}"`.
+
+Begin by setting up a project. Note that the feature is not currently versioned;
+this should be done before merging.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+
+As we will see later in the test, it is imperative that build dependencies
+needed to evaluate the `(modules)` field not live in the same directory as the
+containing stanza. We will put them in a subdirectory:
+
+  $ mkdir -p gen
+
+We define a rule that creates a file (in sexp syntax, to be passed to
+`(:include)`) containing a single name:
+
+  $ cat >gen/dune <<EOF
+  > (rule (with-stdout-to lst (echo mod)))
+  > EOF
+
+The unit `mod.ml` is present in the working tree:
+
+  $ cat >mod.ml <<EOF
+  > let () = print_endline "Hello, Mod!"
+  > EOF
+
+We declare a `executable` where the list of modules is read from the (generated)
+file `gen/lst`:
+
+  $ cat >dune <<EOF
+  > (executable (name mod) (modules (:include gen/lst)))
+  > EOF
+
+Let's check that it works:
+
+  $ dune exec ./mod.exe
+  Hello, Mod!
+
+Let's check that error messages owning to non-existent modules continue to work:
+
+  $ cat >dune <<EOF
+  > (executable (name does_not_exist) (modules (:include gen/lst)))
+  > EOF
+
+  $ dune exec ./does_not_exist.exe
+  File "dune", line 1, characters 18-32:
+  1 | (executable (name does_not_exist) (modules (:include gen/lst)))
+                        ^^^^^^^^^^^^^^
+  Error: The name "Does_not_exist" is not listed in the (modules) field of this
+  stanza.
+  [1]
+
+  $ cat >dune <<EOF
+  > (executable (name mod) (modules does_not_exist (:include gen/lst)))
+  > EOF
+
+  $ dune exec ./mod.exe
+  File "dune", line 1, characters 32-46:
+  1 | (executable (name mod) (modules does_not_exist (:include gen/lst)))
+                                      ^^^^^^^^^^^^^^
+  Error: Module Does_not_exist doesn't exist.
+  [1]
+
+  $ mv mod.ml mod2.ml
+  $ cat >dune <<EOF
+  > (executable (name mod) (modules (:include gen/lst)))
+  > EOF
+
+Locations are accurate even for generated files:
+
+  $ dune exec ./mod.exe
+  File "_build/default/gen/lst", line 1, characters 0-3:
+  1 | mod
+      ^^^
+  Error: Module Mod doesn't exist.
+  [1]
+
+  $ mv mod2.ml mod.ml
+
+Let's do some examples using libraries:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name lib)
+  >  (modules (:include gen/lst)))
+  > EOF
+
+  $ dune build --display short
+        ocamlc .lib.objs/byte/lib.{cmi,cmo,cmt}
+      ocamldep .lib.objs/lib__Mod.impl.d
+      ocamlopt .lib.objs/native/lib.{cmx,o}
+        ocamlc .lib.objs/byte/lib__Mod.{cmi,cmo,cmt}
+      ocamlopt .lib.objs/native/lib__Mod.{cmx,o}
+        ocamlc lib.cma
+      ocamlopt lib.{a,cmxa}
+      ocamlopt lib.cmxs
+
+We can also use special forms such as `%{read-lines:}`:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name lib)
+  >  (modules %{read-lines:gen/lst}))
+  > EOF
+
+  $ cat >gen/dune <<EOF
+  > (rule (with-stdout-to lst (echo "mod\nmod2\n")))
+  > EOF
+
+  $ touch mod2.ml
+
+  $ dune build --display short
+        ocamlc .lib.objs/byte/lib.{cmi,cmo,cmt}
+      ocamldep .lib.objs/lib__Mod2.impl.d
+      ocamlopt .lib.objs/native/lib.{cmx,o}
+        ocamlc .lib.objs/byte/lib__Mod.{cmi,cmo,cmt}
+        ocamlc .lib.objs/byte/lib__Mod2.{cmi,cmo,cmt}
+      ocamlopt .lib.objs/native/lib__Mod.{cmx,o}
+      ocamlopt .lib.objs/native/lib__Mod2.{cmx,o}
+        ocamlc lib.cma
+      ocamlopt lib.{a,cmxa}
+      ocamlopt lib.cmxs
+
+Next, we illustrate the issue mentioned above: the build dependencies must not
+live in the same directory as the containing stanza, otherwise a cycle
+appears. We need to handle this cycle gracefully and report it to the user.
+
+  $ cat >dune <<EOF
+  > (rule (with-stdout-to lst (echo "mod")))
+  > (executable (name mod) (modules (:include lst)))
+  > EOF
+
+  $ dune exec ./mod.exe
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("internal dependency cycle",
+    { frames =
+        [ ("build-file", In_build_dir "default/lst")
+        ; ("<unnamed>", ())
+        ; ("<unnamed>", ())
+        ; ("load-dir", In_build_dir "default")
+        ]
+    })
+  Raised at Memo.Exec.exec_dep_node.(fun) in file "src/memo/memo.ml", line
+    1289, characters 29-62
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
+  [1]

--- a/test/blackbox-tests/test-cases/modules-expansion.t
+++ b/test/blackbox-tests/test-cases/modules-expansion.t
@@ -1,8 +1,7 @@
 Here we test the ability of (modules) to be contain dynamic forms such as
 `(:include)` and variables such as `"%{read-lines:}"`.
 
-Begin by setting up a project. Note that the feature is not currently versioned;
-this should be done before merging.
+Begin by setting up a project and check the versioning guards.
 
   $ cat >dune-project <<EOF
   > (lang dune 3.11)
@@ -34,7 +33,24 @@ file `gen/lst`:
   > (executable (name mod) (modules (:include gen/lst)))
   > EOF
 
-Let's check that it works:
+Let's check that it fails in the current version of Dune:
+
+  $ dune exec ./mod.exe
+  File "dune", line 1, characters 23-51:
+  1 | (executable (name mod) (modules (:include gen/lst)))
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: the ability to specify non-constant module lists is only available
+  since version 3.13 of the dune language. Please update your dune-project file
+  to have (lang dune 3.13).
+  [1]
+
+Update the version...
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > EOF
+
+... and it works!
 
   $ dune exec ./mod.exe
   Hello, Mod!

--- a/test/blackbox-tests/test-cases/modules-expansion.t
+++ b/test/blackbox-tests/test-cases/modules-expansion.t
@@ -134,44 +134,8 @@ appears. We need to handle this cycle gracefully and report it to the user.
   > EOF
 
   $ dune exec ./mod.exe
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("internal dependency cycle",
-    { frames =
-        [ ("build-file", In_build_dir "default/lst")
-        ; ("<unnamed>", ())
-        ; ("<unnamed>", ())
-        ; ("load-dir", In_build_dir "default")
-        ]
-    })
-  Raised at Memo.Exec.exec_dep_node.(fun) in file "src/memo/memo.ml", line
-    1289, characters 29-62
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
+  Error: Dependency cycle between:
+     Finding source files in directory _build/default
+  -> Evaluating modules field in directory _build/default
+  -> Finding source files in directory _build/default
   [1]


### PR DESCRIPTION
Currently `(modules)` has to be an "ordered set" consisting of literal string elements. This PR proposes to allow expansion to take place in this field, allowing in particular the use of `(:include)` and `%{read-lines:}` to specify lists of modules that depend on other artifacts built by Dune. Apart from representing a real improvement on the expresiveness of the build language, I have a feeling this change would also cover a considerable portion of use-cases of the OCaml syntax.

I suggest to start by looking at the test to understand what is being done in the PR.

The first commit is preparatory: it moves a submodule to avoid a dependency cycle in the second commit. The second commit contains the meat of the change:

- Replace `Ordered_set_lang.t` by `Ordered_set_lang.Unexpanded.t` for all `(modules)` fields (eg `(private_modules)`, `(modules_without_implementation)`, etc).
- Introduce an "expand" step in the function `Modules_field_evaluator.eval` (which now takes and `Expander.t` as argument). This means that we enter the `Action_builder.t` monad in this code; however, immediately after expansion we exit back to `Memo` by calling `Action_builder.evaluate_and_collect_facts`.
- Currently the `fake_modules` logic in `Modules_field_evaluator` is disabled; I didn't know what this was for and the existing implementation used side-effects that wouldn't work well in the `Memo` monad.
- Note that it is not possible to have the build-time dependencies of the `(modules)` field in the same directory as the containing stanza (see the test); however, the error (a dependency cycle in `Memo`) is not currently caught and Dune brutally crashes. How do I handle this error gracefully?

Suggestions for improvements or if I missed anything are warmly welcome! Thanks.