### PR TITLE
pkg: user error when non-existent repo specified

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -276,11 +276,11 @@ let fetch_others ~unpack ~checksum ~target (url : OpamUrl.t) =
     Error (Checksum_mismatch (Checksum.of_opam_hash expected))
 ;;
 
-let fetch_git rev_store ~target (url : OpamUrl.t) =
-  OpamUrl.resolve url rev_store
+let fetch_git rev_store ~target ~url:(url_loc, url) =
+  OpamUrl.resolve url ~loc:url_loc rev_store
   >>= (function
          | Error _ as e -> Fiber.return e
-         | Ok r -> OpamUrl.fetch_revision url r rev_store)
+         | Ok r -> OpamUrl.fetch_revision url ~loc:url_loc r rev_store)
   >>= function
   | Error msg -> Fiber.return @@ Error (Unavailable (Some msg))
   | Ok at_rev ->
@@ -288,7 +288,7 @@ let fetch_git rev_store ~target (url : OpamUrl.t) =
     Ok res
 ;;
 
-let fetch ~unpack ~checksum ~target (url : OpamUrl.t) =
+let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
   let event =
     Dune_stats.(
       start (global ()) (fun () ->
@@ -315,7 +315,7 @@ let fetch ~unpack ~checksum ~target (url : OpamUrl.t) =
       match url.backend with
       | `git ->
         let* rev_store = Rev_store.get in
-        fetch_git rev_store ~target url
+        fetch_git rev_store ~target ~url:(url_loc, url)
       | `http -> fetch_curl ~unpack ~checksum ~target url
       | _ -> fetch_others ~unpack ~checksum ~target url)
 ;;

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -16,11 +16,11 @@ val fetch
   :  unpack:bool
   -> checksum:Checksum.t option
   -> target:Path.t
-  -> OpamUrl.t
+  -> url:Loc.t * OpamUrl.t
   -> (unit, failure) result Fiber.t
 
 val fetch_git
   :  Rev_store.t
   -> target:Path.t
-  -> OpamUrl.t
+  -> url:Loc.t * OpamUrl.t
   -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -44,7 +44,7 @@ let local_or_git_only url loc =
 
 include Comparable.Make (T)
 
-let remote t rev_store = Rev_store.remote rev_store ~url:(OpamUrl.base_url t)
+let remote t ~loc rev_store = Rev_store.remote rev_store ~url:(loc, OpamUrl.base_url t)
 
 type resolve =
   | Resolved of Rev_store.Object.resolved
@@ -61,9 +61,9 @@ let not_found t =
        ])
 ;;
 
-let resolve t rev_store =
+let resolve t ~loc rev_store =
   let open Fiber.O in
-  let remote = remote t rev_store in
+  let remote = remote t ~loc rev_store in
   match
     match rev t with
     | None -> `Default_branch
@@ -91,8 +91,8 @@ let resolve t rev_store =
      | Some o -> Ok (Resolved o))
 ;;
 
-let fetch_revision t resolve rev_store =
-  let remote = remote t rev_store in
+let fetch_revision t ~loc resolve rev_store =
+  let remote = remote t ~loc rev_store in
   let open Fiber.O in
   match resolve with
   | Resolved o -> Rev_store.fetch_resolved rev_store remote o >>| Result.ok

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -23,16 +23,17 @@ val local_or_git_only : t -> Loc.t -> [ `Path of Path.t | `Git ]
 module Map : Map.S with type key = t
 module Set : Set.S with type elt = t and type 'a map = 'a Map.t
 
-val remote : t -> Rev_store.t -> Rev_store.Remote.t
+val remote : t -> loc:Loc.t -> Rev_store.t -> Rev_store.Remote.t
 
 type resolve =
   | Resolved of Rev_store.Object.resolved
   | Unresolved of Rev_store.Object.t
 
-val resolve : t -> Rev_store.t -> (resolve, User_message.t) result Fiber.t
+val resolve : t -> loc:Loc.t -> Rev_store.t -> (resolve, User_message.t) result Fiber.t
 
 val fetch_revision
   :  t
+  -> loc:Loc.t
   -> resolve
   -> Rev_store.t
   -> (Rev_store.At_rev.t, User_message.t) result Fiber.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -96,10 +96,10 @@ let of_opam_repo_dir_path loc opam_repo_dir_path =
 let of_git_repo loc url =
   let+ at_rev =
     let* rev_store = Rev_store.get in
-    OpamUrl.resolve url rev_store
+    OpamUrl.resolve url ~loc rev_store
     >>= function
     | Error _ as e -> Fiber.return e
-    | Ok s -> OpamUrl.fetch_revision url s rev_store
+    | Ok s -> OpamUrl.fetch_revision url ~loc s rev_store
   in
   let at_rev =
     match at_rev with

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -46,7 +46,7 @@ module Remote : sig
   val default_branch : t -> Object.resolved option Fiber.t
 end
 
-val remote : t -> url:string -> Remote.t
+val remote : t -> url:Loc.t * string -> Remote.t
 val resolve_revision : t -> Remote.t -> revision:string -> Object.resolved option Fiber.t
 val content_of_files : t -> File.t list -> string list Fiber.t
 val load_or_create : dir:Path.t -> t Fiber.t

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -47,10 +47,10 @@ let to_dyn = function
 
 let fetch_and_hash_archive_cached =
   let cache = Single_run_file_cache.create () in
-  fun url ->
+  fun (url_loc, url) ->
     let open Fiber.O in
     Single_run_file_cache.with_ cache ~key:(OpamUrl.to_string url) ~f:(fun target ->
-      Fetch.fetch ~unpack:false ~checksum:None ~target url)
+      Fetch.fetch ~unpack:false ~checksum:None ~target ~url:(url_loc, url))
     >>| function
     | Ok target -> Some (Dune_digest.file target |> Checksum.of_dune_digest)
     | Error (Checksum_mismatch _) ->
@@ -94,7 +94,7 @@ let compute_missing_checksum_of_fetch
                (OpamUrl.to_string url)
            ; Pp.text "Dune will compute its own checksum for this source archive."
            ]);
-    fetch_and_hash_archive_cached url
+    fetch_and_hash_archive_cached (url_loc, url)
     >>| Option.map ~f:(fun checksum ->
       { url = url_loc, url; checksum = Some (Loc.none, checksum) })
     >>| Option.value ~default:fetch

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -43,7 +43,7 @@ let resolve_url =
     let open Fiber.O in
     let* rev_store = Rev_store.get in
     let+ git_object =
-      OpamUrl.resolve url rev_store
+      OpamUrl.resolve url ~loc:Loc.none rev_store
       >>| function
       | Ok (Resolved r) -> (r :> Rev_store.Object.t)
       | Ok (Unresolved r) -> r
@@ -107,7 +107,7 @@ module Spec = struct
           | `Directory -> true)
        ~checksum
        ~target:(Path.build target)
-       url)
+       ~url:(loc_url, url))
     >>= function
     | Ok () -> Fiber.return ()
     | Error (Checksum_mismatch actual_checksum) ->

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -14,21 +14,25 @@ Demonstrate what happens when we try to fetch from a source that doesn't exist:
   > }
 
 Local file system
-  $ runtest "(copy \"$PWD/dummy\")" 2>&1 | sed -ne '/Error: /,$ p'
+  $ runtest "(copy \"$PWD/dummy\")" 2>&1 | sed "s#$(pwd)#PWD#" | sed '/ *^\^*$/d' | sed '\#^File "dune.lock/foo.pkg", line 2, characters#d'
+  2 | (source (copy "PWD/dummy"))
   Error: Unable to read
-  $TESTCASE_ROOT/dummy
-  opendir($TESTCASE_ROOT/dummy): No such file or directory
+  PWD/dummy
+  opendir(PWD/dummy): No such file or directory
 
 Git
-  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | awk '/fatal:/,/Description/'
-  fatal: '$TESTCASE_ROOT/dummy' does not appear to be a git repository
+  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | sed "s#$(pwd)#PWD#"
+  fatal: 'PWD/dummy' does not appear to be a git repository
   fatal: Could not read from remote repository.
   
   Please make sure you have the correct access rights
   and the repository exists.
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-
+  Error: Failed to run external command:
+  'git ls-remote "file://PWD/dummy"'
+  -> required by _build/_private/default/.pkg/foo/source
+  -> required by _build/_private/default/.pkg/foo/target
+  Hint: Check that this Git URL in the project configuration is correct:
+  "file://PWD/dummy"
 
 Http
 A bit annoying that this test can pass by accident if there's a server running

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -55,12 +55,12 @@ let%expect_test "adding remotes" =
     let remote_path = Path.relative cwd "git-remote" in
     let* _head = create_repo_at remote_path in
     let opam_url = remote_path |> Path.to_string |> OpamUrl.parse in
-    Dune_pkg.OpamUrl.resolve opam_url rev_store
+    Dune_pkg.OpamUrl.resolve opam_url ~loc:Loc.none rev_store
     >>= function
     | Error _ -> Fiber.return @@ print_endline "Unable to find revision"
     | Ok r ->
       print_endline "Successfully found remote";
-      Dune_pkg.OpamUrl.fetch_revision opam_url r rev_store
+      Dune_pkg.OpamUrl.fetch_revision opam_url ~loc:Loc.none r rev_store
       >>| (function
        | Error _ -> print_endline "Unable to fetch revision"
        | Ok _ -> print_endline "successfully fetched revision"));


### PR DESCRIPTION
Previously it would be a code error if a user specified an invalid git repo url when pinning a package. This change makes it a user error instead.