### PR TITLE
ci: add an action to build binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,34 @@
+name: Binaries
+
+on:
+  workflow_dispatch:
+
+jobs:
+  binary:
+    name: Create
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-13
+            name: mac-intel
+          - os: macos-14
+            name: mac-arm
+          - os: ubuntu-22.04
+            name: linux-intel
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v22
+      - run: nix build
+      - uses: actions/upload-artifact@v4
+        with:
+          path: result/bin/dune
+          name: dune-${{ matrix.name }}
+  combine:
+    runs-on: ubuntu-latest
+    needs: binary
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          separate-directories: true


### PR DESCRIPTION
This adds a manual workflow to get binaries for:

- linux (intel)
- mac (intel)
- mac (arm)

In addition, a combined zip is available.