### PR TITLE
fix(pkg): do not lock unreachable packages

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
@@ -44,8 +44,6 @@ lists to prevent circular dependencies at package build time.
 
   $ solve ocaml-base-compiler 
   Solution for dune.lock:
-  - host-system-other.0.0.1
-  - ocaml.0.0.1
   - ocaml-base-compiler.0.0.1
 
 Ensure that packages can be resolved at build time. This checks that

--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -9,15 +9,13 @@ Solving for post dependencies:
   > depends: [ "bar" {post} ]
   > EOF
 
-We don't need bar, but we still include it:
+We don't need bar, so we skip it
 
   $ solve foo
   Solution for dune.lock:
-  - bar.0.0.1
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg dune.lock/bar.pkg
-  (version 0.0.1)
+  $ cat dune.lock/foo.pkg
   (version 0.0.1)
 
 Self dependency
@@ -66,11 +64,9 @@ post "cycle":
 
   $ solve foo
   Solution for dune.lock:
-  - bar.0.0.1
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg dune.lock/bar.pkg
-  (version 0.0.1)
+  $ cat dune.lock/foo.pkg
   (version 0.0.1)
 
 In depopts:


### PR DESCRIPTION
unreachable packages are those that aren't reachable via the dependencies of local packages

typically, such packages are included when solving via post deps

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>
