### PR TITLE
Allow defining libs with same name in multiple contexts (alt implementation)

### DIFF
--- a/src/dune_rules/coq/coq_lib.mli
+++ b/src/dune_rules/coq/coq_lib.mli
@@ -68,7 +68,7 @@ module DB : sig
       in [resolve_*] below and properly memoized. *)
   val create_from_coqlib_stanzas
     :  parent:t option
-    -> find_db:(Path.Build.t -> Lib.DB.t)
+    -> find_db:(Path.Build.t -> Lib.DB.t Memo.t)
     -> (Coq_stanza.Theory.t * Entry.t) list
     -> t
 

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -407,9 +407,9 @@ module Valid = struct
             let* vendored = Source_tree.is_vendored (Dune_project.root proj) in
             if vendored
             then Memo.return (libs_acc, pkg_acc)
-            else (
-              let lib_db =
-                let scope = find proj in
+            else
+              let* lib_db =
+                let+ scope = find proj in
                 Scope.libs scope
               in
               let+ libs_acc =
@@ -436,7 +436,7 @@ module Valid = struct
                 in
                 pkgs @ pkg_acc
               in
-              libs_acc, pkg_acc)))
+              libs_acc, pkg_acc))
       in
       let* libs, packages = libs_and_pkgs in
       let+ libs_list =

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -27,5 +27,5 @@ module DB : sig
   end
 
   val lib_entries_of_package : Context_name.t -> Package.Name.t -> Lib_entry.t list Memo.t
-  val with_all : Context.t -> f:((Dune_project.t -> t) -> 'a) -> 'a Memo.t
+  val with_all : Context.t -> f:((Dune_project.t -> t Memo.t) -> 'a) -> 'a Memo.t
 end

--- a/src/dune_rules/stanzas/library_redirect.ml
+++ b/src/dune_rules/stanzas/library_redirect.ml
@@ -8,7 +8,7 @@ type 'old_name t =
   }
 
 module Local = struct
-  type nonrec t = (Loc.t * Lib_name.Local.t) t
+  type nonrec t = Library.t t
 
   include Stanza.Make (struct
       type nonrec t = t
@@ -17,7 +17,7 @@ module Local = struct
     end)
 
   let for_lib (lib : Library.t) ~new_public_name ~loc : t =
-    { loc; new_public_name; old_name = lib.name; project = lib.project }
+    { loc; new_public_name; old_name = lib; project = lib.project }
   ;;
 
   let of_private_lib (lib : Library.t) : t option =

--- a/src/dune_rules/stanzas/library_redirect.mli
+++ b/src/dune_rules/stanzas/library_redirect.mli
@@ -20,7 +20,7 @@ type 'old_name t =
   }
 
 module Local : sig
-  type nonrec t = (Loc.t * Lib_name.Local.t) t
+  type nonrec t = Library.t t
 
   include Stanza.S with type t := t
 

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-cycle.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-cycle.t
@@ -1,0 +1,17 @@
+Test cycles in enabled_if field of libraries
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.15)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name foo)
+  >  (enabled_if %{read:foo}))
+  > (rule (with-stdout-to foo (echo true)))
+  > EOF
+
+  $ dune build
+  Error: Dependency cycle between:
+     %{read:foo} at dune:3
+  [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
@@ -29,7 +29,10 @@ in the same dune file
   > EOF
 
   $ dune build --display=short
-  Error: Library foo is defined twice:
+  Error: Multiple rules generated for _build/alt-context/foo.cmxs:
+  - dune:4
+  - dune:1
+  Error: Multiple rules generated for _build/default/foo.cmxs:
   - dune:4
   - dune:1
   [1]
@@ -48,7 +51,61 @@ For public libraries
   > EOF
 
   $ dune build
-  Error: Library foo is defined twice:
-  - dune:7
-  - dune:3
+
+Mixing public and private libraries
+
+  $ cat > dune << EOF
+  > (library
+  >  (name foo)
+  >  (enabled_if (= %{context_name} "default")))
+  > (library
+  >  (name foo)
+  >  (public_name baz.foo)
+  >  (enabled_if (= %{context_name} "alt-context")))
+  > EOF
+
+  $ dune build
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("modules_and_obj_dir: failed lookup",
+    { keys = [ "baz.foo" ]; for_ = Library "foo" })
+  Raised at Stdune__Code_error.raise in file
+    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  Called from Dune_rules__Ml_sources.modules in file
+    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
+  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
+    line 253, characters 36-41
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  -> required by ("<unnamed>", ())
+  -> required by ("load-dir", In_build_dir "alt-context")
+  -> required by
+     ("build-alias", { dir = In_build_dir "alt-context"; name = "default" })
+  -> required by ("toplevel", ())
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
   [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision-same-folder.t
@@ -29,13 +29,16 @@ in the same dune file
   > EOF
 
   $ dune build --display=short
-  Error: Multiple rules generated for _build/alt-context/foo.cmxs:
-  - dune:4
-  - dune:1
-  Error: Multiple rules generated for _build/default/foo.cmxs:
-  - dune:4
-  - dune:1
-  [1]
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt} [alt-context]
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+      ocamlopt .foo.objs/native/foo.{cmx,o} [alt-context]
+        ocamlc foo.cma [alt-context]
+      ocamlopt .foo.objs/native/foo.{cmx,o}
+        ocamlc foo.cma
+      ocamlopt foo.{a,cmxa} [alt-context]
+      ocamlopt foo.{a,cmxa}
+      ocamlopt foo.cmxs [alt-context]
+      ocamlopt foo.cmxs
 
 For public libraries
 
@@ -65,47 +68,3 @@ Mixing public and private libraries
   > EOF
 
   $ dune build
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("modules_and_obj_dir: failed lookup",
-    { keys = [ "baz.foo" ]; for_ = Library "foo" })
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
-  Called from Dune_rules__Ml_sources.modules in file
-    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
-  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
-    line 253, characters 36-41
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  -> required by ("<unnamed>", ())
-  -> required by ("load-dir", In_build_dir "alt-context")
-  -> required by
-     ("build-alias", { dir = In_build_dir "alt-context"; name = "default" })
-  -> required by ("toplevel", ())
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
@@ -37,9 +37,53 @@ For private libraries
   > EOF
 
   $ dune build
-  Error: Library foo is defined twice:
-  - a/dune:1
-  - b/dune:1
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("modules_and_obj_dir: failed lookup", { keys = []; for_ = Library "foo" })
+  Raised at Stdune__Code_error.raise in file
+    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  Called from Dune_rules__Ml_sources.modules in file
+    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
+  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
+    line 253, characters 36-41
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  -> required by ("<unnamed>", ())
+  -> required by ("load-dir", In_build_dir "default/b")
+  -> required by ("<unnamed>", ())
+  -> required by
+     ("build-alias", { dir = In_build_dir "default"; name = "default" })
+  -> required by ("toplevel", ())
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
   [1]
 
 For public libraries
@@ -59,7 +103,67 @@ For public libraries
   > EOF
 
   $ dune build
-  Error: Library foo is defined twice:
-  - a/dune:3
-  - b/dune:3
+
+Mixing public and private libraries
+
+  $ cat > a/dune << EOF
+  > (library
+  >  (name foo)
+  >  (enabled_if (= %{context_name} "default")))
+  > EOF
+  $ cat > b/dune << EOF
+  > (library
+  >  (name foo)
+  >  (public_name baz.foo)
+  >  (enabled_if (= %{context_name} "alt-context")))
+  > EOF
+
+  $ dune build
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("modules_and_obj_dir: failed lookup", { keys = []; for_ = Library "foo" })
+  Raised at Stdune__Code_error.raise in file
+    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  Called from Dune_rules__Ml_sources.modules in file
+    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
+  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
+    line 253, characters 36-41
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 76, characters 8-11
+  -> required by ("<unnamed>", ())
+  -> required by ("load-dir", In_build_dir "alt-context/a")
+  -> required by ("<unnamed>", ())
+  -> required by
+     ("build-alias", { dir = In_build_dir "alt-context"; name = "default" })
+  -> required by ("toplevel", ())
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
   [1]

--- a/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-library-name-collision.t
@@ -37,54 +37,6 @@ For private libraries
   > EOF
 
   $ dune build
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("modules_and_obj_dir: failed lookup", { keys = []; for_ = Library "foo" })
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
-  Called from Dune_rules__Ml_sources.modules in file
-    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
-  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
-    line 253, characters 36-41
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  -> required by ("<unnamed>", ())
-  -> required by ("load-dir", In_build_dir "default/b")
-  -> required by ("<unnamed>", ())
-  -> required by
-     ("build-alias", { dir = In_build_dir "default"; name = "default" })
-  -> required by ("toplevel", ())
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  [1]
 
 For public libraries
 
@@ -119,51 +71,3 @@ Mixing public and private libraries
   > EOF
 
   $ dune build
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("modules_and_obj_dir: failed lookup", { keys = []; for_ = Library "foo" })
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
-  Called from Dune_rules__Ml_sources.modules in file
-    "src/dune_rules/ml_sources.ml", line 249, characters 22-49
-  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
-    line 253, characters 36-41
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 76, characters 8-11
-  -> required by ("<unnamed>", ())
-  -> required by ("load-dir", In_build_dir "alt-context/a")
-  -> required by ("<unnamed>", ())
-  -> required by
-     ("build-alias", { dir = In_build_dir "alt-context"; name = "default" })
-  -> required by ("toplevel", ())
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  [1]


### PR DESCRIPTION
This PR adds the same feature as #10179 —enabling "multi-context" libraries— but following an alternate implementation.

In #10179 we attempted to defer the resolution of the `enabled_if` field in libraries as much as possible, until the lib databases are queried. This led to a few issues, the most important ones being:
- keep track of multiple libraries with the same name in a given database
- honor the existing behavior in `main`, which handles the duplicated public or private libraries pretty well

In this PR, we move the resolution of `enabled_if` field to the library databases creation. This works because even in a multi-context world, there following invariant still exists:

**There can be at most 1 library behind a given name under a given context.**

Fortunately, different library databases are created for different contexts, so by discerning between enabled and disabled libraries, we can just ignore disabled ones when building each lib db.

Most of the diff is about moving the `Memo.t` monad inside the `create_db_from_stanzas` function, and everything that entailed. There are two parts that were brought along from #10179 as they were:

- The addition of `enabled_in_context` in `Gen_rules` when handling the `Library` case
- Some improvements on the `eif*` tests that verifies the case of mixing public and private libs

Commits:
- https://github.com/ocaml/dune/pull/10296/commits/c7f35a5498e24c9c18c0032543cee40b820fe699 moves the enabled_if checks to the lib db creation, one can see how this on its own it's not enough and there are some crashes on the `eif*` tests due to attempts to create rules for libraries that are disabled (and not added to the DB anymore)
- https://github.com/ocaml/dune/pull/10296/commits/c9d77c8f282938da1ac2e7bdd631db5b0270f99c stops adding rules for disabled libs