### PR TITLE
Improve tests on macOS

### DIFF
--- a/test/blackbox-tests/test-cases/corrupt-persistent.t
+++ b/test/blackbox-tests/test-cases/corrupt-persistent.t
@@ -10,11 +10,10 @@
 
 Delete last 10 chars of the .db file to corrupt it
 
-  $ truncate --size=-10 _build/.db
+  $ truncate -s -10 _build/.db
 
 Dune log the corrupted file and recover
 
   $ dune build a
   $ grep "truncated object" _build/log
   # Failed to load corrupted file _build/.db: input_value: truncated object
-

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -37,8 +37,8 @@
  (applies_to compute-checksums-when-missing e2e source-caching tarball))
 
 (cram
- (deps %{bin:md5sum})
- (applies_to source-caching))
+ (deps ./md5sum.sh)
+ (applies_to source-caching e2e))
 
 (cram
  (deps %{bin:tar})

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -46,7 +46,7 @@ Make a package for the library:
   > url {
   >  src: "http://0.0.0.0:$PORT"
   >  checksum: [
-  >   "md5=$(md5sum foo.tar.gz | cut -f1 -d' ')"
+  >   "md5=$(./md5sum.sh foo.tar.gz)"
   >  ]
   > }
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/md5sum.sh
+++ b/test/blackbox-tests/test-cases/pkg/md5sum.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  md5 "$1" | awk '{ print $4 }'
+else
+  # Linux
+  md5sum "$1" | awk '{ print $1 }'
+fi

--- a/test/blackbox-tests/test-cases/pkg/source-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/source-caching.t
@@ -8,7 +8,7 @@ This test demonstratest that fetching package sources should be cached
   $ sources="sources/"
   $ mkdir $sources; touch $sources/dummy
   $ tar -czf $tarball $sources
-  $ checksum=$(md5sum $tarball | awk '{ print $1 }')
+  $ checksum=$(./md5sum.sh $tarball)
   $ webserver_oneshot --content-file $tarball --port-file port.txt &
   $ until test -f port.txt ; do sleep 0.1; done
   $ port=$(cat port.txt)


### PR DESCRIPTION
This makes more tests pass on macOS but I still have a few issues:

in `test/expect-tests`:

```
_boot/dune.exe test test/expect-tests/
File "test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml", line 1, characters 0-0:
------ test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
++++++ test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml.corrected
File "test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml", line 43, characters 0-1:
 |      | list ->
 |        events_buffer := [];
 |        Some
 |          (List.filter_map list ~f:(function
 |            | Dune_file_watcher.Event.Sync _ -> None
 |            | Queue_overflow -> assert false
 |            | Fs_memo_event e -> Some e
 |            | Watcher_terminated -> assert false)))
 |  in
 |  let print_events n = print_events ~try_to_get_events ~expected:n in
 |  Dune_file_watcher.wait_for_initial_watches_established_blocking watcher;
 |  Stdio.Out_channel.write_all "x" ~data:"x";
 |  print_events 3;
 |  [%expect
 |    {|
 |    { path = In_source_tree "."; kind = "Created" }
-|    { path = In_build_dir "."; kind = "Created" }
-|    { path = In_source_tree "x"; kind = "Unknown" } |}];
+|    Timed out waiting for more events: expected 3, saw 1 |}];
 |  Unix.rename "x" "y";
 |  print_events 2;
 |  [%expect
 |    {|
-|    { path = In_source_tree "x"; kind = "Unknown" }
-|    { path = In_source_tree "y"; kind = "Unknown" } |}];
+|    Timed out waiting for more events: expected 2, saw 0 |}];
 |  let (_ : _) = Fpath.mkdir_p "d/w" in
 |  Stdio.Out_channel.write_all "d/w/x" ~data:"x";
 |  print_events 3;
 |  [%expect
 |    {|
-|    { path = In_source_tree "d"; kind = "Created" }
-|    { path = In_source_tree "d/w"; kind = "Created" }
-|    { path = In_source_tree "d/w/x"; kind = "Unknown" } |}];
+|    Timed out waiting for more events: expected 3, saw 0 |}];
 |  Stdio.Out_channel.write_all "d/w/y" ~data:"y";
 |  print_events 1;
-|  [%expect {| { path = In_source_tree "d/w/y"; kind = "Unknown" } |}]
+|  [%expect {| Timed out waiting for more events: expected 1, saw 0 |}]
 |;;
```

and `test/blackbox-test` have a few other issues (including non-completing tests that got stuck). I'm trying to debug this.