### PR TITLE
test(pkg): use explicit build targets

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -21,6 +21,6 @@ Test that section pforms are substituted with absolute paths.
 
 Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
-  $ dune build 2>&1 | strip_sandbox
+  $ build_pkg test 2>&1 | strip_sandbox
   --prefix $SANDBOX/_private/default/.pkg/test/target
   $SANDBOX/_private/default/.pkg/test/target

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -63,7 +63,7 @@ Make lockfiles for the packages.
   > EOF
 
 Test that the project can be built normally.
-  $ dune build
+  $ build_pkg foo
 
 Make a fake dune exe:
   $ mkdir bin
@@ -76,6 +76,7 @@ Make a fake dune exe:
   $ dune clean
 Try building in an environment where `dune` refers to the fake dune.
   $ DUNE=$(which dune)  # otherwise we would start by running the wrong dune
-  $ PATH=$PWD/bin:$PATH $DUNE build
-  Fake dune! (args: build -p bar @install)
+  $ PATH=$PWD/bin:$PATH $DUNE build $pkg_root/foo/target/
   Fake dune! (args: build -p foo @install)
+  $ PATH=$PWD/bin:$PATH $DUNE build $pkg_root/bar/target/
+  Fake dune! (args: build -p bar @install)

--- a/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
@@ -27,7 +27,7 @@ file in the package's source.
   >  (depends foo))
   > EOF
 
-  $ dune build
+  $ build_pkg foo
 
 Make sure that the package's source directory ends up with the version
 of foo.txt from extra_sources:

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -33,7 +33,7 @@ Set up a project that depends on a package that is being downloaded
 The first build should succeed, fetching the source, populating the cache and
 disabling the download of the source a second time.
 
-  $ dune build
+  $ build_pkg test
 
 Make sure that the file that was fetched is in the cache:
 
@@ -44,7 +44,7 @@ cache, it will fail, as the source is 404 now:
 
   $ dune clean
   $ export DUNE_CACHE=disabled
-  $ dune build
+  $ build_pkg test
   File "dune.lock/test.pkg", line 4, characters 7-25:
   4 |   (url http://localhost:1)
              ^^^^^^^^^^^^^^^^^^
@@ -57,4 +57,4 @@ build should be retrieved from the cache and the build succeed:
 
   $ dune clean
   $ export DUNE_CACHE=enabled
-  $ dune build
+  $ build_pkg test

--- a/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
@@ -27,7 +27,7 @@ Create a fake project and lock it:
   - foo.0.0.1
 
 As the lock file is syncronised with `dune-pkg`, the build succeeds:
-  $ dune build
+  $ build_pkg foo
   foo
 
 We add the bar dependency to the test package
@@ -51,5 +51,6 @@ We fix it and the build succeeds again:
   Solution for dune.lock:
   - bar.0.0.1
   - foo.0.0.1
-  $ dune build
+  $ build_pkg foo
+  $ build_pkg bar
   bar

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -37,7 +37,7 @@ Make a package "foo" whose build will fail after printing a message:
 
 Attempt to build the package the first time:
 (the error from make is grep'd out because it is not consistant across different systems)
-  $ dune build 2>&1 | grep -v -e "^make" -e "^gmake"
+  $ build_pkg foo 2>&1 | grep -v -e "^make" -e "^gmake"
   echo aaa
   aaa
   false
@@ -55,7 +55,7 @@ Update the message that gets printed while building foo:
   > EOF
 
 The change to the package is picked up:
-  $ dune build 2>&1 | grep -v -e "^make" -e "^gmake"
+  $ build_pkg foo 2>&1 | grep -v -e "^make" -e "^gmake"
   echo bbb
   bbb
   false

--- a/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
@@ -78,12 +78,7 @@ name so the output is consistent across test runs.
 
 Attempt to build the project. This will fail due to the fake compiler
 but the fake compiler will end up installed as a toolchain package.
-  $ XDG_CACHE_HOME=$PWD/fake-cache DUNE_CONFIG__TOOLCHAINS=enabled dune build 2>&1 | remove_hash
-  Error: Failed to parse the output of
-  '$TESTCASE_ROOT/fake-cache/dune/toolchains/ocaml-base-compiler.1-HASH/target/bin/ocamlc
-  -config':
-  Unrecognized line: "Hello from fake ocamlc!"
-  -> required by loading the OCaml compiler for context "default"
+  $ XDG_CACHE_HOME=$PWD/fake-cache DUNE_CONFIG__TOOLCHAINS=enabled build_pkg ocaml-base-compiler 2>&1 | remove_hash
 
 Enumerate the contents of the fake toolchains directory:
   $ find fake-cache/dune/toolchains | sort | remove_hash


### PR DESCRIPTION
Instead of assuming that packages live in [@all], just build the package we want.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>