### PR TITLE
(library (extra_objects)): avoid double linking

### DIFF
--- a/doc/changes/10783.md
+++ b/doc/changes/10783.md
@@ -1,3 +1,3 @@
-- In a `(library)` stanza with `(extra_objects)`, avoid double linking the extra
-  object files in the final executable.
+- In a `(library)` stanza with `(extra_objects)` and `(foreign_stubs)`, avoid
+  double linking the extra object files in the final executable.
   (#10783, @nojb)

--- a/doc/changes/10783.md
+++ b/doc/changes/10783.md
@@ -1,0 +1,3 @@
+- In a `(library)` stanza with `(extra_objects)`, avoid double linking the extra
+  object files in the final executable.
+  (#10783, @nojb)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -289,20 +289,13 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
     Foreign_sources.for_lib foreign_sources ~name
   in
   let* o_files =
-    let lib_foreign_o_files =
-      let { Lib_config.ext_obj; _ } = (Compilation_context.ocaml cctx).lib_config in
-      Foreign.Objects.build_paths lib.buildable.extra_objects ~ext_obj ~dir
-    in
-    let+ tbl =
-      Foreign_rules.build_o_files
-        ~sctx
-        ~dir
-        ~expander
-        ~requires
-        ~dir_contents
-        ~foreign_sources
-    in
-    Mode.Map.Multi.add_all tbl Mode.Select.All lib_foreign_o_files
+    Foreign_rules.build_o_files
+      ~sctx
+      ~dir
+      ~expander
+      ~requires
+      ~dir_contents
+      ~foreign_sources
   in
   let all_o_files = Mode.Map.Multi.to_flat_list o_files in
   let* () = Check_rules.add_files sctx ~dir all_o_files in

--- a/test/blackbox-tests/test-cases/extra-objects/extra-objects-indirect.t
+++ b/test/blackbox-tests/test-cases/extra-objects/extra-objects-indirect.t
@@ -21,7 +21,8 @@ Build an library which indirectly depends on foreign object files.
 
   $ cat >lib/dep.c <<EOF
   > #include <caml/mlvalues.h>
-  > value add(value x, value y);
+  > extern value add(value x, value y);
+  > value dummy() { return add(Val_int(1), Val_int(2)); }
   > EOF
 
   $ cat >lib/add.c <<EOF

--- a/test/blackbox-tests/test-cases/extra-objects/extra-objects-indirect.t
+++ b/test/blackbox-tests/test-cases/extra-objects/extra-objects-indirect.t
@@ -1,0 +1,39 @@
+----------------------------------------------------------------------------------
+Build an library which indirectly depends on foreign object files.
+
+----------------------------------------------------------------------------------
+* Building library with indirect dependency on object file
+
+  $ echo "(lang dune 3.5)" > dune-project
+
+  $ mkdir -p lib
+
+  $ cat >lib/dune <<EOF
+  > (library
+  >  (name calc)
+  >  (extra_objects add)
+  >  (foreign_stubs (language c) (names dep)))
+  > EOF
+
+  $ cat >lib/calc.ml <<EOF
+  > external add : int -> int -> int = "add"
+  > EOF
+
+  $ cat >lib/dep.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value add(value x, value y);
+  > EOF
+
+  $ cat >lib/add.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value add(value x, value y) { return Val_int(Int_val(x) + Int_val(y)); }
+  > EOF
+
+  $ cat >>lib/dune <<EOF
+  > (rule
+  >  (target add.o)
+  >  (deps add.c)
+  >  (action (run %{bin:ocamlc} add.c)))
+  > EOF
+
+  $ dune build

--- a/test/blackbox-tests/test-cases/extra-objects/extra-objects-lib.t
+++ b/test/blackbox-tests/test-cases/extra-objects/extra-objects-lib.t
@@ -10,19 +10,13 @@ Build a library which depends on foreign object files.
   $ cat >lib/dune <<EOF
   > (library
   >  (name calc)
-  >  (extra_objects add)
-  >  (foreign_stubs (language c) (names mul)))
-  > EOF
-
-  $ cat >lib/mul.c <<EOF
-  > #include <caml/mlvalues.h>
-  > value mul(value x, value y) { return Val_int(Int_val(x) * Int_val(y)); }
+  >  (extra_objects add mul))
   > EOF
 
   $ dune build
-  File "lib/dune", line 3, characters 1-20:
-  3 |  (extra_objects add)
-       ^^^^^^^^^^^^^^^^^^^
+  File "lib/dune", line 3, characters 1-24:
+  3 |  (extra_objects add mul))
+       ^^^^^^^^^^^^^^^^^^^^^^^
   Error: 'extra_objects' is only available since version 3.5 of the dune
   language. Please update your dune-project file to have (lang dune 3.5).
   [1]
@@ -43,12 +37,16 @@ Build a library which depends on foreign object files.
   > EOF
 
   $ dune build
-  File "lib/dune", lines 1-4, characters 0-85:
+  File "lib/dune", lines 1-3, characters 0-47:
   1 | (library
   2 |  (name calc)
-  3 |  (extra_objects add)
-  4 |  (foreign_stubs (language c) (names mul)))
+  3 |  (extra_objects add mul))
   Error: No rule found for lib/add.o
+  File "lib/dune", lines 1-3, characters 0-47:
+  1 | (library
+  2 |  (name calc)
+  3 |  (extra_objects add mul))
+  Error: No rule found for lib/mul.o
   [1]
 
 ----------------------------------------------------------------------------------
@@ -59,7 +57,16 @@ Build a library which depends on foreign object files.
   > value add(value x, value y) { return Val_int(Int_val(x) + Int_val(y)); }
   > EOF
 
+  $ cat >lib/mul.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value mul(value x, value y) { return Val_int(Int_val(x) * Int_val(y)); }
+  > EOF
+
   $ cat >>lib/dune <<EOF
+  > (rule
+  >  (target mul.o)
+  >  (deps mul.c)
+  >  (action (run %{bin:ocamlc} mul.c)))
   > (rule
   >  (target add.o)
   >  (deps add.c)

--- a/test/blackbox-tests/test-cases/extra-objects/extra-objects-lib.t
+++ b/test/blackbox-tests/test-cases/extra-objects/extra-objects-lib.t
@@ -10,13 +10,19 @@ Build a library which depends on foreign object files.
   $ cat >lib/dune <<EOF
   > (library
   >  (name calc)
-  >  (extra_objects add mul))
+  >  (extra_objects add)
+  >  (foreign_stubs (language c) (names mul)))
+  > EOF
+
+  $ cat >lib/mul.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value mul(value x, value y) { return Val_int(Int_val(x) * Int_val(y)); }
   > EOF
 
   $ dune build
-  File "lib/dune", line 3, characters 1-24:
-  3 |  (extra_objects add mul))
-       ^^^^^^^^^^^^^^^^^^^^^^^
+  File "lib/dune", line 3, characters 1-20:
+  3 |  (extra_objects add)
+       ^^^^^^^^^^^^^^^^^^^
   Error: 'extra_objects' is only available since version 3.5 of the dune
   language. Please update your dune-project file to have (lang dune 3.5).
   [1]
@@ -37,16 +43,12 @@ Build a library which depends on foreign object files.
   > EOF
 
   $ dune build
-  File "lib/dune", lines 1-3, characters 0-47:
+  File "lib/dune", lines 1-4, characters 0-85:
   1 | (library
   2 |  (name calc)
-  3 |  (extra_objects add mul))
+  3 |  (extra_objects add)
+  4 |  (foreign_stubs (language c) (names mul)))
   Error: No rule found for lib/add.o
-  File "lib/dune", lines 1-3, characters 0-47:
-  1 | (library
-  2 |  (name calc)
-  3 |  (extra_objects add mul))
-  Error: No rule found for lib/mul.o
   [1]
 
 ----------------------------------------------------------------------------------
@@ -57,16 +59,7 @@ Build a library which depends on foreign object files.
   > value add(value x, value y) { return Val_int(Int_val(x) + Int_val(y)); }
   > EOF
 
-  $ cat >lib/mul.c <<EOF
-  > #include <caml/mlvalues.h>
-  > value mul(value x, value y) { return Val_int(Int_val(x) * Int_val(y)); }
-  > EOF
-
   $ cat >>lib/dune <<EOF
-  > (rule
-  >  (target mul.o)
-  >  (deps mul.c)
-  >  (action (run %{bin:ocamlc} mul.c)))
   > (rule
   >  (target add.o)
   >  (deps add.c)


### PR DESCRIPTION
Fixes https://discuss.ocaml.org/t/build-error-when-using-c-stubs-and-external-object-file/15041/7
Fixes #10785