### PR TITLE
refactor: simplify melange js rules setup

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -422,12 +422,11 @@ let setup_js_rules_libraries
   let build_js = build_js ~sctx ~mode ~module_systems:mel.module_systems in
   Memo.parallel_iter requires_link ~f:(fun lib ->
     let open Memo.O in
-    let lib_name = Lib.name lib in
-    let* lib, lib_compile_info =
-      Lib.DB.get_compile_info
-        (Scope.libs scope)
-        lib_name
+    let lib_compile_info =
+      Lib.Compile.for_lib
         ~allow_overlaps:mel.allow_overlapping_dependencies
+        (Scope.libs scope)
+        lib
     in
     let info = Lib.info lib in
     let loc = Lib_info.loc info in


### PR DESCRIPTION
Extracted from https://github.com/ocaml/dune/pull/9839, where the `get_compile_info` is being discussed, as in its current state it could get the wrong compile info in cases of two libraries with the same name in different contexts.

There are only 2 usages of `get_compile_info`, this PR gets rid of one of them, which was used in Melange js rules creation. The code is already iterating over a list of `Lib.t` values, so we can just call `Lib.Compile.for_lib` directly, avoiding some unnecessary work that is done in `get_compile_info` to get a `Lib.t` value from a lib db based on a lib name.