### PR TITLE
fix(pkg): workaround for libraries not being found

### DIFF
--- a/src/fs/fs.ml
+++ b/src/fs/fs.ml
@@ -42,7 +42,10 @@ let dir_exists dir =
   let* () = Memo.return () in
   match Path.destruct_build_dir dir with
   | `Outside dir -> Fs_memo.dir_exists dir
-  | `Inside _ -> exists dir Unix.S_DIR
+  | `Inside _ ->
+    (* CR-rgrinberg: unfortunately, [Build_system.file_exists] always returns
+       false for directories. *)
+    Memo.return true
 ;;
 
 let with_lexbuf_from_file file ~f =


### PR DESCRIPTION
There's no way to check if $path is a directory inside the build dir if
it's a sub directory of a directory targets. Luckily, the findlib code
only needs this check for an optimization, so we can pretend that such
directories always exist.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 13cf28b1-7e0c-4b9a-97dc-0c5660235ce1 -->