### PR TITLE
fix(pkg): improve url validation in repos

### DIFF
--- a/src/dune_pkg/workspace.mli
+++ b/src/dune_pkg/workspace.mli
@@ -22,5 +22,5 @@ module Repository : sig
   end
 
   val name : t -> Name.t
-  val create : name:Name.t -> source:string -> t
+  val create : name:Name.t -> source:OpamUrl.t -> t
 end


### PR DESCRIPTION
* Set the type of [source] to [OpamUrl.t]. Using a proper type earlier
  is better for catching errors earlier.

* Properly display parse errors with locations

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1534001c-c167-4ae6-a0e4-f0a053334a47 -->