### PR TITLE
fix: optional binaries handling

### DIFF
--- a/doc/changes/9707.md
+++ b/doc/changes/9707.md
@@ -1,0 +1,3 @@
+- Fix handling of `enabled_if` in binary install stanzas. Previously, we'd
+  ignore the result of `enabled_if` when evaluating `%{bin:..}` (#9707,
+  @rgrinberg)

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -6,6 +6,7 @@ type origin =
   { binding : File_binding.Unexpanded.t
   ; dir : Path.Build.t
   ; dst : Path.Local.t
+  ; enabled_if : bool Memo.t
   }
 
 type where =
@@ -35,7 +36,11 @@ val binary
 
 val binary_available : t -> string -> bool Memo.t
 val add_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list -> t
-val create : Context.t -> local_bins:origin Filename.Map.t Memo.Lazy.t -> t
+
+val create
+  :  Context.t
+  -> local_bins:origin Appendable_list.t Filename.Map.t Memo.Lazy.t
+  -> t
 
 val expand
   : (context:Context.t -> dir:Path.Build.t -> String_with_vars.t -> string Memo.t) Fdecl.t

--- a/src/dune_rules/file_binding.ml
+++ b/src/dune_rules/file_binding.ml
@@ -115,6 +115,7 @@ end
 module Unexpanded = struct
   type nonrec t = (String_with_vars.t, String_with_vars.t) t
 
+  let loc t = String_with_vars.loc t.src
   let to_dyn = to_dyn String_with_vars.to_dyn String_with_vars.to_dyn
   let equal = equal String_with_vars.equal_no_loc String_with_vars.equal_no_loc
 

--- a/src/dune_rules/file_binding.mli
+++ b/src/dune_rules/file_binding.mli
@@ -21,6 +21,7 @@ module Unexpanded : sig
 
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
+  val loc : t -> Loc.t
 
   val make
     :  src:Loc.t * string

--- a/test/blackbox-tests/test-cases/bin-available.t
+++ b/test/blackbox-tests/test-cases/bin-available.t
@@ -37,5 +37,5 @@ Test for %{bin-available:...}
   non existent program: false
   local path foo: false
   local path bar: false
-  disabled binary is available: true
+  disabled binary is available: false
   disabled by enabled_if: false

--- a/test/blackbox-tests/test-cases/more-than-one-optional.t
+++ b/test/blackbox-tests/test-cases/more-than-one-optional.t
@@ -1,0 +1,31 @@
+Demonstrate an optional executable available from more than one definition
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir a b
+  $ touch a/foo.ml b/foo.ml
+  $ cat >a/dune <<EOF
+  > (executable
+  >  (public_name foo)
+  >  (enabled_if true))
+  $ cat >b/dune <<EOF
+  > (executable
+  >  (public_name foo)
+  >  (enabled_if true))
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action (run %{bin:foo})))
+  > EOF
+
+  $ dune build @foo
+  File "a/dune", line 2, characters 14-17:
+  2 |  (public_name foo)
+                    ^^^
+  Error: binary "foo" is available from more than one definition. It is also
+  available in:
+  - b/dune:2
+  [1]


### PR DESCRIPTION
We wait until the binaries are resolved to determine if they are optional or not. This allows things to be a little more lazy as we avoid evaluating whether a binary is available until it's used.

Moreover, the handling of `enabled_if` on install sections is no longer ignored when generating the artifacts map

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: da705232-7f02-4a6e-8775-bbc164aff6a6 -->