### PR TITLE
chore: upgrade ocamlformat to 0.26.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.26.1
+version=0.26.2
 profile=janestreet
 ocaml-version=4.08.0


### PR DESCRIPTION
This does not change formatting but is compatible with OCaml 5.2.
