### PR TITLE
fix(pkg): tighten validation around url's

### DIFF
--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -32,9 +32,9 @@ let is_local t = String.equal t.transport "file"
 
 let local_or_git_only url loc =
   match (url : t).backend with
-  | `rsync -> `Path (Path.of_string url.path)
+  | `rsync when is_local url -> `Path (Path.of_string url.path)
   | `git -> `Git
-  | `http | `darcs | `hg ->
+  | `rsync | `http | `darcs | `hg ->
     User_error.raise
       ~loc
       ~hints:[ Pp.text "Specify either a file path or git repo via SSH/HTTPS" ]


### PR DESCRIPTION
we don't support rsync:// url's so there's no need to pretend we do.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>