### PR TITLE
refactor: do not always evaluate :standard in osl

### DIFF
--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -340,18 +340,6 @@ module Unexpanded = struct
       (Option.forall ~f:is_expanded)
   ;;
 
-  let has_special_forms t =
-    let rec loop (t : ast) =
-      let open Ast in
-      match t with
-      | Standard | Include _ -> true
-      | Element _ -> false
-      | Union l -> List.exists l ~f:loop
-      | Diff (l, r) -> loop l || loop r
-    in
-    loop t.ast
-  ;;
-
   let has_standard t =
     let rec loop ast =
       match ast with

--- a/src/dune_lang/ordered_set_lang.mli
+++ b/src/dune_lang/ordered_set_lang.mli
@@ -66,7 +66,6 @@ module Unexpanded : sig
     -> string
     -> t option Decoder.fields_parser
 
-  val has_special_forms : t -> bool
   val has_standard : t -> bool
 
   type position =

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -893,8 +893,7 @@ let expand_ordered_set_lang =
 
 let expand_and_eval_set t set ~standard =
   let+ standard =
-    (* This optimization builds [standard] if it's unused by the expander. *)
-    if Ordered_set_lang.Unexpanded.has_special_forms set
+    if Ordered_set_lang.Unexpanded.has_standard set
     then standard
     else Action_builder.return []
   and+ set = expand_ordered_set_lang t set in


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4174945e-466c-445d-8e5c-8052e3a85f0d -->