### PR TITLE
Remove incorrect validation step for dir targets

### DIFF
--- a/test/blackbox-tests/test-cases/disable-rule-with-directory-target.t
+++ b/test/blackbox-tests/test-cases/disable-rule-with-directory-target.t
@@ -1,0 +1,15 @@
+
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.14)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (enabled_if false)
+  >  (target (dir x))
+  >  (action (run mkdir x)))
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
The validation in question was comparing directory targets discovered in the project from directories that are the target of enabled rules (rules which lack an `enabled_if` field, or whose `enabled_if` condition is false). This was incorrect as it doesn't account for directory targets which are the target of disabled rules so the validation fails if any rule with a directory target is disabled. The validation step was introduced in 1fd19d78e8 but there aren't any clues to why it was necessary.

Fixes https://github.com/ocaml/dune/issues/10310