### PR TITLE
test: fix error message detection with XCode CLI 15

### DIFF
--- a/test/blackbox-tests/test-cases/github7146.t/run.t
+++ b/test/blackbox-tests/test-cases/github7146.t/run.t
@@ -27,7 +27,7 @@ The error should point to our dune file
   File "problem/dune", line 1, characters 0-234:
 
 We make sure the error contains a message from the linker:
-  $ grep -q "ld: \(library not found for -lnative\|cannot find -lnative\)" stderr
+  $ grep -q "ld: \(library not found for -lnative\|cannot find -lnative\|library 'native' not found\)" stderr
 
 The workaround is to use a rule to capture the path to the working directory
 into a file, and then read the file inside the (c_library_flags ...) field:


### PR DESCRIPTION
The full error message is:

```
File "problem/dune", line 1, characters 0-234:
   1 | (library
   2 |  (name foo_problem)
   3 |  (foreign_stubs
   4 |   (language c)
   5 |   (names native_wrapper))
   6 |  (no_dynlink)
   7 |  (foreign_archives native)
   8 |  (c_library_flags :standard -lnative -L.)
   9 | ;(c_library_flags :standard -lnative -L%{project_root}/problem)
  10 | )
  ld: library 'native' not found
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```