### PR TITLE
fix(pkg): add location hash mismatch error

### DIFF
--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -143,9 +143,8 @@ let up_to_date local_packages ~dependency_hash:saved_dependency_hash =
            non_local_dependencies_hash -> `Valid
   | None, Some _ ->
     `Valid (* This case happens when the user writes themselves their lock.dune. *)
-  | Some _, Some non_local_dependencies_hash ->
-    `Invalid (Some non_local_dependencies_hash)
-  | Some _, None -> `Invalid None
+  | Some _, Some _ -> `Invalid
+  | Some _, None -> `Invalid
 ;;
 
 let validate_dependency_hash local_packages ~saved_dependency_hash =

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -16,7 +16,7 @@ val create
 val up_to_date
   :  Local_package.t Package_name.Map.t
   -> dependency_hash:Local_package.Dependency_hash.t option
-  -> [ `Valid | `Invalid of Local_package.Dependency_hash.t option ]
+  -> [ `Valid | `Invalid ]
 
 (** Returns the dependencies of the specified package within the package
     universe *)

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -3,6 +3,7 @@ module Pkg = Dune_pkg.Lock_dir.Pkg
 
 type t := Dune_pkg.Lock_dir.t
 
+val get_with_path : Context_name.t -> (Path.Source.t * t, User_message.t) result Memo.t
 val get : Context_name.t -> (t, User_message.t) result Memo.t
 val get_exn : Context_name.t -> t Memo.t
 val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t

--- a/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
@@ -41,6 +41,7 @@ We add the bar dependency to the test package
 
 It fails as we have not regenerated the lock:
   $ dune build
+  File "dune.lock/lock.dune", line 1, characters 0-0:
   Error: The lock dir is not sync with your dune-project
   Hint: run dune pkg lock
   [1]


### PR DESCRIPTION
We use the lock directory as the location rather than pointing at the hash, as the user shouldn't really touch the hash.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>