### PR TITLE
Improve dune runtest hints for non-test files

### DIFF
--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -278,7 +278,9 @@ let levenshtein_distance s t =
 
 let did_you_mean s ~candidates =
   let candidates =
-    List.filter candidates ~f:(fun candidate -> levenshtein_distance s candidate < 3)
+    List.filter candidates ~f:(fun candidate ->
+      let distance = levenshtein_distance s candidate in
+      0 < distance && distance < 3)
   in
   match candidates with
   | [] -> []

--- a/test/blackbox-tests/test-cases/runtest-cmd.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd.t
@@ -104,5 +104,4 @@ messages are informative enough.
 - Running a non-test file should give a suitable error message
   $ dune test dune-project
   Error: "dune-project" was not found.
-  Hint: did you mean dune-project?
   [1]

--- a/test/blackbox-tests/test-cases/runtest-cmd.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd.t
@@ -101,3 +101,8 @@ messages are informative enough.
   Error: "mytest1.t" was not found.
   Hint: did you mean mytest.t?
   [1]
+- Running a non-test file should give a suitable error message
+  $ dune test dune-project
+  Error: "dune-project" was not found.
+  Hint: did you mean dune-project?
+  [1]


### PR DESCRIPTION
### Issue

When running dune runtest on a file that is not a test, dune hints

```
Hint: did you mean <file>
```
even though the user just gave `<file>`.

### Fix

This stems from a deeper issue with `User_message.did_you_mean` which accepts hints that are identical to the original name. It doesn't make sense to give a "did you mean" hint in the case they are identical, so we check that the Levenshtein distance is greater than 0.

This removes the useless "did you mean" as observed in the tests.

We will improve the error message in a follow up PR.



