### PR TITLE
Implicit relock if the dependencies have changed

### DIFF
--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -1,4 +1,10 @@
 open Import
 
+(** creates a lock file at the specified location(s) *)
+val lock
+  :  version_preference:Dune_pkg.Version_preference.t option
+  -> lock_dirs_arg:Pkg_common.Lock_dirs_arg.t
+  -> unit Fiber.t
+
 (** Command to create lock directory *)
 val command : unit Cmd.t

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -136,6 +136,8 @@ module Lock_dirs_arg = struct
        All)
   ;;
 
+  let of_path p = Selected [ p ]
+
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
     let workspace_lock_dirs =
       Lock_dir.default_path

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -62,6 +62,10 @@ module Lock_dirs_arg : sig
         of the workspace are considered. *)
   val term : t Term.t
 
+  (** [Lock_dirs_arg.of_path] creates a specific lock dir argument out of a
+      source path *)
+  val of_path : Path.Source.t -> t
+
   (** [Lock_dirs_arg.lock_dirs_of_workspace t workspace] returns the list of
       lock directories that should be considered for various operations.
 

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -5,6 +5,11 @@ open! Import
     solution for the local packages. *)
 type t
 
+val up_to_date
+  :  Local_package.t Package_name.Map.t
+  -> Lock_dir.t
+  -> [ `Valid | `Invalid of Local_package.Dependency_hash.t option ]
+
 val create
   :  Local_package.t Package_name.Map.t
   -> Lock_dir.t


### PR DESCRIPTION
If lockfiles exist *and* these are out of date, this PR runs the solver again to re-create the lock directory.

Obsoletes #10487 as this only does the automatic locking only if the user opted in by running `dune pkg lock` before.