### PR TITLE
nix: convert to Melange v3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -23,33 +23,60 @@
         "flake-utils": [
           "flake-utils"
         ],
+        "melange-compiler-libs": "melange-compiler-libs",
         "nix-filter": "nix-filter",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1700157818,
-        "narHash": "sha256-BAT0/885I7dRrGtpxp2WMB3rubkC06CGx/tj73A2J08=",
-        "owner": "alizter",
+        "lastModified": 1707255164,
+        "narHash": "sha256-eJ2+nbjEGnTinf67lhUPuE8fzfGXeC2ErGRvU2omUgs=",
+        "owner": "melange-re",
         "repo": "melange",
-        "rev": "15ea670d97ec5a235e84a0a3832761d987990c23",
+        "rev": "71cc9a89b4236cbf02668b21602e86b653b9a6a0",
         "type": "github"
       },
       "original": {
-        "owner": "alizter",
-        "ref": "melange-1.0-without-failing-test",
+        "owner": "melange-re",
+        "ref": "v3-414",
         "repo": "melange",
+        "type": "github"
+      }
+    },
+    "melange-compiler-libs": {
+      "inputs": {
+        "flake-utils": [
+          "melange",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "melange",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1705107784,
+        "narHash": "sha256-tN+g+m2yXUL5Mik2I0SbMDhhoqatHL/it0VR9cjVYag=",
+        "owner": "melange-re",
+        "repo": "melange-compiler-libs",
+        "rev": "2c06d6ea9257c52a18cef82f154307eaa2a1bbae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "melange-re",
+        "ref": "4.14",
+        "repo": "melange-compiler-libs",
         "type": "github"
       }
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1681154353,
-        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
+        "lastModified": 1705332318,
+        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
+        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
         "type": "github"
       },
       "original": {
@@ -60,11 +87,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700108881,
-        "narHash": "sha256-+Lqybl8kj0+nD/IlAWPPG/RDTa47gff9nbei0u7BntE=",
+        "lastModified": 1707171055,
+        "narHash": "sha256-7ZiKRdhrScsDfhDkGy8yJWAT6BfHqa8PYMX04roU03k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7414e9ee0b3e9903c24d3379f577a417f0aae5f1",
+        "rev": "4b1aab22192b787355733c9495d47f4c66af084c",
         "type": "github"
       },
       "original": {
@@ -84,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697959944,
-        "narHash": "sha256-i77VXRk3w9X4dPG/U+vqMo9rQNFqr8XKtHB8P25YpE0=",
+        "lastModified": 1706623517,
+        "narHash": "sha256-WUFQvkLkvnFzq+T/N3he6glVqs9GmbTGeEdeO7rm5uk=",
         "ref": "refs/heads/master",
-        "rev": "c6eafd83d40c89f0832503c9509b1bcc01acc54d",
-        "revCount": 2052,
+        "rev": "a74fb4add55bcaab7ac72d3a3a51972401c64e39",
+        "revCount": 2061,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/ocaml/ocaml-lsp"

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,8 @@
       inputs.flake-utils.follows = "flake-utils";
     };
     melange = {
-      # We use melange 1.0 because later versions do not work on OCaml < 5.0.
-      # melange 1.0 has a non-reproducible test causing issues. This branch removes that test.
-      url = "github:alizter/melange/melange-1.0-without-failing-test";
+      # When moving the compiler tests to OCaml 5.1, change to v3-51
+      url = "github:melange-re/melange/v3-414";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
follow-up to https://github.com/ocaml/dune/pull/9936

converts the nix shell to use the melange v3 upstream branch, with instructions to upgrade to OCaml 5.1 as suggested by the requirement in https://github.com/ocaml/dune/issues/9935