### PR TITLE
Add developer preview features

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -18,9 +18,6 @@ jobs:
             installable: .#
           - os: ubuntu-22.04
             name: linux-intel
-            installable: .#
-          - os: ubuntu-22.04
-            name: linux-intel-static
             installable: .#dune-static
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -21,6 +21,6 @@ jobs:
     - run: sed -i s/1.3/2.7/ dune-project
     - run: opam pin add -n dune.dev git+https://github.com/ocaml/dune#$GITHUB_SHA
     - run: sudo apt install libseccomp-dev
-    - run: opam install mirage.4.4.2 opam-monorepo.0.3.6
+    - run: opam install mirage opam-monorepo.0.3.6
     - run: cd mirage; opam exec -- mirage configure -f config.ml -t hvt
     - run: cd mirage; opam exec -- make depend lock pull build

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -47,7 +47,48 @@ let run_build_system ~common ~request =
       Cached_digest.invalidate_cached_timestamps ();
       let* setup = Import.Main.setup () in
       let request =
-        Action_builder.bind (Action_builder.of_memo setup) ~f:(fun setup -> request setup)
+        let open Action_builder.O in
+        let autorelock =
+          match Dune_pkg.Feature_flags.use_autorelock with
+          | false -> Memo.return ()
+          | true ->
+            Memo.of_thunk (fun () ->
+              let open Memo.O in
+              let lock_dir_path = Dune_pkg.Lock_dir.default_path in
+              let lock_dirs = Pkg_common.Lock_dirs_arg.of_path lock_dir_path in
+              let* per_contexts =
+                Workspace.workspace ()
+                >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
+              in
+              let lock_dirs =
+                List.filter_map per_contexts ~f:(fun lock_dir_path ->
+                  match Path.exists (Path.source lock_dir_path) with
+                  | true -> Some (lock_dir_path, Dune_pkg.Lock_dir.read_disk lock_dir_path)
+                  | false -> None)
+              in
+              match lock_dirs with
+              | [] -> Memo.return ()
+              | lock_dirs ->
+                let* local_packages = Pkg_common.find_local_packages in
+                let locks =
+                  List.map lock_dirs ~f:(fun (lock_dir_path, lock_dir) ->
+                    match
+                      Dune_pkg.Package_universe.up_to_date local_packages lock_dir
+                    with
+                    | `Valid -> Memo.return ()
+                    | `Invalid _ ->
+                      let lock_dirs_arg =
+                        Pkg_common.Lock_dirs_arg.of_path lock_dir_path
+                      in
+                      Lock.lock ~version_preference:None ~lock_dirs_arg
+                      |> Memo.of_non_reproducible_fiber)
+                in
+                let+ (_ : unit list) = Memo.all_concurrently locks in
+                ())
+        in
+        let setup = Memo.both setup autorelock |> Memo.map ~f:fst in
+        let* setup = Action_builder.of_memo setup in
+        request setup
       in
       (* CR-someday cmoseley: Can we avoid creating a new lazy memo node every
          time the build system is rerun? *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -38,6 +38,7 @@ let all : _ Cmdliner.Cmd.t list =
     ; Init.group
     ; Promotion.group
     ; Pkg.group
+    ; Toolchain.group
     ]
   in
   terms @ groups

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -1,4 +1,10 @@
 open Import
 
+(** creates a lock file at the specified location(s) *)
+val lock
+  :  version_preference:Dune_pkg.Version_preference.t option
+  -> lock_dirs_arg:Pkg_common.Lock_dirs_arg.t
+  -> unit Fiber.t
+
 (** Command to create lock directory *)
 val command : unit Cmd.t

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -136,6 +136,8 @@ module Lock_dirs_arg = struct
        All)
   ;;
 
+  let of_path p = Selected [ p ]
+
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
     let workspace_lock_dirs =
       Lock_dir.default_path

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -62,6 +62,10 @@ module Lock_dirs_arg : sig
         of the workspace are considered. *)
   val term : t Term.t
 
+  (** [Lock_dirs_arg.of_path] creates a specific lock dir argument out of a
+      source path *)
+  val of_path : Path.Source.t -> t
+
   (** [Lock_dirs_arg.lock_dirs_of_workspace t workspace] returns the list of
       lock directories that should be considered for various operations.
 

--- a/bin/toolchain.ml
+++ b/bin/toolchain.ml
@@ -1,0 +1,57 @@
+open Import
+module Toolchain = Dune_pkg.Toolchain
+
+module Get = struct
+  let run package =
+    let open Fiber.O in
+    let* available_compiler_packages =
+      Toolchain.Available_compilers.load_upstream_opam_repo ()
+    in
+    let package_name =
+      Dune_pkg.Package_name.of_opam_package_name (OpamPackage.name package)
+    in
+    let package_version =
+      Dune_pkg.Package_version.of_opam_package_version (OpamPackage.version package)
+    in
+    let* compiler =
+      Toolchain.Available_compilers.find
+        available_compiler_packages
+        package_name
+        package_version
+        ~deps:[]
+    in
+    match compiler with
+    | Some compiler -> Toolchain.Compiler.get ~log_when:`Always compiler
+    | None ->
+      User_error.raise
+        [ Pp.textf
+            "Unknown compiler package %s.%s"
+            (Package_name.to_string package_name)
+            (Package_version.to_string package_version)
+        ]
+  ;;
+
+  let term =
+    let+ builder = Common.Builder.term
+    and+ package = Arg.(required & pos 0 (some string) None & info [] ~docv:"PACKAGE") in
+    let common, config = Common.init builder in
+    let package = OpamPackage.of_string package in
+    Scheduler.go ~common ~config (fun () -> run package)
+  ;;
+
+  let info = Cmd.info "get" ~doc:"Install a given toolchain version"
+  let cmd = Cmd.v info term
+end
+
+let info =
+  let doc = "Manage OCaml compiler toolchains" in
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P {|Commands for managing compiler toolchains|}
+    ; `Blocks Common.help_secs
+    ]
+  in
+  Cmd.info "x-experimental-toolchain" ~doc ~man
+;;
+
+let group = Cmd.group info [ Get.cmd ]

--- a/bin/toolchain.mli
+++ b/bin/toolchain.mli
@@ -1,0 +1,3 @@
+open Import
+
+val group : unit Cmd.t

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -296,3 +296,12 @@
  (package dune)
  (files   dune-utop.1))
 
+(rule
+ (with-stdout-to dune-x-experimental-toolchain.1
+  (run dune x-experimental-toolchain --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-x-experimental-toolchain.1))
+

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -488,6 +488,7 @@ module External : sig
   include Path_intf.S
   module Table : Hashtbl.S with type key = t
 
+  val root : t
   val relative : t -> string -> t
   val mkdir_p : ?perms:int -> t -> unit
   val initial_cwd : t

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -71,6 +71,7 @@ end
 module External : sig
   include Path_intf.S
 
+  val root : t
   val initial_cwd : t
   val cwd : unit -> t
   val relative : t -> string -> t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -143,9 +143,9 @@ val cancel_current_build : unit -> unit Fiber.t
 
 val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
 
-(** [sleep duration] wait for [duration] to elapse. Sleepers are checked for
-    wake up at a rate of once per 0.1 seconds. So [duration] should be at least
-    this long. *)
+(** [sleep duration] wait for [duration] seconds to elapse. Sleepers
+    are checked for wake up at a rate of once per 0.1 seconds. So
+    [duration] should be at least this long. *)
 val sleep : float -> unit Fiber.t
 
 val stats : unit -> Dune_stats.t option Fiber.t

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -50,6 +50,11 @@ let version = of_string "version"
 let name = of_string "name"
 let build = of_string "build"
 let post = of_string "post"
+let jobs = of_string "jobs"
+let make = of_string "make"
+let prefix = of_string "prefix"
+let doc = of_string "doc"
+let installed = of_string "installed"
 let one_of t xs = List.mem xs ~equal t
 let dev = of_string "dev"
 

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -30,6 +30,11 @@ val version : t
 val post : t
 val build : t
 val dev : t
+val jobs : t
+val make : t
+val prefix : t
+val doc : t
+val installed : t
 val one_of : t -> t list -> bool
 
 module Project : sig

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -36,3 +36,5 @@ include Comparable.Make (struct
     let compare x y = Ordering.of_int (OpamHash.compare x y)
     let to_dyn = to_dyn
   end)
+
+let choose_strongest ts = OpamHash.sort ts |> List.hd_opt

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -20,3 +20,6 @@ val pp : t -> 'a Pp.t
 val equal : t -> t -> bool
 
 module Map : Map.S with type key = t
+
+(** Returns the hash whose kind is the strongest (e.g. SHA512 is stronger than MD5) *)
+val choose_strongest : t list -> t option

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -22,3 +22,5 @@ module Variable_value = Variable_value
 module Resolved_package = Resolved_package
 module Pin_stanza = Pin_stanza
 module Package_name = Package_name
+module Toolchain = Toolchain
+module Feature_flags = Feature_flags

--- a/src/dune_pkg/feature_flags.ml
+++ b/src/dune_pkg/feature_flags.ml
@@ -1,0 +1,4 @@
+open! Import
+
+let use_toolchains = false
+let use_autorelock = false

--- a/src/dune_pkg/feature_flags.mli
+++ b/src/dune_pkg/feature_flags.mli
@@ -1,0 +1,27 @@
+open! Import
+
+(** Ad-hoc feature flags for enabling various features for the dune
+    developer preview. These should be false in the upstream version of
+    dune and only manually set to true when building dune for the
+    developer preview. If you find yourself enabling these when commiting
+    to main, instead just remove the flag and permanently enable the
+    feature. *)
+
+(** Dune will download and build the ocaml-base-compiler and
+    ocaml-variants packages into a user-wide directory (shared among
+    projects) rather than using the usual package management mechanism to
+    install such packages. Currently compiler packages can't be installed
+    by dune's package management features as the compiler is not
+    relocatable, and this flag allows dune to workaround this problem
+    providing an experience to users that is almost identical to dune
+    installing the compiler packgae.
+
+    When this flag is disabled, users of dune package management need to
+    manage their compiler installation with opam or a system package
+    manager, as compilers packages that would be installed by dune will
+    not work correctly. *)
+val use_toolchains : bool
+
+(** Dune will automatically re-create lock files if the contents of
+    the dependency list in the dune-project goes out of date. *)
+val use_autorelock : bool

--- a/src/dune_pkg/flock.ml
+++ b/src/dune_pkg/flock.ml
@@ -1,0 +1,148 @@
+open! Stdune
+module Flock = Dune_util.Flock
+module Scheduler = Dune_engine.Scheduler
+
+type t =
+  { flock : Flock.t
+  ; lock_path : Path.t
+  }
+
+(* Global mutable set of names, used to prevent printing "waiting for
+   lock" messages multiple times when multiple concurrent fibers try
+   to take a lock at the same time. *)
+module Global_waiting_names = struct
+  let state = lazy (String.Table.create 1)
+
+  (* add a name to the set, returning [true] iff the name wasn't
+     already in the set *)
+  let add name =
+    let state = Lazy.force state in
+    String.Table.add state name () |> Result.is_ok
+  ;;
+
+  let remove name =
+    let state = Lazy.force state in
+    String.Table.remove state name
+  ;;
+end
+
+let attempt_to_lock { flock; lock_path } ~name_for_messages ~timeout_s =
+  let open Fiber.O in
+  let current_dune_pid = Unix.getpid () in
+  let rec loop timeout_s =
+    match Flock.lock_non_block flock Flock.Exclusive with
+    | Error e -> Fiber.return @@ Error e
+    | Ok `Success ->
+      Global_waiting_names.remove name_for_messages;
+      Fiber.return (Ok `Success)
+    | Ok `Failure -> handle_failure timeout_s
+  and handle_failure timeout_s =
+    let locked_by_pid = int_of_string (Io.read_file lock_path) in
+    let sleep_duration_s = 0.1 in
+    let remaining_duration_s = timeout_s -. sleep_duration_s in
+    if remaining_duration_s <= 0.0
+    then Fiber.return (Ok `Timeout)
+    else (
+      if locked_by_pid <> current_dune_pid && Global_waiting_names.add name_for_messages
+      then
+        (* Only print this message if the dune process that holds the
+           lock isn't the current process and this is the first time
+           that the current process has failed to take the lock since
+           the last time it successfully took the lock. This prevents
+           the situation where multiple fibers all attempt to take the
+           lock concurrently while it's held by another process from
+           causing the following message from being printed multiple
+           times. *)
+        User_message.print
+          (User_message.make
+             [ Pp.textf
+                 "Waiting for another instance of dune (pid %d) to release the lock for \
+                  the resource %S..."
+                 locked_by_pid
+                 name_for_messages
+             ]);
+      let* () = Scheduler.sleep sleep_duration_s in
+      loop remaining_duration_s)
+  in
+  loop timeout_s
+;;
+
+let with_flock lock_path ~name_for_messages ~timeout_s ~f =
+  let open Fiber.O in
+  let parent = Path.parent_exn lock_path in
+  Path.mkdir_p parent;
+  let fd =
+    Unix.openfile
+      (Path.to_string lock_path)
+      [ Unix.O_CREAT; O_WRONLY; O_SHARE_DELETE; O_CLOEXEC ]
+      0o600
+  in
+  let flock = Flock.create fd in
+  let current_dune_pid = Unix.getpid () in
+  Fiber.finalize
+    ~finally:(fun () ->
+      let+ () = Fiber.return () in
+      Unix.close fd)
+    (fun () ->
+      attempt_to_lock { flock; lock_path } ~name_for_messages ~timeout_s
+      >>= function
+      | Ok `Success ->
+        Fiber.finalize
+          (fun () ->
+            Dune_util.Global_lock.write_pid fd;
+            f ())
+          ~finally:(fun () ->
+            let+ () = Fiber.return () in
+            match Flock.unlock flock with
+            | Ok () ->
+              (* Note that after the lock has been released, we
+                 deliberately don't delete the lock file to avoid a race
+                 condition where other processes or fibers still need to
+                 read the file to determine the process that held the
+                 lock. Even though the lock has been released, other
+                 parties may be in between timing out waiting for the
+                 lock and reading the lock file to get the pid to
+                 include in their error message. *)
+              ()
+            | Error ue ->
+              Unix_error.Detailed.create ue ~syscall:"flock" ~arg:"unlock"
+              |> Unix_error.Detailed.raise)
+      | Ok `Timeout ->
+        let locked_by_pid = int_of_string (Io.read_file lock_path) in
+        if locked_by_pid == current_dune_pid
+        then
+          Code_error.raise
+            "timeout while waiting for flock, but flock was currently held by the \
+             current process"
+            [ "name_for_messages", Dyn.string name_for_messages ]
+        else
+          User_error.raise
+            ~hints:
+              [ Pp.textf
+                  "Another instance of dune (pid %d) currently holds the lock for the \
+                   resource %S. If this is unexpected, terminate that process and re-run \
+                   the command."
+                  locked_by_pid
+                  name_for_messages
+              ; Pp.textf
+                  "As a last resort, if the other instance of dune (pid %d) is no longer \
+                   running, manually delete the lock file %s."
+                  locked_by_pid
+                  (Path.to_string_maybe_quoted lock_path)
+              ]
+            [ Pp.textf
+                "Timed out after %.2f seconds while waiting for another instance of dune \
+                 (pid %d) to release the lock on the resource %S."
+                timeout_s
+                locked_by_pid
+                name_for_messages
+            ]
+      | Error error ->
+        User_error.raise
+          [ Pp.textf
+              "Failed to get a lock for the resource %S with lock file %s: %s"
+              name_for_messages
+              (Path.to_string_maybe_quoted lock_path)
+              (Unix.error_message error)
+          ])
+;;

--- a/src/dune_pkg/flock.mli
+++ b/src/dune_pkg/flock.mli
@@ -1,0 +1,23 @@
+open! Stdune
+
+(** [with_flock path ~name_for_messages ~timeout_s ~f] ensures mutual
+    exclusion for the function [f] across multiple concurrent
+    instances of dune, using the lock file at [path] to coordinate
+    between different dune instances. If the lock is not acquired
+    after [timeout_s] seconds then a [User_error] is raised. Pass
+    [infinity] to keep trying to take the lock
+    forever. [name_for_messages] is the name used to refer to this
+    lock in error messages.
+
+    Within the a dune process, this function also ensures mutual
+    exclusion between fibers. Note that if this function times out
+    waiting for the lock while the lock is held by a different fiber
+    of the same dune process, a [Code_error] is raised rather than a
+    [User_error]. If a timeout is possible, avoid allowing multiple
+    fibers to concurrently attempt to take a flock. *)
+val with_flock
+  :  Path.t
+  -> name_for_messages:string
+  -> timeout_s:float
+  -> f:(unit -> 'a Fiber.t)
+  -> 'a Fiber.t

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -128,11 +128,26 @@ let check_for_unnecessary_packges_in_lock_dir
          ]))
 ;;
 
-let validate_dependency_hash { local_packages; lock_dir; _ } =
+let up_to_date local_packages (lock_dir : Lock_dir.t) =
   let local_packages =
     Package_name.Map.values local_packages |> List.map ~f:Local_package.for_solver
   in
-  let regenerate_lock_dir_hints =
+  let non_local_dependencies =
+    Local_package.For_solver.list_non_local_dependency_set local_packages
+  in
+  let dependency_hash = Local_package.Dependency_set.hash non_local_dependencies in
+  match lock_dir.dependency_hash, dependency_hash with
+  | None, None -> `Valid
+  | Some (_, lock_dir_dependency_hash), Some non_local_dependency_hash
+    when Local_package.Dependency_hash.equal
+           lock_dir_dependency_hash
+           non_local_dependency_hash -> `Valid
+  | _, Some non_local_dependency_hash -> `Invalid (Some non_local_dependency_hash)
+  | _, None -> `Invalid None
+;;
+
+let validate_dependency_hash { local_packages; lock_dir; _ } =
+  let hints =
     [ Pp.concat
         ~sep:Pp.space
         [ Pp.text "Regenerate the lockdir by running"
@@ -140,54 +155,38 @@ let validate_dependency_hash { local_packages; lock_dir; _ } =
         ]
     ]
   in
-  let non_local_dependencies =
-    Local_package.For_solver.list_non_local_dependency_set local_packages
-  in
-  let dependency_hash = Local_package.Dependency_set.hash non_local_dependencies in
-  match lock_dir.dependency_hash, dependency_hash with
-  | None, None -> Ok ()
-  | Some (loc, lock_dir_dependency_hash), None ->
+  let res = up_to_date local_packages lock_dir in
+  match res, lock_dir.dependency_hash with
+  | `Valid, _ -> Ok ()
+  | `Invalid (Some _), None ->
+    Error
+      (User_error.make
+         ~hints
+         [ Pp.text
+             "This project has specified dependencies but the lockdir doesn't contain a \
+              dependency hash."
+         ])
+  | `Invalid None, _ ->
+    Error
+      (User_error.make
+         ~hints
+         [ Pp.text
+             "This project does not have dependencies but the lockdir specifies \
+              dependencies"
+         ])
+  | `Invalid (Some non_local_dependency_hash), Some (loc, lock_dir_dependency_hash) ->
     Error
       (User_error.make
          ~loc
-         ~hints:regenerate_lock_dir_hints
-         [ Pp.textf
-             "This project has no non-local dependencies yet the lockfile contains a \
-              dependency hash: %s"
-             (Local_package.Dependency_hash.to_string lock_dir_dependency_hash)
-         ])
-  | None, Some _ ->
-    let any_non_local_dependency : Package_dependency.t =
-      List.hd (Local_package.Dependency_set.package_dependencies non_local_dependencies)
-    in
-    Error
-      (User_error.make
-         ~hints:regenerate_lock_dir_hints
+         ~hints
          [ Pp.text
-             "This project has at least one non-local dependency but the lockdir doesn't \
-              contain a dependency hash."
-         ; Pp.textf
-             "An example of a non-local dependency of this project is: %s"
-             (Package_name.to_string any_non_local_dependency.name)
+             "Dependency hash in lockdir does not match the hash of non-local \
+              dependencies of this project. The lockdir expects the the non-local \
+              dependencies to hash to:"
+         ; Pp.text (Local_package.Dependency_hash.to_string lock_dir_dependency_hash)
+         ; Pp.text "...but the non-local dependencies of this project hash to:"
+         ; Pp.text (Local_package.Dependency_hash.to_string non_local_dependency_hash)
          ])
-  | Some (loc, lock_dir_dependency_hash), Some non_local_dependency_hash ->
-    if Local_package.Dependency_hash.equal
-         lock_dir_dependency_hash
-         non_local_dependency_hash
-    then Ok ()
-    else
-      Error
-        (User_error.make
-           ~loc
-           ~hints:regenerate_lock_dir_hints
-           [ Pp.text
-               "Dependency hash in lockdir does not match the hash of non-local \
-                dependencies of this project. The lockdir expects the the non-local \
-                dependencies to hash to:"
-           ; Pp.text (Local_package.Dependency_hash.to_string lock_dir_dependency_hash)
-           ; Pp.text "...but the non-local dependencies of this project hash to:"
-           ; Pp.text (Local_package.Dependency_hash.to_string non_local_dependency_hash)
-           ])
 ;;
 
 let validate t =

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -5,6 +5,11 @@ open! Import
     solution for the local packages. *)
 type t
 
+val up_to_date
+  :  Local_package.t Package_name.Map.t
+  -> Lock_dir.t
+  -> [ `Valid | `Invalid of Local_package.Dependency_hash.t option ]
+
 val create
   :  Local_package.t Package_name.Map.t
   -> Lock_dir.t

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -4,6 +4,15 @@ type extra_files =
   | Inside_files_dir of Path.t option
   | Git_files of Path.Local.t option * Rev_store.At_rev.t
 
+let extra_files_equal a b =
+  match a, b with
+  | Inside_files_dir a, Inside_files_dir b -> Option.equal Path.equal a b
+  | Git_files (a_path, a_at_rev), Git_files (b_path, b_at_rev) ->
+    Option.equal Path.Local.equal a_path b_path
+    && Rev_store.At_rev.equal a_at_rev b_at_rev
+  | _ -> false
+;;
+
 type nonrec t =
   { opam_file : OpamFile.OPAM.t
   ; package : OpamPackage.t
@@ -11,6 +20,14 @@ type nonrec t =
   ; loc : Loc.t
   ; dune_build : bool
   }
+
+let equal t { opam_file; package; extra_files; loc; dune_build } =
+  OpamFile.OPAM.equal t.opam_file opam_file
+  && OpamPackage.equal t.package package
+  && extra_files_equal t.extra_files extra_files
+  && Loc.equal t.loc loc
+  && Bool.equal t.dune_build dune_build
+;;
 
 let dune_build t = t.dune_build
 let loc t = t.loc

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -2,6 +2,7 @@ open Import
 
 type t
 
+val equal : t -> t -> bool
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t

--- a/src/dune_pkg/toolchain.ml
+++ b/src/dune_pkg/toolchain.ml
@@ -1,0 +1,530 @@
+open! Import
+open! Stdune
+
+module Make = struct
+  let path ~path =
+    (* TODO: prefer gmake over make if it's available for compatibility with the BSDs *)
+    match Bin.which ~path "make" with
+    | Some p -> p
+    | None ->
+      User_error.raise
+        ~hints:[ Pp.text "Install \"make\" with your system package manager." ]
+        [ Pp.text
+            "The program \"make\" does not appear to be installed. This program is \
+             needed to compile the ocaml toolchain."
+        ]
+  ;;
+end
+
+module Compiler = struct
+  (* Value of the PATH variable *)
+  let env_path = Env_path.path Env.initial
+
+  module Name = struct
+    type t =
+      { name : Package_name.t
+      ; version : Package_version.t
+      ; deps : Package_name.t list
+      }
+
+    (* A string identifying the compiler for use in paths and
+       messages. In the case of ocaml-variants, the compiler that gets
+       installed will have different features enabled depending on which
+       packages the compiler depends on (the [deps] field of [t]). Thus it
+       must be possible to install multiple instances of the same version
+       of ocaml-variants at the same time, provided that they differ in
+       their dependencies. This means that the list of dependencies must be
+       present in the name of the directory where the compiler gets
+       installed.
+
+       An example identifier string for ocaml-variants with multiple
+       dependencies is:
+       ocaml-variants.5.2.0+options.with_deps.ocaml-option-flambda,ocaml-option-no-flat-float-array *)
+    let identifier_string t =
+      let deps_suffix =
+        match t.deps with
+        | [] -> ""
+        | _ ->
+          sprintf
+            ".with_deps.%s"
+            (String.concat
+               ~sep:","
+               (List.map t.deps ~f:Package_name.to_string
+                |> List.sort ~compare:String.compare))
+      in
+      sprintf
+        "%s.%s%s"
+        (Package_name.to_string t.name)
+        (Package_version.to_string t.version)
+        deps_suffix
+    ;;
+
+    module Paths = struct
+      (* The path to the directory that will contain all toolchain
+         versions. Creates the directory if it doesn't already exist. *)
+      let toolchain_base_dir () =
+        let cache_dir =
+          Xdg.create ~env:Sys.getenv_opt ()
+          |> Xdg.cache_dir
+          |> Path.Outside_build_dir.of_string
+        in
+        let path =
+          Path.Outside_build_dir.relative
+            (Path.Outside_build_dir.relative cache_dir "dune")
+            "toolchains"
+        in
+        (let path = Path.outside_build_dir path in
+         if not (Path.exists path) then Path.mkdir_p path;
+         if not (Path.is_directory path)
+         then
+           User_error.raise
+             [ Pp.textf
+                 "Expected %s to be a directory but it is not."
+                 (Path.to_string path)
+             ]);
+        path
+      ;;
+
+      (* The path to a directory named after the given version inside the
+         toolchains directory. This directory will contain the source code
+         and binary artifacts associated with a particular version of the
+         compiler toolchain. *)
+      let toolchain_dir t =
+        Path.Outside_build_dir.relative (toolchain_base_dir ()) (identifier_string t)
+      ;;
+
+      let source_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "source"
+      let target_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "target"
+
+      (* A temporary directory within the given version's toolchain
+         directory where files will be installed before moving them into
+         the target directory. This two stage installation means that we
+         can guarantee that if the target directory exists then it
+         contains the complete installation of the toolchain. *)
+      let tmp_install_dir t = Path.Outside_build_dir.relative (toolchain_dir t) "_install"
+
+      (* When installing with the DESTDIR the full path from the root
+         directory to the target directory is instantiated inside the
+         directory passed as DESTDIR. This function returns the absolute
+         path to the copy of the target directory inside DESTDIR. This
+         assumes that the output of [tmp_install_dir_dir] will be passed as
+         DESTDIR when installing. *)
+      let target_dir_within_tmp_install_dir t =
+        let target_dir = target_dir t in
+        let target_without_root_prefix =
+          (* Remove the root directory prefix from the target directory so
+             it can be used to create a path relative to the temporary
+             install dir. *)
+          match
+            String.drop_prefix
+              (Path.Outside_build_dir.to_string target_dir)
+              ~prefix:(Path.External.to_string Path.External.root)
+          with
+          | Some x -> x
+          | None ->
+            Code_error.raise
+              "Expected target dir to start with root"
+              [ "target_dir", Path.Outside_build_dir.to_dyn target_dir
+              ; "root", Path.External.to_dyn Path.External.root
+              ]
+        in
+        Path.Outside_build_dir.relative (tmp_install_dir t) target_without_root_prefix
+      ;;
+
+      let flock t =
+        Path.Outside_build_dir.relative (toolchain_dir t) "lock" |> Path.outside_build_dir
+      ;;
+    end
+
+    let depends_on { deps; _ } dep = List.mem deps dep ~equal:Package_name.equal
+
+    (* An opam filter environment for evaluating opam commands for
+       building and installing packages. *)
+    let opam_env t =
+      let open Fiber.O in
+      let make = Make.path ~path:env_path in
+      let sys_poll = Sys_poll.make ~path:env_path in
+      let prefix = Paths.target_dir t in
+      let+ solver_env = Sys_poll.solver_env_from_current_system sys_poll in
+      let solver_env =
+        [ Package_variable_name.make, Path.to_string make
+        ; (* set jobs to "" so that `make -j%{jobs}%` evaluates to `make -j` *)
+          Package_variable_name.jobs, ""
+        ; Package_variable_name.prefix, Path.Outside_build_dir.to_string prefix
+        ; ( Package_variable_name.doc
+          , Path.Outside_build_dir.relative prefix "doc"
+            |> Path.Outside_build_dir.to_string )
+        ]
+        |> List.fold_left ~init:solver_env ~f:(fun acc (variable_name, string_value) ->
+          Solver_env.set acc variable_name (Variable_value.string string_value))
+      in
+      let global_env = Solver_env.to_env solver_env in
+      fun full_variable ->
+        match OpamVariable.Full.scope full_variable with
+        | Global -> global_env full_variable
+        | Self -> None
+        | Package package_name ->
+          let package_name = Package_name.of_opam_package_name package_name in
+          let variable =
+            Package_variable_name.of_opam (OpamVariable.Full.variable full_variable)
+          in
+          if Package_variable_name.equal variable Package_variable_name.installed
+          then (
+            let value = depends_on t package_name in
+            Some (B value))
+          else None
+    ;;
+  end
+
+  module Command = struct
+    type t =
+      { prog : [ `Relative_to_cwd of string | `Absolute of Path.t ]
+      ; args : string list
+      }
+
+    let of_list ~path = function
+      | [] -> None
+      | prog :: args ->
+        let prog =
+          if Filename.is_implicit prog
+          then (
+            match Bin.which ~path prog with
+            | Some prog -> `Absolute prog
+            | None ->
+              User_error.raise
+                [ Pp.textf "The program %S does not appear to be installed." prog ])
+          else if Filename.is_relative prog
+          then `Relative_to_cwd prog
+          else `Absolute (Path.of_string prog)
+        in
+        Some { prog; args }
+    ;;
+
+    let list_of_opam_command_list env opam_commands =
+      OpamFilter.commands env opam_commands |> List.filter_map ~f:(of_list ~path:env_path)
+    ;;
+
+    let run ~dir { prog; args } =
+      let output_on_success =
+        Dune_engine.Execution_parameters.Action_output_on_success.Swallow
+      in
+      let output_limit = Dune_engine.Execution_parameters.Action_output_limit.default in
+      let stdout_to = Process.Io.make_stdout ~output_on_success ~output_limit in
+      let stderr_to = Process.Io.make_stderr ~output_on_success ~output_limit in
+      let prog =
+        match prog with
+        | `Relative_to_cwd relative_path -> Path.relative dir relative_path
+        | `Absolute path -> path
+      in
+      Process.run ~dir ~stdout_to ~stderr_to ~display:Quiet Strict prog args
+    ;;
+  end
+
+  type t =
+    { name : Name.t
+    ; url : OpamUrl0.t
+    ; opam_file : OpamFile.OPAM.t
+    ; opam_env : OpamFilter.env
+    }
+
+  let build_commands t = Command.list_of_opam_command_list t.opam_env t.opam_file.build
+
+  (* Run the build commands for the compiler. The build commands are
+     taken from the compiler's opam file. *)
+  let build t =
+    let dir = Path.outside_build_dir (Name.Paths.source_dir t.name) in
+    Fiber.sequential_iter (build_commands t) ~f:(Command.run ~dir)
+  ;;
+
+  (* Append "DESTDIR=..." to the install commands from the package's
+     opam file so that when the install command is run it will install
+     the compiler into a temporary directory. This also validates that
+     the install command from the package's opam file begins with "make
+     install", as otherwise appending "DESTDIR=..." to its argument list
+     will have an unintentional effect. Raises user errors if the
+     install command doesn't look as expected. *)
+  let validate_and_add_destdir_to_install_commands t =
+    let expectation_message =
+      [ Pp.text "Expected a single unfiltered install command of the form "
+      ; User_message.command "make install ..."
+      ]
+    in
+    match t.opam_file.install with
+    | [ (((CIdent "make", None) :: (CString "install", None) :: _ as args), None) ] ->
+      let destdir_arg =
+        sprintf
+          "DESTDIR=%s"
+          (Name.Paths.tmp_install_dir t.name |> Path.Outside_build_dir.to_string)
+      in
+      [ args @ [ CString destdir_arg, None ], None ]
+    | [] ->
+      User_error.raise
+        (Pp.textf
+           "Toolchain compiler %s has no install commands."
+           (Name.identifier_string t.name)
+         :: expectation_message)
+    | [ (_, Some filter) ] ->
+      User_error.raise
+        (Pp.textf
+           "Toolchain compiler %s has a filter on its install command:  %s"
+           (Name.identifier_string t.name)
+           (OpamFilter.to_string filter)
+         :: expectation_message)
+    | [ (_, None) ] ->
+      User_error.raise
+        (Pp.textf
+           "Toolchain compiler %s is not of the form "
+           (Name.identifier_string t.name)
+         :: User_message.command "make install..."
+         :: expectation_message)
+    | _many ->
+      User_error.raise
+        (Pp.textf
+           "Toolchain compiler %s has multiple install commands."
+           (Name.identifier_string t.name)
+         :: expectation_message)
+  ;;
+
+  (* The install commands from the package's opam file, modified to
+     install the package into a temporary directory. *)
+  let install_commands_with_destdir t =
+    Command.list_of_opam_command_list
+      t.opam_env
+      (validate_and_add_destdir_to_install_commands t)
+  ;;
+
+  (* Run the install commands from the opam file, modified to install
+     the package into a temporary directory. *)
+  let install_tmp t =
+    let dir = Path.outside_build_dir (Name.Paths.source_dir t.name) in
+    Fiber.sequential_iter (install_commands_with_destdir t) ~f:(Command.run ~dir)
+  ;;
+
+  (* Install the compiler in the appropriate toolchain directory.
+
+     Installation happens in two steps. First, run the package's
+     install command passing "compilerIR=..." to install the toolchain
+     into a temporary directory. Then the target directory from the
+     temporary directory is copied into the final installation
+     directory. This allows us to use the fact that the final
+     installation directory exists to check that the toolchain is
+     installed. *)
+  let install t =
+    let open Fiber.O in
+    let dest_dir = Path.outside_build_dir (Name.Paths.tmp_install_dir t.name) in
+    let target_dir = Path.outside_build_dir (Name.Paths.target_dir t.name) in
+    Fpath.rm_rf (Path.to_string target_dir);
+    Fpath.rm_rf (Path.to_string dest_dir);
+    let+ () = install_tmp t in
+    Path.rename
+      (Path.outside_build_dir (Name.Paths.target_dir_within_tmp_install_dir t.name))
+      (Path.outside_build_dir (Name.Paths.target_dir t.name));
+    Fpath.rm_rf (Path.to_string dest_dir)
+  ;;
+
+  let bin_dir t = Path.Outside_build_dir.relative (Name.Paths.target_dir t.name) "bin"
+  let is_installed t = Path.exists (Path.outside_build_dir (Name.Paths.target_dir t.name))
+
+  (* The strongest checksum from the compiler's opam file. This will
+     be used to validate the complier's source archive. Note that ideally
+     we would validate the compiler source archive against all the
+     checksums from the compiler's opam file however [Fetch.fetch]
+     currently only accepts a single checksum for validation. *)
+  let strongest_checksum { opam_file; _ } =
+    Option.bind opam_file.url ~f:(fun opam_file_url ->
+      OpamFile.URL.checksum opam_file_url
+      |> List.map ~f:Checksum.of_opam_hash
+      |> Checksum.choose_strongest)
+  ;;
+
+  let of_resolved_package resolved_package ~deps =
+    let open Fiber.O in
+    let package = Resolved_package.package resolved_package in
+    let opam_file : OpamFile.OPAM.t = Resolved_package.opam_file resolved_package in
+    match opam_file.url with
+    | Some opam_file_url ->
+      let url = OpamFile.URL.url opam_file_url in
+      let name =
+        { Name.name = Package_name.of_opam_package_name package.name
+        ; version = Package_version.of_opam_package_version package.version
+        ; deps
+        }
+      in
+      let+ opam_env = Name.opam_env name in
+      Some { name; url; opam_file; opam_env }
+    | None -> Fiber.return None
+  ;;
+
+  let handle_checksum_mismatch t ~got_checksum =
+    let checksum =
+      match strongest_checksum t with
+      | Some checksum -> checksum
+      | None ->
+        Code_error.raise
+          "checksum mismatch, but this packgae has no checksum"
+          [ "got_checksum", Checksum.to_dyn got_checksum ]
+    in
+    User_error.raise
+      [ Pp.textf
+          "Checksum mismatch when downloading compiler toolchain %s from %s."
+          (Name.identifier_string t.name)
+          (OpamUrl0.to_string t.url)
+      ; Pp.textf "Expected checksum: %s" (Checksum.to_string checksum)
+      ; Pp.textf "Got checksum: %s" (Checksum.to_string got_checksum)
+      ]
+  ;;
+
+  let handle_unavailable t ~msg =
+    let msg_context =
+      Pp.textf
+        "Unable to download compiler toolchain %s from %s."
+        (Name.identifier_string t.name)
+        (OpamUrl0.to_string t.url)
+    in
+    let msg =
+      match (msg : User_message.t option) with
+      | Some msg -> { msg with paragraphs = msg_context :: msg.paragraphs }
+      | None -> User_message.make [ msg_context ]
+    in
+    raise (User_error.E msg)
+  ;;
+
+  let fetch t =
+    let open Fiber.O in
+    let source_dir = Path.outside_build_dir (Name.Paths.source_dir t.name) in
+    Fpath.rm_rf (Path.to_string source_dir);
+    Path.mkdir_p source_dir;
+    let+ result =
+      Fetch.fetch
+        ~unpack:true
+        ~checksum:(strongest_checksum t)
+        ~target:source_dir
+        ~url:(Loc.none, t.url)
+    in
+    match result with
+    | Ok () -> ()
+    | Error (Fetch.Checksum_mismatch got_checksum) ->
+      handle_checksum_mismatch t ~got_checksum
+    | Error (Fetch.Unavailable msg) -> handle_unavailable t ~msg
+  ;;
+
+  let log_print ~log_when style pp =
+    match log_when with
+    | `Never -> ()
+    | _ -> User_message.print (User_message.make [ Pp.tag style pp ])
+  ;;
+
+  let print_already_installed_message t ~log_when =
+    match log_when with
+    | `Always ->
+      log_print ~log_when User_message.Style.Success
+      @@ Pp.textf
+           "Compiler toolchain %s is already installed in %s"
+           (Name.identifier_string t.name)
+           (Name.Paths.target_dir t.name |> Path.Outside_build_dir.to_string)
+    | _ -> ()
+  ;;
+
+  let download_build_install t ~log_when =
+    let open Fiber.O in
+    let detail_log_style = User_message.Style.Details in
+    log_print ~log_when detail_log_style
+    @@ Pp.textf
+         "Will install compiler toolchain %s to %s"
+         (Name.identifier_string t.name)
+         (Name.Paths.target_dir t.name |> Path.Outside_build_dir.to_string);
+    log_print ~log_when detail_log_style @@ Pp.text "Downloading...";
+    let* () = fetch t in
+    log_print ~log_when detail_log_style @@ Pp.text "Building...";
+    let* () = build t in
+    log_print ~log_when detail_log_style @@ Pp.text "Installing...";
+    let+ () = install t in
+    log_print ~log_when User_message.Style.Success
+    @@ Pp.textf
+         "Success! Compiler toolchain %s installed to %s."
+         (Name.identifier_string t.name)
+         (Name.Paths.target_dir t.name |> Path.Outside_build_dir.to_string)
+  ;;
+
+  let with_flock t ~f =
+    Flock.with_flock
+      (Name.Paths.flock t.name)
+      ~name_for_messages:(sprintf "compiler toolchain %s" (Name.identifier_string t.name))
+      ~timeout_s:infinity
+      ~f
+  ;;
+
+  let get t ~log_when =
+    if is_installed t
+    then (
+      print_already_installed_message t ~log_when;
+      Fiber.return ())
+    else
+      with_flock t ~f:(fun () ->
+        (* Note that we deliberately check if the toolchain is
+           installed before and after taking the flock.
+
+           The first check prevents us from trying to take the lock if
+           the toolchain is installed. To build any package dune first
+           checks if the necessary toolchain is installed, so to build
+           a project with many dependencies, dune will check if the
+           toolchain is installed many times. If this check required
+           first taking a lock, multiple concurrent dune instances
+           would sometimes contest the lock. This isn't too bad for
+           performance as the lock is only held briefly, but when dune
+           waits on a flock it prints a message, so freqeunt, brief
+           lock acquisitions can lead to a lot of noise in the
+           output.
+
+           The second check is to handle the case where the toolchain
+           was installed in between the first check, and the flock
+           being acquired.
+        *)
+        if is_installed t
+        then (
+          print_already_installed_message t ~log_when;
+          Fiber.return ())
+        else download_build_install t ~log_when)
+  ;;
+end
+
+module Available_compilers = struct
+  type t = Opam_repo.t
+
+  let equal = Opam_repo.equal
+
+  let load_upstream_opam_repo () =
+    let loc, opam_url = Workspace.Repository.(opam_url upstream) in
+    Opam_repo.of_git_repo loc opam_url
+  ;;
+
+  (* The names of packages that can be installed by the toolchains
+     mechanism. Note that for a package to be compatible with the
+     toolchains mechanism, it is necessary that the package can be
+     installed by running `make install` in its source directory after
+     running whatever build commands are specified in its opam
+     file. Additionally, the package's makefile must implement the
+     DESTDIR protocol. *)
+  let compiler_package_names =
+    List.map ~f:Package_name.of_string [ "ocaml-base-compiler"; "ocaml-variants" ]
+  ;;
+
+  let is_compiler_package_name = List.mem compiler_package_names ~equal:Package_name.equal
+
+  let find t package_name package_version ~deps =
+    if is_compiler_package_name package_name
+    then
+      let open Fiber.O in
+      let* resolved_packages_by_version =
+        Opam_repo.load_all_versions [ t ] (Package_name.to_opam_package_name package_name)
+      in
+      match
+        OpamPackage.Version.Map.find_opt
+          (Package_version.to_opam_package_version package_version)
+          resolved_packages_by_version
+      with
+      | Some resolved_package -> Compiler.of_resolved_package resolved_package ~deps
+      | None -> Fiber.return None
+    else Fiber.return None
+  ;;
+end

--- a/src/dune_pkg/toolchain.mli
+++ b/src/dune_pkg/toolchain.mli
@@ -1,0 +1,23 @@
+open! Import
+open! Stdune
+
+module Compiler : sig
+  type t
+
+  val bin_dir : t -> Path.Outside_build_dir.t
+  val get : t -> log_when:[ `Always | `Never | `Install_only ] -> unit Fiber.t
+end
+
+module Available_compilers : sig
+  type t
+
+  val equal : t -> t -> bool
+  val load_upstream_opam_repo : unit -> t Fiber.t
+
+  val find
+    :  t
+    -> Package_name.t
+    -> Package_version.t
+    -> deps:Package_name.t list
+    -> Compiler.t option Fiber.t
+end

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -143,6 +143,21 @@ let of_binaries ~path name env binaries =
   make name ~env ~get_ocaml_tool ~which
 ;;
 
+let of_toolchain_compiler compiler name env =
+  let module Toolchain = Dune_pkg.Toolchain in
+  let bin_dir = Toolchain.Compiler.bin_dir compiler in
+  let* () =
+    Memo.of_reproducible_fiber (Toolchain.Compiler.get ~log_when:`Install_only compiler)
+  in
+  let which prog =
+    let path = Path.Outside_build_dir.relative bin_dir prog in
+    let+ exists = Fs_memo.file_exists path in
+    if exists then Some (Path.outside_build_dir path) else None
+  in
+  let get_ocaml_tool ~dir:_ prog = which prog in
+  make name ~which ~env ~get_ocaml_tool
+;;
+
 (* Seems wrong to support this at the level of the engine. This is easily
    implemented at the level of the rules and is noly needed for windows *)
 let register_response_file_support t =

--- a/src/dune_rules/ocaml_toolchain.mli
+++ b/src/dune_rules/ocaml_toolchain.mli
@@ -26,6 +26,12 @@ val of_env_with_findlib
 
 val of_binaries : path:Path.t list -> Context_name.t -> Env.t -> Path.Set.t -> t Memo.t
 
+val of_toolchain_compiler
+  :  Dune_pkg.Toolchain.Compiler.t
+  -> Context_name.t
+  -> Env.t
+  -> t Memo.t
+
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Ocaml.Mode.t -> Action.Prog.t
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -9,6 +9,7 @@ include struct
   module Checksum = Checksum
   module Source = Source
   module Build_command = Lock_dir.Build_command
+  module Toolchain = Dune_pkg.Toolchain
 end
 
 module Variable = struct
@@ -152,6 +153,7 @@ module Value_list_env = struct
 
   let parse_strings s = Bin.parse s |> List.map ~f:(fun s -> Value.String s)
   let of_env env : t = Env.to_map env |> Env.Map.map ~f:parse_strings
+  let global () = of_env (Global.env ())
 
   (* Concatenate a list of values in the style of lists found in
      environment variables, such as PATH *)
@@ -193,7 +195,112 @@ module Value_list_env = struct
   let add_path (t : t) var path : t =
     Env.Map.update t var ~f:(fun paths ->
       let paths = Option.value paths ~default:[] in
-      Some (Value.Dir (Path.build path) :: paths))
+      Some (Value.Dir path :: paths))
+  ;;
+
+  (* Prepends the bin dir of a given toolchain compiler to the PATH
+     variable in the environment. *)
+  let add_toolchain_bin_dir_to_path t compiler =
+    let toolchain_bin_dir =
+      Toolchain.Compiler.bin_dir compiler |> Path.outside_build_dir
+    in
+    add_path t Env_path.var toolchain_bin_dir
+  ;;
+end
+
+module DB = struct
+  type t =
+    { all : Lock_dir.Pkg.t Package.Name.Map.t
+    ; system_provided : Package.Name.Set.t
+    ; available_compilers : Toolchain.Available_compilers.t
+    }
+
+  let equal t { all; system_provided; available_compilers } =
+    Package.Name.Map.equal ~equal:Lock_dir.Pkg.equal t.all all
+    && Package.Name.Set.equal t.system_provided system_provided
+    && Toolchain.Available_compilers.equal t.available_compilers available_compilers
+  ;;
+
+  let get =
+    let dune = Package.Name.Set.singleton (Package.Name.of_string "dune") in
+    fun context ->
+      let+ all = Lock_dir.get context
+      and+ available_compilers =
+        Memo.of_reproducible_fiber
+        @@ Toolchain.Available_compilers.load_upstream_opam_repo ()
+      in
+      { all = all.packages; system_provided = dune; available_compilers }
+  ;;
+end
+
+module Compiler = struct
+  type t =
+    | Toolchain of Toolchain.Compiler.t
+    (* The lockdir specifies a compiler dependency as a package. *)
+    | Inside_lock_dir of (Loc.t * Pkg_info.t)
+    (* The lockdir specifies that the system compiler toolchain will
+       be used rather than one managed by dune. *)
+    | System_provided
+
+  let find_and_install_toolchain_compiler available_compilers name version deps =
+    if Dune_pkg.Feature_flags.use_toolchains
+    then
+      Memo.of_reproducible_fiber
+        (let open Fiber.O in
+         let* toolchain_compiler =
+           Toolchain.Available_compilers.find available_compilers name version ~deps
+         in
+         match toolchain_compiler with
+         | None -> Fiber.return None
+         | Some toolchain_compiler ->
+           let+ () = Toolchain.Compiler.get ~log_when:`Install_only toolchain_compiler in
+           Some toolchain_compiler)
+    else Memo.return None
+  ;;
+
+  let of_context context =
+    let* lock_dir = Lock_dir.get context in
+    let* db = DB.get context in
+    match lock_dir.ocaml with
+    | None ->
+      (* The lockdir doesn't specify a compiler dependency. Assume
+         that the user is managing their own ocaml compiler if they need
+         it. *)
+      Memo.return System_provided
+    | Some (loc, ocaml) ->
+      if Package.Name.Set.mem db.system_provided ocaml
+      then Memo.return System_provided
+      else (
+        match Package.Name.Map.find db.all ocaml with
+        | None ->
+          User_error.raise
+            ~loc
+            [ Pp.textf "Unknown compiler package %S" (Package.Name.to_string ocaml) ]
+        | Some { depends; info; _ } ->
+          if not (Package.Name.equal ocaml info.name)
+          then
+            Code_error.raise
+              "lockfile info for compiler package has unexpected name"
+              [ "expected name", Package.Name.to_dyn ocaml
+              ; "actual name", Package.Name.to_dyn info.name
+              ];
+          let+ toolchain_compiler =
+            find_and_install_toolchain_compiler
+              db.available_compilers
+              info.name
+              info.version
+              (List.map depends ~f:snd)
+          in
+          (match toolchain_compiler with
+           | Some toolchain_compiler -> Toolchain toolchain_compiler
+           | None -> Inside_lock_dir (loc, info)))
+  ;;
+
+  let add_path_to_env t ~env =
+    match t with
+    | Inside_lock_dir _ | System_provided -> env
+    | Toolchain toolchain_compiler ->
+      Value_list_env.add_toolchain_bin_dir_to_path env toolchain_compiler
   ;;
 end
 
@@ -344,10 +451,10 @@ module Pkg = struct
     List.fold_left ts ~init:Env.Map.empty ~f:(fun env t ->
       let env =
         let roots = Paths.install_roots t.paths in
-        let init = Value_list_env.add_path env Env_path.var roots.bin in
+        let init = Value_list_env.add_path env Env_path.var (Path.build roots.bin) in
         let vars = Install.Roots.to_env_without_path roots in
         List.fold_left vars ~init ~f:(fun acc (var, path) ->
-          Value_list_env.add_path acc var path)
+          Value_list_env.add_path acc var (Path.build path))
       in
       List.fold_left t.exported_env ~init:env ~f:Env_update.set)
   ;;
@@ -801,7 +908,7 @@ module Action_expander = struct
              (match Filename.Map.find t.artifacts program with
               | Some s -> Memo.return @@ Ok s
               | None ->
-                (let path = Global.env () |> Env_path.path in
+                (let path = Value_list_env.to_env t.env |> Env_path.path in
                  Which.which ~path program)
                 >>| (function
                  | Some p -> Ok p
@@ -996,10 +1103,13 @@ module Action_expander = struct
   end
 
   let expander context (pkg : Pkg.t) =
-    let+ { Artifacts_and_deps.binaries; dep_info } =
+    let* { Artifacts_and_deps.binaries; dep_info } =
       Pkg.deps_closure pkg |> Artifacts_and_deps.of_closure
     in
-    let env = Pkg.exported_value_env pkg in
+    let+ env =
+      Compiler.of_context context
+      >>| Compiler.add_path_to_env ~env:(Pkg.exported_value_env pkg)
+    in
     let depends =
       Package.Name.Map.add_exn
         dep_info
@@ -1061,31 +1171,16 @@ module Action_expander = struct
   ;;
 end
 
-module DB = struct
-  type t =
-    { all : Lock_dir.Pkg.t Package.Name.Map.t
-    ; system_provided : Package.Name.Set.t
-    }
-
-  let equal t { all; system_provided } =
-    Package.Name.Map.equal ~equal:Lock_dir.Pkg.equal t.all all
-    && Package.Name.Set.equal t.system_provided system_provided
-  ;;
-
-  let get =
-    let dune = Package.Name.Set.singleton (Package.Name.of_string "dune") in
-    fun context ->
-      let+ all = Lock_dir.get context in
-      { all = all.packages; system_provided = dune }
-  ;;
-end
-
 module rec Resolve : sig
   val resolve
     :  DB.t
     -> Context_name.t
     -> Loc.t * Package.Name.t
-    -> [ `Inside_lock_dir of Pkg.t | `System_provided ] Memo.t
+    -> [ `Inside_lock_dir of Pkg.t
+       | `System_provided
+       | `Toolchain of Toolchain.Compiler.t
+       ]
+         Memo.t
 end = struct
   open Resolve
 
@@ -1094,38 +1189,48 @@ end = struct
     | None -> Memo.return None
     | Some { Lock_dir.Pkg.build_command; install_command; depends; info; exported_env } ->
       assert (Package.Name.equal name info.name);
-      let* depends =
-        Memo.parallel_map depends ~f:(fun name ->
-          resolve db ctx name
-          >>| function
-          | `Inside_lock_dir pkg -> Some pkg
-          | `System_provided -> None)
-        >>| List.filter_opt
-      and+ files_dir =
-        let+ lock_dir = Lock_dir.get_path ctx >>| Option.value_exn in
-        Path.Build.append_source
-          (Context_name.build_dir ctx)
-          (Dune_pkg.Lock_dir.Pkg.files_dir info.name ~lock_dir)
+      let* compiler =
+        Compiler.find_and_install_toolchain_compiler
+          db.available_compilers
+          info.name
+          info.version
+          (List.map depends ~f:snd)
       in
-      let id = Pkg.Id.gen () in
-      let paths = Paths.make name ctx in
-      let t =
-        { Pkg.id
-        ; build_command
-        ; install_command
-        ; depends
-        ; paths
-        ; info
-        ; files_dir
-        ; exported_env = []
-        }
-      in
-      let+ exported_env =
-        let* expander = Action_expander.expander ctx t in
-        Memo.parallel_map exported_env ~f:(Action_expander.exported_env expander)
-      in
-      t.exported_env <- exported_env;
-      Some t
+      (match compiler with
+       | Some compiler -> Memo.return (Some (`Toolchain compiler))
+       | None ->
+         let* depends =
+           Memo.parallel_map depends ~f:(fun name ->
+             resolve db ctx name
+             >>| function
+             | `Inside_lock_dir pkg -> Some pkg
+             | `Toolchain _ | `System_provided -> None)
+           >>| List.filter_opt
+         and+ files_dir =
+           let+ lock_dir = Lock_dir.get_path ctx >>| Option.value_exn in
+           Path.Build.append_source
+             (Context_name.build_dir ctx)
+             (Dune_pkg.Lock_dir.Pkg.files_dir info.name ~lock_dir)
+         in
+         let id = Pkg.Id.gen () in
+         let paths = Paths.make name ctx in
+         let t =
+           { Pkg.id
+           ; build_command
+           ; install_command
+           ; depends
+           ; paths
+           ; info
+           ; files_dir
+           ; exported_env = []
+           }
+         in
+         let+ exported_env =
+           let* expander = Action_expander.expander ctx t in
+           Memo.parallel_map exported_env ~f:(Action_expander.exported_env expander)
+         in
+         t.exported_env <- exported_env;
+         Some (`Inside_lock_dir t))
   ;;
 
   let resolve =
@@ -1151,7 +1256,7 @@ end = struct
       else
         Memo.exec memo (db, ctx, name)
         >>| function
-        | Some s -> `Inside_lock_dir s
+        | Some s -> s
         | None ->
           User_error.raise
             ~loc
@@ -1533,6 +1638,7 @@ let source_rules (pkg : Pkg.t) =
 ;;
 
 let build_rule context_name ~source_deps (pkg : Pkg.t) =
+  let* compiler = Compiler.of_context context_name in
   let+ build_action =
     let+ build_and_install =
       let+ copy_action =
@@ -1606,7 +1712,10 @@ let build_rule context_name ~source_deps (pkg : Pkg.t) =
   Action_builder.deps deps
   |> Action_builder.with_no_targets
   (* TODO should we add env deps on these? *)
-  >>> add_env (Pkg.exported_env pkg) build_action
+  >>> add_env
+        (Compiler.add_path_to_env compiler ~env:(Pkg.exported_value_env pkg)
+         |> Value_list_env.to_env)
+        build_action
   |> Action_builder.With_targets.add_directories
        ~directory_targets:[ pkg.paths.target_dir ]
 ;;
@@ -1627,6 +1736,13 @@ let setup_package_rules context ~dir ~pkg_name : Gen_rules.result Memo.t =
     Resolve.resolve db context (Loc.none, name)
     >>| function
     | `Inside_lock_dir pkg -> pkg
+    | `Toolchain _ ->
+      User_error.raise
+        (* TODO loc, toolchain info *)
+        [ Pp.textf
+            "There are no rules for %S because it's provided by the toolchain"
+            (Package.Name.to_string name)
+        ]
     | `System_provided ->
       User_error.raise
         (* TODO loc *)
@@ -1676,6 +1792,7 @@ let setup_rules ~components ~dir ctx =
 ;;
 
 let ocaml_toolchain context =
+  let memoize = Action_builder.memoize "ocaml_toolchain" in
   (let* lock_dir = Lock_dir.get context in
    let* db = DB.get context in
    match lock_dir.ocaml with
@@ -1696,7 +1813,17 @@ let ocaml_toolchain context =
       let path = Env_path.path (Global.env ()) in
       Action_builder.of_memo @@ Ocaml_toolchain.of_binaries ~path context env binaries
     in
-    Some (Action_builder.memoize "ocaml_toolchain" toolchain)
+    Some (memoize toolchain)
+  | `Toolchain toolchain_compiler ->
+    let toolchain =
+      let env =
+        Value_list_env.(
+          add_toolchain_bin_dir_to_path (global ()) toolchain_compiler |> to_env)
+      in
+      Action_builder.of_memo
+      @@ Ocaml_toolchain.of_toolchain_compiler toolchain_compiler context env
+    in
+    Some (memoize toolchain)
 ;;
 
 let all_packages context =
@@ -1707,7 +1834,7 @@ let all_packages context =
     Resolve.resolve db context (Loc.none, package)
     >>| function
     | `Inside_lock_dir pkg -> Some pkg
-    | `System_provided -> None)
+    | `System_provided | `Toolchain _ -> None)
   >>| List.filter_opt
   >>| Pkg.top_closure
 ;;
@@ -1726,8 +1853,11 @@ let which context =
 ;;
 
 let ocamlpath context =
-  let+ all_packages = all_packages context in
-  let env = Pkg.build_env_of_deps all_packages in
+  let* all_packages = all_packages context in
+  let+ env =
+    Compiler.of_context context
+    >>| Compiler.add_path_to_env ~env:(Pkg.build_env_of_deps all_packages)
+  in
   Env.Map.find env Dune_findlib.Config.ocamlpath_var
   |> Option.value ~default:[]
   |> List.map ~f:(function
@@ -1739,8 +1869,11 @@ let lock_dir_active = Lock_dir.lock_dir_active
 let lock_dir_path = Lock_dir.get_path
 
 let exported_env context =
-  let+ all_packages = all_packages context in
-  let env = Pkg.build_env_of_deps all_packages in
+  let* all_packages = all_packages context in
+  let+ env =
+    Compiler.of_context context
+    >>| Compiler.add_path_to_env ~env:(Pkg.build_env_of_deps all_packages)
+  in
   let vars = Env.Map.map env ~f:Value_list_env.string_of_env_values in
   Env.extend Env.empty ~vars
 ;;
@@ -1753,7 +1886,7 @@ let find_package ctx pkg =
     let* db = DB.get ctx in
     Resolve.resolve db ctx (Loc.none, pkg)
     >>| (function
-           | `System_provided -> Action_builder.return ()
+           | `System_provided | `Toolchain _ -> Action_builder.return ()
            | `Inside_lock_dir pkg ->
              let open Action_builder.O in
              let+ _cookie = (Pkg_installed.of_paths pkg.paths).cookie in


### PR DESCRIPTION
This adds several experimental features to dune which are disabled by default by some ad-hoc feature flags. The two notable features are "toolchains" and "autolocking". These features are included in experimental versions of dune used in interviews to evaluate dune's developer experience. The goal of upstreaming these features is to reduce the maintenance burden of a long-lived feature branch.

Toolchains refers to a feature where dune downloads and builds ocaml compiler packages using an alternative mechanism to regular dune package management. Toolchains are installed into
`$XDG_CACHE_DIR/dune/toolchains/<name.version>`. Both the ocaml-base-compiler and ocaml-variants compilers are supported. In the case of the latter, multiple different configurations may be installed concurrently, by concatenating the names of enabled options to the end of the name of the directory containing the toolchain.

The toolchains feature is a temporary workaround for the fact that the compiler packages are not currently relocatable. That is, the artifacts from the compiler packages built inside dune's build sandbox cannot be used after moving them into the dune cache or their eventual location within the _build directory. Work is currently being done to make the compiler relocatable, at which point dune will be able to build compiler packages in its sandbox and the toolchains feature can be deleted.

Autolocking refers to generating and updating the lock directory in any command that would use the metadata it contains (e.g. `dune build`). This removes the need to explicitly run `dune pkg lock`, bringing the behavior of dune more in line with that of other popular language package managers such as cargo and npm.