### PR TITLE
refactor: make [Expander.context] return context name

### DIFF
--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -508,12 +508,12 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
     O.Symlink (x, y)
   | Copy_and_add_line_directive (x, y) ->
     A.with_expander (fun expander ->
-      Memo.return
-      @@
-      let context = Expander.context expander in
-      let+ x = E.dep x
-      and+ y = E.target y in
-      Copy_line_directive.action context ~src:x ~dst:y)
+      Expander.context expander
+      |> Context.DB.get
+      |> Memo.map ~f:(fun context ->
+        let+ x = E.dep x
+        and+ y = E.target y in
+        Copy_line_directive.action context ~src:x ~dst:y))
   | System x ->
     let+ x = E.string x in
     O.System x

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -234,7 +234,7 @@ let rec dep expander : Dep_conf.t -> _ = function
     Other
       (let+ () =
          let* pkg = Expander.expand_str expander p in
-         let context = Context.build_context (Expander.context expander) in
+         let context = Build_context.create ~name:(Expander.context expander) in
          let loc = String_with_vars.loc p in
          let* dune_version =
            Action_builder.of_memo

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -62,7 +62,7 @@ type t =
 
 let artifacts t = t.artifacts_host
 let dir t = t.dir
-let context t = t.context
+let context t = Context.name t.context
 
 let set_local_env_var t ~var ~value =
   { t with local_env = Env.Var.Map.set t.local_env var value }

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -5,7 +5,7 @@ open Import
 type t
 
 val dir : t -> Path.Build.t
-val context : t -> Context.t
+val context : t -> Context_name.t
 
 val make_root
   :  scope:Scope.t

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -415,7 +415,7 @@ module Unprocessed = struct
        | Some args ->
          let action =
            let action = Action_unexpanded.Run args in
-           let chdir = Expander.context expander |> Context.build_dir in
+           let chdir = Expander.context expander |> Context_name.build_dir in
            Action_unexpanded.expand_no_targets
              ~loc
              ~expander

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -518,7 +518,6 @@ let sandbox_of_setting = function
 ;;
 
 let action_for_pp ~sandbox ~loc ~expander ~action ~src =
-  let chdir = Expander.context expander |> Context.build_dir in
   let expander =
     let bindings = Pform.Map.singleton (Var Input_file) [ Value.Path (Path.build src) ] in
     Expander.add_bindings expander ~bindings
@@ -527,7 +526,7 @@ let action_for_pp ~sandbox ~loc ~expander ~action ~src =
   Action_builder.path (Path.build src)
   >>> Action_unexpanded.expand_no_targets
         action
-        ~chdir
+        ~chdir:(Expander.context expander |> Context_name.build_dir)
         ~loc
         ~expander
         ~deps:[]

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -41,8 +41,8 @@ let scope_host ~scope (context : Context.t) =
     Scope.DB.find_by_dir dir
 ;;
 
-let expander_for_artifacts ~scope ~external_env ~root_expander ~dir =
-  let+ scope_host = scope_host ~scope (Expander.context root_expander) in
+let expander_for_artifacts context ~scope ~external_env ~root_expander ~dir =
+  let+ scope_host = scope_host ~scope context in
   Expander.extend_env root_expander ~env:external_env
   |> Expander.set_scope ~scope ~scope_host
   |> Expander.set_dir ~dir
@@ -64,7 +64,12 @@ let expander t ~dir =
     let* node = t.get_node dir in
     let scope = Env_node.scope node in
     let* external_env = Env_node.external_env node in
-    expander_for_artifacts ~scope ~external_env ~root_expander:t.root_expander ~dir
+    expander_for_artifacts
+      t.context
+      ~scope
+      ~external_env
+      ~root_expander:t.root_expander
+      ~dir
   in
   extend_expander t ~dir ~expander_for_artifacts
 ;;
@@ -100,7 +105,12 @@ let get_impl t dir =
   let expander_for_artifacts =
     Memo.lazy_ (fun () ->
       let* external_env = t.get_node dir >>= Env_node.external_env in
-      expander_for_artifacts ~scope ~root_expander:t.root_expander ~external_env ~dir)
+      expander_for_artifacts
+        t.context
+        ~scope
+        ~root_expander:t.root_expander
+        ~external_env
+        ~dir)
   in
   let profile = Context.profile t.context in
   Env_node.make


### PR DESCRIPTION
This is needed to expand pforms without loading the context

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3954636e-b8b2-4fd5-8d67-3c165c41127a -->