### PR TITLE
refactor: move [Dune_load.Dune_files.in_dir]

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -56,7 +56,7 @@ let get_pped_file super_context file =
          >>| Source_tree.Dir.path
          >>| Path.source
        in
-       let* dune_file = Dune_rules.Dune_load.Dune_files.in_dir (dir |> in_build_dir) in
+       let* dune_file = Dune_rules.Dune_load.in_dir (dir |> in_build_dir) in
        let staged_pps =
          Option.bind dune_file ~f:(fun dune_file ->
            dune_file.stanzas

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -10,11 +10,11 @@ module Dune_files : sig
   type t
 
   val eval : t -> context:Context_name.t -> Dune_file.t list Memo.t
-  val in_dir : Path.Build.t -> Dune_file.t option Memo.t
 end
 
 type t
 
+val in_dir : Path.Build.t -> Dune_file.t option Memo.t
 val dune_files : t -> Dune_files.t
 val packages : t -> Package.t Package.Name.Map.t
 val projects : t -> Dune_project.t list

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -128,7 +128,7 @@ let stanzas_in_dir dir =
   if Path.Build.is_root dir
   then Memo.return None
   else
-    Dune_load.Dune_files.in_dir dir
+    Dune_load.in_dir dir
     >>= function
     | None -> Memo.return None
     | Some dune_file ->


### PR DESCRIPTION
It doesn't need to be in the [Dune_files] submodule

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 63511604-57a0-40fa-93f9-0259abbeaf65 -->