### PR TITLE
fix(pkg): dependency closure should be lazier

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
@@ -34,11 +34,8 @@ Dune file in OCaml syntax and a files directory should work
   Error: Dependency cycle between:
      - evaluating dune file "dune" in OCaml syntax
   -> _build/_private/default/.pkg/ocamlfind/target/cookie
-  -> Computing closure for package "base-bytes"
-  -> - package base-bytes
-  -> lock directory environment for context "default"
-  -> base environment for context "default"
-  -> loading findlib for context "default"
+  -> Loading all binaries in the lock directory for "default"
+  -> looking up binary "ocamlc" in context "default"
   -> loading the OCaml compiler for context "default"
   -> - evaluating dune file "dune" in OCaml syntax
   [1]


### PR DESCRIPTION
This is a pre-requesite for fixing OCaml syntax dune files. There are two independent steps to fix this. This is the first step. Although it has no effect on its own, we can see from memo trace that at least we aren't loading a pointless package.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>