### PR TITLE
Better patch format parsing

### DIFF
--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -15,18 +15,15 @@ include struct
 end
 
 let re =
-  let line xs = Re.seq ((Re.bol :: xs) @ [ Re.eol ]) in
-  let followed_by_line xs = Re.seq [ Re.str "\n"; line xs ] in
-  Re.compile
-  @@ Re.seq
-       [ Re.alt
-           [ line [ Re.str {|--- a/|}; Re.group (Re.rep1 Re.notnl) ]
-           ; line [ Re.str {|--- |}; Re.group (Re.rep1 Re.notnl) ]
-           ]
-       ; Re.alt
-           [ followed_by_line [ Re.str {|+++ b/|}; Re.group (Re.rep1 Re.notnl) ]
-           ; followed_by_line [ Re.str {|+++ |}; Re.group (Re.rep1 Re.notnl) ]
-           ]
+  let open Re in
+  let line xs = seq ((bol :: xs) @ [ eol ]) in
+  let filename = group @@ rep1 @@ compl [ space ] in
+  let timestamp = rep notnl in
+  compile
+  @@ seq
+       [ line [ str {|--- |}; opt (str "a/"); filename; timestamp ]
+       ; str "\n"
+       ; line [ str {|+++ |}; opt (str "b/"); filename; timestamp ]
        ]
 ;;
 
@@ -44,25 +41,22 @@ let patches_of_string patch_string =
   Re.all re patch_string
   |> List.filter_map ~f:(fun group ->
     let open Option.O in
-    (* If these are [Some] then they are [/dev/null] *)
-    let old_file_dev_null = Re.Group.get_opt group 2 in
-    let new_file_dev_null = Re.Group.get_opt group 4 in
-    match old_file_dev_null, new_file_dev_null with
-    | Some _dev_null, Some _ ->
+    (* A match failure means a file name couldn't be parsed. *)
+    let* old_file = Re.Group.get_opt group 1 in
+    let* new_file = Re.Group.get_opt group 2 in
+    match old_file = "/dev/null", new_file = "/dev/null" with
+    | true, true ->
       (* when both files are /dev/null we don't care about the patch. *)
       None
-    | Some _, None ->
+    | true, false ->
       (* New file *)
-      let+ new_file = Re.Group.get_opt group 3 in
-      Patch.New (Path.Local.of_string new_file)
-    | None, Some _ ->
+      Some (Patch.New (Path.Local.of_string new_file))
+    | false, true ->
       (* Delete file *)
-      let+ new_file = Re.Group.get_opt group 1 in
-      Patch.Delete (Path.Local.of_string new_file)
-    | None, None ->
+      Some (Patch.Delete (Path.Local.of_string old_file))
+    | false, false ->
       (* Replace file *)
-      let+ new_file = Re.Group.get_opt group 3 in
-      Patch.Replace (Path.Local.of_string new_file))
+      Some (Patch.Replace (Path.Local.of_string new_file)))
 ;;
 
 let prog =

--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -15,16 +15,15 @@ include struct
 end
 
 let re =
-  let open Re in
-  let line xs = seq ((bol :: xs) @ [ eol ]) in
-  let filename = group @@ rep1 @@ compl [ space ] in
+  let line xs = Re.seq ((Re.bol :: xs) @ [ Re.eol ]) in
+  let followed_by_line xs = Re.seq [ Re.str "\n"; line xs ] in
+  let filename = Re.group (Re.rep1 (Re.compl [ Re.space ])) in
   (* We don't care about what's after the filename. (likely a timestamp) *)
-  let junk = rep notnl in
-  compile
-  @@ seq
-       [ line [ str {|--- |}; opt (str "a/"); filename; junk ]
-       ; str "\n"
-       ; line [ str {|+++ |}; opt (str "b/"); filename; junk ]
+  let junk = Re.rep Re.notnl in
+  Re.compile
+  @@ Re.seq
+       [ line [ Re.str {|--- |}; Re.opt (Re.str "a/"); filename; junk ]
+       ; followed_by_line [ Re.str {|+++ |}; Re.opt (Re.str "b/"); filename; junk ]
        ]
 ;;
 

--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -18,12 +18,13 @@ let re =
   let open Re in
   let line xs = seq ((bol :: xs) @ [ eol ]) in
   let filename = group @@ rep1 @@ compl [ space ] in
-  let timestamp = rep notnl in
+  (* We don't care about what's after the filename. (likely a timestamp) *)
+  let junk = rep notnl in
   compile
   @@ seq
-       [ line [ str {|--- |}; opt (str "a/"); filename; timestamp ]
+       [ line [ str {|--- |}; opt (str "a/"); filename; junk ]
        ; str "\n"
-       ; line [ str {|+++ |}; opt (str "b/"); filename; timestamp ]
+       ; line [ str {|+++ |}; opt (str "b/"); filename; junk ]
        ]
 ;;
 

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -171,15 +171,10 @@ let%expect_test "patching a deleted file" =
 ;;
 
 let%expect_test "Using a patch from 'diff' with a timestamp" =
-  try
-    test [ "foo.ml", "This is wrong\n" ] ("foo.patch", unified);
-    check "foo.ml";
-    [%expect.unreachable]
-  with
-  | Dune_util.Report_error.Already_reported ->
-    if String.ends_with ~suffix:"No such file or directory\n" [%expect.output]
-    then [%expect ""]
-    else [%expect.unreachable]
+  test [ "foo.ml", "This is wrong\n" ] ("foo.patch", unified);
+  check "foo.ml";
+  [%expect {|
+    This is right |}]
 ;;
 
 let%expect_test "patching a file without prefix" =


### PR DESCRIPTION
## What
Fixes a bug found in #10856, with repro pending in #10859:
A fair amount of packages fail to build when there was a patch made to their entry in the opam-repo, and that patch didn't follow a specific format.

## How
The regexp matching a filename was a simple `.+` (or `rep1 notnl` in Re terms). This has the unfortunate side effect of capturing the entire rest of the line, including a potential timestamp attached to the filename.
The new regexp is a still simple `[^\s]+` (or `rep1 (compl [space])`), which will stop when encountering whitespace. The rest of the line is caught and not used.
This has the unfortunate side effect of failing on filenames containing spaces.

I think this tradeoff is a good one for this scenario, since we expect patches to be applied to normal dev-created files, not adversarial edge-case crafters.
We could absolutely try to cover everything here, but the range of different formats that GNU patch can emit, along with the fact that filenames can contain almost anything, makes that a lot more effort.
Maybe we still should though?
