### PR TITLE
test(melange): make tests more reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -17,7 +17,7 @@ Show that the merlin config knows about melange.compile_flags
   $ touch bar.ml $lib.ml
   $ dune build @check
 
-  $ dune ocaml merlin dump-config "$PWD" | grep -i 42
+  $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
      +42)))
      +42)))
      +42)))
@@ -30,7 +30,7 @@ Show that the merlin config knows about melange.compile_flags
 
   $ dune build @check
 
-  $ dune ocaml merlin dump-config "$PWD" | grep -i 42
+  $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
      +42)))
      +42)))
      +42)))


### PR DESCRIPTION
Do not include sandbox paths if they have the number 42

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2279759c-d570-407f-bdaf-5e9ead170062 -->