### PR TITLE
feat: create an alias from pkg to package

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -38,6 +38,7 @@ let all : _ Cmdliner.Cmd.t list =
     ; Init.group
     ; Promotion.group
     ; Pkg.group
+    ; Pkg.Alias.group
     ]
   in
   terms @ groups

--- a/bin/pkg/pkg.ml
+++ b/bin/pkg/pkg.ml
@@ -1,22 +1,23 @@
 open Import
 
-let info =
-  let doc = "Experimental package management" in
-  let man =
-    [ `S "DESCRIPTION"
-    ; `P {|Commands for doing package management with dune|}
-    ; `Blocks Common.help_secs
-    ]
-  in
-  Cmd.info "pkg" ~doc ~man
+let man =
+  [ `S "DESCRIPTION"
+  ; `P {|Commands for doing package management with dune|}
+  ; `Blocks Common.help_secs
+  ]
 ;;
 
-let group =
-  Cmd.group
-    info
-    [ Lock.command
-    ; Print_solver_env.command
-    ; Outdated.command
-    ; Validate_lock_dir.command
-    ]
+let subcommands =
+  [ Lock.command; Print_solver_env.command; Outdated.command; Validate_lock_dir.command ]
 ;;
+
+let info name =
+  let doc = "Experimental package management" in
+  Cmd.info name ~doc ~man
+;;
+
+let group = Cmd.group (info "pkg") subcommands
+
+module Alias = struct
+  let group = Cmd.group (info "package") subcommands
+end

--- a/bin/pkg/pkg.ml
+++ b/bin/pkg/pkg.ml
@@ -2,7 +2,7 @@ open Import
 
 let man =
   [ `S "DESCRIPTION"
-  ; `P {|Commands for doing package management with dune|}
+  ; `P {|Commands for OCaml package management|}
   ; `Blocks Common.help_secs
   ]
 ;;

--- a/bin/pkg/pkg.mli
+++ b/bin/pkg/pkg.mli
@@ -1,3 +1,7 @@
 open Import
 
 val group : unit Cmd.t
+
+module Alias : sig
+  val group : unit Cmd.t
+end

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -189,6 +189,15 @@
  (files   dune-ocaml-merlin.1))
 
 (rule
+ (with-stdout-to dune-package.1
+  (run dune package --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-package.1))
+
+(rule
  (with-stdout-to dune-pkg.1
   (run dune pkg --help=groff)))
 


### PR DESCRIPTION
From the interviews conducted by @leostera it appears that, intuitively, people tend to write `package` instead of `pkg`. To respond to this, I have added a `dune package` command, with the same sub commands as `dune pkg` and a test to make sure we keep track of both. 

It doesn't seem that _Cmdliner_ provides a way to do aliases, so I had to introduce a new command.