### PR TITLE
fix: Don't fail on symlinks to folders

### DIFF
--- a/src/dune_digest/cached_digest.ml
+++ b/src/dune_digest/cached_digest.ml
@@ -283,7 +283,7 @@ let refresh_and_remove_write_permissions ~allow_dirs path =
       (match stats.st_kind with
        | S_LNK ->
          (match Path.stat_exn path with
-          | stats -> refresh stats ~allow_dirs:false path
+          | stats -> refresh stats ~allow_dirs path
           | exception Unix.Unix_error (ELOOP, _, _) -> Error Cyclic_symlink
           | exception Unix.Unix_error (ENOENT, _, _) -> Error Broken_symlink)
        | S_REG ->

--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -84,7 +84,7 @@ mode:
   444
   
 
-Now we demonstrate that symlinks aren't supported:
+Now we demonstrate that symlinks are handled:
 
   $ mkdir sub
 
@@ -108,13 +108,7 @@ Now we demonstrate that symlinks aren't supported:
   test
 
   $ runtest "mkdir bar && touch bar/somefileinbar && ln -s bar symlinktobar"
-  File "sub/dune", lines 1-3, characters 0-151:
-  1 | (rule
-  2 |  (target (dir targetdir))
-  3 |  (action (system "mkdir targetdir && cd targetdir && mkdir bar && touch bar/somefileinbar && ln -s bar symlinktobar")))
-  Error: Error trying to read targets after a rule was run:
-  - sub/targetdir/symlinktobar: Unexpected file kind "S_DIR" (directory)
-  [1]
+  test
 
 Now we try a broken symlink:
 

--- a/test/blackbox-tests/test-cases/directory-targets/symlink-dir.t
+++ b/test/blackbox-tests/test-cases/directory-targets/symlink-dir.t
@@ -22,17 +22,3 @@ See #9873.
   > EOF
 
   $ dune build d
-  File "dune", lines 1-10, characters 0-154:
-   1 | (rule
-   2 |  (target (dir d))
-   3 |  (action
-   4 |   (progn
-   5 |    (run mkdir -p d)
-   6 |    (chdir d
-   7 |     (progn
-   8 |      (run mkdir a)
-   9 |      (run touch a/x.txt)
-  10 |      (run ln -s a b))))))
-  Error: Error trying to read targets after a rule was run:
-  - d/b: Unexpected file kind "S_DIR" (directory)
-  [1]


### PR DESCRIPTION
Trying to figure out why it the code was forbidding symlinks to folders.

Locally the tests seem to succeed.