### PR TITLE
Add links between tutorial sections

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,7 @@ libraries, run tests, and much more.
    :maxdepth: 2
 
    getting-started/index
+   tutorials/index
    howto/index
    reference/index
    explanation/index

--- a/doc/tutorials/developing-with-dune/index.md
+++ b/doc/tutorials/developing-with-dune/index.md
@@ -1,6 +1,5 @@
 ---
 author: Etienne Millon
-orphan: true
 ---
 
 Developing with Dune

--- a/doc/tutorials/index.md
+++ b/doc/tutorials/index.md
@@ -1,0 +1,10 @@
+Tutorials
+=========
+
+These tutorials are hands-on lessons to learn about Dune.
+
+:::{toctree}
+:maxdepth: 1
+
+developing-with-dune/index
+:::


### PR DESCRIPTION
Up to my understanding, tutorial introduced in PR #10711 does
not provide user discoverable means to navigate between its
parts. This add a links to the next section.
