### PR TITLE
fix: improve error message for dune subst failures

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -155,10 +155,11 @@ module Dune_project = struct
     let+ project = Dune_project.load ~dir ~files ~infer_from_opam_files in
     let open Option.O in
     let* project = project in
-    let file = Dune_project.file project |> Path.Source.to_string |> Path.in_source in
-    let contents = Io.read_file file in
+    let* project_file = Dune_project.file project in
+    let project_file = Path.source project_file in
+    let contents = Io.read_file project_file in
     let sexp =
-      let lb = Lexbuf.from_string contents ~fname:(Path.to_string file) in
+      let lb = Lexbuf.from_string contents ~fname:(Path.to_string project_file) in
       Dune_lang.Parser.parse lb ~mode:Many_as_one
     in
     let parser =

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -24,7 +24,7 @@ type t =
   ; info : Package_info.t
   ; packages : Package.t Package.Name.Map.t
   ; stanza_parser : Stanza.t list Dune_lang.Decoder.t
-  ; project_file : Path.Source.t
+  ; project_file : Path.Source.t option
   ; extension_args : Univ_map.t
   ; parsing_context : Univ_map.t
   ; implicit_transitive_deps : bool
@@ -112,7 +112,7 @@ let to_dyn
     ; "version", (option Package_version.to_dyn) version
     ; "dune_version", Dune_lang.Syntax.Version.to_dyn dune_version
     ; "info", Package_info.to_dyn info
-    ; "project_file", Path.Source.to_dyn project_file
+    ; "project_file", Dyn.option Path.Source.to_dyn project_file
     ; ( "packages"
       , (list (pair Package.Name.to_dyn Package.to_dyn))
           (Package.Name.Map.to_list packages) )
@@ -399,7 +399,6 @@ let default_name ~dir ~(packages : Package.t Package.Name.Map.t) =
 let infer ~dir info packages =
   let lang = get_dune_lang () in
   let name = default_name ~dir ~packages in
-  let project_file = Path.Source.relative dir filename in
   let parsing_context, stanza_parser, extension_args =
     interpret_lang_and_extensions ~lang ~explicit_extensions:String.Map.empty
   in
@@ -427,7 +426,7 @@ let infer ~dir info packages =
   ; executables_implicit_empty_intf
   ; accept_alternative_dune_file_name = false
   ; stanza_parser
-  ; project_file
+  ; project_file = None
   ; extension_args
   ; parsing_context
   ; generate_opam_files = false
@@ -867,7 +866,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
        ; info
        ; packages
        ; stanza_parser
-       ; project_file = file
+       ; project_file = Some file
        ; extension_args
        ; parsing_context
        ; implicit_transitive_deps

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -38,7 +38,7 @@ val equal : t -> t -> bool
 val hash : t -> int
 
 (** Return the path of the project file. *)
-val file : t -> Path.Source.t
+val file : t -> Path.Source.t option
 
 module Lang : sig
   (** [register id stanzas_parser] register a new language. Users will select

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -377,17 +377,19 @@ let gen_project_rules =
       | Named _ -> Memo.return ()
       | Anonymous _ ->
         (match
-           Dune_project.dune_version project >= (2, 8)
-           && Dune_project.generate_opam_files project
+           if Dune_project.dune_version project >= (2, 8)
+              && Dune_project.generate_opam_files project
+           then Dune_project.file project
+           else None
          with
-         | false -> Memo.return ()
-         | true ->
+         | None -> Memo.return ()
+         | Some project_file ->
            Warning_emit.emit
              missing_project_name
              (Warning_emit.Context.project project)
              (fun () ->
                 let+ () = Memo.return () in
-                let loc = Loc.in_file (Path.source (Dune_project.file project)) in
+                let loc = Loc.in_file (Path.source project_file) in
                 User_message.make
                   ~loc
                   [ Pp.text

--- a/test/blackbox-tests/test-cases/subst/missing-project-file.t
+++ b/test/blackbox-tests/test-cases/subst/missing-project-file.t
@@ -5,5 +5,7 @@ subst assumes that dune-project always exists:
   $ git add -A
   $ git commit -m "test" -q
   $ dune subst
-  Error: dune-project: No such file or directory
+  Error: There is no dune-project file in the current directory, please add one
+  with a (name <name>) field in it.
+  Hint: 'dune subst' must be executed from the root of the project.
   [1]


### PR DESCRIPTION
Also change the type of Dune_project.file to be an option. The previous
type was rather confusing as it assumed the project file always existed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 20a563f0-1e64-4341-8b36-3ce7cb2297f3 -->