### PR TITLE
pkg(fix): use upstream or overlay as repository name (#10605)

### DIFF
--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -856,7 +856,11 @@ let step1 clflags =
        in
        let defined_names = ref Context_name.Set.empty in
        let env = Lazy.force env in
-       let repos = default_repositories @ List.map ~f:Lazy.force repos in
+       let repos =
+         if List.is_empty repos
+         then default_repositories
+         else List.map ~f:Lazy.force repos
+       in
        let merlin_context =
          List.fold_left contexts ~init:None ~f:(fun acc ctx ->
            let name = Context.name ctx in

--- a/test/blackbox-tests/test-cases/pkg/github10605.t
+++ b/test/blackbox-tests/test-cases/pkg/github10605.t
@@ -1,0 +1,61 @@
+This reproduces the issue from #10605.
+Dune fails when we upstream or overlay as repository name.
+It fixed now.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ mkpkg foo 1.0 <<EOF
+  > EOF
+  $ cd mock-opam-repository
+  $ git init --quiet
+  $ git add -A
+  $ git commit --quiet -m "foo 1.0"
+  $ cd ..
+
+upstream repository
+
+  $ mv mock-opam-repository upstream-mock-opam-repository
+
+  $ mkrepo
+  $ mkpkg bar 1.0 <<EOF
+  > EOF
+  $ cd mock-opam-repository
+  $ git init --quiet
+  $ git add -A
+  $ git commit --quiet -m "bar 1.0"
+  $ cd ..
+
+overlay repository
+  $ mv mock-opam-repository overlay-mock-opam-repository
+
+We set up a project that uses upstream and overlay repository
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (lock_dir
+  >  (repositories upstream overlay))
+  > (repository
+  >  (name upstream)
+  >  (source "git+file://$PWD/upstream-mock-opam-repository"))
+  > (repository
+  >  (name overlay)
+  >  (source "git+file://$PWD/overlay-mock-opam-repository"))
+  > (context
+  >  (default
+  >   (name default)))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.10)
+  > 
+  > (package
+  >  (name baz)
+  >  (depends foo bar))
+  > EOF
+  $ cat > dune <<EOF
+  > EOF
+
+  $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
+  Solution for dune.lock:
+  - bar.1.0
+  - foo.1.0


### PR DESCRIPTION
Fixes #10605 