### PR TITLE
Clarify some env handling for pkg rules

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -109,10 +109,10 @@ We currently have the following issues:
   > append_without_leading_sep="foo:bar" \
   > append_with_leading_sep="foo:bar" \
   > build_pkg deps-on-with-setenv-2
-  Hello from the second package!
-  Prepended 2nd time without trailing sep:Prepended without trailing sep
-  Prepended 2nd time with sep:Prepended with trailing sep
-  Appended without leading sep:Appended 2nd time without leading sep
-  Appended with leading sep:Appended 2nd time with leading sep
+  Hello from the other package!
+  Prepended without trailing sep:Prepended 2nd time without trailing sep
+  Prepended with trailing sep:Prepended 2nd time with sep
+  Appended 2nd time without leading sep:Appended without leading sep
+  Appended 2nd time with leading sep:Appended with leading sep
 
 

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -73,7 +73,7 @@ Printing out PATH without setting it when the package has a dependency:
   > EOF
   $ dune clean
   $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
+  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
   $ cat >dune.lock/test.pkg <<'EOF'
@@ -99,7 +99,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
+  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ cat >dune.lock/test.pkg <<'EOF'
@@ -114,4 +114,4 @@ Try adding multiple paths to PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
+  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin


### PR DESCRIPTION
The logic for handling environments used when building packages is complicated. This change breaks it up into smaller functions, simplifies some of the logic, and adds some comments explaining what each one does.

A consequence of this change is that the order in which the bin directories of dependencies appear in the PATH variable while building a package is the same as the order in which the dependencies appear in the package's lockfile (previously the order was reversed).

---

This mostly consists of notes I made for myself and experimental changes I made to help me understand how this logic works. I think it's worth checking it in to help the next person better understand this code.