### PR TITLE
Add repro for gh10788

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
@@ -1,0 +1,24 @@
+Test for packages with no source field but with extra_sources.
+
+  $ . ./helpers.sh
+  $ make_lockdir
+
+  $ cat > dune.lock/foo.pkg <<EOF
+  > (version 1)
+  > (extra_sources
+  >  (foo.txt
+  >   (fetch
+  >    (url file://$PWD/foo.txt))))
+  > EOF
+
+  $ touch foo.txt
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (package
+  >  (allow_empty)
+  >  (name a)
+  >  (depends foo))
+  > EOF
+
+  $ dune build

--- a/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
@@ -1,0 +1,35 @@
+Test for packages with an extra-source file with the same name as a
+file in the package's source.
+
+  $ . ./helpers.sh
+  $ make_lockdir
+
+  $ cat > dune.lock/foo.pkg <<EOF
+  > (version 1)
+  > (source
+  >  (copy $PWD/foo-source))
+  > (extra_sources
+  >  (foo.txt
+  >   (fetch
+  >    (url file://$PWD/foo.txt))))
+  > EOF
+
+  $ mkdir -p foo-source
+  $ echo "from source" > foo-source/foo.txt
+
+  $ echo "from extra source" > foo.txt
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (package
+  >  (allow_empty)
+  >  (name a)
+  >  (depends foo))
+  > EOF
+
+  $ dune build
+
+Make sure that the package's source directory ends up with the version
+of foo.txt from extra_sources:
+  $ cat _build/_private/default/.pkg/foo/source/foo.txt
+  from extra source


### PR DESCRIPTION
Reproduces https://github.com/ocaml/dune/issues/10788, as well as a related issue where dune would attempt to copy extra_source files into a location where they already exist, leading to a permission error.