### PR TITLE
refactor: define lock_dev_tools feature flag in dune_rules

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -2,13 +2,9 @@ open Dune_config
 open Import
 module Lock_dir = Dune_pkg.Lock_dir
 
-let enabled =
-  Config.make_toggle ~name:"lock_dev_tool" ~default:Dune_rules.Setup.lock_dev_tool
-;;
-
 let is_enabled =
   lazy
-    (match Config.get enabled with
+    (match Config.get Dune_rules.Compile_time.lock_dev_tools with
      | `Enabled -> true
      | `Disabled -> false)
 ;;

--- a/src/dune_rules/compile_time.ml
+++ b/src/dune_rules/compile_time.ml
@@ -5,3 +5,5 @@ let toolchains = Config.make_toggle ~name:"toolchains" ~default:Setup.toolchains
 let pkg_build_progress =
   Config.make_toggle ~name:"pkg_build_progress" ~default:Setup.pkg_build_progress
 ;;
+
+let lock_dev_tools = Config.make_toggle ~name:"lock_dev_tool" ~default:Setup.lock_dev_tool

--- a/src/dune_rules/compile_time.mli
+++ b/src/dune_rules/compile_time.mli
@@ -17,3 +17,6 @@ val toolchains : Config.Toggle.t Config.t
 (** Enable or disable the displaying of package build progress.
     For more detail, see src/dune_rules/pkg_build_progress.mli *)
 val pkg_build_progress : Config.Toggle.t Config.t
+
+(** Enable or disable using package management to install dev tools. *)
+val lock_dev_tools : Config.Toggle.t Config.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -72,6 +72,7 @@ module Stanzas = Stanzas
 module Lock_dir = Lock_dir
 module Pkg_dev_tool = Pkg_dev_tool
 module Pkg_build_progress = Pkg_build_progress
+module Compile_time = Compile_time
 
 module Install_rules = struct
   let install_file = Install_rules.install_file


### PR DESCRIPTION
The other feature flags are defined in `Dune_rules.Compile_time` so moving lock_dev_tools there too for consistency.