### PR TITLE
refactor: high-level dune-package rewriting

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -206,6 +206,7 @@ module File_ops_real (W : sig
   let print_line = print_line ~verbosity
   let get_vcs p = Dune_rules.Vcs_db.nearest_vcs p
 
+  (* CR-emillon rework this API or at least remove the optional argument *)
   type load_special_file_result =
     { need_version : bool
     ; callback : ?version:string -> Format.formatter -> unit

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -217,7 +217,7 @@ module File_ops_real (W : sig
 
   let copy_special_file ~src ~package ~ic ~oc ~f =
     let open Fiber.O in
-    match f ic with
+    match f ic ~src with
     | None -> Fiber.return Use_plain_copy
     (* XXX should we really be catching everything here? *)
     | exception _ ->
@@ -245,7 +245,7 @@ module File_ops_real (W : sig
       Done
   ;;
 
-  let process_meta ic =
+  let process_meta ic ~src:_ =
     let module Meta = Dune_findlib.Findlib.Meta in
     let lb = Lexing.from_channel ic in
     let meta : Meta.t = { name = None; entries = Meta.parse_entries lb } in
@@ -268,69 +268,32 @@ module File_ops_real (W : sig
       Some { need_version = true; callback })
   ;;
 
-  let replace_sites ~(get_location : Section.t -> Package.Name.t -> Stdune.Path.t) dp =
-    match
-      List.find_map dp ~f:(function
-        | Dune_lang.List [ Atom (A "name"); Atom (A name) ] -> Some name
-        | _ -> None)
-    with
-    | None -> dp
-    | Some name ->
-      List.map dp ~f:(function
-        | Dune_lang.List ((Atom (A "sections") as sexp_sections) :: sections) ->
-          let sections =
-            List.map sections ~f:(function
-              | Dune_lang.List [ (Atom (A section) as section_sexp); _ ] ->
-                let path =
-                  get_location
-                    (Option.value_exn (Section.of_string section))
-                    (Package.Name.of_string name)
-                in
-                let open Dune_lang.Encoder in
-                pair sexp string (section_sexp, Path.to_absolute_filename path)
-              | _ -> assert false)
-          in
-          Dune_lang.List (sexp_sections :: sections)
-        | x -> x)
-  ;;
-
-  let process_dune_package ~get_location ic =
+  let process_dune_package ~get_location ic ~src =
     let lb = Lexing.from_channel ic in
-    let dp =
-      Dune_lang.Parser.parse ~mode:Many lb |> List.map ~f:Dune_lang.Ast.remove_locs
-    in
-    (* replace sites with external path in the file *)
-    let dp = replace_sites ~get_location dp in
-    (* replace version if needed in the file *)
-    let need_version =
-      not
-        (List.exists dp ~f:(function
-          | Dune_lang.List (Atom (A "version") :: _)
-          | Dune_lang.List [ Atom (A "use_meta"); Atom (A "true") ]
-          | Dune_lang.List [ Atom (A "use_meta") ] -> true
-          | _ -> false))
-    in
-    let callback ?version ppf =
-      let dp =
-        match version with
-        | Some version ->
-          let version =
-            Dune_lang.List
-              [ Dune_lang.atom "version"; Dune_lang.atom_or_quoted_string version ]
-          in
-          (match dp with
-           | lang :: name :: rest -> lang :: name :: version :: rest
-           | [ lang ] -> [ lang; version ]
-           | [] -> [ version ])
-        | _ -> dp
+    let dune_version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax in
+    match Dune_package.Or_meta.parse src lb |> User_error.ok_exn with
+    | Use_meta ->
+      let callback ?version:_ ppf = Dune_package.Or_meta.pp_use_meta ~dune_version ppf in
+      Some { need_version = false; callback }
+    | Dune_package dp ->
+      (* replace sites with external path in the file *)
+      let dp, replace_info = Dune_package.replace_site_sections ~get_location dp in
+      (* replace version if needed in the file *)
+      let need_version = Option.is_none dp.version in
+      let callback ?version ppf =
+        let dp =
+          match version with
+          | Some version -> { dp with version = Some (Package_version.of_string version) }
+          | None -> dp
+        in
+        (* CR-emillon: we should write absolute paths only if necessary *)
+        Dune_package.Or_meta.pp
+          ~dune_version
+          ppf
+          (Dune_package dp)
+          ~encoding:(Absolute replace_info)
       in
-      Format.pp_open_vbox ppf 0;
-      List.iter dp ~f:(fun x ->
-        Dune_lang.Deprecated.pp ppf x;
-        Format.pp_print_cut ppf ());
-      Format.pp_close_box ppf ()
-    in
-    Some { need_version; callback }
+      Some { need_version; callback }
   ;;
 
   let copy_file

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -70,14 +70,36 @@ type t =
   ; files : (Section.t * path list) list
   }
 
+type replace_info
+
+(** Replace sections by the external paths for sites to refer to them.
+    It saves some information that needs to be passed to [Or_meta.pp] using
+    [~encoding:Absolute info]. *)
+val replace_site_sections
+  :  t
+  -> get_location:(Section.t -> Package.Name.t -> Path.t)
+  -> t * replace_info
+
 val to_dyn : t Dyn.builder
+
+type encoding =
+  | Absolute of replace_info
+  | Relative
 
 module Or_meta : sig
   type nonrec t =
     | Use_meta
     | Dune_package of t
 
-  val pp : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
+  val pp
+    :  encoding:encoding
+    -> dune_version:Dune_lang.Syntax.Version.t
+    -> Format.formatter
+    -> t
+    -> unit
+
+  val pp_use_meta : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> unit
+  val parse : Path.t -> Lexbuf.t -> (t, User_message.t) result
   val load : Path.t -> (t, User_message.t) result Memo.t
   val to_dyn : t Dyn.builder
 end

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -715,7 +715,10 @@ end = struct
                 ~then_:(Action_builder.return Dune_package.Or_meta.Use_meta)
                 ~else_:(make_dune_package sctx lib_entries pkg)
          in
-         Format.asprintf "%a" (Dune_package.Or_meta.pp ~dune_version) pkg)
+         Format.asprintf
+           "%a"
+           (Dune_package.Or_meta.pp ~dune_version ~encoding:Relative)
+           pkg)
     in
     let* () =
       let deprecated_dune_packages =
@@ -768,7 +771,7 @@ end = struct
             (Package_paths.deprecated_dune_package_file ctx pkg dune_pkg.name)
             (Format.asprintf
                "%a"
-               (Dune_package.Or_meta.pp ~dune_version)
+               (Dune_package.Or_meta.pp ~dune_version ~encoding:Relative)
                (Dune_package dune_pkg))
         in
         Super_context.add_rule sctx ~dir:ctx.build_dir ~loc action_with_targets)


### PR DESCRIPTION
`dune install` rewrites `dune-package` files on the fly to store sections as computed by the installation step.

The previous implementation used to rely on sexp manipulation, which is brittle and does not evolve with the `dune-package` codecs.

This uses a more end-to-end approach where the data structure is decoded, modified, and encoded again.
    
Some aspects are not as easy as they seem because there are different encodings for paths; some are relative to the package root, other from the `Stublibs` section, so the API is not as simple as it could be.