### PR TITLE
chore: Add Cache Directory Tagging Specification

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/cache-dir-tag.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-dir-tag.t
@@ -1,0 +1,37 @@
+Test that the 'CACHEDIR.TAG' file is created in the default dune cache 
+directory.
+
+  $ export DUNE_CACHE=enabled
+  $ export XDG_CACHE_HOME=$PWD/.xdg-cache
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.5)
+  > EOF
+
+  $ dune build
+
+Check that the 'CACHEDIR.TAG' file was created and sits at the top level of the
+default dune cache directory.
+
+  $ ls $XDG_CACHE_HOME/dune
+  CACHEDIR.TAG
+  db
+
+Check that the contents of the 'CACHEDIR.TAG' file conform to the specification
+found at 'https://bford.info/cachedir/'
+
+  $ cat $XDG_CACHE_HOME/dune/CACHEDIR.TAG
+  Signature: 8a477f597d28d172789f06886806bc55
+
+Set the enviornment variable 'DUNE_CACHE_ROOT' to a custom value overriding the
+default dune cache directory. In this case the 'CACHEDIR.TAG' file should NOT
+be created.
+
+  $ export DUNE_CACHE_ROOT=$PWD/personal-cache
+  $ dune build
+
+  $ ls $DUNE_CACHE_ROOT
+  files
+  meta
+  temp
+  values


### PR DESCRIPTION
This pull requests closes #9054 implementing the format specification found at https://bford.info/cachedir/.

I opted to follow @Alizter's specification in the issue only creating the `CACHEDIR.TAG` file when the default directory for the dune cache is being used. So if the environment variable `DUNE_CACHE_ROOT` is set this file will not be generated! Additionally, I omitted adding comments to the file but the specification does say that comments beginning with a `#` character are permitted after the signature, giving the following example:

```
Signature: 8a477f597d28d172789f06886806bc55
# This file is a cache directory tag created by (application name).
# For information about cache directory tags, see:
#	http://www.brynosaurus.com/cachedir/
```