### PR TITLE
refactor(engine): Move [Diff_promotion.display]

### DIFF
--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -224,18 +224,6 @@ let filter_db files_to_promote db =
       r)
 ;;
 
-let display files_to_promote =
-  let open Fiber.O in
-  let files = load_db () |> filter_db files_to_promote in
-  let+ diff_opts =
-    Fiber.parallel_map files ~f:(fun file ->
-      let+ diff_opt = diff_for_file file in
-      match diff_opt with
-      | Ok diff -> Some (file, diff)
-      | Error _ -> None)
-  in
-  diff_opts
-  |> List.filter_opt
-  |> List.sort ~compare:(fun (file, _) (file', _) -> File.compare file file')
-  |> List.iter ~f:(fun (_file, diff) -> Print_diff.Diff.print diff)
+let load_db files_to_promote =
+  load_db () |> filter_db files_to_promote |> List.sort ~compare:File.compare
 ;;

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -45,8 +45,6 @@ type files_to_promote =
   | All
   | These of Path.Source.t list * (Path.Source.t -> unit)
 
-val load_db : unit -> File.t list
-val filter_db : files_to_promote -> File.t list -> File.t list
+val load_db : files_to_promote -> File.t list
 val diff_for_file : File.t -> (Print_diff.Diff.t, User_message.t) result Fiber.t
 val promote_files_registered_in_last_run : files_to_promote -> unit
-val display : files_to_promote -> unit Fiber.t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -27,6 +27,7 @@ module Action_to_sh = Action_to_sh
 module Scheduler = Scheduler
 module Hooks = Hooks
 module Diff_promotion = Diff_promotion
+module Print_diff = Print_diff
 module Cached_digest = Cached_digest
 module Fs_cache = Fs_cache
 module Fs_memo = Fs_memo


### PR DESCRIPTION
This function is only used in the dune command line to pretty print
promotions. Therefore it is moved to the command line.

This requires exposing a couple of functions to implement pretty
printing:

1. [load_db] to load the the available promotions. The files are now
   returned in sorted order by default to avoid users introducing
   non-determinism by accident. Previously, the display function
   did this.
2. [diff_for_file] print the diff the promoted file

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 958cb66f-0cf4-416c-a9a5-8002c535d907 -->