### PR TITLE
Revert "test: fix oneshot webserver for large binary files (#10705)"

### DIFF
--- a/test/blackbox-tests/utils/webserver_oneshot.ml
+++ b/test/blackbox-tests/utils/webserver_oneshot.ml
@@ -50,10 +50,11 @@ let main content_files port_file ~simulate_not_found =
   Out_channel.with_open_text port_file (fun out_channel ->
     Out_channel.output_string out_channel (Printf.sprintf "%d\n" port));
   List.iter content_files ~f:(fun content_file ->
-    Http.Server.accept server ~f:(fun out_channel ->
+    Http.Server.accept server ~f:(fun session ->
+      let () = Http.Server.accept_request session in
       if simulate_not_found
-      then Http.Server.respond_not_found out_channel
-      else Http.Server.respond_file out_channel ~file:content_file))
+      then Http.Server.respond session ~status:`Not_found ~content:""
+      else Http.Server.respond_file session ~file:content_file))
 ;;
 
 let () =

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -33,8 +33,9 @@ let serve_once ~filename =
   let thread =
     Thread.create
       (fun server ->
-        Http.Server.accept server ~f:(fun write_end ->
-          Http.Server.respond_file write_end ~file:filename);
+        Http.Server.accept server ~f:(fun session ->
+          let () = Http.Server.accept_request session in
+          Http.Server.respond_file session ~file:filename);
         Http.Server.stop server)
       server
   in

--- a/test/http/http.mli
+++ b/test/http/http.mli
@@ -6,17 +6,16 @@ module Server : sig
   type t
   type session
 
+  val close_session : session -> unit
   val make : Unix.sockaddr -> t
   val accept : t -> f:(session -> unit) -> unit
+  val accept_request : session -> unit
   val stop : t -> unit
   val port : t -> int
   val start : t -> unit
-
-  (** Respond with a 404 error *)
-  val respond_not_found : session -> unit
+  val respond : session -> status:[ `Ok | `Not_found ] -> content:string -> unit
 
   (** Send the content of the file at path [file]. Works for both text
-      and binary files. Raises an exception if the [file] doesn't
-      refer to a file. *)
+      and binary files. Raises an exception if the [file] doesn't refer to a file. *)
   val respond_file : session -> file:string -> unit
 end


### PR DESCRIPTION
This reverts commit 5905292de45d62a8c204bac2f86498fbde4ac1f9.

Also properly implement request flushing to fix the actual issue and gets rid of workarounds for buggy tests.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>