### PR TITLE
Bump Dune lang version to 3.18

### DIFF
--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -456,7 +456,7 @@ lang<coq-lang>` stanza present:
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using coq 0.8)
 
 Next we need a :doc:`/reference/dune/index` file with a :ref:`coq-theory`
@@ -687,7 +687,7 @@ the plugin to sit in, otherwise Coq will not be able to find it.
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using coq 0.8)
 
   (package

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -103,7 +103,7 @@ file:
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using ctypes 0.3)
 
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -286,7 +286,7 @@ Such languages must be enabled in the ``dune`` project file separately:
 
 .. code:: dune
 
-   (lang dune 3.17)
+   (lang dune 3.18)
    (using coq 0.8)
 
 If such extensions are experimental, it's recommended that they pass

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -96,14 +96,14 @@ To enable an instrumentation backend globally, type the following in your
 
 .. code:: dune
 
-   (lang dune 3.17)
+   (lang dune 3.18)
    (instrument_with bisect_ppx)
 
 or for each context individually:
 
 .. code:: dune
 
-   (lang dune 3.17)
+   (lang dune 3.18)
    (context default)
    (context (default (name coverage) (instrument_with bisect_ppx)))
    (context (default (name profiling) (instrument_with landmarks)))

--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -42,7 +42,7 @@ is enabled:
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using melange 0.1)
 
 Next, write a :doc:`/reference/dune/index` file with a

--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -34,7 +34,7 @@ will be installed as a sub-directory.
 
 .. code:: dune
 
-   (lang dune 3.17)
+   (lang dune 3.18)
    (using dune_site 0.1)
    (name mygui)
 
@@ -235,7 +235,7 @@ Main Executable (C)
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using dune_site 0.1)
   (name app)
 
@@ -295,7 +295,7 @@ The Plugin "plugin1"
 
 .. code:: dune
 
-  (lang dune 3.17)
+  (lang dune 3.18)
   (using dune_site 0.1)
 
   (generate_opam_files true)

--- a/doc/test/run.t
+++ b/doc/test/run.t
@@ -8,15 +8,5 @@ is fine, but you then need to update the list of such exceptions below.
 
   $ DUNE_LANG=$(dune internal latest-lang-version)
   $ grep '(lang dune' ../*.rst | grep -v "$DUNE_LANG"
-  ../coq.rst:  (lang dune 3.17)
-  ../coq.rst:  (lang dune 3.17)
-  ../foreign-code.rst:  (lang dune 3.17)
   ../hacking.rst:``(lang dune 2.7)`` in their ``dune`` project file to use it.
-  ../hacking.rst:   (lang dune 3.17)
-  ../instrumentation.rst:   (lang dune 3.17)
-  ../instrumentation.rst:   (lang dune 3.17)
-  ../melange.rst:  (lang dune 3.17)
-  ../sites.rst:   (lang dune 3.17)
-  ../sites.rst:  (lang dune 3.17)
-  ../sites.rst:  (lang dune 3.17)
   ../tests.rst:   (lang dune 2.7)

--- a/doc/test/run.t
+++ b/doc/test/run.t
@@ -8,5 +8,15 @@ is fine, but you then need to update the list of such exceptions below.
 
   $ DUNE_LANG=$(dune internal latest-lang-version)
   $ grep '(lang dune' ../*.rst | grep -v "$DUNE_LANG"
+  ../coq.rst:  (lang dune 3.17)
+  ../coq.rst:  (lang dune 3.17)
+  ../foreign-code.rst:  (lang dune 3.17)
   ../hacking.rst:``(lang dune 2.7)`` in their ``dune`` project file to use it.
+  ../hacking.rst:   (lang dune 3.17)
+  ../instrumentation.rst:   (lang dune 3.17)
+  ../instrumentation.rst:   (lang dune 3.17)
+  ../melange.rst:  (lang dune 3.17)
+  ../sites.rst:   (lang dune 3.17)
+  ../sites.rst:  (lang dune 3.17)
+  ../sites.rst:  (lang dune 3.17)
   ../tests.rst:   (lang dune 2.7)

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -27,7 +27,7 @@ end
 module Version = struct
   type t = int * int
 
-  let latest = 3, 17
+  let latest = 3, 18
 
   let sexp : t Conv.value =
     let open Conv in

--- a/src/dune_lang/format.ml
+++ b/src/dune_lang/format.ml
@@ -27,7 +27,7 @@ let print_wrapped_list ~version x =
   if version < (2, 8)
   then Pp.char '(' ++ Pp.hovbox ~indent:1 inner ++ Pp.char ')'
   else
-    (if version < (3, 17) then Pp.hvbox else Pp.hovbox)
+    (if version < (3, 18) then Pp.hvbox else Pp.hovbox)
       ~indent:1
       (Pp.char '(' ++ inner ++ Pp.char ')')
 ;;

--- a/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
+++ b/test/blackbox-tests/test-cases/directory-targets/installed-dependency.t
@@ -25,7 +25,7 @@ Allow directories to be installable
   Leaving directory 'a'
 
   $ cat a/_build/install/default/lib/foo/dune-package
-  (lang dune 3.17)
+  (lang dune 3.18)
   (name foo)
   (sections (lib .) (share ../../share/foo))
   (files (lib (META dune-package)) (share ((dir bar) x y)))

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -384,7 +384,7 @@ And the opam file will be generated as expected
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
-    $dune {>= "3.17"}
+    $dune {>= "3.18"}
     "ocaml"
     "odoc" {with-doc}
   ]
@@ -494,7 +494,7 @@ And the opam file will be generated as expected
   doc: "https://url/to/documentation"
   bug-reports: "https://github.com/username/reponame/issues"
   depends: [
-    "dune" {>= "3.17"}
+    "dune" {>= "3.18"}
     "ocaml"
     "odoc" {with-doc}
   ]

--- a/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install/install-stublibs.t/run.t
@@ -32,7 +32,7 @@ Begin by installing a library with C stubs.
   Installing install/lib/libA/libA.cmxs
   Installing install/lib/stublibs/dlllibA_stubs.so
   $ cat ./install/lib/libA/dune-package
-  (lang dune 3.17)
+  (lang dune 3.18)
   (name libA)
   (sections
    (lib

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -27,7 +27,7 @@ Test that we can install melange mode libraries
   ]
 
   $ cat ./_build/install/default/lib/foo/dune-package
-  (lang dune 3.17)
+  (lang dune 3.18)
   (name foo)
   (sections (lib .))
   (files

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -22,9 +22,9 @@ dependency.
   Couldn't solve the package dependency formula.
   Selected candidates: foo.0.0.1 x.dev
   - dune -> (problem)
-      User requested = 3.17
+      User requested = 3.18
       Rejected candidates:
-        dune.3.11.0: Incompatible with restriction: = 3.17
+        dune.3.11.0: Incompatible with restriction: = 3.18
   [1]
   $ test "4.0.0"
   Solution for dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
@@ -31,5 +31,5 @@ We are unable to pin projects that the version of dune doesn't understand.
   Supported versions of this extension in version 100.1 of the dune language:
   - 1.0 to 1.12
   - 2.0 to 2.9
-  - 3.0 to 3.17
+  - 3.0 to 3.18
   [1]


### PR DESCRIPTION
See https://github.com/ocaml/dune/pull/11166#issuecomment-2510124098

The second commit fixes the versioning guard of a change that was initially in 3.17 but was later reverted (see #11164).