### PR TITLE
ci: skip mdx tests on macos

### DIFF
--- a/test/blackbox-tests/test-cases/mdx-stanza/dune
+++ b/test/blackbox-tests/test-cases/mdx-stanza/dune
@@ -2,7 +2,10 @@
  (applies_to :whole_subtree)
  (deps
   (package mdx))
- (alias all-mdx-tests))
+ (alias all-mdx-tests)
+ (enabled_if
+  ; temporary workaround for #10874
+  (<> %{system} macosx)))
 
 (cram
  (applies_to shared-libraries)


### PR DESCRIPTION
Temporary workaround for #10874
