### PR TITLE
fix: truncation with large output

### DIFF
--- a/doc/changes/9813.md
+++ b/doc/changes/9813.md
@@ -1,0 +1,2 @@
+- do not crash on 32-bit systems when a command has a large output (#9813,
+  fixes #4194, @emillon)

--- a/test/blackbox-tests/test-cases/github4194.t
+++ b/test/blackbox-tests/test-cases/github4194.t
@@ -17,8 +17,5 @@
   >   done
   > EOF
 
-  $ dune runtest 2>&1 | head -n 5 |grep -v 'fn ='
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("read_file: file is larger than Sys.max_string_length",
-  Raised at Stdune__Code_error.raise in file
+  $ dune runtest 2>&1| grep .
+  ...TRUNCATED BY DUNE...


### PR DESCRIPTION
Fixes #4194

When a command has a large output (larger than `Sys.max_string_length`, only an issue on 32-bit systems), we would crash. Instead, this truncates the start of the output.
