### PR TITLE
refactor: simplify expander api

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -849,16 +849,18 @@ let expand_ordered_set_lang =
       include String_expander.Action_builder
     end)
   in
-  Expander.expand
+  fun t osl ->
+    let dir = Path.build (dir t) in
+    Expander.expand osl ~dir ~f:(expand_pform t)
 ;;
 
 let expand_and_eval_set t set ~standard =
-  let dir = Path.build (dir t) in
   let+ standard =
+    (* This optimization builds [standard] if it's unused by the expander. *)
     if Ordered_set_lang.Unexpanded.has_special_forms set
     then standard
     else Action_builder.return []
-  and+ set = expand_ordered_set_lang set ~dir ~f:(expand_pform t) in
+  and+ set = expand_ordered_set_lang t set in
   Ordered_set_lang.eval set ~standard ~eq:String.equal ~parse:(fun ~loc:_ s -> s)
 ;;
 

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -92,9 +92,8 @@ module With_deps_if_necessary : sig
 end
 
 val expand_ordered_set_lang
-  :  Ordered_set_lang.Unexpanded.t
-  -> dir:Path.t
-  -> f:Value.t list Action_builder.t String_with_vars.expander
+  :  t
+  -> Ordered_set_lang.Unexpanded.t
   -> Ordered_set_lang.t Action_builder.t
 
 (** Expand forms of the form (:standard \ foo bar). Expansion is only possible

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -34,11 +34,12 @@ let eval0 =
      they are only removed from a set (for jbuild file compatibility) *)
   let expand_and_eval t set ~parse ~key ~standard =
     let open Action_builder.O in
-    let dir = Path.build (Expander.dir t) in
-    let+ set = Expander.expand_ordered_set_lang set ~dir ~f:(Expander.expand_pform t) in
+    let+ set = Expander.expand_ordered_set_lang t set in
     let fake_modules = ref Module_name.Map.empty in
-    let parse ~loc x = parse ~loc ~fake_modules x in
-    let r = Unordered.eval_loc set ~parse ~key ~standard in
+    let r =
+      let parse ~loc x = parse ~loc ~fake_modules x in
+      Unordered.eval_loc set ~parse ~key ~standard
+    in
     r, !fake_modules
   in
   let parse ~all_modules ~loc ~fake_modules s =


### PR DESCRIPTION
[Expander.expand_ordered_set_lang] can take [Expander.t] to simplify the
signature of the function.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a7fa5657-6c28-4d57-bd72-883f8d2b5c0e -->