### PR TITLE
refactor(pkg): keep the files dir in dune_pkg

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -31,6 +31,7 @@ module Pkg : sig
 
   val equal : t -> t -> bool
   val decode : (lock_dir:Path.Source.t -> Package_name.t -> t) Decoder.t
+  val files_dir : Package_name.t -> lock_dir:Path.Source.t -> Path.Source.t
 end
 
 module Repositories : sig

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1099,10 +1099,7 @@ end = struct
         let+ lock_dir = Lock_dir.get_path ctx >>| Option.value_exn in
         Path.Build.append_source
           (Context_name.build_dir ctx)
-          (Path.Source.relative
-             lock_dir
-             (* TODO this should come from [Dune_pkg] *)
-             (sprintf "%s.files" (Package.Name.to_string info.name)))
+          (Dune_pkg.Lock_dir.Pkg.files_dir info.name ~lock_dir)
       in
       let id = Pkg.Id.gen () in
       let paths = Paths.make name ctx in


### PR DESCRIPTION
Since this directory is created along with the lock directory, we might as well keep the path there.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>