### PR TITLE
dune-rpc-lwt: drop `result` compatibility package dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -153,7 +153,6 @@ understood by dune language."))
  (synopsis "Communicate with dune using rpc and Lwt")
  (depends
   (dune-rpc (= :version))
-  (result (>= 1.5))
   (csexp (>= 1.5.0))
   (lwt (>= 5.3.0))
   base-unix)

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
   "dune-rpc" {= version}
-  "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.3.0"}
   "base-unix"

--- a/otherlibs/dune-rpc-lwt/src/dune
+++ b/otherlibs/dune-rpc-lwt/src/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_rpc_lwt)
  (public_name dune-rpc-lwt)
- (libraries result csexp dune_rpc lwt lwt.unix unix)
+ (libraries csexp dune_rpc lwt lwt.unix unix)
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
this package doesn't seem used, and I think it's pointless to have if our lower bound is 4.08+