### PR TITLE
boot: add a --static option to build a static dune

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -17,6 +17,7 @@ let keep_generated_files =
     ; ( "--force-byte-compilation"
       , Arg.Unit ignore
       , " Force bytecode compilation even if ocamlopt is available" )
+    ; "--static", Arg.Unit ignore, " Build a static binary"
     ]
     anon
     "Usage: ocaml bootstrap.ml <options>\nOptions are:";

--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,7 @@
         ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
           dune_3 = osuper.dune_3.overrideAttrs (a: {
             src = ./.;
-            postPatch = ''
-              substituteInPlace \
-                boot/duneboot.ml \
-                --replace-fail \
-                '; link_flags' \
-                '; link_flags; ["-ccopt"; "-static"]'
-            '';
+            preBuild = "ocaml boot/bootstrap.ml --static";
           });
         });
       };


### PR DESCRIPTION
This options adds `-ccopt -static` to the link flags (this requires a libc that supports static linking).

The motivation is `nix build .#dune-static`, which otherwise requires patching sources.
