### PR TITLE
Make scheduler type mutable instead of containing fields with ref types

### DIFF
--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -71,10 +71,7 @@ let%expect_test "cancelling a build: effect on other fibers" =
           Scheduler.inject_memo_invalidation (Memo.Cell.invalidate cell ~reason:Unknown)
         in
         let* () = Scheduler.wait_for_build_input_change () in
-        let* res =
-          Fiber.collect_errors (fun () ->
-            Scheduler.with_job_slot (fun _ _ -> Fiber.return ()))
-        in
+        let* res = Fiber.collect_errors (fun () -> Fiber.return ()) in
         print_endline
           (match res with
            | Ok () -> "PASS: we can still run things outside the build"


### PR DESCRIPTION
For better or worse, the current state of the scheduler is that at any point in time, it has exactly one conceptual "current build". Putting the cancellation token inside a fiber-local variable means there could be more than one cancellation token flying around, which is misleading.

This patch does not preclude us from eventually making the scheduler and cancellation flow more build-agnostic, but until that happens, we I think this is a better state to be in.

@rgrinberg We have an analogous internal patch to this one, so this won't cause the scheduler to diverge more than it has already. I'll wait to merge the internal patch until you get the opportunity to object to this direction. 

From our in-person discussion, I think you were imagining we would the cancellation token would get taken out of the scheduler altogether in favor of being set in its won fiber-local var in all the places that care about it. I'm not against ultimately getting there, but I think it is a larger jump than this PR.