### PR TITLE
feat: configure-time toggles

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -101,6 +101,7 @@ let exit_and_flush code =
 ;;
 
 let () =
+  Dune_config.set_configure_time_toggles ~names:Dune_rules.Setup.toggles;
   Dune_rules.Colors.setup_err_formatter_colors ();
   try
     match Cmd.eval_value cmd ~catch:false with

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -29,6 +29,7 @@ let () =
   let libexecdir = ref None in
   let datadir = ref None in
   let cwd = lazy (Sys.getcwd ()) in
+  let toggles = ref [] in
   let dir_of_string s =
     if Filename.is_relative s then Filename.concat (Lazy.force cwd) s else s
   in
@@ -41,6 +42,7 @@ let () =
     let dir = dir_of_string s in
     v := Some dir
   in
+  let set_toggles s = toggles := String.split_on_char ~sep:',' s in
   let args =
     [ ( "--libdir"
       , Arg.String set_libdir
@@ -70,6 +72,7 @@ let () =
       , Arg.String (set_dir datadir)
       , "DIR where files for the share_root section are installed for the default build \
          context" )
+    ; "--toggles", Arg.String set_toggles, "TODO"
     ]
   in
   let anon s = bad "Don't know what to do with %s" s in
@@ -89,6 +92,7 @@ let () =
   pr "  ; bin = %s" (option string !bindir);
   pr "  ; sbin = %s" (option string !sbindir);
   pr "  ; libexec_root = %s" (option string !libexecdir);
-  pr "  }";
+  pr "  }\n";
+  pr "let toggles = %s" (list string !toggles);
   close_out oc
 ;;

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -162,3 +162,5 @@ let threaded_console_frames_per_second =
     ~default:`Default
     ~witness:(Type_eq.Id.create () (* XXX *))
 ;;
+
+let party_mode = make_toggle ~name:"party_mode" ~default:`Disabled

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -1,11 +1,15 @@
 open Stdune
 
 let initialized = ref false
+let configure_time_frozen = ref false
 
 type 'a t =
   { name : string
   ; of_string : string -> ('a, string) result
-  ; mutable value : 'a
+  ; mutable value : 'a option
+  ; default : 'a
+  ; witness : 'a Type_eq.Id.t
+  ; mutable configure_time_value : 'a option
   }
 
 let env_name t = sprintf "DUNE_CONFIG__%s" (String.uppercase_ascii t.name)
@@ -13,7 +17,10 @@ let env_name t = sprintf "DUNE_CONFIG__%s" (String.uppercase_ascii t.name)
 let get t =
   if not !initialized
   then Code_error.raise "Config.get: invalid access" [ "name", Dyn.string t.name ];
-  t.value
+  configure_time_frozen := true;
+  match t.value with
+  | Some v -> v
+  | None -> Option.value t.configure_time_value ~default:t.default
 ;;
 
 type packed = E : 'a t -> packed
@@ -27,6 +34,7 @@ module Toggle = struct
     | `Disabled
     ]
 
+  let witness : t Type_eq.Id.t = Type_eq.Id.create ()
   let all : (string * t) list = [ "enabled", `Enabled; "disabled", `Disabled ]
 
   let to_string t =
@@ -70,28 +78,42 @@ let init values =
     in
     let env_name = env_name t in
     match Sys.getenv_opt env_name with
-    | None -> Option.iter config ~f:(fun config -> t.value <- config)
+    | None -> Option.iter config ~f:(fun config -> t.value <- Some config)
     | Some v ->
       (match t.of_string v with
-       | Ok v -> t.value <- v
+       | Ok v -> t.value <- Some v
        | Error e ->
          User_error.raise [ Pp.textf "Invalid value for %S" env_name; Pp.text e ]));
   initialized := true
 ;;
 
-let make ~name ~of_string ~default =
-  let t = { name; of_string; value = default } in
+let make ~name ~of_string ~default ~witness =
+  let t =
+    { name; of_string; value = None; default; configure_time_value = None; witness }
+  in
   register t;
   t
 ;;
 
-let global_lock = make ~name:"global_lock" ~of_string:Toggle.of_string ~default:`Enabled
+let set_configure_time_toggles ~names =
+  if !configure_time_frozen
+  then Code_error.raise "Config.set_configure_time_toggles: invalid access" [];
+  List.iter names ~f:(fun name ->
+    let (E t) = List.find_exn !all ~f:(fun (E t) -> String.equal t.name name) in
+    match Type_eq.Id.same t.witness Toggle.witness with
+    | Some T -> t.configure_time_value <- Some `Enabled
+    | None -> ());
+  configure_time_frozen := true
+;;
+
+let make_toggle ~name ~default =
+  make ~name ~default ~of_string:Toggle.of_string ~witness:Toggle.witness
+;;
+
+let global_lock = make_toggle ~name:"global_lock" ~default:`Enabled
 
 let cutoffs_that_reduce_concurrency_in_watch_mode =
-  make
-    ~name:"cutoffs_that_reduce_concurrency_in_watch_mode"
-    ~of_string:Toggle.of_string
-    ~default:`Disabled
+  make_toggle ~name:"cutoffs_that_reduce_concurrency_in_watch_mode" ~default:`Disabled
 ;;
 
 let copy_file =
@@ -101,6 +123,7 @@ let copy_file =
       | "portable" -> Ok `Portable
       | "fast" -> Ok `Best
       | _ -> Error (sprintf "only %S and %S are allowed" "fast" "portable"))
+    ~witness:(Type_eq.Id.create () (* XXX *))
     ~default:`Best
 ;;
 
@@ -110,31 +133,23 @@ let background_default =
   | _ -> `Disabled
 ;;
 
-let background_actions =
-  make ~name:"background_actions" ~of_string:Toggle.of_string ~default:`Disabled
-;;
+let background_actions = make_toggle ~name:"background_actions" ~default:`Disabled
 
 let background_digests =
-  make ~name:"background_digests" ~of_string:Toggle.of_string ~default:background_default
+  make_toggle ~name:"background_digests" ~default:background_default
 ;;
 
 let background_sandboxes =
-  make
-    ~name:"background_sandboxes"
-    ~of_string:Toggle.of_string
-    ~default:background_default
+  make_toggle ~name:"background_sandboxes" ~default:background_default
 ;;
 
 let background_file_system_operations_in_rule_execution =
-  make
+  make_toggle
     ~name:"background_file_system_operations_in_rule_execution"
-    ~of_string:Toggle.of_string
     ~default:`Disabled
 ;;
 
-let threaded_console =
-  make ~name:"threaded_console" ~of_string:Toggle.of_string ~default:background_default
-;;
+let threaded_console = make_toggle ~name:"threaded_console" ~default:background_default
 
 let threaded_console_frames_per_second =
   make
@@ -145,4 +160,5 @@ let threaded_console_frames_per_second =
       | Some _ -> Error (sprintf "value must be between 1 and 1000")
       | None -> Error (sprintf "could not parse %S as an integer" x))
     ~default:`Default
+    ~witness:(Type_eq.Id.create () (* XXX *))
 ;;

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -22,9 +22,18 @@ module Toggle : sig
   val to_dyn : t -> Dyn.t
 end
 
+val set_configure_time_toggles : names:string list -> unit
+
 (** [make ~name ~of_string ~default] registers a config value called [name],
     parsed using [of_string], defaulting to [default]. *)
-val make : name:string -> of_string:(string -> ('a, string) result) -> default:'a -> 'a t
+val make
+  :  name:string
+  -> of_string:(string -> ('a, string) result)
+  -> default:'a
+  -> witness:'a Type_eq.Id.t
+  -> 'a t
+
+val make_toggle : name:string -> default:Toggle.t -> Toggle.t t
 
 (** [get t] return the value of the configuration for [t] *)
 val get : 'a t -> 'a

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -74,3 +74,5 @@ val threaded_console_frames_per_second : [ `Default | `Custom of int ] t
     Note that environment variables take precedence over the values passed here
     for easy overriding. *)
 val init : (Loc.t * string) String.Map.t -> unit
+
+val party_mode : Toggle.t t

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -501,4 +501,5 @@ module Dune_config = struct
         | Simple { verbosity; _ } -> verbosity);
     { Scheduler.Config.concurrency; stats; print_ctrl_c_warning; watch_exclusions }
   ;;
+  let set_configure_time_toggles = Config.set_configure_time_toggles
 end

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -111,4 +111,6 @@ module Dune_config : sig
     -> Dune_stats.t option
     -> print_ctrl_c_warning:bool
     -> Dune_engine.Scheduler.Config.t
+
+  val set_configure_time_toggles : names:string list -> unit
 end

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1132,6 +1132,22 @@ let handle_final_exns exns =
 let run f =
   let open Fiber.O in
   Hooks.End_of_build.once Diff_promotion.finalize;
+  (match Dune_config.Config.get Dune_config.Config.party_mode with
+   | `Enabled ->
+     let tag i =
+       match i mod 4 with
+       | 0 -> User_message.Style.Ok
+       | 1 -> Error
+       | 2 -> Warning
+       | _ -> Kwd
+     in
+     let festive s =
+       String.fold_left s ~init:(Pp.nop, 0) ~f:(fun (acc, i) c ->
+         Pp.seq acc (Pp.tag (tag i) (Pp.char c)), i + 1)
+       |> fst
+     in
+     User_message.print (User_message.make [ festive "PARTY MODE enabled." ])
+   | `Disabled -> ());
   let* () = State.reset_progress () in
   let* () = State.reset_errors () in
   let f () =

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -51,7 +51,11 @@ let run_capture_line ~path ~prog ~args =
 module Config_override_variables = struct
   let string_option_config name =
     let config =
-      Dune_config.Config.make ~name ~of_string:(fun s -> Ok (Some s)) ~default:None
+      Dune_config.Config.make
+        ~name
+        ~of_string:(fun s -> Ok (Some s))
+        ~default:None
+        ~witness:(Type_eq.Id.create () (* XXX *))
     in
     fun () -> Dune_config.Config.get config
   ;;

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -159,5 +159,5 @@ let ( == ) = `Use_phys_equal
 
 (** Controls whether we use background threads in the dune rules *)
 let background_dune_rules =
-  Config.make ~name:"background_dune_rules" ~of_string:Toggle.of_string ~default:`Disabled
+  Config.make_toggle ~name:"background_dune_rules" ~default:`Disabled
 ;;

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -10,3 +10,5 @@ let roots : string option Install.Roots.t =
   ; sbin = None
   ; libexec_root = None
   }
+
+let toggles = []

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -9,3 +9,5 @@ val library_path : string list
 
 (** Where to install files. All the directories are absolute path *)
 val roots : string option Install.Roots.t
+
+val toggles : string list


### PR DESCRIPTION
This is a demo of configure-time toggles, a way to set some configuration values at configure time.

A `party_mode` toggle is included, that displays a colored message when the build system starts.

By default, it is off. It can be enabled either:

- at runtime, by setting `DUNE_CONFIG__PARTY_MODE=enabled`
- at configure time, by running `./configure --toggles party_mode`
