### PR TITLE
refactor: treat deprecated lib case explicitly

### DIFF
--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -101,7 +101,8 @@ module DB : sig
     val found : Lib_info.external_ -> t
     val to_dyn : t Dyn.builder
     val redirect : db -> Loc.t * Lib_name.t -> t
-    val redirect_in_the_same_db : Loc.t * Lib_name.t -> t
+    val redirect_in_the_same_db : (Loc.t * Lib_name.t) -> t
+    val deprecated_library_name : Loc.t * Lib_name.t -> t
   end
 
   (** Create a new library database. [resolve] is used to resolve library names

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -101,7 +101,7 @@ module DB : sig
     val found : Lib_info.external_ -> t
     val to_dyn : t Dyn.builder
     val redirect : db -> Loc.t * Lib_name.t -> t
-    val redirect_in_the_same_db : (Loc.t * Lib_name.t) -> t
+    val redirect_in_the_same_db : Loc.t * Lib_name.t -> t
     val deprecated_library_name : Loc.t * Lib_name.t -> t
   end
 


### PR DESCRIPTION
This change will help with enabling multi-context libraries in #10179.

The reason is that with the changes in that PR, the checks in `create_db_from_stanzas` change a bit, with two redirects being a potentially valid situation (e.g. if there are two public libraries with the same name defined in different contexts).

Having a way to explicitly recognize the deprecated library case allows to keep the behavior of that feature untouched while unlocking multi-context public libraries.