### PR TITLE
Fix rule target conflict with extra source

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1589,7 +1589,7 @@ let source_rules (pkg : Pkg.t) =
         | `Directory_or_archive src ->
           loc, Action_builder.copy ~src:(Path.external_ src) ~dst:extra_source
         | `Fetch ->
-          let rule = Fetch_rules.fetch ~target:pkg.paths.source_dir `File fetch in
+          let rule = Fetch_rules.fetch ~target:extra_source `File fetch in
           loc, rule
       in
       Path.build extra_source, rule)

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -35,12 +35,13 @@ First we need a project that will have the patch applied:
   $ git init --quiet
   $ cat > dune-project <<EOF
   > (lang dune 3.15)
+  > (name needs-patch)
   > EOF
-  $ cat > needs_patch.opam <<EOF
+  $ cat > needs-patch.opam <<EOF
   > opam-version: "2.0"
   > EOF
   $ cat > dune <<EOF
-  > (library (public_name needs_patch))
+  > (library (public_name needs-patch) (name needs_patch))
   > EOF
   $ cat > needs_patch.ml <<EOF
   > let msg = "Needs to be patched"
@@ -62,6 +63,7 @@ First we need a project that will have the patch applied:
   > EOF
   $ git diff > ../additional.patch
   $ cd ..
+  $ rm -rf needs-patch
   $ REQUIRED_PATCH_MD5=$(md5sum required.patch | cut -f1 -d' ')
   $ ADDITIONAL_PATCH_MD5=$(md5sum additional.patch | cut -f1 -d' ')
 
@@ -79,6 +81,7 @@ package.
 
   $ mkrepo
   $ mkpkg needs-patch 0.0.1 <<EOF
+  > build: ["dune" "build" "-p" name "-j" jobs]
   > patches: ["required.patch"]
   > url {
   >   src: "http://localhost:$SRC_PORT"
@@ -98,7 +101,7 @@ that is supposed to get patched.
   > (package (name my) (depends needs-patch))
   > EOF
   $ cat > dune <<EOF
-  > (executable (public_name display) (libraries needs_patch))
+  > (executable (public_name display) (libraries needs-patch))
   > EOF
   $ cat > display.ml <<EOF
   > let () = print_endline Needs_patch.msg
@@ -132,6 +135,7 @@ application order of them mattering:
   $ ADDITIONAL_PATCH_PORT=$(cat additional-patch-port.txt)
 
   $ mkpkg needs-patch 0.0.2 <<EOF
+  > build: ["dune" "build" "-p" name "-j" jobs]
   > patches: ["required.patch" "additional.patch"]
   > url {
   >   src: "http://localhost:$SRC_PORT"

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -116,13 +116,7 @@ Running the binary should download the tarball & patch, build them and show the
 correct, patched, message:
 
   $ dune exec ./display.exe
-  File "dune.lock/needs-patch.pkg", line 8, characters 7-29:
-  8 |   (url http://localhost:61144)
-             ^^^^^^^^^^^^^^^^^^^^^^
-  Error: curl returned an invalid error code 56
-         
-         
-  [1]
+  Patch successfully applied
 
 Set up a new version of the package which has multiple `extra-sources`, the
 application order of them mattering:
@@ -162,8 +156,4 @@ Lock the project to use that new package
 Running the binary should work and output the double patched message:
 
   $ dune exec ./display.exe
-  Error: Multiple rules generated for
-  _build/_private/default/.pkg/needs-patch/source:
-  - dune.lock/needs-patch.pkg:16
-  - dune.lock/needs-patch.pkg:20
-  [1]
+  Patch successfully applied, multiple times

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -116,10 +116,12 @@ Running the binary should download the tarball & patch, build them and show the
 correct, patched, message:
 
   $ dune exec ./display.exe
-  Error: Multiple rules generated for
-  _build/_private/default/.pkg/needs-patch/source:
-  - dune.lock/needs-patch.pkg:14
-  - dune.lock/needs-patch.pkg:8
+  File "dune.lock/needs-patch.pkg", line 8, characters 7-29:
+  8 |   (url http://localhost:61144)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  Error: curl returned an invalid error code 56
+         
+         
   [1]
 
 Set up a new version of the package which has multiple `extra-sources`, the

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -46,12 +46,12 @@ First we need a project that will have the patch applied:
   $ cat > needs_patch.ml <<EOF
   > let msg = "Needs to be patched"
   > EOF
-  $ git add -A
-  $ git commit -m "Initial" --quiet
   $ cd ..
   $ tar cf needs-patch.tar needs-patch
   $ SRC_MD5=$(md5sum needs-patch.tar | cut -f1 -d' ')
   $ cd needs-patch
+  $ git add -A
+  $ git commit -m "Initial" --quiet
   $ cat > needs_patch.ml <<EOF
   > let msg = "Patch successfully applied"
   > EOF


### PR DESCRIPTION
This is a quick fix that addresses the "Error: Multiple rules generated for <target>" when building a package with the extra-source field. This isn't expected to work in cases where a package has multiple extra-source entries, which will come in a later change.

Note that the test is currently complaining about `curl` returning an unexpected result. This is fixed in https://github.com/ocaml/dune/pull/10705, so we'll merge that first.