### PR TITLE
chore: use with-dev-setup to manage opam test deps

### DIFF
--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -24,6 +24,12 @@ To create a directory-local opam switch with the dependencies necessary to build
 
   $ make dev-switch
 
+This can also be used to keep the switch updated when dependencies change.
+
+The ``Makefile`` also has a ``make dev-deps`` which will install just the
+dependencies used by tests. These are marked ``{ with-dev-setup }`` in Dune's
+opam file.
+
 Bootstrapping
 =============
 

--- a/dune.opam
+++ b/dune.opam
@@ -46,4 +46,19 @@ depends: [
   ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.16.0" & os != "win32" }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "4.0.0-414" & os != "win32" }
 ]

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -8,4 +8,19 @@ depends: [
   ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.16.0" & os != "win32" }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "4.0.0-414" & os != "win32" }
 ]


### PR DESCRIPTION
The goal is to simplify setting up the test dependencies. We use `{with-dev-setup}` in `dune.opam`. By default, these dependencies are not installed, but passing `--with-dev-setup` will install them.

Because the test dependencies are now expressed in an opam file, this is more expressive, and it makes it possible to use opam filters to install different dependencies on different configurations for example (#10712 is an example).

The source of truth for the ocamlformat version is moved to the opam file, so the parsing code in `make install-ocamlformat` and `flake.nix` is adapted. This means that `ocamlformat` will not be able to check its version at runtime anymore, but CI will do it and it's likely that Dune is going to manage `.ocamlformat` itself in the future (#10647).

`make dev-deps` continues working as before, but it can now be expressed as an opam command. `make dev-switch` is now an idempotent way to keep the switch in sync (which should cover #6939 as it was reported).

Fixes #6939
