### PR TITLE
pkg: build and make ocamlformat dev-tool available

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -231,6 +231,20 @@ let fmt =
     in
     let common, config = Common.init builder in
     let request (setup : Import.Main.build_system) =
+      let open Action_builder.O in
+      let* () =
+        if Lazy.force Lock_dev_tool.is_enabled
+        then
+          (* Note that generating the ocamlformat lockdir here means
+             that it will be created when a user runs `dune fmt` but not
+             when a user runs `dune build @fmt`. It's important that
+             this logic remain outside of `dune build`, as `dune
+             build` is intended to only build targets, and generating
+             a lockdir is not building a target. *)
+          Action_builder.of_memo
+            (Lock_dev_tool.lock_ocamlformat () |> Memo.of_non_reproducible_fiber)
+        else Action_builder.return ()
+      in
       let dir = Path.(relative root) (Common.prefix_target common ".") in
       Alias.in_dir ~name:Dune_rules.Alias.fmt ~recursive:true ~contexts:setup.contexts dir
       |> Alias.request

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -1,0 +1,82 @@
+open Dune_config
+open Import
+
+let enabled =
+  Config.make_toggle ~name:"lock_dev_tool" ~default:Dune_rules.Setup.lock_dev_tool
+;;
+
+let is_enabled =
+  lazy
+    (match Config.get enabled with
+     | `Enabled -> true
+     | `Disabled -> false)
+;;
+
+(* The solver satisfies dependencies for local packages, but dev tools
+   are not local packages. As a workaround, create an empty local package
+   which depends on the dev tool package. *)
+let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version
+  : Dune_pkg.Local_package.t
+  =
+  let dev_tool_pkg_name = Dune_pkg.Dev_tool.package_name dev_tool in
+  let dependency =
+    let open Dune_lang in
+    let open Package_dependency in
+    let constraint_ =
+      Option.map dev_tool_version ~f:(fun version ->
+        Package_constraint.Uop
+          ( Relop.Eq
+          , Package_constraint.Value.String_literal (Package_version.to_string version) ))
+    in
+    { name = dev_tool_pkg_name; constraint_ }
+  in
+  let local_package_name =
+    Package_name.of_string (Package_name.to_string dev_tool_pkg_name ^ "_dev_tool_wrapper")
+  in
+  { Dune_pkg.Local_package.name = local_package_name
+  ; version = None
+  ; dependencies = [ dependency ]
+  ; conflicts = []
+  ; depopts = []
+  ; pins = Package_name.Map.empty
+  ; conflict_class = []
+  ; loc = Loc.none
+  }
+;;
+
+let solve ~local_packages ~lock_dirs =
+  let open Fiber.O in
+  let* solver_env_from_current_system =
+    Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
+    |> Dune_pkg.Sys_poll.solver_env_from_current_system
+    >>| Option.some
+  and* workspace =
+    Memo.run
+    @@
+    let open Memo.O in
+    let+ workspace = Workspace.workspace () in
+    workspace
+  in
+  Lock.solve
+    workspace
+    ~local_packages
+    ~project_sources:Dune_pkg.Pin_stanza.DB.empty
+    ~solver_env_from_current_system
+    ~version_preference:None
+    ~lock_dirs
+;;
+
+let lock_ocamlformat () : unit Fiber.t =
+  let version = Dune_pkg.Ocamlformat.version_of_current_project's_ocamlformat_config () in
+  let ocamlformat_dev_tool_lock_dir =
+    Dune_pkg.Lock_dir.dev_tool_lock_dir_path Ocamlformat
+  in
+  if not (Path.exists @@ Path.source ocamlformat_dev_tool_lock_dir)
+  then (
+    let local_pkg =
+      make_local_package_wrapping_dev_tool ~dev_tool:Ocamlformat ~dev_tool_version:version
+    in
+    let local_packages = Package_name.Map.singleton local_pkg.name local_pkg in
+    solve ~local_packages ~lock_dirs:[ ocamlformat_dev_tool_lock_dir ])
+  else Fiber.return ()
+;;

--- a/bin/lock_dev_tool.mli
+++ b/bin/lock_dev_tool.mli
@@ -1,0 +1,2 @@
+val is_enabled : bool Lazy.t
+val lock_ocamlformat : unit -> unit Fiber.t

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -144,16 +144,13 @@ let solve
   ~project_sources
   ~solver_env_from_current_system
   ~version_preference
-  ~lock_dirs_arg
+  ~lock_dirs
   =
   let open Fiber.O in
   (* a list of thunks that will perform all the file IO side
      effects after performing validation so that if materializing any
      lockdir would fail then no side effect takes place. *)
   (let+ errors, solutions =
-     let lock_dirs =
-       Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
-     in
      let progress_indicator =
        List.map lock_dirs ~f:Progress_indicator.Per_lockdir.create
      in
@@ -216,13 +213,16 @@ let lock ~version_preference ~lock_dirs_arg =
     and+ project_sources = project_sources in
     workspace, local_packages, project_sources
   in
+  let lock_dirs =
+    Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
+  in
   solve
     workspace
     ~local_packages
     ~project_sources
     ~solver_env_from_current_system
     ~version_preference
-    ~lock_dirs_arg
+    ~lock_dirs
 ;;
 
 let term =

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -1,4 +1,13 @@
 open Import
 
+val solve
+  :  Workspace.t
+  -> local_packages:Dune_pkg.Local_package.t Package_name.Map.t
+  -> project_sources:Dune_pkg.Pin_stanza.DB.t
+  -> solver_env_from_current_system:Dune_pkg.Solver_env.t option
+  -> version_preference:Dune_pkg.Version_preference.t option
+  -> lock_dirs:Path.Source.t list
+  -> unit Fiber.t
+
 (** Command to create lock directory *)
 val command : unit Cmd.t

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -18,7 +18,7 @@ let out =
 ;;
 
 let default_toggles : (string * [ `Disabled | `Enabled ]) list =
-  [ "toolchains", `Disabled; "pkg_build_progress", `Disabled ]
+  [ "toolchains", `Disabled; "pkg_build_progress", `Disabled; "lock_dev_tool", `Disabled ]
 ;;
 
 let () =
@@ -86,6 +86,11 @@ let () =
     ; ( "--enable-pkg-build-progress"
       , Arg.Unit (toggle "pkg_build_progress")
       , " Enable the displaying of package build progress.\n\
+        \      This flag is experimental and shouldn't be relied on by packagers." )
+    ; ( "--enable-lock-dev-tool"
+      , Arg.Unit (toggle "lock_dev_tool")
+      , " Enable ocamlformat dev-tool, allows 'dune fmt' to build ocamlformat and use \
+         it, independently from the project depenedencies .\n\
         \      This flag is experimental and shouldn't be relied on by packagers." )
     ]
   in

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -1,0 +1,27 @@
+open! Import
+
+type t = Ocamlformat
+
+let equal a b =
+  match a, b with
+  | Ocamlformat, Ocamlformat -> true
+;;
+
+let package_name = function
+  | Ocamlformat -> Package_name.of_string "ocamlformat"
+;;
+
+let of_package_name package_name =
+  match Package_name.to_string package_name with
+  | "ocamlformat" -> Ocamlformat
+  | other -> User_error.raise [ Pp.textf "No such dev tool: %s" other ]
+;;
+
+let exe_name = function
+  | Ocamlformat -> "ocamlformat"
+;;
+
+let exe_path_components_within_package t =
+  match t with
+  | Ocamlformat -> [ "bin"; exe_name t ]
+;;

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -1,0 +1,12 @@
+open! Import
+
+type t = Ocamlformat
+
+val equal : t -> t -> bool
+val package_name : t -> Package_name.t
+val of_package_name : Package_name.t -> t
+val exe_name : t -> string
+
+(** Returns the path to this tool's executable relative to the root of
+    this tool's package directory *)
+val exe_path_components_within_package : t -> string list

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -22,3 +22,5 @@ module Variable_value = Variable_value
 module Resolved_package = Resolved_package
 module Pin_stanza = Pin_stanza
 module Package_name = Package_name
+module Ocamlformat = Ocamlformat
+module Dev_tool = Dev_tool

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -392,6 +392,14 @@ let create_latest_version
   }
 ;;
 
+let dev_tools_path = Path.Source.(relative root "dev-tools.locks")
+
+let dev_tool_lock_dir_path dev_tool =
+  Path.Source.relative
+    dev_tools_path
+    (Package_name.to_string (Dev_tool.package_name dev_tool))
+;;
+
 let default_path = Path.Source.(relative root "dune.lock")
 let metadata_filename = "lock.dune"
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -36,6 +36,10 @@ module Pkg : sig
   val files_dir : Package_name.t -> lock_dir:Path.Source.t -> Path.Source.t
 end
 
+module Package_filename : sig
+  val of_package_name : Package_name.t -> string
+end
+
 module Repositories : sig
   type t
 end
@@ -73,6 +77,10 @@ val create_latest_version
   -> t
 
 val default_path : Path.Source.t
+
+(** Returns the path to the lockdir that will be used to lock the
+    given dev tool *)
+val dev_tool_lock_dir_path : Dev_tool.t -> Path.Source.t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 

--- a/src/dune_pkg/ocamlformat.ml
+++ b/src/dune_pkg/ocamlformat.ml
@@ -1,0 +1,16 @@
+open Import
+
+let version_of_ocamlformat_config ocamlformat_config =
+  Io.lines_of_file ocamlformat_config
+  |> List.find_map ~f:(fun line ->
+    match String.split_on_char ~sep:'=' line |> List.map ~f:String.trim with
+    | [ "version"; value ] -> Some (Package_version.of_string value)
+    | _ -> None)
+;;
+
+let version_of_current_project's_ocamlformat_config () =
+  let ocamlformat_config = Path.Source.of_string ".ocamlformat" |> Path.source in
+  match Path.exists ocamlformat_config with
+  | false -> None
+  | true -> version_of_ocamlformat_config ocamlformat_config
+;;

--- a/src/dune_pkg/ocamlformat.mli
+++ b/src/dune_pkg/ocamlformat.mli
@@ -1,0 +1,5 @@
+open! Import
+
+(** Returns the version from the current project's .ocamlformat file,
+    if it exists *)
+val version_of_current_project's_ocamlformat_config : unit -> Package_version.t option

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -145,6 +145,16 @@ let get ctx =
 
 let get_exn ctx = get ctx >>| User_error.ok_exn
 
+let of_dev_tool dev_tool =
+  let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool in
+  Fs_memo.dir_exists (In_source_dir path)
+  >>= function
+  | true -> Load.load_exn path
+  | false ->
+    User_error.raise
+      [ Pp.textf "%s does not exist" (Path.Source.to_string_maybe_quoted path) ]
+;;
+
 let lock_dir_active ctx =
   if !Clflags.ignore_lock_dir
   then Memo.return false

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -5,6 +5,7 @@ type t := Dune_pkg.Lock_dir.t
 
 val get : Context_name.t -> (t, User_message.t) result Memo.t
 val get_exn : Context_name.t -> t Memo.t
+val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.Source.t option Memo.t
 

--- a/src/dune_rules/pkg_dev_tool.ml
+++ b/src/dune_rules/pkg_dev_tool.ml
@@ -1,0 +1,30 @@
+open! Import
+include Dune_pkg.Dev_tool
+
+let install_path_base_dir_name = ".dev-tool"
+
+let install_path_base =
+  lazy
+    (let dev_tool_context_name = Dune_engine.Context_name.default in
+     Path.Build.L.relative
+       Private_context.t.build_dir
+       [ Dune_engine.Context_name.to_string dev_tool_context_name
+       ; install_path_base_dir_name
+       ])
+;;
+
+let universe_install_path t =
+  Path.Build.relative
+    (Lazy.force install_path_base)
+    (Package.Name.to_string @@ package_name t)
+;;
+
+let package_install_path t =
+  Path.Build.relative (universe_install_path t) (Package.Name.to_string @@ package_name t)
+;;
+
+let exe_path t =
+  Path.Build.L.relative
+    (package_install_path t)
+    ("target" :: exe_path_components_within_package t)
+;;

--- a/src/dune_rules/pkg_dev_tool.mli
+++ b/src/dune_rules/pkg_dev_tool.mli
@@ -1,0 +1,16 @@
+open! Import
+include module type of Dune_pkg.Dev_tool
+
+val install_path_base_dir_name : string
+
+(** The path to the package universe inside the _build directory
+    containing the package dependency closure for the package
+    containing the given dev tool *)
+val universe_install_path : t -> Path.Build.t
+
+(** The path to the directory inside the _build directory containing
+    the installation of the package containing the given dev tool *)
+val package_install_path : t -> Path.Build.t
+
+(** The path to the executable for running the given dev tool *)
+val exe_path : t -> Path.Build.t

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -13,3 +13,4 @@ let roots : string option Install.Roots.t =
 
 let toolchains = `Disabled
 let pkg_build_progress = `Disabled
+let lock_dev_tool = `Disabled

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -12,3 +12,4 @@ val roots : string option Install.Roots.t
 
 val toolchains : Dune_config.Config.Toggle.t
 val pkg_build_progress : Dune_config.Config.Toggle.t
+val lock_dev_tool : Dune_config.Config.Toggle.t

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -43,13 +43,18 @@
   unavailable-source-package
   compute-checksums-when-missing
   e2e
+  ocamlformat-dev-tool
   source-caching
   tarball
   extra-sources))
 
 (cram
  (deps %{bin:md5sum})
- (applies_to source-caching extra-sources))
+ (applies_to
+  source-caching
+  extra-sources
+  ocamlformat-dev-tool
+  dev-tool-conflict-test))
 
 (cram
  (deps %{bin:tar})

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps helpers.sh)
+ (applies_to :whole_subtree))

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -1,0 +1,168 @@
+. ../helpers.sh
+
+make_fake_ocamlformat() {
+  version=$1
+  if [ "$#" -eq "1" ]
+  then
+    ml_file=""
+  else
+    ml_file="$2"
+  fi
+  mkdir ocamlformat
+  cat > ocamlformat/dune-project <<EOF
+(lang dune 3.13)
+(package (name ocamlformat))
+EOF
+  if [ ! "$ml_file" = "no-ml-file" ]
+  then
+    cat > ocamlformat/ocamlformat.ml <<EOF
+let version = "$version"
+let () =
+  if Sys.file_exists ".ocamlformat-ignore" then
+  print_endline "ignoring some files"
+;;
+let () = print_endline ("formatted with version "^version)
+EOF
+  fi
+  cat > ocamlformat/dune <<EOF
+(executable
+ (public_name ocamlformat))
+EOF
+  tar -czf ocamlformat-$version.tar.gz ocamlformat
+  rm -rf ocamlformat
+}
+
+make_ocamlformat_opam_pkg() {
+  version=$1
+  if [ "$#" -eq "2" ]
+  then
+    port="$2"
+  else
+    port=""
+  fi
+  if [ ! "$port" = "" ]
+  then
+    mkpkg ocamlformat $version <<EOF
+build: [
+  [
+     "dune"
+     "build"
+     "-p"
+     name
+     "@install"
+  ]
+]
+url {
+  src: "http://127.0.0.1:$port"
+  checksum: [
+    "md5=$(md5sum ocamlformat-$version.tar.gz | cut -f1 -d' ')"
+  ]
+}
+EOF
+  else
+    mkpkg ocamlformat $version <<EOF
+build: [
+  [
+     "dune"
+     "build"
+     "-p"
+     name
+     "@install"
+  ]
+]
+url {
+  src: "file://$PWD/ocamlformat-$version.tar.gz"
+  checksum: [
+    "md5=$(md5sum ocamlformat-$version.tar.gz | cut -f1 -d' ')"
+  ]
+}
+EOF
+  fi
+}
+
+make_project_with_dev_tool_lockdir() {
+  cat > dune-project <<EOF
+(lang dune 3.13)
+(package
+ (name foo))
+EOF
+  cat > foo.ml <<EOF
+let () = print_endline "Hello, world"
+EOF
+  cat > dune <<EOF
+(executable
+ (public_name foo))
+EOF
+  cat > dune-workspace <<EOF
+(lang dune 3.13)
+ (lock_dir
+  (path "dev-tools.locks/ocamlformat")
+  (repositories mock))
+  (lock_dir
+   (repositories mock))
+ (repository
+  (name mock)
+  (source "file://$(pwd)/mock-opam-repository"))
+EOF
+}
+
+
+make_printer_lib() {
+  version=$1
+  mkdir printer
+  cat > printer/dune-project <<EOF
+(lang dune 3.13)
+(package (name printer))
+EOF
+  if [ $version = "1.0" ]
+  then
+  cat > printer/printer.ml <<EOF
+let print () = print_endline "formatted"
+EOF
+  else
+  cat > printer/printer.ml <<EOF
+let print () = print_endline "Hello World!"
+EOF
+  fi
+  cat > printer/dune <<EOF
+(library
+ (public_name printer))
+EOF
+  tar -czf printer.$version.tar.gz printer
+  rm -r printer
+}
+
+make_opam_printer() {
+  version=$1
+  mkpkg printer $version <<EOF
+build: [
+   [
+    "dune"
+    "build"
+    "-p"
+    name
+    "@install"
+   ]
+ ]
+ url {
+ src: "file://$PWD/printer.$version.tar.gz"
+ checksum: [
+  "md5=$(md5sum printer.$version.tar.gz | cut -f1 -d' ')"
+ ]
+}
+EOF
+}
+
+make_fake_ocamlformat_from_path() {
+  mkdir .bin
+  cat > .bin/ocamlformat <<EOF
+#!/bin/sh
+if [ -f ".ocamlformat-ignore" ]
+then
+  echo "ignoring some files"
+fi
+echo "fake ocamlformat from PATH"
+EOF
+  chmod +x .bin/ocamlformat
+  PATH=$PWD/.bin:$PATH
+}

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -1,0 +1,44 @@
+If the dev-tool feature is enabled then "dune fmt" should invoke the "ocamlformat"
+executable from the dev-tool and not the one from PATH.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.2"
+  $ make_ocamlformat_opam_pkg "0.26.2"
+
+Make dune-project that uses the mocked dev-tool opam-reposiotry.
+  $ make_project_with_dev_tool_lockdir
+
+Change the 'dune' file to use an executable called 'ocamlformat'
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name foo))
+  > (rule
+  >  (target none)
+  >  (action
+  >     (progn
+  >       (run ocamlformat foo.ml)
+  >       (run touch none))))
+  > EOF
+
+Add a fake executable in the PATH
+  $ make_fake_ocamlformat_from_path
+  $ which ocamlformat
+  $TESTCASE_ROOT/.bin/ocamlformat
+
+Build the OCamlFormat binary dev-tool
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+  File "dune", line 1, characters 0-0:
+  Error: Files _build/default/dune and _build/default/.formatted/dune differ.
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+
+When the dev-tool feature is disabled dune runs the OCamlFormat binary from the
+PATH and not the dev-tool one.
+  $ dune build
+  fake ocamlformat from PATH

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -1,0 +1,69 @@
+If the dev-tool feature is enabled then "dune fmt" should invoke the "ocamlformat"
+executable from the dev-tool and not the one from the project's regular package
+dependencies.
+
+If the dev-tool feature is not enabled then "dune fmt" should invoke the
+"ocamlformat" executable from the project's regular package dependencies.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.2"
+  $ make_fake_ocamlformat "0.26.3"
+
+  $ make_ocamlformat_opam_pkg "0.26.2"
+  $ make_ocamlformat_opam_pkg "0.26.3"
+
+
+Make a project that depends on the fake ocamlformat.0.26.2:
+  $ make_project_with_dev_tool_lockdir
+
+Update dune-project to add the dependency on OCamlFormat.
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo)
+  >  (depends (ocamlformat (= 0.26.2))))
+  > EOF
+
+Lock and build the project to make OCamlFormat from the project dependencies available.
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocamlformat.0.26.2
+
+Run "dune fmt" without the dev-tools feature enabled. This should invoke the ocamlformat
+executable from the package dependencies (ie., 'ocamlformat.0.26.2').
+  $ dune fmt --preview
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted with version 0.26.2
+
+Format using the dev-tools feature, it does not invoke the OCamlFormat binary from
+the project dependencies (0.26.2) but instead builds and runs the OCamlFormat binary as a
+dev-tool (0.26.3).
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.3
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  Promoting _build/default/.formatted/foo.ml to foo.ml.
+  [1]
+  $ cat foo.ml
+  formatted with version 0.26.3
+
+Retry, without dev-tools feature and without cleaning. This time it uses the OCamlFormat
+binary from the project dependencies rather than the dev-tool. This exercises the
+behavior when OCamlFormat is installed simultaneously as both a dev-tool and as a
+regular package dependency.
+  $ rm -rf dev-tools.locks/ocamlformat
+  $ dune fmt --preview
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -1,0 +1,150 @@
+Testing the conflicts that could occur between the dependencies of "dune-project"
+and dev-tool dependencies.
+
+The scenario here is that the fake OCamlFormat dev-tool depends on
+printer.1.0, and the project depends on a different version, printer.2.0.
+It shows those two do not conflict, and the dev-tools dependencies do not leak
+into the user build environment.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a fake OCamlFormat which depends on printer lib:
+  $ mkdir ocamlformat
+  $ cd ocamlformat
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name ocamlformat))
+  > EOF
+  $ cat > ocamlformat.ml <<EOF
+  > let () = Printer.print ()
+  > EOF
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name ocamlformat)
+  >  (libraries printer))
+  > EOF
+  $ cd ..
+  $ tar -czf ocamlformat.tar.gz ocamlformat
+  $ rm -rf ocamlformat
+
+Make a printer lib(version 1) that prints "formatted":
+  $ make_printer_lib "1.0"
+  $ make_opam_printer "1.0"
+
+Make a printer lib(version 2) that prints "Hello world!":
+  $ make_printer_lib "2.0"
+  $ make_opam_printer "2.0"
+
+Make a package for the fake OCamlFormat library which depends on printer.1.0:
+  $ mkpkg ocamlformat 0.26.2 <<EOF
+  > depends: [
+  >  "printer" {= "1.0"}
+  > ]
+  > build: [
+  >   [
+  >     "dune"
+  >     "build"
+  >     "-p"
+  >     name
+  >     "@install"
+  >   ]
+  > ]
+  > url {
+  >  src: "file://$PWD/ocamlformat.tar.gz"
+  >  checksum: [
+  >   "md5=$(md5sum ocamlformat.tar.gz | cut -f1 -d' ')"
+  >  ]
+  > }
+  > EOF
+
+Make dune-project that uses the mocked dev-tool opam-reposiotry.
+  $ make_project_with_dev_tool_lockdir
+
+Update the project to depends on printer.2.0:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo)
+  >  (depends (printer (= 2.0))))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let () = Printer.print ()
+  > EOF
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name foo)
+  >  (libraries printer))
+  > EOF
+
+Add ".ocamlformat" file.
+  $ cat > .ocamlformat <<EOF
+  > version = 0.26.2
+  > EOF
+
+Lock the to trigger package management
+  $ dune pkg lock
+  Solution for dune.lock:
+  - printer.2.0
+
+It shows that the project uses printer.2.0
+  $ dune exec -- foo
+  Hello World!
+
+Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with different
+versions of the same dependency.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+  - printer.1.0
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted
+
+Update "dune-project", removing the dependency on the "printer" package. This
+demonstrates that even though OCamlFormat depends on the "printer" package, building the
+project will not work because foo's dependency on the library "printer" (specified in
+the "dune" file) cannot be resolved. This is because dependencies of dev-tools and
+dependencies of the project are isolated from one another.
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name foo))
+  > EOF
+
+Relock the project.
+  $ dune pkg lock
+  Solution for dune.lock:
+  (no dependencies to lock)
+
+There is no leak here. It is not taking the "printer" lib from dev-tools.
+  $ dune exec -- foo
+  File "dune", line 3, characters 12-19:
+  3 |  (libraries printer))
+                  ^^^^^^^
+  Error: Library "printer" not found.
+  -> required by _build/default/.foo.eobjs/byte/dune__exe__Foo.cmi
+  -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
+  -> required by _build/default/foo.exe
+  -> required by _build/install/default/bin/foo
+  [1]
+
+Update the executable "foo" to not depend on the library "printer", but "foo.ml" still
+refers to the "Printer" module. This won't compile, demonstrating that modules from
+dev-tools don't leak into the project.
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name foo))
+  > EOF
+
+There is no leak here. It is not taking Printer module from the printer of dev-tools dependency.
+  $ dune exec -- foo
+  File "foo.ml", line 1, characters 9-22:
+  1 | let () = Printer.print ()
+               ^^^^^^^^^^^^^
+  Error: Unbound module Printer
+  Hint: Did you mean Printexc or Printf?
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -1,0 +1,27 @@
+With a faulty version of OCamlFormat, "dune fmt" is supposed to stop with the
+build error of "ocamlformat".
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a fake ocamlformat with a missing ocamlformat.ml file:
+  $ make_fake_ocamlformat "0.26.4" "no-ml-file"
+  $ make_ocamlformat_opam_pkg "0.26.4"
+
+Make dune-project that uses the mocked dev-tool opam-reposiotry.
+  $ make_project_with_dev_tool_lockdir
+
+It fails during the build because of missing OCamlFormat module.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.4
+  File "dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
+  4 |  (run dune build -p %{pkg-self:name} @install))
+            ^^^^
+  Error: Logs for package ocamlformat
+  File "dune", line 2, characters 14-25:
+  2 |  (public_name ocamlformat))
+                    ^^^^^^^^^^^
+  Error: Module "Ocamlformat" doesn't exist.
+  
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -1,0 +1,75 @@
+Exercises end to end, locking and building ocamlformat dev tool.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.2"
+  $ make_fake_ocamlformat "0.26.3"
+
+Add the tar file for the fake curl to copy it:
+  $ echo ocamlformat-0.26.2.tar.gz > fake-curls
+  $ PORT=1
+
+  $ make_ocamlformat_opam_pkg "0.26.2" $PORT
+
+Add the tar file for the fake curl to copy it:
+  $ echo ocamlformat-0.26.3.tar.gz >> fake-curls
+  $ PORT=2
+
+We consider this version of OCamlFormat as the latest version:
+  $ make_ocamlformat_opam_pkg "0.26.3" $PORT
+
+Make dune-project that uses the mocked dev-tool opam-reposiotry.
+  $ make_project_with_dev_tool_lockdir
+
+Without a ".ocamlformat" file, "dune fmt" takes the latest version of
+OCamlFormat.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.3
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted with version 0.26.3
+
+Create .ocamlformat file
+  $ cat > .ocamlformat <<EOF
+  > version = 0.26.2
+  > EOF
+
+An important cleaning here, "dune fmt" will relock and build the new version(0.26.2) of OCamlFormat.
+  $ rm -r dev-tools.locks/ocamlformat
+  $ dune clean
+
+With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocamlformat"
+file.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted with version 0.26.2
+
+Formating a second time would not trigger the lock/solve.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  formatted with version 0.26.2
+
+When "dev-tools.locks" is removed, the solving/lock is renewed
+  $ rm -r dev-tools.locks/ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -1,0 +1,58 @@
+Make sure the format rules depends on ".ocamlformat-ignore" file when it exists.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.2"
+  $ make_ocamlformat_opam_pkg "0.26.2"
+
+Make a project that uses the fake ocamlformat:
+  $ make_project_with_dev_tool_lockdir
+
+Add a fake binary in the PATH
+  $ make_fake_ocamlformat_from_path
+  $ which ocamlformat
+  $TESTCASE_ROOT/.bin/ocamlformat
+
+Check without ".ocamlformat-ignore" file and the feature.
+  $ dune fmt --preview
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ cat _build/default/.formatted/foo.ml
+  fake ocamlformat from PATH
+
+Create ".ocamlformat-ignore"
+  $ touch .ocamlformat-ignore
+
+Check with the feature when ".ocamlformat-ignore" file exists.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  [1]
+  $ ls _build/default/.ocamlformat-ignore
+  _build/default/.ocamlformat-ignore
+  $ cat _build/default/.formatted/foo.ml
+  ignoring some files
+  formatted with version 0.26.2
+
+An important cleaning here, "dune fmt" takes the dev-tool when the lock directory
+exists even if the dev-tool feature is disabled.
+  $ rm -r dev-tools.locks/ocamlformat
+
+Check without the feature when ".ocamlformat-ignore" file exists.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=disabled dune fmt
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
+  Promoting _build/default/.formatted/foo.ml to foo.ml.
+  [1]
+  $ ls _build/default/.ocamlformat-ignore
+  _build/default/.ocamlformat-ignore
+  $ cat foo.ml
+  ignoring some files
+  fake ocamlformat from PATH

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -1,0 +1,23 @@
+When an OCamlFormat version does not exist, "dune fmt" would fail with a
+solving error.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a project with no dependency on OCamlFormat.
+  $ make_project_with_dev_tool_lockdir
+
+Update ".ocamlformat" file with unknown version of OCamlFormat.
+  $ cat > .ocamlformat <<EOF
+  > version = 0.26.9
+  > EOF
+
+Format, it shows the solving error.
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dev-tools.locks/ocamlformat:
+  Can't find all required versions.
+  Selected: ocamlformat_dev_tool_wrapper.dev
+  - ocamlformat -> (problem)
+      No known implementations at all
+  [1]


### PR DESCRIPTION
Attempts to implement #10688.

Reopen the PR #10613 to target `main` branch instead of toolchain one.


To avoid dune capturing a dev-tool like `ocamlformat` when using `dune build @fmt`. This PR is about to build this tool independently from dune-project dependencies, to avoid conflict. After a successful build it will be directly available whenever `dune build @fmt` or `dune fmt` is invoked. 

- [X] ocamlformat: build and make it available
- [x] ~~prioritize `dev tools` to `PATH` when `dune.lock` dir is present in the project.~~
- [x] Solve ocamlformat when `dune fmt` invoke it. (you're right here @Leonidas-from-XIV, it is needed to keep the pkg tests using `dune pkg lock` intact or facilitate adding new test for this PR)
- [x] Fix the fetch of ocamlformat dev tool dependencies ( It turns out that the fetch rules are missing those packages)
- [x] add a cram test

The next works that would be done:
- The ocamlformat stanza `(ocamlformat <version>)` could be added in another PR in order to make this one simple. 
- A PR for `odoc` tool will the same as this PR.