### PR TITLE
[3.13] backport #9810

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -1,23 +1,33 @@
 open Import
 
-let is_a_source_file path =
-  (match Path.extension path with
-   | ".flv"
-   | ".gif"
-   | ".ico"
-   | ".jpeg"
-   | ".jpg"
-   | ".mov"
-   | ".mp3"
-   | ".mp4"
-   | ".otf"
-   | ".pdf"
-   | ".png"
-   | ".ttf"
-   | ".woff" -> false
-   | _ -> true)
-  && (Path.stat_exn path).st_kind = Unix.S_REG
+let is_path_a_source_file path =
+  match Path.extension path with
+  | ".flv"
+  | ".gif"
+  | ".ico"
+  | ".jpeg"
+  | ".jpg"
+  | ".mov"
+  | ".mp3"
+  | ".mp4"
+  | ".otf"
+  | ".pdf"
+  | ".png"
+  | ".ttf"
+  | ".woff" -> false
+  | _ -> true
 ;;
+
+let is_kind_a_source_file path =
+  match Path.stat path with
+  | Ok st -> st.st_kind = S_REG
+  | Error (ENOENT, "stat", _) ->
+    (* broken symlink *)
+    false
+  | Error e -> Unix_error.Detailed.raise e
+;;
+
+let is_a_source_file path = is_path_a_source_file path && is_kind_a_source_file path
 
 let subst_string s path ~map =
   let len = String.length s in

--- a/doc/changes/9810.md
+++ b/doc/changes/9810.md
@@ -1,0 +1,2 @@
+- subst: ignore broken symlinks when looking at source files
+(#9810, fixes #9593, @emillon)

--- a/test/blackbox-tests/test-cases/subst/broken-symlink.t
+++ b/test/blackbox-tests/test-cases/subst/broken-symlink.t
@@ -1,0 +1,23 @@
+dune subst should not fail when encountering broken symlinks.
+See #9593.
+
+  $ cat > dune-project << EOF
+  > (lang dune 1.0)
+  > (name proj)
+  > (package
+  >  (name proj))
+  > EOF
+  $ ln -s nonexistent broken 
+
+This test requires a git repository, otherwise `dune subst` does nothing.
+
+  $ git init -q
+  $ git add dune-project broken
+  $ git commit -m create |grep -v root-commit
+   2 files changed, 5 insertions(+)
+   create mode 120000 broken
+   create mode 100644 dune-project
+
+  $ dune subst
+  Error: stat(broken): No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/subst/broken-symlink.t
+++ b/test/blackbox-tests/test-cases/subst/broken-symlink.t
@@ -19,5 +19,3 @@ This test requires a git repository, otherwise `dune subst` does nothing.
    create mode 100644 dune-project
 
   $ dune subst
-  Error: stat(broken): No such file or directory
-  [1]


### PR DESCRIPTION
- test: subst should not fail on broken symlinks (#9637)
- fix(subst): ignore broken symlinks (#9810)
