### PR TITLE
chore(actions): remove unused dynamic gnu target

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -17,9 +17,6 @@ jobs:
             name: aarch64-apple-darwin
             installable: .#
           - os: ubuntu-22.04
-            name: x86_64-unknown-linux-gnu
-            installable: .#
-          - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR removes the arm mac target that is not provided as a binary distribution.

