### PR TITLE
Add action.yaml file for dune

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,14 @@
+name: ocaml/dune
+description: Setup dune using the latest dune release
+branding:
+  icon: ci
+  color: green
+author: ocaml
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download and install dune
+      run: curl -fsSL https://get.dune.build/install | sh
+    - name: Add dune to PATH
+      run: echo "$HOME/.dune/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
I just set up Dune for DBCaml and thought it would be nice to have an official action for It.

The dev would invoke the action by:
``` 
- uses: ocaml/dune@main
```

This would download Dune and install it to the path. A bigger example of how this would work is for instance:

``` 
- uses: OCaml/dune@main
- name: run tests
  run: dune runtest
```

Does the install script have any versioning?