### PR TITLE
Document that Reason dialect is supported out of the box

### DIFF
--- a/doc/reference/files/dune-project/dialect.rst
+++ b/doc/reference/files/dune-project/dialect.rst
@@ -65,3 +65,17 @@ dialect
       This field supports the same sub-fields as ``implementation``.
 
       .. versionchanged:: 3.9 This field is made optional.
+
+
+Default dialects
+----------------
+
+Dune ships with two dialects pre-configured and enabled:
+
+* ``ocaml`` for the default OCaml syntax which consumes `.ml` and `.mli` files
+  and uses ``ocamlformat`` for formatting.
+* ``reason`` for the Reason syntax and enabled in `.re`/`.rei` files. ``refmt``
+  is used for formatting.
+
+A third dialect, ``rescript``, is added when Melange support (see :doc:`/melange`)
+is enabled in the project.


### PR DESCRIPTION
Today I learned that we support Reason code out of the box with no additional configuration, which is fairly nice but doesn't appear to be documented so this PR is a suggestion to add a paragraph about that.

Its a fairly neat feature and I assume it could be used more if people were aware of how easy it is to use.

@emillon also suggested that a general howto on how to use reason in a dune project could be useful and that could be a good next step. It's fairly easy after all but if it is not documented, people won't know.