### PR TITLE
fix(pkg): filter ls-remote

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -177,7 +177,7 @@ let ref_type =
            ])
   in
   fun t ~source ~ref ->
-    let command = [ "ls-remote"; source; ref ] in
+    let command = [ "ls-remote"; "--heads"; "--tags"; source; ref ] in
     let+ hits = run_capture_lines t ~display:!Dune_engine.Clflags.display command in
     List.find_map hits ~f:(fun line ->
       match Re.exec_opt re line with


### PR DESCRIPTION
We can limit ls-remote to with --heads and --tags to not fetch unwated
refs.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d109c640-a3b9-4cff-9009-3620d730ed06 -->