### PR TITLE
test(pkg): wait for jobs to finish

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -32,6 +32,8 @@ Run the server in the background:
   The source archive will be downloaded from: <addr>
   Dune will compute its own checksum for this source archive.
 
+  $ wait
+
 Replace the path in the lockfile as it would otherwise include the sandbox
 path.
   $ cat dune.lock/foo.pkg | strip_transient
@@ -73,6 +75,8 @@ Recreate the foo package as the port number will have changed:
     (url <addr>)))
   
   (dev)
+
+  $ wait
 
 Check that no checksum is computed for a local source file:
 

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -78,3 +78,5 @@ Lock, build, and run the executable in the project:
 
   $ dune exec bar
   Hello, World!
+
+  $ wait


### PR DESCRIPTION
When running our test webserver, we should wait make sure that it
terminates after we're doing using it. The reasons are twofold:

1. Make sure that we indeed downloaded something form it and it
   terminated
2. To make sure it doensn't leak outside the current test if it doesn't
   terminate.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 97ef5211-8b4c-4a69-b849-e8d4d7581f73 -->