### PR TITLE
test: extend dune-constraint test to reproduce #11096

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -1,6 +1,7 @@
 By default, we introduce a constraint on in the build plan that will require
 the dune version to match the version of dune being used to generate the
-constraint.
+constraint. On another hand, we ensure `dune` can be used as a declared 
+dependency.
 
   $ . ./helpers.sh
   $ mkrepo
@@ -28,3 +29,15 @@ constraint.
   $ test "4.0.0"
   Solution for dune.lock:
   - foo.0.0.1
+
+Create a fake project and ensure `dune` can be used as a dependency:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name bar)
+  >  (allow_empty)
+  >  (depends dune))
+  > EOF
+  $ dune pkg lock 2>&1 | head -2
+  Internal error, please report upstream including the contents of _build/log.
+  Description:


### PR DESCRIPTION
This PR adds a reproduction case for #11096. It modifies the test about the implicit dune constraint instead of adding a new one for readability. Indeed, this test is also about `dune` constraint.