### PR TITLE
refactor: ask for [Merlin_ident.t] in [with_lib_deps]

### DIFF
--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -40,12 +40,11 @@ let gen_select_rules sctx ~dir compile_info =
           Action.Full.make (Copy_line_directive.action context ~src ~dst))))
 ;;
 
-let with_lib_deps (t : Context.t) compile_info ~dir ~f =
+let with_lib_deps (t : Context.t) merlin_ident ~dir ~f =
   let prefix =
     if Context.merlin t
     then
-      Lib.Compile.merlin_ident compile_info
-      |> Merlin_ident.merlin_file_path dir
+      Merlin_ident.merlin_file_path dir merlin_ident
       |> Path.build
       |> Action_builder.path
       |> Action_builder.goal

--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -15,7 +15,7 @@ val gen_select_rules : Super_context.t -> dir:Path.Build.t -> Lib.Compile.t -> u
 (** Generate the rules for the [(select ...)] forms in library dependencies *)
 val with_lib_deps
   :  Context.t
-  -> Lib.Compile.t
+  -> Merlin_ident.t
   -> dir:Path.Build.t
   -> f:(unit -> 'a Memo.t)
   -> 'a Memo.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -335,5 +335,6 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander (exes : Executables.t) =
     let requires_link = Lib.Compile.requires_link compile_info in
     Bootstrap_info.gen_rules sctx exes ~dir ~requires_link
   in
-  Buildable_rules.with_lib_deps (Super_context.context sctx) compile_info ~dir ~f
+  let merlin_ident = Lib.Compile.merlin_ident compile_info in
+  Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -676,5 +676,6 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
       ~ctx_dir:dir
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir in
-  Buildable_rules.with_lib_deps (Super_context.context sctx) compile_info ~dir ~f
+  let merlin_ident = Lib.Compile.merlin_ident compile_info in
+  Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -368,7 +368,8 @@ let setup_emit_cmj_rules
         ~modes:`Melange_emit )
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir in
-  Buildable_rules.with_lib_deps ctx compile_info ~dir ~f
+  let merlin_ident = Lib.Compile.merlin_ident compile_info in
+  Buildable_rules.with_lib_deps ctx merlin_ident ~dir ~f
 ;;
 
 module Runtime_deps = struct


### PR DESCRIPTION
We don't want to take [Lib.Compile.t] just for a single value

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>