### PR TITLE
refactor: Remove duplicated match when calculating digest

### DIFF
--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -153,8 +153,5 @@ let path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) =
           | contents -> Ok (generic (directory_digest_version, contents, stats.st_perm))))
     | S_DIR | S_BLK | S_CHR | S_FIFO | S_SOCK -> Error Unexpected_kind
   in
-  match stats.st_kind with
-  | S_DIR when not allow_dirs -> Error Path_digest_error.Unexpected_kind
-  | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK -> Error Unexpected_kind
-  | _ -> loop path stats
+  loop path stats
 ;;


### PR DESCRIPTION
As I was trying to understand the caching code I came across the fact that the match inside the loop and outside of it seemed to have the exact condition, so I removed the outermost.