### PR TITLE
fix: pass -w -53 in wrapped_compat modules

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -304,7 +304,11 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   }
 ;;
 
-let for_wrapped_compat t = { t with includes = Includes.empty; stdlib = None }
+let for_wrapped_compat t =
+  (* See #10689 *)
+  let flags = Ocaml_flags.append_common t.flags [ "-w"; "-53" ] in
+  { t with includes = Includes.empty; stdlib = None; flags }
+;;
 
 let for_plugin_executable t ~embed_in_plugin_libraries =
   let libs = Scope.libs t.scope in


### PR DESCRIPTION
On OCaml 5.2, this feature triggers warning 53, which is justified.

Quoting @nojb:

> Dune first builds bar.cmi and bar.cmo from bar.ml-gen and this part
> works well (bar.ml-gen contains a top-level attribute but no .cmi).
> However, when it is the turn of the native-code compiler, bar.cmi
> already exists (and contains the expected deprecation attribute), so the
> top-level attribute in Bar.ml-gen is correctly ignored by the compiler,
> hence the warning.

Fixes #10689
