### PR TITLE
fix: `refmt` arguments in `Dialect.print_ast`

### DIFF
--- a/src/dune_rules/dialect.ml
+++ b/src/dune_rules/dialect.ml
@@ -203,8 +203,8 @@ let reason =
     in
     let print_ast =
       let flag_of_kind = function
-        | Ml_kind.Impl -> "-i=false"
-        | Intf -> "-i=true"
+        | Ml_kind.Impl -> "false"
+        | Intf -> "true"
       in
       let module S = String_with_vars in
       Action.chdir
@@ -212,6 +212,7 @@ let reason =
         (Action.run
            (S.make_text Loc.none "refmt")
            [ S.make_text Loc.none "--parse=binary"
+           ; S.make_text Loc.none "-i"
            ; S.make_text Loc.none (flag_of_kind kind)
            ; S.make_pform Loc.none (Var Input_file)
            ])

--- a/test/blackbox-tests/utils/refmt.ml
+++ b/test/blackbox-tests/utils/refmt.ml
@@ -21,7 +21,7 @@ let () =
   let args =
     [ "--print", Arg.String set_binary, ""
     ; "--parse", Arg.String set_binary, ""
-    ; "-i=false", Arg.Unit ignore, ""
+    ; "-i", Arg.Bool ignore, ""
     ]
   in
   let source = ref None in


### PR DESCRIPTION
- we can't actually pass `-i=true` or `-i=false` as arguments. they need to be passed in separately in the argv array