### PR TITLE
Change colors to be more readable in light themes

### DIFF
--- a/doc/changes/10890.md
+++ b/doc/changes/10890.md
@@ -1,0 +1,2 @@
+- Change some colors to improve readability in light-mode terminals
+  (#10890, @gridbugs)

--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -159,9 +159,9 @@ module Print_config = struct
     | Kwd -> [ `Bold; `Fg_blue ]
     | Id -> [ `Bold; `Fg_yellow ]
     | Prompt -> [ `Bold; `Fg_green ]
-    | Hint -> [ `Italic; `Fg_white ]
-    | Details -> [ `Dim; `Fg_white ]
-    | Ok -> [ `Dim; `Fg_green ]
+    | Hint -> [ `Italic ]
+    | Details -> [ `Dim ]
+    | Ok -> [ `Fg_green ]
     | Debug -> [ `Underline; `Fg_bright_cyan ]
     | Success -> [ `Bold; `Fg_green ]
     | Ansi_styles l -> l


### PR DESCRIPTION
Some of the text colors used by dune tend not to be readable on default light-themes terminals. Of course it will always be possible to configure your terminal so that some colors are too light/dark to read, but some of the preset themes on macos are unable to display some colors commonly used by dune.

The three types of text in question are `Ok` seen below as the green program names in the output of `dune build --display=short`, `Details` seen below as the dim text on the right side of the output of `dune build --display=short`, and `Hint` seen below as the inverted colors or italic text displaying the word "Hint" in the output of `dune pkg validate`.

The light theme is MacOS Terminal's "Novel" theme, the dark theme is MacOS Terminal's "Basic" theme, and the purple themes are "Catpuccin Mocha" themes of WezTerm (top) and Emacs (bottom).

@leostera you've mentioned issues with being able to read the output of dune on light themes a couple of times. Can you share the terminals and themes where you run into this issue and confirm whether this change fixes it.

Before:
<img width="1440" alt="Screenshot 2024-09-06 at 19 11 06" src="https://github.com/user-attachments/assets/06e4402a-5ae3-4de0-8f1d-d25b4e483820">

After:
<img width="1440" alt="Screenshot 2024-09-06 at 19 13 36" src="https://github.com/user-attachments/assets/ae42b2f3-9d58-41fd-986e-c43a35250f92">