### PR TITLE
test: add for opam switch name with absolute path

### DIFF
--- a/test/blackbox-tests/test-cases/github10721.t
+++ b/test/blackbox-tests/test-cases/github10721.t
@@ -1,0 +1,19 @@
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.0)
+  > (context
+  >  (opam
+  >   (switch /absolute/path/to/opam/switch)))
+  > EOF
+
+  $ dune build
+  File "dune-workspace", line 4, characters 10-39:
+  4 |   (switch /absolute/path/to/opam/switch)))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Generated context name "/absolute/path/to/opam/switch" is invalid
+  Please specify a context name manually with the (name ..) field
+  [1]

--- a/test/blackbox-tests/test-cases/github10721.t
+++ b/test/blackbox-tests/test-cases/github10721.t
@@ -1,4 +1,3 @@
-
   $ cat > dune-project << EOF
   > (lang dune 3.0)
   > EOF


### PR DESCRIPTION
This PR provides a test to display the error input when trying to use an absolute path in a opam switch context.

Linked to #10723
