### PR TITLE
[3.13] backport #9811

### DIFF
--- a/doc/changes/9811.md
+++ b/doc/changes/9811.md
@@ -1,0 +1,1 @@
+- subst: do not fail on 32-bit systems when large files are encountered. Just log a warning in this case. (#9811, fixes #9538, @emillon)

--- a/otherlibs/stdune/src/io.mli
+++ b/otherlibs/stdune/src/io.mli
@@ -9,7 +9,16 @@ val input_lines : in_channel -> string list
     unrelated channels because it uses a statically-allocated global buffer. *)
 val copy_channels : in_channel -> out_channel -> unit
 
-val read_all : in_channel -> string
+(** Try to read everything from a channel. Returns [Error ()] if the contents
+    are larger than [Sys.max_string_length]. This is generally a problem only
+    on 32-bit systems.
+    Overflow detection does not happen in the following cases:
+    - channel is not a file (for example, a pipe)
+    - if the detected size is unreliable (/proc)
+    - race condition with another process changing the size of the underlying
+      file.
+      In these cases, an exception might be raised by [Buffer] functions. *)
+val read_all_unless_large : in_channel -> (string, unit) result
 
 include Io_intf.S with type path = Path.t
 module String_path : Io_intf.S with type path = string

--- a/test/blackbox-tests/test-cases/subst/32bit.t
+++ b/test/blackbox-tests/test-cases/subst/32bit.t
@@ -1,0 +1,35 @@
+When dune subst is called on a file larger than 16MiB, it should not crash.
+See #9538.
+
+  $ cat > create.ml << EOF
+  > let () = Unix.truncate "large.dat" 0x1_00_00_00
+  > EOF
+  $ touch large.dat
+  $ ocaml unix.cma create.ml
+  $ rm create.ml
+
+  $ cat > dune-project << EOF
+  > (lang dune 1.0)
+  > (name project)
+  > (package
+  >  (name project))
+  > EOF
+
+This test uses subst, which needs a git repository:
+
+  $ git init
+  Initialized empty Git repository in $TESTCASE_ROOT/.git/
+  $ git add dune-project
+  $ git add large.dat
+  $ git commit -m create | tail -n 3
+   2 files changed, 4 insertions(+)
+   create mode 100644 dune-project
+   create mode 100644 large.dat
+
+  $ dune subst 2>&1 | head -n 6
+  Error: exception Invalid_argument("Bytes.create")
+  Raised by primitive operation at Stdune__Io.Make.eagerly_input_string in file
+    "otherlibs/stdune/src/io.ml", line 273, characters 14-30
+  Called from Stdune__Io.Make.read_all.(fun) in file
+    "otherlibs/stdune/src/io.ml", line 308, characters 16-40
+  Called from Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line

--- a/test/blackbox-tests/test-cases/subst/32bit.t
+++ b/test/blackbox-tests/test-cases/subst/32bit.t
@@ -26,10 +26,7 @@ This test uses subst, which needs a git repository:
    create mode 100644 dune-project
    create mode 100644 large.dat
 
-  $ dune subst 2>&1 | head -n 6
-  Error: exception Invalid_argument("Bytes.create")
-  Raised by primitive operation at Stdune__Io.Make.eagerly_input_string in file
-    "otherlibs/stdune/src/io.ml", line 273, characters 14-30
-  Called from Stdune__Io.Make.read_all.(fun) in file
-    "otherlibs/stdune/src/io.ml", line 308, characters 16-40
-  Called from Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line
+  $ dune subst
+  Warning: Ignoring large file: large.dat
+  Hint: Dune has been built as a 32-bit binary so the maximum size "dune subst"
+  can operate on is 16MiB.

--- a/test/blackbox-tests/test-cases/subst/dune
+++ b/test/blackbox-tests/test-cases/subst/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to 32bit)
+ (enabled_if
+  (not %{arch_sixtyfour}))
+ (deps %{bin:git}))

--- a/test/blackbox-tests/utils/melc_stdlib_prefix.ml
+++ b/test/blackbox-tests/utils/melc_stdlib_prefix.ml
@@ -2,7 +2,11 @@ open Stdune
 
 let command cmd args =
   let p = Unix.open_process_args_in cmd (Array.of_list (cmd :: args)) in
-  let output = Io.read_all p in
+  let output =
+    match Io.read_all_unless_large p with
+    | Ok x -> x
+    | Error () -> assert false
+  in
   match Unix.close_process_in p with
   | WEXITED n when n = 0 -> Ok output
   | WEXITED n -> Error n


### PR DESCRIPTION
- test: add repro for #9538 (subst on 32-bit) (#9539)
- fix(subst): ignore large files (#9811)
