### PR TITLE
fix(pkg): set (dev true) for packages without checksums

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -517,9 +517,9 @@ let opam_package_to_lock_file_pkg
         Source.Fetch { Source.url; checksum } ))
   in
   let info =
+    let url = OpamFile.OPAM.url opam_file in
     let source =
-      OpamFile.OPAM.url opam_file
-      |> Option.map ~f:(fun (url : OpamFile.URL.t) ->
+      Option.map url ~f:(fun (url : OpamFile.URL.t) ->
         let checksum =
           OpamFile.URL.checksum url
           |> List.hd_opt
@@ -528,13 +528,12 @@ let opam_package_to_lock_file_pkg
         let url = Loc.none, OpamFile.URL.url url in
         Source.Fetch { url; checksum })
     in
-    { Lock_dir.Pkg_info.name
-    ; version
-    ; (* CR-rgrinberg: should be true for pinned packages or without a checksum *)
-      dev = false
-    ; source
-    ; extra_sources
-    }
+    let dev =
+      match url with
+      | None -> false
+      | Some url -> List.is_empty (OpamFile.URL.checksum url)
+    in
+    { Lock_dir.Pkg_info.name; version; dev; source; extra_sources }
   in
   let deps =
     match

--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -33,6 +33,8 @@ path.
     (url
      file://<pwd>/foo.txt)
     (checksum md5=bea8252ff4e80f41719ea13cdf007273)))
+  
+  (dev)
 
 Now make sure we can gracefully handle the case when the archive is missing.
 
@@ -53,3 +55,5 @@ Now make sure we can gracefully handle the case when the archive is missing.
    (fetch
     (url
      file://<pwd>/foo.txt)))
+  
+  (dev)


### PR DESCRIPTION
Package sources without a checksum can be considered "in development"