### PR TITLE
fix: lazier directory target extraction

### DIFF
--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -85,10 +85,38 @@ let error_no_module_consumer ~loc (qualification : Include_subdirs.qualification
     ]
 ;;
 
-let extract_directory_targets ~dir stanzas =
-  Memo.parallel_map stanzas ~f:(fun stanza ->
-    match Stanza.repr stanza with
-    | Rule_conf.T { targets = Static { targets; _ }; loc = rule_loc; enabled_if; _ } ->
+let directory_targets_of_rule ~dir { Rule_conf.targets; loc = rule_loc; enabled_if; _ } =
+  match targets with
+  | Infer ->
+    (* we don't infer directory targets *)
+    Memo.return Path.Build.Map.empty
+  | Static { targets; _ } ->
+    let directory_targets =
+      List.fold_left targets ~init:Path.Build.Map.empty ~f:(fun acc (target, kind) ->
+        match (kind : Targets_spec.Kind.t) with
+        | File -> acc
+        | Directory ->
+          let loc = String_with_vars.loc target in
+          (match String_with_vars.text_only target with
+           | None ->
+             User_error.raise
+               ~loc
+               [ Pp.text "Variables are not allowed in directory targets." ]
+           | Some target ->
+             let dir_target = Path.Build.relative ~error_loc:loc dir target in
+             if Path.Build.is_descendant dir_target ~of_:dir
+             then
+               (* We ignore duplicates here as duplicates are detected and
+                  reported by [Load_rules]. *)
+               Path.Build.Map.set acc dir_target rule_loc
+             else
+               (* This will be checked when we interpret the stanza
+                  completely, so just ignore this rule for now. *)
+               acc))
+    in
+    if Path.Build.Map.is_empty directory_targets
+    then Memo.return directory_targets
+    else
       (match enabled_if with
        | Blang.Const const -> Memo.return const
        | _ ->
@@ -99,28 +127,13 @@ let extract_directory_targets ~dir stanzas =
          Expander0.eval_blang expander enabled_if)
       >>| (function
        | false -> Path.Build.Map.empty
-       | true ->
-         List.fold_left targets ~init:Path.Build.Map.empty ~f:(fun acc (target, kind) ->
-           match (kind : Targets_spec.Kind.t) with
-           | File -> acc
-           | Directory ->
-             let loc = String_with_vars.loc target in
-             (match String_with_vars.text_only target with
-              | None ->
-                User_error.raise
-                  ~loc
-                  [ Pp.text "Variables are not allowed in directory targets." ]
-              | Some target ->
-                let dir_target = Path.Build.relative ~error_loc:loc dir target in
-                if Path.Build.is_descendant dir_target ~of_:dir
-                then
-                  (* We ignore duplicates here as duplicates are detected and
-                     reported by [Load_rules]. *)
-                  Path.Build.Map.set acc dir_target rule_loc
-                else
-                  (* This will be checked when we interpret the stanza
-                     completely, so just ignore this rule for now. *)
-                  acc)))
+       | true -> directory_targets)
+;;
+
+let extract_directory_targets ~dir stanzas =
+  Memo.parallel_map stanzas ~f:(fun stanza ->
+    match Stanza.repr stanza with
+    | Rule_conf.T rule -> directory_targets_of_rule ~dir rule
     | Coq_stanza.Theory.T m ->
       (* It's unfortunate that we need to pull in the coq rules here. But
          we don't have a generic mechanism for this yet. *)


### PR DESCRIPTION
If no directory targets are defined, then do not evaluate enabled_if

might fix the bug reported by @anmonteiro 

cc @gridbugs 