### PR TITLE
pkg: improve readability of progress messages

### DIFF
--- a/src/dune_rules/pkg_build_progress.ml
+++ b/src/dune_rules/pkg_build_progress.ml
@@ -22,10 +22,10 @@ module Message = struct
     }
 
   let user_message { package_name; package_version; status } =
-    let status_tag = User_message.Style.Ok in
+    let status_tag = User_message.Style.Success in
     User_message.make
       [ Pp.concat
-          [ Pp.tag status_tag (Pp.text (Status.to_string status))
+          [ Pp.tag status_tag (Pp.textf "%12s" (Status.to_string status))
           ; Pp.textf
               " %s.%s"
               (Package.Name.to_string package_name)


### PR DESCRIPTION
Two tweaks to improve readability:
- Use the `Success` colour (bright green) rather than the `Ok` colour (basic green) as some light-themed terminals seem to display basic green as too light to read. This also happens to match the colour with the corresponding messages printed by `cargo`.
- Pad the status component of the messages so that all package names are aligned.