### PR TITLE
fix: don't add odoc private rules in unavailable libs

### DIFF
--- a/doc/changes/9897.md
+++ b/doc/changes/9897.md
@@ -1,0 +1,2 @@
+- Odoc private rules are not set up if a library is not available due to
+  `enabled_if` (#9897, @rgrinberg and @jchavarri)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -112,12 +112,13 @@ end = struct
       let+ () = toplevel_setup ~sctx ~dir ~toplevel in
       empty_none
     | Library.T lib ->
-      (* XXX why are we setting up private doc rules for disabled libraries? *)
-      let* () = Odoc.setup_private_library_doc_alias sctx ~scope ~dir:ctx_dir lib
-      and+ enabled_if = Lib.DB.available (Scope.libs scope) (Library.best_name lib) in
+      let* enabled_if = Lib.DB.available (Scope.libs scope) (Library.best_name lib) in
       if_available_buildable
         ~loc:lib.buildable.loc
-        (fun () -> Lib_rules.rules lib ~sctx ~dir ~scope ~dir_contents ~expander)
+        (fun () ->
+          let+ () = Odoc.setup_private_library_doc_alias sctx ~scope ~dir:ctx_dir lib
+          and+ rules = Lib_rules.rules lib ~sctx ~dir ~scope ~dir_contents ~expander in
+          rules)
         enabled_if
     | Foreign.Library.T lib ->
       let+ () = Lib_rules.foreign_rules lib ~sctx ~dir ~dir_contents ~expander in

--- a/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
+++ b/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
@@ -14,6 +14,3 @@ Show behavior of doc-private alias when it's part of an unavailable library
   > EOF
 
   $ dune build @doc-private
-  Error: No rule found for alias _doc/_html/foo@26bb1931b3ad/doc
-  -> required by alias doc-private
-  [1]

--- a/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
+++ b/test/blackbox-tests/test-cases/odoc/eif-lib-unavailable-doc-private.t
@@ -1,0 +1,19 @@
+Show behavior of doc-private alias when it's part of an unavailable library
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.13)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name foo)
+  >  (enabled_if (= %{context_name} "unavailable")))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+
+  $ dune build @doc-private
+  Error: No rule found for alias _doc/_html/foo@26bb1931b3ad/doc
+  -> required by alias doc-private
+  [1]


### PR DESCRIPTION
As discussed in https://github.com/ocaml/dune/pull/9839#issuecomment-1917934343.

The previous code was causing trouble when introducing conditionally builds of libraries using `enabled_if` (what's being done in #9839), because Dune would try to add the alias rules for a library that didn't exist.

The test uses the guidelines shared by @rgrinberg in https://github.com/ocaml/dune/pull/9875#issuecomment-1920223246.

Can check the [first commit](https://github.com/ocaml/dune/commit/6d7cab9999e4624a70415278794d3812840787de) in the PR to see current behavior in `main`.