### PR TITLE
chore(nix): provide a `dune` binary in the scope shell too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,9 +122,7 @@
                 export DUNE_SOURCE_ROOT=$PWD
               '';
               inherit meta;
-              nativeBuildInputs =
-                testNativeBuildInputs ++
-                lib.optionals (!duneFromScope) [ duneScript ];
+              nativeBuildInputs = testNativeBuildInputs ++ [ duneScript ];
               inputsFrom = [ slimPkgs.ocamlPackages.dune_3 ];
               buildInputs = testBuildInputs ++ (with slimPkgs.ocamlPackages; [
                 merlin


### PR DESCRIPTION
Otherwise you'd have to resort to `./dune.exe`