### PR TITLE
makefile: add watch rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ $(BIN):
 dev: $(BIN)
 	$(BIN) build @install
 
+watch: $(BIN)
+	$(BIN) build @install --watch
+
 all: $(BIN)
 	$(BIN) build
 


### PR DESCRIPTION
It is convenient to have a quick way to compile in watch mode.