### PR TITLE
fix(pkg): remove External_copy

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -569,7 +569,7 @@ let opam_package_to_lock_file_pkg
           (* opam discards the later checksums, so we only take the first one *)
           | checksum :: _ -> Some (Loc.none, Checksum.of_opam_hash checksum)
         in
-        Source.Fetch { Source.url; checksum } ))
+        { Source.url; checksum } ))
   in
   let info =
     let url = OpamFile.OPAM.url opam_file in
@@ -581,7 +581,7 @@ let opam_package_to_lock_file_pkg
           |> Option.map ~f:(fun hash -> Loc.none, Checksum.of_opam_hash hash)
         in
         let url = Loc.none, OpamFile.URL.url url in
-        Source.Fetch { url; checksum })
+        { Source.url; checksum })
     in
     let dev =
       Package_name.Set.mem pinned_package_names name

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -1,13 +1,9 @@
 open Import
 
-type fetch =
+type t =
   { url : Loc.t * OpamUrl.t
   ; checksum : (Loc.t * Checksum.t) option
   }
-
-type t =
-  | External_copy of Loc.t * Path.External.t
-  | Fetch of fetch
 
 val equal : t -> t -> bool
 val decode : (Path.External.t -> t) Dune_sexp.Decoder.t
@@ -15,3 +11,5 @@ val encode : t -> Dune_sexp.t
 val to_dyn : t -> Dyn.t
 val remove_locs : t -> t
 val compute_missing_checksum : t -> Package_name.t -> pinned:bool -> t Fiber.t
+val external_copy : Loc.t * Path.External.t -> t
+val kind : t -> [ `Directory_or_archive of Path.External.t | `Fetch ]

--- a/src/dune_rules/fetch_rules.mli
+++ b/src/dune_rules/fetch_rules.mli
@@ -8,8 +8,7 @@ val context : Build_context.t
 val fetch
   :  target:Path.Build.t
   -> [ `File | `Directory ]
-  -> Loc.t * OpamUrl.t
-  -> (Loc.t * Dune_pkg.Checksum.t) option
+  -> Dune_pkg.Source.t
   -> Action.Full.t With_targets.t
 
 val gen_rules

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -19,3 +19,7 @@ module Sys_vars : sig
 
   val poll : t
 end
+
+val source_kind
+  :  Dune_pkg.Source.t
+  -> [ `Local of [ `Directory | `File ] * Path.External.t | `Fetch ] Memo.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -314,10 +314,16 @@ module Pkg = struct
         in
         Path.Local.Set.union_all (acc :: dirs)
     in
-    match t.info.source with
+    (match t.info.source with
+     | None -> Memo.return None
+     | Some source ->
+       Lock_dir.source_kind source
+       >>| (function
+        | `Local (`File, _) | `Fetch -> None
+        | `Local (`Directory, root) -> Some root))
+    >>= function
     | None -> Memo.return Path.Local.Set.empty
-    | Some (External_copy (_, root)) -> loop root Path.Local.Set.empty Path.Local.root
-    | Some (Fetch _) -> assert false
+    | Some root -> loop root Path.Local.Set.empty Path.Local.root
   ;;
 
   let dep t = Dep.file (Path.build t.paths.target_dir)
@@ -1482,32 +1488,37 @@ let source_rules (pkg : Pkg.t) =
   let+ source_deps, copy_rules =
     match pkg.info.source with
     | None -> Memo.return (Dep.Set.empty, [])
-    | Some (Fetch { url = (loc, _) as url; checksum }) ->
-      let fetch =
-        Fetch_rules.fetch ~target:pkg.paths.source_dir `Directory url checksum
-      in
-      Memo.return (Dep.Set.of_files [ Path.build pkg.paths.source_dir ], [ loc, fetch ])
-    | Some (External_copy (loc, source_root)) ->
-      let+ source_files, rules =
-        let source_root = Path.external_ source_root in
-        Pkg.source_files pkg ~loc
-        >>| Path.Local.Set.fold ~init:([], []) ~f:(fun file (source_files, rules) ->
-          let src = Path.append_local source_root file in
-          let dst = Path.Build.append_local pkg.paths.source_dir file in
-          let copy = loc, Action_builder.copy ~src ~dst in
-          Path.build dst :: source_files, copy :: rules)
-      in
-      Dep.Set.of_files source_files, rules
+    | Some source ->
+      let loc = fst source.url in
+      Lock_dir.source_kind source
+      >>= (function
+       | `Local (`File, _) | `Fetch ->
+         let fetch = Fetch_rules.fetch ~target:pkg.paths.source_dir `Directory source in
+         Memo.return (Dep.Set.of_files [ Path.build pkg.paths.source_dir ], [ loc, fetch ])
+       | `Local (`Directory, source_root) ->
+         let+ source_files, rules =
+           let source_root = Path.external_ source_root in
+           Pkg.source_files pkg ~loc
+           >>| Path.Local.Set.fold ~init:([], []) ~f:(fun file (source_files, rules) ->
+             let src = Path.append_local source_root file in
+             let dst = Path.Build.append_local pkg.paths.source_dir file in
+             let copy = loc, Action_builder.copy ~src ~dst in
+             Path.build dst :: source_files, copy :: rules)
+         in
+         Dep.Set.of_files source_files, rules)
   in
   let extra_source_deps, extra_copy_rules =
-    List.map pkg.info.extra_sources ~f:(fun (local, fetch) ->
+    List.map pkg.info.extra_sources ~f:(fun (local, (fetch : Source.t)) ->
       let extra_source = Paths.extra_source pkg.paths local in
       let rule =
-        match (fetch : Source.t) with
-        | External_copy (loc, src) ->
+        let loc = fst fetch.url in
+        (* We assume that [fetch] is always a file. Would be good
+           to give a decent error message if it's not *)
+        match Source.kind fetch with
+        | `Directory_or_archive src ->
           loc, Action_builder.copy ~src:(Path.external_ src) ~dst:extra_source
-        | Fetch { url = (loc, _) as url; checksum } ->
-          let rule = Fetch_rules.fetch ~target:pkg.paths.source_dir `File url checksum in
+        | `Fetch ->
+          let rule = Fetch_rules.fetch ~target:pkg.paths.source_dir `File fetch in
           loc, rule
       in
       Path.build extra_source, rule)
@@ -1608,8 +1619,8 @@ module Gen_rules = Build_config.Gen_rules
 
 let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
   let name = User_error.ok_exn (Package.Name.of_string_user_error (Loc.none, pkg_name)) in
-  let* db = DB.get context in
-  let+ pkg =
+  let* pkg =
+    let* db = DB.get context in
     Resolve.resolve db context (Loc.none, name)
     >>| function
     | `Inside_lock_dir pkg -> pkg
@@ -1622,12 +1633,19 @@ let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
         ]
   in
   let paths = Paths.make name context in
-  let directory_targets =
-    let target_dir = paths.target_dir in
-    let map = Path.Build.Map.singleton target_dir Loc.none in
+  let+ directory_targets =
+    let map =
+      let target_dir = paths.target_dir in
+      Path.Build.Map.singleton target_dir Loc.none
+    in
     match pkg.info.source with
-    | Some (Fetch f) -> Path.Build.Map.add_exn map paths.source_dir (fst f.url)
-    | _ -> map
+    | None -> Memo.return map
+    | Some source ->
+      Lock_dir.source_kind source
+      >>| (function
+       | `Local (`Directory, _) -> map
+       | `Local (`File, _) | `Fetch ->
+         Path.Build.Map.add_exn map paths.source_dir (fst source.url))
   in
   let build_dir_only_sub_dirs =
     Gen_rules.Build_only_sub_dirs.singleton ~dir Subdir_set.empty

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -1,6 +1,6 @@
-This demonstrates an issue when pinning a non-opam package. After attempting to
-build the package, changes to the package are only picked up by dune after
-running `dune clean`, even if building the package failed.
+This demonstrates pinning a non-opam package and then modifying its sources.
+Whenever the sources are modified, dune should rebuild the package in the
+workspace where it's locked.
 
   $ . ../helpers.sh
 
@@ -35,7 +35,7 @@ Make a package "foo" whose build will fail after printing a message:
   Solution for dune.lock:
   - foo.dev
 
-Attempt to build the packgage the first time:
+Attempt to build the package the first time:
 (the error from make is grep'd out because it is not consistant across different systems)
   $ dune build 2>&1 | grep -v make
   echo aaa
@@ -50,16 +50,7 @@ Update the message that gets printed while building foo:
   > 	false
   > EOF
 
-The change to the package is ignored:
-  $ dune build 2>&1 | grep -v make
-  echo aaa
-  aaa
-  false
-  -> required by _build/_private/default/.pkg/foo/target/cookie
-
-  $ dune clean
-
-The change to the package is picked up now that we've run `dune clean`:
+The change to the package is picked up:
   $ dune build 2>&1 | grep -v make
   echo bbb
   bbb

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -16,9 +16,9 @@ Demonstrate what happens when we try to fetch from a source that doesn't exist:
 Local file system
   $ runtest "(copy \"$PWD/dummy\")" 2>&1 | sed "s#$(pwd)#PWD#" | sed '/ *^\^*$/d' | sed '\#^File "dune.lock/foo.pkg", line 2, characters#d'
   2 | (source (copy "PWD/dummy"))
-  Error: Unable to read
+  Error:
   PWD/dummy
-  opendir(PWD/dummy): No such file or directory
+  does not exist
 
 Git
   $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | sed "s#$(pwd)#PWD#"

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -208,7 +208,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     let pkg_a =
       let name = Package_name.of_string "a" in
       let extra_source : Source.t =
-        External_copy (Loc.none, Path.External.of_string "/tmp/a")
+        Source.external_copy (Loc.none, Path.External.of_string "/tmp/a")
       in
       ( name
       , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
@@ -230,10 +230,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
             ; extra_sources =
                 [ Path.Local.of_string "one", extra_source
                 ; ( Path.Local.of_string "two"
-                  , Fetch
-                      { url = Loc.none, OpamUrl.of_string "file://randomurl"
-                      ; checksum = None
-                      } )
+                  , { url = Loc.none, OpamUrl.of_string "file://randomurl"
+                    ; checksum = None
+                    } )
                 ]
             }
         ; exported_env =
@@ -256,15 +255,14 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               dev = true
             ; source =
                 Some
-                  (Fetch
-                     { url = Loc.none, OpamUrl.of_string "https://github.com/foo/b"
-                     ; checksum =
-                         Some
-                           ( Loc.none
-                           , Checksum.of_string
-                               "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
-                           )
-                     })
+                  { url = Loc.none, OpamUrl.of_string "https://github.com/foo/b"
+                  ; checksum =
+                      Some
+                        ( Loc.none
+                        , Checksum.of_string
+                            "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                        )
+                  }
             }
         } )
     in
@@ -279,10 +277,9 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
               dev = false
             ; source =
                 Some
-                  (Fetch
-                     { url = Loc.none, OpamUrl.of_string "https://github.com/foo/c"
-                     ; checksum = None
-                     })
+                  { url = Loc.none, OpamUrl.of_string "https://github.com/foo/c"
+                  ; checksum = None
+                  }
             }
         } )
     in
@@ -313,10 +310,10 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "a"
                   ; version = "0.1.0"
                   ; dev = false
-                  ; source = Some External_copy External "/tmp/a"
+                  ; source = Some { url = "file:///tmp/a"; checksum = None }
                   ; extra_sources =
-                      [ ("one", External_copy External "/tmp/a")
-                      ; ("two", Fetch "file://randomurl", None)
+                      [ ("one", { url = "file:///tmp/a"; checksum = None })
+                      ; ("two", { url = "file://randomurl"; checksum = None })
                       ]
                   }
               ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
@@ -331,10 +328,11 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   ; dev = true
                   ; source =
                       Some
-                        Fetch
-                          "https://github.com/foo/b",
-                          Some
-                            "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                        { url = "https://github.com/foo/b"
+                        ; checksum =
+                            Some
+                              "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                        }
                   ; extra_sources = []
                   }
               ; exported_env = []
@@ -350,7 +348,8 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "c"
                   ; version = "0.2"
                   ; dev = false
-                  ; source = Some Fetch "https://github.com/foo/c", None
+                  ; source =
+                      Some { url = "https://github.com/foo/c"; checksum = None }
                   ; extra_sources = []
                   }
               ; exported_env = []


### PR DESCRIPTION
Make it the same as file://. Both of these constructors mean the same thing, so let's keep one of them. This simplification also fixes dune reacting to changes made to pinned packages.

There's still some ugliness around the types. In particular, we should be more careful about where we expect the url to point to a file vs a directory.

Note that I still haven't yet removed the separate constructors in the frontend. That's going to conflict with some PR's I have, so I will do that later.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>