### PR TITLE
refactor(engine): move some dap code into separate module

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -1,5 +1,6 @@
 open Import
 module DAP = Dune_action_plugin.Private.Protocol
+open Action_plugin
 
 let maybe_async =
   let maybe_async =
@@ -9,26 +10,6 @@ let maybe_async =
        | `Disabled -> fun f -> Fiber.return (f ()))
   in
   fun f -> (Lazy.force maybe_async) f
-;;
-
-let to_dune_dep_set =
-  let of_DAP_dep ~loc ~working_dir : DAP.Dependency.t -> Dep.t =
-    let to_dune_path = Path.relative working_dir in
-    function
-    | File fn -> Dep.file (to_dune_path fn)
-    | Directory dir ->
-      let dir = to_dune_path dir in
-      let selector = File_selector.of_glob ~dir Glob.universal in
-      Dep.file_selector selector
-    | Glob { path; glob } ->
-      let dir = to_dune_path path in
-      let glob = Glob.of_string_exn loc glob in
-      let selector = File_selector.of_glob ~dir glob in
-      Dep.file_selector selector
-  in
-  fun set ~loc ~working_dir ->
-    DAP.Dependency.Set.to_list_map set ~f:(of_DAP_dep ~loc ~working_dir)
-    |> Dep.Set.of_list
 ;;
 
 module Duration = struct
@@ -156,23 +137,6 @@ module Exec_result = struct
         (List.map errs ~f:(fun e -> Exn_with_backtrace.capture (Error.to_exn e)))
   ;;
 end
-
-type done_or_more_deps =
-  | Done
-  (* This code assumes that there can be at most one 'dynamic-run' within single
-     action. [DAP.Dependency.t] stores relative paths so name clash would be
-     possible if multiple 'dynamic-run' would be executed in different
-     subdirectories that contains targets having the same name. *)
-  | Need_more_deps of (DAP.Dependency.Set.t * Dep.Set.t)
-
-let done_or_more_deps_union x y =
-  match x, y with
-  | Done, Done -> Done
-  | Done, Need_more_deps x | Need_more_deps x, Done -> Need_more_deps x
-  | Need_more_deps (deps1, dyn_deps1), Need_more_deps (deps2, dyn_deps2) ->
-    Need_more_deps
-      (DAP.Dependency.Set.union deps1 deps2, Dep.Set.union dyn_deps1 dyn_deps2)
-;;
 
 type exec_context =
   { targets : Targets.Validated.t option
@@ -303,7 +267,11 @@ let exec_run_dynamic_client ~display ~ectx ~eenv prog args =
   | Ok Done -> Done
   | Ok (Need_more_deps deps) ->
     Need_more_deps
-      (deps, to_dune_dep_set deps ~loc:ectx.rule_loc ~working_dir:eenv.working_dir)
+      ( deps
+      , Action_plugin.to_dune_dep_set
+          deps
+          ~loc:ectx.rule_loc
+          ~working_dir:eenv.working_dir )
 ;;
 
 let exec_echo stdout_to str =

--- a/src/dune_engine/action_plugin.ml
+++ b/src/dune_engine/action_plugin.ml
@@ -1,0 +1,39 @@
+open Import
+module DAP = Dune_action_plugin.Private.Protocol
+
+let to_dune_dep_set =
+  let of_DAP_dep ~loc ~working_dir : DAP.Dependency.t -> Dep.t =
+    let to_dune_path = Path.relative working_dir in
+    function
+    | File fn -> Dep.file (to_dune_path fn)
+    | Directory dir ->
+      let dir = to_dune_path dir in
+      let selector = File_selector.of_glob ~dir Glob.universal in
+      Dep.file_selector selector
+    | Glob { path; glob } ->
+      let dir = to_dune_path path in
+      let glob = Glob.of_string_exn loc glob in
+      let selector = File_selector.of_glob ~dir glob in
+      Dep.file_selector selector
+  in
+  fun set ~loc ~working_dir ->
+    DAP.Dependency.Set.to_list_map set ~f:(of_DAP_dep ~loc ~working_dir)
+    |> Dep.Set.of_list
+;;
+
+type done_or_more_deps =
+  | Done
+  (* This code assumes that there can be at most one 'dynamic-run' within single
+     action. [DAP.Dependency.t] stores relative paths so name clash would be
+     possible if multiple 'dynamic-run' would be executed in different
+     subdirectories that contains targets having the same name. *)
+  | Need_more_deps of (DAP.Dependency.Set.t * Dep.Set.t)
+
+let done_or_more_deps_union x y =
+  match x, y with
+  | Done, Done -> Done
+  | Done, Need_more_deps x | Need_more_deps x, Done -> Need_more_deps x
+  | Need_more_deps (deps1, dyn_deps1), Need_more_deps (deps2, dyn_deps2) ->
+    Need_more_deps
+      (DAP.Dependency.Set.union deps1 deps2, Dep.Set.union dyn_deps1 dyn_deps2)
+;;

--- a/src/dune_engine/action_plugin.mli
+++ b/src/dune_engine/action_plugin.mli
@@ -1,0 +1,13 @@
+open Import
+module DAP := Dune_action_plugin.Private.Protocol
+
+type done_or_more_deps =
+  | Done
+  (* This code assumes that there can be at most one 'dynamic-run' within single
+     action. [DAP.Dependency.t] stores relative paths so name clash would be
+     possible if multiple 'dynamic-run' would be executed in different
+     subdirectories that contains targets having the same name. *)
+  | Need_more_deps of (DAP.Dependency.Set.t * Dep.Set.t)
+
+val to_dune_dep_set : DAP.Dependency.Set.t -> loc:Loc.t -> working_dir:Path.t -> Dep.Set.t
+val done_or_more_deps_union : done_or_more_deps -> done_or_more_deps -> done_or_more_deps


### PR DESCRIPTION
This code has been eliminated in the JS fork. Action execution is easier to sync if the removed bits live in a separate file.

cc @snowleopard 

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>