### PR TITLE
update nixpkgs in flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726142289,
-        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
+        "lastModified": 1727524699,
+        "narHash": "sha256-k6YxGj08voz9NvuKExojiGXAVd69M8COtqWSKr6sQS4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
+        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This allows for `./dune.exe build @check` to run again in the `nix develop`er mode.

I tried updating the entire flake, but there are build errors in ocaml-lsp so I stuck to nixpkgs for the time being.