### PR TITLE
Encourage adding email in author & maintainer info

### DIFF
--- a/src/dune_lang/package_info.ml
+++ b/src/dune_lang/package_info.ml
@@ -45,8 +45,8 @@ let example =
   { source =
       Some (Host (Source_kind.Host.Github { user = "username"; repo = "reponame" }))
   ; license = Some [ "LICENSE" ]
-  ; authors = Some [ "Author Name" ]
-  ; maintainers = Some [ "Maintainer Name" ]
+  ; authors = Some [ "Author Name <author@example.com>" ]
+  ; maintainers = Some [ "Maintainer Name <maintainer@example.com>" ]
   ; documentation =
       Some "https://url/to/documentation"
       (* homepage and bug_reports are inferred from the source *)

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -345,9 +345,9 @@ In particular, the `dune-project` file has the expected content:
   (source
    (github username/reponame))
   
-  (authors "Author Name")
+  (authors "Author Name <author@example.com>")
   
-  (maintainers "Maintainer Name")
+  (maintainers "Maintainer Name <maintainer@example.com>")
   
   (license LICENSE)
   
@@ -376,8 +376,8 @@ And the opam file will be generated as expected
   opam-version: "2.0"
   synopsis: "A short synopsis"
   description: "A longer description"
-  maintainer: ["Maintainer Name"]
-  authors: ["Author Name"]
+  maintainer: ["Maintainer Name <maintainer@example.com>"]
+  authors: ["Author Name <author@example.com>"]
   license: "LICENSE"
   tags: ["topics" "to describe" "your" "project"]
   homepage: "https://github.com/username/reponame"
@@ -455,9 +455,9 @@ In particular, the `dune-project` file has the expected content:
   (source
    (github username/reponame))
   
-  (authors "Author Name")
+  (authors "Author Name <author@example.com>")
   
-  (maintainers "Maintainer Name")
+  (maintainers "Maintainer Name <maintainer@example.com>")
   
   (license LICENSE)
   
@@ -486,8 +486,8 @@ And the opam file will be generated as expected
   opam-version: "2.0"
   synopsis: "A short synopsis"
   description: "A longer description"
-  maintainer: ["Maintainer Name"]
-  authors: ["Author Name"]
+  maintainer: ["Maintainer Name <maintainer@example.com>"]
+  authors: ["Author Name <author@example.com>"]
   license: "LICENSE"
   tags: ["topics" "to describe" "your" "project"]
   homepage: "https://github.com/username/reponame"


### PR DESCRIPTION
For packages submitted to the opam-repository, it would help to have the email addresses of the maintainers. See ocaml/infrastructure#152. This commit subtly encourages package authors/maintainers to do so.