### PR TITLE
fix(pkg): Fix conditional dependencies test failure

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -38,6 +38,9 @@ Create a workspace config that defines separate build contexts for macos and lin
   >  (repositories mock)
   >  (solver_env
   >   (os macos)))
+  > (lock_dir
+  >  (path dune.lock)
+  >  (repositories mock))
   > (context
   >  (default
   >   (name linux)


### PR DESCRIPTION
The test used the default repos for the `dune.lock` lock directory accidentally, which default to locations on the internet.

Closes #9571.