### PR TITLE
fix(10685): display hint when no action field in rule

### DIFF
--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -158,10 +158,10 @@ let long_form =
        | Some action -> action
        | None ->
          let hints =
-           if List.is_non_empty aliases
-           then
+           if List.is_empty aliases
+           then []
+           else
              [ Pp.text "You can use the (alias) stanza to add dependencies to an alias." ]
-           else []
          in
          field_missing ~hints loc "action"
      in

--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -102,7 +102,7 @@ let long_form =
   String_with_vars.add_user_vars_to_decoding_env
     (Bindings.var_names deps)
     (let+ loc = loc
-     and+ action = field "action" (located Dune_lang.Action.decode_dune_file)
+     and+ action_o = field_o "action" (located Dune_lang.Action.decode_dune_file)
      and+ targets = Targets_spec.field ~allow_directory_targets
      and+ locks = Locks.field ()
      and+ () =
@@ -152,6 +152,18 @@ let long_form =
                   patch-back-source-tree)."
              ];
          Standard, true
+     in
+     let action =
+       match action_o with
+       | Some action -> action
+       | None ->
+         let hints =
+           if List.is_non_empty aliases
+           then
+             [ Pp.text "You can use the (alias) stanza to add dependencies to an alias." ]
+           else []
+         in
+         field_missing ~hints loc "action"
      in
      { targets
      ; deps

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -584,7 +584,7 @@ let map_validate t ~f ctx state1 =
     raise (User_error.E msg)
 ;;
 
-let field_missing loc name = User_error.raise ~loc [ Pp.textf "Field %S is missing" name ]
+let field_missing ?hints loc name = User_error.raise ~loc ?hints [ Pp.textf "Field %S is missing" name ]
 [@@inline never] [@@specialise never] [@@local never]
 ;;
 

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -584,7 +584,8 @@ let map_validate t ~f ctx state1 =
     raise (User_error.E msg)
 ;;
 
-let field_missing ?hints loc name = User_error.raise ~loc ?hints [ Pp.textf "Field %S is missing" name ]
+let field_missing ?hints loc name =
+  User_error.raise ~loc ?hints [ Pp.textf "Field %S is missing" name ]
 [@@inline never] [@@specialise never] [@@local never]
 ;;
 

--- a/src/dune_sexp/decoder.mli
+++ b/src/dune_sexp/decoder.mli
@@ -298,6 +298,9 @@ val field_o_b
   -> string
   -> bool option fields_parser
 
+(* [field_missing] raises the error raised by [field]. *)
+val field_missing : ?hints:User_message.Style.t Pp.t list -> Loc.t -> string -> _
+
 (** [multi_field] is a field that can appear multiple times. *)
 val multi_field : string -> 'a t -> 'a list fields_parser
 

--- a/test/blackbox-tests/test-cases/github10685.t
+++ b/test/blackbox-tests/test-cases/github10685.t
@@ -1,0 +1,55 @@
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias child_one)
+  >  (action (echo "Child one")))
+  > 
+  > (rule
+  >  (alias child_two)
+  >  (action (echo "Child two")))
+  > 
+  > (rule
+  >  (alias parent)
+  >  (deps
+  >   (alias child_one)
+  >   (alias child_two)))
+  > EOF
+
+  $ dune build
+  File "dune", lines 9-13, characters 0-70:
+   9 | (rule
+  10 |  (alias parent)
+  11 |  (deps
+  12 |   (alias child_one)
+  13 |   (alias child_two)))
+  Error: Field "action" is missing
+  Hint: You can use the (alias) stanza to add dependencies to an alias.
+  [1]
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias child_one)
+  >  (action (echo "Child one")))
+  > 
+  > (rule
+  >  (alias child_two)
+  >  (action (echo "Child two")))
+  > 
+  > (rule
+  >  (deps
+  >   (alias child_one)
+  >   (alias child_two)))
+  > EOF
+
+  $ dune build
+  File "dune", lines 9-12, characters 0-54:
+   9 | (rule
+  10 |  (deps
+  11 |   (alias child_one)
+  12 |   (alias child_two)))
+  Error: Field "action" is missing
+  [1]

--- a/test/blackbox-tests/test-cases/github10685.t
+++ b/test/blackbox-tests/test-cases/github10685.t
@@ -1,4 +1,3 @@
-
   $ cat > dune-project << EOF
   > (lang dune 3.0)
   > EOF


### PR DESCRIPTION
This PR allows `dune` to display a hint when trying to use `rule` without an `action` stanza.

Closes #10685
