### PR TITLE
fix: Add missing EOF in test

### DIFF
--- a/test/blackbox-tests/test-cases/more-than-one-optional.t
+++ b/test/blackbox-tests/test-cases/more-than-one-optional.t
@@ -11,10 +11,12 @@ Demonstrate an optional executable available from more than one definition
   > (executable
   >  (public_name foo)
   >  (enabled_if true))
+  > EOF
   $ cat >b/dune <<EOF
   > (executable
   >  (public_name foo)
   >  (enabled_if true))
+  > EOF
   $ cat >dune <<EOF
   > (rule
   >  (alias foo)


### PR DESCRIPTION
While running the tests I noticed some warnings about EOF missing, so here's a fix.