### PR TITLE
fix(pkg): read default branch correctly

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -458,7 +458,9 @@ let read_head_branch =
     let headline = sprintf {|[remote "%s"]|} handle in
     let path = Path.relative t.dir "config" in
     let lines = Io.lines_of_file path in
-    let _front, back = List.split_while lines ~f:(String.equal headline) in
+    let _front, back =
+      List.split_while lines ~f:(fun line -> not (String.equal headline line))
+    in
     match back with
     | [] -> None
     | [ _heading ] -> None


### PR DESCRIPTION
We need to skip until we find the correct [remote ..] line. The current
implementation just fails on the first line if it isn't the remote we
need.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4bd10fcf-340b-4fa9-b5c5-0cd07f612e9c -->