### PR TITLE
test(pkg): pin-depends should create opam files

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -22,7 +22,9 @@ Demonstrate our support for pin-depends.
 Local pinned source:
 
   $ mkdir _bar_file
-  $ touch _bar_file
+  $ cat >_bar_file/opam <<EOF
+  > opam-version: "2.0"
+  > EOF
   $ runtest "file://$PWD/_bar_file"
   Solution for dune.lock:
   - bar.0.0.1
@@ -33,6 +35,11 @@ Git pinned source:
   $ mkdir _bar_git
   $ cd _bar_git
   $ git init --quiet
+  $ cat >opam <<EOF
+  > opam-version: "2.0"
+  > EOF
+  $ git add -A
+  $ git commit --quiet -m "Initial commit"
   $ cd ..
   $ runtest "git+file://$PWD/_bar_git"
   Solution for dune.lock:


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f4fc9a7d-7b3e-4222-a092-c53d41ad202e -->