### PR TITLE
[Vendored Opam] fix partial-match warnings by removing a lot of dead code

### DIFF
--- a/vendor/opam/src/repository/opamDownload.ml
+++ b/vendor/opam/src/repository/opamDownload.ml
@@ -321,7 +321,7 @@ module SWHID = struct
             (log "SWH fallback for %s"
                (OpamUrl.to_string (OpamFile.URL.url urlf));
              get_url ?max_tries swhid @@+ function
-             | Not_available _ as error -> Done error
+             | (Not_available _ | Checksum_mismatch _) as error -> Done error
              | Up_to_date _ -> assert false
              | Result url ->
                let hash = OpamSWHID.hash swhid in

--- a/vendor/opam/src/repository/opamRepository.ml
+++ b/vendor/opam/src/repository/opamRepository.ml
@@ -13,7 +13,6 @@ open OpamTypes
 open OpamProcess.Job.Op
 
 let log fmt = OpamConsole.log "REPOSITORY" fmt
-let slog = OpamConsole.slog
 
 
 let find_backend_by_kind = function
@@ -29,8 +28,6 @@ let find_vcs_backend = function
   | `darcs -> (module OpamDarcs.VCS: OpamVCS.VCS)
 
 let url_backend url = find_backend_by_kind url.OpamUrl.backend
-
-let find_backend r = url_backend r.repo_url
 
 let cache_url root_cache_url checksum =
   List.fold_left OpamUrl.Op.(/) root_cache_url
@@ -115,11 +112,10 @@ let fetch_from_cache =
         | [] -> let m = "cache miss" in Done (Not_available (Some m, m))
         | root_cache_url::other_caches ->
           OpamProcess.Job.catch
-            (function
-              Failure _
+            (function Failure _
               | OpamDownload.Download_fail _
               | OpamDownload.Checksum_mismatch _ -> try_cache_dl other_caches
-                    | e -> raise e)
+              | e -> raise e)
           @@ fun () ->
           dl_from_cache_job root_cache_url checksum tmpfile
           @@+ fun () ->
@@ -252,7 +248,7 @@ let pull_from_mirrors label ?working_dir ?subpath cache_dir destdir checksums ur
 (* handle subpathes *)
 let pull_tree_t
     ?cache_dir ?(cache_urls=[]) ?working_dir
-    dirnames checksums remote_urls =
+    ~label ~local_dirname ~subpath checksums remote_urls =
   let extract_archive =
     let fallback success = function
       | None -> success ()
@@ -263,40 +259,11 @@ let pull_tree_t
                              OpamProcess.string_of_result pe))
       | Some e -> Done (Not_available (None, Printexc.to_string e))
     in
-    match dirnames with
-    | [ _label, local_dirname, _subpath ] ->
-      (fun archive msg ->
-         OpamFilename.cleandir local_dirname;
-         OpamFilename.extract_job archive local_dirname
-         @@+ fallback (fun () ->  Done (Up_to_date msg)))
-    | _ ->
-      fun archive msg ->
-        OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
-        let copies () = failwith "stubbed out" in
-        OpamFilename.extract_job archive tmpdir
-        @@+ fallback (fun () ->
-            let failing =
-              OpamStd.List.filter_map (function
-                  | Result _ | Up_to_date _ -> None
-                  | Not_available (Some s,l) -> Some (s,l)
-                  | Not_available (None, _) -> assert false
-                  | Checksum_mismatch _ -> assert false
-                ) (copies ())
-            in
-            if failing = [] then Done (Up_to_date msg) else
-            let simple =
-              Printf.sprintf "Failed to copy source of %s"
-                (OpamStd.Format.pretty_list (List.map fst failing))
-            in
-            let long =
-              Printf.sprintf "Failed to copy source of:\n%s"
-                (OpamStd.Format.itemize (fun (nv, msg) ->
-                     Printf.sprintf "%s: %s" nv msg)
-                    failing)
-            in
-            Done (Not_available (Some simple, long)))
+    fun archive msg ->
+      OpamFilename.cleandir local_dirname;
+      OpamFilename.extract_job archive local_dirname
+      @@+ fallback (fun () ->  Done (Up_to_date msg))
   in
-  let label = OpamStd.List.concat_map ", " (fun (x,_,_) -> x) dirnames in
   (match cache_dir with
    | Some cache_dir ->
      let text = OpamProcess.make_command_text label "dl" in
@@ -326,25 +293,16 @@ let pull_tree_t
     else
       OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
       let extract url archive =
-        match dirnames with
-        | [_] ->
           let tmp_archive = OpamFilename.(create tmpdir (basename archive)) in
           OpamFilename.move ~src:archive ~dst:tmp_archive;
           extract_archive tmp_archive url
-        | _ -> extract_archive archive url
       in
       let pull label checksums remote_urls =
-        match dirnames with
-        | [ label, local_dirname, subpath ] ->
-          pull_from_mirrors label ?working_dir ?subpath cache_dir local_dirname
-            checksums remote_urls
-          @@| fun (url, res) ->
-          (OpamUrl.to_string_w_subpath subpath url),
-          res
-        | _ ->
-          pull_from_mirrors label ?working_dir cache_dir tmpdir
-            checksums remote_urls
-          @@| fun (url, res) -> OpamUrl.to_string url, res
+        pull_from_mirrors label ?working_dir ?subpath cache_dir local_dirname
+          checksums remote_urls
+        @@| fun (url, res) ->
+        (OpamUrl.to_string_w_subpath subpath url),
+        res
       in
       pull label checksums remote_urls
       @@+ function
@@ -355,19 +313,10 @@ let pull_tree_t
       | _, (Checksum_mismatch _ as na) -> Done na
       | _, (Not_available _ as na) -> Done na
 
-
 let pull_tree label ?cache_dir ?(cache_urls=[]) ?working_dir ?subpath
     local_dirname  =
   pull_tree_t ?cache_dir ~cache_urls ?working_dir
-  [label, local_dirname, subpath]
-
-let pull_shared_tree ?cache_dir ?(cache_urls=[]) dirnames checksums remote_urls =
-  pull_tree_t ?cache_dir ~cache_urls dirnames checksums remote_urls
-
-let revision dirname url =
-  let kind = url.OpamUrl.backend in
-  let module B = (val find_backend_by_kind kind: OpamRepositoryBackend.S) in
-  B.revision dirname
+    ~label ~local_dirname ~subpath
 
 let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
     file checksums remote_urls =
@@ -410,184 +359,3 @@ let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
           | _, Result None -> let m = "is a directory" in Not_available (Some m, m)
           | _, (Checksum_mismatch _ as na) -> na
           | _, (Not_available _ as na) -> na)
-
-let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
-  let text = OpamProcess.make_command_text label "dl" in
-  OpamProcess.Job.with_text text @@
-  fetch_from_cache cache_dir cache_urls checksums @@+ function
-  | Checksum_mismatch e -> Done (Checksum_mismatch e)
-  | Up_to_date (_, _) ->
-    Done (Up_to_date "cached")
-  | Result (_, url) ->
-    Done (Result (OpamUrl.to_string url))
-  | Not_available _ ->
-    OpamFilename.with_tmp_dir_job (fun tmpdir ->
-        pull_from_mirrors label (Some cache_dir) tmpdir checksums remote_urls
-        @@| function
-        | _, Up_to_date _ -> assert false
-        | _, Checksum_mismatch _ -> assert false
-        | url, Result (Some _) -> Result (OpamUrl.to_string url)
-        | _, Result None -> let m = "is a directory" in Not_available (Some m, m)
-        | _, (Not_available _ as na) -> na)
-
-let packages repo_root =
-  OpamPackage.list (OpamRepositoryPath.packages_dir repo_root)
-
-let packages_with_prefixes repo_root =
-  OpamPackage.prefixes (OpamRepositoryPath.packages_dir repo_root)
-
-let validate_repo_update repo repo_root update =
-  match
-    repo.repo_trust,
-    OpamRepositoryConfig.(!r.validation_hook),
-    OpamRepositoryConfig.(!r.force_checksums)
-  with
-  | None, Some _, Some true ->
-    OpamConsole.error
-      "No trust anchors for repository %s, and security was enforced: \
-       not updating"
-      (OpamRepositoryName.to_string repo.repo_name);
-    Done false
-  | None, _, _ | _, None, _ | _, _, Some false ->
-    Done true
-  | Some ta, Some hook, _ ->
-    let cmd =
-      let open OpamRepositoryBackend in
-      let env v = match OpamVariable.Full.to_string v, update with
-        | "anchors", _ -> Some (S (String.concat "," ta.fingerprints))
-        | "quorum", _ -> Some (S (string_of_int ta.quorum))
-        | "repo", _ -> Some (S (OpamFilename.Dir.to_string repo_root))
-        | "patch", Update_patch f -> Some (S (OpamFilename.to_string f))
-        | "incremental", Update_patch _ -> Some (B true)
-        | "incremental", _ -> Some (B false)
-        | "dir", Update_full d -> Some (S (OpamFilename.Dir.to_string d))
-        | _ -> None
-      in
-      match OpamFilter.single_command env hook with
-      | cmd::args ->
-        OpamSystem.make_command
-          ~name:"validation-hook"
-          ~verbose:OpamCoreConfig.(!r.verbose_level >= 2)
-          cmd args
-      | [] -> failwith "Empty validation hook"
-    in
-    cmd @@> fun r ->
-    log "validation: %s" (OpamProcess.result_summary r);
-    Done (OpamProcess.check_success_and_cleanup r)
-
-open OpamRepositoryBackend
-
-let apply_repo_update repo repo_root = function
-  | Update_full d ->
-    log "%a: applying update from scratch at %a"
-      (slog OpamRepositoryName.to_string) repo.repo_name
-      (slog OpamFilename.Dir.to_string) d;
-    OpamFilename.rmdir repo_root;
-    if OpamFilename.is_symlink_dir d then
-      (OpamFilename.copy_dir ~src:d ~dst:repo_root;
-       OpamFilename.rmdir d)
-    else
-      OpamFilename.move_dir ~src:d ~dst:repo_root;
-    OpamConsole.msg "[%s] Initialised\n"
-      (OpamConsole.colorise `green
-         (OpamRepositoryName.to_string repo.repo_name));
-    Done ()
-  | Update_patch f ->
-    OpamConsole.msg "[%s] synchronised from %s\n"
-      (OpamConsole.colorise `green
-         (OpamRepositoryName.to_string repo.repo_name))
-      (OpamUrl.to_string repo.repo_url);
-    log "%a: applying patch update at %a"
-      (slog OpamRepositoryName.to_string) repo.repo_name
-      (slog OpamFilename.to_string) f;
-    let preprocess =
-      match repo.repo_url.OpamUrl.backend with
-      | `http | `rsync -> false
-      | _ -> true
-    in
-    (OpamFilename.patch ~preprocess f repo_root @@+ function
-      | Some e ->
-        if not (OpamConsole.debug ()) then OpamFilename.remove f;
-        raise e
-      | None -> OpamFilename.remove f; Done ())
-  | Update_empty ->
-    OpamConsole.msg "[%s] no changes from %s\n"
-      (OpamConsole.colorise `green
-         (OpamRepositoryName.to_string repo.repo_name))
-      (OpamUrl.to_string repo.repo_url);
-    log "%a: applying empty update"
-      (slog OpamRepositoryName.to_string) repo.repo_name;
-    Done ()
-  | Update_err _ -> assert false
-
-let cleanup_repo_update upd =
-  if not (OpamConsole.debug ()) then
-    match upd with
-    | Update_full d -> OpamFilename.rmdir d
-    | Update_patch f -> OpamFilename.remove f
-    | _ -> ()
-
-let update repo repo_root =
-  log "update %a" (slog OpamRepositoryBackend.to_string) repo;
-  let module B = (val find_backend repo: OpamRepositoryBackend.S) in
-  B.fetch_repo_update repo.repo_name repo_root repo.repo_url @@+ function
-  | Update_err e -> raise e
-  | Update_empty ->
-    log "update empty, no validation performed";
-    apply_repo_update repo repo_root Update_empty @@+ fun () ->
-    B.repo_update_complete repo_root repo.repo_url @@+ fun () ->
-    Done `No_changes
-  | (Update_full _ | Update_patch _) as upd ->
-    OpamProcess.Job.catch (fun exn ->
-        cleanup_repo_update upd;
-        raise exn)
-    @@ fun () ->
-    validate_repo_update repo repo_root upd @@+ function
-    | false ->
-      cleanup_repo_update upd;
-      failwith "Invalid repository signatures, update aborted"
-    | true ->
-      apply_repo_update repo repo_root upd @@+ fun () ->
-      B.repo_update_complete repo_root repo.repo_url @@+ fun () ->
-      Done `Changes
-
-let on_local_version_control url ~default f =
-  match url.OpamUrl.backend with
-  | #OpamUrl.version_control as backend ->
-    (match OpamUrl.local_dir url with
-     | None -> default
-     | Some dir ->
-       f dir (find_vcs_backend backend))
-  | #OpamUrl.backend -> default
-
-let current_branch url =
-  on_local_version_control url ~default:(Done None) @@
-  fun dir (module VCS) -> VCS.current_branch dir
-
-let is_dirty ?subpath url =
-  on_local_version_control url ~default:(Done false) @@
-  fun dir (module VCS) -> VCS.is_dirty ?subpath dir
-
-let report_fetch_result pkg = function
-  | Checksum_mismatch s ->
-    let msg = "Checksum Mismatch" in
-    OpamConsole.msg "[%s] fetching sources failed: %s\n"
-      (OpamConsole.colorise `red (OpamPackage.to_string pkg)) msg;
-      Checksum_mismatch s
-  | Result msg ->
-    OpamConsole.msg
-      "[%s] synchronised (%s)\n"
-      (OpamConsole.colorise `green (OpamPackage.to_string pkg))
-      msg;
-    Result ()
-  | Up_to_date msg ->
-    OpamConsole.msg
-      "[%s] synchronised (%s)\n"
-      (OpamConsole.colorise `green (OpamPackage.to_string pkg))
-      msg;
-    Up_to_date ()
-  | Not_available (s, l) ->
-    let msg = match s with None -> l | Some s -> s in
-    OpamConsole.msg "[%s] fetching sources failed: %s\n"
-      (OpamConsole.colorise `red (OpamPackage.to_string pkg)) msg;
-    Not_available (s, l)

--- a/vendor/opam/src/repository/opamRepository.mli
+++ b/vendor/opam/src/repository/opamRepository.mli
@@ -14,34 +14,6 @@
 
 open OpamTypes
 
-(** Get the list of packages *)
-val packages: dirname -> package_set
-
-(** Get the list of packages (and their possible prefix) *)
-val packages_with_prefixes: dirname -> string option package_map
-
-(** {2 Repository backends} *)
-
-(** Update {i $opam/repo/$repo}. Raises [Failure] in case the update couldn't be
-    achieved. Returns [`No_changes] if the update did not bring any changes, and
-    [`Changes] otherwise. *)
-val update: repository -> dirname -> [`Changes | `No_changes] OpamProcess.job
-
-(** [pull_shared_tree ?cache_dir ?cache_url labels_dirnames checksums urls]
-    Fetch an URL and put the resulting tree into the supplied directories
-    specified in [labels_dirnames]. The string in [labels_dirnames] are text
-    labels of this given dirname for display. [urls] must either point to a
-    tree (VCS, rsync) or to a known archive type. In case of an archive, the
-    [cache_dir] is used and supplied the hashes verified, then the archive
-    uncompressed. In case of a version-controlled URL, it's checked out, or
-    synchronised directly if local and [working_dir] was set.  [cache_urls] is
-    used to retrieve from repository caches. *)
-val pull_shared_tree:
-  ?cache_dir:dirname ->
-  ?cache_urls:OpamUrl.t list ->
-  (string * OpamFilename.Dir.t * subpath option) list -> OpamHash.t list ->
-  url list -> string download OpamProcess.job
-
 (* Same as [pull_shared_tree], but for a unique label/dirname. *)
 val pull_tree:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
@@ -53,31 +25,3 @@ val pull_file:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?silent_hits:bool ->
   filename -> OpamHash.t list -> url list ->
   unit download OpamProcess.job
-
-(** Same as [pull_file], but without a destination file: just ensures the file
-    is present in the cache. *)
-val pull_file_to_cache:
-  string -> cache_dir:dirname -> ?cache_urls:url list ->
-  OpamHash.t list -> url list -> string download OpamProcess.job
-
-(** The file where the file with the given hash is stored under cache at given
-    dirname. *)
-val cache_file: dirname -> OpamHash.t -> filename
-
-(** Get the optional revision associated to a backend (git hash, etc.). *)
-val revision: dirname -> url -> version option OpamProcess.job
-
-(** Get the version-control branch for that url. Only applicable for local,
-    version controlled URLs. Returns [None] in other cases. *)
-val current_branch: url -> string option OpamProcess.job
-
-(** Returns true if the url points to a local, version-controlled directory that
-    has uncommitted changes *)
-val is_dirty: ?subpath:subpath -> url -> bool OpamProcess.job
-
-(** Find a backend *)
-val find_backend: repository -> (module OpamRepositoryBackend.S)
-val find_backend_by_kind: OpamUrl.backend -> (module OpamRepositoryBackend.S)
-
-(** Prints user messages upon the result of a download *)
-val report_fetch_result: package -> string download -> unit download

--- a/vendor/opam/src/repository/opamVCS.ml
+++ b/vendor/opam/src/repository/opamVCS.ml
@@ -179,7 +179,7 @@ module Make (VCS: VCS) = struct
       Done (match result with
           | Up_to_date _ when rm_list = [] -> Up_to_date None
           | Up_to_date _ | Result _ -> Result None
-          | Not_available _ as na -> na)
+          | (Not_available _ | Checksum_mismatch _) as error -> error)
 
   let get_remote_url = VCS.get_remote_url
 


### PR DESCRIPTION
Fixes #10216.
The only functions in `OpamRepository.ml` that are used externally are `pull_file` and `pull_tree`. I removed everything else, as we now have our own fetching code in dune_pkg