### PR TITLE
[RFC] Add support for order-only and post-use dependencies to Dune engine

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -99,6 +99,7 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
   | Mkdir x -> List [ atom "mkdir"; target x ]
   | Pipe (outputs, l) ->
     List (atom (sprintf "pipe-%s" (Outputs.to_string outputs)) :: List.map l ~f:encode)
+  | Needed_deps xs -> List (atom "needed_deps" :: List.map xs ~f:path)
   | Extension ext -> List [ atom "ext"; Dune_sexp.Quoted_string (Sexp.to_string ext) ]
 ;;
 

--- a/doc/concepts/dependency-spec.rst
+++ b/doc/concepts/dependency-spec.rst
@@ -46,6 +46,9 @@ Dependencies in ``dune`` files can be specified using one of the following:
 - ``(include <file>)`` read the s-expression in ``<file>`` and interpret it as
   additional dependencies. The s-expression is expected to be a list of the
   same constructs enumerated here.
+- ``(order_only <deps>)`` declares ``<deps>`` as "order only" dependencies.
+  This means that these dependencies will be guaranteed to be up-to-date before
+  building the target, but changes in them will not cause the target to be rebuilt.
 
 In all these cases, the argument supports :doc:`variables`.
 

--- a/doc/reference/actions/needed_deps.rst
+++ b/doc/reference/actions/needed_deps.rst
@@ -1,0 +1,38 @@
+needed_deps
+----
+
+.. highlight:: dune
+
+.. describe:: (needed_deps <file> ...)
+
+   Declare the contents of ``<file>`` assumed to as dependencies of the rule.
+   Each ``<file>`` is assumed to contain a valid dependency specification (see
+   below).
+
+   This is used to declare that certain "order only" dependencies (see
+   :docs:`concepts/dependency-spec`) are actual dependencies of the rule.
+
+   The file passed as an argument is assumed to contain zero or more
+   S-expressions using the following constructors which cover a subset of the
+   usual dependency sepecification:
+
+   - ``(file <filename>)``
+   - ``(alias <alias_name>)``
+   - ``(file_selector <glob>)``
+   - ``(universe)``
+
+   (see :docs:`concepts/dependency-spec` for the details of each constructor).
+
+   In the following example, both ``a`` and ``b`` are declared as "order only"
+   dependencies. The file ``b`` is in addition declared as a needed dependency
+   for the rule. The rule will only be reran if ``b`` changes, but not if ``a``
+   changes.
+
+   Example::
+
+   (rule
+    (deps (order_only (file a) (file b)))
+    (action
+     (progn
+     (with-stdout-to deps (echo "(file b)"))
+     (needed_deps deps))))

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -54,6 +54,7 @@ struct
   let rename a b = Rename (a, b)
   let remove_tree path = Remove_tree path
   let mkdir path = Mkdir path
+  let needed_deps xs = Needed_deps xs
 end
 
 module Prog = struct
@@ -193,7 +194,8 @@ let fold_one_step t ~init:acc ~f =
   | Rename _
   | Remove_tree _
   | Mkdir _
-  | Extension _ -> acc
+  | Extension _
+  | Needed_deps _ -> acc
 ;;
 
 include Action_mapper.Make (Ast) (Ast)
@@ -238,7 +240,8 @@ let rec is_dynamic = function
   | Rename _
   | Remove_tree _
   | Mkdir _
-  | Extension _ -> false
+  | Extension _
+  | Needed_deps _ -> false
 ;;
 
 let maybe_sandbox_path sandbox p =
@@ -291,6 +294,7 @@ let is_useful_to memoize =
     | Dynamic_run _ -> true
     | Bash _ -> true
     | Extension (module A) -> A.Spec.is_useful_to ~memoize
+    | Needed_deps _ -> false
   in
   fun t ->
     match loop t with

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -125,6 +125,7 @@ module Exec_result = struct
   type ok =
     { dynamic_deps_stages : (Dep.Set.t * Dep.Facts.t) list
     ; duration : float option
+    ; needed_deps : Dep.Set.t * Dep.Facts.t
     }
 
   type t = (ok, Error.t list) Result.t
@@ -178,12 +179,12 @@ let bash_exn =
 let zero = Predicate_lang.element 0
 let maybe_async f = Produce.of_fiber (maybe_async f)
 
-let rec exec t ~display ~ectx ~eenv : done_or_more_deps Produce.t =
+let rec exec t ~display ~ectx ~eenv : Action_res.t Produce.t =
   match (t : Action.t) with
   | Run (Error e, _) -> Action.Prog.Not_found.raise e
   | Run (Ok prog, args) ->
     let+ () = exec_run ~display ~ectx ~eenv prog (Array.Immutable.to_list args) in
-    Done
+    Action_res.done_
   | With_accepted_exit_codes (exit_codes, t) ->
     let eenv =
       let exit_codes =
@@ -204,7 +205,7 @@ let rec exec t ~display ~ectx ~eenv : done_or_more_deps Produce.t =
       maybe_async (fun () ->
         Io.write_file (Path.build fn) (String.concat s ~sep:" ") ~perm)
     in
-    Done
+    Action_res.done_
   | Redirect_out (outputs, fn, perm, t) ->
     let fn = Path.build fn in
     redirect_out t ~display ~ectx ~eenv outputs ~perm fn
@@ -214,10 +215,10 @@ let rec exec t ~display ~ectx ~eenv : done_or_more_deps Produce.t =
   | Progn ts -> exec_list ts ~display ~ectx ~eenv
   | Concurrent ts ->
     Produce.parallel_map ts ~f:(exec ~display ~ectx ~eenv)
-    >>| List.fold_left ~f:done_or_more_deps_union ~init:Done
+    >>| List.fold_left ~f:Action_res.union ~init:Action_res.done_
   | Echo strs ->
     let+ () = exec_echo eenv.stdout_to (String.concat strs ~sep:" ") in
-    Done
+    Action_res.done_
   | Cat xs ->
     let+ () =
       maybe_async (fun () ->
@@ -225,17 +226,17 @@ let rec exec t ~display ~ectx ~eenv : done_or_more_deps Produce.t =
           Io.with_file_in fn ~f:(fun ic ->
             Io.copy_channels ic (Process.Io.out_channel eenv.stdout_to))))
     in
-    Done
+    Action_res.done_
   | Copy (src, dst) ->
     let dst = Path.build dst in
     let+ () = maybe_async (fun () -> Io.copy_file ~src ~dst ()) in
-    Done
+    Action_res.done_
   | Symlink (src, dst) ->
     let+ () = maybe_async (fun () -> Io.portable_symlink ~src ~dst:(Path.build dst)) in
-    Done
+    Action_res.done_
   | Hardlink (src, dst) ->
     let+ () = maybe_async (fun () -> Io.portable_hardlink ~src ~dst:(Path.build dst)) in
-    Done
+    Action_res.done_
   | Bash cmd ->
     let+ () =
       exec_run
@@ -245,26 +246,34 @@ let rec exec t ~display ~ectx ~eenv : done_or_more_deps Produce.t =
         (bash_exn ~loc:ectx.rule_loc ~needed_to:"interpret (bash ...) actions")
         [ "-e"; "-u"; "-o"; "pipefail"; "-c"; cmd ]
     in
-    Done
+    Action_res.done_
   | Write_file (fn, perm, s) ->
     let perm = Action.File_perm.to_unix_perm perm in
     let+ () = maybe_async (fun () -> Io.write_file (Path.build fn) s ~perm) in
-    Done
+    Action_res.done_
   | Rename (src, dst) ->
     let src = Path.Build.to_string src in
     let dst = Path.Build.to_string dst in
     let+ () = maybe_async (fun () -> Unix.rename src dst) in
-    Done
+    Action_res.done_
   | Remove_tree path ->
     let+ () = maybe_async (fun () -> Path.rm_rf (Path.build path)) in
-    Done
+    Action_res.done_
   | Mkdir path ->
     let+ () = maybe_async (fun () -> Path.mkdir_p (Path.build path)) in
-    Done
+    Action_res.done_
   | Pipe (outputs, l) -> exec_pipe ~display ~ectx ~eenv outputs l
   | Extension (module A) ->
     let+ () = Produce.of_fiber @@ A.Spec.action A.v ~ectx ~eenv in
-    Done
+    Action_res.done_
+  | Needed_deps paths ->
+    let needed_deps =
+      Dep.Set.union_map paths ~f:(fun path ->
+        Dep.Set.of_list_map
+          ~f:(Dune_sexp.Decoder.parse (Dep.decode eenv.working_dir) Univ_map.empty)
+          (Dune_sexp.Parser.load ~mode:Many path))
+    in
+    Produce.return (Action_res.needed_deps needed_deps)
 
 and redirect_out t ~display ~ectx ~eenv ~perm outputs fn =
   redirect t ~display ~ectx ~eenv ~out:(outputs, fn, perm) ()
@@ -302,22 +311,25 @@ and redirect t ~display ~ectx ~eenv ?in_ ?out () =
   release_out ();
   result
 
-and exec_list ts ~display ~ectx ~eenv : done_or_more_deps Produce.t =
+and exec_list ts ~display ~ectx ~eenv : Action_res.t Produce.t =
   match ts with
-  | [] -> Produce.return Done
+  | [] -> Produce.return Action_res.done_
   | [ t ] -> exec t ~display ~ectx ~eenv
   | t :: rest ->
-    let* done_or_deps =
+    let* action_res =
       let stdout_to = Process.Io.multi_use eenv.stdout_to in
       let stderr_to = Process.Io.multi_use eenv.stderr_to in
       let stdin_from = Process.Io.multi_use eenv.stdin_from in
       exec t ~display ~ectx ~eenv:{ eenv with stdout_to; stderr_to; stdin_from }
     in
-    (match done_or_deps with
-     | Need_more_deps _ as need -> Produce.return need
-     | Done -> exec_list rest ~display ~ectx ~eenv)
+    (match action_res with
+     | { done_or_more_deps = Need_more_deps _; _ } -> Produce.return action_res
+     | { done_or_more_deps = Done; needed_deps } ->
+       let* x = exec_list rest ~display ~ectx ~eenv in
+       let needed_deps = Dep.Set.union x.needed_deps needed_deps in
+       Produce.return (Action_res.needed_deps needed_deps))
 
-and exec_pipe outputs ts ~display ~ectx ~eenv : done_or_more_deps Produce.t =
+and exec_pipe outputs ts ~display ~ectx ~eenv : Action_res.t Produce.t =
   let tmp_file () =
     Dtemp.file ~prefix:"dune-pipe-action-" ~suffix:("." ^ Action.Outputs.to_string outputs)
   in
@@ -335,14 +347,17 @@ and exec_pipe outputs ts ~display ~ectx ~eenv : done_or_more_deps Produce.t =
       result
     | t :: ts ->
       let out = tmp_file () in
-      let* done_or_deps =
+      let* action_res =
         let eenv = { eenv with stderr_to = Process.Io.multi_use eenv.stderr_to } in
         redirect t ~display ~ectx ~eenv ~in_:(Stdin, in_) ~out:(Stdout, out, Normal) ()
       in
       Dtemp.destroy File in_;
-      (match done_or_deps with
-       | Need_more_deps _ as need -> Produce.return need
-       | Done -> loop ~in_:out ts)
+      (match action_res with
+       | { done_or_more_deps = Need_more_deps _; _ } -> Produce.return action_res
+       | { done_or_more_deps = Done; needed_deps } ->
+         let* res = loop ~in_:out ts in
+         let needed_deps = Dep.Set.union res.needed_deps needed_deps in
+         Produce.return (Action_res.needed_deps needed_deps))
   in
   match ts with
   | [] -> assert false
@@ -356,16 +371,23 @@ and exec_pipe outputs ts ~display ~ectx ~eenv : done_or_more_deps Produce.t =
     in
     let* done_or_deps = redirect_out t1 ~display ~ectx ~eenv ~perm:Normal outputs out in
     (match done_or_deps with
-     | Need_more_deps _ as need -> Produce.return need
-     | Done -> loop ~in_:out ts)
+     | { done_or_more_deps = Need_more_deps _; _ } -> Produce.return done_or_deps
+     | { done_or_more_deps = Done; needed_deps } ->
+       let* res = loop ~in_:out ts in
+       let needed_deps = Dep.Set.union res.needed_deps needed_deps in
+       Produce.return (Action_res.needed_deps needed_deps))
 ;;
 
 let exec_until_all_deps_ready ~display ~ectx ~eenv t =
   let rec loop ~eenv stages =
     let* result = exec ~display ~ectx ~eenv t in
     match result with
-    | Done -> Produce.return stages
-    | Need_more_deps (relative_deps, deps_to_build) ->
+    | { done_or_more_deps = Done; needed_deps = deps } ->
+      let* fact_map = Produce.of_fiber @@ ectx.build_deps deps in
+      Produce.return (stages, (deps, fact_map))
+    | { done_or_more_deps = Need_more_deps (relative_deps, deps_to_build)
+      ; needed_deps = _
+      } ->
       let* fact_map = Produce.of_fiber @@ ectx.build_deps deps_to_build in
       let stages = (deps_to_build, fact_map) :: stages in
       let eenv =
@@ -377,8 +399,11 @@ let exec_until_all_deps_ready ~display ~ectx ~eenv t =
       loop ~eenv stages
   in
   let open Fiber.O in
-  let+ stages, state = Produce.run Produce.State.empty (loop ~eenv []) in
-  { Exec_result.dynamic_deps_stages = List.rev stages; duration = state.duration }
+  let+ (stages, needed_deps), state = Produce.run Produce.State.empty (loop ~eenv []) in
+  { Exec_result.dynamic_deps_stages = List.rev stages
+  ; duration = state.duration
+  ; needed_deps
+  }
 ;;
 
 type input =

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -19,6 +19,7 @@ module Exec_result : sig
            facts map. We don't do it because conversion isn't free *)
         (Dep.Set.t * Dep.Facts.t) list
     ; duration : float option
+    ; needed_deps : Dep.Set.t * Dep.Facts.t
     }
 
   type t = (ok, Error.t list) Result.t

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -51,6 +51,7 @@ module type Ast = sig
     | Mkdir of target
     | Pipe of Outputs.t * t list
     | Extension of ext
+    | Needed_deps of path list
 end
 
 module type Helpers = sig
@@ -82,6 +83,7 @@ module type Helpers = sig
   val rename : target -> target -> t
   val remove_tree : target -> t
   val mkdir : target -> t
+  val needed_deps : path list -> t
 end
 
 module Exec = struct

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -41,6 +41,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     | Mkdir x -> Mkdir (f_target ~dir x)
     | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(fun t -> f t ~dir))
     | Extension ext -> Extension (f_ext ~dir ext)
+    | Needed_deps xs -> Needed_deps (List.map xs ~f:(f_path ~dir))
   ;;
 
   let rec map t ~dir ~f_program ~f_string ~f_path ~f_target ~f_ext =

--- a/src/dune_engine/action_plugin.mli
+++ b/src/dune_engine/action_plugin.mli
@@ -11,10 +11,22 @@ type done_or_more_deps =
 
 val done_or_more_deps_union : done_or_more_deps -> done_or_more_deps -> done_or_more_deps
 
+module Action_res : sig
+  type t =
+    { done_or_more_deps : done_or_more_deps
+    ; needed_deps : Dep.Set.t
+    }
+
+  val union : t -> t -> t
+  val done_ : t
+  val needed_deps : Dep.Set.t -> t
+  val need_more_deps : Dependency.Set.t -> Dep.Set.t -> t
+end
+
 val exec
   :  display:Display.t
   -> ectx:Action_intf.Exec.context
   -> eenv:Action_intf.Exec.env
   -> Path.t
   -> string list
-  -> done_or_more_deps Fiber.t
+  -> Action_res.t Fiber.t

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -70,6 +70,7 @@ let simplify act =
     | Mkdir x -> mkdir x :: acc
     | Pipe (outputs, l) -> Pipe (List.map ~f:block l, outputs) :: acc
     | Extension _ -> Sh "# extensions are not supported" :: acc
+    | Needed_deps _ -> Sh "# needed deps are not supported" :: acc
   and block act =
     match List.rev (loop act []) with
     | [] -> [ Run ("true", []) ]

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -586,7 +586,7 @@ end = struct
                 ~file:remove_target_file
                 ~dir:remove_target_dir)
           in
-          let* produced_targets, dynamic_deps_stages =
+          let* produced_targets, dynamic_deps_stages, needed_deps =
             (* Step III. Try to restore artifacts from the shared cache. *)
             Rule_cache.Shared.lookup ~can_go_in_shared_cache ~rule_digest ~targets
             >>= function
@@ -598,7 +598,8 @@ end = struct
                  is precisely the reason why we don't store dynamic actions in
                  the shared cache. *)
               let dynamic_deps_stages = [] in
-              Fiber.return (produced_targets, dynamic_deps_stages)
+              let needed_deps = Dep.Set.empty, Dep.Facts.empty in
+              Fiber.return (produced_targets, dynamic_deps_stages, needed_deps)
             | None ->
               (* Step IV. Execute the build action. *)
               let* exec_result =
@@ -612,6 +613,7 @@ end = struct
                   ~sandbox_mode
                   ~targets
               in
+              let needed_deps = exec_result.action_exec_result.needed_deps in
               (* Step V. Examine produced targets and store them to the shared
                  cache if needed. *)
               let* produced_targets =
@@ -632,7 +634,11 @@ end = struct
                   ~f:(fun (deps, fact_map) ->
                     deps, Dep.Facts.digest fact_map ~env:action.env)
               in
-              Fiber.return (produced_targets, dynamic_deps_stages)
+              Fiber.return (produced_targets, dynamic_deps_stages, needed_deps)
+          in
+          let needed_deps =
+            let deps, facts = needed_deps in
+            deps, Dep.Facts.digest facts ~env:action.env
           in
           (* We do not include target names into [targets_digest] because they
              are already included into the rule digest. *)
@@ -640,7 +646,8 @@ end = struct
             ~head_target
             ~rule_digest
             ~dynamic_deps_stages
-            ~targets_digest:(Targets.Produced.digest produced_targets);
+            ~targets_digest:(Targets.Produced.digest produced_targets)
+            ~needed_deps;
           Fiber.return produced_targets
       in
       let* () =

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -13,6 +13,7 @@ val universe : t
 val file_selector : File_selector.t -> t
 val alias : Alias.t -> t
 val compare : t -> t -> Ordering.t
+val decode : Dpath.t -> t Dune_sexp.Decoder.t
 
 module Map : sig
   type dep := t

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -33,7 +33,8 @@
   dune_file_watcher
   dune_filesystem_stubs
   dune_digest
-  dune_metrics)
+  dune_metrics
+  dune_lang)
  (synopsis "Internal Dune library, do not use!")
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -27,6 +27,7 @@ module Workspace_local : sig
     -> rule_digest:Digest.t
     -> dynamic_deps_stages:(Dep.Set.t * Digest.t) list
     -> targets_digest:Digest.t
+    -> needed_deps:Dep.Set.t * Digest.t
     -> unit
 end
 

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -119,6 +119,7 @@ type t =
   | Substitute of String_with_vars.t * String_with_vars.t
   | Withenv of String_with_vars.t Env_update.t list * t
   | When of Slang.blang * t
+  | Needed_deps of String_with_vars.t list
 
 val encode : t Encoder.t
 val decode_dune_file : t Decoder.t

--- a/src/dune_lang/dep_conf.mli
+++ b/src/dune_lang/dep_conf.mli
@@ -42,6 +42,7 @@ type t =
      (e.g. absolute path of cwd) and you want to allow it) *)
   | Sandbox_config of Sandbox_config.t
   | Include of string
+  | Order_only of t list
 
 val remove_locs : t -> t
 

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -569,6 +569,9 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
   | Withenv _ | Substitute _ | Patch _ | When _ ->
     (* these can only be provided by the package language which isn't expanded here *)
     assert false
+  | Needed_deps xs ->
+    let+ xs = A.all (List.map ~f:E.dep xs) in
+    O.Needed_deps xs
 ;;
 
 let expand_no_targets t ~loc ~chdir ~deps:deps_written_by_user ~expander ~what =

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -256,6 +256,12 @@ let rec dep expander : Dep_conf.t -> _ = function
        let+ () = Action_builder.env_var var in
        [])
   | Sandbox_config _ -> Other (Action_builder.return [])
+  | Order_only s ->
+    let l = List.map ~f:(dep expander) s in
+    let builder =
+      Action_builder.goal (Action_builder.List.concat_map l ~f:to_action_builder)
+    in
+    Other builder
 
 and named_paths_builder ~expander l =
   let builders, bindings =

--- a/test/blackbox-tests/test-cases/needed-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/needed-deps.t/run.t
@@ -1,0 +1,56 @@
+Test the needed_deps action, which declares the dependencies written
+in the passed files as needed dependencies for the rule. The tests are
+made for all the constructors.
+
+  $ generatefile () {
+  > cat >$1 <<EOF
+  > contents of $2
+  > EOF
+  > }
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ generatefile a a_now
+
+  $ generatefile b b_now
+
+  $ generatefile c c_now
+
+  $ generatefile d d_now
+
+  $ cat >dune <<EOF
+  > (alias
+  >  (name test) (deps c))
+  > (rule
+  >  (alias foo)
+  >  (deps (order_only (file a) (file b) (file d) (alias test)))
+  >  (action
+  >  (progn
+  >  (echo "executing foo")
+  >  (with-stdout-to deps (echo "(file b) (alias test) (file_selector d)"))
+  >  (needed_deps deps))))
+  > EOF
+
+  $ dune build @foo
+  executing foo
+
+  $ generatefile a a_changed
+
+  $ dune build @foo
+
+  $ generatefile b b_changed
+
+  $ dune build @foo
+  executing foo
+
+  $ generatefile c c_changed
+
+  $ dune build @foo
+  executing foo
+
+  $ generatefile d d_changed
+
+  $ dune build @foo
+  executing foo

--- a/test/blackbox-tests/test-cases/order-only.t/run.t
+++ b/test/blackbox-tests/test-cases/order-only.t/run.t
@@ -1,0 +1,27 @@
+This test ensures that dependencies defined with 'order_only'
+specification do not retrigger the concerned rule.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.17)
+  > EOF
+
+  $ cat >a <<EOF
+  > contents of a
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (deps (order_only (file a)))
+  >  (action
+  >  (echo "executing foo")))
+  > EOF
+
+  $ dune build @foo
+  executing foo
+
+  $ cat >a <<EOF
+  > contents of a changed
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
This PR (written as part of an internship at LexiFi) is an attempt to add support for order-only and post-use dependencies to the Dune engine. For a discussion of these notions and further background, see #5514. However, for simplicity, we explain the notions briefly:

- **Order-only** dependencies: an order-only dependency of a rule is a dependency that is guaranteed to be up-to-date when the rule is refreshed, but that changes to the dependency **do not** retrigger the rule.

- **Post-use** dependencies: a post-use dependency of a rule is an (ordinary) dependency that is declared **after** the rule action executes. This may sound a bit weird but it becomes interesting when the dependency is also declared as an order-only dependency of the rule.

The prototypical use of these notions is as follows: you have a rule for which the precise set of actual dependencies is hard to specify (eg the set of headers needed to compile a C file), so you declare an overapproximation (eg: all `*.h` files in a given directory) of the dependency set as order-only dependencies of the rule. When the rule is triggered, it produces as a side-effect the set of precise dependencies (eg `gcc -MD`) which can then be declared as "actual" (post-use) dependencies. Dune is then able to use this information to avoid retriggering the rule if a non-actual order-only dependency changes.

The PR contains two commits:

**First commit**

Here, we add support for "order-only" dependencies. This notion is actually already supported by the Dune engine (via the `Action_builder.goal` combinator), but not currently exposed in the Dune language. This commit exposes this notion in the Dune language via a `(order_only <dep>)` constructor. There is a small test to exhibit its effect.

**Second commit**

In this commit we add support for "post-use" dependencies. Concretely we add an **action** `(needed_deps <paths>)` that can be used to declare "actual" dependencies as part of the action (the idea being that `<paths>` are created as a side-effect of previous actions). Each `<path>` is supposed to contain zero or more S-expressions describing dependencies (following a grammar corresponding almost exactly to a subset of the usual dependency language). A few remarks about the implementation are below. A test for this feature is similarly included.

Both features are documented in the PR, but the intent is not necessarily to expose the features to the user at this time; the documentation was mainly to help understand the features for review. If we want to keep these features, we may decide not to expose them to the user in this way at this time.

**What is missing.**

- When one declares "post-use" dependencies in the way described above, it is necessary for correctness that these dependencies be a subset of the declared dependencies of the rule. Otherwise the dependencies in question may not be up-to-date when the action that needs them executes. In other words, the whole point of "post-use" dependencies is that they should already be up-to-date when the action begins to execute and `(needed_deps)` is only there to help Dune refine the condition for retriggering the rule. This means that `(needed_deps)` should never actually trigger any building; and it is an error if actual building is necessary. However, this is not checked at this time. I have a patch more or less ready for this, but it seems better to leave this for later once an initial review of the general approach is done.

- For now, rules using `(needed_deps)` are not stored in the shared cache. However, in principle this should be possible to do, but it was left for later for simplicity. (Some changes to the semantics of the shared cache appear to be required.)

**Indications about the implementation of the second commit**

The goal is to use the knowledge of actual/post-use dependencies to optimize rebuilding of a rule. To do that, we reuse the code path used to transmit "dynamic" dependencies (as in the Action plugin) back to the build system. We extend the relevant type to also transmit back the set of needed dependencies gathered during action execution. This set of actual dependencies so obtained are then stored in the local workspace cache entry for the rule. When Dune looks up a rule in the local cache to decide whether to re-execute it (using `Rule_cache.Workspace_local.lookup`), the digest of the needed deps is checked to decide if the rule is up-to-date or not. If these dependencies are additionally declared as order-only, then the net effect is that the rule will not be retriggered if an order-only, non-actual dependency changes.

The work in this PR was supervised by @nojb.

Assigning to engine expert @snowleopard, but any and all comments warmly welcome.