### PR TITLE
fix: typo: exist_if -> exists_if

### DIFF
--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -35,7 +35,7 @@ let term =
              | Hidden_library lib ->
                Some
                  ( Dune_package.Lib.info lib |> Dune_rules.Lib_info.name
-                 , "unsatisfied 'exist_if'" )
+                 , "unsatisfied 'exists_if'" )
              | _ -> None)
          in
          let all =

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -48,7 +48,7 @@ module Entry : sig
 
         - are not built with dune
 
-        - have a [META] file with an unsatisfied [exist_if] field
+        - have a [META] file with an unsatisfied [exists_if] field
 
         Dune itself never produces hidden libraries. *)
 

--- a/src/dune_rules/findlib.mli
+++ b/src/dune_rules/findlib.mli
@@ -8,7 +8,7 @@ type t
 module Unavailable_reason : sig
   type t =
     | Not_found
-    (** The package is hidden because it contains an unsatisfied 'exist_if'
+    (** The package is hidden because it contains an unsatisfied 'exists_if'
         clause *)
     | Invalid_dune_package of User_message.t
 

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -379,10 +379,10 @@ module Hidden = struct
     Error.hidden ~loc ~name ~dir:path ~reason
   ;;
 
-  let unsatisfied_exist_if pkg =
+  let unsatisfied_exists_if pkg =
     let info = Dune_package.Lib.info pkg in
     let path = Lib_info.src_dir info in
-    { lib = info; reason = "unsatisfied 'exist_if'"; path }
+    { lib = info; reason = "unsatisfied 'exists_if'"; path }
   ;;
 end
 
@@ -1937,7 +1937,7 @@ module DB = struct
         | Ok (Library pkg) -> [ Found (Dune_package.Lib.info pkg) ]
         | Ok (Deprecated_library_name d) ->
           [ Redirect_in_the_same_db (d.loc, d.new_public_name) ]
-        | Ok (Hidden_library pkg) -> [ Hidden (Hidden.unsatisfied_exist_if pkg) ]
+        | Ok (Hidden_library pkg) -> [ Hidden (Hidden.unsatisfied_exists_if pkg) ]
         | Error e ->
           [ (match e with
              | Invalid_dune_package why -> Invalid why


### PR DESCRIPTION
The ocamlfind field is called `exists_if`, so let's use that.
