### PR TITLE
pkg: dedup package names in dependencies

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
+++ b/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
@@ -17,9 +17,7 @@ constraints.
   - a.0.0.1
   - foo.0.0.1
 
-Note that this is currently incorrect as the package "a" is duplicated
-in the "depends" field.
   $ cat dune.lock/foo.pkg
   (version 0.0.1)
   
-  (depends a a)
+  (depends a)


### PR DESCRIPTION
Fixes a bug where depending on a package with a constraint involving a conjunction would lead to the package appearing in the "depends" lockfile field multiple times.

Fixes https://github.com/ocaml/dune/issues/10542