### PR TITLE
chore(nix): update flakes, use upstream mdx/logs fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708501555,
-        "narHash": "sha256-zJaF0RkdIPbh8LTmnpW/E7tZYpqIE+MePzlWwUNob4c=",
+        "lastModified": 1708532945,
+        "narHash": "sha256-0KucnySzsz5Zgonjjm8cQMql+HGHa/OhB0fnKmGeD+0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b50a77c03d640716296021ad58950b1bb0345799",
+        "rev": "ac4c5a60bebfb783f1106d126b9f39cc8e809e0e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,19 +26,9 @@
       pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
         (self: super: {
           ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
-            mdx = osuper.mdx.overrideAttrs (_: {
-              # https://github.com/NixOS/nixpkgs/pull/290291
-              propagatedBuildInputs = with oself; [
-                astring
-                fmt
-                logs
-                csexp
-                ocaml-version
-                camlp-streams
-                re
-                findlib
-              ];
-            });
+            mdx = osuper.mdx.override {
+              logs = oself.logs;
+            };
             utop = osuper.utop.overrideAttrs {
               dontGzipMan = true;
             };


### PR DESCRIPTION
follow-up to #10078 