### PR TITLE
test: fix oneshot webserver for large binary files

### DIFF
--- a/test/blackbox-tests/utils/webserver_oneshot.ml
+++ b/test/blackbox-tests/utils/webserver_oneshot.ml
@@ -52,7 +52,7 @@ let main content_files port_file ~simulate_not_found =
   List.iter content_files ~f:(fun content_file ->
     Http.Server.accept server ~f:(fun out_channel ->
       if simulate_not_found
-      then Http.Server.respond out_channel ~status:`Not_found ~content:""
+      then Http.Server.respond_not_found out_channel
       else Http.Server.respond_file out_channel ~file:content_file))
 ;;
 

--- a/test/http/http.ml
+++ b/test/http/http.ml
@@ -76,14 +76,13 @@ module Server = struct
       send_bytes out_fd header_bytes (Bytes.length header_bytes);
       let buf_size = 4096 in
       let buf = Bytes.create buf_size in
-      let pos = ref 0 in
-      try
-        while true do
-          let bytes_read = In_channel.input in_channel buf !pos buf_size in
+      let rec write () =
+        match In_channel.input in_channel buf 0 buf_size with
+        | 0 -> ()
+        | bytes_read ->
           send_bytes out_fd buf bytes_read;
-          if Int.equal bytes_read 0 then raise End_of_file
-        done
-      with
-      | End_of_file -> ())
+          write ()
+      in
+      write ())
   ;;
 end

--- a/test/http/http.mli
+++ b/test/http/http.mli
@@ -11,6 +11,12 @@ module Server : sig
   val stop : t -> unit
   val port : t -> int
   val start : t -> unit
-  val respond : session -> status:[ `Ok | `Not_found ] -> content:string -> unit
+
+  (** Respond with a 404 error *)
+  val respond_not_found : session -> unit
+
+  (** Send the content of the file at path [file]. Works for both text
+      and binary files. Raises an exception if the [file] doesn't
+      refer to a file. *)
   val respond_file : session -> file:string -> unit
 end


### PR DESCRIPTION
Fixes several issues where the oneshot webserver used for testing package downloading would exit before the transfer was complete. This involves transefering data as byte arrays rather than as strings, and properly shutting down the socket before exiting the server.

The only remaining use case for the `respond_string` function was in sending 404 errors, so I've replaced it with a specialized function that only sends 404 errors.