### PR TITLE
Reproduction case to show that installing deps to the stdlib breaks

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
@@ -1,0 +1,61 @@
+A package that installs itself into the ocaml stdlib should work.
+
+  $ . ./helpers.sh
+
+  $ mkdir nondune
+  $ cd nondune
+  $ cat > nondune.ml <<EOF
+  > let main () = print_endline "Nondune"
+  > let () = main ()
+  > EOF
+  $ ocamlc -c nondune.ml
+  $ ocamlc -o nondune.cma -a nondune.cmo
+  $ cat > nondune.install <<EOF
+  > lib_root: [
+  >   "nondune.cma" {"ocaml/nondune.cma"}
+  >   "nondune.cmi" {"ocaml/nondune.cmi"}
+  > ]
+  > lib: [
+  >   "META" {"META"}
+  > ]
+  > EOF
+  $ cat > META <<EOF
+  > directory = "^"
+  > archive(byte) = "nondune.cma"
+  > EOF
+  $ cat > nondune.opam <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >  [true]
+  > ]
+  > EOF
+  $ cd ..
+
+With this project set up, lets depend on it.
+
+  $ mkdir foo
+  $ cd foo
+  $ mkrepo
+  $ solve_project <<EOF
+  > (lang dune 3.15)
+  > (pin
+  >  (url "file://$PWD/../nondune")
+  >  (package (name nondune)))
+  > (package
+  >  (name foo)
+  >  (depends nondune))
+  > EOF
+  Solution for dune.lock:
+  - nondune.dev
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (modules foo)
+  >  (libraries nondune)
+  >  (modes byte))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let () = Nondune.main ()
+  > EOF
+  $ dune exec ./foo.exe 2>&1 | grep -o "Unbound module Nondune"
+  Unbound module Nondune


### PR DESCRIPTION
When a package specifies in its `META` file that its artifacts are installed into `^` (or `+`) thus the stdlib and its `.install` file then installs it into `$lib_root/ocaml/...` this does not yield a `-I` flag when compiling (as normally the stdlib is implied).

This works on compilers in OPAM switches, but if the package is installed in `_build` as part of dune-pkg, then the package files are installed into `$pkg_lib_root/ocaml/...` but running `ocamlc` does not pick up the path.

This attempts to reproduce the issue, however the actual issue with `num` looks a bit different as `ocamlc` fails to locate `big_int.cmi` but the `cmi` is not in any path that is added to `-I`.