### PR TITLE
refactor(pkg): separate read from write paths

### DIFF
--- a/otherlibs/stdune/src/lazy.ml
+++ b/otherlibs/stdune/src/lazy.ml
@@ -1,0 +1,3 @@
+include Stdlib.Lazy
+
+let map t ~f = lazy (f (force t))

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -18,6 +18,7 @@ module Table = Table
 module Int = Int
 module Id = Id
 module Io = Io
+module Lazy = Lazy
 module List = List
 module Map = Map
 module Option = Option

--- a/src/install/roots.ml
+++ b/src/install/roots.ml
@@ -80,10 +80,10 @@ open Dune_findlib
 let ocamlpath = Findlib.Config.ocamlpath_var
 let ocamlfind_ignore_dups_in = Findlib.Config.ocamlfind_ignore_dups_in
 
-let to_env_without_path t =
-  [ Ocaml.Env.caml_ld_library_path, Path.Build.relative t.lib_root "stublibs"
+let to_env_without_path t ~relative =
+  [ Ocaml.Env.caml_ld_library_path, relative t.lib_root "stublibs"
   ; ocamlpath, t.lib_root
-  ; "OCAMLTOP_INCLUDE_PATH", Path.Build.relative t.lib_root "toplevel"
+  ; "OCAMLTOP_INCLUDE_PATH", relative t.lib_root "toplevel"
   ; ocamlfind_ignore_dups_in, t.lib_root
   ; "MANPATH", t.man
   ]
@@ -96,7 +96,7 @@ let sep var =
 ;;
 
 let add_to_env t env =
-  to_env_without_path t
+  to_env_without_path t ~relative:Path.Build.relative
   |> List.fold_left ~init:env ~f:(fun env (var, path) ->
     Env.update env ~var ~f:(fun _PATH ->
       let path_sep = sep var in

--- a/src/install/roots.mli
+++ b/src/install/roots.mli
@@ -22,7 +22,7 @@ val map : f:('a -> 'b) -> 'a t -> 'b t
 (** return the roots of the first argument if present *)
 val first_has_priority : 'a option t -> 'a option t -> 'a option t
 
-val to_env_without_path : Path.Build.t t -> (Env.Var.t * Path.Build.t) list
+val to_env_without_path : 'a t -> relative:('a -> string -> 'a) -> (Env.Var.t * 'a) list
 val add_to_env : Path.Build.t t -> Env.t -> Env.t
 val make : 'a -> relative:('a -> string -> 'a) -> 'a t
 val make_all : 'a -> 'a t


### PR DESCRIPTION
write paths are used for targets and read paths are used for dependencies and expansions

@gridbugs this should make it possible to do without override pforms. 