### PR TITLE
fix(spawn): update spawn for gcc 4.8.5

### DIFF
--- a/doc/changes/10428.md
+++ b/doc/changes/10428.md
@@ -1,0 +1,1 @@
+- spawn: fix compatibility with RHEL7 (#10428, @emillon)

--- a/vendor/spawn/src/spawn_stubs.c
+++ b/vendor/spawn/src/spawn_stubs.c
@@ -523,8 +523,8 @@ static void init_spawn_info(struct spawn_info *info,
         caml_failwith("Unknown sigprocmask action");
     }
 
-    for (value v_signals_list = Field(v_sigprocmask, 1);
-         v_signals_list != Val_emptylist;
+    value v_signals_list = Field(v_sigprocmask, 1);
+    for (; v_signals_list != Val_emptylist;
          v_signals_list = Field(v_signals_list, 1)) {
       int signal = caml_convert_signal_number(Long_val(Field(v_signals_list, 0)));
       switch (sigprocmask_command) {

--- a/vendor/update-spawn.sh
+++ b/vendor/update-spawn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=6c752122070f377c2607f6969a821f166a43bd5e
+version=835c49833d41221758c4ad71f07829ee259668e1
 
 set -e -o pipefail
 


### PR DESCRIPTION
Updated to a version that contains janestreet/spawn#62.
