### PR TITLE
Fix error/warnings for config file

### DIFF
--- a/doc/changes/10923.md
+++ b/doc/changes/10923.md
@@ -1,0 +1,3 @@
+- Fix the file referred to in the error/warning message displayed due to the
+  dune configuration version not supporting a particular configuration
+  stanza in use. (#10923, @H-ANSEN)

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -367,8 +367,10 @@ module Dune_config = struct
 
   let decode_generic ~min_dune_version =
     let check min_ver =
-      let ver = Dune_lang.Syntax.Version.max min_ver min_dune_version in
-      Dune_lang.Syntax.since Stanza.syntax ver
+      let module S = Dune_lang.Syntax in
+      let ver = S.Version.max min_ver min_dune_version in
+      let* loc, what = S.desc () in
+      S.since_fmt ~fmt:(S.Error_msg.since_config ~what) Stanza.syntax ver loc
     in
     let field_o n v d = field_o n (check v >>> d) in
     let+ display = field_o "display" (1, 0) (enum Display.all)

--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -29,7 +29,14 @@ end
 type t
 
 module Error_msg : sig
+  (** [since t ver what] formats an error string indicating that the syntax
+      [t] described by [what] is only available since [ver] of the dune-project
+      file. *)
   val since : t -> Version.t -> what:string -> string
+
+  (** Like [since] but formats an error message relating to the dune config file
+      rather than the dune-project file. *)
+  val since_config : t -> Version.t -> what:string -> string
 end
 
 module Error : sig
@@ -71,6 +78,9 @@ val create
 (** Return the name of the syntax. *)
 val name : t -> string
 
+(** Indicate the location and kind of value being parsed *)
+val desc : unit -> (Loc.t * string, 'a) Decoder.parser
+
 (** Check that the given version is supported and raise otherwise. *)
 val check_supported : dune_lang_ver:Version.t -> t -> Loc.t * Version.t -> unit
 
@@ -97,6 +107,16 @@ val renamed_in : t -> Version.t -> to_:string -> (unit, _) Decoder.parser
     version. When [fatal] is false, simply emit a warning instead of error.
     [fatal] defaults to true. [what] allows customizing the error message. *)
 val since : ?what:string -> ?fatal:bool -> t -> Version.t -> (unit, _) Decoder.parser
+
+(** Like [since] but accepts a function [fmt] allowing custom formatting of the
+    entire error/warning message. See [Error_msg] for format functions. *)
+val since_fmt
+  :  ?fatal:bool
+  -> fmt:(t -> Version.t -> string)
+  -> t
+  -> Version.t
+  -> Loc.t
+  -> (unit, 'a) Decoder.parser
 
 (** {2 Low-level functions} *)
 

--- a/test/blackbox-tests/test-cases/config-project-defaults.t
+++ b/test/blackbox-tests/test-cases/config-project-defaults.t
@@ -39,7 +39,7 @@ Change the version of the config file to one which does not support the
   4 |  (maintainers MaintainerTest)
   5 |  (license MIT))
   Error: 'project_defaults' is only available since version 3.17 of the dune
-  language. Please update your dune-project file to have (lang dune 3.17).
+  language. Please update your dune config file to have (lang dune 3.17).
   [1]
 
   $ sed -i -e '1s|.*|(lang dune 3.17)|' dune-config

--- a/test/blackbox-tests/test-cases/config/config-in-workspace-file.t
+++ b/test/blackbox-tests/test-cases/config/config-in-workspace-file.t
@@ -19,7 +19,7 @@ Setting such options is not supported with older Dune:
   2 | (display short)
       ^^^^^^^^^^^^^^^
   Error: 'display' is only available since version 3.0 of the dune language.
-  Please update your dune-project file to have (lang dune 3.0).
+  Please update your dune config file to have (lang dune 3.0).
   [1]
 
 But is supported with Dune >= 3.0.0:

--- a/test/blackbox-tests/test-cases/config/config-version.t
+++ b/test/blackbox-tests/test-cases/config/config-version.t
@@ -1,0 +1,49 @@
+Tests verifying that the config file presents accurate error or warning
+messages when a stanza is used with a version of dune which does not support
+such a stanza.
+
+Create a config file to use in the following tests. We will initialize the 
+config with a version and a stanza incompatable with that version.
+
+  $ export DUNE_CACHE_ROOT=$PWD/dune-cache
+  $ touch dune-config
+  $ cat >dune-config <<EOF
+  > (lang dune 1.0)
+  > (cache enabled)
+  > EOF
+
+Attempt to initialize a new project while an invaild stanza due to versioning
+exists in the config.
+
+  $ dune init proj test --config-file=dune-config
+  File "$TESTCASE_ROOT/dune-config", line 2, characters 0-15:
+  2 | (cache enabled)
+      ^^^^^^^^^^^^^^^
+  Error: 'cache' is only available since version 2.0 of the dune language.
+  Please update your dune config file to have (lang dune 2.0).
+  [1]
+
+Update the dune configuration with a version that would support the 
+'(cache enabled)' stanza and attempt a successful project initialization.
+
+  $ cat >dune-config <<EOF
+  > (lang dune 2.0)
+  > (cache enabled)
+  > EOF
+
+  $ dune init proj test_vaild --config-file=dune-config
+  Entering directory 'test_vaild'
+  Success: initialized project component named test_vaild
+  Leaving directory 'test_vaild'
+
+Append an invaild stanza to the config file and attempt project initialzation.
+
+  $ echo "(cache-check-probability 0.5)" >> dune-config
+  $ dune init proj test --config-file=dune-config
+  File "$TESTCASE_ROOT/dune-config", line 3, characters 0-29:
+  3 | (cache-check-probability 0.5)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'cache-check-probability' is only available since version 2.7 of the
+  dune language. Please update your dune config file to have (lang dune 2.7).
+  [1]
+


### PR DESCRIPTION
The following pull request seeks to resolve the issue listed below!

## Expected Behavior
The configuration file for dune makes use of the same version numbering scheme as dune-project files *`(lang dune <ver>)`*. When attempting to use dune with a configuration file that has a mismatch between a stanza and it's supported dune version an error indicating this mismatch in the configuration file should be displayed:
```cmd
File "dune/config", line 2, characters 0-15:
2 | (cache enabled)
Error: 'cache' is only available since version 2.0 of the dune language.
Please update your dune config file to have (lang dune 2.0).
```
## Actual Behavior
The actual recommends changing the version in the `dune-project` file as opposed to the users config file:
```cmd
File "dune/config" line 2, characters 0-15:
2 | (cache enabled)
Error: 'cache' is only available since version 2.0 of the dune language.
Please update your dune-project file to have (lang dune 2.0).
```
## Reproduction
```cmd
printf "(lang dune 1.0)\n(cache enabled)" > dune-config
dune init proj test --config-file=dune-config
```