### PR TITLE
fix(pkg): rev store improvements

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -75,7 +75,6 @@ let unset_solver_vars_of_workspace workspace ~lock_dir_path =
 ;;
 
 let get_repos repos ~repositories =
-  let open Fiber.O in
   let module Repository = Dune_pkg.Pkg_workspace.Repository in
   repositories
   |> Fiber.parallel_map ~f:(fun (loc, name) ->
@@ -90,9 +89,7 @@ let get_repos repos ~repositories =
       let loc, opam_url = Repository.opam_url repo in
       let module Opam_repo = Dune_pkg.Opam_repo in
       (match Dune_pkg.OpamUrl.local_or_git_only opam_url loc with
-       | `Git ->
-         let* source = Opam_repo.Source.of_opam_url loc opam_url in
-         Opam_repo.of_git_repo source
+       | `Git -> Opam_repo.of_git_repo loc opam_url
        | `Path path -> Fiber.return @@ Opam_repo.of_opam_repo_dir_path loc path))
 ;;
 

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -22,5 +22,5 @@ val fetch
 val fetch_git
   :  Rev_store.t
   -> target:Path.t
-  -> Opam_repo.Source.t
+  -> OpamUrl.t
   -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/mount.ml
+++ b/src/dune_pkg/mount.ml
@@ -14,7 +14,7 @@ let of_opam_url loc url =
   match OpamUrl.local_or_git_only url loc with
   | `Path dir -> Fiber.return (Path dir)
   | `Git ->
-    let+ rev = Opam_repo.Source.of_opam_url loc url >>= Opam_repo.Source.rev in
+    let+ rev = Opam_repo.of_git_repo loc url >>| Opam_repo.revision in
     Git rev
 ;;
 

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -22,3 +22,8 @@ val local_or_git_only : t -> Loc.t -> [ `Path of Path.t | `Git ]
 
 module Map : Map.S with type key = t
 module Set : Set.S with type elt = t and type 'a map = 'a Map.t
+
+val find_revision
+  :  t
+  -> Rev_store.t
+  -> (Rev_store.At_rev.t, User_message.t) result Fiber.t

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -13,28 +13,6 @@ end
 
 val equal : t -> t -> bool
 
-module Source : sig
-  module Commitish : sig
-    type t =
-      | Commit of string
-      | Branch of string
-      | Tag of string
-  end
-
-  type t
-
-  val commit : t -> Commitish.t option
-  val url : t -> string
-  val of_opam_url : Loc.t -> OpamUrl.t -> t Fiber.t
-  val to_dyn : t -> Dyn.t
-  val equal : t -> t -> bool
-  val rev : t -> Rev_store.At_rev.t Fiber.t
-
-  module Private : sig
-    val of_opam_url : Rev_store.t -> Loc.t -> OpamUrl.t -> t Fiber.t
-  end
-end
-
 (** [of_opam_repo_dir_path opam_repo_dir] creates a repo represented by a local
     directory in the path given by [opam_repo_dir]. *)
 val of_opam_repo_dir_path : Loc.t -> Path.t -> t
@@ -42,8 +20,9 @@ val of_opam_repo_dir_path : Loc.t -> Path.t -> t
 (** [of_git_repo git source] loads the opam repository located
     at [source] from git. [source] can be any URL that [git remote add]
     supports. *)
-val of_git_repo : Source.t -> t Fiber.t
+val of_git_repo : Loc.t -> OpamUrl.t -> t Fiber.t
 
+val revision : t -> Rev_store.At_rev.t
 val serializable : t -> Serializable.t option
 
 (** Load package metadata for all versions of a package with a given name *)

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -7,19 +7,60 @@ module Re = Dune_re
 module Flock = Dune_util.Flock
 open Fiber.O
 
-type t = { dir : Path.t }
+module Object = struct
+  type t = Sha1 of string
 
-let lock_path { dir } =
+  let compare (Sha1 x) (Sha1 y) = String.compare x y
+  let to_string (Sha1 s) = s
+  let equal (Sha1 x) (Sha1 y) = String.equal x y
+  let to_dyn (Sha1 s) = Dyn.string s
+  let hash (Sha1 s) = String.hash s
+
+  type resolved = t
+
+  let of_sha1 s =
+    if String.length s = 40
+       && String.for_all s ~f:(function
+         | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
+         | _ -> false)
+    then Some (Sha1 (String.lowercase_ascii s))
+    else None
+  ;;
+end
+
+module Remote = struct
+  type nonrec t =
+    { url : string
+    ; default_branch : Object.resolved option Fiber.t
+    ; branches_and_tags : Object.resolved String.Map.t Fiber.t
+    }
+
+  let default_branch t = t.default_branch
+end
+
+type t =
+  { dir : Path.t
+  ; remotes : (string, Remote.t) Table.t
+  ; (* The mutex that needs to be acquired before touching [present_objects] *)
+    object_mutexes : (Object.t, Fiber.Mutex.t) Table.t
+  ; present_objects : (Object.t, unit) Table.t
+  }
+
+let with_mutex t obj ~f =
+  let* () = Fiber.return () in
+  let mutex =
+    (* ideally, we'd like to clear this table if there's nobody queued for
+       mutex, but it's not safe to do without tracking the number of fiber
+       awaiting. *)
+    Table.find_or_add t.object_mutexes obj ~f:(fun _ -> Fiber.Mutex.create ())
+  in
+  Fiber.Mutex.with_lock mutex ~f
+;;
+
+let lock_path { dir; _ } =
   let parent = dir |> Path.parent_exn in
   Path.relative parent "rev-store.lock"
 ;;
-
-module Rev = struct
-  type t = Rev of string
-
-  let compare (Rev a) (Rev b) = String.compare a b
-  let to_dyn (Rev r) = Dyn.variant "Rev" [ Dyn.string r ]
-end
 
 let rec attempt_to_lock flock lock ~max_retries =
   let sleep_duration = 0.1 in
@@ -88,7 +129,6 @@ let with_flock lock_path ~f =
           ])
 ;;
 
-let equal { dir } t = Path.equal dir t.dir
 let failure_mode = Process.Failure_mode.Return
 let output_limit = Sys.max_string_length
 let make_stdout () = Process.Io.make_stdout ~output_on_success:Swallow ~output_limit
@@ -109,27 +149,23 @@ let git_code_error ~dir ~args ~exit_code ~output =
     ]
 ;;
 
-let run { dir } ~display args =
+let run_with_exit_code { dir; _ } ~allow_codes ~display args =
   let stdout_to = make_stdout () in
   let stderr_to = make_stderr () in
   let git = Lazy.force Vcs.git in
   let+ (), exit_code =
     Process.run ~dir ~display ~stdout_to ~stderr_to ~env failure_mode git args
   in
-  if exit_code <> 0 then git_code_error ~dir ~args ~exit_code ~output:[]
+  if allow_codes exit_code
+  then exit_code
+  else git_code_error ~dir ~args ~exit_code ~output:[]
 ;;
 
-let run_capture_line { dir } args =
-  let git = Lazy.force Vcs.git in
-  let+ output, exit_code =
-    Process.run_capture_line ~dir ~display:Quiet ~env failure_mode git args
-  in
-  if exit_code = 0
-  then output
-  else git_code_error ~dir ~args ~exit_code ~output:[ output ]
+let run t ~display args =
+  run_with_exit_code t ~allow_codes:(Int.equal 0) ~display args >>| ignore
 ;;
 
-let run_capture_lines { dir } ~display args =
+let run_capture_lines { dir; _ } ~display args =
   let git = Lazy.force Vcs.git in
   let+ output, exit_code =
     Process.run_capture_lines ~dir ~display ~env failure_mode git args
@@ -137,7 +173,7 @@ let run_capture_lines { dir } ~display args =
   if exit_code = 0 then output else git_code_error ~dir ~args ~exit_code ~output
 ;;
 
-let run_capture_zero_separated_lines { dir } args =
+let run_capture_zero_separated_lines { dir; _ } args =
   let git = Lazy.force Vcs.git in
   let+ output, exit_code =
     Process.run_capture_zero_separated ~dir ~display:Quiet ~env failure_mode git args
@@ -145,7 +181,7 @@ let run_capture_zero_separated_lines { dir } args =
   if exit_code = 0 then output else git_code_error ~dir ~args ~exit_code ~output
 ;;
 
-let cat_file { dir } command =
+let cat_file { dir; _ } command =
   let git = Lazy.force Vcs.git in
   let failure_mode = Vcs.git_accept () in
   let stderr_to = make_stderr () in
@@ -155,49 +191,61 @@ let cat_file { dir } command =
   >>| Result.is_ok
 ;;
 
-let mem repo ~rev = cat_file repo [ "-t"; rev ]
-
-let mem_path repo rev path =
-  let (Rev.Rev rev) = rev in
-  cat_file repo [ "-e"; sprintf "%s:%s" rev (Path.Local.to_string path) ]
+let rev_parse { dir; _ } rev =
+  let git = Lazy.force Vcs.git in
+  let+ line, code =
+    Process.run_capture_line
+      ~dir
+      ~display:Quiet
+      ~env
+      Return
+      git
+      [ "rev-parse"; "--verify"; "--quiet"; sprintf "%s^{commit}" rev ]
+  in
+  if code = 0 then Some (Option.value_exn (Object.of_sha1 line)) else None
 ;;
 
-let ref_type =
-  let hash = Re.(rep1 alnum) in
-  let re =
-    Re.(
-      compile
-      @@ seq
-           [ bol
-           ; hash
-           ; rep1 space
-           ; str "refs/"
-           ; group (alt [ str "heads"; str "tags" ])
-           ; str "/"
-           ])
+let object_exists_no_lock { dir; _ } (Object.Sha1 sha1) =
+  let git = Lazy.force Vcs.git in
+  let+ (), code =
+    Process.run ~dir ~display:Quiet ~env Return git [ "cat-file"; "-e"; sha1 ]
   in
-  fun t ~source ~ref ->
-    let command = [ "ls-remote"; "--heads"; "--tags"; source; ref ] in
-    let+ hits = run_capture_lines t ~display:!Dune_engine.Clflags.display command in
-    List.find_map hits ~f:(fun line ->
-      match Re.exec_opt re line with
-      | None -> None
-      | Some m ->
-        (match Re.Group.get m 1 with
-         | "heads" -> Some `Head
-         | "tags" -> Some `Tag
-         | _ -> None))
+  code = 0
+;;
+
+let object_exists ({ present_objects; _ } as t) obj =
+  let* () = Fiber.return () in
+  match Table.find present_objects obj with
+  | Some () -> Fiber.return true
+  | None ->
+    Table.set present_objects obj ();
+    let+ res = object_exists_no_lock t obj in
+    (* We clear objects that aren't present, so that they can be re-queried
+       after fetches *)
+    if res then Table.set present_objects obj ();
+    res
+;;
+
+let resolve_object t hash =
+  with_mutex t hash ~f:(fun () -> object_exists t hash)
+  >>| function
+  | false -> None
+  | true -> Some hash
+;;
+
+let mem_path repo (Object.Sha1 sha1) path =
+  cat_file repo [ "-e"; sprintf "%s:%s" sha1 (Path.Local.to_string path) ]
 ;;
 
 let show =
-  let show { dir } revs_and_paths =
+  let show { dir; _ } revs_and_paths =
     let git = Lazy.force Vcs.git in
     let failure_mode = Vcs.git_accept () in
     let command =
       "show"
       :: List.map revs_and_paths ~f:(function
         | `Object o -> o
-        | `Path (Rev.Rev r, path) -> sprintf "%s:%s" r (Path.Local.to_string path))
+        | `Path (Object.Sha1 r, path) -> sprintf "%s:%s" r (Path.Local.to_string path))
     in
     let stderr_to = make_stderr () in
     Process.run_capture ~dir ~display:Quiet ~stderr_to failure_mode git command
@@ -219,7 +267,7 @@ let show =
           +
           match cmd with
           | `Object o -> String.length o
-          | `Path (Rev.Rev r, path) ->
+          | `Path (Object.Sha1 r, path) ->
             String.length r + String.length (Path.Local.to_string path) + 1
         in
         let new_remaining = cmd_len_remaining - cmd_len in
@@ -236,7 +284,13 @@ let show =
 ;;
 
 let load_or_create ~dir =
-  let t = { dir } in
+  let t =
+    { dir
+    ; remotes = Table.create (module String) 4
+    ; present_objects = Table.create (module Object) 16
+    ; object_mutexes = Table.create (module Object) 16
+    }
+  in
   let lock = lock_path t in
   let* () = Fiber.return () in
   let+ () =
@@ -258,17 +312,17 @@ module Commit = struct
   module T = struct
     type t =
       { path : Path.Local.t
-      ; rev : Rev.t
+      ; rev : Object.t
       }
 
     let compare { path; rev } t =
       let open Ordering.O in
       let= () = Path.Local.compare path t.path in
-      Rev.compare rev t.rev
+      Object.compare rev t.rev
     ;;
 
     let to_dyn { path; rev } =
-      Dyn.record [ "path", Path.Local.to_dyn path; "rev", Rev.to_dyn rev ]
+      Dyn.record [ "path", Path.Local.to_dyn path; "rev", Object.to_dyn rev ]
     ;;
   end
 
@@ -384,27 +438,51 @@ module Entry = struct
         | "commit" ->
           Some
             (Commit
-               { rev = Rev (Re.Group.get m 2)
+               { rev = Re.Group.get m 2 |> Object.of_sha1 |> Option.value_exn
                ; path = Path.Local.of_string @@ Re.Group.get m 4
                })
         | _ -> None)
   ;;
 end
 
+let fetch_allow_failure repo ~url obj =
+  with_mutex repo obj ~f:(fun () ->
+    object_exists repo obj
+    >>= function
+    | true -> Fiber.return `Fetched
+    | false ->
+      run_with_exit_code
+        ~allow_codes:(fun x -> x = 0 || x = 128)
+        repo
+        ~display:!Dune_engine.Clflags.display
+        [ "fetch"; "--no-write-fetch-head"; url; Object.to_string obj ]
+      >>| (function
+       | 128 -> `Not_found
+       | 0 ->
+         Table.set repo.present_objects obj ();
+         `Fetched
+       | _ -> assert false))
+;;
+
+let fetch repo ~url obj =
+  fetch_allow_failure repo ~url obj
+  >>| function
+  | `Fetched -> ()
+  | `Not_found ->
+    User_error.raise [ Pp.textf "unable to fetch %S from %S" (Object.to_string obj) url ]
+;;
+
 module At_rev = struct
   type repo = t
 
   type t =
     { repo : repo
-    ; revision : Rev.t
-    ; source : string
+    ; revision : Object.t
     ; files : File.Set.t
     }
 
-  let rev t =
-    let (Rev r) = t.revision in
-    r
-  ;;
+  let equal x y = Object.equal x.revision y.revision
+  let rev t = t.revision
 
   module Config = struct
     type bindings = string * string
@@ -440,8 +518,7 @@ module At_rev = struct
       section, arg, binding, value
     ;;
 
-    let config repo revision path : t Fiber.t =
-      let (Rev.Rev rev) = revision in
+    let config repo (Object.Sha1 rev) path : t Fiber.t =
       [ "config"; "--list"; "--blob"; sprintf "%s:%s" rev (Path.Local.to_string path) ]
       |> run_capture_lines repo ~display:Quiet
       >>| List.fold_left ~init:KV.Map.empty ~f:(fun acc line ->
@@ -498,7 +575,7 @@ module At_rev = struct
     ;;
   end
 
-  let files_and_submodules repo (Rev.Rev rev) =
+  let files_and_submodules repo (Object.Sha1 rev) =
     run_capture_zero_separated_lines repo [ "ls-tree"; "-z"; "--long"; "-r"; rev ]
     >>| List.fold_left
           ~init:(File.Set.empty, Commit.Set.empty)
@@ -516,8 +593,8 @@ module At_rev = struct
       ~f:(fun { Commit.path; rev } m ->
         match Path.Local.Map.add m path rev with
         | Ok m -> m
-        | Error (Rev existing_rev) ->
-          let (Rev found_rev) = rev in
+        | Error (Sha1 existing_rev) ->
+          let (Sha1 found_rev) = rev in
           User_error.raise
             [ Pp.textf
                 "Path %s specified multiple times as submodule pointing to different \
@@ -528,7 +605,7 @@ module At_rev = struct
             ])
   ;;
 
-  let rec of_rev repo ~add_remote ~revision ~source =
+  let rec of_rev repo ~revision =
     let* files, submodules = files_and_submodules repo revision in
     let+ files =
       let commit_paths = path_commit_map submodules in
@@ -551,20 +628,18 @@ module At_rev = struct
                 (Path.Local.to_string path)
             ]
         | Some revision ->
-          let* () = add_remote source in
-          let+ at_rev = of_rev repo ~add_remote ~revision ~source in
+          let* () = fetch repo ~url:source revision in
+          let+ at_rev = of_rev repo ~revision in
           File.Set.map at_rev.files ~f:(fun file ->
             let path = Path.Local.append path (File.path file) in
             File.Redirect { path; to_ = file }))
       >>| List.cons files
       >>| File.Set.union_all
     in
-    { repo; revision; source; files }
+    { repo; revision; files }
   ;;
 
-  let content { repo; revision; source = _; files = _ } path =
-    show repo [ `Path (revision, path) ]
-  ;;
+  let content { repo; revision; files = _ } path = show repo [ `Path (revision, path) ]
 
   let directory_entries_recursive t path =
     (* TODO: there are much better ways of implementing this:
@@ -598,17 +673,7 @@ module At_rev = struct
       path
   ;;
 
-  let repo_equal = equal
-
-  let equal { repo; revision = Rev revision; source; files } t =
-    let (Rev revision') = t.revision in
-    repo_equal repo t.repo
-    && String.equal revision revision'
-    && String.equal source t.source
-    && File.Set.equal files t.files
-  ;;
-
-  let check_out { repo = { dir }; revision = Rev rev; source = _; files = _ } ~target =
+  let check_out { repo = { dir; _ }; revision = Sha1 rev; files = _ } ~target =
     (* TODO iterate over submodules to output sources *)
     let git = Lazy.force Vcs.git in
     let tar = Lazy.force Tar.bin in
@@ -654,205 +719,81 @@ module At_rev = struct
   ;;
 end
 
-module Remote = struct
-  type nonrec t =
-    { repo : t
-    ; handle : string
-    ; source : string
-    ; default_branch : string
-    ; add_remote : string -> unit Fiber.t
-    }
-
-  type uninit = t
-
-  let update ({ repo; handle; source = _; default_branch = _; add_remote = _ } as t) =
-    let+ () =
-      run
-        repo
-        ~display:!Dune_engine.Clflags.display
-        [ "fetch"; "--no-write-fetch-head"; handle ]
-    in
-    t
-  ;;
-
-  let don't_update t = t
-
-  let default_branch { repo = _; handle = _; source = _; default_branch; add_remote = _ } =
-    default_branch
-  ;;
-
-  let rev_of_name { repo; handle; source; default_branch = _; add_remote } ~name =
-    (* TODO handle non-existing name *)
-    let* rev = run_capture_line repo [ "rev-parse"; sprintf "%s/%s" handle name ] in
-    let revision = Rev.Rev rev in
-    At_rev.of_rev repo ~add_remote ~revision ~source >>| Option.some
-  ;;
-
-  let rev_of_ref { repo; handle = _; source; default_branch = _; add_remote } ~ref =
-    let revision = Rev.Rev ref in
-    At_rev.of_rev repo ~add_remote ~revision ~source >>| Option.some
-  ;;
-end
-
-let remote_exists dir ~name =
-  let stderr_to = make_stderr () in
-  let command = [ "remote"; "--verbose" ] in
-  let+ lines =
-    let git = Lazy.force Vcs.git in
-    Process.run_capture_lines ~dir ~display:Quiet ~stderr_to ~env Strict git command
-  in
-  lines
-  |> List.find ~f:(fun line ->
-    match String.lsplit2 ~on:'\t' line with
-    | None -> false
-    | Some (candidate, _) -> String.equal candidate name)
-  |> Option.is_some
-;;
-
-let query_head_branch =
+let remote =
+  let hash = Re.(rep1 alnum) in
+  let head_mark, head = Re.mark (Re.str "HEAD") in
   let re =
     Re.(
       compile
       @@ seq
            [ bol
-           ; str "ref: refs/heads/"
-           ; group (rep1 (diff any space))
+           ; group hash
            ; rep1 space
-           ; str "HEAD"
-           ; eol
+           ; alt
+               [ head
+               ; seq
+                   [ str "refs/"
+                   ; alt [ str "heads"; str "tags" ]
+                   ; str "/"
+                   ; group (rep1 any)
+                   ]
+               ]
            ])
   in
-  fun t source ->
-    let+ lines =
-      run_capture_lines
-        t
-        ~display:!Dune_engine.Clflags.display
-        [ "ls-remote"; "--symref"; source ]
+  fun t ~url ->
+    let f url =
+      let command = [ "ls-remote"; url ] in
+      let refs =
+        Fiber_lazy.create (fun () ->
+          let+ hits = run_capture_lines t ~display:!Dune_engine.Clflags.display command in
+          let default_branch, branches_and_tags =
+            List.fold_left
+              hits
+              ~init:(None, [])
+              ~f:(fun (default_branch, branches_and_tags) line ->
+                match Re.exec_opt re line with
+                | None -> default_branch, branches_and_tags
+                | Some group ->
+                  let hash = Re.Group.get group 1 |> Object.of_sha1 |> Option.value_exn in
+                  if Re.Mark.test group head_mark
+                  then Some hash, branches_and_tags
+                  else (
+                    let name = Re.Group.get group 2 in
+                    default_branch, (name, hash) :: branches_and_tags))
+          in
+          default_branch, String.Map.of_list_exn branches_and_tags)
+      in
+      { Remote.url
+      ; default_branch = Fiber_lazy.force refs >>| fst
+      ; branches_and_tags = Fiber_lazy.force refs >>| snd
+      }
     in
-    List.find_map lines ~f:(fun line ->
-      match Re.exec_opt re line with
-      | None -> None
-      | Some m -> Some (Re.Group.get m 1))
+    Table.find_or_add t.remotes ~f url
 ;;
 
-let branch_of_refspec refspec =
-  refspec
-  |> String.drop_prefix_if_exists ~prefix:"+"
-  |> String.lsplit2 ~on:':'
-  |> Option.bind ~f:(fun (remote_ref, _local_ref) ->
-    String.drop_prefix remote_ref ~prefix:"refs/heads/")
+let fetch_resolved t (remote : Remote.t) revision =
+  let* () = fetch t ~url:remote.url revision in
+  At_rev.of_rev t ~revision
 ;;
 
-let find_section =
-  let re =
-    Re.seq
-      [ Re.(rep space)
-      ; Re.str "[remote "
-      ; Re.char '"'
-      ; Re.group (Re.rep (Re.diff Re.any (Re.char '"')))
-      ; Re.char '"'
-      ; Re.char ']'
-      ; Re.(rep space)
-      ]
-    |> Re.compile
-  in
-  fun contents ~name ->
-    let rec loop (xs : Re.split_token list) =
-      match xs with
-      | [] -> None
-      | `Text _ :: rest -> loop rest
-      | `Delim delim :: rest ->
-        if Re.Group.get delim 1 = name
-        then
-          Some
-            (match rest with
-             | `Text s :: _ -> s
-             | _ -> "")
-        else loop rest
-    in
-    loop (Re.split_full re contents)
+let resolve_revision t (remote : Remote.t) ~revision =
+  let* branches_and_tags = remote.branches_and_tags in
+  match String.Map.find branches_and_tags revision with
+  | Some obj as s ->
+    let+ () = fetch t ~url:remote.url obj in
+    s
+  | None ->
+    rev_parse t revision
+    >>= (function
+     | None -> Fiber.return None
+     | Some obj -> resolve_object t obj)
 ;;
 
-let read_head_branch =
-  let fetch_line = Re.(compile @@ seq [ str "fetch = "; group (rep1 any); eol ]) in
-  fun t handle ->
-    Path.relative t.dir "config"
-    |> Io.read_file ~binary:true
-    |> find_section ~name:handle
-    |> Option.bind ~f:(fun section ->
-      String.split_lines section
-      |> List.find_map ~f:(fun line ->
-        Re.exec_opt fetch_line line
-        |> Option.bind ~f:(fun m ->
-          let refspec = Re.Group.get m 1 in
-          branch_of_refspec refspec)))
-;;
-
-let remote_add t ~branch ~handle ~source =
-  let* () = run ~display:Quiet t [ "remote"; "add"; "--track"; branch; handle; source ] in
-  (* add a refspec to fetch the remotes' tags into <handle>/<tag> namespace *)
-  run
-    t
-    ~display:Quiet
-    [ "config"
-    ; "--add"
-    ; sprintf "remote.%s.fetch" handle
-    ; sprintf "+refs/tags/*:refs/tags/%s/*" handle
-    ]
-;;
-
-let remote_name ~source ~branch =
-  let decoded_remote =
-    match branch with
-    | None -> source
-    | Some branch -> sprintf "%s %s" source branch
-  in
-  decoded_remote |> Dune_digest.string |> Dune_digest.to_string
-;;
-
-let rec add_repo ({ dir } as t) ~source ~branch =
-  let handle = remote_name ~source ~branch in
-  let lock = lock_path t in
-  with_flock lock ~f:(fun () ->
-    let* exists = remote_exists dir ~name:handle in
-    let+ default_branch =
-      match exists, branch with
-      | true, Some branch -> Fiber.return branch
-      | true, None ->
-        (match read_head_branch t handle with
-         | Some head_branch -> Fiber.return head_branch
-         | None ->
-           (* the rev store is in some sort of unexpected state *)
-           Code_error.raise
-             (sprintf "Could not load default branch of repository")
-             [ "source", Dyn.string source; "handle", Dyn.string handle ])
-      | false, Some branch ->
-        let+ () = remote_add t ~branch ~handle ~source in
-        branch
-      | false, None ->
-        let* branch =
-          query_head_branch t source
-          >>| function
-          | Some head_branch -> head_branch
-          | None ->
-            User_error.raise
-              ~hints:
-                [ Pp.textf
-                    "Make sure '%s' is a valid git repository and has a HEAD branch"
-                    source
-                ]
-              [ Pp.textf "Could not determine default branch of repository at '%s'" source
-              ]
-        in
-        let+ () = remote_add t ~branch ~handle ~source in
-        branch
-    in
-    let add_remote source =
-      let* remote = add_repo t ~branch:None ~source in
-      let+ (_ : Remote.t) = Remote.update remote in
-      ()
-    in
-    { Remote.repo = t; handle; source; default_branch; add_remote })
+let fetch_object t (remote : Remote.t) revision =
+  fetch_allow_failure t ~url:remote.url revision
+  >>= function
+  | `Not_found -> Fiber.return None
+  | `Fetched -> At_rev.of_rev t ~revision >>| Option.some
 ;;
 
 let content_of_files t files =

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -2,6 +2,20 @@ open Stdune
 
 type t
 
+module Object : sig
+  (** A git object that can exist in storage *)
+  type t
+
+  (** An object that definitely exists in the storage, but might still not be
+      fetched *)
+  type resolved = private t
+
+  val of_sha1 : string -> t option
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val to_dyn : t -> Dyn.t
+end
+
 module File : sig
   type t
 
@@ -18,7 +32,7 @@ module At_rev : sig
     val parse : string -> (string * string option * string * string) option
   end
 
-  val rev : t -> string
+  val rev : t -> Object.t
   val content : t -> Path.Local.t -> string option Fiber.t
   val directory_entries : t -> recursive:bool -> Path.Local.t -> File.Set.t
   val equal : t -> t -> bool
@@ -26,38 +40,16 @@ module At_rev : sig
 end
 
 module Remote : sig
-  (** [uninit] represents an uninitialized remote. Use [update] or
-      [don't_update] to get a remote [t] *)
-  type uninit
-
   (** handle representing a particular git repository *)
   type t
 
-  (** [update remote] will fetch the most current revisions from the remote *)
-  val update : uninit -> t Fiber.t
-
-  (** [don't_update] signals that the remote should not be updated *)
-  val don't_update : uninit -> t
-
-  val default_branch : t -> string
-  val rev_of_name : t -> name:string -> At_rev.t option Fiber.t
-  val rev_of_ref : t -> ref:string -> At_rev.t option Fiber.t
+  val default_branch : t -> Object.resolved option Fiber.t
 end
 
+val remote : t -> url:string -> Remote.t
+val resolve_revision : t -> Remote.t -> revision:string -> Object.resolved option Fiber.t
 val content_of_files : t -> File.t list -> string list Fiber.t
 val load_or_create : dir:Path.t -> t Fiber.t
-
-(** [add_repo t ~source ~branch] idempotently registers a git repo to the rev store.
-    [source] is any URL that is supported by [git remote add].
-
-    This only adds the remote metadata, to get a remote you need to either
-    use [Remote.update] if you want to fetch from the remote (thus potentially
-    triggering network IO) or if you are sure the [t] already contains all
-    required revisions (e.g. from a previous run) then use [don't_update]. *)
-val add_repo : t -> source:string -> branch:string option -> Remote.uninit Fiber.t
-
-(** [mem t ~rev] returns whether the revision [rev] is part of the repository *)
-val mem : t -> rev:string -> bool Fiber.t
-
-val ref_type : t -> source:string -> ref:string -> [ `Head | `Tag ] option Fiber.t
 val get : t Fiber.t
+val fetch_object : t -> Remote.t -> Object.t -> At_rev.t option Fiber.t
+val fetch_resolved : t -> Remote.t -> Object.resolved -> At_rev.t Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
+++ b/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
@@ -41,6 +41,5 @@ Depend on foo from the repo
 
 Which foo will we get?
 
-  $ dune pkg lock
-  Solution for dune.lock:
-  - foo.1.0
+  $ dune pkg lock 2>&1 | head -1 | sed "s/$AMBIGUOUS_REF/AMBIGUOUS_REF/g"
+  revision "AMBIGUOUS_REF" not found in

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -20,8 +20,14 @@ Local file system
   opendir($TESTCASE_ROOT/dummy): No such file or directory
 
 Git
-  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | sed -ne '/Command exited/,$ p'
-  Command exited with code 128.
+  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | awk '/fatal:/,/Description/'
+  fatal: '$TESTCASE_ROOT/dummy' does not appear to be a git repository
+  fatal: Could not read from remote repository.
+  
+  Please make sure you have the correct access rights
+  and the repository exists.
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
 
 
 Http

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -208,8 +208,8 @@ let%expect_test "downloading, tarball with no checksum match" =
 
 let download_git rev_store url ~target =
   let open Fiber.O in
-  let+ res = Fetch.fetch_git rev_store ~target url in
-  match res with
+  Fetch.fetch_git rev_store ~target url
+  >>| function
   | Error _ ->
     let errs = [ Pp.text "Failure while downloading" ] in
     User_error.raise ~loc:Loc.none errs
@@ -228,8 +228,7 @@ let%expect_test "downloading via git" =
     let open Fiber.O in
     let* rev_store = Dune_pkg.Rev_store.load_or_create ~dir:rev_store_dir in
     let* (_commit : string) = Rev_store_tests.create_repo_at source in
-    let* source = Dune_pkg.Opam_repo.Source.Private.of_opam_url rev_store Loc.none url in
-    let+ () = download_git rev_store source ~target in
+    let+ () = download_git rev_store url ~target in
     print_endline (Io.read_file entry));
   [%expect {| just some content |}]
 ;;

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -55,25 +55,11 @@ let%expect_test "adding remotes" =
     let remote_path = Path.relative cwd "git-remote" in
     let* _head = create_repo_at remote_path in
     let opam_url = remote_path |> Path.to_string |> OpamUrl.parse in
-    let* (src : Opam_repo.Source.t) = Opam_repo.Source.of_opam_url Loc.none opam_url in
-    let source = Opam_repo.Source.url src in
-    let* remote = Rev_store.add_repo rev_store ~source ~branch:None in
-    let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote in
-    print_endline "Creating first remote succeeded";
-    [%expect {|
-    Creating first remote succeeded
-    |}];
-    let* remote' = Rev_store.add_repo rev_store ~source ~branch:None in
-    let (_ : Rev_store.Remote.t) = Rev_store.Remote.don't_update remote' in
-    print_endline "Adding same remote without update succeeded";
-    [%expect {|
-    Adding same remote without update succeeded
-    |}];
-    let* remote'' = Rev_store.add_repo rev_store ~source ~branch:None in
-    let* (_ : Rev_store.Remote.t) = Rev_store.Remote.update remote'' in
-    print_endline "Adding same remote with update succeeded";
-    [%expect {|
-    Adding same remote with update succeeded
-    |}];
-    Fiber.return ())
+    Dune_pkg.OpamUrl.find_revision opam_url rev_store
+    >>| function
+    | Error _ -> print_endline "Unable to find revision"
+    | Ok _ -> print_endline "Successfully found remote");
+  [%expect {|
+    Successfully found remote
+     |}]
 ;;


### PR DESCRIPTION
This is a set of improvements to the rev store that aims at simplifying
the implementation and interface. The following changes are notable:

* We no longer record any remote names in the git repo. There's no need
  as we can just fetch individual objects and url's.

* We cache and reuse all remotes. This makes it more efficient to use
  the same remotes more than once.

* We read branches/tags/default branches every time without saving it.
  This is the correct thing to do as it has to be updated every single
  we run dune as it can change.

* We cache the existence checks of git objects

* We now use the remote store to fetch sources when building packages

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 92088c78-a061-46cd-b25f-3282377e120b -->