### PR TITLE
ci: bump the OCaml trunk version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
           - 4.14.x
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.2.0+trunk
+          - ocaml-compiler: ocaml-variants.5.3.0+trunk
             os: ubuntu-latest
             skip_test: true
           # OCaml 5:


### PR DESCRIPTION
these were added in https://github.com/ocaml/opam-repository/pull/24986