### PR TITLE
pkg: simplify the display logs

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -567,6 +567,7 @@ module Builder = struct
     ; debug_artifact_substitution : bool
     ; debug_load_dir : bool
     ; debug_digests : bool
+    ; debug_package_logs : bool
     ; wait_for_filesystem_clock : bool
     ; only_packages : Only_packages.Clflags.t
     ; capture_outputs : bool
@@ -666,6 +667,16 @@ module Builder = struct
             [ "debug-digests" ]
             ~docs
             ~doc:"Explain why Dune decides to re-digest some files")
+    and+ debug_package_logs =
+      let doc = "Always print the standard logs when building packages" in
+      Arg.(
+        value
+        & flag
+        & info
+            [ "debug-package-logs" ]
+            ~docs
+            ~doc
+            ~env:(Cmd.Env.info ~doc "DUNE_DEBUG_PACKAGE_LOGS"))
     and+ no_buffer =
       let doc =
         "Do not buffer the output of commands executed by dune. By default dune buffers \
@@ -970,6 +981,7 @@ module Builder = struct
     ; debug_artifact_substitution
     ; debug_load_dir
     ; debug_digests
+    ; debug_package_logs
     ; wait_for_filesystem_clock
     ; only_packages
     ; capture_outputs = not no_buffer
@@ -1236,6 +1248,7 @@ let init (builder : Builder.t) =
   Dune_engine.Clflags.debug_load_dir := c.builder.debug_load_dir;
   Dune_engine.Clflags.debug_fs_cache := c.builder.cache_debug_flags.fs_cache;
   Dune_digest.Clflags.debug_digests := c.builder.debug_digests;
+  Dune_rules.Clflags.debug_package_logs := c.builder.debug_package_logs;
   Dune_digest.Clflags.wait_for_filesystem_clock := c.builder.wait_for_filesystem_clock;
   Dune_engine.Clflags.capture_outputs := c.builder.capture_outputs;
   Dune_engine.Clflags.diff_command := c.builder.diff_command;

--- a/doc/changes/10662.md
+++ b/doc/changes/10662.md
@@ -1,0 +1,3 @@
+- pkg: only logs the standard output when the command fails or the user explicitly requests it.
+  Add new flag `--debug-package-logs`, which force dune to display the stdout logs when dealing
+  with package management (#10662, @maiste)

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -4,6 +4,7 @@ let promote_install_files = ref false
 let display = Dune_engine.Clflags.display
 let capture_outputs = Dune_engine.Clflags.capture_outputs
 let debug_artifact_substitution = ref false
+let debug_package_logs = ref false
 let ignore_lock_dir = ref false
 
 type on_missing_dune_project_file =

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -16,6 +16,9 @@ val capture_outputs : bool ref
 (** Print debug info about artifact substitution *)
 val debug_artifact_substitution : bool ref
 
+(** Print package output when building with package management *)
+val debug_package_logs : bool ref
+
 (** Whether we are ignoring "dune.lock/". *)
 val ignore_lock_dir : bool ref
 

--- a/test/blackbox-tests/test-cases/pkg/build-package-logs.t
+++ b/test/blackbox-tests/test-cases/pkg/build-package-logs.t
@@ -1,0 +1,48 @@
+Test the error message when installing package that fails.
+
+  $ . ./helpers.sh
+  $ make_lockdir
+  $ export DUNE_DEBUG_PACKAGE_LOGS=0
+
+Make a project with two packages, one successful and one that fails:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.12)
+  > EOF
+
+Create a package with a failing command that throws an error:
+
+  $ make_lockpkg x << EOF
+  > (version 0.0.1)
+  > (build
+  >    (progn
+  >       (run cat i_dont_exist)))
+  > EOF
+
+Building the package should fail and print an error:
+
+  $ build_pkg x 2>&1 | sed -E 's#/.*/cat#cat#g'
+  File "dune.lock/x.pkg", line 4, characters 11-14:
+  4 |       (run cat i_dont_exist)))
+                 ^^^
+  Error: Logs for package x
+  cat: i_dont_exist: No such file or directory
+  
+
+Create a package with a succeeding command that displays some text:
+
+  $ make_lockpkg y << EOF
+  > (version 0.0.1)
+  > (build
+  >    (progn
+  >       (run echo "Success!")))
+  > EOF
+
+Building the package should succeed and print no output:
+
+  $ build_pkg y
+
+Checks the package is installed:
+
+  $ show_pkg_cookie y
+  { files = map {}; variables = [] }

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -2,6 +2,11 @@
  (alias pkg)
  (applies_to :whole_subtree))
 
+(env
+ (_
+  (env-vars
+   (DUNE_DEBUG_PACKAGE_LOGS 1))))
+
 (cram
  (deps helpers.sh)
  (applies_to :whole_subtree))

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -41,7 +41,10 @@ Attempt to build the package the first time:
   echo aaa
   aaa
   false
-  -> required by _build/_private/default/.pkg/foo/target/cookie
+  File "dune.lock/foo.pkg", line 4, characters 6-13:
+            ^^^^^^^
+  Error: Logs for package foo
+  
 
 Update the message that gets printed while building foo:
   $ cat >foo/Makefile <<EOF
@@ -55,4 +58,7 @@ The change to the package is picked up:
   echo bbb
   bbb
   false
-  -> required by _build/_private/default/.pkg/foo/target/cookie
+  File "dune.lock/foo.pkg", line 4, characters 6-13:
+            ^^^^^^^
+  Error: Logs for package foo
+  


### PR DESCRIPTION
Hi,
This PR is an attempt to make the _toolchain_ logs less verbose.  As the packages are evaluated as common rules, they printed a lot of lots. To overcome such behavior, the idea is to redirect the error logs into a file and print them in case of errors.

This PR is structured in 3 parts:
1. A modification of the `User_message` module to embedded `headers`. This information is printed before any other logs. It allows displaying the name of the package or a piece of information to give a bit of context. Maybe, this part is too much for this PR. I can either extract it or remove it.
2. Propagate the information such as the `package name` and the `location` to the function in charge of handling it.
3. Provide a `Output` module to sink the error logs into a file and display them as : Error if it fails and, warning if the command succeeds, but in verbose mode.

:warning: I left the feature flags turn to true for the review, but it might need to be removed before merging.

Note that I'm not award of most of the functionalities provided by the dune helper modules (`Stdune`, `User_message`, etc). So, feel free to suggest better implementation if it can improve the readability and fit better in the dune codebase! :pray: 

Closes tarides/team-build-system#30