### PR TITLE
feat: ensure `@pkg-install` is not registered without lock file

### DIFF
--- a/doc/reference/aliases/pkg-install.rst
+++ b/doc/reference/aliases/pkg-install.rst
@@ -18,7 +18,6 @@ downloaded, ``dune build`` will **also** take care of getting and building them.
     change less regularly.
 
 If you are building the ``@pkg-install`` alias in a repository where package
-management is not activated, the command will fail as we do not register the
-alias.
+management is not activated, the command will fail.
 
 .. seealso:: :doc:`/explanation/package-management`

--- a/doc/reference/aliases/pkg-install.rst
+++ b/doc/reference/aliases/pkg-install.rst
@@ -18,6 +18,7 @@ downloaded, ``dune build`` will **also** take care of getting and building them.
     change less regularly.
 
 If you are building the ``@pkg-install`` alias in a repository where package
-management is not activated, the command has no effect.
+management is not activated, the command will fail as we do not register the
+alias.
 
 .. seealso:: :doc:`/explanation/package-management`

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1983,7 +1983,14 @@ let setup_pkg_install_alias =
       | true ->
         Lock_dir.lock_dir_active ctx_name
         >>= (function
-         | false -> Memo.return Rules.empty
+         | false ->
+           let error =
+             [ Pp.text "The @pkg-install alias can't be used without a lock dir" ]
+           in
+           let hints =
+             [ Pp.text "You might want to create the lock dir with dune pkg lock" ]
+           in
+           User_error.raise ~hints error
          | true ->
            Rules.collect_unit (fun () ->
              let alias = Alias.make ~dir Alias0.pkg_install in

--- a/test/blackbox-tests/test-cases/describe/aliases.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/aliases.t/run.t
@@ -9,6 +9,7 @@ In an empty dune project, the following aliases are available.
   default
   fmt
   ocaml-index
+  pkg-install
 
 User defined aliases can be added to a dune file. These should be picked up by
 the command.
@@ -24,6 +25,7 @@ the command.
   fmt
   foo
   ocaml-index
+  pkg-install
 
 Aliases in subdirectories should not be picked up.
 
@@ -39,6 +41,7 @@ Aliases in subdirectories should not be picked up.
   fmt
   foo
   ocaml-index
+  pkg-install
 
 But checking the subdirectory it should be available.
 
@@ -62,6 +65,7 @@ Adding an OCaml library will introduce OCaml specific aliases:
   doc-private
   fmt
   ocaml-index
+  pkg-install
 
 Adding a cram test will introduce an alias with the name of the test and also
 introduce the runtest alias:
@@ -75,6 +79,7 @@ bbb
   fmt
   mytest
   ocaml-index
+  pkg-install
   runtest
 
 We can also show aliases in multiple directories at once:
@@ -86,6 +91,7 @@ We can also show aliases in multiple directories at once:
   fmt
   mytest
   ocaml-index
+  pkg-install
   runtest
   
   subdir:
@@ -104,6 +110,7 @@ Including those in the _build/ directory:
   fmt
   mytest
   ocaml-index
+  pkg-install
   runtest
   
   _build/default:
@@ -112,6 +119,7 @@ Including those in the _build/ directory:
   fmt
   mytest
   ocaml-index
+  pkg-install
   runtest
 
 These are context sensitive:
@@ -132,4 +140,5 @@ These are context sensitive:
   fmt
   mytest
   ocaml-index
+  pkg-install
   runtest

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -14,8 +14,8 @@ Create a project using the fake library as a dependency:
 
 Ensure the alias is not available outside of the package manamgent context:
   $ dune build @pkg-install
-  Error: Alias "pkg-install" specified on the command line is empty.
-  It is not defined in . or any of its descendants.
+  Error: The @pkg-install alias can't be used without a lock dir
+  Hint: You might want to create the lock dir with dune pkg lock
   [1]
 
 Create a fake package which echoes information to stdout when build:

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -14,8 +14,9 @@ Create a project using the fake library as a dependency:
 
 Ensure the alias is not available outside of the package manamgent context:
   $ dune build @pkg-install
-  Error: The @pkg-install alias can't be used without a lock dir
-  Hint: You might want to create the lock dir with dune pkg lock
+  Error: The @pkg-install alias cannot be used without a lock dir
+  -> required by alias pkg-install
+  Hint: You might want to create the lock dir with 'dune pkg lock'
   [1]
 
 Create a fake package which echoes information to stdout when build:

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -3,6 +3,21 @@ without building the project itself.
 
   $ . ./helpers.sh
 
+Create a project using the fake library as a dependency:
+  $ cat > dune-project << EOF
+  > (lang dune 3.16)
+  > (package
+  >  (name bar)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+Ensure the alias is not available outside of the package manamgent context:
+  $ dune build @pkg-install
+  Error: Alias "pkg-install" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  [1]
+
 Create a fake package which echoes information to stdout when build:
   $ make_lockdir
   $ cat > dune.lock/foo.pkg << EOF
@@ -11,15 +26,6 @@ Create a fake package which echoes information to stdout when build:
   >  (run echo "Build package foo"))
   > (install
   >  (run echo "Install package foo"))
-  > EOF
-
-Create a project using the fake library as a dependency:
-  $ cat > dune-project << EOF
-  > (lang dune 3.16)
-  > (package
-  >  (name bar)
-  >  (allow_empty)
-  >  (depends foo))
   > EOF
 
 Create a rule to show that this rule is not called with `@pkg-install` as `bar`


### PR DESCRIPTION
This PR improves the test and the documentation regarding the @pkg-install alias. It shows that it fails outside of packagement context and changes the documentation to reflect the true behavior.
