### PR TITLE
refactor(pkg test): Avoid `gzip` on tarballs

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -8,7 +8,7 @@ Make a library that would fail when building it:
   $ mkdir foo
   $ cat > foo/dune-project <<EOF
   > EOF
-  $ tar -czf foo.tar.gz foo
+  $ tar cf foo.tar foo
   $ rm -rf foo
 
 Make a project that uses the foo library:
@@ -33,8 +33,8 @@ Make dune.lock files
   > (depexts unzip gnupg)
   > (source
   >  (fetch
-  >   (url file://$PWD/foo.tar.gz)
-  >   (checksum md5=$(md5sum foo.tar.gz | cut -f1 -d' '))))
+  >   (url file://$PWD/foo.tar)
+  >   (checksum md5=$(md5sum foo.tar | cut -f1 -d' '))))
   > EOF
 
 Build the project, when it fails building 'foo' package, it shows

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -12,7 +12,7 @@ Clarify the behavior when the `dune` in PATH is not the one used to start the bu
   >  (allow_empty))
   > EOF
   > cd ..
-  > tar -czf $1.tar.gz tmp
+  > tar cf $1.tar tmp
   > rm -rf tmp
   > }
 
@@ -43,7 +43,7 @@ Make lockfiles for the packages.
   > 
   > (source
   >  (fetch
-  >   (url $PWD/foo.tar.gz)))
+  >   (url $PWD/foo.tar)))
   > 
   > (dev)
   > EOF
@@ -57,7 +57,7 @@ Make lockfiles for the packages.
   > 
   > (source
   >  (fetch
-  >   (url $PWD/bar.tar.gz)))
+  >   (url $PWD/bar.tar)))
   > 
   > (dev)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -19,12 +19,12 @@ Make a library:
   >  (public_name foo))
   > EOF
   $ cd ..
-  $ tar -czf foo.tar.gz foo
+  $ tar cf foo.tar foo
   $ rm -rf foo
 
 Configure our fake curl to serve the tarball
 
-  $ echo foo.tar.gz >> fake-curls
+  $ echo foo.tar >> fake-curls
   $ PORT=1
 
 Make a package for the library:
@@ -46,7 +46,7 @@ Make a package for the library:
   > url {
   >  src: "http://0.0.0.0:$PORT"
   >  checksum: [
-  >   "md5=$(md5sum foo.tar.gz | cut -f1 -d' ')"
+  >   "md5=$(md5sum foo.tar | cut -f1 -d' ')"
   >  ]
   > }
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -28,7 +28,7 @@ EOF
 (executable
  (public_name ocamlformat))
 EOF
-  tar -czf ocamlformat-$version.tar.gz ocamlformat
+  tar cf ocamlformat-$version.tar ocamlformat
   rm -rf ocamlformat
 }
 
@@ -55,7 +55,7 @@ build: [
 url {
   src: "http://127.0.0.1:$port"
   checksum: [
-    "md5=$(md5sum ocamlformat-$version.tar.gz | cut -f1 -d' ')"
+    "md5=$(md5sum ocamlformat-$version.tar | cut -f1 -d' ')"
   ]
 }
 EOF
@@ -71,9 +71,9 @@ build: [
   ]
 ]
 url {
-  src: "file://$PWD/ocamlformat-$version.tar.gz"
+  src: "file://$PWD/ocamlformat-$version.tar"
   checksum: [
-    "md5=$(md5sum ocamlformat-$version.tar.gz | cut -f1 -d' ')"
+    "md5=$(md5sum ocamlformat-$version.tar | cut -f1 -d' ')"
   ]
 }
 EOF
@@ -128,7 +128,7 @@ EOF
 (library
  (public_name printer))
 EOF
-  tar -czf printer.$version.tar.gz printer
+  tar cf printer.$version.tar printer
   rm -r printer
 }
 
@@ -145,9 +145,9 @@ build: [
    ]
  ]
  url {
- src: "file://$PWD/printer.$version.tar.gz"
+ src: "file://$PWD/printer.$version.tar"
  checksum: [
-  "md5=$(md5sum printer.$version.tar.gz | cut -f1 -d' ')"
+  "md5=$(md5sum printer.$version.tar | cut -f1 -d' ')"
  ]
 }
 EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -25,7 +25,7 @@ Make a fake OCamlFormat which depends on printer lib:
   >  (libraries printer))
   > EOF
   $ cd ..
-  $ tar -czf ocamlformat.tar.gz ocamlformat
+  $ tar cf ocamlformat.tar ocamlformat
   $ rm -rf ocamlformat
 
 Make a printer lib(version 1) that prints "formatted":
@@ -51,9 +51,9 @@ Make a package for the fake OCamlFormat library which depends on printer.1.0:
   >   ]
   > ]
   > url {
-  >  src: "file://$PWD/ocamlformat.tar.gz"
+  >  src: "file://$PWD/ocamlformat.tar"
   >  checksum: [
-  >   "md5=$(md5sum ocamlformat.tar.gz | cut -f1 -d' ')"
+  >   "md5=$(md5sum ocamlformat.tar | cut -f1 -d' ')"
   >  ]
   > }
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -7,13 +7,13 @@ Exercises end to end, locking and building ocamlformat dev tool.
   $ make_fake_ocamlformat "0.26.3"
 
 Add the tar file for the fake curl to copy it:
-  $ echo ocamlformat-0.26.2.tar.gz > fake-curls
+  $ echo ocamlformat-0.26.2.tar > fake-curls
   $ PORT=1
 
   $ make_ocamlformat_opam_pkg "0.26.2" $PORT
 
 Add the tar file for the fake curl to copy it:
-  $ echo ocamlformat-0.26.3.tar.gz >> fake-curls
+  $ echo ocamlformat-0.26.3.tar >> fake-curls
   $ PORT=2
 
 We consider this version of OCamlFormat as the latest version:

--- a/test/blackbox-tests/test-cases/pkg/source-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/source-caching.t
@@ -4,10 +4,10 @@ This test demonstrates that fetching package sources should be cached
 
   $ make_lockdir
 
-  $ tarball=source.tar.gz
+  $ tarball=source.tar
   $ sources="sources/"
   $ mkdir $sources; touch $sources/dummy
-  $ tar -czf $tarball $sources
+  $ tar cf $tarball $sources
   $ checksum=$(md5sum $tarball | awk '{ print $1 }')
   $ echo $tarball > fake-curls
   $ port=1


### PR DESCRIPTION
This avoids gzipping the tarballs that are created to test end to end functionality. Compressing and decompressing them takes time for minimal space saving so this PR just removes it.

It retains the compression in the tarballs test, to make sure compressed tarballs continue to work.