### PR TITLE
Remove `--skip-update` and make it implied when possible

### DIFF
--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -14,7 +14,6 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
         get_repos
           (repositories_of_workspace workspace)
           ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
-          ~update_opam_repositories:true
       and+ local_packages = find_local_packages in
       let lock_dir = Lock_dir.read_disk lock_dir_path in
       let+ results = Dune_pkg_outdated.find ~repos ~local_packages lock_dir.packages in

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -86,7 +86,7 @@ let location_of_opam_url loc url =
       ]
 ;;
 
-let get_repos repos ~repositories ~update_opam_repositories =
+let get_repos repos ~repositories =
   let open Fiber.O in
   let module Repository = Dune_pkg.Pkg_workspace.Repository in
   repositories
@@ -104,7 +104,7 @@ let get_repos repos ~repositories ~update_opam_repositories =
       (match location_of_opam_url loc opam_url with
        | `Git ->
          let* source = Opam_repo.Source.of_opam_url loc opam_url in
-         Opam_repo.of_git_repo ~update:update_opam_repositories source
+         Opam_repo.of_git_repo source
        | `Path path -> Fiber.return @@ Opam_repo.of_opam_repo_dir_path loc path))
 ;;
 

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -41,7 +41,6 @@ val constraints_of_workspace
 val get_repos
   :  Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
   -> repositories:(Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list
-  -> update_opam_repositories:bool
   -> Dune_pkg.Opam_repo.t list Fiber.t
 
 val find_local_packages : Dune_pkg.Local_package.t Package_name.Map.t Fiber.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -174,7 +174,7 @@ let of_opam_repo_dir_path loc opam_repo_dir_path =
   { source = Directory opam_repo_dir_path; serializable = None; loc }
 ;;
 
-let of_git_repo ~update (source : Source.t) =
+let of_git_repo (source : Source.t) =
   let+ at_rev =
     let* remote =
       let* repo = Rev_store.get in
@@ -183,10 +183,7 @@ let of_git_repo ~update (source : Source.t) =
         | Some (Branch b) -> Some b
         | _ -> None
       in
-      let* remote = Rev_store.add_repo repo ~source:source.url ~branch in
-      match update with
-      | true -> Rev_store.Remote.update remote
-      | false -> Fiber.return @@ Rev_store.Remote.don't_update remote
+      Rev_store.add_repo repo ~source:source.url ~branch >>= Rev_store.Remote.update
     in
     match source.commit with
     | Some (Commit ref) -> Rev_store.Remote.rev_of_ref remote ~ref

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -38,13 +38,10 @@ end
     directory in the path given by [opam_repo_dir]. *)
 val of_opam_repo_dir_path : Loc.t -> Path.t -> t
 
-(** [of_git_repo git ~update source] loads the opam repository located
+(** [of_git_repo git source] loads the opam repository located
     at [source] from git. [source] can be any URL that [git remote add]
-    supports.
-
-    Set [update] to true to update the source to the newest revision, otherwise
-    it will use the latest data available in the cache (if any). *)
-val of_git_repo : update:bool -> Source.t -> t Fiber.t
+    supports. *)
+val of_git_repo : Source.t -> t Fiber.t
 
 val serializable : t -> Serializable.t option
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -127,7 +127,7 @@ let mem { dir } ~rev =
   let failure_mode = Vcs.git_accept () in
   let stderr_to = make_stderr () in
   let stdout_to = make_stdout () in
-  let command = [ "rev-parse"; rev ] in
+  let command = [ "cat-file"; "-t"; rev ] in
   let+ res =
     Process.run ~dir ~display ~stdout_to ~stderr_to ~env failure_mode git command
   in

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -155,7 +155,7 @@ restored the repo to where it was before)
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (source "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"))
   > (lock_dir
   >  (repositories mock))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -123,40 +123,6 @@ A new package is released in the repo:
   $ git commit -m "bar.1.0.0" --quiet
   $ cd ..
 
-Since we have a working cached copy we get the old version of `bar` if we opt
-out of the auto update.
-
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
-
-To be safe it doesn't access the repo, we make sure to move the mock-repo away
-
-  $ mv mock-opam-repository elsewhere
-
-So now the test should work as it can't access the repo:
-
-  $ rm -r dune.lock
-  $ dune pkg lock --skip-update
-  Solution for dune.lock:
-  - bar.0.0.1
-  - foo.0.1.0
-
-But it will also get the new version of bar if we attempt to lock again (having
-restored the repo to where it was before)
-
-  $ mv elsewhere mock-opam-repository
-  $ rm -r dune.lock
-  $ dune pkg lock
-  Solution for dune.lock:
-  - bar.1.0.0
-  - foo.0.1.0
-
 We also want to make sure that branches work, so we add `bar.2.0.0` as a new
 package on a `bar-2` branch (and switch back to the default branch, to make
 sure that the default branch differs from `bar-2`).

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -63,6 +63,12 @@ let%expect_test "adding remotes" =
     [%expect {|
     Creating first remote succeeded
     |}];
+    let* remote' = Rev_store.add_repo rev_store ~source ~branch:None in
+    let (_ : Rev_store.Remote.t) = Rev_store.Remote.don't_update remote' in
+    print_endline "Adding same remote without update succeeded";
+    [%expect {|
+    Adding same remote without update succeeded
+    |}];
     let* remote'' = Rev_store.add_repo rev_store ~source ~branch:None in
     let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote'' in
     print_endline "Adding same remote with update succeeded";

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -63,12 +63,6 @@ let%expect_test "adding remotes" =
     [%expect {|
     Creating first remote succeeded
     |}];
-    let* remote' = Rev_store.add_repo rev_store ~source ~branch:None in
-    let (_ : Rev_store.Remote.t) = Rev_store.Remote.don't_update remote' in
-    print_endline "Adding same remote without update succeeded";
-    [%expect {|
-    Adding same remote without update succeeded
-    |}];
     let* remote'' = Rev_store.add_repo rev_store ~source ~branch:None in
     let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote'' in
     print_endline "Adding same remote with update succeeded";


### PR DESCRIPTION
The only place where offline mode would work is if the repositoy URL didn't specify any hash or specified a hash that exists in the rev store.

It is easier to make the distinction on whether to update dependent on the `Source` than an CLI option (which if used wrong will just make dune fail).

I've fixed `of_opam_url` to update the repo if the revision was not found locally and is not a tag or branch, that way specifying a revision can work offline if the rev store is up to date but will transparently go online if it is out of date.

Closes #9354