### PR TITLE
pkg: Undo change reversing order of env updates

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -330,14 +330,12 @@ module Pkg = struct
   (* Given a list of packages, construct an env containing variables
      set by each package. Variables containing delimited lists of
      paths (e.g. PATH) which appear in multiple package's envs are
-     concatenated in the order of their associated packages in the
-     input list. Environment updates via the `exported_env` field
+     concatenated in the reverse order of their associated packages in
+     the input list. Environment updates via the `exported_env` field
      (equivalent to opam's `setenv` field) are applied for each
-     package in reverse order to the argument list so that packages
-     appearing earlier can overwrite the values of variables set by
-     packages appearing later. *)
+     package in the same order as the argument list. *)
   let build_env_of_deps ts =
-    List.fold_left (List.rev ts) ~init:Env.Map.empty ~f:(fun env t ->
+    List.fold_left ts ~init:Env.Map.empty ~f:(fun env t ->
       let env =
         let roots = Paths.install_roots t.paths in
         let init = Value_list_env.add_path env Env_path.var roots.bin in

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -57,6 +57,14 @@ The exported env from the first package should be in the lock dir.
 When building the second package the exported env vars from the first package should be
 available and all the env updates should be applied correctly.
 
+The output of opam when building the equivalent package is:
+
+Hello from the other package!
+Prepended without trailing sep
+Prepended with trailing sep:
+Appended without leading sep
+:Appended with leading sep
+
   $ EXPORTED_ENV_VAR="I have not been exported yet." \
   > prepend_without_trailing_sep="foo:bar" \
   > prepend_with_trailing_sep="foo:bar" \
@@ -102,6 +110,15 @@ We can now observe how the environment updates are applied a second time.
 We currently have the following issues:
 - The leading and trailing separators are missing.
 - The initial environment is missing.
+- The order of applying environment updates is different from opam's.
+
+The output of opam when building the equivalent package is:
+
+Hello from the other package!
+Prepended without trailing sep:Prepended 2nd time without trailing sep
+Prepended with trailing sep:Prepended 2nd time with sep:
+Appended 2nd time without leading sep:Appended without leading sep
+:Appended 2nd time with leading sep:Appended with leading sep
 
   $ EXPORTED_ENV_VAR="I have not been exported yet." \
   > prepend_without_trailing_sep="foo:bar" \
@@ -109,10 +126,10 @@ We currently have the following issues:
   > append_without_leading_sep="foo:bar" \
   > append_with_leading_sep="foo:bar" \
   > build_pkg deps-on-with-setenv-2
-  Hello from the other package!
-  Prepended without trailing sep:Prepended 2nd time without trailing sep
-  Prepended with trailing sep:Prepended 2nd time with sep
-  Appended 2nd time without leading sep:Appended without leading sep
-  Appended 2nd time with leading sep:Appended with leading sep
+  Hello from the second package!
+  Prepended 2nd time without trailing sep:Prepended without trailing sep
+  Prepended 2nd time with sep:Prepended with trailing sep
+  Appended without leading sep:Appended 2nd time without leading sep
+  Appended with leading sep:Appended 2nd time with leading sep
 
 

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -73,7 +73,7 @@ Printing out PATH without setting it when the package has a dependency:
   > EOF
   $ dune clean
   $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin
+  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
   $ cat >dune.lock/test.pkg <<'EOF'
@@ -99,7 +99,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin
+  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ cat >dune.lock/test.pkg <<'EOF'
@@ -114,4 +114,4 @@ Try adding multiple paths to PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | sed -e "s#$DUNE_PATH#DUNE_PATH#"
-  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:DUNE_PATH:/bin
+  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin


### PR DESCRIPTION
In 3ea5444cd the order of env updates performed by packages was reversed. This brought the behaviour of dune closer to opam but introduced a regression which prevents ocamlfind from building with dune package management.

Here's an issue for tracking investigating why this change caused the regression: https://github.com/ocaml/dune/issues/10473

I'm proposing we merge this to revert to the old behaviour in the short term and then investigate why changing the order of updates caused the regression.