### PR TITLE
Add --files to dune describe opam-files

### DIFF
--- a/bin/describe/describe_opam_files.ml
+++ b/bin/describe/describe_opam_files.ml
@@ -3,7 +3,13 @@ open Import
 let term =
   let+ builder = Common.Builder.term
   and+ format = Describe_format.arg
-  and+ _ = Describe_lang_compat.arg in
+  and+ _ = Describe_lang_compat.arg
+  and+ filenames_only =
+    let doc =
+      "Print opam filenames, each on their own line. This ignores the --format argument."
+    in
+    Arg.(value & flag & info [ "files" ] ~doc)
+  in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
@@ -28,7 +34,14 @@ let term =
     in
     Dyn.Tuple [ String (Path.to_string opam_file); String contents ]
   in
-  packages |> Dyn.list opam_file_to_dyn |> Describe_format.print_dyn format
+  if filenames_only
+  then
+    Console.print
+      [ Pp.vbox
+          (Pp.concat_map ~sep:Pp.cut packages ~f:(fun pkg ->
+             Package.opam_file pkg |> Path.source |> Path.pp))
+      ]
+  else packages |> Dyn.list opam_file_to_dyn |> Describe_format.print_dyn format
 ;;
 
 let command =

--- a/doc/changes/9793.md
+++ b/doc/changes/9793.md
@@ -1,0 +1,2 @@
+- Add `--files` flag to `dune describe opam-files` to print only the names of
+  the opam files line by line. (#9793, @reynir and @Alizter)

--- a/test/blackbox-tests/test-cases/describe/describe-opam-files.t
+++ b/test/blackbox-tests/test-cases/describe/describe-opam-files.t
@@ -1,0 +1,28 @@
+Testing the behaviour of dune describe opam-files
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (generate_opam_files)
+  > (package
+  >  (name a)
+  >  (allow_empty))
+  > (package
+  >  (name b)
+  >  (allow_empty))
+  > (package
+  >  (name c)
+  >  (allow_empty))
+  > EOF
+
+  $ dune describe opam-files --files
+  a.opam
+  b.opam
+  c.opam
+
+  $ cat >> dune-project <<EOF
+  > (opam_file_location inside_opam_directory)
+  > EOF
+  $ dune describe opam-files --files
+  opam/a.opam
+  opam/b.opam
+  opam/c.opam


### PR DESCRIPTION
This flag makes dune describe opam-files only print the opam file names, each on their own line. This is useful for shell scripts where parsing sexp can be somewhat complicated.

The flag unfortunately ignores the `--format` argument. Another option could be to add a NUL-byte delimited format assuming none of the output would include NUL bytes (which I'm not sure is a reasonable assumption).

- [x] changelog