### PR TITLE
Update monorepo benchmark

### DIFF
--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -124,6 +124,12 @@ ENV HOME=/home/user
 USER user
 WORKDIR $HOME
 
+# Download the monorepo benchmark and copy files into the benchmark project
+ENV MONOREPO_BENCHMARK_TAG=2024-02-01.0
+RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
+  tar xf ocaml-monorepo-benchmark.tar.gz && \
+  mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark
+
 # set up opam
 RUN opam init --disable-sandboxing --auto-setup
 
@@ -135,12 +141,7 @@ RUN opam install -y dune ocamlbuild
 RUN opam switch create prepare 4.14.1
 RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl
 
-# Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-12-25.0
-RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
-  tar xf ocaml-monorepo-benchmark.tar.gz && \
-  mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark && \
-  opam install -y monorepo-benchmark/dune-monorepo-benchmark-runner
+RUN opam install -y monorepo-benchmark/dune-monorepo-benchmark-runner
 
 # Build the dune binary that we'll be benchmarking.
 # Only copy the files needed to build dune so that changes to other files in this project


### PR DESCRIPTION
Also downloads the monorepo benchmark before installing ocaml so that future updates to the monorepo cause docker's cache to be invalidated so that new releases of dune become visible.