### PR TITLE
doc: remove outdated info about variants

### DIFF
--- a/doc/howto/index.rst
+++ b/doc/howto/index.rst
@@ -16,7 +16,7 @@ These guides will help you use Dune's features in your project.
    ../instrumentation
    ../jsoo
    ../melange
-   ../variants
+   ../virtual-libraries
    ../tests
    bundle
    toplevel

--- a/doc/reference/dune/external_variant.rst
+++ b/doc/reference/dune/external_variant.rst
@@ -1,4 +1,0 @@
-external_variant
------------------
-
-This stanza was experimental and removed in Dune 2.6. See :ref:`dune-variants`.

--- a/doc/reference/dune/index.rst
+++ b/doc/reference/dune/index.rst
@@ -78,5 +78,4 @@ The following pages describe the available stanzas and their meanings.
       :caption: Deprecated
       :maxdepth: 1
     
-      external_variant
       jbuild_version

--- a/doc/virtual-libraries.rst
+++ b/doc/virtual-libraries.rst
@@ -22,6 +22,13 @@ implementations. Executable using ``clock`` or libraries that use ``clock``
 would conditionally select one of the implementations, depending on the target
 platform.
 
+.. note::
+
+   This feature is sometimes informally called "variants". However, this term
+   refers to a related feature that has been removed in Dune 2.6 in favor of
+   default implementation, and the correct term for the mechanism as a whole is
+   "virtual libraries".
+
 Virtual Library
 ===============
 

--- a/doc/virtual-libraries.rst
+++ b/doc/virtual-libraries.rst
@@ -1,6 +1,6 @@
-****************************
-Virtual Libraries & Variants
-****************************
+*****************
+Virtual Libraries
+*****************
 
 .. TODO(diataxis) This is a guide, with reference info in it.
 
@@ -84,13 +84,6 @@ implementation for every virtual library that we've used:
      clock_unix ;; leaving this dependency will make dune loudly complain
      calendar))
 
-.. _dune-variants:
-
-Variants
-========
-
-Variants were an experimental feature that were removed in Dune 2.6.
-
 Default Implementation
 ======================
 
@@ -107,11 +100,6 @@ variant resolution if no suitable implementation has been found.
 The default implementation must live in the same package as the virtual
 library. In the example above, that would mean that the ``time-js`` and
 ``time`` libraries must be in the same package
-
-Before version 2.6, this feature was experimental and guarded under the
-``library_variants`` language. In 2.6, this feature was promoted to the stable
-Dune language, and all uses of ``(using library_variants)`` are forbidden since
-2.6.
 
 Limitations
 ===========


### PR DESCRIPTION
Some of our docs about virtual libraries mention "variants", which is a feature that doesn't exist anymore (since 2020).

This removes the history part and uses consistent naming.
