### PR TITLE
fix: correctly output -open flags in merlin

### DIFF
--- a/doc/changes/9659.md
+++ b/doc/changes/9659.md
@@ -1,0 +1,2 @@
+- Fix merlin configuration for `(include_subdirs qualified)` modules (#9659,
+  fixes #8297, @rgrinberg)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -577,7 +577,7 @@ module Unprocessed = struct
         |> Path.Build.Set.fold ~init ~f:(fun src acc ->
           let config =
             { Processed.module_ = Module.set_pp m None
-            ; opens = Modules.alias_for modules m |> List.map ~f:Module.name
+            ; opens = Modules.local_open modules m
             }
           in
           (src, config) :: acc))

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -149,7 +149,7 @@
     $TESTCASE_ROOT/groupintf)
    (S
     $TESTCASE_ROOT/utils)
-   (FLG (-open Utils -open Foo))
+   (FLG (-open Foo__Utils -open Foo))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40


### PR DESCRIPTION
Use the same -open flags that are used for compilation

Fixes #8297

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f8c2fcc7-4268-401a-9b59-4e734fcb923c -->