### PR TITLE
test(dune-rpc-lwt): set XDG_STATE_HOME

### DIFF
--- a/otherlibs/dune-rpc-lwt/examples/rpc_client/test/rpc-client-example.t/run.t
+++ b/otherlibs/dune-rpc-lwt/examples/rpc_client/test/rpc-client-example.t/run.t
@@ -1,5 +1,9 @@
 Start Dune in watch mode, sending errors to `/dev/null` to suppress the alerts
 about using the unstable module Dune_rpc.
+
+  $ export XDG_STATE_HOME=".dune.state"
+  $ mkdir $XDG_STATE_HOME
+
   $ dune build -w 2> /dev/null &
 
 Wait for the program produced by the above step to exist.
@@ -13,3 +17,5 @@ Run the program. The program takes care of shutting down the build server.
   Waiting for next progress event...
   Got progress_event: Success
   Shutting down RPC server...
+
+  $ wait


### PR DESCRIPTION
to make sure the tests don't register themselves globally

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>