### PR TITLE
doc: Add version info to the codeberg documentation

### DIFF
--- a/doc/reference/dune-project/generate_opam_files.rst
+++ b/doc/reference/dune-project/generate_opam_files.rst
@@ -86,7 +86,7 @@ defined in the project:
      * - `Sourcehut <https://sr.ht>`_
        - ``(sourcehut user/repo)``
      * - `Codeberg <https://codeberg.org>`_
-       - ``(codeberg user/repo)``
+       - ``(codeberg user/repo)`` *(New in 3.17)*
 
    Examples:
 


### PR DESCRIPTION
When #10904 was merged it missed to declare the version support for `codeberg` was added.