### PR TITLE
refactor: remove concrete paths from [Pinned_package.t]

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -527,7 +527,7 @@ let opam_package_to_lock_file_pkg
       |> OpamPackage.Version.Map.find (Package_version.to_opam_package_version version)
     in
     let opam_file = Resolved_package.opam_file resolved_package in
-    let loc = Loc.in_file (Resolved_package.file resolved_package) in
+    let loc = Resolved_package.loc resolved_package in
     opam_file, loc
   in
   let extra_sources =

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -7,11 +7,11 @@ type extra_files =
 type nonrec t =
   { opam_file : OpamFile.OPAM.t
   ; package : OpamPackage.t
-  ; opam_file_path : Path.t
   ; extra_files : extra_files
+  ; loc : Loc.t
   }
 
-let file t = t.opam_file_path
+let loc t = t.loc
 let package t = t.package
 let opam_file t = t.opam_file
 
@@ -29,7 +29,8 @@ let read_opam_file package ~opam_file_path ~opam_file_contents =
 let git_repo package ~opam_file ~opam_file_contents rev ~files_dir =
   let opam_file_path = Path.of_local (Rev_store.File.path opam_file) in
   let opam_file = read_opam_file package ~opam_file_path ~opam_file_contents in
-  { opam_file; package; opam_file_path; extra_files = Git_files (files_dir, rev) }
+  let loc = Loc.in_file opam_file_path in
+  { loc; package; opam_file; extra_files = Git_files (files_dir, rev) }
 ;;
 
 let local_fs package ~dir ~opam_file_path ~files_dir =
@@ -39,7 +40,8 @@ let local_fs package ~dir ~opam_file_path ~files_dir =
     let opam_file_contents = Io.read_file ~binary:true opam_file_path in
     read_opam_file package ~opam_file_path ~opam_file_contents
   in
-  { package; opam_file_path; extra_files = Inside_files_dir files_dir; opam_file }
+  let loc = Loc.in_file opam_file_path in
+  { loc; package; extra_files = Inside_files_dir files_dir; opam_file }
 ;;
 
 (* Scan a path recursively down retrieving a list of all files together with their

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -4,7 +4,7 @@ type t
 
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
-val file : t -> Path.t
+val loc : t -> Loc.t
 val set_url : t -> OpamUrl.t -> t
 
 val git_repo


### PR DESCRIPTION
It's fragile to use them since some data comes from the revision store

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 439c5a74-aec3-4f6f-aae1-04d88ae51d8b -->