### PR TITLE
Fix gh10408

### DIFF
--- a/otherlibs/stdune/src/bin.ml
+++ b/otherlibs/stdune/src/bin.ml
@@ -1,7 +1,8 @@
 let path_sep = if Sys.win32 then ';' else ':'
+let parse ?(sep = path_sep) s = String.split s ~on:sep
 
 let parse_path ?(sep = path_sep) s =
-  String.split s ~on:sep
+  parse ~sep s
   |> List.filter_map ~f:(function
     | "" -> None
     | p -> Some (Path.of_filename_relative_to_initial_cwd p))

--- a/otherlibs/stdune/src/bin.mli
+++ b/otherlibs/stdune/src/bin.mli
@@ -5,8 +5,13 @@
 val path_sep : char
 
 (** Parse a [PATH] like variable *)
+val parse : ?sep:char -> string -> string list
+
+(** Parse a [PATH] like variable expecting each element to be a path *)
 val parse_path : ?sep:char -> string -> Path.t list
 
+(** Return a delimited string encoding of a list of strings, such as
+    is used by the [PATH] variable *)
 val encode_strings : string list -> string
 
 (** Add an entry to the contents of a [PATH] variable. *)

--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -31,8 +31,8 @@ type t =
 
 let equal t { vars; unix = _ } = Map.equal ~equal:String.equal t.vars vars
 let hash { vars; unix = _ } = Poly.hash vars
-let make vars = { vars; unix = None }
-let empty = make Map.empty
+let of_map vars = { vars; unix = None }
+let empty = of_map Map.empty
 let vars t = Var.Set.of_keys t.vars
 let get t k = Map.find t.vars k
 
@@ -62,12 +62,12 @@ let of_unix arr =
     | x :: _ -> x)
 ;;
 
-let initial = make (of_unix (Unix.environment ()))
-let of_unix u = make (of_unix u)
-let add t ~var ~value = make (Map.set t.vars var value)
+let initial = of_map (of_unix (Unix.environment ()))
+let of_unix u = of_map (of_unix u)
+let add t ~var ~value = of_map (Map.set t.vars var value)
 let mem t ~var = Map.mem t.vars var
-let remove t ~var = make (Map.remove t.vars var)
-let extend t ~vars = if Map.is_empty vars then t else make (Map.superpose vars t.vars)
+let remove t ~var = of_map (Map.remove t.vars var)
+let extend t ~vars = if Map.is_empty vars then t else of_map (Map.superpose vars t.vars)
 let extend_env x y = if Map.is_empty x.vars then y else extend x ~vars:y.vars
 
 let to_dyn t =
@@ -80,13 +80,13 @@ let diff x y =
     match vy with
     | Some _ -> None
     | None -> vx)
-  |> make
+  |> of_map
 ;;
 
-let update t ~var ~f = make (Map.update t.vars var ~f)
+let update t ~var ~f = of_map (Map.update t.vars var ~f)
 
 let of_string_map m =
-  make (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.set acc k v) m)
+  of_map (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.set acc k v) m)
 ;;
 
 let iter t = Map.iteri t.vars

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -45,4 +45,5 @@ val update : t -> var:Var.t -> f:(string option -> string option) -> t
 val to_dyn : t -> Dyn.t
 val of_string_map : string String.Map.t -> t
 val to_map : t -> string Map.t
+val of_map : string Map.t -> t
 val iter : t -> f:(string -> string -> unit) -> unit

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -39,7 +39,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/tmp/bin
+  PATH=/tmp/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ cat >dune.lock/test.pkg <<'EOF'
@@ -53,4 +53,4 @@ Try adding multiple paths to PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/bar/bin:/foo/bin:/tmp/bin
+  PATH=/bar/bin:/foo/bin:/tmp/bin:DUNE_PATH:/bin


### PR DESCRIPTION
When updating the PATH variable with the `withenv` action, dune would previously clobber the existing PATH from the environment rather than updating it. Withenv applies environment updates iteratively starting from some base environment. Prior to this change, the base environment did not include the global environment, so as far as withenv knew the PATH was originally empty. The fix is to start withenv with an environment which includes the global environment.

Fixes https://github.com/ocaml/dune/issues/10408