### PR TITLE
fix(pkg): do not run Memo.run more than once per command

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -105,13 +105,13 @@ let solve
 
 let lock ~version_preference ~lock_dirs_arg =
   let open Fiber.O in
-  let* workspace = Memo.run (Workspace.workspace ())
-  and* solver_env_from_current_system =
+  let* solver_env_from_current_system =
     Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
     |> Dune_pkg.Sys_poll.solver_env_from_current_system
     >>| Option.some
+  and* workspace, local_packages =
+    Memo.both (Workspace.workspace ()) find_local_packages |> Memo.run
   in
-  let* local_packages = find_local_packages in
   solve
     workspace
     ~local_packages

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -14,7 +14,7 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
         get_repos
           (repositories_of_workspace workspace)
           ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
-      and+ local_packages = find_local_packages in
+      and+ local_packages = Memo.run find_local_packages in
       let lock_dir = Lock_dir.read_disk lock_dir_path in
       let+ results = Dune_pkg_outdated.find ~repos ~local_packages lock_dir.packages in
       ( Dune_pkg_outdated.pp ~transitive ~lock_dir_path results

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -101,7 +101,6 @@ let find_local_packages =
   Dune_rules.Dune_load.load ()
   >>| Dune_rules.Dune_load.packages
   >>| Package.Name.Map.map ~f:Package.to_local_package
-  |> Memo.run
 ;;
 
 let pp_packages packages =

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -43,7 +43,7 @@ val get_repos
   -> repositories:(Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list
   -> Dune_pkg.Opam_repo.t list Fiber.t
 
-val find_local_packages : Dune_pkg.Local_package.t Package_name.Map.t Fiber.t
+val find_local_packages : Dune_pkg.Local_package.t Package_name.Map.t Memo.t
 
 module Lock_dirs_arg : sig
   (** [Lock_dirs_arg.t] is the type of lock directory arguments. This can be

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -15,10 +15,9 @@ let info =
    to be and can be simplified. *)
 
 let enumerate_lock_dirs_by_path ~lock_dirs () =
-  let open Fiber.O in
+  let open Memo.O in
   let+ per_contexts =
-    Memo.run (Workspace.workspace ())
-    >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
+    Workspace.workspace () >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
   in
   List.filter_map per_contexts ~f:(fun lock_dir_path ->
     if Path.exists (Path.source lock_dir_path)
@@ -30,8 +29,10 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
 
 let validate_lock_dirs ~lock_dirs () =
   let open Fiber.O in
-  let+ lock_dirs_by_path = enumerate_lock_dirs_by_path ~lock_dirs ()
-  and+ local_packages = Pkg_common.find_local_packages in
+  let+ lock_dirs_by_path, local_packages =
+    Memo.both (enumerate_lock_dirs_by_path ~lock_dirs ()) Pkg_common.find_local_packages
+    |> Memo.run
+  in
   if List.is_empty lock_dirs_by_path
   then Console.print [ Pp.text "No lockdirs to validate." ]
   else (


### PR DESCRIPTION
Doing [Memo.run] clears the caches and the result is duplicate work not being shared. Another annoying side effect is that some errors/warnings are emitted more than once.