### PR TITLE
docs: use furo theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ language = "en"
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'friendly'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -85,13 +85,13 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {'navigation_depth': 6}
+html_theme_options = {}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -154,12 +154,6 @@ texinfo_documents = [
      author, 'dune', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-
-import sphinx_rtd_theme
-
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_context = {
     'display_github': True,

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -11,9 +11,6 @@ Coq
    - reference info for stanzas and variables
    - tutorials (the examples part)
 
-.. contents:: Table of Contents
-    :depth: 3
-
 Introduction
 ------------
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -10,11 +10,6 @@ general guidelines specific to Dune. However, given that Dune is a large project
 developed by many different people, it's important to follow these guidelines in
 order to keep the project in a good state and pleasant to work on for everybody.
 
-.. contents:: Table of Contents
-   :depth: 1
-   :local:
-   :backlinks: none
-
 Dependencies
 ============
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 sphinx >= 4.5.0, < 6
-sphinx_rtd_theme >= 1.0.0
+furo
 sphinx-copybutton >= 0.5.0
 sphinx-design

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.5.0, < 6
+sphinx >= 6
 furo
 sphinx-copybutton >= 0.5.0
 sphinx-design

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
 
               docInputs = with pkgs'.python3.pkgs; [
                 sphinx-autobuild
-                sphinx_rtd_theme
+                furo
                 sphinx-copybutton
                 sphinx-design
               ];
@@ -168,7 +168,7 @@
                   sphinx
                   sphinx-autobuild
                   python310Packages.sphinx-copybutton
-                  python310Packages.sphinx-rtd-theme
+                  python310Packages.furo
                   python310Packages.sphinx-design
                 ]
               );


### PR DESCRIPTION
This theme has several advantages compared to `sphinx_rtd_theme`:

- support for light and dark mode
- a sidebar on the right with a table of contents for the current documentation
- better use of horizontal space (half of the screen is unused with `sphinx_rtd_theme`)
- "it looks better"
