### PR TITLE
chore(nix): add dev tool as experimental flags

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
           [
             "--enable-toolchains"
             "--enable-pkg-build-progress"
+            "--enable-lock-dev-tool"
           ];
       };
 


### PR DESCRIPTION
This adds the `dev-tools` experimental flag to the nix experimental builds.