### PR TITLE
doc-new: Omit docs for 'empty libraries'

### DIFF
--- a/doc/changes/10319.md
+++ b/doc/changes/10319.md
@@ -1,0 +1,2 @@
+- Don't try to document non-existent libraries in doc-new target (#10319,
+  fixes #10056, @jonludlam)

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -1619,21 +1619,24 @@ let standard_index_contents b entry_modules =
   entry_modules
   |> List.sort ~compare:(fun (x, _) (y, _) -> Lib_name.compare x y)
   |> List.iter ~f:(fun (lib, modules) ->
-    Printf.bprintf b "{1 Library %s}\n" (Lib_name.to_string lib);
-    Buffer.add_string
-      b
-      (match modules with
-       | [ x ] ->
-         sprintf
-           "The entry point of this library is the module:\n{!%s}.\n"
-           (Artifact.reference x)
-       | _ ->
-         sprintf
-           "This library exposes the following toplevel modules:\n{!modules:%s}\n"
-           (modules
-            |> List.map ~f:Artifact.name
-            |> List.sort ~compare:String.compare
-            |> String.concat ~sep:" ")))
+    match modules with
+    | [] -> () (* No library here! *)
+    | _ ->
+      Printf.bprintf b "{1 Library %s}\n" (Lib_name.to_string lib);
+      Buffer.add_string
+        b
+        (match modules with
+         | [ x ] ->
+           sprintf
+             "The entry point of this library is the module:\n{!%s}.\n"
+             (Artifact.reference x)
+         | _ ->
+           sprintf
+             "This library exposes the following toplevel modules:\n{!modules:%s}\n"
+             (modules
+              |> List.map ~f:Artifact.name
+              |> List.sort ~compare:String.compare
+              |> String.concat ~sep:" ")))
 ;;
 
 let fallback_index_contents b entry_modules artifacts =


### PR DESCRIPTION
In fact this is likely not an empty library, but a package that either doesn't contain libraries or only contains sublibraries. In either case, it's not at all useful to say a library exists and has no modules!

Fixes #10056