### PR TITLE
doc: js targets & the `@all` alias

### DIFF
--- a/doc/reference/aliases.rst
+++ b/doc/reference/aliases.rst
@@ -64,6 +64,11 @@ Some aliases are defined and managed by Dune itself.
 
 This alias corresponds to every known file target in a directory.
 
+Since version 2.0 of the dune language, JS targets of executables are no longer
+included in the `all` alias by default. To get back the old behavior of
+including the JS targets in `all`, one can add the ``js`` target to the
+executable's ``modes`` field.
+
 @check
 ^^^^^^
 


### PR DESCRIPTION
Describe that the `all` alias doesn't include js targets by default and what to do to get back the old behavior.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>