### PR TITLE
refactor(pkg): tweak experimental flag names

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,9 @@
       add-experimental-configure-flags = pkg: pkg.overrideAttrs {
         configureFlags =
           [
-            "--enable-toolchains"
-            "--enable-pkg-build-progress"
-            "--enable-lock-dev-tool"
+            "--toolchains" "enable"
+            "--pkg-build-progress" "enable"
+            "--lock-dev-tool" "enable"
           ];
       };
 


### PR DESCRIPTION
If only have "enable" flags, it will be impossible to disable existing flags once we change the defaults. With this change, we can tweak the defaults without adding/removing more flags.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>