### PR TITLE
Bump ocaml version in tests, update hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DEV_DEPS := \
 "dkml-workflows>=1.2.0" \
 patdiff
 
-TEST_OCAMLVERSION := 4.14.1
+TEST_OCAMLVERSION := 5.1.1
 
 -include Makefile.dev
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -53,10 +53,10 @@ Here are the most common commands you'll be running:
    $ ./dune.exe build @foo
 
 
-Note that tests are currently written for version 4.14.1 of the OCaml compiler.
+Note that tests are currently written for version 5.1.1 of the OCaml compiler.
 Some tests depend on the specific wording of compilation errors which can change
 between compiler versions, so to reliably run the tests make sure that
-``ocaml.4.14.1`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
+``ocaml.5.1.1`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
 the root of the Dune repo contains the current compiler version for which tests
 are written.
 

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [13c77218604dc994750d09a29ee8afbc] (_build/default/source): not found in cache
+  Shared cache miss [336d1a8283f1097557c047e6a3f440e4] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [20702b179e0171aac33d40d83f666fc2] (_build/default/target1): not found in cache
+  Shared cache miss [cf6246e80dbc827c134803daf7b6dc45] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [3ad1761950da90e34e52b4c065db1504] (_build/default/source): not found in cache
+  Shared cache miss [731ad27774db51b36ac167bd02a2d64e] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [b5096eeda3d7be4e9a631c563907399e] (_build/default/target1): not found in cache
+  Shared cache miss [9eb3ddc684318ff4f7ac759ca0c2ed46] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [e4096cb8e17c59cb28c421878c60fbfa]: ((in_cache
+  Warning: cache store error [7023123f1b4cb82f49eaa79218583aec]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./c2/c2ad4d4223dc4899614b496fe575ab08:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./d9/d9253f5d1695e3bee65f4e6e63b4dc5e:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./4e/4e86d96c474b2bf21f00736e524add20:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./da/dadf48eff6efc0cc0eced61607e4c673:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/error_messages_separated.t
+++ b/test/blackbox-tests/test-cases/error_messages_separated.t
@@ -36,9 +36,9 @@ Actual tests
 
 We check that the errors reported for different files are separated by
 blank lines. If a file generates several errors (which is the case for
-the `a.ml` file, then no blank lines are inserted between them,
-because this is the exact message that is reported by the Ocaml
-compiler, and we do not parse or modify such messages.
+the `a.ml` file), then there already is a blank line between each error,
+as it is the exact message reported by OCaml (since 5.1.0).
+We do not parse or modify such messages.
 
 Without the --display-separate-messages flag, no blank line is put
 between error messages for different files, as expected.
@@ -50,10 +50,12 @@ between error messages for different files, as expected.
   1 | let f x y z = ()
             ^
   Error (warning 27 [unused-var-strict]): unused variable x.
+  
   File "a.ml", line 1, characters 8-9:
   1 | let f x y z = ()
               ^
   Error (warning 27 [unused-var-strict]): unused variable y.
+  
   File "a.ml", line 1, characters 10-11:
   1 | let f x y z = ()
                 ^
@@ -78,10 +80,12 @@ message either.
   1 | let f x y z = ()
             ^
   Error (warning 27 [unused-var-strict]): unused variable x.
+  
   File "a.ml", line 1, characters 8-9:
   1 | let f x y z = ()
               ^
   Error (warning 27 [unused-var-strict]): unused variable y.
+  
   File "a.ml", line 1, characters 10-11:
   1 | let f x y z = ()
                 ^

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -201,7 +201,7 @@ produced in the sandbox and copied back:
 This is the internal stamp file:
 
   $ ls _build/.actions/default/blah*
-  _build/.actions/default/blah-98b715ceb840414fcdd2546357b09ca0
+  _build/.actions/default/blah-9ccb713f7544d8d658a354f7df85fcd7
 
 And we check that it isn't copied in the source tree:
 

--- a/test/blackbox-tests/test-cases/vendor/alerts.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/alerts.t/run.t
@@ -12,6 +12,7 @@ When compiling vendored code, all alerts should be disabled
               ^^^^^^^^^^^^^^^^
   Alert alertx: Lib__.Trigger_alerts.x
   You should not use x
+  
   File "vendored/lib.ml", line 3, characters 8-24:
   3 | let y = Trigger_alerts.y
               ^^^^^^^^^^^^^^^^
@@ -22,6 +23,7 @@ When compiling vendored code, all alerts should be disabled
               ^^^^^^^^^^^^^^^^
   Alert alertx: Lib__.Trigger_alerts.x
   You should not use x
+  
   File "vendored/lib.ml", line 3, characters 8-24:
   3 | let y = Trigger_alerts.y
               ^^^^^^^^^^^^^^^^

--- a/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
@@ -4,11 +4,13 @@
       ^^^^^^^
   Error (alert deprecated): module Bar
   Will be removed past 2020-20-20. Use Mylib.Bar instead.
+  
   File "fooexe.ml", line 4, characters 0-7:
   4 | Foo.run ();;
       ^^^^^^^
   Error (alert deprecated): module Foo
   Will be removed past 2020-20-20. Use Mylib.Foo instead.
+  
   File "fooexe.ml", line 7, characters 11-22:
   7 | module X : Intf_only.S = struct end
                  ^^^^^^^^^^^

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -28,7 +28,7 @@ let%expect_test "persistent digests" =
     ---
 
     DIGEST-DB version 6
-    a4ae8e07cf52a9fb38c47c32b6d59fa6
+    a6df9e528c50debc9264b7a95489392e
     ---
 
     INSTALL-COOKIE version 1
@@ -40,7 +40,7 @@ let%expect_test "persistent digests" =
     ---
 
     COPY-LINE-DIRECTIVE-MAP version 1
-    7e311b06ebde9ff1708e4c3a1d3f5633
+    7dac5b11f6f654bb6f230392493b363f
     ---
 
     merlin-conf version 4
@@ -48,6 +48,6 @@ let%expect_test "persistent digests" =
     ---
 
     INCREMENTAL-DB version 5
-    fa67cc9b60c9f3a1b9b1ad93a56df691
+    1cc656a4502ef88e70adab1f3c9a868e
     --- |}]
 ;;


### PR DESCRIPTION
This PR contains fixes for the first 9 items in the list in #9954.

While it works and compiles alright, the other tests mentionned in the tracking issue haven't been changed and hence don't pass.