### PR TITLE
fix: decoding dune-package crashes with (include_subdirs qualified)

### DIFF
--- a/doc/changes/10269.md
+++ b/doc/changes/10269.md
@@ -1,0 +1,2 @@
+- fix crash when decoding dune-package for libraries with `(include_subdirs
+  qualified)` (#10269, fixes #10264, @emillon)

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -92,7 +92,7 @@ module Kind = struct
           match next with
           | None -> return (Alias [])
           | Some _ ->
-            let+ path = Module_name.Path.decode in
+            let+ path = enter Module_name.Path.decode in
             Alias path )
       ]
   ;;

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -21,6 +21,8 @@ module Kind : sig
     | Root
 
   include Dune_lang.Conv.S with type t := t
+
+  val to_dyn : t -> Dyn.t
 end
 
 module Source : sig

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -398,7 +398,8 @@ module Group = struct
     Module_name.Map.to_list_map modules ~f:(fun _ t ->
       Dune_lang.List
         (match t with
-         | Group g -> Dune_lang.atom "group" :: encode ~src_dir g
+         | Group g ->
+           Dune_lang.atom "group" :: Module_name.encode g.name :: encode ~src_dir g
          | Module m -> Dune_lang.atom "module" :: Module.encode ~src_dir m))
   ;;
 

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -1,0 +1,47 @@
+open Stdune
+module Kind = Dune_rules.Module.Kind
+
+(* See #10264 *)
+let%expect_test "Module.Kind encoding round trip" =
+  let module_name s = Dune_rules.Module_name.of_string s in
+  let test k =
+    let ast = Kind.encode k in
+    let sexp = Dune_sexp.Ast.add_loc ~loc:Loc.none ast in
+    let decoded =
+      match Dune_lang.Decoder.parse Kind.decode Univ_map.empty sexp with
+      | r -> Ok r
+      | exception e -> Error e
+    in
+    let dyn =
+      Dyn.record
+        [ "ast", Dyn.string (Dune_sexp.to_string ast)
+        ; "decoded", Or_exn.to_dyn Kind.to_dyn decoded
+        ]
+    in
+    Dune_tests_common.print_dyn dyn
+  in
+  test Impl;
+  [%expect {| { ast = "impl"; decoded = Ok Impl } |}];
+  test (Alias []);
+  [%expect {| { ast = "alias"; decoded = Ok Alias [] } |}];
+  test (Alias [ module_name "A" ]);
+  [%expect
+    {|
+    { ast = "(alias (A))"
+    ; decoded =
+        Error
+          "File \"<none>\", line 1, characters 0-0:\n\
+           Error: Atom or quoted string expected\n\
+           "
+    } |}];
+  test (Alias [ module_name "A"; module_name "B" ]);
+  [%expect
+    {|
+    { ast = "(alias (A B))"
+    ; decoded =
+        Error
+          "File \"<none>\", line 1, characters 0-0:\n\
+           Error: Atom or quoted string expected\n\
+           "
+    } |}]
+;;

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -25,23 +25,7 @@ let%expect_test "Module.Kind encoding round trip" =
   test (Alias []);
   [%expect {| { ast = "alias"; decoded = Ok Alias [] } |}];
   test (Alias [ module_name "A" ]);
-  [%expect
-    {|
-    { ast = "(alias (A))"
-    ; decoded =
-        Error
-          "File \"<none>\", line 1, characters 0-0:\n\
-           Error: Atom or quoted string expected\n\
-           "
-    } |}];
+  [%expect {| { ast = "(alias (A))"; decoded = Ok Alias [ "A" ] } |}];
   test (Alias [ module_name "A"; module_name "B" ]);
-  [%expect
-    {|
-    { ast = "(alias (A B))"
-    ; decoded =
-        Error
-          "File \"<none>\", line 1, characters 0-0:\n\
-           Error: Atom or quoted string expected\n\
-           "
-    } |}]
+  [%expect {| { ast = "(alias (A B))"; decoded = Ok Alias [ "A"; "B" ] } |}]
 ;;


### PR DESCRIPTION
Fixes #10264

This fixes the round-trip (encoding/decoding) of `Modules.t` and `Module.Kind.t`.
The visible effect was a crash when `(include_subdir qualified)` was set for an installed library.

This area is difficult to test because we don't have an easy way to load dune-package files.
One part is tested via an expect test, but the other isn't (`Modules.t` is difficult to construct); however it has been tested on the repo mentioned in the original bug report.