### PR TITLE
doc: document more `dune describe` commands

### DIFF
--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -105,7 +105,7 @@ module Aliases_cmd = struct
   let term = ls_term fetch_results
 
   let command =
-    let doc = "Print aliases in a given directory. Works similalry to ls." in
+    let doc = "Print aliases in a given directory. Works similarly to ls." in
     Cmd.v (Cmd.info "aliases" ~doc ~envs:Common.envs) term
   ;;
 end
@@ -134,7 +134,7 @@ module Targets_cmd = struct
   let term = ls_term fetch_results
 
   let command =
-    let doc = "Print targets in a given directory. Works similalry to ls." in
+    let doc = "Print targets in a given directory. Works similarly to ls." in
     Cmd.v (Cmd.info "targets" ~doc ~envs:Common.envs) term
   ;;
 end

--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -20,7 +20,7 @@ let term =
 ;;
 
 let command =
-  let doc = "prints information about the entries per package" in
+  let doc = "prints information about the entries per package." in
   let info = Cmd.info ~doc "package-entries" in
   Cmd.v info term
 ;;

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -117,7 +117,7 @@ let term =
 ;;
 
 let command =
-  let doc = "Print the environment of a directory" in
+  let doc = "Print the environment of a directory." in
   let man =
     [ `S "DESCRIPTION"
     ; `P {|$(b,dune show env DIR) prints the environment of a directory|}

--- a/doc/reference/cli.rst
+++ b/doc/reference/cli.rst
@@ -36,6 +36,49 @@ documentation for each command is available through ``dune COMMAND --help``.
 
    Describe the workspace.
 
+   .. describe:: dune describe aliases
+
+      Print aliases in a given directory. Works similarly to ls.
+
+   .. describe:: dune describe env
+
+      Print the environment of a directory.
+
+   .. describe:: dune describe external-lib-deps
+
+      Print out the external libraries needed to build the project. It's an
+      approximated set of libraries.
+
+   .. describe:: dune describe installed-libraries
+
+      Print out the libraries installed on the system.
+
+   .. describe:: dune describe opam-files
+
+      Print information about the opam files that have been discovered.
+
+   .. describe:: dune describe package-entries
+
+      prints information about the entries per package.
+
+   .. describe:: dune describe pp
+
+      Build a given file and print the preprocessed output.
+
+   .. describe:: dune describe rules
+
+      Dump rules.
+
+   .. describe:: dune describe targets
+
+      Print targets in a given directory. Works similarly to ls.
+
+   .. describe:: dune describe workspace
+
+      Print a description of the workspace's structure. If some directories
+      are provided, then only those directories of the workspace are
+      considered.
+
 .. describe:: dune diagnostics
 
    Fetch and return errors from the current build.


### PR DESCRIPTION
I left `dune describe pkg` out for now because I'm not sure what the plan is around that.