### PR TITLE
configurator: make c file name  last in compiler args to workaround clang bug

### DIFF
--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -418,9 +418,9 @@ let compile_and_link_c_prog t ?(c_flags = []) ?(link_flags = []) code =
          [ c_flags
          ; [ "-I"; t.stdlib_dir ]
          ; output_flag
-         ; [ c_fname ]
          ; t.c_libraries
          ; link_flags
+         ; [ c_fname ]
          ])
   in
   if ok then Ok () else Error ()


### PR DESCRIPTION
Re-order the compiler arguments so the c file name is last. This works around a clang bug which will suppress errors for unsupported flags if linker arguments come after the c file name. This suppression is a problem because it indicates that some argument is supported when it is not which can result in build errors.

https://github.com/llvm/llvm-project/issues/116278

after this change the `base` module will build again with clang > 16 on systems without popcnt.
https://github.com/janestreet/base/blob/6ddf3438c79184fa443727058b623ccfe1d82ead/src/discover/discover.ml#L13-L20

eg: on aarch64 darwin and clang > 16 `-mpopcnt` will generate an error

```
$ clang -mpopcnt hello.c
clang: error: unsupported option '-mpopcnt' for target 'aarch64-apple-darwin'
$ echo $?
1
```

however, if appending `-lpthread`:

```
$ clang -mpopcnt hello.c -lpthread
$ echo $?
0
```

Which is a problem as code will assume `-mpopcnt` is supported and will then break later when compiling with the unsupported flag