### PR TITLE
fix: correct expander for cram stanzas

### DIFF
--- a/doc/changes/10185.md
+++ b/doc/changes/10185.md
@@ -1,0 +1,3 @@
+- Fix expanding dependencies and locks specified in the cram stanza.
+  Previously, they would be installed in the context of the cram test, rather
+  than the cram stanza itself (#10165, @rgrinberg)

--- a/src/dune_rules/cram/cram_rules.mli
+++ b/src/dune_rules/cram/cram_rules.mli
@@ -2,9 +2,4 @@
 
 open Import
 
-val rules
-  :  sctx:Super_context.t
-  -> expander:Expander.t
-  -> dir:Path.Build.t
-  -> Source_tree.Dir.t
-  -> unit Memo.t
+val rules : sctx:Super_context.t -> dir:Path.Build.t -> Source_tree.Dir.t -> unit Memo.t

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -880,15 +880,7 @@ let eval_blang t blang =
   Blang_expand.eval ~f:(No_deps.expand_pform t) ~dir:(Path.build t.dir) blang
 ;;
 
-let expand_lock ~base expander (Locks.Lock sw) =
-  let open Memo.O in
-  match base with
-  | `Of_expander -> No_deps.expand_path expander sw
-  | `This base ->
-    let+ str = No_deps.expand_str expander sw in
-    Path.relative base str
-;;
-
-let expand_locks ~base expander locks =
-  Memo.List.map locks ~f:(expand_lock ~base expander) |> Action_builder.of_memo
+let expand_locks t (locks : Locks.t) =
+  Memo.List.map locks ~f:(fun (Lock x) -> No_deps.expand_path t x)
+  |> Action_builder.of_memo
 ;;

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -108,12 +108,7 @@ val expand_and_eval_set
 val eval_blang : t -> Blang.t -> bool Memo.t
 val map_exe : t -> Path.t -> Path.t
 val artifacts : t -> Artifacts.t
-
-val expand_locks
-  :  base:[ `Of_expander | `This of Path.t ]
-  -> t
-  -> Locks.t
-  -> Path.t list Action_builder.t
+val expand_locks : t -> Locks.t -> Path.t list Action_builder.t
 
 val foreign_flags
   : (dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -293,18 +293,16 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander dune_file ~dir:ctx_di
   cctxs
 ;;
 
-let gen_format_and_cram_rules sctx ~expander ~dir source_dir =
+let gen_format_and_cram_rules sctx ~dir source_dir =
   let+ () = Format_rules.setup_alias ~dir
-  and+ () = Cram_rules.rules source_dir ~sctx ~expander ~dir in
+  and+ () = Cram_rules.rules source_dir ~sctx ~dir in
   ()
 ;;
 
 let gen_rules_source_only sctx ~dir source_dir =
   Rules.collect_unit (fun () ->
     let* sctx = sctx in
-    let+ () =
-      let* expander = Super_context.expander sctx ~dir in
-      gen_format_and_cram_rules sctx ~expander ~dir source_dir
+    let+ () = gen_format_and_cram_rules sctx ~dir source_dir
     and+ () =
       define_all_alias ~dir ~js_targets:[] ~project:(Source_tree.Dir.project source_dir)
     in
@@ -315,7 +313,7 @@ let gen_rules_group_part_or_root sctx dir_contents cctxs ~source_dir ~dir
   : (Loc.t * Compilation_context.t) list Memo.t
   =
   let* expander = Super_context.expander sctx ~dir in
-  let* () = gen_format_and_cram_rules sctx ~expander ~dir source_dir
+  let* () = gen_format_and_cram_rules sctx ~dir source_dir
   and+ stanzas =
     (* CR-soon rgrinberg: we shouldn't have to fetch the stanzas yet again *)
     Dune_load.stanzas_in_dir dir

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -396,8 +396,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
               executable
               command_line
       and+ locks =
-        Expander.expand_locks expander ~base:`Of_expander stanza.locks
-        |> Action_builder.with_no_targets
+        Expander.expand_locks expander stanza.locks |> Action_builder.with_no_targets
       in
       Action.Full.add_locks locks action |> Action.Full.add_sandbox sandbox
     in

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -53,7 +53,7 @@ let rule_kind ~(rule : Rule_conf.t) ~(action : _ Action_builder.With_targets.t) 
 
 let interpret_and_add_locks ~expander locks action =
   let open Action_builder.O in
-  Expander.expand_locks expander ~base:`Of_expander locks
+  Expander.expand_locks expander locks
   >>= function
   | [] -> action
   | locks -> Action_builder.map action ~f:(Action.Full.add_locks locks)

--- a/test/blackbox-tests/test-cases/cram/enabled_if-expansion.t
+++ b/test/blackbox-tests/test-cases/cram/enabled_if-expansion.t
@@ -30,7 +30,3 @@ stanza was defined.
   > EOF
 
   $ dune runtest
-  File "sub/foo.t", line 1, characters 0-0:
-  Error: Files _build/default/sub/foo.t and _build/default/sub/foo.t.corrected
-  differ.
-  [1]


### PR DESCRIPTION
We should use the expander where the stanza is defined, rather than the
expander of the test.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 99bf8567-5f12-47e1-bf82-0def504fea7d -->