### PR TITLE
melange: better error message for offending runtime_dep in public libs

### DIFF
--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -64,8 +64,10 @@ let check_runtime_deps_relative_path local_path ~loc ~lib_info =
       ]
       ~hints:
         [ Pp.textf
-            "Move the dependency to a descendant of the folder where the library is \
-             defined"
+            "Move the offending dependency somewhere inside `%s'."
+            (Path.build lib_src_dir
+             |> Path.drop_optional_build_context_src_exn
+             |> Path.Source.to_string)
         ]
   | Some _ -> ()
 ;;

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested-errors.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested-errors.t
@@ -29,7 +29,6 @@ Test errors when public library runtime dependencies escape the dune file dir
                              ^^^^^^^^^^^^^^^^
   Error: Public library `foo' depends on assets outside its source tree. This
   is not allowed.
-  Hint: Move the dependency to a descendant of the folder where the library is
-  defined
+  Hint: Move the offending dependency somewhere inside `packages/foo/src'.
   Leaving directory 'lib'
   [1]


### PR DESCRIPTION
in the hint, use simpler language a give a clearer suggestion.