### PR TITLE
chore: Update changelog with entries from 3.14 branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,14 @@ If you're a contributor, please include your CHANGES entry in a file
 `doc/changes/$PR_NAME.md`. At release time, it will be incoporated into the
 changelog properly.  
 
+3.14.2 (2024-03-12)
+-------------------
+
+### Fixed
+
+- fix compilation on non-glibc systems due to `signal.h` not being pulled in
+  spawn stubs. (#10256, @emillon)
+
 3.14.1 (2024-03-11)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,27 @@ If you're a contributor, please include your CHANGES entry in a file
 `doc/changes/$PR_NAME.md`. At release time, it will be incoporated into the
 changelog properly.  
 
+3.14.1 (2024-03-11)
+-------------------
+
+### Fixed
+
+- When a directory is changed to a file, correctly remove it in subsequent
+  `dune build` runs. (#9327, fix #6575, @emillon)
+
+- Fix a problem with the doc-new target where transitive dependencies were
+  missed during compile. This leads to missing expansions in the output docs.
+  (#9955, @jonludlam)
+
+- coq: fix performance regression in coqdep unescaping (#10115, fixes #10088,
+  @ejgallego, thanks to Dan Christensen for the report)
+
+- coq: memoize coqdep parsing, this will reduce build times for Coq users, in
+  particular for those with many .v files (#10116, @ejgallego, see also #10088)
+
+- on Windows, use an unicode-aware version of `CreateProcess` to avoid crashes
+  when paths contains non-ascii characters. (#10212, fixes #10180, @emillon)
+
 3.14.0 (2024-02-12)
 -------------------
 

--- a/doc/changes/10115.md
+++ b/doc/changes/10115.md
@@ -1,2 +1,0 @@
-- coq: fix performance regression in coqdep unescaping (#10115, fixes
-  #10088, @ejgallego, thanks to Dan Christensen for the report)

--- a/doc/changes/10116.md
+++ b/doc/changes/10116.md
@@ -1,3 +1,0 @@
-- coq: memoize coqdep parsing, this will reduce build times for Coq
-  users, in particular for those with many .v files (#10116,
-  @ejgallego, see also #10088)

--- a/doc/changes/10212.md
+++ b/doc/changes/10212.md
@@ -1,2 +1,0 @@
-- on Windows, use an unicode-aware version of `CreateProcess` to avoid crashes
-  when paths contains non-ascii characters. (#10212, fixes #10180, @emillon)

--- a/doc/changes/10256.md
+++ b/doc/changes/10256.md
@@ -1,2 +1,0 @@
-- fix compilation on non-glibc systems due to `signal.h` not being pulled in
-  spawn stubs. (#10256, @emillon)

--- a/doc/changes/9327.md
+++ b/doc/changes/9327.md
@@ -1,2 +1,0 @@
-- When a directory is changed to a file, correctly remove it in subsequent
-  `dune build` runs. (#9327, fix #6575, @emillon)

--- a/doc/changes/9955.md
+++ b/doc/changes/9955.md
@@ -1,2 +1,0 @@
-- Fix a problem with the doc-new target where transitive dependencies were missed during
-  compile. This leads to missing expansions in the output docs. (#9955, @jonludlam)


### PR DESCRIPTION
Cherry picked the changelog commits from 3.14.1 and 3.14.2.