### PR TITLE
Bump dune `lang` version to 3.17 + add unix deps to vendor

### DIFF
--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -451,7 +451,7 @@ lang<coq-lang>` stanza present:
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using coq 0.8)
 
 Next we need a :doc:`/reference/dune/index` file with a :ref:`coq-theory`
@@ -682,7 +682,7 @@ the plugin to sit in, otherwise Coq will not be able to find it.
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using coq 0.8)
 
   (package

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -102,7 +102,7 @@ file:
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using ctypes 0.3)
 
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -283,7 +283,7 @@ Such languages must be enabled in the ``dune`` project file separately:
 
 .. code:: dune
 
-   (lang dune 3.16)
+   (lang dune 3.17)
    (using coq 0.8)
 
 If such extensions are experimental, it's recommended that they pass

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -96,14 +96,14 @@ To enable an instrumentation backend globally, type the following in your
 
 .. code:: dune
 
-   (lang dune 3.16)
+   (lang dune 3.17)
    (instrument_with bisect_ppx)
 
 or for each context individually:
 
 .. code:: dune
 
-   (lang dune 3.16)
+   (lang dune 3.17)
    (context default)
    (context (default (name coverage) (instrument_with bisect_ppx)))
    (context (default (name profiling) (instrument_with landmarks)))

--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -42,7 +42,7 @@ is enabled:
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using melange 0.1)
 
 Next, write a :doc:`/reference/dune/index` file with a

--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -34,7 +34,7 @@ will be installed as a sub-directory.
 
 .. code:: dune
 
-   (lang dune 3.16)
+   (lang dune 3.17)
    (using dune_site 0.1)
    (name mygui)
 
@@ -235,7 +235,7 @@ Main Executable (C)
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using dune_site 0.1)
   (name app)
 
@@ -295,7 +295,7 @@ The Plugin "plugin1"
 
 .. code:: dune
 
-  (lang dune 3.16)
+  (lang dune 3.17)
   (using dune_site 0.1)
 
   (generate_opam_files true)

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -27,7 +27,7 @@ end
 module Version = struct
   type t = int * int
 
-  let latest = 3, 16
+  let latest = 3, 17
 
   let sexp : t Conv.value =
     let open Conv in

--- a/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
+++ b/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
@@ -25,7 +25,7 @@ Allow directories to be installable
   Leaving directory 'a'
 
   $ cat a/_build/install/default/lib/foo/dune-package
-  (lang dune 3.16)
+  (lang dune 3.17)
   (name foo)
   (sections (lib .) (share ../../share/foo))
   (files (lib (META dune-package)) (share ((dir bar) x y)))

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -385,7 +385,7 @@ And the opam file will be generated as expected
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
     "ocaml"
-    $dune {>= "3.16"}
+    $dune {>= "3.17"}
     "odoc" {with-doc}
   ]
   build: [
@@ -495,7 +495,7 @@ And the opam file will be generated as expected
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
     "ocaml"
-    "dune" {>= "3.16"}
+    "dune" {>= "3.17"}
     "odoc" {with-doc}
   ]
   build: [

--- a/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
@@ -32,7 +32,7 @@ Begin by installing a library with C stubs.
   Installing install/lib/libA/libA.cmxs
   Installing install/lib/stublibs/dlllibA_stubs.so
   $ cat ./install/lib/libA/dune-package
-  (lang dune 3.16)
+  (lang dune 3.17)
   (name libA)
   (sections
    (lib

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -27,7 +27,7 @@ Test that we can install melange mode libraries
   ]
 
   $ cat ./_build/install/default/lib/foo/dune-package
-  (lang dune 3.16)
+  (lang dune 3.17)
   (name foo)
   (sections (lib .))
   (files

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -21,9 +21,9 @@ constraint.
   Can't find all required versions.
   Selected: foo.0.0.1 x.dev
   - dune -> (problem)
-      User requested = 3.16
+      User requested = 3.17
       Rejected candidates:
-        dune.3.11.0: Incompatible with restriction: = 3.16
+        dune.3.11.0: Incompatible with restriction: = 3.17
   [1]
   $ test "4.0.0"
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
@@ -31,5 +31,5 @@ We are unable to pin projects that the version of dune doesn't understand.
   Supported versions of this extension in version 100.1 of the dune language:
   - 1.0 to 1.12
   - 2.0 to 2.9
-  - 3.0 to 3.16
+  - 3.0 to 3.17
   [1]

--- a/vendor/lwd/nottui/dune
+++ b/vendor/lwd/nottui/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_nottui)
  (wrapped false)
- (libraries dune_lwd dune_notty dune_notty_unix))
+ (libraries unix dune_lwd dune_notty dune_notty_unix))

--- a/vendor/opam-0install/lib/dune
+++ b/vendor/opam-0install/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name opam_0install)
- (libraries opam_state opam_format zeroinstall_solver fmt))
+ (libraries unix opam_state opam_format zeroinstall_solver fmt))

--- a/vendor/opam/src/format/dune
+++ b/vendor/opam/src/format/dune
@@ -2,7 +2,7 @@
   (name        opam_format)
   (synopsis    "OCaml Package Manager file format handling library")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   (re_export opam_core) (re_export opam_file_format) dune_re)
+  (libraries   unix (re_export opam_core) (re_export opam_file_format) dune_re)
   (modules_without_implementation OpamTypes)
   (wrapped     false))
 

--- a/vendor/opam/src/repository/dune
+++ b/vendor/opam/src/repository/dune
@@ -1,5 +1,5 @@
 (library
   (name        opam_repository)
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   (re_export opam_format))
+  (libraries   unix (re_export opam_format))
   (wrapped     false))

--- a/vendor/opam/src/state/dune
+++ b/vendor/opam/src/state/dune
@@ -1,5 +1,5 @@
 (library
  (name        opam_state)
- (libraries   opam_repository dune_re)
+ (libraries   unix opam_repository dune_re)
  (modules_without_implementation OpamStateTypes OpamScript)
  (wrapped     false))


### PR DESCRIPTION
This PR has two small edits:

-  Bump the dune version into 3.17.

- Add unix as a direct dependency for some vendored libraries.

 See #10644 for more details.