### PR TITLE
pkg: user error when non-local->local dep

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -769,6 +769,21 @@ let solve_lock_dir solver_env version_preference repos ~local_packages ~constrai
             stats.expanded_variables
             solver_env
         in
+        Package_name.Map.iter
+          pkgs_by_name
+          ~f:(fun { Lock_dir.Pkg.deps; info = { name; _ }; _ } ->
+            List.iter deps ~f:(fun (loc, dep_name) ->
+              if Package_name.Map.mem local_packages dep_name
+              then
+                User_error.raise
+                  ~loc
+                  [ Pp.textf
+                      "Dune does not support packages outside the workspace depending on \
+                       packages in the workspace. The package %S is not in the workspace \
+                       but it depends on the package %S which is in the workspace."
+                      (Package_name.to_string name)
+                      (Package_name.to_string dep_name)
+                  ]));
         Lock_dir.create_latest_version
           pkgs_by_name
           ~local_packages:(Package_name.Map.values local_packages)

--- a/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
+++ b/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
@@ -1,0 +1,27 @@
+Test that we produce an error message when a non-local package depends on a
+local package.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg remote <<EOF
+  > depends: [
+  >  "local_b"
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name local_a)
+  >  (depends remote))
+  > (package
+  >  (name local_b))
+  > EOF
+
+  $ dune pkg lock
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "remote" is not in the workspace but
+  it depends on the package "local_b" which is in the workspace.
+  [1]


### PR DESCRIPTION
Prints an error message when a non-local dependency depends on a local package.

Fixes https://github.com/ocaml/dune/issues/9753