### PR TITLE
refactor: reuse `Dune_rules.Top_module.find_module` in describe-pp

### DIFF
--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -48,135 +48,54 @@ let print_pped_file sctx file pp_file =
   Build_system.execute_action ~observing_facts { action; loc; dir; alias = None }
 ;;
 
-let in_build_dir context file =
-  file |> Path.to_string |> Path.Build.relative (Context.build_dir context)
-;;
-
-let module_for_file =
-  let rec closest_dune_file dir =
-    let open Memo.O in
-    let* dune_file = Dune_rules.Dune_load.stanzas_in_dir dir in
-    match dune_file with
-    | None ->
-      (match Path.Build.parent dir with
-       | None -> Memo.return None
-       | Some parent_dir -> closest_dune_file parent_dir)
-    | Some dune_file -> Memo.return (Some dune_file)
-  in
-  let module_for_src =
-    let exception Local of Dune_rules.Module.t in
-    fun modules ~ml_kind file ->
-      try
-        Dune_rules.Modules.fold_user_written modules ~init:() ~f:(fun m () ->
-          Dune_rules.Module.source m ~ml_kind
-          |> Option.iter ~f:(fun src ->
-            if Path.equal file (Dune_rules.Module.File.path src) then raise (Local m)));
-        None
-      with
-      | Local m -> Some m
-  in
-  fun ~sctx ~ml_kind file ->
-    let open Memo.O in
-    let* dir =
-      let+ dir =
-        Source_tree.nearest_dir (Path.drop_optional_build_context_src_exn file)
-        >>| Source_tree.Dir.path
-      in
-      in_build_dir (Super_context.context sctx) (Path.source dir)
-    in
-    let* dune_file =
-      (* This module could be inside an `include_subdirs` directory. *)
-      closest_dune_file dir
-    in
-    match dune_file with
-    | None -> Memo.return None
-    | Some dune_file ->
-      Dune_rules.Dune_file.stanzas dune_file
-      >>= Memo.List.find_map ~f:(fun stanza ->
-        let for_and_preprocess =
-          match Stanza.repr stanza with
-          | Library.T lib ->
-            Some
-              ( Dune_rules.Ml_sources.Library (Library.best_name lib)
-              , lib.buildable.preprocess )
-          | Executables.T exes ->
-            Some
-              ( Exe { first_exe = snd (Nonempty_list.hd exes.names) }
-              , exes.buildable.preprocess )
-          | Melange_stanzas.Emit.T mel ->
-            Some (Melange { target = mel.target }, mel.preprocess)
-          | _ -> None
-        in
-        match for_and_preprocess with
-        | None -> Memo.return None
-        | Some (for_, preprocess) ->
-          let+ modules =
-            Dune_rules.Dir_contents.get sctx ~dir
-            >>= Dune_rules.Dir_contents.ocaml
-            >>| Dune_rules.Ml_sources.modules ~for_
-          in
-          module_for_src modules ~ml_kind file |> Option.map ~f:(fun m -> m, preprocess))
-      >>= (function
-       | None -> Memo.return None
-       | Some (m, preprocess) ->
-         (match
-            Dune_rules.Preprocess.Per_module.find (Dune_rules.Module.name m) preprocess
-          with
-          | Dune_rules.Preprocess.Pps { staged = true; loc; _ } ->
-            Memo.return (Some (`Staged_pps loc))
-          | _ ->
-            let+ pped_map =
-              let+ version =
-                let+ ocaml = Context.ocaml (Super_context.context sctx) in
-                ocaml.version
-              and+ preprocess =
-                let* scope = Dune_rules.Scope.DB.find_by_dir dir in
-                Resolve.Memo.read_memo
-                  (Dune_rules.Preprocess.Per_module.with_instrumentation
-                     preprocess
-                     ~instrumentation_backend:
-                       (Dune_rules.Lib.DB.instrumentation_backend
-                          (Dune_rules.Scope.libs scope)))
-              in
-              Staged.unstage
-                (Dune_rules.Preprocessing.pped_modules_map preprocess version)
-            in
-            Some (`Module (pped_map m))))
+let find_module ~sctx file =
+  let open Memo.O in
+  let src = Path.drop_optional_build_context_src_exn (Path.build file) in
+  Dune_rules.Top_module.find_module sctx src
+  >>| function
+  | None -> None
+  | Some (m, _, _, origin) ->
+    (match
+       Dune_rules.Ml_sources.Origin.preprocess origin
+       |> Dune_rules.Preprocess.Per_module.find (Dune_rules.Module.name m)
+     with
+     | Pps { staged = true; loc; _ } -> Some (`Staged_pps loc)
+     | _ -> Some (`Module m))
 ;;
 
 let get_pped_file super_context file =
   let open Memo.O in
-  let in_build_dir =
-    let context = Super_context.context super_context in
-    in_build_dir context
+  let context = Super_context.context super_context in
+  let in_build_dir file =
+    file |> Path.to_string |> Path.Build.relative (Context.build_dir context)
   in
   let file_in_build_dir =
     if String.is_empty file
     then User_error.raise [ Pp.textf "No file given." ]
-    else Path.of_string file |> in_build_dir |> Path.build
+    else Path.of_string file |> in_build_dir
   in
   let* ml_kind =
     let+ _, ml_kind = dialect_and_ml_kind file in
     ml_kind
   in
-  let* module_for_file = module_for_file ~sctx:super_context ~ml_kind file_in_build_dir in
   let file_not_found () =
     User_error.raise
-      [ Pp.textf "%s does not exist" (Path.to_string_maybe_quoted file_in_build_dir) ]
+      [ Pp.textf "%s does not exist" (Path.Build.to_string_maybe_quoted file_in_build_dir)
+      ]
   in
-  match module_for_file with
+  find_module ~sctx:super_context file_in_build_dir
+  >>= function
+  | None -> file_not_found ()
   | Some (`Module m) ->
-    let pp_file =
-      m |> Dune_rules.Module.source ~ml_kind |> Option.map ~f:Dune_rules.Module.File.path
-    in
-    (match pp_file with
+    (match
+       Dune_rules.Module.source m ~ml_kind |> Option.map ~f:Dune_rules.Module.File.path
+     with
      | None -> file_not_found ()
      | Some pp_file ->
        let+ () = Build_system.build_file pp_file in
        Ok pp_file)
   | Some (`Staged_pps loc) ->
     User_error.raise ~loc [ Pp.text "staged_pps are not supported." ]
-  | None -> file_not_found ()
 ;;
 
 let term =

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -104,7 +104,9 @@ module Module = struct
     let* top_module_info = Dune_rules.Top_module.find_module sctx mod_ in
     match top_module_info with
     | None -> User_error.raise [ Pp.text "no module found" ]
-    | Some (module_, cctx, merlin) ->
+    | Some (_, _, _, Melange _) ->
+      User_error.raise [ Pp.text "Modules belonging to `melange.emit' are not supported" ]
+    | Some (module_, cctx, merlin, _) ->
       let module Compilation_context = Dune_rules.Compilation_context in
       let module Obj_dir = Dune_rules.Obj_dir in
       let module Top_module = Dune_rules.Top_module in

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -14,6 +14,12 @@ module Origin = struct
     | Melange mel -> mel.loc
   ;;
 
+  let preprocess = function
+    | Library l -> l.buildable.preprocess
+    | Executables e -> e.buildable.preprocess
+    | Melange mel -> mel.preprocess
+  ;;
+
   let to_dyn = function
     | Library _ -> Dyn.variant "Library" [ Dyn.Opaque ]
     | Executables _ -> Dyn.variant "Executables" [ Dyn.Opaque ]

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -11,6 +11,7 @@ module Origin : sig
     | Executables of Executables.t
     | Melange of Melange_stanzas.Emit.t
 
+  val preprocess : t -> Preprocess.With_instrumentation.t Preprocess.Per_module.t
   val loc : t -> Loc.t
   val to_dyn : t -> Dyn.t
 end

--- a/src/dune_rules/top_module.mli
+++ b/src/dune_rules/top_module.mli
@@ -3,7 +3,7 @@ open Import
 val find_module
   :  Super_context.t
   -> Path.Source.t
-  -> (Module.t * Compilation_context.t * Merlin.t) option Memo.t
+  -> (Module.t * Compilation_context.t * Merlin.t * Ml_sources.Origin.t) option Memo.t
 
 val private_obj_dir : Context.t -> Path.Source.t -> Path.Build.t Obj_dir.t
 val gen_rules : Super_context.t -> dir:Path.Build.t -> comps:string list -> unit Memo.t


### PR DESCRIPTION
This was suggested in https://github.com/ocaml/dune/pull/10321#discussion_r1545646674