### PR TITLE
fix: include argument in __pthread_chdir error

### DIFF
--- a/src/csexp_rpc/csexp_rpc_stubs.c
+++ b/src/csexp_rpc/csexp_rpc_stubs.c
@@ -34,7 +34,7 @@ static int __pthread_chdir(const char *path) {
 CAMLprim value dune_pthread_chdir(value dir) {
   CAMLparam1(dir);
   if (__pthread_chdir(String_val(dir))) {
-    uerror("__pthread_chdir", Nothing);
+    uerror("__pthread_chdir", dir);
   }
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6264ce5d-dbec-4700-b6f3-787b8597af6b -->