### PR TITLE
fix(lib-collision): tolerate `public_name` collisions in different contexts

### DIFF
--- a/test/blackbox-tests/test-cases/enabled_if/eif-public-name-collision.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-public-name-collision.t
@@ -5,7 +5,6 @@ contexts
 
   $ cat > dune-workspace << EOF
   > (lang dune 3.13)
-  > 
   > (context default)
   > (context
   >  (default
@@ -18,14 +17,17 @@ contexts
 
   $ cat > a/dune << EOF
   > (library
-  >  (name libname)
+  >  (name foo)
   >  (public_name foo.lib)
   >  (enabled_if (= %{context_name} "default")))
+  > EOF
+  $ cat > a/foo.ml << EOF
+  > let x = "hello"
   > EOF
 
   $ cat > b/dune << EOF
   > (library
-  >  (name libname)
+  >  (name foo)
   >  (public_name foo.lib)
   >  (enabled_if (= %{context_name} "melange")))
   > EOF
@@ -33,13 +35,6 @@ contexts
 Without any consumers of the libraries
 
   $ dune build
-  File "b/dune", line 3, characters 14-21:
-  3 |  (public_name foo.lib)
-                    ^^^^^^^
-  Error: Public library foo.lib is defined twice:
-  - a/dune:3
-  - b/dune:3
-  [1]
 
 With some consumer
 
@@ -51,15 +46,9 @@ With some consumer
   > EOF
 
   $ cat > main.ml <<EOF
-  > let () = Foo.x
+  > let () = print_endline Foo.x
   > EOF
 
-  $ dune build
-  File "b/dune", line 3, characters 14-21:
-  3 |  (public_name foo.lib)
-                    ^^^^^^^
-  Error: Public library foo.lib is defined twice:
-  - a/dune:3
-  - b/dune:3
-  [1]
+  $ dune exec ./main.exe
+  hello
 

--- a/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-public-name.t
+++ b/test/blackbox-tests/test-cases/lib-collision/lib-collision-public-same-public-name.t
@@ -23,13 +23,6 @@ different folders.
 Without any consumers of the libraries
 
   $ dune build
-  File "b/dune", line 3, characters 14-21:
-  3 |  (public_name bar.foo))
-                    ^^^^^^^
-  Error: Public library bar.foo is defined twice:
-  - a/dune:3
-  - b/dune:3
-  [1]
 
 With some consumer
 
@@ -44,10 +37,11 @@ With some consumer
   > EOF
 
   $ dune build
-  File "b/dune", line 3, characters 14-21:
+  File "a/dune", lines 1-3, characters 0-44:
+  1 | (library
+  2 |  (name foo)
   3 |  (public_name bar.foo))
-                    ^^^^^^^
-  Error: Public library bar.foo is defined twice:
-  - a/dune:3
-  - b/dune:3
+  Error: Library with name "bar.foo" is already defined in b/dune:1. Either
+  change one of the names, or enable them conditionally using the 'enabled_if'
+  field.
   [1]


### PR DESCRIPTION
- fixes the test added in https://github.com/ocaml/dune/pull/10471
- we use the same strategy for public libraries that we use elsewhere in `scope.ml`: we store and `enabled` `Toggle.t Memo.t` that we evaluate when resolving a public library by its name.
