### PR TITLE
Add fake curl exe to ocamlformat tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
@@ -1,3 +1,7 @@
 (cram
  (deps helpers.sh)
  (applies_to :whole_subtree))
+
+(cram
+ (deps %{bin:curl})
+ (applies_to ocamlformat-e2e))


### PR DESCRIPTION
The tests would sometimes try to run the system curl executable which would cause the tests to fail.