### PR TITLE
pkg: change progress message color

### DIFF
--- a/src/dune_rules/pkg_build_progress.ml
+++ b/src/dune_rules/pkg_build_progress.ml
@@ -13,7 +13,7 @@ module Status = struct
 end
 
 let format_user_message ~verb ~object_ =
-  let status_tag = User_message.Style.Success in
+  let status_tag = User_message.Style.Ok in
   User_message.make
     [ User_message.aligned_message ~left:(status_tag, verb) ~right:object_ ]
 ;;


### PR DESCRIPTION
This changes the message of the verbs in progress messages (e.g. "Building") to match the colours of the corresponding messages printed when running `dune build --display=short`.