### PR TITLE
refactor: move [Deprecated_library_name] to own module

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -15,55 +15,6 @@ let () =
   Dune_project.Extension.register_deleted ~name:"library_variants" ~deleted_in:(2, 6)
 ;;
 
-module Deprecated_library_name = struct
-  module Old_name = struct
-    type deprecation =
-      | Not_deprecated
-      | Deprecated of { deprecated_package : Package.Name.t }
-
-    type t = Public_lib.t * deprecation
-
-    let decode =
-      let+ public = Public_lib.decode ~allow_deprecated_names:true in
-      let deprecation =
-        let deprecated_package = Lib_name.package_name (Public_lib.name public) in
-        if let name = Package.name (Public_lib.package public) in
-           Package.Name.equal deprecated_package name
-        then Not_deprecated
-        else Deprecated { deprecated_package }
-      in
-      public, deprecation
-    ;;
-  end
-
-  type t = Old_name.t Library_redirect.t
-
-  include Stanza.Make (struct
-      type nonrec t = t
-
-      include Poly
-    end)
-
-  let old_public_name (t : t) = Public_lib.name (fst t.old_name)
-
-  let decode =
-    fields
-      (let+ loc = loc
-       and+ project = Dune_project.get_exn ()
-       and+ old_name = field "old_public_name" Old_name.decode
-       and+ new_public_name = field "new_public_name" (located Lib_name.decode) in
-       let () =
-         let loc, old_name = (fst old_name).name in
-         if Lib_name.equal (snd new_public_name) old_name
-         then
-           User_error.raise
-             ~loc
-             [ Pp.text "old_public_name cannot be the same as the new_public_name" ]
-       in
-       { Library_redirect.loc; project; old_name; new_public_name })
-  ;;
-end
-
 module Include = struct
   type t = Loc.t * string
 

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -2,22 +2,6 @@
 
 open Import
 
-module Deprecated_library_name : sig
-  module Old_name : sig
-    type deprecation =
-      | Not_deprecated
-      | Deprecated of { deprecated_package : Package.Name.t }
-
-    type t = Public_lib.t * deprecation
-  end
-
-  type t = Old_name.t Library_redirect.t
-
-  include Stanza.S with type t := t
-
-  val old_public_name : t -> Lib_name.t
-end
-
 val stanza_package : Stanza.t -> Package.t option
 
 (** [of_ast project ast] is the list of [Stanza.t]s derived from decoding the

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -23,7 +23,7 @@ module DB : sig
   module Lib_entry : sig
     type t =
       | Library of Lib.Local.t
-      | Deprecated_library_name of Dune_file.Deprecated_library_name.t
+      | Deprecated_library_name of Deprecated_library_name.t
   end
 
   val lib_entries_of_package : Context.t -> Package.Name.t -> Lib_entry.t list Memo.t

--- a/src/dune_rules/stanzas/deprecated_library_name.ml
+++ b/src/dune_rules/stanzas/deprecated_library_name.ml
@@ -1,0 +1,49 @@
+open Import
+open Dune_lang.Decoder
+
+module Old_name = struct
+  type deprecation =
+    | Not_deprecated
+    | Deprecated of { deprecated_package : Package.Name.t }
+
+  type t = Public_lib.t * deprecation
+
+  let decode =
+    let+ public = Public_lib.decode ~allow_deprecated_names:true in
+    let deprecation =
+      let deprecated_package = Lib_name.package_name (Public_lib.name public) in
+      if let name = Package.name (Public_lib.package public) in
+         Package.Name.equal deprecated_package name
+      then Not_deprecated
+      else Deprecated { deprecated_package }
+    in
+    public, deprecation
+  ;;
+end
+
+type t = Old_name.t Library_redirect.t
+
+include Stanza.Make (struct
+    type nonrec t = t
+
+    include Poly
+  end)
+
+let old_public_name (t : t) = Public_lib.name (fst t.old_name)
+
+let decode =
+  fields
+    (let+ loc = loc
+     and+ project = Dune_project.get_exn ()
+     and+ old_name = field "old_public_name" Old_name.decode
+     and+ new_public_name = field "new_public_name" (located Lib_name.decode) in
+     let () =
+       let loc, old_name = (fst old_name).name in
+       if Lib_name.equal (snd new_public_name) old_name
+       then
+         User_error.raise
+           ~loc
+           [ Pp.text "old_public_name cannot be the same as the new_public_name" ]
+     in
+     { Library_redirect.loc; project; old_name; new_public_name })
+;;

--- a/src/dune_rules/stanzas/deprecated_library_name.mli
+++ b/src/dune_rules/stanzas/deprecated_library_name.mli
@@ -1,0 +1,17 @@
+open Import
+
+module Old_name : sig
+  type deprecation =
+    | Not_deprecated
+    | Deprecated of { deprecated_package : Package.Name.t }
+
+  type t = Public_lib.t * deprecation
+end
+
+type t = Old_name.t Library_redirect.t
+
+val decode : t Dune_lang.Decoder.t
+
+include Stanza.S with type t := t
+
+val old_public_name : t -> Lib_name.t


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2819011a-8163-4474-8bdf-6e26d5040c21 -->