### PR TITLE
test: demonstrate that we can't select binaries using %{read:..}

### DIFF
--- a/test/blackbox-tests/test-cases/install-binary-read-pform.t
+++ b/test/blackbox-tests/test-cases/install-binary-read-pform.t
@@ -1,0 +1,41 @@
+Allow binary name to vary using pforms
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section bin)
+  >  (files (script as %{read:foo})))
+  > EOF
+
+  $ cat >script <<EOF
+  > #!/bin/sh
+  > echo script
+  > EOF
+  $ chmod +x script
+
+  $ runtest() {
+  > printf $1 > foo
+  > dune build foo.install && cat _build/default/foo.install
+  > }
+
+  $ runtest x
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  bin: [
+    "_build/install/default/bin/x"
+  ]
+
+  $ runtest y
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  bin: [
+    "_build/install/default/bin/y"
+  ]


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 722eb837-7aa9-40fe-b51a-d7cf81bf7aec -->