### PR TITLE
Bump the test odoc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ js_of_ocaml-compiler \
 menhir \
 ocamlfind \
 ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat) \
-"odoc>=2.0.1" \
+"odoc>=2.4.0" \
 "ppx_expect>=v0.16.0" \
 ppx_inline_test \
 ppxlib \


### PR DESCRIPTION
This bump the test version of odoc so that the test for sherlodoc do not fail (they require odoc 2.4.0)

We do not need to add a regular deps to odoc.2.4.0 because the 2.4.0 flags are only given to odoc when sherlodoc is installed, and sherlodoc has a dependency on `odoc >= 2.4.0`. This failsafe does not work in the tests because the tests provide their own mock sherlodoc executable, so it is always available no matter the odoc version.