### PR TITLE
fix(pkg): respect global display flags for downloads

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -72,7 +72,12 @@ module Curl = struct
     let stderr = Path.relative temp_dir "curl.stderr" in
     let+ http_code, exit_code =
       let stderr_to = Process.Io.file stderr Out in
-      Process.run_capture_line Return ~stderr_to ~display:Quiet (Lazy.force bin) args
+      Process.run_capture_line
+        Return
+        ~stderr_to
+        ~display:!Dune_engine.Clflags.display
+        (Lazy.force bin)
+        args
     in
     if exit_code <> 0
     then (


### PR DESCRIPTION
Whenever we do a network operation, we should make sure the user is
aware we're running something. So we switch the display mode for such
operations to respect the global default.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a98aacc5-e780-4570-a1ae-2135a0ba111e -->