### PR TITLE
test: show crash when defining a context named "install"

### DIFF
--- a/test/blackbox-tests/test-cases/workspaces/custom-context-names.t
+++ b/test/blackbox-tests/test-cases/workspaces/custom-context-names.t
@@ -1,0 +1,27 @@
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.13)
+  > (context default)
+  > (context
+  >  (default
+  >   (name log)))
+  > EOF
+
+  $ dune build
+  File "dune-workspace", line 5, characters 8-11:
+  5 |   (name log)))
+              ^^^
+  Error: "log" is an invalid context name.
+  [1]
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.13)
+  > (context default)
+  > (context
+  >  (default
+  >   (name install)))
+  > EOF
+  $ dune build 2>&1 | grep "must not crash"
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+
+


### PR DESCRIPTION
There's a special `Install.Context` module that tracks this context. 

`log` is already forbidden as a name in `Context_name.of_string_opt`, but "install" is a bit of a special case.