### PR TITLE
refactor: remove [chop_extension] from [Stdune]

### DIFF
--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -97,7 +97,7 @@ module Module = struct
     then User_error.raise [ Pp.text "file is missing an extension" ];
     let open Memo.O in
     let module_name =
-      let name = Filename.chop_extension filename in
+      let name = Filename.remove_extension filename in
       Dune_rules.Module_name.of_string_user_error (Loc.none, name) |> User_error.ok_exn
     in
     let* expander = Super_context.expander sctx ~dir in

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -32,6 +32,7 @@ let analyze_program_name fn =
 
 let compare = String.compare
 let equal = String.equal
+let chop_extension = `Use_remove_extension
 
 module Set = String.Set
 module Map = String.Map

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -24,6 +24,7 @@ type program_name_kind =
 val analyze_program_name : t -> program_name_kind
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
+val chop_extension : [ `Use_remove_extension ]
 
 module Set = String.Set
 module Map = String.Map

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -406,7 +406,7 @@ module Package_filename = struct
 
   let to_package_name package_filename =
     if String.equal (Filename.extension package_filename) file_extension
-    then Ok (Filename.chop_extension package_filename |> Package_name.of_string)
+    then Ok (Filename.remove_extension package_filename |> Package_name.of_string)
     else Error `Bad_extension
   ;;
 end

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -199,7 +199,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
                   then Ok None
                   else (
                     match
-                      let name = Filename.chop_extension fname in
+                      let name = Filename.remove_extension fname in
                       Module_name.of_string_user_error (Loc.in_dir src_dir, name)
                     with
                     | Ok s -> Ok (Some s)

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -143,7 +143,7 @@ let eval_foreign_stubs
           ~f:(fun acc (fd : Ctypes_field.Function_description.t) ->
             let loc = Loc.none (* TODO *) in
             let fname = Ctypes_field.c_generated_functions_cout_c ctypes fd in
-            let name = Filename.chop_extension fname in
+            let name = Filename.remove_extension fname in
             let path =
               match find_source C (loc, name) with
               | Some p -> p

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -210,7 +210,7 @@ end = struct
   let create p = p
 
   let odoc_file ~doc_dir t =
-    let t = Filename.chop_extension (Path.Build.basename t) in
+    let t = Filename.remove_extension (Path.Build.basename t) in
     Path.Build.relative doc_dir (sprintf "page-%s%s" t odoc_ext)
   ;;
 
@@ -601,7 +601,7 @@ let entry_modules sctx ~pkg =
 let create_odoc ctx ~target odoc_file =
   let html_base = Paths.html ctx target in
   let odocl_base = Paths.odocl ctx target in
-  let basename = Path.Build.basename odoc_file |> Filename.chop_extension in
+  let basename = Path.Build.basename odoc_file |> Filename.remove_extension in
   let odocl_file = odocl_base ++ (basename ^ ".odocl") in
   match target with
   | Lib _ ->
@@ -622,7 +622,7 @@ let create_odoc ctx ~target odoc_file =
 let check_mlds_no_dupes ~pkg ~mlds =
   match
     List.rev_map mlds ~f:(fun mld ->
-      Filename.chop_extension (Path.Build.basename mld), mld)
+      Filename.remove_extension (Path.Build.basename mld), mld)
     |> Filename.Map.of_list
   with
   | Ok m -> m

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -718,11 +718,11 @@ end = struct
   let reference v =
     match v.ty with
     | Mld ->
-      let basename = Path.basename v.source |> Filename.chop_extension in
+      let basename = Path.basename v.source |> Filename.remove_extension in
       sprintf "page-\"%s\"" basename
     | Module _ ->
       let basename =
-        Path.basename v.source |> Filename.chop_extension |> Stdune.String.capitalize
+        Path.basename v.source |> Filename.remove_extension |> Stdune.String.capitalize
       in
       sprintf "module-%s" basename
   ;;
@@ -731,18 +731,18 @@ end = struct
     match v.ty with
     | Module _ ->
       let basename =
-        Path.basename v.source |> Filename.chop_extension |> Stdune.String.capitalize
+        Path.basename v.source |> Filename.remove_extension |> Stdune.String.capitalize
       in
       Some (Module_name.of_string_allow_invalid (Loc.none, basename))
     | _ -> None
   ;;
 
-  let name v = Path.basename v.source |> Filename.chop_extension
+  let name v = Path.basename v.source |> Filename.remove_extension
   let v ~source ~odoc ~html_dir ~html_file ~ty = { source; odoc; html_dir; html_file; ty }
 
   let make_module ctx ~all index source ~visible =
     let basename =
-      Path.basename source |> Filename.chop_extension |> Stdune.String.uncapitalize
+      Path.basename source |> Filename.remove_extension |> Stdune.String.uncapitalize
     in
     let odoc = Index.odoc_dir ctx ~all index ++ (basename ^ ".odoc") in
     let html_dir = Index.html_dir ctx ~all index ++ Stdune.String.capitalize basename in
@@ -756,7 +756,7 @@ end = struct
   ;;
 
   let int_make_mld ctx ~all index source ~is_index =
-    let basename = Path.basename source |> Filename.chop_extension in
+    let basename = Path.basename source |> Filename.remove_extension in
     let odoc =
       (if is_index then Index.obj_dir ctx ~all index else Index.odoc_dir ctx ~all index)
       ++ ("page-" ^ basename ^ ".odoc")
@@ -1154,7 +1154,7 @@ let modules_of_dir d : (Module_name.t * (Path.t * [ `Cmti | `Cmt | `Cmi ])) list
     let list = Fs_cache.Dir_contents.to_list dc in
     List.filter_map list ~f:(fun (x, ty) ->
       match ty, List.assoc extensions (Filename.extension x) with
-      | Unix.S_REG, Some _ -> Some (Filename.chop_extension x)
+      | Unix.S_REG, Some _ -> Some (Filename.remove_extension x)
       | _, _ -> None)
     |> List.sort_uniq ~compare:String.compare
     |> List.map ~f:(fun m ->
@@ -1257,7 +1257,7 @@ let pkg_mlds sctx pkg =
 
 let check_mlds_no_dupes ~pkg ~mlds =
   match
-    List.rev_map mlds ~f:(fun mld -> Filename.chop_extension (Path.basename mld), mld)
+    List.rev_map mlds ~f:(fun mld -> Filename.remove_extension (Path.basename mld), mld)
     |> Filename.Map.of_list
   with
   | Ok m -> m

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1175,7 +1175,7 @@ module Install_action = struct
         let paths =
           let package =
             Path.basename install_file
-            |> Filename.chop_extension
+            |> Filename.remove_extension
             |> Package.Name.of_string
           in
           let roots =


### PR DESCRIPTION
This function raises [Invalid_argument ..] on error which is almost
never what we want. We shadow it and recommend using [remove_extension]
instead.

@snowleopard I don't think this function is being used internally, but copying you just in case it is.