### PR TITLE
feature(pkg): dune native pinning

### DIFF
--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -20,3 +20,4 @@ module Local_package = Local_package
 module Package_universe = Package_universe
 module Variable_value = Variable_value
 module Resolved_package = Resolved_package
+module Pin_stanza = Pin_stanza

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -2,7 +2,15 @@ open! Import
 module Package_constraint = Dune_lang.Package_constraint
 module Digest = Dune_digest
 
-type pins = (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
+type pin =
+  { loc : Loc.t
+  ; version : Package_version.t
+  ; url : Loc.t * OpamUrl.t
+  ; name : Package_name.t
+  ; origin : [ `Dune | `Opam ]
+  }
+
+type pins = pin Package_name.Map.t
 
 type t =
   { name : Package_name.t
@@ -82,7 +90,7 @@ module For_solver = struct
     ; conflicts : Package_dependency.t list
     ; depopts : Package_dependency.t list
     ; conflict_class : Package_name.t list
-    ; pins : (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
+    ; pins : pins
     }
 
   let to_opam_file { name; dependencies; conflicts; conflict_class; depopts; pins = _ } =

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -1,6 +1,14 @@
 open! Import
 
-type pins = (Loc.t * Package_version.t * OpamUrl.t) Package_name.Map.t
+type pin =
+  { loc : Loc.t
+  ; version : Package_version.t
+  ; url : Loc.t * OpamUrl.t
+  ; name : Package_name.t
+  ; origin : [ `Dune | `Opam ]
+  }
+
+type pins = pin Package_name.Map.t
 
 (** Information about a local package that's relevant for package management.
     This is intended to represent local packages defined in a dune-project file

--- a/src/dune_pkg/mount.ml
+++ b/src/dune_pkg/mount.ml
@@ -1,0 +1,89 @@
+open Import
+open Fiber.O
+
+type backend =
+  | Path of Path.t
+  | Git of Rev_store.At_rev.t
+
+type t = backend
+
+let backend t = t
+
+let of_opam_url loc url =
+  let* () = Fiber.return () in
+  match OpamUrl.local_or_git_only url loc with
+  | `Path dir -> Fiber.return (Path dir)
+  | `Git ->
+    let+ rev = Opam_repo.Source.of_opam_url loc url >>= Opam_repo.Source.rev in
+    Git rev
+;;
+
+let read t file =
+  match t with
+  | Git rev -> Rev_store.At_rev.content rev file
+  | Path dir ->
+    let+ () = Fiber.return () in
+    let file = Path.append_local dir file in
+    (match Io.read_file ~binary:true file with
+     | s -> Some s
+     | exception Unix.Unix_error (ENOENT, _, _) -> None)
+;;
+
+let stat t path =
+  let+ () = Fiber.return () in
+  match t with
+  | Path dir ->
+    let path = Path.append_local dir path in
+    (match (Path.stat_exn path).st_kind with
+     | S_REG -> `File
+     | S_DIR -> `Dir
+     | _ -> `Absent_or_unrecognized
+     | exception Unix.Unix_error (ENOENT, _, _) -> `Absent_or_unrecognized)
+  | Git rev ->
+    (match
+       Rev_store.File.Set.is_empty
+         (Rev_store.At_rev.directory_entries rev ~recursive:false path)
+     with
+     | false -> `Dir
+     | true ->
+       (match Path.Local.parent path with
+        | None -> `Absent_or_unrecognized
+        | Some parent ->
+          let files = Rev_store.At_rev.directory_entries ~recursive:false rev parent in
+          let basename = Path.Local.basename path in
+          if Rev_store.File.Set.exists files ~f:(fun file ->
+               let path = Rev_store.File.path file in
+               String.equal basename (Path.Local.basename path))
+          then `File
+          else `Absent_or_unrecognized))
+;;
+
+let readdir t dir =
+  let+ () = Fiber.return () in
+  match t with
+  | Git rev ->
+    Rev_store.At_rev.directory_entries ~recursive:false rev dir
+    |> Rev_store.File.Set.to_list_map ~f:(fun file ->
+      Rev_store.File.path file |> Path.Local.basename)
+    |> Filename.Map.of_list_map_exn ~f:(fun fname -> fname, `File)
+  | Path p ->
+    let dir = Path.append_local p dir in
+    (match Path.readdir_unsorted_with_kinds dir with
+     | Error e -> Unix_error.Detailed.raise e
+     | Ok listing ->
+       List.filter_map listing ~f:(fun (name, kind) ->
+         match
+           match kind with
+           | S_REG -> Some `File
+           | S_DIR -> Some `Dir
+           | S_LNK ->
+             (match (Path.stat_exn (Path.relative dir name)).st_kind with
+              | S_REG -> Some `File
+              | S_DIR -> Some `Dir
+              | _ -> None)
+           | _ -> None
+         with
+         | None -> None
+         | Some kind -> Some (name, kind))
+       |> Filename.Map.of_list_exn)
+;;

--- a/src/dune_pkg/mount.mli
+++ b/src/dune_pkg/mount.mli
@@ -1,0 +1,15 @@
+open Import
+
+(** Access the contents of OpamUrl.t without (necessarily) extracting it *)
+
+type t
+
+type backend =
+  | Path of Path.t
+  | Git of Rev_store.At_rev.t
+
+val backend : t -> backend
+val of_opam_url : Loc.t -> OpamUrl.t -> t Fiber.t
+val stat : t -> Path.Local.t -> [ `Absent_or_unrecognized | `Dir | `File ] Fiber.t
+val read : t -> Path.Local.t -> string option Fiber.t
+val readdir : t -> Path.Local.t -> [ `File | `Dir ] Filename.Map.t Fiber.t

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -1,6 +1,15 @@
 include OpamUrl
 open Stdune
 
+module T = struct
+  type nonrec t = t
+
+  let to_dyn t = Dyn.string (OpamUrl.to_string t)
+  let compare x y = Ordering.of_int (OpamUrl.compare x y)
+end
+
+include T
+
 let decode_loc =
   let open Dune_sexp.Decoder in
   map_validate (located string) ~f:(fun (loc, s) ->
@@ -32,3 +41,5 @@ let local_or_git_only url loc =
       [ Pp.textf "Could not determine location of repository %s" @@ OpamUrl.to_string url
       ]
 ;;
+
+include Comparable.Make (T)

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -5,6 +5,7 @@ type t = OpamUrl.t
 val equal : t -> t -> bool
 val hash : t -> int
 val to_string : t -> string
+val to_dyn : t -> Dyn.t
 val of_string : string -> t
 val decode_loc : (Stdune.Loc.t * t) Dune_sexp.Decoder.t
 val rev : t -> string option
@@ -18,3 +19,6 @@ val is_local : t -> bool
    file system or [`Git] if it's a git repository (remote or otherwise). If
    it's neither of those cases, it will error out. *)
 val local_or_git_only : t -> Loc.t -> [ `Path of Path.t | `Git ]
+
+module Map : Map.S with type key = t
+module Set : Set.S with type elt = t and type 'a map = 'a Map.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -267,7 +267,7 @@ let all_packages_versions_in_dir loc ~dir opam_package_name =
 
 let all_packages_versions_at_rev rev opam_package_name =
   Paths.package_root opam_package_name
-  |> Rev_store.At_rev.directory_entries rev
+  |> Rev_store.At_rev.directory_entries rev ~recursive:true
   |> Rev_store.File.Set.to_list
   |> List.filter_map ~f:(fun file ->
     let path = Rev_store.File.path file in

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -686,8 +686,14 @@ module Solver_result = struct
     }
 end
 
-let solve_lock_dir solver_env version_preference repos ~local_packages ~constraints =
-  let* pinned_packages = Pinned_package.resolve_pins local_packages in
+let solve_lock_dir
+  solver_env
+  version_preference
+  repos
+  ~local_packages
+  ~pins:pinned_packages
+  ~constraints
+  =
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
   let context =

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -13,5 +13,6 @@ val solve_lock_dir
   -> Version_preference.t
   -> Opam_repo.t list
   -> local_packages:Local_package.For_solver.t Package_name.Map.t
+  -> pins:Resolved_package.t Package_name.Map.t
   -> constraints:Dune_lang.Package_dependency.t list
   -> (Solver_result.t, [ `Diagnostic_message of _ Pp.t ]) result Fiber.t

--- a/src/dune_pkg/package_version.ml
+++ b/src/dune_pkg/package_version.ml
@@ -6,3 +6,4 @@ let of_opam_package_version opam_version =
 ;;
 
 let to_opam_package_version t = to_string t |> OpamPackage.Version.of_string
+let dev = of_string "dev"

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -10,3 +10,4 @@ val encode : t Dune_lang.Encoder.t
 val decode : t Dune_lang.Decoder.t
 val of_opam_package_version : OpamPackage.Version.t -> t
 val to_opam_package_version : t -> OpamPackage.Version.t
+val dev : t

--- a/src/dune_pkg/pin_stanza.ml
+++ b/src/dune_pkg/pin_stanza.ml
@@ -1,0 +1,352 @@
+open Import
+
+module Package = struct
+  type t =
+    { version : Package_version.t option
+    ; name : Package_name.t
+    ; loc : Loc.t
+    }
+
+  let decode =
+    let open Dune_lang.Decoder in
+    fields
+    @@
+    let+ name = field "name" Package_name.decode
+    and+ loc = loc
+    and+ version = field_o "version" Package_version.decode in
+    { name; version; loc }
+  ;;
+end
+
+type t =
+  { url : Loc.t * OpamUrl.t
+  ; packages : Package.t list
+  }
+
+let url t = t.url
+
+let decode =
+  let open Dune_lang.Decoder in
+  fields
+  @@
+  let+ url = field "url" OpamUrl.decode_loc
+  and+ packages = multi_field "package" Package.decode in
+  { url; packages }
+;;
+
+module DB = struct
+  type context =
+    | Workspace
+    | Project of { dir : Path.Source.t }
+
+  type nonrec t =
+    { all : t list (* we keep this for [encode] *)
+    ; map : (Local_package.pin * context) Package_name.Map.t
+    ; context : context
+    }
+
+  let empty context = { all = []; map = Package_name.Map.empty; context }
+  let to_dyn = Dyn.opaque
+  let hash = Poly.hash
+  let equal = Poly.equal
+
+  let add_opam_pins t pins =
+    let pins = Pinned_package.collect pins in
+    { t with
+      map =
+        Package_name.Map.fold pins ~init:t.map ~f:(fun (pin : Local_package.pin) acc ->
+          (match pin.origin with
+           | `Dune -> Code_error.raise "add_opam_pins: can only pin opam packages" []
+           | `Opam -> ());
+          Package_name.Map.update acc pin.name ~f:(function
+            | None -> Some (pin, t.context)
+            | Some _ as x -> x))
+    }
+  ;;
+
+  let decode context =
+    let open Dune_lang.Decoder in
+    let+ all = multi_field "pin" decode in
+    let map =
+      match
+        List.concat_map all ~f:(fun source ->
+          List.map source.packages ~f:(fun (package : Package.t) ->
+            let name = package.name in
+            let package =
+              { Local_package.url = source.url
+              ; version = Option.value ~default:Package_version.dev package.version
+              ; loc = package.loc
+              ; origin = `Dune
+              ; name
+              }
+            in
+            name, (package, context)))
+        |> Package_name.Map.of_list
+      with
+      | Ok map -> map
+      | Error (name, (pin, _), _) ->
+        User_error.raise
+          ~loc:pin.loc
+          [ Pp.textf "package %S is already defined" (Package_name.to_string name) ]
+    in
+    { all; map; context }
+  ;;
+
+  let super_context ((_, ctx) as x) ((_, ctx') as x') =
+    match ctx, ctx' with
+    | Workspace, Workspace -> Code_error.raise "more than one workspace context" []
+    | Workspace, _ -> Ok x
+    | _, Workspace -> Ok x'
+    | Project { dir }, Project { dir = dir' } ->
+      if Path.Source.equal dir dir'
+      then
+        Code_error.raise
+          "two projects in the same directory in the workspace"
+          [ "dir", Path.Source.to_dyn dir ]
+      else if Path.Source.is_descendant dir ~of_:dir'
+      then Ok x'
+      else if Path.Source.is_descendant dir' ~of_:dir
+      then Ok x
+      else Error ()
+  ;;
+
+  let combine_exn t { all; map; context } =
+    { all = t.all @ all
+    ; map =
+        Package_name.Map.union t.map map ~f:(fun name lhs rhs ->
+          match super_context lhs rhs with
+          | Ok res -> Some res
+          | Error () ->
+            let pin = fst lhs in
+            User_error.raise
+              ~loc:pin.loc
+              [ Pp.textf
+                  "package %S is defined in more than one source"
+                  (Package_name.to_string name)
+              ; Pp.textf "it is also defined in %s" (Loc.to_file_colon_line (fst lhs).loc)
+              ])
+    ; context
+    }
+  ;;
+
+  let encode _ = (* CR-rgrinberg: needed for dune init *) []
+end
+
+module Scan_project = struct
+  type t =
+    read:(Path.Source.t -> string Fiber.t)
+    -> files:Filename.Set.t
+    -> (DB.t * Local_package.t Package_name.Map.t) option Fiber.t
+
+  type state =
+    { mutable traversed :
+        (DB.t * Local_package.t Package_name.Map.t) option Fiber.Ivar.t OpamUrl.Map.t
+    }
+
+  let make_state () = { traversed = OpamUrl.Map.empty }
+
+  let eval_url t state (loc, url) =
+    let open Fiber.O in
+    let* () = Fiber.return () in
+    match OpamUrl.Map.find state.traversed url with
+    | Some x -> Fiber.Ivar.read x
+    | None ->
+      let ivar = Fiber.Ivar.create () in
+      state.traversed <- OpamUrl.Map.add_exn state.traversed url ivar;
+      let* res =
+        let open Fiber.O in
+        let* mount = Mount.of_opam_url loc url in
+        let* files =
+          Mount.readdir mount Path.Local.root
+          >>| Filename.Map.filter ~f:(function
+            | `File -> true
+            | `Dir -> false)
+          >>| Filename.Set.of_keys
+        in
+        let read path =
+          let path = Path.Source.to_local path in
+          Mount.read mount path
+          >>| function
+          | Some s -> s
+          | None ->
+            Code_error.raise
+              "expected file to exist"
+              [ "path", Path.Local.to_dyn path; "url", OpamUrl.to_dyn url ]
+        in
+        t ~read ~files
+      in
+      let+ () = Fiber.Ivar.fill ivar res in
+      res
+  ;;
+end
+
+open DB
+
+module Stack : sig
+  type t
+
+  val empty : t
+  val pp : t -> _ Pp.t
+  val is_prefix : t -> prefix:t -> bool
+  val push : t -> Local_package.pin -> t
+end = struct
+  module Id = Id.Make ()
+
+  type element =
+    { id : Id.t
+    ; pin : Local_package.pin
+    }
+
+  type t = element list
+
+  let empty = []
+
+  let is_prefix (t : t) ~(prefix : t) =
+    match prefix with
+    | [] -> true
+    | p :: _ -> List.mem t p ~equal:(fun x y -> Id.equal x.id y.id)
+  ;;
+
+  let pp (t : t) =
+    Pp.chain t ~f:(fun { pin; _ } ->
+      Pp.textf
+        "URL %s for package %s in %s"
+        (OpamUrl.to_string (snd pin.url))
+        (Package_name.to_string pin.name)
+        (Loc.to_file_colon_line pin.loc))
+  ;;
+
+  let push (t : t) (package : Local_package.pin) : t =
+    { id = Id.gen (); pin = package } :: t
+  ;;
+end
+
+let resolve (t : DB.t) ~(scan_project : Scan_project.t)
+  : Resolved_package.t Package_name.Map.t Fiber.t
+  =
+  let open Fiber.O in
+  let* () = Fiber.return () in
+  (* Assigned packages cannot be traversed because we already assigned
+     them to a source.
+     Invariant: a workspace's pins are assigned before all of its children *)
+  let assigned = ref Package_name.Map.empty in
+  (* The concrete opam metadata we determined for every assigned package. *)
+  let resolved = ref Package_name.Map.empty in
+  let resolve name resolved_package =
+    resolved := Package_name.Map.add_exn !resolved name resolved_package
+  in
+  let assign (stack : Stack.t) (package : Local_package.pin) =
+    match Package_name.Map.find !assigned package.name with
+    | None ->
+      assigned := Package_name.Map.add_exn !assigned package.name (package, stack);
+      `Continue
+    | Some (assigned, prefix) ->
+      if Stack.is_prefix stack ~prefix
+         || (OpamUrl.equal (snd assigned.url) (snd package.url)
+             && Package_version.equal package.version assigned.version)
+      then `Skip
+      else
+        (* CR-rgrinberg: we need to cancel all the other fibers *)
+        User_error.raise
+          ~loc:package.loc
+          [ Pp.textf
+              "package %s is assigned more than once"
+              (Package_name.to_string package.name)
+          ; Pp.textf
+              "it's already assigned to %s at:"
+              (OpamUrl.to_string (snd package.url))
+          ; Pp.verbatim (Loc.to_file_colon_line assigned.loc)
+          ; Pp.text "prefix"
+          ; Stack.pp prefix
+          ; Pp.text "stack"
+          ; Stack.pp stack
+          ]
+  in
+  let opam_package stack (package : Local_package.pin) =
+    let* resolved_package = Pinned_package.resolve_package package in
+    resolve package.name resolved_package;
+    Resolved_package.opam_file resolved_package
+    |> OpamFile.OPAM.pin_depends
+    |> List.filter_map ~f:(fun (pkg, url) ->
+      let name = Package_name.of_opam_package_name (OpamPackage.name pkg) in
+      let package =
+        let version =
+          OpamPackage.version pkg |> Package_version.of_opam_package_version
+        in
+        { Local_package.url = package.loc, url
+        ; version
+        ; name
+        ; loc = package.loc
+        ; origin = `Opam
+        }
+      in
+      let stack = Stack.push stack package in
+      match assign stack package with
+      | `Skip -> None
+      | `Continue -> Some package)
+    |> Fiber.parallel_iter ~f:(fun package ->
+      Pinned_package.resolve_package package >>| resolve package.name)
+  in
+  let dune_package packages (package : Local_package.pin) =
+    match Package_name.Map.find packages package.name with
+    | None ->
+      User_error.raise
+        ~loc:package.loc
+        [ Pp.textf
+            "package %s doesn't exist in source %s"
+            (Package_name.to_string package.name)
+            (OpamUrl.to_string (snd package.url))
+        ]
+    | Some pkg ->
+      let resolved_package =
+        let opam_file =
+          Local_package.for_solver pkg
+          |> Local_package.For_solver.to_opam_file
+          |> OpamFile.OPAM.with_url (OpamFile.URL.create (snd package.url))
+          |> OpamFile.OPAM.with_build
+               [ (* CR-rgrinberg: this needs to be addressed in a more
+                    principled manner *)
+                 (let cmd =
+                    ([ "dune"; "build"; "-p" ]
+                     |> List.map ~f:(fun x -> OpamTypes.CString x))
+                    @ [ OpamTypes.CIdent "name" ]
+                    |> List.map ~f:(fun x -> x, None)
+                  in
+                  cmd, None)
+               ]
+        in
+        let opam_package =
+          OpamPackage.create
+            (Package_name.to_opam_package_name package.name)
+            (Package_version.to_opam_package_version package.version)
+        in
+        Resolved_package.dune_package package.loc opam_file opam_package
+      in
+      resolve package.name resolved_package
+  in
+  let eval_url =
+    let state = Scan_project.make_state () in
+    Scan_project.eval_url scan_project state
+  in
+  let rec loop (stack : Stack.t) t =
+    Package_name.Map.values t.map
+    |> List.filter_map ~f:(fun (package, _) ->
+      match assign stack package with
+      | `Skip -> None
+      | `Continue -> Some package)
+    |> Fiber.parallel_iter ~f:(fun (package : Local_package.pin) ->
+      let stack = Stack.push stack package in
+      match package.origin with
+      | `Opam -> opam_package stack package
+      | `Dune ->
+        eval_url package.url
+        >>= (function
+         | None -> opam_package stack package
+         | Some (more_sources, packages) ->
+           dune_package packages package;
+           let more_sources = DB.add_opam_pins more_sources packages in
+           loop stack more_sources))
+  in
+  let+ () = loop Stack.empty t in
+  !resolved
+;;

--- a/src/dune_pkg/pin_stanza.mli
+++ b/src/dune_pkg/pin_stanza.mli
@@ -1,0 +1,36 @@
+open Import
+
+type t
+
+val url : t -> Loc.t * OpamUrl.t
+
+module Package : sig end
+
+module DB : sig
+  type t
+
+  type context =
+    | Workspace
+    | Project of { dir : Path.Source.t }
+
+  val empty : context -> t
+  val to_dyn : t -> Dyn.t
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val decode : context -> t Dune_lang.Decoder.fields_parser
+  val encode : t -> Dune_lang.t list
+  val combine_exn : t -> t -> t
+  val add_opam_pins : t -> Local_package.t Package_name.Map.t -> t
+end
+
+module Scan_project : sig
+  type t =
+    read:(Path.Source.t -> string Fiber.t)
+    -> files:Filename.Set.t
+    -> (DB.t * Local_package.t Package_name.Map.t) option Fiber.t
+end
+
+val resolve
+  :  DB.t
+  -> scan_project:Scan_project.t
+  -> Resolved_package.t Package_name.Map.t Fiber.t

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -1,31 +1,26 @@
 open Import
 open Fiber.O
 
-let collect local_packages =
+let collect (local_packages : Local_package.t Package_name.Map.t) =
   match
     Package_name.Map.values local_packages
-    |> List.concat_map ~f:(fun (local_pacakge : Local_package.For_solver.t) ->
-      Package_name.Map.to_list_map local_pacakge.pins ~f:(fun name (loc, version, url) ->
-        let version = Package_version.to_opam_package_version version in
-        name, (loc, version, url)))
+    |> List.concat_map ~f:(fun (local_package : Local_package.t) ->
+      Package_name.Map.to_list_map local_package.pins ~f:(fun name pin -> name, pin))
     |> Package_name.Map.of_list
   with
   | Ok s -> s
-  | Error (package, (loc, _, _), _) ->
+  | Error (_, pin, _) ->
     User_error.raise
-      ~loc
-      [ Pp.textf "local package %s cannot be pinned" (Package_name.to_string package) ]
+      ~loc:pin.loc
+      [ Pp.textf "local package %s cannot be pinned" (Package_name.to_string pin.name) ]
 ;;
 
 (* There's many layouts for pinned packages:
    - toplevel opam file
    - $name.opam file
    - opam/$name.opam
-   - opam/opam
-
-   This function tries them one by one. The [stat] argument is to there so that it works
-   for both the local file system and the revision store. *)
-let discover_layout loc ~stat name =
+   - opam/opam *)
+let discover_layout loc name mount =
   let name_opam = Package_name.to_string name ^ ".opam" in
   let opam_file = Path.Local.of_string name_opam in
   let abort () =
@@ -41,93 +36,69 @@ let discover_layout loc ~stat name =
       ~loc
       [ Pp.textf "%s must be a file" (Path.Local.to_string_maybe_quoted p) ]
   in
-  match stat opam_file with
-  | `File -> opam_file, None
+  Mount.stat mount opam_file
+  >>= function
+  | `File -> Fiber.return (opam_file, None)
   | _ ->
     let opam_file_or_dir = Path.Local.of_string "opam" in
-    (match stat opam_file_or_dir with
-     | `File -> opam_file_or_dir, None
+    Mount.stat mount opam_file_or_dir
+    >>= (function
+     | `File -> Fiber.return (opam_file_or_dir, None)
+     | `Absent_or_unrecognized -> abort ()
      | `Dir ->
        let opam_file = Path.Local.relative opam_file_or_dir name_opam in
-       (match stat opam_file with
-        | `File -> opam_file, None
+       Mount.stat mount opam_file
+       >>= (function
+        | `File -> Fiber.return (opam_file, None)
         | `Dir -> must_be_a_file opam_file
         | `Absent_or_unrecognized ->
           let file = Path.Local.relative opam_file_or_dir "opam" in
-          (match stat file with
+          Mount.stat mount file
+          >>| (function
            | `File -> file, Some (Path.Local.relative opam_file_or_dir "files")
            | `Dir -> must_be_a_file file
-           | `Absent_or_unrecognized -> abort ()))
-     | `Absent_or_unrecognized -> abort ())
+           | `Absent_or_unrecognized -> abort ())))
 ;;
 
-let resolve_package loc name (url : OpamUrl.t) version =
-  let package = OpamPackage.create (Package_name.to_opam_package_name name) version in
-  let discover_layout = discover_layout loc name in
+let resolve_package { Local_package.loc; url = loc_url, url; name; version; origin = _ } =
+  let package =
+    OpamPackage.create
+      (Package_name.to_opam_package_name name)
+      (Package_version.to_opam_package_version version)
+  in
   let+ resolved_package =
-    match OpamUrl.local_or_git_only url loc with
-    | `Path dir ->
-      let stat path =
-        let path = Path.append_local dir path in
-        match (Path.stat_exn path).st_kind with
-        | S_REG -> `File
-        | S_DIR -> `Dir
-        | _ -> `Absent_or_unrecognized
-        | exception Unix.Unix_error (ENOENT, _, _) -> `Absent_or_unrecognized
-      in
-      let opam_file_path, files_dir = discover_layout ~stat in
+    let* mount = Mount.of_opam_url loc_url url in
+    let* opam_file_path, files_dir = discover_layout loc name mount in
+    match Mount.backend mount with
+    | Path dir ->
       Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir |> Fiber.return
-    | `Git ->
-      let* rev = Opam_repo.Source.of_opam_url loc url >>= Opam_repo.Source.rev in
-      let stat path =
-        match
-          Rev_store.File.Set.is_empty (Rev_store.At_rev.directory_entries rev path)
-        with
-        | false -> `Dir
-        | true ->
-          (match Path.Local.parent path with
-           | None -> `Absent_or_unrecognized
-           | Some parent ->
-             let files = Rev_store.At_rev.directory_entries rev parent in
-             let basename = Path.Local.basename path in
-             if Rev_store.File.Set.exists files ~f:(fun file ->
-                  let path = Rev_store.File.path file in
-                  String.equal basename (Path.Local.basename path))
-             then `File
-             else `Absent_or_unrecognized)
-      in
-      let opam_file, files_dir = discover_layout ~stat in
+    | Git rev ->
       let+ opam_file_contents =
         (* CR-rgrinberg: not efficient to make such individual calls *)
-        Rev_store.At_rev.content rev opam_file
+        Mount.read mount opam_file_path
         >>| function
         | Some p -> p
         | None ->
           let files =
-            match Path.Local.parent opam_file with
+            match Path.Local.parent opam_file_path with
             | None -> []
             | Some parent ->
-              Rev_store.At_rev.directory_entries rev parent
+              Rev_store.At_rev.directory_entries rev parent ~recursive:false
               |> Rev_store.File.Set.to_list_map ~f:Rev_store.File.path
           in
           Code_error.raise
             ~loc
             "unable to find file"
-            [ "opam_file_path", Path.Local.to_dyn opam_file
+            [ "opam_file_path", Path.Local.to_dyn opam_file_path
             ; "files", Dyn.list Path.Local.to_dyn files
             ]
       in
-      Resolved_package.git_repo package ~opam_file ~opam_file_contents rev ~files_dir
+      Resolved_package.git_repo
+        package
+        ~opam_file:opam_file_path
+        ~opam_file_contents
+        rev
+        ~files_dir
   in
   Resolved_package.set_url resolved_package url
 ;;
-
-let resolve pins =
-  Package_name.Map.to_list pins
-  |> Fiber.parallel_map ~f:(fun (name, (loc, version, url)) ->
-    let+ resolved = resolve_package loc name url version in
-    name, resolved)
-  >>| Package_name.Map.of_list_exn
-;;
-
-let resolve_pins local_packages = collect local_packages |> resolve

--- a/src/dune_pkg/pinned_package.mli
+++ b/src/dune_pkg/pinned_package.mli
@@ -6,6 +6,6 @@
     Pins are defined using the [pin-depends] field of opam files. We traverse
     all local packages to collect such fields and then fetch and return all the
     opam files they correspond to *)
-val resolve_pins
-  :  Local_package.For_solver.t Package_name.Map.t
-  -> Resolved_package.t Package_name.Map.t Fiber.t
+
+val collect : Local_package.t Package_name.Map.t -> Local_package.pin Package_name.Map.t
+val resolve_package : Local_package.pin -> Resolved_package.t Fiber.t

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -22,4 +22,5 @@ val local_fs
   -> files_dir:Path.Local.t option
   -> t
 
+val dune_package : Loc.t -> OpamFile.OPAM.t -> OpamPackage.t -> t
 val get_opam_package_files : t list -> File_entry.t list list Fiber.t

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -19,7 +19,7 @@ module At_rev : sig
   end
 
   val content : t -> Path.Local.t -> string option Fiber.t
-  val directory_entries : t -> Path.Local.t -> File.Set.t
+  val directory_entries : t -> recursive:bool -> Path.Local.t -> File.Set.t
   val equal : t -> t -> bool
   val opam_url : t -> OpamUrl.t
   val check_out : t -> target:Path.t -> unit Fiber.t

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -94,6 +94,13 @@ val load
   -> infer_from_opam_files:bool
   -> t option Memo.t
 
+val gen_load
+  :  read:(Path.Source.t -> string Memo.t)
+  -> dir:Path.Source.t
+  -> files:Filename.Set.t
+  -> infer_from_opam_files:bool
+  -> t option Memo.t
+
 (** Create an anonymous project at the given directory
 
     Optional arguments:
@@ -129,6 +136,7 @@ val strict_package_deps : t -> bool
 val cram : t -> bool
 val info : t -> Package_info.t
 val warnings : t -> Warning.Settings.t
+val sources : t -> Dune_pkg.Pin_stanza.DB.t
 
 (** Update the execution parameters according to what is written in the
     [dune-project] file. *)

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -71,8 +71,8 @@ val map_depends : t -> f:(Dependency.t list -> Dependency.t list) -> t
 (** Construct a default package (e.g., for project initialization) *)
 val default : Name.t -> Path.Source.t -> t
 
-(** Construct a package description from an opam file. *)
-val load_opam_file : Path.Source.t -> Name.t -> t Memo.t
+(** Construct a package description from an opam file and its contents *)
+val load_opam_file_with_contents : contents:string -> Path.Source.t -> Name.t -> t
 
 val missing_deps : t -> effective_deps:Name.Set.t -> Name.Set.t
 val to_local_package : t -> Dune_pkg.Local_package.t

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -10,6 +10,7 @@ module Lock_dir : sig
     ; unset_solver_vars : Dune_lang.Package_variable_name.Set.t option
     ; repositories : (Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list
     ; constraints : Dune_lang.Package_dependency.t list
+    ; sources : string list
     }
 
   val equal : t -> t -> bool
@@ -106,6 +107,7 @@ type t = private
   ; repos : Dune_pkg.Pkg_workspace.Repository.t list
   ; lock_dirs : Lock_dir.t list
   ; dir : Path.Source.t
+  ; sources : Dune_pkg.Pin_stanza.DB.t
   }
 
 val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -110,6 +110,10 @@ make_project() {
 EOF
 }
 
+print_source() {
+  cat dune.lock/$1.pkg | sed -n "/source/,//p" | sed "s#$PWD#PWD#g" | tr '\n' ' '| tr -s " "
+}
+
 solve() {
   make_project $@ | solve_project
 }

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -15,11 +15,12 @@ Demonstrate our support for pin-depends.
   > depends: [ "bar" ]
   > pin-depends: [ "bar.1.0.0" "$1" ]
   > EOF
-  > dune pkg lock
-  > local pkg="dune.lock/bar.pkg"
-  > grep version $pkg
-  > grep dev $pkg
-  > grep "$1" $pkg | sed "s#$PWD#PWD#g"
+  > dune pkg lock && {
+  >   local pkg="dune.lock/bar.pkg";
+  >   grep version $pkg;
+  >   grep dev $pkg;
+  >   print_source "bar";
+  >   } 
   > }
 
 Local pinned source.
@@ -36,7 +37,7 @@ Local pinned source.
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     file://PWD/_bar_file)))
+  (source (fetch (url file://PWD/_bar_file))) (dev) 
 
 "opam" directory at the root
 
@@ -50,7 +51,7 @@ Local pinned source.
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     file://PWD/_bar_file_opam_dir)))
+  (source (fetch (url file://PWD/_bar_file_opam_dir))) (dev) 
 
 "bar.opam" file at the root
 
@@ -64,7 +65,7 @@ Local pinned source.
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     file://PWD/_bar_named_opam_root)))
+  (source (fetch (url file://PWD/_bar_named_opam_root))) (dev) 
 
 "bar.opam" file at opam/
 
@@ -78,7 +79,7 @@ Local pinned source.
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     file://PWD/_bar_named_opam_subdir)))
+  (source (fetch (url file://PWD/_bar_named_opam_subdir))) (dev) 
 
 Git pinned source:
 
@@ -97,7 +98,7 @@ Git pinned source:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     git+file://PWD/_bar_git)))
+  (source (fetch (url git+file://PWD/_bar_git))) (dev) 
 
 Git pinned source with toplevel opam file:
 
@@ -116,7 +117,7 @@ Git pinned source with toplevel opam file:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     git+file://PWD/_bar_opam_git)))
+  (source (fetch (url git+file://PWD/_bar_opam_git))) (dev) 
 
 Git pinned source with toplevel opam dir 1
 
@@ -136,7 +137,7 @@ Git pinned source with toplevel opam dir 1
   - bar.1.0.0
   (version 1.0.0)
   (dev)
-     git+file://PWD/_bar_opam_dir_git1)))
+  (source (fetch (url git+file://PWD/_bar_opam_dir_git1))) (dev) 
 
 Git pinned source with toplevel opam dir 2
 
@@ -154,8 +155,7 @@ Git pinned source with toplevel opam dir 2
   $ runtest "git+file://$PWD/$dir"
   File "foo.opam", line 1, characters 0-0:
   Error: unable to discover an opam file for package bar
-  (version 1.0.0)
-  (dev)
+  [1]
 
 Pin to something that doesn't have an opam file
 
@@ -163,8 +163,7 @@ Pin to something that doesn't have an opam file
   $ runtest "file://$PWD/$dir"
   File "foo.opam", line 1, characters 0-0:
   Error: unable to discover an opam file for package bar
-  (version 1.0.0)
-  (dev)
+  [1]
 
 Pin to an invalid opam file
 
@@ -174,5 +173,4 @@ Pin to an invalid opam file
   File "$TESTCASE_ROOT/_invalid_opam/opam", line 1, characters 0-0:
   Error: unexpected version
   unsupported or missing file format version; should be 2.0 or older
-  (version 1.0.0)
-  (dev)
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
@@ -1,0 +1,48 @@
+The pin stanza allows us to define packages that are not available
+in any repository
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_extra_source")
+  >  (package
+  >   (name foo)
+  >   (version 1.0.0)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ mkdir _extra_source
+  $ cat >_extra_source/dune-project <<EOF
+  > (lang dune 3.12)
+  > (package (name foo))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.1.0.0
+
+
+Now we verify the metadata we generated for the package. First we verify the
+build instructions and version are set correctly.
+
+We print the source separately for ease of post processing the output.
+  $ cat dune.lock/foo.pkg | sed "/source/,//d"
+  (version 1.0.0)
+  
+  (build
+   (run dune build -p %{pkg-self:name}))
+  
+  
+  (dev)
+
+Now we make sure that the source is set correctly.
+
+  $ print_source "foo"
+  (source (fetch (url file://PWD/_extra_source))) 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -1,0 +1,59 @@
+Demonstrate the build command we construct for different types of projects:
+
+  $ mkdir _template _dune-only _mixed
+
+  $ cat >_template/dune-project <<EOF
+  > (lang dune 3.13)
+  > (generate_opam_files true)
+  > (package (name template))
+  > EOF
+  $ cat >_template/mixed.opam.template <<EOF
+  > build: [ "echo" "template" ]
+  > EOF
+
+  $ cat >_dune-only/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name dune-only))
+  > EOF
+
+  $ cat >_mixed/dune-project <<EOF
+  > (lang dune 3.13)
+  > EOF
+  $ cat >_mixed/mixed.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "mixed" ]
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "$PWD/_template")
+  >  (package (name template)))
+  > (pin
+  >  (url "$PWD/_dune-only")
+  >  (package (name dune-only)))
+  > (pin
+  >  (url "$PWD/_mixed")
+  >  (package (name mixed)))
+  > (package
+  >  (name main)
+  >  (depends dune-only mixed template))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - dune-only.dev
+  - mixed.dev
+  - template.dev
+  $ build_command() {
+  > cat dune.lock/$1.pkg | awk '/build/{ p=1 } /^$/{ if (p) {exit} } { if (p) { print $0 } }'
+  > }
+  $ build_command "dune-only"
+  (build
+   (run dune build -p %{pkg-self:name}))
+  $ build_command "mixed"
+  (build
+   (run dune build -p %{pkg-self:name}))
+  $ build_command "template"
+  (build
+   (run dune build -p %{pkg-self:name}))

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/cycle.t
@@ -1,0 +1,49 @@
+Demonstrate a cycle from package sources:
+
+CR-rgrinberg: the cycle checking is disabled for now because it's not clear if
+it's even worth checking for. What matters is that there are no cycles at the
+package level, the sources can contain a cycle, we just need to make sure we
+detect it and not descend into an infinite loop.
+
+  $ . ../helpers.sh
+
+  $ mkdir a b
+
+  $ cat >a/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "$PWD/b")
+  >  (package (name b)))
+  > (package
+  >  (name a)
+  >  (depends b))
+  > EOF
+
+  $ cat >b/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "$PWD/a")
+  >  (package (name a)))
+  > (package
+  >  (name b)
+  >  (depends a))
+  > EOF
+
+  $ runtest() {
+  > local res;
+  > res=$(cd $1 && mkrepo && add_mock_repo_if_needed && dune pkg lock 2>&1)
+  > local code=$?
+  > printf "$res" $res
+  > return $code
+  > }
+
+  $ runtest a
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "b" is not in the workspace but it
+  depends on the package "a" which is in the workspace.
+  [1]
+  $ runtest b
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "a" is not in the workspace but it
+  depends on the package "b" which is in the workspace.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source-nested.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source-nested.t
@@ -1,0 +1,37 @@
+Package sources can be set to git and be nested:
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkdir _repo
+  $ cd _repo
+  $ git init --quiet
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ mkdir bar
+  $ cat >bar/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name bar))
+  > EOF
+  $ git add -A
+  $ git commit -qm "initial commit"
+  $ cd ..
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "git+file://$PWD/_repo")
+  >  (package (name foo))
+  >  (package (name bar)))
+  > EOF
+
+  $ dune pkg lock 2>&1 | sed 's#git+file://.*/#$URL#'
+  File "dune-project", line 5, characters 1-21:
+  5 |  (package (name bar)))
+       ^^^^^^^^^^^^^^^^^^^^
+  Error: package bar doesn't exist in source
+  $URL_repo

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
@@ -1,0 +1,31 @@
+Package sources can be set to git:
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkdir _repo
+  $ cd _repo
+  $ git init --quiet
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ git add -A
+  $ git commit -qm "initial commit"
+  $ cd ..
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "git+file://$PWD/_repo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
@@ -1,0 +1,39 @@
+Pulling projects should respect ignored directories.
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ mkdir -p _foo/subproject
+  $ cat >_foo/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo))
+  > EOF
+
+Although subproject has a dune-project, it lives in a data_only_dirs, so it
+should be ignored.
+
+  $ cat >_foo/dune <<EOF
+  > (data_only_dirs subproject)
+  > EOF
+
+  $ cat >_foo/subproject/dune-project <<EOF
+  > should not be parsed because it's ignored by the stanza above
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
@@ -1,0 +1,51 @@
+We try to use a project that has both opam files and a dune-project file. We
+should favor the dune metadata in such a case.
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_source")
+  >  (package (name foo))
+  >  (package (name bar)))
+  > (package
+  >  (name main)
+  >  (depends foo bar))
+  > EOF
+
+  $ mkdir _source
+  $ cat >_source/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+  $ cat >_source/bar.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "bar" ]
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.dev
+  - foo.dev
+
+  $  cat dune.lock/bar.pkg | sed "/source/,//d"
+  (version dev)
+  
+  (build
+   (run dune build -p %{pkg-self:name}))
+  
+  
+  (dev)
+  $  cat dune.lock/foo.pkg | sed "/source/,//d"
+  (version dev)
+  
+  (build
+   (run dune build -p %{pkg-self:name}))
+  
+  
+  (dev)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
@@ -1,0 +1,30 @@
+We can pull multiple packages from a single source
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+
+  $ mkdir _multiple
+  $ cat >_multiple/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url file://$PWD/_multiple)
+  >  (package (name foo))
+  >  (package (name bar)))
+  > (package
+  >  (name main)
+  >  (depends foo bar))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.dev
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/no-package.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/no-package.t
@@ -1,0 +1,29 @@
+Here we try to pin a package to a source that doesn't define said package:
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkdir _bar
+  $ cat >_bar/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name no-bar))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "$PWD/_bar")
+  >  (package (name bar)))
+  > (package
+  >  (name main)
+  >  (depends bar))
+  > EOF
+
+  $ dune pkg lock 2>&1 | sed 's#file://.*#$URL#g'
+  File "dune-project", line 4, characters 1-21:
+  4 |  (package (name bar)))
+       ^^^^^^^^^^^^^^^^^^^^
+  Error: package bar doesn't exist in source
+  $URL

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
@@ -1,0 +1,34 @@
+We try to pull an opam package that isn't a dune project
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ mkdir _foo
+  $ cat >_foo/foo.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "foo" ]
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.dev
+  $ pkg="dune.lock/foo.pkg"
+  $ grep version $pkg
+  (version dev)
+  $ grep dev $pkg
+  (version dev)
+  (dev)
+  $ grep "file://" $pkg | sed "s#$PWD#PWD#g"
+     file://PWD/_foo)))

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
@@ -1,0 +1,74 @@
+Override a source when multiple projects in a workspace set it.
+
+  $ . ../helpers.sh
+
+Here we demonstrate that projects override their sub projects:
+
+  $ mkdir a && cd a
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar")
+  >  (package (name bar)))
+  > (package
+  >  (name main)
+  >  (depends bar))
+  > EOF
+
+  $ mkdir sub
+  $ cat >sub/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar_overriden")
+  >  (package (name bar)))
+  > EOF
+
+  $ mkdir _bar
+  $ cat >_bar/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name bar))
+  > EOF
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.dev
+
+  $ print_source "bar"
+  (source (fetch (url file://PWD/_bar))) (dev) 
+
+  $ cd ..
+
+However, when two projects are at the same level, dune is unable to correctly
+select a priority:
+
+  $ mkdir b && cd b
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkdir prj1
+  $ cat >prj1/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar1")
+  >  (package (name bar)))
+  > EOF
+
+  $ mkdir prj2
+  $ cat >prj2/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar2")
+  >  (package (name bar)))
+  > EOF
+
+  $ dune pkg lock
+  File "prj2/dune-project", line 4, characters 1-21:
+  4 |  (package (name bar)))
+       ^^^^^^^^^^^^^^^^^^^^
+  Error: package "bar" is defined in more than one source
+  it is also defined in prj2/dune-project:4
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
@@ -1,0 +1,41 @@
+We can override the sources set by packages we're fetching:
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar")
+  >  (package (name bar)))
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ mkdir _foo
+  $ cat >_foo/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_fake_bar") ;; doesn't exist but unused
+  >  (package (name bar)))
+  > (package
+  >  (name foo)
+  >  (depends bar))
+  > EOF
+
+  $ mkdir _bar
+  $ cat >_bar/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name bar))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.dev
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
@@ -1,0 +1,36 @@
+Setting the source of a package to a non dune package with pin-depends should
+respect the pin-depends
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ mkdir _foo
+  $ cat >_foo/foo.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "foo" ]
+  > depends: [ "bar" ]
+  > pin-depends: [ "bar.1.0.0" "file://$PWD/_bar" ]
+  > EOF
+
+  $ mkdir _bar
+  $ cat >_bar/bar.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "bar" ]
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.1.0.0
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
@@ -1,0 +1,38 @@
+Sources are traversed recursively (unlike pins)
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkdir _foo
+  $ cat >_foo/dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_bar")
+  >  (package (name bar)))
+  > (package
+  >  (name foo)
+  >  (depends bar))
+  > EOF
+
+  $ mkdir _bar
+  $ cat >_bar/dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name bar))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.dev
+  - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
@@ -1,0 +1,35 @@
+We are unable to pin projects that the version of dune doesn't understand.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "$PWD/_b")
+  >  (package (name a)))
+  > (package
+  >  (name main)
+  >  (depends a))
+  > EOF
+
+  $ mkdir _b
+  $ cat >_b/dune-project <<EOF
+  > (lang dune 100.1)
+  > ;; one day we'll get here
+  > EOF
+
+# The location here is messed up b/c we are using a source path (incorrectly)
+# to construct the project
+
+  $ dune pkg lock
+  File "dune-project", line 1, characters 11-16:
+  1 | (lang dune 3.13)
+                 ^^^^^
+  Error: Version 100.1 of the dune language is not supported.
+  Supported versions of this extension in version 100.1 of the dune language:
+  - 1.0 to 1.12
+  - 2.0 to 2.9
+  - 3.0 to 3.14
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
@@ -1,0 +1,42 @@
+It should be possible to include custom repos from the workspace:
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ cat >dune-workspace<<EOF
+  > (lang dune 3.10)
+  > (pin
+  >  (name foo)
+  >  (url "file://$PWD/_foo")
+  >  (package (name foo)))
+  > (lock_dir
+  >  (sources foo)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (source "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Note that sources in the projects are overriden by the workspace
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin ;; does not exist
+  >  (url "file://$PWD/_does_not_exist")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ dune pkg lock
+  File "dune-workspace", line 3, characters 2-6:
+  3 |  (name foo)
+        ^^^^
+  Error: Unknown field name
+  [1]


### PR DESCRIPTION
Introduce a [(package_source ..)] stanza in [dune-project] files to
define dune pins

# TL;DR

A new stanza is available in dune-workspace and dune-project files:
```
(package_source
 (url "...")
 (package (name ..) (version ..))
 (package ..)
 ..)
```

This stanza makes all the package specified in the package_source immediately resolve to `url`.

The work is still WIP, but the important is complete.

## Features

### Recursion

`package_source` definitions are recursive (unlike pin-depends). That means dune will scan the `dune-project` files of all dependencies to discover their `package_source` stanzas.

### Compatibility with `pin-depends`

Works transparently with opam pins. If you do `(package_source ..)` on an opam project with a pin, we will respect the pin.

### Subproject Handling

projects are allowed to override the `package_source` assignments of their sub-projects or dependencies. The rules are as follows:
- `a/dune-project` will override any `package_source` set in `a/b/dune-project` b/c `b` is a sub-project of `a`.
- `a/dune-project` can override any `package_source` set in the subprojects that it pulls in `a/dune-project`.

### Workspaces

It's possible to set pins in the workspace file per lock directory

To review this PR, it's best to start by reading the tests.

## TODO

The following elements are still missing:

- proper support for build instructions of dune projects
- recursive project scanning
- workspace sources

## Naming

I dislike the `package_source` name, and I would have much preferred `source`. Unfortunately, `source` is already taken.

## Why a stanza?

I've seen the suggestion of specifying the source inside the `(depends ..)` field floating around more than a few times, so I thought I would explain my rationale for a separate stanza over cramming everything into `(depends ..)`

We could inline the definition of package sources into the `depends` field: 

```
(package
 (depends (a (url git+https://github.com/foo/bar))))
```

But it has a few disadvantages over a separate stanza. Those include:

* When pulling multiple packages from the same url, we don't need to duplicate the URL's
* It's easier to extend to conditional sources with things like `enabled_if` in the stanza. In general, it's easy to extend stanzas with new functionality than an inline specification.
* This syntax might not compose with the full dependency specification from opam
* It's easier to implement because we don't need to touch opam file generation code.