### PR TITLE
fix: virtual libraries bug

### DIFF
--- a/test/blackbox-tests/test-cases/virtual-libraries/github10460.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github10460.t
@@ -52,12 +52,3 @@ Reproduces the issue reported in #10460
   > EOF
 
   $ dune build main.exe
-  Error: No implementation found for virtual library "vlib1" in
-  _build/default/vlib1.
-  -> required by library "lib" in _build/default/lib
-  -> required by library "impl2" in _build/default/impl2
-  -> required by executable main in dune:2
-  -> required by _build/default/.main.eobjs/byte/dune__exe__Main.cmi
-  -> required by _build/default/.main.eobjs/native/dune__exe__Main.cmx
-  -> required by _build/default/main.exe
-  [1]


### PR DESCRIPTION
When compiling an implementation of a virtual library, there's a check that makes sure we don't the virtual library doesn't exist in the closure of the implementation.

This check tried to compute the linking closure of the library to do so. However, the linking closure might not be complete if the implementation contains other virtual library.

To fix the issue, we use a "partial" linking closure that tries to compute the closure as much as possible, but doesn't fail on missing implementation.

Fix #10460

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>