### PR TITLE
[3.17] remove breaking change for `alpha1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,9 +41,6 @@
 - Fix an issue where C stubs would be rebuilt whenever the stderr of Dune was
   redirected. (#10883, fixes #10882, @nojb)
 
-- Format long lists in s-expressions to fill the line instead of formatting
-  them in a vertical way (#10892, fixes #10860, @nojb)
-
 - Fix the URL opened by the command `dune ocaml doc`. (#10897, @gridbugs)
 
 - Fix the file referred to in the error/warning message displayed due to the

--- a/src/dune_lang/format.ml
+++ b/src/dune_lang/format.ml
@@ -26,10 +26,7 @@ let print_wrapped_list ~version x =
   let inner = Pp.concat_map ~sep:Pp.space ~f:pp_simple x in
   if version < (2, 8)
   then Pp.char '(' ++ Pp.hovbox ~indent:1 inner ++ Pp.char ')'
-  else
-    (if version < (3, 17) then Pp.hvbox else Pp.hovbox)
-      ~indent:1
-      (Pp.char '(' ++ inner ++ Pp.char ')')
+  else Pp.hvbox ~indent:1 (Pp.char '(' ++ inner ++ Pp.char ')')
 ;;
 
 let pp_comment_line l = Pp.char ';' ++ Pp.verbatim l

--- a/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
+++ b/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
@@ -104,13 +104,20 @@ not stable across different setups.
    (executables
     ((names (exe))
      (requires
-      (c39d8e11db2363236e69af7750ce7b9a c9367091ddd9a70d99fc22ede348f17c
-       1f2b5eb300ea716920494385a31bb5fb 5014e215e204cf8da6c32644cda1b31e
-       249b2edaf3cc552a247667041bb5f015 ba85adfb1c97e7d7af3df35b16b2fc0d
-       2363fd46dac995a1c79679dfa1a9881b 43b7cbe1f93f4f502ec614971027cff9
-       e68a558facd1546b51c7abdbf6aed1cb 24f4eb12e3ff51b310dbf7443c6087be
-       449445be7a24ce51e119d57e9e255d3f 5ae836dcdead11d5c16815297c5a1ae6
-       2c61db8e94cb08e0fe642152aee8121a 6fb5d46437c55abca48c8b995f8afa51
+      (c39d8e11db2363236e69af7750ce7b9a
+       c9367091ddd9a70d99fc22ede348f17c
+       1f2b5eb300ea716920494385a31bb5fb
+       5014e215e204cf8da6c32644cda1b31e
+       249b2edaf3cc552a247667041bb5f015
+       ba85adfb1c97e7d7af3df35b16b2fc0d
+       2363fd46dac995a1c79679dfa1a9881b
+       43b7cbe1f93f4f502ec614971027cff9
+       e68a558facd1546b51c7abdbf6aed1cb
+       24f4eb12e3ff51b310dbf7443c6087be
+       449445be7a24ce51e119d57e9e255d3f
+       5ae836dcdead11d5c16815297c5a1ae6
+       2c61db8e94cb08e0fe642152aee8121a
+       6fb5d46437c55abca48c8b995f8afa51
        f9851d3f8ae32391e7594cf97332a78c))
      (modules
       (((name Exe)
@@ -140,7 +147,8 @@ not stable across different setups.
      (uid f9851d3f8ae32391e7594cf97332a78c)
      (local true)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2c61db8e94cb08e0fe642152aee8121a
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2c61db8e94cb08e0fe642152aee8121a
        6fb5d46437c55abca48c8b995f8afa51))
      (source_dir _build/default/dummy_ppx)
      (modules
@@ -179,10 +187,14 @@ not stable across different setups.
      (uid 2c61db8e94cb08e0fe642152aee8121a)
      (local false)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2363fd46dac995a1c79679dfa1a9881b
-       5014e215e204cf8da6c32644cda1b31e 43b7cbe1f93f4f502ec614971027cff9
-       e68a558facd1546b51c7abdbf6aed1cb 24f4eb12e3ff51b310dbf7443c6087be
-       5ae836dcdead11d5c16815297c5a1ae6 249b2edaf3cc552a247667041bb5f015
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2363fd46dac995a1c79679dfa1a9881b
+       5014e215e204cf8da6c32644cda1b31e
+       43b7cbe1f93f4f502ec614971027cff9
+       e68a558facd1546b51c7abdbf6aed1cb
+       24f4eb12e3ff51b310dbf7443c6087be
+       5ae836dcdead11d5c16815297c5a1ae6
+       249b2edaf3cc552a247667041bb5f015
        449445be7a24ce51e119d57e9e255d3f))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
@@ -284,7 +296,8 @@ not stable across different setups.
      (uid f9851d3f8ae32391e7594cf97332a78c)
      (local true)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2c61db8e94cb08e0fe642152aee8121a
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2c61db8e94cb08e0fe642152aee8121a
        6fb5d46437c55abca48c8b995f8afa51))
      (source_dir _build/default/dummy_ppx)
      (modules
@@ -336,10 +349,14 @@ not stable across different setups.
      (uid 2c61db8e94cb08e0fe642152aee8121a)
      (local false)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2363fd46dac995a1c79679dfa1a9881b
-       5014e215e204cf8da6c32644cda1b31e 43b7cbe1f93f4f502ec614971027cff9
-       e68a558facd1546b51c7abdbf6aed1cb 24f4eb12e3ff51b310dbf7443c6087be
-       5ae836dcdead11d5c16815297c5a1ae6 249b2edaf3cc552a247667041bb5f015
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2363fd46dac995a1c79679dfa1a9881b
+       5014e215e204cf8da6c32644cda1b31e
+       43b7cbe1f93f4f502ec614971027cff9
+       e68a558facd1546b51c7abdbf6aed1cb
+       24f4eb12e3ff51b310dbf7443c6087be
+       5ae836dcdead11d5c16815297c5a1ae6
+       249b2edaf3cc552a247667041bb5f015
        449445be7a24ce51e119d57e9e255d3f))
      (source_dir /FINDLIB/ppxlib)
      (modules ())

--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -546,10 +546,14 @@ not stable across different setups.
      (uid 2c61db8e94cb08e0fe642152aee8121a)
      (local false)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2363fd46dac995a1c79679dfa1a9881b
-       5014e215e204cf8da6c32644cda1b31e 43b7cbe1f93f4f502ec614971027cff9
-       e68a558facd1546b51c7abdbf6aed1cb 24f4eb12e3ff51b310dbf7443c6087be
-       5ae836dcdead11d5c16815297c5a1ae6 249b2edaf3cc552a247667041bb5f015
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2363fd46dac995a1c79679dfa1a9881b
+       5014e215e204cf8da6c32644cda1b31e
+       43b7cbe1f93f4f502ec614971027cff9
+       e68a558facd1546b51c7abdbf6aed1cb
+       24f4eb12e3ff51b310dbf7443c6087be
+       5ae836dcdead11d5c16815297c5a1ae6
+       249b2edaf3cc552a247667041bb5f015
        449445be7a24ce51e119d57e9e255d3f))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
@@ -1116,10 +1120,14 @@ not stable across different setups.
      (uid 2c61db8e94cb08e0fe642152aee8121a)
      (local false)
      (requires
-      (ba85adfb1c97e7d7af3df35b16b2fc0d 2363fd46dac995a1c79679dfa1a9881b
-       5014e215e204cf8da6c32644cda1b31e 43b7cbe1f93f4f502ec614971027cff9
-       e68a558facd1546b51c7abdbf6aed1cb 24f4eb12e3ff51b310dbf7443c6087be
-       5ae836dcdead11d5c16815297c5a1ae6 249b2edaf3cc552a247667041bb5f015
+      (ba85adfb1c97e7d7af3df35b16b2fc0d
+       2363fd46dac995a1c79679dfa1a9881b
+       5014e215e204cf8da6c32644cda1b31e
+       43b7cbe1f93f4f502ec614971027cff9
+       e68a558facd1546b51c7abdbf6aed1cb
+       24f4eb12e3ff51b310dbf7443c6087be
+       5ae836dcdead11d5c16815297c5a1ae6
+       249b2edaf3cc552a247667041bb5f015
        449445be7a24ce51e119d57e9e255d3f))
      (source_dir /FINDLIB/ppxlib)
      (modules ())

--- a/test/blackbox-tests/test-cases/formatting/format-dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/format-dune-file.t/run.t
@@ -49,7 +49,7 @@ When a list is indented, there is no extra space at the end.
 When there is a long list of atoms, quoted strings, templates and singletons,
 it gets wrapped.
 
-  $ echo '(library (name dune) (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang ocaml_config which_program) (synopsis "Internal Dune library, do not use!") (preprocess  (action (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))' | dune format-dune-file --dune-version 3.16
+  $ echo '(library (name dune) (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang ocaml_config which_program) (synopsis "Internal Dune library, do not use!") (preprocess  (action (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))' | dune format-dune-file
   (library
    (name dune)
    (libraries
@@ -63,18 +63,6 @@ it gets wrapped.
     dune_lang
     ocaml_config
     which_program)
-   (synopsis "Internal Dune library, do not use!")
-   (preprocess
-    (action
-     (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))
-
-The same file, but in the current version:
-
-  $ echo '(library (name dune) (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang ocaml_config which_program) (synopsis "Internal Dune library, do not use!") (preprocess  (action (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))' | dune format-dune-file
-  (library
-   (name dune)
-   (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang
-    ocaml_config which_program)
    (synopsis "Internal Dune library, do not use!")
    (preprocess
     (action

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -16,8 +16,12 @@ It builds on its own (with a warning) when lang dune is 3.2 or below:
   $ dune printenv --root=inner --field flags
   Entering directory 'inner'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'inner'
   $ dune build --root=inner
   Entering directory 'inner'
@@ -37,8 +41,12 @@ Note that in versions of lang dune above 3.2 this warning becomes an error:
   $ dune printenv --root=inner --field flags
   Entering directory 'inner'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'inner'
   $ dune build --root=inner
   Entering directory 'inner'
@@ -60,8 +68,12 @@ Building the outer project works when lang dune is 3.2 or below:
   $ dune printenv --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
 
   $ dune build --root=outer
@@ -77,14 +89,22 @@ But when lang dune is 3.3 or higher the warning becomes an error:
   $ dune printenv --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
   $ dune printenv outer/vendored/inner --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
 
   $ dune build --root=outer


### PR DESCRIPTION
This PR reverts the patch made in #10892 for the `3.17.0~alpha1` release. Indeed, while releasing `3.17.0` we have seen that it would break `odoc` tests because of the indentation. Further discussions have occurred in the PR about how to fix it in `main` in a more sustainable way. However, we have decided to remove the patch for `3.17.0` and reintroduce it in later released.