### PR TITLE
refactor: move [Library_redirect] to own module

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -15,53 +15,6 @@ let () =
   Dune_project.Extension.register_deleted ~name:"library_variants" ~deleted_in:(2, 6)
 ;;
 
-module Library_redirect = struct
-  type 'old_name t =
-    { project : Dune_project.t
-    ; loc : Loc.t
-    ; old_name : 'old_name
-    ; new_public_name : Loc.t * Lib_name.t
-    }
-
-  module Local = struct
-    type nonrec t = (Loc.t * Lib_name.Local.t) t
-
-    include Stanza.Make (struct
-        type nonrec t = t
-
-        include Poly
-      end)
-
-    let for_lib (lib : Library.t) ~new_public_name ~loc : t =
-      { loc; new_public_name; old_name = lib.name; project = lib.project }
-    ;;
-
-    let of_private_lib (lib : Library.t) : t option =
-      match lib.visibility with
-      | Public _ | Private None -> None
-      | Private (Some package) ->
-        let loc, name = lib.name in
-        let package_name = Package.name package in
-        let new_public_name = loc, Lib_name.mangled package_name name in
-        Some (for_lib lib ~loc ~new_public_name)
-    ;;
-
-    let of_lib (lib : Library.t) : t option =
-      let open Option.O in
-      let* public_name =
-        match lib.visibility with
-        | Public plib -> Some plib.name
-        | Private _ -> None
-      in
-      if Lib_name.equal (Lib_name.of_local lib.name) (snd public_name)
-      then None
-      else (
-        let loc = fst public_name in
-        Some (for_lib lib ~loc ~new_public_name:public_name))
-    ;;
-  end
-end
-
 module Deprecated_library_name = struct
   module Old_name = struct
     type deprecation =

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -2,34 +2,6 @@
 
 open Import
 
-(** The purpose of [Library_redirect] stanza is to create a redirection from an
-    [old_name] to a [new_public_name].
-
-    This is used in two cases:
-
-    - When a library changes its public name, a redirection is created for
-      backwards compatibility with the code using its old name.
-      (deprecated_library_name stanza in dune files)
-
-    - When hiding public libraries with [--only-packages] (or [-p]), we use this
-      stanza to make sure that their project-local names remain in scope. *)
-module Library_redirect : sig
-  type 'old_name t = private
-    { project : Dune_project.t
-    ; loc : Loc.t
-    ; old_name : 'old_name
-    ; new_public_name : Loc.t * Lib_name.t
-    }
-
-  module Local : sig
-    type nonrec t = (Loc.t * Lib_name.Local.t) t
-
-    include Stanza.S with type t := t
-
-    val of_private_lib : Library.t -> t option
-  end
-end
-
 module Deprecated_library_name : sig
   module Old_name : sig
     type deprecation =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -740,7 +740,7 @@ end = struct
                 ~f:
                   (fun
                     acc
-                    { Dune_file.Library_redirect.old_name = old_public_name, _
+                    { Library_redirect.old_name = old_public_name, _
                     ; new_public_name = _, new_public_name
                     ; loc
                     ; _

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -95,8 +95,8 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
       match Stanza.repr stanza with
       | Library.T l ->
         let open Option.O in
-        let+ redirect = Dune_file.Library_redirect.Local.of_private_lib l in
-        Dune_file.Library_redirect.Local.make_stanza redirect
+        let+ redirect = Library_redirect.Local.of_private_lib l in
+        Library_redirect.Local.make_stanza redirect
       | _ -> None))
 ;;
 

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -47,7 +47,7 @@ module DB = struct
   module Library_related_stanza = struct
     type t =
       | Library of Path.Build.t * Library.t
-      | Library_redirect of Dune_file.Library_redirect.Local.t
+      | Library_redirect of Library_redirect.Local.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
   end
 
@@ -151,8 +151,7 @@ module DB = struct
              let named p loc = Option.some_if (name = p) loc in
              match stanza with
              | Library (_, { buildable = { loc; _ }; visibility = Public p; _ })
-             | Deprecated_library_name
-                 { Dune_file.Library_redirect.loc; old_name = p, _; _ } ->
+             | Deprecated_library_name { Library_redirect.loc; old_name = p, _; _ } ->
                named (Public_lib.name p) loc
              | _ -> None)
          with
@@ -317,7 +316,7 @@ module DB = struct
             Library_related_stanza.Library (ctx_dir, lib) :: acc, coq_acc
           | Dune_file.Deprecated_library_name.T d ->
             Deprecated_library_name d :: acc, coq_acc
-          | Dune_file.Library_redirect.Local.T d -> Library_redirect d :: acc, coq_acc
+          | Library_redirect.Local.T d -> Library_redirect d :: acc, coq_acc
           | Coq_stanza.Theory.T coq_lib ->
             let ctx_dir = Path.Build.append_source build_dir dune_file.dir in
             acc, (ctx_dir, coq_lib) :: coq_acc

--- a/src/dune_rules/stanzas/library_redirect.ml
+++ b/src/dune_rules/stanzas/library_redirect.ml
@@ -1,0 +1,46 @@
+open Import
+
+type 'old_name t =
+  { project : Dune_project.t
+  ; loc : Loc.t
+  ; old_name : 'old_name
+  ; new_public_name : Loc.t * Lib_name.t
+  }
+
+module Local = struct
+  type nonrec t = (Loc.t * Lib_name.Local.t) t
+
+  include Stanza.Make (struct
+      type nonrec t = t
+
+      include Poly
+    end)
+
+  let for_lib (lib : Library.t) ~new_public_name ~loc : t =
+    { loc; new_public_name; old_name = lib.name; project = lib.project }
+  ;;
+
+  let of_private_lib (lib : Library.t) : t option =
+    match lib.visibility with
+    | Public _ | Private None -> None
+    | Private (Some package) ->
+      let loc, name = lib.name in
+      let package_name = Package.name package in
+      let new_public_name = loc, Lib_name.mangled package_name name in
+      Some (for_lib lib ~loc ~new_public_name)
+  ;;
+
+  let of_lib (lib : Library.t) : t option =
+    let open Option.O in
+    let* public_name =
+      match lib.visibility with
+      | Public plib -> Some plib.name
+      | Private _ -> None
+    in
+    if Lib_name.equal (Lib_name.of_local lib.name) (snd public_name)
+    then None
+    else (
+      let loc = fst public_name in
+      Some (for_lib lib ~loc ~new_public_name:public_name))
+  ;;
+end

--- a/src/dune_rules/stanzas/library_redirect.mli
+++ b/src/dune_rules/stanzas/library_redirect.mli
@@ -1,0 +1,29 @@
+open Import
+
+(** The purpose of [Library_redirect] stanza is to create a redirection from an
+    [old_name] to a [new_public_name].
+
+    This is used in two cases:
+
+    - When a library changes its public name, a redirection is created for
+      backwards compatibility with the code using its old name.
+      (deprecated_library_name stanza in dune files)
+
+    - When hiding public libraries with [--only-packages] (or [-p]), we use this
+      stanza to make sure that their project-local names remain in scope. *)
+
+type 'old_name t =
+  { project : Dune_project.t
+  ; loc : Loc.t
+  ; old_name : 'old_name
+  ; new_public_name : Loc.t * Lib_name.t
+  }
+
+module Local : sig
+  type nonrec t = (Loc.t * Lib_name.Local.t) t
+
+  include Stanza.S with type t := t
+
+  val of_private_lib : Library.t -> t option
+  val of_lib : Library.t -> t option
+end


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3cdad799-2989-42b4-a1b0-f0f1507b1506 -->