### PR TITLE
refactor: Use `Stdlib.String(Labels)` implementations if available

### DIFF
--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -78,8 +78,8 @@ val longest : string list -> int
 
 val longest_map : 'a list -> f:('a -> string) -> int
 val longest_prefix : t list -> t
-val exists : t -> f:(char -> bool) -> bool
-val for_all : t -> f:(char -> bool) -> bool
+val exists : f:(char -> bool) -> t -> bool
+val for_all : f:(char -> bool) -> t -> bool
 
 (** [maybe_quoted s] is [s] if [s] doesn't need escaping according to OCaml
     lexing conventions and [sprintf "%S" s] otherwise.


### PR DESCRIPTION
This uses the Stdlib implementations if the stdlib supports these. Has the advantage that if the stdlib has an optimized implementation, we automatically get to benefit of it.

This uses a trick to define the fallback functions and overwrite them if they're available in the included module, otherwise they will be used. Needs to silence warning 32 but that's a small price to pay to avoid conditional compilation.