### PR TITLE
test(cram): expansion bug in the cram stanza

### DIFF
--- a/test/blackbox-tests/test-cases/cram/enabled_if-expansion.t
+++ b/test/blackbox-tests/test-cases/cram/enabled_if-expansion.t
@@ -1,0 +1,36 @@
+Expansion of enabled_if in the cram stanza
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.14)
+  > EOF
+
+We define a test that is disabled by default but can be turned using the FOO
+env var.
+
+  $ cat >dune <<EOF
+  > (cram
+  >  (applies_to :whole_subtree)
+  >  (enabled_if %{env:FOO=false}))
+  > EOF
+
+  $ mkdir sub
+
+We set the FOO env var in the sub directory of the test, but this shouldn't
+have an effect because environment variable should be expanded where the cram
+stanza was defined.
+
+  $ cat >sub/dune <<EOF
+  > (env
+  >  (_
+  >   (env-vars (FOO true))))
+  > EOF
+
+  $ cat >sub/foo.t <<EOF
+  >   $ echo should be disabled
+  > EOF
+
+  $ dune runtest
+  File "sub/foo.t", line 1, characters 0-0:
+  Error: Files _build/default/sub/foo.t and _build/default/sub/foo.t.corrected
+  differ.
+  [1]


### PR DESCRIPTION
The expansion is done in the context of the tests rather than the cram
stanza.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 84a8e70c-e75f-4d98-983a-6dc0d49d4301 -->