### PR TITLE
stop recording deps in Action_builder.contents

### DIFF
--- a/doc/changes/10446.md
+++ b/doc/changes/10446.md
@@ -1,0 +1,2 @@
+- Fix a bug where Coq projects were being rebuilt from scratch each time the
+  dependency graph changed. (#10446, fixes #10149, @alizter) 

--- a/src/dune_rules/action_builder.ml
+++ b/src/dune_rules/action_builder.ml
@@ -37,12 +37,7 @@ let paths ps = deps (Dep.Set.of_files ps)
 let path_set ps = deps (Dep.Set.of_files_set ps)
 let dyn_paths paths = dyn_deps (paths >>| fun (x, paths) -> x, Dep.Set.of_files paths)
 let dyn_paths_unit paths = dyn_deps (paths >>| fun paths -> (), Dep.Set.of_files paths)
-
-let contents p =
-  let* () = Dep.file p |> Dep.Set.singleton |> Build_system.record_deps in
-  of_memo (Build_system.read_file p)
-;;
-
+let contents p = of_memo (Build_system.read_file p)
 let lines_of p = contents p >>| String.split_lines
 
 let read_sexp p =

--- a/test/blackbox-tests/test-cases/coq/no-rebuild-on-dep-change.t
+++ b/test/blackbox-tests/test-cases/coq/no-rebuild-on-dep-change.t
@@ -11,8 +11,7 @@
 This test makes sure that a full rebuild is not triggered when the output of
 coqdep is changed.
 
-Currently this is the case and a bug:
+This is as expected:
   $ dune build --display=short
         coqdep .bug.theory.d
-          coqc root.{glob,vo}
           coqc leaf.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/no-rebuild-on-dep-change.t
+++ b/test/blackbox-tests/test-cases/coq/no-rebuild-on-dep-change.t
@@ -1,0 +1,18 @@
+  $ echo "(coq.theory (name bug) (mode vo))" > dune
+  $ echo "(lang dune 3.12)" > dune-project
+  $ echo "(using coq 0.8)" >> dune-project
+  $ touch root.v leaf.v
+  $ dune build
+  $ find _build -name "*.vo" | sort
+  _build/default/leaf.vo
+  _build/default/root.vo
+  $ echo "Require Import bug.root." >> leaf.v
+
+This test makes sure that a full rebuild is not triggered when the output of
+coqdep is changed.
+
+Currently this is the case and a bug:
+  $ dune build --display=short
+        coqdep .bug.theory.d
+          coqc root.{glob,vo}
+          coqc leaf.{glob,vo}


### PR DESCRIPTION
PR https://github.com/ocaml/dune/pull/9552 changed the semantics of `Action_builder.contents` so that it records a dependency. The Coq rules were relying on the previous behaviour of not recording a dependency in order to generate a build plan. This caused issue https://github.com/ocaml/dune/issues/10149 to appear.

This PR fixes https://github.com/ocaml/dune/issues/10149 by removing the dependency being recorded in `Action_builder.contents` matching the previous semantics.

cc @rgrinberg 

Here is the semantic change in #9552 
https://github.com/ocaml/dune/pull/9552/files#r1573098164

- [x] changelog