### PR TITLE
refactor(ml_sources): classify tests stanzas

### DIFF
--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -9,6 +9,7 @@ module Origin : sig
   type t =
     | Library of Library.t
     | Executables of Executables.t
+    | Tests of Tests.t
     | Melange of Melange_stanzas.Emit.t
 
   val preprocess : t -> Preprocess.With_instrumentation.t Preprocess.Per_module.t

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -44,6 +44,7 @@ let find_module sctx src =
          match origin with
          | Executables exes ->
            Exe_rules.rules ~sctx ~dir ~dir_contents ~scope ~expander exes
+         | Tests tests -> Test_rules.rules ~sctx ~dir_contents ~dir ~expander ~scope tests
          | Library lib -> Lib_rules.rules lib ~sctx ~dir_contents ~dir ~expander ~scope
          | Melange mel ->
            Melange_rules.setup_emit_cmj_rules


### PR DESCRIPTION
We allow for `Ml_sources.find_origin` to differentiate between tests stanzas and executables stanzas rather than treating them the same.

Without this, it is not possible to determine if a module came from a `(tests)` stanza or an `(executables)` stanza which is important when looking to run tests with `dune runtest`.