### PR TITLE
[3.13] backport #9861

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -102,12 +102,12 @@ module Status_line = struct
   let () = at_exit (fun () -> Printf.printf "\r%*s\r" (String.length !displayed) "")
 end
 
-(* Return list of entries in [path] as [path/entry] *)
+(* Return a sorted list of entries in [path] as [path/entry] *)
 let readdir path =
-  Array.fold_right
-    ~f:(fun entry dir -> (path ^/ entry) :: dir)
-    ~init:[]
-    (Sys.readdir path)
+  Sys.readdir path
+  |> Array.to_list
+  |> List.map ~f:(fun entry -> path ^/ entry)
+  |> List.sort ~cmp:String.compare
 ;;
 
 let open_out file =

--- a/doc/changes/9861-readdir-boot.md
+++ b/doc/changes/9861-readdir-boot.md
@@ -1,0 +1,2 @@
+- boot: sort directory entries in readdir. This makes the dune binary
+  reproducible in terms of filesystem order. (#9861, fixes #9794, @emillon)


### PR DESCRIPTION
Fixes #9794

`_boot/dune.exe` is installed, so it needs to be reproducible. This
change ensures that the source files are scanned in an order that is
independent from the underlying directory entries.

This has been tested with `disorderfs --shuffle-dirents=yes`: two runs
of `make bootstrap` create the same binary.

Signed-off-by: Etienne Millon <me@emillon.org>