### PR TITLE
Minor changes to package management tutorial

### DIFF
--- a/doc/tutorials/dune-package-management/dependencies.md
+++ b/doc/tutorials/dune-package-management/dependencies.md
@@ -24,7 +24,7 @@ First we update the `dune-project` file to add a dependeny on the opam package.
 After this change to our project dependencies, we need to relock dependencies
 to update our lock directory with the new packages.
 
-```sh
+```
 $ dune pkg lock
 Solution for dune.lock:
 - base-unix.base
@@ -45,7 +45,7 @@ including transitive dependencies.
 :::
 
 This will take care of installing the dependencies, but we still need to add it to
-our build as a library, as usual:
+our build as a library as usual:
 
 ::::{dropdown} `dune`
 :icon: file-code
@@ -76,7 +76,7 @@ and then use it to print the value.
 
 To build it we just call `build` again.
 
-```sh
+```
 $ dune build
 ```
 
@@ -85,7 +85,7 @@ before.
 
 As we see, the code works and uses `fmt` to do the pretty-printing:
 
-```sh
+```
 $ dune exec ./test.exe
 Hello, OCaml, Rust!
 ```
@@ -110,7 +110,7 @@ This ensures the `fmt` package to install will be compatible with
 our request. These constraints will be taken into account the next time the
 package is locked:
 
-```sh
+```
 $ dune pkg lock
 Solution for dune.lock:
 - base-unix.base

--- a/doc/tutorials/dune-package-management/pinning.md
+++ b/doc/tutorials/dune-package-management/pinning.md
@@ -45,8 +45,8 @@ Unlike previously, the version of the `fmt` library that is picked is `dev`, to
 signify a development version.
 
 The next time the project is built, the `fmt` package will be built from the
-source in the specified git repository rather than from the source tarball
-released in the opam repository.
+source in the specified Git repository rather than from the source tarball
+released in the `opam-repository`.
 
 ```
 $ dune exec ./test.exe

--- a/doc/tutorials/dune-package-management/pinning.md
+++ b/doc/tutorials/dune-package-management/pinning.md
@@ -2,8 +2,8 @@
 
 When Dune is looking up packages to lock, it uses the (pre)configured OCaml
 package repositories. However it is also possible to manually specify the
-sources for packages; for example, if the package is not released in a package
-repository. This is called "pinning."
+sources of packages; for example, if the package is not released in a package
+repository. This is called "pinning".
 
 ## Installing Packages From a Pin
 
@@ -14,18 +14,21 @@ To pin a package, a new `pin` has to be declared in the `dune-project` file.
 
 :::{literalinclude} pinning/dune-project
 :language: dune
-:emphasize-lines: 4-6
+:emphasize-lines: 4-6,12
 :::
 
 This will create a pin on the `fmt` package and use the specified Git repository
 URL to retrieve the sources.
+
+Don't forget to remove the version constraints from `fmt` in the list of
+dependencies.
 
 ::::
 
 The next time the package is locked, Dune will use this repository instead of
 the information from the selected package repositories.
 
-```sh
+```
 $ dune pkg lock
 Solution for dune.lock:
 - base-unix.base
@@ -41,10 +44,11 @@ Solution for dune.lock:
 Unlike previously, the version of the `fmt` library that is picked is `dev`, to
 signify a development version.
 
-The next build will check out the sources from that repository instead of
-downloading the release tarball:
+The next time the project is built, the `fmt` package will be built from the
+source in the specified git repository rather than from the source tarball
+released in the opam repository.
 
-```sh
+```
 $ dune exec ./test.exe
 Hello, OCaml, Rust!
 ```

--- a/doc/tutorials/dune-package-management/repos.md
+++ b/doc/tutorials/dune-package-management/repos.md
@@ -22,14 +22,14 @@ if it didn't exist):
 ::::
 
 In this case, we want to select a specific revision of the community repository
-instead of always using the most recent one, as it would do by default. We
+instead of always using the most recent one as it would do by default. We
 define a new repository and configure the lock directory to use this
 repository.
 
 When relocking the dependencies, the list of packages that are found as
 dependencies changes accordingly:
 
-```sh
+```
 $ dune pkg lock
 Solution for dune.lock:
 - base-unix.base

--- a/doc/tutorials/dune-package-management/setup.md
+++ b/doc/tutorials/dune-package-management/setup.md
@@ -20,7 +20,7 @@ dependencies in the `dune-project` file.
 :emphasize-lines: 6-7
 :::
 
-We define a project called `test` and define that to build it we need an OCaml
+We define a project called `test` and declare that to build it we need an OCaml
 compiler that is at least version 4.14.
 
 This is exactly the same information that is used to generate opam files using
@@ -61,7 +61,7 @@ After declaring the dependencies, you will need to tell Dune which package
 versions to use for your project. This is done by creating a lock directory.
 This is easily done with a new Dune command:
 
-```sh
+```
 $ dune pkg lock
 Solution for dune.lock:
 - ocaml.5.2.0
@@ -95,7 +95,7 @@ before.
 
 We can show that the package has been built successfully and works as expected:
 
-```sh
+```
 $ dune exec ./test.exe
 Hello, OCaml, Rust!
 ```
@@ -103,7 +103,7 @@ Hello, OCaml, Rust!
 ## Conclusion
 
 In this section we learned how to set up a Dune project that picks a compiler
-and installs it without need for any additional tooling.
+and installs it without the need for any additional tooling.
 
 In the next section {doc}`dependencies` we will look on how to add third party
 dependencies.


### PR DESCRIPTION
A couple of minor rewords and formatting changes:
 - Removed the `sh` syntax highlighting on terminal sessions (anything starting with a `$`) to prevent unintentionally-highlighted words, such as the "for" in "Solution for dune.lock:".
 - Removed some unnecessary commas
 - A note about removing the version constraints from the `fmt` dependency as readers will probably forget to do this (I did!) and the resulting solver error is hard to read.
 - Clarified some text about pinning