### PR TITLE
refactor: introduce `Modules.With_vlib.t`

### DIFF
--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -371,7 +371,7 @@ module Crawl = struct
 
   (* Builds the list of modules *)
   let modules ~obj_dir ~deps_of modules_ : Descr.Mod.t list Memo.t =
-    Modules.fold_no_vlib ~init:(Memo.return []) modules_ ~f:(fun m macc ->
+    Modules.With_vlib.fold_no_vlib ~init:(Memo.return []) modules_ ~f:(fun m macc ->
       let* acc = macc in
       let deps = deps_of m in
       let+ { Ocaml.Ml_kind.Dict.intf = deps_for_intf; impl = deps_for_impl }, _ =
@@ -389,11 +389,14 @@ module Crawl = struct
       Scope.DB.find_by_project (Super_context.context sctx |> Context.name) project
     in
     let* modules_, obj_dir =
-      Dir_contents.get sctx ~dir
-      >>= Dir_contents.ocaml
-      >>= Ml_sources.modules_and_obj_dir
-            ~libs:(Scope.libs scope)
-            ~for_:(Exe { first_exe })
+      let+ modules_, obj_dir =
+        Dir_contents.get sctx ~dir
+        >>= Dir_contents.ocaml
+        >>= Ml_sources.modules_and_obj_dir
+              ~libs:(Scope.libs scope)
+              ~for_:(Exe { first_exe })
+      in
+      Modules.With_vlib.modules modules_, obj_dir
     in
     let* pp_map =
       let+ version =
@@ -454,11 +457,14 @@ module Crawl = struct
             let* libs =
               Scope.DB.find_by_dir (Path.as_in_build_dir_exn src_dir) >>| Scope.libs
             in
-            Dir_contents.get sctx ~dir:(Path.as_in_build_dir_exn src_dir)
-            >>= Dir_contents.ocaml
-            >>= Ml_sources.modules_and_obj_dir
-                  ~libs
-                  ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
+            let+ modules_, obj_dir_ =
+              Dir_contents.get sctx ~dir:(Path.as_in_build_dir_exn src_dir)
+              >>= Dir_contents.ocaml
+              >>= Ml_sources.modules_and_obj_dir
+                    ~libs
+                    ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
+            in
+            Modules.With_vlib.modules modules_, obj_dir_
           in
           let* pp_map =
             let+ version =

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -371,7 +371,9 @@ module Crawl = struct
 
   (* Builds the list of modules *)
   let modules ~obj_dir ~deps_of modules_ : Descr.Mod.t list Memo.t =
-    Modules.With_vlib.fold_no_vlib ~init:(Memo.return []) modules_ ~f:(fun m macc ->
+    modules_
+    |> Modules.With_vlib.drop_vlib
+    |> Modules.fold ~init:(Memo.return []) ~f:(fun m macc ->
       let* acc = macc in
       let deps = deps_of m in
       let+ { Ocaml.Ml_kind.Dict.intf = deps_for_intf; impl = deps_for_impl }, _ =

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -181,7 +181,7 @@ module Module = struct
       let+ (pp, ppx), files_to_load = Memo.fork_and_join pps files_to_load in
       let code =
         let modules = Dune_rules.Compilation_context.modules cctx in
-        let opens_ = Dune_rules.Modules.local_open modules module_ in
+        let opens_ = Dune_rules.Modules.With_vlib.local_open modules module_ in
         List.map opens_ ~f:(fun name ->
           sprintf "open %s" (Dune_rules.Module_name.to_string name))
       in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -151,8 +151,7 @@ let gen_rules sctx t ~dir ~scope =
       ~scope
   in
   let* modules =
-    Modules.singleton_exe module_
-    |> Modules.map_user_written ~f:(Pp_spec.pp_module preprocess)
+    Pp_spec.pp_module preprocess module_ >>| Modules.With_vlib.singleton_exe
   in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let names = [ t.loc, name ] in

--- a/src/dune_rules/cm_files.ml
+++ b/src/dune_rules/cm_files.ml
@@ -15,7 +15,7 @@ let filter_excluded_modules t modules =
 ;;
 
 let make ?(excluded_modules = []) ~obj_dir ~modules ~top_sorted_modules ~ext_obj () =
-  let modules = Modules.impl_only modules in
+  let modules = Modules.With_vlib.impl_only modules in
   let excluded_modules = Module_name.Set.of_list excluded_modules in
   { obj_dir; modules; top_sorted_modules; ext_obj; excluded_modules }
 ;;

--- a/src/dune_rules/cm_files.mli
+++ b/src/dune_rules/cm_files.mli
@@ -9,7 +9,7 @@ type t
 val make
   :  ?excluded_modules:Module_name.t list
   -> obj_dir:Path.Build.t Obj_dir.t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> top_sorted_modules:Module.t list Action_builder.t
   -> ext_obj:Filename.Extension.t
   -> unit

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -59,12 +59,12 @@ let eval_opaque (ocaml : Ocaml_toolchain.t) profile = function
 ;;
 
 type modules =
-  { modules : Modules.t
+  { modules : Modules.With_vlib.t
   ; dep_graphs : Dep_graph.t Ml_kind.Dict.t
   }
 
 let singleton_modules m =
-  { modules = Modules.singleton m; dep_graphs = Dep_graph.Ml_kind.dummy m }
+  { modules = Modules.With_vlib.singleton m; dep_graphs = Dep_graph.Ml_kind.dummy m }
 ;;
 
 type t =
@@ -212,7 +212,7 @@ let alias_and_root_module_flags =
 ;;
 
 let for_alias_module t alias_module =
-  let keep_flags = Modules.is_stdlib_alias (modules t) alias_module in
+  let keep_flags = Modules.With_vlib.is_stdlib_alias (modules t) alias_module in
   let flags =
     if keep_flags
     then (* in the case of stdlib, these flags can be written by the user *)
@@ -232,7 +232,7 @@ let for_alias_module t alias_module =
     else Sandbox_config.no_special_requirements
   in
   let (modules, includes) : modules * Includes.t =
-    match Modules.is_stdlib_alias t.modules.modules alias_module with
+    match Modules.With_vlib.is_stdlib_alias t.modules.modules alias_module with
     | false -> singleton_modules alias_module, Includes.empty
     | true ->
       (* The stdlib alias module is different from the alias modules usually
@@ -302,7 +302,7 @@ let entry_module_names sctx t =
     let open Memo.O in
     let+ modules = Dir_contents.modules_of_lib sctx t in
     let modules = Option.value_exn modules in
-    Resolve.return (Modules.entry_modules modules |> List.map ~f:Module.name)
+    Resolve.return (Modules.With_vlib.entry_modules modules |> List.map ~f:Module.name)
 ;;
 
 let root_module_entries t =

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -23,7 +23,7 @@ val create
   :  super_context:Super_context.t
   -> scope:Scope.t
   -> obj_dir:Path.Build.t Obj_dir.t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> flags:Ocaml_flags.t
   -> requires_compile:Lib.t list Resolve.Memo.t
   -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
@@ -52,7 +52,7 @@ val scope : t -> Scope.t
 val dir : t -> Path.Build.t
 
 val obj_dir : t -> Path.Build.t Obj_dir.t
-val modules : t -> Modules.t
+val modules : t -> Modules.With_vlib.t
 val flags : t -> Ocaml_flags.t
 val requires_link : t -> Lib.t list Resolve.Memo.t
 val requires_compile : t -> Lib.t list Resolve.Memo.t

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -9,7 +9,7 @@ val for_module
 
 val immediate_deps_of
   :  Module.t
-  -> Modules.t
+  -> Modules.With_vlib.t
   -> obj_dir:Path.Build.t Obj_dir.t
   -> ml_kind:Ml_kind.t
   -> Module.t list Action_builder.t

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -469,7 +469,7 @@ let modules_of_lib sctx lib =
   | External modules -> Memo.return modules
   | Local ->
     let+ modules = modules_of_local_lib sctx (Lib.Local.of_lib_exn lib) in
-    Some modules
+    Some (Modules.With_vlib.modules modules)
 ;;
 
 let () =

--- a/src/dune_rules/dir_contents.mli
+++ b/src/dune_rules/dir_contents.mli
@@ -34,7 +34,7 @@ val coq : t -> Coq_sources.t Memo.t
 (** Get the directory contents of the given directory. *)
 val get : Super_context.t -> dir:Path.Build.t -> t Memo.t
 
-val modules_of_lib : Super_context.t -> Lib.t -> Modules.t option Memo.t
+val modules_of_lib : Super_context.t -> Lib.t -> Modules.With_vlib.t option Memo.t
 val modules_of_local_lib : Super_context.t -> Lib.Local.t -> Modules.t Memo.t
 
 (** All directories in this group if [t] is a group root or just [t] if it is

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -144,7 +144,7 @@ module Lib = struct
        ; field_o "main_module_name" Module_name.encode main_module_name
        ; field_l "modes" sexp (Lib_mode.Map.Set.encode modes)
        ; field_l "obj_dir" sexp (Obj_dir.encode obj_dir)
-       ; field_o "modules" (Modules.encode ~src_dir:package_root) modules
+       ; field_o "modules" (Modules.With_vlib.encode ~src_dir:package_root) modules
        ; paths "melange_runtime_deps" melange_runtime_deps
        ; field_o
            "special_builtin_support"
@@ -228,7 +228,6 @@ module Lib = struct
          field_o "instrumentation.backend" (located Lib_name.decode)
        in
        let modes = Lib_mode.Map.Set.of_list modes in
-       let entry_modules = Modules.entry_modules modules |> List.map ~f:Module.name in
        let info : Path.t Lib_info.t =
          let src_dir = Obj_dir.dir obj_dir in
          let lib_id = Lib_id.External (loc, name) in
@@ -248,7 +247,13 @@ module Lib = struct
          let virtual_ =
            if virtual_ then Some (Lib_info.Source.External modules) else None
          in
-         let wrapped = Some (Lib_info.Inherited.This (Modules.wrapped modules)) in
+         let modules = Modules.With_vlib.modules modules in
+         let entry_modules =
+           Modules.With_vlib.entry_modules modules |> List.map ~f:Module.name
+         in
+         let wrapped =
+           Some (Lib_info.Inherited.This (Modules.With_vlib.wrapped modules))
+         in
          let entry_modules = Lib_info.Source.External (Ok entry_modules) in
          let modules = Lib_info.Source.External (Some modules) in
          let melange_runtime_deps = Lib_info.File_deps.External melange_runtime_deps in
@@ -309,7 +314,7 @@ module Lib = struct
 
   let wrapped t =
     match Lib_info.modules t.info with
-    | External modules -> Option.map modules ~f:Modules.wrapped
+    | External modules -> Option.map modules ~f:Modules.With_vlib.wrapped
     | Local -> None
   ;;
 

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -278,13 +278,13 @@ let link_many
     Memo.parallel_map programs ~f:(fun { Program.name; main_module_name; loc } ->
       let top_sorted_modules =
         let main =
-          match Modules.find modules main_module_name with
+          match Modules.With_vlib.find modules main_module_name with
           | Some m -> m
           | None ->
             Code_error.raise
               "link_many: unable to find module"
               [ "main_module_name", Module_name.to_dyn main_module_name
-              ; "modules", Modules.to_dyn modules
+              ; "modules", Modules.With_vlib.to_dyn modules
               ]
         in
         Dep_graph.top_closed_implementations

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -94,7 +94,7 @@ include Sub_system.Register_end_point (struct
         Module.generated ~kind:Impl ~src_dir:inline_test_dir [ name ]
       in
       let open Memo.O in
-      let modules = Modules.singleton_exe main_module in
+      let modules = Modules.With_vlib.singleton_exe main_module in
       let runner_libs =
         let open Resolve.Memo.O in
         let* libs =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -94,6 +94,7 @@ end = struct
         ml_sources
         ~libs:(Scope.libs scope)
         ~for_:(Library (Lib_info.lib_id lib |> Lib_id.to_local_exn))
+      >>| Modules.With_vlib.modules
       >>| Option.some
     and+ foreign_archives =
       match Lib_info.virtual_ lib with
@@ -192,7 +193,7 @@ end = struct
               ~libs:(Scope.libs scope)
               ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
       and+ impl = Virtual_rules.impl sctx ~lib ~scope in
-      Vimpl.impl_modules impl modules |> Modules.split_by_lib
+      Vimpl.impl_modules impl modules |> Modules.With_vlib.split_by_lib
     in
     let lib_src_dir = Lib_info.src_dir info in
     let sources =
@@ -674,6 +675,7 @@ end = struct
             >>= Ml_sources.modules
                   ~libs
                   ~for_:(Library (Lib_info.lib_id info |> Lib_id.to_local_exn))
+            >>| Modules.With_vlib.modules
           and* melange_runtime_deps = file_deps (Lib_info.melange_runtime_deps info)
           and* public_headers = file_deps (Lib_info.public_headers info) in
           let+ dune_lib =

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2156,7 +2156,10 @@ let to_dune_lib
   in
   let modules =
     let install_dir = Obj_dir.dir obj_dir in
-    Modules.version_installed modules ~src_root:(Lib_info.src_dir lib.info) ~install_dir
+    Modules.With_vlib.version_installed
+      modules
+      ~src_root:(Lib_info.src_dir lib.info)
+      ~install_dir
   in
   let use_public_name ~lib_field ~info_field =
     match info_field, lib_field with

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -212,7 +212,7 @@ end
 
 val to_dune_lib
   :  t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> foreign_objects:Path.t list
   -> melange_runtime_deps:Path.t list
   -> public_headers:Path.t list

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -330,7 +330,7 @@ type 'path t =
   ; wrapped : Wrapped.t Inherited.t option
   ; main_module_name : Main_module_name.t
   ; modes : Lib_mode.Map.Set.t
-  ; modules : Modules.t option Source.t
+  ; modules : Modules.With_vlib.t option Source.t
   ; special_builtin_support : (Loc.t * Special_builtin_support.t) option
   ; exit_module : Module_name.t option
   ; instrumentation_backend : (Loc.t * Lib_name.t) option
@@ -381,7 +381,8 @@ let eval_native_archives_exn (type path) (t : path t) ~modules =
   match t.native_archives, modules with
   | Files f, _ -> f
   | Needs_module_info _, None -> Code_error.raise "missing module information" []
-  | Needs_module_info f, Some modules -> if Modules.has_impl modules then [ f ] else []
+  | Needs_module_info f, Some modules ->
+    if Modules.With_vlib.has_impl modules then [ f ] else []
 ;;
 
 let user_written_deps t =
@@ -597,7 +598,7 @@ let to_dyn
     ; "wrapped", option (Inherited.to_dyn Wrapped.to_dyn) wrapped
     ; "main_module_name", Main_module_name.to_dyn main_module_name
     ; "modes", Lib_mode.Map.Set.to_dyn modes
-    ; "modules", Source.to_dyn (Dyn.option Modules.to_dyn) modules
+    ; "modules", Source.to_dyn (Dyn.option Modules.With_vlib.to_dyn) modules
     ; ( "special_builtin_support"
       , option (snd Special_builtin_support.to_dyn) special_builtin_support )
     ; "exit_module", option Module_name.to_dyn exit_module

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -115,7 +115,7 @@ val native_archives : 'path t -> 'path native_archives
 
 (** [eval_native_archives] is like [native_archives] but it knows how to
     evaluate [Needs_module_info] into the list of archives *)
-val eval_native_archives_exn : 'path t -> modules:Modules.t option -> 'path list
+val eval_native_archives_exn : 'path t -> modules:Modules.With_vlib.t option -> 'path list
 
 (** [dll*.so] files for stubs. These are read when linking a bytecode executable
     and are loaded dynamically at runtime by bytecode executables. *)
@@ -144,7 +144,7 @@ val main_module_name : _ t -> Main_module_name.t
 val wrapped : _ t -> Wrapped.t Inherited.t option
 val special_builtin_support : _ t -> (Loc.t * Special_builtin_support.t) option
 val modes : _ t -> Lib_mode.Map.Set.t
-val modules : _ t -> Modules.t option Source.t
+val modules : _ t -> Modules.With_vlib.t option Source.t
 val implements : _ t -> (Loc.t * Lib_name.t) option
 val requires : _ t -> Lib_dep.t list
 val ppx_runtime_deps : _ t -> (Loc.t * Lib_name.t) list
@@ -179,7 +179,7 @@ val for_dune_package
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
   -> melange_runtime_deps:Path.t list
   -> public_headers:Path.t list
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> Path.t t
 
 val map_path : Path.t t -> f:(Path.t -> Path.t) -> Path.t t
@@ -221,7 +221,7 @@ val create
   -> implements:(Loc.t * Lib_name.t) option
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> modes:Lib_mode.Map.Set.t
-  -> modules:Modules.t option Source.t
+  -> modules:Modules.With_vlib.t option Source.t
   -> wrapped:Wrapped.t Inherited.t option
   -> special_builtin_support:(Loc.t * Special_builtin_support.t) option
   -> exit_module:Module_name.t option

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -120,10 +120,10 @@ let build_lib
 
 let gen_wrapped_compat_modules (lib : Library.t) cctx =
   let modules = Compilation_context.modules cctx in
-  let wrapped_compat = Modules.wrapped_compat modules in
+  let wrapped_compat = Modules.With_vlib.wrapped_compat modules in
   let transition_message =
     lazy
-      (match Modules.wrapped modules with
+      (match Modules.With_vlib.wrapped modules with
        | Simple _ -> assert false
        | Yes_with_transition r -> r)
   in
@@ -439,7 +439,7 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
   let { Lib_config.ext_obj; natdynlink_supported; _ } = ocaml.lib_config in
   let open Memo.O in
   let* () =
-    Modules.exit_module modules
+    Modules.With_vlib.exit_module modules
     |> Memo.Option.iter ~f:(fun m ->
       (* These files needs to be alongside stdlib.cma as the compiler
          implicitly adds this module. *)
@@ -581,7 +581,7 @@ let library_rules
   let ocaml = Compilation_context.ocaml cctx in
   let stdlib_dir = ocaml.lib_config.stdlib_dir in
   let top_sorted_modules =
-    let impl_only = Modules.impl_only modules in
+    let impl_only = Modules.With_vlib.impl_only modules in
     Dep_graph.top_closed_implementations
       (Compilation_context.dep_graphs cctx).impl
       impl_only

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -16,7 +16,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~obj_name ~name ~lib ~code
       | Some _ -> obj_name
       | None ->
         Option.map modules ~f:(fun modules ->
-          Modules.find modules name |> Option.value_exn |> Module.obj_name)
+          Modules.With_vlib.find modules name |> Option.value_exn |> Module.obj_name)
     in
     let src_dir =
       let obj_dir = Compilation_context.obj_dir cctx in

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -475,7 +475,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
     let obj_dir = Obj_dir.make_exe ~dir ~name in
     let modules =
       Module.generated ~kind:Impl ~src_dir:dir [ main_module_name ]
-      |> Modules.singleton_exe
+      |> Modules.With_vlib.singleton_exe
     in
     let flags = Ocaml_flags.default ~dune_version ~profile:Release in
     Compilation_context.create

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -157,7 +157,9 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
 
 let js_targets_of_modules modules ~module_systems ~output =
   List.map module_systems ~f:(fun (_, js_ext) ->
-    Modules.With_vlib.fold_no_vlib modules ~init:Path.Set.empty ~f:(fun m acc ->
+    modules
+    |> Modules.With_vlib.drop_vlib
+    |> Modules.fold ~init:Path.Set.empty ~f:(fun m acc ->
       if Module.has m ~ml_kind:Impl
       then (
         let target = Path.build @@ make_js_name ~js_ext ~output m in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -62,9 +62,8 @@ let modules_in_obj_dir ~sctx ~scope ~preprocess modules =
 ;;
 
 let impl_only_modules_defined_in_this_lib ~sctx ~scope lib =
-  let* modules = Dir_contents.modules_of_lib sctx lib in
-  match modules with
-  | None ->
+  match Lib_info.modules (Lib.info lib) with
+  | External None ->
     User_error.raise
       [ Pp.textf
           "The library %s was not compiled with Dune or it was compiled with Dune but \
@@ -72,11 +71,18 @@ let impl_only_modules_defined_in_this_lib ~sctx ~scope lib =
            melange support"
           (Lib.name lib |> Lib_name.to_string)
       ]
-  | Some modules ->
-    let info = Lib.info lib in
+  | External (Some modules) ->
+    Memo.return
+      ( modules
+      , (Modules.With_vlib.split_by_lib modules).impl
+        |> List.filter ~f:(Module.has ~ml_kind:Impl) )
+  | Local ->
+    let lib = Lib.Local.of_lib_exn lib in
+    let info = Lib.Local.info lib in
     let+ modules =
+      let* modules = Dir_contents.modules_of_local_lib sctx lib in
       let preprocess = Lib_info.preprocess info in
-      modules_in_obj_dir ~sctx ~scope ~preprocess modules
+      modules_in_obj_dir ~sctx ~scope ~preprocess modules >>| Modules.With_vlib.modules
     in
     let () =
       let modes = Lib_info.modes info in
@@ -95,8 +101,8 @@ let impl_only_modules_defined_in_this_lib ~sctx ~scope lib =
       | true -> ()
     in
     ( modules
-    , (* for a virtual library, this will return all modules *)
-      (Modules.split_by_lib modules).impl |> List.filter ~f:(Module.has ~ml_kind:Impl) )
+    , (Modules.With_vlib.split_by_lib modules).impl
+      |> List.filter ~f:(Module.has ~ml_kind:Impl) )
 ;;
 
 let cmj_glob = Glob.of_string_exn Loc.none "*.cmj"
@@ -151,7 +157,7 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
 
 let js_targets_of_modules modules ~module_systems ~output =
   List.map module_systems ~f:(fun (_, js_ext) ->
-    Modules.fold_no_vlib modules ~init:Path.Set.empty ~f:(fun m acc ->
+    Modules.With_vlib.fold_no_vlib modules ~init:Path.Set.empty ~f:(fun m acc ->
       if Module.has m ~ml_kind:Impl
       then (
         let target = Path.build @@ make_js_name ~js_ext ~output m in
@@ -272,20 +278,23 @@ let setup_emit_cmj_rules
     in
     let* () = Check_rules.add_obj_dir sctx ~obj_dir Melange in
     let* modules, pp =
-      Buildable_rules.modules_rules
-        sctx
-        (Melange
-           { preprocess = mel.preprocess
-           ; preprocessor_deps = mel.preprocessor_deps
-           ; (* TODO still needed *)
-             lint = Preprocess.Per_module.default ()
-           ; (* why is this always false? *)
-             empty_module_interface_if_absent = false
-           })
-        expander
-        ~dir
-        scope
-        modules
+      let+ modules, pp =
+        Buildable_rules.modules_rules
+          sctx
+          (Melange
+             { preprocess = mel.preprocess
+             ; preprocessor_deps = mel.preprocessor_deps
+             ; (* TODO still needed *)
+               lint = Preprocess.Per_module.default ()
+             ; (* why is this always false? *)
+               empty_module_interface_if_absent = false
+             })
+          expander
+          ~dir
+          scope
+          modules
+      in
+      Modules.With_vlib.modules modules, pp
     in
     let requires_link = Lib.Compile.requires_link compile_info in
     let* flags =
@@ -434,7 +443,7 @@ let modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope (mel : Melange_stanzas
   in
   let+ modules = modules_in_obj_dir ~sctx ~scope ~preprocess:mel.preprocess modules in
   let modules_for_js =
-    Modules.fold_no_vlib modules ~init:[] ~f:(fun x acc ->
+    Modules.fold modules ~init:[] ~f:(fun x acc ->
       if Module.has x ~ml_kind:Impl then x :: acc else acc)
   in
   modules, modules_for_js, obj_dir
@@ -464,8 +473,10 @@ let setup_entries_js
   let* () =
     setup_runtime_assets_rules sctx ~dir ~target_dir ~mode ~output ~for_:`Emit mel
   in
+  let local_modules_and_obj_dir =
+    Some (Modules.With_vlib.modules local_modules, local_obj_dir)
+  in
   Memo.parallel_iter modules_for_js ~f:(fun m ->
-    let local_modules_and_obj_dir = Some (local_modules, local_obj_dir) in
     build_js
       ~dir
       ~loc
@@ -487,14 +498,14 @@ let setup_js_rules_libraries =
       let obj_dir = Lib.Local.obj_dir lib in
       modules, obj_dir)
   in
-  let parallel_build_source_modules ~sctx ~scope ~f lib =
+  let parallel_build_source_modules ~sctx ~scope ~f:build_js lib =
     let* local_modules_and_obj_dir, source_modules =
       let+ lib_modules, source_modules =
         impl_only_modules_defined_in_this_lib ~sctx ~scope lib
       in
       local_modules_and_obj_dir ~lib lib_modules, source_modules
     in
-    Memo.parallel_iter source_modules ~f:(f ~local_modules_and_obj_dir)
+    Memo.parallel_iter source_modules ~f:(build_js ~local_modules_and_obj_dir)
   in
   fun ~dir ~scope ~target_dir ~sctx ~requires_link ~mode (mel : Melange_stanzas.Emit.t) ->
     let build_js = build_js ~sctx ~mode ~module_systems:mel.module_systems in
@@ -642,7 +653,7 @@ let setup_emit_js_rules ~dir_contents ~dir ~scope ~sctx mel =
        package). When resolution fails, we replace the JS entries with the
        resolution error inside [Action_builder.fail] to give Dune a chance to
        fail if any of the targets end up attached to a package installation. *)
-    let* _local_modules, modules_for_js, _obj_dir =
+    let* _, modules_for_js, _obj_dir =
       modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope mel
     in
     let module_systems = mel.module_systems in

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -341,7 +341,7 @@ module Unprocessed = struct
   type t =
     { ident : Merlin_ident.t
     ; config : config
-    ; modules : Modules.t
+    ; modules : Modules.With_vlib.t
     }
 
   let make
@@ -465,11 +465,10 @@ module Unprocessed = struct
   ;;
 
   let src_dirs sctx lib =
-    match Lib.is_local lib with
-    | false -> Lib.info lib |> Lib_info.src_dir |> Path.Set.singleton |> Memo.return
-    | true ->
-      Dir_contents.modules_of_lib sctx lib
-      >>| Option.value_exn
+    match Lib.Local.of_lib lib with
+    | None -> Lib.info lib |> Lib_info.src_dir |> Path.Set.singleton |> Memo.return
+    | Some lib ->
+      Dir_contents.modules_of_local_lib sctx lib
       >>| Modules.source_dirs
       >>| Path.Set.map ~f:Path.drop_optional_build_context
   ;;
@@ -565,14 +564,14 @@ module Unprocessed = struct
     and+ pp_config = pp_config t (Super_context.context sctx) ~expander in
     let per_module_config =
       (* And copy for each module the resulting pp flags *)
-      Modules.fold_no_vlib modules ~init:[] ~f:(fun m init ->
+      Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m init ->
         Module.sources m
         |> Path.Build.Set.of_list_map ~f:(fun src ->
           Path.as_in_build_dir_exn src |> remove_extension)
         |> Path.Build.Set.fold ~init ~f:(fun src acc ->
           let config =
             { Processed.module_ = Module.set_pp m None
-            ; opens = Modules.local_open modules m
+            ; opens = Modules.With_vlib.local_open modules m
             }
           in
           (src, config) :: acc))

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -564,7 +564,9 @@ module Unprocessed = struct
     and+ pp_config = pp_config t (Super_context.context sctx) ~expander in
     let per_module_config =
       (* And copy for each module the resulting pp flags *)
-      Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m init ->
+      modules
+      |> Modules.With_vlib.drop_vlib
+      |> Modules.fold ~init:[] ~f:(fun m init ->
         Module.sources m
         |> Path.Build.Set.of_list_map ~f:(fun src ->
           Path.as_in_build_dir_exn src |> remove_extension)

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -47,7 +47,7 @@ val make
   -> preprocess:Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
   -> libname:Lib_name.Local.t option
   -> source_dirs:Path.Source.Set.t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> obj_dir:Path.Build.t Obj_dir.t
   -> dialects:Dialect.DB.t
   -> ident:Merlin_ident.t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -28,7 +28,7 @@ module Origin = struct
 end
 
 module Modules = struct
-  type component = Origin.t * Modules.t * Path.Build.t Obj_dir.t
+  type component = Origin.t * Modules_group.t * Path.Build.t Obj_dir.t
 
   type t =
     { libraries : component Lib_id.Local.Map.t

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -14,7 +14,7 @@ let force_read_cmi source_file = [ "-intf-suffix"; Path.extension source_file ]
    generation *)
 
 let opens modules m =
-  Command.Args.As (Modules.local_open modules m |> Ocaml_flags.open_flags)
+  Command.Args.As (Modules.With_vlib.local_open modules m |> Ocaml_flags.open_flags)
 ;;
 
 let other_cm_files ~opaque ~cm_kind ~obj_dir =
@@ -421,7 +421,7 @@ module Alias_module = struct
     let aliases =
       Modules.Group.for_alias group
       |> List.map ~f:(fun (local_name, m) ->
-        let canonical_path = Modules.canonical_path modules group m in
+        let canonical_path = Modules.With_vlib.canonical_path modules group m in
         let obj_name = Module.obj_name m in
         { canonical_path; local_name; obj_name })
     in
@@ -499,7 +499,7 @@ let build_all cctx =
   let for_wrapped_compat = lazy (Compilation_context.for_wrapped_compat cctx) in
   let modules = Compilation_context.modules cctx in
   Memo.parallel_iter
-    (Modules.fold_no_vlib_with_aliases
+    (Modules.With_vlib.fold_no_vlib_with_aliases
        modules
        ~init:[]
        ~normal:(fun x acc -> `Normal x :: acc)
@@ -515,7 +515,7 @@ let build_all cctx =
            build_module cctx m
          | _ ->
            let cctx =
-             if Modules.is_stdlib_alias modules m
+             if Modules.With_vlib.is_stdlib_alias modules m
              then
                (* XXX it would probably be simpler if the flags were just for this
                   module in the definition of the stanza *)

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -1158,11 +1158,12 @@ module With_vlib = struct
     exists ~f:has
   ;;
 
-  let fold_no_vlib t ~init ~f =
-    match t with
-    | Modules t -> fold t ~init ~f
-    | Impl { vlib = _; impl; _ } -> fold impl ~f ~init
+  let drop_vlib = function
+    | Modules t -> t
+    | Impl { vlib = _; impl; _ } -> impl
   ;;
+
+  let fold_no_vlib t ~init ~f = fold (drop_vlib t) ~init ~f
 
   let fold_no_vlib_with_aliases =
     let group_of_alias t m =

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -1163,8 +1163,6 @@ module With_vlib = struct
     | Impl { vlib = _; impl; _ } -> impl
   ;;
 
-  let fold_no_vlib t ~init ~f = fold (drop_vlib t) ~init ~f
-
   let fold_no_vlib_with_aliases =
     let group_of_alias t m =
       match t.modules with
@@ -1200,7 +1198,9 @@ module With_vlib = struct
            Some { impl with Group.modules })
     in
     fun t ~init ~normal ~alias ->
-      fold_no_vlib t ~init ~f:(fun m acc ->
+      t
+      |> drop_vlib
+      |> fold ~init ~f:(fun m acc ->
         match Module.kind m with
         | Alias _ ->
           (match group_of_alias t m with

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -762,24 +762,18 @@ module Sourced_module = struct
   ;;
 end
 
+type modules =
+  | Singleton of Module.t
+  | Unwrapped of Unwrapped.t
+  | Wrapped of Wrapped.t
+  | Stdlib of Stdlib.t
+
 type t =
   { obj_map : Sourced_module.t Module_name.Unique.Map.t Lazy.t
   ; modules : modules
   }
 
-and modules =
-  | Singleton of Module.t
-  | Unwrapped of Unwrapped.t
-  | Wrapped of Wrapped.t
-  | Impl of impl
-  | Stdlib of Stdlib.t
-
-and impl =
-  { impl : t
-  ; vlib : t
-  }
-
-let rec obj_map : 'a. modules -> Sourced_module.t Module_name.Unique.Map.t =
+let obj_map : 'a. modules -> Sourced_module.t Module_name.Unique.Map.t =
   let module Map = Module_name.Unique.Map in
   let normal m = Sourced_module.Normal m in
   let f m acc = Map.add_exn acc (Module.obj_name m) (normal m) in
@@ -789,16 +783,6 @@ let rec obj_map : 'a. modules -> Sourced_module.t Module_name.Unique.Map.t =
     | Unwrapped m -> Unwrapped.fold m ~init:Map.empty ~f
     | Wrapped w -> Wrapped.fold w ~init:Map.empty ~f
     | Stdlib w -> Stdlib.fold w ~init:Map.empty ~f
-    | Impl { vlib; impl } ->
-      Map.merge (obj_map vlib.modules) (obj_map impl.modules) ~f:(fun _ vlib impl ->
-        match vlib, impl with
-        | None, None -> assert false
-        | Some (Normal m), None -> Some (Sourced_module.Imported_from_vlib m)
-        | None, Some (Normal m) -> Some (Normal m)
-        | Some (Normal intf), Some (Normal impl) ->
-          Some (Sourced_module.Impl_of_virtual_module { intf; impl })
-        | Some (Imported_from_vlib _ | Impl_of_virtual_module _), _
-        | _, Some (Imported_from_vlib _ | Impl_of_virtual_module _) -> assert false)
 ;;
 
 let with_obj_map modules =
@@ -807,18 +791,6 @@ let with_obj_map modules =
 ;;
 
 let obj_map t = Lazy.force t.obj_map
-
-let rec encode t ~src_dir =
-  let open Dune_sexp in
-  match t.modules with
-  | Singleton m -> List (atom "singleton" :: Module.encode m ~src_dir)
-  | Unwrapped m -> List (atom "unwrapped" :: Unwrapped.encode m ~src_dir)
-  | Wrapped m -> List (atom "wrapped" :: Wrapped.encode m ~src_dir)
-  | Stdlib m -> List (atom "stdlib" :: Stdlib.encode m ~src_dir)
-  | Impl { impl; _ } -> encode impl ~src_dir
-;;
-
-let singleton m = with_obj_map (Singleton m)
 
 let decode ~src_dir =
   let open Dune_lang.Decoder in
@@ -839,36 +811,13 @@ let decode ~src_dir =
   >>| with_obj_map
 ;;
 
-let rec to_dyn t =
+let to_dyn t =
   let open Dyn in
   match t.modules with
   | Singleton m -> variant "Singleton" [ Module.to_dyn m ]
   | Unwrapped m -> variant "Unwrapped" [ Unwrapped.to_dyn m ]
   | Wrapped w -> variant "Wrapped" [ Wrapped.to_dyn w ]
   | Stdlib s -> variant "Stdlib" [ Stdlib.to_dyn s ]
-  | Impl impl -> variant "Impl" [ dyn_of_impl impl ]
-
-and dyn_of_impl { impl; vlib } =
-  let open Dyn in
-  record [ "impl", to_dyn impl; "vlib", to_dyn vlib ]
-;;
-
-let rec lib_interface t =
-  match t.modules with
-  | Singleton m -> Some m
-  | Unwrapped _ -> None
-  | Wrapped w -> Some (Wrapped.lib_interface w)
-  | Stdlib w -> Stdlib.lib_interface w
-  | Impl { impl = _; vlib } -> lib_interface vlib
-;;
-
-let rec main_module_name t =
-  match t.modules with
-  | Singleton m -> Some (Module.name m)
-  | Unwrapped _ -> None
-  | Wrapped w -> Some w.group.name
-  | Stdlib w -> Some w.main_module_name
-  | Impl { vlib; impl = _ } -> main_module_name vlib
 ;;
 
 let lib ~obj_dir ~main_module_name ~wrapped ~stdlib ~lib_name ~implements ~modules =
@@ -900,67 +849,6 @@ let lib ~obj_dir ~main_module_name ~wrapped ~stdlib ~lib_name ~implements ~modul
   with_obj_map modules
 ;;
 
-let impl impl ~vlib =
-  let modules =
-    match impl.modules, vlib.modules with
-    | _, Impl _ | Impl _, _ | Stdlib _, _ | _, Stdlib _ ->
-      Code_error.raise
-        "Modules.impl: invalid arguments"
-        [ "impl", to_dyn impl; "vlib", to_dyn vlib ]
-    | _, _ -> Impl { impl; vlib }
-  in
-  with_obj_map modules
-;;
-
-let rec find t name =
-  match t.modules with
-  | Singleton m -> Option.some_if (Module.name m = name) m
-  | Unwrapped m -> Unwrapped.find m name
-  | Stdlib w -> Stdlib.find w name
-  | Wrapped w -> Wrapped.find w name
-  | Impl { impl; vlib } ->
-    (match find impl name with
-     | Some _ as m -> m
-     | None -> find vlib name)
-;;
-
-exception Parent_cycle
-
-let find_dep =
-  let from_impl_or_lib = List.map ~f:(fun m -> `Impl_or_lib, m) in
-  let find_dep_result =
-    List.filter_map ~f:(fun (from, m) ->
-      match from with
-      | `Impl_or_lib -> Some m
-      | `Vlib -> Option.some_if (Module.visibility m = Public) m)
-  in
-  let raise_parent_cycle = function
-    | Ok s -> from_impl_or_lib s
-    | Error `Parent_cycle -> raise_notrace Parent_cycle
-  in
-  let rec find_dep t ~of_ name : Module.t list =
-    if Module.name of_ = name
-    then []
-    else (
-      let result =
-        match t.modules with
-        | Singleton _ -> find t name |> Option.to_list |> from_impl_or_lib
-        | Unwrapped w -> Unwrapped.find_dep w ~of_ name |> raise_parent_cycle
-        | Wrapped w -> Wrapped.find_dep w ~of_ name |> raise_parent_cycle
-        | Stdlib s -> Stdlib.find_dep s ~of_ name |> Option.to_list |> from_impl_or_lib
-        | Impl { vlib; impl } ->
-          (match find_dep impl ~of_ name with
-           | [] -> find_dep vlib ~of_ name |> List.map ~f:(fun m -> `Vlib, m)
-           | xs -> from_impl_or_lib xs)
-      in
-      find_dep_result result)
-  in
-  fun t ~of_ name ->
-    match find_dep t ~of_ name with
-    | s -> Ok s
-    | exception Parent_cycle -> Error `Parent_cycle
-;;
-
 let make_singleton m mangle =
   let modules =
     Singleton
@@ -970,8 +858,6 @@ let make_singleton m mangle =
   in
   with_obj_map modules
 ;;
-
-let singleton_exe m = make_singleton m Exe
 
 let exe_unwrapped modules ~obj_dir =
   let mangle = Mangle.Unwrapped in
@@ -992,125 +878,19 @@ let make_wrapped ~obj_dir ~modules kind =
     with_obj_map modules
 ;;
 
-let rec impl_only t =
-  match t.modules with
-  | Stdlib w -> Stdlib.impl_only w
-  | Singleton m -> if Module.has ~ml_kind:Impl m then [ m ] else []
-  | Unwrapped m ->
-    Unwrapped.fold m ~init:[] ~f:(fun v acc ->
-      if Module.has v ~ml_kind:Impl then v :: acc else acc)
-  | Wrapped w -> Wrapped.impl_only w
-  | Impl { vlib; impl } -> impl_only impl @ impl_only vlib
-;;
-
-let rec exists t ~f =
-  match t.modules with
-  | Stdlib w -> Stdlib.exists w ~f
-  | Wrapped m -> Wrapped.exists m ~f
-  | Singleton m -> f m
-  | Unwrapped m -> Unwrapped.exists m ~f
-  | Impl { vlib; impl } -> exists vlib ~f || exists impl ~f
-;;
-
-let has_impl =
-  let has = Module.has ~ml_kind:Impl in
-  exists ~f:has
-;;
-
-let rec fold_no_vlib t ~init ~f =
+let fold t ~init ~f =
   match t.modules with
   | Stdlib w -> Stdlib.fold w ~init ~f
   | Singleton m -> f m init
   | Unwrapped m -> Unwrapped.fold m ~f ~init
   | Wrapped w -> Wrapped.fold w ~init ~f
-  | Impl { vlib = _; impl } -> fold_no_vlib impl ~f ~init
 ;;
 
-let fold_no_vlib_with_aliases =
-  let rec group_of_alias t m =
-    match t.modules with
-    | Wrapped w -> Some (Wrapped.group_of_alias w m)
-    | Unwrapped w -> Some (Unwrapped.group_of_alias w m)
-    | Impl { vlib; impl } ->
-      let vlib = group_of_alias vlib m in
-      let impl = group_of_alias impl m in
-      (match vlib, impl with
-       | None, None -> assert false
-       | Some _, None -> vlib
-       | None, Some _ -> impl
-       | Some vlib, Some impl ->
-         let modules =
-           Module_name.Map.merge vlib.modules impl.modules ~f:(fun _ vlib impl ->
-             match vlib, impl with
-             | None, None -> assert false
-             | _, Some _ -> impl
-             | Some vlib, _ ->
-               let vlib =
-                 match (vlib : Group.node) with
-                 | Module m -> m
-                 | Group g -> Group.lib_interface g
-               in
-               Option.some_if (Module.visibility vlib = Public) vlib
-               |> Option.map ~f:(fun m -> Group.Module m))
-         in
-         Some { impl with Group.modules })
-    | _ -> None
-  in
-  fun t ~init ~normal ~alias ->
-    fold_no_vlib t ~init ~f:(fun m acc ->
-      match Module.kind m with
-      | Alias _ ->
-        (match group_of_alias t m with
-         | None ->
-           Code_error.raise
-             "alias module for group without alias"
-             [ "t", to_dyn t; "m", Module.to_dyn m ]
-         | Some group -> alias group acc)
-      | _ -> normal m acc)
-;;
-
-type split_by_lib =
-  { vlib : Module.t list
-  ; impl : Module.t list
-  }
-
-let split_by_lib t =
-  let f m acc = m :: acc in
-  let init = [] in
+let wrapped t =
   match t.modules with
-  | Impl { vlib; impl } ->
-    let vlib = fold_no_vlib vlib ~init ~f in
-    let impl = fold_no_vlib impl ~init ~f in
-    { vlib; impl }
-  | _ -> { impl = fold_no_vlib t ~init ~f; vlib = [] }
-;;
-
-let compat_for_exn t m =
-  match t.modules with
-  | Singleton _ | Stdlib _ | Unwrapped _ -> assert false
-  | Impl _ -> Code_error.raise "wrapped compat not supported for vlib" []
-  | Wrapped { group; _ } ->
-    (match Module_name.Map.find group.modules (Module.name m) with
-     | None -> assert false
-     | Some (Module m) -> m
-     | Some (Group g) -> Group.lib_interface g)
-;;
-
-let wrapped_compat t =
-  match t.modules with
-  | Stdlib _ | Singleton _ | Impl _ | Unwrapped _ -> Module_name.Map.empty
-  | Wrapped w -> w.wrapped_compat
-;;
-
-let rec fold_user_available t ~f ~init =
-  match t.modules with
-  | Stdlib w -> Stdlib.fold w ~init ~f
-  | Singleton m -> f m init
-  | Unwrapped modules -> Unwrapped.fold modules ~init ~f
-  | Wrapped w -> Wrapped.fold_user_available w ~init ~f
-  | Impl { impl; vlib = _ } ->
-    (* XXX shouldn't we folding over [vlib] as well? *)
-    fold_user_available impl ~f ~init
+  | Wrapped w -> w.wrapped
+  | Singleton _ | Unwrapped _ -> Simple false
+  | Stdlib _ -> Simple true
 ;;
 
 let is_user_written m =
@@ -1119,17 +899,15 @@ let is_user_written m =
   | _ -> true
 ;;
 
-let rec fold_user_written t ~f ~init =
-  let f m acc = if is_user_written m then f m acc else acc in
+let fold_user_available t ~f ~init =
   match t.modules with
   | Stdlib w -> Stdlib.fold w ~init ~f
   | Singleton m -> f m init
   | Unwrapped modules -> Unwrapped.fold modules ~init ~f
-  | Wrapped { group; _ } -> Group.fold group ~init ~f
-  | Impl { impl; vlib = _ } -> fold_user_written impl ~f ~init
+  | Wrapped w -> Wrapped.fold_user_available w ~init ~f
 ;;
 
-let rec map_user_written t ~f =
+let map_user_written t ~f =
   let f m = if is_user_written m then f m else Memo.return m in
   let open Memo.O in
   let+ modules =
@@ -1146,101 +924,24 @@ let rec map_user_written t ~f =
     | Wrapped ({ group; wrapped_compat = _; wrapped = _; toplevel_module = _ } as w) ->
       let+ group = Group.Memo_traversals.parallel_map group ~f in
       Wrapped { w with group }
-    | Impl t ->
-      let+ modules = map_user_written t.impl ~f in
-      Impl { t with impl = modules }
   in
   with_obj_map modules
 ;;
 
-let version_installed t ~src_root ~install_dir =
-  let f = Module.version_installed ~src_root ~install_dir in
-  let rec loop t =
-    let modules =
-      match t.modules with
-      | Singleton m -> Singleton (f m)
-      | Unwrapped m -> Unwrapped (Unwrapped.map ~f m)
-      | Stdlib w -> Stdlib (Stdlib.map w ~f)
-      | Wrapped w -> Wrapped (Wrapped.map w ~f)
-      | Impl w -> Impl { w with impl = loop w.impl }
-    in
-    with_obj_map modules
-  in
-  loop t
-;;
-
-let entry_modules t =
-  List.filter
-    ~f:(fun m -> Module.visibility m = Public)
-    (match t.modules with
-     | Stdlib w -> Stdlib.lib_interface w |> Option.to_list
-     | Singleton m -> [ m ]
-     | Unwrapped m -> Unwrapped.entry_modules m
-     | Wrapped m ->
-       (* we assume this is never called for implementations *)
-       [ Wrapped.lib_interface m ]
-     | Impl i ->
-       Code_error.raise
-         "entry_modules: not defined for implementations"
-         [ "impl", dyn_of_impl i ])
+let fold_user_written t ~f ~init =
+  let f m acc = if is_user_written m then f m acc else acc in
+  match t.modules with
+  | Stdlib w -> Stdlib.fold w ~init ~f
+  | Singleton m -> f m init
+  | Unwrapped modules -> Unwrapped.fold modules ~init ~f
+  | Wrapped { group; _ } -> Group.fold group ~init ~f
 ;;
 
 let virtual_module_names =
-  fold_no_vlib ~init:Module_name.Path.Set.empty ~f:(fun m acc ->
+  fold ~init:Module_name.Path.Set.empty ~f:(fun m acc ->
     match Module.kind m with
     | Virtual -> Module_name.Path.Set.add acc [ Module.name m ]
     | _ -> acc)
-;;
-
-let rec wrapped t =
-  match t.modules with
-  | Wrapped w -> w.wrapped
-  | Singleton _ | Unwrapped _ -> Simple false
-  | Stdlib _ -> Simple true
-  | Impl { vlib = _; impl } -> wrapped impl
-;;
-
-let rec alias_for t m =
-  match Module.kind m with
-  | Root -> []
-  | _ ->
-    (match t.modules with
-     | Singleton _ -> []
-     | Unwrapped w -> Unwrapped.alias_for w m
-     | Wrapped w -> Wrapped.alias_for w m
-     | Stdlib w -> Stdlib.alias_for w m |> Option.to_list
-     | Impl { impl; vlib = _ } -> alias_for impl m)
-;;
-
-let rec group_interfaces t m =
-  match t.modules with
-  | Wrapped w -> Wrapped.group_interfaces w m
-  | Impl { impl; vlib } -> group_interfaces impl m @ group_interfaces vlib m
-  | Singleton w -> [ w ]
-  | _ -> []
-;;
-
-let local_open t m =
-  alias_for t m
-  |> List.map ~f:(fun m -> Module.obj_name m |> Module_name.Unique.to_name ~loc:Loc.none)
-;;
-
-let is_stdlib_alias t m =
-  match t.modules with
-  | Stdlib w -> w.main_module_name = Module.name m
-  | _ -> false
-;;
-
-let exit_module t =
-  match t.modules with
-  | Stdlib w -> Stdlib.exit_module w
-  | _ -> None
-;;
-
-let as_singleton t =
-  match t.modules with
-  | Singleton m -> Some m
-  | _ -> None
 ;;
 
 let source_dirs =
@@ -1249,19 +950,411 @@ let source_dirs =
     |> List.fold_left ~init:acc ~f:(fun acc f -> Path.Set.add acc (Path.parent_exn f)))
 ;;
 
-let canonical_path t (group : Group.t) m =
-  let path =
-    let path = Module.path m in
-    match Module_name.Map.find group.modules (Module.name m) with
-    | None | Some (Group.Module _) -> path
-    | Some (Group _) ->
-      (* The path for group interfaces always duplicates
-         the last component.
+module With_vlib = struct
+  type impl =
+    { obj_map : Sourced_module.t Module_name.Unique.Map.t Lazy.t
+    ; impl : t
+    ; vlib : t
+    }
 
-         For example: foo/foo.ml would has the path [ "Foo"; "Foo" ] *)
-      List.remove_last_exn path
-  in
-  match t.modules with
-  | Impl { impl = { modules = Wrapped w; _ }; _ } | Wrapped w -> w.group.name :: path
-  | _ -> Module.path m
-;;
+  type nonrec t =
+    | Modules of t
+    | Impl of impl
+
+  let modules m = Modules m
+  let with_modules_obj_map = with_obj_map
+
+  let with_obj_map =
+    let modules_obj_map = obj_map in
+    let obj_map : impl -> Sourced_module.t Module_name.Unique.Map.t =
+      let module Map = Module_name.Unique.Map in
+      fun t ->
+        let { obj_map = _; vlib; impl } = t in
+        Map.merge (modules_obj_map vlib) (modules_obj_map impl) ~f:(fun _ vlib impl ->
+          match vlib, impl with
+          | None, None -> assert false
+          | Some (Normal m), None -> Some (Sourced_module.Imported_from_vlib m)
+          | None, Some (Normal m) -> Some (Normal m)
+          | Some (Normal intf), Some (Normal impl) ->
+            Some (Sourced_module.Impl_of_virtual_module { intf; impl })
+          | Some (Imported_from_vlib _ | Impl_of_virtual_module _), _
+          | _, Some (Imported_from_vlib _ | Impl_of_virtual_module _) -> assert false)
+    in
+    function
+    | Modules t -> Modules (with_modules_obj_map t.modules)
+    | Impl t ->
+      let obj_map = lazy (obj_map t) in
+      Impl { t with obj_map }
+  ;;
+
+  let obj_map = function
+    | Modules t -> obj_map t
+    | Impl { obj_map; _ } -> Lazy.force obj_map
+  ;;
+
+  let encode =
+    let encode t ~src_dir =
+      let open Dune_sexp in
+      match t.modules with
+      | Singleton m -> List (atom "singleton" :: Module.encode m ~src_dir)
+      | Unwrapped m -> List (atom "unwrapped" :: Unwrapped.encode m ~src_dir)
+      | Wrapped m -> List (atom "wrapped" :: Wrapped.encode m ~src_dir)
+      | Stdlib m -> List (atom "stdlib" :: Stdlib.encode m ~src_dir)
+    in
+    fun t ~src_dir ->
+      match t with
+      | Modules m -> encode m ~src_dir
+      | Impl { impl; _ } -> encode impl ~src_dir
+  ;;
+
+  let singleton m = Modules (with_modules_obj_map (Singleton m))
+
+  let dyn_of_impl { impl; vlib; _ } =
+    let open Dyn in
+    record [ "impl", to_dyn impl; "vlib", to_dyn vlib ]
+  ;;
+
+  let modules_to_dyn = to_dyn
+
+  let to_dyn t =
+    let open Dyn in
+    match t with
+    | Modules t -> variant "Modules" [ modules_to_dyn t ]
+    | Impl impl -> variant "Impl" [ dyn_of_impl impl ]
+  ;;
+
+  let lib_interface =
+    let lib_interface t =
+      match t.modules with
+      | Singleton m -> Some m
+      | Unwrapped _ -> None
+      | Wrapped w -> Some (Wrapped.lib_interface w)
+      | Stdlib w -> Stdlib.lib_interface w
+    in
+    function
+    | Modules t -> lib_interface t
+    | Impl { impl = _; vlib; _ } -> lib_interface vlib
+  ;;
+
+  let main_module_name =
+    let main_module_name t =
+      match t.modules with
+      | Singleton m -> Some (Module.name m)
+      | Unwrapped _ -> None
+      | Wrapped w -> Some w.group.name
+      | Stdlib w -> Some w.main_module_name
+    in
+    function
+    | Modules t -> main_module_name t
+    | Impl { vlib; impl = _; _ } -> main_module_name vlib
+  ;;
+
+  let impl =
+    let empty = lazy Module_name.Unique.Map.empty in
+    fun impl ~vlib ->
+      let modules =
+        match impl.modules, vlib.modules with
+        | Stdlib _, _ | _, Stdlib _ ->
+          Code_error.raise
+            "Modules.impl: invalid arguments"
+            [ "impl", modules_to_dyn impl; "vlib", modules_to_dyn vlib ]
+        | _, _ -> Impl { obj_map = empty; impl; vlib }
+      in
+      with_obj_map modules
+  ;;
+
+  let modules_find t name =
+    match t.modules with
+    | Singleton m -> Option.some_if (Module.name m = name) m
+    | Unwrapped m -> Unwrapped.find m name
+    | Stdlib w -> Stdlib.find w name
+    | Wrapped w -> Wrapped.find w name
+  ;;
+
+  let find t name =
+    match t with
+    | Modules t -> modules_find t name
+    | Impl { impl; vlib; _ } ->
+      (match modules_find impl name with
+       | Some _ as m -> m
+       | None -> modules_find vlib name)
+  ;;
+
+  exception Parent_cycle
+
+  let find_dep =
+    let from_impl_or_lib = List.map ~f:(fun m -> `Impl_or_lib, m) in
+    let find_dep_result =
+      List.filter_map ~f:(fun (from, m) ->
+        match from with
+        | `Impl_or_lib -> Some m
+        | `Vlib -> Option.some_if (Module.visibility m = Public) m)
+    in
+    let raise_parent_cycle = function
+      | Ok s -> from_impl_or_lib s
+      | Error `Parent_cycle -> raise_notrace Parent_cycle
+    in
+    let find_dep t ~of_ name : Module.t list =
+      if Module.name of_ = name
+      then []
+      else (
+        let result =
+          match t.modules with
+          | Singleton _ -> modules_find t name |> Option.to_list |> from_impl_or_lib
+          | Unwrapped w -> Unwrapped.find_dep w ~of_ name |> raise_parent_cycle
+          | Wrapped w -> Wrapped.find_dep w ~of_ name |> raise_parent_cycle
+          | Stdlib s -> Stdlib.find_dep s ~of_ name |> Option.to_list |> from_impl_or_lib
+        in
+        find_dep_result result)
+    in
+    fun t ~of_ name ->
+      try
+        Ok
+          (match t with
+           | Modules t -> find_dep t ~of_ name
+           | Impl { vlib; impl; _ } ->
+             (match find_dep impl ~of_ name with
+              | [] -> find_dep vlib ~of_ name |> List.map ~f:(fun m -> `Vlib, m)
+              | xs -> from_impl_or_lib xs)
+             |> find_dep_result)
+      with
+      | Parent_cycle -> Error `Parent_cycle
+  ;;
+
+  let singleton_exe m = Modules (make_singleton m Exe)
+
+  let impl_only =
+    let impl_only t =
+      match t.modules with
+      | Stdlib w -> Stdlib.impl_only w
+      | Singleton m -> if Module.has ~ml_kind:Impl m then [ m ] else []
+      | Unwrapped m ->
+        Unwrapped.fold m ~init:[] ~f:(fun v acc ->
+          if Module.has v ~ml_kind:Impl then v :: acc else acc)
+      | Wrapped w -> Wrapped.impl_only w
+    in
+    fun t ->
+      match t with
+      | Modules t -> impl_only t
+      | Impl { vlib; impl; _ } -> impl_only impl @ impl_only vlib
+  ;;
+
+  let exists =
+    let exists t ~f =
+      match t.modules with
+      | Stdlib w -> Stdlib.exists w ~f
+      | Wrapped m -> Wrapped.exists m ~f
+      | Singleton m -> f m
+      | Unwrapped m -> Unwrapped.exists m ~f
+    in
+    fun t ~f ->
+      match t with
+      | Modules t -> exists t ~f
+      | Impl { vlib; impl; _ } -> exists vlib ~f || exists impl ~f
+  ;;
+
+  let has_impl =
+    let has = Module.has ~ml_kind:Impl in
+    exists ~f:has
+  ;;
+
+  let fold_no_vlib t ~init ~f =
+    match t with
+    | Modules t -> fold t ~init ~f
+    | Impl { vlib = _; impl; _ } -> fold impl ~f ~init
+  ;;
+
+  let fold_no_vlib_with_aliases =
+    let group_of_alias t m =
+      match t.modules with
+      | Wrapped w -> Some (Wrapped.group_of_alias w m)
+      | Unwrapped w -> Some (Unwrapped.group_of_alias w m)
+      | _ -> None
+    in
+    let group_of_alias t m =
+      match t with
+      | Modules t -> group_of_alias t m
+      | Impl { vlib; impl; _ } ->
+        let vlib = group_of_alias vlib m in
+        let impl = group_of_alias impl m in
+        (match vlib, impl with
+         | None, None -> assert false
+         | Some _, None -> vlib
+         | None, Some _ -> impl
+         | Some vlib, Some impl ->
+           let modules =
+             Module_name.Map.merge vlib.modules impl.modules ~f:(fun _ vlib impl ->
+               match vlib, impl with
+               | None, None -> assert false
+               | _, Some _ -> impl
+               | Some vlib, _ ->
+                 let vlib =
+                   match (vlib : Group.node) with
+                   | Module m -> m
+                   | Group g -> Group.lib_interface g
+                 in
+                 Option.some_if (Module.visibility vlib = Public) vlib
+                 |> Option.map ~f:(fun m -> Group.Module m))
+           in
+           Some { impl with Group.modules })
+    in
+    fun t ~init ~normal ~alias ->
+      fold_no_vlib t ~init ~f:(fun m acc ->
+        match Module.kind m with
+        | Alias _ ->
+          (match group_of_alias t m with
+           | None ->
+             Code_error.raise
+               "alias module for group without alias"
+               [ "t", to_dyn t; "m", Module.to_dyn m ]
+           | Some group -> alias group acc)
+        | _ -> normal m acc)
+  ;;
+
+  type split_by_lib =
+    { vlib : Module.t list
+    ; impl : Module.t list
+    }
+
+  let split_by_lib t =
+    let f m acc = m :: acc in
+    let init = [] in
+    match t with
+    | Impl { vlib; impl; _ } ->
+      let vlib = fold vlib ~init ~f in
+      let impl = fold impl ~init ~f in
+      { vlib; impl }
+    | Modules t -> { impl = fold t ~init ~f; vlib = [] }
+  ;;
+
+  let compat_for_exn t m =
+    match t with
+    | Impl _ -> Code_error.raise "wrapped compat not supported for vlib" []
+    | Modules t ->
+      (match t.modules with
+       | Singleton _ | Stdlib _ | Unwrapped _ -> assert false
+       | Wrapped { group; _ } ->
+         (match Module_name.Map.find group.modules (Module.name m) with
+          | None -> assert false
+          | Some (Module m) -> m
+          | Some (Group g) -> Group.lib_interface g))
+  ;;
+
+  let wrapped_compat t =
+    match t with
+    | Impl _ | Modules { modules = Stdlib _ | Singleton _ | Unwrapped _; _ } ->
+      Module_name.Map.empty
+    | Modules { modules = Wrapped w; _ } -> w.wrapped_compat
+  ;;
+
+  let version_installed t ~src_root ~install_dir =
+    let f = Module.version_installed ~src_root ~install_dir in
+    let map t =
+      let modules =
+        match t.modules with
+        | Singleton m -> Singleton (f m)
+        | Unwrapped m -> Unwrapped (Unwrapped.map ~f m)
+        | Stdlib w -> Stdlib (Stdlib.map w ~f)
+        | Wrapped w -> Wrapped (Wrapped.map w ~f)
+      in
+      with_modules_obj_map modules
+    in
+    match t with
+    | Modules t -> Modules (map t)
+    | Impl w -> Impl { w with impl = map w.impl }
+  ;;
+
+  let entry_modules = function
+    | Impl i ->
+      Code_error.raise
+        "entry_modules: not defined for implementations"
+        [ "impl", dyn_of_impl i ]
+    | Modules t ->
+      List.filter
+        ~f:(fun m -> Module.visibility m = Public)
+        (match t.modules with
+         | Stdlib w -> Stdlib.lib_interface w |> Option.to_list
+         | Singleton m -> [ m ]
+         | Unwrapped m -> Unwrapped.entry_modules m
+         | Wrapped m ->
+           (* we assume this is never called for implementations *)
+           [ Wrapped.lib_interface m ])
+  ;;
+
+  let wrapped = function
+    | Modules t -> wrapped t
+    | Impl { vlib = _; impl; _ } -> wrapped impl
+  ;;
+
+  let alias_for =
+    let alias_for t m =
+      match t.modules with
+      | Singleton _ -> []
+      | Unwrapped w -> Unwrapped.alias_for w m
+      | Wrapped w -> Wrapped.alias_for w m
+      | Stdlib w -> Stdlib.alias_for w m |> Option.to_list
+    in
+    fun t m ->
+      match Module.kind m with
+      | Root -> []
+      | _ ->
+        (match t with
+         | Modules t -> alias_for t m
+         | Impl { impl; vlib = _; _ } -> alias_for impl m)
+  ;;
+
+  let group_interfaces =
+    let group_interfaces t m =
+      match t.modules with
+      | Wrapped w -> Wrapped.group_interfaces w m
+      | Singleton w -> [ w ]
+      | _ -> []
+    in
+    fun t m ->
+      match t with
+      | Modules t -> group_interfaces t m
+      | Impl { impl; vlib; _ } -> group_interfaces impl m @ group_interfaces vlib m
+  ;;
+
+  let local_open t m =
+    alias_for t m
+    |> List.map ~f:(fun m ->
+      Module.obj_name m |> Module_name.Unique.to_name ~loc:Loc.none)
+  ;;
+
+  let is_stdlib_alias t m =
+    match t with
+    | Modules { modules = Stdlib w; _ } -> w.main_module_name = Module.name m
+    | _ -> false
+  ;;
+
+  let exit_module t =
+    match t with
+    | Modules { modules = Stdlib w; _ } -> Stdlib.exit_module w
+    | _ -> None
+  ;;
+
+  let as_singleton t =
+    match t with
+    | Modules { modules = Singleton m; _ } -> Some m
+    | _ -> None
+  ;;
+
+  let canonical_path t (group : Group.t) m =
+    let path =
+      let path = Module.path m in
+      match Module_name.Map.find group.modules (Module.name m) with
+      | None | Some (Group.Module _) -> path
+      | Some (Group _) ->
+        (* The path for group interfaces always duplicates
+           the last component.
+
+           For example: foo/foo.ml would has the path [ "Foo"; "Foo" ] *)
+        List.remove_last_exn path
+    in
+    match t with
+    | Impl { impl = { modules = Wrapped w; _ }; _ } | Modules { modules = Wrapped w; _ }
+      -> w.group.name :: path
+    | _ -> Module.path m
+  ;;
+end

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -60,6 +60,7 @@ module With_vlib : sig
   type modules := t
   type t
 
+  val drop_vlib : t -> modules
   val to_dyn : t -> Dyn.t
   val encode : t -> src_dir:Path.t -> Dune_lang.t
   val impl : modules -> vlib:modules -> t
@@ -79,7 +80,6 @@ module With_vlib : sig
       executables. *)
   val singleton : Module.t -> t
 
-  val fold_no_vlib : t -> init:'acc -> f:(Module.t -> 'acc -> 'acc) -> 'acc
   val canonical_path : t -> Group.t -> Module.t -> Module_name.Path.t
 
   val fold_no_vlib_with_aliases

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -16,27 +16,8 @@ val lib
   -> modules:Module.t Module_trie.t
   -> t
 
-val encode : t -> src_dir:Path.t -> Dune_lang.t
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
-val impl : t -> vlib:t -> t
-
-val find_dep
-  :  t
-  -> of_:Module.t
-  -> Module_name.t
-  -> (Module.t list, [ `Parent_cycle ]) result
-
-val find : t -> Module_name.t -> Module.t option
-val compat_for_exn : t -> Module.t -> Module.t
-val impl_only : t -> Module.t list
-
-(** A set of modules from a single module. Not suitable for single module exe as
-    this produce an unwrapped set of modules. Use [singleton_exe] instead for
-    executables. *)
-val singleton : Module.t -> t
-
-val singleton_exe : Module.t -> t
-val fold_no_vlib : t -> init:'acc -> f:(Module.t -> 'acc -> 'acc) -> 'acc
+val fold : t -> init:'acc -> f:(Module.t -> 'acc -> 'acc) -> 'acc
 
 module Group : sig
   type t
@@ -46,15 +27,6 @@ module Group : sig
   val for_alias : t -> (Module_name.t * Module.t) list
 end
 
-val canonical_path : t -> Group.t -> Module.t -> Module_name.Path.t
-
-val fold_no_vlib_with_aliases
-  :  t
-  -> init:'acc
-  -> normal:(Module.t -> 'acc -> 'acc)
-  -> alias:(Group.t -> 'acc -> 'acc)
-  -> 'acc
-
 val exe_unwrapped : Module.t Module_trie.t -> obj_dir:Path.Build.t -> t
 
 val make_wrapped
@@ -63,16 +35,9 @@ val make_wrapped
   -> [ `Exe | `Melange ]
   -> t
 
-(** For wrapped libraries, this is the user written entry module for the
-    library. For single module libraries, it's the sole module in the library *)
-val lib_interface : t -> Module.t option
-
 val fold_user_written : t -> f:(Module.t -> 'acc -> 'acc) -> init:'acc -> 'acc
 val map_user_written : t -> f:(Module.t -> Module.t Memo.t) -> t Memo.t
 val fold_user_available : t -> f:(Module.t -> 'acc -> 'acc) -> init:'acc -> 'acc
-
-(** Returns all the compatibility modules. *)
-val wrapped_compat : t -> Module.Name_map.t
 
 module Sourced_module : sig
   type t =
@@ -85,34 +50,81 @@ end
 
 val obj_map : t -> Sourced_module.t Module_name.Unique.Map.t
 
-(** List of entry modules visible to users of the library. For wrapped
-    libraries, this is always one module. For unwrapped libraries, this could be
-    more than one. *)
-val entry_modules : t -> Module.t list
-
-(** Returns the main module name if it exists. It exist for libraries with
-    [(wrapped true)] or one module libraries. *)
-val main_module_name : t -> Module_name.t option
-
 (** Returns only the virtual module names in the library *)
 val virtual_module_names : t -> Module_name.Path.Set.t
 
 val wrapped : t -> Wrapped.t
-val version_installed : t -> src_root:Path.t -> install_dir:Path.t -> t
-val alias_for : t -> Module.t -> Module.t list
-val group_interfaces : t -> Module.t -> Module.t list
-val local_open : t -> Module.t -> Module_name.t list
-val is_stdlib_alias : t -> Module.t -> bool
-val exit_module : t -> Module.t option
-val as_singleton : t -> Module.t option
 val source_dirs : t -> Path.Set.t
 
-type split_by_lib =
-  { vlib : Module.t list
-  ; impl : Module.t list
-  }
+module With_vlib : sig
+  type modules := t
+  type t
 
-val split_by_lib : t -> split_by_lib
+  val to_dyn : t -> Dyn.t
+  val encode : t -> src_dir:Path.t -> Dune_lang.t
+  val impl : modules -> vlib:modules -> t
 
-(** [has_impl t] is true if there's at least one implementation in [t]*)
-val has_impl : t -> bool
+  val find_dep
+    :  t
+    -> of_:Module.t
+    -> Module_name.t
+    -> (Module.t list, [ `Parent_cycle ]) result
+
+  val find : t -> Module_name.t -> Module.t option
+  val compat_for_exn : t -> Module.t -> Module.t
+  val impl_only : t -> Module.t list
+
+  (** A set of modules from a single module. Not suitable for single module exe as
+      this produce an unwrapped set of modules. Use [singleton_exe] instead for
+      executables. *)
+  val singleton : Module.t -> t
+
+  val fold_no_vlib : t -> init:'acc -> f:(Module.t -> 'acc -> 'acc) -> 'acc
+  val canonical_path : t -> Group.t -> Module.t -> Module_name.Path.t
+
+  val fold_no_vlib_with_aliases
+    :  t
+    -> init:'acc
+    -> normal:(Module.t -> 'acc -> 'acc)
+    -> alias:(Group.t -> 'acc -> 'acc)
+    -> 'acc
+
+  (** For wrapped libraries, this is the user written entry module for the
+      library. For single module libraries, it's the sole module in the library *)
+  val lib_interface : t -> Module.t option
+
+  (** Returns all the compatibility modules. *)
+  val wrapped_compat : t -> Module.Name_map.t
+
+  (** List of entry modules visible to users of the library. For wrapped
+      libraries, this is always one module. For unwrapped libraries, this could be
+      more than one. *)
+  val entry_modules : t -> Module.t list
+
+  (** Returns the main module name if it exists. It exist for libraries with
+      [(wrapped true)] or one module libraries. *)
+  val main_module_name : t -> Module_name.t option
+
+  val version_installed : t -> src_root:Path.t -> install_dir:Path.t -> t
+  val alias_for : t -> Module.t -> Module.t list
+  val group_interfaces : t -> Module.t -> Module.t list
+  val local_open : t -> Module.t -> Module_name.t list
+  val is_stdlib_alias : t -> Module.t -> bool
+  val exit_module : t -> Module.t option
+  val as_singleton : t -> Module.t option
+
+  type split_by_lib =
+    { vlib : Module.t list
+    ; impl : Module.t list
+    }
+
+  val split_by_lib : t -> split_by_lib
+
+  (** [has_impl t] is true if there's at least one implementation in [t]*)
+  val has_impl : t -> bool
+
+  val modules : modules -> t
+  val singleton_exe : Module.t -> t
+  val obj_map : t -> Sourced_module.t Module_name.Unique.Map.t
+  val wrapped : t -> Wrapped.t
+end

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -6,7 +6,7 @@ module Modules_data = struct
     ; obj_dir : Path.Build.t Obj_dir.t
     ; sctx : Super_context.t
     ; vimpl : Vimpl.t option
-    ; modules : Modules.t
+    ; modules : Modules.With_vlib.t
     ; stdlib : Ocaml_stdlib.t option
     ; sandbox : Sandbox_config.t
     }
@@ -17,7 +17,7 @@ open Modules_data
 let parse_module_names ~dir ~(unit : Module.t) ~modules words =
   List.concat_map words ~f:(fun m ->
     let m = Module_name.of_string m in
-    match Modules.find_dep modules ~of_:unit m with
+    match Modules.With_vlib.find_dep modules ~of_:unit m with
     | Ok s -> s
     | Error `Parent_cycle ->
       User_error.raise
@@ -37,7 +37,7 @@ let parse_module_names ~dir ~(unit : Module.t) ~modules words =
 ;;
 
 let parse_compilation_units ~modules =
-  let obj_map = Modules.obj_map modules in
+  let obj_map = Modules.With_vlib.obj_map modules in
   List.filter_map ~f:(fun m ->
     let obj_name = Module_name.Unique.of_string m in
     Module_name.Unique.Map.find obj_map obj_name

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -13,7 +13,7 @@ module Modules_data : sig
     ; obj_dir : Path.Build.t Obj_dir.t
     ; sctx : Super_context.t
     ; vimpl : Vimpl.t option
-    ; modules : Modules.t
+    ; modules : Modules.With_vlib.t
     ; stdlib : Ocaml_stdlib.t option
     ; sandbox : Sandbox_config.t
     }
@@ -27,7 +27,7 @@ val deps_of
 
 val read_deps_of
   :  obj_dir:Path.Build.t Obj_dir.t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t
@@ -38,7 +38,7 @@ val read_deps_of
     [ml_kind], then an empty list of dependencies is returned. *)
 val read_immediate_deps_of
   :  obj_dir:Path.Build.t Obj_dir.t
-  -> modules:Modules.t
+  -> modules:Modules.With_vlib.t
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -413,7 +413,7 @@ let setup_library_odoc_rules cctx (local_lib : Lib.Local.t) =
     in
     Dep.deps ctx package requires, odoc_include_flags
   in
-  Modules.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
+  Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
     let compiled =
       let modes = Lib_info.modes info in
       let mode = Lib_mode.Map.Set.for_merlin modes in
@@ -590,7 +590,9 @@ let libs_of_pkg ctx ~pkg =
 ;;
 
 let entry_modules_by_lib sctx lib =
-  Dir_contents.modules_of_local_lib sctx lib >>| Modules.entry_modules
+  Dir_contents.modules_of_local_lib sctx lib
+  >>| Modules.With_vlib.modules
+  >>| Modules.With_vlib.entry_modules
 ;;
 
 let entry_modules sctx ~pkg =

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -413,7 +413,9 @@ let setup_library_odoc_rules cctx (local_lib : Lib.Local.t) =
     in
     Dep.deps ctx package requires, odoc_include_flags
   in
-  Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
+  modules
+  |> Modules.With_vlib.drop_vlib
+  |> Modules.fold ~init:[] ~f:(fun m acc ->
     let compiled =
       let modes = Lib_info.modes info in
       let mode = Lib_mode.Map.Set.for_merlin modes in

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -1211,8 +1211,8 @@ let lib_artifacts ctx all index lib modules =
     | Melange -> Melange Cmi
   in
   let obj_dir = Lib_info.obj_dir info in
-  let entry_modules = Modules.entry_modules modules in
-  Modules.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
+  let entry_modules = Modules.With_vlib.entry_modules modules in
+  Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
     let visible =
       let visible =
         List.mem entry_modules m ~equal:(fun m1 m2 ->

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -1212,7 +1212,9 @@ let lib_artifacts ctx all index lib modules =
   in
   let obj_dir = Lib_info.obj_dir info in
   let entry_modules = Modules.With_vlib.entry_modules modules in
-  Modules.With_vlib.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
+  modules
+  |> Modules.With_vlib.drop_vlib
+  |> Modules.fold ~init:[] ~f:(fun m acc ->
     let visible =
       let visible =
         List.mem entry_modules m ~equal:(fun m1 m2 ->

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -316,7 +316,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
     let requires_link = Memo.lazy_ (fun () -> Memo.return requires_compile) in
     let flags = Ocaml_flags.of_list [ "-g"; "-w"; "-24" ] in
     let opaque = Compilation_context.Explicit false in
-    let modules = Modules.singleton_exe module_ in
+    let modules = Modules.With_vlib.singleton_exe module_ in
     Compilation_context.create
       ~super_context:sctx
       ~scope

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -56,7 +56,7 @@ let find_module sctx src =
        in
        let module_ =
          let modules = Compilation_context.modules cctx in
-         match Modules.find modules module_name with
+         match Modules.With_vlib.find modules module_name with
          | Some m -> m
          | None ->
            User_error.raise

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -25,7 +25,7 @@ module Source = struct
 
   let modules t pp =
     let open Memo.O in
-    main_module t |> Pp_spec.pp_module pp >>| Modules.singleton_exe
+    main_module t |> Pp_spec.pp_module pp >>| Modules.With_vlib.singleton_exe
   ;;
 
   let make ~dir ~loc ~main ~name = { dir; main; name; loc }

--- a/src/dune_rules/toplevel.mli
+++ b/src/dune_rules/toplevel.mli
@@ -5,7 +5,7 @@ module Source : sig
 
   val make : dir:Path.Build.t -> loc:Loc.t -> main:string -> name:string -> t
   val loc : t -> Loc.t
-  val modules : t -> Pp_spec.t -> Modules.t Memo.t
+  val modules : t -> Pp_spec.t -> Modules.With_vlib.t Memo.t
   val obj_dir : t -> Path.Build.t Obj_dir.t
 end
 

--- a/src/dune_rules/vimpl.ml
+++ b/src/dune_rules/vimpl.ml
@@ -15,8 +15,8 @@ let impl_cm_kind t = t.impl_cm_kind
 
 let impl_modules t m =
   match t with
-  | None -> m
-  | Some t -> Modules.impl ~vlib:t.vlib_modules m
+  | None -> Modules.With_vlib.modules m
+  | Some t -> Modules.With_vlib.impl ~vlib:t.vlib_modules m
 ;;
 
 let make ~vlib ~impl ~vlib_modules ~vlib_foreign_objects =

--- a/src/dune_rules/vimpl.mli
+++ b/src/dune_rules/vimpl.mli
@@ -18,7 +18,7 @@ val impl : t -> Library.t
     setting up the copying rules *)
 val vlib_modules : t -> Modules.t
 
-val impl_modules : t option -> Modules.t -> Modules.t
+val impl_modules : t option -> Modules.t -> Modules.With_vlib.t
 val vlib : t -> Lib.t
 
 (** Return the combined list of .o files for stubs consisting of .o files from

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -56,8 +56,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
         copy_to_obj_dir ~src:(object_file vlib_obj_dir) ~dst:(object_file impl_obj_dir)))
   in
   let vlib_modules = Vimpl.vlib_modules vimpl in
-  Modules.fold_no_vlib vlib_modules ~init:(Memo.return ()) ~f:(fun m acc ->
-    acc >>> copy_objs m)
+  Modules.fold vlib_modules ~init:(Memo.return ()) ~f:(fun m acc -> acc >>> copy_objs m)
 ;;
 
 let impl sctx ~(lib : Library.t) ~scope =

--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/mel.ml
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/mel.ml
@@ -1,1 +1,1 @@
-let () = print_endline Vlib_impl.hello
+let () = print_endline Vlib.Vlib_impl.hello

--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/ml.ml
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/ml.ml
@@ -1,1 +1,1 @@
-let () = print_endline Vlib_impl.hello
+let () = print_endline Vlib.Vlib_impl.hello

--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/vlib/dune
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/vlib/dune
@@ -1,5 +1,4 @@
 (library
  (name vlib)
- (wrapped false)
  (modes :standard melange)
  (virtual_modules virt))


### PR DESCRIPTION
testing an alternative for https://github.com/ocaml/dune/pull/10369:

- adding a `Modules.With_vlib.t`:
    1. reading a modules field and source modules produces `Modules.t`
    2. augmenting a `Modules.t` with virtual module implementations (`Vimpl.impl_modules`) produces a `Modules.With_vlib.t`
- most functions migrate to operate on the new type `Modules.With_vlib.t`
    - the distinction is roughly: `Compilation_context.t` operates on `Modules.With_vlib.t`; `Ml_sources.t` and `Dir_contents.t` operate on `Modules.t`
- the main benefit of this change is that `{map,fold}_user_written` / `fold_user_available` always operate on `Modules.t` and not on `Modules.With_vlib.t`.
    - which does make the code changed in #10369 effectively dead code
- we don't need `Modules.fold_no_vlib` anymore, so it's rather called `Modules.fold`
- `fold_no_vlib{,_with_no_aliases}` are only functions of the `Modules.With_vlib` module.