### PR TITLE
toolchain: Remove locations from pkg before hashing

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -30,6 +30,7 @@ module Pkg : sig
     ; exported_env : String_with_vars.t Action.Env_update.t list
     }
 
+  val remove_locs : t -> t
   val equal : t -> t -> bool
   val decode : (lock_dir:Path.Source.t -> Package_name.t -> t) Decoder.t
   val files_dir : Package_name.t -> lock_dir:Path.Source.t -> Path.Source.t

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -27,7 +27,7 @@ let pkg_dir (pkg : Dune_pkg.Lock_dir.Pkg.t) =
      way). *)
   let dir_name =
     (* TODO should include resolved deps *)
-    let pkg_hash = Digest.generic pkg in
+    let pkg_hash = Digest.generic (Lock_dir.Pkg.remove_locs pkg) in
     (* A hash of the fields of a package that affect its installed artifacts *)
     sprintf
       "%s.%s-%s"


### PR DESCRIPTION
When computing the hash of a toolchain package, first remove all locations. Without doing this, identical compiler packages inside different lockdirs will have different hashes and require unnecessarily recompiling the compiler package.