### PR TITLE
[coq] Memoize coqdep parsing

### DIFF
--- a/doc/changes/10116.md
+++ b/doc/changes/10116.md
@@ -1,0 +1,3 @@
+- coq: memoize coqdep parsing, this will reduce build times for Coq
+  users, in particular for those with many .v files (#10116,
+  @ejgallego, see also #10088)

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -570,6 +570,26 @@ let get_dep_map ~dir ~wrapper_name : Path.t list Dep_map.t Action_builder.t =
       ]
 ;;
 
+(* EJGA: Would be nice to have a functor in [Stdune.Tuple] to do this *)
+module DWInput : Memo.Input with type t = Path.Build.t * string = struct
+  type t = Path.Build.t * string
+
+  let hash = Tuple.T2.hash Path.Build.hash String.hash
+  let equal = Tuple.T2.equal Path.Build.equal String.equal
+  let to_dyn = Tuple.T2.to_dyn Path.Build.to_dyn String.to_dyn
+end
+
+(* EJGA: with this code, we have a combined memo node that will be
+   re-executed iff [dir], [wrapper_name], or the deps of the original
+   action builder (the [.v.d] file from [dep_theory_file ~dir
+   ~wrapper_name]) change *)
+let memo_get_dep_map =
+  Action_builder.create_memo
+    "coq_dep_map"
+    ~input:(module DWInput)
+    (fun (dir, wrapper_name) -> get_dep_map ~dir ~wrapper_name)
+;;
+
 let deps_of ~dir ~boot_type ~wrapper_name ~mode coq_module =
   let open Action_builder.O in
   let vo_target =
@@ -580,7 +600,7 @@ let deps_of ~dir ~boot_type ~wrapper_name ~mode coq_module =
     in
     Path.set_extension ~ext (Coq_module.source coq_module)
   in
-  let* dep_map = get_dep_map ~dir ~wrapper_name in
+  let* dep_map = Action_builder.exec_memo memo_get_dep_map (dir, wrapper_name) in
   let* boot_type = Resolve.Memo.read boot_type in
   match Dep_map.find dep_map vo_target with
   | None ->


### PR DESCRIPTION
I was under the impression that our current code was taking care of this already, however it was not.

Suggestions on what is best w.r.t. `Memo/Action_builder` code dance welcome.

Obviously, this has a dramatic effect on most Coq builds, for example HoTT's zero build is now:

```
before:
-------

real	0m5,302s
user	0m5,197s
sys	0m0,056s

after:
------

real	0m0,210s
user	0m0,143s
sys	0m0,034s
```

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>