### PR TITLE
pkg: fix bug preventing paths from being sandboxed

### DIFF
--- a/otherlibs/stdune/src/list.ml
+++ b/otherlibs/stdune/src/list.ml
@@ -242,3 +242,12 @@ let truncate ~max_length xs =
   in
   loop [] 0 xs
 ;;
+
+let intersperse xs ~sep =
+  let rec loop acc = function
+    | [] -> rev acc
+    | [ x ] -> rev (x :: acc)
+    | x :: xs -> loop (sep :: x :: acc) xs
+  in
+  loop [] xs
+;;

--- a/otherlibs/stdune/src/list.mli
+++ b/otherlibs/stdune/src/list.mli
@@ -62,3 +62,7 @@ val split_while : 'a t -> f:('a -> bool) -> 'a t * 'a t
 val truncate : max_length:int -> 'a t -> [> `Not_truncated of 'a t | `Truncated of 'a t ]
 val of_seq : 'a Seq.t -> 'a t
 val to_seq : 'a t -> 'a Seq.t
+
+(** [list_intersperse t ~sep] returns [t] with [sep] inserted between each pair
+    of consecutive values. *)
+val intersperse : 'a t -> sep:'a -> 'a t

--- a/otherlibs/stdune/test/list_tests.ml
+++ b/otherlibs/stdune/test/list_tests.ml
@@ -1,0 +1,20 @@
+open! Stdune
+open Dyn
+open Dune_tests_common
+
+let intersperse t ~sep = List.intersperse t ~sep |> list string |> print_dyn
+
+let%expect_test _ =
+  intersperse [] ~sep:"sep";
+  [%expect {| [] |}]
+;;
+
+let%expect_test _ =
+  intersperse [ "foo" ] ~sep:"sep";
+  [%expect {| [ "foo" ] |}]
+;;
+
+let%expect_test _ =
+  intersperse [ "foo"; "bar"; "baz" ] ~sep:"sep";
+  [%expect {| [ "foo"; "sep"; "bar"; "sep"; "baz" ] |}]
+;;

--- a/src/dune_lang/ordered_set_lang_intf.ml
+++ b/src/dune_lang/ordered_set_lang_intf.ml
@@ -59,8 +59,8 @@ module type Action_builder = sig
 
   val expand
     :  String_with_vars.t
-    -> mode:'a String_with_vars.Mode.t
+    -> mode:(_, 'value) String_with_vars.Mode.t
     -> dir:Path.t
     -> f:Value.t list t String_with_vars.expander
-    -> 'a t
+    -> 'value t
 end

--- a/src/dune_lang/value.ml
+++ b/src/dune_lang/value.ml
@@ -72,7 +72,6 @@ module L = struct
   let to_dyn = Dyn.list to_dyn
   let to_strings t ~dir = List.map t ~f:(to_string ~dir)
   let compare_vals ~dir = List.compare ~compare:(compare_vals ~dir)
-  let concat ts ~dir = List.map ~f:(to_string ~dir) ts |> String.concat ~sep:" "
 
   let deps_only =
     List.filter_map ~f:(function
@@ -83,4 +82,35 @@ module L = struct
   let strings = List.map ~f:(fun x -> String x)
   let paths = List.map ~f:(fun x -> Path x)
   let dirs = List.map ~f:(fun x -> Dir x)
+end
+
+module Deferred_concat = struct
+  type value = t
+  type t = value list
+
+  let singleton value = [ value ]
+  let parts values = values
+
+  let concat_values values ~sep =
+    match sep with
+    | None -> values
+    | Some sep -> List.intersperse values ~sep:(String sep)
+  ;;
+
+  let concat ts ~sep =
+    match sep with
+    | None -> List.concat_map ts ~f:parts
+    | Some sep ->
+      List.map ts ~f:parts |> List.intersperse ~sep:[ String sep ] |> List.concat
+  ;;
+
+  let force_string values ~dir =
+    List.map values ~f:(to_string ~dir) |> String.concat ~sep:""
+  ;;
+
+  let force t ~dir =
+    match t with
+    | [ x ] -> x
+    | _ -> String (force_string t ~dir)
+  ;;
 end

--- a/src/dune_lang/value.mli
+++ b/src/dune_lang/value.mli
@@ -35,6 +35,39 @@ module L : sig
   val paths : Path.t list -> t list
   val deps_only : t list -> Path.t list
   val dirs : Path.t list -> t list
-  val concat : t list -> dir:Path.t -> string
   val to_strings : t list -> dir:Path.t -> string list
+end
+
+module Deferred_concat : sig
+  type value = t
+
+  (** When concatenating multiple values together it can sometimes be useful to
+      preserve the paths in the [Path] and [Dir] constructors. This type
+      represents a concatenation of [value]s which can be forced into a single
+      [value] or string. *)
+  type t
+
+  val singleton : value -> t
+
+  (** [parts t] returns a list of [value]s that can be concatenated (without a
+      delimeter) to produce the [value] represented by [t]. If the [value] is all
+      that's required, consider using [force] instead. Use the [parts] function
+      if additional processing is to be done on [value]s prior to
+      concatenation. *)
+  val parts : t -> value list
+
+  (** Construct a [t] by concatenating [value]s *)
+  val concat_values : value list -> sep:string option -> t
+
+  (** Construct a [t] by concatenating [t]s *)
+  val concat : t list -> sep:string option -> t
+
+  (** [force t ~dir] returns the [value] represented by [t]. If it's necessary
+      to stringify a path, (e.g. if a [Path] or [Dir] [value] is concatenated
+      with another value) then the stringified path will be relative to the
+      provided [dir] argument. *)
+  val force : t -> dir:Path.t -> value
+
+  (** Similar to [force] but stringifies the result *)
+  val force_string : t -> dir:Path.t -> string
 end

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -61,9 +61,9 @@ val extend_env : t -> env:Env.t -> t
 
 val expand
   :  t
-  -> mode:'a String_with_vars.Mode.t
+  -> mode:('deferred, 'value) String_with_vars.Mode.t
   -> String_with_vars.t
-  -> 'a Action_builder.t
+  -> 'value Action_builder.t
 
 val expand_path : t -> String_with_vars.t -> Path.t Action_builder.t
 val expand_str : t -> String_with_vars.t -> string Action_builder.t
@@ -74,7 +74,13 @@ module No_deps : sig
       dependencies, such as [%{dep:...}] *)
 
   val expand_pform : t -> Value.t list Memo.t String_with_vars.expander
-  val expand : t -> mode:'a String_with_vars.Mode.t -> String_with_vars.t -> 'a Memo.t
+
+  val expand
+    :  t
+    -> mode:('deferred, 'value) String_with_vars.Mode.t
+    -> String_with_vars.t
+    -> 'value Memo.t
+
   val expand_path : t -> String_with_vars.t -> Path.t Memo.t
   val expand_str : t -> String_with_vars.t -> string Memo.t
 end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -722,20 +722,22 @@ module Action_expander = struct
       Result.map prog ~f:(map_exe t)
     ;;
 
+    let slang_expander t sw =
+      String_expander.Memo.expand_result_deferred_concat sw ~mode:Many ~f:(expand_pform t)
+    ;;
+
     let eval_blang t blang =
       Slang_expand.eval_blang
         blang
         ~dir:(Path.build t.paths.source_dir)
-        ~f:(fun sw ~dir ->
-          String_expander.Memo.expand_result sw ~mode:Many ~f:(expand_pform t) ~dir)
+        ~f:(slang_expander t)
     ;;
 
     let eval_slangs_located t slangs =
       Slang_expand.eval_multi_located
         slangs
         ~dir:(Path.build t.paths.source_dir)
-        ~f:(fun sw ~dir ->
-          String_expander.Memo.expand_result sw ~mode:Many ~f:(expand_pform t) ~dir)
+        ~f:(slang_expander t)
     ;;
   end
 
@@ -765,20 +767,15 @@ module Action_expander = struct
          User_error.raise
            ?loc
            [ Pp.text "\"run\" action must have at least one argument" ]
-       | (prog_loc, `Concat prog) :: args ->
+       | (prog_loc, prog) :: args ->
          let+ exe =
-           let prog =
-             match prog with
-             | [ Path prog ] -> Value.Path prog
-             | [ Dir prog ] -> Value.Dir prog
-             | prog ->
-               String (List.map prog ~f:(Value.to_string ~dir) |> String.concat ~sep:"")
-           in
+           let prog = Value.Deferred_concat.force prog ~dir in
            Expander.expand_exe_value expander prog ~loc:prog_loc
          in
          let args =
-           Array.Immutable.of_list_map args ~f:(fun (_, `Concat arg) ->
-             Array.Immutable.of_list_map arg ~f:(fun (arg : Value.t) ->
+           Array.Immutable.of_list_map args ~f:(fun (_loc, arg) ->
+             Value.Deferred_concat.parts arg
+             |> Array.Immutable.of_list_map ~f:(fun (arg : Value.t) ->
                match arg with
                | String s -> Run_with_path.Spec.String s
                | Path p | Dir p -> Path p))

--- a/src/dune_rules/slang_expand.mli
+++ b/src/dune_rules/slang_expand.mli
@@ -3,14 +3,15 @@ open Import
 
 type expander =
   String_with_vars.t
-  -> dir:Path.t
-  -> (Value.t list, [ `Undefined_pkg_var of Dune_lang.Package_variable_name.t ]) result
+  -> ( Value.Deferred_concat.t list
+       , [ `Undefined_pkg_var of Dune_lang.Package_variable_name.t ] )
+       result
        Memo.t
 
 val eval_multi_located
   :  Slang.t list
   -> dir:Path.t
   -> f:expander
-  -> (Loc.t * [ `Concat of Value.t list ]) list Memo.t
+  -> (Loc.t * Value.Deferred_concat.t) list Memo.t
 
 val eval_blang : Slang.blang -> dir:Path.t -> f:expander -> bool Memo.t

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -23,4 +23,4 @@ Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
   $ dune build 2>&1 | strip_sandbox
   --prefix $SANDBOX/_private/default/.pkg/test/target
-  --prefix=../target
+  $SANDBOX/_private/default/.pkg/test/target


### PR DESCRIPTION
Pform variables which appear in build/install commands that refer to paths (e.g. `%{target}`) are resolved in two steps. First the normal pform substitution is applied, replacing the variable with some path, then the path is further transformed to refer to the corresponding path within the sandbox specific to the package being built/installed.

Path pform variables which appeared in string interpolations (such as `--target=%{target}`) were erroneously not subject to the second transformation, meaning that they were left as the original, unsandboxed path. This was due to string interpolations being collapsed into strings too early so that path information was lost at the point when the sandboxing transformation is applied.

This fixes this by introducing the concept of "deferred concatenations" which represent a sequence of values to be concatenated in the future. This lets the path-iness of the path variable components of string interpolations to be preserved until the point when the sandboxing transformation is applied.