### PR TITLE
perf: add names to source tree events

### DIFF
--- a/bin/target.ml
+++ b/bin/target.ml
@@ -53,6 +53,7 @@ let all_direct_targets dir =
     Source_tree_map_reduce.map_reduce
       root
       ~traverse:Source_dir_status.Set.all
+      ~trace_event_name:"All direct targets"
       ~f:(fun dir ->
         Dune_engine.Load_rules.load_dir
           ~dir:

--- a/doc/changes/10884.md
+++ b/doc/changes/10884.md
@@ -1,0 +1,1 @@
+- Add names to source tree events in performance traces (#10884, @jchavarri)

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -70,6 +70,10 @@ include Alias_builder.Alias_rec (struct
       >>= function
       | None -> Action_builder.return Alias_builder.Alias_status.Not_defined
       | Some src_dir ->
-        Map_reduce.map_reduce src_dir ~traverse:Source_dir_status.Set.normal_only ~f
+        Map_reduce.map_reduce
+          src_dir
+          ~traverse:Source_dir_status.Set.normal_only
+          ~trace_event_name:"Alias builder"
+          ~f
     ;;
   end)

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -64,7 +64,10 @@ let load () =
       in
       Memo.return (projects, dune_files)
     in
-    Source_tree_map_reduce.map_reduce ~traverse:Source_dir_status.Set.all ~f
+    Source_tree_map_reduce.map_reduce
+      ~traverse:Source_dir_status.Set.all
+      ~trace_event_name:"Dune load"
+      ~f
   in
   let projects = Appendable_list.to_list_rev projects in
   let packages, vendored_packages =

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -164,6 +164,7 @@ let include_dir_flags ~expander ~dir ~include_dirs =
                      Source_tree_map_reduce.map_reduce
                        dir
                        ~traverse:Source_dir_status.Set.all
+                       ~trace_event_name:"Foreign rules"
                        ~f:(fun t ->
                          let deps =
                            let dir =

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -13,17 +13,21 @@ let files dir =
   | None -> Memo.return (Dep.Set.empty, Path.Set.empty)
   | Some dir ->
     let+ files, empty_directories =
-      Map_reduce.map_reduce dir ~traverse:Source_dir_status.Set.all ~f:(fun dir ->
-        let path = Path.append_source prefix_with @@ Source_tree.Dir.path dir in
-        let files =
-          Source_tree.Dir.filenames dir
-          |> String.Set.to_list
-          |> Path.Set.of_list_map ~f:(fun fn -> Path.relative path fn)
-        in
-        let empty_directories =
-          if Path.Set.is_empty files then Path.Set.singleton path else Path.Set.empty
-        in
-        Memo.return (files, empty_directories))
+      Map_reduce.map_reduce
+        dir
+        ~traverse:Source_dir_status.Set.all
+        ~trace_event_name:"Source deps"
+        ~f:(fun dir ->
+          let path = Path.append_source prefix_with @@ Source_tree.Dir.path dir in
+          let files =
+            Source_tree.Dir.filenames dir
+            |> String.Set.to_list
+            |> Path.Set.of_list_map ~f:(fun fn -> Path.relative path fn)
+          in
+          let empty_directories =
+            if Path.Set.is_empty files then Path.Set.singleton path else Path.Set.empty
+          in
+          Memo.return (files, empty_directories))
     in
     Dep.Set.of_source_files ~files ~empty_directories, files
 ;;

--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -19,6 +19,7 @@ module Dir : sig
     val map_reduce
       :  t
       -> traverse:Source_dir_status.Set.t
+      -> trace_event_name:string
       -> f:(t -> Outcome.t M.t)
       -> Outcome.t M.t
   end
@@ -41,6 +42,7 @@ module Make_map_reduce_with_progress (M : Memo.S) (Outcome : Monoid) : sig
   (** Traverse starting from the root and report progress in the status line *)
   val map_reduce
     :  traverse:Source_dir_status.Set.t
+    -> trace_event_name:string
     -> f:(Dir.t -> Outcome.t M.t)
     -> Outcome.t M.t
 end

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -118,6 +118,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
       Source_tree_map_reduce.map_reduce
         dir
         ~traverse:Source_dir_status.Set.all
+        ~trace_event_name:"Utop rules loading"
         ~f:(fun dir ->
           let dir =
             Path.Build.append_source

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -369,10 +369,13 @@ let upgrade () =
                   type t = Source_tree.Dir.t * project_version
                 end))
          in
-        M.map_reduce ~traverse:Source_dir_status.Set.normal_only ~f:(fun dir ->
-          let project = Source_tree.Dir.project dir in
-          let detected_version = detect_project_version project dir in
-          Memo.return (Appendable_list.singleton (dir, detected_version))))
+        M.map_reduce
+          ~traverse:Source_dir_status.Set.normal_only
+          ~trace_event_name:"Upgrader"
+          ~f:(fun dir ->
+            let project = Source_tree.Dir.project dir in
+            let detected_version = detect_project_version project dir in
+            Memo.return (Appendable_list.singleton (dir, detected_version))))
       >>| Appendable_list.to_list
     in
     let v1_updates = ref false in

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -3,7 +3,7 @@
 This captures the commands that are being run:
 
   $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
-  {"args":{"dir":"."},"ph":"X","dur":...,"name":"Source tree scan","cat":"","ts":...,"pid":...,"tid":...}
+  {"args":{"dir":"."},"ph":"X","dur":...,"name":"Dune load: .","cat":"","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-config"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}


### PR DESCRIPTION
Partially fixes #10880.

There is a trace event being registered in `map_reduce` function of `Source_tree`, but I noticed this function is used from different places, with different traversal functions and logic.

This PR:
- passes around a label to be used as the event name, so that viewers can notice distinctions between different traversals
- includes the dir being evaluated into the event name as well. It was already added to the `args` of the event, but having it upfront makes things easier when visualizing the traces too.

Here are some demo traces and screenshots, visualized in [Firefox profiler](https://profiler.firefox.com/) (which also support Chrome traces).

The build profiled goes through a lot of rules but none of them has to be built, except for a huge executable at the end (see the long `ocamlc.opt` event on the right).

Before ([trace file]((https://github.com/user-attachments/files/16894320/main-build.txt))):

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/de1b3d56-40cd-4500-aef9-28be9b23a113">

After ([trace file](https://github.com/user-attachments/files/16894354/add-event-names-build.txt)):

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/4a8a049e-dacf-4390-ab03-c3e02c1892b3">

I am a bit confused as to why "Alias builder" traversal is running twice, with the first time not including the large `ocamlc.opt` chunk, but the second time including it.
