### PR TITLE
test: Add repro case for #11113

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
@@ -5,9 +5,11 @@ Package sources can be set to git:
   $ mkrepo
   $ add_mock_repo_if_needed
 
+We create a repo with a fixed name for the default branch.
+
   $ mkdir _repo
   $ cd _repo
-  $ git init --quiet
+  $ git init --initial-branch=duplicated --quiet
   $ cat >dune-project <<EOF
   > (lang dune 3.13)
   > (package (name foo))
@@ -29,3 +31,15 @@ Package sources can be set to git:
   $ dune pkg lock
   Solution for dune.lock:
   - foo.dev
+
+We create a tag that clashes with the name of the branch (hence we needed to
+fix the name of the branch eariler):
+
+  $ git -C _repo tag duplicated
+
+This should work but it fails at the moment:
+
+  $ dune pkg lock 2>&1 | head -n 3
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("Map.of_list_exn", { key = "duplicated" })


### PR DESCRIPTION
Building the FStar repo fails because the branch and tag are named the same, as reported in #11113.

This simplifies the setup into a test-case.