### PR TITLE
[3.15] backport #10564

### DIFF
--- a/doc/changes/10564.md
+++ b/doc/changes/10564.md
@@ -1,0 +1,2 @@
+- fix interpretation of `exists_if` predicate in `META` files of installed
+  libraries containing more than one element. (#10564, @dbuenzli, @nojb)

--- a/doc/changes/10564.md
+++ b/doc/changes/10564.md
@@ -1,2 +1,3 @@
 - fix interpretation of `exists_if` predicate in `META` files of installed
-  libraries containing more than one element. (#10564, @dbuenzli, @nojb)
+  libraries containing more than one element. (#10564, fixes #10563, @dbuenzli,
+  @nojb)

--- a/src/dune_findlib/package0.ml
+++ b/src/dune_findlib/package0.ml
@@ -56,7 +56,7 @@ let exists t ~is_builtin =
   let exists_if = Vars.get_words t.vars "exists_if" Ps.empty in
   match exists_if with
   | _ :: _ ->
-    Memo.List.for_all exists_if ~f:(fun fn -> Fs.file_exists (Path.relative t.dir fn))
+    Memo.List.exists exists_if ~f:(fun fn -> Fs.file_exists (Path.relative t.dir fn))
   | [] ->
     if not is_builtin
     then Memo.return true


### PR DESCRIPTION
- Fix interpretation of 'exists_if' in META files (#10564)
- Add fixes
