### PR TITLE
Fix compiler opts - native and bytecode opts split

### DIFF
--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -306,8 +306,8 @@ let fill_in_fields_that_depends_on_ocamlc_config t =
   let get_flags var = get var |> String.trim |> Flags.extract_blank_separated_words in
   let c_compiler, c_libraries =
     match Ocaml_config.Vars.find t.ocamlc_config "c_compiler" with
-    | Some c_comp -> c_comp ^ " " ^ get "ocamlc_cflags", get_flags "native_c_libraries"
-    | None -> get "bytecomp_c_compiler", get_flags "bytecomp_c_libraries"
+    | Some c_comp -> c_comp ^ " " ^ get "native_cflags", get_flags "native_c_libraries"
+    | None -> get "bytecomp_c_compiler" ^ " " ^ get "bytecode_cflags", get_flags "bytecomp_c_libraries"
   in
   { t with
     ext_obj = get "ext_obj"

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -555,10 +555,10 @@ let make vars =
            with ocaml{c,opt}_cflags and ocaml{c,opt}_cppflags. *)
         let get_flags var = args @ get_words vars var in
         ( prog
-        , get_flags "ocamlc_cflags"
-        , get_flags "ocamlc_cppflags"
-        , get_flags "ocamlopt_cflags"
-        , get_flags "ocamlopt_cppflags" )
+        , get_flags "native_cflags"
+        , get_flags "native_cppflags"
+        , get_flags "bytecode_cflags"
+        , get_flags "bytecode_cppflags" )
       | None ->
         bytecomp_c_compiler.prog, bytecomp_c_compiler.args, [], native_c_compiler.args, []
     in


### PR DESCRIPTION
It looks like a breaking change has been made in https://github.com/ocaml/ocaml/commit/51e5cf226b39986abf03cbaad47cf49a1c35bc69 that causes the builds of some packages to fail, for instance: 

```sh
#=== ERROR while compiling base64.3.4.0 =======================================#
# context     2.2.0~beta2 | linux/x86_64 | ocaml-variants.5.3.0+trunk | https://opam.ocaml.org/#b502ec76
# path        ~/.opam/ocaml-ocaml-51e5cf226b39986abf03cbaad47cf49a1c35bc69/.opam-switch/build/base64.3.4.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p base64 -j 31
# exit-code   1
# env-file    ~/.opam/log/base64-436405-1a5bf6.env
# output-file ~/.opam/log/base64-436405-1a5bf6.out
### output ###
# File "src/dune", line 7, characters 0-126:
#  7 | (rule
#  8 |  (targets unsafe.ml)
#  9 |  (deps (:config ../config/config.exe) unsafe_pre407.ml unsafe_stable.ml)
# 10 |  (action (run %{config})))
# (cd _build/default/src && ../config/config.exe)
# Error: variable "ocamlc_cflags" not found in the output of `/home/punchagan/.opam/ocaml-ocaml-51e5cf226b39986abf03cbaad47cf49a1c35bc69/bin/ocamlc.opt -config`
```

I'm not familiar with the dune configurator and other related code. I'm also not sure how Dune deals with such breaking changes in the compiler, etc. I wanted to notify the team about an upcoming breaking change with the trunk version of OCaml and share a patch that I'm using with the Sandmark benchmark builds.