### PR TITLE
fix(pkg): force repos to use git:// prefix for git

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -74,9 +74,8 @@ let unset_solver_vars_of_workspace workspace ~lock_dir_path =
 let location_of_opam_url url =
   match (url : OpamUrl.t).backend with
   | `rsync -> `Path (Path.of_string url.path)
-  (* contrary to OPAM we also attempt to load HTTP sources via git *)
-  | `git | `http -> `Git
-  | `darcs | `hg ->
+  | `git -> `Git
+  | `http | `darcs | `hg ->
     User_error.raise
       ~hints:[ Pp.text "Specify either a file path or git repo via SSH/HTTPS" ]
       [ Pp.textf "Could not determine location of repository %s" @@ OpamUrl.to_string url


### PR DESCRIPTION
This is consistent with how we specify sources for packages

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d0590e43-8648-4d4b-866b-6403cd9c264c -->