### PR TITLE
Indexing rules: correctly declare indexes dependencies

### DIFF
--- a/doc/changes/10623.md
+++ b/doc/changes/10623.md
@@ -1,0 +1,2 @@
+- Correctly declare dependencies of indexes so that they are rebuilt when
+  needed. (#10623, @voodoos)

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -20,11 +20,10 @@ let cctx_rules cctx =
      definitions are used by all the cmts of modules in this cctx. *)
   let sctx = Compilation_context.super_context cctx in
   let dir = Compilation_context.dir cctx in
-  let open Memo.O in
-  let* aggregate =
+  let aggregate =
     let obj_dir = Compilation_context.obj_dir cctx in
     let fn = index_path_in_obj_dir obj_dir in
-    let* additional_libs =
+    let additional_libs =
       let open Resolve.Memo.O in
       let+ non_compile_libs =
         (* The indexer relies on the load_path of cmt files. When
@@ -42,7 +41,7 @@ let cctx_rules cctx =
     (* Indexing depends (recursively) on [required_compile] libs:
        - These libs's cmt files should be built before indexing starts
        - If these libs are rebuilt a re-indexation is needed *)
-    let+ other_indexes_deps =
+    let other_indexes_deps =
       let open Resolve.Memo.O in
       let+ requires_compile = Compilation_context.requires_compile cctx in
       let deps =
@@ -81,8 +80,8 @@ let cctx_rules cctx =
       ; A "-o"
       ; Target fn
       ; Deps modules_deps
-      ; Resolve.args additional_libs
-      ; Resolve.args other_indexes_deps
+      ; Dyn (Resolve.Memo.read additional_libs)
+      ; Dyn (Resolve.Memo.read other_indexes_deps)
       ]
   in
   Super_context.add_rule sctx ~dir aggregate

--- a/test/blackbox-tests/utils/ocaml_index.ml
+++ b/test/blackbox-tests/utils/ocaml_index.ml
@@ -29,7 +29,7 @@ module Common = struct
 end
 
 module Aggregate = struct
-  let from_files _ _ output_file _ _ () = touch output_file
+  let from_files _ _ output_file _ _ _ () = touch output_file
 
   let root =
     let doc = "if provided all locations will be appended to that path" in
@@ -51,6 +51,11 @@ module Aggregate = struct
     Arg.(value & flag & info [ "store-shapes" ] ~doc)
   ;;
 
+  let no_cmt =
+    let doc = "" in
+    Arg.(value & flag & info [ "no-cmt-load-path" ] ~doc)
+  ;;
+
   let term =
     Term.(
       const from_files
@@ -58,6 +63,7 @@ module Aggregate = struct
       $ root
       $ Common.output_file
       $ build_path
+      $ no_cmt
       $ files
       $ Common.with_log)
   ;;


### PR DESCRIPTION
I overlooked dependencies in the indexing rules: I though that passing build folders of transitive deps as command args to the indexer was also declaring dependencies on these libs. This is actually not the case.

This means that indexes are not correctly rebuilt when one of their dependencies is updated.

This PR adds a set of `Hidden_deps` that correspond to all the index files of the direct dependencies local to the build.

@emillon sadly this means that the rules released in 3.16 are not working properly. Do you think there will be a patch release ?