### PR TITLE
Fix partial-match warnings

### DIFF
--- a/vendor/opam/src/format/opamTypes.mli
+++ b/vendor/opam/src/format/opamTypes.mli
@@ -51,7 +51,6 @@ type std_path =
 (** Download result *)
 type 'a download =
   | Up_to_date of 'a
-  | Checksum_mismatch of OpamHash.t
   | Not_available of string option * string
   (** Arguments are respectively the short and long version of an error message.
       The usage is: the first argument is displayed on normal mode (nothing

--- a/vendor/opam/src/repository/opamHTTP.ml
+++ b/vendor/opam/src/repository/opamHTTP.ml
@@ -74,10 +74,6 @@ module B = struct
       (slog OpamUrl.to_string) remote_url;
     OpamProcess.Job.catch
       (fun e ->
-        match e with
-        | OpamDownload.Checksum_mismatch e -> 
-          Done (Checksum_mismatch e)
-        | _ ->
          OpamStd.Exn.fatal e;
          let s,l =
            let str = Printf.sprintf "%s (%s)" (OpamUrl.to_string remote_url) in


### PR DESCRIPTION
With this change, dune can now be compiled with `OCAMLPARAM=warn-error=+8,_` again.
Alternative to https://github.com/ocaml/dune/pull/10224

@rgrinberg was that what you were thinking of?