### PR TITLE
flake: add dep on myst-parser to docInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,7 @@
                 furo
                 sphinx-copybutton
                 sphinx-design
+                myst-parser
               ];
               duneScript =
                 writeScriptBin "dune" ''


### PR DESCRIPTION
This is needed to run `make doc` when dependencies are installed from flake.nix.