### PR TITLE
refactor: move cram test discovery to rules

### DIFF
--- a/src/dune_rules/cram/cram_rules.mli
+++ b/src/dune_rules/cram/cram_rules.mli
@@ -6,5 +6,5 @@ val rules
   :  sctx:Super_context.t
   -> expander:Expander.t
   -> dir:Path.Build.t
-  -> (Cram_test.t, Source_tree.Dir.error) result list
+  -> Source_tree.Dir.t
   -> unit Memo.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -296,9 +296,7 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander dune_file ~dir:ctx_di
 
 let gen_format_and_cram_rules sctx ~expander ~dir source_dir =
   let+ () = Format_rules.setup_alias ~dir
-  and+ () =
-    Source_tree.Dir.cram_tests source_dir >>= Cram_rules.rules ~sctx ~expander ~dir
-  in
+  and+ () = Cram_rules.rules source_dir ~sctx ~expander ~dir in
   ()
 ;;
 

--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -21,9 +21,7 @@ end
 
 module Dir : sig
   type t
-  type error = Missing_run_t of Cram_test.t
 
-  val cram_tests : t -> (Cram_test.t, error) result list Memo.t
   val path : t -> Path.Source.t
   val filenames : t -> Filename.Set.t
 


### PR DESCRIPTION
It doesn't belong to [Source_tree]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cb06a918-b94c-444f-a0c6-a36ae51b2d26 -->