### PR TITLE
Support ocaml-variants with toolchains

### DIFF
--- a/bin/toolchain.ml
+++ b/bin/toolchain.ml
@@ -14,13 +14,14 @@ module Get = struct
       Dune_pkg.Package_version.of_opam_package_version (OpamPackage.version package)
     in
     let* compiler =
-      Toolchain.Available_compilers.find_package
+      Toolchain.Available_compilers.find
         available_compiler_packages
         package_name
         package_version
+        ~deps:[]
     in
     match compiler with
-    | Some compiler_package -> Toolchain.Compiler.get ~log_when:`Always compiler_package
+    | Some compiler -> Toolchain.Compiler.get ~log_when:`Always compiler
     | None ->
       User_error.raise
         [ Pp.textf

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -54,6 +54,7 @@ let jobs = of_string "jobs"
 let make = of_string "make"
 let prefix = of_string "prefix"
 let doc = of_string "doc"
+let installed = of_string "installed"
 let one_of t xs = List.mem xs ~equal t
 let dev = of_string "dev"
 

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -34,6 +34,7 @@ val jobs : t
 val make : t
 val prefix : t
 val doc : t
+val installed : t
 val one_of : t -> t list -> bool
 
 module Project : sig

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -740,9 +740,6 @@ let solve_lock_dir
   ~pins:pinned_packages
   ~constraints
   =
-  (* Make sure that the solution contains a version of the compiler
-     that's compatible with dune toolchains. *)
-  let constraints = Toolchain.Compiler.constraint_ :: constraints in
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
   let context =

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -6,7 +6,6 @@ module Compiler : sig
 
   val bin_dir : t -> Path.Outside_build_dir.t
   val get : t -> log_when:[ `Always | `Never | `Install_only ] -> unit Fiber.t
-  val constraint_ : Package_dependency.t
 end
 
 module Available_compilers : sig
@@ -14,5 +13,11 @@ module Available_compilers : sig
 
   val equal : t -> t -> bool
   val load_upstream_opam_repo : unit -> t Fiber.t
-  val find_package : t -> Package_name.t -> Package_version.t -> Compiler.t option Fiber.t
+
+  val find
+    :  t
+    -> Package_name.t
+    -> Package_version.t
+    -> deps:Package_name.t list
+    -> Compiler.t option Fiber.t
 end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1150,10 +1150,11 @@ end = struct
       assert (Package.Name.equal name info.name);
       let* compiler =
         Memo.of_reproducible_fiber
-          (Toolchain.Available_compilers.find_package
+          (Toolchain.Available_compilers.find
              db.available_compilers
              info.name
-             info.version)
+             info.version
+             ~deps:(List.map depends ~f:snd))
       in
       (match compiler with
        | Some compiler -> Memo.return (Some (`Toolchain compiler))


### PR DESCRIPTION
This changes the toolchains mechanism to accept the ocaml-variants package, and allow the build commands of a package to check whether certain packages are installed which allows the ocaml-variants package to be configured by the installation of its depopts.