### PR TITLE
fix(pkg): `dune fmt` missing extra files from the locks.

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -82,12 +82,40 @@ let run_build_system ~common ~request =
       Fiber.return ())
 ;;
 
-let run_build_command_poll_eager ~(common : Common.t) ~config ~request : unit =
-  Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config (fun () ->
-    Scheduler.Run.poll (run_build_system ~common ~request))
+let lock_ocamlformat () =
+  if Lazy.force Lock_dev_tool.is_enabled
+  then
+    (* Note that generating the ocamlformat lockdir here means
+       that it will be created when a user runs `dune fmt` but not
+       when a user runs `dune build @fmt`. It's important that
+       this logic remain outside of `dune build`, as `dune
+       build` is intended to only build targets, and generating
+       a lockdir is not building a target. *)
+    Lock_dev_tool.lock_ocamlformat () |> Memo.run
+  else Fiber.return ()
 ;;
 
-let run_build_command_poll_passive ~(common : Common.t) ~config ~request:_ : unit =
+let run_build_command_poll_eager
+  ~with_lock_ocamlformat
+  ~(common : Common.t)
+  ~config
+  ~request
+  : unit
+  =
+  let open Fiber.O in
+  Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config (fun () ->
+    Scheduler.Run.poll
+      (let* () = if with_lock_ocamlformat then lock_ocamlformat () else Fiber.return () in
+       run_build_system ~common ~request))
+;;
+
+let run_build_command_poll_passive
+  ~with_lock_ocamlformat
+  ~(common : Common.t)
+  ~config
+  ~request:_
+  : unit
+  =
   (* CR-someday aalekseyev: It would've been better to complain if [request] is
      non-empty, but we can't check that here because [request] is a function.*)
   let open Fiber.O in
@@ -99,16 +127,20 @@ let run_build_command_poll_passive ~(common : Common.t) ~config ~request:_ : uni
   Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config (fun () ->
     Scheduler.Run.poll_passive
       ~get_build_request:
-        (let+ (Build (targets, ivar)) = Dune_rpc_impl.Server.pending_build_action rpc in
+        (let* () =
+           if with_lock_ocamlformat then lock_ocamlformat () else Fiber.return ()
+         in
+         let+ (Build (targets, ivar)) = Dune_rpc_impl.Server.pending_build_action rpc in
          let request setup =
            Target.interpret_targets (Common.root common) config setup targets
          in
          run_build_system ~common ~request, ivar))
 ;;
 
-let run_build_command_once ~(common : Common.t) ~config ~request =
+let run_build_command_once ~with_lock_ocamlformat ~(common : Common.t) ~config ~request =
   let open Fiber.O in
   let once () =
+    let* () = if with_lock_ocamlformat then lock_ocamlformat () else Fiber.return () in
     let+ res = run_build_system ~common ~request in
     match res with
     | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
@@ -122,6 +154,18 @@ let run_build_command ~(common : Common.t) ~config ~request =
    | Yes Eager -> run_build_command_poll_eager
    | Yes Passive -> run_build_command_poll_passive
    | No -> run_build_command_once)
+    ~with_lock_ocamlformat:false
+    ~common
+    ~config
+    ~request
+;;
+
+let run_build_command_fmt ~(common : Common.t) ~config ~request =
+  (match Common.watch common with
+   | Yes Eager -> run_build_command_poll_eager
+   | Yes Passive -> run_build_command_poll_passive
+   | No -> run_build_command_once)
+    ~with_lock_ocamlformat:true
     ~common
     ~config
     ~request

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -13,6 +13,31 @@ let man =
   ]
 ;;
 
+let lock_ocamlformat () =
+  if Lazy.force Lock_dev_tool.is_enabled
+  then
+    (* Note that generating the ocamlformat lockdir here means
+       that it will be created when a user runs `dune fmt` but not
+       when a user runs `dune build @fmt`. It's important that
+       this logic remain outside of `dune build`, as `dune
+       build` is intended to only build targets, and generating
+       a lockdir is not building a target. *)
+    Lock_dev_tool.lock_ocamlformat () |> Memo.run
+  else Fiber.return ()
+;;
+
+let run_fmt_command ~(common : Common.t) ~config ~request =
+  let open Fiber.O in
+  let once () =
+    let* () = lock_ocamlformat () in
+    let+ res = Build_cmd.run_build_system ~common ~request in
+    match res with
+    | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
+    | Ok () -> ()
+  in
+  Scheduler.go ~common ~config once
+;;
+
 let command =
   let term =
     let+ builder = Common.Builder.term
@@ -32,24 +57,11 @@ let command =
     in
     let common, config = Common.init builder in
     let request (setup : Import.Main.build_system) =
-      let open Action_builder.O in
-      let* () =
-        if Lazy.force Lock_dev_tool.is_enabled
-        then
-          (* Note that generating the ocamlformat lockdir here means
-             that it will be created when a user runs `dune fmt` but not
-             when a user runs `dune build @fmt`. It's important that
-             this logic remain outside of `dune build`, as `dune
-             build` is intended to only build targets, and generating
-             a lockdir is not building a target. *)
-          Action_builder.of_memo (Lock_dev_tool.lock_ocamlformat ())
-        else Action_builder.return ()
-      in
       let dir = Path.(relative root) (Common.prefix_target common ".") in
       Alias.in_dir ~name:Dune_rules.Alias.fmt ~recursive:true ~contexts:setup.contexts dir
       |> Alias.request
     in
-    Build_cmd.run_build_command ~common ~config ~request
+    run_fmt_command ~common ~config ~request
   in
   Cmd.v (Cmd.info "fmt" ~doc ~man ~envs:Common.envs) term
 ;;


### PR DESCRIPTION
This PR follows https://github.com/ocaml/dune/pull/10947  in which we could see the reproduction of the bug from the issue https://github.com/ocaml/dune/issues/10903.

It turns out, the issue is not a race condition, the auto-locking/solve for the dev-tool save the lock files after the setup of the build. Since `dune` setup once in the same run, the patch files ends up missing during the build. 