### PR TITLE
fix(pkg): handle nested [Or] in depopts

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -558,8 +558,8 @@ let resolve_depopts ~resolve depopts =
     | Empty -> acc
     | _ ->
       (* We rely on depopts always being a list of or'ed package names. Opam
-         verifies this for us at parsing time. Dune projects have this
-         restriction for depopts and regular deps *)
+         verifies this for us at parsing time. Packages defined in dune-project
+         files have this restriction for depopts and regular deps *)
       Code_error.raise "invalid depopts" [ "depopts", Opam_dyn.filtered_formula depopts ]
   in
   OpamFormula.ors_to_list depopts

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
@@ -9,35 +9,5 @@ Handling of more than one depopt:
   > EOF
 
   $ solve bar
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("invalid depopts",
-     { depopts =
-         Or [ Or [ Atom ("a", Empty); Atom ("b", Empty) ]; Atom ("c", Empty) ]
-     })
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
-  Called from Dune_pkg__Opam_solver.resolve_depopts in file
-    "src/dune_pkg/opam_solver.ml", line 565, characters 3-21
-  Called from Dune_pkg__Opam_solver.opam_package_to_lock_file_pkg in file
-    "src/dune_pkg/opam_solver.ml", line 645, characters 6-48
-  Called from Stdlib__List.rev_map.rmap_f in file "list.ml" (inlined), line
-    105, characters 22-25
-  Called from Stdlib__List.rev_map in file "list.ml", line 107, characters 2-13
-  Called from Stdune__List.map in file "otherlibs/stdune/src/list.ml", line 5,
-    characters 19-33
-  Called from Dune_pkg__Opam_solver.solve_lock_dir.(fun) in file
-    "src/dune_pkg/opam_solver.ml", lines 889-896, characters 8-30
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 79, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 79, characters 8-11
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  [1]
+  Solution for dune.lock:
+  - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
@@ -4,10 +4,40 @@ Handling of more than one depopt:
 
   $ . ../helpers.sh
 
-  $ mkpkg bar <<'EOF'
+  $ mkpkg a
+  $ mkpkg b
+  $ mkpkg c
+  $ mkpkg d
+  $ mkpkg e
+  $ mkpkg f
+
+  $ runtest() {
+  > mkpkg bar <<'EOF'
   > depopts: [ "a" "b" "c" ]
   > EOF
+  > solve bar
+  > }
 
-  $ solve bar
+  $ runtest <<'EOF'
+  > depopts: [ "a" "b" "c" ]
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+
+  $ runtest <<'EOF'
+  > depopts: [ "a" "b" "c" "d" ]
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+
+  $ runtest <<'EOF'
+  > depopts: [ ("a" | "b") "c" "d" ]
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+
+  $ runtest <<'EOF'
+  > depopts: [ (("e" | "a") | ("d" | "f")) "b" "c" ]
+  > EOF
   Solution for dune.lock:
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
@@ -1,0 +1,43 @@
+Reproduce github issue #11058
+
+Handling of more than one depopt:
+
+  $ . ../helpers.sh
+
+  $ mkpkg bar <<'EOF'
+  > depopts: [ "a" "b" "c" ]
+  > EOF
+
+  $ solve bar
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("invalid depopts",
+     { depopts =
+         Or [ Or [ Atom ("a", Empty); Atom ("b", Empty) ]; Atom ("c", Empty) ]
+     })
+  Raised at Stdune__Code_error.raise in file
+    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  Called from Dune_pkg__Opam_solver.resolve_depopts in file
+    "src/dune_pkg/opam_solver.ml", line 565, characters 3-21
+  Called from Dune_pkg__Opam_solver.opam_package_to_lock_file_pkg in file
+    "src/dune_pkg/opam_solver.ml", line 645, characters 6-48
+  Called from Stdlib__List.rev_map.rmap_f in file "list.ml" (inlined), line
+    105, characters 22-25
+  Called from Stdlib__List.rev_map in file "list.ml", line 107, characters 2-13
+  Called from Stdune__List.map in file "otherlibs/stdune/src/list.ml", line 5,
+    characters 19-33
+  Called from Dune_pkg__Opam_solver.solve_lock_dir.(fun) in file
+    "src/dune_pkg/opam_solver.ml", lines 889-896, characters 8-30
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 79, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 79, characters 8-11
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
+  [1]


### PR DESCRIPTION
Flatten expressions such as `Or (Or _,..)` before processing depopts
