### PR TITLE
pkg: back single_run_file_cache with fiber_cache

### DIFF
--- a/src/dune_pkg/single_run_file_cache.ml
+++ b/src/dune_pkg/single_run_file_cache.ml
@@ -1,14 +1,9 @@
 open! Import
-open! Stdune
 
-type entry =
-  { filename : Filename.t
-  ; complete : unit Fiber.Ivar.t
-  }
-
-type t =
+type 'error t =
   { temp_dir : Path.t lazy_t
-  ; key_to_filename : entry String.Table.t
+  ; key_to_filename : (string, (Path.t, 'error) result) Fiber_cache.t
+  ; mutable num_entries : int
   }
 
 let create () =
@@ -18,33 +13,24 @@ let create () =
        at_exit (fun () -> Temp.destroy Dir temp_dir);
        temp_dir)
   in
-  { temp_dir; key_to_filename = String.Table.create 1 }
+  { temp_dir; key_to_filename = Fiber_cache.create (module String); num_entries = 0 }
 ;;
 
-let with_ { temp_dir; key_to_filename } ~key ~f =
+let with_ ({ temp_dir; key_to_filename; _ } as t) ~key ~f =
   let open Fiber.O in
   let temp_dir = Lazy.force temp_dir in
-  match String.Table.find key_to_filename key with
-  | Some { filename; complete } ->
-    (* If the file is currently being created then this ivar will be empty.
-       Wait for it to become filled, indicating that the file is ready. *)
-    let+ () = Fiber.Ivar.read complete in
-    Ok (Path.relative temp_dir filename)
-  | None ->
-    let filename = string_of_int (String.Table.length key_to_filename) in
+  Fiber_cache.find_or_add key_to_filename key ~f:(fun () ->
+    let filename = string_of_int t.num_entries in
+    t.num_entries <- t.num_entries + 1;
     let output_path = Path.relative temp_dir filename in
-    let complete = Fiber.Ivar.create () in
-    String.Table.add_exn key_to_filename key { filename; complete };
-    let* result = f output_path in
-    (* Fill the ivar signaling that the file is read. *)
-    let+ () = Fiber.Ivar.fill complete () in
-    (match result with
-     | Ok () ->
-       if not (Path.exists output_path)
-       then
-         Code_error.raise
-           "Callback failed to create file"
-           [ "output", Path.to_dyn output_path; "key", Dyn.string key ];
-       Ok output_path
-     | Error _ as e -> e)
+    let+ result = f output_path in
+    match result with
+    | Ok () ->
+      if not (Path.exists output_path)
+      then
+        Code_error.raise
+          "Callback failed to create file"
+          [ "output", Path.to_dyn output_path; "key", Dyn.string key ];
+      Ok (Path.relative temp_dir filename)
+    | Error _ as e -> e)
 ;;

--- a/src/dune_pkg/single_run_file_cache.mli
+++ b/src/dune_pkg/single_run_file_cache.mli
@@ -6,17 +6,18 @@ open! Stdune
     downloaded files keyed by their URLs to prevent the same file being
     downloaded multiple times in a single invocation of dune. Files are stored
     in a temporary directory. *)
-type t
+type 'error t
 
-val create : unit -> t
+val create : unit -> _ t
 
 (** Retrieve the path to a file associated with a given key. If the key has no
     associated file then the function [f] is called on a path and is expected
     to create a new file at that path. The resulting file will be associated
     with the [key] in the cache. If [f] returns [Ok ()] but fails to create the
-    file then a [Code_error] is raised. *)
+    file then a [Code_error] is raised. If [f] returns an error then the error
+    will be cached and returned by subsequent calls. *)
 val with_
-  :  t
+  :  'error t
   -> key:string
-  -> f:(Path.t -> (unit, 'a) result Fiber.t)
-  -> (Path.t, 'a) result Fiber.t
+  -> f:(Path.t -> (unit, 'error) result Fiber.t)
+  -> (Path.t, 'error) result Fiber.t


### PR DESCRIPTION
Part of https://github.com/ocaml/dune/issues/9952

This also fixes a bug where previously if the argument to `Single_run_file_cache.with_` returned an `Error`, the ivar signalling that the file is created would still by filled. The new behaviour is that the error will be cached and returned by subsequent calls.