### PR TITLE
Allow printing custom build progress messages

### DIFF
--- a/src/dune_rules/pkg_build_progress.ml
+++ b/src/dune_rules/pkg_build_progress.ml
@@ -12,6 +12,12 @@ module Status = struct
   ;;
 end
 
+let format_user_message ~verb ~object_ =
+  let status_tag = User_message.Style.Success in
+  User_message.make
+    [ Pp.concat ~sep:Pp.space [ Pp.tag status_tag (Pp.textf "%12s" verb); object_ ] ]
+;;
+
 module Message = struct
   type t =
     { package_name : Package.Name.t
@@ -20,16 +26,13 @@ module Message = struct
     }
 
   let user_message { package_name; package_version; status } =
-    let status_tag = User_message.Style.Success in
-    User_message.make
-      [ Pp.concat
-          [ Pp.tag status_tag (Pp.textf "%12s" (Status.to_string status))
-          ; Pp.textf
-              " %s.%s"
-              (Package.Name.to_string package_name)
-              (Package_version.to_string package_version)
-          ]
-      ]
+    format_user_message
+      ~verb:(Status.to_string status)
+      ~object_:
+        (Pp.textf
+           "%s.%s"
+           (Package.Name.to_string package_name)
+           (Package_version.to_string package_version))
   ;;
 
   let display t =

--- a/src/dune_rules/pkg_build_progress.mli
+++ b/src/dune_rules/pkg_build_progress.mli
@@ -1,5 +1,19 @@
 open! Import
 
+(** Formats a message in the style of a progress message. The text of
+    the message will be "<verb> <object_>" with the verb colored to match
+    the verb in progress messages (e.g. "Downloading", and the message
+    will be left-padded so that the space between the verb and object_
+    lines up with the spaces in progress messages, as long as the length
+    of the verb does not exceed 12 characters.
+
+    TODO(steve): unify this with the logic for printing build progress
+    messages in dune_engine/process.ml *)
+val format_user_message
+  :  verb:string
+  -> object_:User_message.Style.t Pp.t
+  -> User_message.t
+
 (** An action which prints a progress message about a package to
     the console so users can be informed about which of their
     project's dependencies are currently being installed.


### PR DESCRIPTION
Expose the function for formatting build progress messages so other code can print messages in the same style. This will be used to print messages such as "Running <dev-tool>" in the same format as package build progress messages.