### PR TITLE
refactor: move coq scopes to own module

### DIFF
--- a/src/dune_rules/coq/coq_scope.ml
+++ b/src/dune_rules/coq/coq_scope.ml
@@ -1,0 +1,70 @@
+open Import
+open Memo.O
+
+type t = { scopes : Coq_lib.DB.t Lazy.t Path.Source.Map.t Memo.Lazy.t }
+
+let public_theories context public_libs coq_stanzas =
+  let+ installed_theories =
+    let+ coqpaths_of_coq = Coq_path.of_coq_install context
+    and+ coqpaths_of_env = Context.installed_env context >>= Coq_path.of_env in
+    Coq_lib.DB.create_from_coqpaths (coqpaths_of_env @ coqpaths_of_coq)
+  in
+  List.filter_map coq_stanzas ~f:(fun (dir, (stanza : Coq_stanza.Theory.t)) ->
+    if Option.is_some stanza.package
+    then Some (stanza, Coq_lib.DB.Entry.Theory dir)
+    else None)
+  |> Coq_lib.DB.create_from_coqlib_stanzas
+       ~find_db:(Fun.const public_libs)
+       ~parent:(Some installed_theories)
+;;
+
+let coq_scopes_by_dir
+  db_by_project_dir
+  projects_by_dir
+  public_theories
+  coq_stanzas_by_project_dir
+  =
+  let parent = Some public_theories in
+  let find_db dir = snd (Find_closest_source_dir.find_by_dir db_by_project_dir ~dir) in
+  Path.Source.Map.merge
+    projects_by_dir
+    coq_stanzas_by_project_dir
+    ~f:(fun _dir project coq_stanzas ->
+      assert (Option.is_some project);
+      Option.some
+      @@ lazy
+           (let coq_stanzas = Option.value coq_stanzas ~default:[] in
+            List.map coq_stanzas ~f:(fun (dir, (stanza : Coq_stanza.Theory.t)) ->
+              let (entry : Coq_lib.DB.Entry.t) =
+                match stanza.package with
+                | None -> Theory dir
+                | Some _ -> Redirect public_theories
+              in
+              stanza, entry)
+            |> Coq_lib.DB.create_from_coqlib_stanzas ~parent ~find_db))
+;;
+
+let coq_stanzas_by_project_dir coq_stanzas =
+  List.map coq_stanzas ~f:(fun (dir, (stanza : Coq_stanza.Theory.t)) ->
+    let project = stanza.project in
+    Dune_project.root project, (dir, stanza))
+  |> Path.Source.Map.of_list_multi
+;;
+
+let make context ~public_libs ~db_by_project_dir ~projects_by_root coq_stanzas =
+  { scopes =
+      Memo.lazy_ (fun () ->
+        let+ public_theories = public_theories context public_libs coq_stanzas in
+        let coq_stanzas_by_project_dir = coq_stanzas_by_project_dir coq_stanzas in
+        coq_scopes_by_dir
+          db_by_project_dir
+          projects_by_root
+          public_theories
+          coq_stanzas_by_project_dir)
+  }
+;;
+
+let find t ~dir =
+  let+ scopes = Memo.Lazy.force t.scopes in
+  Path.Source.Map.find_exn scopes dir |> Lazy.force
+;;

--- a/src/dune_rules/coq/coq_scope.mli
+++ b/src/dune_rules/coq/coq_scope.mli
@@ -1,0 +1,13 @@
+open Import
+
+type t
+
+val make
+  :  Context.t
+  -> public_libs:Lib.DB.t
+  -> db_by_project_dir:('a * Lib.DB.t) Path.Source.Map.t
+  -> projects_by_root:'b Path.Source.Map.t
+  -> (Path.Build.t * Coq_stanza.Theory.t) list
+  -> t
+
+val find : t -> dir:Path.Source.t -> Coq_lib.DB.t Memo.t


### PR DESCRIPTION
cc @ejgallego and @Alizter . I need to refactor OCaml scope handling in dune and it would be helpful to have the coq stuff live on its own. No semantic changes here, but I did remove some intermediate lazy cells whose purpose I did not see.