### PR TITLE
refactor: optimize [Fpath.is_root]

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -1,4 +1,12 @@
-let is_root t = Filename.dirname t = t
+let is_root =
+  if Sys.unix
+  then fun x -> x = "/" || x = "."
+  else
+    (* CR-someday rgrinberg: can we do better on windows? *)
+    fun s ->
+    Filename.dirname s = s
+;;
+
 let initial_cwd = Stdlib.Sys.getcwd ()
 
 type mkdir_result =


### PR DESCRIPTION
On unix, the old implementation of Filename.dirname was exactly
equivalent to x = "." || x = "/", but was implemented in a way that
allocated a string only to throw it away every time.

On windows, we leave the old implementation as I'm unable to verify the
above.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8fe160c3-5dfd-4a75-8d4c-4b2d7849c114 -->