### PR TITLE
refactor: model Executables.names as a Nonempty_list.t

### DIFF
--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -154,7 +154,7 @@ let libs db (context : Context.t) =
           dir
           exes.buildable.libraries
           exes.buildable.preprocess
-          (List.map exes.names ~f:snd)
+          (List.map (Nonempty_list.to_list exes.names) ~f:snd)
           exes.package
           Item.Kind.Executables
           (exes_extensions ocaml.lib_config exes.modes)
@@ -177,7 +177,7 @@ let libs db (context : Context.t) =
           dir
           tests.exes.buildable.libraries
           tests.exes.buildable.preprocess
-          (List.map tests.exes.names ~f:snd)
+          (List.map (Nonempty_list.to_list tests.exes.names) ~f:snd)
           (if Option.is_none tests.package then tests.exes.package else tests.package)
           Item.Kind.Tests
           (exes_extensions ocaml.lib_config tests.exes.modes)

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -384,7 +384,10 @@ module Crawl = struct
   let executables sctx ~options ~project ~dir (exes : Executables.t)
     : (Descr.Item.t * Lib.Set.t) option Memo.t
     =
-    let first_exe = snd (List.hd exes.names) in
+    let first_exe =
+      let ((_, first) :: _) = exes.names in
+      first
+    in
     let* modules_, obj_dir =
       Dir_contents.get sctx ~dir
       >>= Dir_contents.ocaml
@@ -424,7 +427,7 @@ module Crawl = struct
     | Ok libs ->
       let include_dirs = Obj_dir.all_cmis obj_dir in
       let exe_descr =
-        { Descr.Exe.names = List.map ~f:snd exes.names
+        { Descr.Exe.names = List.map ~f:snd (Nonempty_list.to_list exes.names)
         ; requires = List.map ~f:uid_of_library libs
         ; modules = modules_
         ; include_dirs

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -384,10 +384,7 @@ module Crawl = struct
   let executables sctx ~options ~project ~dir (exes : Executables.t)
     : (Descr.Item.t * Lib.Set.t) option Memo.t
     =
-    let first_exe =
-      let ((_, first) :: _) = exes.names in
-      first
-    in
+    let first_exe = snd (Nonempty_list.hd exes.names) in
     let* modules_, obj_dir =
       Dir_contents.get sctx ~dir
       >>= Dir_contents.ocaml

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -41,8 +41,8 @@ module File = struct
 
     let executables_conflict (a : Dune_rules.Executables.t) (b : Dune_rules.Executables.t)
       =
-      let a_names = String.Set.of_list_map ~f:snd a.names in
-      let b_names = String.Set.of_list_map ~f:snd b.names in
+      let a_names = String.Set.of_list_map ~f:snd (Nonempty_list.to_list a.names) in
+      let b_names = String.Set.of_list_map ~f:snd (Nonempty_list.to_list b.names) in
       String.Set.inter a_names b_names |> String.Set.is_empty |> not
     ;;
 

--- a/otherlibs/stdune/src/nonempty_list.ml
+++ b/otherlibs/stdune/src/nonempty_list.ml
@@ -1,5 +1,7 @@
 type 'a t = ( :: ) of 'a * 'a list
 
+let hd (x :: _) = x
+
 let of_list = function
   | [] -> None
   | x :: xs -> Some (x :: xs)

--- a/otherlibs/stdune/src/nonempty_list.mli
+++ b/otherlibs/stdune/src/nonempty_list.mli
@@ -2,5 +2,6 @@
 
 type 'a t = ( :: ) of 'a * 'a list
 
+val hd : 'a t -> 'a
 val of_list : 'a list -> 'a t option
 val to_list : 'a t -> 'a list

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -19,10 +19,11 @@ let available_exes ~dir (exes : Executables.t) =
       |> Resolve.Memo.read_memo
       >>| Preprocess.Per_module.pps
     in
-    let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names) in
+    let names = Nonempty_list.to_list exes.names in
+    let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
     Lib.DB.resolve_user_written_deps
       libs
-      (`Exe exes.names)
+      (`Exe names)
       exes.buildable.libraries
       ~pps
       ~dune_version

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -1,7 +1,10 @@
 open Import
 open Memo.O
 
-let first_exe (exes : Executables.t) = snd (List.hd exes.names)
+let first_exe (exes : Executables.t) =
+  let ((_, first) :: _) = exes.names in
+  first
+;;
 
 let linkages
   ~dynamically_linked_foreign_archives
@@ -43,7 +46,7 @@ let linkages
 ;;
 
 let programs ~modules ~(exes : Executables.t) =
-  List.map exes.names ~f:(fun (loc, name) ->
+  List.map (Nonempty_list.to_list exes.names) ~f:(fun (loc, name) ->
     let mod_name = Module_name.of_string_allow_invalid (loc, name) in
     match Modules.find modules mod_name with
     | Some m ->
@@ -145,7 +148,7 @@ let executables_rules
   let* modules, pp =
     Buildable_rules.modules_rules
       sctx
-      (Executables (exes.buildable, exes.names))
+      (Executables (exes.buildable, Nonempty_list.to_list exes.names))
       expander
       ~dir
       scope
@@ -240,7 +243,10 @@ let executables_rules
          that to the [Exe.link_many] call here as well as the Ctypes_rules. This
          dance is done to avoid triggering duplicate rule exceptions. *)
       let+ () =
-        let loc = fst (List.hd exes.names) in
+        let loc =
+          let ((loc, _) :: _) = exes.names in
+          loc
+        in
         Ctypes_rules.gen_rules ~cctx ~buildable ~loc ~sctx ~scope ~dir
       and+ () = Module_compilation.build_all cctx
       and+ link =
@@ -285,10 +291,11 @@ let compile_info ~scope (exes : Executables.t) =
          ~instrumentation_backend:(Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names) in
+  let names = Nonempty_list.to_list exes.names in
+  let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
   Lib.DB.resolve_user_written_deps
     (Scope.libs scope)
-    (`Exe exes.names)
+    (`Exe names)
     exes.buildable.libraries
     ~pps
     ~dune_version

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -1,10 +1,7 @@
 open Import
 open Memo.O
 
-let first_exe (exes : Executables.t) =
-  let ((_, first) :: _) = exes.names in
-  first
-;;
+let first_exe (exes : Executables.t) = snd (Nonempty_list.hd exes.names)
 
 let linkages
   ~dynamically_linked_foreign_archives
@@ -243,10 +240,7 @@ let executables_rules
          that to the [Exe.link_many] call here as well as the Ctypes_rules. This
          dance is done to avoid triggering duplicate rule exceptions. *)
       let+ () =
-        let loc =
-          let ((loc, _) :: _) = exes.names in
-          loc
-        in
+        let loc = fst (Nonempty_list.hd exes.names) in
         Ctypes_rules.gen_rules ~cctx ~buildable ~loc ~sctx ~scope ~dir
       and+ () = Module_compilation.build_all cctx
       and+ link =

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -242,7 +242,12 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version =
   in
   (* TODO: Make this more type-safe by switching to non-empty lists. *)
   let executables =
-    String.Map.of_list_map_exn exes ~f:(fun (exes, m) -> snd (List.hd exes.names), m)
+    String.Map.of_list_map_exn exes ~f:(fun (exes, m) ->
+      let first_exe =
+        let ((_, first) :: _) = exes.names in
+        first
+      in
+      first_exe, m)
   in
   let libraries =
     match Lib_name.Map.of_list_map libs ~f:(fun (lib, m) -> Library.best_name lib, m) with

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -243,10 +243,7 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version =
   (* TODO: Make this more type-safe by switching to non-empty lists. *)
   let executables =
     String.Map.of_list_map_exn exes ~f:(fun (exes, m) ->
-      let first_exe =
-        let ((_, first) :: _) = exes.names in
-        first
-      in
+      let first_exe = snd (Nonempty_list.hd exes.names) in
       first_exe, m)
   in
   let libraries =

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -132,7 +132,7 @@ end = struct
         { (with_cctx_merlin ~loc:exes.buildable.loc cctx_merlin) with
           js =
             Some
-              (List.map exes.names ~f:(fun (_, exe) ->
+              (List.map (Nonempty_list.to_list exes.names) ~f:(fun (_, exe) ->
                  Path.Build.relative dir (exe ^ Js_of_ocaml.Ext.exe)))
         })
     | Alias_conf.T alias ->

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -365,13 +365,12 @@ end = struct
                  |> Resolve.Memo.read_memo
                  >>| Preprocess.Per_module.pps
                in
-               let merlin_ident =
-                 Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
-               in
+               let names = Nonempty_list.to_list exes.names in
+               let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
                Lib.DB.resolve_user_written_deps
                  (Scope.libs scope)
                  ~forbidden_libraries:[]
-                 (`Exe exes.names)
+                 (`Exe names)
                  exes.buildable.libraries
                  ~pps
                  ~dune_version

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -71,7 +71,11 @@ module Modules = struct
     let executables =
       match
         String.Map.of_list_map exes ~f:(fun (part : Executables.t group_part) ->
-          snd (List.hd part.stanza.names), (part.modules, part.obj_dir))
+          let first_exe =
+            let ((_, first) :: _) = part.stanza.names in
+            first
+          in
+          first_exe, (part.modules, part.obj_dir))
       with
       | Ok x -> x
       | Error (name, _, part) ->

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -71,10 +71,7 @@ module Modules = struct
     let executables =
       match
         String.Map.of_list_map exes ~f:(fun (part : Executables.t group_part) ->
-          let first_exe =
-            let ((_, first) :: _) = part.stanza.names in
-            first
-          in
+          let first_exe = snd (Nonempty_list.hd part.stanza.names) in
           first_exe, (part.modules, part.obj_dir))
       with
       | Ok x -> x

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -545,6 +545,6 @@ let has_foreign t = Buildable.has_foreign t.buildable
 let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
 
 let obj_dir t ~dir =
-  let ((_, name) :: _) = t.names in
+  let name = snd (Nonempty_list.hd t.names) in
   Obj_dir.make_exe ~dir ~name
 ;;

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -4,7 +4,7 @@ open Dune_lang.Decoder
 module Names : sig
   type t
 
-  val names : t -> (Loc.t * string) list
+  val names : t -> (Loc.t * string) Nonempty_list.t
   val package : t -> Package.t option
   val has_public_name : t -> bool
 
@@ -26,7 +26,7 @@ end = struct
     }
 
   type t =
-    { names : (Loc.t * string) list
+    { names : (Loc.t * string) Nonempty_list.t
     ; public : public option
     ; dune_syntax : Syntax.Version.t
     }
@@ -89,60 +89,63 @@ end = struct
     and+ project = Dune_project.get_exn () in
     let names, public_names = names in
     let names =
-      let open Dune_lang.Syntax.Version.Infix in
-      if dune_syntax >= check_valid_name_version
-      then
-        Option.iter
-          names
-          ~f:
-            (List.iter ~f:(fun name ->
-               ignore (Module_name.parse_string_exn name : Module_name.t)));
-      match names, public_names with
-      | Some names, _ -> names
-      | None, Some public_names ->
-        if dune_syntax >= allow_omit_names_version
-        then (
-          let check_names = dune_syntax >= check_valid_name_version in
-          List.map public_names ~f:(fun (loc, p) ->
-            match p, check_names with
-            | None, _ ->
-              User_error.raise ~loc [ Pp.text "This executable must have a name field" ]
-            | Some s, false -> loc, s
-            | Some s, true ->
-              (match Module_name.of_string_user_error (loc, s) with
-               | Ok _ -> loc, s
-               | Error user_message ->
-                 User_error.raise
-                   ~loc
-                   [ Pp.textf "Invalid module name."
-                   ; Pp.text
-                       "Public executable names don't have this restriction. You can \
-                        either change this public name to be a valid module name or add \
-                        a \"name\" field with a valid module name."
-                   ]
-                   ~hints:(Module_name.valid_format_doc :: user_message.hints))))
-        else
-          User_error.raise
-            ~loc
-            [ Pp.textf
-                "%s field may not be omitted before dune version %s"
-                (pluralize ~multi "name")
-                (Dune_lang.Syntax.Version.to_string allow_omit_names_version)
-            ]
-      | None, None ->
-        if dune_syntax >= allow_omit_names_version
+      let names =
+        let open Dune_lang.Syntax.Version.Infix in
+        if dune_syntax >= check_valid_name_version
         then
-          User_error.raise
-            ~loc
-            [ Pp.textf
-                "either the %s or the %s field must be present"
-                (pluralize ~multi "name")
-                (pluralize ~multi "public_name")
-            ]
-        else
-          User_error.raise
-            ~loc
-            [ Pp.textf "field %s is missing" (pluralize ~multi "name") ]
+          Option.iter
+            names
+            ~f:
+              (List.iter ~f:(fun name ->
+                 ignore (Module_name.parse_string_exn name : Module_name.t)));
+        match names, public_names with
+        | Some names, _ -> names
+        | None, Some public_names ->
+          if dune_syntax >= allow_omit_names_version
+          then (
+            let check_names = dune_syntax >= check_valid_name_version in
+            List.map public_names ~f:(fun (loc, p) ->
+              match p, check_names with
+              | None, _ ->
+                User_error.raise ~loc [ Pp.text "This executable must have a name field" ]
+              | Some s, false -> loc, s
+              | Some s, true ->
+                (match Module_name.of_string_user_error (loc, s) with
+                 | Ok _ -> loc, s
+                 | Error user_message ->
+                   User_error.raise
+                     ~loc
+                     [ Pp.textf "Invalid module name."
+                     ; Pp.text
+                         "Public executable names don't have this restriction. You can \
+                          either change this public name to be a valid module name or \
+                          add a \"name\" field with a valid module name."
+                     ]
+                     ~hints:(Module_name.valid_format_doc :: user_message.hints))))
+          else
+            User_error.raise
+              ~loc
+              [ Pp.textf
+                  "%s field may not be omitted before dune version %s"
+                  (pluralize ~multi "name")
+                  (Dune_lang.Syntax.Version.to_string allow_omit_names_version)
+              ]
+        | None, None ->
+          if dune_syntax >= allow_omit_names_version
+          then
+            User_error.raise
+              ~loc
+              [ Pp.textf
+                  "either the %s or the %s field must be present"
+                  (pluralize ~multi "name")
+                  (pluralize ~multi "public_name")
+              ]
+          else
+            User_error.raise
+              ~loc
+              [ Pp.textf "field %s is missing" (pluralize ~multi "name") ]
+      in
+      Nonempty_list.of_list names |> Option.value_exn
     in
     let public =
       match package, public_names with
@@ -171,14 +174,17 @@ end = struct
   let install_conf t ~ext ~enabled_if ~dir =
     Option.map t.public ~f:(fun { package; public_names } ->
       let files =
-        List.map2 t.names public_names ~f:(fun (locn, name) (locp, pub) ->
-          Option.map pub ~f:(fun pub ->
-            Install_entry.File.of_file_binding
-              (File_binding.Unexpanded.make
-                 ~src:(locn, name ^ ext)
-                 ~dst:(locp, pub)
-                 ~dune_syntax:t.dune_syntax
-                 ~dir:(Some dir))))
+        List.map2
+          (Nonempty_list.to_list t.names)
+          public_names
+          ~f:(fun (locn, name) (locp, pub) ->
+            Option.map pub ~f:(fun pub ->
+              Install_entry.File.of_file_binding
+                (File_binding.Unexpanded.make
+                   ~src:(locn, name ^ ext)
+                   ~dst:(locp, pub)
+                   ~dune_syntax:t.dune_syntax
+                   ~dir:(Some dir))))
         |> List.filter_opt
       in
       let loc =
@@ -378,7 +384,7 @@ module Link_mode = struct
 end
 
 type t =
-  { names : (Loc.t * string) list
+  { names : (Loc.t * string) Nonempty_list.t
   ; link_flags : Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t
@@ -537,4 +543,8 @@ let single, multi =
 
 let has_foreign t = Buildable.has_foreign t.buildable
 let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
-let obj_dir t ~dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd t.names))
+
+let obj_dir t ~dir =
+  let ((_, name) :: _) = t.names in
+  Obj_dir.make_exe ~dir ~name
+;;

--- a/src/dune_rules/stanzas/executables.mli
+++ b/src/dune_rules/stanzas/executables.mli
@@ -35,7 +35,7 @@ module Link_mode : sig
 end
 
 type t =
-  { names : (Loc.t * string) list
+  { names : (Loc.t * string) Nonempty_list.t
   ; link_flags : Link_flags.Spec.t
   ; link_deps : Dep_conf.t list
   ; modes : Loc.t Link_mode.Map.t

--- a/src/dune_rules/stanzas/tests.ml
+++ b/src/dune_rules/stanzas/tests.ml
@@ -58,7 +58,7 @@ let gen_parse names =
             ; modes
             ; optional = false
             ; buildable
-            ; names
+            ; names = Nonempty_list.of_list names |> Option.value_exn
             ; package = None
             ; promote = None
             ; install_conf = None

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -32,7 +32,7 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
       |> List.sort_uniq ~compare:Poly.compare
   in
   let* () =
-    Memo.parallel_iter t.exes.names ~f:(fun (loc, s) ->
+    Memo.parallel_iter (Nonempty_list.to_list t.exes.names) ~f:(fun (loc, s) ->
       Memo.parallel_iter runtest_modes ~f:(fun runtest_mode ->
         let ext =
           match runtest_mode with

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -79,10 +79,11 @@ let add_stanza db ~dir (acc, pps) stanza =
                  (Lib.DB.instrumentation_backend (Scope.libs scope)))
           >>| Preprocess.Per_module.pps
         in
-        let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names) in
+        let names = Nonempty_list.to_list exes.names in
+        let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
         Lib.DB.resolve_user_written_deps
           db
-          (`Exe exes.names)
+          (`Exe names)
           exes.buildable.libraries
           ~pps
           ~dune_version


### PR DESCRIPTION
- it's impossible, by construction, to create an empty list of executable names (parsing error)
- this change makes it easier to pattern match on the first name in `executable.names` which we use across the codebase to derive the obj dir name