### PR TITLE
Move 'can_go_in_shared_cache' from Action to Rule, with the same default

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -328,24 +328,17 @@ module Full = struct
       { action : t
       ; env : Env.t
       ; locks : Path.t list
-      ; can_go_in_shared_cache : bool
       ; sandbox : Sandbox_config.t
       }
 
     let empty =
-      { action = Progn []
-      ; env = Env.empty
-      ; locks = []
-      ; can_go_in_shared_cache = true
-      ; sandbox = Sandbox_config.default
-      }
+      { action = Progn []; env = Env.empty; locks = []; sandbox = Sandbox_config.default }
     ;;
 
-    let combine { action; env; locks; can_go_in_shared_cache; sandbox } x =
+    let combine { action; env; locks; sandbox } x =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
-      ; can_go_in_shared_cache = can_go_in_shared_cache && x.can_go_in_shared_cache
       ; sandbox = Sandbox_config.inter sandbox x.sandbox
       }
     ;;
@@ -354,23 +347,12 @@ module Full = struct
   include T
   include Monoid.Make (T)
 
-  let make
-    ?(env = Env.empty)
-    ?(locks = [])
-    ?(can_go_in_shared_cache = true)
-    ?(sandbox = Sandbox_config.default)
-    action
-    =
-    { action; env; locks; can_go_in_shared_cache; sandbox }
+  let make ?(env = Env.empty) ?(locks = []) ?(sandbox = Sandbox_config.default) action =
+    { action; env; locks; sandbox }
   ;;
 
   let map t ~f = { t with action = f t.action }
   let add_env e t = { t with env = Env.extend_env t.env e }
   let add_locks l t = { t with locks = t.locks @ l }
-
-  let add_can_go_in_shared_cache b t =
-    { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
-  ;;
-
   let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
 end

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -144,14 +144,12 @@ module Full : sig
     { action : action
     ; env : Env.t
     ; locks : Path.t list
-    ; can_go_in_shared_cache : bool
     ; sandbox : Sandbox_config.t
     }
 
   val make
     :  ?env:Env.t (** default [Env.empty] *)
     -> ?locks:Path.t list (** default [[]] *)
-    -> ?can_go_in_shared_cache:bool (** default [true] *)
     -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
     -> action
     -> t
@@ -168,7 +166,6 @@ module Full : sig
   val add_env : Env.t -> t -> t
   val add_locks : Path.t list -> t -> t
   val add_sandbox : Sandbox_config.t -> t -> t
-  val add_can_go_in_shared_cache : bool -> t -> t
 
   include Monoid with type t := t
 end

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -57,6 +57,7 @@ module T = struct
     ; mode : Mode.t
     ; info : Info.t
     ; loc : Loc.t
+    ; can_go_in_shared_cache : bool
     }
 
   let compare a b = Id.compare a.id b.id
@@ -69,7 +70,13 @@ end
 include T
 include Comparable.Make (T)
 
-let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
+let make
+  ?(mode = Mode.Standard)
+  ?(info = Info.Internal)
+  ?(can_go_in_shared_cache = true)
+  ~targets
+  action
+  =
   let action = Action_builder.memoize "Rule.make" action in
   let report_error ?(extra_pp = []) message =
     match info with
@@ -106,7 +113,7 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
            (Path.build (Path.Build.relative targets.root "_unknown_")))
     | Source_file_copy p -> Loc.in_file (Path.source p)
   in
-  { id = Id.gen (); targets; action; mode; info; loc }
+  { id = Id.gen (); targets; action; mode; info; loc; can_go_in_shared_cache }
 ;;
 
 let set_action t action =

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -59,6 +59,7 @@ type t = private
   ; mode : Mode.t
   ; info : Info.t
   ; loc : Loc.t
+  ; can_go_in_shared_cache : bool
   }
 
 include Comparable_intf.S with type key := t
@@ -72,6 +73,7 @@ val to_dyn : t -> Dyn.t
 val make
   :  ?mode:Mode.t
   -> ?info:Info.t
+  -> ?can_go_in_shared_cache:bool (** default [true]*)
   -> targets:Targets.t
   -> Action.Full.t Action_builder.t
   -> t

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -211,7 +211,7 @@ let gen_rules_for_checksum_or_url (loc_url, (url : OpamUrl.t)) checksum =
     let rule =
       let info = Rule.Info.of_loc_opt (Some loc_url) in
       fun { Action_builder.With_targets.build; targets } ->
-        Rules.Produce.rule (Rule.make ~info ~targets build)
+        Rules.Produce.rule (Rule.make ~info ~targets ~can_go_in_shared_cache:false build)
     in
     let make_target = make_target checksum_or_url in
     let action ~target ~kind =


### PR DESCRIPTION
This is my second attempt at going in the direction of caching by default, and caching downloads, following the discussion over at #10729.
I realized that the field `can_go_in_shared_cache` in `Dune_Engine.Action.Full.t` already existed, had a default to true, and was never set to false anywhere. I then hijack this by moving the field to `Rule.t` instead. This makes it so that all calls to `Rule.make` can now set this variable, and the goal is to change the call in `pkg_rule` to true when the PR is ready.

cc @Leonidas-from-XIV 