### PR TITLE
Fix build on 5.3.0+trunk

### DIFF
--- a/src/dune_digest/dune_digest_stubs.c
+++ b/src/dune_digest/dune_digest_stubs.c
@@ -1,4 +1,4 @@
-#define CAML_INTERNALS
+#define CAML_INTERNALS  // needed to access md5.h functions
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/bigarray.h>

--- a/src/dune_digest/dune_digest_stubs.c
+++ b/src/dune_digest/dune_digest_stubs.c
@@ -1,3 +1,4 @@
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/bigarray.h>
@@ -6,9 +7,7 @@
 #include <caml/threads.h>
 #include <caml/unixsupport.h>
 #include <errno.h>
-#define CAML_INTERNALS
 #include <caml/md5.h>
-#undef CAML_INTERNALS
 
 /* yanked from:
  * https://github.com/janestreet/core/blob/master/core/src/md5_stubs.c


### PR DESCRIPTION
After a recent change to the internal compiler headers, `dune` no longer compiles on `trunk` (named 5.3.0) on macOS.
I spotted it since it is breaking out multicoretests CI run:
https://github.com/ocaml-multicore/multicoretests/actions/runs/7502879005/job/20426416884?pr=431#step:5:128
```
  #=== ERROR while compiling dune.3.12.2 ========================================#
  # context     2.1.5 | macos/x86_64 | ocaml-variants.5.3.0+trunk | git+https://github.com/ocaml/opam-repository.git
  # path        ~/work/multicoretests/multicoretests/_opam/.opam-switch/build/dune.3.12.2
  # command     ~/.opam/opam-init/hooks/sandbox.sh build ocaml boot/bootstrap.ml -j 4
  # exit-code   2
  # env-file    ~/.opam/log/dune-5096-92e0aa.env
  # output-file ~/.opam/log/dune-5096-92e0aa.out
  ### output ###
  # ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot -I +unix unix.cma boot/libs.ml boot/duneboot.ml
  # ./.duneboot.exe -j 4
  # cd _boot && /Users/runner/work/multicoretests/multicoretests/_opam/bin/ocamlopt.opt -c -g -I +unix -I +threads dune_digest_stubs.c
  # In file included from src/dune_digest/dune_digest_stubs.c:10:
  # In file included from /Users/runner/work/multicoretests/multicoretests/_opam/lib/ocaml/caml/md5.h:24:
  # In file included from /Users/runner/work/multicoretests/multicoretests/_opam/lib/ocaml/caml/io.h:26:
  # /Users/runner/work/multicoretests/multicoretests/_opam/lib/ocaml/caml/platform.h:79:17: error: implicit declaration of function 'atomic_load_acquire' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  #     uintnat v = atomic_load_acquire(p);
  #                 ^
  # 1 error generated.
  # 
```

The fix is to `#define CAML_INTERNALS` before loading any ocaml headers as documented in the OCaml manual:
https://v2.ocaml.org/manual/intfc.html#ss:c-internals
> "Since OCaml 4.04, it is possible to get access to every part of the internal runtime API by defining the CAML_INTERNALS macro before loading caml header files."

CC to @dra27 who co-authored the PR