### PR TITLE
[3.15] Compile changelog for 3.15.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,69 @@ If you're a contributor, please include your CHANGES entry in a file
 `doc/changes/$PR_NAME.md`. At release time, it will be incoporated into the
 changelog properly.  
 
+3.15.0~alpha1 (2024-03-26)
+--------------------------
+
+### Added
+
+- Add link flags to to `ocamlmklib` for ctypes stubs (#8784, @frejsoya)
+
+- Remove some unnecessary limitations in the expansions of percent forms in
+  install stanza. For example, the `%{env:..}` form can be used to select files
+  to be installed. (#10160, @rgrinberg)
+
+- Allow artifact expansion percent forms (`%{cma:..}`, `%{cmo:..}`, etc.) in
+  more contexts. Previously, they would be randomly forbidden in some fields.
+  (#10169, @rgrinberg)
+
+- Allow `%{inline_tests}` in more contexts (#10191, @rgrinberg)
+
+- Remove limitations on percent forms in the `(enabled_if ..)` field of
+  libraries (#10250, @rgrinberg)
+
+- Support dialects in `dune describe pp` (#10283, @emillon)
+
+- Allow defining executables or melange emit stanzas with the same name in the
+  same folder under different contexts. (#10220, @rgrinberg, @jchavarri)
+
+### Fixed
+
+- coq: Delay Coq rule setup checks so OCaml-only packages can build in hybrid
+  Coq/OCaml projects when `coqc` is not present. Thanks to @vzaliva for the
+  test case and report (#9845, fixes #9818, @rgrinberg, @ejgallego)
+
+- Fix conditional source selection with `select` on `bigarray` in OCaml 5
+  (#10011, @moyodiallo)
+
+- melange: fix inconsistency in virtual library implementation. Concrete
+  modules within a virtual library can now refer to its virtual modules too
+  (#10051, fixes #7104, @anmonteiro)
+
+- melange: fix a bug that would cause stale `import` paths to be emitted when
+  moving source files within `(include_subdirs ..)` (#10286, fixes #9190,
+  @anmonteiro)
+
+- Dune file formatting: output utf8 if input is correctly encoded (#10113,
+  fixes #9728, @moyodiallo)
+
+- Fix expanding dependencies and locks specified in the cram stanza.
+  Previously, they would be installed in the context of the cram test, rather
+  than the cram stanza itself (#10165, @rgrinberg)
+
+- Fix bug with `dune exec --watch` where the working directory would always be
+  set to the project root rather than the directory where the command was run
+  (#10262, @gridbugs)
+
+- Regression fix: sign executables that are promoted into the source tree
+  (#10263, fixes #9272, @emillon)
+
+- Fix crash when decoding dune-package for libraries with `(include_subdirs
+  qualified)` (#10269, fixes #10264, @emillon)
+
+### Changed
+
+- Remove the `--react-to-insignificant-changes` option. (#10083, @rgrinberg)
+
 3.14.2 (2024-03-12)
 -------------------
 

--- a/doc/changes/10011.md
+++ b/doc/changes/10011.md
@@ -1,2 +1,0 @@
-- Fix conditional source selection with `select` on `bigarray` in OCaml 5
-  (#10011, @moyodiallo)

--- a/doc/changes/10051.md
+++ b/doc/changes/10051.md
@@ -1,3 +1,0 @@
-- melange: fix inconsistency in virtual library implementation. Concrete
-  modules within a virtual library can now refer to its virtual modules too
-  (#10051, fixes #7104, @anmonteiro)

--- a/doc/changes/10083.md
+++ b/doc/changes/10083.md
@@ -1,1 +1,0 @@
-- Remove the `--react-to-insignifcant-changes` option. (#10083, @rgrinberg)

--- a/doc/changes/10113.md
+++ b/doc/changes/10113.md
@@ -1,2 +1,0 @@
-- dune file formatting: output utf8 if input is correctly encoded (#10113,
-  fixes #9728, @moyodiallo)

--- a/doc/changes/10160.md
+++ b/doc/changes/10160.md
@@ -1,3 +1,0 @@
-- Remove some unnecessary limitations in the expansions of percent forms in
-  install stanza. For example, the `%{env:..}` form can be used to select files
-  to be installed. (#10160, @rgrinberg)

--- a/doc/changes/10169.md
+++ b/doc/changes/10169.md
@@ -1,2 +1,0 @@
-- Allow artifact expansion percent forms (`%{cma:..}`, `%{cmo:..}`, etc.) in
-  more contexts. Previously, they would be randomly forbidden in some fields.

--- a/doc/changes/10185.md
+++ b/doc/changes/10185.md
@@ -1,3 +1,0 @@
-- Fix expanding dependencies and locks specified in the cram stanza.
-  Previously, they would be installed in the context of the cram test, rather
-  than the cram stanza itself (#10165, @rgrinberg)

--- a/doc/changes/10191.md
+++ b/doc/changes/10191.md
@@ -1,1 +1,0 @@
-- Allow `%{inline_tests}` in more contexts (#10191, @rgrinberg)

--- a/doc/changes/10220.md
+++ b/doc/changes/10220.md
@@ -1,2 +1,0 @@
-- Allow defining executables or melange emit stanzas with the same name in the
-  same folder under different contexts. (#10220, @rgrinberg, @jchavarri)

--- a/doc/changes/10250.md
+++ b/doc/changes/10250.md
@@ -1,2 +1,0 @@
-- Remove limitations on percent forms in the `(enabled_if ..)` field of
-  libraries (#10250, @rgrinberg)

--- a/doc/changes/10262.md
+++ b/doc/changes/10262.md
@@ -1,3 +1,0 @@
-- Fix bug with `dune exec --watch` where the working directory would always be
-  set to the project root rather than the directory where the command was run
-  (#10262, @gridbugs)

--- a/doc/changes/10263.md
+++ b/doc/changes/10263.md
@@ -1,2 +1,0 @@
-- regression fix: sign executables that are promoted into the source tree
-  (#10263, fixes #9272, @emillon)

--- a/doc/changes/10269.md
+++ b/doc/changes/10269.md
@@ -1,2 +1,0 @@
-- fix crash when decoding dune-package for libraries with `(include_subdirs
-  qualified)` (#10269, fixes #10264, @emillon)

--- a/doc/changes/10283.md
+++ b/doc/changes/10283.md
@@ -1,1 +1,0 @@
-- support dialects in `dune describe pp` (#10283, @emillon)

--- a/doc/changes/10286.md
+++ b/doc/changes/10286.md
@@ -1,3 +1,0 @@
-- melange: fix a bug that would cause stale `import` paths to be emitted when
-  moving source files within `(include_subdirs ..)`
-  (#10286, fixes #9190, @anmonteiro)

--- a/doc/changes/8784.md
+++ b/doc/changes/8784.md
@@ -1,1 +1,0 @@
-- Add link flags to to ocamlmklib for ctypes stubs (#8784, @frejsoya)

--- a/doc/changes/9845.md
+++ b/doc/changes/9845.md
@@ -1,4 +1,0 @@
-- Delay Coq rule setup checks so OCaml-only packages can build in
-  hybrid Coq/OCaml projects when `coqc` is not present. Thanks to
-  @vzaliva for the test case and report (#9845, fixes #9818,
-  @rgrinberg, @ejgallego)


### PR DESCRIPTION
Includes and classifies all the changes from the markdown files.