### PR TITLE
test: fixes to version-corruption.t

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -129,7 +129,12 @@
 
 (cram
  (applies_to version-corruption)
- (deps %{bin:git} %{bin:chmod}))
+ (deps %{bin:git} %{bin:chmod})
+ (enabled_if
+  ; code signing moves placeholders in the binary
+  (or
+   (<> %{system} macosx)
+   (<> %{architecture} arm64))))
 
 (cram
  (applies_to corrupt-persistent)

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -129,7 +129,7 @@
 
 (cram
  (applies_to version-corruption)
- (deps %{bin:od} %{bin:git} %{bin:cmp} %{bin:sed} %{bin:chmod}))
+ (deps %{bin:git} %{bin:chmod}))
 
 (cram
  (applies_to corrupt-persistent)


### PR DESCRIPTION
- refactor(test): rewrite compare.sh in ocaml. This removes the external dependencies and makes intent clearer. The count changes because it was counting the numbers of characters differing in the hexdump instead of a byte count.
- fix(test): disable version-corruption.t on mac. When codesigning triggers, the binary layout is completely changed to it's not meaningful to count the number of changed bytes.
