### PR TITLE
boot: remove single-command bootstrap

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1141,27 +1141,6 @@ let build
        ])
 ;;
 
-let build_with_single_command
-  ~ocaml_config:_
-  ~dependencies
-  ~c_files
-  ~link_flags
-  { target = name, main; external_libraries; _ }
-  =
-  let external_libraries, external_includes = resolve_externals external_libraries in
-  write_args "mods_list" (sort_files dependencies ~main);
-  Process.run
-    ~cwd:build_dir
-    Config.compiler
-    (List.concat
-       [ common_build_args name ~external_includes ~external_libraries
-       ; [ "-no-alias-deps"; "-w"; "-49-6" ]
-       ; c_files
-       ; [ "-args"; "mods_list" ] @ link_flags
-       ; allow_unstable_sources
-       ])
-;;
-
 let rec rm_rf fn =
   match Unix.lstat fn with
   | { st_kind = S_DIR; _ } ->
@@ -1193,7 +1172,6 @@ let main () =
        | None -> []
        | Some flags -> flags)
   in
-  let build = if concurrency = 1 || Sys.win32 then build_with_single_command else build in
   build ~ocaml_config ~dependencies ~c_files ~link_flags task
 ;;
 

--- a/doc/changes/9735-single-command-boot.md
+++ b/doc/changes/9735-single-command-boot.md
@@ -1,0 +1,4 @@
+- boot: remove single-command bootstrap. This was an alternative bootstrap
+  strategy that was used in certain conditions. Removal makes the bootstrap a
+  bit slower on Linux when only a single core is available, but bootstrap is
+  now reproducible in all cases. (#9735, fixes #9507, @emillon)


### PR DESCRIPTION
Fixes #9507

The bootstrap process can use 2 strategies:
- parallel: run compile commands in parallel and link the rest
- single-command: run ocamlopt with a long list of arguments

The single-command strategy is used if win32 or if `-j 1` is set (implicitly or explicitly).

One problem is that: parallel and single-command create different binaries (#9507).

The assumption was that single-command would be faster than `-j 1` on Linux and any parallel build on Windows. However, from a quick benchmark the assumption is true on Linux but false on Windows.

The tiny savings in the case of Linux where only a single core is available are not enough to justify the extra code path and reproducibility gotcha.
