### PR TITLE
fix: error message for duplicate opam files

### DIFF
--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -83,10 +83,10 @@ let load () =
           Package.Name.Map.union acc_packages packages ~f:(fun name a b ->
             User_error.raise
               [ Pp.textf
-                  "Too many opam files for package %S:"
+                  "The package %S is defined more than once:"
                   (Package.Name.to_string name)
-              ; Pp.textf "- %s" (Path.Source.to_string_maybe_quoted (Package.opam_file a))
-              ; Pp.textf "- %s" (Path.Source.to_string_maybe_quoted (Package.opam_file b))
+              ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc a))
+              ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc b))
               ])
         in
         acc_packages, vendored)

--- a/test/blackbox-tests/test-cases/vendor/duplicate-packages.t
+++ b/test/blackbox-tests/test-cases/vendor/duplicate-packages.t
@@ -18,7 +18,7 @@ However, adding dune-project files causes the duplicate detection to fire:
   $ cp dune-project ./vendor/duped/
   $ cp dune-project ./vendor/pkg/vendor/duped/
   $ dune build @all
-  Error: Too many opam files for package "duped":
-  - vendor/duped/duped.opam
-  - vendor/pkg/vendor/duped/duped.opam
+  Error: The package "duped" is defined more than once:
+  - vendor/duped/duped.opam:1
+  - vendor/pkg/vendor/duped/duped.opam:1
   [1]


### PR DESCRIPTION
Use [Package.loc] instead. The opam file in [Package.opam_file] doesn't
necessarily exist, so the error is confusing.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ebc5c30d-9cc8-4582-ab12-bcd39564e4fa -->