### PR TITLE
fix: use the correct expander for cram stanzas

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -919,17 +919,9 @@ let eval_blang t blang =
   Blang_expand.eval ~f:(No_deps.expand_pform t) ~dir:(Path.build t.dir) blang
 ;;
 
-let expand_lock ~base expander (Locks.Lock sw) =
-  let open Memo.O in
-  match base with
-  | `Of_expander -> No_deps.expand_path expander sw
-  | `This base ->
-    let+ str = No_deps.expand_str expander sw in
-    Path.relative base str
-;;
-
-let expand_locks ~base expander locks =
-  Memo.List.map locks ~f:(expand_lock ~base expander) |> Action_builder.of_memo
+let expand_locks t (locks : Locks.t) =
+  Memo.List.map locks ~f:(fun (Lock x) -> No_deps.expand_path t x)
+  |> Action_builder.of_memo
 ;;
 
 let () =

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -131,12 +131,7 @@ val expand_and_eval_set
 val eval_blang : t -> Blang.t -> bool Memo.t
 val map_exe : t -> Path.t -> Path.t
 val artifacts : t -> Artifacts.t
-
-val expand_locks
-  :  base:[ `Of_expander | `This of Path.t ]
-  -> t
-  -> Locks.t
-  -> Path.t list Action_builder.t
+val expand_locks : t -> Locks.t -> Path.t list Action_builder.t
 
 val foreign_flags
   : (dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -396,8 +396,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
               executable
               command_line
       and+ locks =
-        Expander.expand_locks expander ~base:`Of_expander stanza.locks
-        |> Action_builder.with_no_targets
+        Expander.expand_locks expander stanza.locks |> Action_builder.with_no_targets
       in
       Action.Full.add_locks locks action |> Action.Full.add_sandbox sandbox
     in

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -53,7 +53,7 @@ let rule_kind ~(rule : Rule_conf.t) ~(action : _ Action_builder.With_targets.t) 
 
 let interpret_and_add_locks ~expander locks action =
   let open Action_builder.O in
-  Expander.expand_locks expander ~base:`Of_expander locks
+  Expander.expand_locks expander locks
   >>= function
   | [] -> action
   | locks -> Action_builder.map action ~f:(Action.Full.add_locks locks)


### PR DESCRIPTION
We should use the expander where the stanza is defined, rather than the
expander of the test.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 56efa496-8491-4481-bb80-044f423de902 -->