### PR TITLE
fix(merlin): tolerate files without extension

### DIFF
--- a/doc/changes/11128.md
+++ b/doc/changes/11128.md
@@ -1,0 +1,2 @@
+- Tolerate files without extension when generating merlin rules.
+  (#11128, @anmonteiro)

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -3,7 +3,12 @@ open Memo.O
 
 let remove_extension file =
   let dir = Path.Build.parent_exn file in
-  let basename, _ext = String.lsplit2_exn (Path.Build.basename file) ~on:'.' in
+  let basename =
+    let basename = Path.Build.basename file in
+    match String.lsplit2 basename ~on:'.' with
+    | Some (basename, _ext) -> basename
+    | None -> basename
+  in
   Path.Build.relative dir basename
 ;;
 


### PR DESCRIPTION
I saw this unfortunate crash in my LSP logs:


```
("lsplit2_exn", { s = ":merlin-type-history:"; on = . })
Raised at Stdune__Code_error.raise in file
  "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
Called from Dune_rules__Merlin.remove_extension in file
  "src/dune_rules/merlin/merlin.ml", line 6, characters 23-76
Called from Dune_rules__Merlin.Processed.get in file
  "src/dune_rules/merlin/merlin.ml", line 303, characters 47-70
Called from Stdune__List.find_map in file "otherlibs/stdune/src/list.ml",
  line 106, characters 11-14
Called from Main__Ocaml_merlin.Server.load_merlin_file.find_closest in file
  "bin/ocaml/ocaml_merlin.ml" (inlined), lines 105-110, characters 11-59
Called from Main__Ocaml_merlin.Server.load_merlin_file.find_closest in file
  "bin/ocaml/ocaml_merlin.ml", lines 104-110, characters 8-59
Called from Main__Ocaml_merlin.Server.load_merlin_file in file
  "bin/ocaml/ocaml_merlin.ml", line 118, characters 10-51
Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
  line 253, characters 36-41
Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
  line 76, characters 8-11nI must not crash.  Uncertainty is the mind-killer. Exceptions are the
little-death that brings total obliteration.  I will fully express my cases.
Execution will pass over me and through me.  And when it has gone past, I
will unwind the stack along its path.  Where the cases are handled there will
be nothing.  Only I will remain.
'
```