### PR TITLE
refactor(pkg): remove [At_rev.opam_url]

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -220,7 +220,12 @@ let of_opam_repo_dir_path loc opam_repo_dir_path =
 
 let of_git_repo (source : Source.t) =
   let+ at_rev = Source.rev source in
-  let serializable = Some (at_rev |> Rev_store.At_rev.opam_url |> OpamUrl.to_string) in
+  let serializable =
+    Some
+      (sprintf "%s#%s" source.url (Rev_store.At_rev.rev at_rev)
+       |> OpamUrl.of_string
+       |> OpamUrl.to_string)
+  in
   { source = Repo at_rev; serializable; loc = source.loc }
 ;;
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -408,6 +408,11 @@ module At_rev = struct
     ; files : File.Set.t
     }
 
+  let rev t =
+    let (Rev r) = t.revision in
+    r
+  ;;
+
   module Config = struct
     type bindings = string * string
 
@@ -608,10 +613,6 @@ module At_rev = struct
     && String.equal revision revision'
     && String.equal source t.source
     && File.Set.equal files t.files
-  ;;
-
-  let opam_url { revision = Rev rev; source; repo = _; files = _ } =
-    OpamUrl.parse (sprintf "%s#%s" source rev)
   ;;
 
   let check_out { repo = { dir }; revision = Rev rev; source = _; files = _ } ~target =

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -18,10 +18,10 @@ module At_rev : sig
     val parse : string -> (string * string option * string * string) option
   end
 
+  val rev : t -> string
   val content : t -> Path.Local.t -> string option Fiber.t
   val directory_entries : t -> recursive:bool -> Path.Local.t -> File.Set.t
   val equal : t -> t -> bool
-  val opam_url : t -> OpamUrl.t
   val check_out : t -> target:Path.t -> unit Fiber.t
 end
 


### PR DESCRIPTION
Opam url's are an implementation detail of opam and the store shouldn't
be aware of them. We eliminate the function and inline its only call.

This change is required to move [Rev_store] into its own library that
doesn't depend on opam stuff.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 58587011-3173-4a9e-88b0-56c03e9166e1 -->