### PR TITLE
ci: run build on macOS x86_64 again

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,6 +44,10 @@ jobs:
           - ocaml-compiler: 5.1.x
             os: macos-latest
             skip_test: true
+          # macOS x86_64 (Intel)
+          - ocaml-compiler: 4.14.x
+            os: macos-13
+            skip_test: true
           # OCaml 4:
           - ocaml-compiler: 4.13.x
             os: ubuntu-latest


### PR DESCRIPTION
- macOS runners in GitHub Actions were upgraded to M1 macs (they migrated the `macos-latest` label)
- https://github.com/ocaml/dune/pull/10468 adapted the test suite to m1 macs, but we're not running tests on macOS x86 anymore