### PR TITLE
enabled_if: add test that targets cmo of a disabled lib

### DIFF
--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-disabled-cmo-error.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-disabled-cmo-error.t
@@ -1,0 +1,21 @@
+Test behavior when targeting artifacts of a disabled library
+
+  $ mkdir -p a b
+  $ cat > dune-project << EOF
+  > (lang dune 3.13)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name foo)
+  >  (enabled_if false))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+
+  $ dune build %{cmo:foo}
+  Error: No rule found for .foo.objs/byte/foo.cmo
+  -> required by %{cmo:foo} at command line:1
+  [1]
+


### PR DESCRIPTION
Extracted from https://github.com/ocaml/dune/pull/9839#issuecomment-1942829730.