### PR TITLE
Auto format `dune-project` files with `dune fmt`

### DIFF
--- a/doc/howto/formatting.rst
+++ b/doc/howto/formatting.rst
@@ -16,6 +16,9 @@ configuration happens in that file. If you want to format OCaml sources and
 ``dune`` files, you don't have anything to add. Otherwise, refer to the
 :doc:`/reference/dune-project/formatting` stanza.
 
+Starting with version ``3.17`` ``dune`` will also automatically format ``dune-project``
+files.
+
 Next we need to install some code formatting tools. For OCaml code, this means
 installing OCamlFormat_ with ``opam install ocamlformat``. Formatting ``dune``
 files is built into Dune and does not require any extra tools. For Reason code,

--- a/doc/reference/dune-project/formatting.rst
+++ b/doc/reference/dune-project/formatting.rst
@@ -21,7 +21,7 @@ formatting
         (formatting
          (enabled_for <languages>))
 
-     The list of `<languages>` can be either ``dune`` (formatting of ``dune``
-     files) or a :term:`dialect` name.
+     Valid entries for the list of `<languages>` are ``dune``, ``dune-project``,
+     or a :term:`dialect` name.
 
    .. seealso:: :doc:`/howto/formatting`

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,9 @@
 (lang dune 3.12)
+
 ;          ^^^^
 ; When changing the version, don't forget to regenerate *.opam files
 ; by running [dune build].
+
 (name dune)
 
 (generate_opam_files true)
@@ -11,12 +13,18 @@
 (strict_package_deps false)
 
 ; Reserved for Dune itself. This is to help with the bootstrap
+
 (using dune-bootstrap-info 0.1)
 
 (license MIT)
+
 (maintainers "Jane Street Group, LLC <opensource@janestreet.com>")
+
 (authors "Jane Street Group, LLC <opensource@janestreet.com>")
-(source (github ocaml/dune))
+
+(source
+ (github ocaml/dune))
+
 (documentation "https://dune.readthedocs.io/")
 
 (implicit_transitive_deps false)
@@ -26,135 +34,125 @@
  (synopsis "Fast, portable, and opinionated build system")
  ; The "depends" and "build" field are written in dune.opam.template
  (conflicts
-  (merlin (< 3.4.0))
-  (ocaml-lsp-server (< 1.3.0))
-  (dune-configurator (< 2.3.0))
-  (odoc (< 2.0.1))
-  (dune-release (< 1.3.0))
-  (js_of_ocaml-compiler (< 3.6.0))
-  (jbuilder (= transition)))
- (description "
-Dune is a build system that was designed to simplify the release of
-Jane Street packages. It reads metadata from \"dune\" files following a
-very simple s-expression syntax.
-
-Dune is fast, has very low-overhead, and supports parallel builds on
-all platforms. It has no system dependencies; all you need to build
-dune or packages using dune is OCaml. You don't need make or bash
-as long as the packages themselves don't use bash explicitly.
-
-Dune is composable; supporting multi-package development by simply
-dropping multiple repositories into the same directory.
-
-Dune also supports multi-context builds, such as building against
-several opam roots/switches simultaneously. This helps maintaining
-packages across several versions of OCaml and gives cross-compilation
-for free.
-"))
+  (merlin
+   (< 3.4.0))
+  (ocaml-lsp-server
+   (< 1.3.0))
+  (dune-configurator
+   (< 2.3.0))
+  (odoc
+   (< 2.0.1))
+  (dune-release
+   (< 1.3.0))
+  (js_of_ocaml-compiler
+   (< 3.6.0))
+  (jbuilder
+   (= transition)))
+ (description
+  "\nDune is a build system that was designed to simplify the release of\nJane Street packages. It reads metadata from \"dune\" files following a\nvery simple s-expression syntax.\n\nDune is fast, has very low-overhead, and supports parallel builds on\nall platforms. It has no system dependencies; all you need to build\ndune or packages using dune is OCaml. You don't need make or bash\nas long as the packages themselves don't use bash explicitly.\n\nDune is composable; supporting multi-package development by simply\ndropping multiple repositories into the same directory.\n\nDune also supports multi-context builds, such as building against\nseveral opam roots/switches simultaneously. This helps maintaining\npackages across several versions of OCaml and gives cross-compilation\nfor free.\n"))
 
 (package
  (name dune-build-info)
  (synopsis "Embed build information inside executable")
  (depends
-  (ocaml (>= 4.08)))
- (description "\
-The build-info library allows to access information about how the
-executable was built, such as the version of the project at which it
-was built or the list of statically linked libraries with their
-versions.  It supports reporting the version from the version control
-system during development to get an precise reference of when the
-executable was built.
-"))
+  (ocaml
+   (>= 4.08)))
+ (description
+  "The build-info library allows to access information about how the\nexecutable was built, such as the version of the project at which it\nwas built or the list of statically linked libraries with their\nversions.  It supports reporting the version from the version control\nsystem during development to get an precise reference of when the\nexecutable was built.\n"))
 
 (package
  (name dune-private-libs)
  (synopsis "Private libraries of Dune")
  (depends
-  (csexp (>= 1.5.0))
-  (pp (>= 1.1.0))
-  (dyn (= :version))
-  (stdune (= :version))
-  (ocaml (>= 4.08)))
- (description "\
-!!!!!!!!!!!!!!!!!!!!!!
-!!!!! DO NOT USE !!!!!
-!!!!!!!!!!!!!!!!!!!!!!
-
-This package contains code that is shared between various dune-xxx
-packages. However, it is not meant for public consumption and provides
-no stability guarantee.
-"))
+  (csexp
+   (>= 1.5.0))
+  (pp
+   (>= 1.1.0))
+  (dyn
+   (= :version))
+  (stdune
+   (= :version))
+  (ocaml
+   (>= 4.08)))
+ (description
+  "!!!!!!!!!!!!!!!!!!!!!!\n!!!!! DO NOT USE !!!!!\n!!!!!!!!!!!!!!!!!!!!!!\n\nThis package contains code that is shared between various dune-xxx\npackages. However, it is not meant for public consumption and provides\nno stability guarantee.\n"))
 
 (package
  (name dune-configurator)
  (synopsis "Helper library for gathering system configuration")
  (depends
-  (ocaml (>= 4.04.0))
+  (ocaml
+   (>= 4.04.0))
   base-unix
-  (csexp (>= 1.5.0)))
- (description "\
-dune-configurator is a small library that helps writing OCaml scripts that
-test features available on the system, in order to generate config.h
-files for instance.
-Among other things, dune-configurator allows one to:
-- test if a C program compiles
-- query pkg-config
-- import #define from OCaml header files
-- generate config.h file
-"))
+  (csexp
+   (>= 1.5.0)))
+ (description
+  "dune-configurator is a small library that helps writing OCaml scripts that\ntest features available on the system, in order to generate config.h\nfiles for instance.\nAmong other things, dune-configurator allows one to:\n- test if a C program compiles\n- query pkg-config\n- import #define from OCaml header files\n- generate config.h file\n"))
 
 (package
  (name dune-action-plugin)
  (synopsis "[experimental] API for writing dynamic Dune actions")
  (depends
-  (dune-glob (= :version))
-  (csexp (>= 1.5.0))
+  (dune-glob
+   (= :version))
+  (csexp
+   (>= 1.5.0))
   (ppx_expect :with-test)
-  (stdune (= :version))
-  (dune-private-libs (= :version))
-  (dune-rpc (= :version))
+  (stdune
+   (= :version))
+  (dune-private-libs
+   (= :version))
+  (dune-rpc
+   (= :version))
   base-unix)
- (description "\
-
-This library is experimental. No backwards compatibility is implied.
-
-dune-action-plugin provides an API for writing dynamic Dune actions.
-Dynamic dune actions do not need to declare their dependencies
-upfront; they are instead discovered automatically during the
-execution of the action.
-"))
+ (description
+  "\nThis library is experimental. No backwards compatibility is implied.\n\ndune-action-plugin provides an API for writing dynamic Dune actions.\nDynamic dune actions do not need to declare their dependencies\nupfront; they are instead discovered automatically during the\nexecution of the action.\n"))
 
 (package
  (name dune-glob)
  (synopsis "Glob string matching language supported by dune")
  (depends
-  (stdune (= :version))
+  (stdune
+   (= :version))
   dyn
   ordering
-  (dune-private-libs (= :version)))
- (description "\
-dune-glob provides a parser and interpreter for globs as \
-understood by dune language."))
+  (dune-private-libs
+   (= :version)))
+ (description
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."))
 
 (package
  (name dune-site)
  (synopsis "Embed locations information inside executable and libraries")
- (depends (dune-private-libs (= :version)))
+ (depends
+  (dune-private-libs
+   (= :version)))
  (description ""))
 
 (package
  (name dune-rpc)
  (synopsis "Communicate with dune using rpc")
- (depends csexp ordering dyn xdg (stdune (= :version)) (pp (>= 1.1.0)))
+ (depends
+  csexp
+  ordering
+  dyn
+  xdg
+  (stdune
+   (= :version))
+  (pp
+   (>= 1.1.0)))
  (description "Library to connect and control a running dune instance"))
 
 (package
  (name dune-rpc-lwt)
  (synopsis "Communicate with dune using rpc and Lwt")
  (depends
-  (dune-rpc (= :version))
-  (csexp (>= 1.5.0))
-  (lwt (>= 5.6.0))
+  (dune-rpc
+   (= :version))
+  (csexp
+   (>= 1.5.0))
+  (lwt
+   (>= 5.6.0))
   base-unix)
  (description "Specialization of dune-rpc to Lwt"))
 
@@ -162,50 +160,68 @@ understood by dune language."))
  (name dyn)
  (synopsis "Dynamic type")
  (depends
-  (ocaml (>= 4.08.0))
-  (ordering (= :version))
-  (pp (>= 1.1.0)))
+  (ocaml
+   (>= 4.08.0))
+  (ordering
+   (= :version))
+  (pp
+   (>= 1.1.0)))
  (description "Dynamic type"))
 
 (package
  (name ordering)
  (synopsis "Element ordering")
  (depends
-  (ocaml (>= 4.08.0)))
+  (ocaml
+   (>= 4.08.0)))
  (description "Element ordering"))
 
 (package
  (name xdg)
  (synopsis "XDG Base Directory Specification")
  (depends
-  (ocaml (>= 4.08)))
- (description "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"))
+  (ocaml
+   (>= 4.08)))
+ (description
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"))
 
 (package
  (name stdune)
  (synopsis "Dune's unstable standard library")
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml
+   (>= 4.08.0))
   base-unix
-  (dyn (= :version))
-  (ordering (= :version))
-  (pp (>= 1.2.0))
-  (csexp (>= 1.5.0)))
- (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
+  (dyn
+   (= :version))
+  (ordering
+   (= :version))
+  (pp
+   (>= 1.2.0))
+  (csexp
+   (>= 1.5.0)))
+ (description
+  "This library offers no backwards compatibility guarantees. Use at your own risk."))
 
 (package
  (name ocamlc-loc)
  (synopsis "Parse ocaml compiler output into structured form")
  (conflicts
-  (ocaml-lsp-server (< 1.15.0)))
+  (ocaml-lsp-server
+   (< 1.15.0)))
  (depends
-  (ocaml (>= 4.08.0))
-  (dyn (= :version)))
- (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
+  (ocaml
+   (>= 4.08.0))
+  (dyn
+   (= :version)))
+ (description
+  "This library offers no backwards compatibility guarantees. Use at your own risk."))
 
 (package
  (name chrome-trace)
  (synopsis "Chrome trace event generation library")
  (depends
-  (ocaml (>= 4.08.0)))
- (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
+  (ocaml
+   (>= 4.08.0)))
+ (description
+  "This library offers no backwards compatibility guarantees. Use at your own risk."))

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -33,7 +33,7 @@ end
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> Loaded.t Memo.t
 
-(** Return the rule that has the given file has target, if any *)
+(** Return the rule that has the given file as target, if any *)
 val get_rule : Path.t -> Rule.t option Memo.t
 
 (** Return the definition of an alias. *)

--- a/src/dune_lang/format_config.ml
+++ b/src/dune_lang/format_config.ml
@@ -14,19 +14,19 @@ module Language = struct
     type t =
       | Dialect of string
       | Dune
-      | DuneProject
+      | Dune_project
 
     let compare t1 t2 =
       match t1, t2 with
       | Dialect s1, Dialect s2 -> String.compare s1 s2
       | Dialect _, Dune -> Gt
-      | Dialect _, DuneProject -> Gt
+      | Dialect _, Dune_project -> Gt
       | Dune, Dune -> Eq
       | Dune, Dialect _ -> Lt
-      | Dune, DuneProject -> Gt
-      | DuneProject, DuneProject -> Eq
-      | DuneProject, Dialect _ -> Lt
-      | DuneProject, Dune -> Lt
+      | Dune, Dune_project -> Gt
+      | Dune_project, Dune_project -> Eq
+      | Dune_project, Dialect _ -> Lt
+      | Dune_project, Dune -> Lt
     ;;
 
     let to_dyn =
@@ -34,7 +34,7 @@ module Language = struct
       function
       | Dialect name -> variant "dialect" [ string name ]
       | Dune -> variant "dune" []
-      | DuneProject -> variant "dune-project" []
+      | Dune_project -> variant "dune-project" []
     ;;
   end
 
@@ -42,7 +42,7 @@ module Language = struct
   include T
 
   let of_string = function
-    | "dune-project" -> DuneProject
+    | "dune-project" -> Dune_project
     | "dune" -> Dune
     | s -> Dialect s
   ;;
@@ -54,7 +54,7 @@ module Language = struct
     let open Encoder in
     function
     | Dune -> string "dune"
-    | DuneProject -> string "dune-project"
+    | Dune_project -> string "dune-project"
     | Dialect d -> string d
   ;;
 end

--- a/src/dune_lang/format_config.ml
+++ b/src/dune_lang/format_config.ml
@@ -189,7 +189,9 @@ let of_config ~ext ~dune_lang ~version =
   | None, None, _, true -> enabled_for_all
   | None, None, true, false -> enabled_dune_2
   | None, None, false, _ -> disabled
-  | Some x, None, false, _ | None, Some x, true, _ -> x
+  | Some x, None, false, _ | None, Some x, true, true -> x
+  | None, Some x, true, false ->
+    if x.enabled_for == Enabled_for.All then enabled_dune_2 else x
   | _, Some _, false, _ ->
     Code_error.raise "(formatting ...) stanza requires version 2.0" []
   | Some ext, _, true, _ ->

--- a/src/dune_lang/format_config.mli
+++ b/src/dune_lang/format_config.mli
@@ -8,7 +8,7 @@ module Language : sig
   type t =
     | Dialect of string
     | Dune
-    | DuneProject
+    | Dune_project
 end
 
 type t

--- a/src/dune_lang/format_config.mli
+++ b/src/dune_lang/format_config.mli
@@ -8,6 +8,7 @@ module Language : sig
   type t =
     | Dialect of string
     | Dune
+    | DuneProject
 end
 
 type t

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -150,7 +150,7 @@ let gen_rules_output
           |> Memo.Option.iter
                ~f:(add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version)))
   and* () =
-    match Format_config.includes config Dune with
+    match Format_config.includes config DuneProject with
     | false -> Memo.return ()
     | true ->
       Dune_project.file project

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -155,7 +155,8 @@ let gen_rules_output
     | true ->
       Dune_project.file project
       |> Memo.Option.iter ~f:(fun path ->
-        if String.equal "_build/default" (Path.Build.to_string dir)
+        let build_dir = Super_context.context sctx |> Context.build_dir in
+        if Path.Build.equal build_dir dir
         then add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version path
         else Memo.return ())
   in

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -150,7 +150,7 @@ let gen_rules_output
           |> Memo.Option.iter
                ~f:(add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version)))
   and* () =
-    match Format_config.includes config DuneProject with
+    match Format_config.includes config Dune_project with
     | false -> Memo.return ()
     | true ->
       Dune_project.file project

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -68,6 +68,19 @@ module Alias = struct
   let fmt ~dir = Alias.make Alias0.fmt ~dir
 end
 
+let add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version path =
+  let open Memo.O in
+  let input_basename = Path.Source.basename path in
+  let input = Path.build (Path.Build.relative dir input_basename) in
+  let output = Path.Build.relative output_dir input_basename in
+  (let open Action_builder.O in
+   let+ () = Action_builder.path input in
+   Action.Full.make (action ~version input output))
+  |> Action_builder.with_file_targets ~file_targets:[ output ]
+  |> Super_context.add_rule sctx ~mode:Standard ~loc ~dir
+  >>> add_diff sctx loc alias_formatted ~dir ~input ~output
+;;
+
 let gen_rules_output
   sctx
   (config : Format_config.t)
@@ -75,6 +88,7 @@ let gen_rules_output
   ~dialects
   ~expander
   ~output_dir
+  ~project
   =
   assert (formatted_dir_basename = Path.Build.basename output_dir);
   let loc = Format_config.loc config in
@@ -133,16 +147,17 @@ let gen_rules_output
         Source_tree.Dir.dune_file source_dir
         |> Memo.Option.iter ~f:(fun f ->
           Dune_file0.path f
-          |> Memo.Option.iter ~f:(fun path ->
-            let input_basename = Path.Source.basename path in
-            let input = Path.build (Path.Build.relative dir input_basename) in
-            let output = Path.Build.relative output_dir input_basename in
-            (let open Action_builder.O in
-             let+ () = Action_builder.path input in
-             Action.Full.make (action ~version input output))
-            |> Action_builder.with_file_targets ~file_targets:[ output ]
-            |> Super_context.add_rule sctx ~mode:Standard ~loc ~dir
-            >>> add_diff sctx loc alias_formatted ~dir ~input ~output)))
+          |> Memo.Option.iter
+               ~f:(add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version)))
+  and* () =
+    match Format_config.includes config Dune with
+    | false -> Memo.return ()
+    | true ->
+      Dune_project.file project
+      |> Memo.Option.iter ~f:(fun path ->
+        if String.equal "_build/default" (Path.Build.to_string dir)
+        then add_diff_rule ~sctx ~loc ~alias_formatted ~dir ~output_dir ~version path
+        else Memo.return ())
   in
   Rules.Produce.Alias.add_deps alias_formatted (Action_builder.return ())
 ;;
@@ -181,7 +196,7 @@ let gen_rules sctx ~output_dir =
     let* project = Dune_load.find_project ~dir in
     let dialects = Dune_project.dialects project in
     let version = Dune_project.dune_version project in
-    gen_rules_output sctx config ~version ~dialects ~expander ~output_dir)
+    gen_rules_output sctx config ~version ~dialects ~expander ~output_dir ~project)
 ;;
 
 let setup_alias ~dir =

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -95,7 +95,7 @@ end = struct
      we'd have the following map (in associative list syntax):
 
      {[
-       [ 1, [ 0, (1, 4); 1, (1, 6); 2, (2, 3) ]; 2, [ 0, (2, 3) ] ]
+       [ 1, [ 0, (1, 4); 1, (1, 6); 2, (2, 3) ]; 2, [ 0, (2, 4) ] ]
      ]} *)
   type t =
     { version_map : Version.t Int.Map.t Int.Map.t

--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -271,3 +271,18 @@ dune fmt automatically formats dune-project files starting from dune 3.17.
   (lang dune 3.17)
   
   (name format_project)
+
+But does not format if formatting is disabled for dune-project files.
+
+  $ cat > dune-project-files/dune-project << EOF
+  > (lang dune 3.17)
+  > (name
+  > format_project)
+  > (formatting (enabled_for ocaml dune reason))
+  > EOF
+  $ (cd dune-project-files && dune fmt)
+  $ cat dune-project-files/dune-project
+  (lang dune 3.17)
+  (name
+  format_project)
+  (formatting (enabled_for ocaml dune reason))

--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -190,7 +190,8 @@ Sometimes, the suggestion is to just remove the configuration.
   5 | (using fmt 1.2)
       ^^^^^^^^^^^^^^^
   Error: Starting with (lang dune 2.0), formatting is enabled by default.
-  To port it to the new syntax, you can delete this part.
+  To port it to the new syntax, you can replace this part by:
+  (formatting (enabled_for dune ocaml reason))
   [1]
 
 Formatting can also be set in the (env ...) stanza
@@ -251,12 +252,12 @@ settings as dictated by the dune language version.
   > EOF
   $ (cd using-env && dune build @fmt)
 
-dune fmt automatically formats dune-project files.
+dune fmt automatically formats dune-project files starting from dune 3.17.
 
   $ mkdir dune-project-files
   $ touch dune-project-files/.ocamlformat
   $ cat > dune-project-files/dune-project << EOF
-  > (lang dune 3.16)
+  > (lang dune 3.17)
   > (name
   > format_project)
   > EOF
@@ -267,6 +268,6 @@ dune fmt automatically formats dune-project files.
   Promoting _build/default/.formatted/dune-project to dune-project.
   [1]
   $ cat dune-project-files/dune-project
-  (lang dune 3.16)
+  (lang dune 3.17)
   
   (name format_project)

--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -250,3 +250,23 @@ settings as dictated by the dune language version.
   > ;; formatting disabled by default
   > EOF
   $ (cd using-env && dune build @fmt)
+
+dune fmt automatically formats dune-project files.
+
+  $ mkdir dune-project-files
+  $ touch dune-project-files/.ocamlformat
+  $ cat > dune-project-files/dune-project << EOF
+  > (lang dune 3.16)
+  > (name
+  > format_project)
+  > EOF
+  $ (cd dune-project-files && dune fmt)
+  File "dune-project", line 1, characters 0-0:
+  Error: Files _build/default/dune-project and
+  _build/default/.formatted/dune-project differ.
+  Promoting _build/default/.formatted/dune-project to dune-project.
+  [1]
+  $ cat dune-project-files/dune-project
+  (lang dune 3.16)
+  
+  (name format_project)


### PR DESCRIPTION
Hi!

This PR enables automatic formatting of `dune-project` files when running `dune fmt`. This should close #3223. Note that there were some concerns raised on that issue regarding the formatting, but those should have been addressed by #3928, see also #2291.

Note: I'm new to OCaml, especially working on such a mature codebase so there will probably a lot of mistakes in my submission. I hope it can still be of use and I'm more than happy to learn and address any problems with this PR.