### PR TITLE
fix(pkg): correctly set [OCAMLPATH] for context

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -408,9 +408,14 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
       let env = Env_path.extend_env_concat_path builder.env env in
       which, { builder with env }
   in
-  let ocamlpath =
-    let ocamlpath = Findlib_config.ocamlpath_of_env builder.env in
-    Kind.ocamlpath kind ~ocamlpath ~findlib_toolchain:builder.findlib_toolchain
+  let* ocamlpath =
+    (* CR-rgrinberg: we're forcing this too early *)
+    match kind with
+    | Lock _ -> Pkg_rules.ocamlpath builder.name
+    | Default | Opam _ ->
+      let ocamlpath = Findlib_config.ocamlpath_of_env builder.env in
+      Kind.ocamlpath kind ~ocamlpath ~findlib_toolchain:builder.findlib_toolchain
+      |> Memo.return
   in
   let* findlib =
     let findlib_toolchain =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1622,6 +1622,16 @@ let which context =
     Filename.Map.find artifacts program)
 ;;
 
+let ocamlpath context =
+  let+ all_packages = all_packages context in
+  let env = Pkg.build_env_of_deps all_packages in
+  Env.Map.find env Dune_findlib.Config.ocamlpath_var
+  |> Option.value ~default:[]
+  |> List.map ~f:(function
+    | Value.Dir p | Path p -> p
+    | String s -> Path.of_filename_relative_to_initial_cwd s)
+;;
+
 let lock_dir_active = Lock_dir.lock_dir_active
 let lock_dir_path = Lock_dir.get_path
 

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -20,4 +20,5 @@ val lock_dir_active : Context_name.t -> bool Memo.t
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t
 val exported_env : Context_name.t -> Env.t Memo.t
+val ocamlpath : Context_name.t -> Path.t list Memo.t
 val find_package : Context_name.t -> Package.Name.t -> unit Action_builder.t option Memo.t


### PR DESCRIPTION
Previously, we'd set the [OCAMLPATH] using the full environment, but
that would convert all the findlib paths to [Path.External.t] which
isn't correct, as those paths exist in the build dir.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6f88e732-90dd-4dce-bf4c-49af52908ff2 -->