### PR TITLE
test(pkg): package caching

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -34,4 +34,8 @@
 
 (cram
  (deps %{bin:webserver_oneshot})
- (applies_to compute-checksums-when-missing e2e))
+ (applies_to compute-checksums-when-missing e2e source-caching))
+
+(cram
+ (deps %{bin:tar} %{bin:md5sum})
+ (applies_to source-caching))

--- a/test/blackbox-tests/test-cases/pkg/source-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/source-caching.t
@@ -1,0 +1,41 @@
+This test demonstratest that fetching package sources should be cached
+
+  $ . ./helpers.sh
+
+  $ make_lockdir
+
+  $ tarball=source.tar.gz
+  $ sources="sources/"
+  $ mkdir $sources; touch $sources/dummy
+  $ tar -czf $tarball $sources
+  $ checksum=$(md5sum $tarball | awk '{ print $1 }')
+  $ webserver_oneshot --content-file $tarball --port-file port.txt &
+  $ until test -f port.txt ; do sleep 0.1; done
+  $ port=$(cat port.txt)
+
+  $ makepkg() {
+  > make_lockpkg $1 <<EOF
+  > (build (run echo building $1))
+  > (source
+  >  (fetch
+  >   (url "http://0.0.0.0:$port")
+  >   (checksum md5=$checksum)))
+  > (version dev)
+  > EOF
+  > }
+  $ makepkg foo
+
+This command is expected to download the source:
+  $ build_pkg foo
+  building foo
+
+  $ wait
+
+  $ makepkg bar
+
+This command isn't expected to download the source. It will not be available as
+the server will dissapear after serving the first command.
+  $ build_pkg bar 2>&1 | sed -ne '/Error:/,$ p'
+  Error: curl returned an invalid error code 7
+         
+         


### PR DESCRIPTION
demonstrate that we redownload the same package sources

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 109762b5-c579-4ca4-8038-55b6d0de46bb -->