### PR TITLE
fix: Support prefixes other than `a/` & `b/` when modifying files

### DIFF
--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -79,7 +79,10 @@ let patches_of_string patch_string =
           ( Path.Local.split_first_component old_path
           , Path.Local.split_first_component new_path )
         with
-        | Some ("a", _old_path), Some ("b", new_path) -> new_path, 1
+        | Some (_, old_path), Some (_, new_path)
+          when Path.Local.equal old_path new_path && not (Path.Local.is_root new_path) ->
+          (* suffixes are the same and not empty *)
+          new_path, 1
         | _, _ -> new_path, 0
       in
       (* Replace file *)

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -239,14 +239,9 @@ let%expect_test "patching a file without prefix" =
 ;;
 
 let%expect_test "patching files with freestyle prefix" =
-  try
-    test [ "foo.ml", "This is wrong\n" ] ("foo.patch", random_prefix);
-    check "foo.ml";
-    [%expect.unreachable]
-  with
-  | Dune_util.Report_error.Already_reported ->
-    print_endline @@ normalize_error_path [%expect.output];
-    [%expect {| Error: foo.ml: No such file or directory |}]
+  test [ "foo.ml", "This is wrong\n" ] ("foo.patch", random_prefix);
+  check "foo.ml";
+  [%expect {| This is right |}]
 ;;
 
 let%expect_test "patching files with spaces" =


### PR DESCRIPTION
This allows using any prefix like `old/` and `new/` when diffing, as long as the path matches. For adding and removing files it can't be generalized because we don't know what the suffix should be as the other file is `/dev/null`.