### PR TITLE
chore: Avoid result < 1.5 when installing, as this breaks on 4.08+

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -156,7 +156,9 @@ understood by dune language."))
   (csexp (>= 1.5.0))
   (lwt (>= 5.3.0))
   base-unix)
- (description "Specialization of dune-rpc to Lwt"))
+ (description "Specialization of dune-rpc to Lwt")
+ (conflicts
+   (result (< 1.5))))
 
 (package
  (name dyn)

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -16,6 +16,9 @@ depends: [
   "base-unix"
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Detected as part of #10300, the alternate solution in https://github.com/ocaml/opam-repository/pull/25603 is unlikely to go forward at this point so this implements the policy of opam-repository and adds the conflict on our side.