### PR TITLE
chore: remove unused plugin/dune file

### DIFF
--- a/plugin/dune
+++ b/plugin/dune
@@ -1,4 +1,0 @@
-(library
- (name jbuild_plugin)
- (libraries compiler-libs)
- (synopsis "Internal Dune library, do not use!"))


### PR DESCRIPTION
The `jbuild_plugin.*` are never used as a library, they are used in a `(mode promote)` rule in `dune_rules`.
