### PR TITLE
[coq] Add support for per-file flags.

### DIFF
--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -69,6 +69,7 @@ The Coq theory stanza is very similar in form to the OCaml
      (modules <ordered_set_lang>)
      (plugins <ocaml_plugins>)
      (flags <coq_flags>)
+     (modules_flags <flags_map>)
      (coqdoc_flags <coqdoc_flags>)
      (stdlib <stdlib_included>)
      (mode <coq_native_mode>)
@@ -116,6 +117,25 @@ The semantics of the fields are:
 - ``<coq_flags>`` are passed to ``coqc`` as command-line options. ``:standard``
   is taken from the value set in the ``(coq (flags <flags>))`` field in ``env``
   profile. See :doc:`/reference/dune/env` for more information.
+
+- ``<flags_map>`` is a list of pairs of valid Coq module names and a
+  list of ``<coq_flags>``. Note that if a module is present here, the
+  ``:standard`` variable will be bound to the value of ``<coq_flags>``
+  effective for the theory. This way it is possible to override the
+  default flags for particular files of the theory, for example:
+
+  .. code:: dune
+
+    (coq.theory
+      (name Foo)
+      (modules_flags
+        (bar (:standard \ -quiet))))
+
+
+  It is more common to just use this field to *add* some particular
+  flags, but that should be done using ``(:standard <flag1> <flag2>
+  ...)`` as to propagate the default flags. (Appeared in :ref:`Coq
+  lang 0.9<coq-lang>`)
 
 - ``<coqdoc_flags>`` are extra user-configurable flags passed to ``coqdoc``. The
   default value for ``:standard`` is ``--toc``. The ``--html`` or ``--latex``
@@ -329,6 +349,7 @@ The Coq lang can be modified by adding the following to a
 
 The supported Coq language versions (not the version of Coq) are:
 
+- ``0.9``: Support for per-module flags with the ``(module_flags ...)``` field.
 - ``0.8``: Support for composition with installed Coq theories;
   support for ``vos`` builds.
 

--- a/editor-integration/emacs/dune.el
+++ b/editor-integration/emacs/dune.el
@@ -101,7 +101,9 @@
        ;; + for env
        "binaries"
        ;; + for "install"
-       "section" "files")
+       "section" "files"
+       ;; Coq fields
+       "theories" "modules_flags" "plugins")
      'symbols))
   "Field names allowed in dune files.")
 

--- a/src/dune_rules/coq/coq_module.ml
+++ b/src/dune_rules/coq/coq_module.ml
@@ -5,13 +5,19 @@
 open Import
 
 module Name = struct
-  type t = string
+  module Self = struct
+    type t = string
 
-  let make x = x
-  let compare = String.compare
-  let equal = String.equal
-  let to_dyn s = Dyn.String s
-  let to_string s = s
+    let make x = x
+    let compare = String.compare
+    let equal = String.equal
+    let to_dyn s = Dyn.String s
+    let to_string s = s
+    let decode = Dune_lang.Decoder.string
+  end
+
+  include Self
+  module Map = Map.Make (Self)
 end
 
 module Module = struct

--- a/src/dune_rules/coq/coq_module.mli
+++ b/src/dune_rules/coq/coq_module.mli
@@ -12,6 +12,9 @@ module Name : sig
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
   val to_string : t -> string
+  val decode : t Dune_lang.Decoder.t
+
+  module Map : Map.S with type key = t
 end
 
 type t

--- a/src/dune_rules/coq/coq_stanza.mli
+++ b/src/dune_rules/coq/coq_stanza.mli
@@ -31,6 +31,7 @@ module Theory : sig
     ; project : Dune_project.t
     ; synopsis : string option
     ; modules : Ordered_set_lang.t
+    ; modules_flags : (Coq_module.Name.t * Ordered_set_lang.Unexpanded.t) list option
     ; boot : bool
     ; enabled_if : Blang.t
     ; buildable : Buildable.t

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
@@ -45,5 +45,5 @@ This test is currently broken due to the workspace resolution being faulty #5899
   1 | (coq.theory
   2 |  (name foo))
   Error: 'coq.theory' is available only when coq is enabled in the dune-project
-  file. You must enable it using (using coq 0.8) in your dune-project file.
+  file. You must enable it using (using coq 0.9) in your dune-project file.
   [1]

--- a/test/blackbox-tests/test-cases/coq/github3624.t
+++ b/test/blackbox-tests/test-cases/coq/github3624.t
@@ -17,5 +17,5 @@ good when the coq extension is not enabled.
   1 | (coq.theory
   2 |  (name foo))
   Error: 'coq.theory' is available only when coq is enabled in the dune-project
-  file. You must enable it using (using coq 0.8) in your dune-project file.
+  file. You must enable it using (using coq 0.9) in your dune-project file.
   [1]

--- a/test/blackbox-tests/test-cases/coq/per_file_flags.t/bar.v
+++ b/test/blackbox-tests/test-cases/coq/per_file_flags.t/bar.v
@@ -1,0 +1,6 @@
+From basic Require Import foo.
+
+Definition mynum (i : mynat) := 3.
+
+(* This should not emit a warning *)
+Variable (A : nat).

--- a/test/blackbox-tests/test-cases/coq/per_file_flags.t/dune
+++ b/test/blackbox-tests/test-cases/coq/per_file_flags.t/dune
@@ -1,0 +1,12 @@
+(coq.theory
+ (name basic)
+ (package base)
+ (modules :standard)
+ (flags :standard)
+ (modules_flags
+  (bar (:standard -w -local-declaration)))
+ (synopsis "Test Coq library"))
+
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/per_file_flags.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/per_file_flags.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.16)
+
+(using coq 0.9)

--- a/test/blackbox-tests/test-cases/coq/per_file_flags.t/foo.v
+++ b/test/blackbox-tests/test-cases/coq/per_file_flags.t/foo.v
@@ -1,0 +1,4 @@
+Definition mynat := nat.
+
+(* This should emit a warning *)
+Variable (A : nat).

--- a/test/blackbox-tests/test-cases/coq/per_file_flags.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/per_file_flags.t/run.t
@@ -1,0 +1,25 @@
+  $ dune build --display short @all
+        coqdep .basic.theory.d
+          coqc Nbasic_foo.{cmi,cmxs},foo.{glob,vo}
+  File "./foo.v", line 4, characters 0-19:
+  Warning: Interpreting this declaration as if a global declaration prefixed by
+  "Local", i.e. as a global declaration which shall not be available without
+  qualification when imported. [local-declaration,scope]
+          coqc Nbasic_bar.{cmi,cmxs},bar.{glob,vo}
+
+  $ dune build --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_bar.cmi" {"coq/user-contrib/basic/.coq-native/Nbasic_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_bar.cmxs" {"coq/user-contrib/basic/.coq-native/Nbasic_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_foo.cmi" {"coq/user-contrib/basic/.coq-native/Nbasic_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_foo.cmxs" {"coq/user-contrib/basic/.coq-native/Nbasic_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.v" {"coq/user-contrib/basic/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.vo" {"coq/user-contrib/basic/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.v" {"coq/user-contrib/basic/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.vo" {"coq/user-contrib/basic/foo.vo"}
+  ]


### PR DESCRIPTION
We add a field:
```
  (modules_flags
    (lib.string.mod1 (-w -this_is_not_for_me)))
```

to enable per-file flags. The field supports `:standard`, instantiated with the value that applies for the theory.

We bump the Coq language version, as well as the Dune language version as we need to register the dependency correctly.

cc #61 #2019 #2796