### PR TITLE
refactor: remove [Merlin_ident.t] from compile info

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -19,9 +19,6 @@ let available_exes ~dir (exes : Executables.t) =
       |> Resolve.Memo.read_memo
       >>| Preprocess.Per_module.pps
     in
-    let merlin_ident =
-      Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names)
-    in
     Lib.DB.resolve_user_written_deps
       libs
       (`Exe exes.names)
@@ -30,7 +27,6 @@ let available_exes ~dir (exes : Executables.t) =
       ~dune_version
       ~forbidden_libraries:exes.forbidden_libraries
       ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
-      ~merlin_ident
   in
   let open Memo.O in
   let+ available = Lib.Compile.direct_requires compile_info in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -155,7 +155,6 @@ let gen_rules sctx t ~dir ~scope =
   in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let names = Nonempty_list.[ t.loc, name ] in
-  let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd names) in
   let compile_info =
     Lib.DB.resolve_user_written_deps
       (Scope.libs scope)
@@ -163,7 +162,6 @@ let gen_rules sctx t ~dir ~scope =
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~pps:(Preprocess.Per_module.pps t.preprocess)
       ~dune_version
-      ~merlin_ident
       ~allow_overlaps:false
       ~forbidden_libraries:[]
   in

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -291,7 +291,7 @@ let executables_rules
       ~preprocess:
         (Preprocess.Per_module.without_instrumentation exes.buildable.preprocess)
       ~dialects:(Dune_project.dialects (Scope.project scope))
-      ~ident:(Lib.Compile.merlin_ident compile_info)
+      ~ident:(Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names))
       ~modes:`Exe )
 ;;
 
@@ -305,7 +305,6 @@ let compile_info ~scope (exes : Executables.t) =
          ~instrumentation_backend:(Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
   Lib.DB.resolve_user_written_deps
     (Scope.libs scope)
     (`Exe exes.names)
@@ -314,7 +313,6 @@ let compile_info ~scope (exes : Executables.t) =
     ~dune_version
     ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
     ~forbidden_libraries:exes.forbidden_libraries
-    ~merlin_ident
 ;;
 
 let rules ~sctx ~dir ~dir_contents ~scope ~expander (exes : Executables.t) =
@@ -335,6 +333,6 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander (exes : Executables.t) =
     let requires_link = Lib.Compile.requires_link compile_info in
     Bootstrap_info.gen_rules sctx exes ~dir ~requires_link
   in
-  let merlin_ident = Lib.Compile.merlin_ident compile_info in
+  let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
   Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -383,9 +383,6 @@ end = struct
                  |> Resolve.Memo.read_memo
                  >>| Preprocess.Per_module.pps
                in
-               let merlin_ident =
-                 Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names)
-               in
                Lib.DB.resolve_user_written_deps
                  (Scope.libs scope)
                  ~forbidden_libraries:[]
@@ -394,7 +391,6 @@ end = struct
                  ~pps
                  ~dune_version
                  ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
-                 ~merlin_ident
              in
              let+ requires = Lib.Compile.direct_requires compile_info in
              Resolve.is_ok requires)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1826,7 +1826,6 @@ module Compile = struct
     ; pps : t list Resolve.Memo.t
     ; resolved_selects : Resolved_select.t list Resolve.Memo.t
     ; sub_systems : Sub_system0.Instance.t Memo.Lazy.t Sub_system_name.Map.t
-    ; merlin_ident : Merlin_ident.t
     }
 
   let for_lib ~allow_overlaps db (t : lib) =
@@ -1850,13 +1849,11 @@ module Compile = struct
               db
               ~forbidden_libraries:Map.empty)
     in
-    let merlin_ident = Merlin_ident.for_lib t.name in
     { direct_requires = requires
     ; requires_link
     ; resolved_selects = Memo.return t.resolved_selects
     ; pps = Memo.return t.pps
     ; sub_systems = t.sub_systems
-    ; merlin_ident
     }
   ;;
 
@@ -1864,7 +1861,6 @@ module Compile = struct
   let requires_link t = t.requires_link
   let resolved_selects t = t.resolved_selects
   let pps t = t.pps
-  let merlin_ident t = t.merlin_ident
 
   let sub_systems t =
     Sub_system_name.Map.values t.sub_systems
@@ -2050,7 +2046,6 @@ module DB = struct
     deps
     ~pps
     ~dune_version
-    ~merlin_ident
     =
     let resolved =
       Memo.lazy_ (fun () ->
@@ -2120,7 +2115,6 @@ module DB = struct
     ; pps
     ; resolved_selects = resolved_selects |> Memo.map ~f:Resolve.return
     ; sub_systems = Sub_system_name.Map.empty
-    ; merlin_ident
     }
   ;;
 

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -77,8 +77,6 @@ module Compile : sig
   (** Transitive closure of all used ppx rewriters *)
   val pps : t -> lib list Resolve.Memo.t
 
-  val merlin_ident : t -> Merlin_ident.t
-
   (** Sub-systems used in this compilation context *)
   val sub_systems : t -> sub_system list Memo.t
 end
@@ -153,7 +151,6 @@ module DB : sig
     -> Lib_dep.t list
     -> pps:(Loc.t * Lib_name.t) list
     -> dune_version:Dune_lang.Syntax.Version.t
-    -> merlin_ident:Merlin_ident.t
     -> Compile.t
 
   val resolve_pps : t -> (Loc.t * Lib_name.t) list -> lib list Resolve.Memo.t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -637,7 +637,7 @@ let library_rules
       ~libname:(Some (snd lib.name))
       ~obj_dir
       ~dialects:(Dune_project.dialects (Scope.project scope))
-      ~ident:(Lib.Compile.merlin_ident compile_info)
+      ~ident:(Merlin_ident.for_lib (Library.best_name lib))
       ~modes:(`Lib (Lib_info.modes lib_info)) )
 ;;
 
@@ -675,6 +675,6 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
       ~ctx_dir:dir
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir in
-  let merlin_ident = Lib.Compile.merlin_ident compile_info in
+  let merlin_ident = Merlin_ident.for_lib (Library.best_name lib) in
   Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -453,17 +453,14 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
   let lib name = Lib_dep.Direct (loc, Lib_name.of_string name) in
   let* cctx =
     let compile_info =
-      let names = Nonempty_list.[ t.loc, name ] in
-      let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps
         (Scope.libs scope)
-        (`Exe names)
+        (`Exe Nonempty_list.[ t.loc, name ])
         ~allow_overlaps:false
         ~forbidden_libraries:[]
         (lib "mdx.test" :: lib "mdx.top" :: t.libraries)
         ~pps:[]
         ~dune_version
-        ~merlin_ident
     in
     let requires_compile = Lib.Compile.direct_requires compile_info
     and requires_link = Lib.Compile.requires_link compile_info in

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -204,7 +204,6 @@ module Stanza = struct
         Lib_name.parse_string_exn (source.loc, "compiler-libs.toplevel")
       in
       let names = Nonempty_list.[ source.loc, source.name ] in
-      let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps
         (Scope.libs scope)
         (`Exe names)
@@ -214,7 +213,6 @@ module Stanza = struct
         ~pps
         ~dune_version
         ~allow_overlaps:false
-        ~merlin_ident
     in
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -79,9 +79,6 @@ let add_stanza db ~dir (acc, pps) stanza =
                  (Lib.DB.instrumentation_backend (Scope.libs scope)))
           >>| Preprocess.Per_module.pps
         in
-        let merlin_ident =
-          Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names)
-        in
         Lib.DB.resolve_user_written_deps
           db
           (`Exe exes.names)
@@ -90,7 +87,6 @@ let add_stanza db ~dir (acc, pps) stanza =
           ~dune_version
           ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
           ~forbidden_libraries:exes.forbidden_libraries
-          ~merlin_ident
       in
       let+ available = Lib.Compile.direct_requires compile_info in
       Resolve.peek available


### PR DESCRIPTION
This field wasn't used sometimes and it's just as easy to generate it when needed without passing it around.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>