### PR TITLE
fix: [map_result Accept] is broken

### DIFF
--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -25,14 +25,11 @@ module Failure_mode = struct
   ;;
 
   let map_result : type a b. (a, b) t -> int -> f:(unit -> a) -> b =
-    fun mode t ~f ->
+    fun mode code ~f ->
     match mode with
     | Strict -> f ()
-    | Accept _ ->
-      (match t with
-       | 0 -> Ok (f ())
-       | n -> Error n)
-    | Return -> f (), t
+    | Return -> f (), code
+    | Accept accept -> if Predicate.test accept code then Ok (f ()) else Error code
   ;;
 end
 

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -83,7 +83,7 @@ let run t args =
 ;;
 
 let git_accept () : (_, _) Process.Failure_mode.t =
-  Accept (Predicate.create (fun x -> Int.equal x 0 || Int.equal x 128))
+  Accept (Predicate.create (fun x -> Int.equal x 0))
 ;;
 
 let run_git t args =


### PR DESCRIPTION
It's hard coded to only accept 0 as the error code instead of consulting
the predicate.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3620ad96-ee8c-4689-af8b-04257b6a1616 -->