### PR TITLE
Use compiler toolchains when building packages

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -733,6 +733,9 @@ let solve_lock_dir
   ~pins:pinned_packages
   ~constraints
   =
+  (* Make sure that the solution contains a version of the compiler
+     that's compatible with dune toolchains. *)
+  let constraints = Toolchain.Compiler_package.constraint_ :: constraints in
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
   let context =

--- a/src/dune_pkg/toolchain.ml
+++ b/src/dune_pkg/toolchain.ml
@@ -20,14 +20,21 @@ end
 module Dir = struct
   let toolchain_base_dir () =
     let cache_dir =
-      Xdg.create ~env:Sys.getenv_opt () |> Xdg.cache_dir |> Path.of_string
+      Xdg.create ~env:Sys.getenv_opt ()
+      |> Xdg.cache_dir
+      |> Path.Outside_build_dir.of_string
     in
-    let path = Path.relative (Path.relative cache_dir "dune") "toolchains" in
-    if not (Path.exists path) then Path.mkdir_p path;
-    if not (Path.is_directory path)
-    then
-      User_error.raise
-        [ Pp.textf "Expected %s to be a directory but it is not." (Path.to_string path) ];
+    let path =
+      Path.Outside_build_dir.relative
+        (Path.Outside_build_dir.relative cache_dir "dune")
+        "toolchains"
+    in
+    (let path = Path.outside_build_dir path in
+     if not (Path.exists path) then Path.mkdir_p path;
+     if not (Path.is_directory path)
+     then
+       User_error.raise
+         [ Pp.textf "Expected %s to be a directory but it is not." (Path.to_string path) ]);
     path
   ;;
 end
@@ -38,21 +45,26 @@ module Version = struct
   let all = [ "4.14.2"; "5.1.1" ]
   let all_by_string = List.map all ~f:(fun t -> t, t)
   let to_string t = t
+  let of_string s = if List.exists all ~f:(String.equal s) then Some s else None
+  let of_package_version v = of_string (Package_version.to_string v)
 
   (* The path to a directory named after this version inside the
      toolchains directory. This directory will contain the source code
      and binary artifacts associated with a particular version of the
      compiler toolchain. *)
-  let toolchain_dir t = Path.relative (Dir.toolchain_base_dir ()) (to_string t)
-  let source_dir t = Path.relative (toolchain_dir t) "source"
-  let target_dir t = Path.relative (toolchain_dir t) "target"
+  let toolchain_dir t =
+    Path.Outside_build_dir.relative (Dir.toolchain_base_dir ()) (to_string t)
+  ;;
+
+  let source_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "source"
+  let target_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "target"
 
   (* A temporary directory within this version's toolchain directory
      where files will be installed before moving them into the target
      directory. This two stage installation means that we can
      guarantee that if the target directory exists then it contains
      the complete installation of the toolchain. *)
-  let tmp_install_dir t = Path.relative (toolchain_dir t) "_install"
+  let tmp_install_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "_install"
 
   (* When installing with the DESTDIR the full path from the root
      directory to the target directory is instantiated inside the
@@ -68,21 +80,22 @@ module Version = struct
          install dir. *)
       match
         String.drop_prefix
-          (Path.to_string target_dir)
+          (Path.Outside_build_dir.to_string target_dir)
           ~prefix:(Path.External.to_string Path.External.root)
       with
       | Some x -> x
       | None ->
         Code_error.raise
           "Expected target dir to start with root"
-          [ "target_dir", Path.to_dyn target_dir
+          [ "target_dir", Path.Outside_build_dir.to_dyn target_dir
           ; "root", Path.External.to_dyn Path.External.root
           ]
     in
-    Path.relative (tmp_install_dir t) target_dir_without_root_prefix
+    Path.Outside_build_dir.relative (tmp_install_dir t) target_dir_without_root_prefix
   ;;
 
-  let is_installed t = Path.exists (target_dir t)
+  let bin_dir t = Path.Outside_build_dir.relative (target_dir t) "bin"
+  let is_installed t = Path.exists (Path.outside_build_dir (target_dir t))
 end
 
 module Compiler_package = struct
@@ -147,7 +160,7 @@ let handle_unavailable { Compiler_package.version; url; _ } ~msg_opt =
 
 let fetch ({ Compiler_package.version; url; checksum } as t) =
   let open Fiber.O in
-  let source_dir = Version.source_dir version in
+  let source_dir = Path.outside_build_dir (Version.source_dir version) in
   Fpath.rm_rf (Path.to_string source_dir);
   Path.mkdir_p source_dir;
   let+ result =
@@ -175,15 +188,18 @@ let run_command ~dir prog args =
 ;;
 
 let configure version =
-  let source_dir = Version.source_dir version in
+  let source_dir = Path.outside_build_dir (Version.source_dir version) in
   let configure_script = Path.relative source_dir "configure" in
   let prefix = Version.target_dir version in
-  run_command ~dir:source_dir configure_script [ "--prefix"; Path.to_string prefix ]
+  run_command
+    ~dir:source_dir
+    configure_script
+    [ "--prefix"; Path.Outside_build_dir.to_string prefix ]
 ;;
 
 let make version args =
   let make = Lazy.force Make.path in
-  let source_dir = Version.source_dir version in
+  let source_dir = Path.outside_build_dir (Version.source_dir version) in
   run_command ~dir:source_dir make args
 ;;
 
@@ -200,14 +216,14 @@ let build version =
    installed. *)
 let install version =
   let open Fiber.O in
-  let dest_dir = Version.tmp_install_dir version in
-  let target_dir = Version.target_dir version in
+  let dest_dir = Path.outside_build_dir (Version.tmp_install_dir version) in
+  let target_dir = Path.outside_build_dir (Version.target_dir version) in
   Fpath.rm_rf (Path.to_string target_dir);
   Fpath.rm_rf (Path.to_string dest_dir);
   let+ () = make version [ "install"; sprintf "DESTDIR=%s" (Path.to_string dest_dir) ] in
   Path.rename
-    (Version.target_dir_within_tmp_install_dir version)
-    (Version.target_dir version);
+    (Path.outside_build_dir (Version.target_dir_within_tmp_install_dir version))
+    (Path.outside_build_dir (Version.target_dir version));
   Fpath.rm_rf (Path.to_string dest_dir)
 ;;
 
@@ -226,7 +242,7 @@ let get ~log version =
        @@ Pp.textf
             "Version %s of the compiler toolchain is already installed in %s"
             (Version.to_string version)
-            (Version.target_dir version |> Path.to_string)
+            (Version.target_dir version |> Path.Outside_build_dir.to_string)
      | _ -> ());
     Fiber.return ())
   else (
@@ -235,7 +251,7 @@ let get ~log version =
     @@ Pp.textf
          "Will install version %s of the compiler toolchain to %s"
          (Version.to_string version)
-         (Version.target_dir version |> Path.to_string);
+         (Version.target_dir version |> Path.Outside_build_dir.to_string);
     log_print Details @@ Pp.text "Downloading...";
     let* () = fetch compiler_package in
     log_print Details @@ Pp.text "Configuring...";
@@ -248,5 +264,5 @@ let get ~log version =
     @@ Pp.textf
          "Success! Compiler toolchain version %s installed to %s."
          (Version.to_string version)
-         (Version.target_dir version |> Path.to_string))
+         (Version.target_dir version |> Path.Outside_build_dir.to_string))
 ;;

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -5,6 +5,14 @@ module Version : sig
   type t
 
   val all_by_string : (string * t) list
+  val of_package_version : Package_version.t -> t option
+
+  (** The path to the directory containing the binaries contained in
+      the compiler toolchain of a given version. Does not guarantee that
+      the specified toolchain is installed. *)
+  val bin_dir : t -> Path.Outside_build_dir.t
+
+  val is_installed : t -> bool
 end
 
 (** Downloads, builds, and installs a compiler toolchain of a given

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -1,6 +1,19 @@
 open! Import
 open! Stdune
 
+module Compiler_package : sig
+  (** Names of packages that dune considers to be compiler
+      packages. These packages should not be downloaded or built when
+      using dune toolchains as the compiler from the toolchain should be
+      used instead. *)
+  val package_names : Package_name.t list
+
+  (** Constraint to apply to the dependency solver to guarantee a
+      solution that's includes a version of a compiler package that's
+      supported by dune toolchains. *)
+  val constraint_ : Package_dependency.t
+end
+
 module Version : sig
   type t
 

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -7,6 +7,10 @@ module Version : sig
   val all_by_string : (string * t) list
   val of_package_version : Package_version.t -> t option
 
+  (** The path to the directory containing both the source and binary
+      artifacts of this compiler version. *)
+  val toolchain_dir : t -> Path.Outside_build_dir.t
+
   (** The path to the directory containing the binaries contained in
       the compiler toolchain of a given version. Does not guarantee that
       the specified toolchain is installed. *)

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -143,6 +143,19 @@ let of_binaries ~path name env binaries =
   make name ~env ~get_ocaml_tool ~which
 ;;
 
+let of_toolchain_version version name env =
+  let module Toolchain = Dune_pkg.Toolchain in
+  let bin_dir = Toolchain.Version.bin_dir version in
+  let* () = Memo.of_reproducible_fiber (Toolchain.get ~log:`Install_only version) in
+  let which prog =
+    let path = Path.Outside_build_dir.relative bin_dir prog in
+    let+ exists = Fs_memo.file_exists path in
+    if exists then Some (Path.outside_build_dir path) else None
+  in
+  let get_ocaml_tool ~dir:_ prog = which prog in
+  make name ~which ~env ~get_ocaml_tool
+;;
+
 (* Seems wrong to support this at the level of the engine. This is easily
    implemented at the level of the rules and is noly needed for windows *)
 let register_response_file_support t =

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -26,6 +26,12 @@ val of_env_with_findlib
 
 val of_binaries : path:Path.t list -> Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
 
+val of_toolchain_version
+  :  Dune_pkg.Toolchain.Version.t
+  -> Context_name.t
+  -> Env.t
+  -> t Memo.t
+
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Ocaml.Mode.t -> Action.Prog.t
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -348,19 +348,10 @@ module Pkg = struct
       List.fold_left t.exported_env ~init:env ~f:Env_update.set)
   ;;
 
-  let name_is_compiler =
-    let module Package_name = Dune_pkg.Package_name in
-    let compiler_package_names =
-      (* TODO: use package metadata to determine whether a package
-         contains the compiler *)
-      lazy
-        (Package_name.Set.of_list
-           [ Package_name.of_string "ocaml-base-compiler"
-           ; Package_name.of_string "ocaml-system"
-           ; Package_name.of_string "ocaml-variants"
-           ])
-    in
-    fun name -> Package_name.Set.mem (Lazy.force compiler_package_names) name
+  let name_is_compiler name =
+    List.exists
+      ~f:(Dune_pkg.Package_name.equal name)
+      Dune_pkg.Toolchain.Compiler_package.package_names
   ;;
 
   let is_compiler t = name_is_compiler t.info.name


### PR DESCRIPTION
After this change dune will use compiler toolchains when building packages rather than using a compiler from an opam package or the system. This allows dune to build projects on systems where ocaml is not installed, and avoids the relocation issues affecting the compiler package. If the necessary toolchain to build a project is not installed, dune will download, build, and install it before proceeding to build the project.