### PR TITLE
fix: better grep granularity in pkg test output

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -37,11 +37,12 @@ Make a package "foo" whose build will fail after printing a message:
 
 Attempt to build the package the first time:
 (the error from make is grep'd out because it is not consistant across different systems)
-  $ dune build 2>&1 | grep -v make
+  $ dune build 2>&1 | grep -v -e "^make"
   echo aaa
   aaa
   false
   File "dune.lock/foo.pkg", line 4, characters 6-13:
+  4 |  (run %{make}))
             ^^^^^^^
   Error: Logs for package foo
   
@@ -54,11 +55,12 @@ Update the message that gets printed while building foo:
   > EOF
 
 The change to the package is picked up:
-  $ dune build 2>&1 | grep -v make
+  $ dune build 2>&1 | grep -v -e "^make"
   echo bbb
   bbb
   false
   File "dune.lock/foo.pkg", line 4, characters 6-13:
+  4 |  (run %{make}))
             ^^^^^^^
   Error: Logs for package foo
   

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -37,7 +37,7 @@ Make a package "foo" whose build will fail after printing a message:
 
 Attempt to build the package the first time:
 (the error from make is grep'd out because it is not consistant across different systems)
-  $ dune build 2>&1 | grep -v -e "^make"
+  $ dune build 2>&1 | grep -v -e "^make" -e "^gmake"
   echo aaa
   aaa
   false
@@ -55,7 +55,7 @@ Update the message that gets printed while building foo:
   > EOF
 
 The change to the package is picked up:
-  $ dune build 2>&1 | grep -v -e "^make"
+  $ dune build 2>&1 | grep -v -e "^make" -e "^gmake"
   echo bbb
   bbb
   false


### PR DESCRIPTION
This PR improves the granularity for `update-non-dune-local-pin.t` test. The issue wasn't with the _Logs output_ changes but with the test itself.

Closes #10686
