### PR TITLE
ci: do not bootstrap twice

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,9 +95,6 @@ jobs:
       # away this makes it possible to see build errors as soon as possible
       - run: opam exec -- make _boot/dune.exe
 
-      # Ensure Dune can build itself
-      - run: opam exec -- make bootstrap
-
       - name: Install deps
         run: |
           opam install . --deps-only --with-test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -93,7 +93,7 @@ jobs:
 
       # dune doesn't have any additional dependencies so we can build it right
       # away this makes it possible to see build errors as soon as possible
-      - run: opam exec -- make _boot/dune.exe
+      - run: opam exec -- make release
 
       - name: Install deps
         run: |


### PR DESCRIPTION
`make bootstrap` does exactly `make -B _boot/dune.exe`, which is done just before, so we bootstrap twice in the workflow.
