### PR TITLE
Create reference documentation for current state of package management support

### DIFF
--- a/doc/reference/dune-project/index.rst
+++ b/doc/reference/dune-project/index.rst
@@ -27,6 +27,7 @@ Additionally, they can contains the following stanzas.
   name
   opam_file_location
   package
+  pin
   subst
   use_standard_c_and_cxx_flags
   using

--- a/doc/reference/dune-project/pin.rst
+++ b/doc/reference/dune-project/pin.rst
@@ -1,0 +1,50 @@
+pin
+---
+
+.. warning::
+
+   :doc:`Dune Package Management </explanation/package-management>` is not
+   final yet and the configuration options are subject to change.
+
+Pins are package overrides used in the context of package management. They
+allow to fix a package at a specific version which is not affected by the
+package repositories selected.
+
+.. describe:: (pin ...)
+
+   .. versionadded:: 3.14
+
+   Define a package override.
+
+   .. describe:: (url <string>)
+
+      The URL of the package source.
+
+      This can be a path to a directory on the local file system or remote Git
+      repository. Local paths can be absolute or relative, and may optionally
+      begin with ``file://`` though this is not necessary. Remote Git
+      repository URLs must begin with ``git+``, for example
+      ``git+https://github.com/user/repo`` or
+      ``git+git@github.com:user/repo.git``.
+
+      This must be specified.
+
+   .. describe:: (package ...)
+
+      Defines which package is to be pinned.
+
+      This must be specified.
+
+      .. describe:: (name <string>)
+
+         The name of the package.
+
+         This must be specified.
+
+      .. describe:: (version <string>)
+
+         The version that the package should be assumed to be. Defaults to
+         ``dev`` if unspecified.
+
+.. seealso:: :doc:`pin stanza in dune-workspace </reference/dune-workspace/pin>` for
+   workspace-wide pinning.

--- a/doc/reference/dune-workspace/context.rst
+++ b/doc/reference/dune-workspace/context.rst
@@ -15,6 +15,12 @@ the description of an opam switch, as follows:
 -  ``(name <name>)`` is the subdirectory's name for ``_build``, where this
    build's context artifacts will be stored.
 
+-  ``(lock_dir <path>)`` specifies the lock directory that will be used for
+   building this context (if any). If no lock directory is specified
+   ``dune.lock`` will be used. See the
+   :doc:`/reference/dune-workspace/lock_dir` stanza for lock directory
+   configuration options.
+
 -  ``(root <opam-root>)`` is the opam root. By default, it will take the opam
    root defined by the environment in which ``dune`` is run, which is usually
    ``~/.opam``.

--- a/doc/reference/dune-workspace/index.rst
+++ b/doc/reference/dune-workspace/index.rst
@@ -43,4 +43,7 @@ project.
   config
   context
   env
+  lock_dir
+  pin
   profile
+  repository

--- a/doc/reference/dune-workspace/lock_dir.rst
+++ b/doc/reference/dune-workspace/lock_dir.rst
@@ -1,0 +1,73 @@
+lock_dir
+========
+
+.. warning::
+
+   :doc:`Dune Package Management </explanation/package-management>` is not
+   final yet and the configuration options are subject to change.
+
+This stanza configures the lock directory settings for the current workspace.
+For the default workflow no configuration is necessary, but the defaults can be
+changed if desired.
+
+.. describe:: (lock_dir ...)
+
+   .. versionadded:: 3.13
+
+   Configures a specific lock directory to be created or used.
+
+   .. describe:: (path <string>)
+
+      The location in the source tree where the lock directory will be
+      created or read from. If not specified defaults to ``dune.lock``.
+
+   .. describe:: (repositories <name list>)
+
+      The repositories to be used for finding a package solution, specified
+      in priority order. Supports ``:default`` which contains ``upsteam`` and
+      ``overlay``.
+
+      Additional repositories can be defined using the
+      :doc:`/reference/dune-workspace/repository` stanza.
+
+   .. describe:: (solver_env ...)
+
+      The environment that is injected into the solver when creating the lock
+      directory.
+
+      It consists of a sequence of ``(<name> <value>)`` pairs.
+
+   .. describe:: (unset_variables <name list>)
+
+      A list of variables that are used in solving that are deliberately unset
+      even if the solver could provide bindings for them.
+
+      The variables here cannot overlap with those defined in ``solver_env``.
+
+   .. describe:: (pins <name list>)
+
+      .. versionadded:: 3.15
+
+      Define which pins are enabled for this particular lock dir. See
+      :doc:`/reference/dune-workspace/pin` for details on how to define pins.
+
+   .. describe:: (version_preference <string>)
+
+      Can be one of:
+
+      - ``newest`` (default): The solver will pick the newest available
+         version of a package that satisfies the constraints.
+      - ``oldest``: The solver will pick the lowest version that will satisfy
+         the constraints
+
+   .. describe:: (constraints <dep-specification>)
+
+      Adds additional solver constraints that are passed to the solver. Follows
+      the :token:`~pkg-dep:dep_specification` format.
+
+      .. note::
+
+         Names introduced through ``constraints`` are not considered
+         dependencies and not added to the lockfile. They exist solely to add
+         additional constraints if the packages to which the constraint is
+         applied are selected and don't do anything otherwise.

--- a/doc/reference/dune-workspace/pin.rst
+++ b/doc/reference/dune-workspace/pin.rst
@@ -1,0 +1,57 @@
+pin
+===
+
+.. warning::
+
+   :doc:`Dune Package Management </explanation/package-management>` is not
+   final yet and the configuration options are subject to change.
+
+This stanza is used to define additional package sources to use when locking a
+project and used for building dependencies.
+
+.. note::
+
+   Defining a pin does not enable it by default. It needs to be enabled in a
+   lock directory using the :doc:`/reference/dune-workspace/lock_dir` stanza.
+
+.. describe:: (pin ...)
+
+   .. versionadded:: 3.15
+
+   Defines a new package source.
+
+   .. describe:: (name <string>)
+
+      The name of the newly defined pin. This can be anything, it does not
+      have to match the package.
+
+      This must be specified.
+
+   .. describe:: (url <string>)
+
+      This can be a path to a directory on the local file system or remote Git
+      repository. Local paths can be absolute or relative, and may optionally
+      begin with ``file://`` though this is not necessary. Remote Git
+      repository URLs must begin with ``git+``, for example
+      ``git+https://github.com/user/repo`` or
+      ``git+git@github.com:user/repo.git``.
+
+      This must be specified.
+
+   .. describe:: (package ...)
+
+      Specifies the the packages to assign this pin to.
+
+      .. describe:: (name <string>)
+
+         The name of the package.
+
+         This must be specified.
+
+      .. describe:: (version <string>)
+
+         The version that the package should be assumed to be. Defaults to
+         ``dev`` if unspecified.
+
+.. seealso:: :doc:`pin stanza in dune-project </reference/dune-project/pin>` for
+   per-project pins.

--- a/doc/reference/dune-workspace/repository.rst
+++ b/doc/reference/dune-workspace/repository.rst
@@ -1,0 +1,38 @@
+repository
+==========
+
+.. warning::
+
+   :doc:`Dune Package Management </explanation/package-management>` is not
+   final yet and the configuration options are subject to change.
+
+This stanza defines a new named package repository and attaches a source
+location to it.
+
+.. note::
+
+   Defining a repository does not enable it in project by default. It needs to be
+   enabled in a lock directory using the :doc:`/reference/dune-workspace/lock_dir`
+   stanza.
+
+.. describe:: (repository ...)
+
+   .. versionadded:: 3.12
+
+   Defines a named package repository.
+
+   .. describe:: (name <string>)
+
+      The name used to refer to the respository. Names have to be unique.
+
+      This must be specified.
+
+   .. describe:: (url <string>)
+
+      The location from which the repository will be loaded.
+
+      Both HTTP and Git locations can be specified, the latter allowing for
+      extensive control of the version by specifying an exact revision, tag or
+      branch.
+
+      This must be specified.

--- a/doc/tutorials/dune-package-management/pinning.md
+++ b/doc/tutorials/dune-package-management/pinning.md
@@ -17,8 +17,9 @@ To pin a package, a new `pin` has to be declared in the `dune-project` file.
 :emphasize-lines: 4-6,12
 :::
 
-This will create a pin on the `fmt` package and use the specified Git repository
-URL to retrieve the sources.
+This will create a pin on the `fmt` package and use the specified Git
+repository URL to retrieve the sources. For more information refer to {doc}`the
+pin stanza reference </reference/dune-project/pin>`.
 
 Don't forget to remove the version constraints from `fmt` in the list of
 dependencies.

--- a/doc/tutorials/dune-package-management/repos.md
+++ b/doc/tutorials/dune-package-management/repos.md
@@ -26,6 +26,10 @@ instead of always using the most recent one as it would do by default. We
 define a new repository and configure the lock directory to use this
 repository.
 
+For more information about the stanzas refer to the {doc}`repositories stanza
+</reference/dune-workspace/repository>` as well as the {doc}`lock_dir stanza
+</reference/dune-workspace/lock_dir>`.
+
 When relocking the dependencies, the list of packages that are found as
 dependencies changes accordingly:
 


### PR DESCRIPTION
For a proper release it makes sense to document the package management extensions to the `dune-project` and `dune-workspace`. This PR documents the current state, though it is to be discussed if this is what we plan to roll out as final form of the feature.