### PR TITLE
fix(pkg): [Lib.is_local] should handle dune installed packages

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -421,7 +421,17 @@ let implements t = Option.map ~f:Memo.return t.implements
 let requires t = Memo.return t.requires
 let ppx_runtime_deps t = Memo.return t.ppx_runtime_deps
 let pps t = Memo.return t.pps
-let is_local t = Lib_info.obj_dir t.info |> Obj_dir.byte_dir |> Path.is_managed
+
+let is_local t =
+  match Lib_info.obj_dir t.info |> Obj_dir.byte_dir with
+  | External _ -> false
+  | In_source_tree _ -> true
+  | In_build_dir dir ->
+    (match Path.Build.extract_build_context dir with
+     | None -> true
+     | Some (name, _) ->
+       not (Context_name.equal (Context_name.of_string name) Private_context.t.name))
+;;
 
 let main_module_name t =
   match Lib_info.main_module_name t.info with

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -14,7 +14,7 @@ val name : t -> Lib_name.t
 val lib_config : t -> Lib_config.t
 val implements : t -> t Resolve.Memo.t option
 
-(** Same as [Path.is_managed (obj_dir t)] *)
+(** [is_local t] returns [true] whenever [t] is defined in the local workspace *)
 val is_local : t -> bool
 
 val info : t -> Path.t Lib_info.t


### PR DESCRIPTION
The old condition for verifying that the directory is extenral is no
longer enough. Libraries can now exist in the build directory, but still
not be "external"

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5e95a273-1672-4596-baa2-0ce843ce91f6 -->