### PR TITLE
feat: update prepare function for atomic lock

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -498,6 +498,32 @@ module Write_disk = struct
     | Ok _ -> Error `Not_directory
   ;;
 
+  let raise_user_error_on_check_existance path e =
+    let error_reason_pp =
+      match e with
+      | `Unreadable -> Pp.text "Unable to read lock directory"
+      | `Not_directory -> Pp.text "Specified lock dir path is not a directory"
+      | `No_metadata_file ->
+        Pp.textf "Specified lock dir lacks metadata file (%s)" metadata_filename
+      | `Failed_to_parse_metadata (path, exn) ->
+        Pp.concat
+          ~sep:Pp.cut
+          [ Pp.textf
+              "Unable to parse lock directory metadata file (%s):"
+              (Path.to_string_maybe_quoted path)
+            |> Pp.hovbox
+          ; Exn.pp exn |> Pp.hovbox
+          ]
+        |> Pp.vbox
+    in
+    User_error.raise
+      [ Pp.textf
+          "Refusing to regenerate lock directory %s"
+          (Path.to_string_maybe_quoted path)
+      ; error_reason_pp
+      ]
+  ;;
+
   (* Removes the existing lock directory at the specified path if it exists and
      is a valid lock directory. Checks the validity of the existing lockdir (if
      any) and raises if it's invalid before constructing the returned thunk, so
@@ -507,23 +533,20 @@ module Write_disk = struct
     match check_existing_lock_dir path with
     | Ok `Non_existant -> Fun.const ()
     | Ok `Is_existing_lock_dir -> fun () -> Path.rm_rf path
-    | Error e ->
+    | Error e -> raise_user_error_on_check_existance path e
+  ;;
+
+  (* Does the same checks as [safely_remove_lock_dir_if_exists_thunk] but it raises an
+     error if the lock dir already exists. [dst] is the new file name *)
+  let safely_rename_lock_dir ~dst path =
+    match check_existing_lock_dir dst, check_existing_lock_dir path with
+    | Ok `Non_existant, Ok `Is_existing_lock_dir -> fun () -> Path.rename path dst
+    | Ok `Non_existant, Ok `Non_existant -> Fun.const ()
+    | Ok `Is_existing_lock_dir, _ ->
       let error_reason_pp =
-        match e with
-        | `Unreadable -> Pp.text "Unable to read lock directory"
-        | `Not_directory -> Pp.text "Specified lock dir path is not a directory"
-        | `No_metadata_file ->
-          Pp.textf "Specified lock dir lacks metadata file (%s)" metadata_filename
-        | `Failed_to_parse_metadata (path, exn) ->
-          Pp.concat
-            ~sep:Pp.cut
-            [ Pp.textf
-                "Unable to parse lock directory metadata file (%s):"
-                (Path.to_string_maybe_quoted path)
-              |> Pp.hovbox
-            ; Exn.pp exn |> Pp.hovbox
-            ]
-          |> Pp.vbox
+        Pp.textf
+          "Directory %s already exists: can't rename safely"
+          (Path.to_string_maybe_quoted path)
       in
       User_error.raise
         [ Pp.textf
@@ -531,15 +554,31 @@ module Write_disk = struct
             (Path.to_string_maybe_quoted path)
         ; error_reason_pp
         ]
+    | Error e, _ | _, Error e -> raise_user_error_on_check_existance path e
   ;;
 
   type t = unit -> unit
 
-  let prepare ~lock_dir_path:lock_dir_path_src ~files lock_dir =
-    let lock_dir_path = Path.source lock_dir_path_src in
-    let remove_dir_if_exists = safely_remove_lock_dir_if_exists_thunk lock_dir_path in
-    fun () ->
-      remove_dir_if_exists ();
+  let prepare
+    ~lock_dir_path:lock_dir_path_src
+    ~(files : File_entry.t Package_name.Map.Multi.t)
+    lock_dir
+    =
+    let lock_dir_hidden_src =
+      Format.sprintf ".%s" (Path.Source.to_string lock_dir_path_src)
+      |> Path.Source.of_string
+    in
+    let lock_dir_hidden_src = Path.source lock_dir_hidden_src in
+    let lock_dir_path_external = Path.source lock_dir_path_src in
+    let remove_hidden_dir_if_exists =
+      safely_remove_lock_dir_if_exists_thunk lock_dir_hidden_src
+    in
+    let rename_old_lock_dir_to_hidden =
+      safely_rename_lock_dir ~dst:lock_dir_hidden_src lock_dir_path_external
+    in
+    let build lock_dir_path =
+      rename_old_lock_dir_to_hidden ();
+      let lock_dir_path = Result.ok_exn lock_dir_path in
       Path.mkdir_p lock_dir_path;
       file_contents_by_path lock_dir
       |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
@@ -563,7 +602,16 @@ module Write_disk = struct
             Path.mkdir_p (Path.parent_exn dst);
             match original with
             | Path src -> Io.copy_file ~src ~dst ()
-            | Content content -> Io.write_file dst content)))
+            | Content content -> Io.write_file dst content)));
+      safely_rename_lock_dir ~dst:lock_dir_path_external lock_dir_path ();
+      remove_hidden_dir_if_exists ()
+    in
+    fun () ->
+      Temp.with_temp_dir
+        ~parent_dir:(Path.of_string "/tmp")
+        ~prefix:"dune"
+        ~suffix:"lock"
+        ~f:build
   ;;
 
   let commit t = t ()

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -570,8 +570,8 @@ module Write_disk = struct
     in
     let lock_dir_hidden_src = Path.source lock_dir_hidden_src in
     let lock_dir_path_external = Path.source lock_dir_path_src in
-    let remove_hidden_dir_if_exists =
-      safely_remove_lock_dir_if_exists_thunk lock_dir_hidden_src
+    let remove_hidden_dir_if_exists () =
+      safely_remove_lock_dir_if_exists_thunk lock_dir_hidden_src ()
     in
     let rename_old_lock_dir_to_hidden =
       safely_rename_lock_dir ~dst:lock_dir_hidden_src lock_dir_path_external

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -501,8 +501,12 @@ module Write_disk = struct
   let raise_user_error_on_check_existance path e =
     let error_reason_pp =
       match e with
-      | `Unreadable -> Pp.text "Unable to read lock directory"
-      | `Not_directory -> Pp.text "Specified lock dir path is not a directory"
+      | `Unreadable ->
+        Pp.textf "Unable to read lock directory (%s)" (Path.to_string_maybe_quoted path)
+      | `Not_directory ->
+        Pp.textf
+          "Specified lock dir path (%s) is not a directory"
+          (Path.to_string_maybe_quoted path)
       | `No_metadata_file ->
         Pp.textf "Specified lock dir lacks metadata file (%s)" metadata_filename
       | `Failed_to_parse_metadata (path, exn) ->
@@ -538,23 +542,24 @@ module Write_disk = struct
 
   (* Does the same checks as [safely_remove_lock_dir_if_exists_thunk] but it raises an
      error if the lock dir already exists. [dst] is the new file name *)
-  let safely_rename_lock_dir ~dst path =
-    match check_existing_lock_dir dst, check_existing_lock_dir path with
-    | Ok `Non_existant, Ok `Is_existing_lock_dir -> fun () -> Path.rename path dst
+  let safely_rename_lock_dir_thunk ~dst src =
+    match check_existing_lock_dir src, check_existing_lock_dir dst with
+    | Ok `Is_existing_lock_dir, Ok `Non_existant -> fun () -> Path.rename src dst
     | Ok `Non_existant, Ok `Non_existant -> Fun.const ()
-    | Ok `Is_existing_lock_dir, _ ->
+    | _, Ok `Is_existing_lock_dir ->
       let error_reason_pp =
         Pp.textf
           "Directory %s already exists: can't rename safely"
-          (Path.to_string_maybe_quoted path)
+          (Path.to_string_maybe_quoted src)
       in
       User_error.raise
         [ Pp.textf
             "Refusing to regenerate lock directory %s"
-            (Path.to_string_maybe_quoted path)
+            (Path.to_string_maybe_quoted src)
         ; error_reason_pp
         ]
-    | Error e, _ | _, Error e -> raise_user_error_on_check_existance path e
+    | Error e, _ -> raise_user_error_on_check_existance src e
+    | _, Error e -> raise_user_error_on_check_existance dst e
   ;;
 
   type t = unit -> unit
@@ -565,8 +570,7 @@ module Write_disk = struct
     lock_dir
     =
     let lock_dir_hidden_src =
-      Format.sprintf ".%s" (Path.Source.to_string lock_dir_path_src)
-      |> Path.Source.of_string
+      Path.Source.(Format.sprintf ".%s" (to_string lock_dir_path_src) |> of_string)
     in
     let lock_dir_hidden_src = Path.source lock_dir_hidden_src in
     let lock_dir_path_external = Path.source lock_dir_path_src in
@@ -574,7 +578,7 @@ module Write_disk = struct
       safely_remove_lock_dir_if_exists_thunk lock_dir_hidden_src ()
     in
     let rename_old_lock_dir_to_hidden =
-      safely_rename_lock_dir ~dst:lock_dir_hidden_src lock_dir_path_external
+      safely_rename_lock_dir_thunk ~dst:lock_dir_hidden_src lock_dir_path_external
     in
     let build lock_dir_path =
       rename_old_lock_dir_to_hidden ();
@@ -602,7 +606,7 @@ module Write_disk = struct
             match original with
             | Path src -> Io.copy_file ~src ~dst ()
             | Content content -> Io.write_file dst content)));
-      safely_rename_lock_dir ~dst:lock_dir_path_external lock_dir_path ();
+      safely_rename_lock_dir_thunk ~dst:lock_dir_path_external lock_dir_path ();
       remove_hidden_dir_if_exists ()
     in
     fun () ->

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -579,7 +579,6 @@ module Write_disk = struct
     let build lock_dir_path =
       rename_old_lock_dir_to_hidden ();
       let lock_dir_path = Result.ok_exn lock_dir_path in
-      Path.mkdir_p lock_dir_path;
       file_contents_by_path lock_dir
       |> List.iter ~f:(fun (path_within_lock_dir, contents) ->
         let path = Path.relative lock_dir_path path_within_lock_dir in
@@ -594,7 +593,7 @@ module Write_disk = struct
         Format.asprintf "%a" Pp.to_fmt pp |> Io.write_file path;
         Package_name.Map.iteri files ~f:(fun package_name files ->
           let files_dir =
-            Pkg.files_dir package_name ~lock_dir:lock_dir_path_src |> Path.source
+            Path.relative lock_dir_path (Package_name.to_string package_name ^ ".files")
           in
           Path.mkdir_p files_dir;
           List.iter files ~f:(fun { File_entry.original; local_file } ->
@@ -608,7 +607,7 @@ module Write_disk = struct
     in
     fun () ->
       Temp.with_temp_dir
-        ~parent_dir:(Path.of_string "/tmp")
+        ~parent_dir:(Path.source Path.Source.root)
         ~prefix:"dune"
         ~suffix:"lock"
         ~f:build

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -53,5 +53,5 @@ Attempt to create a lock directory with the same name as an existing regular fil
   $ touch dune.lock
   $ dune pkg lock
   Error: Refusing to regenerate lock directory dune.lock
-  Specified lock dir path is not a directory
+  Specified lock dir path (dune.lock) is not a directory
   [1]


### PR DESCRIPTION
This PR is a proposition for updating the `dune.lock` directory in an atomic way. Its goal is to prevent the user of unwanted behavior while running the `dune build --watch` command. It consists of 4 steps:
1. Rename the `dune.lock` into `.dune.lock` (in case of failure, it can still be restored)
2. Create a temporary directory and solve the new constraints
3. Rename the temporary directory to `dune.lock`
4. Erase the `.dune.lock` (as it has been replaced)

This is the first piece of the solution for  #10842.