### PR TITLE
feature(coq): extra_sources field for coq.theory stanza

### DIFF
--- a/src/dune_rules/coq/coq_stanza.ml
+++ b/src/dune_rules/coq/coq_stanza.ml
@@ -13,6 +13,7 @@ let coq_syntax =
     ; (0, 6), `Since (3, 5)
     ; (0, 7), `Since (3, 7)
     ; (0, 8), `Since (3, 8)
+    ; (0, 9), `Since (3, 13)
     ]
 ;;
 
@@ -77,6 +78,7 @@ module Buildable = struct
     ; plugins : (Loc.t * Lib_name.t) list (** ocaml libraries *)
     ; theories : (Loc.t * Coq_lib_name.t) list (** coq libraries *)
     ; loc : Loc.t
+    ; extra_sources : string list
     }
 
   let merge_plugins_libraries ~plugins ~libraries =
@@ -121,9 +123,14 @@ module Buildable = struct
         "theories"
         (Dune_lang.Syntax.since coq_syntax (0, 2) >>> repeat Coq_lib_name.decode)
         ~default:[]
+    and+ extra_sources =
+      field
+        "extra_sources"
+        (Dune_lang.Syntax.since coq_syntax (0, 9) >>> repeat string)
+        ~default:[]
     in
     let plugins = merge_plugins_libraries ~plugins ~libraries in
-    { flags; mode; use_stdlib; coq_lang_version; plugins; theories; loc }
+    { flags; mode; use_stdlib; coq_lang_version; plugins; theories; loc; extra_sources }
   ;;
 end
 

--- a/src/dune_rules/coq/coq_stanza.mli
+++ b/src/dune_rules/coq/coq_stanza.mli
@@ -9,6 +9,7 @@ module Buildable : sig
     ; plugins : (Loc.t * Lib_name.t) list (** ocaml plugins *)
     ; theories : (Loc.t * Coq_lib_name.t) list (** coq libraries *)
     ; loc : Loc.t
+    ; extra_sources : string list
     }
 end
 

--- a/test/blackbox-tests/test-cases/coq/extra-dep.t
+++ b/test/blackbox-tests/test-cases/coq/extra-dep.t
@@ -1,0 +1,20 @@
+Testing the Extra Dependency command in coqc and how dune is able to support its
+dependencies.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (using coq 0.9)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (coq.theory
+  >  (name foo)
+  >  (extra_sources a))
+  > EOF
+
+  $ cat > a
+  $ cat > b.v <<EOF
+  > From foo Extra Dependency "a".
+  > EOF
+
+  $ dune build b.vo

--- a/test/blackbox-tests/test-cases/coq/load.t
+++ b/test/blackbox-tests/test-cases/coq/load.t
@@ -1,0 +1,41 @@
+Testing the Load command in coqc and how dune is able to support its
+dependencies.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (using coq 0.9)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (coq.theory
+  >  (name foo)
+  >  (extra_sources a.v)
+  >  (modules :standard \ a))
+  > EOF
+
+  $ cat > a.v
+  $ cat > b.v <<EOF
+  > Load a.
+  > EOF
+
+  $ dune build b.vo
+
+  $ ls _build/default/
+  Nfoo_b.cmi
+  Nfoo_b.cmx
+  Nfoo_b.cmxs
+  Nfoo_b.o
+  a.v
+  b.glob
+  b.v
+  b.vo
+  b.vok
+  b.vos
+
+Dune should have compiled b.vo:
+
+  $ [ -e _build/default/b.vo ]
+
+Making sure that a.vo doesn't exist:
+ 
+  $ [ -n _build/default/a.vo ]


### PR DESCRIPTION
We add an extra_sources field to the coq-theory and coq.extraction stanzas that allows the decleration of extra sources. This allows Coq features such as Load and Extra Dependency to be used correctly.

We add two tests that demonstrates how it can be used for those features.

The extra_sources field finds the declared files and makes sure that Dune declares a dependency on them before calling coqdep for the theory being built.

- [ ] docs
- [ ] changelog
