### PR TITLE
Allow toolchains to be disabled with flag

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -1,13 +1,5 @@
 open Import
 
-(** ad-hoc feature flag that automatically re-creates lock files if the
-    contents of the dependency list in the dune-project goes out of date
-
-    Supposed to be enabled in the developer preview and disabled in the
-    release, if you find yourself enabling this on release remove the
-    check altogether *)
-let use_autorelock = true
-
 let with_metrics ~common f =
   let start_time = Unix.gettimeofday () in
   Fiber.finalize f ~finally:(fun () ->
@@ -57,7 +49,7 @@ let run_build_system ~common ~request =
       let request =
         let open Action_builder.O in
         let autorelock =
-          match use_autorelock with
+          match Dune_pkg.Feature_flags.use_autorelock with
           | false -> Memo.return ()
           | true ->
             Memo.of_thunk (fun () ->

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -23,3 +23,4 @@ module Resolved_package = Resolved_package
 module Pin_stanza = Pin_stanza
 module Package_name = Package_name
 module Toolchain = Toolchain
+module Feature_flags = Feature_flags

--- a/src/dune_pkg/feature_flags.ml
+++ b/src/dune_pkg/feature_flags.ml
@@ -1,0 +1,4 @@
+open! Import
+
+let use_toolchains = false
+let use_autorelock = false

--- a/src/dune_pkg/feature_flags.mli
+++ b/src/dune_pkg/feature_flags.mli
@@ -1,0 +1,27 @@
+open! Import
+
+(** Ad-hoc feature flags for enabling various features for the dune
+    developer preview. These should be false in the upstream version of
+    dune and only manually set to true when building dune for the
+    developer preview. If you find yourself enabling these when commiting
+    to main, instead just remove the flag and permanently enable the
+    feature. *)
+
+(** Dune will download and build the ocaml-base-compiler and
+    ocaml-variants packages into a user-wide directory (shared among
+    projects) rather than using the usual package management mechanism to
+    install such packages. Currently compiler packages can't be installed
+    by dune's package management features as the compiler is not
+    relocatable, and this flag allows dune to workaround this problem
+    providing an experience to users that is almost identical to dune
+    installing the compiler packgae.
+
+    When this flag is disabled, users of dune package management need to
+    manage their compiler installation with opam or a system package
+    manager, as compilers packages that would be installed by dune will
+    not work correctly. *)
+val use_toolchains : bool
+
+(** Dune will automatically re-create lock files if the contents of
+    the dependency list in the dune-project goes out of date. *)
+val use_autorelock : bool

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -454,7 +454,9 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
           Pkg_rules.ocaml_toolchain builder.name
           >>= (function
            | None -> toolchain `Lock
-           | Some toolchain -> Memo.return (toolchain, `Default))
+           | Some toolchain ->
+             let+ toolchain, _ = Action_builder.evaluate_and_collect_facts toolchain in
+             toolchain, `Default)
       in
       Ocaml_toolchain.register_response_file_support ocaml;
       if Option.is_some builder.fdo_target_exe

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -17,7 +17,7 @@ val setup_rules
 
 val lock_dir_path : Context_name.t -> Path.Source.t option Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
-val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t option Memo.t
+val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t
 val exported_env : Context_name.t -> Env.t Memo.t
 val ocamlpath : Context_name.t -> Path.t list Memo.t


### PR DESCRIPTION
Also fixes a bug that was introduced with the initial toolchains implementation that leads to a memo cycle when resolving the ocaml-variants package. Breaking the memo cycle also let us remove the code that tracks the compiler dependency of individual packages which was adimitedly a hack to work around the same circular dependency that caused the memo cycle. Removing this code should make it less contraversial to merge the toolchains branch upstream.