### PR TITLE
test(windows): set eol=lf on sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.rst             text eol=lf
 *.c               text eol=lf
 *.t               text eol=lf -linguist-detectable
+*.sh              text eol=lf
 *.ps1             text working-tree-encoding=UTF-16 eol=crlf
 dune              text eol=lf
 dune.inc          text eol=lf


### PR DESCRIPTION
This ensures that these files are created with LF endings, even when checking out on windows. Otherwise, some tests using these will fail.
