### PR TITLE
refactor: remove [Modules.equal]

### DIFF
--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -806,7 +806,6 @@ let with_obj_map modules =
 ;;
 
 let obj_map t = Lazy.force t.obj_map
-let equal (x : t) (y : t) = Poly.equal x.modules y.modules
 
 let rec encode t ~src_dir =
   let open Dune_sexp in

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -5,7 +5,6 @@ open Import
 type t
 
 val to_dyn : t -> Dyn.t
-val equal : t -> t -> bool
 
 val lib
   :  obj_dir:Path.Build.t


### PR DESCRIPTION
it's implemented using polymorphic comparison and isn't used anywhere

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 28c856b1-969f-4eb5-a9f8-493333670295 -->