### PR TITLE
fix(melange): during JS emission, depend on virtual lib implementations

### DIFF
--- a/doc/changes/10412.md
+++ b/doc/changes/10412.md
@@ -1,0 +1,2 @@
+- melange: remove all restrictions around virtual libraries in Melange. They
+  may be used as otherwise in libraries and executables. (#10412, @anmonteiro)

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -484,6 +484,22 @@ let setup_js_rules_libraries =
   in
   fun ~dir ~scope ~target_dir ~sctx ~requires_link ~mode (mel : Melange_stanzas.Emit.t) ->
     let build_js = build_js ~sctx ~mode ~module_systems:mel.module_systems in
+    let with_vlib_implementations =
+      let vlib_implementations =
+        (* vlib_name => concrete_impl *)
+        List.fold_left requires_link ~init:Lib_name.Map.empty ~f:(fun acc dep ->
+          match Lib_info.implements (Lib.info dep) with
+          | None -> acc
+          | Some (_, vlib_name) -> Lib_name.Map.add_exn acc vlib_name dep)
+      in
+      fun lib deps ->
+        (* Depend on the concrete implementations of virtual libraries so
+           that Melange can find their `.cmj` files. *)
+        List.fold_left deps ~init:deps ~f:(fun acc dep ->
+          match Lib_name.Map.find vlib_implementations (Lib.name dep) with
+          | None -> acc
+          | Some sub -> if Lib.equal sub lib then acc else sub :: acc)
+    in
     Memo.parallel_iter requires_link ~f:(fun lib ->
       let lib_compile_info =
         Lib.Compile.for_lib
@@ -502,6 +518,7 @@ let setup_js_rules_libraries =
       let* includes =
         let+ requires_link =
           Memo.Lazy.force (Lib.Compile.requires_link lib_compile_info)
+          |> Resolve.Memo.map ~f:(with_vlib_implementations lib)
         in
         cmj_includes ~requires_link ~scope
       in

--- a/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
+++ b/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
@@ -45,6 +45,3 @@ transitively
   > EOF
 
   $ dune build @melange
-  File "_none_", line 1:
-  Error: Vlib__Virt not found, it means either the module does not exist or it is a namespace
-  [1]


### PR DESCRIPTION
fixes the test in https://github.com/ocaml/dune/pull/10411