### PR TITLE
feat(melange): support `esm` for module_systems too

### DIFF
--- a/src/dune_rules/melange/melange.ml
+++ b/src/dune_rules/melange/melange.ml
@@ -2,14 +2,14 @@ open Import
 
 module Module_system = struct
   type t =
-    | Es6
-    | CommonJs
+    | ESM
+    | CommonJS
 
-  let default = CommonJs, ".js"
+  let default = CommonJS, ".js"
 
   let to_string = function
-    | Es6 -> "es6"
-    | CommonJs -> "commonjs"
+    | ESM -> "es6"
+    | CommonJS -> "commonjs"
   ;;
 end
 

--- a/src/dune_rules/melange/melange.mli
+++ b/src/dune_rules/melange/melange.mli
@@ -2,8 +2,8 @@ open! Import
 
 module Module_system : sig
   type t =
-    | Es6
-    | CommonJs
+    | ESM
+    | CommonJS
 
   val default : t * Filename.Extension.t
   val to_string : t -> string

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -33,7 +33,7 @@ module Emit = struct
     let extension_field = extension in
     let module_systems =
       let module_system =
-        enum [ "es6", Melange.Module_system.Es6; "commonjs", CommonJs ]
+        enum [ "esm", Melange.Module_system.ESM; "es6", ESM; "commonjs", CommonJS ]
       in
       let+ module_systems =
         repeat

--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -59,6 +59,22 @@ Parses the simplified form and defaults extension to `.js`
   main.js
   main.mjs
 
+Accepts `"esm"` too for ESM modules
+
+  $ dune clean
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias mel)
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (module_systems commonjs (esm mjs)))
+  > EOF
+
+  $ dune build @mel
+  $ ls _build/default/output
+  main.js
+  main.mjs
+
 Defaults to commonjs / `.js` if no config present at all
 
   $ dune clean


### PR DESCRIPTION
In Melange, we're starting to rename `es6` to `esm` (for **E**CMA**S**cript **M**odules). This change will have to be very gradual, over at least one deprecation cycle. For now, let's start accepting `esm` in addition to `es6` too.

See https://github.com/melange-re/melange/issues/1066.
