### PR TITLE
fix(subst): skip large files on 32-bit

### DIFF
--- a/doc/changes/9811.md
+++ b/doc/changes/9811.md
@@ -1,0 +1,1 @@
+- subst: do not fail on 32-bit systems when large files are encountered. Just log a warning in this case. (#9811, fixes #9538, @emillon)

--- a/test/blackbox-tests/test-cases/subst/32bit.t
+++ b/test/blackbox-tests/test-cases/subst/32bit.t
@@ -26,10 +26,7 @@ This test uses subst, which needs a git repository:
    create mode 100644 dune-project
    create mode 100644 large.dat
 
-  $ dune subst 2>&1 | head -n 6
-  Error: exception Invalid_argument("Bytes.create")
-  Raised by primitive operation at Stdune__Io.Make.eagerly_input_string in file
-    "otherlibs/stdune/src/io.ml", line 273, characters 14-30
-  Called from Stdune__Io.Make.read_all.(fun) in file
-    "otherlibs/stdune/src/io.ml", line 308, characters 16-40
-  Called from Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line
+  $ dune subst
+  Warning: Ignoring large file: large.dat
+  Hint: Dune has been built as a 32-bit binary so the maximum size "dune subst"
+  can operate on is 16MiB.


### PR DESCRIPTION
Fixes #9538

When `subst` tries to work on a file, it first loads it in memory as an OCaml `string`. This type has a maximum size, `Sys.max_string_length`. This is not an issue on 64-bit systems, but the 32-bit limit can be below the size of actual files.

However, it is unlikely that these files need substitutions, so we just log a warning in this case.
