### PR TITLE
test: add repro for #9272 (codesign regression)

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -138,3 +138,11 @@
  (enabled_if
   (not %{arch_sixtyfour}))
  (deps %{bin:ocaml}))
+
+(cram
+ (applies_to github9272)
+ (enabled_if
+  (and
+   (= %{system} macosx)
+   (= %{architecture} arm64)))
+ (deps %{bin:ocaml}))

--- a/test/blackbox-tests/test-cases/github9272.t
+++ b/test/blackbox-tests/test-cases/github9272.t
@@ -1,0 +1,42 @@
+Repro for #9272: when an executable that depends on dune-site is promoted to
+the source tree, the executable in the source tree segfaults.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > (using dune_site 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (executable
+  >  (name hello)
+  >  (promote (until-clean))
+  >  (libraries dune-site))
+  > EOF
+
+  $ touch hello.ml
+
+  $ dune build
+
+Test peculiarity: we can not do ./hello.exe directly, because the shell itself
+(that runs the cram test) will display the pid of the crashing process.
+Instead, we start and wait for it in an OCaml program and only display the
+code.
+
+Once the bug is fixed, this can be replaced by just `./hello.exe` and the test
+can be enabled for all systems.
+
+  $ cat > exec.ml << EOF
+  > let () =
+  >   let pid =
+  >     Unix.create_process
+  >       "./hello.exe" [|"./hello.exe"|]
+  >       Unix.stdin Unix.stdout Unix.stderr
+  >   in
+  >   match Unix.waitpid [] pid with
+  >   | _, WEXITED n -> Printf.printf "WEXITED %d" n
+  >   | _, WSTOPPED n -> Printf.printf "WSTOPPED %d" n
+  >   | _, WSIGNALED n -> Printf.printf "WSIGNALED %d" n
+  > EOF
+
+  $ ocaml -I +unix unix.cma exec.ml
+  WSIGNALED -7


### PR DESCRIPTION
The test doesn't run in CI, but I've tested locally on a M1 mac and it passes both with opam and under nix develop.