### PR TITLE
Return [result] from Lock_dir.read_disk

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -11,7 +11,7 @@ module Show_lock = struct
     in
     Console.print
     @@ List.map lock_dir_paths ~f:(fun lock_dir_path ->
-      let lock_dir = Lock_dir.read_disk lock_dir_path in
+      let lock_dir = Lock_dir.read_disk_exn lock_dir_path in
       Pp.concat
         ~sep:Pp.space
         [ Pp.hovbox
@@ -120,7 +120,7 @@ module List_locked_dependencies = struct
     List.filter_map lock_dirs ~f:(fun lock_dir_path ->
       if Path.exists (Path.source lock_dir_path)
       then (
-        try Some (lock_dir_path, Lock_dir.read_disk lock_dir_path) with
+        try Some (lock_dir_path, Lock_dir.read_disk_exn lock_dir_path) with
         | User_error.E e ->
           User_warning.emit
             [ Pp.textf

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -15,7 +15,7 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
           (repositories_of_workspace workspace)
           ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
       and+ local_packages = Memo.run find_local_packages in
-      let lock_dir = Lock_dir.read_disk lock_dir_path in
+      let lock_dir = Lock_dir.read_disk_exn lock_dir_path in
       let+ results = Dune_pkg_outdated.find ~repos ~local_packages lock_dir.packages in
       ( Dune_pkg_outdated.pp ~transitive ~lock_dir_path results
       , ( Dune_pkg_outdated.packages_that_were_not_found results

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -22,7 +22,7 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
   List.filter_map per_contexts ~f:(fun lock_dir_path ->
     if Path.exists (Path.source lock_dir_path)
     then (
-      try Some (Ok (lock_dir_path, Lock_dir.read_disk lock_dir_path)) with
+      try Some (Ok (lock_dir_path, Lock_dir.read_disk_exn lock_dir_path)) with
       | User_error.E e -> Some (Error (lock_dir_path, `Parse_error e)))
     else None)
 ;;

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -806,7 +806,8 @@ module Load_immediate = Make_load (struct
     let with_lexbuf_from_file path ~f = Io.with_lexbuf_from_file (Path.source path) ~f
   end)
 
-let read_disk = Load_immediate.load_exn
+let read_disk = Load_immediate.load
+let read_disk_exn = Load_immediate.load_exn
 
 let transitive_dependency_closure t start =
   let missing_packages =

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -90,7 +90,8 @@ module Write_disk : sig
   val commit : t -> unit
 end
 
-val read_disk : Path.Source.t -> t
+val read_disk : Path.Source.t -> (t, User_message.t) result
+val read_disk_exn : Path.Source.t -> t
 
 module Make_load (Io : sig
     include Monad.S

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -68,7 +68,7 @@ let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   Lock_dir.Write_disk.(
     prepare ~lock_dir_path ~files:Package_name.Map.empty lock_dir |> commit);
   let lock_dir_round_tripped =
-    try Lock_dir.read_disk lock_dir_path with
+    try Lock_dir.read_disk_exn lock_dir_path with
     | User_error.E _ as exn ->
       let metadata_path =
         Path.Source.relative lock_dir_path Lock_dir.metadata_filename |> Path.source


### PR DESCRIPTION
Make it possible to attempt to read a lockdir from a directory without raising a [User_error] if the lockdir is not present.