### PR TITLE
refactor(pkg): Use OpamUrl.t of strings for urls

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -503,7 +503,7 @@ let opam_package_to_lock_file_pkg
     OpamFile.OPAM.extra_sources opam_file
     |> List.map ~f:(fun (opam_basename, opam_url) ->
       ( Path.Local.of_string (OpamFilename.Base.to_string opam_basename)
-      , let url = Loc.none, OpamUrl.to_string (OpamFile.URL.url opam_url) in
+      , let url = Loc.none, OpamFile.URL.url opam_url in
         let checksum =
           match OpamFile.URL.checksum opam_url with
           | [] -> None
@@ -521,10 +521,7 @@ let opam_package_to_lock_file_pkg
           |> List.hd_opt
           |> Option.map ~f:(fun hash -> Loc.none, Checksum.of_opam_hash hash)
         in
-        let url =
-          let url = OpamFile.URL.url url in
-          Loc.none, OpamUrl.to_string url
-        in
+        let url = Loc.none, OpamFile.URL.url url in
         Source.Fetch { url; checksum })
     in
     { Lock_dir.Pkg_info.name = Package_name.of_opam_package_name name

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -1,7 +1,7 @@
 open Import
 
 type fetch =
-  { url : Loc.t * string
+  { url : Loc.t * OpamUrl.t
   ; checksum : (Loc.t * Checksum.t) option
   }
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1439,7 +1439,7 @@ module Fetch = struct
   module Spec = struct
     type ('path, 'target) t =
       { target_dir : 'target
-      ; url : Loc.t * string
+      ; url : Loc.t * OpamUrl.t
       ; checksum : (Loc.t * Checksum.t) option
       }
 
@@ -1458,7 +1458,9 @@ module Fetch = struct
       List
         ([ Dune_lang.atom_or_quoted_string name
          ; target target_dir
-         ; encode_loc Dune_lang.atom_or_quoted_string url
+         ; encode_loc
+             (fun url -> Dune_lang.atom_or_quoted_string (OpamUrl.to_string url))
+             url
          ]
          @
          match checksum with
@@ -1475,11 +1477,7 @@ module Fetch = struct
       let* () = Fiber.return () in
       let* res =
         let checksum = Option.map checksum ~f:snd in
-        Dune_pkg.Fetch.fetch
-          ~unpack:true
-          ~checksum
-          ~target:(Path.build target_dir)
-          (OpamUrl.of_string url)
+        Dune_pkg.Fetch.fetch ~unpack:true ~checksum ~target:(Path.build target_dir) url
       in
       match res with
       | Ok () -> Fiber.return ()

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -258,7 +258,10 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; extra_sources =
                   [ Path.Local.of_string "one", extra_source
                   ; ( Path.Local.of_string "two"
-                    , Fetch { url = Loc.none, "randomurl"; checksum = None } )
+                    , Fetch
+                        { url = Loc.none, OpamUrl.of_string "file://randomurl"
+                        ; checksum = None
+                        } )
                   ]
               }
           ; exported_env =
@@ -282,7 +285,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               ; source =
                   Some
                     (Fetch
-                       { url = Loc.none, "https://github.com/foo/b"
+                       { url = Loc.none, OpamUrl.of_string "https://github.com/foo/b"
                        ; checksum =
                            Some
                              ( Loc.none
@@ -304,7 +307,10 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                 dev = false
               ; source =
                   Some
-                    (Fetch { url = Loc.none, "https://github.com/foo/c"; checksum = None })
+                    (Fetch
+                       { url = Loc.none, OpamUrl.of_string "https://github.com/foo/c"
+                       ; checksum = None
+                       })
               }
           } )
       in
@@ -344,7 +350,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; source = Some External_copy External "/tmp/a"
                   ; extra_sources =
                       [ ("one", External_copy External "/tmp/a")
-                      ; ("two", Fetch "randomurl", None)
+                      ; ("two", Fetch "file://randomurl", None)
                       ]
                   }
               ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3569be0f-5a2d-4a72-9571-12986edb2be8 -->