### PR TITLE
test(menhir): avoid warning 63 on OCaml 5.2

### DIFF
--- a/test/blackbox-tests/test-cases/menhir/library-interface.t
+++ b/test/blackbox-tests/test-cases/menhir/library-interface.t
@@ -11,19 +11,18 @@ We should be able to use menhir as a library interface:
   > (menhir (modules foo))
   > EOF
 
-  $ touch m.ml
+  $ cat > m.ml << EOF
+  > let x = ()
+  > EOF
 
   $ cat >foo.mly <<EOF
-  > %{
-  > module M = M
-  > %}
   > %token EOF
   > 
   > %start<unit> unit
   > %%
   > 
   > unit:
-  > | EOF { () }
+  > | EOF { M.x }
   > EOF
 
   $ dune build foo.cma


### PR DESCRIPTION
The use of `module X = X` triggers warning 63 when using OCaml 5.2.
We can demonstrate that `M` is accessible by using it in the semantic action instead.
