### PR TITLE
boot: use several processes to bootstrap on Win32

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1193,7 +1193,7 @@ let main () =
        | None -> []
        | Some flags -> flags)
   in
-  let build = if concurrency = 1 || Sys.win32 then build_with_single_command else build in
+  let build = if concurrency = 1 then build_with_single_command else build in
   build ~ocaml_config ~dependencies ~c_files ~link_flags task
 ;;
 


### PR DESCRIPTION
This workaround does not seem to be necessary (anymore?); the mechanism with several commands work, including when `concurrency = 1`.
