### PR TITLE
Set `Clflags.concurrency` for non watch builds

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -196,6 +196,7 @@ module Scheduler = struct
         ~print_ctrl_c_warning:true
         ~watch_exclusions
     in
+    Dune_rules.Clflags.concurrency := config.concurrency;
     let f =
       match Common.rpc common with
       | `Allow server -> fun () -> Dune_engine.Rpc.with_background_rpc (rpc server) f


### PR DESCRIPTION
In 35b3e0de73a1599ed1e2b8f91c8c8ba03eee353a we started passing the configured parallelism to package builds by setting their `jobs` variable to the degree of parallelism configured for dune, but it seems this change was only applied for builds started with `--watch`. This commit applies the configured parallelism to package builds when dune is run without `--watch`.