### PR TITLE
Faster `Dune_file.t` equality check

### DIFF
--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -86,9 +86,10 @@ module Dune_file = struct
   ;;
 
   let equal { path; kind; plain } t =
-    Option.equal Path.Source.equal path t.path
-    && equal_kind kind t.kind
-    && Plain.equal plain t.plain
+    match path, t.path with
+    | Some a, Some b -> Path.Source.equal a b
+    | Some _, None | None, Some _ -> false
+    | None, None -> equal_kind kind t.kind && Plain.equal plain t.plain
   ;;
 
   let get_static_sexp t = t.plain.contents.sexps


### PR DESCRIPTION
Fixes #9738, bringing down the build times measured in that issue to ~21s.

Makes the assumption that given two `Dune_file.t` values, if their `path` exists and it is the same, then they are the same. I am not 100% sure this is correct.