### PR TITLE
fix(cram): improve error message on sh unavailable

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -424,7 +424,12 @@ let run ~env ~script lexbuf : string Fiber.t =
   let+ () =
     let sh =
       let path = Env_path.path Env.initial in
-      Option.value_exn (Bin.which ~path "sh")
+      match Bin.which ~path "sh" with
+      | Some sh -> sh
+      | None ->
+        let hints = Pp.[ text "Try to add (deps %{bin:sh} ) to the (cram) stanza" ] in
+        let msg = Pp.[ text "CRAM test aborted, \"sh\" can not be found PATH" ] in
+        User_error.raise ~hints msg
     in
     let metadata =
       let name =

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -427,8 +427,7 @@ let run ~env ~script lexbuf : string Fiber.t =
       match Bin.which ~path "sh" with
       | Some sh -> sh
       | None ->
-        let msg = Pp.[ text "CRAM test aborted, \"sh\" can not be found PATH" ] in
-        User_error.raise msg
+        User_error.raise [ Pp.text "CRAM test aborted, \"sh\" can not be found in PATH" ]
     in
     let metadata =
       let name =

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -427,9 +427,8 @@ let run ~env ~script lexbuf : string Fiber.t =
       match Bin.which ~path "sh" with
       | Some sh -> sh
       | None ->
-        let hints = Pp.[ text "Try to add (deps %{bin:sh} ) to the (cram) stanza" ] in
         let msg = Pp.[ text "CRAM test aborted, \"sh\" can not be found PATH" ] in
-        User_error.raise ~hints msg
+        User_error.raise msg
     in
     let metadata =
       let name =


### PR DESCRIPTION
This PR improves the message of the error mentioned in #10872. It is a simple improvement to make the error more readable and provide a hint when users forget to add the `sh` dependency.

However, as it happens on Windows, I can't test the behaviour. @rgrinberg do you think it is fine to not add a test here as it only improves an error message?
