### PR TITLE
refactor: take package name instead of whole package when memoizing

### DIFF
--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -405,11 +405,11 @@ module As_memo_key = struct
   let hash = hash
   let to_dyn = to_dyn_concise
 
-  module And_package = struct
-    type nonrec t = t * Package.t
+  module And_package_name = struct
+    type nonrec t = t * Package.Name.t
 
-    let hash = Tuple.T2.hash hash Package.hash
-    let equal (x1, y1) (x2, y2) = equal x1 x2 && Package.equal y1 y2
-    let to_dyn (s, p) = Dyn.Tuple [ to_dyn s; Package.to_dyn p ]
+    let hash = Tuple.T2.hash hash Package.Name.hash
+    let equal (x1, y1) (x2, y2) = equal x1 x2 && Package.Name.equal y1 y2
+    let to_dyn (s, p) = Dyn.Tuple [ to_dyn s; Package.Name.to_dyn p ]
   end
 end

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -89,5 +89,5 @@ val expander : t -> dir:Path.Build.t -> Expander.t Memo.t
 
 module As_memo_key : sig
   include Memo.Input with type t = t
-  module And_package : Memo.Input with type t = t * Package.t
+  module And_package_name : Memo.Input with type t = t * Package.Name.t
 end


### PR DESCRIPTION
we're only using the name anyway

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2ae36b8c-b19c-49a6-a9d6-525c663ff27c -->