### PR TITLE
refactor(pkg): share results between sys poll vars

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -112,8 +112,8 @@ let lock ~version_preference ~update_opam_repositories ~lock_dirs_arg =
   let open Fiber.O in
   let* workspace = Memo.run (Workspace.workspace ())
   and* solver_env_from_current_system =
-    Dune_pkg.Sys_poll.solver_env_from_current_system
-      ~path:(Env_path.path Stdune.Env.initial)
+    Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
+    |> Dune_pkg.Sys_poll.solver_env_from_current_system
     >>| Option.some
   in
   solve

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -25,8 +25,8 @@ let print_solver_env ~lock_dirs_arg =
   let open Fiber.O in
   let+ workspace = Memo.run (Workspace.workspace ())
   and+ solver_env_from_current_system =
-    Dune_pkg.Sys_poll.solver_env_from_current_system
-      ~path:(Env_path.path Stdune.Env.initial)
+    Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
+    |> Dune_pkg.Sys_poll.solver_env_from_current_system
     >>| Option.some
   in
   let lock_dirs = Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace in

--- a/src/dune_pkg/sys_poll.mli
+++ b/src/dune_pkg/sys_poll.mli
@@ -2,24 +2,28 @@
     or "os". *)
 open Import
 
+type t
+
+val make : path:Path.t list -> t
+
 (** Returns the value of [arch] *)
-val arch : path:Path.t list -> string option Fiber.t
+val arch : t -> string option Fiber.t
 
 (** Returns the value of [os] *)
-val os : path:Path.t list -> string option Fiber.t
+val os : t -> string option Fiber.t
 
 (** Returns the value of [os-version] *)
-val os_version : path:Path.t list -> string option Fiber.t
+val os_version : t -> string option Fiber.t
 
 (** Returns the value of [os-distribution] *)
-val os_distribution : path:Path.t list -> string option Fiber.t
+val os_distribution : t -> string option Fiber.t
 
 (** Returns the value of [os-family] *)
-val os_family : path:Path.t list -> string option Fiber.t
+val os_family : t -> string option Fiber.t
 
 (** Returns the value of [sys-ocaml-version] *)
-val sys_ocaml_version : path:Path.t list -> string option Fiber.t
+val sys_ocaml_version : t -> string option Fiber.t
 
 (** Returns a solver environment where all the system-dependent values that
     could be retrieved are set *)
-val solver_env_from_current_system : path:Path.t list -> Solver_env.t Fiber.t
+val solver_env_from_current_system : t -> Solver_env.t Fiber.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -13,11 +13,15 @@ module Sys_vars = struct
     }
 
   let poll =
-    let path = lazy (Env_path.path (Global.env ())) in
+    let vars =
+      lazy
+        (let path = Env_path.path (Global.env ()) in
+         Sys_poll.make ~path)
+    in
     let sys_poll_memo key =
       Memo.lazy_ (fun () ->
-        let path = Lazy.force path in
-        Memo.of_reproducible_fiber @@ key ~path)
+        let vars = Lazy.force vars in
+        Memo.of_reproducible_fiber @@ key vars)
     in
     { os = sys_poll_memo Sys_poll.os
     ; os_version = sys_poll_memo Sys_poll.os_version


### PR DESCRIPTION
This shaves off a bunch of `uname` calls on every build