### PR TITLE
test: remove module that isn't generated

### DIFF
--- a/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
@@ -19,7 +19,7 @@ isn't set
   > (library
   >  (name repro)
   >  (public_name repro)
-  >  (modules foo))
+  >  (modules))
   > EOF
 
   $ mkdir ocaml-bin


### PR DESCRIPTION
The test refers to a module that doesn't exist

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d96f18e1-c78b-405f-a7ec-d54024583c80 -->