### PR TITLE
fix(pkg): allow OCaml syntax in dune files with lock dirs

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -413,9 +413,10 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
       in
       { builder with env }
   in
+  let which_outside_lockdir = Which.which ~path:builder.path in
   let which =
     match kind with
-    | Default | Opam _ -> Which.which ~path:builder.path
+    | Default | Opam _ -> which_outside_lockdir
     | Lock _ ->
       let which = Staged.unstage @@ Pkg_rules.which builder.name in
       fun prog ->
@@ -467,7 +468,11 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
           and* env = builder.env in
           let toolchain kind =
             let+ toolchain =
-              Ocaml_toolchain.of_env_with_findlib builder.name env findlib ~which
+              Ocaml_toolchain.of_env_with_findlib
+                builder.name
+                env
+                findlib
+                ~which:which_outside_lockdir
             in
             toolchain, kind
           in

--- a/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
@@ -31,11 +31,3 @@ Dune file in OCaml syntax and a files directory should work
   $ touch dune.lock/ocamlfind.files/foo.patch
 
   $ dune build
-  Error: Dependency cycle between:
-     - evaluating dune file "dune" in OCaml syntax
-  -> _build/_private/default/.pkg/ocamlfind/target/cookie
-  -> Loading all binaries in the lock directory for "default"
-  -> looking up binary "ocamlc" in context "default"
-  -> loading the OCaml compiler for context "default"
-  -> - evaluating dune file "dune" in OCaml syntax
-  [1]


### PR DESCRIPTION
When there's no OCaml defined in the lock directory, we should try to get the OCaml toolchain without loading any packages.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>