### PR TITLE
refactor: remove [Ocaml_index.project_index]

### DIFF
--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -11,8 +11,6 @@ let index_path_in_obj_dir obj_dir =
   Path.Build.relative dir index_file_name
 ;;
 
-let project_index ~build_dir = Path.Build.relative build_dir "project.ocaml-index"
-
 let cctx_rules cctx =
   (* Indexing is performed by the external binary [ocaml-index] which performs
      full shape reduction to compute the actual definition of all the elements in

--- a/src/dune_rules/merlin/ocaml_index.mli
+++ b/src/dune_rules/merlin/ocaml_index.mli
@@ -10,8 +10,6 @@ open Import
       modules in that cctx in the corresponding obj_dir.
     - then we aggregate all these separate indexes into a unique one. *)
 
-val project_index : build_dir:Path.Build.t -> Path.Build.t
-
 (** [cctx_rules cctx] sets the rules needed to generate the indexes for every
     module in the compilation context [cctx] and aggregate them in a
     [cctx.uideps] index covering the whole compilation context. *)


### PR DESCRIPTION
doesn't seem to be used anywhere

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>