### PR TITLE
ci: use nix for coq job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -187,20 +187,9 @@ jobs:
     name: Coq 8.16.1
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Use OCaml 4.14.x
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 4.14.x
-          opam-pin: false
-          opam-depext: false
-          dune-cache: true
-
-      - name: Install Coq
-        run: opam install coq.8.16.1 coq-native
-
-      - run: opam exec -- make test-coq
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v22
+      - run: nix develop .#coq -c make test-coq
         env:
           # We disable the Dune cache when running the tests
           DUNE_CACHE: disabled

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,11 @@
         })
         melange.overlays.default
         ocamllsp.overlays.default
+        (self: super: {
+          coq_8_16_native = super.coq_8_16.overrideAttrs (a: {
+            configureFlags = [ "-native-compiler" "yes" ];
+          });
+        })
       ];
       dune-static-overlay = self: super: {
         ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
@@ -214,8 +219,8 @@
               nativeBuildInputs = testNativeBuildInputs;
               inputsFrom = [ pkgs.dune_3 ];
               buildInputs = with pkgs; [
-                coq_8_16
-                coq_8_16.ocamlPackages.findlib
+                coq_8_16_native
+                coq_8_16_native.ocamlPackages.findlib
               ];
               meta.description = ''
                 Provides a minimal shell environment built purely from nixpkgs


### PR DESCRIPTION
We have to override the nixpkgs definition to get `coq-native`.
