### PR TITLE
refactor(pkg): type safe fetch without checksum

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -323,3 +323,11 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
       | `http -> fetch_curl ~unpack ~checksum ~target url
       | _ -> fetch_others ~unpack ~checksum ~target url)
 ;;
+
+let fetch_without_checksum ~unpack ~target ~url =
+  fetch ~unpack ~checksum:None ~url ~target
+  >>| function
+  | Ok () -> Ok ()
+  | Error (Checksum_mismatch _) -> assert false
+  | Error (Unavailable message) -> Error message
+;;

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -7,17 +7,23 @@ type failure =
 (** [fetch ~checksum ~target url] will fetch [url] into [target]. It will verify
     the downloaded file against [checksum], unless it [checksum] is [None].
 
-    @raise Checksum_mismatch
-      When the downloaded file doesn't match the expected [checksum], this will
-      pass the actually computed checksum.
-    @raise Unavailable
-      When the file can't be retrieved, e.g. not available at the location. *)
+    return [Error (Checksum_mismatch _)] When the downloaded file doesn't match
+    the expected [checksum], this will pass the actually computed checksum.
+
+    return [Error (Unavailable _))] When the file can't be retrieved, e.g. not
+    available at the location. *)
 val fetch
   :  unpack:bool
   -> checksum:Checksum.t option
   -> target:Path.t
   -> url:Loc.t * OpamUrl.t
   -> (unit, failure) result Fiber.t
+
+val fetch_without_checksum
+  :  unpack:bool
+  -> target:Path.t
+  -> url:Loc.t * OpamUrl.t
+  -> (unit, User_message.t option) result Fiber.t
 
 val fetch_git
   :  Rev_store.t

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -50,12 +50,10 @@ let fetch_and_hash_archive_cached =
   fun (url_loc, url) ->
     let open Fiber.O in
     Single_run_file_cache.with_ cache ~key:(OpamUrl.to_string url) ~f:(fun target ->
-      Fetch.fetch ~unpack:false ~checksum:None ~target ~url:(url_loc, url))
+      Fetch.fetch_without_checksum ~unpack:false ~target ~url:(url_loc, url))
     >>| function
     | Ok target -> Some (Dune_digest.file target |> Checksum.of_dune_digest)
-    | Error (Checksum_mismatch _) ->
-      Code_error.raise "Checksum mismatch when no checksum was provided" []
-    | Error (Unavailable message_opt) ->
+    | Error message_opt ->
       let message =
         match message_opt with
         | Some message -> message


### PR DESCRIPTION
Introduce [Fetch.fetch_without_checksum]. This function should never return [Checksum_mismatch]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>