### PR TITLE
test: for non-ASCII characters (#9728)

### DIFF
--- a/test/blackbox-tests/test-cases/enabled_if/non-ascii.t
+++ b/test/blackbox-tests/test-cases/enabled_if/non-ascii.t
@@ -1,0 +1,13 @@
+Afer the parsing non-ascii characters could be compared through expressions.
+Linked to the issue #9728
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat >dune <<"EOF"
+  > (rule
+  >  (alias default)
+  >  (enabled_if (= "É" "\195\137"))
+  >  (action (echo "Hello, world!\n")))
+  > EOF
+
+  $ dune build
+  Hello, world!

--- a/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
+++ b/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
@@ -8,7 +8,6 @@ How the non-ASCII characters are handled, this is also related to the issue #972
   $ dune format-dune-file <<EOF
   > (run foo %{bin:é})
   > EOF
-  > (run foo %{bin:é})
   File "", line 1, characters 15-16:
   Error: The character '\195' is not allowed inside %{...} forms
   run: not found

--- a/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
+++ b/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
@@ -10,10 +10,4 @@ How the non-ASCII characters are handled, this is also related to the issue #972
   > EOF
   File "", line 1, characters 15-16:
   Error: The character '\195' is not allowed inside %{...} forms
-  run: not found
-  [127]
-
-  $ dune format-dune-file <<EOF
-  > (= "É" "\195\137")
-  > EOF
-  (= "\195\137" "\195\137")
+  [1]

--- a/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
+++ b/test/blackbox-tests/test-cases/formatting/non-ascii-characters.t
@@ -1,0 +1,20 @@
+How the non-ASCII characters are handled, this is also related to the issue #9728
+
+  $ dune format-dune-file <<EOF
+  > ("É")
+  > EOF
+  ("\195\137")
+
+  $ dune format-dune-file <<EOF
+  > (run foo %{bin:é})
+  > EOF
+  > (run foo %{bin:é})
+  File "", line 1, characters 15-16:
+  Error: The character '\195' is not allowed inside %{...} forms
+  run: not found
+  [127]
+
+  $ dune format-dune-file <<EOF
+  > (= "É" "\195\137")
+  > EOF
+  (= "\195\137" "\195\137")


### PR DESCRIPTION
See #9728.