### PR TITLE
feature(pkg): proper build instructions for dune packages

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -14,9 +14,15 @@ module Pkg_info : sig
   val default_version : Package_version.t
 end
 
+module Build_command : sig
+  type t =
+    | Action of Action.t
+    | Dune (** pinned dune packages do not need to define a command *)
+end
+
 module Pkg : sig
   type t =
-    { build_command : Action.t option
+    { build_command : Build_command.t option
     ; install_command : Action.t option
     ; depends : (Loc.t * Package_name.t) list
     ; info : Pkg_info.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -521,11 +521,11 @@ let opam_package_to_lock_file_pkg
   let version =
     OpamPackage.version opam_package |> Package_version.of_opam_package_version
   in
+  let resolved_package =
+    (Table.find_exn candidates_cache name).resolved
+    |> OpamPackage.Version.Map.find (Package_version.to_opam_package_version version)
+  in
   let opam_file, loc =
-    let resolved_package =
-      (Table.find_exn candidates_cache name).resolved
-      |> OpamPackage.Version.Map.find (Package_version.to_opam_package_version version)
-    in
     let opam_file = Resolved_package.opam_file resolved_package in
     let loc = Resolved_package.loc resolved_package in
     opam_file, loc
@@ -594,39 +594,43 @@ let opam_package_to_lock_file_pkg
     Solver_env.get solver_env variable_name
   in
   let build_command =
-    let subst_step =
-      OpamFile.OPAM.substs opam_file
-      |> List.map ~f:(fun x ->
-        let x = OpamFilename.Base.to_string x in
-        let input = String_with_vars.make_text Loc.none (x ^ ".in") in
-        let output = String_with_vars.make_text Loc.none x in
-        Action.Substitute (input, output))
-    in
-    let patch_step =
-      OpamFile.OPAM.patches opam_file
-      |> List.map ~f:(fun (basename, filter) ->
-        let action =
-          Action.Patch
-            (String_with_vars.make_text Loc.none (OpamFilename.Base.to_string basename))
-        in
-        match filter with
-        | None -> action
-        | Some filter ->
-          Action.When
-            ( filter_to_blang ~package:opam_package ~loc:Loc.none filter
-              |> Slang.simplify_blang
-            , action ))
-    in
-    let build_step =
-      opam_commands_to_actions
-        get_solver_var
-        loc
-        opam_package
-        (OpamFile.OPAM.build opam_file)
-    in
-    List.concat [ subst_step; patch_step; build_step ]
-    |> make_action
-    |> Option.map ~f:build_env
+    if Resolved_package.dune_build resolved_package
+    then Some Lock_dir.Build_command.Dune
+    else (
+      let subst_step =
+        OpamFile.OPAM.substs opam_file
+        |> List.map ~f:(fun x ->
+          let x = OpamFilename.Base.to_string x in
+          let input = String_with_vars.make_text Loc.none (x ^ ".in") in
+          let output = String_with_vars.make_text Loc.none x in
+          Action.Substitute (input, output))
+      in
+      let patch_step =
+        OpamFile.OPAM.patches opam_file
+        |> List.map ~f:(fun (basename, filter) ->
+          let action =
+            Action.Patch
+              (String_with_vars.make_text Loc.none (OpamFilename.Base.to_string basename))
+          in
+          match filter with
+          | None -> action
+          | Some filter ->
+            Action.When
+              ( filter_to_blang ~package:opam_package ~loc:Loc.none filter
+                |> Slang.simplify_blang
+              , action ))
+      in
+      let build_step =
+        opam_commands_to_actions
+          get_solver_var
+          loc
+          opam_package
+          (OpamFile.OPAM.build opam_file)
+      in
+      List.concat [ subst_step; patch_step; build_step ]
+      |> make_action
+      |> Option.map ~f:build_env
+      |> Option.map ~f:(fun action -> Lock_dir.Build_command.Action action))
   in
   let install_command =
     OpamFile.OPAM.install opam_file

--- a/src/dune_pkg/pin_stanza.ml
+++ b/src/dune_pkg/pin_stanza.ml
@@ -303,17 +303,6 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
           Local_package.for_solver pkg
           |> Local_package.For_solver.to_opam_file
           |> OpamFile.OPAM.with_url (OpamFile.URL.create (snd package.url))
-          |> OpamFile.OPAM.with_build
-               [ (* CR-rgrinberg: this needs to be addressed in a more
-                    principled manner *)
-                 (let cmd =
-                    ([ "dune"; "build"; "-p" ]
-                     |> List.map ~f:(fun x -> OpamTypes.CString x))
-                    @ [ OpamTypes.CIdent "name" ]
-                    |> List.map ~f:(fun x -> x, None)
-                  in
-                  cmd, None)
-               ]
         in
         let opam_package =
           OpamPackage.create

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -9,8 +9,10 @@ type nonrec t =
   ; package : OpamPackage.t
   ; extra_files : extra_files
   ; loc : Loc.t
+  ; dune_build : bool
   }
 
+let dune_build t = t.dune_build
 let loc t = t.loc
 let package t = t.package
 let opam_file t = t.opam_file
@@ -35,7 +37,12 @@ let git_repo package ~opam_file ~opam_file_contents rev ~files_dir =
   let opam_file_path = Path.of_local opam_file in
   let opam_file = read_opam_file package ~opam_file_path ~opam_file_contents in
   let loc = Loc.in_file opam_file_path in
-  { loc; package; opam_file; extra_files = Git_files (files_dir, rev) }
+  { dune_build = false
+  ; loc
+  ; package
+  ; opam_file
+  ; extra_files = Git_files (files_dir, rev)
+  }
 ;;
 
 let local_fs package ~dir ~opam_file_path ~files_dir =
@@ -46,7 +53,12 @@ let local_fs package ~dir ~opam_file_path ~files_dir =
     read_opam_file package ~opam_file_path ~opam_file_contents
   in
   let loc = Loc.in_file opam_file_path in
-  { loc; package; extra_files = Inside_files_dir files_dir; opam_file }
+  { dune_build = false
+  ; loc
+  ; package
+  ; extra_files = Inside_files_dir files_dir
+  ; opam_file
+  }
 ;;
 
 (* Scan a path recursively down retrieving a list of all files together with their
@@ -75,7 +87,7 @@ let scan_files_entries path =
 let dune_package loc opam_file opam_package =
   let opam_file = add_opam_package_to_opam_file opam_package opam_file in
   let package = OpamFile.OPAM.package opam_file in
-  { opam_file; package; loc; extra_files = Inside_files_dir None }
+  { dune_build = true; opam_file; package; loc; extra_files = Inside_files_dir None }
 ;;
 
 open Fiber.O

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -6,6 +6,7 @@ val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t
 val set_url : t -> OpamUrl.t -> t
+val dune_build : t -> bool
 
 val git_repo
   :  OpamPackage.t

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
@@ -36,8 +36,7 @@ We print the source separately for ease of post processing the output.
   $ cat dune.lock/foo.pkg | sed "/source/,//d"
   (version 1.0.0)
   
-  (build
-   (run dune build -p %{pkg-self:name}))
+  (dune)
   
   
   (dev)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -46,14 +46,11 @@ Demonstrate the build command we construct for different types of projects:
   - mixed.dev
   - template.dev
   $ build_command() {
-  > cat dune.lock/$1.pkg | awk '/build/{ p=1 } /^$/{ if (p) {exit} } { if (p) { print $0 } }'
+  > grep "(dune)" dune.lock/$1.pkg
   > }
-  $ build_command "dune-only"
-  (build
-   (run dune build -p %{pkg-self:name}))
-  $ build_command "mixed"
-  (build
-   (run dune build -p %{pkg-self:name}))
-  $ build_command "template"
-  (build
-   (run dune build -p %{pkg-self:name}))
+  $ build_command dune-only
+  (dune)
+  $ build_command mixed
+  (dune)
+  $ build_command template
+  (dune)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
@@ -36,16 +36,14 @@ should favor the dune metadata in such a case.
   $  cat dune.lock/bar.pkg | sed "/source/,//d"
   (version dev)
   
-  (build
-   (run dune build -p %{pkg-self:name}))
+  (dune)
   
   
   (dev)
   $  cat dune.lock/foo.pkg | sed "/source/,//d"
   (version dev)
   
-  (build
-   (run dune build -p %{pkg-self:name}))
+  (dune)
   
   
   (dev)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
@@ -37,6 +37,5 @@ command is currently not respected when the package is pinned.
   $ cat dune.lock/opam-template.pkg | sed "/source/,//d"
   (version dev)
   
-  (build
-   (run dune build -p %{pkg-self:name}))
+  (dune)
   

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -219,7 +219,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
         { pkg with
           build_command =
-            Some Action.(Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ])
+            Some
+              (Action
+                 Action.(Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ]))
         ; install_command =
             Some
               (Action.System
@@ -309,7 +311,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     ; packages =
         map
           { "a" :
-              { build_command = Some [ "progn"; [ "echo"; "hello" ] ]
+              { build_command = Some Action [ "progn"; [ "echo"; "hello" ] ]
               ; install_command = Some [ "system"; "echo 'world'" ]
               ; depends = []
               ; info =


### PR DESCRIPTION
When pinning a dune package, we don't need to record the build command
because we are going to interpret it ourselves based on the version in
the dune-project file.

In the future, this will give us ability to build such packages without
spawning any additional dune binaries.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 24192d75-0e8d-4326-94e9-781ae2e7403b -->