### PR TITLE
Fix the compilation of OCaml 5 programs on Cygwin

### DIFF
--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -14,7 +14,7 @@ let base_cxx_compile_flags version = function
   | Gcc | Clang ->
     "-x"
     :: "c++"
-    :: (if Ocaml.Version.add_std_cxx_flag version then [ "-std=c++11" ] else [])
+    :: (if Ocaml.Version.add_std_cxx_flag version then [ "-std=gnu++11" ] else [])
   | Msvc -> [ "/TP" ]
   | Other _ -> []
 ;;

--- a/test/blackbox-tests/test-cases/cpp-std-ocaml5.t/cpp11.cpp
+++ b/test/blackbox-tests/test-cases/cpp-std-ocaml5.t/cpp11.cpp
@@ -1,8 +1,14 @@
 #include <caml/misc.h>
 #include <caml/mlvalues.h>
 #include <iostream>
+#include <cstring>
 
+// strdup is not part of the C standard library but is part of POSIX.
+// By default GCC and Clang both use the GNU variant of the C standard,
+// so we are using strdup here to ensure users have access to it by default.
+// If -std=c++11 is used instead of -std=gnu++11 this would fail to compile
+// on non-POSIX platforms such as Cygwin.
 extern "C" CAMLprim value cpp11(value _unit) {
-  std::cout << "Hi from C++11" << std::endl;
+  std::cout << strdup("Hi from C++11") << std::endl;
   return Val_unit;
 }


### PR DESCRIPTION
Functions like `strdup` are not part of the C standard library but is part of POSIX. By default GCC and Clang both use the GNU variant of the C standard, so we are using strdup here to ensure users have access to it by default. If `-std=c++11` is used instead of `-std=gnu++11` this would fail to compile on non-POSIX platforms such as Cygwin.

This fixes an oversight from #10962 