### PR TITLE
Always pass `-fdiagnostics-color=always` to `cc`-style compilers to avoid useless recompilations when Dune's stderr is redirected

### DIFF
--- a/doc/changes/10883.md
+++ b/doc/changes/10883.md
@@ -1,0 +1,2 @@
+- Fix an issue where C stubs would be rebuilt whenever the stderr of Dune was
+  redirected. (#10883, @nojb)

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -22,8 +22,7 @@ let base_cxx_flags ~for_ cc =
 ;;
 
 let fdiagnostics_color = function
-  | (Gcc | Clang) when Lazy.force Ansi_color.stderr_supports_color ->
-    [ "-fdiagnostics-color=always" ]
+  | Gcc | Clang -> [ "-fdiagnostics-color=always" ]
   | _ -> []
 ;;
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
@@ -45,11 +45,7 @@ test that we correctly filter out the color codes
   >   (language c) (names stub)))
   > EOF
 
-  $ dune build
-  File "dune", line 4, characters 22-26:
-  4 |   (language c) (names stub)))
-                            ^^^^
-  stub.c:1:2: error: #error "error message"
-      1 | #error "error message"
-        |  ^~~~~
+We check there is no ESC [ sequence.
+
+  $ dune build 2>&1 | grep `printf '\033\\['`
   [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
@@ -1,9 +1,6 @@
 This test won't work with MSVC as it's using GCC and clang CLI
 parameters.
 
-We have to force Dune outputting colors, for that we use
-`CLICOLOR_FORCE=1`.
-
 The flag should be present in the command, as we want it in the
 :standard set.
 
@@ -11,8 +8,8 @@ We don't actually test that the compiler outputs colors, just that
 Dune correctly passes the flag when required, and doesn't when it's
 not.
 
-test, color enabled, color flag default (enabled)
-=================================================
+test that we pass the flag
+==========================
 
   $ cat >dune <<EOF
   > (library
@@ -20,11 +17,11 @@ test, color enabled, color flag default (enabled)
   >  (foreign_stubs (language c) (names stub)))
   > EOF
 
-  $ CLICOLOR_FORCE=1 dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
+  $ dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
   1
 
-test, color enabled, color flag disabled
-========================================
+test color flag disabled
+========================
 
   $ cat >dune <<EOF
   > (library
@@ -34,12 +31,12 @@ test, color enabled, color flag disabled
   >   (language c) (names stub)))
   > EOF
 
-  $ CLICOLOR_FORCE=1 dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
+  $ dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
   0
   [1]
 
-test, color disabled, color flag default (enabled)
-==================================================
+test that we correctly filter out the color codes
+=================================================
 
   $ cat >dune <<EOF
   > (library
@@ -48,6 +45,11 @@ test, color disabled, color flag default (enabled)
   >   (language c) (names stub)))
   > EOF
 
-  $ CLICOLOR=0 dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
-  0
+  $ dune build
+  File "dune", line 4, characters 22-26:
+  4 |   (language c) (names stub)))
+                            ^^^^
+  stub.c:1:2: error: #error "error message"
+      1 | #error "error message"
+        |  ^~~~~
   [1]

--- a/test/blackbox-tests/test-cases/variables/var-cc.t/run.t
+++ b/test/blackbox-tests/test-cases/variables/var-cc.t/run.t
@@ -51,7 +51,7 @@ No env
   >   (action (echo %{cc})))
   > EOF
 
-  $ dune build @cc28 | sed "s,${O_CC} ${O_CCF} ${O_CCPPF},OK,"
+  $ dune build @cc28 | sed "s,${O_CC} ${O_CCF} ${O_CCPPF} -fdiagnostics-color=always,OK,"
   OK
 
 With added env flags
@@ -59,7 +59,7 @@ With added env flags
   > (env (_ (c_flags :standard -fPIC)))
   > EOF
 
-  $ dune build @cc28 | sed "s,${O_CC} ${O_CCF} ${O_CCPPF} -fPIC,OK,"
+  $ dune build @cc28 | sed "s,${O_CC} ${O_CCF} ${O_CCPPF} -fdiagnostics-color=always -fPIC,OK,"
   OK
 
 With redefining env flags


### PR DESCRIPTION
Fixes #10882 