### PR TITLE
chore: use 4.14.2 to run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DEV_DEPS := \
 "dkml-workflows>=1.2.0" \
 patdiff
 
-TEST_OCAMLVERSION := 4.14.1
+TEST_OCAMLVERSION := 4.14.2
 
 -include Makefile.dev
 

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -134,11 +134,11 @@ RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tag
 RUN opam init --disable-sandboxing --auto-setup
 
 # make an opam switch for running benchmarks
-RUN opam switch create bench 4.14.1
+RUN opam switch create bench 4.14.2
 RUN opam install -y dune ocamlbuild
 
 # make an opam switch for preparing the files for the benchmark
-RUN opam switch create prepare 4.14.1
+RUN opam switch create prepare 4.14.2
 RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl
 
 RUN opam install -y monorepo-benchmark/dune-monorepo-benchmark-runner

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -125,7 +125,7 @@ USER user
 WORKDIR $HOME
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2024-02-01.0
+ENV MONOREPO_BENCHMARK_TAG=2024-06-25.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
   tar xf ocaml-monorepo-benchmark.tar.gz && \
   mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -134,7 +134,7 @@ RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tag
 RUN opam init --disable-sandboxing --auto-setup
 
 # make an opam switch for running benchmarks
-RUN opam switch create bench 4.14.2
+RUN opam update && opam switch create bench 4.14.2
 RUN opam install -y dune ocamlbuild
 
 # make an opam switch for preparing the files for the benchmark

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -53,10 +53,10 @@ Here are the most common commands you'll be running:
    $ ./dune.exe build @foo
 
 
-Note that tests are currently written for version 4.14.1 of the OCaml compiler.
+Note that tests are currently written for version 4.14.2 of the OCaml compiler.
 Some tests depend on the specific wording of compilation errors which can change
 between compiler versions, so to reliably run the tests make sure that
-``ocaml.4.14.1`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
+``ocaml.4.14.2`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
 the root of the Dune repo contains the current compiler version for which tests
 are written.
 


### PR DESCRIPTION
The CI uses `4.14.x` so will pick it up as well. No tests are broken.
