### PR TITLE
pkg: fix applying additional constraints to disjunction

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
@@ -56,4 +56,4 @@ chosen due to the latter's conflict with "ocaml-system".
   $ dune pkg lock
   Solution for dune.lock:
   - ocaml.0.0.1
-  - ocaml-base-compiler.0.0.1
+  - ocaml-system.0.0.1


### PR DESCRIPTION
This fixes a bug where additional constraints were not applied correctly to dependency formulae where the constraint package appeared inside a disjunction (opam's `|` operator). "Additional constraints" refers to the feature of dune where packages and version constraints may appear in a field `constraints` inside a lock_dir stanza of dune-workspace.

The bug was that the additional constraints were being and-ed to the "atom" representing a single package dependency within the disjunction (e.g. the `b` in `a | b | c`) rather than the disjunction as a whole. This produced dependency formulae which could be satisfied without including the additional package. This prevented the use case where `ocaml-system` is specified as an additional constraint to force the solve to use the system-wide ocaml rather than attempting to install the compiler from opam.

The fix was to identify the constraints applicable to a given package and then create the formula which is the conjunction of those constraints and the existing formula.

Fixes https://github.com/ocaml/dune/issues/9972