### PR TITLE
Support patches without a prefix by determining the prefix depth

### DIFF
--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -224,13 +224,7 @@ let%expect_test "Using a patch from 'diff' with a timestamp" =
 let%expect_test "patching a file without prefix" =
   test [ "foo.ml", "This is wrong\n" ] ("foo.patch", no_prefix);
   check "foo.ml";
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (Dune_util__Report_error.Already_reported)
-  Trailing output
-  ---------------
-  Command exited with code 1. |}]
+  [%expect {| This is right |}]
 ;;
 
 let%expect_test "patching files with spaces" =


### PR DESCRIPTION
This reads the prefix depth from the file. We currently only support only `1` but this adds support for `0` which the regex already supported.

For arbitrary depth prefixes this would require a more complex parsing regex but also these are presumably rather rare in the real world.