### PR TITLE
feature: add aliases for inline tests

### DIFF
--- a/doc/changes/11109.md
+++ b/doc/changes/11109.md
@@ -1,0 +1,3 @@
+- Inline test libraries now produce aliases `runtest-name_of_lib` allowing
+  users to run specific inline tests as `dune build @runtest-name_of_lib`.
+  (#11109, partially adresses #10239, @Alizter)

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -129,6 +129,10 @@ instance, if we make the test fail by replacing ``120`` by ``0`` we get:
 
    FAILED 1 / 1 tests
 
+Every inline test library generates an alias with the library name prefixed by
+`inline-test-`. You can build the specific inline test library by running
+``dune build @inline-test-foo`` in this case.
+
 Note that in this case Dune knew how to build and run the tests
 without any special configuration. This is because ``ppx_inline_test``
 defines an inline tests backend that's used by the library. Some

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -336,9 +336,8 @@ include Sub_system.Register_end_point (struct
           ~link_args
           ~promote:None
       in
-      let partitions_flags =
-        partition_flags ~expander ~lib_name:(snd lib.name) ~backends
-      in
+      let lib_name = snd lib.name in
+      let partitions_flags = partition_flags ~expander ~lib_name ~backends in
       let deps, sandbox =
         let sandbox =
           let project = Scope.project scope in
@@ -363,16 +362,27 @@ include Sub_system.Register_end_point (struct
             |> Action_builder.with_stdout_to partition_file
             |> Super_context.add_rule sctx ~dir ~loc
         in
-        let* runtest_alias =
-          match mode with
-          | Native | Best | Byte -> Memo.return Alias0.runtest
-          | Jsoo mode -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir ~mode
+        let alias =
+          "runtest-" ^ Lib_name.Local.to_string lib_name
+          |> Alias.Name.of_string
+          |> Alias.make ~dir
+        in
+        let* () =
+          let* runtest_alias =
+            (match mode with
+             | Native | Best | Byte -> Memo.return Alias0.runtest
+             | Jsoo mode -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir ~mode)
+            >>| Alias.make ~dir
+          in
+          Dep.alias alias
+          |> Action_builder.dep
+          |> Rules.Produce.Alias.add_deps runtest_alias ~loc
         in
         Super_context.add_alias_action
           sctx
           ~dir
           ~loc:info.loc
-          (Alias.make ~dir runtest_alias)
+          alias
           (let open Action_builder.O in
            let source_files = List.concat_map source_modules ~f:Module.sources in
            let+ actions =

--- a/test/blackbox-tests/test-cases/inline_tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline_tests/alias-cycle.t
@@ -1,0 +1,50 @@
+In this test we check a cycle when a library depends on a genrated source file which in
+turn depends on the inline-test-name alias of the inline tests of the library.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat >test.ml <<EOF
+  > (*TEST: assert (1 = 2) *)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name backend_simple)
+  >  (modules ())
+  >  (inline_tests.backend
+  >   (generate_runner (run sed "s/(\\\\*TEST:\\\\(.*\\\\)\\\\*)/let () = if \\"%{inline_tests}\\" = \\"enabled\\" then \\\\1;;/" %{impl-files}))))
+  > 
+  > (library
+  >  (name foo_simple)
+  >  (inline_tests (backend backend_simple)))
+  > 
+  > (rule
+  >  (deps
+  >   (alias runtest-foo_simple))
+  >  (action
+  >   (with-outputs-to bar.ml
+  >    (echo "let message = \"Hello world\""))))
+  > EOF
+
+This kind of cycle has a difficult to understand error message.
+  $ dune build 2>&1 | grep -vwE "sed"
+  File "dune", lines 7-9, characters 0-69:
+  7 | (library
+  8 |  (name foo_simple)
+  9 |  (inline_tests (backend backend_simple)))
+  Error: Dependency cycle between:
+     _build/default/.foo_simple.objs/foo_simple__Bar.impl.all-deps
+  -> _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmi
+  -> _build/default/.foo_simple.inline-tests/.t.eobjs/byte/dune__exe__Main.cmi
+  -> _build/default/.foo_simple.inline-tests/.t.eobjs/native/dune__exe__Main.cmx
+  -> _build/default/.foo_simple.inline-tests/inline-test-runner.exe
+  -> alias runtest-foo_simple in dune:9
+  -> _build/default/bar.ml
+  -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.d
+  -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.all-deps
+  -> required by _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmo
+  -> required by _build/default/foo_simple.cma
+  -> required by alias all
+  -> required by alias default

--- a/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
@@ -5,14 +5,14 @@ First, build silently to avoid some noise
 See that `test1/runtest`, which uses `fake_backend_1, only runs one inline test runner
 
   $ dune build --display short @test1/runtest 2>&1 | grep alias
-  inline-test-runner alias test1/runtest
+  inline-test-runner alias test1/runtest-test_lib1
 
 See that `test2/runtest`, which uses `fake_backend_2`, runs one inline test runner per partition
 
   $ dune build --display short @test2/runtest 2>&1 | grep alias
-  inline-test-runner alias test2/runtest
-  inline-test-runner alias test2/runtest
-  inline-test-runner alias test2/runtest
+  inline-test-runner alias test2/runtest-test_lib2
+  inline-test-runner alias test2/runtest-test_lib2
+  inline-test-runner alias test2/runtest-test_lib2
 
 See that we indeed have 3 partitions
 

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t
@@ -30,6 +30,27 @@
   Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 
+Inline tests also generate an alias
+  $ dune build @runtest-foo_simple
+  File "dune", line 9, characters 1-40:
+  9 |  (inline_tests (backend backend_simple)))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
+  [1]
+
+Make sure building both aliases doesn't build both
+  $ dune build @runtest @lib-foo_simple
+  Error: Alias "lib-foo_simple" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  File "dune", line 9, characters 1-40:
+  9 |  (inline_tests (backend backend_simple)))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
+  [1]
+This test demonstrates that the action is being run once
+  $ cat _build/log | sed 's/\$ //g' | grep inline-test-runner 
+  (cd _build/default && .foo_simple.inline-tests/inline-test-runner.exe)
+
 The expected behavior for the following three tests is to output nothing: the tests are disabled or ignored.
   $ env -u OCAMLRUNPARAM dune runtest --profile release
 


### PR DESCRIPTION
For a given library with inlines tests, we add an alias with the name of the library for running those tests prefixed by `inline-test-`.

Further work on separating out the partition actions would allow us to have an alias for each partition.

For now, this will allow us to run inline tests with the runtest command. Further work on that will follow this PR.

This addresses part of https://github.com/ocaml/dune/issues/10239 the remaining part would be to add an alias to the `(test)` stanza.

- [x] changelog
- [x] documentation