### PR TITLE
favour odocls that are not dependencies

### DIFF
--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -802,7 +802,7 @@ let search_db_for_lib sctx lib =
   let dir = Paths.html ctx target in
   let* odocs = odoc_artefacts sctx target in
   let odocls = List.map odocs ~f:(fun odoc -> odoc.odocl_file) in
-  Sherlodoc.search_db sctx ~dir odocls
+  Sherlodoc.search_db sctx ~dir ~external_odocls:[] odocls
 ;;
 
 let setup_lib_html_rules sctx ~search_db lib =
@@ -826,7 +826,7 @@ let setup_pkg_html_rules_def =
     let all_odocs = pkg_odocs @ lib_odocs in
     let* search_db =
       let odocls = List.map all_odocs ~f:(fun artefact -> artefact.odocl_file) in
-      Sherlodoc.search_db sctx ~dir odocls
+      Sherlodoc.search_db sctx ~dir ~external_odocls:[] odocls
     in
     let* () = Memo.parallel_iter libs ~f:(setup_lib_html_rules sctx ~search_db) in
     let* () = Memo.parallel_iter pkg_odocs ~f:(setup_generate_all ~search_db sctx) in

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -1930,17 +1930,21 @@ let setup_all_html_rules sctx ~all =
   let* tree = full_tree sctx ~all in
   let* search_db =
     let dir = Index.html_dir ctx ~all [] in
-    let odocls =
-      Index_tree.fold tree ~init:[] ~f:(fun index ii acc ->
+    let external_odocls, odocls =
+      Index_tree.fold tree ~init:([], []) ~f:(fun index ii acc ->
+        let externals, odocls = acc in
+        let is_external = Index.is_external index in
         let index_artifact = Artifact.index ctx ~all:true index in
         let new_artifacts =
           index_artifact :: Index_tree.all_artifacts ii
           |> List.filter_map ~f:(fun a ->
             if Artifact.is_visible a then Some (Artifact.odocl_file a) else None)
         in
-        new_artifacts @ acc)
+        if is_external
+        then new_artifacts @ externals, odocls
+        else externals, new_artifacts @ odocls)
     in
-    Sherlodoc.search_db sctx ~dir odocls
+    Sherlodoc.search_db sctx ~dir ~external_odocls odocls
   in
   let+ () =
     let html =

--- a/src/dune_rules/sherlodoc.mli
+++ b/src/dune_rules/sherlodoc.mli
@@ -7,6 +7,7 @@ open Import
 val search_db
   :  Super_context.t
   -> dir:Path.Build.t
+  -> external_odocls:Path.Build.t list
   -> Path.Build.t list
   -> Path.Build.t Memo.t
 

--- a/test/blackbox-tests/test-cases/odoc/new/odoc-unique-mlds/diff-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/odoc-unique-mlds/diff-scope.t/run.t
@@ -3,14 +3,14 @@ Duplicate mld's in different scope
           odoc _doc_new/index/page-docs.odoc
           odoc _doc_new/index/stdlib/page-stdlib.odoc
           odoc _doc_new/index/local/page-local.odoc
-          odoc _doc_new/index/local/scope1/page-scope1.odoc
           odoc _doc_new/index/local/scope2/page-scope2.odoc
-          odoc _doc_new/odoc/local/scope1/page-foo.odoc
+          odoc _doc_new/index/local/scope1/page-scope1.odoc
           odoc _doc_new/odoc/local/scope2/page-foo.odoc
+          odoc _doc_new/odoc/local/scope1/page-foo.odoc
+          odoc _doc_new/index/stdlib/page-stdlib.odocl
           odoc _doc_new/index/local/page-local.odocl
           odoc _doc_new/index/page-docs.odocl
-          odoc _doc_new/index/stdlib/page-stdlib.odocl
-          odoc _doc_new/index/local/scope1/page-scope1.odocl
-          odoc _doc_new/odoc/local/scope1/page-foo.odocl
           odoc _doc_new/index/local/scope2/page-scope2.odocl
           odoc _doc_new/odoc/local/scope2/page-foo.odocl
+          odoc _doc_new/index/local/scope1/page-scope1.odocl
+          odoc _doc_new/odoc/local/scope1/page-foo.odocl

--- a/test/blackbox-tests/test-cases/odoc/new/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/warnings.t/run.t
@@ -30,9 +30,9 @@ These packages are in a nested env, the option is disabled, should success with 
 In release mode, no error:
 
   $ dune build -p foo_doc,foo_lib @doc-new
-  (cd _build/default/_doc_new/odoc/local/foo_doc && odoc compile -o page-foo.odoc ../../../../foo_doc/foo.mld -I ../../../index/local/foo_doc --parent 'page-"foo_doc"')
-  File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
-  Warning: End of text is not allowed in '[...]' (code).
   (cd _build/default/_doc_new/odoc/local/foo_lib && odoc compile -I . -I ../../stdlib -o foo.odoc ../../../../foo_lib/.foo.objs/byte/foo.cmti -I ../../../index/local/foo_lib --parent 'page-"foo_lib"')
   File "foo_lib/foo.mli", line 1, characters 7-7:
+  Warning: End of text is not allowed in '[...]' (code).
+  (cd _build/default/_doc_new/odoc/local/foo_doc && odoc compile -o page-foo.odoc ../../../../foo_doc/foo.mld -I ../../../index/local/foo_doc --parent 'page-"foo_doc"')
+  File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
   Warning: End of text is not allowed in '[...]' (code).

--- a/test/blackbox-tests/test-cases/odoc/odoc-new-sherlodoc.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-new-sherlodoc.t/run.t
@@ -45,15 +45,6 @@ This test if the sherlodoc js files are generated
 
   $ cat ./_build/default/_doc_new/html/docs/db.js
   /* Sherlodoc DB for: */
-  /*   - ../../index/page-docs.odocl */
-  /*   - ../../index/local/page-local.odocl */
-  /*   - ../../odoc/local/bar/bar.odocl */
-  /*   - ../../index/local/bar/page-bar.odocl */
-  /*   - ../../odoc/local/foo/foo2.odocl */
-  /*   - ../../odoc/local/foo/foo.odocl */
-  /*   - ../../index/local/foo/page-foo.odocl */
-  /*   - ../../odoc/local/foo/byte/foo_byte.odocl */
-  /*   - ../../index/local/foo/byte/page-byte.odocl */
   /*   - ../../odoc/stdlib/arith_status.odocl */
   /*   - ../../odoc/stdlib/big_int.odocl */
   /*   - ../../odoc/stdlib/bigarray.odocl */
@@ -74,6 +65,15 @@ This test if the sherlodoc js files are generated
   /*   - ../../odoc/stdlib/topdirs.odocl */
   /*   - ../../odoc/stdlib/unix.odocl */
   /*   - ../../odoc/stdlib/unixLabels.odocl */
+  /*   - --favored ../../index/page-docs.odocl */
+  /*   - --favored ../../index/local/page-local.odocl */
+  /*   - --favored ../../odoc/local/bar/bar.odocl */
+  /*   - --favored ../../index/local/bar/page-bar.odocl */
+  /*   - --favored ../../odoc/local/foo/foo2.odocl */
+  /*   - --favored ../../odoc/local/foo/foo.odocl */
+  /*   - --favored ../../index/local/foo/page-foo.odocl */
+  /*   - --favored ../../odoc/local/foo/byte/foo_byte.odocl */
+  /*   - --favored ../../index/local/foo/byte/page-byte.odocl */
   $ dune runtest
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">

--- a/test/blackbox-tests/test-cases/odoc/odoc-sherlodoc.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-sherlodoc.t/run.t
@@ -18,6 +18,17 @@ This test if `.odocl` files are generated
   ./_build/default/_doc/_html/odoc.support/katex.min.js
   ./_build/default/_doc/_html/odoc.support/odoc_search.js
   ./_build/default/_doc/_html/sherlodoc.js
+  $ cat ./_build/default/_doc/_html/bar/db.js
+  /* Sherlodoc DB for: */
+  /*   - ../../_odocls/bar/page-index.odocl */
+  /*   - --favored ../../_odocls/bar/bar.odocl */
+  $ cat ./_build/default/_doc/_html/foo/db.js
+  /* Sherlodoc DB for: */
+  /*   - ../../_odocls/foo/page-index.odocl */
+  /*   - --favored ../../_odocls/foo/foo_byte.odocl */
+  /*   - --favored ../../_odocls/foo/foo2.odocl */
+  /*   - --favored ../../_odocls/foo/foo.odocl */
+
 
 
   $ dune runtest

--- a/test/blackbox-tests/utils/sherlodoc.ml
+++ b/test/blackbox-tests/utils/sherlodoc.ml
@@ -4,10 +4,14 @@
 open Stdune
 
 let arg_db = ref ""
+let args_favored = ref []
 
 let args_index =
   [ "--format", Arg.String ignore, ""
   ; "--favoured-prefixes", Arg.String ignore, ""
+  ; ( "--favoured"
+    , Arg.String (fun fav_odocl -> args_favored := fav_odocl :: !args_favored)
+    , "" )
   ; "--db", Arg.Set_string arg_db, ""
   ]
 ;;
@@ -32,7 +36,8 @@ let () =
     let deps, target = parse_index_args index_args in
     Out_channel.with_open_bin target (fun oc ->
       Out_channel.output_string oc "/* Sherlodoc DB for: */\n";
-      List.iter deps ~f:(fun dep -> Printf.fprintf oc "/*   - %s */\n" dep))
+      List.iter deps ~f:(fun dep -> Printf.fprintf oc "/*   - %s */\n" dep) ;
+      List.iter !args_favored ~f:(fun dep -> Printf.fprintf oc "/*   - --favored %s */\n" dep))
   | _ :: args ->
     Printf.ksprintf failwith "sherlodoc(fake): %s" (String.concat ~sep:"," args)
 ;;

--- a/test/blackbox-tests/utils/sherlodoc.ml
+++ b/test/blackbox-tests/utils/sherlodoc.ml
@@ -36,8 +36,9 @@ let () =
     let deps, target = parse_index_args index_args in
     Out_channel.with_open_bin target (fun oc ->
       Out_channel.output_string oc "/* Sherlodoc DB for: */\n";
-      List.iter deps ~f:(fun dep -> Printf.fprintf oc "/*   - %s */\n" dep) ;
-      List.iter !args_favored ~f:(fun dep -> Printf.fprintf oc "/*   - --favored %s */\n" dep))
+      List.iter deps ~f:(fun dep -> Printf.fprintf oc "/*   - %s */\n" dep);
+      List.iter !args_favored ~f:(fun dep ->
+        Printf.fprintf oc "/*   - --favored %s */\n" dep))
   | _ :: args ->
     Printf.ksprintf failwith "sherlodoc(fake): %s" (String.concat ~sep:"," args)
 ;;


### PR DESCRIPTION
When calling sherlodoc on with @doc-new, all the .odocl are indexed by sherlodoc. It makes sense to index the dependencies, but the entries from the dependencies should be given less priority as search results. 

This PR passes a `--favoured` flag to sherlodoc, this flag identifies the .odocls that are not external. In turn, sherlodoc ranks these entries higher.