### PR TITLE
refactor(pkg): rename [deps] to [depends]

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -46,15 +46,15 @@ module Pkg = struct
   type t =
     { build_command : Action.t option
     ; install_command : Action.t option
-    ; deps : (Loc.t * Package_name.t) list
+    ; depends : (Loc.t * Package_name.t) list
     ; info : Pkg_info.t
     ; exported_env : String_with_vars.t Action.Env_update.t list
     }
 
-  let equal { build_command; install_command; deps; info; exported_env } t =
+  let equal { build_command; install_command; depends; info; exported_env } t =
     Option.equal Action.equal_no_locs build_command t.build_command
     && Option.equal Action.equal_no_locs install_command t.install_command
-    && List.equal (Tuple.T2.equal Loc.equal Package_name.equal) deps t.deps
+    && List.equal (Tuple.T2.equal Loc.equal Package_name.equal) depends t.depends
     && Pkg_info.equal info t.info
     && List.equal
          (Action.Env_update.equal String_with_vars.equal)
@@ -62,21 +62,21 @@ module Pkg = struct
          t.exported_env
   ;;
 
-  let remove_locs { build_command; install_command; deps; info; exported_env } =
+  let remove_locs { build_command; install_command; depends; info; exported_env } =
     { info = Pkg_info.remove_locs info
     ; exported_env =
         List.map exported_env ~f:(Action.Env_update.map ~f:String_with_vars.remove_locs)
-    ; deps = List.map deps ~f:(fun (_, pkg) -> Loc.none, pkg)
+    ; depends = List.map depends ~f:(fun (_, pkg) -> Loc.none, pkg)
     ; build_command = Option.map build_command ~f:Action.remove_locs
     ; install_command = Option.map install_command ~f:Action.remove_locs
     }
   ;;
 
-  let to_dyn { build_command; install_command; deps; info; exported_env } =
+  let to_dyn { build_command; install_command; depends; info; exported_env } =
     Dyn.record
       [ "build_command", Dyn.option Action.to_dyn build_command
       ; "install_command", Dyn.option Action.to_dyn install_command
-      ; "deps", Dyn.list (Dyn.pair Loc.to_dyn_hum Package_name.to_dyn) deps
+      ; "depends", Dyn.list (Dyn.pair Loc.to_dyn_hum Package_name.to_dyn) depends
       ; "info", Pkg_info.to_dyn info
       ; ( "exported_env"
         , Dyn.list (Action.Env_update.to_dyn String_with_vars.to_dyn) exported_env )
@@ -98,7 +98,7 @@ module Pkg = struct
     let version = "version"
     let install = "install"
     let build = "build"
-    let deps = "deps"
+    let depends = "depends"
     let source = "source"
     let dev = "dev"
     let exported_env = "exported_env"
@@ -112,7 +112,8 @@ module Pkg = struct
     @@ let+ version = field Fields.version Package_version.decode
        and+ install_command = field_o Fields.install Action.decode_pkg
        and+ build_command = field_o Fields.build Action.decode_pkg
-       and+ deps = field ~default:[] Fields.deps (repeat (located Package_name.decode))
+       and+ depends =
+         field ~default:[] Fields.depends (repeat (located Package_name.decode))
        and+ source = field_o Fields.source Source.decode
        and+ dev = field_b Fields.dev
        and+ exported_env =
@@ -137,7 +138,7 @@ module Pkg = struct
            in
            { Pkg_info.name; version; dev; source; extra_sources }
          in
-         { build_command; deps; install_command; info; exported_env }
+         { build_command; depends; install_command; info; exported_env }
   ;;
 
   let encode_extra_source (local, source) : Dune_sexp.t =
@@ -150,7 +151,7 @@ module Pkg = struct
   let encode
     { build_command
     ; install_command
-    ; deps
+    ; depends
     ; info = { Pkg_info.name = _; extra_sources; version; dev; source }
     ; exported_env
     }
@@ -160,7 +161,7 @@ module Pkg = struct
       [ field Fields.version Package_version.encode version
       ; field_o Fields.install Action.encode install_command
       ; field_o Fields.build Action.encode build_command
-      ; field_l Fields.deps Package_name.encode (List.map deps ~f:snd)
+      ; field_l Fields.depends Package_name.encode (List.map depends ~f:snd)
       ; field_o Fields.source Source.encode source
       ; field_b Fields.dev dev
       ; field_l Fields.exported_env Action.Env_update.encode exported_env
@@ -278,7 +279,7 @@ let validate_packages packages =
   let missing_dependencies =
     Package_name.Map.values packages
     |> List.concat_map ~f:(fun (dependant_package : Pkg.t) ->
-      List.filter_map dependant_package.deps ~f:(fun (loc, dependency) ->
+      List.filter_map dependant_package.depends ~f:(fun (loc, dependency) ->
         if Package_name.Map.mem packages dependency
         then None
         else Some { dependant_package; dependency; loc }))
@@ -696,7 +697,7 @@ let transitive_dependency_closure t start =
              that its map of dependencies is closed under "depends on". *)
           Package_name.Set.(
             diff
-              (of_list_map (Package_name.Map.find_exn t.packages node).deps ~f:snd)
+              (of_list_map (Package_name.Map.find_exn t.packages node).depends ~f:snd)
               seen)
         in
         push_set unseen_deps;

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -18,7 +18,7 @@ module Pkg : sig
   type t =
     { build_command : Action.t option
     ; install_command : Action.t option
-    ; deps : (Loc.t * Package_name.t) list
+    ; depends : (Loc.t * Package_name.t) list
     ; info : Pkg_info.t
     ; exported_env : String_with_vars.t Action.Env_update.t list
     }

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -564,7 +564,7 @@ let opam_package_to_lock_file_pkg
     in
     { Lock_dir.Pkg_info.name; version; dev; source; extra_sources }
   in
-  let deps =
+  let depends =
     match
       Resolve_opam_formula.filtered_formula_to_package_names
         ~with_test:false
@@ -642,7 +642,7 @@ let opam_package_to_lock_file_pkg
     then `Compiler
     else `Non_compiler
   in
-  kind, { Lock_dir.Pkg.build_command; install_command; deps; info; exported_env }
+  kind, { Lock_dir.Pkg.build_command; install_command; depends; info; exported_env }
 ;;
 
 let solve_package_list packages context =
@@ -771,8 +771,8 @@ let solve_lock_dir solver_env version_preference repos ~local_packages ~constrai
         in
         Package_name.Map.iter
           pkgs_by_name
-          ~f:(fun { Lock_dir.Pkg.deps; info = { name; _ }; _ } ->
-            List.iter deps ~f:(fun (loc, dep_name) ->
+          ~f:(fun { Lock_dir.Pkg.depends; info = { name; _ }; _ } ->
+            List.iter depends ~f:(fun (loc, dep_name) ->
               if Package_name.Map.mem local_packages dep_name
               then
                 User_error.raise

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -6,7 +6,7 @@ Some environment variables are automatically exported by packages:
   $ echo "(version 0.0.1)" > dune.lock/test.pkg
   $ cat >dune.lock/usetest.pkg <<'EOF'
   > (version 0.0.1)
-  > (deps test)
+  > (depends test)
   > (build
   >  (system "\| echo MANPATH=$MANPATH
   >          "\| echo OCAMLPATH=$OCAMLPATH

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -13,7 +13,7 @@ Packages can export environment variables
   > EOF
 
   $ cat >dune.lock/usetest.pkg <<'EOF'
-  > (deps test)
+  > (depends test)
   > (version 1.2.3)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/file-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/file-depends.t
@@ -26,7 +26,7 @@ Now we make a package depending on file-depends.
 
   $ cat > dune.lock/dep.pkg <<EOF
   > (version 0.0.1)
-  > (deps file-depends)
+  > (depends file-depends)
   > (build
   >  (system "echo Building dep"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -29,7 +29,7 @@ Now it fails since adding the dependency modified PATH.
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > ; adding deps breaks cat
-  > (deps dependency)
+  > (depends dependency)
   > (build
   >  (system "command -v cat > /dev/null 2>&1 || echo no cat"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -20,7 +20,7 @@ Test that installed binaries are visible in dependent packages
 
   $ cat >dune.lock/usetest.pkg <<EOF
   > (version 0.0.1)
-  > (deps test)
+  > (depends test)
   > (build
   >  (progn
   >   (run foo)

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -8,15 +8,15 @@ package graph then it's caught when loading the lockdir.
 
   $ cat >dune.lock/a.pkg <<EOF
   > (version 0.0.1)
-  > (deps b)
+  > (depends b)
   > EOF
   $ cat >dune.lock/b.pkg <<EOF
   > (version 0.0.1)
-  > (deps c)
+  > (depends c)
   > EOF
   $ cat >dune.lock/c.pkg <<EOF
   > (version 0.0.1)
-  > (deps a)
+  > (depends a)
   > EOF
 
   $ dune describe pkg lock
@@ -27,11 +27,11 @@ package graph then it's caught when loading the lockdir.
 
   $ cat >dune.lock/c.pkg <<EOF
   > (version 0.0.1)
-  > (deps a d)
+  > (depends a d)
   > EOF
 
   $ dune describe pkg lock
-  File "dune.lock/c.pkg", line 2, characters 8-9:
+  File "dune.lock/c.pkg", line 2, characters 11-12:
   The package "c" depends on the package "d", but "d" does not appear in the
   lockdir dune.lock.
   Error: At least one package dependency is itself not present as a package in
@@ -43,10 +43,10 @@ package graph then it's caught when loading the lockdir.
   $ rm dune.lock/a.pkg
 
   $ dune describe pkg lock
-  File "dune.lock/c.pkg", line 2, characters 6-7:
+  File "dune.lock/c.pkg", line 2, characters 9-10:
   The package "c" depends on the package "a", but "a" does not appear in the
   lockdir dune.lock.
-  File "dune.lock/c.pkg", line 2, characters 8-9:
+  File "dune.lock/c.pkg", line 2, characters 11-12:
   The package "c" depends on the package "d", but "d" does not appear in the
   lockdir dune.lock.
   Error: At least one package dependency is itself not present as a package in

--- a/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
@@ -42,4 +42,4 @@ of "a" that "c" could depend on is "a.0.0.1" which isn't part of the solution.
   $ cat dune.lock/c.pkg
   (version 0.0.1)
   
-  (deps b)
+  (depends b)

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -69,7 +69,7 @@ Print the contents of each file in the lockdir:
   
   (version 0.0.1)
   
-  (deps baz bar)
+  (depends baz bar)
   
   
   ---
@@ -114,7 +114,7 @@ Run the solver again preferring oldest versions of dependencies:
   
   (version 0.0.1)
   
-  (deps baz bar)
+  (depends baz bar)
   
   
   ---

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
@@ -29,4 +29,4 @@ Demonstrate the translation of filtered dependencies
   $ cat dune.lock/bar.pkg
   (version 0.0.1)
   
-  (deps pkg-build)
+  (depends pkg-build)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -52,7 +52,7 @@ The exported env from the first package should be in the lock dir.
     (run sh -c "echo $append_without_leading_sep")
     (run sh -c "echo $append_with_leading_sep")))
   
-  (deps with-setenv)
+  (depends with-setenv)
 
 When building the second package the exported env vars from the first package should be
 available and all the env updates should be applied correctly.

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -23,4 +23,4 @@ Only a1 or a2 should appear but not both.
   $ cat dune.lock/b.pkg
   (version 0.0.1)
   
-  (deps a1)
+  (depends a1)

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -109,7 +109,7 @@ corresponding Dune version.
     (run echo 41 %{pkg-self:with-dev-setup})
     (run echo 42 %{pkg:foo:with-dev-setup})))
   
-  (deps foo)
+  (depends foo)
 
 The values here are not important, but Dune should be able to interpret the variables.
 

--- a/test/blackbox-tests/test-cases/pkg/package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/package-cycle.t
@@ -6,15 +6,15 @@ Package resolution creating a cycle
 
   $ cat >dune.lock/a.pkg <<EOF
   > (version 0.0.1)
-  > (deps b)
+  > (depends b)
   > EOF
   $ cat >dune.lock/b.pkg <<EOF
   > (version 0.0.1)
-  > (deps c)
+  > (depends c)
   > EOF
   $ cat >dune.lock/c.pkg <<EOF
   > (version 0.0.1)
-  > (deps a)
+  > (depends a)
   > EOF
 
   $ build_pkg a

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -116,7 +116,7 @@ It is also possible to use variables of your dependencies:
   $ cat >dune.lock/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
-  > (deps dependency)
+  > (depends dependency)
   > (build
   >  (progn
   >   (substitute dependencies.ml.in dependencies.ml)

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -20,7 +20,7 @@ Test that we can set variables
 
   $ cat >dune.lock/usetest.pkg <<EOF
   > (version 0.0.1)
-  > (deps test)
+  > (depends test)
   > (build
   >  (progn
   >   (system "\| echo abool: %{pkg:test:abool}

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -134,7 +134,7 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
 let empty_package name ~version =
   { Lock_dir.Pkg.build_command = None
   ; install_command = None
-  ; deps = []
+  ; depends = []
   ; info =
       { Lock_dir.Pkg_info.name; version; dev = false; source = None; extra_sources = [] }
   ; exported_env = []
@@ -173,7 +173,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
           { "bar" :
               { build_command = None
               ; install_command = None
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "bar"
                   ; version = "0.2.0"
@@ -186,7 +186,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
           ; "foo" :
               { build_command = None
               ; install_command = None
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "foo"
                   ; version = "0.1.0"
@@ -253,7 +253,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       , let pkg = empty_package name ~version:(Package_version.of_string "dev") in
         { pkg with
           install_command = None
-        ; deps = [ Loc.none, fst pkg_a ]
+        ; depends = [ Loc.none, fst pkg_a ]
         ; info =
             { pkg.info with
               dev = true
@@ -276,7 +276,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ( name
       , let pkg = empty_package name ~version:(Package_version.of_string "0.2") in
         { pkg with
-          deps = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
+          depends = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
         ; info =
             { pkg.info with
               dev = false
@@ -311,7 +311,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
           { "a" :
               { build_command = Some [ "progn"; [ "echo"; "hello" ] ]
               ; install_command = Some [ "system"; "echo 'world'" ]
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "a"
                   ; version = "0.1.0"
@@ -327,7 +327,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
           ; "b" :
               { build_command = None
               ; install_command = None
-              ; deps = [ ("complex_lock_dir/b.pkg:3", "a") ]
+              ; depends = [ ("complex_lock_dir/b.pkg:3", "a") ]
               ; info =
                   { name = "b"
                   ; version = "dev"
@@ -345,7 +345,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
           ; "c" :
               { build_command = None
               ; install_command = None
-              ; deps =
+              ; depends =
                   [ ("complex_lock_dir/c.pkg:3", "a")
                   ; ("complex_lock_dir/c.pkg:3", "b")
                   ]
@@ -416,7 +416,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
           { "a" :
               { build_command = None
               ; install_command = None
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "a"
                   ; version = "0.1.0"
@@ -429,7 +429,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
           ; "b" :
               { build_command = None
               ; install_command = None
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "b"
                   ; version = "dev"
@@ -442,7 +442,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
           ; "c" :
               { build_command = None
               ; install_command = None
-              ; deps = []
+              ; depends = []
               ; info =
                   { name = "c"
                   ; version = "0.2"


### PR DESCRIPTION
This is more consistent with how the depends field in dune-project

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b0f015be-af23-423d-a964-bb527bca389f -->