### PR TITLE
Fix locating program in exec watch mode

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -235,14 +235,13 @@ module Scheduler = struct
   ;;
 end
 
-let restore_cwd_and_execve (common : Common.t) prog argv env =
-  let prog =
-    if Filename.is_relative prog
-    then (
-      let root = Common.root common in
-      Filename.concat root.dir prog)
-    else prog
-  in
+let resolve_relative_path_within_root_dir (root : Workspace_root.t) path =
+  if Filename.is_relative path then Filename.concat root.dir path else path
+;;
+
+let restore_cwd_and_execve common prog argv env =
+  let root = Common.root common in
+  let prog = resolve_relative_path_within_root_dir root prog in
   Proc.restore_cwd_and_execve prog argv ~env
 ;;
 

--- a/doc/changes/10386.md
+++ b/doc/changes/10386.md
@@ -1,0 +1,3 @@
+- Fix bug with exec watch mode where paths to executables in the current project
+  could not be resolved unless the user's current directory is the project root.
+  (#10386, @gridbugs)


### PR DESCRIPTION
This fixes a bug where running an executable from the current project
with `dune exec --watch` would be unable to find the executable unless
the command was run from the project's root directory.

The problem was introduced when we started setting the cwd of processes
spawned by exec in watch mode to the user's current directory
(https://github.com/ocaml/dune/pull/10262). If the program argument to
exec refers to a file to be built in the current project (such as an
executable implemented in the current project) then the path to the
executable to spawn will be a path inside the _build directory relative
to the project root. Since the cwd of the new process was set to the
user's current directory, this relative path was being resolved within
the current directory, whereas it should have been resolved relative to
the project root.

The fix was to convert relative paths into absolute paths relative to
the project root (this was already being done for exec when not in watch
mode).