### PR TITLE
chore(issue): package management report

### DIFF
--- a/.github/ISSUE_TEMPLATE/package_management.md
+++ b/.github/ISSUE_TEMPLATE/package_management.md
@@ -1,0 +1,21 @@
+---
+name: Package Management bug report
+about: Report a problem related to Dune Package Management
+title: '[Package Management]'
+labels: 'package management build failures'
+assignees: ''
+---
+
+## Specification
+
+<!-- output of `dune --version` --> 
+- Version of `dune`: 
+- Operating system (distribution and version):
+
+## Context
+
+<!-- What happened? What is the error message you have seen? What package is it related to? -->
+
+## Reproduction
+
+<!-- Put a link to a gist, a public repository or describe how we can reproduce this bug -->


### PR DESCRIPTION
As we are starting to promote Dune Package Management to get some feedback from users (to improve the experience), there is a risk to have bug report in Dune. This PR is a proposition to filter the result by having a dedicated form for Package Management issue. It would directly assign the right label. WDYT?