### PR TITLE
fix(spawn): fix headers issues on non-glibc

### DIFF
--- a/doc/changes/10256.md
+++ b/doc/changes/10256.md
@@ -1,0 +1,2 @@
+- fix compilation on non-glibc systems due to `signal.h` not being pulled in
+  spawn stubs. (#10256, @emillon)

--- a/vendor/spawn/src/spawn_stubs.c
+++ b/vendor/spawn/src/spawn_stubs.c
@@ -15,16 +15,14 @@
 #endif
 #endif
 
-/* for [caml_convert_signal_number] */
-#include <caml/signals.h>
-
-#undef CAML_INTERNALS
-
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/unixsupport.h>
 #include <caml/fail.h>
+
+/* for [caml_convert_signal_number]; must come after public caml headers */
+#include <caml/signals.h>
 
 #include <errno.h>
 

--- a/vendor/update-spawn.sh
+++ b/vendor/update-spawn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=d5991f7eb4073c85b440789587936d14b4e0417f
+version=6c752122070f377c2607f6969a821f166a43bd5e
 
 set -e -o pipefail
 


### PR DESCRIPTION
`caml/signals.h` is not public API; it does not include `caml/config.h` and so it will not include `signal.h` because it does not know about `POSIX_SIGNAL`. This issue is visible on musl as "unknown type `sigset_t`".
