### PR TITLE
Add failing test pulling empty directory from cache.

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/empty-dir.t
+++ b/test/blackbox-tests/test-cases/dune-cache/empty-dir.t
@@ -1,0 +1,34 @@
+Check the cache restores empty directories
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/dune-cache
+  $ cat >dune-project <<EOF
+  > (lang dune 3.10)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir output))
+  >  (action
+  >   (progn
+  >    (run mkdir output)
+  >    (run mkdir output/child)
+  >    (run touch output/file))))
+  > EOF
+
+Build an empty directory.
+
+  $ dune build output
+  $ find _build/default/output | sort
+  _build/default/output
+  _build/default/output/child
+  _build/default/output/file
+
+Restore it from cache.
+
+  $ rm -rf _build
+  $ dune build output
+  $ find _build/default/output | sort
+  _build/default/output
+  _build/default/output/file


### PR DESCRIPTION
Dune cache does not restore empty directories. On top of not being very nice, this has really bad consequences with caching because dune's rule digest algorithm does take empty directories in account, so restoring a rule from cache will invalidate all dependent rules as the sources hash will have changed.

This is especially painful with the `dune pkg` feature, as the Ocaml 5.2.0 tarball has an empty `flexdll` directory at the root, so pulling it from the cache will rebuild absolutely everything.

I suppose the correct behavior is to properly restore empty directories from cache. If not, they probably shouldn't count towards rule digests.