### PR TITLE
Chore: Explicitly call Stdlib.Mutex in file with open Base

### DIFF
--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -4,8 +4,14 @@ open Base
 open Stdune
 
 let critical_section mutex ~f =
-  Stdlib.Mutex.lock mutex;
-  Exn.protect ~f ~finally:(fun () -> Stdlib.Mutex.unlock mutex)
+  (* Since 5.0, using "Mutex" with Base open rings an alert and suggests
+     we use "Stdlib.Mutex" instead.
+     Prior to OCaml 5.0, "Stdlib.Mutex" didn't exist, it was just "Mutex".
+     Since 5.1 there is Stdlib.Mutex.protect which replaces this function.
+  *)
+  let module Mutex = Mutex [@alert "-deprecated"] in
+  Mutex.lock mutex;
+  Exn.protect ~f ~finally:(fun () -> Mutex.unlock mutex)
 ;;
 
 let init () =

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -4,8 +4,8 @@ open Base
 open Stdune
 
 let critical_section mutex ~f =
-  Mutex.lock mutex;
-  Exn.protect ~f ~finally:(fun () -> Mutex.unlock mutex)
+  Stdlib.Mutex.lock mutex;
+  Exn.protect ~f ~finally:(fun () -> Stdlib.Mutex.unlock mutex)
 ;;
 
 let init () =


### PR DESCRIPTION
When compiling with OCaml 5.0 or 5.1 we get this error:

```
File "test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml", line 7, characters 2-12:
7 |   Mutex.lock mutex;
      ^^^^^^^^^^
Error (alert deprecated): module Base.Mutex
[2016-09] this element comes from the stdlib distributed with OCaml.
Referring to the stdlib directly is discouraged by Base. You should either
use the equivalent functionality offered by Base, or if you really want to
refer to the stdlib, use Stdlib.Mutex instead

File "test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml", line 8, characters 37-49:
8 |   Exn.protect ~f ~finally:(fun () -> Mutex.unlock mutex)
                                         ^^^^^^^^^^^^
Error (alert deprecated): module Base.Mutex
[2016-09] this element comes from the stdlib distributed with OCaml.
Referring to the stdlib directly is discouraged by Base. You should either
use the equivalent functionality offered by Base, or if you really want to
refer to the stdlib, use Stdlib.Mutex instead
```

This PR explicitly calls the Stdlib and removes the error.