### PR TITLE
Automatically lock on `build` if there is no lock dir

### DIFF
--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -1,4 +1,10 @@
 open Import
 
+(** creates a lock file at the specified location(s) *)
+val lock
+  :  version_preference:Dune_pkg.Version_preference.t option
+  -> lock_dirs_arg:Pkg_common.Lock_dirs_arg.t
+  -> unit Fiber.t
+
 (** Command to create lock directory *)
 val command : unit Cmd.t

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -136,6 +136,8 @@ module Lock_dirs_arg = struct
        All)
   ;;
 
+  let of_path p = Selected [ p ]
+
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
     let workspace_lock_dirs =
       Lock_dir.default_path

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -62,6 +62,10 @@ module Lock_dirs_arg : sig
         of the workspace are considered. *)
   val term : t Term.t
 
+  (** [Lock_dirs_arg.of_path] creates a specific lock dir argument out of a
+      source path *)
+  val of_path : Path.Source.t -> t
+
   (** [Lock_dirs_arg.lock_dirs_of_workspace t workspace] returns the list of
       lock directories that should be considered for various operations.
 


### PR DESCRIPTION
This is more of an exploration of the toolchains work as it would automatically lock whenever any user that does not yet have a lock file calls `dune build`.

For an inclusion in the main dune this would need to be configurable on... something. The right criterion is up for discussion.