### PR TITLE
refactor(pkg): use [Fiber_lazy] to simplify

### DIFF
--- a/src/dune_pkg/fiber_lazy.ml
+++ b/src/dune_pkg/fiber_lazy.ml
@@ -1,0 +1,20 @@
+open Fiber.O
+
+type 'a t =
+  { value : 'a Fiber.Ivar.t
+  ; mutable f : (unit -> 'a Fiber.t) option
+  }
+
+let create f = { f = Some f; value = Fiber.Ivar.create () }
+
+let force t =
+  let* () = Fiber.return () in
+  match t.f with
+  | None -> Fiber.Ivar.read t.value
+  | Some f ->
+    Fiber.of_thunk (fun () ->
+      t.f <- None;
+      let* v = f () in
+      let+ () = Fiber.Ivar.fill t.value v in
+      v)
+;;

--- a/src/dune_pkg/fiber_lazy.mli
+++ b/src/dune_pkg/fiber_lazy.mli
@@ -1,0 +1,6 @@
+(** Like [Lazy], but is allowed to run the computation inside a fiber *)
+
+type 'a t
+
+val create : (unit -> 'a Fiber.t) -> 'a t
+val force : 'a t -> 'a Fiber.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -2,19 +2,14 @@ open Import
 open Fiber.O
 
 let rev_store =
-  let store = ref None in
-  Fiber.of_thunk (fun () ->
-    match !store with
-    | Some s -> Fiber.return s
-    | None ->
-      let dir =
-        Path.L.relative
-          (Path.of_string (Xdg.cache_dir (Lazy.force Dune_util.xdg)))
-          [ "dune"; "git-repo" ]
-      in
-      let+ rev_store = Rev_store.load_or_create ~dir in
-      store := Some rev_store;
-      rev_store)
+  Fiber_lazy.create (fun () ->
+    let dir =
+      Path.L.relative
+        (Path.of_string (Xdg.cache_dir (Lazy.force Dune_util.xdg)))
+        [ "dune"; "git-repo" ]
+    in
+    Rev_store.load_or_create ~dir)
+  |> Fiber_lazy.force
 ;;
 
 module Paths = struct


### PR DESCRIPTION
[Fiber_lazy] can be used to simplify the lazily saved [rev_store]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: dd45f64e-c4d9-4342-b369-f5cf0cafcfb6 -->