### PR TITLE
fix: pp_infinity is unused in the mli on 5.2

### DIFF
--- a/otherlibs/stdune/src/format.mli
+++ b/otherlibs/stdune/src/format.mli
@@ -1,3 +1,3 @@
-val pp_infinity : int
+val pp_infinity : int [@@warning "-32"]
 
 include module type of Stdlib.Format


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>
