### PR TITLE
feat(pkg): Enable cache on fetch actions

### DIFF
--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -206,7 +206,7 @@ let gen_rules_for_checksum_or_url (loc_url, (url : OpamUrl.t)) checksum =
     let make_target = make_target checksum_or_url in
     let action ~target ~kind =
       action ~url:(loc_url, url) ~checksum ~target ~kind
-      |> Action.Full.make
+      |> Action.Full.make ~can_go_in_shared_cache:true
       |> Action_builder.return
       |> Action_builder.with_no_targets
     in
@@ -327,7 +327,7 @@ let fetch ~target kind (source : Source.t) =
            .fetch context. This would just add pointless additional overhead. *)
         action ~url:source.url ~checksum:source.checksum ~target ~kind
     in
-    Action.Full.make action
+    Action.Full.make ~can_go_in_shared_cache:true action
     |> Action_builder.With_targets.return
     |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
 ;;

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -1,0 +1,61 @@
+Testing that files are only fetched once.
+
+  $ . ./helpers.sh
+
+No need to set DUNE_CACHE (enabled by default) nor DUNE_CACHE_RULES as the
+fetch rules are always considered safe to cache, but we'll set a custom
+directory for the shared cache.
+
+  $ export DUNE_CACHE_ROOT=$(pwd)/dune-cache
+  $ unset DUNE_CACHE
+  $ unset DUNE_CACHE_RULES
+
+Set up a project that depends on a package that is being downloaded
+
+  $ make_lockdir
+  $ echo "Contents" > tar-contents
+  $ CONTENT_CHECKSUM=$(md5sum tar-contents | cut -f1 -d' ')
+  $ tar cf test.tar tar-contents
+  $ echo test.tar > fake-curls
+  $ SRC_PORT=1
+  $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
+  $ cat >dune.lock/test.pkg <<EOF
+  > (version 0.0.1)
+  > (source
+  >  (fetch
+  >   (url http://localhost:$SRC_PORT)
+  >   (checksum md5=$SRC_CHECKSUM)))
+  > EOF
+  $ cat > dune-project <<EOF
+  > (lang dune 3.17)
+  > (package (name my) (depends test) (allow_empty))
+  > EOF
+
+The first build should succeed, fetching the source, populating the cache and
+disabling the download of the source a second time.
+
+  $ dune build
+
+Make sure that the file that was fetched is in the cache:
+
+  $ find $DUNE_CACHE_ROOT/files -type f -exec md5sum {} \; | grep --quiet $CONTENT_CHECKSUM
+
+Cleaning the project to force rebuilding. If we attempt to build without the
+cache, it will fail, as the source is 404 now:
+
+  $ dune clean
+  $ export DUNE_CACHE=disabled
+  $ dune build
+  File "dune.lock/test.pkg", line 4, characters 7-25:
+  4 |   (url http://localhost:1)
+             ^^^^^^^^^^^^^^^^^^
+  Error: download failed with code 404
+         
+  [1]
+
+However when enabling the cache again, the file that was fetched in the first
+build should be retrieved from the cache and the build succeed:
+
+  $ dune clean
+  $ export DUNE_CACHE=enabled
+  $ dune build


### PR DESCRIPTION
This enables caching of downloaded files as part of the fetch action, if the file to be retrieved is retrieved via a cryptographic hash (and thus presumably the exact same as the first time it was downloaded).

@rgrinberg  I've added a new function to the engine to force-set the cache flag, as `add_can_go_in_shared_cache` can only be flipped to `false` but never back to `true`. It's not used at the moment, so another option would be to remove that `&&` but just in case I made it a separate function.