### PR TITLE
test: explicitly use str in multi-context-error.t

### DIFF
--- a/test/blackbox-tests/test-cases/multi-context-error.t
+++ b/test/blackbox-tests/test-cases/multi-context-error.t
@@ -18,6 +18,7 @@
   > (library
   >  (name foo)
   >  (public_name bar.foo)
+  >  (libraries str)
   >  (enabled_if (= %{context_name} "default")))
   > (library
   >  (name foo)


### PR DESCRIPTION
This causes a warning on OCaml 5.
