### PR TITLE
pkg: disable hg/darcs fetch code

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -117,72 +117,6 @@ module Curl = struct
   ;;
 end
 
-module Fiber_job = struct
-  let run (command : OpamProcess.command) =
-    let prefix = "dune-source-fetch" in
-    let stderr_file = Temp.create File ~prefix ~suffix:"stderr" in
-    let stderr_to = Process.Io.file stderr_file Out in
-    let stdout_file =
-      match command.cmd_stdout with
-      | None -> Temp.create File ~prefix ~suffix:"stdout"
-      | Some path -> path |> Path.External.of_string |> Path.external_
-    in
-    let stdout_to = Process.Io.file stdout_file Out in
-    let* times =
-      let prog = command.cmd |> Path.External.of_string |> Path.external_ in
-      let args = command.args in
-      let stdin_from =
-        match command.cmd_stdin with
-        | Some true -> Some Process.Io.stdin
-        | None | Some false -> None
-      in
-      let dir =
-        command.cmd_dir
-        |> Option.map ~f:(fun path ->
-          path |> Path.Outside_build_dir.of_string |> Path.outside_build_dir)
-      in
-      let env = command.cmd_env |> Option.map ~f:Env.of_unix in
-      Process.run_with_times
-        ~display:Quiet
-        ?dir
-        ?env
-        ?stdin_from
-        ~stderr_to
-        ~stdout_to
-        Strict
-        prog
-        args
-    in
-    let r_stdout = Io.lines_of_file stdout_file in
-    let r_stderr = Io.lines_of_file stderr_file in
-    Temp.destroy File stderr_file;
-    Temp.destroy File stdout_file;
-    (* Process.run_with_times forces Strict failure-mode, so the return code is 0 *)
-    let r_code = 0 in
-    let r_duration = times.elapsed_time in
-    Fiber.return
-      { OpamProcess.r_code
-      ; r_signal = None
-      ; r_duration
-      ; r_info = []
-      ; r_stdout
-      ; r_stderr
-      ; r_cleanup = []
-      }
-  ;;
-
-  let run =
-    let rec run1 = function
-      | OpamProcess.Job.Op.Done x -> Fiber.return x
-      | Run (cmd, cont) ->
-        let* r = run cmd in
-        let k = cont r in
-        run1 k
-    in
-    run1
-  ;;
-end
-
 type failure =
   | Checksum_mismatch of Checksum.t
   | Unavailable of User_message.t option
@@ -251,38 +185,6 @@ let fetch_curl ~unpack:unpack_flag ~checksum ~target (url : OpamUrl.t) =
          Error (Unavailable (Some exn))))
 ;;
 
-let fetch_others ~unpack ~checksum ~target (url : OpamUrl.t) =
-  (Fiber_job.run
-   @@
-   let hashes =
-     match checksum with
-     | None -> []
-     | Some checksum -> [ Checksum.to_opam_hash checksum ]
-   in
-   let path = Path.to_string target in
-   if OpamUrl.is_version_control url || unpack
-   then (
-     let dirname = OpamFilename.Dir.of_string path in
-     let open OpamProcess.Job.Op in
-     OpamRepository.pull_tree label dirname hashes [ url ]
-     @@| function
-     | Up_to_date _ -> OpamTypes.Up_to_date ()
-     | Checksum_mismatch e -> Checksum_mismatch e
-     | Result _ -> Result ()
-     | Not_available (a, b) -> Not_available (a, b))
-   else (
-     let fname = OpamFilename.of_string path in
-     OpamRepository.pull_file label fname hashes [ url ]))
-  >>| function
-  | Up_to_date () | Result () -> Ok ()
-  | Not_available (None, _verbose) -> Error (Unavailable None)
-  | Not_available (Some normal, verbose) ->
-    let msg = User_message.make [ Pp.text normal; Pp.text verbose ] in
-    Error (Unavailable (Some msg))
-  | Checksum_mismatch expected ->
-    Error (Checksum_mismatch (Checksum.of_opam_hash expected))
-;;
-
 let fetch_git rev_store ~target ~url:(url_loc, url) =
   OpamUrl.resolve url ~loc:url_loc rev_store
   >>= (function
@@ -330,6 +232,9 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
                   ("checksum", `String (Checksum.to_string checksum)) :: args))
         }))
   in
+  let unsupported_backend s =
+    User_error.raise ~loc:url_loc [ Pp.textf "Unsupported backend: %s" s ]
+  in
   Fiber.finalize
     ~finally:(fun () ->
       Dune_stats.finish event;
@@ -345,7 +250,8 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
         then
           Code_error.raise "fetch_local: unpack is not set" [ "url", OpamUrl.to_dyn url ];
         fetch_local ~checksum ~target (url, url_loc)
-      | _ -> fetch_others ~unpack ~checksum ~target url)
+      | `hg -> unsupported_backend "mercurial"
+      | `darcs -> unsupported_backend "darcs")
 ;;
 
 let fetch_without_checksum ~unpack ~target ~url =


### PR DESCRIPTION
This marks hg and darcs backends as unsupported, and removes the code path that uses opam libs to download sources.
