### PR TITLE
refactor: introduce [Dune_file.find_stanzas]

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -59,17 +59,14 @@ let get_pped_file super_context file =
        let* dune_file = Dune_rules.Only_packages.stanzas_in_dir (dir |> in_build_dir) in
        let staged_pps =
          Option.bind dune_file ~f:(fun dune_file ->
-           Dune_file.stanzas dune_file
-           |> List.fold_left ~init:None ~f:(fun acc stanza ->
-             match Stanza.repr stanza with
-             | Dune_rules.Library.T lib ->
-               let preprocess =
-                 Dune_rules.Preprocess.Per_module.(
-                   lib.buildable.preprocess |> single_preprocess)
-               in
-               (match preprocess with
-                | Dune_rules.Preprocess.Pps ({ staged = true; _ } as pps) -> Some pps
-                | _ -> acc)
+           Dune_file.find_stanzas dune_file Dune_rules.Library.key
+           |> List.fold_left ~init:None ~f:(fun acc (lib : Dune_rules.Library.t) ->
+             let preprocess =
+               Dune_rules.Preprocess.Per_module.(
+                 lib.buildable.preprocess |> single_preprocess)
+             in
+             match preprocess with
+             | Dune_rules.Preprocess.Pps ({ staged = true; _ } as pps) -> Some pps
              | _ -> acc))
        in
        (match staged_pps with

--- a/src/dune_lang/stanza.ml
+++ b/src/dune_lang/stanza.ml
@@ -17,12 +17,20 @@ end
 
 type t = E : 'a * (module T with type t = 'a) -> t
 
+module Key = struct
+  type stanza = t
+  type nonrec 'a t = t -> 'a option
+
+  let get (t : _ t) (x : stanza) = t x
+end
+
 module type S = sig
   type stanza := t
   type t
   type repr += T of t
 
   val make_stanza : t -> stanza
+  val key : t Key.t
 end
 
 let repr (E (a, (module T))) = T.repr a
@@ -45,9 +53,16 @@ struct
     type _ witness += W : t witness
   end
 
-  include T
-
   let make_stanza (a : S.t) = E (a, (module T))
+
+  let key : S.t Key.t =
+    fun t ->
+    match repr t with
+    | T x -> Some x
+    | _ -> None
+  ;;
+
+  include T
 end
 
 let compare (E (x, (module X))) (E (y, (module Y))) =

--- a/src/dune_lang/stanza.mli
+++ b/src/dune_lang/stanza.mli
@@ -8,12 +8,20 @@ type t
 
 val repr : t -> repr
 
+module Key : sig
+  type stanza := t
+  type 'a t
+
+  val get : 'a t -> stanza -> 'a option
+end
+
 module type S = sig
   type stanza := t
   type t
   type repr += T of t
 
   val make_stanza : t -> stanza
+  val key : t Key.t
 end
 
 module Make (S : sig

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -51,12 +51,9 @@ include Alias_builder.Alias_rec (struct
           | Some stanzas ->
             let+ in_melange_target_dirs =
               let melange_target_dirs =
-                Dune_file.stanzas stanzas
-                |> List.filter_map ~f:(fun stanza ->
-                  match Stanza.repr stanza with
-                  | Melange_stanzas.Emit.T mel ->
-                    Some (Melange_stanzas.Emit.target_dir ~dir:build_path mel)
-                  | _ -> None)
+                Dune_file.find_stanzas stanzas Melange_stanzas.Emit.key
+                |> List.map ~f:(fun mel ->
+                  Melange_stanzas.Emit.target_dir ~dir:build_path mel)
               in
               Action_builder.List.map
                 melange_target_dirs

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -103,11 +103,8 @@ let collect_stanzas =
     match stanzas with
     | None -> []
     | Some (d : Dune_file.t) ->
-      Dune_file.stanzas d
-      |> List.filter_map ~f:(fun x ->
-        match Stanza.repr x with
-        | Cram_stanza.T c -> Option.some_if (f c) (dir, c)
-        | _ -> None)
+      Dune_file.find_stanzas d Cram_stanza.key
+      |> List.filter_map ~f:(fun c -> Option.some_if (f c) (dir, c))
   in
   let rec collect_whole_subtree acc dir =
     let* acc =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -118,3 +118,8 @@ let equal t { dir; project; stanzas } =
 
 let hash = Poly.hash
 let to_dyn = Dyn.opaque
+
+let find_stanzas t key =
+  (* CR-rgrinberg: save a map to represent the stanzas to make this fast. *)
+  List.filter_map t.stanzas ~f:(Stanza.Key.get key)
+;;

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -12,6 +12,7 @@ val project : t -> Dune_project.t
 val equal : t -> t -> bool
 val hash : t -> int
 val to_dyn : t -> Dyn.t
+val find_stanzas : t -> 'a Stanza.Key.t -> 'a list
 
 val parse
   :  Dune_lang.Ast.t list

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -26,11 +26,9 @@ module Node = struct
     >>| function
     | None -> None
     | Some stanzas ->
-      Dune_file.stanzas stanzas
-      |> List.find_map ~f:(fun stanza ->
-        match Stanza.repr stanza with
-        | Dune_env.T config -> Some config
-        | _ -> None)
+      (match Dune_file.find_stanzas stanzas Dune_env.key with
+       | [ config ] -> Some config
+       | _ -> None)
   ;;
 
   let rec by_dir dir =

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -577,13 +577,10 @@ let rec under_melange_emit_target ~dir =
      | None -> under_melange_emit_target ~dir:parent
      | Some stanzas ->
        (match
-          Dune_file.stanzas stanzas
-          |> List.find_map ~f:(fun stanza ->
-            match Stanza.repr stanza with
-            | Melange_stanzas.Emit.T mel ->
-              let target_dir = Melange_stanzas.Emit.target_dir ~dir:parent mel in
-              Option.some_if (Path.Build.equal target_dir dir) mel
-            | _ -> None)
+          Dune_file.find_stanzas stanzas Melange_stanzas.Emit.key
+          |> List.find_map ~f:(fun mel ->
+            let target_dir = Melange_stanzas.Emit.target_dir ~dir:parent mel in
+            Option.some_if (Path.Build.equal target_dir dir) mel)
         with
         | None -> under_melange_emit_target ~dir:parent
         | Some stanza -> Memo.return @@ Some { stanza_dir = parent; stanza }))
@@ -645,11 +642,8 @@ let setup_emit_js_rules sctx ~dir =
      | None -> Gen_rules.no_rules
      | Some dune_file ->
        let build_dir_only_sub_dirs =
-         Dune_file.stanzas dune_file
-         |> List.filter_map ~f:(fun stanza ->
-           match Stanza.repr stanza with
-           | Melange_stanzas.Emit.T mel -> Some mel.target
-           | _ -> None)
+         Dune_file.find_stanzas dune_file Melange_stanzas.Emit.key
+         |> List.map ~f:(fun (mel : Melange_stanzas.Emit.t) -> mel.target)
          |> Subdir_set.of_list
          |> Gen_rules.Build_only_sub_dirs.singleton ~dir
        in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -99,11 +99,10 @@ end = struct
     @@
     let open Option.O in
     let* stanzas = stanzas in
-    Dune_file.stanzas stanzas
-    |> List.find_map ~f:(fun stanza ->
-      match Stanza.repr stanza with
-      | Dune_env.T config -> Some config
-      | _ -> None)
+    match Dune_file.find_stanzas stanzas Dune_env.key with
+    | [] -> None
+    | [ x ] -> Some x
+    | _ :: _ -> assert false
   ;;
 
   let get_impl t dir =


### PR DESCRIPTION
This allows to fetch all stanzas of a single type without traversing the
list.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b440bb4d-99b4-4b36-a38b-853b1e2389e4 -->