### PR TITLE
Add more test updating PATH with withenv

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -6,8 +6,17 @@ using the withenv action.
 This path is system-specific so we need to be able to remove it from the output.
   $ DUNE_PATH=$(dirname $(which dune))
 
-Printing out PATH without setting it:
   $ make_lockdir
+
+Make some packages so that the test package can have dependencies:
+  $ cat >dune.lock/hello1.pkg <<'EOF'
+  > (version 0.0.1)
+  > EOF
+  $ cat >dune.lock/hello2.pkg <<'EOF'
+  > (version 0.0.1)
+  > EOF
+
+Printing out PATH without setting it:
   $ cat >dune.lock/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
@@ -54,3 +63,55 @@ Try adding multiple paths to PATH:
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
   PATH=/bar/bin:/foo/bin:/tmp/bin:DUNE_PATH:/bin
+
+Printing out PATH without setting it when the package has a dependency:
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (version 0.0.1)
+  > (depends hello1 hello2)
+  > (build
+  >  (system "echo PATH=$PATH"))
+  > EOF
+  $ dune clean
+  $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
+  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
+
+Setting PATH to a specific value:
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (version 0.0.1)
+  > (depends hello1 hello2)
+  > (build
+  >  (withenv
+  >   ((= PATH /tmp/bin))
+  >   (system "echo PATH=$PATH")))
+  > EOF
+  $ dune clean
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
+  PATH=/tmp/bin
+
+Attempting to add a path to PATH replaces the entire PATH:
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (version 0.0.1)
+  > (depends hello1 hello2)
+  > (build
+  >  (withenv
+  >   ((+= PATH /tmp/bin))
+  >   (system "echo PATH=$PATH")))
+  > EOF
+  $ dune clean
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
+  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
+
+Try adding multiple paths to PATH:
+  $ cat >dune.lock/test.pkg <<'EOF'
+  > (version 0.0.1)
+  > (depends hello1 hello2)
+  > (build
+  >  (withenv
+  >   ((+= PATH /tmp/bin)
+  >    (+= PATH /foo/bin)
+  >    (+= PATH /bar/bin))
+  >   (system "echo PATH=$PATH")))
+  > EOF
+  $ dune clean
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
+  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin


### PR DESCRIPTION
This adds additional tests of updating PATH with the `withenv` action to check that it behaves as expected when a package's build environment includes PATH entries from its dependencies.

Expect some of the tests to fail until https://github.com/ocaml/dune/pull/10444/files is merged.