### PR TITLE
refactor: move stanza/package evaluation from Only_packages

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -139,12 +139,9 @@ let exes_extensions (lib_config : Dune_rules.Lib_config.t) modes =
       ~ext_dll:lib_config.ext_dll)
 ;;
 
-let libs db (context : Context.t) (build_system : Dune_rules.Main.build_system) =
-  let { Dune_rules.Main.conf; contexts = _; _ } = build_system in
+let libs db (context : Context.t) =
   let open Memo.O in
-  let* dune_files =
-    Dune_rules.Dune_load.dune_files conf ~context:(Context.name context)
-  in
+  let* dune_files = Context.name context |> Dune_rules.Dune_load.dune_files in
   Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_rules.Dune_file.t) ->
     Dune_file.stanzas dune_file
     |> Memo.parallel_map ~f:(fun stanza ->
@@ -190,11 +187,11 @@ let libs db (context : Context.t) (build_system : Dune_rules.Main.build_system) 
   >>| List.concat
 ;;
 
-let external_resolved_libs setup (context : Context.t) =
+let external_resolved_libs (context : Context.t) =
   let open Memo.O in
   let* scope = Dune_rules.Scope.DB.find_by_dir (Context.build_dir context) in
   let db = Dune_rules.Scope.libs scope in
-  libs db context setup
+  libs db context
   >>| List.filter ~f:(fun (x : Item.t) ->
     not (List.is_empty x.external_deps && List.is_empty x.internal_deps))
 ;;
@@ -224,7 +221,7 @@ let term =
     |> Context.name
     |> Dune_engine.Context_name.to_string
   in
-  external_resolved_libs setup (Super_context.context super_context)
+  external_resolved_libs (Super_context.context super_context)
   >>| to_dyn context_name
   >>| Describe_format.print_dyn format
 ;;

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -56,7 +56,7 @@ let get_pped_file super_context file =
          >>| Source_tree.Dir.path
          >>| Path.source
        in
-       let* dune_file = Dune_rules.Only_packages.stanzas_in_dir (dir |> in_build_dir) in
+       let* dune_file = Dune_rules.Dune_load.stanzas_in_dir (dir |> in_build_dir) in
        let staged_pps =
          Option.bind dune_file ~f:(fun dune_file ->
            Dune_file.find_stanzas dune_file Dune_rules.Library.key

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -518,7 +518,7 @@ module Crawl = struct
   (* Builds a workspace description for the provided dune setup and context *)
   let workspace
     options
-    ({ Dune_rules.Main.conf; contexts = _; scontexts } : Dune_rules.Main.build_system)
+    ({ Dune_rules.Main.contexts = _; scontexts } : Dune_rules.Main.build_system)
     (context : Context.t)
     dirs
     : Descr.Workspace.t Memo.t
@@ -527,8 +527,7 @@ module Crawl = struct
     let sctx = Context_name.Map.find_exn scontexts context_name in
     let open Memo.O in
     let* dune_files =
-      Dune_load.dune_files conf ~context:context_name
-      >>| List.filter ~f:(dune_file_is_in_dirs dirs)
+      Dune_load.dune_files context_name >>| List.filter ~f:(dune_file_is_in_dirs dirs)
     in
     let* exes, exe_libs =
       (* the list of workspace items that describe executables, and the list of
@@ -556,8 +555,8 @@ module Crawl = struct
     in
     let* project_libs =
       (* the list of libraries declared in the project *)
-      Dune_load.projects conf
-      |> Memo.parallel_map ~f:(fun project ->
+      Dune_load.projects ()
+      >>= Memo.parallel_map ~f:(fun project ->
         Scope.DB.find_by_project context project >>| Scope.libs >>= Lib.DB.all)
       >>| Lib.Set.union_all
       >>| Lib.Set.filter ~f:(lib_is_in_dirs dirs)

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -81,7 +81,7 @@ module Workspace = struct
   let get () =
     let open Memo.O in
     Memo.run
-      (let+ packages = Dune_rules.Dune_load.load () >>| Dune_rules.Dune_load.packages
+      (let+ packages = Dune_rules.Dune_load.packages ()
        and+ contexts = Context.DB.all () in
        { packages; contexts })
   ;;

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -98,9 +98,7 @@ let get_repos repos ~repositories =
 
 let find_local_packages =
   let open Memo.O in
-  Dune_rules.Dune_load.load ()
-  >>| Dune_rules.Dune_load.packages
-  >>| Package.Name.Map.map ~f:Package.to_local_package
+  Dune_rules.Dune_load.packages () >>| Package.Name.Map.map ~f:Package.to_local_package
 ;;
 
 let pp_packages packages =

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -359,7 +359,7 @@ let subst vcs =
       | Some n -> n.loc_of_arg, n.arg
     in
     let package_named_after_project =
-      let packages = Dune_project.packages dune_project.project in
+      let packages = Dune_project.including_hidden_packages dune_project.project in
       Package.Name.Map.find packages name
     in
     let metadata_from_dune_project () = Dune_project.info dune_project.project in

--- a/doc/changes/9879.md
+++ b/doc/changes/9879.md
@@ -1,0 +1,2 @@
+- Fix `$ dune install -p` incorrectly recognizing packages that are supposed to
+  be filtered (#9879, fixes #4814, @rgrinberg)

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -44,7 +44,7 @@ include Alias_builder.Alias_rec (struct
             =
             f ~path:build_path
           and* stanzas_in_dir =
-            Action_builder.of_memo (Only_packages.stanzas_in_dir build_path)
+            Action_builder.of_memo (Dune_load.stanzas_in_dir build_path)
           in
           match stanzas_in_dir with
           | None -> Action_builder.return found_in_source

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -103,8 +103,7 @@ let all =
     let artifacts =
       let local_bins =
         Memo.lazy_ ~name:"get_installed_binaries" (fun () ->
-          let* stanzas = Only_packages.filtered_stanzas (Context.name context) in
-          get_installed_binaries ~context stanzas)
+          Context.name context |> Dune_load.dune_files >>= get_installed_binaries ~context)
       in
       Artifacts.create context ~local_bins |> Memo.return
     in

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -99,7 +99,7 @@ let test_rule
 
 let collect_stanzas =
   let stanzas dir ~f =
-    let+ stanzas = Only_packages.stanzas_in_dir dir in
+    let+ stanzas = Dune_load.stanzas_in_dir dir in
     match stanzas with
     | None -> []
     | Some (d : Dune_file.t) ->
@@ -128,7 +128,7 @@ let rules ~sctx ~expander ~dir tests =
   let open Memo.O in
   let* stanzas = collect_stanzas ~dir
   and* with_package_mask =
-    Only_packages.get_mask ()
+    Dune_load.mask ()
     >>| function
     | None -> fun _packages f -> f ()
     | Some only ->

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -232,7 +232,7 @@ end = struct
        | true -> Memo.return Lock_dir
        | false ->
          let build_dir_is_project_root = build_dir_is_project_root st_dir in
-         Only_packages.stanzas_in_dir dir
+         Dune_load.stanzas_in_dir dir
          >>= (function
           | Some d -> has_dune_file ~dir st_dir ~build_dir_is_project_root d
           | None ->

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -7,7 +7,6 @@ type t
 
 val dir : t -> Path.Source.t
 val stanzas : t -> Stanza.t list
-val set_stanzas : t -> Stanza.t list -> t
 val project : t -> Dune_project.t
 val equal : t -> t -> bool
 val hash : t -> int
@@ -17,7 +16,8 @@ val fold_stanzas : t list -> init:'acc -> f:(t -> Stanza.t -> 'acc -> 'acc) -> '
 
 val eval
   :  (Path.Source.t * Dune_project.t * Dune_file0.t) Appendable_list.t
-  -> (Context_name.t -> t list Memo.t) Staged.t Memo.t
+  -> Only_packages.t
+  -> t list Per_context.t Memo.t
 
 module Memo_fold : sig
   val fold_stanzas

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -1,26 +1,38 @@
 open Import
 open Memo.O
 
+module Dune_file_db = struct
+  type t = Dune_file.t Path.Source.Map.t
+
+  let make all =
+    Path.Source.Map.of_list_map_exn all ~f:(fun dune_file ->
+      Dune_file.dir dune_file, dune_file)
+  ;;
+
+  let per_context dune_files =
+    Per_context.create_by_name ~name:"dune-file-db" (fun ctx ->
+      Memo.lazy_ (fun () -> dune_files ctx >>| make) |> Memo.Lazy.force)
+  ;;
+end
+
 type t =
-  { dune_files : (Context_name.t -> Dune_file.t list Memo.t) Staged.t Memo.t
+  { dune_files : Dune_file.t list Per_context.t
   ; packages : Package.t Package.Name.Map.t
   ; projects : Dune_project.t list
   ; projects_by_root : Dune_project.t Path.Source.Map.t
+  ; dune_file_by_dir : Dune_file_db.t Per_context.t
+  ; mask : Only_packages.t
   }
 
-let dune_files t ~context =
-  let* f = t.dune_files in
-  (Staged.unstage f) context
-;;
-
-let packages t = t.packages
-let projects t = t.projects
-let projects_by_root t = t.projects_by_root
+type status =
+  [ `Vendored
+  | `Regular
+  ]
 
 module Projects_and_dune_files =
   Monoid.Product
     (Monoid.Appendable_list (struct
-      type t = Dune_project.t
+      type t = status * Dune_project.t
     end))
     (Monoid.Appendable_list (struct
          type t = Path.Source.t * Dune_project.t * Dune_file0.t
@@ -31,13 +43,18 @@ module Source_tree_map_reduce =
 
 let load () =
   let open Memo.O in
+  let status dir =
+    match Source_tree.Dir.status dir with
+    | Vendored -> `Vendored
+    | Normal | Data_only -> `Regular
+  in
   let+ projects, dune_files =
     let f dir : Projects_and_dune_files.t Memo.t =
       let path = Source_tree.Dir.path dir in
       let project = Source_tree.Dir.project dir in
       let projects =
         if Path.Source.equal path (Dune_project.root project)
-        then Appendable_list.singleton project
+        then Appendable_list.singleton (status dir, project)
         else Appendable_list.empty
       in
       let dune_files =
@@ -50,26 +67,46 @@ let load () =
     Source_tree_map_reduce.map_reduce ~traverse:Source_dir_status.Set.all ~f
   in
   let projects = Appendable_list.to_list projects in
-  let packages =
+  let packages, vendored_packages =
     List.fold_left
       projects
-      ~init:Package.Name.Map.empty
-      ~f:(fun acc (p : Dune_project.t) ->
-        Package.Name.Map.merge acc (Dune_project.packages p) ~f:(fun name a b ->
-          Option.merge a b ~f:(fun a b ->
+      ~init:(Package.Name.Map.empty, Package.Name.Set.empty)
+      ~f:(fun (acc_packages, vendored) (status, (project : Dune_project.t)) ->
+        let packages = Dune_project.including_hidden_packages project in
+        let vendored =
+          match status with
+          | `Regular -> vendored
+          | `Vendored ->
+            Package.Name.Set.of_keys packages |> Package.Name.Set.union vendored
+        in
+        let acc_packages =
+          Package.Name.Map.union acc_packages packages ~f:(fun name a b ->
             User_error.raise
               [ Pp.textf
                   "Too many opam files for package %S:"
                   (Package.Name.to_string name)
               ; Pp.textf "- %s" (Path.Source.to_string_maybe_quoted (Package.opam_file a))
               ; Pp.textf "- %s" (Path.Source.to_string_maybe_quoted (Package.opam_file b))
-              ])))
+              ])
+        in
+        acc_packages, vendored)
   in
+  let mask = Only_packages.mask packages ~vendored:vendored_packages in
+  let packages = Only_packages.filter_packages mask packages in
+  let projects = List.rev_map projects ~f:snd in
   let dune_files =
-    Memo.Lazy.create ~name:"dune-file-evaluation" (fun () -> Dune_file.eval dune_files)
-    |> Memo.Lazy.force
+    let without_ctx = Memo.lazy_ (fun () -> Dune_file.eval dune_files mask) in
+    Per_context.create_by_name ~name:"dune-files" (fun ctx ->
+      Memo.Lazy.create (fun () ->
+        let* f = Memo.Lazy.force without_ctx in
+        f ctx)
+      |> Memo.Lazy.force)
+    |> Staged.unstage
   in
+  let dune_file_by_dir = Dune_file_db.per_context dune_files |> Staged.unstage in
   { dune_files
+  ; mask
+  ; dune_file_by_dir
   ; packages
   ; projects
   ; projects_by_root =
@@ -86,4 +123,42 @@ let load =
 let find_project ~dir =
   let+ { projects_by_root; _ } = load () in
   Find_closest_source_dir.find_by_dir projects_by_root ~dir
+;;
+
+let stanzas_in_dir dir =
+  if Path.Build.is_root dir
+  then Memo.return None
+  else (
+    match Install.Context.of_path dir with
+    | None -> Memo.return None
+    | Some ctx ->
+      let dir = Path.Build.drop_build_context_exn dir in
+      let* { dune_file_by_dir; _ } = load () in
+      let+ map = dune_file_by_dir ctx in
+      Path.Source.Map.find map dir)
+;;
+
+let mask () =
+  let+ { mask; _ } = load () in
+  mask
+;;
+
+let packages () =
+  let+ { packages; _ } = load () in
+  packages
+;;
+
+let dune_files context =
+  let* t = load () in
+  t.dune_files context
+;;
+
+let projects_by_root () =
+  let+ t = load () in
+  t.projects_by_root
+;;
+
+let projects () =
+  let+ t = load () in
+  t.projects
 ;;

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -1,17 +1,14 @@
-(** Loads dune files from the file system.
+(** Loads dune files from the workspace and query the workspace for various
+    global data such as dune files, projects, pcakages.
 
-    Also responsible for evaluating dune files written in OCaml syntax. *)
+    All the functions here are memoized. *)
 
 open Import
 
-type t
-
-val dune_files : t -> context:Context_name.t -> Dune_file.t list Memo.t
-val packages : t -> Package.t Package.Name.Map.t
-val projects : t -> Dune_project.t list
-val projects_by_root : t -> Dune_project.t Path.Source.Map.t
-
-(** Load all dune files. This function is memoized. *)
-val load : unit -> t Memo.t
-
+val dune_files : Context_name.t -> Dune_file.t list Memo.t
+val projects_by_root : unit -> Dune_project.t Path.Source.Map.t Memo.t
 val find_project : dir:Path.Build.t -> Dune_project.t Memo.t
+val stanzas_in_dir : Path.Build.t -> Dune_file.t option Memo.t
+val mask : unit -> Only_packages.t Memo.t
+val packages : unit -> Package.t Package.Name.Map.t Memo.t
+val projects : unit -> Dune_project.t list Memo.t

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -45,6 +45,7 @@ type t =
   ; cram : bool
   ; expand_aliases_in_sandbox : bool
   ; opam_file_location : [ `Relative_to_project | `Inside_opam_directory ]
+  ; including_hidden_packages : Package.t Package.Name.Map.t
   }
 
 let key = Univ_map.Key.create ~name:"dune-project" Dyn.opaque
@@ -103,6 +104,7 @@ let to_dyn
   ; cram
   ; expand_aliases_in_sandbox
   ; opam_file_location
+  ; including_hidden_packages = _
   }
   =
   let open Dyn in
@@ -448,6 +450,7 @@ let infer ~dir info packages =
   ; cram
   ; expand_aliases_in_sandbox
   ; opam_file_location
+  ; including_hidden_packages = packages
   }
 ;;
 
@@ -489,6 +492,7 @@ let encode : t -> Dune_lang.t list =
       ; root = _
       ; expand_aliases_in_sandbox
       ; opam_file_location = _
+      ; including_hidden_packages = _
       } ->
   let open Dune_lang.Encoder in
   let lang = Lang.get_exn "dune" in
@@ -893,6 +897,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
        ; cram
        ; expand_aliases_in_sandbox
        ; opam_file_location
+       ; including_hidden_packages = packages
        }
 ;;
 
@@ -956,3 +961,10 @@ let update_execution_parameters t ep =
 ;;
 
 let opam_file_location t = t.opam_file_location
+
+let filter_packages t ~f =
+  let packages = Package.Name.Map.filter t.packages ~f:(fun p -> f (Package.name p)) in
+  { t with packages }
+;;
+
+let including_hidden_packages t = t.including_hidden_packages

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -138,6 +138,8 @@ val encode : t -> Dune_lang.t list
 val dune_site_extension : unit Extension.t
 val opam_file_location : t -> [ `Relative_to_project | `Inside_opam_directory ]
 val allow_approximate_merlin : t -> Loc.t option
+val filter_packages : t -> f:(Package.Name.t -> bool) -> t
+val including_hidden_packages : t -> Package.t Package.Name.Map.t
 
 module Melange_syntax : sig
   val name : string

--- a/src/dune_rules/env_binaries.ml
+++ b/src/dune_rules/env_binaries.ml
@@ -16,7 +16,7 @@ let impl dir =
     Code_error.raise "no context for this directory" [ "dir", Path.Build.to_dyn dir ]
   | Some ctx ->
     let* binaries =
-      Only_packages.stanzas_in_dir dir
+      Dune_load.stanzas_in_dir dir
       >>= function
       | None -> Memo.return []
       | Some stanzas ->

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -22,7 +22,7 @@ module Node = struct
   ;;
 
   let in_dir ~dir =
-    Only_packages.stanzas_in_dir dir
+    Dune_load.stanzas_in_dir dir
     >>| function
     | None -> None
     | Some stanzas ->
@@ -129,7 +129,7 @@ module Inherit = struct
         (sprintf "%s-root" name)
         ~input:(module Path.Source)
         (fun dir ->
-          let* projects_by_root = Dune_load.load () >>| Dune_load.projects_by_root
+          let* projects_by_root = Dune_load.projects_by_root ()
           and* envs = Memo.Lazy.force for_context in
           let project = Path.Source.Map.find_exn projects_by_root dir in
           let root = root context project in

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -113,7 +113,13 @@ let expand_version { scope; _ } ~(source : Dune_lang.Template.Pform.t) s =
   in
   let project = Scope.project scope in
   match
-    Package.Name.Map.find (Dune_project.packages project) (Package.Name.of_string s)
+    let name = Package.Name.of_string s in
+    let packages =
+      (* CR-rgrinberg: craziness to preserve buggy behavior people are relying
+         on at the moment *)
+      Dune_project.including_hidden_packages project
+    in
+    Package.Name.Map.find packages name
   with
   | Some p -> Memo.return (value_from_version (Package.version p))
   | None when Dune_project.dune_version project < (2, 9) ->

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -324,7 +324,7 @@ let gen_rules_group_part_or_root sctx dir_contents cctxs ~source_dir ~dir
   let* () = gen_format_and_cram_rules sctx ~expander ~dir source_dir
   and+ stanzas =
     (* CR-soon rgrinberg: we shouldn't have to fetch the stanzas yet again *)
-    Only_packages.stanzas_in_dir dir
+    Dune_load.stanzas_in_dir dir
     >>= function
     | Some d -> Memo.return (Some d)
     | None ->

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -858,10 +858,9 @@ end = struct
   let projects_by_package =
     Memo.lazy_ (fun () ->
       let open Memo.O in
-      Dune_load.load ()
-      >>| Dune_load.projects
+      Dune_load.projects ()
       >>| List.concat_map ~f:(fun project ->
-        Dune_project.packages project
+        Dune_project.including_hidden_packages project
         |> Package.Name.Map.to_list_map ~f:(fun _ (pkg : Package.t) ->
           let name = Package.name pkg in
           name, project))

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -3,8 +3,7 @@ open Import
 let () = Inline_tests.linkme
 
 type build_system =
-  { conf : Dune_load.t
-  ; contexts : Context.t list
+  { contexts : Context.t list
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
@@ -104,11 +103,10 @@ let init
 
 let get () =
   let open Memo.O in
-  let* conf = Dune_load.load () in
   let* contexts = Context.DB.all () in
   let* scontexts = Memo.Lazy.force Super_context.all in
   let* () = Super_context.all_init_deferred () in
-  Memo.return { conf; contexts; scontexts }
+  Memo.return { contexts; scontexts }
 ;;
 
 let find_context_exn t ~name =

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -12,8 +12,7 @@ val init
   -> unit
 
 type build_system =
-  { conf : Dune_load.t
-  ; contexts : Context.t list
+  { contexts : Context.t list
   ; scontexts : Super_context.t Context_name.Map.t
   }
 

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -524,7 +524,7 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
       files_to_mdx
       ~f:(gen_rules_for_single_file t ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_gen)
   in
-  let* only_packages = Only_packages.get_mask () in
+  let* only_packages = Dune_load.mask () in
   let do_it =
     match only_packages, t.package with
     | None, _ | Some _, None -> true

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -572,7 +572,7 @@ let rec under_melange_emit_target ~dir =
   match Path.Build.parent dir with
   | None -> Memo.return None
   | Some parent ->
-    Only_packages.stanzas_in_dir parent
+    Dune_load.stanzas_in_dir parent
     >>= (function
      | None -> under_melange_emit_target ~dir:parent
      | Some stanzas ->
@@ -637,7 +637,7 @@ let setup_emit_js_rules sctx ~dir =
      | Some melange -> Gen_rules.make melange)
   | None ->
     (* this should probably be handled by [Dir_status] *)
-    Only_packages.stanzas_in_dir dir
+    Dune_load.stanzas_in_dir dir
     >>| (function
      | None -> Gen_rules.no_rules
      | Some dune_file ->

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -399,7 +399,7 @@ module Valid = struct
     let run (ctx, all, projects) =
       let* libs_and_pkgs =
         let* mask =
-          let+ mask = Only_packages.get_mask () in
+          let+ mask = Dune_load.mask () in
           Option.map ~f:Package.Name.Map.keys mask
         in
         Scope.DB.with_all ctx ~f:(fun find ->
@@ -485,7 +485,7 @@ module Valid = struct
   ;;
 
   let get ctx ~all =
-    let* projects = Dune_load.load () >>| Dune_load.projects in
+    let* projects = Dune_load.projects () in
     Memo.exec valid_libs_and_packages (ctx, all, projects)
   ;;
 
@@ -1247,7 +1247,7 @@ let ext_package_mlds (ctx : Context.t) (pkg : Package.Name.t) =
 ;;
 
 let pkg_mlds sctx pkg =
-  let* pkgs = Only_packages.get () in
+  let* pkgs = Dune_load.packages () in
   if Package.Name.Map.mem pkgs pkg
   then Packages.mlds sctx pkg >>| List.map ~f:Path.build
   else (
@@ -1952,8 +1952,8 @@ let setup_all_html_rules sctx ~all =
 
 let gen_project_rules sctx project =
   let ctx = Super_context.context sctx in
-  Only_packages.packages_of_project project
-  >>= Package.Name.Map_traversals.parallel_iter ~f:(fun _ (pkg : Package.t) ->
+  Dune_project.packages project
+  |> Package.Name.Map_traversals.parallel_iter ~f:(fun _ (pkg : Package.t) ->
     let dir =
       let pkg_dir = Package.dir pkg in
       Path.Build.append_source (Context.build_dir ctx) pkg_dir

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -1,5 +1,4 @@
 open Import
-open Memo.O
 
 module Clflags = struct
   type t =
@@ -26,51 +25,36 @@ module Clflags = struct
   let t () = Fdecl.get t
 end
 
-let conf =
-  Memo.lazy_ ~name:"only_packages" (fun () ->
-    match Clflags.t () with
-    | No_restriction -> Memo.return None
-    | Restrict { names; command_line_option } ->
-      let* packages = Dune_load.load () >>| Dune_load.packages in
-      Package.Name.Set.iter names ~f:(fun pkg_name ->
-        if not (Package.Name.Map.mem packages pkg_name)
-        then (
-          let pkg_name = Package.Name.to_string pkg_name in
-          User_error.raise
-            [ Pp.textf
-                "I don't know about package %s (passed through %s)"
-                pkg_name
-                command_line_option
-            ]
-            ~hints:
-              (User_message.did_you_mean
-                 pkg_name
-                 ~candidates:
-                   (Package.Name.Map.keys packages |> List.map ~f:Package.Name.to_string))));
-      Package.Name.Map.to_list packages
-      |> Memo.parallel_map ~f:(fun (name, pkg) ->
-        let+ vendored = Source_tree.is_vendored (Package.dir pkg) in
-        let included = Package.Name.Set.mem names name in
-        if vendored && included
-        then
-          User_error.raise
-            [ Pp.textf
-                "Package %s is vendored and so will never be masked. It is redundant to \
-                 pass it to %s."
-                (Package.Name.to_string name)
-                command_line_option
-            ];
-        Option.some_if (vendored || included) (name, pkg))
-      >>| List.filter_opt
-      >>| Package.Name.Map.of_list_exn
-      >>| Option.some)
+type t = Package.t Package.Name.Map.t option
+
+let mask packages ~vendored : t =
+  match Clflags.t () with
+  | No_restriction -> None
+  | Restrict { names; command_line_option } ->
+    Package.Name.Set.iter names ~f:(fun pkg_name ->
+      if not (Package.Name.Map.mem packages pkg_name)
+      then (
+        let pkg_name = Package.Name.to_string pkg_name in
+        User_error.raise
+          [ Pp.textf
+              "I don't know about package %s (passed through %s)"
+              pkg_name
+              command_line_option
+          ]
+          ~hints:
+            (User_message.did_you_mean
+               pkg_name
+               ~candidates:
+                 (Package.Name.Map.keys packages |> List.map ~f:Package.Name.to_string))));
+    Package.Name.Map.filter_map packages ~f:(fun pkg ->
+      let name = Package.name pkg in
+      let vendored = Package.Name.Set.mem vendored name in
+      let included = Package.Name.Set.mem names name in
+      Option.some_if (vendored || included) pkg)
+    |> Option.some
 ;;
 
-let get_mask () = Memo.Lazy.force conf
-
-let packages_of_project project =
-  let+ t = Memo.Lazy.force conf in
-  let packages = Dune_project.packages project in
+let filter_packages (t : t) packages =
   match t with
   | None -> packages
   | Some mask ->
@@ -80,78 +64,25 @@ let packages_of_project project =
       | _ -> None)
 ;;
 
-let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
-  List.filter_map ~f:(fun stanza ->
-    let include_stanza =
-      match Stanzas.stanza_package stanza with
-      | None -> true
-      | Some package ->
-        let name = Package.name package in
-        Package.Name.Map.mem visible_pkgs name
-    in
-    if include_stanza
-    then Some stanza
-    else (
-      match Stanza.repr stanza with
-      | Library.T l ->
-        let open Option.O in
-        let+ redirect = Library_redirect.Local.of_private_lib l in
-        Library_redirect.Local.make_stanza redirect
-      | _ -> None))
-;;
-
-type filtered_stanzas =
-  { all : Dune_file.t list
-  ; map : Dune_file.t Path.Source.Map.t
-  }
-
-let filtered_stanzas =
-  let db =
-    Per_context.create_by_name ~name:"filtered_stanzas"
-    @@ fun context ->
-    Memo.lazy_ (fun () ->
-      let+ only_packages = Memo.Lazy.force conf
-      and+ stanzas = Dune_load.load () >>= Dune_load.dune_files ~context in
-      let all =
-        match only_packages with
-        | None -> stanzas
-        | Some visible_pkgs ->
-          List.map stanzas ~f:(fun (dune_file : Dune_file.t) ->
-            Dune_file.set_stanzas
-              dune_file
-              (filter_out_stanzas_from_hidden_packages
-                 ~visible_pkgs
-                 (Dune_file.stanzas dune_file)))
-      in
-      let map =
-        Path.Source.Map.of_list_map_exn all ~f:(fun dune_file ->
-          Dune_file.dir dune_file, dune_file)
-      in
-      { all; map })
-    |> Memo.Lazy.force
-  in
-  fun ctx -> Staged.unstage db ctx
-;;
-
-let get () =
-  let* packages = Dune_load.load () >>| Dune_load.packages in
-  let+ only_packages = Memo.Lazy.force conf in
-  Option.value only_packages ~default:packages
-;;
-
-let stanzas_in_dir dir =
-  if Path.Build.is_root dir
-  then Memo.return None
-  else (
-    match Install.Context.of_path dir with
-    | None -> Memo.return None
-    | Some ctx ->
-      let+ filtered_stanzas = filtered_stanzas ctx in
-      let dir = Path.Build.drop_build_context_exn dir in
-      Path.Source.Map.find filtered_stanzas.map dir)
-;;
-
-let filtered_stanzas ctx =
-  let+ filtered_stanzas = filtered_stanzas ctx in
-  filtered_stanzas.all
+let filter_packages_in_project ~vendored project =
+  match Clflags.t () with
+  | No_restriction -> project
+  | Restrict { names; command_line_option } ->
+    (match vendored with
+     | false -> Dune_project.filter_packages project ~f:(Package.Name.Set.mem names)
+     | true ->
+       let () =
+         Dune_project.packages project
+         |> Package.Name.Set.of_keys
+         |> Package.Name.Set.inter names
+         |> Package.Name.Set.iter ~f:(fun name ->
+           User_error.raise
+             [ Pp.textf
+                 "Package %s is vendored and so will never be masked. It is redundant to \
+                  pass it to %s."
+                 (Package.Name.to_string name)
+                 command_line_option
+             ])
+       in
+       project)
 ;;

--- a/src/dune_rules/only_packages.mli
+++ b/src/dune_rules/only_packages.mli
@@ -1,7 +1,5 @@
 (** Restrict the set of visible packages *)
 
-open Import
-
 module Clflags : sig
   type t =
     | No_restriction
@@ -15,16 +13,8 @@ module Clflags : sig
   val set : t -> unit
 end
 
-(** Returns the filtered set of packages. This function is memoized. *)
-val get : unit -> Package.t Package.Name.Map.t Memo.t
+type t = Package.t Package.Name.Map.t option
 
-(** Returns the package restrictions. This function is memoized. *)
-val get_mask : unit -> Package.t Package.Name.Map.t option Memo.t
-
-(** Apply the package mask to the packages defined by the project *)
-val packages_of_project : Dune_project.t -> Package.t Package.Name.Map.t Memo.t
-
-(** Apply the package mask to the stanzas in the workspace *)
-val filtered_stanzas : Context_name.t -> Dune_file.t list Memo.t
-
-val stanzas_in_dir : Path.Build.t -> Dune_file.t option Memo.t
+val mask : Package.t Package.Name.Map.t -> vendored:Package.Name.Set.t -> t
+val filter_packages : t -> Package.t Package.Name.Map.t -> Package.t Package.Name.Map.t
+val filter_packages_in_project : vendored:bool -> Dune_project.t -> Dune_project.t

--- a/src/dune_rules/package_db.ml
+++ b/src/dune_rules/package_db.ml
@@ -9,7 +9,7 @@ type any_package =
   | Build of unit Action_builder.t
 
 let find_package ctx pkg =
-  let* packages = Only_packages.get () in
+  let* packages = Dune_load.packages () in
   match Package.Name.Map.find packages pkg with
   | Some p -> Memo.return (Some (Local p))
   | None ->

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -11,7 +11,7 @@ let mlds_by_package_def =
     (fun sctx ->
       let ctx = Super_context.context sctx in
       Context.name ctx
-      |> Only_packages.filtered_stanzas
+      |> Dune_load.dune_files
       >>= Memo.parallel_map ~f:(fun dune_file ->
         Dune_file.stanzas dune_file
         |> Memo.parallel_map ~f:(fun stanza ->

--- a/src/dune_rules/per_context.ml
+++ b/src/dune_rules/per_context.ml
@@ -1,6 +1,8 @@
 open Import
 open Memo.O
 
+type 'a t = Context_name.t -> 'a Memo.t
+
 let all =
   Memo.lazy_ ~name:"context-db"
   @@ fun () ->

--- a/src/dune_rules/per_context.mli
+++ b/src/dune_rules/per_context.mli
@@ -2,6 +2,8 @@
 
 open Import
 
+type 'a t = Context_name.t -> 'a Memo.t
+
 val create_by_name
   :  name:string
   -> (Context_name.t -> 'a Memo.t)

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -333,8 +333,8 @@ module DB = struct
       let scopes =
         Memo.Lazy.create
         @@ fun () ->
-        let* projects_by_root = Dune_load.load () >>| Dune_load.projects_by_root in
-        let* stanzas = Only_packages.filtered_stanzas (Context.name context) in
+        let* projects_by_root = Dune_load.projects_by_root () in
+        let* stanzas = Dune_load.dune_files (Context.name context) in
         create_from_stanzas ~projects_by_root ~context stanzas
       in
       Context.name context, scopes)
@@ -434,7 +434,7 @@ module DB = struct
     let memo = Memo.create "lib-entries-map" ~input:(module Input) make_map in
     fun (ctx : Context.t) pkg_name ->
       let* public_libs = public_libs ctx in
-      let* stanzas = Only_packages.filtered_stanzas (Context.name ctx) in
+      let* stanzas = Dune_load.dune_files (Context.name ctx) in
       let+ map = Memo.exec memo (Context.build_dir ctx, public_libs, stanzas) in
       Package.Name.Map.Multi.find map pkg_name
   ;;

--- a/src/dune_rules/sites/generate_sites_module_rules.ml
+++ b/src/dune_rules/sites/generate_sites_module_rules.ml
@@ -133,7 +133,7 @@ let plugins_code packages buf pkg sites =
 
 let setup_rules sctx ~dir (def : Generate_sites_module_stanza.t) =
   let open Memo.O in
-  let* packages = Only_packages.get () in
+  let* packages = Dune_load.packages () in
   let impl () =
     let buf = Buffer.create 1024 in
     if def.sourceroot then sourceroot_code buf;

--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -272,6 +272,9 @@ end = struct
       | Some p -> p
       | None -> Dune_project.anonymous ~dir:path Package_info.empty Package.Name.Map.empty
     in
+    let project =
+      Only_packages.filter_packages_in_project project ~vendored:(dir_status = Vendored)
+    in
     let* dirs_visited =
       Readdir.File.of_source_path (In_source_dir path)
       >>| function
@@ -324,6 +327,10 @@ end = struct
                ~dir:path
                ~files:(Readdir.files readdir)
                ~infer_from_opam_files:false
+             >>| Option.map
+                   ~f:
+                     (Only_packages.filter_packages_in_project
+                        ~vendored:(dir_status = Vendored))
              >>| Option.value ~default:parent_dir.project
          in
          let+ dir, visited =

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -20,7 +20,7 @@ module Pkg = struct
   ;;
 
   let default (project : Dune_project.t) stanza =
-    let packages = Dune_project.packages project in
+    let packages = Dune_project.including_hidden_packages project in
     match Package.Name.Map.values packages with
     | [ pkg ] -> Ok pkg
     | [] ->
@@ -50,7 +50,7 @@ module Pkg = struct
   ;;
 
   let resolve (project : Dune_project.t) name =
-    let packages = Dune_project.packages project in
+    let packages = Dune_project.including_hidden_packages project in
     match Package.Name.Map.find packages name with
     | Some pkg -> Ok pkg
     | None ->

--- a/src/dune_rules/stanzas/public_lib.ml
+++ b/src/dune_rules/stanzas/public_lib.ml
@@ -20,7 +20,7 @@ let make ~allow_deprecated_names project ((_, s) as loc_name) =
     match allow_deprecated_names with
     | false -> None
     | true ->
-      Dune_project.packages project
+      Dune_project.including_hidden_packages project
       |> Package.Name.Map.values
       |> List.find_map ~f:(fun package ->
         let deprecated_package_names = Package.deprecated_package_names package in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -94,7 +94,7 @@ end = struct
 
   let get_env_stanza ~dir =
     let open Memo.O in
-    let+ stanzas = Only_packages.stanzas_in_dir dir in
+    let+ stanzas = Dune_load.stanzas_in_dir dir in
     Option.value ~default:Dune_env.empty
     @@
     let open Option.O in
@@ -348,7 +348,7 @@ let create ~(context : Context.t) ~(host : t option) ~packages ~stanzas =
 let all =
   Memo.lazy_ ~name:"Super_context.all" (fun () ->
     let open Memo.O in
-    let* packages = Only_packages.get ()
+    let* packages = Dune_load.packages ()
     and* contexts = Context.DB.all () in
     let rec sctxs =
       lazy
@@ -367,8 +367,7 @@ let all =
           Some sctx
       in
       let* host, stanzas =
-        Memo.fork_and_join host (fun () ->
-          Only_packages.filtered_stanzas (Context.name context))
+        Memo.fork_and_join host (fun () -> Dune_load.dune_files (Context.name context))
       in
       create ~host ~context ~packages ~stanzas
     in

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -48,7 +48,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
               (Context.build_dir (Super_context.context sctx))
               (Source_tree.Dir.path dir)
           in
-          Only_packages.stanzas_in_dir dir
+          Dune_load.stanzas_in_dir dir
           >>= function
           | None -> Memo.return Libs_and_ppxs.empty
           | Some (d : Dune_file.t) ->

--- a/test/blackbox-tests/test-cases/github4814.t/run.t
+++ b/test/blackbox-tests/test-cases/github4814.t/run.t
@@ -1,9 +1,10 @@
 Issue #4814:
 When multiple packages are present, `dune build -p PKG` and `dune install -p
 PKG` should be able to build and install only that package, instead of all.
+
   $ dune build -p pkg1
-  $ dune install -p pkg1
-  Error: The following <package>.install are missing:
-  - _build/default/pkg2.install
-  Hint: try running 'dune build [-p <pkg>] @install'
-  [1]
+
+This is now fixed, although we should really just not allow -p on $ dune
+install
+
+  $ dune install -p pkg1 --dry-run --prefix _install


### PR DESCRIPTION
Previously, one would need to remember whether to use [Only_packages] to
[Dune_load] to access stanazs or packages. Now, everything lives in
[Dune_load] so it's not possible to confuse.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f085dca8-b5ca-44bd-93b0-72b3e1605834 -->