### PR TITLE
Download and use toolchain while building packages

### DIFF
--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -5,6 +5,14 @@ module Version : sig
   type t
 
   val all_by_string : (string * t) list
+  val of_package_version : Package_version.t -> t option
+
+  (** The path to the directory containing the binaries contained in
+      the compiler toolchain of a given version. Does not guarantee that
+      the specified toolchain is installed. *)
+  val bin_dir : t -> Path.Outside_build_dir.t
+
+  val is_installed : t -> bool
 end
 
 (** Downloads, builds, and installs a compiler toolchain of a given

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -143,6 +143,19 @@ let of_binaries ~path name env binaries =
   make name ~env ~get_ocaml_tool ~which
 ;;
 
+let of_toolchain_version version name env =
+  let module Toolchain = Dune_pkg.Toolchain in
+  let bin_dir = Toolchain.Version.bin_dir version in
+  let* () = Memo.of_reproducible_fiber (Toolchain.get ~log:`Install_only version) in
+  let which prog =
+    let path = Path.Outside_build_dir.relative bin_dir prog in
+    let+ exists = Fs_memo.file_exists path in
+    if exists then Some (Path.outside_build_dir path) else None
+  in
+  let get_ocaml_tool ~dir:_ prog = which prog in
+  make name ~which ~env ~get_ocaml_tool
+;;
+
 (* Seems wrong to support this at the level of the engine. This is easily
    implemented at the level of the rules and is noly needed for windows *)
 let register_response_file_support t =

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -26,6 +26,12 @@ val of_env_with_findlib
 
 val of_binaries : path:Path.t list -> Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
 
+val of_toolchain_version
+  :  Dune_pkg.Toolchain.Version.t
+  -> Context_name.t
+  -> Env.t
+  -> t Memo.t
+
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Ocaml.Mode.t -> Action.Prog.t
 


### PR DESCRIPTION
Download, build, and install the necessary toolchains when building packages that depend on versions of ocaml supported by the toolchains feature.