### PR TITLE
Fix before the next jsoo release

### DIFF
--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/lib/runtime.js
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/lib/runtime.js
@@ -2,5 +2,5 @@
 
 //Provides: jsPrint
 function jsPrint(x){
-  joo_global_object.console.log(x);
+  console.log(x);
 }

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/lib/runtime.js
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/lib/runtime.js
@@ -2,5 +2,5 @@
 
 //Provides: jsPrint
 function jsPrint(x){
-  joo_global_object.console.log(x);
+  console.log(x);
 }


### PR DESCRIPTION
The next jsoo release will warn when using `joo_global_object`. One should used `globalThis` instead.
In the current case, jsoo now considers `console` as available, one no longer need to get it from the global object.   