### PR TITLE
refactor: expand %{project_root} without scope

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -522,7 +522,15 @@ let expand_pform_var (context : Context.t) ~source (var : Pform.Var.t) =
     string_of_bool !Clflags.ignore_promoted_rules |> string |> Memo.return |> static
   | Project_root ->
     Need_full_expander
-      (fun t -> Without (Memo.return [ Value.Dir (Path.build (Scope.root t.scope)) ]))
+      (fun t ->
+        Without
+          (let+ project = Dune_load.find_project ~dir:t.dir in
+           [ Value.Dir
+               (Path.Build.append_source
+                  (Context.build_dir t.context)
+                  (Dune_project.root project)
+                |> Path.build)
+           ]))
   | Cc -> Need_full_expander (fun t -> With (cc t).c)
   | Cxx -> Need_full_expander (fun t -> With (cc t).cxx)
   | Toolchain ->


### PR DESCRIPTION
This is equivalent, but in the future, it will allow expanding
%{project_root} in more contexts.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 871d3052-5279-4fe6-acce-57b8e1f58e3c -->