### PR TITLE
feature: dynamic_include stanza

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -144,7 +144,7 @@ let libs db (context : Context.t) =
   let* dune_files = Context.name context |> Dune_rules.Dune_load.dune_files in
   Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_rules.Dune_file.t) ->
     Dune_file.stanzas dune_file
-    |> Memo.parallel_map ~f:(fun stanza ->
+    >>= Memo.parallel_map ~f:(fun stanza ->
       let dir = Dune_file.dir dune_file in
       match Stanza.repr stanza with
       | Dune_rules.Executables.T exes ->

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -536,7 +536,7 @@ module Crawl = struct
          their direct library dependencies *)
       Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_file.t) ->
         Dune_file.stanzas dune_file
-        |> Memo.parallel_map ~f:(fun stanza ->
+        >>= Memo.parallel_map ~f:(fun stanza ->
           match Stanza.repr stanza with
           | Executables.T exes ->
             let dir =

--- a/doc/changes/9913.md
+++ b/doc/changes/9913.md
@@ -1,0 +1,4 @@
+- Introduce a `(dynamic_include ..)` stanza. This is like `(include foo)` but
+  allows `foo` to be the target of a rule. Currently, there are some
+  limitations on the stanzas that can be generated. For example, public
+  executables, libraries are currently forbidden. (#9913, @rgrinberg)

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -768,6 +768,7 @@ The following sections describe the available stanzas and their meanings.
 .. include:: stanzas/test.rst
 .. include:: stanzas/toplevel.rst
 .. include:: stanzas/vendored_dirs.rst
+.. include:: stanzas/dynamic_include.rst
 
 .. _dune-workspace:
 

--- a/doc/stanzas/dynamic_include.rst
+++ b/doc/stanzas/dynamic_include.rst
@@ -1,0 +1,26 @@
+dynamic_include
+---------------
+
+The ``dynamic_include`` stanza allows including the contents of another file in
+the current dune file like the ``include`` stanza.  However, the
+``dynamic_include`` stanza allows the included file to be the target of a rule
+and disallows generating some stanzas.
+
+For instance:
+
+.. code:: dune
+
+   (subdir b (dynamic_include ../a/foo.inc))
+   (subdir a
+    (with-stdout-to foo.inc
+     (echo "(rule (with-stdout-to file) (echo bar))")))
+
+In the example above, the dynamic rule loading and generation are split into
+different directories to avoid rule loading cycles as rules are loaded per
+directory.
+
+The following stanzas cannot be dynamically generated:
+
+* Libraries, coq theories, library redirects
+* Public executables or install section with the ``bin`` section
+* Plugin stanzas

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -50,9 +50,10 @@ include Alias_builder.Alias_rec (struct
           | None -> Action_builder.return found_in_source
           | Some stanzas ->
             let+ in_melange_target_dirs =
-              let melange_target_dirs =
+              let* melange_target_dirs =
                 Dune_file.find_stanzas stanzas Melange_stanzas.Emit.key
-                |> List.map ~f:(fun mel ->
+                |> Action_builder.of_memo
+                >>| List.map ~f:(fun mel ->
                   Melange_stanzas.Emit.target_dir ~dir:build_path mel)
               in
               Action_builder.List.map

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -71,14 +71,15 @@ let get_installed_binaries ~(context : Context.t) stanzas =
         y)
       >>| Filename.Map.map ~f:Appendable_list.singleton
     in
-    Dune_file.stanzas d
+    Dune_file.static_stanzas d
     |> Memo.List.map ~f:(fun stanza ->
       match Stanza.repr stanza with
-      | Install_conf.T { section = Section Bin; files; enabled_if; _ } ->
+      | Install_conf.T { section = _loc, Section Bin; files; enabled_if; _ } ->
         let enabled_if = eval_blang ~dir enabled_if in
         binaries_from_install ~enabled_if files
       | Executables.T
-          ({ install_conf = Some { section = Section Bin; files; _ }; _ } as exes) ->
+          ({ install_conf = Some { section = _loc, Section Bin; files; _ }; _ } as exes)
+        ->
         let enabled_if =
           let enabled_if = eval_blang ~dir exes.enabled_if in
           match exes.optional with

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -99,12 +99,12 @@ let test_rule
 
 let collect_stanzas =
   let stanzas dir ~f =
-    let+ stanzas = Dune_load.stanzas_in_dir dir in
-    match stanzas with
-    | None -> []
+    Dune_load.stanzas_in_dir dir
+    >>= function
+    | None -> Memo.return []
     | Some (d : Dune_file.t) ->
       Dune_file.find_stanzas d Cram_stanza.key
-      |> List.filter_map ~f:(fun c -> Option.some_if (f c) (dir, c))
+      >>| List.filter_map ~f:(fun c -> Option.some_if (f c) (dir, c))
   in
   let rec collect_whole_subtree acc dir =
     let* acc =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -3,11 +3,13 @@ open Import
 type t =
   { dir : Path.Source.t
   ; project : Dune_project.t
-  ; stanzas : Stanza.t list
+  ; stanzas : Stanza.t list Memo.Lazy.t
+  ; static_stanzas : Stanza.t list
   }
 
 let dir t = t.dir
-let stanzas t = t.stanzas
+let stanzas t = Memo.Lazy.force t.stanzas
+let static_stanzas t = t.static_stanzas
 let project t = t.project
 
 module Mask = struct
@@ -22,19 +24,24 @@ module Mask = struct
     | Fun f, Fun g -> Fun (fun x -> f x && g x)
   ;;
 
-  let filter_stanzas t list =
+  type keep_stanza =
+    | Keep
+    | Drop
+    | Convert of Stanza.t
+
+  let keep_stanza t stanza =
     match t with
-    | True -> list
+    | True -> Keep
     | Fun f ->
-      List.filter_map list ~f:(fun stanza ->
-        if f stanza
-        then Some stanza
-        else (
-          match Stanza.repr stanza with
-          | Library.T l ->
-            Library_redirect.Local.of_private_lib l
-            |> Option.map ~f:Library_redirect.Local.make_stanza
-          | _ -> None))
+      if f stanza
+      then Keep
+      else (
+        match Stanza.repr stanza with
+        | Library.T l ->
+          (match Library_redirect.Local.of_private_lib l with
+           | None -> Drop
+           | Some p -> Convert (Library_redirect.Local.make_stanza p))
+        | _ -> Drop)
   ;;
 
   let of_only_packages_mask mask =
@@ -90,57 +97,76 @@ let rec parse_file_includes ~stanza_parser ~context sexps =
     | _ -> Memo.return [ stanza ])
 ;;
 
-let parse ~file ~dir (project : Dune_project.t) sexps =
-  let stanza_parser = Dune_project.stanza_parser project in
+type eval =
+  { project : Dune_project.t
+  ; dir : Path.Source.t
+  ; mask : Stanza.t Mask.t
+  }
+
+let parse_stanzas ~file ~(eval : eval) sexps =
   let warnings = Warning_emit.Bag.create () in
-  let stanza_parser = Warning_emit.Bag.set warnings stanza_parser in
   let open Memo.O in
   let* stanzas =
     let context =
-      Include_stanza.in_file
+      Include_stanza.in_src_file
       @@
       match file with
       | Some f -> f
       | None ->
         (* TODO this is wrong *)
-        Path.Source.relative dir Dune_file0.fname
+        Path.Source.relative eval.dir Dune_file0.fname
+    in
+    let stanza_parser =
+      Dune_project.stanza_parser eval.project |> Warning_emit.Bag.set warnings
     in
     parse_file_includes ~stanza_parser ~context sexps
   in
-  let (_ : bool) =
-    List.fold_left stanzas ~init:false ~f:(fun env stanza ->
-      match Stanza.repr stanza with
-      | Dune_env.T e ->
-        if env
-        then
-          User_error.raise
-            ~loc:e.loc
-            [ Pp.text "The 'env' stanza cannot appear more than once" ]
-        else true
-      | _ -> env)
+  let rec loop stanzas dynamic_includes env = function
+    | [] -> List.rev stanzas, dynamic_includes
+    | stanza :: rest ->
+      (match Stanza.repr stanza with
+       | Dune_env.T e ->
+         if env
+         then
+           User_error.raise
+             ~loc:e.loc
+             [ Pp.text "The 'env' stanza cannot appear more than once" ]
+         else loop (stanza :: stanzas) dynamic_includes true rest
+       | Stanzas.Dynamic_include.T (loc, fn) ->
+         loop stanzas ((loc, fn) :: dynamic_includes) env rest
+       | _ ->
+         (match Mask.keep_stanza eval.mask stanza with
+          | Keep -> loop (stanza :: stanzas) dynamic_includes env rest
+          | Drop -> loop stanzas dynamic_includes env rest
+          | Convert stanza -> loop (stanza :: stanzas) dynamic_includes env rest))
   in
+  let stanzas, dynamic_includes = loop [] [] false stanzas in
   let+ () = Warning_emit.Bag.emit_all warnings in
-  stanzas
+  stanzas, dynamic_includes
 ;;
 
-let parse sexps ~mask ~dir ~file ~project =
+let parse sexps ~file ~(eval : eval) =
   let open Memo.O in
-  let+ stanzas = parse ~file ~dir project sexps in
-  let stanzas = Mask.filter_stanzas mask stanzas in
-  { dir; project; stanzas }
+  let+ stanzas, dynamic_includes = parse_stanzas sexps ~file ~eval in
+  ( { dir = eval.dir
+    ; project = eval.project
+    ; static_stanzas = stanzas
+    ; stanzas = Memo.Lazy.of_val stanzas
+    }
+  , dynamic_includes )
 ;;
 
 module Make_fold (M : Monad.S) = struct
   open M.O
 
-  let rec fold_stanzas l ~init ~f =
+  let rec fold_static_stanzas l ~init ~f =
     match l with
     | [] -> M.return init
-    | t :: l -> inner_fold t t.stanzas l ~init ~f
+    | t :: l -> inner_fold t t.static_stanzas l ~init ~f
 
   and inner_fold t inner_list l ~init ~f =
     match inner_list with
-    | [] -> fold_stanzas l ~init ~f
+    | [] -> fold_static_stanzas l ~init ~f
     | x :: inner_list ->
       let* init = f t x init in
       inner_fold t inner_list l ~init ~f
@@ -150,12 +176,14 @@ end
 module Memo_fold = Make_fold (Memo)
 module Id_fold = Make_fold (Monad.Id)
 
-let fold_stanzas t ~init ~f = Id_fold.fold_stanzas t ~init ~f
+let fold_static_stanzas t ~init ~f = Id_fold.fold_static_stanzas t ~init ~f
 let to_dyn = Dyn.opaque
 
 let find_stanzas t key =
+  let open Memo.O in
+  let+ stanzas = Memo.Lazy.force t.stanzas in
   (* CR-rgrinberg: save a map to represent the stanzas to make this fast. *)
-  List.filter_map t.stanzas ~f:(Stanza.Key.get key)
+  List.filter_map stanzas ~f:(Stanza.Key.get key)
 ;;
 
 module Jbuild_plugin : sig
@@ -277,9 +305,8 @@ module Script = struct
   open Memo.O
 
   type t =
-    { dir : Path.Source.t
-    ; file : Path.Source.t
-    ; project : Dune_project.t
+    { file : Path.Source.t
+    ; eval : eval
     ; from_parent : Dune_lang.Ast.t list
     }
 
@@ -287,7 +314,7 @@ module Script = struct
      directory *)
   let generated_dune_files_dir = Path.Build.relative Path.Build.root ".dune"
 
-  let eval_one ~mask ~context { dir; file; project; from_parent } =
+  let eval_one ~context { file; from_parent; eval } =
     let generated_dune_file =
       Path.Build.append_source
         (Path.Build.relative generated_dune_files_dir (Context_name.to_string context))
@@ -301,7 +328,7 @@ module Script = struct
       Jbuild_plugin.create_plugin_wrapper
         (Context.name context)
         ocaml.ocaml_config
-        ~exec_dir:(Path.source dir)
+        ~exec_dir:(Path.source eval.dir)
         ~plugin:(In_source_dir file)
         ~wrapper
         ~target:generated_dune_file
@@ -312,7 +339,7 @@ module Script = struct
       let args =
         [ "-I"; "+compiler-libs"; Path.to_absolute_filename (Path.build wrapper) ]
       in
-      Process.run Strict ~display:Quiet ~dir:(Path.source dir) ~env ocaml args
+      Process.run Strict ~display:Quiet ~dir:(Path.source eval.dir) ~env ocaml args
       |> Memo.of_reproducible_fiber
     in
     if not (Path.Untracked.exists (Path.build generated_dune_file))
@@ -327,56 +354,123 @@ module Script = struct
     Path.build generated_dune_file
     |> Io.Untracked.with_lexbuf_from_file ~f:(Dune_lang.Parser.parse ~mode:Many)
     |> List.rev_append from_parent
-    |> parse ~mask ~dir ~file:(Some file) ~project
+    |> parse ~file:(Some file) ~eval
   ;;
 end
 
+let check_dynamic_stanza =
+  (* CR-rgrinberg: unfortunately this needs to kept in sync with the rules
+     manually *)
+  let err = [ Pp.text "This stanza cannot be generated dynamically" ] in
+  fun stanza ->
+    match Stanza.repr stanza with
+    | Install_conf.T { section = loc, Section Bin; _ } ->
+      User_error.raise ~loc [ Pp.text "binary section cannot be generated dynamically" ]
+    | Coq_stanza.Theory.T { buildable = { Coq_stanza.Buildable.loc; _ }; _ }
+    | Library.T { buildable = { loc; _ }; _ }
+    | Install_conf.T { section = _, Site { loc; _ }; _ }
+    | Executables.T
+        { buildable = { loc; _ }; install_conf = Some { section = _, Section Bin; _ }; _ }
+    | Deprecated_library_name.T { Library_redirect.loc; _ }
+    | Plugin.T { site = loc, (_, _); _ } -> User_error.raise ~loc err
+    | _ -> ()
+;;
+
 module Eval = struct
-  type nonrec t =
-    | Literal of t
+  type script =
+    | Literal of eval * t * (Loc.t * string) list
     | Script of Script.t
 
   open Memo.O
 
-  let context_independent ~mask ~dir project dune_file =
+  let context_independent ~eval dune_file =
     let file = Dune_file0.path dune_file in
     let static = Dune_file0.get_static_sexp dune_file in
     match Dune_file0.kind dune_file with
+    | Plain ->
+      let+ dune_file, dynamic_includes = parse static ~file ~eval in
+      Literal (eval, dune_file, dynamic_includes)
     | Ocaml_script ->
       Memo.return
         (Script
-           { dir
-           ; project
+           { eval
            ; file =
                (* we can't introduce ocaml syntax with [(sudir ..)] *)
                Option.value_exn file
            ; from_parent = static
            })
-    | Plain ->
-      let+ stanzas = parse static ~mask ~dir ~file ~project in
-      Literal stanzas
   ;;
 
-  let eval dune_files (mask : Only_packages.t) =
+  let rec collect_dynamic_includes (eval : eval) include_context origin dynamic_includes =
+    Memo.List.concat_map dynamic_includes ~f:(fun (loc, include_file) ->
+      Memo.push_stack_frame
+        ~human_readable_description:(fun () ->
+          Pp.textf
+            "dynamic_include %s in directroy %s"
+            (Include_stanza.file_path include_context loc include_file
+             |> Path.build
+             |> Path.drop_optional_build_context
+             |> Path.to_string_maybe_quoted)
+            (Path.Source.to_string_maybe_quoted eval.dir))
+        (fun () ->
+          let* ast, include_context =
+            Include_stanza.load_sexps ~context:include_context (loc, include_file)
+          in
+          let* stanzas, dynamic_includes = parse_stanzas ast ~file:None ~eval in
+          let+ dynamic =
+            collect_dynamic_includes eval include_context origin dynamic_includes
+          in
+          List.rev_append stanzas dynamic))
+  ;;
+
+  let set_dynamic_stanzas t ~context ~eval ~dynamic_includes =
+    let stanzas =
+      match dynamic_includes with
+      | [] -> Memo.Lazy.of_val t.static_stanzas
+      | _ :: _ ->
+        Memo.lazy_
+        @@ fun () ->
+        let+ stanzas =
+          let origin =
+            Path.Build.append_source
+              (Context_name.build_dir context)
+              (Path.Source.relative eval.dir Dune_file0.fname)
+          in
+          let include_context = Include_stanza.in_build_file origin in
+          collect_dynamic_includes eval include_context origin dynamic_includes
+        in
+        List.iter stanzas ~f:check_dynamic_stanza;
+        t.static_stanzas @ stanzas
+    in
+    { t with stanzas }
+  ;;
+
+  let eval dune_files mask =
     let mask = Mask.of_only_packages_mask mask in
     (* CR-rgrinberg: all this evaluation complexity is to share
        some work in multi context builds. Is it worth it? *)
-    let+ static, dynamic =
+    let+ dune_syntax, ocaml_syntax =
       Appendable_list.to_list dune_files
       |> Memo.parallel_map ~f:(fun (dir, project, dune_file) ->
         let mask = Mask.combine mask (Mask.ignore_promote project) in
-        context_independent ~mask ~dir project dune_file)
+        let eval = { dir; project; mask } in
+        context_independent ~eval dune_file)
       >>| List.partition_map ~f:(function
-        | Literal x -> Left x
+        | Literal (eval, t, dynamic_includes) -> Left (eval, t, dynamic_includes)
         | Script s -> Right s)
     in
     fun context ->
-      let+ dynamic =
-        Memo.parallel_map dynamic ~f:(fun script ->
-          let mask = Mask.combine mask (Mask.ignore_promote script.project) in
-          Script.eval_one ~mask ~context script)
+      let set_dynamic_stanzas = set_dynamic_stanzas ~context in
+      let+ ocaml_syntax =
+        Memo.parallel_map ocaml_syntax ~f:(fun script ->
+          let+ dune_file, dynamic_includes = Script.eval_one ~context script in
+          set_dynamic_stanzas dune_file ~eval:script.eval ~dynamic_includes)
       in
-      static @ dynamic
+      let dune_syntax =
+        List.map dune_syntax ~f:(fun (eval, t, dynamic_includes) ->
+          set_dynamic_stanzas t ~eval ~dynamic_includes)
+      in
+      dune_syntax @ ocaml_syntax
   ;;
 end
 

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -6,11 +6,12 @@ open Import
 type t
 
 val dir : t -> Path.Source.t
-val stanzas : t -> Stanza.t list
+val stanzas : t -> Stanza.t list Memo.t
+val static_stanzas : t -> Stanza.t list
 val project : t -> Dune_project.t
 val to_dyn : t -> Dyn.t
-val find_stanzas : t -> 'a Stanza.Key.t -> 'a list
-val fold_stanzas : t list -> init:'acc -> f:(t -> Stanza.t -> 'acc -> 'acc) -> 'acc
+val find_stanzas : t -> 'a Stanza.Key.t -> 'a list Memo.t
+val fold_static_stanzas : t list -> init:'acc -> f:(t -> Stanza.t -> 'acc -> 'acc) -> 'acc
 
 val eval
   :  (Path.Source.t * Dune_project.t * Dune_file0.t) Appendable_list.t
@@ -18,7 +19,7 @@ val eval
   -> t list Per_context.t Memo.t
 
 module Memo_fold : sig
-  val fold_stanzas
+  val fold_static_stanzas
     :  t list
     -> init:'acc
     -> f:(t -> Stanza.t -> 'acc -> 'acc Memo.t)

--- a/src/dune_rules/dune_file0.ml
+++ b/src/dune_rules/dune_file0.ml
@@ -444,7 +444,7 @@ let decode ~file project sexps =
           Dune_lang.Decoder.parse d Univ_map.empty (Dune_lang.Ast.List (Loc.none, ast)))
     }
   in
-  let context = Include_stanza.in_file file in
+  let context = Include_stanza.in_src_file file in
   let inside_include = false in
   let inside_subdir = false in
   Ast.decode ~inside_include ~inside_subdir

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -95,7 +95,9 @@ let load () =
   let packages = Only_packages.filter_packages mask packages in
   let projects = List.rev_map projects ~f:snd in
   let dune_files =
-    let without_ctx = Memo.lazy_ (fun () -> Dune_file.eval dune_files mask) in
+    let without_ctx =
+      Memo.lazy_ ~name:"dune-files-eval" (fun () -> Dune_file.eval dune_files mask)
+    in
     Per_context.create_by_name ~name:"dune-files" (fun ctx ->
       Memo.Lazy.create (fun () ->
         let* f = Memo.Lazy.force without_ctx in

--- a/src/dune_rules/env_binaries.ml
+++ b/src/dune_rules/env_binaries.ml
@@ -20,13 +20,13 @@ let impl dir =
       >>= function
       | None -> Memo.return []
       | Some stanzas ->
-        let+ profile = Per_context.profile ctx in
-        (match
-           match Dune_file.find_stanzas stanzas Dune_env.key with
-           | [ config ] -> Some config
-           | [] -> None
-           | _ :: _ :: _ -> assert false
-         with
+        let* profile = Per_context.profile ctx in
+        Dune_file.find_stanzas stanzas Dune_env.key
+        >>| (function
+               | [ config ] -> Some config
+               | [] -> None
+               | _ :: _ :: _ -> assert false)
+        >>| (function
          | None -> []
          | Some stanza ->
            (match Dune_env.find_opt stanza ~profile with

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -23,10 +23,11 @@ module Node = struct
 
   let in_dir ~dir =
     Dune_load.stanzas_in_dir dir
-    >>| function
-    | None -> None
+    >>= function
+    | None -> Memo.return None
     | Some stanzas ->
-      (match Dune_file.find_stanzas stanzas Dune_env.key with
+      Dune_file.find_stanzas stanzas Dune_env.key
+      >>| (function
        | [ config ] -> Some config
        | _ -> None)
   ;;

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -211,7 +211,7 @@ let define_all_alias ~dir ~project ~js_targets =
 
 let gen_rules_for_stanzas sctx dir_contents cctxs expander dune_file ~dir:ctx_dir =
   let src_dir = Dune_file.dir dune_file in
-  let stanzas = Dune_file.stanzas dune_file in
+  let* stanzas = Dune_file.stanzas dune_file in
   let* { For_stanza.merlin = merlins; cctx = cctxs; js = js_targets; source_dirs } =
     let* scope = Scope.DB.find_by_dir ctx_dir in
     For_stanza.of_stanzas

--- a/src/dune_rules/include_stanza.ml
+++ b/src/dune_rules/include_stanza.ml
@@ -1,13 +1,54 @@
 open Import
 
-type context =
-  { current_file : Path.Source.t
-  ; include_stack : (Loc.t * Path.Source.t) list
+module type Path = sig
+  type t
+
+  val parent_exn : t -> t
+  val to_string_maybe_quoted : t -> string
+  val relative : t -> Loc.t -> Filename.t -> t
+  val equal : t -> t -> bool
+  val file_exists : t -> bool Memo.t
+  val with_lexbuf_from_file : t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.t
+end
+
+module Source = struct
+  include Path.Source
+
+  let relative t loc f = relative ~error_loc:loc t f
+  let file_exists t = Fs_memo.file_exists (In_source_dir t)
+  let with_lexbuf_from_file t ~f = Fs_memo.with_lexbuf_from_file (In_source_dir t) ~f
+end
+
+module Build = struct
+  include Path.Build
+
+  let relative t loc f = relative ~error_loc:loc t f
+  let file_exists _ = Memo.return true
+
+  let with_lexbuf_from_file t ~f =
+    Build_system.with_file (Path.build t) ~f:(fun path ->
+      Io.Untracked.with_lexbuf_from_file path ~f)
+  ;;
+end
+
+type 'a context =
+  { current_file : 'a
+  ; include_stack : (Loc.t * 'a) list
+  ; path : (module Path with type t = 'a)
   }
 
-let in_file file = { current_file = file; include_stack = [] }
+let in_file file path = { current_file = file; include_stack = []; path }
+let in_src_file file = in_file file (module Source)
+let in_build_file file = in_file file (module Build)
 
-let error { current_file = file; include_stack } =
+let file_path (type a) { path; current_file; _ } loc fn =
+  let module Path = (val path : Path with type t = a) in
+  let dir = Path.parent_exn current_file in
+  Path.relative dir loc fn
+;;
+
+let error (type a) { current_file = (file : a); include_stack; path } =
+  let module Path = (val path : Path with type t = a) in
   let last, rest =
     match include_stack with
     | [] -> assert false
@@ -15,39 +56,39 @@ let error { current_file = file; include_stack } =
   in
   let loc = fst (Option.value (List.last rest) ~default:last) in
   let line_loc (loc, file) =
-    sprintf "%s:%d" (Path.Source.to_string_maybe_quoted file) (Loc.start loc).pos_lnum
+    sprintf "%s:%d" (Path.to_string_maybe_quoted file) (Loc.start loc).pos_lnum
   in
   User_error.raise
     ~loc
     [ Pp.text "Recursive inclusion of dune files detected:"
     ; Pp.textf
         "File %s is included from %s"
-        (Path.Source.to_string_maybe_quoted file)
+        (Path.to_string_maybe_quoted file)
         (line_loc last)
     ; Pp.chain rest ~f:(fun x -> Pp.textf "included from %s" (line_loc x))
     ]
 ;;
 
-let load_sexps ~context:{ current_file; include_stack } (loc, fn) =
+let load_sexps
+  (type a)
+  ~context:({ current_file; include_stack; path } as context)
+  (loc, fn)
+  =
+  let module Path = (val path : Path with type t = a) in
   let include_stack = (loc, current_file) :: include_stack in
-  let dir = Path.Source.parent_exn current_file in
-  let current_file = Path.Source.relative ~error_loc:loc dir fn in
+  let current_file = file_path context loc fn in
   let open Memo.O in
-  let* exists = Fs_memo.file_exists (In_source_dir current_file) in
+  let* exists = Path.file_exists current_file in
   if not exists
   then
     User_error.raise
       ~loc
-      [ Pp.textf
-          "File %s doesn't exist."
-          (Path.Source.to_string_maybe_quoted current_file)
-      ];
-  if List.exists include_stack ~f:(fun (_, f) -> Path.Source.equal f current_file)
-  then error { current_file; include_stack };
+      [ Pp.textf "File %s doesn't exist." (Path.to_string_maybe_quoted current_file) ];
+  let context = { context with current_file; include_stack } in
+  if List.exists include_stack ~f:(fun (_, f) -> Path.equal f current_file)
+  then error context;
   let+ sexps =
-    Fs_memo.with_lexbuf_from_file
-      (In_source_dir current_file)
-      ~f:(Dune_lang.Parser.parse ~mode:Many)
+    Path.with_lexbuf_from_file current_file ~f:(Dune_lang.Parser.parse ~mode:Many)
   in
-  sexps, { current_file; include_stack }
+  sexps, context
 ;;

--- a/src/dune_rules/include_stanza.mli
+++ b/src/dune_rules/include_stanza.mli
@@ -1,10 +1,12 @@
 open Import
 
-type context
+type 'a context
 
-val in_file : Path.Source.t -> context
+val in_src_file : Path.Source.t -> Path.Source.t context
+val in_build_file : Path.Build.t -> Path.Build.t context
+val file_path : 'a context -> Loc.t -> string -> 'a
 
 val load_sexps
-  :  context:context
+  :  context:'a context
   -> Loc.t * string
-  -> (Dune_lang.Ast.t list * context) Memo.t
+  -> (Dune_lang.Ast.t list * 'a context) Memo.t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -397,7 +397,7 @@ end = struct
       fun fb ~kind ->
         let src = File_binding.Expanded.src fb in
         let dst = File_binding.Expanded.dst fb in
-        Install_entry_with_site.make_with_site ?dst ~kind i.section section src
+        Install_entry_with_site.make_with_site ?dst ~kind (snd i.section) section src
     in
     let+ files =
       let* files_expanded =
@@ -536,7 +536,7 @@ end = struct
             else acc))
     and+ l =
       let* package_db = Package_db.create (Context.name ctx) in
-      Dune_file.fold_stanzas stanzas ~init:[] ~f:(fun dune_file stanza acc ->
+      Dune_file.fold_static_stanzas stanzas ~init:[] ~f:(fun dune_file stanza acc ->
         let dir =
           Path.Build.append_source (Context.build_dir ctx) (Dune_file.dir dune_file)
         in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -576,12 +576,11 @@ let rec under_melange_emit_target ~dir =
     >>= (function
      | None -> under_melange_emit_target ~dir:parent
      | Some stanzas ->
-       (match
-          Dune_file.find_stanzas stanzas Melange_stanzas.Emit.key
-          |> List.find_map ~f:(fun mel ->
-            let target_dir = Melange_stanzas.Emit.target_dir ~dir:parent mel in
-            Option.some_if (Path.Build.equal target_dir dir) mel)
-        with
+       Dune_file.find_stanzas stanzas Melange_stanzas.Emit.key
+       >>| List.find_map ~f:(fun mel ->
+         let target_dir = Melange_stanzas.Emit.target_dir ~dir:parent mel in
+         Option.some_if (Path.Build.equal target_dir dir) mel)
+       >>= (function
         | None -> under_melange_emit_target ~dir:parent
         | Some stanza -> Memo.return @@ Some { stanza_dir = parent; stanza }))
 ;;
@@ -638,14 +637,14 @@ let setup_emit_js_rules sctx ~dir =
   | None ->
     (* this should probably be handled by [Dir_status] *)
     Dune_load.stanzas_in_dir dir
-    >>| (function
-     | None -> Gen_rules.no_rules
+    >>= (function
+     | None -> Memo.return Gen_rules.no_rules
      | Some dune_file ->
-       let build_dir_only_sub_dirs =
+       let+ build_dir_only_sub_dirs =
          Dune_file.find_stanzas dune_file Melange_stanzas.Emit.key
-         |> List.map ~f:(fun (mel : Melange_stanzas.Emit.t) -> mel.target)
-         |> Subdir_set.of_list
-         |> Gen_rules.Build_only_sub_dirs.singleton ~dir
+         >>| List.map ~f:(fun (mel : Melange_stanzas.Emit.t) -> mel.target)
+         >>| Subdir_set.of_list
+         >>| Gen_rules.Build_only_sub_dirs.singleton ~dir
        in
        Gen_rules.make ~build_dir_only_sub_dirs (Memo.return Rules.empty))
 ;;

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -14,7 +14,7 @@ let mlds_by_package_def =
       |> Dune_load.dune_files
       >>= Memo.parallel_map ~f:(fun dune_file ->
         Dune_file.stanzas dune_file
-        |> Memo.parallel_map ~f:(fun stanza ->
+        >>= Memo.parallel_map ~f:(fun stanza ->
           match Stanza.repr stanza with
           | Documentation.T d ->
             let+ mlds =

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -307,7 +307,7 @@ module DB = struct
 
   let create_from_stanzas ~projects_by_root ~(context : Context_name.t) stanzas =
     let stanzas, coq_stanzas =
-      Dune_file.fold_stanzas
+      Dune_file.fold_static_stanzas
         stanzas
         ~init:([], [])
         ~f:(fun dune_file stanza (acc, coq_acc) ->
@@ -375,7 +375,7 @@ module DB = struct
   let lib_entries_of_package =
     let make_map build_dir public_libs stanzas =
       let+ libs =
-        Dune_file.Memo_fold.fold_stanzas stanzas ~init:[] ~f:(fun d stanza acc ->
+        Dune_file.Memo_fold.fold_static_stanzas stanzas ~init:[] ~f:(fun d stanza acc ->
           match Stanza.repr stanza with
           | Library.T ({ visibility = Private (Some pkg); _ } as lib) ->
             let+ lib =

--- a/src/dune_rules/sites/site_env.ml
+++ b/src/dune_rules/sites/site_env.ml
@@ -47,7 +47,7 @@ let add_packages_env context ~base stanzas packages =
       in
       let+ package_sections =
         let* package_db = Package_db.create context in
-        Dune_file.Memo_fold.fold_stanzas
+        Dune_file.Memo_fold.fold_static_stanzas
           stanzas
           ~init:Package.Name.Map.empty
           ~f:(fun _ stanza acc ->
@@ -66,7 +66,7 @@ let add_packages_env context ~base stanzas packages =
                 add_in_package_section acc pkg_name section
             in
             match Stanza.repr stanza with
-            | Install_conf.T { section = Site { pkg; site; loc }; _ } ->
+            | Install_conf.T { section = _loc, Site { pkg; site; loc }; _ } ->
               add_in_package_sites pkg site loc
             | Plugin.T { site = loc, (pkg, site); _ } -> add_in_package_sites pkg site loc
             | _ -> Memo.return acc)

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -181,7 +181,12 @@ end = struct
                  ~dir:(Some dir))))
         |> List.filter_opt
       in
-      { Install_conf.section = Section Bin
+      let loc =
+        match public_names with
+        | [] -> assert false
+        | (loc, _) :: _ -> loc
+      in
+      { Install_conf.section = loc, Section Bin
       ; files
       ; dirs = []
       ; package

--- a/src/dune_rules/stanzas/install_conf.ml
+++ b/src/dune_rules/stanzas/install_conf.ml
@@ -1,7 +1,7 @@
 open Import
 
 type t =
-  { section : Section_with_site.t
+  { section : Loc.t * Section_with_site.t
   ; files : Install_entry.File.t list
   ; dirs : Install_entry.Dir.t list
   ; source_trees : Install_entry.Dir.t list
@@ -19,7 +19,7 @@ let decode =
   let open Dune_lang.Decoder in
   fields
     (let+ loc = loc
-     and+ section = field "section" Section_with_site.decode
+     and+ section = field "section" (located Section_with_site.decode)
      and+ files = field_o "files" (repeat Install_entry.File.decode)
      and+ dirs =
        field_o

--- a/src/dune_rules/stanzas/install_conf.mli
+++ b/src/dune_rules/stanzas/install_conf.mli
@@ -1,7 +1,7 @@
 open Import
 
 type t =
-  { section : Section_with_site.t
+  { section : Loc.t * Section_with_site.t
   ; files : Install_entry.File.t list
   ; dirs : Install_entry.Dir.t list
   ; source_trees : Install_entry.Dir.t list

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -15,6 +15,22 @@ let () =
 module Include = struct
   type t = Loc.t * string
 
+  let decode =
+    let+ loc = loc
+    and+ fn = relative_file in
+    loc, fn
+  ;;
+
+  include Stanza.Make (struct
+      type nonrec t = t
+
+      include Poly
+    end)
+end
+
+module Dynamic_include = struct
+  type t = Include.t
+
   include Stanza.Make (struct
       type nonrec t = t
 
@@ -117,6 +133,10 @@ let stanzas : constructors =
       , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
         and+ t = Deprecated_library_name.decode in
         [ Deprecated_library_name.make_stanza t ] )
+    ; ( "dynamic_include"
+      , let+ () = Dune_lang.Syntax.since Stanza.syntax (3, 14)
+        and+ include_ = Include.decode in
+        [ Dynamic_include.make_stanza include_ ] )
     ]
   ]
   |> List.concat

--- a/src/dune_rules/stanzas/stanzas.mli
+++ b/src/dune_rules/stanzas/stanzas.mli
@@ -6,6 +6,12 @@ module Include : sig
   include Stanza.S with type t := t
 end
 
+module Dynamic_include : sig
+  type t = Include.t
+
+  include Stanza.S with type t := t
+end
+
 val stanza_package : Stanza.t -> Package.t option
 
 (** [of_ast project ast] is the list of [Stanza.t]s derived from decoding the

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -128,7 +128,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
           | None -> Memo.return Libs_and_ppxs.empty
           | Some (d : Dune_file.t) ->
             Dune_file.stanzas d
-            |> Memo.List.fold_left ~init:Libs_and_ppxs.empty ~f:(add_stanza db ~dir))
+            >>= Memo.List.fold_left ~init:Libs_and_ppxs.empty ~f:(add_stanza db ~dir))
     in
     Appendable_list.to_list libs, Appendable_list.to_list pps
 ;;

--- a/test/blackbox-tests/test-cases/dynamic-include-stanza/cycle.t
+++ b/test/blackbox-tests/test-cases/dynamic-include-stanza/cycle.t
@@ -1,0 +1,22 @@
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > EOF
+
+  $ mkdir a b
+
+  $ cat >a/dune<<EOF
+  > (dynamic_include ../b/dune)
+  > EOF
+
+  $ cat >b/dune<<EOF
+  > (dynamic_include ../a/dune)
+  > EOF
+
+  $ dune build
+  Error: Dependency cycle between:
+     dynamic_include b/dune in directroy a
+  -> dynamic_include a/dune in directroy b
+  -> dynamic_include b/dune in directroy a
+  -> required by alias default
+  [1]

--- a/test/blackbox-tests/test-cases/dynamic-include-stanza/dynamic-include-stanza.t
+++ b/test/blackbox-tests/test-cases/dynamic-include-stanza/dynamic-include-stanza.t
@@ -1,0 +1,21 @@
+Demonstrate that we can load dynamically generated rules
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > EOF
+
+  $ mkdir a b
+
+  $ cat >a/dune <<EOF
+  > (rule
+  >  (with-stdout-to dune.inc
+  >   (echo "(rule (with-stdout-to foo (echo dynamic)))")))
+  > EOF
+
+  $ dune build a/dune.inc
+
+  $ cat >b/dune <<EOF
+  > (dynamic_include ../a/dune.inc)
+  > EOF
+
+  $ dune build b/foo

--- a/test/blackbox-tests/test-cases/dynamic-include-stanza/forbidden-stanzas.t
+++ b/test/blackbox-tests/test-cases/dynamic-include-stanza/forbidden-stanzas.t
@@ -1,0 +1,77 @@
+Some stanzas aren't allowed to be generated:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > (using dune_site 0.1)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir a b
+
+  $ cat >b/dune <<EOF
+  > (dynamic_include ../a/dune.inc)
+  > (rule (with-stdout-to x (echo "")))
+  > EOF
+
+  $ cat >a/dune <<EOF
+  > (copy_files ../dune.inc)
+  > EOF
+
+  $ runtest() {
+  > cat >dune.inc
+  > dune build b/x
+  > }
+
+  $ runtest <<EOF
+  > (library (name foo))
+  > EOF
+  File "_build/default/a/dune.inc", line 1, characters 0-20:
+  1 | (library (name foo))
+      ^^^^^^^^^^^^^^^^^^^^
+  Error: This stanza cannot be generated dynamically
+  [1]
+
+  $ runtest <<EOF
+  > (install
+  >  (section bin)
+  >  (files foo as bar))
+  > EOF
+  File "_build/default/a/dune.inc", line 2, characters 10-13:
+  2 |  (section bin)
+                ^^^
+  Error: binary section cannot be generated dynamically
+  [1]
+
+  $ runtest <<EOF
+  > (executable
+  >  (public_name foo))
+  > EOF
+  File "_build/default/a/dune.inc", line 1, characters 0-31:
+  1 | (executable
+  2 |  (public_name foo))
+  Error: This stanza cannot be generated dynamically
+  [1]
+
+  $ runtest <<EOF
+  > (plugin
+  >  (libraries)
+  >  (name foo)
+  >  (site (foo bar)))
+  > EOF
+  File "_build/default/a/dune.inc", line 4, characters 7-16:
+  4 |  (site (foo bar)))
+             ^^^^^^^^^
+  Error: This stanza cannot be generated dynamically
+  [1]
+
+  $ runtest <<EOF
+  > (deprecated_library_name
+  >  (old_public_name foo)
+  >  (new_public_name y))
+  > EOF
+  File "_build/default/a/dune.inc", line 1, characters 0-69:
+  1 | (deprecated_library_name
+  2 |  (old_public_name foo)
+  3 |  (new_public_name y))
+  Error: This stanza cannot be generated dynamically
+  [1]

--- a/test/blackbox-tests/test-cases/dynamic-include-stanza/nested.t
+++ b/test/blackbox-tests/test-cases/dynamic-include-stanza/nested.t
@@ -1,0 +1,25 @@
+Nesting of dynamic_include stanzas
+
+  $ mkdir a b c
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > EOF
+
+  $ cat >a/dune <<EOF
+  > (dynamic_include ../b/dune.inc)
+  > EOF
+
+  $ cat >b/dune <<EOF
+  > (rule
+  >  (with-stdout-to dune.inc
+  >   (echo "(dynamic_include ../c/dune.inc)")))
+  > EOF
+
+  $ cat >c/dune <<EOF
+  > (rule
+  >  (with-stdout-to dune.inc
+  >   (echo "(rule (with-stdout-to foo (echo bar)))")))
+  > EOF
+
+  $ dune build a/foo

--- a/test/blackbox-tests/test-cases/dynamic-include-stanza/static-inside-dynamic.t
+++ b/test/blackbox-tests/test-cases/dynamic-include-stanza/static-inside-dynamic.t
@@ -1,0 +1,20 @@
+Normal include from a dynamic include
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > EOF
+
+  $ mkdir a b
+  $ cat >a/dune <<EOF
+  > (dynamic_include ../b/dune.inc)
+  > EOF
+
+  $ cat >b/dune.inc <<EOF
+  > (include ../b/dune2.inc)
+  > EOF
+
+  $ cat >b/dune2.inc <<EOF
+  > (rule (with-stdout-to foo (echo bar)))
+  > EOF
+
+  $ dune build a/foo


### PR DESCRIPTION
Introduce the [dynamic_include] stanza. It's like [(include ..)], but
doesn't allow us to generate static stanzas and a few other stanzas that can affect the entire context. Those include:

* libraries, coq theories, and other library like stanzas
* public executables
* install stanzas with `(section bin)`.
* plugin stanzas

The limitation on generating private libraries is possible to lift, but it will take quite a bit more effort. I will do so in subsequent PR's.

# TODO

- [x] `dynamic_include` in `dynamic_include`
- [x] `include` in `dynamic_include`.
- [x] cycle checking for the above.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 55957fb9-7975-4cd6-aced-4d9d348dfbd6 -->