### PR TITLE
Fix ignored-dune-lock test on macos

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -16,6 +16,8 @@ Test that shows what happens when dune.lock is ignored.
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml
   > +++ b/foo.ml
+  > @@ -0,0 +1 @@
+  > +let () = print_endline "Hello, World!"
   > EOF
 
   $ mkdir src


### PR DESCRIPTION
The macos patch utility doesn't like it when a patch contains no hunks, so this change adds a hunk to the patch used in the ignored-dune-lock test.