### PR TITLE
fix(pkg): set jobs to -j

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -223,6 +223,7 @@ module Scheduler = struct
         ~print_ctrl_c_warning:true
         ~watch_exclusions
     in
+    Dune_rules.Clflags.concurrency := config.concurrency;
     let file_watcher = Common.file_watcher common in
     let run () =
       let open Fiber.O in

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -6,6 +6,7 @@ let capture_outputs = Dune_engine.Clflags.capture_outputs
 let debug_artifact_substitution = ref false
 let debug_package_logs = ref false
 let ignore_lock_dir = ref false
+let concurrency = ref 1
 
 type on_missing_dune_project_file =
   | Error

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -29,3 +29,5 @@ type on_missing_dune_project_file =
 
 (** Desired behavior when dune project file is absent *)
 val on_missing_dune_project_file : on_missing_dune_project_file ref
+
+val concurrency : int ref

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -750,7 +750,7 @@ module Action_expander = struct
       | Build -> Memo.return [ Value.Dir (Path.build paths.source_dir) ]
       | Prefix -> Memo.return [ Value.Dir (Path.build paths.target_dir) ]
       | User -> Memo.return [ Value.String (Unix.getlogin ()) ]
-      | Jobs -> Memo.return [ Value.String "1" ]
+      | Jobs -> Memo.return [ Value.String (Int.to_string !Clflags.concurrency) ]
       | Arch -> sys_poll_var (fun { arch; _ } -> arch)
       | Group ->
         let group = Unix.getgid () |> Unix.getgrgid in


### PR DESCRIPTION
This behavior isn't ideal, as it means that we will spawn way more jobs than necessary. However, this matches what opam does so it is an improvement.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>