### PR TITLE
fix(pkg): Create temporary directories on same FS

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -195,9 +195,19 @@ let unpack ~target ~archive =
     Pp.textf "unable to extract %S" (Path.to_string archive))
 ;;
 
-let with_download url checksum ~f =
+let with_download url checksum ~target ~f =
   let url = OpamUrl.to_string url in
-  let temp_dir = Temp.create Dir ~prefix:"dune" ~suffix:(Filename.basename url) in
+  let temp_dir =
+    let prefix = "dune" in
+    let suffix = Filename.basename url in
+    match (target : Path.t) with
+    | In_build_dir _ ->
+      Temp.temp_in_dir Dir ~dir:(Lazy.force Temp_dir.in_build) ~prefix ~suffix
+    | _ ->
+      let parent = Path.parent_exn target in
+      Path.mkdir_p parent;
+      Temp.temp_in_dir Dir ~dir:parent ~prefix ~suffix
+  in
   let output = Path.relative temp_dir "download" in
   Fiber.finalize ~finally:(fun () ->
     Temp.destroy Dir temp_dir;
@@ -222,10 +232,9 @@ let with_download url checksum ~f =
 ;;
 
 let fetch_curl ~unpack:unpack_flag ~checksum ~target (url : OpamUrl.t) =
-  with_download url checksum ~f:(fun output ->
+  with_download url checksum ~target ~f:(fun output ->
     match unpack_flag with
     | false ->
-      Path.mkdir_p (Path.parent_exn target);
       Path.rename output target;
       Fiber.return @@ Ok ()
     | true ->

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -200,13 +200,7 @@ let with_download url checksum ~target ~f =
   let temp_dir =
     let prefix = "dune" in
     let suffix = Filename.basename url in
-    match (target : Path.t) with
-    | In_build_dir _ ->
-      Temp.temp_in_dir Dir ~dir:(Lazy.force Temp_dir.in_build) ~prefix ~suffix
-    | _ ->
-      let parent = Path.parent_exn target in
-      Path.mkdir_p parent;
-      Temp.temp_in_dir Dir ~dir:parent ~prefix ~suffix
+    Temp_dir.dir_for_target ~target ~prefix ~suffix
   in
   let output = Path.relative temp_dir "download" in
   Fiber.finalize ~finally:(fun () ->

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -710,7 +710,13 @@ module At_rev = struct
   let check_out { repo = { dir; _ }; revision = Sha1 rev; files = _ } ~target =
     (* TODO iterate over submodules to output sources *)
     let git = Lazy.force Vcs.git in
-    let temp_dir = Temp.create Dir ~prefix:"rev-store" ~suffix:rev in
+    let temp_dir =
+      Temp.temp_in_dir
+        Dir
+        ~dir:(Lazy.force Temp_dir.in_build)
+        ~prefix:"rev-store"
+        ~suffix:rev
+    in
     Fiber.finalize ~finally:(fun () ->
       let+ () = Fiber.return () in
       Temp.destroy Dir temp_dir)

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -710,13 +710,7 @@ module At_rev = struct
   let check_out { repo = { dir; _ }; revision = Sha1 rev; files = _ } ~target =
     (* TODO iterate over submodules to output sources *)
     let git = Lazy.force Vcs.git in
-    let temp_dir =
-      Temp.temp_in_dir
-        Dir
-        ~dir:(Lazy.force Temp_dir.in_build)
-        ~prefix:"rev-store"
-        ~suffix:rev
-    in
+    let temp_dir = Temp_dir.dir_for_target ~target ~prefix:"rev-store" ~suffix:rev in
     Fiber.finalize ~finally:(fun () ->
       let+ () = Fiber.return () in
       Temp.destroy Dir temp_dir)

--- a/src/dune_pkg/tar.ml
+++ b/src/dune_pkg/tar.ml
@@ -11,13 +11,6 @@ let bin =
 
 let output_limit = 1_000_000
 
-let temp_dir_in_build =
-  lazy
-    (let dir = Path.relative (Path.build Path.Build.root) ".temp" in
-     Path.mkdir_p dir;
-     dir)
-;;
-
 let extract ~archive ~target =
   let* () = Fiber.return () in
   let tar = Lazy.force bin in
@@ -26,8 +19,10 @@ let extract ~archive ~target =
     let suffix = Path.basename archive in
     match target with
     | In_build_dir _ ->
-      Temp.temp_in_dir Dir ~dir:(Lazy.force temp_dir_in_build) ~prefix ~suffix
-    | _ -> Temp.create Dir ~prefix ~suffix
+      Temp.temp_in_dir Dir ~dir:(Lazy.force Temp_dir.in_build) ~prefix ~suffix
+    | _ ->
+      let parent = Path.parent_exn target in
+      Temp.temp_in_dir Dir ~dir:parent ~prefix ~suffix
   in
   Fiber.finalize ~finally:(fun () ->
     Temp.destroy Dir target_in_temp;

--- a/src/dune_pkg/tar.ml
+++ b/src/dune_pkg/tar.ml
@@ -17,12 +17,7 @@ let extract ~archive ~target =
   let target_in_temp =
     let prefix = Path.basename target in
     let suffix = Path.basename archive in
-    match target with
-    | In_build_dir _ ->
-      Temp.temp_in_dir Dir ~dir:(Lazy.force Temp_dir.in_build) ~prefix ~suffix
-    | _ ->
-      let parent = Path.parent_exn target in
-      Temp.temp_in_dir Dir ~dir:parent ~prefix ~suffix
+    Temp_dir.dir_for_target ~target ~prefix ~suffix
   in
   Fiber.finalize ~finally:(fun () ->
     Temp.destroy Dir target_in_temp;

--- a/src/dune_pkg/temp_dir.ml
+++ b/src/dune_pkg/temp_dir.ml
@@ -1,0 +1,8 @@
+open Stdune
+
+let in_build =
+  lazy
+    (let dir = Path.relative (Path.build Path.Build.root) ".temp" in
+     Path.mkdir_p dir;
+     dir)
+;;

--- a/src/dune_pkg/temp_dir.ml
+++ b/src/dune_pkg/temp_dir.ml
@@ -6,3 +6,12 @@ let in_build =
      Path.mkdir_p dir;
      dir)
 ;;
+
+let dir_for_target ~target ~prefix ~suffix =
+  match (target : Path.t) with
+  | In_build_dir _ -> Temp.temp_in_dir Dir ~dir:(Lazy.force in_build) ~prefix ~suffix
+  | _ ->
+    let parent = Path.parent_exn target in
+    Path.mkdir_p parent;
+    Temp.temp_in_dir Dir ~dir:parent ~prefix ~suffix
+;;

--- a/src/dune_pkg/temp_dir.mli
+++ b/src/dune_pkg/temp_dir.mli
@@ -1,3 +1,3 @@
 open Stdune
 
-val in_build : Path.t Lazy.t
+val dir_for_target : target:Path.t -> prefix:string -> suffix:string -> Path.t

--- a/src/dune_pkg/temp_dir.mli
+++ b/src/dune_pkg/temp_dir.mli
@@ -1,0 +1,3 @@
+open Stdune
+
+val in_build : Path.t Lazy.t


### PR DESCRIPTION
The problem in #10213 is that `Temp.create` creates a temporary directory and then `Path.rename` is used to move the files to the actual target directory. This unfortunately only works if the directory that `Temp.create` picks and `~target` are on the same file system.

Multiple solutions exist:

  1. Attempt to write to the same filesystem, e.g. by hoping that the parent directory of `target` is also on the same file system as `~target`. This isn't necessarily true, but given we write to `_build` it should be true in most cases.
  2. Write to a temporary directory but then copy the files manually. This makes the whole operation non-atomic and incurs potentially a lot of file I/O

This PR attempts #1. An unfortunate consequence of this is that `Path.mkdir_p` is necessary to create the parent directory and if it didn't exist, in the case of failure it is left behind and not deleted. We could probably solve this by keeping track of directories that are created in such case, if it proves to be an issue. Input welcome!

Fixes #10213