### PR TITLE
refactor: share [Subst_config] with [Toggle]

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -315,7 +315,7 @@ let subst vcs =
           ]
   in
   (match Dune_project.subst_config dune_project.project with
-   | Dune_lang.Subst_config.Disabled ->
+   | `Disabled ->
      User_error.raise
        [ Pp.concat
            ~sep:Pp.space
@@ -328,7 +328,7 @@ let subst vcs =
              "If you wish to re-enable it, change to (subst enabled) in the dune-project \
               file."
          ]
-   | Enabled -> ());
+   | `Enabled -> ());
   let info =
     let loc, name =
       match dune_project.name with

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -23,6 +23,7 @@ let local_libraries =
   ; ("otherlibs/dune-glob/src", Some "Dune_glob", false, None)
   ; ("otherlibs/xdg", Some "Xdg", false, None)
   ; ("otherlibs/dune-rpc/private", Some "Dune_rpc_private", false, None)
+  ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("vendor/sha", None, false, None)
   ; ("vendor/uutf", None, false, None)
   ; ("vendor/opam/src/core", None, false, None)
@@ -33,7 +34,6 @@ let local_libraries =
   ; ("src/dune_stats", Some "Dune_stats", false, None)
   ; ("vendor/build_path_prefix_map/src", Some "Build_path_prefix_map", false,
     None)
-  ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("src/dune_util", Some "Dune_util", false, None)
   ; ("src/dune_metrics", Some "Dune_metrics", false, None)
   ; ("src/dune_digest", Some "Dune_digest", false, None)

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -5,6 +5,7 @@
   stdune
   dune_glob
   dune_rpc_private
+  dune_config
   opam_format
   ocaml
   dune_util

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -33,3 +33,4 @@ module Visibility = Visibility
 module Dep_conf = Dep_conf
 module Relop = Relop
 module Cond = Cond
+module Toggle = Toggle

--- a/src/dune_lang/subst_config.ml
+++ b/src/dune_lang/subst_config.ml
@@ -1,26 +1,18 @@
 open Dune_sexp.Decoder
 
 (* Can be extended later if needed *)
-type t =
-  | Disabled
-  | Enabled
-
-let is_enabled = function
-  | Enabled -> true
-  | Disabled -> false
-;;
+type t = Toggle.t
 
 let to_string = function
-  | Disabled -> "disabled"
-  | Enabled -> "enabled"
+  | `Disabled -> "disabled"
+  | `Enabled -> "enabled"
 ;;
 
-let to_dyn conf = to_string conf |> Dyn.string
 let encode t = Dune_sexp.Encoder.string (to_string t)
-let decoder = enum [ "disabled", Disabled; "enabled", Enabled ]
-let field ~since = field_o "subst" (Dune_sexp.Syntax.since Stanza.syntax since >>> decoder)
+let decoder = enum [ "disabled", `Disabled; "enabled", `Enabled ]
+let field = field_o "subst" (Dune_sexp.Syntax.since Stanza.syntax (3, 0) >>> decoder)
 
 let of_config = function
-  | None -> Enabled
+  | None -> `Enabled
   | Some conf -> conf
 ;;

--- a/src/dune_lang/subst_config.mli
+++ b/src/dune_lang/subst_config.mli
@@ -1,9 +1,5 @@
-type t =
-  | Disabled
-  | Enabled
+type t = Toggle.t
 
-val is_enabled : t -> bool
-val to_dyn : t -> Dyn.t
 val encode : t Dune_sexp.Encoder.t
-val field : since:Dune_sexp.Syntax.Version.t -> t option Dune_sexp.Decoder.fields_parser
+val field : t option Dune_sexp.Decoder.fields_parser
 val of_config : t option -> t

--- a/src/dune_lang/toggle.ml
+++ b/src/dune_lang/toggle.ml
@@ -1,0 +1,41 @@
+open Stdune
+open Dune_sexp
+open Dune_config
+include Config.Toggle
+
+let enabled : t -> bool = function
+  | `Enabled -> true
+  | `Disabled -> false
+;;
+
+let of_bool = function
+  | true -> `Enabled
+  | false -> `Disabled
+;;
+
+let all = [ "enable", `Enabled; "disable", `Disabled ]
+
+let encode t =
+  let open Encoder in
+  let v =
+    List.find_map all ~f:(fun (k, v) -> Option.some_if (v = t) k) |> Option.value_exn
+  in
+  string v
+;;
+
+let decode : t Decoder.t =
+  Decoder.(map_validate string) ~f:(fun s ->
+    match List.assoc all s with
+    | Some v -> Ok v
+    | None -> Error (User_error.make [ Pp.text "must be 'disable' or 'enable'" ]))
+;;
+
+let field ?check name =
+  let open Decoder in
+  let decode =
+    match check with
+    | None -> decode
+    | Some check -> check >>> decode
+  in
+  field_o name decode
+;;

--- a/src/dune_lang/toggle.mli
+++ b/src/dune_lang/toggle.mli
@@ -1,0 +1,9 @@
+open Dune_config
+module Decoder := Dune_sexp.Decoder
+include module type of Config.Toggle with type t = Config.Toggle.t
+
+val enabled : t -> bool
+val of_bool : bool -> t
+val encode : t Dune_sexp.Encoder.t
+val decode : t Decoder.t
+val field : ?check:unit Decoder.t -> string -> t option Decoder.fields_parser

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -128,7 +128,7 @@ let to_dyn
     ; "dialects", Dialect.DB.to_dyn dialects
     ; "explicit_js_mode", bool explicit_js_mode
     ; "format_config", option Format_config.to_dyn format_config
-    ; "subst_config", option Subst_config.to_dyn subst_config
+    ; "subst_config", option Toggle.to_dyn subst_config
     ; "strict_package_deps", bool strict_package_deps
     ; "cram", bool cram
     ; "allow_approximate_merlin", opaque allow_approximate_merlin
@@ -445,47 +445,6 @@ let infer ~dir info packages =
   }
 ;;
 
-module Toggle = struct
-  include Config.Toggle
-
-  let enabled : t -> bool = function
-    | `Enabled -> true
-    | `Disabled -> false
-  ;;
-
-  let of_bool = function
-    | true -> `Enabled
-    | false -> `Disabled
-  ;;
-
-  let all = [ "enable", `Enabled; "disable", `Disabled ]
-
-  let encode t =
-    let open Dune_lang.Encoder in
-    let v =
-      List.find_map all ~f:(fun (k, v) -> Option.some_if (v = t) k) |> Option.value_exn
-    in
-    string v
-  ;;
-
-  let decode =
-    Dune_lang.Decoder.(map_validate string) ~f:(fun s ->
-      match List.assoc all s with
-      | Some v -> Ok v
-      | None -> Error (User_error.make [ Pp.text "must be 'disable' or 'enable'" ]))
-  ;;
-
-  let field ?check name =
-    let open Dune_lang.Decoder in
-    let decode =
-      match check with
-      | None -> decode
-      | Some check -> check >>> decode
-    in
-    field_o name decode
-  ;;
-end
-
 let anonymous ~dir info packages = infer ~dir info packages
 
 let encode : t -> Dune_lang.t list =
@@ -799,7 +758,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
      and+ explicit_js_mode =
        field_o_b "explicit_js_mode" ~check:(Dune_lang.Syntax.since Stanza.syntax (1, 11))
      and+ format_config = Format_config.field ~since:(2, 0)
-     and+ subst_config = Subst_config.field ~since:(3, 0)
+     and+ subst_config = Subst_config.field
      and+ strict_package_deps =
        field_o_b
          "strict_package_deps"

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -33,7 +33,7 @@ val use_standard_c_and_cxx_flags : t -> bool option
 val dialects : t -> Dialect.DB.t
 val explicit_js_mode : t -> bool
 val format_config : t -> Format_config.t
-val subst_config : t -> Subst_config.t
+val subst_config : t -> Config.Toggle.t
 val equal : t -> t -> bool
 val hash : t -> int
 

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -92,6 +92,7 @@ include struct
   module Package_version = Package_version
   module Relop = Relop
   module Package_variable_name = Package_variable_name
+  module Toggle = Toggle
 end
 
 include Dune_engine.No_io
@@ -152,8 +153,5 @@ let ( == ) = `Use_phys_equal
 
 (** Controls whether we use background threads in the dune rules *)
 let background_dune_rules =
-  Config.make
-    ~name:"background_dune_rules"
-    ~of_string:Config.Toggle.of_string
-    ~default:`Disabled
+  Config.make ~name:"background_dune_rules" ~of_string:Toggle.of_string ~default:`Disabled
 ;;

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -104,7 +104,7 @@ let default_build_command =
        then from_2_9
        else
          from_3_0
-           ~with_subst:(Subst_config.is_enabled (Dune_project.subst_config project))
+           ~with_subst:(Toggle.enabled (Dune_project.subst_config project))
            ~with_sites:Dune_project.(is_extension_set project dune_site_extension))
 ;;
 


### PR DESCRIPTION
Remove the duplicated type for [Subst_config]. Toggle already exists and
is good enough.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 881cc530-a698-4162-8a36-61176ee8be13 -->