### PR TITLE
refactor: remove [Li.DB.{equal,hash}]

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -413,7 +413,6 @@ and resolve_result =
   | Redirect_in_the_same_db of (Loc.t * Lib_name.t)
   | Redirect of db * (Loc.t * Lib_name.t)
 
-let equal_db : db -> db -> bool = phys_equal
 let lib_config (t : lib) = t.lib_config
 let name t = t.name
 let info t = t.info
@@ -1796,9 +1795,6 @@ module DB = struct
   end
 
   type t = db
-
-  let equal = equal_db
-  let hash = Poly.hash
 
   let create ~parent ~resolve ~all ~lib_config ~instrument_with () =
     let rec t =

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -91,8 +91,6 @@ module DB : sig
   (** A database allow to resolve library names *)
   type t = db
 
-  val equal : t -> t -> bool
-  val hash : t -> int
   val installed : Context.t -> t Memo.t
 
   module Resolve_result : sig


### PR DESCRIPTION
they aren't correct anyway

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 09f99882-80e9-4425-ba3b-02e0b31a81be -->