### PR TITLE
fix: allow different foreign sources for exes

### DIFF
--- a/test/blackbox-tests/test-cases/github10675.t
+++ b/test/blackbox-tests/test-cases/github10675.t
@@ -19,7 +19,9 @@ stubs, dune should not crash. See #10675.
 
   $ touch startup.c main.ml
 
-  $ dune build 2>&1 | head -n 3
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Map.of_list_map_exn", { key = "main" })
+  $ dune build
+  File "dune", line 3, characters 7-11:
+  3 |  (name main))
+             ^^^^
+  Error: Executables with same name "main" use different foreign sources
+  [1]


### PR DESCRIPTION
Executables with same name can have different `(foreign_stubs)` attached to them, as long as there's no name collision.

Fixes #10675
