### PR TITLE
Set install_roots for toolchain packages

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1212,8 +1212,9 @@ end = struct
           let pkg_dir = Pkg_toolchain.pkg_dir pkg in
           let suffix = Path.basename (Path.outside_build_dir pkg_dir) in
           let prefix = Pkg_toolchain.installation_prefix ~pkg_dir in
-          let doc =
-            Path.outside_build_dir @@ Path.Outside_build_dir.relative prefix "doc"
+          let install_roots =
+            Pkg_toolchain.install_roots ~prefix
+            |> Install.Roots.map ~f:Path.outside_build_dir
           in
           let* build_command =
             match build_command with
@@ -1231,9 +1232,7 @@ end = struct
           in
           ( { paths with
               prefix = Path.outside_build_dir prefix
-            ; install_roots =
-                Lazy.map paths.install_roots ~f:(fun root ->
-                  { root with Install.Roots.doc_root = doc })
+            ; install_roots = Lazy.from_val install_roots
             }
           , build_command
           , install_command )

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -208,3 +208,7 @@ let modify_build_action ~prefix action =
     touch_config_cache
   else action
 ;;
+
+let install_roots ~prefix =
+  Install.Roots.make prefix ~relative:Path.Outside_build_dir.relative
+;;

--- a/src/dune_rules/pkg_toolchain.mli
+++ b/src/dune_rules/pkg_toolchain.mli
@@ -43,3 +43,7 @@ val modify_build_action
   :  prefix:Path.Outside_build_dir.t
   -> Dune_lang.Action.t
   -> Dune_lang.Action.t Memo.t
+
+val install_roots
+  :  prefix:Path.Outside_build_dir.t
+  -> Path.Outside_build_dir.t Install.Roots.t


### PR DESCRIPTION
This fixes an issue with toolchain packages where they would export an environment based on their target dir within the _build directory rather than an environment based on their actual install location (their "prefix").

After this change toolchains should be functional.