### PR TITLE
Exec watch mode spawns processes with initial cwd

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -82,7 +82,8 @@ module Command_to_exec = struct
       let path = Path.to_string path in
       let env = Env.to_unix env |> Spawn.Env.of_list in
       let argv = path :: args in
-      Spawn.spawn ~prog:path ~env ~argv ()
+      let cwd = Spawn.Working_dir.Path Fpath.initial_cwd in
+      Spawn.spawn ~prog:path ~env ~cwd ~argv ()
     in
     Pid.of_int pid
   ;;

--- a/doc/changes/10262.md
+++ b/doc/changes/10262.md
@@ -1,0 +1,3 @@
+- Fix bug with `dune exec --watch` where the working directory would always be
+  set to the project root rather than the directory where the command was run
+  (#10262, @gridbugs)

--- a/test/blackbox-tests/test-cases/exec-watch/exec-pwd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-pwd.t/run.t
@@ -10,7 +10,7 @@ In normal (non-watching) mode, pwd is the folder from which dune is launched
   $ rm -rf $OUTPUT
   $ cd ..
 
-While in watch mode, pwd is always the root project folder
+In watch mode, pwd is also the folder from which dune is launched.
   $ cd bin
   $ dune exec --root .. -w -- pwd > $OUTPUT &
   Entering directory '..'
@@ -20,6 +20,6 @@ While in watch mode, pwd is always the root project folder
   $ until test -s $OUTPUT; do sleep 0.1; done;
   $ kill $PID
   $ cat $OUTPUT
-  $TESTCASE_ROOT
+  $TESTCASE_ROOT/bin
   $ rm -rf $OUTPUT
   $ cd ..


### PR DESCRIPTION
Fixes a bug where commands run from `dune exec -w` would have the cwd of the project root rather than the directory where the command was run.

Fixes https://github.com/ocaml/dune/issues/10236

I haven't added any tests as a good test is added in https://github.com/ocaml/dune/pull/10241.