### PR TITLE
fix(pkg): directory_entries bug

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -307,7 +307,10 @@ module At_rev = struct
        1. using libgit or ocamlgit
        2. possibly using [$ git archive] *)
     File.Set.filter files_at_rev ~f:(fun (file : File.t) ->
-      Path.Local.is_descendant file.path ~of_:path)
+      (* [directory_entries "foo"] shouldn't return "foo" as an entry, but
+         "foo" is indeed a descendant of itself. So we filter it manually. *)
+      (not (Path.Local.equal file.path path))
+      && Path.Local.is_descendant file.path ~of_:path)
   ;;
 
   let equal { repo; revision = Rev revision; source; files_at_rev } t =


### PR DESCRIPTION
Whenever "foo" is a file, [directory_entires "foo"] would return itself.
That's not the correct behavior for things that are directories. The fix
is so to stop considering itself as a directory entry.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c4371ba0-ec40-4d67-9e57-94c9f185e52f -->