### PR TITLE
pkg: reuse downloaded archives within single run

### DIFF
--- a/src/dune_pkg/single_run_file_cache.ml
+++ b/src/dune_pkg/single_run_file_cache.ml
@@ -1,0 +1,50 @@
+open! Import
+open! Stdune
+
+type entry =
+  { filename : Filename.t
+  ; complete : unit Fiber.Ivar.t
+  }
+
+type t =
+  { temp_dir : Path.t lazy_t
+  ; key_to_filename : entry String.Table.t
+  }
+
+let create () =
+  let temp_dir =
+    lazy
+      (let temp_dir = Temp.create Dir ~prefix:"dune" ~suffix:"single-run-file-cache" in
+       at_exit (fun () -> Temp.destroy Dir temp_dir);
+       temp_dir)
+  in
+  { temp_dir; key_to_filename = String.Table.create 1 }
+;;
+
+let with_ { temp_dir; key_to_filename } ~key ~f =
+  let open Fiber.O in
+  let temp_dir = Lazy.force temp_dir in
+  match String.Table.find key_to_filename key with
+  | Some { filename; complete } ->
+    (* If the file is currently being created then this ivar will be empty.
+       Wait for it to become filled, indicating that the file is ready. *)
+    let+ () = Fiber.Ivar.read complete in
+    Ok (Path.relative temp_dir filename)
+  | None ->
+    let filename = string_of_int (String.Table.length key_to_filename) in
+    let output_path = Path.relative temp_dir filename in
+    let complete = Fiber.Ivar.create () in
+    String.Table.add_exn key_to_filename key { filename; complete };
+    let* result = f output_path in
+    (* Fill the ivar signaling that the file is read. *)
+    let+ () = Fiber.Ivar.fill complete () in
+    (match result with
+     | Ok () ->
+       if not (Path.exists output_path)
+       then
+         Code_error.raise
+           "Callback failed to create file"
+           [ "output", Path.to_dyn output_path; "key", Dyn.string key ];
+       Ok output_path
+     | Error _ as e -> e)
+;;

--- a/src/dune_pkg/single_run_file_cache.mli
+++ b/src/dune_pkg/single_run_file_cache.mli
@@ -1,0 +1,22 @@
+open! Import
+open! Stdune
+
+(** A cache that stores an association between files and string keys that will
+    be deleted when dune terminates. For example this could be used to cache
+    downloaded files keyed by their URLs to prevent the same file being
+    downloaded multiple times in a single invocation of dune. Files are stored
+    in a temporary directory. *)
+type t
+
+val create : unit -> t
+
+(** Retrieve the path to a file associated with a given key. If the key has no
+    associated file then the function [f] is called on a path and is expected
+    to create a new file at that path. The resulting file will be associated
+    with the [key] in the cache. If [f] returns [Ok ()] but fails to create the
+    file then a [Code_error] is raised. *)
+val with_
+  :  t
+  -> key:string
+  -> f:(Path.t -> (unit, 'a) result Fiber.t)
+  -> (Path.t, 'a) result Fiber.t


### PR DESCRIPTION
Archives downloaded over http by package management code will be cached in a temporary directory that persists during a single invocation of dune. This is intended to reduce the number of times that dune downloads the same file during package management operations. Note that it's common in the ocaml ecosystem for a single source archive to contain multiple packages.