### PR TITLE
Read toolchain source url from opam repo

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -742,7 +742,7 @@ let solve_lock_dir
   =
   (* Make sure that the solution contains a version of the compiler
      that's compatible with dune toolchains. *)
-  let constraints = Toolchain.Compiler_package.constraint_ :: constraints in
+  let constraints = Toolchain.Compiler.constraint_ :: constraints in
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
   let context =

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -4,6 +4,15 @@ type extra_files =
   | Inside_files_dir of Path.t option
   | Git_files of Path.Local.t option * Rev_store.At_rev.t
 
+let extra_files_equal a b =
+  match a, b with
+  | Inside_files_dir a, Inside_files_dir b -> Option.equal Path.equal a b
+  | Git_files (a_path, a_at_rev), Git_files (b_path, b_at_rev) ->
+    Option.equal Path.Local.equal a_path b_path
+    && Rev_store.At_rev.equal a_at_rev b_at_rev
+  | _ -> false
+;;
+
 type nonrec t =
   { opam_file : OpamFile.OPAM.t
   ; package : OpamPackage.t
@@ -11,6 +20,14 @@ type nonrec t =
   ; loc : Loc.t
   ; dune_build : bool
   }
+
+let equal t { opam_file; package; extra_files; loc; dune_build } =
+  OpamFile.OPAM.equal t.opam_file opam_file
+  && OpamPackage.equal t.package package
+  && extra_files_equal t.extra_files extra_files
+  && Loc.equal t.loc loc
+  && Bool.equal t.dune_build dune_build
+;;
 
 let dune_build t = t.dune_build
 let loc t = t.loc

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -2,6 +2,7 @@ open Import
 
 type t
 
+val equal : t -> t -> bool
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t

--- a/src/dune_pkg/toolchain.ml
+++ b/src/dune_pkg/toolchain.ml
@@ -17,323 +17,268 @@ module Make = struct
   ;;
 end
 
-module Dir = struct
-  let toolchain_base_dir () =
-    let cache_dir =
-      Xdg.create ~env:Sys.getenv_opt ()
-      |> Xdg.cache_dir
-      |> Path.Outside_build_dir.of_string
-    in
-    let path =
-      Path.Outside_build_dir.relative
-        (Path.Outside_build_dir.relative cache_dir "dune")
-        "toolchains"
-    in
-    (let path = Path.outside_build_dir path in
-     if not (Path.exists path) then Path.mkdir_p path;
-     if not (Path.is_directory path)
-     then
-       User_error.raise
-         [ Pp.textf "Expected %s to be a directory but it is not." (Path.to_string path) ]);
-    path
-  ;;
+module Names = struct
+  let ocaml_base_compiler = Package_name.of_string "ocaml-base-compiler"
 end
 
-module Compiler_package = struct
+module Compiler = struct
   type t =
     { version : Package_version.t
     ; url : OpamUrl0.t
-    ; checksum : Checksum.t
+    ; checksum : Checksum.t option
     }
 
-  let supported =
-    let entry version_string url_string checksum_string =
-      { version = Package_version.of_string version_string
-      ; url = OpamUrl0.of_string url_string
-      ; checksum = Checksum.of_string checksum_string
-      }
-    in
-    [ entry
-        "5.1.1"
-        "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz"
-        "sha256=57f7b382b3d71198413ede405d95ef3506f1cdc480cda1dca1e26b37cb090e17"
-    ; entry
-        "4.14.2"
-        "https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz"
-        "sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43"
-    ]
+  let version_string t = Package_version.to_string t.version
+
+  module Paths = struct
+    (* The path to the directory that will contain all toolchain
+       versions. Creates the directory if it doesn't already exist. *)
+    let toolchain_base_dir () =
+      let cache_dir =
+        Xdg.create ~env:Sys.getenv_opt ()
+        |> Xdg.cache_dir
+        |> Path.Outside_build_dir.of_string
+      in
+      let path =
+        Path.Outside_build_dir.relative
+          (Path.Outside_build_dir.relative cache_dir "dune")
+          "toolchains"
+      in
+      (let path = Path.outside_build_dir path in
+       if not (Path.exists path) then Path.mkdir_p path;
+       if not (Path.is_directory path)
+       then
+         User_error.raise
+           [ Pp.textf "Expected %s to be a directory but it is not." (Path.to_string path)
+           ]);
+      path
+    ;;
+
+    (* The path to a directory named after the given version inside the
+       toolchains directory. This directory will contain the source code
+       and binary artifacts associated with a particular version of the
+       compiler toolchain. *)
+    let toolchain_dir t =
+      Path.Outside_build_dir.relative (toolchain_base_dir ()) (version_string t)
+    ;;
+
+    let source_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "source"
+    let target_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "target"
+
+    (* A temporary directory within the given version's toolchain
+       directory where files will be installed before moving them into
+       the target directory. This two stage installation means that we
+       can guarantee that if the target directory exists then it
+       contains the complete installation of the toolchain. *)
+    let tmp_install_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "_install"
+
+    (* When installing with the DESTDIR the full path from the root
+       directory to the target directory is instantiated inside the
+       directory passed as DESTDIR. This function returns the absolute
+       path to the copy of the target directory inside DESTDIR. This
+       assumes that the output of [tmp_install_dir_dir] will be passed as
+       DESTDIR when installing. *)
+    let target_dir_within_tmp_install_dir t =
+      let target_dir = target_dir t in
+      let target_without_root_prefix =
+        (* Remove the root directory prefix from the target directory so
+           it can be used to create a path relative to the temporary
+           install dir. *)
+        match
+          String.drop_prefix
+            (Path.Outside_build_dir.to_string target_dir)
+            ~prefix:(Path.External.to_string Path.External.root)
+        with
+        | Some x -> x
+        | None ->
+          Code_error.raise
+            "Expected target dir to start with root"
+            [ "target_dir", Path.Outside_build_dir.to_dyn target_dir
+            ; "root", Path.External.to_dyn Path.External.root
+            ]
+      in
+      Path.Outside_build_dir.relative (tmp_install_dir t) target_without_root_prefix
+    ;;
+
+    let flock t =
+      Path.Outside_build_dir.relative (toolchain_dir t) "lock" |> Path.outside_build_dir
+    ;;
+  end
+
+  module Command = struct
+    let run ~dir prog args =
+      let output_on_success =
+        Dune_engine.Execution_parameters.Action_output_on_success.Swallow
+      in
+      let output_limit = Dune_engine.Execution_parameters.Action_output_limit.default in
+      let stdout_to = Process.Io.make_stdout ~output_on_success ~output_limit in
+      let stderr_to = Process.Io.make_stderr ~output_on_success ~output_limit in
+      Process.run ~dir ~stdout_to ~stderr_to ~display:Quiet Strict prog args
+    ;;
+
+    let configure version =
+      let source_dir = Path.outside_build_dir (Paths.source_dir version) in
+      let configure_script = Path.relative source_dir "configure" in
+      let prefix = Paths.target_dir version in
+      run
+        ~dir:source_dir
+        configure_script
+        [ "--prefix"; Path.Outside_build_dir.to_string prefix ]
+    ;;
+
+    let make version args =
+      let make = Lazy.force Make.path in
+      let source_dir = Path.outside_build_dir (Paths.source_dir version) in
+      run ~dir:source_dir make args
+    ;;
+
+    let build version =
+      (* TODO: limit the amount of parallelism to a reasonable number of cores *)
+      make version [ "-j" ]
+    ;;
+
+    (* Installation happens in two steps. First, run `make install
+       DESTDIR=...` to install the toolchain into a temporary directory. Then
+       the target directory from the temporary directory is copied into the
+       final installation directory. This allows us to use the fact that the
+       final installation directory exists to check that the toolchain is
+       installed. *)
+    let install version =
+      let open Fiber.O in
+      let dest_dir = Path.outside_build_dir (Paths.tmp_install_dir version) in
+      let target_dir = Path.outside_build_dir (Paths.target_dir version) in
+      Fpath.rm_rf (Path.to_string target_dir);
+      Fpath.rm_rf (Path.to_string dest_dir);
+      let+ () =
+        make version [ "install"; sprintf "DESTDIR=%s" (Path.to_string dest_dir) ]
+      in
+      Path.rename
+        (Path.outside_build_dir (Paths.target_dir_within_tmp_install_dir version))
+        (Path.outside_build_dir (Paths.target_dir version));
+      Fpath.rm_rf (Path.to_string dest_dir)
+    ;;
+  end
+
+  let bin_dir t = Path.Outside_build_dir.relative (Paths.target_dir t) "bin"
+  let is_version_installed t = Path.exists (Path.outside_build_dir (Paths.target_dir t))
+
+  let of_version_and_resolved_package version resolved_package =
+    let opam_file : OpamFile.OPAM.t = Resolved_package.opam_file resolved_package in
+    Option.map opam_file.url ~f:(fun opam_file_url ->
+      let url = OpamFile.URL.url opam_file_url in
+      let checksum =
+        OpamFile.URL.checksum opam_file_url
+        |> List.hd_opt
+        |> Option.map ~f:Checksum.of_opam_hash
+      in
+      { version; url; checksum })
   ;;
 
-  let latest = List.hd supported
-
-  let of_version version =
-    match List.find supported ~f:(fun t -> Package_version.equal t.version version) with
-    | Some t -> t
-    | None ->
-      (* This is a code error as the [Version.t] type doesn't allow
-         the construction of versions that don't appear in the
-         supported list. *)
-      Code_error.raise
-        "Invalid compiler toolchain version"
-        [ "version", Package_version.to_dyn version ]
-  ;;
-
-  (* Dune will require that this compiler package be chosen in
-     solutions, with a version that's supported by dune toolchains.
-
-     TODO: This will not work with packages that explicitly specify an
-     alternative compiler. The ideal behaviour would be for dune to
-     constrain whatever compiler package a package already depends on
-     to the versions supported by dune toolchains. *)
-  let preferred_compiler_package_name = Package_name.of_string "ocaml-base-compiler"
-
-  (* The names of packages which dune will treat as compiler packages
-     for the purposes of using dune toolchains instead.
-
-     TODO: use package metadata to determine whether a package
-     contains the compiler *)
-  let package_names =
-    preferred_compiler_package_name
-    :: ([ "ocaml-system"; "ocaml-variants" ] |> List.map ~f:Package_name.of_string)
-  ;;
-
-  let is_compiler_package_by_name name =
-    List.exists ~f:(Package_name.equal name) package_names
-  ;;
-
-  let constraint_ =
-    let open Dune_lang in
-    let constraint_ =
-      Package_constraint.Or
-        (List.map supported ~f:(fun { version; _ } ->
-           let version_value =
-             Package_constraint.Value.String_literal (Package_version.to_string version)
-           in
-           Package_constraint.Uop (Relop.Eq, version_value)))
-    in
-    { Package_dependency.name = preferred_compiler_package_name
-    ; constraint_ = Some constraint_
-    }
-  ;;
-end
-
-module Version = struct
-  type t = Package_version.t
-
-  let latest = Compiler_package.latest.version
-  let to_string = Package_version.to_string
-
-  let all =
-    List.map Compiler_package.supported ~f:(fun { Compiler_package.version; _ } ->
-      version)
-  ;;
-
-  let all_by_string = List.map all ~f:(fun version -> to_string version, version)
-
-  let of_string s =
-    List.find_map all_by_string ~f:(fun (s', t) ->
-      if String.equal s s' then Some t else None)
-  ;;
-
-  let of_package_version v = of_string (Package_version.to_string v)
-
-  (* The path to a directory named after this version inside the
-     toolchains directory. This directory will contain the source code
-     and binary artifacts associated with a particular version of the
-     compiler toolchain. *)
-  let toolchain_dir t =
-    Path.Outside_build_dir.relative (Dir.toolchain_base_dir ()) (to_string t)
-  ;;
-
-  let source_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "source"
-  let target_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "target"
-
-  (* A temporary directory within this version's toolchain directory
-     where files will be installed before moving them into the target
-     directory. This two stage installation means that we can
-     guarantee that if the target directory exists then it contains
-     the complete installation of the toolchain. *)
-  let tmp_install_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "_install"
-
-  (* When installing with the DESTDIR the full path from the root
-     directory to the target directory is instantiated inside the
-     directory passed as DESTDIR. This function returns the absolute
-     path to the copy of the target directory inside DESTDIR. This
-     assumes that the output of [tmp_install_dir] will be passed as
-     DESTDIR when installing. *)
-  let target_dir_within_tmp_install_dir t =
-    let target_dir = target_dir t in
-    let target_dir_without_root_prefix =
-      (* Remove the root directory prefix from the target directory so
-         it can be used to create a path relative to the temporary
-         install dir. *)
-      match
-        String.drop_prefix
-          (Path.Outside_build_dir.to_string target_dir)
-          ~prefix:(Path.External.to_string Path.External.root)
-      with
-      | Some x -> x
+  let handle_checksum_mismatch t ~got_checksum =
+    let checksum =
+      match t.checksum with
+      | Some checksum -> checksum
       | None ->
         Code_error.raise
-          "Expected target dir to start with root"
-          [ "target_dir", Path.Outside_build_dir.to_dyn target_dir
-          ; "root", Path.External.to_dyn Path.External.root
-          ]
+          "checksum mismatch, but this packgae has no checksum"
+          [ "got_checksum", Checksum.to_dyn got_checksum ]
     in
-    Path.Outside_build_dir.relative (tmp_install_dir t) target_dir_without_root_prefix
+    User_error.raise
+      [ Pp.textf
+          "Checksum mismatch when downloading version %s of the compiler toolchain from \
+           %s."
+          (version_string t)
+          (OpamUrl0.to_string t.url)
+      ; Pp.textf "Expected checksum: %s" (Checksum.to_string checksum)
+      ; Pp.textf "Got checksum: %s" (Checksum.to_string got_checksum)
+      ]
   ;;
 
-  let bin_dir t = Path.Outside_build_dir.relative (target_dir t) "bin"
-  let is_installed t = Path.exists (Path.outside_build_dir (target_dir t))
-
-  let flock_path t =
-    Path.Outside_build_dir.relative (toolchain_dir t) "lock" |> Path.outside_build_dir
+  let handle_unavailable t ~msg =
+    let msg_context =
+      Pp.textf
+        "Unable to download version %s of the compiler toolchain from %s."
+        (version_string t)
+        (OpamUrl0.to_string t.url)
+    in
+    let msg =
+      match (msg : User_message.t option) with
+      | Some msg -> { msg with paragraphs = msg_context :: msg.paragraphs }
+      | None -> User_message.make [ msg_context ]
+    in
+    raise (User_error.E msg)
   ;;
-end
 
-let handle_checksum_mismatch { Compiler_package.version; url; checksum } ~got_checksum =
-  User_error.raise
-    [ Pp.textf
-        "Checksum mismatch when downloading version %s of the compiler toolchain from %s."
-        (Version.to_string version)
-        (OpamUrl0.to_string url)
-    ; Pp.textf "Expected checksum: %s" (Checksum.to_string checksum)
-    ; Pp.textf "Got checksum: %s" (Checksum.to_string got_checksum)
-    ]
-;;
+  let fetch ({ url; checksum; _ } as t) =
+    let open Fiber.O in
+    let source_dir = Path.outside_build_dir (Paths.source_dir t) in
+    Fpath.rm_rf (Path.to_string source_dir);
+    Path.mkdir_p source_dir;
+    let+ result =
+      Fetch.fetch ~unpack:true ~checksum ~target:source_dir ~url:(Loc.none, url)
+    in
+    match result with
+    | Ok () -> ()
+    | Error (Fetch.Checksum_mismatch got_checksum) ->
+      handle_checksum_mismatch t ~got_checksum
+    | Error (Fetch.Unavailable msg) -> handle_unavailable t ~msg
+  ;;
 
-let handle_unavailable { Compiler_package.version; url; _ } ~msg_opt =
-  let msg_context =
-    Pp.textf
-      "Unable to download version %s of the compiler toolchain from %s."
-      (Version.to_string version)
-      (OpamUrl0.to_string url)
-  in
-  let msg =
-    match (msg_opt : User_message.t option) with
-    | Some msg -> { msg with paragraphs = msg_context :: msg.paragraphs }
-    | None -> User_message.make [ msg_context ]
-  in
-  raise (User_error.E msg)
-;;
-
-let fetch ({ Compiler_package.version; url; checksum } as t) =
-  let open Fiber.O in
-  let source_dir = Path.outside_build_dir (Version.source_dir version) in
-  Fpath.rm_rf (Path.to_string source_dir);
-  Path.mkdir_p source_dir;
-  let+ result =
-    Fetch.fetch
-      ~unpack:true
-      ~checksum:(Some checksum)
-      ~target:source_dir
-      ~url:(Loc.none, url)
-  in
-  match result with
-  | Ok () -> ()
-  | Error (Fetch.Checksum_mismatch got_checksum) ->
-    handle_checksum_mismatch t ~got_checksum
-  | Error (Fetch.Unavailable msg_opt) -> handle_unavailable t ~msg_opt
-;;
-
-let run_command ~dir prog args =
-  let output_on_success =
-    Dune_engine.Execution_parameters.Action_output_on_success.Swallow
-  in
-  let output_limit = Dune_engine.Execution_parameters.Action_output_limit.default in
-  let stdout_to = Process.Io.make_stdout ~output_on_success ~output_limit in
-  let stderr_to = Process.Io.make_stderr ~output_on_success ~output_limit in
-  Process.run ~dir ~stdout_to ~stderr_to ~display:Quiet Strict prog args
-;;
-
-let configure version =
-  let source_dir = Path.outside_build_dir (Version.source_dir version) in
-  let configure_script = Path.relative source_dir "configure" in
-  let prefix = Version.target_dir version in
-  run_command
-    ~dir:source_dir
-    configure_script
-    [ "--prefix"; Path.Outside_build_dir.to_string prefix ]
-;;
-
-let make version args =
-  let make = Lazy.force Make.path in
-  let source_dir = Path.outside_build_dir (Version.source_dir version) in
-  run_command ~dir:source_dir make args
-;;
-
-let build version =
-  (* TODO: limit the amount of parallelism to a reasonable number of cores *)
-  make version [ "-j" ]
-;;
-
-(* Installation happens in two steps. First, run `make install
-   DESTDIR=...` to install the toolchain into a temporary directory. Then
-   the target directory from the temporary directory is copied into the
-   final installation directory. This allows us to use the fact that the
-   final installation directory exists to check that the toolchain is
-   installed. *)
-let install version =
-  let open Fiber.O in
-  let dest_dir = Path.outside_build_dir (Version.tmp_install_dir version) in
-  let target_dir = Path.outside_build_dir (Version.target_dir version) in
-  Fpath.rm_rf (Path.to_string target_dir);
-  Fpath.rm_rf (Path.to_string dest_dir);
-  let+ () = make version [ "install"; sprintf "DESTDIR=%s" (Path.to_string dest_dir) ] in
-  Path.rename
-    (Path.outside_build_dir (Version.target_dir_within_tmp_install_dir version))
-    (Path.outside_build_dir (Version.target_dir version));
-  Fpath.rm_rf (Path.to_string dest_dir)
-;;
-
-let get ~log version =
-  let open Fiber.O in
-  let log_print style pp =
-    match log with
+  let log_print ~log_when style pp =
+    match log_when with
     | `Never -> ()
     | _ -> User_message.print (User_message.make [ Pp.tag style pp ])
-  in
-  let print_already_installed_message () =
-    match log with
+  ;;
+
+  let print_already_installed_message t ~log_when =
+    match log_when with
     | `Always ->
-      log_print Success
+      log_print ~log_when User_message.Style.Success
       @@ Pp.textf
            "Version %s of the compiler toolchain is already installed in %s"
-           (Version.to_string version)
-           (Version.target_dir version |> Path.Outside_build_dir.to_string)
+           (version_string t)
+           (Paths.target_dir t |> Path.Outside_build_dir.to_string)
     | _ -> ()
-  in
-  let download_build_install () =
-    let compiler_package = Compiler_package.of_version version in
-    log_print Details
+  ;;
+
+  let download_build_install t ~log_when =
+    let open Fiber.O in
+    let detail_log_style = User_message.Style.Details in
+    log_print ~log_when detail_log_style
     @@ Pp.textf
          "Will install version %s of the compiler toolchain to %s"
-         (Version.to_string version)
-         (Version.target_dir version |> Path.Outside_build_dir.to_string);
-    log_print Details @@ Pp.text "Downloading...";
-    let* () = fetch compiler_package in
-    log_print Details @@ Pp.text "Configuring...";
-    let* () = configure version in
-    log_print Details @@ Pp.text "Building...";
-    let* () = build version in
-    log_print Details @@ Pp.text "Installing...";
-    let+ () = install version in
-    log_print Success
+         (version_string t)
+         (Paths.target_dir t |> Path.Outside_build_dir.to_string);
+    log_print ~log_when detail_log_style @@ Pp.text "Downloading...";
+    let* () = fetch t in
+    log_print ~log_when detail_log_style @@ Pp.text "Configuring...";
+    let* () = Command.configure t in
+    log_print ~log_when detail_log_style @@ Pp.text "Building...";
+    let* () = Command.build t in
+    log_print ~log_when detail_log_style @@ Pp.text "Installing...";
+    let+ () = Command.install t in
+    log_print ~log_when User_message.Style.Success
     @@ Pp.textf
          "Success! Compiler toolchain version %s installed to %s."
-         (Version.to_string version)
-         (Version.target_dir version |> Path.Outside_build_dir.to_string)
-  in
-  if Version.is_installed version
-  then (
-    print_already_installed_message ();
-    Fiber.return ())
-  else
+         (version_string t)
+         (Paths.target_dir t |> Path.Outside_build_dir.to_string)
+  ;;
+
+  let with_flock t ~f =
     Flock.with_flock
-      (Version.flock_path version)
-      ~name_for_messages:(sprintf "toolchain version %s" (Version.to_string version))
+      (Paths.flock t)
+      ~name_for_messages:(sprintf "toolchain version %s" (version_string t))
       ~timeout_s:infinity
-      ~f:(fun () ->
+      ~f
+  ;;
+
+  let get t ~log_when =
+    if is_version_installed t
+    then (
+      print_already_installed_message t ~log_when;
+      Fiber.return ())
+    else
+      with_flock t ~f:(fun () ->
         (* Note that we deliberately check if the toolchain is
            installed before and after taking the flock.
 
@@ -353,9 +298,47 @@ let get ~log version =
            was installed in between the first check, and the flock
            being acquired.
         *)
-        if Version.is_installed version
+        if is_version_installed t
         then (
-          print_already_installed_message ();
+          print_already_installed_message t ~log_when;
           Fiber.return ())
-        else download_build_install ())
-;;
+        else download_build_install t ~log_when)
+  ;;
+
+  (* TODO: Currently we still need to add a constraint on the
+     ocaml-base-compiler, as otherwise the solver tends to choose the
+     ocaml-variants compiler instead. This won't be an issue once
+     toolchains supports the ocaml-variants compiler at which point we
+     can remove this constraint. We sholud also work out if the solver
+     should be prefering ocaml-base-compiler over ocaml-variants. *)
+  let constraint_ =
+    { Package_dependency.name = Names.ocaml_base_compiler; constraint_ = None }
+  ;;
+end
+
+module Available_compilers = struct
+  type t = Resolved_package.t OpamPackage.Version.Map.t
+
+  let equal = OpamPackage.Version.Map.equal Resolved_package.equal
+
+  let upstream_opam_repo () =
+    let loc, opam_url = Workspace.Repository.(opam_url upstream) in
+    Opam_repo.of_git_repo loc opam_url
+  ;;
+
+  let load_upstream_opam_repo () =
+    let open Fiber.O in
+    let* repo = upstream_opam_repo () in
+    Opam_repo.load_all_versions
+      [ repo ]
+      (Package_name.to_opam_package_name Names.ocaml_base_compiler)
+  ;;
+
+  let find_package t package_name version =
+    if Package_name.equal package_name Names.ocaml_base_compiler
+    then
+      OpamPackage.Version.Map.find_opt (Package_version.to_opam_package_version version) t
+      |> Option.bind ~f:(Compiler.of_version_and_resolved_package version)
+    else None
+  ;;
+end

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -1,42 +1,18 @@
 open! Import
 open! Stdune
 
-module Compiler_package : sig
-  (** Names of packages that dune considers to be compiler
-      packages. These packages should not be downloaded or built when
-      using dune toolchains as the compiler from the toolchain should be
-      used instead. *)
-  val package_names : Package_name.t list
+module Compiler : sig
+  type t
 
-  val is_compiler_package_by_name : Package_name.t -> bool
-
-  (** Constraint to apply to the dependency solver to guarantee a
-      solution that's includes a version of a compiler package that's
-      supported by dune toolchains. *)
+  val bin_dir : t -> Path.Outside_build_dir.t
+  val get : t -> log_when:[ `Always | `Never | `Install_only ] -> unit Fiber.t
   val constraint_ : Package_dependency.t
 end
 
-module Version : sig
+module Available_compilers : sig
   type t
 
-  val latest : t
-  val to_string : t -> string
-  val all : t list
-  val of_package_version : Package_version.t -> t option
-
-  (** The path to the directory containing both the source and binary
-      artifacts of this compiler version. *)
-  val toolchain_dir : t -> Path.Outside_build_dir.t
-
-  (** The path to the directory containing the binaries contained in
-      the compiler toolchain of a given version. Does not guarantee that
-      the specified toolchain is installed. *)
-  val bin_dir : t -> Path.Outside_build_dir.t
-
-  val is_installed : t -> bool
+  val equal : t -> t -> bool
+  val load_upstream_opam_repo : unit -> t Fiber.t
+  val find_package : t -> Package_name.t -> Package_version.t -> Compiler.t option
 end
-
-(** Downloads, builds, and installs a compiler toolchain of a given
-    version. Performs no actions if the specified toolchain is already
-    installed. *)
-val get : log:[ `Always | `Never | `Install_only ] -> Version.t -> unit Fiber.t

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -143,10 +143,12 @@ let of_binaries ~path name env binaries =
   make name ~env ~get_ocaml_tool ~which
 ;;
 
-let of_toolchain_version version name env =
+let of_toolchain_compiler compiler name env =
   let module Toolchain = Dune_pkg.Toolchain in
-  let bin_dir = Toolchain.Version.bin_dir version in
-  let* () = Memo.of_reproducible_fiber (Toolchain.get ~log:`Install_only version) in
+  let bin_dir = Toolchain.Compiler.bin_dir compiler in
+  let* () =
+    Memo.of_reproducible_fiber (Toolchain.Compiler.get ~log_when:`Install_only compiler)
+  in
   let which prog =
     let path = Path.Outside_build_dir.relative bin_dir prog in
     let+ exists = Fs_memo.file_exists path in

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -26,8 +26,8 @@ val of_env_with_findlib
 
 val of_binaries : path:Path.t list -> Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
 
-val of_toolchain_version
-  :  Dune_pkg.Toolchain.Version.t
+val of_toolchain_compiler
+  :  Dune_pkg.Toolchain.Compiler.t
   -> Context_name.t
   -> Env.t
   -> t Memo.t


### PR DESCRIPTION
Rather than hardcoding the source urls and checksums of ocaml compilers, this information is taken from the opam repo. Currently the only supported compiler package is ocaml-base-compiler, but this change attempts to make it simpler to introduce support for the ocaml-variants package in the near future.

We used to pass around toolchain versions as a proxy for toolchains to keep track of which toolchain to use, mostly in pkg_rules.ml. I've replaced this with what I'm calling a "compiler package" which contains a bit more information than just the version, mostly so that when we add support for ocaml-variants, that the compiler options can be added to this type.