### PR TITLE
fix(melange): account for preprocessing when getting library's Modules.t during emission

### DIFF
--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -92,7 +92,7 @@ val visibility : t -> Visibility.t
 val encode : t -> src_dir:Path.t -> Dune_lang.t list
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 
-(** [pped m] return [m] but with the preprocessed source paths paths *)
+(** [pped m] return [m] but with the preprocessed source paths *)
 val pped : t -> t
 
 (** [ml_source m] returns [m] but with the OCaml syntax source paths *)

--- a/test/blackbox-tests/test-cases/melange/unexpected-ocamldep-output.t
+++ b/test/blackbox-tests/test-cases/melange/unexpected-ocamldep-output.t
@@ -30,11 +30,6 @@ file after any dialects have run
   > let name = "Zoe"
   > EOF
   $ dune build @mel
-  Error: ocamldep returned unexpected output for _build/default/lib/foo.myd:
-  > lib/foo.myd.ml: Bar
-  -> required by _build/default/output/lib/foo.js
-  -> required by alias mel
-  [1]
 
 Now try preprocessing too
 
@@ -46,12 +41,3 @@ Now try preprocessing too
   >  (modes melange))
   > EOF
   $ dune build @mel
-  Error: ocamldep returned unexpected output for _build/default/lib/bar.ml:
-  > lib/bar.pp.ml:
-  -> required by _build/default/output/lib/bar.js
-  -> required by alias mel
-  Error: ocamldep returned unexpected output for _build/default/lib/foo.myd.ml:
-  > lib/foo.pp.myd.ml: Bar
-  -> required by _build/default/output/lib/foo.js
-  -> required by alias mel
-  [1]

--- a/test/blackbox-tests/test-cases/melange/unexpected-ocamldep-output.t
+++ b/test/blackbox-tests/test-cases/melange/unexpected-ocamldep-output.t
@@ -1,0 +1,57 @@
+Show that `melange.emit` + correct dependency tracking reads the processed
+file after any dialects have run
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.11)
+  > (using melange 0.1)
+  > (dialect
+  >  (name myd)
+  >  (implementation
+  >   (preprocess (run cat %{input-file}))
+  >   (extension myd)))
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (alias mel)
+  >  (libraries foo)
+  >  (emit_stdlib false))
+  > EOF
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name foo)
+  >  (modes melange))
+  > EOF
+  $ cat > lib/foo.myd <<EOF
+  > let name = Bar.name
+  > EOF
+  $ cat > lib/bar.ml <<EOF
+  > let name = "Zoe"
+  > EOF
+  $ dune build @mel
+  Error: ocamldep returned unexpected output for _build/default/lib/foo.myd:
+  > lib/foo.myd.ml: Bar
+  -> required by _build/default/output/lib/foo.js
+  -> required by alias mel
+  [1]
+
+Now try preprocessing too
+
+  $ dune clean
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name foo)
+  >  (preprocess (action (run cat %{input-file})))
+  >  (modes melange))
+  > EOF
+  $ dune build @mel
+  Error: ocamldep returned unexpected output for _build/default/lib/bar.ml:
+  > lib/bar.pp.ml:
+  -> required by _build/default/output/lib/bar.js
+  -> required by alias mel
+  Error: ocamldep returned unexpected output for _build/default/lib/foo.myd.ml:
+  > lib/foo.pp.myd.ml: Bar
+  -> required by _build/default/output/lib/foo.js
+  -> required by alias mel
+  [1]


### PR DESCRIPTION
- this is a regression introduced in #10286, caused by reading `immediate_deps_of` the current cmj file
- ~`Ocamldep.read_immediate_deps_of` needs to account for the fact that the file may have been pre-processed by a dialect, and use the final filename instead.~
- we need to account for preprocessing (which changes the module target filenames in the build directory) when getting the `Modules.t` structure where we consult `.impl.d` files
- this diff is best reviewed [without whitespace](https://github.com/ocaml/dune/pull/10297/files?w=1)


the error can be seen in the first commit:

```
  Error: ocamldep returned unexpected output for _build/default/lib/foo.myd:
  > lib/foo.myd.ml: Bar
  -> required by _build/default/output/lib/foo.js
  -> required by alias mel
  [1]
```