### PR TITLE
fix(pkg): stop using opam's untar code

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -21,13 +21,6 @@ module Rev = struct
   let to_dyn (Rev r) = Dyn.variant "Rev" [ Dyn.string r ]
 end
 
-let tar =
-  lazy
-    (match Bin.which ~path:(Env_path.path Env.initial) "tar" with
-     | Some x -> x
-     | None -> Dune_engine.Utils.program_not_found "tar" ~loc:None)
-;;
-
 let rec attempt_to_lock flock lock ~max_retries =
   let sleep_duration = 0.1 in
   match Flock.lock_non_block flock lock with
@@ -618,7 +611,7 @@ module At_rev = struct
   let check_out { repo = { dir }; revision = Rev rev; source = _; files = _ } ~target =
     (* TODO iterate over submodules to output sources *)
     let git = Lazy.force Vcs.git in
-    let tar = Lazy.force tar in
+    let tar = Lazy.force Tar.bin in
     let temp_dir = Temp.create Dir ~prefix:"rev-store" ~suffix:rev in
     Fiber.finalize ~finally:(fun () ->
       let+ () = Fiber.return () in

--- a/src/dune_pkg/tar.ml
+++ b/src/dune_pkg/tar.ml
@@ -1,0 +1,8 @@
+open Stdune
+
+let bin =
+  lazy
+    (match Bin.which ~path:(Env_path.path Env.initial) "tar" with
+     | Some x -> x
+     | None -> Dune_engine.Utils.program_not_found "tar" ~loc:None)
+;;

--- a/src/dune_pkg/tar.mli
+++ b/src/dune_pkg/tar.mli
@@ -1,0 +1,3 @@
+open Stdune
+
+val bin : Path.t Lazy.t

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -76,7 +76,17 @@ Lock, build, and run the executable in the project:
   Solution for dune.lock:
   - foo.0.0.1
 
+# Temporary failure until 10080 is fixed
+
   $ dune exec bar
-  Hello, World!
+  File "dune", line 3, characters 12-15:
+  3 |  (libraries foo))
+                  ^^^
+  Error: Library "foo" not found.
+  -> required by _build/default/.bar.eobjs/byte/dune__exe__Bar.cmi
+  -> required by _build/default/.bar.eobjs/native/dune__exe__Bar.cmx
+  -> required by _build/default/bar.exe
+  -> required by _build/install/default/bin/bar
+  [1]
 
   $ wait


### PR DESCRIPTION
It does a bunch of illegal things like chdir that are illegal in dune

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fa308cd9-a52e-427c-b938-3bcc87ae2a4d -->