### PR TITLE
doc: fix list level of 'extra_deps'

### DIFF
--- a/doc/reference/foreign-stubs.rst
+++ b/doc/reference/foreign-stubs.rst
@@ -62,9 +62,9 @@ Here is a complete list of supported subfields:
     The contents of included directories are tracked recursively, e.g., if you
     use ``(include_dir dir)`` and have headers ``dir/base.h`` and
     ``dir/lib/lib.h``, they both will be tracked as dependencies.
-  - ``extra_deps`` specifies any other dependencies that should be tracked.
-    This is useful when dealing with ``#include`` statements that escape into
-    a parent directory like ``#include "../a.h"``.
+- ``extra_deps`` specifies any other dependencies that should be tracked.  This
+    is useful when dealing with ``#include`` statements that escape into a
+    parent directory like ``#include "../a.h"``.
 
 
 Mode-Dependent Stubs


### PR DESCRIPTION
Fixes the rendering of the `(extra_deps)` field in the docs:

![image](https://github.com/user-attachments/assets/4e1047a2-ce83-4c52-b7de-cdc847f88f55)
