### PR TITLE
test(pkg): source copying mask

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/source-copy-mask.t
+++ b/test/blackbox-tests/test-cases/pkg/source-copy-mask.t
@@ -1,0 +1,41 @@
+We shouldn't copy files that aren't sources
+
+  $ . ./helpers.sh
+  $ make_lockdir
+
+  $ src=_foo
+  $ mkdir $src
+  $ cd $src
+
+Should we include node_modules in this list?
+  $ mkdir .git .hg _darcs _esy _opam _build node_modules
+
+We include an empty file because of a bug that prevents us from copying empty directories
+  $ find . -type d -exec touch {}/file \;
+  $ touch .#foo
+  $ cd ..
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build (system "find . | sort"))
+  > (source (copy $PWD/$src))
+  > EOF
+
+  $ build_pkg foo
+  .
+  ./.#foo
+  ./.git
+  ./.git/file
+  ./.hg
+  ./.hg/file
+  ./_build
+  ./_build/file
+  ./_darcs
+  ./_darcs/file
+  ./_esy
+  ./_esy/file
+  ./_opam
+  ./_opam/file
+  ./file
+  ./node_modules
+  ./node_modules/file


### PR DESCRIPTION
demonstrate that we copy a whole bunch of unnecessary stuff unlike opam

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3201503f-0607-47ef-abd4-eaa33dbdf962 -->