### PR TITLE
refactor: improve findlib loading performance

### DIFF
--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -91,6 +91,15 @@ module DB = struct
   ;;
 end
 
+let resolve_link ~dir ~fname (kind : File_kind.t) =
+  match kind with
+  | S_LNK ->
+    (match Path.Untracked.stat (Path.relative dir fname) with
+     | Ok { Unix.st_kind; _ } -> Some st_kind
+     | Error _ -> None)
+  | _ -> Some kind
+;;
+
 let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_location =
   let loc = Loc.in_file t.meta_file in
   let add_loc x = loc, x in
@@ -104,6 +113,15 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
       if Mode.Dict.Set.is_empty discovered then Mode.Dict.Set.all else discovered
     in
     { Lib_mode.Map.ocaml = modes; melange = false }
+  in
+  let dir_contents =
+    Result.map
+      dir_contents
+      ~f:
+        (List.filter_map ~f:(fun (fname, kind) ->
+           match resolve_link ~dir:t.dir ~fname kind with
+           | Some S_REG -> Some fname
+           | _ -> None))
   in
   let (info : Path.t Lib_info.t) =
     let kind = Findlib.Package.kind t in
@@ -268,6 +286,45 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
 module Loader = struct
   open Memo.O
 
+  module Findlib_dir = struct
+    type t =
+      { sub_dirs : Filename.Set.t
+      ; metas : Filename.Set.t
+      }
+
+    let empty = { sub_dirs = Filename.Set.empty; metas = Filename.Set.empty }
+    let file_prefix = Findlib.Package.meta_fn ^ "."
+
+    let of_path =
+      let impl path =
+        Fs.dir_contents path
+        >>| function
+        | Error e -> Error e
+        | Ok contents ->
+          let sub_dirs, metas =
+            List.filter_partition_map contents ~f:(fun (name, kind) ->
+              match resolve_link ~dir:path ~fname:name kind with
+              | Some S_DIR -> Left name
+              | Some S_REG when String.is_prefix name ~prefix:file_prefix -> Right name
+              | _ -> Skip)
+          in
+          Ok
+            { sub_dirs = Filename.Set.of_list sub_dirs
+            ; metas = Filename.Set.of_list metas
+            }
+      in
+      let memo = Memo.create "read-findlib-path" ~input:(module Path) impl in
+      Memo.exec memo
+    ;;
+
+    let of_path_ignore_error path =
+      of_path path
+      >>| function
+      | Error _ -> empty
+      | Ok s -> s
+    ;;
+  end
+
   (* Parse all the packages defined in a META file *)
   let dune_package_of_meta (db : DB.t) ~loc ~meta_file ~(meta : Meta.Simplified.t) =
     let dir_of_loc (loc : Dune_package.External_location.t) =
@@ -336,13 +393,6 @@ module Loader = struct
     }
   ;;
 
-  let load_meta name file =
-    Fs.file_exists file
-    >>= function
-    | false -> Memo.return None
-    | true -> Fs.with_lexbuf_from_file file ~f:(Meta.of_lex ~name) >>| Option.some
-  ;;
-
   let load_builtin db meta =
     dune_package_of_meta
       db
@@ -355,34 +405,53 @@ module Loader = struct
     : (Dune_package.t, Unavailable_reason.t) result option Memo.t
     =
     let load_meta ~findlib_dir ~dir meta_file =
-      load_meta (Some name) meta_file
-      >>= function
-      | None -> Memo.return None
-      | Some meta ->
-        let loc = Dune_package.External_location.Relative_to_findlib (findlib_dir, dir) in
-        dune_package_of_meta db ~loc ~meta_file ~meta >>| Option.some
+      let* meta = Fs.with_lexbuf_from_file meta_file ~f:(Meta.of_lex ~name:(Some name)) in
+      let loc = Dune_package.External_location.Relative_to_findlib (findlib_dir, dir) in
+      dune_package_of_meta db ~loc ~meta_file ~meta >>| Option.some
     in
+    let* dir_contents = Findlib_dir.of_path_ignore_error findlib_dir in
     (* XXX DUNE4 why do we allow [META.foo] override [dune-package] file? *)
-    Path.relative findlib_dir (Findlib.Package.meta_fn ^ "." ^ Package.Name.to_string name)
-    |> load_meta ~findlib_dir ~dir:(Path.Local.of_string ".")
-    >>= function
-    | Some pkg -> Memo.return (Some (Ok pkg))
-    | None ->
-      let dir = Path.relative findlib_dir (Package.Name.to_string name) in
-      (let dune = Path.relative dir Dune_package.fn in
-       Fs.file_exists dune
-       >>= function
-       | true -> Dune_package.Or_meta.load dune
-       | false -> Memo.return (Ok Dune_package.Or_meta.Use_meta))
-      >>= (function
-       | Error e -> Memo.return (Some (Error (Unavailable_reason.Invalid_dune_package e)))
-       | Ok (Dune_package.Or_meta.Dune_package p) -> Memo.return (Some (Ok p))
-       | Ok Use_meta ->
-         Path.relative dir Findlib.Package.meta_fn
-         |> load_meta
-              ~findlib_dir
-              ~dir:(Path.Local.of_string (Package.Name.to_string name))
-         >>| Option.map ~f:(fun pkg -> Ok pkg))
+    let meta_fn = Findlib_dir.file_prefix ^ Package.Name.to_string name in
+    if Filename.Set.mem dir_contents.metas meta_fn
+    then
+      Path.relative findlib_dir meta_fn
+      |> load_meta ~findlib_dir ~dir:Path.Local.root
+      >>| Option.map ~f:Result.ok
+    else (
+      match Filename.Set.mem dir_contents.sub_dirs (Package.Name.to_string name) with
+      | false -> Memo.return None
+      | true ->
+        let dir = Path.relative findlib_dir (Package.Name.to_string name) in
+        let* files =
+          Fs.dir_contents dir
+          >>| (function
+           | Error _ -> []
+           | Ok s -> s)
+          >>| List.filter_map ~f:(fun (name, (kind : File_kind.t)) ->
+            match name = Dune_package.fn || name = Findlib.Package.meta_fn with
+            | false -> None
+            | true ->
+              (match resolve_link ~dir ~fname:name kind with
+               | Some S_REG -> Some name
+               | _ -> None))
+          >>| Filename.Set.of_list
+        in
+        (if Filename.Set.mem files Dune_package.fn
+         then Path.relative dir Dune_package.fn |> Dune_package.Or_meta.load
+         else Memo.return (Ok Dune_package.Or_meta.Use_meta))
+        >>= (function
+         | Error e ->
+           Memo.return (Some (Error (Unavailable_reason.Invalid_dune_package e)))
+         | Ok (Dune_package.Or_meta.Dune_package p) -> Memo.return (Some (Ok p))
+         | Ok Use_meta ->
+           (match Filename.Set.mem files Findlib.Package.meta_fn with
+            | false -> Memo.return None
+            | true ->
+              Path.relative dir Findlib.Package.meta_fn
+              |> load_meta
+                   ~findlib_dir
+                   ~dir:(Path.Local.of_string (Package.Name.to_string name))
+              >>| Option.map ~f:(fun pkg -> Ok pkg))))
   ;;
 
   let lookup_and_load (db : DB.t) name =
@@ -401,7 +470,7 @@ module Loader = struct
   let root_packages (db : DB.t) =
     let+ pkgs =
       Memo.List.concat_map db.paths ~f:(fun dir ->
-        Fs.dir_contents dir
+        Findlib_dir.of_path dir
         >>= function
         | Error (ENOENT, _, _) -> Memo.return []
         | Error (unix_error, _, _) ->
@@ -411,12 +480,23 @@ module Loader = struct
                 (Path.to_string_maybe_quoted dir)
             ; Pp.textf "Reason: %s" (Unix.error_message unix_error)
             ]
-        | Ok dir_contents ->
-          Memo.List.filter_map dir_contents ~f:(fun name ->
-            let+ exists =
-              Fs.file_exists (Path.L.relative dir [ name; Findlib.Package.meta_fn ])
-            in
-            if exists then Some (Package.Name.of_string name) else None))
+        | Ok { sub_dirs; metas } ->
+          let+ sub_dirs =
+            Filename.Set.to_list sub_dirs
+            |> Memo.List.filter_map ~f:(fun name ->
+              Path.L.relative dir [ name; Findlib.Package.meta_fn ]
+              |> Fs.file_exists
+              >>| function
+              | true -> Some (Package.Name.of_string name)
+              | false -> None)
+          in
+          let metas =
+            Filename.Set.to_list_map metas ~f:(fun fn ->
+              String.drop_prefix ~prefix:Findlib_dir.file_prefix fn
+              |> Option.value_exn
+              |> Package.Name.of_string)
+          in
+          List.rev_append sub_dirs metas)
       >>| Package.Name.Set.of_list
     in
     Package.Name.Set.of_keys db.builtins |> Package.Name.Set.union pkgs

--- a/src/fs/fs.ml
+++ b/src/fs/fs.ml
@@ -12,13 +12,11 @@ let dir_contents (dir : Path.t) =
   let* () = Memo.return () in
   match Path.destruct_build_dir dir with
   | `Outside dir ->
-    Fs_memo.dir_contents dir
-    >>| Result.map ~f:(fun contents ->
-      Fs_cache.Dir_contents.to_list contents |> List.map ~f:fst)
+    Fs_memo.dir_contents dir >>| Result.map ~f:Fs_cache.Dir_contents.to_list
   | `Inside _ ->
     let* already_exists = Build_system.file_exists dir in
     let+ () = if already_exists then Build_system.build_dir dir else Memo.return () in
-    Path.readdir_unsorted dir
+    Path.readdir_unsorted_with_kinds dir
 ;;
 
 let exists path kind =

--- a/src/fs/fs.mli
+++ b/src/fs/fs.mli
@@ -3,7 +3,10 @@
 
 open Stdune
 
-val dir_contents : Path.t -> (Filename.t list, Unix_error.Detailed.t) result Memo.t
+val dir_contents
+  :  Path.t
+  -> ((Filename.t * File_kind.t) list, Unix_error.Detailed.t) result Memo.t
+
 val file_exists : Path.t -> bool Memo.t
 val dir_exists : Path.t -> bool Memo.t
 val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.t


### PR DESCRIPTION
Do not call [Path.stat] for every single package. Just build an index of
packages for every directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 03ea951a-8240-4023-8d3b-5a3829af6d9d -->