### PR TITLE
pkg: use our unpack code for rsync urls

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -296,6 +296,8 @@ let fetch_git rev_store ~target ~url:(url_loc, url) =
 ;;
 
 let fetch_local ~checksum ~target (url, url_loc) =
+  if not (OpamUrl.is_local url)
+  then Code_error.raise "fetch_local: url should be file://" [ "url", OpamUrl.to_dyn url ];
   let path =
     match OpamUrl.local_or_git_only url url_loc with
     | `Path p -> p
@@ -338,7 +340,11 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
         let* rev_store = Rev_store.get in
         fetch_git rev_store ~target ~url:(url_loc, url)
       | `http -> fetch_curl ~unpack ~checksum ~target url
-      | `rsync -> fetch_local ~checksum ~target (url, url_loc)
+      | `rsync ->
+        if not unpack
+        then
+          Code_error.raise "fetch_local: unpack is not set" [ "url", OpamUrl.to_dyn url ];
+        fetch_local ~checksum ~target (url, url_loc)
       | _ -> fetch_others ~unpack ~checksum ~target url)
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
+++ b/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
@@ -19,5 +19,5 @@ Make sure that we verify archives of local archives
   4 |   (checksum md5=069aa55d40e548280f92af693f6c625a)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Invalid checksum, got
-  md5=069aa55d40e548280f92af693f6c625a
+  md5=d41d8cd98f00b204e9800998ecf8427e
   [1]


### PR DESCRIPTION
This removes an important use of `fetch_others`.

(the test was printing the expected hash instead of the computed one)
