### PR TITLE
feature(pkg): Submodule support

### DIFF
--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -20,3 +20,8 @@ module Local_package = Local_package
 module Package_universe = Package_universe
 module Variable_value = Variable_value
 module Resolved_package = Resolved_package
+
+module Private = struct
+  (* only exposed for tests *)
+  module Git_config_parser = Git_config_parser
+end

--- a/src/dune_pkg/git_config_parser.ml
+++ b/src/dune_pkg/git_config_parser.ml
@@ -1,0 +1,70 @@
+open Import
+
+type bindings = string * string
+
+type section =
+  { name : string
+  ; arg : string option
+  ; bindings : bindings list
+  }
+
+type t = section list
+
+let strip =
+  let re = Re.(compile (alt [ seq [ bos; rep blank ]; seq [ rep blank; eos ] ])) in
+  Re.replace_string ~all:true re ~by:""
+;;
+
+let parse_section_bindings =
+  let binding_re =
+    Re.(
+      compile
+      @@ seq [ rep space; group (rep1 (diff any (char '='))); char '='; group (rep1 any) ])
+  in
+  fun lines ->
+    List.filter_map lines ~f:(fun line ->
+      Re.exec_opt binding_re line
+      |> Option.map ~f:(fun m ->
+        let name = Re.Group.get m 1 |> strip in
+        let value = Re.Group.get m 2 |> strip in
+        name, value))
+;;
+
+let parse_section_header =
+  let identifier = Re.(rep1 (diff any blank)) in
+  let section_re =
+    Re.(
+      compile
+      @@ seq
+           [ char '['
+           ; group identifier
+           ; alt [ char ']'; seq [ rep1 blank; char '"'; group (rep1 any); str "\"]" ] ]
+           ])
+  in
+  fun line ->
+    Re.exec_opt section_re line
+    |> Option.map ~f:(fun m -> Re.Group.get m 1, Re.Group.get_opt m 2)
+;;
+
+let rec parse_sections acc lines =
+  match lines with
+  | [] -> List.rev acc
+  | header :: rest ->
+    (match parse_section_header header with
+     | Some (name, arg) ->
+       let this, rest =
+         List.split_while rest ~f:(fun line ->
+           not @@ String.is_prefix ~prefix:"[" @@ strip line)
+       in
+       let bindings = parse_section_bindings this in
+       let section = { name; arg; bindings } in
+       parse_sections (section :: acc) rest
+     | None ->
+       (* not a header, skip line *)
+       parse_sections acc rest)
+;;
+
+let parse s =
+  let lines = String.split ~on:'\n' s in
+  parse_sections [] lines |> Result.ok
+;;

--- a/src/dune_pkg/git_config_parser.ml
+++ b/src/dune_pkg/git_config_parser.ml
@@ -90,7 +90,19 @@ let rec parse_sections acc lines =
        parse_sections acc rest)
 ;;
 
+let strip_comment =
+  let from_char_to_end c = Re.(compile (seq [ c; rep any ])) in
+  let hash_comment = from_char_to_end @@ Re.char '#' in
+  let semicolon_comment = from_char_to_end @@ Re.char ';' in
+  let by = "" in
+  let all = false in
+  fun line ->
+    line
+    |> Re.replace_string ~all ~by hash_comment
+    |> Re.replace_string ~all ~by semicolon_comment
+;;
+
 let parse s =
-  let lines = String.split ~on:'\n' s in
+  let lines = s |> String.split ~on:'\n' |> List.map ~f:strip_comment in
   parse_sections [] lines |> Result.ok
 ;;

--- a/src/dune_pkg/git_config_parser.mli
+++ b/src/dune_pkg/git_config_parser.mli
@@ -1,3 +1,5 @@
+(** simplistic parser for git config files *)
+
 type bindings = string * string
 
 type section =

--- a/src/dune_pkg/git_config_parser.mli
+++ b/src/dune_pkg/git_config_parser.mli
@@ -1,0 +1,11 @@
+type bindings = string * string
+
+type section =
+  { name : string
+  ; arg : string option
+  ; bindings : bindings list
+  }
+
+type t = section list
+
+val parse : string -> (t, string) result

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -388,6 +388,7 @@ let parse_submodules lines =
         let url = List.find_map bindings ~f:(find_key "url") in
         (match path, url with
          | Some path, Some source ->
+           (* CR-rginberg: we need to handle this *)
            let path = Path.Local.of_string path in
            Some { path; source }
          | _, _ ->
@@ -471,6 +472,7 @@ module At_rev = struct
 
   let submodule_path submodules path =
     List.find_map submodules ~f:(fun (submodule_path, at_rev) ->
+      (* CR-rgrinberg: should be Path.Local.descendant *)
       Path.drop_prefix (Path.of_local path) ~prefix:(Path.of_local submodule_path)
       |> Option.map ~f:(fun path_in_at_rev -> path_in_at_rev, at_rev))
   ;;
@@ -486,6 +488,7 @@ module At_rev = struct
     path
     =
     match submodule_path submodules path with
+    | Some (path_in_at_rev, at_rev) -> directory_entries at_rev path_in_at_rev
     | None ->
       (* TODO: there are much better ways of implementing this:
          1. using libgit or ocamlgit
@@ -498,7 +501,6 @@ module At_rev = struct
              "foo" is indeed a descendant of itself. So we filter it manually. *)
           (not (Path.Local.equal file.path path))
           && Path.Local.is_descendant file.path ~of_:path)
-    | Some (path_in_at_rev, at_rev) -> directory_entries at_rev path_in_at_rev
   ;;
 
   let repo_equal = equal

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -743,7 +743,7 @@ let rec add_repo ({ dir } as t) ~source ~branch =
          | None ->
            (* the rev store is in some sort of unexpected state *)
            Code_error.raise
-             (sprintf "Could not load default branch of repository '%s'" source)
+             (sprintf "Could not load default branch of repository")
              [ "source", Dyn.string source; "handle", Dyn.string handle ])
       | false, Some branch ->
         let+ () = remote_add t ~branch ~handle ~source in

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -738,8 +738,7 @@ let rec add_repo ({ dir } as t) ~source ~branch =
       match exists, branch with
       | true, Some branch -> Fiber.return branch
       | true, None ->
-        let head_branch = read_head_branch t handle in
-        (match head_branch with
+        (match read_head_branch t handle with
          | Some head_branch -> Fiber.return head_branch
          | None ->
            (* the rev store is in some sort of unexpected state *)
@@ -750,9 +749,9 @@ let rec add_repo ({ dir } as t) ~source ~branch =
         let+ () = remote_add t ~branch ~handle ~source in
         branch
       | false, None ->
-        let* head_branch = query_head_branch t source in
-        let branch =
-          match head_branch with
+        let* branch =
+          query_head_branch t source
+          >>| function
           | Some head_branch -> head_branch
           | None ->
             User_error.raise

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -251,17 +251,21 @@ And create it as a separate repo, this time with the packages in the root:
   $ git init --quiet
   $ git add -A
   $ git commit -m "Initial subrepo commit" --quiet
+  $ SUBMODULE_REVISION=$(git rev-parse HEAD)
+  $ SUBMODULE_LOCATION=$(pwd)
   $ cd ..
 
 In our mock repository, we make sure to add the submodule as `packages`:
 
   $ cd mock-opam-repository
   $ git init --quiet
-  $ GIT_ALLOW_PROTOCOL=file git submodule add ../remote-submodule packages
+  $ GIT_ALLOW_PROTOCOL=file git submodule add ${SUBMODULE_LOCATION} packages
   Cloning into '$TESTCASE_ROOT/mock-opam-repository/packages'...
   done.
   $ git commit -m "Initial opam-repo commit" --quiet
   $ git submodule init
+  $ git ls-tree -r HEAD | grep "commit ${SUBMODULE_REVISION}" > /dev/null && echo "Submodule exists at expected revision"
+  Submodule exists at expected revision
   $ cd ..
 
 We'll use the mock repository as source:
@@ -280,10 +284,6 @@ however due to some issues this currently fails:
 
   $ rm -r dune.lock
   $ dune pkg lock
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: baz.dev
-  - bar -> (problem)
-      No known implementations at all
-  [1]
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1

--- a/test/expect-tests/dune_pkg/git_config.ml
+++ b/test/expect-tests/dune_pkg/git_config.ml
@@ -61,6 +61,16 @@ let%expect_test "parsing with equal" =
   |}]
 ;;
 
+let%expect_test "parsing without equal" =
+  let config = {|[foo]
+    enabled
+    |} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("enabled", "true") ] } ]
+  |}]
+;;
+
 let%expect_test "parsing multiple bindings" =
   let config = {|[foo]
     bar = baz
@@ -133,5 +143,16 @@ let%expect_test "parsing named section" =
   [%expect
     {|
   [ { name = "foo"; arg = Some "name"; bindings = [ ("bar", "baz") ] } ]
+  |}]
+;;
+
+let%expect_test "case sensitivity" =
+  let config = {|[fOO "nAmE"]
+    bar = baz
+    |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = Some "nAmE"; bindings = [ ("bar", "baz") ] } ]
   |}]
 ;;

--- a/test/expect-tests/dune_pkg/git_config.ml
+++ b/test/expect-tests/dune_pkg/git_config.ml
@@ -1,0 +1,137 @@
+open Stdune
+
+module Git_config_parser = struct
+  include Dune_pkg.Private.Git_config_parser
+
+  let binding_to_dyn = Dyn.(pair string string)
+
+  let section_to_dyn { name; arg; bindings } =
+    Dyn.record
+      [ "name", Dyn.string name
+      ; "arg", Dyn.option Dyn.string arg
+      ; "bindings", Dyn.list binding_to_dyn bindings
+      ]
+  ;;
+
+  let to_dyn = Dyn.list section_to_dyn
+end
+
+let print_or_fail s =
+  match Git_config_parser.parse s with
+  | Ok v -> print_endline @@ Dyn.to_string @@ Git_config_parser.to_dyn v
+  | Error e -> print_endline e
+;;
+
+let%expect_test "parsing simple section" =
+  let config = {|[foo]
+    bar = baz
+    |} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz") ] } ]
+  |}]
+;;
+
+let%expect_test "parsing without spaces" =
+  let config = {|[foo]
+bar=baz|} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz") ] } ]
+  |}]
+;;
+
+let%expect_test "parsing with space" =
+  let config = {|[foo]
+    bar = baz qux
+    |} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz qux") ] } ]
+  |}]
+;;
+
+let%expect_test "parsing with equal" =
+  let config = {|[foo]
+    bar = baz=qux
+    |} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz=qux") ] } ]
+  |}]
+;;
+
+let%expect_test "parsing multiple bindings" =
+  let config = {|[foo]
+    bar = baz
+    foo = baz
+  |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz"); ("foo", "baz") ] }
+  ]
+  |}]
+;;
+
+let%expect_test "parsing no bindings" =
+  let config = {|[empty]
+  [filled]
+  baz=qux
+  |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "empty"; arg = None; bindings = [] }
+  ; { name = "filled"; arg = None; bindings = [ ("baz", "qux") ] }
+  ]
+  |}]
+;;
+
+let%expect_test "parsing multiple sections" =
+  let config = {|[foo]
+    bar = baz
+    
+   [bar]
+   foo = baz
+  |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz") ] }
+  ; { name = "bar"; arg = None; bindings = [ ("foo", "baz") ] }
+  ]
+  |}]
+;;
+
+let%expect_test "parsing whitespaces" =
+  let config = {|
+
+  [foo]
+
+
+    bar = baz
+
+  [qux]
+
+    quux = corge
+  |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz") ] }
+  ; { name = "qux"; arg = None; bindings = [ ("quux", "corge") ] }
+  ]
+  |}]
+;;
+
+let%expect_test "parsing named section" =
+  let config = {|[foo "name"]
+    bar = baz
+    |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = Some "name"; bindings = [ ("bar", "baz") ] } ]
+  |}]
+;;

--- a/test/expect-tests/dune_pkg/git_config.ml
+++ b/test/expect-tests/dune_pkg/git_config.ml
@@ -84,6 +84,31 @@ let%expect_test "parsing multiple bindings" =
   |}]
 ;;
 
+let%expect_test "parsing duplicate bindings" =
+  let config = {|[foo]
+    bar = baz
+    bar = qux
+  |} in
+  print_or_fail config;
+  [%expect
+    {|
+  [ { name = "foo"; arg = None; bindings = [ ("bar", "baz"); ("bar", "qux") ] }
+  ]
+  |}]
+;;
+
+let%expect_test "comments" =
+  let config = {|[foo]
+    #set = wrong
+    ;set = incorrect
+    set = correct
+  |} in
+  print_or_fail config;
+  [%expect {|
+  [ { name = "foo"; arg = None; bindings = [ ("set", "correct") ] } ]
+  |}]
+;;
+
 let%expect_test "parsing no bindings" =
   let config = {|[empty]
   [filled]


### PR DESCRIPTION
This adds support for repos with submodules. If submodules are defined in the repo and commit objects exist at the specified location, the specified repo will be added as a remote and the revisions will get added to the rev-store.

When accessing the revisions, the `At_rev` will look up directories and content in the submodule `At_rev`s.