### PR TITLE
test(win): use bash instead of system when needed

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/dune
+++ b/test/blackbox-tests/test-cases/directory-targets/dune
@@ -1,3 +1,7 @@
 (cram
  (deps helpers.sh)
  (applies_to :whole_subtree))
+
+(cram
+ (applies_to remove-write-permissions)
+ (deps %{bin:bash}))

--- a/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
+++ b/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
@@ -9,7 +9,7 @@ Write permissions on directory targets.
 
   $ cat >dune <<EOF
   > (rule
-  >  (action (system "mkdir -p foo/foo2 && touch foo/foo2/bar"))
+  >  (action (bash "mkdir -p foo/foo2 && touch foo/foo2/bar"))
   >  (targets (dir foo)))
   > EOF
 

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -156,3 +156,11 @@
  (enabled_if
   (not %{arch_sixtyfour}))
  (deps %{bin:ocaml}))
+
+(cram
+ (applies_to interfere-sandbox-deletion)
+ (deps %{bin:bash}))
+
+(cram
+ (applies_to sandboxing-stale-directory-target)
+ (deps %{bin:bash}))

--- a/test/blackbox-tests/test-cases/interfere-sandbox-deletion.t
+++ b/test/blackbox-tests/test-cases/interfere-sandbox-deletion.t
@@ -6,8 +6,8 @@ the rule and the sandbox cleanup.
   $ cat >dune <<EOF
   > (rule
   >  (target foo)
-  >  (action (system "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
-  >                  "\| echo failed action && exit 1
+  >  (action (bash "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
+  >                "\| echo failed action && exit 1
   >           )))
   > EOF
 
@@ -16,21 +16,21 @@ the rule and the sandbox cleanup.
   > EOF
 
   $ dune build ./foo --sandbox=copy 2>&1 | sed -E 's#/.*.sandbox/[^/]+#/.sandbox/$SANDBOX#g'
-  File "dune", lines 1-5, characters 0-161:
+  File "dune", lines 1-5, characters 0-157:
   1 | (rule
   2 |  (target foo)
-  3 |  (action (system "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
-  4 |                  "\| echo failed action && exit 1
+  3 |  (action (bash "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
+  4 |                "\| echo failed action && exit 1
   5 |           )))
   Error: failed to delete sandbox in
   _build/.sandbox/$SANDBOX
   Reason:
   rmdir(_build/.sandbox/$SANDBOX/default/bar): Directory not empty
-  File "dune", lines 1-5, characters 0-161:
+  File "dune", lines 1-5, characters 0-157:
   1 | (rule
   2 |  (target foo)
-  3 |  (action (system "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
-  4 |                  "\| echo failed action && exit 1
+  3 |  (action (bash "\| touch foo && mkdir bar && touch bar/x && chmod -w bar &&
+  4 |                "\| echo failed action && exit 1
   5 |           )))
   failed action
 

--- a/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
+++ b/test/blackbox-tests/test-cases/sandboxing-stale-directory-target.t
@@ -8,14 +8,14 @@ A faulty test escapes the sandbox by creating its target outside the sandbox
   $ cat >dune <<EOF
   > (rule
   >  (target (dir foo))
-  >  (action (system "mkdir $PWD/_build/default/foo && mkdir foo")))
+  >  (action (bash "mkdir $PWD/_build/default/foo && mkdir foo")))
   > EOF
 
   $ dune build foo/ --sandbox=copy 2>&1 | sed -E 's/characters [0-9]+-[0-9]+/characters <REDACTED>/'
   File "dune", lines 1-3, characters <REDACTED>:
   1 | (rule
   2 |  (target (dir foo))
-  3 |  (action (system "mkdir $TESTCASE_ROOT/_build/default/foo && mkdir foo")))
+  3 |  (action (bash "mkdir $TESTCASE_ROOT/_build/default/foo && mkdir foo")))
   Error: Target _build/default/foo of kind "directory" already exists in the
   build directory
   Hint: delete this file manually or check the permissions of the parent


### PR DESCRIPTION
On Windows, `(system)` uses `cmd` and fails on these commands.
Using `(bash)` ensures that it is used even on Windows.
