### PR TITLE
pkg: add binary dev tools repo

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -78,7 +78,7 @@ let solve ~dev_tool ~local_packages =
   let lock_dir = Lock_dir.dev_tool_lock_dir_path dev_tool in
   Memo.of_reproducible_fiber
   @@ Lock.solve
-       workspace
+       (Workspace.add_repo workspace Dune_pkg.Pkg_workspace.Repository.binary_packages)
        ~local_packages
        ~project_sources:Dune_pkg.Pin_stanza.DB.empty
        ~solver_env_from_current_system

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -62,7 +62,7 @@ let repositories_of_lock_dir workspace ~lock_dir_path =
   match Workspace.find_lock_dir workspace lock_dir_path with
   | Some lock_dir -> lock_dir.repositories
   | None ->
-    List.map Workspace.default_repositories ~f:(fun repo ->
+    List.map workspace.repos ~f:(fun repo ->
       let name = Dune_pkg.Pkg_workspace.Repository.name repo in
       let loc = Loc.none in
       loc, name)

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -47,6 +47,14 @@ type t =
   ; serializable : Serializable.t option
   }
 
+let to_dyn { source; loc; serializable } =
+  Dyn.record
+    [ "source", Source_backend.to_dyn source
+    ; "loc", Loc.to_dyn loc
+    ; "serializable", Dyn.option Serializable.to_dyn serializable
+    ]
+;;
+
 let equal { source; serializable; loc } t =
   Source_backend.equal source t.source
   && Option.equal Serializable.equal serializable t.serializable

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -11,6 +11,7 @@ module Serializable : sig
   val to_dyn : t -> Dyn.t
 end
 
+val to_dyn : t -> Dyn.t
 val equal : t -> t -> bool
 
 (** [of_opam_repo_dir_path opam_repo_dir] creates a repo represented by a local

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -52,6 +52,15 @@ module Repository = struct
     }
   ;;
 
+  let binary_packages =
+    { name = "binary-packages"
+    ; source =
+        ( Loc.none
+        , OpamUrl.of_string "git+https://github.com/ocaml-dune/ocaml-binary-packages.git"
+        )
+    }
+  ;;
+
   let decode =
     let open Decoder in
     fields

--- a/src/dune_pkg/workspace.mli
+++ b/src/dune_pkg/workspace.mli
@@ -9,6 +9,7 @@ module Repository : sig
   val equal : t -> t -> bool
   val upstream : t
   val overlay : t
+  val binary_packages : t
   val decode : t Decoder.t
 
   module Name : sig

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -682,6 +682,8 @@ let find_lock_dir t path =
   List.find t.lock_dirs ~f:(fun lock_dir -> Path.Source.equal lock_dir.path path)
 ;;
 
+let add_repo t repo = { t with repos = repo :: t.repos }
+
 include Dune_lang.Versioned_file.Make (struct
     type t = unit
   end)

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -124,6 +124,7 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val hash : t -> int
 val find_lock_dir : t -> Path.Source.t -> Lock_dir.t option
+val add_repo : t -> Dune_pkg.Pkg_workspace.Repository.t -> t
 val default_repositories : Dune_pkg.Pkg_workspace.Repository.t list
 
 module Clflags : sig


### PR DESCRIPTION
Adds a repo of binary dev tools to dune so that dev tools can be quickly installed without the need to download and compile their entire dependency cone on supported platforms. Currently ocamlfind and ocamllsp are included in the repo.