### PR TITLE
Skip hidden libs in `get_compile_info` and `ml_sources`

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1898,7 +1898,7 @@ module DB = struct
 
   let get_compile_info t ~allow_overlaps name =
     let open Memo.O in
-    find_even_when_hidden t name
+    find t name
     >>| function
     | Some lib -> lib, Compile.for_lib ~allow_overlaps t lib
     | None ->

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -304,7 +304,7 @@ let make_lib_modules
       let* resolved =
         let* libs = libs in
         Library.best_name lib
-        |> Lib.DB.find_even_when_hidden libs
+        |> Lib.DB.find libs
         (* can't happen because this library is defined using the current
            stanza *)
         >>| Option.value_exn


### PR DESCRIPTION
Extracted from #9839.

The fact that Dune tries to get compile info for hidden libraries is problematic for the new use cases that that PR enables.

From what this code says:

https://github.com/ocaml/dune/blob/98c576e643450659e2893ced9ae8e076b6129d95/src/dune_rules/dune_package.mli#L47-L53

I infer that Dune should not consider hidden libs when building rules or gathering the modules from a given library, because it never has to build them?

I looked for the original commit where `find_even_when_hidden` was introduced, but it doesn't provide a lot of information, besides "This makes everything else simpler": https://github.com/ocaml/dune/commit/17f4567014d533ae0135e940e3613bfa247e2f67