### PR TITLE
pkg: ocamlformat dev tool requires lockdir

### DIFF
--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -43,7 +43,15 @@ let exe_path_components_within_package t =
 ;;
 
 let needs_to_build_with_same_compiler_as_project = function
-  | Ocamlformat -> false
+  | Ocamlformat ->
+    (* XXX Technically ocamlformat doesn't need to build with the same
+       compiler as the project, however without a lockdir, `dune fmt` will
+       attempt to run `ocamlc -compile` to get system info, and `ocamlc`
+       might not be in PATH. Forcing the user to lock their project before
+       running commands involving ocamlformat is a workaround for this
+       problem until it can be solved in a better way. See this issue for
+       more information: https://github.com/ocaml/dune/issues/11038 *)
+    true
   | Odoc -> true
   | Ocamllsp -> true
 ;;

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
@@ -18,8 +18,17 @@ Initial file:
   $ cat foo.ml
   let () = print_endline "Hello, world"
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -80,11 +80,17 @@ EOF
   fi
 }
 
+make_ocaml_opam_pkg() {
+  mkpkg ocaml <<EOF
+EOF
+}
+
 make_project_with_dev_tool_lockdir() {
   cat > dune-project <<EOF
 (lang dune 3.13)
 (package
- (name foo))
+ (name foo)
+ (depends ocaml))
 EOF
   cat > foo.ml <<EOF
 let () = print_endline "Hello, world"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -27,9 +27,18 @@ Add a fake executable in the PATH
   $ which ocamlformat
   $TESTCASE_ROOT/.bin/ocamlformat
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 Build the OCamlFormat binary dev-tool
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   File "dune", line 1, characters 0-0:
   Error: Files _build/default/dune and _build/default/.formatted/dune differ.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -23,12 +23,18 @@ Update dune-project to add the dependency on OCamlFormat.
   > (lang dune 3.13)
   > (package
   >  (name foo)
-  >  (depends (ocamlformat (= 0.26.2))))
+  >  (depends
+  >   (ocamlformat (= 0.26.2))
+  >   ocaml))
   > EOF
+
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
 
 Lock and build the project to make OCamlFormat from the project dependencies available.
   $ dune pkg lock
   Solution for dune.lock:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
 
 Run "dune fmt" without the dev-tools feature enabled. This should invoke the ocamlformat
@@ -46,6 +52,7 @@ the project dependencies (0.26.2) but instead builds and runs the OCamlFormat bi
 dev-tool (0.26.3).
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -66,7 +66,9 @@ Update the project to depends on printer.2.0:
   > (lang dune 3.13)
   > (package
   >  (name foo)
-  >  (depends (printer (= 2.0))))
+  >  (depends
+  >   (printer (= 2.0))
+  >   ocaml))
   > EOF
   $ cat > foo.ml <<EOF
   > let () = Printer.print ()
@@ -82,9 +84,13 @@ Add ".ocamlformat" file.
   > version = 0.26.2
   > EOF
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
 Lock the to trigger package management
   $ dune pkg lock
   Solution for dune.lock:
+  - ocaml.0.0.1
   - printer.2.0
 
 It shows that the project uses printer.2.0
@@ -95,6 +101,7 @@ Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with di
 versions of the same dependency.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   - printer.1.0
   File "foo.ml", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -11,9 +11,18 @@ Make a fake ocamlformat with a missing ocamlformat.ml file:
 Make dune-project that uses the mocked dev-tool opam-reposiotry.
   $ make_project_with_dev_tool_lockdir
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.4
   File "dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
   4 |  (run dune build -p %{pkg-self:name} @install))

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -22,10 +22,19 @@ We consider this version of OCamlFormat as the latest version:
 Make dune-project that uses the mocked dev-tool opam-reposiotry.
   $ make_project_with_dev_tool_lockdir
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 Without a ".ocamlformat" file, "dune fmt" takes the latest version of
 OCamlFormat.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -47,6 +56,7 @@ With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocam
 file.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -68,6 +78,7 @@ When "dev-tools.locks" is removed, the solving/lock is renewed
   $ rm -r dev-tools.locks/ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -26,9 +26,18 @@ Check without ".ocamlformat-ignore" file and the feature.
 Create ".ocamlformat-ignore"
   $ touch .ocamlformat-ignore
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 Check with the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -59,9 +59,18 @@ Make the ocamlformat opam package which uses a patch:
 Make a project that uses the fake ocamlformat:
   $ make_project_with_dev_tool_lockdir
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 First run of 'dune fmt' is supposed to format the fail.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -25,10 +25,19 @@ Initial file:
   $ cat foo.ml
   let () = print_endline "Hello, world"
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 This should choose the 0.24+foo version:
   $ echo "version=0.24" > .ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.24+foo
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -44,6 +53,7 @@ This should choose the 0.24+bar version:
   $ rm -rf dev-tools.locks
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for dev-tools.locks/ocamlformat:
+  - ocaml.0.0.1
   - ocamlformat.0.25+bar
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -62,7 +72,7 @@ This should fail as there is no version matching 0.24.1:
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dev-tools.locks/ocamlformat:
   Couldn't solve the package dependency formula.
-  Selected candidates: ocamlformat_dev_tool_wrapper.dev
+  Selected candidates: ocaml.0.0.1 ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)
       ocamlformat_dev_tool_wrapper dev requires
         >= 0.24.1 & <= 0.24.1___MAX_VERSION

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -12,6 +12,14 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
   > version = 0.26.9
   > EOF
 
+The project depends on ocaml, so provide a fake ocaml package:
+  $ make_ocaml_opam_pkg
+
+The ocamlformat dev tool requires the project to be locked:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - ocaml.0.0.1
+
 Format, it shows the solving error.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:


### PR DESCRIPTION
This is a workaround for an issue where dune needs to locate an ocaml toolchain in order to run `dune fmt`, and in the absence of a lockdir dune will look in PATH for ocaml tools, which may not be present. The consequence of this issue is that users of the developer preview can have an ocaml toolchain installed by dune (in their ~/.cache/dune/toolchains directory), and running `dune fmt` will complain about `ocamlc` not being found. Forcing the lockdir to exist means that dune will always take the toolchain implied by the lockdir, and there won't be a situation where the command fails due to `ocamlc` being missing.

More info in this issue:
https://github.com/ocaml/dune/issues/11038