### PR TITLE
Use [Config.Toggle] for toolchains

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -85,6 +85,7 @@ let make ~name ~of_string ~default =
   t
 ;;
 
+let make_toggle ~name ~default = make ~name ~default ~of_string:Toggle.of_string
 let global_lock = make ~name:"global_lock" ~of_string:Toggle.of_string ~default:`Enabled
 
 let cutoffs_that_reduce_concurrency_in_watch_mode =

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -26,6 +26,8 @@ end
     parsed using [of_string], defaulting to [default]. *)
 val make : name:string -> of_string:(string -> ('a, string) result) -> default:'a -> 'a t
 
+val make_toggle : name:string -> default:Toggle.t -> Toggle.t t
+
 (** [get t] return the value of the configuration for [t] *)
 val get : 'a t -> 'a
 

--- a/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
@@ -78,7 +78,7 @@ name so the output is consistent across test runs.
 
 Attempt to build the project. This will fail due to the fake compiler
 but the fake compiler will end up installed as a toolchain package.
-  $ XDG_CACHE_HOME=$PWD/fake-cache DUNE_CONFIG__TOOLCHAINS_ENABLED=true dune build 2>&1 | remove_hash
+  $ XDG_CACHE_HOME=$PWD/fake-cache DUNE_CONFIG__TOOLCHAINS=enabled dune build 2>&1 | remove_hash
   Error: Failed to parse the output of
   '$TESTCASE_ROOT/fake-cache/dune/toolchains/ocaml-base-compiler.1-HASH/target/bin/ocamlc
   -config':


### PR DESCRIPTION
This changes the variable that enables toolchains from DUNE_CONFIG__TOOLCHAINS_ENABLED=[true|false] to
DUNE_CONFIG__TOOLCHAINS=[enabled|disabled], following the established convention for such variables in dune, and for compatibility with [upcoming support for compile-time configuration](https://github.com/ocaml/dune/pull/10724).