### PR TITLE
Add `dune promotion list` to display the current changes files.

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -59,11 +59,25 @@ module Diff = struct
   let command = Cmd.v info term
 end
 
+module Files = struct
+  let info = Cmd.info ~doc:"List promotions files" "list"
+
+  let term =
+    let+ builder = Common.Builder.term
+    and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
+    let common, config = Common.init builder in
+    let files_to_promote = files_to_promote ~common files in
+    Scheduler.go ~common ~config (fun () -> Diff_promotion.display_files files_to_promote)
+  ;;
+
+  let command = Cmd.v info term
+end
+
 let info =
   Cmd.info ~doc:"Control how changes are propagated back to source code." "promotion"
 ;;
 
-let group = Cmd.group info [ Apply.command; Diff.command ]
+let group = Cmd.group info [ Files.command; Apply.command; Diff.command ]
 
 let promote =
   command_alias ~orig_name:"promotion apply" Apply.command Apply.term "promote"

--- a/doc/changes/9705.md
+++ b/doc/changes/9705.md
@@ -1,0 +1,2 @@
+- Introduce `$ dune promotion list` to print the list of available promotions.
+  (#9705, @moyodiallo)

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -251,6 +251,6 @@ let display_files files_to_promote =
   file_opts
   |> List.filter_opt
   |> List.sort ~compare:(fun file file' -> File.compare file file')
-  |> List.map ~f:File.to_dyn
-  |> List.iter ~f:(fun file -> Console.print [ Dyn.pp file ])
+  |> List.iter ~f:(fun (file : File.t) ->
+    Console.printf "%s" (Path.Source.to_string file.dst))
 ;;

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -18,6 +18,8 @@ module File : sig
 
   val to_dyn : t -> Dyn.t
   val in_staging_area : Path.Source.t -> Path.Build.t
+  val compare : t -> t -> ordering
+  val source : t -> Path.Source.t
 
   (** Register an intermediate file to promote. The build path may point to the
       sandbox and the file will be moved to the staging area. *)
@@ -43,6 +45,8 @@ type files_to_promote =
   | All
   | These of Path.Source.t list * (Path.Source.t -> unit)
 
+val load_db : unit -> File.t list
+val filter_db : files_to_promote -> File.t list -> File.t list
+val diff_for_file : File.t -> (Print_diff.Diff.t, User_message.t) result Fiber.t
 val promote_files_registered_in_last_run : files_to_promote -> unit
 val display : files_to_promote -> unit Fiber.t
-val display_files : files_to_promote -> unit Fiber.t

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -45,3 +45,4 @@ type files_to_promote =
 
 val promote_files_registered_in_last_run : files_to_promote -> unit
 val display : files_to_promote -> unit Fiber.t
+val display_files : files_to_promote -> unit Fiber.t

--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -1,0 +1,56 @@
+  $ cat > dune-project << EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (diff a.expected a.actual)))
+  > 
+  > (rule
+  >  (with-stdout-to a.actual
+  >   (echo "A actual\n")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (progn
+  >    (with-stdout-to b.actual
+  >     (echo "B actual\n"))
+  >   (diff? b.expected b.actual))))
+  > EOF
+
+  $ echo 'A expected' > a.expected
+  $ echo 'B expected' > b.expected
+  $ touch nothing-to-promote.txt
+
+  $ dune runtest
+  File "a.expected", line 1, characters 0-0:
+  Error: Files _build/default/a.expected and _build/default/a.actual differ.
+  File "b.expected", line 1, characters 0-0:
+  Error: Files _build/default/b.expected and _build/default/b.actual differ.
+  [1]
+
+  $ dune promotion list --diff-command 'diff -u' 2>&1
+  { src = In_build_dir "default/a.actual"
+  ; staging = None
+  ; dst = In_source_tree "a.expected"
+  }
+  { src = In_build_dir "default/b.actual"
+  ; staging = Some In_build_dir ".promotion-staging/b.expected"
+  ; dst = In_source_tree "b.expected"
+  }
+
+  $ dune promotion list b.expected --diff-command 'diff -u' 2>&1
+  { src = In_build_dir "default/b.actual"
+  ; staging = Some In_build_dir ".promotion-staging/b.expected"
+  ; dst = In_source_tree "b.expected"
+  }
+
+  $ dune promotion list a.expected nothing-to-promote.txt --diff-command 'diff -u' 2>&1
+  Warning: Nothing to promote for nothing-to-promote.txt.
+  { src = In_build_dir "default/a.actual"
+  ; staging = None
+  ; dst = In_source_tree "a.expected"
+  }

--- a/test/blackbox-tests/test-cases/promote/promotion-list.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-list.t
@@ -33,24 +33,12 @@
   [1]
 
   $ dune promotion list --diff-command 'diff -u' 2>&1
-  { src = In_build_dir "default/a.actual"
-  ; staging = None
-  ; dst = In_source_tree "a.expected"
-  }
-  { src = In_build_dir "default/b.actual"
-  ; staging = Some In_build_dir ".promotion-staging/b.expected"
-  ; dst = In_source_tree "b.expected"
-  }
+  a.expected
+  b.expected
 
   $ dune promotion list b.expected --diff-command 'diff -u' 2>&1
-  { src = In_build_dir "default/b.actual"
-  ; staging = Some In_build_dir ".promotion-staging/b.expected"
-  ; dst = In_source_tree "b.expected"
-  }
+  b.expected
 
   $ dune promotion list a.expected nothing-to-promote.txt --diff-command 'diff -u' 2>&1
   Warning: Nothing to promote for nothing-to-promote.txt.
-  { src = In_build_dir "default/a.actual"
-  ; staging = None
-  ; dst = In_source_tree "a.expected"
-  }
+  a.expected


### PR DESCRIPTION
It is a starting point of `dune promotion list`. One of the concern would be the print format.
An example of Dyn format printed directly.
```
{ src = In_build_dir "default/bin/.formatted/main.ml"
; staging = None
; dst = In_source_tree "bin/main.ml"
}
{ src = In_build_dir "default/src/dune_patch/.formatted/dune_patch.ml"
; staging = None
; dst = In_source_tree "src/dune_patch/dune_patch.ml"
}
```