### PR TITLE
refactor: use more precise type for ocaml-config pforms

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -556,7 +556,7 @@ let ocaml_config_macro source macro_invocation context =
      | Int x -> string (string_of_int x)
      | String x -> string x
      | Words x -> strings x
-     | Prog_and_args x -> strings (x.prog :: x.args))
+     | Prog_and_args x -> Value.Path (Path.of_string x.prog) :: strings x.args)
 ;;
 
 let env_macro t source macro_invocation =


### PR DESCRIPTION
return programs from ocaml config as [Value.Path] rather than
[Value.String]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 25b56e70-eb18-4afc-a4b0-f042e6af50e7 -->