### PR TITLE
fix: Make the dune trim test reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -141,17 +141,15 @@ sizes might vary on different platforms
 The cache deletes oldest files first.
 
   $ reset
-  $ dune build target_a target_b
-
-The [rm] commands below update the [ctime] of the corresponding cache entries.
-By deleting [target_b] first, we make its [ctime] older. The trimmer deletes
-older entries first, which is why [target_b] is trimmed while [target_a] is not.
-We know that [target_b] was trimmed, because it had to be rebuilt as indicated
-by the existence of [beacon_b].
-
-  $ rm -f _build/default/beacon_b _build/default/target_b
+  $ dune build target_b
   $ dune_cmd wait-for-fs-clock-to-advance
-  $ rm -f _build/default/beacon_a _build/default/target_a
+  $ dune build target_a
+
+The trimmer deletes older entries first, which is why [target_b] is trimmed
+while [target_a] is not. We know that [target_b] was trimmed, because it had to
+be rebuilt as indicated by the existence of [beacon_b].
+
+  $ rm -f _build/default/{target_a,target_b,beacon_a,beacon_b}
   $ dune cache trim --trimmed-size 1B
   Freed 79B (2 files removed)
   $ dune build target_a target_b


### PR DESCRIPTION
Since a while I have been reliably running into a this test failure:

```
File "test/blackbox-tests/test-cases/dune-cache/trim.t", line 1, characters 0-0:
diff --git a/_build/.sandbox/5f36f67e5370f082210438d2f14adc1a/default/test/blackbox-tests/test-cases/dune-cache/trim.t b/_build/.sandbox/5f36f67e5370f082210438d2f14adc1a/default/test/blackbox-tests/test-cases/dune-cache/trim.t.corrected
index dcda72696..87298ed0d 100644
--- a/_build/.sandbox/5f36f67e5370f082210438d2f14adc1a/default/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/_build/.sandbox/5f36f67e5370f082210438d2f14adc1a/default/test/blackbox-tests/test-cases/dune-cache/trim.t.corrected
@@ -160,9 +160,9 @@ by the existence of [beacon_b].
   $ dune_cmd stat hardlinks _build/default/target_b
   2
   $ dune_cmd exists _build/default/beacon_a
-  false
-  $ dune_cmd exists _build/default/beacon_b
   true
+  $ dune_cmd exists _build/default/beacon_b
+  false
```

Weirdly enough it doesn't seem to be reproducible on CI or other people's machines (not even my old one before).

However the description why it was supposed to work seemed strange to me as it claimed that deleting the files in order would make the ctime older, but deleted files do not have a ctime. My hunch is that the order of deletion does not make a difference and the only thing that differs is the order in which the targets are built, so I've changed the test to make sure the order of building the targets is well-defined (and the FS gets time to update the timestamps in between so we get to reliably measure a difference).