### PR TITLE
Stop VCS discovery choking on unreadable root

### DIFF
--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -512,7 +512,16 @@ let ancestor_vcs =
             |> Vcs.Kind.of_dir_contents
           with
           | Some kind -> Some { Vcs.kind; root = Path.of_string dir }
-          | None -> loop dir)
+          | None -> loop dir
+          | exception Sys_error msg ->
+            User_warning.emit
+              [ Pp.textf
+                  "Unable to read directory %s. Will not look for VCS root in parent \
+                   directories."
+                  dir
+              ; Pp.textf "Reason: %s" msg
+              ];
+            None)
       in
       Memo.return (loop (Path.to_absolute_filename Path.root))))
 ;;


### PR DESCRIPTION
On Android devices, the root directory is not readable. This stops the VCS discovery failing the whole install by just ignoring that for VCS discovery, in the same manner as for root.

In my case, a dune package was not in a VCS folder because it was being built by `nix`, which for reproducibility doesn't include the `.git` folder in the build environment (because even though the commit contents are the same, the git database isn't, e.g. it can contain different tags etc).