### PR TITLE
fix: use `Long_val` for sendfile() parameters to fix file copying in docker

### DIFF
--- a/10333.md
+++ b/10333.md
@@ -1,0 +1,2 @@
+- fix overflow in sendfile stubs (copy of large files could fail or end with
+  truncated files) (#10333, @tonyfettes)

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -74,7 +74,7 @@ CAMLprim value stdune_copyfile(value v_from, value v_to) {
 }
 
 static int dune_sendfile(int in, int out, size_t length) {
-  int ret;
+  ssize_t ret;
   while (length > 0) {
     ret = sendfile(out, in, NULL, length);
     if (ret < 0) {

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -73,7 +73,7 @@ CAMLprim value stdune_copyfile(value v_from, value v_to) {
   caml_failwith("copyfile: only on macos");
 }
 
-static int dune_sendfile(int in, int out, int length) {
+static int dune_sendfile(int in, int out, size_t length) {
   int ret;
   while (length > 0) {
     ret = sendfile(out, in, NULL, length);
@@ -90,7 +90,7 @@ CAMLprim value stdune_sendfile(value v_in, value v_out, value v_size) {
   caml_release_runtime_system();
   /* TODO Use copy_file_range once we have a good mechanism to test for its
    * existence */
-  int ret = dune_sendfile(FD_val(v_in), FD_val(v_out), Int_val(v_size));
+  int ret = dune_sendfile(FD_val(v_in), FD_val(v_out), Long_val(v_size));
   caml_acquire_runtime_system();
   if (ret < 0) {
     uerror("sendfile", Nothing);

--- a/test/blackbox-tests/test-cases/sendfile-large-file.t
+++ b/test/blackbox-tests/test-cases/sendfile-large-file.t
@@ -17,6 +17,6 @@ We create a large file and check that it is copied completely.
   4294967299
 
   $ dune_cmd stat size _build/default/file.dat
-  3
+  4294967299
 
 (3 indicates that the file size is taken modulo 2**32)


### PR DESCRIPTION
I was using dune in docker, and every it copies some large file in a data_only_dirs it reports that `sendfile: No such file or directory`. I tried digging into the source and I think converting the ocaml integer to 32-bit version will make it impossible to copy any file that is larger than 4 GB. I have tested in a docker, but I cannot really confirm whether it really works on real linux machine (I'm using macOS).