### PR TITLE
pkg: Set OCAMLFIND_DESTDIR for install actions

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -1,0 +1,14 @@
+Test that the OCAMLFIND_DESTDIR environment variable is set when running
+install and build commands.
+  $ . ./helpers.sh
+
+  $ make_lockdir
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (version 0.0.1)
+  > (build (run sh -c "echo [build] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))
+  > (install (run sh -c "echo [install] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))
+  > EOF
+
+  $ build_pkg test 2>&1 | sed "s#$(pwd)#PWD#" | sed 's#\.sandbox/.*/_private#\.sandbox/SANDBOX/_private#'
+  [build] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test/target/lib
+  [install] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test/target/lib


### PR DESCRIPTION
If a package uses ocamlfind to install its files then ocamlfind will consult its config file to determine where in the filesystem the installed files ought to go. In dune, each package is built in an isolated sandbox, and so by default ocamlfind won't install files to the correct location. The OCAMLFIND_DESTDIR environment variable can be used to override ocamlfind's default behaviour for determining where to install files.

This change sets the OCAMLFIND_DESTDIR variable to the "target/lib" directory within a package's build sandbox when executing a package's install command. Build commands are unaffected by this change.

Fixes https://github.com/ocaml/dune/issues/10252.

Necessary for fixing https://github.com/ocaml/dune/issues/8931, but we also need to merge https://github.com/ocaml/ocamlfind/pull/72 (relocatable ocamlfind) to fix that issue.

In addition to the simple test included in this change, I've also manually tested this change by building zarith using a patched version of ocamlfind (patched with https://github.com/ocaml/ocamlfind/pull/72).