### PR TITLE
fix: name suggestion on opam context

### DIFF
--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -462,6 +462,14 @@ module Context = struct
       Common.equal base t.base && Opam_switch.equal switch t.switch
     ;;
 
+    let name_hint_opt name =
+      if String.is_prefix ~prefix:"/" name
+      then (
+        let context_name = Filename.basename name in
+        Some [ Pp.textf "(name %s) would be a valid context name" context_name ])
+      else None
+    ;;
+
     let decode =
       let+ loc_switch, switch = field "switch" (located string)
       and+ name = field_o "name" Context_name.decode
@@ -479,9 +487,10 @@ module Context = struct
              | None ->
                User_error.raise
                  ~loc:loc_switch
-                 [ Pp.textf "Generated context name %S is invalid" name
-                 ; Pp.text
-                     "Please specify a context name manually with the (name ..) field"
+                 ?hints:(name_hint_opt name)
+                 [ Pp.textf
+                     "The name generated from this switch can not be used as a context \
+                      name. Please use (name) to disambiguate."
                  ])
         in
         let base = { base with targets = Target.add base.targets x; name } in

--- a/test/blackbox-tests/test-cases/github10721.t
+++ b/test/blackbox-tests/test-cases/github10721.t
@@ -6,13 +6,14 @@
   > (lang dune 3.0)
   > (context
   >  (opam
-  >   (switch /absolute/path/to/opam/switch)))
+  >   (switch /absolute/path/to/opam/switchname)))
   > EOF
 
   $ dune build
-  File "dune-workspace", line 4, characters 10-39:
-  4 |   (switch /absolute/path/to/opam/switch)))
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Generated context name "/absolute/path/to/opam/switch" is invalid
-  Please specify a context name manually with the (name ..) field
+  File "dune-workspace", line 4, characters 10-43:
+  4 |   (switch /absolute/path/to/opam/switchname)))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: The name generated from this switch can not be used as a context name.
+  Please use (name) to disambiguate.
+  Hint: (name switchname) would be a valid context name
   [1]


### PR DESCRIPTION
Hi,
This PR fixes #10721. It provides more information when someone set a switch using an absolute path.
The new error message is:
```
Error: Generated context name
"/path/to/switch" is invalid
The generated context name "/path/to/switch-name" from the switch name is invalid.
Please specify a context name manually with the (name ..) field
Hint: you may want to add (name switch-name) 
```
