### PR TITLE
pkg: add cond statement for choosing lockdir

### DIFF
--- a/src/dune_lang/cond.ml
+++ b/src/dune_lang/cond.ml
@@ -1,0 +1,49 @@
+open! Stdune
+open Dune_sexp
+
+type t =
+  { cases : (Blang.t * String_with_vars.t) list
+  ; default : String_with_vars.t option
+  ; loc : Loc.t
+  }
+
+let to_dyn { cases; default; loc } =
+  Dyn.record
+    [ "cases", Dyn.list (Dyn.pair Blang.to_dyn String_with_vars.to_dyn) cases
+    ; "default", Dyn.option String_with_vars.to_dyn default
+    ; "loc", Loc.to_dyn loc
+    ]
+;;
+
+let decode =
+  let open Decoder in
+  let decode_condition =
+    (let+ () = keyword "default" in
+     `Default)
+    <|> let+ blang = Blang.decode in
+        `Case blang
+  in
+  let+ loc, conditions =
+    located (repeat (pair (located decode_condition) String_with_vars.decode))
+  in
+  let cases, default =
+    let rec loop = function
+      | [] -> [], None
+      | [ ((_loc, `Default), value) ] -> [], Some value
+      | ((_loc, `Case blang), value) :: xs ->
+        let cases, default = loop xs in
+        (blang, value) :: cases, default
+      | ((loc, `Default), _) :: _ ->
+        User_error.raise
+          ~loc
+          [ Pp.text "The default case may only appear as the final case." ]
+    in
+    loop conditions
+  in
+  { cases; default; loc }
+;;
+
+let equal { cases; default; loc = _ } t =
+  List.equal (Tuple.T2.equal Blang.equal String_with_vars.equal) cases t.cases
+  && Option.equal String_with_vars.equal default t.default
+;;

--- a/src/dune_lang/cond.mli
+++ b/src/dune_lang/cond.mli
@@ -1,0 +1,13 @@
+open! Stdune
+open Dune_sexp
+
+(** A cond statement *)
+type t =
+  { cases : (Blang.t * String_with_vars.t) list
+  ; default : String_with_vars.t option
+  ; loc : Loc.t
+  }
+
+val to_dyn : t -> Dyn.t
+val decode : t Decoder.t
+val equal : t -> t -> bool

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -31,3 +31,4 @@ module Wrapped = Wrapped
 module Visibility = Visibility
 module Dep_conf = Dep_conf
 module Relop = Relop
+module Cond = Cond

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -13,6 +13,7 @@
   dune_console
   dune_re
   dune_vcs
+  dune_config
   opam_core
   opam_repository
   opam_format

--- a/src/dune_rules/cond_expand.ml
+++ b/src/dune_rules/cond_expand.ml
@@ -1,0 +1,18 @@
+open! Stdune
+open! Import
+
+let eval (cond : Dune_lang.Cond.t) ~dir ~f =
+  let open Memo.O in
+  let expand_sw = String_expander.Memo.expand ~mode:Single ~dir ~f in
+  let* from_case =
+    Memo.List.find_map cond.cases ~f:(fun (blang, sw) ->
+      let* condition = Blang_expand.eval blang ~dir ~f in
+      if condition then expand_sw sw >>| Option.some else Memo.return None)
+  in
+  if Option.is_some from_case
+  then Memo.return from_case
+  else (
+    match cond.default with
+    | None -> Memo.return None
+    | Some default -> expand_sw default >>| Option.some)
+;;

--- a/src/dune_rules/cond_expand.mli
+++ b/src/dune_rules/cond_expand.mli
@@ -1,0 +1,10 @@
+open! Stdune
+open! Import
+
+(** Evaluate a cond statement, choosing the first value whose condition was met
+    or [None] if none of the conditions were met. *)
+val eval
+  :  Dune_lang.Cond.t
+  -> dir:Path.t
+  -> f:Value.t list Memo.t String_with_vars.expander
+  -> Value.t option Memo.t

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -6,3 +6,16 @@ type t := Dune_pkg.Lock_dir.t
 val get : Context_name.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.Source.t option Memo.t
+
+module Sys_vars : sig
+  type t =
+    { os : string option Memo.Lazy.t
+    ; os_version : string option Memo.Lazy.t
+    ; os_distribution : string option Memo.Lazy.t
+    ; os_family : string option Memo.Lazy.t
+    ; arch : string option Memo.Lazy.t
+    ; sys_ocaml_version : string option Memo.Lazy.t
+    }
+
+  val poll : t
+end

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -159,6 +159,49 @@ let env_field, env_field_lazy =
   make Fun.id Fun.id, make Lazy.from_val lazy_
 ;;
 
+module Lock_dir_selection = struct
+  type t =
+    | Name of string
+    | Cond of Dune_lang.Cond.t
+
+  let to_dyn = function
+    | Name name -> Dyn.variant "Name" [ Dyn.string name ]
+    | Cond cond -> Dyn.variant "Cond" [ Dune_lang.Cond.to_dyn cond ]
+  ;;
+
+  let decode =
+    enter
+      (let+ () = keyword "cond"
+       and+ cond = Dune_lang.Cond.decode in
+       Cond cond)
+    <|> let+ name = string in
+        Name name
+  ;;
+
+  let equal a b =
+    match a, b with
+    | Name a, Name b -> String.equal a b
+    | Cond a, Cond b -> Dune_lang.Cond.equal a b
+    | _ -> false
+  ;;
+
+  let eval t ~dir ~f =
+    let open Memo.O in
+    match t with
+    | Name name -> Memo.return (Path.Source.relative dir name)
+    | Cond cond ->
+      let+ value = Cond_expand.eval cond ~dir:(Path.source dir) ~f in
+      (match (value : Value.t option) with
+       | None ->
+         User_error.raise
+           ~loc:cond.loc
+           [ Pp.text "None of the conditions matched so no lockdir could be chosen." ]
+       | Some (String s) -> Path.Source.relative dir s
+       | Some (Dir p | Path p) ->
+         Path.reach ~from:(Path.source dir) p |> Path.Source.of_string)
+  ;;
+end
+
 module Context = struct
   module Target = struct
     type t =
@@ -387,17 +430,17 @@ module Context = struct
   module Default = struct
     type t =
       { base : Common.t
-      ; lock_dir : Path.Source.t option
+      ; lock_dir : Lock_dir_selection.t option
       }
 
     let to_dyn { base; lock_dir } =
       Dyn.record
         [ "base", Common.to_dyn base
-        ; "lock_dir", Dyn.(option Path.Source.to_dyn) lock_dir
+        ; "lock_dir", Dyn.(option Lock_dir_selection.to_dyn) lock_dir
         ]
     ;;
 
-    let decode ~dir =
+    let decode =
       let+ common = Common.decode
       and+ name =
         field_o "name" (Dune_lang.Syntax.since syntax (1, 10) >>> Context_name.decode)
@@ -406,8 +449,7 @@ module Context = struct
            1. guard before version check before releasing
            2. allow external paths
         *)
-        let+ path = field_o "lock_dir" string in
-        Option.map path ~f:(Path.Source.relative dir)
+        field_o "lock_dir" Lock_dir_selection.decode
       in
       fun ~profile_default ~instrument_with_default ~x ->
         let common = common ~profile_default ~instrument_with_default in
@@ -422,7 +464,8 @@ module Context = struct
     ;;
 
     let equal { base; lock_dir } t =
-      Common.equal base t.base && Option.equal Path.Source.equal lock_dir t.lock_dir
+      Common.equal base t.base
+      && Option.equal Lock_dir_selection.equal lock_dir t.lock_dir
     ;;
   end
 
@@ -458,10 +501,10 @@ module Context = struct
       -> host_context
   ;;
 
-  let decode ~dir =
+  let decode =
     sum
       [ ( "default"
-        , let+ f = fields (Default.decode ~dir) in
+        , let+ f = fields Default.decode in
           fun ~profile_default ~instrument_with_default ~x ->
             Default (f ~profile_default ~instrument_with_default ~x) )
       ; ( "opam"
@@ -522,9 +565,10 @@ type t =
   ; config : Dune_config.t
   ; repos : Dune_pkg.Pkg_workspace.Repository.t list
   ; lock_dirs : Lock_dir.t list
+  ; dir : Path.Source.t
   }
 
-let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs } =
+let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs; dir } =
   let open Dyn in
   record
     [ "merlin_context", option Context_name.to_dyn merlin_context
@@ -533,26 +577,29 @@ let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs } =
     ; "config", Dune_config.to_dyn config
     ; "repos", list Repository.to_dyn repos
     ; "solver", (list Lock_dir.to_dyn) lock_dirs
+    ; "dir", Path.Source.to_dyn dir
     ]
 ;;
 
-let equal { merlin_context; contexts; env; config; repos; lock_dirs } w =
+let equal { merlin_context; contexts; env; config; repos; lock_dirs; dir } w =
   Option.equal Context_name.equal merlin_context w.merlin_context
   && List.equal Context.equal contexts w.contexts
   && Option.equal Dune_env.equal env w.env
   && Dune_config.equal config w.config
   && List.equal Repository.equal repos w.repos
   && List.equal Lock_dir.equal lock_dirs w.lock_dirs
+  && Path.Source.equal dir w.dir
 ;;
 
-let hash { merlin_context; contexts; env; config; repos; lock_dirs } =
+let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir } =
   Poly.hash
     ( Option.hash Context_name.hash merlin_context
     , List.hash Context.hash contexts
     , Option.hash Dune_env.hash env
     , Dune_config.hash config
     , List.hash Repository.hash repos
-    , List.hash Lock_dir.hash lock_dirs )
+    , List.hash Lock_dir.hash lock_dirs
+    , Path.Source.hash dir )
 ;;
 
 let find_lock_dir t path =
@@ -720,7 +767,7 @@ let step1 clflags =
          ~default:(lazy []))
   and+ config_from_workspace_file = Dune_config.decode_fields_of_workspace_file
   and+ lock_dirs = multi_field "lock_dir" (Lock_dir.decode ~dir) in
-  let+ contexts = multi_field "context" (lazy_ (Context.decode ~dir)) in
+  let+ contexts = multi_field "context" (lazy_ Context.decode) in
   let config =
     create_final_config
       ~config_from_workspace_file
@@ -791,6 +838,7 @@ let step1 clflags =
        ; config
        ; repos
        ; lock_dirs
+       ; dir
        })
   in
   { Step1.t; config }
@@ -822,6 +870,7 @@ let default clflags =
   ; config
   ; repos = default_repositories
   ; lock_dirs = []
+  ; dir = Path.Source.root
   }
 ;;
 

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -16,6 +16,18 @@ module Lock_dir : sig
   val to_dyn : t -> Dyn.t
 end
 
+module Lock_dir_selection : sig
+  (** A dsl for selecting a lockdir either by literally naming it or using a
+      cond expression to select a lockdir based on blangs *)
+  type t
+
+  val eval
+    :  t
+    -> dir:Path.Source.t
+    -> f:Value.t list Memo.t String_with_vars.expander
+    -> Path.Source.t Memo.t
+end
+
 module Context : sig
   module Target : sig
     type t =
@@ -60,7 +72,7 @@ module Context : sig
   module Default : sig
     type t =
       { base : Common.t
-      ; lock_dir : Path.Source.t option
+      ; lock_dir : Lock_dir_selection.t option
       }
   end
 
@@ -93,6 +105,7 @@ type t = private
   ; config : Dune_config.t
   ; repos : Dune_pkg.Pkg_workspace.Repository.t list
   ; lock_dirs : Lock_dir.t list
+  ; dir : Path.Source.t
   }
 
 val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -1,0 +1,139 @@
+Test that dune can dynamically select a lockdir with a cond statement 
+
+  $ . ./helpers.sh
+
+  $ mkrepo
+
+  $ mkpkg arm64-only <<EOF
+  > install: [ "echo" "arm64-only" ]
+  > EOF
+
+  $ mkpkg linux-only <<EOF
+  > install: [ "echo" "linux-only" ]
+  > EOF
+
+  $ mkpkg macos-only <<EOF
+  > install: [ "echo" "macos-only" ]
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.13)
+  > (lock_dir
+  >  (path dune.macos.arm64.lock)
+  >  (repositories mock)
+  >  (solver_env
+  >   (arch arm64)
+  >   (os macos)))
+  > (lock_dir
+  >  (path dune.macos.lock)
+  >  (repositories mock)
+  >  (solver_env
+  >   (arch amd64)
+  >   (os macos)))
+  > (lock_dir
+  >  (path dune.linux.lock)
+  >  (repositories mock)
+  >  (solver_env
+  >   (arch amd64)
+  >   (os linux)))
+  > (lock_dir
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (source "file://$(pwd)/mock-opam-repository"))
+  > (context
+  >  (default
+  >   (lock_dir (cond
+  >    ((and (= %{architecture} arm64) (= %{system} macosx)) dune.macos.arm64.lock)
+  >    ((= %{system} macosx) dune.macos.lock)
+  >    ((= %{system} linux) dune.linux.lock)))))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo)
+  >  (depends
+  >   (arm64-only (= :arch arm64))
+  >   (macos-only (= :os macos))
+  >   (linux-only (= :os linux))))
+  > EOF
+
+Generate all lockdirs:
+  $ dune pkg lock dune.macos.arm64.lock
+  Solution for dune.macos.arm64.lock:
+  - arm64-only.0.0.1
+  - macos-only.0.0.1
+  $ dune pkg lock dune.macos.lock
+  Solution for dune.macos.lock:
+  - macos-only.0.0.1
+  $ dune pkg lock dune.linux.lock
+  Solution for dune.linux.lock:
+  - linux-only.0.0.1
+
+Demonstrate that the correct lockdir is being chosen by building packages that
+are only dependent on on certain systems.
+
+Build macos package on macos:
+  $ dune clean
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=arm64 dune build _build/_private/default/.pkg/macos-only/target/
+  arm64-only
+  macos-only
+
+Build macos package on macos:
+  $ dune clean
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=amd64 dune build _build/_private/default/.pkg/macos-only/target/
+  macos-only
+
+Build linux package on macos (will fail):
+  $ dune clean
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=amd64 dune build _build/_private/default/.pkg/linux-only/target/
+  macos-only
+  Error: Unknown package "linux-only"
+  [1]
+
+Build macos package on linux (will fail):
+  $ dune clean
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=amd64 dune build _build/_private/default/.pkg/macos-only/target/
+  linux-only
+  Error: Unknown package "macos-only"
+  [1]
+
+Build linux package on linux:
+  $ dune clean
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=amd64 dune build _build/_private/default/.pkg/linux-only/target/
+  linux-only
+
+Try setting the os to one which doesn't have a corresponding lockdir:
+  $ dune clean
+  $ DUNE_CONFIG__OS=windows dune build _build/_private/default/.pkg/linux-only/target/
+  File "dune-workspace", line 28, characters 3-162:
+  28 |    ((and (= %{architecture} arm64) (= %{system} macosx)) dune.macos.arm64.lock)
+  29 |    ((= %{system} macosx) dune.macos.lock)
+  30 |    ((= %{system} linux) dune.linux.lock)))))
+  Error: None of the conditions matched so no lockdir could be chosen.
+  [1]
+
+Test that cond statements can have a default value:
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.13)
+  > (lock_dir
+  >  (solver_env
+  >   (os linux))
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (source "file://$(pwd)/mock-opam-repository"))
+  > (context
+  >  (default
+  >   (lock_dir (cond
+  >    (false non-existant)
+  >    (default dune.lock)))))
+  > EOF
+
+  $ dune pkg lock dune.lock
+  Solution for dune.lock:
+  - linux-only.0.0.1
+  $ dune clean
+  $ dune build _build/_private/default/.pkg/linux-only/target/
+  linux-only


### PR DESCRIPTION
We expect projects with system-specific packages to include multiple lockdirs - one for each system. This change adds a dsl for selecting the appropriate lockdir for the current system.