### PR TITLE
Update Wasm_of_ocaml action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -254,8 +254,7 @@ jobs:
       - name: Checkout Wasm_of_ocaml
         uses: actions/checkout@v4
         with:
-          repository: ocaml-wasm/wasm_of_ocaml
-          ref: wasm-dune
+          repository: ocsigen/js_of_ocaml
           path: wasm_of_ocaml
 
       - name: Install Wasm_of_ocaml


### PR DESCRIPTION
The attempts to update the workflow as Wasm_of_ocaml has been merged upstream in https://github.com/ocsigen/js_of_ocaml/pull/1724 and the wasm-dune branch is gone.