### PR TITLE
doc: remove dune:field directive

### DIFF
--- a/doc/reference/files/dune-project/dialect.rst
+++ b/doc/reference/files/dune-project/dialect.rst
@@ -5,22 +5,20 @@ dialect
 
    Declare a new :term:`dialect`.
 
-   .. dune:field:: name
-      :param: <name>
+   .. describe:: (name <name>)
 
       The name of the dialect being defined. It must be unique in a given
       project.
 
       This field is required.
 
-   .. dune:field:: implementation
+   .. describe:: (implementation ...)
 
       Details related to the implementation files (corresponding to `*.ml`).
 
       .. versionchanged:: 3.9 This field is made optional.
 
-      .. dune:field:: extension
-         :param: <string>
+      .. describe:: (extension <string>)
 
          Specify the file extension used for this dialect.
 
@@ -31,8 +29,7 @@ dialect
 
          This field is required.
 
-      .. dune:field:: preprocess
-         :param: <action>
+      .. describe:: (preprocess <action>)
 
          Run `<action>` to produce a valid OCaml abstract syntax tree.
 
@@ -46,8 +43,7 @@ dialect
 
          .. seealso:: :ref:`preprocessing-actions`
 
-      .. dune:field:: format
-         :param: <action>
+      .. describe:: (format <action>)
 
          Run `<action>` to format source code for this dialect.
 
@@ -62,7 +58,7 @@ dialect
 
          .. seealso:: :doc:`/howto/formatting`
 
-   .. dune:field:: interface
+   .. describe:: (interface ...)
 
       Details related to the interface files (corresponding to `*.mli`).
 

--- a/doc/reference/files/dune-project/package.rst
+++ b/doc/reference/files/dune-project/package.rst
@@ -5,94 +5,86 @@ package
 
    Define package-specific metadata.
 
-   .. dune:field:: name
-      :param: <string>
+   .. describe:: (name <string>)
 
       The name of the package.
 
       This must be specified.
 
-   .. dune:field:: synopsis
-      :param: <string>
+   .. describe:: (synopsis <string>)
 
       A short package description.
 
-   .. dune:field:: description
-      :param: <string>
+   .. describe:: (description <string>)
 
       A longer package description.
 
-   .. dune:field:: depends
-      :param: <dep-specification>
+   .. describe:: (depends <dep-specification>)
 
       Package dependencies, as :token:`~pkg-dep:dep_specification`.
 
-   .. dune:field:: conflicts
-      :param: <dep-specification>
+   .. describe:: (conflicts <dep-specification>)
 
       Package conflicts, as :token:`~pkg-dep:dep_specification`.
 
-   .. dune:field:: depopts
-      :param: <dep-specification>
+   .. describe:: (depopts <dep-specification>)
 
       Optional package dependencies, as :token:`~pkg-dep:dep_specification`.
 
-   .. dune:field:: tags
-      :param: <tags>
+   .. describe:: (tags <tags>)
 
       A list of tags.
 
-   .. dune:field:: deprecated_package_names
-      :param: <name list>
+   .. describe:: (deprecated_package_names <name list>)
 
       A list of names that can be used with the
       :doc:`../dune/deprecated_library_name` stanza to migrate legacy libraries
       from other build systems that do not follow Dune's convention of
       prefixing the library's public name with the package name.
 
-   .. dune:field:: license
+   .. describe:: (license ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: authors
+   .. describe:: (authors ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: maintainers
+   .. describe:: (maintainers ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: source
+   .. describe:: (source ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: bug_reports
+   .. describe:: (bug_reports ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: homepage
+   .. describe:: (homepage ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: documentation
+   .. describe:: (documentation ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field.
 
-   .. dune:field:: sites
+   .. describe:: (sites ...)
 
       Define a site.
 

--- a/doc/reference/files/dune-project/warnings.rst
+++ b/doc/reference/files/dune-project/warnings.rst
@@ -7,7 +7,6 @@ warnings
 
    Configure Dune warnings for the project.
 
-   .. dune:field:: <name>
-      :param: <enabled | disabled>
+   .. describe:: (<name> <enabled | disabled>)
 
       Enable or disable the warning <name> for the current project.

--- a/doc/reference/files/dune/cram.rst
+++ b/doc/reference/files/dune/cram.rst
@@ -11,8 +11,7 @@ Cram
 
    .. seealso:: :doc:`/reference/cram`
 
-   .. dune:field:: deps
-      :param: <dep-spec>
+   .. describe:: (deps <dep-spec>)
 
       Specify the dependencies of the test.
 
@@ -33,8 +32,7 @@ Cram
 
       .. seealso:: :doc:`/concepts/dependency-spec`.
 
-   .. dune:field:: applies_to
-      :param: <predicate-lang>
+   .. describe:: (applies_to <predicate-lang>)
 
       Specify the scope of this ``cram`` stanza. By default it applies to all the
       Cram tests in the current directory. The special ``:whole_subtree`` value
@@ -52,34 +50,29 @@ Cram
 
       .. seealso:: :doc:`/reference/predicate-language`
 
-   .. dune:field:: enabled_if
-      :param: <blang>
+   .. describe:: (enabled_if <blang>)
 
       Control whether the tests are enabled.
 
       .. seealso:: :doc:`/reference/boolean-language`, :doc:`/concepts/variables`
 
-   .. dune:field:: alias
-      :param: <name>
+   .. describe:: (alias <name>)
 
       Alias that can be used to run the test. In addition to the user alias,
       every test ``foo.t`` is attached to the ``@runtest`` alias and gets its
       own ``@foo`` alias to make it convenient to run individually.
 
-   .. dune:field:: locks
-      :param: <lock-names>
+   .. describe:: (locks <lock-names>)
 
       Specify that the tests must be run while holding the following locks.
 
       .. seealso:: :doc:`/concepts/locks`
 
-   .. dune:field:: package
-      :param: <name>
+   .. describe:: (package <name>)
 
       Attach the tests selected by this stanza to the specified package.
 
-   .. dune:field:: runtest_alias
-      :param: <true|false>
+   .. describe:: (runtest_alias <true|false>)
 
       .. versionadded:: 3.12
 


### PR DESCRIPTION
This is a followup to #10152, which does the same for `dune:field`. The next and final step is to do the same for `dune:stanza`.
