### PR TITLE
fix: truncate lock file

### DIFF
--- a/doc/changes/10575.md
+++ b/doc/changes/10575.md
@@ -1,0 +1,2 @@
+- Make sure to truncate dune's lock file after locking and unlocking so that
+  users cannot observe incorrect pid's (#10575, @rgrinberg)


### PR DESCRIPTION
Truncate it after successful locks and before an unlock.

This makes sure that we aren't left with garbage from previous runs.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>