### PR TITLE
fix: don't take build lock for `coq top --no-build`

### DIFF
--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -18,7 +18,7 @@ let man =
 let info = Cmd.info "top" ~doc ~man
 
 let term =
-  let+ builder = Common.Builder.term
+  let+ default_builder = Common.Builder.term
   and+ context =
     let doc = "Run the Coq toplevel in this build context." in
     Common.context_arg ~doc
@@ -34,7 +34,12 @@ let term =
       & flag
       & info [ "no-build" ] ~doc:"Don't rebuild dependencies before executing.")
   in
-  let common, config = Common.init builder in
+  let common, config =
+    let builder =
+      if no_rebuild then Common.Builder.forbid_builds default_builder else default_builder
+    in
+    Common.init builder
+  in
   let coq_file_arg = Common.prefix_target common coq_file_arg |> Path.Local.of_string in
   let coqtop, argv, env =
     Scheduler.go ~common ~config

--- a/doc/changes/10547.md
+++ b/doc/changes/10547.md
@@ -1,0 +1,2 @@
+- Don't try to take build lock when running `coq top --no-build` (#10547,
+  fixes #7671, @lzy0505)


### PR DESCRIPTION
This fixes #7671 where `dune coq top` tries to take the global build lock even if `--no-build` is enabled.

The problem was that `Common.Builder.term` had `allow_builds` set to `true` by default and didn't get updated when `--no-build` was specified. This led to the creation of an RPC server at initialization, which triggers the lock.

The fix was to update `allow_builds` to `false` with `Common.Builder.forbid_builds`.