### PR TITLE
fix(doc): Correct `versionadded` reference for `subst`

### DIFF
--- a/doc/reference/dune-project/subst.rst
+++ b/doc/reference/dune-project/subst.rst
@@ -3,7 +3,7 @@ subst
 
 .. describe:: (subst <bool>)
 
-   .. versionadded: 3.0
+   .. versionadded:: 3.0
 
    Control whether :ref:`dune-subst` is enabled for this project.
 


### PR DESCRIPTION
@c-cube mentioned that the `subst` documentation does not have a mention on when it was added, so I dug this up in the source code (3.0) and upon wanting to add this to the docs I realized it already exists.

Turns out, the directive is defined incorrectly thus it doesn't end up getting rendered.