### PR TITLE
[fix] [directory targets] Fix promotion of directory targets in some cases

### DIFF
--- a/doc/changes/10931.md
+++ b/doc/changes/10931.md
@@ -1,0 +1,3 @@
+- Fix promotion of directory targets when the promoted directory has
+  sub-directories with only other sub-directories inside; regression
+  in b1c339b / #9407 (@ejgallego, closes #10609)

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -243,9 +243,7 @@ module Produced = struct
                 acc_filenames, Path.Local.Map.union_exn acc_dirs dir
               | _ -> Error (Unsupported_file (Path.Build.relative dir filename, kind)))
         in
-        if not (Filename.Map.is_empty filenames)
-        then Path.Local.Map.add_exn dirs local filenames
-        else dirs
+        Path.Local.Map.add_exn dirs local filenames
     in
     let directory root dirname =
       let open Result.O in

--- a/test/blackbox-tests/test-cases/directory-targets/github10609/run.t
+++ b/test/blackbox-tests/test-cases/directory-targets/github10609/run.t
@@ -1,0 +1,24 @@
+We test that a directory target with only other subdirs can be
+properly promoted.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir node_modules))
+  >  (mode (promote (until-clean)))
+  >  (action
+  >    (progn
+  >      (system "mkdir -p node_modules/node-cmake/")
+  >      (system "touch    node_modules/node-cmake/.jshintrc")
+  >      (system "mkdir -p node_modules/node-cmake/node_modules/ansi-regex")
+  >      (system "touch    node_modules/node-cmake/node_modules/ansi-regex/index.js")
+  >    )))
+  > EOF
+
+  $ dune build node_modules
+  $ ls node_modules
+  node-cmake

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -57,8 +57,8 @@ Error message when the matching directory target is empty.
   2 |   (deps (sandbox always))
   3 |   (targets (dir output))
   4 |   (action (bash "mkdir output")))
-  Error: Rule produced directory "output" that contains no files nor non-empty
-  subdirectories
+  Error: This rule defines a directory target "output" that matches the
+  requested path "output/x" but the rule's action didn't produce it
   [1]
 
 Error message when the matching directory target doesn't contain a requested path.


### PR DESCRIPTION
When the promoted directory has sub-directories with only other sub-directories inside, the map will miss that directory and it will not be properly re-created, failing at children creation time.

I am not sure I fully follow the logic here (cc: @rleshchinskiy).

The current test case works for me (TM), if we revert the fix we get:

```
Error: Cannot promote files to "node_modules/node-cmake/node_modules/ansi-regex".
Reason: opendir(node_modules/node-cmake/node_modules/ansi-regex): No such file or directory
```

Regression in b1c339b / #9407

Closes #10609 .
