### PR TITLE
bench: [Path.reach] and [Path.root]

### DIFF
--- a/bench/micro/dune
+++ b/bench/micro/dune
@@ -64,3 +64,17 @@
  (allow_overlapping_dependencies)
  (modules digest_bench_main)
  (libraries digest_bench core_bench.inline_benchmarks))
+
+(library
+ (name path_bench)
+ (modules path_bench)
+ (library_flags -linkall)
+ (preprocess
+  (pps ppx_bench))
+ (libraries base stdune core_bench.inline_benchmarks))
+
+(executable
+ (name path_bench_main)
+ (allow_overlapping_dependencies)
+ (modules path_bench_main)
+ (libraries path_bench core_bench.inline_benchmarks))

--- a/bench/micro/path_bench.ml
+++ b/bench/micro/path_bench.ml
@@ -1,0 +1,39 @@
+module Path = Stdune.Path
+module Fpath = Stdune.Fpath
+open Base
+module Filename = Stdlib.Filename
+
+let () = Path.Build.set_build_dir (In_source_dir Path.Source.(relative root "_build"))
+let root = "."
+let short_path = "a/b/c"
+let long_path = List.init 20 ~f:(fun _ -> "foo-bar-baz") |> String.concat ~sep:"/"
+
+let%bench_fun ("is_root" [@params
+                           path
+                           = [ "root", "."
+                             ; "short path", short_path
+                             ; "long path", long_path
+                             ]])
+  =
+  fun () -> ignore (Fpath.is_root path)
+;;
+
+let%bench_fun ("reach" [@params
+                         t
+                         = [ "from root long path", (long_path, root)
+                           ; "from root short path", (short_path, root)
+                           ; "reach root from short path", (root, short_path)
+                           ; "reach root from long path", (root, long_path)
+                           ; ( "reach long path from similar long path"
+                             , ( Filename.concat long_path "a"
+                               , Filename.concat long_path "b" ) )
+                           ; ( "reach short path from similar short path"
+                             , ( Filename.concat short_path "a"
+                               , Filename.concat short_path "b" ) )
+                           ]])
+  =
+  let t, from = t in
+  let t = Path.of_string t in
+  let from = Path.of_string from in
+  fun () -> ignore (Path.reach t ~from)
+;;

--- a/bench/micro/path_bench_main.ml
+++ b/bench/micro/path_bench_main.ml
@@ -1,0 +1,1 @@
+Inline_benchmarks_public.Runner.main ~libname:"path_bench"

--- a/bench/micro/runner.sh
+++ b/bench/micro/runner.sh
@@ -6,6 +6,7 @@ case "$1" in
   "memo" ) test="memo_bench"; main="memo_bench_main";;
   "thread_pool" ) test="thread_pool_bench"; main="thread_pool_bench_main";;
   "digest" ) test="digest_bench"; main="digest_bench_main";;
+  "path" ) test="path_bench"; main="path_bench_main";;
 esac
 shift;
 export BENCH_LIB="$test"


### PR DESCRIPTION
```
┌────────────────────────────────────────────────────────────────────────────┬────────────┬─────────┬──────────┬──────────┬────────────┐
│ Name                                                                       │   Time/Run │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├────────────────────────────────────────────────────────────────────────────┼────────────┼─────────┼──────────┼──────────┼────────────┤
│ [bench/micro/path_bench.ml] is_root:root                                   │    20.03ns │  12.00w │          │          │      1.87% │
│ [bench/micro/path_bench.ml] is_root:short path                             │    37.21ns │  14.00w │          │          │      3.47% │
│ [bench/micro/path_bench.ml] is_root:long path                              │    67.80ns │  42.00w │          │          │      6.33% │
│ [bench/micro/path_bench.ml] reach:from root long path                      │   726.46ns │ 151.00w │          │          │     67.80% │
│ [bench/micro/path_bench.ml] reach:from root short path                     │    93.26ns │  17.00w │          │          │      8.70% │
│ [bench/micro/path_bench.ml] reach:reach root from short path               │   112.17ns │  27.00w │          │          │     10.47% │
│ [bench/micro/path_bench.ml] reach:reach root from long path                │   824.26ns │ 189.00w │          │          │     76.93% │
│ [bench/micro/path_bench.ml] reach:reach long path from similar long path   │ 1_071.47ns │ 255.00w │    0.12w │    0.12w │    100.00% │
│ [bench/micro/path_bench.ml] reach:reach short path from similar short path │   168.35ns │  45.00w │          │          │     15.71% │
└────────────────────────────────────────────────────────────────────────────┴────────────┴─────────┴──────────┴──────────┴────────────┘

```

cc @snowleopard @tov 