### PR TITLE
Fix bug updating lockdir inside subdirectory

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -578,7 +578,9 @@ module Write_disk = struct
     lock_dir
     =
     let lock_dir_hidden_src =
-      lock_dir_path_src |> Path.Source.to_string |> sprintf ".%s" |> Path.Source.of_string
+      (* The original lockdir path with the lockdir renamed to begin with a ".". *)
+      let hidden_basename = sprintf ".%s" (Path.Source.basename lock_dir_path_src) in
+      Path.Source.relative (Path.Source.parent_exn lock_dir_path_src) hidden_basename
     in
     let lock_dir_hidden_src = Path.source lock_dir_hidden_src in
     let lock_dir_path_external = Path.source lock_dir_path_src in


### PR DESCRIPTION
To atomically update a lockdir we rename the existing lockdir to begin with a ".". Prior to this change the entire relative path to the lockdir was renamed which meant that if the lockdir was inside a subdirectory (e.g. a dev tool lockdir) then dune would attempt to rename "path/to/lockdir" to ".path/to/lockdir". This fails because rename/mv doesn't create directories to satisfy the destination path. This change fixes the issue by instead renaming the lockdir to "path/to/.lockdir" which avoids the need to create any directories.