### PR TITLE
chore: add missing unix dependencies

### DIFF
--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -7,6 +7,7 @@
  (libraries
   stdune
   dune_tests_common
+  unix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/src/dune_targets/dune
+++ b/src/dune_targets/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_targets)
- (libraries stdune fiber chrome_trace dyn dune_digest))
+ (libraries stdune fiber chrome_trace dyn dune_digest unix))

--- a/src/fs/dune
+++ b/src/fs/dune
@@ -1,3 +1,3 @@
 (library
  (name fs)
- (libraries dune_engine stdune memo))
+ (libraries dune_engine stdune memo unix))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -99,7 +99,7 @@
 (subdir
  github3766.t
  (executable
-  (libraries stdune spawn)
+  (libraries stdune spawn unix)
   (name test)))
 
 (subdir

--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -6,7 +6,8 @@
   dune-private-libs.dune_re
   dune-configurator
   build_path_prefix_map
-  str))
+  str
+  unix))
 
 (ocamllex dunepp)
 
@@ -17,7 +18,7 @@
 (executable
  (modules melc_stdlib_prefix)
  (name melc_stdlib_prefix)
- (libraries stdune))
+ (libraries stdune unix))
 
 (executable
  (name refmt)

--- a/test/expect-tests/digest/dune
+++ b/test/expect-tests/digest/dune
@@ -4,6 +4,7 @@
  (libraries
   stdune
   dune_digest
+  unix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -1,7 +1,7 @@
 (library
  (name dune_file_watcher_tests_lib)
  (modules dune_file_watcher_tests_lib)
- (libraries dune_file_watcher base stdune threads.posix stdio spawn))
+ (libraries dune_file_watcher base stdune threads.posix stdio spawn unix))
 
 (library
  (name dune_file_watcher_tests_macos)
@@ -47,7 +47,8 @@
   ppx_inline_test.config
   threads.posix
   stdio
-  spawn)
+  spawn
+  unix)
  (preprocess
   (pps ppx_expect)))
 

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -61,6 +61,7 @@
   stdune
   fiber
   xdg
+  unix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config
@@ -84,6 +85,7 @@
   dune_rpc_e2e
   dune_rpc_private
   dune_rpc_impl
+  unix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/dune_stats/dune
+++ b/test/expect-tests/dune_stats/dune
@@ -6,6 +6,7 @@
  (libraries
   dune_stats
   stdune
+  unix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/inotify_tests/dune
+++ b/test/expect-tests/inotify_tests/dune
@@ -16,6 +16,7 @@
   ppx_inline_test.config
   threads.posix
   stdio
-  spawn)
+  spawn
+  unix)
  (preprocess
   (pps ppx_expect)))


### PR DESCRIPTION
See #8607 for a recent example.

OCaml 5 adds a `ocaml_deprecated_auto_include` alert when the `unix` library is referenced but without an explicit dependency.

This commit fixes these alerts by adding a dependency to `unix` in places that refer to `Unix` directly (ie, it makes the metadata correct thus removing the alert).
