### PR TITLE
chore: Update re

### DIFF
--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -1,14 +1,5 @@
 open Stdune
-
-module Re = struct
-  include Dune_re
-
-  module Group = struct
-    include Group
-
-    let get_opt group n = if Group.test group n then Some (get group n) else None
-  end
-end
+module Re = Dune_re
 
 include struct
   open Dune_engine

--- a/vendor/re/src/automata.ml
+++ b/vendor/re/src/automata.ml
@@ -254,11 +254,11 @@ module E = struct
     | TSeq (l', x, _kind) ->
       Format.fprintf ch "@[<2>(Seq@ ";
       print_state_lst ch l' x;
-      Format.fprintf ch " %a)@]" pp x
+      Format.fprintf ch "@ %a)@]" pp x
     | TExp (marks, {def = Eps; _}) ->
-      Format.fprintf ch "(Exp %d (%a) (eps))" y.id Marks.pp_marks marks
+      Format.fprintf ch "@[<2>(Exp@ %d@ (%a)@ (eps))@]" y.id Marks.pp_marks marks
     | TExp (marks, x) ->
-      Format.fprintf ch "(Exp %d (%a) %a)" x.id Marks.pp_marks marks pp x
+      Format.fprintf ch "@[<2>(Exp@ %d@ (%a)@ %a)@]" x.id Marks.pp_marks marks pp x
 
   and print_state_lst ch l y =
     match l with
@@ -268,7 +268,7 @@ module E = struct
       print_state_rec ch e y;
       List.iter
         (fun e ->
-           Format.fprintf ch " | ";
+           Format.fprintf ch "@ | ";
            print_state_rec ch e y)
         rem
 

--- a/vendor/re/src/color_map.ml
+++ b/vendor/re/src/color_map.ml
@@ -24,7 +24,7 @@ let flatten cm =
     Bytes.set c i (Char.chr !v);
     Bytes.set color_repr !v (Char.chr i)
   done;
-  (c, Bytes.sub color_repr 0 (!v + 1), !v + 1)
+  (Bytes.unsafe_to_string c, Bytes.sub_string color_repr 0 (!v + 1), !v + 1)
 
 (* mark all the endpoints of the intervals of the char set with the 1 byte *)
 let split s cm =

--- a/vendor/re/src/color_map.mli
+++ b/vendor/re/src/color_map.mli
@@ -9,6 +9,6 @@ type t
 
 val make : unit -> t
 
-val flatten : t -> bytes * bytes * int
+val flatten : t -> string * string * int
 
 val split : Cset.t -> t -> unit

--- a/vendor/re/src/core.mli
+++ b/vendor/re/src/core.mli
@@ -20,7 +20,8 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 *)
 
-(** Module [Re]: regular expressions commons *)
+(** Module [Re]: code for creating and using regular expressions,
+   independently of regular expression syntax. *)
 
 type t
 (** Regular expression *)
@@ -31,10 +32,15 @@ type re
 (** Manipulate matching groups. *)
 module Group : sig
   type t
-  (** Information about groups in a match. *)
+  (** Information about groups in a match. As is conventional, every
+      match implicitly has a group 0 that covers the whole match, and
+      explicit groups are numbered from 1. *)
 
   val get : t -> int -> string
   (** Raise [Not_found] if the group did not match *)
+
+  val get_opt : t -> int -> string option
+  (** Similar to {!get}, but returns an option instead of using an exception. *)
 
   val offset : t -> int -> int * int
   (** Raise [Not_found] if the group did not match *)
@@ -68,36 +74,128 @@ val compile : t -> re
 (** Compile a regular expression into an executable version that can be
     used to match strings, e.g. with {!exec}. *)
 
+val group_count : re -> int
+(** Return the number of capture groups (including the one
+    corresponding to the entire regexp). *)
+
+val group_names : re -> (string * int) list
+(** Return named capture groups with their index. *)
+
 val exec :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
   re -> string -> Group.t
-(** [exec re str] matches [str] against the compiled expression [re],
+(** [exec re str] searches [str] for a match of the compiled expression [re],
     and returns the matched groups if any.
+
+    More specifically, when a match exists, [exec] returns a match that
+    starts at the earliest position possible. If multiple such matches are
+    possible, the one specified by the match semantics described below is
+    returned.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "//"; rep print ]);;
+        val regex : re = <abstr>
+
+        # Re.exec regex "// a C comment";;
+        - : Re.substrings = <abstr>
+
+        # Re.exec regex "# a C comment?";;
+        Exception: Not_found
+
+        # Re.exec ~pos:1 regex "// a C comment";;
+        Exception: Not_found
+    ]}
+
+
     @param pos optional beginning of the string (default 0)
     @param len length of the substring of [str] that can be matched (default [-1],
-      meaning to the end of the string
+      meaning to the end of the string)
     @raise Not_found if the regular expression can't be found in [str]
 *)
 
 val exec_opt :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
   re -> string -> Group.t option
-(** Similar to {!exec}, but returns an option instead of using an exception. *)
+(** Similar to {!exec}, but returns an option instead of using an exception.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "//"; rep print ]);;
+        val regex : re = <abstr>
+
+        # Re.exec_opt regex "// a C comment";;
+        - : Re.substrings option = Some <abstr>
+
+        # Re.exec_opt regex "# a C comment?";;
+        - : Re.substrings option = None
+
+        # Re.exec_opt ~pos:1 regex "// a C comment";;
+        - : Re.substrings option = None
+    ]}
+*)
 
 val execp :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
   re -> string -> bool
 (** Similar to {!exec}, but returns [true] if the expression matches,
-    and [false] if it doesn't *)
+    and [false] if it doesn't. This function is more efficient than
+    calling {!exec} or {!exec_opt} and ignoring the returned group.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "//"; rep print ]);;
+        val regex : re = <abstr>
+
+        # Re.execp regex "// a C comment";;
+        - : bool = true
+
+        # Re.execp ~pos:1 regex "// a C comment";;
+        - : bool = false
+    ]}
+ *)
 
 val exec_partial :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
   re -> string -> [ `Full | `Partial | `Mismatch ]
-(** More detailed version of {!exec_p} *)
+(** More detailed version of {!execp}. [`Full] is equivalent to [true],
+   while [`Mismatch] and [`Partial] are equivalent to [false], but [`Partial]
+   indicates the input string could be extended to create a match.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [bos; str "// a C comment"]);;
+        val regex : re = <abstr>
+
+        # Re.exec_partial regex "// a C comment here.";;
+        - : [ `Full | `Mismatch | `Partial ] = `Full
+
+        # Re.exec_partial regex "// a C comment";;
+        - : [ `Full | `Mismatch | `Partial ] = `Partial
+
+        # Re.exec_partial regex "//";;
+        - : [ `Full | `Mismatch | `Partial ] = `Partial
+
+        # Re.exec_partial regex "# a C comment?";;
+        - : [ `Full | `Mismatch | `Partial ] = `Mismatch
+    ]}
+*)
+
+val exec_partial_detailed :
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
+  re -> string -> [ `Full of Group.t | `Partial of int | `Mismatch ]
+(** More detailed version of {!exec_opt}. [`Full group] is equivalent to [Some group],
+   while [`Mismatch] and [`Partial _] are equivalent to [None], but [`Partial position]
+   indicates that the input string could be extended to create a match, and no match could
+   start in the input string before the given position.
+   This could be used to not have to search the entirety of the input if more
+   becomes available, and use the given position as the [?pos] argument.
+*)
 
 (** Marks *)
 module Mark : sig
@@ -125,86 +223,196 @@ type split_token =
   | `Delim of Group.t (** Delimiter *)
   ]
 
-type 'a seq = 'a Seq.t
+val all : ?pos:int -> ?len:int -> re -> string -> Group.t list
+(** Repeatedly calls {!exec} on the given string, starting at given position and
+    length.
+    
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "my"; blank; word(rep alpha)]);;
+        val regex : re = <abstr>
+
+        # Re.all regex "my head, my shoulders, my knees, my toes ...";;
+        - : Re.substrings list = [<abstr>; <abstr>; <abstr>; <abstr>]
+
+        # Re.all regex "My head, My shoulders, My knees, My toes ...";;
+        - : Re.substrings list = []
+    ]}
+*)
+
+type 'a gen = unit -> 'a option
+
+val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t gen
+[@@ocaml.deprecated "Use Seq.all"]
+(** @deprecated Use {!module-Seq.all} instead. *)
+
+val all_seq : ?pos:int -> ?len:int -> re -> string -> Group.t Seq.t
+[@@ocaml.deprecated "Use Seq.all"]
+(** @deprecated Use {!module-Seq.all} instead. *)
+
+val matches : ?pos:int -> ?len:int -> re -> string -> string list
+(** Same as {!all}, but extracts the matched substring rather than returning
+    the whole group. This basically iterates over matched strings.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "my"; blank; word(rep alpha)]);;
+        val regex : re = <abstr>
+
+        # Re.matches regex "my head, my shoulders, my knees, my toes ...";;
+        - : string list = ["my head"; "my shoulders"; "my knees"; "my toes"]
+
+        # Re.matches regex "My head, My shoulders, My knees, My toes ...";;
+        - : string list = []
+
+        # Re.matches regex "my my my my head my 1 toe my ...";;
+        - : string list = ["my my"; "my my"]
+
+        # Re.matches ~pos:2 regex "my my my my head my +1 toe my ...";;
+        - : string list = ["my my"; "my head"]
+    ]}
+*)
+
+val matches_gen : ?pos:int -> ?len:int -> re -> string -> string gen
+[@@ocaml.deprecated "Use Seq.matches"]
+(** @deprecated Use {!module-Seq.matches} instead. *)
+
+val matches_seq : ?pos:int -> ?len:int -> re -> string -> string Seq.t
+[@@ocaml.deprecated "Use Seq.matches"]
+(** @deprecated Use {!module-Seq.matches} instead. *)
+
+val split : ?pos:int -> ?len:int -> re -> string -> string list
+(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
+    themselves, not the separator.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile (Re.char ',');;
+        val regex : re = <abstr>
+
+        # Re.split regex "Re,Ocaml,Jerome Vouillon";;
+        - : string list = ["Re"; "Ocaml"; "Jerome Vouillon"]
+
+        # Re.split regex "No commas in this sentence.";;
+        - : string list = ["No commas in this sentence."]
+
+        # Re.split ~pos:3 regex "1,2,3,4. Commas go brrr.";;
+        - : string list = ["3"; "4. Commas go brrr."]
+    ]}
+*)
+
+val split_gen : ?pos:int -> ?len:int -> re -> string -> string gen
+[@@ocaml.deprecated "Use Seq.split"]
+(** @deprecated Use {!module-Seq.split} instead. *)
+
+val split_seq : ?pos:int -> ?len:int -> re -> string -> string Seq.t
+[@@ocaml.deprecated "Use Seq.split"]
+(** @deprecated Use {!module-Seq.split} instead. *)
+
+val split_full : ?pos:int -> ?len:int -> re -> string -> split_token list
+(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
+    along with the separators. For instance this can be used with a
+    whitespace-matching re such as ["[\t ]+"].
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile (Re.char ',');;
+        val regex : re = <abstr>
+
+        # Re.split_full regex "Re,Ocaml,Jerome Vouillon";;
+        - : Re.split_token list =
+          [`Text "Re"; `Delim <abstr>; `Text "Ocaml"; `Delim <abstr>;
+          `Text "Jerome Vouillon"]
+
+        # Re.split_full regex "No commas in this sentence.";;
+        - : Re.split_token list = [`Text "No commas in this sentence."]
+
+        # Re.split_full ~pos:3 regex "1,2,3,4. Commas go brrr.";;
+        - : Re.split_token list =
+          [`Delim <abstr>; `Text "3"; `Delim <abstr>; `Text "4. Commas go brrr."]
+    ]}
+*)
+
+val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token gen
+[@@ocaml.deprecated "Use Seq.split_full"]
+(** @deprecated Use {!module-Seq.split_full} instead. *)
+
+val split_full_seq : ?pos:int -> ?len:int -> re -> string -> split_token Seq.t
+[@@ocaml.deprecated "Use Seq.split_full"]
+(** @deprecated Use {!module-Seq.split_full} instead. *)
 
 module Seq : sig
   val all :
     ?pos:int ->    (** Default: 0 *)
     ?len:int ->
     re -> string -> Group.t Seq.t
-    (** Same as {!all} but returns an iterator
-        @since NEXT_RELEASE *)
+    (** Same as {!module-Re.val-all} but returns an iterator.
+
+    {5 Examples:}
+    {[
+        # let regex = Re.compile Re.(seq [str "my"; blank; word(rep alpha)]);;
+        val regex : re = <abstr>
+
+        # Re.Seq.all regex "my head, my shoulders, my knees, my toes ...";;
+        - : Re.substrings Seq.t = <fun>
+    ]}
+        @since 1.10.0 *)
 
   val matches :
     ?pos:int ->    (** Default: 0 *)
     ?len:int ->
     re -> string -> string Seq.t
-    (** Same as {!matches}, but returns an iterator
-        @since NEXT_RELEASE *)
+    (** Same as {!module-Re.val-matches}, but returns an iterator.
+
+    {5 Example:}
+    {[
+        # let regex = Re.compile Re.(seq [str "my"; blank; word(rep alpha)]);;
+        val regex : re = <abstr>
+
+        # Re.Seq.matches regex "my head, my shoulders, my knees, my toes ...";;
+        - : string Seq.t = <fun>
+    ]}
+        @since 1.10.0 *)
 
   val split :
     ?pos:int ->    (** Default: 0 *)
     ?len:int ->
     re -> string -> string Seq.t
-    (** @since NEXT_RELEASE *)
+    (** Same as {!module-Re.val-split} but returns an iterator.
+
+    {5 Example:}
+    {[
+        # let regex = Re.compile (Re.char ',');;
+        val regex : re = <abstr>
+
+        # Re.Seq.split regex "Re,Ocaml,Jerome Vouillon";;
+        - : string Seq.t = <fun>
+    ]}
+        @since 1.10.0 *)
 
   val split_full :
     ?pos:int ->    (** Default: 0 *)
     ?len:int ->
     re -> string -> split_token Seq.t
-    (** @since NEXT_RELEASE *)
+    (** Same as {!module-Re.val-split_full} but returns an iterator.
+
+    {5 Example:}
+    {[
+        # let regex = Re.compile (Re.char ',');;
+        val regex : re = <abstr>
+
+        # Re.Seq.split_full regex "Re,Ocaml,Jerome Vouillon";;
+        - : Re__Core.split_token Seq.t = <fun>
+    ]}
+        @since 1.10.0 *)
 end
-
-val all : ?pos:int -> ?len:int -> re -> string -> Group.t list
-(** Repeatedly calls {!exec} on the given string, starting at given position and
-    length.*)
-
-type 'a gen = unit -> 'a option
-
-val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t gen
-[@@ocaml.deprecated "Use Seq.all"]
-
-val all_seq : ?pos:int -> ?len:int -> re -> string -> Group.t seq
-[@@ocaml.deprecated "Use Seq.all"]
-
-val matches : ?pos:int -> ?len:int -> re -> string -> string list
-(** Same as {!all}, but extracts the matched substring rather than returning
-    the whole group. This basically iterates over matched strings *)
-
-val matches_gen : ?pos:int -> ?len:int -> re -> string -> string gen
-[@@ocaml.deprecated "Use Seq.matches"]
-
-val matches_seq : ?pos:int -> ?len:int -> re -> string -> string seq
-[@@ocaml.deprecated "Use Seq.matches"]
-
-val split : ?pos:int -> ?len:int -> re -> string -> string list
-(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
-    themselves, not the separator. For instance this can be used with a
-    whitespace-matching re such as ["[\t ]+"]. *)
-
-val split_gen : ?pos:int -> ?len:int -> re -> string -> string gen
-[@@ocaml.deprecated "Use Seq.split"]
-
-val split_seq : ?pos:int -> ?len:int -> re -> string -> string seq
-[@@ocaml.deprecated "Use Seq.split"]
-
-val split_full : ?pos:int -> ?len:int -> re -> string -> split_token list
-(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
-    along with the separators. For instance this can be used with a
-    whitespace-matching re such as ["[\t ]+"]. *)
-
-val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token gen
-[@@ocaml.deprecated "Use Seq.split_full"]
-
-val split_full_seq : ?pos:int -> ?len:int -> re -> string -> split_token seq
-[@@ocaml.deprecated "Use Seq.split_full"]
 
 val replace :
   ?pos:int ->    (** Default: 0 *)
   ?len:int ->
   ?all:bool ->   (** Default: true. Otherwise only replace first occurrence *)
   re ->          (** matched groups *)
-  f:(Group.t -> string) ->  (* how to replace *)
+  f:(Group.t -> string) ->  (** how to replace *)
   string ->     (** string to replace in *)
   string
 (** [replace ~all re ~f s] iterates on [s], and replaces every occurrence
@@ -221,7 +429,20 @@ val replace_string :
   string
 (** [replace_string ~all re ~by s] iterates on [s], and replaces every
     occurrence of [re] with [by]. If [all = false], then only the first
-    occurrence of [re] is replaced. *)
+    occurrence of [re] is replaced. 
+    
+    {5 Examples:}
+    {[
+        # let regex = Re.compile (Re.char ',');;
+        val regex : re = <abstr>
+
+        # Re.replace_string regex ~by:";" "[1,2,3,4,5,6,7]";;
+        - : string = "[1;2;3;4;5;6;7]"
+
+        # Re.replace_string regex ~all:false ~by:";" "[1,2,3,4,5,6,7]";;
+        - : string = "[1;2,3,4,5,6,7]"
+    ]}
+*)
 
 (** {2 String expressions (literal match)} *)
 
@@ -231,7 +452,12 @@ val char : char -> t
 (** {2 Basic operations on regular expressions} *)
 
 val alt : t list -> t
-(** Alternative *)
+(** Alternative.
+
+    [alt []] is equivalent to {!empty}.
+
+    By default, the leftmost match is preferred (see match semantics below).
+*)
 
 val seq : t list -> t
 (** Sequence *)
@@ -257,7 +483,10 @@ val repn : t -> int -> int option -> t
 val opt : t -> t
 (** 0 or 1 matches *)
 
-(** {2 String, line, word} *)
+(** {2 String, line, word}
+
+    We define a word as a sequence of latin1 letters, digits and underscore.
+*)
 
 val bol : t
 (** Beginning of line *)
@@ -272,19 +501,35 @@ val eow : t
 (** End of word *)
 
 val bos : t
-(** Beginning of string *)
+(** Beginning of string. This differs from {!start} because it matches
+    the beginning of the input string even when using [~pos] arguments:
+
+    {[
+      let b = execp (compile (seq [ bos; str "a" ])) "aa" ~pos:1 in
+      assert (not b)
+    ]}
+*)
 
 val eos : t
-(** End of string *)
+(** End of string. This is different from {!stop} in the way described
+    in {!bos}. *)
 
 val leol : t
 (** Last end of line or end of string *)
 
 val start : t
-(** Initial position *)
+(** Initial position. This differs from {!bos} because it takes into
+    account the [~pos] arguments:
+
+    {[
+      let b = execp (compile (seq [ start; str "a" ])) "aa" ~pos:1 in
+      assert b
+    ]}
+*)
 
 val stop : t
-(** Final position *)
+(** Final position. This is different from {!eos} in the way described
+    in {!start}. *)
 
 val word : t -> t
 (** Word *)
@@ -293,38 +538,77 @@ val not_boundary : t
 (** Not at a word boundary *)
 
 val whole_string : t -> t
-(** Only matches the whole string *)
+(** Only matches the whole string, i.e. [fun t -> seq [ eos; t; bos ]]. *)
 
-(** {2 Match semantics} *)
+(** {2 Match semantics}
+
+   A regular expression frequently matches a string in multiple ways.  For
+   instance [exec (compile (opt (str "a"))) "ab"] can match "" or "a". Match
+   semantic can be modified with the functions below, allowing one to choose
+   which of these is preferable.
+
+   By default, the leftmost branch of alternations is preferred, and repetitions
+   are greedy.
+
+   Note that the existence of matches cannot be changed by specifying match
+   semantics.  [seq [ bos; str "a"; non_greedy (opt (str "b")); eos ]] will
+   match when applied to "ab". However if [seq [ bos; str "a"; non_greedy (opt
+   (str "b")) ]] is applied to "ab", it will match "a" rather than "ab".
+
+   Also note that multiple match semantics can conflict. In this case, the one
+   executed earlier takes precedence. For instance, any match of [shortest (seq
+   [ bos; group (rep (str "a")); group (rep (str "a")); eos ])] will always have
+   an empty first group. Conversely, if we use [longest] instead of [shortest],
+   the second group will always be empty.
+*)
 
 val longest : t -> t
-(** Longest match *)
+(** Longest match semantics. That is, matches will match as many bytes as
+    possible. If multiple choices match the maximum amount of bytes, the one
+    respecting the inner match semantics is preferred. *)
 
 val shortest : t -> t
-(** Shortest match *)
+(** Same as {!longest}, but matching the least number of bytes. *)
 
 val first : t -> t
-(** First match *)
-
-(** {2 Repeated match modifiers} *)
+(** First match semantics for alternations (not repetitions). That is, matches
+    will prefer the leftmost branch of the alternation that matches the text. *)
 
 val greedy : t -> t
-(** Greedy *)
+(** Greedy matches for repetitions ({!opt}, {!rep}, {!rep1}, {!repn}): they will
+    match as many times as possible. *)
 
 val non_greedy : t -> t
-(** Non-greedy *)
+(** Non-greedy matches for repetitions ({!opt}, {!rep}, {!rep1}, {!repn}): they
+    will match as few times as possible. *)
 
 (** {2 Groups (or submatches)} *)
 
-val group : t -> t
-(** Delimit a group *)
+val group : ?name:string -> t -> t
+(** Delimit a group. The group is considered as matching if it is used at least
+   once (it may be used multiple times if is nested inside {!rep} for
+   instance). If it is used multiple times, the last match is what gets
+   captured. *)
 
 val no_group : t -> t
 (** Remove all groups *)
 
 val nest : t -> t
-(** when matching against [nest e], only the group matching in the
-       last match of e will be considered as matching *)
+(** When matching against [nest e], only the group matching in the
+    last match of e will be considered as matching.
+
+    For instance:
+    {[
+      let re = compile (rep1 (nest (alt [ group (str "a"); str "b" ]))) in
+      let group = Re.exec re "ab" in
+      assert (Group.get_opt group 1 = None);
+
+      (* same thing but without [nest] *)
+      let re = compile (rep1 (alt [ group (str "a"); str "b" ])) in
+      let group = Re.exec re "ab" in
+      assert (Group.get_opt group 1 = Some "a");
+    ]}
+*)
 
 
 
@@ -374,10 +658,12 @@ val xdigit : t
 (** {2 Case modifiers} *)
 
 val case : t -> t
-(** Case sensitive matching *)
+(** Case sensitive matching. Note that this works on latin1, not ascii and not
+    utf8. *)
 
 val no_case : t -> t
-(** Case insensitive matching *)
+(** Case insensitive matching. Note that this works on latin1, not ascii and not
+    utf8. *)
 
 (****)
 
@@ -405,7 +691,7 @@ module View : sig
     | Last_end_of_line | Start | Stop
     | Sem of Automata.sem * outer
     | Sem_greedy of Automata.rep_kind * outer
-    | Group of outer | No_group of outer | Nest of outer
+    | Group of string option * outer | No_group of outer | Nest of outer
     | Case of outer | No_case of outer
     | Intersection of outer list
     | Complement of outer list
@@ -415,11 +701,14 @@ module View : sig
   val view : outer -> t
 end with type outer := t
 
-(** {2 Experimental functions}. *)
+(** {2 Experimental functions} *)
 
 val witness : t -> string
-(** [witness r] generates a string [s] such that [execp (compile r) s] is
-    true *)
+(** [witness r] generates a string [s] such that [execp (compile r) s] is true.
+
+    Be warned that this function is buggy because it ignores zero-width
+    assertions like beginning of words. As a result it can generate incorrect
+    results. *)
 
 (** {2 Deprecated functions} *)
 

--- a/vendor/re/src/fmt.ml
+++ b/vendor/re/src/fmt.ml
@@ -4,19 +4,7 @@ include Format
 
 type 'a t = Format.formatter -> 'a -> unit
 
-(* Only in the stdlib since 4.02, so we copy. *)
-let rec list ?(pp_sep = pp_print_cut) pp ppf = function
-  | [] -> ()
-  | [v] -> pp ppf v
-  | v :: vs ->
-    pp ppf v;
-    pp_sep ppf ();
-    list ~pp_sep pp ppf vs
-
-(* want this name to make sure we don't use pp_print_list from stdlib
-   accidentally *)
-let pp_print_list = list
-
+let list = pp_print_list
 let str = pp_print_string
 let sexp fmt s pp x = fprintf fmt "@[<3>(%s@ %a)@]" s pp x
 let pair pp1 pp2 fmt (v1,v2) =

--- a/vendor/re/src/glob.mli
+++ b/vendor/re/src/glob.mli
@@ -27,8 +27,10 @@ exception Parse_error
 val glob :
   ?anchored:bool ->
   ?pathname:bool ->
+  ?match_backslashes:bool ->
   ?period:bool ->
   ?expand_braces:bool ->
+  ?double_asterisk:bool ->
   string ->
   Core.t
 (** Implements the semantics of shells patterns. The returned regular
@@ -48,6 +50,11 @@ val glob :
     and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
     expression ('[]') containing a slash. Defaults to true.
 
+    [match_backslashes]: If this flag is set, a forward slash will also match a
+    backslash (useful when globbing Windows paths). Note that a backslash in the
+    pattern will continue to escape the following character. Defaults to
+    [false].
+
     [period]: If this flag is set, a leading period in string has to be matched exactly by
     a period in pattern. A period is considered to be leading if it is the first
     character in string, or if both [pathname] is set and the period immediately follows a
@@ -55,7 +62,11 @@ val glob :
 
     If [expand_braces] is true, braced sets will expand into multiple globs,
     e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
-    expansion is purely textual and can be nested. Defaults to false. *)
+    expansion is purely textual and can be nested. Defaults to false.
+
+    [double_asterisk]: If this flag is set, double asterisks ('**') will match slash
+    characters, even if [pathname] is set. The [period] flag still applies. Default to
+    true. *)
 
 val glob' : ?anchored:bool -> bool -> string -> Core.t
 (** Same, but allows to choose whether dots at the beginning of a

--- a/vendor/re/src/group.ml
+++ b/vendor/re/src/group.ml
@@ -11,8 +11,8 @@ let offset t i =
   if 2 * i + 1 >= Array.length t.marks then raise Not_found;
   let m1 = t.marks.(2 * i) in
   if m1 = -1 then raise Not_found;
-  let p1 = t.gpos.(m1) - 1 in
-  let p2 = t.gpos.(t.marks.(2 * i + 1)) - 1 in
+  let p1 = t.gpos.(m1) in
+  let p2 = t.gpos.(t.marks.(2 * i + 1)) in
   (p1, p2)
 
 let get t i =
@@ -30,6 +30,11 @@ let test t i =
     let idx = t.marks.(2 * i) in
     idx <> -1
 
+let get_opt t i =
+  if test t i
+  then Some (get t i)
+  else None
+
 let dummy_offset = (-1, -1)
 
 let all_offset t =
@@ -39,7 +44,7 @@ let all_offset t =
     if m1 <> -1 then begin
       let p1 = t.gpos.(m1) in
       let p2 = t.gpos.(t.marks.(2 * i + 1)) in
-      res.(i) <- (p1 - 1, p2 - 1)
+      res.(i) <- (p1, p2)
     end
   done;
   res
@@ -53,7 +58,7 @@ let all t =
     if m1 <> -1 then begin
       let p1 = t.gpos.(m1) in
       let p2 = t.gpos.(t.marks.(2 * i + 1)) in
-      res.(i) <- String.sub t.s (p1 - 1) (p2 - p1)
+      res.(i) <- String.sub t.s p1 (p2 - p1)
     end
   done;
   res

--- a/vendor/re/src/group.mli
+++ b/vendor/re/src/group.mli
@@ -27,6 +27,9 @@ type t =
 val get : t -> int -> string
 (** Raise [Not_found] if the group did not match *)
 
+val get_opt : t -> int -> string option
+(** Similar to {!get}, but returns an option instead of using an exception. *)
+
 val offset : t -> int -> int * int
 (** Raise [Not_found] if the group did not match *)
 

--- a/vendor/re/src/pcre.mli
+++ b/vendor/re/src/pcre.mli
@@ -1,6 +1,9 @@
+exception Parse_error
+exception Not_supported
+
 type regexp = Core.re
 
-type flag = [ `CASELESS | `MULTILINE | `ANCHORED ]
+type flag = [ `CASELESS | `MULTILINE | `ANCHORED | `DOTALL ]
 
 type groups = Core.Group.t
 
@@ -25,6 +28,12 @@ val exec : rex:regexp -> ?pos:int -> string -> groups
 
 val get_substring : groups -> int -> string
 (** Equivalent to {!Core.Group.get}. *)
+
+val names : regexp -> string array
+(** Return the names of named groups. *)
+
+val get_named_substring : regexp -> string -> groups -> string
+(** Return the first matched named group, or raise [Not_found]. *)
 
 val get_substring_ofs : groups -> int -> int * int
 (** Equivalent to {!Core.Group.offset}. *)

--- a/vendor/re/src/posix.mli
+++ b/vendor/re/src/posix.mli
@@ -48,7 +48,7 @@ let match_line line =
 ]}
 *)
 
-(** XXX Character classes *)
+(* XXX Character classes *)
 
 exception Parse_error
 exception Not_supported
@@ -60,10 +60,10 @@ val re : ?opts:(opt list) -> string -> Core.t
 (** Parsing of a Posix extended regular expression *)
 
 val compile : Core.t -> Core.re
-(** Regular expression compilation *)
+(** [compile r] is defined as [Core.compile (Core.longest r)] *)
 
 val compile_pat : ?opts:(opt list) -> string -> Core.re
-(** [compile r] is defined as [Core.compile (Core.longest r)] *)
+(** [compile_pat ?opts regex] compiles the Posix extended regular expression [regexp] *)
 
 (*
 Deviation from the standard / ambiguities in the standard

--- a/vendor/re/src/str.ml
+++ b/vendor/re/src/str.ml
@@ -203,16 +203,18 @@ let substitute_first expr repl_fun text =
 
 let global_substitute expr repl_fun text =
   let rec replace accu start last_was_empty =
-    try
-      let startpos = if last_was_empty then start + 1 else start in
-      if startpos > String.length text then raise Not_found;
-      let pos = search_forward expr text startpos in
-      let end_pos = match_end () in
-      let repl_text = repl_fun text in
-      replace (repl_text :: String.sub text start (pos-start) :: accu)
-        end_pos (end_pos = pos)
-    with Not_found ->
-      (string_after text start) :: accu in
+    let startpos = if last_was_empty then start + 1 else start in
+    if startpos > String.length text then
+      (string_after text start) :: accu
+    else
+      match search_forward expr text startpos with
+      | pos ->
+        let end_pos = match_end () in
+        let repl_text = repl_fun text in
+        replace (repl_text :: String.sub text start (pos-start) :: accu)
+          end_pos (end_pos = pos)
+      | exception Not_found -> (string_after text start) :: accu
+  in
   String.concat "" (List.rev (replace [] 0 false))
 
 let global_replace expr repl text =

--- a/vendor/re/src/str.mli
+++ b/vendor/re/src/str.mli
@@ -52,10 +52,11 @@ val quote: string -> string
     [s] and nothing else. *)
 
 val regexp_string: string -> regexp
-val regexp_string_case_fold: string -> regexp
 (** [Str.regexp_string s] returns a regular expression
-    that matches exactly [s] and nothing else.
-    [Str.regexp_string_case_fold] is similar, but the regexp
+    that matches exactly [s] and nothing else. *)
+
+val regexp_string_case_fold: string -> regexp
+(** [Str.regexp_string_case_fold] is similar to [Str.regexp_string], but the regexp
     matches in a case-insensitive way. *)
 
 (** {2 String matching and searching} *)
@@ -88,12 +89,14 @@ val matched_string: string -> string
            that was passed to the matching or searching function. *)
 
 val match_beginning: unit -> int
-val match_end: unit -> int
 (** [match_beginning ()] returns the position of the first character
     of the substring that was matched by [string_match],
-    [search_forward] or [search_backward]. [match_end ()] returns
-    the position of the character following the last character of
-    the matched substring.  *)
+    [search_forward] or [search_backward]. *)
+
+val match_end: unit -> int
+(** [match_end ()] returns the position of the character following the
+    last character of the substring that was matched by [string_match],
+    [search_forward] or [search_backward]. *)
 
 val matched_group: int -> string -> string
 (** [matched_group n s] returns the substring of [s] that was matched
@@ -109,14 +112,14 @@ val matched_group: int -> string -> string
     because the first group itself was not matched. *)
 
 val group_beginning: int -> int
-val group_end: int -> int
 (** [group_beginning n] returns the position of the first character
-    of the substring that was matched by the [n]th group of
-    the regular expression. [group_end n] returns
-    the position of the character following the last character of
-    the matched substring.  Both functions raise [Not_found]
-    if the [n]th group of the regular expression
-    was not matched. *)
+    of the substring that was matched by the [n]th group of the regular expression.
+    Raises [Not_found] if the [n]th group of the regular expression was not matched. *)
+
+val group_end: int -> int
+(** [group_end n] returns the position of the character following
+    the last character of the matched substring.
+    Raises [Not_found] if the [n]th group of the regular expression was not matched. *)
 
 (** {2 Replacement} *)
 
@@ -164,23 +167,35 @@ val bounded_split: regexp -> string -> int -> string list
     where [n] is the extra integer parameter. *)
 
 val split_delim: regexp -> string -> string list
+(** Same as [split], but occurrences of the delimiter at the beginning
+    and at the end of the string are recognized and returned as empty strings
+    in the result.
+    For instance, [split_delim (regexp " ") " abc "] returns [[""; "abc"; ""]],
+    while [split] with the same arguments returns [["abc"]]. *)
+
 val bounded_split_delim: regexp -> string -> int -> string list
-(** Same as [split] and [bounded_split], but occurrences of the
-    delimiter at the beginning and at the end of the string are
-    recognized and returned as empty strings in the result.
-    For instance, [split_delim (regexp " ") " abc "]
-    returns [[""; "abc"; ""]], while [split] with the same
-    arguments returns [["abc"]]. *)
+(** Same as [bounded_split] and [split_delim], but occurrences of
+    the delimiter at the beginning and at the end of the string are recognized
+    and returned as empty strings in the result.
+    For instance, [split_delim (regexp " ") " abc "] returns [[""; "abc"; ""]],
+    while [split] with the same arguments returns [["abc"]]. *)
 
 type split_result = Text of string | Delim of string
 
 val full_split: regexp -> string -> split_result list
+(** Same as [split_delim], but returns the delimiters
+    as well as the substrings contained between delimiters.
+    The former are tagged [Delim] in the result list;
+    the latter are tagged [Text].
+    For instance, [full_split (regexp "[{}]") "{ab}"] returns
+    [[Delim "{"; Text "ab"; Delim "}"]]. *)
+
 val bounded_full_split: regexp -> string -> int -> split_result list
 (** Same as [split_delim] and [bounded_split_delim], but returns
-    the delimiters as well as the substrings contained between
-    delimiters.  The former are tagged [Delim] in the result list;
-    the latter are tagged [Text].  For instance,
-    [full_split (regexp "[{}]") "{ab}"] returns
+    the delimiters as well as the substrings contained between delimiters.
+    The former are tagged [Delim] in the result list;
+    the latter are tagged [Text].
+    For instance, [full_split (regexp "[{}]") "{ab}"] returns
     [[Delim "{"; Text "ab"; Delim "}"]]. *)
 
 (** {2 Extracting substrings} *)

--- a/vendor/update-re.sh
+++ b/vendor/update-re.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.9.0
+version=1.11.0
 
 set -e -o pipefail
 


### PR DESCRIPTION
This PR upgrades our vendored `re` from 1.9.0 to 1.11.0, mostly to gain access to `Re.Group.get_opt`. It also removes our custom implementation of `Re.Group.get_opt`. We don't seem to have any cases where we catch `Not_found` on `Re.Group.get`, so no changes in that regard necessary.