### PR TITLE
refactor: use the same repr for executable names

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -24,7 +24,7 @@ let available_exes ~dir (exes : Executables.t) =
     in
     Lib.DB.resolve_user_written_deps
       libs
-      (`Exe (Nonempty_list.to_list exes.names))
+      (`Exe exes.names)
       exes.buildable.libraries
       ~pps
       ~dune_version

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -159,7 +159,7 @@ let gen_rules sctx t ~dir ~scope =
   let compile_info =
     Lib.DB.resolve_user_written_deps
       (Scope.libs scope)
-      (`Exe (Nonempty_list.to_list names))
+      (`Exe names)
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~pps:(Preprocess.Per_module.pps t.preprocess)
       ~dune_version

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -308,7 +308,7 @@ let compile_info ~scope (exes : Executables.t) =
   let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
   Lib.DB.resolve_user_written_deps
     (Scope.libs scope)
-    (`Exe (Nonempty_list.to_list exes.names))
+    (`Exe exes.names)
     exes.buildable.libraries
     ~pps
     ~dune_version

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -389,7 +389,7 @@ end = struct
                Lib.DB.resolve_user_written_deps
                  (Scope.libs scope)
                  ~forbidden_libraries:[]
-                 (`Exe (Nonempty_list.to_list exes.names))
+                 (`Exe exes.names)
                  exes.buildable.libraries
                  ~pps
                  ~dune_version

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2091,13 +2091,13 @@ module DB = struct
           ~human_readable_description:(fun () ->
             match targets with
             | `Melange_emit name -> Pp.textf "melange target %s" name
-            | `Exe [ (loc, name) ] ->
+            | `Exe Nonempty_list.[ (loc, name) ] ->
               Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
-            | `Exe names ->
-              let loc, _ = List.hd names in
+            | `Exe (Nonempty_list.((loc, _) :: _) as names) ->
               Pp.textf
                 "executables %s in %s"
-                (String.enumerate_and (List.map ~f:snd names))
+                (String.enumerate_and
+                   (Nonempty_list.map ~f:snd names |> Nonempty_list.to_list))
                 (Loc.to_file_colon_line loc)))
     in
     let pps =

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -147,7 +147,7 @@ module DB : sig
       This function is for executables or melange.emit stanzas. *)
   val resolve_user_written_deps
     :  t
-    -> [ `Exe of (Loc.t * string) list | `Melange_emit of string ]
+    -> [ `Exe of (Loc.t * string) Nonempty_list.t | `Melange_emit of string ]
     -> allow_overlaps:bool
     -> forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -457,7 +457,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps
         (Scope.libs scope)
-        (`Exe (Nonempty_list.to_list names))
+        (`Exe names)
         ~allow_overlaps:false
         ~forbidden_libraries:[]
         (lib "mdx.test" :: lib "mdx.top" :: t.libraries)

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -207,7 +207,7 @@ module Stanza = struct
       let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps
         (Scope.libs scope)
-        (`Exe (Nonempty_list.to_list names))
+        (`Exe names)
         ~forbidden_libraries:[]
         (Lib_dep.Direct (source.loc, compiler_libs)
          :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -84,7 +84,7 @@ let add_stanza db ~dir (acc, pps) stanza =
         in
         Lib.DB.resolve_user_written_deps
           db
-          (`Exe (Nonempty_list.to_list exes.names))
+          (`Exe exes.names)
           exes.buildable.libraries
           ~pps
           ~dune_version


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>