### PR TITLE
Rename `source` to `url` in `repository` stanza

### DIFF
--- a/doc/tutorials/dune-package-management/repos/dune-workspace
+++ b/doc/tutorials/dune-package-management/repos/dune-workspace
@@ -5,4 +5,4 @@
 
 (repository
  (name specific-upstream)
- (source "git+https://github.com/ocaml/opam-repository.git#00ac3727bc4ac0eabd3c89e69c1660d6b63a3d48"))
+ (url "git+https://github.com/ocaml/opam-repository.git#00ac3727bc4ac0eabd3c89e69c1660d6b63a3d48"))

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -22,39 +22,38 @@ module Repository = struct
 
   type t =
     { name : Name.t
-    ; source : Loc.t * OpamUrl.t
+    ; url : Loc.t * OpamUrl.t
     }
 
   let name { name; _ } = name
 
-  let to_dyn { name; source = _, source } =
+  let to_dyn { name; url = _, url } =
     let open Dyn in
-    variant "repository" [ Name.to_dyn name; string (OpamUrl.to_string source) ]
+    variant "repository" [ Name.to_dyn name; string (OpamUrl.to_string url) ]
   ;;
 
-  let equal { name; source } t =
-    Name.equal name t.name && Tuple.T2.equal Loc.equal OpamUrl.equal source t.source
+  let equal { name; url } t =
+    Name.equal name t.name && Tuple.T2.equal Loc.equal OpamUrl.equal url t.url
   ;;
 
-  let hash { name; source } = Tuple.T2.hash Name.hash Poly.hash (name, source)
+  let hash { name; url } = Tuple.T2.hash Name.hash Poly.hash (name, url)
 
   let upstream =
     { name = "upstream"
-    ; source =
-        Loc.none, OpamUrl.of_string "git+https://github.com/ocaml/opam-repository.git"
+    ; url = Loc.none, OpamUrl.of_string "git+https://github.com/ocaml/opam-repository.git"
     }
   ;;
 
   let overlay =
     { name = "overlay"
-    ; source =
+    ; url =
         Loc.none, OpamUrl.of_string "git+https://github.com/ocaml-dune/opam-overlays.git"
     }
   ;;
 
   let binary_packages =
     { name = "binary-packages"
-    ; source =
+    ; url =
         ( Loc.none
         , OpamUrl.of_string "git+https://github.com/ocaml-dune/ocaml-binary-packages.git"
         )
@@ -65,9 +64,9 @@ module Repository = struct
     let open Decoder in
     fields
       (let+ name = field "name" Name.decode
-       and+ source = field "source" OpamUrl.decode_loc in
-       { name; source })
+       and+ url = field "url" OpamUrl.decode_loc in
+       { name; url })
   ;;
 
-  let opam_url { source; _ } = source
+  let opam_url { name = _; url } = url
 end

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
@@ -47,7 +47,7 @@ Now make a workspace file adding the constarint on ocaml-system:
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Solve again. This time ocaml-system is chosen.

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints.t
@@ -9,7 +9,7 @@ It's possible to include additional packages or constraints in workspace files:
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
   $ mkrepo

--- a/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
+++ b/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
@@ -23,7 +23,7 @@ Use this ref in a project
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "git+file://$PWD/mock-opam-repository#$AMBIGUOUS_REF"))
+  >  (url "git+file://$PWD/mock-opam-repository#$AMBIGUOUS_REF"))
   > (context
   >  (default
   >   (name default)))

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -27,7 +27,7 @@ First we setup a repo.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Here is the output of solving for multiple contexts:

--- a/test/blackbox-tests/test-cases/pkg/duplicate-repositories.t
+++ b/test/blackbox-tests/test-cases/pkg/duplicate-repositories.t
@@ -4,10 +4,10 @@ Duplicate repository definition in the same workspace file:
   > (lang dune 3.11)
   > (repository
   >  (name foo)
-  >  (source "git+file//$PWD/foo"))
+  >  (url "git+file//$PWD/foo"))
   > (repository
   >  (name foo)
-  >  (source "git+file//$PWD/foo"))
+  >  (url "git+file//$PWD/foo"))
   > EOF
 
   $ dune pkg outdated 2>&1 | awk '/Internal error/,/Raised/'

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -51,7 +51,7 @@ Create a workspace config that defines separate build contexts for macos and lin
   >   (lock_dir dune.macos.lock)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Now the os-specific dependencies are included on their respective systems.

--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -19,7 +19,7 @@ We'll set up a project that uses (only this) this repository, so doesn't use
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "git+file://$PWD/mock-opam-repository"))
+  >  (url "git+file://$PWD/mock-opam-repository"))
   > (context
   >  (default
   >   (name default)))

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -52,7 +52,7 @@ add_mock_repo_if_needed() {
  (repositories mock))
 (repository
  (name mock)
- (source "file://$(pwd)/mock-opam-repository"))
+ (url "file://$(pwd)/mock-opam-repository"))
 EOF
   else
     if ! grep '(name mock)' > /dev/null dune-workspace
@@ -61,7 +61,7 @@ EOF
       cat >>dune-workspace <<EOF
 (repository
  (name mock)
- (source "file://$(pwd)/mock-opam-repository"))
+ (url "file://$(pwd)/mock-opam-repository"))
 EOF
  
       # reference the repo

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -11,21 +11,21 @@ Test the error cases for invalid opam repositories
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/directory-that-does-not-exist"))
+  >  (url "file://$(pwd)/directory-that-does-not-exist"))
   > EOF
 
   $ lock() {
   > out="$(dune pkg lock 2>&1)"
   > local code="$?"
   > echo "$out" | sed 's/character.*:/characters X-X:/g' \
-  >   | sed 's/source ".*"/source ../g' \
+  >   | sed 's/url ".*"/url ../g' \
   >   | grep -v "\^"
   > return $code
   > }
 
   $ lock
   File "dune-workspace", line 6, characters X-X:
-  6 |  (source ..))
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/directory-that-does-not-exist
   does not exist
@@ -38,11 +38,11 @@ Test the error cases for invalid opam repositories
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/empty"))
+  >  (url "file://$(pwd)/empty"))
   > EOF
   $ lock
   File "dune-workspace", line 6, characters X-X:
-  6 |  (source ..))
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/empty
   is not a directory
@@ -54,11 +54,11 @@ Test the error cases for invalid opam repositories
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/no-packages-dir"))
+  >  (url "file://$(pwd)/no-packages-dir"))
   > EOF
   $ lock
   File "dune-workspace", line 6, characters X-X:
-  6 |  (source ..))
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/no-packages-dir
   doesn't look like a path to an opam repository as it lacks a subdirectory

--- a/test/blackbox-tests/test-cases/pkg/invalid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-version.t
@@ -18,7 +18,7 @@ In this case we could also hint at the correct syntax for dune-project files.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
   $ dune pkg lock 2>&1

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -9,7 +9,7 @@ Create a lock directory that didn't originally exist
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
   $ dune pkg lock "dev/dune.lock"
   Solution for dev/dune.lock:

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -40,7 +40,7 @@ Test that dune can dynamically select a lockdir with a cond statement
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > (context
   >  (default
   >   (lock_dir (cond
@@ -121,7 +121,7 @@ Test that cond statements can have a default value:
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > (context
   >  (default
   >   (lock_dir (cond

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -31,7 +31,7 @@ Define some local packages.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Without a lockdir this command prints a hint but exits successfully.

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -34,7 +34,7 @@ Generate a `dune-project` file.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Run the solver and generate a lock directory.

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
@@ -17,10 +17,10 @@ Multiple opam repositories that define the same package:
   $ repos12=`cat <<EOF
   > (repository
   >  (name repo1)
-  >  (source "file://$PWD/repo1"))
+  >  (url "file://$PWD/repo1"))
   > (repository
   >  (name repo2)
-  >  (source "file://$PWD/repo2"))
+  >  (url "file://$PWD/repo2"))
   > EOF
   > `
 
@@ -101,7 +101,7 @@ Now we repeat the tests but with a git repo:
   > $repos12
   > (repository
   >  (name git-repo)
-  >  (source "git+file://$PWD/git-repo"))
+  >  (url "git+file://$PWD/git-repo"))
   > EOF
   > }
 

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -33,10 +33,10 @@ We have to define both repositories in the workspace, but will only use `new`.
   >  (repositories new))
   > (repository
   >  (name new)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (repository
   >  (name old)
-  >  (source "git+file://$(pwd)/old-mock-opam-repository"))
+  >  (url "git+file://$(pwd)/old-mock-opam-repository"))
   > EOF
 
   $ cat > dune-project <<EOF
@@ -65,10 +65,10 @@ solution:
   >  (repositories old))
   > (repository
   >  (name new)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (repository
   >  (name old)
-  >  (source "git+file://$(pwd)/old-mock-opam-repository"))
+  >  (url "git+file://$(pwd)/old-mock-opam-repository"))
   > (context
   >  (default
   >   (name default)))
@@ -88,10 +88,10 @@ package:
   >  (repositories old new))
   > (repository
   >  (name new)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (repository
   >  (name old)
-  >  (source "git+file://$(pwd)/old-mock-opam-repository"))
+  >  (url "git+file://$(pwd)/old-mock-opam-repository"))
   > (context
   >  (default
   >   (name default)))
@@ -110,10 +110,10 @@ older version of foo:
   > (lang dune 3.10)
   > (repository
   >  (name new)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (repository
   >  (name old)
-  >  (source "git+file://$(pwd)/old-mock-opam-repository"))
+  >  (url "git+file://$(pwd)/old-mock-opam-repository"))
   > (lock_dir
   >  (repositories new old \ new))
   > (context

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -102,7 +102,7 @@ EOF
    (repositories mock))
  (repository
   (name mock)
-  (source "file://$(pwd)/mock-opam-repository"))
+  (url "file://$(pwd)/mock-opam-repository"))
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -10,7 +10,7 @@ setup_ocamllsp_workspace() {
   (repositories mock))
 (repository
  (name mock)
- (source "file://$(pwd)/mock-opam-repository"))
+ (url "file://$(pwd)/mock-opam-repository"))
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -10,7 +10,7 @@ setup_odoc_workspace() {
   (repositories mock))
 (repository
  (name mock)
- (source "file://$(pwd)/mock-opam-repository"))
+ (url "file://$(pwd)/mock-opam-repository"))
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -59,7 +59,7 @@ Test that we can read package metadata from opam files.
   >   (with-doc true)))
   > (repository
   >  (name mock)
-  >  (source "$PWD/mock-opam-repository"))
+  >  (url "$PWD/mock-opam-repository"))
   > EOF
 
   $ dune pkg lock

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -31,7 +31,7 @@ Make a mock repo tarball that will get used by dune to download the package
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > EOF
 
   $ dune pkg lock
@@ -58,7 +58,7 @@ other systems and thus shouldn't be included.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
   $ dune pkg lock
   Solution for dune.lock:
@@ -87,7 +87,7 @@ in the repo and make sure it locks the older version.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"))
+  >  (url "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"))
   > EOF
   $ dune pkg lock
   Solution for dune.lock:
@@ -102,7 +102,7 @@ repository and thus the new foo package.
   > (lang dune 3.10)
   > (repository
   >  (name foo)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (lock_dir
   >  (repositories foo))
   > EOF
@@ -130,7 +130,7 @@ out of the auto update.
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository#${NEW_REPO_HASH}"))
+  >  (url "git+file://$(pwd)/mock-opam-repository#${NEW_REPO_HASH}"))
   > (lock_dir
   >  (repositories mock))
   > EOF
@@ -154,7 +154,7 @@ restored the repo to where it was before)
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"))
+  >  (url "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"))
   > (lock_dir
   >  (repositories mock))
   > EOF
@@ -183,7 +183,7 @@ sure that the default branch differs from `bar-2`).
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository#bar-2"))
+  >  (url "git+file://$(pwd)/mock-opam-repository#bar-2"))
   > (lock_dir
   >  (repositories mock))
   > EOF
@@ -215,7 +215,7 @@ The repo should be using the `1.0` tag, as we don't want `bar.3.0.0`.
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository#1.0"))
+  >  (url "git+file://$(pwd)/mock-opam-repository#1.0"))
   > (lock_dir
   >  (repositories mock))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -25,7 +25,7 @@
   >   (lock_dir dune.workspace.lock)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
   $ solve_project --all <<EOF
   > (lang dune 3.11)

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -63,7 +63,7 @@ Make a custom solver env:
   >   (lock_dir dune.lock)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Run the solver using the new env:

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
@@ -22,11 +22,10 @@ It should be possible to include custom repos from the workspace:
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
   $ mkrepo
-  $ add_mock_repo_if_needed
 
 Note that sources in the projects are overriden by the workspace
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -32,7 +32,7 @@ Helper function that creates a workspace file with a given solver env.
   >   (name default)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
   > }
 

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -16,7 +16,7 @@ Thus we first create a repo:
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (lock_dir
   >  (repositories mock))
   > (context

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -20,7 +20,7 @@ We set this repository as sole source for opam repositories.
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (context
   >  (default
   >   (name default)

--- a/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
@@ -1,21 +1,21 @@
+This test checks whether a custom lock dir can be created, without having to
+specify it in the context.
+
   $ . ./helpers.sh
-
   $ mkrepo
-
   $ mkpkg a <<EOF
   > EOF
-
   $ mkpkg b <<EOF
   > EOF
 
-  $  cat > dune-workspace <<EOF
+  $ cat > dune-workspace <<EOF
   > (lang dune 3.12)
   > (lock_dir
   >  (path foo.lock)
   >  (repositories mock))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
   $ cat > dune-project <<EOF
@@ -24,6 +24,8 @@
   >  (name foo)
   >  (depends a b))
   > EOF
+
+Specifying the directory to the lock command should work:
 
   $ dune pkg lock foo.lock
   Solution for foo.lock:

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -63,7 +63,7 @@ Make a workspace file which sets some of the variables.
   >   (name default)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
 
 Solve the packages again, this time with the variables set.

--- a/test/blackbox-tests/test-cases/pkg/submodules.t
+++ b/test/blackbox-tests/test-cases/pkg/submodules.t
@@ -62,7 +62,7 @@ We'll use the mock repository as source and depend on `bar`:
   > (lang dune 3.10)
   > (repository
   >  (name mock)
-  >  (source "git+file://$(pwd)/mock-opam-repository"))
+  >  (url "git+file://$(pwd)/mock-opam-repository"))
   > (lock_dir
   >  (repositories mock))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -22,9 +22,11 @@ Set up two build contexts: a default one for linux and another for macos.
   >   (lock_dir dune.macos.lock)))
   > (repository
   >  (name mock)
-  >  (source "file://$(pwd)/mock-opam-repository"))
+  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
+
 Helper shell function to generate a dune-project file and generate lockdir for both contexts:
+
   $ solve_project() {
   >   cat >dune-project
   >   dune pkg lock dune.lock


### PR DESCRIPTION
When working on #11181 I came across a few issues, so I thought I'll change it and get input on the change in a PR. This PR aligns the naming of `repository` and `pin`, where pin uses `url` and repository used `source` for a field with the same semantics.

Personally I don't have a strong preference for `url` over `source`, I could also reverse the rename and change `pin` instead.

Going through all the failing tests had me improve the helpers a little bit so I could remove a bit of boilerplate where `dune-workspace` is created just do inject the mock repo URL.