### PR TITLE
fix: `select` with `bigarray` in OCaml 5

### DIFF
--- a/doc/changes/10011.md
+++ b/doc/changes/10011.md
@@ -1,0 +1,2 @@
+- Fix conditional source selection with `select` on `bigarray` in OCaml 5
+  (#10011, @moyodiallo)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1154,10 +1154,10 @@ end = struct
 
   let available_internal db (name : Lib_name.t) =
     let open Memo.O in
-    resolve_dep db (Loc.none, name) ~private_deps:Allow_all
+    find_internal db name
     >>| function
-    | Some x -> Resolve.is_ok x
-    | None -> false
+    | Ignore | Found _ -> true
+    | Not_found | Invalid _ | Hidden _ -> false
   ;;
 
   let resolve_simple_deps db names ~private_deps : t list Resolve.Memo.t =

--- a/test/blackbox-tests/test-cases/bigarray.t/d/d.bigarray.ml
+++ b/test/blackbox-tests/test-cases/bigarray.t/d/d.bigarray.ml
@@ -1,0 +1,3 @@
+let _d = Bigarray.C_layout_typ
+
+let () = Printf.eprintf "Welcome to d WITH bigarray support\n%!"

--- a/test/blackbox-tests/test-cases/bigarray.t/d/d.dummy.ml
+++ b/test/blackbox-tests/test-cases/bigarray.t/d/d.dummy.ml
@@ -1,0 +1,1 @@
+let () = Printf.eprintf "Welcome to d with nothing inferred\n%!"

--- a/test/blackbox-tests/test-cases/bigarray.t/d/d.nobigarray.ml
+++ b/test/blackbox-tests/test-cases/bigarray.t/d/d.nobigarray.ml
@@ -1,0 +1,1 @@
+let () = Printf.eprintf "Welcome to d WITHOUT bigarray support\n%!"

--- a/test/blackbox-tests/test-cases/bigarray.t/d/dune
+++ b/test/blackbox-tests/test-cases/bigarray.t/d/dune
@@ -1,0 +1,9 @@
+(executable
+ (name d)
+ (libraries
+  (select
+   d.ml
+   from
+   (bigarray -> d.bigarray.ml)
+   (!bigarray -> d.nobigarray.ml)
+   (-> d.dummy.ml))))

--- a/test/blackbox-tests/test-cases/bigarray.t/run.t
+++ b/test/blackbox-tests/test-cases/bigarray.t/run.t
@@ -31,3 +31,6 @@ This test uses `(libraries (re_export bigarray))` similarly
 This test uses a `(select )` construct and should always select bigarray support
   $ dune exec c/c.exe
   Welcome to c WITH bigarray support
+This test uses a `(select )` construct and should always select bigarray supprot (the evaluation of `select` order differ from the previous test)
+  $ dune exec d/d.exe
+  Welcome to d WITH bigarray support


### PR DESCRIPTION
This is related to #9981.

It turns out the fact that `bigarray` is ignored is not known to `select`.