### PR TITLE
pkg: add cache of asyncronously-computed values

### DIFF
--- a/src/dune_pkg/fiber_cache.ml
+++ b/src/dune_pkg/fiber_cache.ml
@@ -1,0 +1,51 @@
+open! Import
+
+type ('k, 'v) t =
+  { (* The cache stores results so that if an exception was raised while
+       computing a value, concurrent accesses to the cache can find out. *)
+    table : ('k, ('v, Exn_with_backtrace.t list) result Fiber.Ivar.t) Table.t
+      (* This module is stored so it can be reused to create a table from the cache. *)
+  ; key_module : (module Table.Key with type t = 'k)
+  }
+
+let create key_module = { table = Table.create key_module 1; key_module }
+
+let find_or_add t key ~f =
+  let open Fiber.O in
+  let* () = Fiber.return () in
+  match Table.find t.table key with
+  | Some ivar ->
+    let* value_result = Fiber.Ivar.read ivar in
+    (match value_result with
+     | Ok value -> Fiber.return value
+     | Error exns -> Fiber.reraise_all exns)
+  | None ->
+    let ivar = Fiber.Ivar.create () in
+    (* Add the empty ivar to the table before calling [f] so that if the key
+       requested again while [f] is running then the caller will wait on the
+       ivar that will eventually contain the result. *)
+    Table.set t.table key ivar;
+    let* value_result = Fiber.collect_errors f in
+    let* () = Fiber.Ivar.fill ivar value_result in
+    (match value_result with
+     | Ok value -> Fiber.return value
+     | Error errors -> Fiber.reraise_all errors)
+;;
+
+let to_table t =
+  let open Fiber.O in
+  let* () = Fiber.return () in
+  let+ values_by_key =
+    Table.foldi t.table ~init:[] ~f:(fun key ivar acc ->
+      (let+ value_result = Fiber.Ivar.read ivar in
+       match value_result with
+       | Ok value -> Some (key, value)
+       | Error _ -> None)
+      :: acc)
+    |> Fiber.all_concurrently
+    >>| List.filter_opt
+  in
+  let table = Table.create t.key_module 1 in
+  List.iter values_by_key ~f:(fun (key, value) -> Table.add_exn table key value);
+  table
+;;

--- a/src/dune_pkg/fiber_cache.mli
+++ b/src/dune_pkg/fiber_cache.mli
@@ -1,0 +1,15 @@
+open! Import
+
+(** Associates asynchronously-computed values of type ['v] with keys of type ['k] *)
+type ('k, 'v) t
+
+val create : (module Table.Key with type t = 'k) -> ('k, 'v) t
+
+(** Retrieve a value from the cache, computing it with [f] if it doesn't exist.
+    If [f] raises then this function will also raise the same exceptions and
+    future calls to this function will also raise the same exceptions rather
+    than attempting to recompute the value. *)
+val find_or_add : ('k, 'v) t -> 'k -> f:(unit -> 'v Fiber.t) -> 'v Fiber.t
+
+(** [to_table t] returns a table with the same associations as [t]. *)
+val to_table : ('k, 'v) t -> ('k, 'v) Table.t Fiber.t


### PR DESCRIPTION
This replaces the ad-hoc cache of solver candidates with the added benifit that it guarantees that each value will be computed only once.

Part of https://github.com/ocaml/dune/issues/9952