### PR TITLE
refactor(boot): key by system list

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1152,10 +1152,9 @@ let rec rm_rf fn =
 
 and clear dir = List.iter (readdir dir) ~f:rm_rf
 
-let get_flags ocaml_system flags =
-  match List.assoc_opt ocaml_system flags with
-  | None -> []
-  | Some flags -> flags
+let rec get_flags system = function
+  | (set, f) :: r -> if List.mem system ~set then f else get_flags system r
+  | [] -> []
 ;;
 
 (** {2 Bootstrap process} *)

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -95,26 +95,18 @@ let local_libraries =
   ]
 
 let build_flags =
-  [ ("win32", [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
-  ; ("win64", [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
-  ; ("mingw", [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
-  ; ("mingw64", [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
+  [ ([ "win32"; "win64"; "mingw"; "mingw64" ],
+    [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
   ]
 
 let link_flags =
-  [ ("macosx",
+  [ ([ "macosx" ],
     [ "-cclib"
     ; "-framework CoreFoundation"
     ; "-cclib"
     ; "-framework CoreServices"
     ])
-  ; ("win32",
+  ; ([ "win32"; "win64"; "mingw"; "mingw64" ],
     [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
-  ; ("win64",
-    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
-  ; ("mingw",
-    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
-  ; ("mingw64",
-    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
-  ; ("beos", [ "-cclib"; "-lbsd" ])
+  ; ([ "beos" ], [ "-cclib"; "-lbsd" ])
   ]


### PR DESCRIPTION
Windows flags are repeated across several values of `system`, so we duplicate several lists.

This changes the "key" of `build_flags` and `link_flags` to a list of candidates where check if the target system is present.
