### PR TITLE
Add changelog entry for ocamlformat dev-tool feature

### DIFF
--- a/doc/changes/10647.md
+++ b/doc/changes/10647.md
@@ -1,0 +1,2 @@
+- pkg: A new feature that build and install ocamlformat automatically without user
+  having to install it, this is done during the use of `dune fmt`. (#10647, @moyodiallo, @gridbugs)


### PR DESCRIPTION
Due to a mistake when pushing things, the file was remove from https://github.com/ocaml/dune/pull/10647 before the merge. 