### PR TITLE
Pull Dep.Facts.paths computation outside of the Sandbox module

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -42,7 +42,7 @@ val execute_action_stdout
   -> string Memo.t
 
 type rule_execution_result =
-  { deps : Dep.Fact.t Dep.Map.t
+  { facts : Dep.Fact.t Dep.Map.t
   ; targets : Digest.t Targets.Produced.t
   }
 

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -9,15 +9,15 @@ val dir : t -> Path.Build.t
 (** [map_path t p] returns the path corresponding to [p] inside the sandbox. *)
 val map_path : t -> Path.Build.t -> Path.Build.t
 
-(** Create a new sandbox and copy or link dependencies inside it. *)
+(** Create a new sandbox containing [dirs] and copy or link dependencies [deps] inside it. *)
 val create
   :  mode:Sandbox_mode.some
   -> dune_stats:Dune_stats.t option
   -> rule_loc:Loc.t
-  -> deps:Dep.Facts.t
+  -> dirs:Path.Build.Set.t
+  -> deps:Path.Set.t
   -> rule_dir:Path.Build.t
   -> rule_digest:Digest.t
-  -> expand_aliases:bool
   -> t Fiber.t
 
 (** Move all targets created by the action from the sandbox to the build

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1047,7 +1047,7 @@ let package_deps (pkg : Package.t) files =
         let* res = Dune_engine.Build_system.execute_rule rule in
         loop_files
           rules_seen
-          (Dep.Facts.paths ~expand_aliases:true res.deps
+          (Dep.Facts.paths ~expand_aliases:true res.facts
            |> Path.Set.to_list
            |> (* if this file isn't in the build dir, it doesn't belong to any
                  package and it doesn't have dependencies that do *)


### PR DESCRIPTION
Upstreaming a part of a larger internal change whose motivation was to avoid calling `Dep.Fact.paths` twice inside the `execute_action_for_rule` function. This isn't particularly important for upstream but let's keep our patch small.