### PR TITLE
fix(describe-pp): show output on successive runs

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -45,6 +45,13 @@ let print_pped_file sctx file pp_file =
     in
     Action_builder.evaluate_and_collect_facts build
   in
+  let observing_facts =
+    (* We add `(universe)` to the dependencies of this action so that `dune
+       describe pp` always prints output *)
+    match Dep.Map.add observing_facts Dep.universe Dep.Fact.nothing with
+    | Ok x -> x
+    | Error _ -> observing_facts
+  in
   Build_system.execute_action ~observing_facts { action; loc; dir; alias = None }
 ;;
 

--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
@@ -3,6 +3,11 @@ We can show the preprocessed output of a source code
   $ dune describe pp src/main.ml
   ;;Util.log "Hello, world!"
 
+Re-running the command keeps showing output
+
+  $ dune describe pp src/main.ml
+  ;;Util.log "Hello, world!"
+
 We can also show the original source if it is not preprocessed
 
   $ dune describe pp src/util.ml


### PR DESCRIPTION
- #10322 introduced `Build_system.execute_action` which is cached
- this diff adds the `(universe)` to the anonymous action obtained in the dialect so that output is always shown after running `dune describe pp`