### PR TITLE
pkg: Install all the dev-tools that are available

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -229,9 +229,10 @@ let lock_ocamlformat () =
 let lock_odoc () = lock_dev_tool Odoc None
 let lock_ocamllsp () = lock_dev_tool Ocamllsp None
 
-let lock_tools (tools : Dune_pkg.Dev_tool.t list) =
-  List.map tools ~f:(function
-    | Dune_pkg.Dev_tool.Odoc -> lock_odoc ()
+let lock_tools tools =
+  List.map tools ~f:(fun (tool : Dune_pkg.Dev_tool.t) ->
+    match tool with
+    | Odoc -> lock_odoc ()
     | Ocamllsp -> lock_ocamllsp ()
     | Ocamlformat -> lock_ocamlformat ())
 ;;

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -228,3 +228,10 @@ let lock_ocamlformat () =
 
 let lock_odoc () = lock_dev_tool Odoc None
 let lock_ocamllsp () = lock_dev_tool Ocamllsp None
+
+let lock_tools (tools : Dune_pkg.Dev_tool.t list) =
+  List.map tools ~f:(function
+    | Dune_pkg.Dev_tool.Odoc -> lock_odoc ()
+    | Ocamllsp -> lock_ocamllsp ()
+    | Ocamlformat -> lock_ocamlformat ())
+;;

--- a/bin/lock_dev_tool.mli
+++ b/bin/lock_dev_tool.mli
@@ -4,3 +4,4 @@ val is_enabled : bool Lazy.t
 val lock_ocamlformat : unit -> unit Memo.t
 val lock_odoc : unit -> unit Memo.t
 val lock_ocamllsp : unit -> unit Memo.t
+val lock_tools : Dune_pkg.Dev_tool.t list -> unit Memo.t list

--- a/bin/tools/install_tools.ml
+++ b/bin/tools/install_tools.ml
@@ -1,0 +1,41 @@
+open! Import
+module Pkg_dev_tool = Dune_rules.Pkg_dev_tool
+
+let build_dev_tools dev_tools common =
+  let open Fiber.O in
+  let+ result =
+    let dev_tools_path =
+      List.map dev_tools ~f:(fun path -> Pkg_dev_tool.exe_path path |> Path.build)
+    in
+    Build_cmd.run_build_system ~common ~request:(fun _build_system ->
+      List.map dev_tools_path ~f:Action_builder.path |> Action_builder.all_unit)
+  in
+  match result with
+  | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
+  | Ok () -> ()
+;;
+
+let term =
+  let+ builder = Common.Builder.term in
+  let common, config = Common.init builder in
+  let all_dev_tool = Dune_pkg.Dev_tool.all in
+  Scheduler.go ~common ~config (fun () ->
+    let open Fiber.O in
+    if Lazy.force Lock_dev_tool.is_enabled
+    then
+      let* () =
+        Dune_pkg.Dev_tool.all
+        |> Lock_dev_tool.lock_tools
+        |> List.map ~f:Memo.run
+        |> Fiber.all_concurrently_unit
+      in
+      build_dev_tools all_dev_tool common
+    else Fiber.return ())
+;;
+
+let info =
+  let doc = "Install all the dev-tools that are available" in
+  Cmd.info "install" ~doc
+;;
+
+let command = Cmd.v info term

--- a/bin/tools/install_tools.mli
+++ b/bin/tools/install_tools.mli
@@ -1,0 +1,4 @@
+open! Import
+
+(** Command install all the available dev-tools*)
+val command : unit Cmd.t

--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -8,4 +8,4 @@ end
 
 let doc = "Command group for wrapped tools."
 let info = Cmd.info ~doc "tools"
-let group = Cmd.group info [ Exec.group ]
+let group = Cmd.group info [ Exec.group; Install_tools.command ]

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -117,3 +117,15 @@ print_source() {
 solve() {
   make_project $@ | solve_project
 }
+
+make_mock_tool_package() {
+  package=$1
+  binary=$2
+  mkpkg $package <<EOF
+install: [
+  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/$binary" ]
+  [ "sh" "-c" "echo 'echo hello from fake $binary' >> %{bin}%/$binary" ]
+  [ "sh" "-c" "chmod a+x %{bin}%/$binary" ]
+]
+EOF
+}

--- a/test/blackbox-tests/test-cases/pkg/tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/tools-install.t
@@ -1,0 +1,57 @@
+  $ . ./helpers.sh
+
+Test for "dune tools install" command which installs all the available dev-tools .
+The command locks and builds those dev-tools.
+
+  $ mkrepo
+  $ make_mock_tool_package odoc odoc
+  $ make_mock_tool_package ocaml-lsp-server ocamllsp
+  $ make_mock_tool_package ocamlformat ocamlformat
+  $ mkpkg ocaml 5.2.0
+
+Each dev-tool has it own lock-dir
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.16)
+  > (lock_dir
+  >   (path "dev-tools.locks/odoc")
+  >   (repositories mock))
+  > (lock_dir
+  >   (path "dev-tools.locks/ocamlformat")
+  >   (repositories mock))
+  > (lock_dir
+  >   (path "dev-tools.locks/ocaml-lsp-server")
+  >   (repositories mock))
+  > (lock_dir
+  >   (repositories mock))
+  > (repository
+  >   (name mock)
+  >   (source "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (package
+  >  (name foo)
+  >  (depends ocaml))
+  > EOF
+
+Building dev-tool requires the project been locked.
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.5.2.0
+
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools install
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.0.1
+  Solution for dev-tools.locks/odoc:
+  - ocaml.5.2.0
+  - odoc.0.0.1
+  Solution for dev-tools.locks/ocaml-lsp-server:
+  - ocaml.5.2.0
+  - ocaml-lsp-server.0.0.1
+
+Check, if the dev-tools are built.
+  $ ls ./_build/_private/default/.dev-tool
+  ocaml-lsp-server
+  ocamlformat
+  odoc


### PR DESCRIPTION
This is supposed to close https://github.com/ocaml/dune/issues/11001. 

But instead of having `dune tools install` I wonder if `dune build @pkg-tools` could be a better alternative, because this is equivalent building/invoking some aliases. 