### PR TITLE
test(pkg): share http code

### DIFF
--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -26,4 +26,4 @@
 (executable
  (name webserver_oneshot)
  (modules webserver_oneshot)
- (libraries unix))
+ (libraries unix http stdune))

--- a/test/expect-tests/dune_pkg/dune
+++ b/test/expect-tests/dune_pkg/dune
@@ -11,6 +11,7 @@
   dune_lang
   dune_vcs
   fiber
+  http
   opam_core
   threads.posix
   unix

--- a/test/http/dune
+++ b/test/http/dune
@@ -1,0 +1,3 @@
+(library
+ (name http)
+ (libraries unix stdune))

--- a/test/http/http.ml
+++ b/test/http/http.ml
@@ -1,0 +1,52 @@
+open Stdune
+
+module Server = struct
+  type t =
+    { sock : Unix.file_descr
+    ; addr : Unix.sockaddr
+    }
+
+  type session = out_channel
+
+  let make addr =
+    let sock = Unix.socket ~cloexec:true Unix.PF_INET Unix.SOCK_STREAM 0 in
+    { sock; addr }
+  ;;
+
+  let port t =
+    match Unix.getsockname t.sock with
+    | Unix.ADDR_INET (_, port) -> port
+    | ADDR_UNIX _ -> failwith "no port defined"
+  ;;
+
+  let start t =
+    Unix.setsockopt t.sock Unix.SO_REUSEADDR true;
+    Unix.bind t.sock t.addr;
+    Unix.listen t.sock 1
+  ;;
+
+  let accept t ~f =
+    let descr, _sockaddr = Unix.accept ~cloexec:true t.sock in
+    let out = Unix.out_channel_of_descr descr in
+    f out;
+    close_out out
+  ;;
+
+  let stop t = Unix.close t.sock
+
+  let respond out ~status ~content =
+    let status =
+      match status with
+      | `Ok -> "200 Ok"
+      | `Not_found -> "404 Not Found"
+    in
+    let content_length = String.length content in
+    Printf.fprintf out "HTTP/1.1 %s\nContent-Length: %d\n\n" status content_length;
+    Out_channel.output_string out content
+  ;;
+
+  let respond_file out ~file =
+    let content = Io.String_path.read_file ~binary:true file in
+    respond out ~status:`Ok ~content
+  ;;
+end

--- a/test/http/http.mli
+++ b/test/http/http.mli
@@ -1,0 +1,16 @@
+(** Http helpers used for tests *)
+
+module Server : sig
+  (* Dummy http server that requires manual accepting of clients *)
+
+  type t
+  type session
+
+  val make : Unix.sockaddr -> t
+  val accept : t -> f:(session -> unit) -> unit
+  val stop : t -> unit
+  val port : t -> int
+  val start : t -> unit
+  val respond : session -> status:[ `Ok | `Not_found ] -> content:string -> unit
+  val respond_file : session -> file:string -> unit
+end


### PR DESCRIPTION
The unit tests and cram tests both have their own http server that
duplicates some code. This PR introduces an HTTP module to start sharing
some of it.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5df495e8-f3b7-4069-ac61-b97a971c7980 -->