### PR TITLE
Repro case for when a unified patch has no prefix

### DIFF
--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -70,6 +70,16 @@ diff -u a/foo.ml b/foo.ml
 |}
 ;;
 
+let no_prefix =
+  {|
+--- foo.ml	2024-08-29 17:37:53.114980665 +0200
++++ foo.ml	2024-08-29 17:38:00.243088256 +0200
+@@ -1 +1 @@
+-This is wrong
++This is right
+|}
+;;
+
 (* Testing the patch action *)
 
 include struct
@@ -170,4 +180,16 @@ let%expect_test "Using a patch from 'diff' with a timestamp" =
     if String.ends_with ~suffix:"No such file or directory\n" [%expect.output]
     then [%expect ""]
     else [%expect.unreachable]
+;;
+
+let%expect_test "patching a file without prefix" =
+  test [ "foo.ml", "This is wrong\n" ] ("foo.patch", no_prefix);
+  check "foo.ml";
+  [%expect.unreachable]
+[@@expect.uncaught_exn
+  {|
+  (Dune_util__Report_error.Already_reported)
+  Trailing output
+  ---------------
+  Command exited with code 1. |}]
 ;;


### PR DESCRIPTION
In the spirit of finding edge cases to make `dune_patch` be better, here's a a test for when there is no `a/`/`b/` prefix in a patch. This patch file is accepted by `patch -p0` but we currently don't.

I don't know if we want to specify that all patches need to be `-p1` compliant, but in case we want to support both `-p1` and `-p0` style patches is tests the latter.