### PR TITLE
test: fix truncate on macOS

### DIFF
--- a/test/blackbox-tests/test-cases/corrupt-persistent.t
+++ b/test/blackbox-tests/test-cases/corrupt-persistent.t
@@ -10,11 +10,10 @@
 
 Delete last 10 chars of the .db file to corrupt it
 
-  $ truncate --size=-10 _build/.db
+  $ truncate -s -10 _build/.db
 
 Dune log the corrupted file and recover
 
   $ dune build a
   $ grep "truncated object" _build/log
   # Failed to load corrupted file _build/.db: input_value: truncated object
-


### PR DESCRIPTION
Otherwise the test fails with:

```
$ truncate --size=-10 _build/.db
+|  truncate: illegal option -- -
+|  usage: truncate [-c] -s [+|-|%|/]size[K|k|M|m|G|g|T|t] file ...
+|         truncate [-c] -r rfile file ...
+|  [1]
```