### PR TITLE
fix: remove the --react-to-insignificant-changes option

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -593,7 +593,6 @@ module Builder = struct
     ; separate_error_messages : bool
     ; stop_on_first_error : bool
     ; require_dune_project_file : bool
-    ; insignificant_changes : [ `React | `Ignore ]
     ; watch_exclusions : string list
     ; build_dir : string
     ; store_digest_preimage : bool
@@ -963,15 +962,6 @@ module Builder = struct
                of the build in a deterministic order. $(b,twice) reports each error \
                twice: once as soon as the error is discovered and then again at the end \
                of the build, in a deterministic order.")
-    and+ react_to_insignificant_changes =
-      Arg.(
-        value
-        & flag
-        & info
-            [ "react-to-insignificant-changes" ]
-            ~doc:
-              "React to insignificant file system changes; this is only useful for \
-               benchmarking dune.")
     and+ separate_error_messages =
       Arg.(
         value
@@ -1033,7 +1023,6 @@ module Builder = struct
     ; separate_error_messages
     ; stop_on_first_error
     ; require_dune_project_file
-    ; insignificant_changes = (if react_to_insignificant_changes then `React else `Ignore)
     ; watch_exclusions
     ; build_dir = Option.value ~default:default_build_dir build_dir
     ; store_digest_preimage
@@ -1083,7 +1072,6 @@ let signal_watcher t =
 
 let watch_exclusions t = t.builder.watch_exclusions
 let stats t = t.stats
-let insignificant_changes t = t.builder.insignificant_changes
 
 (* To avoid needless recompilations under Windows, where the case of
    [Sys.getcwd] can vary between different invocations of [dune], normalize to

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -24,7 +24,6 @@ val dump_memo_graph_with_timing : t -> bool
 val watch : t -> Dune_rpc_impl.Watch_mode_config.t
 val file_watcher : t -> Dune_engine.Scheduler.Run.file_watcher
 val prefix_target : t -> string -> string
-val insignificant_changes : t -> [ `React | `Ignore ]
 
 module Action_runner : sig
   type t =

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -186,13 +186,12 @@ module Scheduler = struct
   let go ~(common : Common.t) ~config:dune_config f =
     let stats = Common.stats common in
     let config =
-      let insignificant_changes = Common.insignificant_changes common in
       let signal_watcher = Common.signal_watcher common in
       let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler
         dune_config
         stats
-        ~insignificant_changes
+        ~insignificant_changes:`Ignore
         ~signal_watcher
         ~watch_exclusions
     in
@@ -217,12 +216,11 @@ module Scheduler = struct
     let stats = Common.stats common in
     let config =
       let signal_watcher = Common.signal_watcher common in
-      let insignificant_changes = Common.insignificant_changes common in
       let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler
         dune_config
         stats
-        ~insignificant_changes
+        ~insignificant_changes:`Ignore
         ~signal_watcher
         ~watch_exclusions
     in

--- a/doc/changes/10083.md
+++ b/doc/changes/10083.md
@@ -1,0 +1,1 @@
+- Remove the `--react-to-insignifcant-changes` option. (#10083, @rgrinberg)


### PR DESCRIPTION
it was only useful for testing/benchmarking, but now it's not even used
for that.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7f96ba38-cac4-46ca-ac16-83f231ce7341 -->