### PR TITLE
fix(pkg): do not use Pp.newline in errors

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -451,12 +451,14 @@ module Write_disk = struct
           Pp.textf "Specified lock dir lacks metadata file (%s)" metadata_filename
         | `Failed_to_parse_metadata (path, exn) ->
           Pp.concat
-            ~sep:Pp.newline
+            ~sep:Pp.cut
             [ Pp.textf
                 "Unable to parse lock directory metadata file (%s):"
                 (Path.to_string_maybe_quoted path)
-            ; Exn.pp exn
+              |> Pp.hovbox
+            ; Exn.pp exn |> Pp.hovbox
             ]
+          |> Pp.vbox
       in
       User_error.raise
         [ Pp.textf


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 98fca6a7-4216-4f80-b538-8597cb2da0f8 -->