### PR TITLE
Bump oneshot webserver timeout

### DIFF
--- a/test/http/http.ml
+++ b/test/http/http.ml
@@ -38,7 +38,7 @@ module Server = struct
 
   let auto_shutdown_seconds =
     match Sys.getenv_opt "DUNE_WEBSERVER_TIMEOUT" with
-    | None -> 5.
+    | None -> 30.
     | Some s -> Float.of_string s |> Option.value_exn
   ;;
 


### PR DESCRIPTION
This is timing out more frequently in CI recently, so this increases the timeout from 5s to 30s.