### PR TITLE
ci bench: use 5.1

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - bench/fix-melange-pupilfirst
+      - ci-bench/fix-after-ocaml51
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -22,7 +22,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.14.x
+          - 5.1.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Regressed after https://github.com/ocaml/dune/pull/10878.

Updating switch version fixes the pipeline, see [example](https://github.com/jchavarri/dune/actions/runs/10760078800/job/29837546299).