### PR TITLE
Subtle hint that topics is not a keyword

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -391,7 +391,7 @@ module Component = struct
             ~dir
             ~synopsis:(Some "A short synopsis")
             ~description:(Some "A longer description")
-            ~tags:[ "topics"; "to describe"; "your"; "project" ]
+            ~tags:[ "add topics"; "to describe"; "your"; "project" ]
             ~depends:
               [ { Package_dependency.name = Package.Name.of_string "ocaml"
                 ; constraint_ = None

--- a/doc/changes/10849.md
+++ b/doc/changes/10849.md
@@ -1,0 +1,2 @@
+- Tweak the preset value for tags in the `dune-project` file to hint at topics
+  not having a special meaning. (#10849, @punchagan)

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -359,7 +359,7 @@ In particular, the `dune-project` file has the expected content:
    (description "A longer description")
    (depends ocaml dune)
    (tags
-    (topics "to describe" your project)))
+    ("add topics" "to describe" your project)))
   
   ; See the complete stanza docs at https://dune.readthedocs.io/en/stable/reference/dune-project/index.html
 
@@ -379,7 +379,7 @@ And the opam file will be generated as expected
   maintainer: ["Maintainer Name <maintainer@example.com>"]
   authors: ["Author Name <author@example.com>"]
   license: "LICENSE"
-  tags: ["topics" "to describe" "your" "project"]
+  tags: ["add topics" "to describe" "your" "project"]
   homepage: "https://github.com/username/reponame"
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"
@@ -469,7 +469,7 @@ In particular, the `dune-project` file has the expected content:
    (description "A longer description")
    (depends ocaml dune)
    (tags
-    (topics "to describe" your project)))
+    ("add topics" "to describe" your project)))
   
   ; See the complete stanza docs at https://dune.readthedocs.io/en/stable/reference/dune-project/index.html
 
@@ -489,7 +489,7 @@ And the opam file will be generated as expected
   maintainer: ["Maintainer Name <maintainer@example.com>"]
   authors: ["Author Name <author@example.com>"]
   license: "LICENSE"
-  tags: ["topics" "to describe" "your" "project"]
+  tags: ["add topics" "to describe" "your" "project"]
   homepage: "https://github.com/username/reponame"
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"


### PR DESCRIPTION
Number of projects in the opam-repository have the word topics as one of the tags, presumably because of the structure of the `tags` sexp in the dune-project file generated on `dune init`. See ocurrent/opam-ci-check#26