### PR TITLE
chore(pkg): remove pointless channel when writing lock

### DIFF
--- a/src/dune_util/global_lock.mli
+++ b/src/dune_util/global_lock.mli
@@ -8,3 +8,5 @@ val lock_exn : timeout:float option -> unit
 
 (** release a lock and allow it be re-acquired *)
 val unlock : unit -> unit
+
+val write_pid : Unix.file_descr -> unit


### PR DESCRIPTION
No need to allocate a huge buffer to write an integer. Also, we already have a pid writing function, so we can just reuse it.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>