### PR TITLE
fix: Do not depend on `dune` in `dune-project` in `dune init` template

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -404,7 +404,6 @@ module Component = struct
               [ { Package_dependency.name = Package.Name.of_string "ocaml"
                 ; constraint_ = None
                 }
-              ; { name = Package.Name.of_string "dune"; constraint_ = None }
               ]
         in
         let packages = Package.Name.Map.singleton (Package.name package) package in

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -357,7 +357,7 @@ In particular, the `dune-project` file has the expected content:
    (name new_exec_proj)
    (synopsis "A short synopsis")
    (description "A longer description")
-   (depends ocaml dune)
+   (depends ocaml)
    (tags
     ("add topics" "to describe" your project)))
   
@@ -384,8 +384,8 @@ And the opam file will be generated as expected
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
-    "ocaml"
     $dune {>= "3.17"}
+    "ocaml"
     "odoc" {with-doc}
   ]
   build: [
@@ -467,7 +467,7 @@ In particular, the `dune-project` file has the expected content:
    (name new_lib_proj)
    (synopsis "A short synopsis")
    (description "A longer description")
-   (depends ocaml dune)
+   (depends ocaml)
    (tags
     ("add topics" "to describe" your project)))
   
@@ -494,8 +494,8 @@ And the opam file will be generated as expected
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
-    "ocaml"
     "dune" {>= "3.17"}
+    "ocaml"
     "odoc" {with-doc}
   ]
   build: [


### PR DESCRIPTION
Dune automatically adds the right constraint anyway, with the right version constraint. All Dune project implicitely depend on Dune anyway and the tests show that the opam files correctly include Dune.

This helps with #11106 but also would have avoided triggering the bug in #11103 when the project is created with `dune init proj`.