### PR TITLE
[3.12] backport #9530 (slang fix)

### DIFF
--- a/doc/changes/9530.md
+++ b/doc/changes/9530.md
@@ -1,0 +1,2 @@
+- Fix stack overflow when a `(run)` action can not be parsed. (#9530, fixes
+  #9529, @gridbugs)

--- a/test/blackbox-tests/test-cases/run-parse-error.t
+++ b/test/blackbox-tests/test-cases/run-parse-error.t
@@ -1,5 +1,7 @@
 Test that parse errors in the run error produce the expected error message.
 
+See #9529.
+
   $ echo "(lang dune 3.11)" > dune-project
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/run-parse-error.t
+++ b/test/blackbox-tests/test-cases/run-parse-error.t
@@ -1,0 +1,12 @@
+Test that parse errors in the run error produce the expected error message.
+
+  $ echo "(lang dune 3.11)" > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (target foo.txt)
+  >  (action
+  >   (run ())))
+  > EOF
+
+  $ dune build foo.txt 2>&1 | head -n 1
+  Error: exception Stack overflow

--- a/test/blackbox-tests/test-cases/run-parse-error.t
+++ b/test/blackbox-tests/test-cases/run-parse-error.t
@@ -8,5 +8,9 @@ Test that parse errors in the run error produce the expected error message.
   >   (run ())))
   > EOF
 
-  $ dune build foo.txt 2>&1 | head -n 1
-  Error: exception Stack overflow
+  $ dune build foo.txt
+  File "dune", line 4, characters 7-9:
+  4 |   (run ())))
+             ^^
+  Error: Unexpected list
+  [1]


### PR DESCRIPTION
- Add test for parse error when using run action (#9528)
- fix: stop using slang parser in regular dune files (#9530)
- chore: add metadata (xref, changelog) for 9530 (#9634)
