### PR TITLE
feat(boot): specify platform-specific cflags

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -97,6 +97,8 @@ let local_libraries =
   ; ("src/dune_rules_rpc", Some "Dune_rules_rpc", false, None)
   ]
 
+let build_flags = []
+
 let link_flags =
   [ ("macosx",
     [ "-cclib"

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -15,6 +15,7 @@ let rule sctx ~requires_link (exes : Executables.t) =
       | Some x -> Left x
       | None -> Right lib)
   in
+  let build_flags = [] in
   let link_flags =
     let win_link_flags =
       [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ]
@@ -82,6 +83,11 @@ let rule sctx ~requires_link (exes : Executables.t) =
                     else Some (Lib_name.to_dyn name))))
           ; Pp.nop
           ; def "local_libraries" (List locals)
+          ; Pp.nop
+          ; def
+              "build_flags"
+              (let open Dyn in
+               list (pair string (list string)) build_flags)
           ; Pp.nop
           ; def
               "link_flags"


### PR DESCRIPTION
These flags have the same semantics as `link_flags` but are used when building C code.
