### PR TITLE
[3.15] backport #10412

### DIFF
--- a/doc/changes/10412.md
+++ b/doc/changes/10412.md
@@ -1,0 +1,2 @@
+- melange: remove all restrictions around virtual libraries in Melange. They
+  may be used as otherwise in libraries and executables. (#10412, @anmonteiro)

--- a/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
+++ b/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
@@ -45,6 +45,3 @@ transitively
   > EOF
 
   $ dune build @melange
-  File "_none_", line 1:
-  Error: Vlib__Virt not found, it means either the module does not exist or it is a namespace
-  [1]

--- a/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
+++ b/test/blackbox-tests/test-cases/melange/virtual-lib-transitive.t
@@ -1,0 +1,50 @@
+Test a case of virtual libraries where libraries depend on the virtual library
+transitively
+
+  $ mkdir -p foo vlib vlib_impl
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (using melange 0.1)
+  > EOF
+  $ cat > foo/dune <<EOF
+  > (library
+  >  (name foo)
+  >  (modes melange)
+  >  (libraries vlib))
+  > EOF
+  $ cat > foo/virt.ml <<EOF
+  > include Vlib.Virt
+  > EOF
+
+  $ cat > vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (modes melange)
+  >  (virtual_modules virt))
+  > EOF
+  $ cat > vlib/virt.mli <<EOF
+  > type t
+  > EOF
+
+  $ cat > vlib_impl/dune <<EOF
+  > (library
+  >  (name vlib_impl)
+  >  (modes melange)
+  >  (implements vlib))
+  > EOF
+  $ cat > vlib_impl/virt.ml <<EOF
+  > type t = string ref
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target js)
+  >  (modules)
+  >  (emit_stdlib false)
+  >  (libraries foo vlib_impl))
+  > EOF
+
+  $ dune build @melange
+  File "_none_", line 1:
+  Error: Vlib__Virt not found, it means either the module does not exist or it is a namespace
+  [1]


### PR DESCRIPTION
- test(melange): show dependency missing bug with virtual libraries (#10411)
- fix(melange): during JS emission, depend on virtual lib implementations (#10412)
