### PR TITLE
[3.15] backport mac CI fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,6 +44,10 @@ jobs:
           - ocaml-compiler: 5.1.x
             os: macos-latest
             skip_test: true
+          # macOS x86_64 (Intel)
+          - ocaml-compiler: 4.14.x
+            os: macos-13
+            skip_test: true
           # OCaml 4:
           - ocaml-compiler: 4.13.x
             os: ubuntu-latest

--- a/test/blackbox-tests/test-cases/corrupt-persistent.t
+++ b/test/blackbox-tests/test-cases/corrupt-persistent.t
@@ -10,11 +10,10 @@
 
 Delete last 10 chars of the .db file to corrupt it
 
-  $ truncate --size=-10 _build/.db
+  $ truncate -s -10 _build/.db
 
 Dune log the corrupted file and recover
 
   $ dune build a
   $ grep "truncated object" _build/log
   # Failed to load corrupted file _build/.db: input_value: truncated object
-

--- a/test/blackbox-tests/test-cases/cxx-flags.t/dune
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/dune
@@ -8,3 +8,26 @@
  (libraries quad)
  (foreign_stubs (language cxx) (names bazexe))
  (modules main))
+
+(env
+ (_
+  (ocamlopt_flags
+   :standard
+   (:include extra_flags.sexp))))
+
+(rule
+ (enabled_if
+  (or
+   (<> %{system} macosx)
+   (<> %{architecture} arm64)))
+ (action
+  (write-file extra_flags.sexp "()")))
+
+; with XCode 15+, the linker complains about duplicate -lc++ libraries
+(rule
+ (enabled_if
+  (and
+   (= %{system} macosx)
+   (= %{architecture} arm64)))
+ (action
+  (write-file extra_flags.sexp "(-ccopt -Wl,-no_warn_duplicate_libraries)")))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -129,7 +129,12 @@
 
 (cram
  (applies_to version-corruption)
- (deps %{bin:od} %{bin:git} %{bin:cmp} %{bin:sed} %{bin:chmod}))
+ (deps %{bin:git} %{bin:chmod})
+ (enabled_if
+  ; code signing moves placeholders in the binary
+  (or
+   (<> %{system} macosx)
+   (<> %{architecture} arm64))))
 
 (cram
  (applies_to github8041)


### PR DESCRIPTION
- fix(test): silence duplicate -lc++ warnings on mac (#10468)
- test: fixes to version-corruption.t (#10469)
- ci: run build on macOS x86_64 again (#10481)
