### PR TITLE
Remove code related to the --react-to-insignificant-changes flag

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -365,7 +365,6 @@ let () =
     Dune_engine.Clflags.display := Quiet;
     { Scheduler.Config.concurrency = 10
     ; stats = None
-    ; insignificant_changes = `React
     ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -8,7 +8,6 @@ let config =
   Dune_engine.Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
-  ; insignificant_changes = `React
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -193,7 +193,6 @@ module Scheduler = struct
       Dune_config.for_scheduler
         dune_config
         stats
-        ~insignificant_changes:`Ignore
         ~print_ctrl_c_warning:true
         ~watch_exclusions
     in
@@ -221,7 +220,6 @@ module Scheduler = struct
       Dune_config.for_scheduler
         dune_config
         stats
-        ~insignificant_changes:`Ignore
         ~print_ctrl_c_warning:true
         ~watch_exclusions
     in

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -282,7 +282,6 @@ let command =
       Dune_config.for_scheduler
         config
         stats
-        ~insignificant_changes:`Ignore
         ~print_ctrl_c_warning:true
         ~watch_exclusions:[]
     in

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -483,7 +483,6 @@ let term =
        config
        ~watch_exclusions:[]
        None
-       ~insignificant_changes:`React
        ~print_ctrl_c_warning:false)
     subst
 ;;

--- a/otherlibs/ocamlc-loc/test/ocamlc_loc_tests.ml
+++ b/otherlibs/ocamlc-loc/test/ocamlc_loc_tests.ml
@@ -307,7 +307,6 @@ File "test/expect-tests/timer_tests.ml", lines 6-10, characters 2-3:
  6 | ..{ Scheduler.Config.concurrency = 1
  7 |   ; display = { verbosity = Short; status_line = false }
  8 |   ; stats = None
- 9 |   ; insignificant_changes = `React
 10 |   }
 Error: Some record fields are undefined: signal_watcher
 |};

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -486,13 +486,7 @@ module Dune_config = struct
          loop commands))
   ;;
 
-  let for_scheduler
-    (t : t)
-    ~watch_exclusions
-    stats
-    ~insignificant_changes
-    ~print_ctrl_c_warning
-    =
+  let for_scheduler (t : t) ~watch_exclusions stats ~print_ctrl_c_warning =
     let concurrency =
       match t.concurrency with
       | Fixed i -> i
@@ -505,11 +499,6 @@ module Dune_config = struct
      := match t.display with
         | Tui -> Dune_engine.Display.Quiet
         | Simple { verbosity; _ } -> verbosity);
-    { Scheduler.Config.concurrency
-    ; stats
-    ; insignificant_changes
-    ; print_ctrl_c_warning
-    ; watch_exclusions
-    }
+    { Scheduler.Config.concurrency; stats; print_ctrl_c_warning; watch_exclusions }
   ;;
 end

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -102,15 +102,13 @@ module Dune_config : sig
   val hash : t -> int
   val equal : t -> t -> bool
 
-  (** [for_scheduler config ?watch_exclusions stats_opt ~insignificant_changes
-      ~signal_watcher]
+  (** [for_scheduler config ?watch_exclusions stats_opt ~signal_watcher]
       creates a configuration for a scheduler from the user-visible Dune
       [config]. *)
   val for_scheduler
     :  t
     -> watch_exclusions:string list
     -> Dune_stats.t option
-    -> insignificant_changes:[ `React | `Ignore ]
     -> print_ctrl_c_warning:bool
     -> Dune_engine.Scheduler.Config.t
 end

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -6,7 +6,6 @@ module Config : sig
   type t =
     { concurrency : int
     ; stats : Dune_stats.t option
-    ; insignificant_changes : [ `Ignore | `React ]
     ; print_ctrl_c_warning : bool
     ; watch_exclusions : string list
     }

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -91,7 +91,6 @@ let%expect_test "csexp server life cycle" =
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None
-    ; insignificant_changes = `React
     ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }

--- a/test/expect-tests/dune_async_io/async_io_tests.ml
+++ b/test/expect-tests/dune_async_io/async_io_tests.ml
@@ -6,7 +6,6 @@ open Dune_async_io
 let config =
   { Scheduler.Config.concurrency = 1
   ; stats = None
-  ; insignificant_changes = `Ignore
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -87,7 +87,6 @@ let test files (patch, patch_contents) =
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None
-    ; insignificant_changes = `Ignore
     ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -97,12 +97,7 @@ let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
 let run thunk =
   let on_event _config _event = () in
   let config : Scheduler.Config.t =
-    { concurrency = 1
-    ; stats = None
-    ; insignificant_changes = `Ignore
-    ; print_ctrl_c_warning = false
-    ; watch_exclusions = []
-    }
+    { concurrency = 1; stats = None; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
   Scheduler.Run.go config ~on_event thunk
 ;;

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -70,12 +70,7 @@ let download ?(reproducible = true) ~unpack ~port ~filename ~target ?checksum ()
 let run thunk =
   let on_event _config _event = () in
   let config : Scheduler.Config.t =
-    { concurrency = 1
-    ; stats = None
-    ; insignificant_changes = `Ignore
-    ; print_ctrl_c_warning = false
-    ; watch_exclusions = []
-    }
+    { concurrency = 1; stats = None; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
   Scheduler.Run.go config ~on_event thunk
 ;;

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -12,12 +12,7 @@ let () = Dune_tests_common.init ()
 let run thunk =
   let on_event _config _event = () in
   let config : Scheduler.Config.t =
-    { concurrency = 1
-    ; stats = None
-    ; insignificant_changes = `Ignore
-    ; print_ctrl_c_warning = false
-    ; watch_exclusions = []
-    }
+    { concurrency = 1; stats = None; print_ctrl_c_warning = false; watch_exclusions = [] }
   in
   Scheduler.Run.go config ~on_event thunk
 ;;

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -177,7 +177,6 @@ let config =
   Dune_engine.Clflags.display := Quiet;
   { Scheduler.Config.concurrency = 1
   ; stats = None
-  ; insignificant_changes = `React
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -26,7 +26,6 @@ let run =
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None
-    ; insignificant_changes = `React
     ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -7,7 +7,6 @@ let go =
     Clflags.display := Short;
     { Scheduler.Config.concurrency = 1
     ; stats = None
-    ; insignificant_changes = `React
     ; print_ctrl_c_warning = true
     ; watch_exclusions = []
     }

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -9,7 +9,6 @@ let default =
   Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
-  ; insignificant_changes = `React
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }
@@ -78,33 +77,6 @@ let%expect_test "cancelling a build: effect on other fibers" =
            | Error _ -> "FAIL: other fiber got cancelled");
         Scheduler.shutdown ()));
   [%expect {| PASS: we can still run things outside the build |}]
-;;
-
-let%expect_test "empty invalidation wakes up waiter" =
-  let test insignificant_changes =
-    go ~timeout:0.1 ~config:{ default with insignificant_changes }
-    @@ fun () ->
-    let await_invalidation () =
-      print_endline "awaiting invalidation";
-      let+ () = Scheduler.wait_for_build_input_change () in
-      print_endline "awaited invalidation"
-    in
-    Fiber.fork_and_join_unit
-      (fun () -> Scheduler.inject_memo_invalidation Memo.Invalidation.empty)
-      await_invalidation
-  in
-  test `React;
-  [%expect {|
-    awaiting invalidation
-    awaited invalidation |}];
-  test `Ignore;
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  ("shutdown: timeout")
-  Trailing output
-  ---------------
-  awaiting invalidation |}]
 ;;
 
 let%expect_test "raise inside Scheduler.Run.go" =

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -6,7 +6,6 @@ let config =
   Dune_engine.Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
-  ; insignificant_changes = `React
   ; print_ctrl_c_warning = false
   ; watch_exclusions = []
   }

--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -126,7 +126,6 @@ let run kind script =
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None
-    ; insignificant_changes = `React
     ; print_ctrl_c_warning = false
     ; watch_exclusions = []
     }


### PR DESCRIPTION
The flag has already been removed, so we should also remove the code related to it.

This PR is based off https://github.com/ocaml/dune/pull/10513 to avoid merge conflicts, but this can be changed if necessary.