### PR TITLE
refactor: do not assume every syntax extension has a defined version

### DIFF
--- a/bin/describe/describe_format.ml
+++ b/bin/describe/describe_format.ml
@@ -23,7 +23,7 @@ let print_as_sexp dyn =
     |> Dune_lang.Ast.add_loc ~loc:Loc.none
     |> Dune_lang.Cst.concrete
   in
-  let version = Dune_lang.Syntax.greatest_supported_version Stanza.syntax in
+  let version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax in
   Pp.to_fmt Stdlib.Format.std_formatter (Dune_lang.Format.pp_top_sexps ~version [ cst ])
 ;;
 

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -142,7 +142,9 @@ module File = struct
 
   let write_dune_file (dune_file : dune) =
     let path = Path.relative dune_file.path dune_file.name in
-    let version = Dune_lang.Syntax.greatest_supported_version Dune_lang.Stanza.syntax in
+    let version =
+      Dune_lang.Syntax.greatest_supported_version_exn Dune_lang.Stanza.syntax
+    in
     Io.with_file_out
       ~binary:true
       (* Why do we pass [~binary:true] but not anywhere else when formatting? *)

--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -45,7 +45,9 @@ let term =
   and+ version =
     let docv = "VERSION" in
     let doc = "Which version of Dune language to use." in
-    let default = Dune_lang.Syntax.greatest_supported_version Dune_lang.Stanza.syntax in
+    let default =
+      Dune_lang.Syntax.greatest_supported_version_exn Dune_lang.Stanza.syntax
+    in
     Arg.(value & opt version default & info [ "dune-version" ] ~docv ~doc)
   in
   let input = Option.map ~f:Arg.Path.path path_opt in

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -5,7 +5,7 @@ let latest_lang_version =
     (Cmd.info "latest-lang-version")
     (let+ () = Term.const () in
      print_endline
-       (Dune_lang.Syntax.greatest_supported_version Stanza.syntax
+       (Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax
         |> Dune_lang.Syntax.Version.to_string))
 ;;
 

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -50,7 +50,7 @@ let pp ppf ~fields sexps =
     in
     if do_print
     then (
-      let version = Dune_lang.Syntax.greatest_supported_version Stanza.syntax in
+      let version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax in
       Dune_lang.Ast.add_loc sexp ~loc:Loc.none
       |> Dune_lang.Cst.concrete
       |> List.singleton

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -304,7 +304,7 @@ let create_latest_version
            ; "dependency of", Package_name.to_dyn dependant_package.info.name
            ] ))
      |> Code_error.raise "Invalid package table");
-  let version = Syntax.greatest_supported_version Dune_lang.Pkg.syntax in
+  let version = Syntax.greatest_supported_version_exn Dune_lang.Pkg.syntax in
   let dependency_hash =
     Local_package.(
       For_solver.list_non_local_dependency_set local_packages |> Dependency_set.hash)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -701,7 +701,7 @@ end = struct
 
   let gen_dune_package sctx (pkg : Package.t) =
     let ctx = Super_context.context sctx in
-    let dune_version = Dune_lang.Syntax.greatest_supported_version Stanza.syntax in
+    let dune_version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax in
     let* lib_entries = Scope.DB.lib_entries_of_package ctx (Package.name pkg) in
     let action =
       let dune_package_file = Package_paths.dune_package_file ctx pkg in

--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -74,7 +74,10 @@ val name : t -> string
 (** Check that the given version is supported and raise otherwise. *)
 val check_supported : dune_lang_ver:Version.t -> t -> Loc.t * Version.t -> unit
 
-val greatest_supported_version : t -> Version.t
+val greatest_supported_version : t -> Version.t option
+
+(** [greatest_supported_version_exn t] assumes *)
+val greatest_supported_version_exn : t -> Version.t
 
 (** {1 S-expression parsing} *)
 

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -81,7 +81,7 @@ struct
       let t = Table.find_exn langs name in
       { syntax = t.syntax
       ; data = t.data
-      ; version = Syntax.greatest_supported_version t.syntax
+      ; version = Syntax.greatest_supported_version_exn t.syntax
       }
     ;;
   end


### PR DESCRIPTION
If an extension is deleted, it will not have a minimum or maximum
functional version.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8cd7d732-123f-4eeb-8055-d2374637f6b3 -->