### PR TITLE
fix(pkg): do not try to compute checksums of vcs pins

### DIFF
--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -78,7 +78,7 @@ let compute_missing_checksum_of_fetch
   let open Fiber.O in
   match checksum with
   | Some _ -> Fiber.return fetch
-  | None when OpamUrl.is_local url -> Fiber.return fetch
+  | None when OpamUrl.is_local url || OpamUrl.is_version_control url -> Fiber.return fetch
   | None ->
     if not pinned
        (* No point in warning this about pinned packages. The user explicitly


### PR DESCRIPTION
This one is a bit hard to test because it requires setting up a git repo over HTTP