### PR TITLE
Create cookie file for toolchain packages

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1064,6 +1064,12 @@ let as_in_source_tree_exn t =
       [ "t", to_dyn t ]
 ;;
 
+let as_outside_build_dir : t -> Outside_build_dir.t option = function
+  | In_source_tree s -> Some (In_source_dir s)
+  | External s -> Some (External s)
+  | In_build_dir _ -> None
+;;
+
 let as_outside_build_dir_exn : t -> Outside_build_dir.t = function
   | In_source_tree s -> In_source_dir s
   | External s -> External s

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -229,6 +229,7 @@ module Table : sig
 end
 
 val equal : t -> t -> bool
+val as_outside_build_dir : t -> Outside_build_dir.t option
 val as_outside_build_dir_exn : t -> Outside_build_dir.t
 val destruct_build_dir : t -> [ `Inside of Build.t | `Outside of Outside_build_dir.t ]
 val outside_build_dir : Outside_build_dir.t -> t

--- a/src/dune_rules/pkg_toolchain.mli
+++ b/src/dune_rules/pkg_toolchain.mli
@@ -39,21 +39,7 @@ val modify_install_action
   -> Dune_lang.Action.t
   -> Dune_lang.Action.t Memo.t
 
-(** If the toolchain is already installed, just create an empty
-    config.cache file so other packages see that the compiler package is
-    installed. *)
-val build_action : Dune_lang.Action.t
-
-module Override_pform : sig
-  (** Allows various pform values to be overriden when expanding pforms
-      inside package commands. *)
-  type t =
-    { prefix : Path.t
-    ; doc : Path.t
-    }
-
-  (** Fields to override in the variable environment under which
-      commands are evaluated such that the package is installed to the
-      toolchains directory rather than inside the _build directory. *)
-  val make : installation_prefix:Path.Outside_build_dir.t -> t
-end
+val modify_build_action
+  :  prefix:Path.Outside_build_dir.t
+  -> Dune_lang.Action.t
+  -> Dune_lang.Action.t Memo.t


### PR DESCRIPTION
This fixes two issues with cookies for toolchain packages:

Prior to this change, dune expected toolchain cookies to be created inside the toolchains directory, ie. outside of the project. The machinery for creating cookies only works within the build directory, so cookies for toolchain packages were never created. The location of the cookie had to be the same as the location of the installed package, in what dune referred to as the package's "target_dir". The fix is to decouply these two locations by adding a new path "prefix" to packages, corresponding to the "--prefix" argument of most configure scripts. This allows toolchain packages to have a "target_dir" within the build directory, and for a cookie file to be created within its "target_dir", while still allowing the package to be installed outside the project inside its "prefix", inside the toolchains directory.

The second issue is that the contents of the cookie was based on the package's "target_dir", and thus cookies for toolchain packages would be empty (toolchain packages are now installed in the package's "prefix" dir instead). Dune makes the distinction between the "paths" and "write_paths" of a package, the latter being the unsandboxed final install paths of the package, and it's the "target_dir" within a package's "write_paths" that is traversed (in the absence of a <package>.install file) to determine the contents of the package's cookie. The fix was to detect the case where the "paths" of a package contains a prefix referring outside the build directory, and in such a case, traverse the directory at that path rather than the one at "target_dir".

Toolchains still don't completely work, as in some cases build tools are unable to find binaries installed by the compiler package, however manual inspection shows that the cookie is being created for toolchain packages and contains the expected contents. Fixes for the remaining issues will come in later changes.