### PR TITLE
refactor(pkg): only pass what is necessary to various functions

### DIFF
--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -15,7 +15,7 @@ val create
     not the case, it returns the hash of the new dependency set. *)
 val up_to_date
   :  Local_package.t Package_name.Map.t
-  -> Lock_dir.t
+  -> dependency_hash:Local_package.Dependency_hash.t option
   -> [ `Valid | `Invalid of Local_package.Dependency_hash.t option ]
 
 (** Returns the dependencies of the specified package within the package

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -668,7 +668,11 @@ let raise_on_lock_dir_out_of_sync =
           Dune_load.packages ()
           >>| Dune_lang.Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
         in
-        match Dune_pkg.Package_universe.up_to_date local_packages lock_dir with
+        match
+          Dune_pkg.Package_universe.up_to_date
+            local_packages
+            ~dependency_hash:(Option.map ~f:snd lock_dir.dependency_hash)
+        with
         | `Valid -> ()
         | `Invalid _ ->
           let hints = Pp.[ text "run dune pkg lock" ] in


### PR DESCRIPTION
Whenever it's reasonable, try to pass only what is necessary to functions in `Dune_pkg.Universe`. This makes it easier to understand the code as one only has to consider the inputs that are being used.