### PR TITLE
pkg: don't use "compiler" flag to identify compiler

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -537,6 +537,17 @@ let available_depopts solver_env version_by_package_name (opam_package : OpamFil
         else None))
 ;;
 
+(* Heuristic to determine whether a package is an ocaml compiler *)
+let opam_file_is_compiler (opam_package : OpamFile.OPAM.t) =
+  (* Identify compiler packages by using the fact that all compiler
+     Packages declare conflicts with other compiler packages. note
+     that relying on the "compiler" flag to identify compiler packages
+     will not work, as compiler options packages (such as
+     ocaml-option-flambda) also have this flag. *)
+  let ocaml_core_compiler = OpamPackage.Name.of_string "ocaml-core-compiler" in
+  List.mem opam_package.conflict_class ocaml_core_compiler ~equal:OpamPackage.Name.equal
+;;
+
 let opam_package_to_lock_file_pkg
   solver_env
   stats_updater
@@ -676,11 +687,7 @@ let opam_package_to_lock_file_pkg
   let exported_env =
     OpamFile.OPAM.env opam_file |> List.map ~f:opam_env_update_to_env_update
   in
-  let kind =
-    if List.mem (OpamFile.OPAM.flags opam_file) ~equal:Poly.equal Pkgflag_Compiler
-    then `Compiler
-    else `Non_compiler
-  in
+  let kind = if opam_file_is_compiler opam_file then `Compiler else `Non_compiler in
   kind, { Lock_dir.Pkg.build_command; install_command; depends; info; exported_env }
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -3,10 +3,10 @@ The ocaml compiler needs to be marked inside the lock dir:
   $ . ./helpers.sh
   $ mkrepo
 
-To mark it, we use flags: compiler:
+To mark it, we use `conflict-class: "ocaml-core-compiler"`
 
   $ mkpkg foocaml <<EOF
-  > flags: compiler
+  > conflict-class: "ocaml-core-compiler"
   > EOF
 
   $ solve foocaml


### PR DESCRIPTION
Opam's "compiler" flag is used too broadly to accurately identify packages containing ocaml compilers. For example this flag is set for compiler options packages such as ocaml-option-flambda which configure the ocaml-variants package, effectively preventing the use of compiler options packages, as ocaml-variants also has the "compiler" flag set, and dune only permits a single compiler package in a solution.

This change fixes this problem by using the presence of the "ocaml-core-compiler" conflict class to identify compiler packages.