### PR TITLE
pkg: improve error message when curl not installed

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -8,10 +8,11 @@ module Curl = struct
        | Some p -> p
        | None ->
          User_error.raise
-           [ Pp.concat
-               ~sep:Pp.space
-               [ User_message.command "curl"; Pp.text "not available in PATH" ]
-             |> Pp.hovbox
+           ~hints:[ Pp.text "Install curl with your system package manager." ]
+           [ Pp.text
+               "The program \"curl\" does not appear to be installed. Dune uses curl to \
+                download packages. Dune requires that the \"curl\" executable be located \
+                in one of the directories listed in the PATH variable."
            ])
   ;;
 

--- a/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
+++ b/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
@@ -1,0 +1,26 @@
+Test the error message when curl is needed but not installed.
+
+  $ . ./helpers.sh
+  $ make_lockdir
+
+  $ makepkg() {
+  > make_lockpkg $1 <<EOF
+  > (source
+  >  (fetch
+  >   (url "http://0.0.0.0:8000")))
+  > (version dev)
+  > EOF
+  > }
+
+  $ makepkg foo
+
+Build the package in an environment without curl.
+  $ PATH=$(dirname $(which dune)) build_pkg foo
+  File "dune.lock/foo.pkg", line 3, characters 7-28:
+  3 |   (url "http://0.0.0.0:8000")))
+             ^^^^^^^^^^^^^^^^^^^^^
+  Error: The program "curl" does not appear to be installed. Dune uses curl to
+  download packages. Dune requires that the "curl" executable be located in one
+  of the directories listed in the PATH variable.
+  Hint: Install curl with your system package manager.
+  [1]


### PR DESCRIPTION
Adds a hint and some details to the error message when curl is needed by dune but not installed. Also changes the formatting of "curl" in the error message to not use dune's formatting for commands, as it is the name of a program and not a command.