### PR TITLE
tests: Honor `DUNE_CONFIG__SKIP_LINE_BREAK`

### DIFF
--- a/otherlibs/stdune/src/ansi_color.mli
+++ b/otherlibs/stdune/src/ansi_color.mli
@@ -108,6 +108,9 @@ val stdout_supports_color : bool Lazy.t
 val stderr_supports_color : bool Lazy.t
 val output_is_a_tty : bool Lazy.t
 
+(* Whether to avoid breaking long lines *)
+val skip_line_break : bool Lazy.t
+
 (** Filter out escape sequences in a string *)
 val strip : string -> string
 

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -327,7 +327,15 @@ module Processed = struct
         |> Pp.concat_map ~sep:Pp.cut ~f:pp_one
         |> Pp.vbox
       in
-      Format.printf "%a%a@." Format.pp_set_margin 1000 Pp.to_fmt pp
+      let pp_format =
+        match Lazy.force Ansi_color.skip_line_break with
+        | false -> Pp.to_fmt
+        | true ->
+          fun ppf ->
+            Format.pp_set_margin ppf 1000;
+            Pp.to_fmt ppf
+      in
+      Format.printf "%a@." pp_format pp
   ;;
 
   let print_generic_dot_merlin paths =

--- a/test/blackbox-tests/test-cases/github2206.t/run.t
+++ b/test/blackbox-tests/test-cases/github2206.t/run.t
@@ -1,4 +1,7 @@
 copy_files would break the generation of the preprocessing flags
+
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
+
   $ dune build copy_files/.merlin-conf/exe-foo
   $ dune ocaml merlin dump-config $PWD/copy_files |
   > grep -B 1 -A 0 "pp"

--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -1,5 +1,7 @@
 Show that the merlin config knows about melange.compile_flags
 
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
+
   $ cat >dune-project <<EOF
   > (lang dune 3.8)
   > (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -6,6 +6,7 @@
   $ export BUILD_PATH_PREFIX_MAP="$(melc_stdlib_prefix)":$BUILD_PATH_PREFIX_MAP
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
   $ export BUILD_PATH_PREFIX_MAP="/MELC_STDLIB=$(ocamlfind query melange):$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ cat >dune-project <<EOF
   > (lang dune 3.8)

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -1,5 +1,6 @@
   $ export BUILD_PATH_PREFIX_MAP=\
   > "OPAM_PREFIX=$(ocamlc -where):$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 If Merlin field is absent, default context is chosen
 

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -4,6 +4,7 @@
   $ export BUILD_PATH_PREFIX_MAP="$ocamlfind_libs:$BUILD_PATH_PREFIX_MAP"
   $ melc_compiler="$(which melc)"
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release

--- a/test/blackbox-tests/test-cases/merlin/future-syntax.t
+++ b/test/blackbox-tests/test-cases/merlin/future-syntax.t
@@ -2,6 +2,7 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ ocamlfind_libs="$(ocamlfind printconf path | while read line; do printf lib=${line}:; done)"
   $ export BUILD_PATH_PREFIX_MAP="$ocamlfind_libs:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ cat >dune-project <<EOF
   > (lang dune 3.11)

--- a/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
@@ -3,6 +3,7 @@ in the same dune file, but require different ppx specifications
 
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune build @all --profile release
   $ dune ocaml merlin dump-config $PWD

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -1,5 +1,6 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
   $ unset OPAMCONFIRMLEVEL
 
 We call `$(opam switch show)` so that this test always uses an existing switch

--- a/test/blackbox-tests/test-cases/merlin/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github759.t/run.t
@@ -1,5 +1,6 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune build foo.cma --profile release
   $ dune ocaml merlin dump-config $PWD

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -18,6 +18,7 @@
 
   $ opam_prefix="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune build .merlin-conf/lib-foo
   $ dune ocaml merlin dump-config .

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -2,6 +2,7 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ ocamlfind_libs="$(ocamlfind printconf path | while read line; do printf lib=${line}:; done)"
   $ export BUILD_PATH_PREFIX_MAP="$ocamlfind_libs:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 Here we test that instrumentation processing is not passed to merlin by setting
 up a project with instrumentation and testing checking the merlin config.

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -1,5 +1,6 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 We build the project
   $ dune exec ./test.exe

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -2,6 +2,7 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ ocamlfind_libs="$(ocamlfind printconf path | while read line; do printf lib=${line}:; done)"
   $ export BUILD_PATH_PREFIX_MAP="$ocamlfind_libs:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 We're going create a fake findlib library for use:
 

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -2,6 +2,7 @@
 
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
 We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -19,6 +19,7 @@ library also has more than one src dir.
 
   $ opam_prefix="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune build lib2/.merlin-conf/lib-lib2
   $ dune ocaml merlin dump-config $PWD/lib2

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -1,5 +1,6 @@
   $ dune build @check
 
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
   $ dune ocaml merlin dump-config $PWD | grep -o '(SUFFIX.*)'
   (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))
   (SUFFIX ".aml .amli") (SUFFIX ".baml .bamli"))

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -28,6 +28,7 @@ Dune ocaml-merlin also accepts paths relative to the current directory
 
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune ocaml merlin dump-config "." --root=".." | head -n 2
   Foo: _build/default/realsrc/foo

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -1,5 +1,6 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ export DUNE_CONFIG__SKIP_LINE_BREAK=enabled
 
   $ dune exec ./foo.exe
   42


### PR DESCRIPTION
A follow up to #10589 and #10841 this PR attempts to unify the line-break handling a little bit.

At the moment this doesn't really skip the line-break but it sets it to the same value as it was before, to not break all tests but could be changed to use `Format.pp_infinity`, in which case a little bit of special casing could be removed.