### PR TITLE
Doc inclusion for `x-experimental-toolchain`

### DIFF
--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -296,3 +296,12 @@
  (package dune)
  (files   dune-utop.1))
 
+(rule
+ (with-stdout-to dune-x-experimental-toolchain.1
+  (run dune x-experimental-toolchain --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-x-experimental-toolchain.1))
+


### PR DESCRIPTION
When running the build, this include file is updated with the new `toolchains` command. Include it in the tree.