### PR TITLE
fix: symlink `.impl.d` files for virtual library modules too

### DIFF
--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -23,6 +23,14 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     let dst = Obj_dir.Module.cm_file_exn impl_obj_dir m ~kind in
     copy_to_obj_dir ~src ~dst
   in
+  let copy_ocamldep_file m =
+    match Obj_dir.to_local vlib_obj_dir with
+    | None -> Memo.return ()
+    | Some vlib_obj_dir ->
+      let src = Obj_dir.Module.dep vlib_obj_dir (Immediate (m, Impl)) |> Path.build in
+      let dst = Obj_dir.Module.dep impl_obj_dir (Immediate (m, Impl)) in
+      copy_to_obj_dir ~src ~dst
+  in
   let copy_interface_to_impl ~src kind () =
     let dst = Obj_dir.Module.cm_public_file_exn impl_obj_dir src ~kind in
     let src = Obj_dir.Module.cm_public_file_exn vlib_obj_dir src ~kind in
@@ -39,7 +47,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
             >>> Memo.when_ melange (copy_interface_to_impl ~src (Melange Cmi)))
     >>> Memo.when_ (Module.has src ~ml_kind:Impl) (fun () ->
       Memo.when_ byte (fun () -> copy_obj_file src (Ocaml Cmo))
-      >>> Memo.when_ melange (fun () -> copy_obj_file src (Melange Cmj))
+      >>> Memo.when_ melange (fun () ->
+        copy_obj_file src (Melange Cmj) >>> copy_ocamldep_file src)
       >>> Memo.when_ native (fun () ->
         copy_obj_file src (Ocaml Cmx)
         >>>


### PR DESCRIPTION
- when setting up rules for implementation files in a virtual library, their artifacts are symlinked to the object directory for the concrete implementation too
- this change adds rules to symlink the ocamldep resulting files too, as they may be needed in the object directory
- specifically, this fixes the failing test in https://github.com/ocaml/dune/pull/10286 as will be demonstrated once I cherry-pick this commit in that PR.