### PR TITLE
refactor: delay env loading in super context

### DIFF
--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -53,7 +53,7 @@ let term =
        | Some dir -> dir)
       |> Path.Build.append_local (Context.build_dir context)
     in
-    let* coqtop, args =
+    let* coqtop, args, env =
       Build_system.run_exn
       @@ fun () ->
       let open Memo.O in
@@ -138,14 +138,14 @@ let term =
       in
       let* prog = Super_context.resolve_program_memo sctx ~dir ~loc:None coqtop in
       let prog = Action.Prog.ok_exn prog in
-      let+ () = Build_system.build_file prog in
-      Path.to_string prog, args
+      let* () = Build_system.build_file prog in
+      let+ env = Super_context.context_env sctx in
+      Path.to_string prog, args, env
     in
     let argv =
       let topfile = Path.to_absolute_filename (Path.build coq_file_build) in
       (coqtop :: "-topfile" :: topfile :: args) @ extra_args
     in
-    let env = Super_context.context_env sctx in
     Fiber.return (coqtop, argv, env)
   in
   restore_cwd_and_execve common coqtop argv env

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -105,7 +105,7 @@ let term =
       let+ ocaml = Context.ocaml (Super_context.context super_context) in
       ocaml.ocamlc
     in
-    let env = Super_context.context_env super_context in
+    let* env = Super_context.context_env super_context in
     let dialects = Dune_project.dialects project in
     pp_with_ocamlc env ~ocamlc dialects file |> Memo.of_non_reproducible_fiber
 ;;

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -264,7 +264,7 @@ module Exec_context = struct
       let context = Dune_rules.Super_context.context sctx in
       Path.Build.relative (Context.build_dir context) (Common.prefix_target common "")
     in
-    let env = Memo.map sctx ~f:Super_context.context_env in
+    let env = Memo.bind sctx ~f:Super_context.context_env in
     let get_path_and_build_if_necessary ~prog =
       let* sctx = sctx
       and+ dir = dir in

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -33,7 +33,7 @@ let make
   let inherited ~field ~root extend =
     Memo.lazy_ (fun () ->
       (match inherit_from with
-       | None -> Memo.return root
+       | None -> root
        | Some t -> Memo.Lazy.force t >>= field)
       >>= extend)
   in

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -10,8 +10,8 @@ val make
   -> config_stanza:Dune_env.t
   -> profile:Profile.t
   -> expander:Expander.t Memo.t
-  -> default_env:Env.t
-  -> default_artifacts:Artifacts.t
+  -> default_env:Env.t Memo.t
+  -> default_artifacts:Artifacts.t Memo.t
   -> t
 
 val external_env : t -> Env.t Memo.t

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -11,7 +11,7 @@ val make_root
   :  scope:Scope.t
   -> scope_host:Scope.t
   -> context:Context.t
-  -> env:Env.t
+  -> env:Env.t Memo.t
   -> public_libs:Lib.DB.t
   -> public_libs_host:Lib.DB.t
   -> artifacts_host:Artifacts.t
@@ -56,7 +56,7 @@ end
 type value = Value.t list Deps.t
 
 val add_bindings_full : t -> bindings:value Pform.Map.t -> t
-val extend_env : t -> env:Env.t -> t
+val extend_env : t -> env:Env.t Memo.t -> t
 
 val expand
   :  t

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -24,7 +24,7 @@ val to_dyn : t -> Dyn.t
 val context : t -> Context.t
 
 (** Context env with additional variables computed from packages *)
-val context_env : t -> Env.t
+val context_env : t -> Env.t Memo.t
 
 val env_node : t -> dir:Path.Build.t -> Env_node.t Memo.t
 


### PR DESCRIPTION
this allows us to use expanders without loading all the packages/stanzas
in a workspace

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6a662a3a-9619-4643-9f65-408f3ec22bc7 -->