### PR TITLE
Promote the toolchain feature flag to official feature

### DIFF
--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -18,7 +18,7 @@ let out =
 ;;
 
 let default_toggles : (string * [ `Disabled | `Enabled ]) list =
-  [ "toolchains", `Disabled; "pkg_build_progress", `Disabled; "lock_dev_tool", `Disabled ]
+  [ "toolchains", `Enabled; "pkg_build_progress", `Disabled; "lock_dev_tool", `Disabled ]
 ;;
 
 let toggles = ref default_toggles
@@ -89,8 +89,7 @@ let () =
     ; ( "--toolchains"
       , toggle "toolchains"
       , " Enable the toolchains behaviour, allowing dune to install the compiler in a \
-         user-wide directory.\n\
-        \      This flag is experimental and shouldn't be relied on by packagers." )
+         user-wide directory." )
     ; ( "--pkg-build-progress"
       , toggle "pkg_build_progress"
       , " Enable the displaying of package build progress.\n\

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,6 @@
       add-experimental-configure-flags = pkg: pkg.overrideAttrs {
         configureFlags =
           [
-            "--toolchains" "enable"
             "--pkg-build-progress" "enable"
             "--lock-dev-tool" "enable"
           ];

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -11,6 +11,6 @@ let roots : string option Install.Roots.t =
   ; libexec_root = None
   }
 
-let toolchains = `Disabled
+let toolchains = `Enabled
 let pkg_build_progress = `Disabled
 let lock_dev_tool = `Disabled


### PR DESCRIPTION
This PR sports ~~2 commits, the first one being a less-committed approach to the situation, the second a more complete one.~~ just the one commit that makes the flag enabled by default.

There seems to be sentiment around the dune team (cc @Leonidas-from-XIV @rgrinberg @gridbugs in particular) that:
  1. The 'toolchains' feature is stable and tested enough to "ascend" to an official feature of Dune.
  2. The problem that it solves (the compiler being non-relocatable) is going to stay relevant for a while.

Thus, I propose that we ~~get rid of~~ promote the feature flag.
~~Note that this is a **BREAKING** change for users who use `./configure --toolchains disabled` obviously, but also `./configure --toolchains enabled` as the flag will no longer get recognized.~~
Not a breaking change anymore, I just changed the default.