### PR TITLE
doc: update dependencies in the doc itself

### DIFF
--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -206,6 +206,8 @@ consists of two steps:
 * Running ``$ make opam-release`` to create the release tarball. Then publish it
   to GitHub and submit it to opam.
 
+.. _dune-release: https://github.com/tarides/dune-release
+
 Major & Feature Releases
 ------------------------
 
@@ -342,7 +344,7 @@ Documentation
 User documentation lives in the ``./doc`` directory.
 
 In order to build the user documentation, you must install python-sphinx_,
-sphinx-design_, myst-parser_, sphinx-copybutton_, and furo_.
+sphinx-design_, sphinx-copybutton_, myst-parser_, and furo_.
 
 Build the documentation with
 
@@ -356,13 +358,15 @@ For automatically updated builds, you can install sphinx-autobuild_, and run
 
    $ make livedoc
 
+.. seealso::
+    ``doc/requirements.txt`` for an always up-to-date list of packages to install
+
 .. _python-sphinx: http://www.sphinx-doc.org/en/master/usage/installation.html
 .. _sphinx-design: https://sphinx-design.readthedocs.io/en/latest/index.html
-.. _myst-parser: https://myst-parser.readthedocs.io/en/latest/
-.. _sphinx-autobuild: https://pypi.org/project/sphinx-autobuild/
 .. _sphinx-copybutton: https://sphinx-copybutton.readthedocs.io/en/latest/index.html
+.. _sphinx-autobuild: https://pypi.org/project/sphinx-autobuild/
+.. _myst-parser: https://myst-parser.readthedocs.io/en/latest/
 .. _furo: https://sphinx-themes.org/sample-sites/furo/
-.. _dune-release: https://github.com/ocamllabs/dune-release
 
 Nix users may drop into a development shell with the necessary dependencies for
 building docs ``nix develop .#doc``.

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -342,7 +342,7 @@ Documentation
 User documentation lives in the ``./doc`` directory.
 
 In order to build the user documentation, you must install python-sphinx_,
-sphinx_rtd_theme_ and sphinx-copybutton_.
+sphinx-design_, myst-parser_, sphinx-copybutton_, and furo_.
 
 Build the documentation with
 
@@ -357,9 +357,11 @@ For automatically updated builds, you can install sphinx-autobuild_, and run
    $ make livedoc
 
 .. _python-sphinx: http://www.sphinx-doc.org/en/master/usage/installation.html
-.. _sphinx_rtd_theme: https://sphinx-rtd-theme.readthedocs.io/en/stable/
+.. _sphinx-design: https://sphinx-design.readthedocs.io/en/latest/index.html
+.. _myst-parser: https://myst-parser.readthedocs.io/en/latest/
 .. _sphinx-autobuild: https://pypi.org/project/sphinx-autobuild/
 .. _sphinx-copybutton: https://sphinx-copybutton.readthedocs.io/en/latest/index.html
+.. _furo: https://sphinx-themes.org/sample-sites/furo/
 .. _dune-release: https://github.com/ocamllabs/dune-release
 
 Nix users may drop into a development shell with the necessary dependencies for


### PR DESCRIPTION
We changed themes a while back, but the hacking.rst file still mentionned the old one.