### PR TITLE
refactor(engine): remove [Dune_sexp] from the engine

### DIFF
--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -75,7 +75,17 @@ module Dune_config = struct
   module Sandboxing_preference = struct
     type t = Sandbox_mode.t list
 
-    let decode = repeat Sandbox_mode.decode
+    let decode : Sandbox_mode.t Dune_sexp.Decoder.t =
+      let open Dune_sexp.Decoder in
+      enum
+        [ "none", None
+        ; "symlink", Some Sandbox_mode.Symlink
+        ; "copy", Some Copy
+        ; "hardlink", Some Hardlink
+        ]
+    ;;
+
+    let decode = repeat decode
   end
 
   module Cache = struct

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -3,8 +3,6 @@ open Import
 module Name = struct
   include Dune_util.Alias_name
 
-  let encode s = Dune_sexp.Encoder.string (to_string s)
-
   let of_string s =
     match of_string_opt s with
     | Some s -> s
@@ -95,11 +93,6 @@ let register_as_standard name =
 ;;
 
 let default = make_standard Name.default
-
-let encode { dir; name } =
-  let open Dune_sexp.Encoder in
-  record [ "dir", Dpath.encode (Path.build dir); "name", Name.encode name ]
-;;
 
 let get_ctx (path : Path.Build.t) =
   match Path.Build.extract_first_component path with

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -22,7 +22,6 @@ val name : t -> Name.t
 
 val dir : t -> Path.Build.t
 val to_dyn : t -> Dyn.t
-val encode : t Dune_sexp.Encoder.t
 val of_user_written_path : loc:Loc.t -> Path.t -> t
 val fully_qualified_name : t -> Path.Build.t
 val default : dir:Path.Build.t -> t

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -45,17 +45,15 @@ module T = struct
     | Universe, Universe -> Ordering.Eq
   ;;
 
-  let encode t =
-    let open Dune_sexp.Encoder in
+  let to_dyn t =
+    let open Dyn in
     match t with
-    | File_selector g -> pair string File_selector.encode ("glob", g)
-    | Env e -> pair string string ("Env", e)
-    | File f -> pair string Dpath.encode ("File", f)
-    | Alias a -> pair string Alias.encode ("Alias", a)
-    | Universe -> string "Universe"
+    | File_selector g -> variant "File_selector" [ File_selector.to_dyn g ]
+    | Env e -> variant "Env" [ string e ]
+    | File f -> variant "File" [ Path.to_dyn f ]
+    | Alias a -> variant "Alias" [ Alias.to_dyn a ]
+    | Universe -> variant "Universe" []
   ;;
-
-  let to_dyn t = Dyn.String (Dune_sexp.to_string (encode t))
 end
 
 include T
@@ -254,7 +252,6 @@ module Set = struct
   let of_files l = of_list_map l ~f:file
   let of_files_set = Path.Set.fold ~init:empty ~f:(fun f acc -> add acc (file f))
   let add_paths t paths = Path.Set.fold paths ~init:t ~f:(fun p set -> add set (File p))
-  let encode t = Dune_sexp.Encoder.list encode (to_list t)
 
   (* This is to force the rules to be loaded for directories without files when
      depending on [(source_tree x)]. Otherwise, we wouldn't clean up stale

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -73,7 +73,6 @@ module Set : sig
 
   val of_files : Path.t list -> t
   val of_files_set : Path.Set.t -> t
-  val encode : t -> Dune_sexp.t
   val add_paths : t -> Path.Set.t -> t
   val digest : t -> Digest.t
 end

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -108,17 +108,3 @@ let analyse_dir (fn : Path.t) =
 ;;
 
 type t = Path.t
-
-let encode p =
-  (* CR rgrinberg: only reason this lives here is to implement
-     [$ dune rules]. Seems like it should just live there along with all the
-     other encoders in the engine. *)
-  let make constr arg =
-    Dune_sexp.List [ Dune_sexp.atom constr; Dune_sexp.atom_or_quoted_string arg ]
-  in
-  let open Path in
-  match p with
-  | In_build_dir p -> make "In_build_dir" (Path.Build.to_string p)
-  | In_source_tree p -> make "In_source_tree" (Path.Source.to_string p)
-  | External p -> make "External" (Path.External.to_string p)
-;;

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -39,8 +39,6 @@ val describe_path : Path.t -> string
 
 type t = Path.t
 
-val encode : Path.t Dune_sexp.Encoder.t
-
 module Build : sig
   type t = Path.Build.t
 

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -14,7 +14,6 @@
   dune_async_io
   threads.posix
   predicate_lang
-  dune_sexp
   dune_cache
   dune_cache_storage
   dune_glob

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -11,6 +11,7 @@ type t =
 
 let dir t = t.dir
 let only_generated_files t = t.only_generated_files
+let predicate t = t.predicate
 
 let digest_exn { dir; predicate; only_generated_files } =
   Digest.generic (dir, Predicate_lang.Glob.digest_exn predicate, only_generated_files)
@@ -34,15 +35,6 @@ let to_dyn { dir; predicate; only_generated_files } =
     [ "dir", Path.to_dyn dir
     ; "predicate", Predicate_lang.Glob.to_dyn predicate
     ; "only_generated_files", Bool only_generated_files
-    ]
-;;
-
-let encode { dir; predicate; only_generated_files } =
-  let open Dune_sexp.Encoder in
-  record
-    [ "dir", Dpath.encode dir
-    ; "predicate", Predicate_lang.Glob.encode predicate
-    ; "only_generated_files", bool only_generated_files
     ]
 ;;
 

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -8,6 +8,7 @@ type t
 val dir : t -> Path.t
 val only_generated_files : t -> bool
 val of_glob : dir:Path.t -> Glob.t -> t
+val predicate : t -> Predicate_lang.Glob.t
 
 val of_predicate_lang
   :  dir:Path.t
@@ -18,7 +19,6 @@ val of_predicate_lang
 val equal : t -> t -> bool
 val hash : t -> int
 val compare : t -> t -> Ordering.t
-val encode : t Dune_sexp.Encoder.t
 
 (** [to_dyn] is used as a marshallable representation of [t] (to compute
     digests), so it must be injective *)

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -120,16 +120,6 @@ let symlink = Some Symlink
 let copy = Some Copy
 let hardlink = Some Hardlink
 
-let decode =
-  let open Dune_sexp.Decoder in
-  enum
-    [ "none", None
-    ; "symlink", Some Symlink
-    ; "copy", Some Copy
-    ; "hardlink", Some Hardlink
-    ]
-;;
-
 let to_string = function
   | None -> "none"
   | Some Symlink -> "symlink"

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -80,6 +80,5 @@ val none : t
 val symlink : t
 val copy : t
 val hardlink : t
-val decode : t Dune_sexp.Decoder.t
 val to_string : t -> string
 val to_dyn : t -> Dyn.t


### PR DESCRIPTION
Dune_sexp belongs to dune's frontend and the engine has no business relying on it.

This is a change we've done internally, so this is just syncing.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>