### PR TITLE
test(pkg): reproduce depext crash

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
@@ -1,0 +1,25 @@
+Solving with an unknown variable on depexts:
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+The "foobar" variable is not defined:
+  $ mkpkg foo <<EOF
+  > depexts: [[ "unzip" ] {foobar}]
+  > EOF
+
+Make a project that uses the foo library:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+Locking should succeed and not include the "unzip" package
+  $ dune pkg lock 2>&1 | head -n 1
+  Error: exception Failure("Undefined boolean filter value: foobar")
+
+  $ [ -e dune.lock/foo.pkg ] && cat dune.lock/foo.pkg
+  [1]


### PR DESCRIPTION
Demonstrate that an unknown variable on a filter of a depext makes the solver fail