### PR TITLE
Repro: patch doesn't like timestamps

### DIFF
--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -161,13 +161,13 @@ let%expect_test "patching a deleted file" =
 ;;
 
 let%expect_test "Using a patch from 'diff' with a timestamp" =
-  test [ "foo.ml", "This is wrong\n" ] ("foo.patch", unified);
-  check "foo.ml";
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (Dune_util__Report_error.Already_reported)
-  Trailing output
-  ---------------
-  Error: /tmp/build_b1b383_dune/dune_71088f_patch_test/foo.ml	2024-08-29
-  17:38:00.243088256 +0200: No such file or directory |}]
+  try
+    test [ "foo.ml", "This is wrong\n" ] ("foo.patch", unified);
+    check "foo.ml";
+    [%expect.unreachable]
+  with
+  | Dune_util.Report_error.Already_reported ->
+    if String.ends_with ~suffix:"No such file or directory\n" [%expect.output]
+    then [%expect ""]
+    else [%expect.unreachable]
 ;;

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -58,6 +58,18 @@ index ea988f6bd..000000000
 |}
 ;;
 
+(* Use GNU diff 'unified' format instead of 'git diff' *)
+let unified =
+  {|
+diff -u a/foo.ml b/foo.ml
+--- a/foo.ml	2024-08-29 17:37:53.114980665 +0200
++++ b/foo.ml	2024-08-29 17:38:00.243088256 +0200
+@@ -1 +1 @@
+-This is wrong
++This is right
+|}
+;;
+
 (* Testing the patch action *)
 
 include struct
@@ -146,4 +158,16 @@ let%expect_test "patching a deleted file" =
   check "foo.ml";
   [%expect {|
     File foo.ml not found |}]
+;;
+
+let%expect_test "Using a patch from 'diff' with a timestamp" =
+  test [ "foo.ml", "This is wrong\n" ] ("foo.patch", unified);
+  check "foo.ml";
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (Dune_util__Report_error.Already_reported)
+  Trailing output
+  ---------------
+  Error: /tmp/build_b1b383_dune/dune_71088f_patch_test/foo.ml	2024-08-29
+  17:38:00.243088256 +0200: No such file or directory |}]
 ;;


### PR DESCRIPTION
Reproduction test for the bug found in #10856.
We assume the patch format is that of `git diff`, but it happens (like in our case on opam) that the GNU diff tool is used instead.
This produces a timestamp on the same line as the filename, which isn't caught.