### PR TITLE
ci: only the static binary is needed.

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -18,9 +18,6 @@ jobs:
             installable: .#
           - os: ubuntu-22.04
             name: linux-intel
-            installable: .#
-          - os: ubuntu-22.04
-            name: linux-intel-static
             installable: .#dune-static
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
It could be confusing also because the non-static binary doesn't works in general and  only works on a specific environment (nix config).