### PR TITLE
fix(ml-sources): check that a library is available before tracking it

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -452,12 +452,13 @@ include Load
 
 let modules_of_local_lib sctx lib =
   let info = Lib.Local.info lib in
-  let* t =
-    let dir = Lib_info.src_dir info in
-    get sctx ~dir
-  in
+  let dir = Lib_info.src_dir info in
+  let* t = get sctx ~dir
+  and* libs = Scope.DB.find_by_dir dir >>| Scope.libs in
   ocaml t
-  >>| Ml_sources.modules ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
+  >>= Ml_sources.modules
+        ~libs
+        ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
 ;;
 
 let modules_of_lib sctx lib =

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -127,7 +127,7 @@ let executables_rules
   let* modules, obj_dir =
     let first_exe = first_exe exes in
     Dir_contents.ocaml dir_contents
-    >>| Ml_sources.modules_and_obj_dir ~for_:(Exe { first_exe })
+    >>= Ml_sources.modules_and_obj_dir ~libs:(Scope.libs scope) ~for_:(Exe { first_exe })
   in
   let* () = Check_rules.add_obj_dir sctx ~obj_dir (Ocaml Byte) in
   let ctx = Super_context.context sctx in

--- a/src/dune_rules/lib_id.ml
+++ b/src/dune_rules/lib_id.ml
@@ -33,6 +33,7 @@ module Local = struct
   include Comparable.Make (T)
 
   let make ~loc ~src_dir name = { name; loc; src_dir }
+  let name t = t.name
   let loc t = t.loc
 end
 
@@ -69,11 +70,9 @@ let to_local_exn = function
 ;;
 
 let name = function
-  | Local { name; _ } -> name
-  | External (_, name) -> name
+  | Local { name; _ } | External (_, name) -> name
 ;;
 
 let loc = function
-  | Local { loc; _ } -> loc
-  | External (loc, _) -> loc
+  | Local { loc; _ } | External (loc, _) -> loc
 ;;

--- a/src/dune_rules/lib_id.mli
+++ b/src/dune_rules/lib_id.mli
@@ -8,6 +8,7 @@ module Local : sig
 
   val equal : t -> t -> bool
   val make : loc:Loc.t -> src_dir:Path.Source.t -> Lib_name.t -> t
+  val name : t -> Lib_name.t
   val loc : t -> Loc.t
   val to_dyn : t -> Dyn.t
 end

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -657,7 +657,8 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
   let f () =
     let* source_modules =
       Dir_contents.ocaml dir_contents
-      >>| Ml_sources.modules
+      >>= Ml_sources.modules
+            ~libs:(Scope.libs scope)
             ~for_:
               (Library (Lib_info.lib_id (Lib.Local.info local_lib) |> Lib_id.to_local_exn))
     in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -266,7 +266,9 @@ let setup_emit_cmj_rules
   let f () =
     let* modules, obj_dir =
       Dir_contents.ocaml dir_contents
-      >>| Ml_sources.modules_and_obj_dir ~for_:(Melange { target = mel.target })
+      >>= Ml_sources.modules_and_obj_dir
+            ~libs:(Scope.libs scope)
+            ~for_:(Melange { target = mel.target })
     in
     let* () = Check_rules.add_obj_dir sctx ~obj_dir Melange in
     let* modules, pp =
@@ -426,7 +428,9 @@ let setup_runtime_assets_rules sctx ~dir ~target_dir ~mode ~output ~for_ mel =
 let modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope (mel : Melange_stanzas.Emit.t) =
   let* modules, obj_dir =
     Dir_contents.ocaml dir_contents
-    >>| Ml_sources.modules_and_obj_dir ~for_:(Melange { target = mel.target })
+    >>= Ml_sources.modules_and_obj_dir
+          ~libs:(Scope.libs scope)
+          ~for_:(Melange { target = mel.target })
   in
   let+ modules = modules_in_obj_dir ~sctx ~scope ~preprocess:mel.preprocess modules in
   let modules_for_js =

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -27,13 +27,17 @@ type for_ =
       }
   | Melange of { target : string }
 
-val modules_and_obj_dir : t -> for_:for_ -> Modules.t * Path.Build.t Obj_dir.t
+val modules_and_obj_dir
+  :  t
+  -> libs:Lib.DB.t
+  -> for_:for_
+  -> (Modules.t * Path.Build.t Obj_dir.t) Memo.t
 
 (** Modules attached to a library, executable, or melange.emit stanza.*)
-val modules : t -> for_:for_ -> Modules.t
+val modules : t -> libs:Lib.DB.t -> for_:for_ -> Modules.t Memo.t
 
 (** Find out the origin of the stanza for a given module *)
-val find_origin : t -> Module_name.Path.t -> Origin.t option
+val find_origin : t -> libs:Lib.DB.t -> Module_name.Path.t -> Origin.t option Memo.t
 
 val empty : t
 

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -31,12 +31,13 @@ let find_module sctx src =
   | None -> Memo.return None
   | Some module_name ->
     let* dir_contents = drop_rules @@ fun () -> Dir_contents.get sctx ~dir in
-    let* ocaml = Dir_contents.ocaml dir_contents in
-    (match Ml_sources.find_origin ocaml [ module_name ] with
+    let* ocaml = Dir_contents.ocaml dir_contents
+    and* scope = Scope.DB.find_by_dir dir in
+    Ml_sources.find_origin ocaml ~libs:(Scope.libs scope) [ module_name ]
+    >>= (function
      | None -> Memo.return None
      | Some origin ->
-       let* scope = Scope.DB.find_by_dir dir
-       and* expander = Super_context.expander sctx ~dir in
+       let* expander = Super_context.expander sctx ~dir in
        let+ cctx, merlin =
          drop_rules
          @@ fun () ->

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-optional.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-private-optional.t
@@ -1,5 +1,6 @@
 Private libraries using the same library name, in the same context, defined in
-the same folder.
+the same folder. One of them is unavailable because it's `(optional)` and a
+dependency is missing.
 
   $ cat > dune-project << EOF
   > (lang dune 3.13)
@@ -8,30 +9,30 @@ the same folder.
   $ cat > dune << EOF
   > (library
   >  (name foo)
-  >  (modules))
+  >  (libraries xxx)
+  >  (optional))
   > (library
-  >  (name foo)
-  >  (modules))
+  >  (name foo))
+  > EOF
+  $ cat > foo.ml << EOF
+  > let x = "hello"
   > EOF
 
 Without any consumers of the libraries
 
   $ dune build
-  File "dune", line 5, characters 7-10:
-  5 |  (name foo)
-             ^^^
-  Error: Library "foo" appears for the second time in this directory
-  [1]
 
 With some consumer of the library
 
   $ cat > dune << EOF
   > (library
   >  (name foo)
-  >  (modules))
+  >  (modules foo)
+  >  (libraries xxx)
+  >  (optional))
   > (library
-  >  (name foo)
-  >  (modules))
+  >  (modules foo)
+  >  (name foo))
   > (executable
   >  (name main)
   >  (modules main)
@@ -39,12 +40,7 @@ With some consumer of the library
   > EOF
 
   $ cat > main.ml <<EOF
-  > let () = Foo.x
+  > let () = print_endline Foo.x
   > EOF
 
   $ dune build
-  File "dune", line 5, characters 7-10:
-  5 |  (name foo)
-             ^^^
-  Error: Library "foo" appears for the second time in this directory
-  [1]

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-folder.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-folder.t
@@ -19,10 +19,9 @@ the same folder.
 Without any consumers of the libraries
 
   $ dune build
-  File "dune", lines 4-6, characters 0-44:
-  4 | (library
+  File "dune", line 5, characters 7-10:
   5 |  (name foo)
-  6 |  (public_name baz.foo))
+             ^^^
   Error: Library "foo" appears for the second time in this directory
   [1]
 
@@ -31,12 +30,15 @@ With some consumer
   $ cat > dune << EOF
   > (library
   >  (name foo)
+  >  (modules)
   >  (public_name bar.foo))
   > (library
   >  (name foo)
+  >  (modules)
   >  (public_name baz.foo))
   > (executable
   >  (name main)
+  >  (modules main)
   >  (libraries foo))
   > EOF
 
@@ -45,9 +47,8 @@ With some consumer
   > EOF
 
   $ dune build
-  File "dune", lines 4-6, characters 0-44:
-  4 | (library
-  5 |  (name foo)
-  6 |  (public_name baz.foo))
+  File "dune", line 6, characters 7-10:
+  6 |  (name foo)
+             ^^^
   Error: Library "foo" appears for the second time in this directory
   [1]


### PR DESCRIPTION
Since #10307, dune started allowing libraries to share the same name.

Thus, checking `enabled_if` isn't enough for libraries; dune now needs to check whether the library is available before tracking it in ml_sources.


addresses https://github.com/ocaml/dune/pull/10307#issuecomment-2027828644