### PR TITLE
pkg: avoid unstable compiler packages

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
@@ -49,8 +49,9 @@ the same package.
   - ocaml-base-compiler.5.2.0
 
 Now release a new version of ocaml-variants and a new version of ocaml that
-uses it. The dependency specification for ocaml is based on how the package is
-organized in the wild.
+uses it. The dependency specification for the `ocaml` package is based on how
+the package is organized in the wild.
+
   $ mkpkg ocaml-variants $NEXT+trunk << EOF
   > flags: [avoid-version]
   > EOF
@@ -61,14 +62,27 @@ organized in the wild.
   > ]
   > EOF
 
-Here ocaml-variants is chosen despite its avoid-version flag. This is
-because dune does not respect the avoid-version flag when choosing
-which package to use to satisfy a disjunction (the disjunction in
-question is between ocaml-base-compiler and ocaml-variants, where
-ocaml-variants has the avoid-version flag set and ocaml-base-compiler
-does not).  This is a problem because the chosen compiler is not
-officially released and possibly unstable.
+Dune correctly picks the latest released version of `ocaml` that has a
+dependency that is not marked as `avoid-version`. Given that for satisfying
+`ocaml.5.3.0` the only option is `ocaml-variants.5.3.0+trunk` and that has
+`avoid-version` set it then drops down to `5.2.0` which has a package without
+`avoid-version`.
+
   $ solve ocaml
   Solution for dune.lock:
-  - ocaml.5.3.0
-  - ocaml-variants.5.3.0+trunk
+  - ocaml.5.2.0
+  - ocaml-base-compiler.5.2.0
+
+However, removing that `avoid-version` constraint again should make Dune pick
+up `5.3.0`.
+
+It currently doesn't, because of a hack that special-cases
+`ocaml-base-compiler` which in the future should be removed and thus work in
+the way described above.
+
+  $ mkpkg ocaml-variants $NEXT+trunk << EOF
+  > EOF
+  $ solve ocaml
+  Solution for dune.lock:
+  - ocaml.5.2.0
+  - ocaml-base-compiler.5.2.0


### PR DESCRIPTION
This introduces two workarounds to problems caused by the fact that opam-0install-solver - the library underlying dune's dependency solver - does not understand the avoid-version flag which is set on opam packages to indicate that the solver should choose an alternative package if it's able to do so.

The first problem happens when ocaml-base-complier has an alpha, beta, or rc package available with a higher version number than the latest stable release of ocaml-base-compiler. In this case, dune would choose the higher versioned (unstable) package rather than the latest stable version.

The workaround is to reorder the list of candidate versions for each package such that packages that have the avoid-version flag set appear later than those that do not have this flag set. (Note that this is done per-package name, not between different package names.)  This solution will fix the problem for all packages - not just ocaml-base-compiler.

The second problem happens when a version of the meta package named "ocaml" is available with a higher version than the latest version of ocaml-base-compiler, and there is a development version of ocaml-variants available which corresponds to the version of the latest "ocaml" package. In this case, dune would try to choose the latest version of "ocaml" and end up depending on the development version of ocaml-variants rather than ocaml-base-compiler. All versions of ocaml-variants have the avoid-version flag set.

The workaround here is to determine which version of ocaml-base-compiler is the latest stable release (the version with the highest version number that does not have avoid-version set). Then, when considering the version candidates for the "ocaml" meta package, reorder the list of candidates such that any versions that are higher than the latest release of ocaml-base-compiler are moved to the end of the list.

It's worth noting that in both cases, the solution does not restrict which package solutions are possible, it just changes the way that the solver prioritizes packages relative to one another; if a user specifies a dependency on a development version of a package, or the ocaml-variants package, it will still be included in the solution.