### PR TITLE
merlin: do not break lines in dump-config

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -327,7 +327,7 @@ module Processed = struct
         |> Pp.concat_map ~sep:Pp.cut ~f:pp_one
         |> Pp.vbox
       in
-      Format.printf "%a@." Pp.to_fmt pp
+      Format.printf "%a%a@." Format.pp_set_margin 1000 Pp.to_fmt pp
   ;;
 
   let print_generic_dot_merlin paths =

--- a/test/blackbox-tests/test-cases/github2206.t/run.t
+++ b/test/blackbox-tests/test-cases/github2206.t/run.t
@@ -2,16 +2,14 @@ copy_files would break the generation of the preprocessing flags
   $ dune build copy_files/.merlin-conf/exe-foo
   $ dune ocaml merlin dump-config $PWD/copy_files |
   > grep -B 1 -A 0 "pp"
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
+  Foo: _build/default/copy_files/foo
+  ((INDEX $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
   --
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp.exe))
+   (S $TESTCASE_ROOT/copy_files/sources)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp.exe))
   --
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
+  Foo: _build/default/copy_files/foo.ml
+  ((INDEX $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
   --
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp.exe))
+   (S $TESTCASE_ROOT/copy_files/sources)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp.exe))

--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -18,12 +18,12 @@ Show that the merlin config knows about melange.compile_flags
   $ dune build @check
 
   $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
-     +42))
-     +42))
-     +42))
-     +42))
-     +42))
-     +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
 
   $ cat >dune <<EOF
   > (melange.emit
@@ -35,10 +35,10 @@ Show that the merlin config knows about melange.compile_flags
   $ dune build @check
 
   $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
-     +42))
-     +42))
-     +42))
-     +42))
-     +42))
-     +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
 

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -23,31 +23,31 @@
   $ touch bar.ml $lib.ml
   $ dune build @check
   $ dune ocaml merlin dump-config "$PWD" | grep -i "$lib"
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
    (UNIT_NAME foo__Bar))
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
    (UNIT_NAME foo__Bar))
   Foo: _build/default/foo
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
    (UNIT_NAME foo))
   Foo: _build/default/foo.ml
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (FLG (-open Foo__))
    (UNIT_NAME foo))
   Foo__: _build/default/foo__
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (UNIT_NAME foo__))
   Foo__: _build/default/foo__.ml-gen
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (UNIT_NAME foo__))
 
 Paths to Melange stdlib appear in B and S entries without melange.emit stanza
@@ -74,8 +74,8 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   $ touch main.ml
   $ dune build @check
   $ dune ocaml merlin dump-config $PWD | grep -i "$target"
-    $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
-    $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
+   (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
+   (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
 
 Dump-dot-merlin includes the melange flags
 
@@ -128,176 +128,56 @@ User ppx flags should appear in merlin config
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
   Bar: _build/default/bar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    /MELC_STDLIB/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (S
-    /MELC_STDLIB/__private__/melange_mini_stdlib)
-   (S
-    $TESTCASE_ROOT)
    (FLG (-open Foo))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Bar))
   Bar: _build/default/bar.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    /MELC_STDLIB/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (S
-    /MELC_STDLIB/__private__/melange_mini_stdlib)
-   (S
-    $TESTCASE_ROOT)
    (FLG (-open Foo))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Bar))
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    /MELC_STDLIB/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (S
-    /MELC_STDLIB/__private__/melange_mini_stdlib)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo: _build/default/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    /MELC_STDLIB/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (S
-    /MELC_STDLIB/__private__/melange_mini_stdlib)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Fooppx: _build/default/fooppx
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME fooppx))
   Fooppx: _build/default/fooppx.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.fooppx.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME fooppx))

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -23,45 +23,9 @@ If Merlin field is absent, default context is chosen
 
   $ dune ocaml merlin dump-config "$PWD"
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
   Foo: _build/default/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
 
 If Merlin field is present, this context is chosen
 
@@ -86,45 +50,9 @@ If Merlin field is present, this context is chosen
 
   $ dune ocaml merlin dump-config "$PWD"
   Foo: _build/cross/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
   Foo: _build/cross/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
 
 If `generate_merlin_rules` field is present, rules are generated even if merlin
 is disabled in that context
@@ -152,42 +80,6 @@ is disabled in that context
 
   $ dune ocaml merlin dump-config "$PWD"
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
   Foo: _build/default/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -9,57 +9,39 @@ CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml merlin dump-config $PWD/exe
   X: _build/default/exe/x
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exe)
+   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exe)
    (FLG (-w -40 -g))
    (UNIT_NAME dune__exe__X)
    (SUFFIX ".mlx .mlx"))
   X: _build/default/exe/x.mlx
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exe)
+   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exe)
    (FLG (-w -40 -g))
    (UNIT_NAME dune__exe__X)
    (SUFFIX ".mlx .mlx")
    (READER (mlx)))
   X: _build/default/exe/x.mlx.mli
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exe)
+   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exe)
    (FLG (-w -40 -g))
    (UNIT_NAME dune__exe__X)
    (SUFFIX ".mlx .mlx"))
@@ -68,39 +50,27 @@ CRAM sanitization
   $ dune build ./lib/.merlin-conf/lib-x --profile release
   $ dune ocaml merlin dump-config $PWD/lib
   X: _build/default/lib/x
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
+   (B $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
+   (S $TESTCASE_ROOT/lib)
    (FLG (-w -40 -g))
    (UNIT_NAME x)
    (SUFFIX ".mlx .mlx")
    (READER (mlx)))
   X: _build/default/lib/x.mlx
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
+   (B $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
+   (S $TESTCASE_ROOT/lib)
    (FLG (-w -40 -g))
    (UNIT_NAME x)
    (SUFFIX ".mlx .mlx")
@@ -110,55 +80,39 @@ CRAM sanitization
   $ dune build ./melange/.merlin-conf/lib-x_mel --profile release
   $ dune ocaml merlin dump-config $PWD/melange
   X_mel: _build/default/melange/x_mel
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB lib/melange/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
+   (B lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
    (B lib/melange/js/melange)
    (B lib/melange/melange)
-   (B
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
+   (B $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
    (S lib/melange)
-   (S
-    lib/melange/__private__/melange_mini_stdlib)
+   (S lib/melange/__private__/melange_mini_stdlib)
    (S lib/melange/js)
-   (S
-    $TESTCASE_ROOT/melange)
+   (S $TESTCASE_ROOT/melange)
    (FLG (-w -40 -g))
    (UNIT_NAME x_mel)
    (SUFFIX ".mlx .mlx")
    (READER (mlx)))
   X_mel: _build/default/melange/x_mel.mlx
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
    (STDLIB lib/melange/melange)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
+   (B lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
    (B lib/melange/js/melange)
    (B lib/melange/melange)
-   (B
-    $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
+   (B $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
    (S lib/melange)
-   (S
-    lib/melange/__private__/melange_mini_stdlib)
+   (S lib/melange/__private__/melange_mini_stdlib)
    (S lib/melange/js)
-   (S
-    $TESTCASE_ROOT/melange)
+   (S $TESTCASE_ROOT/melange)
    (FLG (-w -40 -g))
    (UNIT_NAME x_mel)
    (SUFFIX ".mlx .mlx")

--- a/test/blackbox-tests/test-cases/merlin/future-syntax.t
+++ b/test/blackbox-tests/test-cases/merlin/future-syntax.t
@@ -18,41 +18,8 @@
   $ dune build ./.merlin-conf/exe-pp_future_syntax --profile release
   $ dune ocaml merlin dump-config .
   Pp_future_syntax: _build/default/pp_future_syntax
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__Pp_future_syntax))
+  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))
   Pp_future_syntax: _build/default/pp_future_syntax.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__Pp_future_syntax))
+  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))
   Pp_future_syntax: _build/default/pp_future_syntax.mli
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__Pp_future_syntax))
+  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))

--- a/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
@@ -7,102 +7,54 @@ in the same dune file, but require different ppx specifications
   $ dune build @all --profile release
   $ dune ocaml merlin dump-config $PWD
   Usesppx1: _build/default/usesppx1
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/c152d6ca3c7e1d83471ffdf48bf729ae/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="usesppx1"'"))
+   (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/c152d6ca3c7e1d83471ffdf48bf729ae/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME usesppx1))
   Usesppx1: _build/default/usesppx1.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/c152d6ca3c7e1d83471ffdf48bf729ae/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="usesppx1"'"))
+   (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/c152d6ca3c7e1d83471ffdf48bf729ae/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME usesppx1))
   Usesppx2: _build/default/usesppx2
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/d7394c27c5e0f7ad7ab1110d6b092c05/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="usesppx2"'"))
+   (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/d7394c27c5e0f7ad7ab1110d6b092c05/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME usesppx2))
   Usesppx2: _build/default/usesppx2.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/d7394c27c5e0f7ad7ab1110d6b092c05/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="usesppx2"'"))
+   (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/d7394c27c5e0f7ad7ab1110d6b092c05/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME usesppx2))

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -23,42 +23,6 @@ We call `$(opam switch show)` so that this test always uses an existing switch
 
   $ dune ocaml merlin dump-config "$PWD"
   Foo: _build/cross/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
   Foo: _build/cross/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))

--- a/test/blackbox-tests/test-cases/merlin/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github759.t/run.t
@@ -4,88 +4,22 @@
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
   Foo: _build/default/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
 
   $ rm -f .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
   Foo: _build/default/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
 
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
   Foo: _build/default/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -22,347 +22,165 @@
   $ dune build .merlin-conf/lib-foo
   $ dune ocaml merlin dump-config .
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo: _build/default/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo__Groupintf__: _build/default/foo__Groupintf__
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf__))
   Foo__Groupintf__: _build/default/foo__Groupintf__.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf__))
   Utils: _build/default/foo__Utils
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Utils))
   Utils: _build/default/foo__Utils.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Utils))
   Calc: _build/default/groupintf/calc
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Groupintf__ -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf__Calc))
   Calc: _build/default/groupintf/calc.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Groupintf__ -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf__Calc))
   Groupintf: _build/default/groupintf/groupintf
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Groupintf__ -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf))
   Groupintf: _build/default/groupintf/groupintf.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Groupintf__ -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Groupintf))
   Main: _build/default/main
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Main))
   Main: _build/default/main.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Main))
   Calc: _build/default/utils/calc
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Utils -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Utils__Calc))
   Calc: _build/default/utils/calc.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/groupintf)
-   (S
-    $TESTCASE_ROOT/utils)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/groupintf)
+   (S $TESTCASE_ROOT/utils)
    (FLG (-open Foo__Utils -open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Utils__Calc))
   $ dune ocaml merlin dump-config utils

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -9,222 +9,134 @@ up a project with instrumentation and testing checking the merlin config.
   $ dune build --instrument-with hello ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
   Bar: _build/default/lib/bar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g))
    (UNIT_NAME bar))
   Bar: _build/default/lib/bar.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g))
    (UNIT_NAME bar))
   File: _build/default/lib/subdir/file
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-open Bar))
    (FLG (-w -40 -g))
    (UNIT_NAME bar__File))
   File: _build/default/lib/subdir/file.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-open Bar))
    (FLG (-w -40 -g))
    (UNIT_NAME bar__File))
   Foo: _build/default/lib/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g))
    (UNIT_NAME foo))
   Foo: _build/default/lib/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-w -40 -g))
    (UNIT_NAME foo))
   Privmod: _build/default/lib/privmod
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-open Foo))
    (FLG (-w -40 -g))
    (UNIT_NAME foo__Privmod))
   Privmod: _build/default/lib/privmod.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (S
-    $TESTCASE_ROOT/ppx)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (S $TESTCASE_ROOT/ppx)
    (FLG (-open Foo))
    (FLG (-w -40 -g))
    (UNIT_NAME foo__Privmod))

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -8,104 +8,50 @@ We build the project
 Verify that merlin configuration was generated...
   $ dune ocaml merlin dump-config $PWD
   Test: _build/default/test
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/411)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME dune__exe__Test))
   Test: _build/default/test.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/411)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME dune__exe__Test))
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/411)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo: _build/default/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/411)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
 
 ...but not in the sub-folder whose content was copied

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -14,362 +14,194 @@ CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml merlin dump-config $PWD/exe
   X: _build/default/exe/x
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/exe)
-   (S
-    $TESTCASE_ROOT/lib)
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp/pp.exe))
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/exe)
+   (S $TESTCASE_ROOT/lib)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
    (FLG (-w -40 -g))
    (UNIT_NAME x))
   X: _build/default/exe/x.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/exe)
-   (S
-    $TESTCASE_ROOT/lib)
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp/pp.exe))
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/exe)
+   (S $TESTCASE_ROOT/lib)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
    (FLG (-w -40 -g))
    (UNIT_NAME x))
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml merlin dump-config $PWD/lib
   Bar: _build/default/lib/bar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="bar"'"))
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME bar))
   Bar: _build/default/lib/bar.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="bar"'"))
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME bar))
   File: _build/default/lib/subdir/file
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-open Bar))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME bar__File))
   File: _build/default/lib/subdir/file.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
+   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-open Bar))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME bar__File))
   Foo: _build/default/lib/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME foo))
   Foo: _build/default/lib/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME foo))
   Privmod: _build/default/lib/privmod
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-open Foo))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME foo__Privmod))
   Privmod: _build/default/lib/privmod.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/_findlib/publicfoo)
-   (S
-    $TESTCASE_ROOT/lib)
-   (S
-    $TESTCASE_ROOT/lib/subdir)
+   (B $TESTCASE_ROOT/_findlib/publicfoo)
+   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
+   (S $TESTCASE_ROOT/_findlib/publicfoo)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-open Foo))
-   (FLG
-    (-ppx
-     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
-     --as-ppx
-     --cookie
-     'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-w -40 -g))
    (UNIT_NAME foo__Privmod))
 
@@ -381,61 +213,35 @@ Make sure pp flag is correct and variables are expanded
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
   $ dune ocaml merlin dump-config $PWD/pp-with-expand
   Foobar: _build/default/pp-with-expand/foobar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/pp-with-expand)
-   (FLG
-    (-pp
-     "$TESTCASE_ROOT/_build/default/pp/pp.exe
-     -nothing"))
+   (B $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
+   (S $TESTCASE_ROOT/pp-with-expand)
+   (FLG (-pp "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"))
    (FLG (-w -40 -g))
    (UNIT_NAME foobar))
   Foobar: _build/default/pp-with-expand/foobar.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/pp-with-expand)
-   (FLG
-    (-pp
-     "$TESTCASE_ROOT/_build/default/pp/pp.exe
-     -nothing"))
+   (B $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
+   (S $TESTCASE_ROOT/pp-with-expand)
+   (FLG (-pp "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"))
    (FLG (-w -40 -g))
    (UNIT_NAME foobar))
 
@@ -443,130 +249,62 @@ Check hash of executables names if more than one
   $ dune build ./exes/.merlin-conf/exe-x-6562915302827c6dce0630390bfa68b7
   $ dune ocaml merlin dump-config $PWD/exes
   X: _build/default/exes/x
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exes)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exes)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME x))
   X: _build/default/exes/x.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exes)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exes)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME x))
   Y: _build/default/exes/y
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exes)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exes)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME y))
   Y: _build/default/exes/y.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S
-    $TESTCASE_ROOT/exes)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
+   (S $TESTCASE_ROOT/exes)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME y))

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -8,96 +8,44 @@ should appear only once since only Foo is using it.
 
   $ dune ocaml merlin dump-config $PWD
   Bar: _build/default/bar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME bar))
   Bar: _build/default/bar.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME bar))
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo: _build/default/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (FLG
-    (-pp
-     $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -23,58 +23,28 @@ library also has more than one src dir.
   $ dune build lib2/.merlin-conf/lib-lib2
   $ dune ocaml merlin dump-config $PWD/lib2
   Lib2: _build/default/lib2/lib2
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib1)
-   (S
-    $TESTCASE_ROOT/lib1/sub)
-   (S
-    $TESTCASE_ROOT/lib2)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
+   (S $TESTCASE_ROOT/lib1)
+   (S $TESTCASE_ROOT/lib1/sub)
+   (S $TESTCASE_ROOT/lib2)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME lib2))
   Lib2: _build/default/lib2/lib2.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
    (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (S
-    $TESTCASE_ROOT/lib1)
-   (S
-    $TESTCASE_ROOT/lib1/sub)
-   (S
-    $TESTCASE_ROOT/lib2)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
+   (S $TESTCASE_ROOT/lib1)
+   (S $TESTCASE_ROOT/lib1/sub)
+   (S $TESTCASE_ROOT/lib2)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME lib2))

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -1,5 +1,5 @@
   $ dune build @check
 
-  $ dune ocaml merlin dump-config $PWD | grep SUFFIX
-  ((INDEX $TESTCASE_ROOT/_build/default/.alterexe.eobjs/cctx.ocaml-index) (STDLIB /home/etienne/src/dune/_opam/lib/ocaml) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.alterexe.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Alterexe) (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))
-  ((INDEX $TESTCASE_ROOT/_build/default/.alterexe.eobjs/cctx.ocaml-index) (STDLIB /home/etienne/src/dune/_opam/lib/ocaml) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.alterexe.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Alterexe) (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))
+  $ dune ocaml merlin dump-config $PWD | grep -o '(SUFFIX.*)'
+  (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))
+  (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -1,7 +1,5 @@
   $ dune build @check
 
   $ dune ocaml merlin dump-config $PWD | grep SUFFIX
-   (SUFFIX ".aml .amli")
-   (SUFFIX ".baml .bamli"))
-   (SUFFIX ".aml .amli")
-   (SUFFIX ".baml .bamli"))
+  ((INDEX $TESTCASE_ROOT/_build/default/.alterexe.eobjs/cctx.ocaml-index) (STDLIB /home/etienne/src/dune/_opam/lib/ocaml) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.alterexe.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Alterexe) (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))
+  ((INDEX $TESTCASE_ROOT/_build/default/.alterexe.eobjs/cctx.ocaml-index) (STDLIB /home/etienne/src/dune/_opam/lib/ocaml) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.alterexe.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Alterexe) (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -31,4 +31,4 @@ Dune ocaml-merlin also accepts paths relative to the current directory
 
   $ dune ocaml merlin dump-config "." --root=".." | head -n 2
   Foo: _build/default/realsrc/foo
-  ((INDEX
+  ((INDEX $TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT/realroot) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/byte) (S $TESTCASE_ROOT/realroot/realsrc) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Foo))

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -6,148 +6,72 @@
 
   $ dune ocaml merlin dump-config $PWD
   Foo: _build/default/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/foo)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/foo)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME dune__exe__Foo))
   Foo: _build/default/foo.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT)
-   (S
-    $TESTCASE_ROOT/foo)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/foo)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME dune__exe__Foo))
 
   $ dune ocaml merlin dump-config $PWD/foo
   Bar: _build/default/foo/bar
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/foo)
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT/foo)
    (FLG (-open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Bar))
   Bar: _build/default/foo/bar.ml
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/foo)
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT/foo)
    (FLG (-open Foo))
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo__Bar))
   Foo: _build/default/foo/foo
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/foo)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT/foo)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
   Foo: _build/default/foo/foo.ml-gen
-  ((INDEX
-    $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
+  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
    (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT
-    $TESTCASE_ROOT)
+   (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
-   (B
-    $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S
-    $TESTCASE_ROOT/foo)
-   (FLG
-    (-w
-     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
-     -strict-sequence
-     -strict-formats
-     -short-paths
-     -keep-locs
-     -g))
+   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
+   (S $TESTCASE_ROOT/foo)
+   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (UNIT_NAME foo))
 
 FIXME : module Foo is not unbound


### PR DESCRIPTION
`dune ocaml merlin dump-config` is meant for testing and debugging.

Breaking horizontal boxes is not useful here and it makes postprocessing more difficult.

Setting a large margin will make some boxes render as a single line.

This also helps with reproducibility, since sometimes long paths could break differently.
