### PR TITLE
Drastically simplify output when packages are missing in solve

### DIFF
--- a/src/0install-solver/diagnostics.ml
+++ b/src/0install-solver/diagnostics.ml
@@ -40,7 +40,8 @@ module Make (Results : S.SOLVER_RESULT) = struct
           (format_role other_role
            ++ Pp.char ' '
            ++ Model.pp_version impl
-           ++ Pp.textf " requires %s" (format_restrictions r))
+           ++ Pp.text " requires "
+           ++ Pp.paragraph (format_restrictions r))
       | Feed_problem msg -> Pp.text msg
     ;;
   end

--- a/test/blackbox-tests/test-cases/pkg/conflict-class.t
+++ b/test/blackbox-tests/test-cases/pkg/conflict-class.t
@@ -32,8 +32,8 @@ Local conflict class defined in a local package:
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: foo.dev x.dev foo&x
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.dev x.dev foo&x
   - bar -> (problem)
       Rejected candidates:
         bar.0.0.1: In same conflict class (ccc) as foo
@@ -51,8 +51,8 @@ Now the conflict class comes from the opam repository
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: foo.0.0.1 x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.0.0.1 x.dev
   - bar -> (problem)
       Rejected candidates:
         bar.0.0.1: In same conflict class (ccc) as foo

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -19,8 +19,8 @@ The solver should say no solution rather than just ignoring the conflict.
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: bar.0.0.1 x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 x.dev
   - foo -> (problem)
       x dev requires conflict with all versions
       Rejected candidates:

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -19,8 +19,8 @@ dependency.
   $ test "2.0.0"
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: foo.0.0.1 x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.0.0.1 x.dev
   - dune -> (problem)
       User requested = 3.17
       Rejected candidates:

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -147,8 +147,8 @@ Run the solver again. This time it will fail.
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: baz.0.1.0 foo.0.0.1 lockfile_generation_test.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: baz.0.1.0 foo.0.0.1 lockfile_generation_test.dev
   - bar -> (problem)
       foo 0.0.1 requires >= 0.2
       lockfile_generation_test dev requires >= 0.6

--- a/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
@@ -1,7 +1,7 @@
 A package depending on a package that doesn't exist.
-The solver should give a more sane error message.
+The solver now gives a more sane error message.
 
-A few packages here so the errors get large.
+A few packages here so the errors could get large.
   $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
@@ -36,14 +36,7 @@ A few packages here so the errors get large.
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: a.0.1.0 abc.dev b.0.0.1 d.0.0.1
-  - c -> (problem)
-      Rejected candidates:
-        c.0.0.1: Requires a < 0.1.0
-  - e -> e.0.1.0
-      abc dev requires = 0.1.0
-  - foobar -> (problem)
-      No known implementations at all
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: foobar
   [1]
-The problem with foobar seems important enough to not show the wall of text above...
+We only report about non-existent packages.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -61,11 +61,11 @@ This should fail as there is no version matching 0.24.1:
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dev-tools.locks/ocamlformat:
-  Can't find all required versions.
-  Selected: ocamlformat_dev_tool_wrapper.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)
-      ocamlformat_dev_tool_wrapper dev requires >= 0.24.1 & <=
-        0.24.1___MAX_VERSION
+      ocamlformat_dev_tool_wrapper dev requires
+        >= 0.24.1 & <= 0.24.1___MAX_VERSION
       Rejected candidates:
         ocamlformat.0.25+bar:
           Incompatible with restriction: >= 0.24.1 & <= 0.24.1___MAX_VERSION

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -16,8 +16,6 @@ Format, it shows the solving error.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dev-tools.locks/ocamlformat:
-  Can't find all required versions.
-  Selected: ocamlformat_dev_tool_wrapper.dev
-  - ocamlformat -> (problem)
-      No known implementations at all
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: ocamlformat
   [1]

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -83,8 +83,8 @@ available on linux.
   - linux-only.0.0.2
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
-  Can't find all required versions.
-  Selected: x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
   - linux-only -> (problem)
       No usable implementations:
         linux-only.0.0.2: Availability condition not satisfied
@@ -107,8 +107,8 @@ variable in its `available` filter. The undefined-var.0.0.2 package has a valid
   - undefined-var.0.0.2
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
-  Can't find all required versions.
-  Selected: x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
   - undefined-var -> (problem)
       No usable implementations:
         undefined-var.0.0.2: Availability condition not satisfied
@@ -120,16 +120,16 @@ filter resolves to a string instead of to a boolean.
   $ solve availability-string
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
   - availability-string -> (problem)
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied
         availability-string.0.0.1: Availability condition not satisfied
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
-  Can't find all required versions.
-  Selected: x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
   - availability-string -> (problem)
       No usable implementations:
         availability-string.0.0.2: Availability condition not satisfied

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -57,8 +57,8 @@ Conflicting packages can't be co-installed:
   $ solve foo conflicts-with-foo
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: foo.0.0.1 foo-dependency.0.0.1 x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.0.0.1 foo-dependency.0.0.1 x.dev
   - conflicts-with-foo -> (problem)
       Rejected candidates:
         conflicts-with-foo.0.0.1: Requires foo conflict with all versions
@@ -68,8 +68,9 @@ Conflicting packages in transitive dependencies can't be co-installed:
   $ solve depends-on-foo conflicts-with-foo
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
-  Can't find all required versions.
-  Selected: depends-on-foo.0.0.1 foo.0.0.1 foo-dependency.0.0.1 x.dev
+  Couldn't solve the package dependency formula.
+  Selected candidates: depends-on-foo.0.0.1 foo.0.0.1 foo-dependency.0.0.1
+                       x.dev
   - conflicts-with-foo -> (problem)
       Rejected candidates:
         conflicts-with-foo.0.0.1: Requires foo conflict with all versions


### PR DESCRIPTION
Fixes #10987.
When some packages are missing entirely, we only report that as that seems way more pressing than the wall of info about the state of the solver seen in the issue.

The fix was found while working on #11015, but is independent from it.