### PR TITLE
test(pkg): build independent packages

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/build-single-package.t
+++ b/test/blackbox-tests/test-cases/pkg/build-single-package.t
@@ -1,0 +1,31 @@
+Requesting to build a single package should not build unrelated things:
+
+  $ . ./helpers.sh
+
+  $ make_lockdir
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.12)
+  > EOF
+
+  $ pkg() {
+  > make_lockpkg $1 <<EOF
+  > (build (run echo building $1))
+  > (version dev)
+  > EOF
+  > }
+
+These two packages are independent:
+
+  $ pkg foo
+  $ pkg bar
+
+We should only see the result of building "foo"
+
+  $ build_pkg foo
+  building bar
+  building foo
+
+We should only see the result of building "bar"
+
+  $ build_pkg bar


### PR DESCRIPTION
Demonstrate that building a single package isn't possible at the moment.
Dune adds the entire package set in the lock dir to the build request.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 79700e04-8474-454f-904c-45b7d959aae5 -->