### PR TITLE
[3.15] backport #10382

### DIFF
--- a/doc/changes/10382.md
+++ b/doc/changes/10382.md
@@ -1,0 +1,2 @@
+- Fix crash when a rule with a directory target is disabled with `enabled_if`
+  (#10382, fixes #10310, @gridbugs)

--- a/test/blackbox-tests/test-cases/gh10310.t
+++ b/test/blackbox-tests/test-cases/gh10310.t
@@ -1,0 +1,23 @@
+Reproduces a bug where if a rule with a directory target is excluded with
+enabled_if then dune crashes.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.14)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (enabled_if false)
+  >  (target (dir x))
+  >  (action (progn)))
+  > EOF
+
+  $ dune build 2>&1 | head -n 7
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("gen_rules returned a set of directory targets that doesn't match the set of directory targets from returned rules",
+    { dir = In_build_dir "default"
+    ; mismatched_directories =
+        map { "default/x" : { message = "not generated"; loc = "dune:1" } }
+    })

--- a/test/blackbox-tests/test-cases/gh10310.t
+++ b/test/blackbox-tests/test-cases/gh10310.t
@@ -1,5 +1,5 @@
-Reproduces a bug where if a rule with a directory target is excluded with
-enabled_if then dune crashes.
+Make sure that dune can handle rules with directory targets that are disabled
+with enabled_if.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.14)
@@ -13,11 +13,4 @@ enabled_if then dune crashes.
   >  (action (progn)))
   > EOF
 
-  $ dune build 2>&1 | head -n 7
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("gen_rules returned a set of directory targets that doesn't match the set of directory targets from returned rules",
-    { dir = In_build_dir "default"
-    ; mismatched_directories =
-        map { "default/x" : { message = "not generated"; loc = "dune:1" } }
-    })
+  $ dune build


### PR DESCRIPTION
- Add repro for gh10310 (#10330)
- Allow rules with directory targets to be disabled (again) (#10382)
