### PR TITLE
fix: do not warn for stanzas introduced with (subdir ..)

### DIFF
--- a/src/dune_rules/dune_file0.ml
+++ b/src/dune_rules/dune_file0.ml
@@ -471,8 +471,11 @@ let load ~dir (status : Source_dir_status.t) project ~files ~parent =
   match parent, file with
   | None, None -> Memo.return None
   | _, _ ->
-    (* CR-rgrinberg: no need to warn if [file = None] *)
-    let* () = ensure_dune_project_file_exists project in
+    let* () =
+      match file with
+      | None -> Memo.return ()
+      | Some _ -> ensure_dune_project_file_exists project
+    in
     let file = Option.map file ~f:(Path.Source.relative dir) in
     load file ~from_parent:parent ~project >>| Option.some
 ;;


### PR DESCRIPTION
It's pointless b/c the warning should come from the dune file where the
stanzas where written.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: dbf79890-e3ef-45b1-a65a-ffb83aeb033d -->