### PR TITLE
always block signals and attempt to shutdown gracefully

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -366,7 +366,7 @@ let () =
     { Scheduler.Config.concurrency = 10
     ; stats = None
     ; insignificant_changes = `React
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -9,7 +9,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React
-  ; signal_watcher = `No
+  ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
 ;;

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1047,14 +1047,6 @@ let rpc t =
   | `Allow rpc -> `Allow (Lazy.force rpc)
 ;;
 
-let signal_watcher t =
-  match t.rpc with
-  | `Allow _ -> `Yes
-  | `Forbid_builds ->
-    (* if we aren't building anything, then we don't mind interrupting dune immediately *)
-    `No
-;;
-
 let watch_exclusions t = t.builder.watch_exclusions
 let stats t = t.stats
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -14,7 +14,6 @@ val rpc
      | `Forbid_builds (** Promise not to build anything. For now, this isn't checked *)
      ]
 
-val signal_watcher : t -> [ `Yes | `No ]
 val watch_exclusions : t -> string list
 val stats : t -> Dune_stats.t option
 val print_metrics : t -> bool

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -189,13 +189,12 @@ module Scheduler = struct
   let go ~(common : Common.t) ~config:dune_config f =
     let stats = Common.stats common in
     let config =
-      let signal_watcher = Common.signal_watcher common in
       let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler
         dune_config
         stats
         ~insignificant_changes:`Ignore
-        ~signal_watcher
+        ~print_ctrl_c_warning:true
         ~watch_exclusions
     in
     let f =
@@ -218,13 +217,12 @@ module Scheduler = struct
     in
     let stats = Common.stats common in
     let config =
-      let signal_watcher = Common.signal_watcher common in
       let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler
         dune_config
         stats
         ~insignificant_changes:`Ignore
-        ~signal_watcher
+        ~print_ctrl_c_warning:true
         ~watch_exclusions
     in
     let file_watcher = Common.file_watcher common in

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -283,7 +283,7 @@ let command =
         config
         stats
         ~insignificant_changes:`Ignore
-        ~signal_watcher:`Yes
+        ~print_ctrl_c_warning:true
         ~watch_exclusions:[]
     in
     Scheduler.Run.go

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -484,7 +484,7 @@ let term =
        ~watch_exclusions:[]
        None
        ~insignificant_changes:`React
-       ~signal_watcher:`No)
+       ~print_ctrl_c_warning:false)
     subst
 ;;
 

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -486,7 +486,12 @@ module Dune_config = struct
          loop commands))
   ;;
 
-  let for_scheduler (t : t) ~watch_exclusions stats ~insignificant_changes ~signal_watcher
+  let for_scheduler
+    (t : t)
+    ~watch_exclusions
+    stats
+    ~insignificant_changes
+    ~print_ctrl_c_warning
     =
     let concurrency =
       match t.concurrency with
@@ -503,7 +508,7 @@ module Dune_config = struct
     { Scheduler.Config.concurrency
     ; stats
     ; insignificant_changes
-    ; signal_watcher
+    ; print_ctrl_c_warning
     ; watch_exclusions
     }
   ;;

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -111,6 +111,6 @@ module Dune_config : sig
     -> watch_exclusions:string list
     -> Dune_stats.t option
     -> insignificant_changes:[ `React | `Ignore ]
-    -> signal_watcher:[ `Yes | `No ]
+    -> print_ctrl_c_warning:bool
     -> Dune_engine.Scheduler.Config.t
 end

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -7,7 +7,7 @@ module Config : sig
     { concurrency : int
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
-    ; signal_watcher : [ `Yes | `No ]
+    ; print_ctrl_c_warning : bool
     ; watch_exclusions : string list
     }
 end

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -92,7 +92,7 @@ let%expect_test "csexp server life cycle" =
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `React
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/dune_async_io/async_io_tests.ml
+++ b/test/expect-tests/dune_async_io/async_io_tests.ml
@@ -7,7 +7,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `Ignore
-  ; signal_watcher = `No
+  ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
 ;;

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -88,7 +88,7 @@ let test files (patch, patch_contents) =
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `Ignore
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -100,7 +100,7 @@ let run thunk =
     { concurrency = 1
     ; stats = None
     ; insignificant_changes = `Ignore
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -73,7 +73,7 @@ let run thunk =
     { concurrency = 1
     ; stats = None
     ; insignificant_changes = `Ignore
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -15,7 +15,7 @@ let run thunk =
     { concurrency = 1
     ; stats = None
     ; insignificant_changes = `Ignore
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -178,7 +178,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React
-  ; signal_watcher = `No
+  ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
 ;;

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -27,7 +27,7 @@ let run =
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `React
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -8,7 +8,7 @@ let go =
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `React
-    ; signal_watcher = `Yes
+    ; print_ctrl_c_warning = true
     ; watch_exclusions = []
     }
   in

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -10,7 +10,7 @@ let default =
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React
-  ; signal_watcher = `No
+  ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
 ;;

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -7,7 +7,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React
-  ; signal_watcher = `No
+  ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
 ;;

--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -127,7 +127,7 @@ let run kind script =
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `React
-    ; signal_watcher = `No
+    ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }
   in


### PR DESCRIPTION
We should always block signals so that we have a chance to shutdown properly instead of violently. However, it's not always appropriate to print the warning message. I'm not claiming that all the decisions in this commit are correct, but they are as close to behavior-preserving as possible.