### PR TITLE
feature(pkg): support pin-depends

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -45,7 +45,7 @@ let solve_lock_dir
         ~constraints:(constraints_of_workspace workspace ~lock_dir_path))
   >>= function
   | Error (`Diagnostic_message message) -> Fiber.return (Error (lock_dir_path, message))
-  | Ok { lock_dir; files; _ } ->
+  | Ok { lock_dir; files; pinned_packages } ->
     let summary_message =
       User_message.make
         [ Pp.tag
@@ -59,7 +59,7 @@ let solve_lock_dir
            | packages -> pp_packages packages)
         ]
     in
-    let+ lock_dir = Lock_dir.compute_missing_checksums lock_dir in
+    let+ lock_dir = Lock_dir.compute_missing_checksums ~pinned_packages lock_dir in
     Ok (Lock_dir.Write_disk.prepare ~lock_dir_path ~files lock_dir, summary_message)
 ;;
 

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -74,18 +74,6 @@ let unset_solver_vars_of_workspace workspace ~lock_dir_path =
   lock_dir.unset_solver_vars
 ;;
 
-let location_of_opam_url loc url =
-  match (url : OpamUrl.t).backend with
-  | `rsync -> `Path (Path.of_string url.path)
-  | `git -> `Git
-  | `http | `darcs | `hg ->
-    User_error.raise
-      ~loc
-      ~hints:[ Pp.text "Specify either a file path or git repo via SSH/HTTPS" ]
-      [ Pp.textf "Could not determine location of repository %s" @@ OpamUrl.to_string url
-      ]
-;;
-
 let get_repos repos ~repositories =
   let open Fiber.O in
   let module Repository = Dune_pkg.Pkg_workspace.Repository in
@@ -101,7 +89,7 @@ let get_repos repos ~repositories =
     | Some repo ->
       let loc, opam_url = Repository.opam_url repo in
       let module Opam_repo = Dune_pkg.Opam_repo in
-      (match location_of_opam_url loc opam_url with
+      (match Dune_pkg.OpamUrl.local_or_git_only opam_url loc with
        | `Git ->
          let* source = Opam_repo.Source.of_opam_url loc opam_url in
          Opam_repo.of_git_repo source

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -5,6 +5,7 @@ module Lock_dir = Lock_dir
 module Opam_file = Opam_file
 module Opam_repo = Opam_repo
 module Opam_solver = Opam_solver
+module OpamUrl = OpamUrl0
 module Package_variable = Package_variable
 module Package_dependency = Package_dependency
 module Rev_store = Rev_store

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -2,6 +2,8 @@ open! Import
 module Package_constraint = Dune_lang.Package_constraint
 module Digest = Dune_digest
 
+type pins = (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
+
 type t =
   { name : Package_name.t
   ; version : Package_version.t option
@@ -9,6 +11,7 @@ type t =
   ; conflicts : Package_dependency.t list
   ; conflict_class : Package_name.t list
   ; depopts : Package_dependency.t list
+  ; pins : pins
   ; loc : Loc.t
   }
 
@@ -79,9 +82,12 @@ module For_solver = struct
     ; conflicts : Package_dependency.t list
     ; depopts : Package_dependency.t list
     ; conflict_class : Package_name.t list
+    ; pins : (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
     }
 
-  let to_opam_file { name; dependencies; conflicts; conflict_class; depopts } =
+  let to_opam_file { name; dependencies; conflicts; conflict_class; depopts; pins = _ } =
+    (* CR-rgrinberg: it's OK to ignore pins here since the solver doesn't touch
+       them *)
     OpamFile.OPAM.empty
     |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
     |> OpamFile.OPAM.with_depends
@@ -108,7 +114,7 @@ module For_solver = struct
 end
 
 let for_solver
-  { name; version = _; dependencies; conflicts; conflict_class; loc = _; depopts }
+  { name; version = _; dependencies; conflicts; conflict_class; loc = _; depopts; pins }
   =
-  { For_solver.name; dependencies; conflicts; conflict_class; depopts }
+  { For_solver.name; dependencies; conflicts; conflict_class; depopts; pins }
 ;;

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -1,5 +1,7 @@
 open! Import
 
+type pins = (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
+
 (** Information about a local package that's relevant for package management.
     This is intended to represent local packages defined in a dune-project file
     (rather than packages in a lockdir). This is distinct from a
@@ -14,6 +16,7 @@ type t =
   ; conflicts : Package_dependency.t list
   ; conflict_class : Package_name.t list
   ; depopts : Package_dependency.t list
+  ; pins : pins
   ; loc : Loc.t
   }
 
@@ -54,6 +57,7 @@ module For_solver : sig
     ; conflicts : Package_dependency.t list
     ; depopts : Package_dependency.t list
     ; conflict_class : Package_name.t list
+    ; pins : pins
     }
 
   (** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -107,4 +107,4 @@ val transitive_dependency_closure
 
 (** Attempt to download and compute checksums for packages that have source
     archive urls but no checksum. *)
-val compute_missing_checksums : t -> t Fiber.t
+val compute_missing_checksums : t -> pinned_packages:Package_name.Set.t -> t Fiber.t

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -20,3 +20,15 @@ let is_version_control t =
 ;;
 
 let is_local t = String.equal t.transport "file"
+
+let local_or_git_only url loc =
+  match (url : t).backend with
+  | `rsync -> `Path (Path.of_string url.path)
+  | `git -> `Git
+  | `http | `darcs | `hg ->
+    User_error.raise
+      ~loc
+      ~hints:[ Pp.text "Specify either a file path or git repo via SSH/HTTPS" ]
+      [ Pp.textf "Could not determine location of repository %s" @@ OpamUrl.to_string url
+      ]
+;;

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 type t = OpamUrl.t
 
 val equal : t -> t -> bool
@@ -11,3 +13,8 @@ val is_version_control : t -> bool
 
 (** [is_file t] is true iff [t] is a url begining with "file://" *)
 val is_local : t -> bool
+
+(* [local_or_git_only t loc] returns [`Path p] for a URL pointing to a local
+   file system or [`Git] if it's a git repository (remote or otherwise). If
+   it's neither of those cases, it will error out. *)
+val local_or_git_only : t -> Loc.t -> [ `Path of Path.t | `Git ]

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -28,6 +28,7 @@ module Source : sig
   val of_opam_url : Loc.t -> OpamUrl.t -> t Fiber.t
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
+  val rev : t -> Rev_store.At_rev.t Fiber.t
 
   module Private : sig
     val of_opam_url : Rev_store.t -> Loc.t -> OpamUrl.t -> t Fiber.t

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -4,6 +4,7 @@ module Solver_result : sig
   type t =
     { lock_dir : Lock_dir.t
     ; files : File_entry.t Package_name.Map.Multi.t
+    ; pinned_packages : Package_name.Set.t
     }
 end
 

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -1,0 +1,134 @@
+open Import
+open Fiber.O
+
+let collect local_packages =
+  match
+    Package_name.Map.values local_packages
+    |> List.concat_map ~f:(fun (local_pacakge : Local_package.For_solver.t) ->
+      Package_name.Map.to_list_map local_pacakge.pins ~f:(fun name (loc, version, url) ->
+        let version = Package_version.to_opam_package_version version in
+        name, (loc, version, url)))
+    |> Package_name.Map.of_list
+  with
+  | Ok s -> s
+  | Error (package, (loc, _, _), _) ->
+    User_error.raise
+      ~loc
+      [ Pp.textf "local package %s cannot be pinned" (Package_name.to_string package) ]
+;;
+
+(* There's many layouts for pinned packages:
+   - toplevel opam file
+   - $name.opam file
+   - opam/$name.opam
+   - opam/opam
+
+   This function tries them one by one. The [stat] argument is to there so that it works
+   for both the local file system and the revision store. *)
+let discover_layout loc ~stat name =
+  let name_opam = Package_name.to_string name ^ ".opam" in
+  let opam_file = Path.Local.of_string name_opam in
+  let abort () =
+    User_error.raise
+      ~loc
+      [ Pp.textf
+          "unable to discover an opam file for package %s"
+          (Package_name.to_string name)
+      ]
+  in
+  let must_be_a_file p =
+    User_error.raise
+      ~loc
+      [ Pp.textf "%s must be a file" (Path.Local.to_string_maybe_quoted p) ]
+  in
+  match stat opam_file with
+  | `File -> opam_file, None
+  | _ ->
+    let opam_file_or_dir = Path.Local.of_string "opam" in
+    (match stat opam_file_or_dir with
+     | `File -> opam_file_or_dir, None
+     | `Dir ->
+       let opam_file = Path.Local.relative opam_file_or_dir name_opam in
+       (match stat opam_file with
+        | `File -> opam_file, None
+        | `Dir -> must_be_a_file opam_file
+        | `Absent_or_unrecognized ->
+          let file = Path.Local.relative opam_file_or_dir "opam" in
+          (match stat file with
+           | `File -> opam_file, Some (Path.Local.relative opam_file_or_dir "files")
+           | `Dir -> must_be_a_file file
+           | `Absent_or_unrecognized -> abort ()))
+     | `Absent_or_unrecognized -> abort ())
+;;
+
+let resolve_package loc name (url : OpamUrl.t) version =
+  let package = OpamPackage.create (Package_name.to_opam_package_name name) version in
+  let discover_layout = discover_layout loc name in
+  let+ resolved_package =
+    match OpamUrl.local_or_git_only url loc with
+    | `Path dir ->
+      let stat path =
+        let path = Path.append_local dir path in
+        match (Path.stat_exn path).st_kind with
+        | S_REG -> `File
+        | S_DIR -> `Dir
+        | _ -> `Absent_or_unrecognized
+        | exception Unix.Unix_error (ENOENT, _, _) -> `Absent_or_unrecognized
+      in
+      let opam_file_path, files_dir = discover_layout ~stat in
+      Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir |> Fiber.return
+    | `Git ->
+      let* rev = Opam_repo.Source.of_opam_url loc url >>= Opam_repo.Source.rev in
+      let opam_file =
+        match
+          Rev_store.At_rev.directory_entries rev (Path.Local.of_string ".")
+          |> Rev_store.File.Set.find ~f:(fun file ->
+            Path.Local.equal (Rev_store.File.path file) (Path.Local.of_string "opam"))
+        with
+        | Some s -> s
+        | None ->
+          User_error.raise ~loc [ Pp.text "unable to find opam file in this repository" ]
+      in
+      let stat path =
+        match
+          Rev_store.File.Set.is_empty (Rev_store.At_rev.directory_entries rev path)
+        with
+        | false -> `Dir
+        | true ->
+          (match Path.Local.parent path with
+           | None -> `Absent_or_unrecognized
+           | Some parent ->
+             let files = Rev_store.At_rev.directory_entries rev parent in
+             let basename = Path.Local.basename path in
+             if Rev_store.File.Set.exists files ~f:(fun file ->
+                  let path = Rev_store.File.path file in
+                  String.equal basename (Path.Local.basename path))
+             then `File
+             else `Absent_or_unrecognized)
+      in
+      let opam_file_path, files_dir = discover_layout ~stat in
+      let+ opam_file_contents =
+        (* CR-rgrinberg: not efficient to make such individual calls *)
+        Rev_store.At_rev.content rev opam_file_path
+        >>| function
+        | Some p -> p
+        | None ->
+          Code_error.raise
+            ~loc
+            "unable to find file"
+            [ "opam_file_path", Path.Local.to_dyn opam_file_path ]
+      in
+      Resolved_package.git_repo package ~opam_file ~opam_file_contents rev ~files_dir
+  in
+  Resolved_package.set_url resolved_package url
+;;
+
+let resolve pins =
+  Package_name.Map.to_list pins
+  |> Fiber.parallel_map ~f:(fun (name, (loc, version, url)) ->
+    let+ resolved = resolve_package loc name url version in
+    name, resolved)
+  >>| Package_name.Map.of_list_exn
+;;
+
+let resolve_pins local_packages = collect local_packages |> resolve

--- a/src/dune_pkg/pinned_package.mli
+++ b/src/dune_pkg/pinned_package.mli
@@ -1,0 +1,11 @@
+(** Support for [pin-depends] *)
+
+(** Collect and resolve all pins in [local_packages] using the sources defined
+    in [local_packages].
+
+    Pins are defined using the [pin-depends] field of opam files. We traverse
+    all local packages to collect such fields and then fetch and return all the
+    opam files they correspond to *)
+val resolve_pins
+  :  Local_package.For_solver.t Package_name.Map.t
+  -> Resolved_package.t Package_name.Map.t Fiber.t

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -5,20 +5,21 @@ type t
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val file : t -> Path.t
+val set_url : t -> OpamUrl.t -> t
 
 val git_repo
   :  OpamPackage.t
   -> opam_file:Rev_store.File.t
   -> opam_file_contents:string
   -> Rev_store.At_rev.t
-  -> files_dir:Path.Local.t
+  -> files_dir:Path.Local.t option
   -> t
 
 val local_fs
   :  OpamPackage.t
   -> dir:Path.t
   -> opam_file_path:Path.Local.t
-  -> files_dir:Path.Local.t
+  -> files_dir:Path.Local.t option
   -> t
 
 val get_opam_package_files : t list -> File_entry.t list list Fiber.t

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -14,4 +14,4 @@ val decode : (Path.External.t -> t) Dune_sexp.Decoder.t
 val encode : t -> Dune_sexp.t
 val to_dyn : t -> Dyn.t
 val remove_locs : t -> t
-val compute_missing_checksum : t -> Package_name.t -> t Fiber.t
+val compute_missing_checksum : t -> Package_name.t -> pinned:bool -> t Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -16,7 +16,10 @@ Demonstrate our support for pin-depends.
   > pin-depends: [ "bar.1.0.0" "$1" ]
   > EOF
   > dune pkg lock
-  > cat dune.lock/bar.pkg
+  > local pkg="dune.lock/bar.pkg"
+  > grep version $pkg
+  > grep dev $pkg
+  > grep "$1" $pkg | sed "s#$PWD#PWD#g"
   > }
 
 Local pinned source.
@@ -30,8 +33,10 @@ Local pinned source.
   > EOF
   $ runtest "file://$PWD/$dir"
   Solution for dune.lock:
-  - bar.0.0.1
-  (version 0.0.1)
+  - bar.1.0.0
+  (version 1.0.0)
+  (dev)
+     file://PWD/_bar_file)))
 
 "opam" directory at the root
 
@@ -42,8 +47,10 @@ Local pinned source.
   > EOF
   $ runtest "file://$PWD/$dir"
   Solution for dune.lock:
-  - bar.0.0.1
-  (version 0.0.1)
+  - bar.1.0.0
+  (version 1.0.0)
+  (dev)
+     file://PWD/_bar_file_opam_dir)))
 
 "bar.opam" file at the root
 
@@ -54,8 +61,10 @@ Local pinned source.
   > EOF
   $ runtest "file://$PWD/$dir"
   Solution for dune.lock:
-  - bar.0.0.1
-  (version 0.0.1)
+  - bar.1.0.0
+  (version 1.0.0)
+  (dev)
+     file://PWD/_bar_named_opam_root)))
 
 "bar.opam" file at opam/
 
@@ -66,8 +75,10 @@ Local pinned source.
   > EOF
   $ runtest "file://$PWD/$dir"
   Solution for dune.lock:
-  - bar.0.0.1
-  (version 0.0.1)
+  - bar.1.0.0
+  (version 1.0.0)
+  (dev)
+     file://PWD/_bar_named_opam_subdir)))
 
 Git pinned source:
 
@@ -83,5 +94,7 @@ Git pinned source:
   $ cd ..
   $ runtest "git+file://$PWD/$dir"
   Solution for dune.lock:
-  - bar.0.0.1
-  (version 0.0.1)
+  - bar.1.0.0
+  (version 1.0.0)
+  (dev)
+     git+file://PWD/_bar_git)))


### PR DESCRIPTION
Dune's package management is intended to be usable in projects that do not use dune's package definition features. Such projects prefer to write their own opam files and make use of opam specific features such as `pin-depends`. This PR adds support for the `pin-depends` feature.