### PR TITLE
bench: benchmark [Path.Local.relative]

### DIFF
--- a/bench/micro/path_bench.ml
+++ b/bench/micro/path_bench.ml
@@ -37,3 +37,16 @@ let%bench_fun ("reach" [@params
   let from = Path.of_string from in
   fun () -> ignore (Path.reach t ~from)
 ;;
+
+let%bench_fun ("relative" [@params
+                            t
+                            = [ "left root", (".", long_path)
+                              ; "right root", (long_path, ".")
+                              ; "short paths", (short_path, short_path)
+                              ; "long paths", (long_path, long_path)
+                              ]])
+  =
+  let x, y = t in
+  let x = Path.Local.of_string x in
+  fun () -> ignore (Path.Local.relative x y)
+;;


### PR DESCRIPTION
```
┌────────────────────────────────────────────────────────────────────────────┬────────────┬───────────┬──────────┬──────────┬────────────┐
│ Name                                                                       │   Time/Run │   mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├────────────────────────────────────────────────────────────────────────────┼────────────┼───────────┼──────────┼──────────┼────────────┤
│ [bench/micro/path_bench.ml] relative:left root                             │ 1_237.13ns │   516.00w │    0.14w │    0.14w │     89.14% │
│ [bench/micro/path_bench.ml] relative:right root                            │     9.66ns │     5.00w │          │          │      0.70% │
│ [bench/micro/path_bench.ml] relative:short paths                           │   151.89ns │    31.00w │          │          │     10.94% │
│ [bench/micro/path_bench.ml] relative:long paths                            │ 1_387.79ns │ 1_122.00w │    0.38w │    0.38w │    100.00% │
└────────────────────────────────────────────────────────────────────────────┴────────────┴───────────┴──────────┴──────────┴────────────┘
```