### PR TITLE
chore: Remove note about failure as the test has been fixed

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -75,8 +75,5 @@ Lock, build, and run the executable in the project:
   $ dune pkg lock
   Solution for dune.lock:
   - foo.0.0.1
-
-# Temporary failure until 10080 is fixed
-
   $ dune exec bar
   Hello, World!


### PR DESCRIPTION
#10080 has been fixed and the test passes so remove the note about the failure.