### PR TITLE
fix: correctly encode package sites

### DIFF
--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -150,7 +150,7 @@ let encode
             "deprecated_package_names"
             Name.encode
             (Name.Map.keys deprecated_package_names)
-        ; field_l "sits" (pair Site.encode Section.encode) (Site.Map.to_list sites)
+        ; field_l "sites" (pair Site.encode Section.encode) (Site.Map.to_list sites)
         ; field_b "allow_empty" allow_empty
         ]
   in


### PR DESCRIPTION
there was a typo in the field name

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 16b7ea74-e374-40f6-986f-77f4c04b10cd -->