### PR TITLE
fix(pkg): webserver-oneshot when downloading a large file

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -44,7 +44,8 @@
   e2e
   source-caching
   tarball
-  extra-sources))
+  extra-sources
+  oneshot-webserver-large-file-curl-error))
 
 (cram
  (deps %{bin:md5sum})

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -45,7 +45,7 @@
   source-caching
   tarball
   extra-sources
-  oneshot-webserver-large-file-curl-error))
+  gh10741))
 
 (cram
  (deps %{bin:md5sum})

--- a/test/blackbox-tests/test-cases/pkg/gh10741.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10741.t
@@ -1,9 +1,9 @@
-Reproduction for an issue with the oneshot webserver used for testing
+The issue with the oneshot webserver used for testing
 package management, where attempting to send a large file causes the
-connection to be reset before the transfer completes.
+connection to be reset before the transfer completes, is now fixed.
 
 Make a large file:
-  $ dd if=/dev/zero of=./large-file iflag=fullblock,count_bytes status=none count=20M
+  $ dd if=/dev/zero of=./large-file iflag=fullblock,count_bytes status=none count=64M
 
 Run the oneshot webserver to serve the large file:
   $ webserver_oneshot --content-file ./large-file --port-file port.txt &
@@ -11,7 +11,3 @@ Run the oneshot webserver to serve the large file:
 
 Download the large file with curl:
   $ curl -sS -o large-file-copy http://localhost:$(cat port.txt) > /dev/null
-  curl: (56) Recv failure: Connection reset by peer
-  [56]
-
-  $ wait

--- a/test/blackbox-tests/test-cases/pkg/oneshot-webserver-large-file-curl-error.t
+++ b/test/blackbox-tests/test-cases/pkg/oneshot-webserver-large-file-curl-error.t
@@ -1,0 +1,17 @@
+Reproduction for an issue with the oneshot webserver used for testing
+package management, where attempting to send a large file causes the
+connection to be reset before the transfer completes.
+
+Make a large file:
+  $ dd if=/dev/zero of=./large-file iflag=fullblock,count_bytes status=none count=20M
+
+Run the oneshot webserver to serve the large file:
+  $ webserver_oneshot --content-file ./large-file --port-file port.txt &
+  $ until test -f port.txt ; do sleep 0.1; done
+
+Download the large file with curl:
+  $ curl -sS -o large-file-copy http://localhost:$(cat port.txt) > /dev/null
+  curl: (56) Recv failure: Connection reset by peer
+  [56]
+
+  $ wait

--- a/test/http/http.ml
+++ b/test/http/http.ml
@@ -85,7 +85,7 @@ module Server = struct
       let out_fd = Unix.descr_of_out_channel out in
       let header_bytes = Bytes.of_string (header `Ok `Binary length) in
       send_bytes out_fd header_bytes (Bytes.length header_bytes);
-      let buf_size = 4096 in
+      let buf_size = 512 in
       let buf = Bytes.create buf_size in
       let rec write () =
         match In_channel.input in_channel buf 0 buf_size with


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/10741

We should merge this PR only after the merge of #10742.