### PR TITLE
Handle non-existing file in print_diff

### DIFF
--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -68,6 +68,7 @@ module File = struct
 
   let do_promote ~correction_file ~dst =
     Path.Source.unlink_no_err dst;
+    Path.mkdir_p (Path.source (Path.Source.parent_exn dst));
     let chmod = Path.Permissions.add Path.Permissions.write in
     Io.copy_file ~chmod ~src:correction_file ~dst:(Path.source dst) ()
   ;;

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -205,12 +205,35 @@ let prepare ~skip_trailing_cr annots path1 path2 =
                      normal_diff ()))
 ;;
 
+let print_aux ~skip_trailing_cr annot path1 path2 =
+  match (Path.Untracked.exists path1, Path.Untracked.exists path2) with
+  | true, true -> prepare ~skip_trailing_cr annot path1 path2
+  | false, false ->
+    let loc = Loc.in_file path1 in
+    User_error.raise ~loc
+      [ Pp.textf "Files %s and %s doesn't exists."
+          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path1))
+          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path2))
+      ]
+  | e1, _ ->
+    Printf.printf "%s--- %s\n+++ %s\n%s"
+      Ansi_color.Style.(escape_sequence [ `Bg_green ])
+      (Path.to_string path1) (Path.to_string path2)
+      Ansi_color.Style.(escape_sequence [ `Bg_blue ]);
+    let print_prefix pre path =
+      List.iter ~f:(Printf.printf "%s%s" pre) (Io.lines_of_file path)
+    in
+    if e1 then print_prefix "-" path1 else print_prefix "+" path2;
+    Printf.printf "%s" (Ansi_color.Style.escape_sequence []);
+    let loc = Loc.in_file path1 in
+    User_error.raise ~loc []
+
 let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
-  let p = prepare ~skip_trailing_cr annots path1 path2 in
+  let p = print_aux ~skip_trailing_cr annots path1 path2 in
   With_fallback.exec p
 ;;
 
 let get ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
-  let p = prepare ~skip_trailing_cr annots path1 path2 in
+  let p = print_aux ~skip_trailing_cr annots path1 path2 in
   With_fallback.capture p
 ;;

--- a/test/blackbox-tests/test-cases/promote/non-existent.t/dune
+++ b/test/blackbox-tests/test-cases/promote/non-existent.t/dune
@@ -3,3 +3,7 @@
 (rule
  (alias blah-non-existent)
  (action (diff x-non-existent x.gen)))
+
+(rule
+ (alias blah-non-existent-in-sub-dir)
+ (action (diff subdir/x-non-existent-in-sub-dir x.gen)))

--- a/test/blackbox-tests/test-cases/promote/non-existent.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent.t/run.t
@@ -7,12 +7,29 @@ Tests for promoting with non existent reference
   [1]
 
   $ dune build @blah-non-existent
-  File "x-non-existent", line 1, characters 0-0:
-  Error: Files _build/default/x-non-existent and _build/default/x.gen differ.
+  File "_build/default/x-non-existent", line 1, characters 0-0:
+  Error:
+  --- _build/default/x-non-existent
+  +++ _build/default/x.gen
+  +toto
   [1]
 
   $ dune promote
   Promoting _build/default/x.gen to x-non-existent.
 
   $ cat x-non-existent
+  toto
+
+  $ dune build @blah-non-existent-in-sub-dir
+  File "_build/default/subdir/x-non-existent-in-sub-dir", line 1, characters 0-0:
+  Error:
+  --- _build/default/subdir/x-non-existent-in-sub-dir
+  +++ _build/default/x.gen
+  +toto
+  [1]
+
+  $ dune promote
+  Promoting _build/default/x.gen to subdir/x-non-existent-in-sub-dir.
+
+  $ cat subdir/x-non-existent-in-sub-dir
   toto


### PR DESCRIPTION
This PR is a revival of #4182 which was closed for inactivity.
### Description
Diff command don't like when one of the file does not exist. The solution implemented is for dune to print the diff when one of the files doesn't exists.

### To discuss
As I said this is just a copy/paste of the previous PR which was waiting for few changes from [this comment](https://github.com/ocaml/dune/pull/4182#issuecomment-780421630) :
- I'm not sure to understand what to do with the first point.
- I created a `Path.t` for `/dev/null` using `let dev_null = Path.external_ @@ Path.External.of_string Filename.null in` but this produces an error, compared to the current implementation :
```diff
-  File "_build/default/subdir/x-non-existent-in-sub-dir", line 1, characters 0-0:
-  Error:
-  --- _build/default/subdir/x-non-existent-in-sub-dir
-  +++ _build/default/x.gen
-  +toto
+  File "/dev/null", line 1, characters 0-0:
+  Error: Files /dev/null and _build/default/x.gen differ.
+  -> required by alias blah-non-existent-in-sub-dir in dune:7
```

So if you can answer / help / give some feedback, do not hesitate !
Thanks