### PR TITLE
fix: add missing locations to invalid ocaml syntax files

### DIFF
--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -183,6 +183,7 @@ module Script = struct
     if not (Path.Untracked.exists (Path.build generated_dune_file))
     then
       User_error.raise
+        ~loc:(Loc.in_file (Path.source file))
         [ Pp.textf
             "%s failed to produce a valid dune file."
             (Path.Source.to_string_maybe_quoted file)


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d7ec8afa-8bd5-4628-a629-c6de5b63a42b -->