### PR TITLE
test(pkg): test local rev store

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -1,3 +1,5 @@
+export XDG_CACHE_HOME="$PWD/.cache"
+
 dune="dune"
 
 pkg_root="_build/_private/default/.pkg"


### PR DESCRIPTION
When running tests, we end up writing things to the global rev store. By
sourcing [helper.sh], we now move the store to be test local.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 477d1918-f0c1-42b7-9eb0-455e27be9573 -->