### PR TITLE
fix(pkg): Use function return value

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -20,7 +20,7 @@ Test the error cases for invalid opam repositories
   > echo "$out" | sed 's/character.*:/characters X-X:/g' \
   >   | sed 's/source ".*"/source ../g' \
   >   | grep -v "\^"
-  > printf "[%d]\n" "$code"
+  > return $code
   > }
 
   $ lock


### PR DESCRIPTION
I was curious whether `return` can be used, since that would allow cram to use its own error code printing logic (e.g. never printing `[0]`) and in my local test it seems to have worked.