### PR TITLE
test: fix tests that make assumptions about umask

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -1,6 +1,8 @@
 Sandbox a rule that depends on a directory target using the copying sandbox
 mode:
 
+  $ umask 022
+
   $ cat >dune-project <<EOF
   > (lang dune 3.8)
   > (using directory-targets 0.1)

--- a/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
+++ b/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
@@ -1,5 +1,7 @@
 Write permissions on directory targets.
 
+  $ umask 022
+
   $ cat >dune-project <<EOF
   > (lang dune 3.4)
   > (using directory-targets 0.1)


### PR DESCRIPTION
Fixes #9408

A couple tests display the full permissions. These can have different results depending on the umask of the main dune process.

The tests are changed to be isolated from this umask.
