### PR TITLE
Simplify addition of mock-repo in a lot of tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
+++ b/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
@@ -17,17 +17,7 @@ What happens if a branch has the same format as a ref?
 
 Use this ref in a project
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$PWD/mock-opam-repository#$AMBIGUOUS_REF"))
-  > (context
-  >  (default
-  >   (name default)))
-  > EOF
+  $ add_mock_repo_if_needed "git+file://$PWD/mock-opam-repository#$AMBIGUOUS_REF"
 
 Depend on foo from the repo
 
@@ -41,5 +31,5 @@ Depend on foo from the repo
 
 Which foo will we get?
 
-  $ dune pkg lock 2>&1 | head -1 | sed "s/$AMBIGUOUS_REF/AMBIGUOUS_REF/g"
-  revision "AMBIGUOUS_REF" not found in
+  $ dune pkg lock 2>&1 | head -1 | sed "s/$AMBIGUOUS_REF/\$AMBIGUOUS_REF/g"
+  revision "$AMBIGUOUS_REF" not found in

--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -13,17 +13,7 @@ We want to make sure our OPAM-repository in git support works well.
 We'll set up a project that uses (only this) this repository, so doesn't use
 :standard:
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$PWD/mock-opam-repository"))
-  > (context
-  >  (default
-  >   (name default)))
-  > EOF
+  $ add_mock_repo_if_needed "git+file://$PWD/mock-opam-repository"
 
 We depend on the foo package
 

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -44,6 +44,9 @@ mkpkg() {
 }
 
 add_mock_repo_if_needed() {
+  # default, but can be overridden, e.g. if git is required
+  repo="${1:-file://$(pwd)/mock-opam-repository}"
+
   if [ ! -e dune-workspace ]
   then
       cat >dune-workspace <<EOF
@@ -52,7 +55,7 @@ add_mock_repo_if_needed() {
  (repositories mock))
 (repository
  (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
+ (url "${repo}"))
 EOF
   else
     if ! grep '(name mock)' > /dev/null dune-workspace
@@ -61,7 +64,7 @@ EOF
       cat >>dune-workspace <<EOF
 (repository
  (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
+ (url "${repo}"))
 EOF
  
       # reference the repo

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -1,18 +1,13 @@
 Test the error cases for invalid opam repositories
 
+  $ . ../helpers.sh
+
   $ cat >dune-project <<EOF
   > (lang dune 3.8)
   > (package
   >  (name lockfile_generation_test))
   > EOF
-  > cat >dune-workspace <<EOF
-  > (lang dune 3.8)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/directory-that-does-not-exist"))
-  > EOF
+  $ add_mock_repo_if_needed "file://$(pwd)/directory-that-does-not-exist"
 
   $ lock() {
   > out="$(dune pkg lock 2>&1)"
@@ -32,14 +27,8 @@ Test the error cases for invalid opam repositories
   [1]
 
   $ touch empty
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/empty"))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "file://$(pwd)/empty"
   $ lock
   File "dune-workspace", line 6, characters X-X:
   6 |  (url ..))
@@ -48,14 +37,8 @@ Test the error cases for invalid opam repositories
   is not a directory
   [1]
 
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/no-packages-dir"))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "file://$(pwd)/no-packages-dir"
   $ lock
   File "dune-workspace", line 6, characters X-X:
   6 |  (url ..))

--- a/test/blackbox-tests/test-cases/pkg/invalid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-version.t
@@ -12,14 +12,7 @@ In this case we could also hint at the correct syntax for dune-project files.
   >  (name invalid)
   >  (depends foo.1.2.3))
   > EOF
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.13)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
-  > EOF
+  $ add_mock_repo_if_needed
 
   $ dune pkg lock 2>&1
   File "dune-project", line 4, characters 10-19:

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -25,14 +25,7 @@ Define some local packages.
   > (package (name foo) (depends a (b (>= 0.0.2))))
   > (package (name bar) (depends foo c))
   > EOF
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.11)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
-  > EOF
+  $ add_mock_repo_if_needed
 
 Without a lockdir this command prints a hint but exits successfully.
   $ dune pkg validate-lockdir

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -28,14 +28,7 @@ Generate a `dune-project` file.
   >     "bar" {>= "0.2"}
   > ]
   > EOF
-  > cat >dune-workspace <<EOF
-  > (lang dune 3.8)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
-  > EOF
+  $ add_mock_repo_if_needed
 
 Run the solver and generate a lock directory.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -25,14 +25,7 @@ Make a mock repo tarball that will get used by dune to download the package
   >   (name baz)
   >   (depends bar))
   > EOF
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository"))
-  > EOF
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
 
   $ dune pkg lock
   Solution for dune.lock:
@@ -51,15 +44,8 @@ Make sure lock.dune contains the repo hash:
 Now try it with an a path. Given it is not a git URL, it can't be reproduced on
 other systems and thus shouldn't be included.
 
-  $ rm -r dune.lock
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
-  > EOF
+  $ rm -r dune.lock dune-workspace
+  $ add_mock_repo_if_needed "file://$(pwd)/mock-opam-repository"
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
@@ -80,15 +66,8 @@ in the repo and make sure it locks the older version.
   $ NEW_REPO_HASH=$(git rev-parse HEAD)
   $ cd ..
 
-  $ rm -r dune.lock
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"))
-  > EOF
+  $ rm -r dune.lock dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
@@ -98,14 +77,8 @@ in the repo and make sure it locks the older version.
 If we specify no branch however, it should be using the latest commit in the
 repository and thus the new foo package.
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name foo)
-  >  (url "git+file://$(pwd)/mock-opam-repository"))
-  > (lock_dir
-  >  (repositories foo))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
@@ -126,14 +99,8 @@ A new package is released in the repo:
 Since we have a working cached copy we get the old version of `bar` if we opt
 out of the auto update.
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository#${NEW_REPO_HASH}"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${NEW_REPO_HASH}"
 
 To be safe it doesn't access the repo, we make sure to move the mock-repo away
 
@@ -150,14 +117,8 @@ So now the test should work as it can't access the repo:
 But it will also get the new version of bar if we attempt to lock again (having
 restored the repo to where it was before)
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
+  $ rm -r dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"
   $ mv elsewhere mock-opam-repository
   $ rm -r dune.lock
   $ dune pkg lock
@@ -179,14 +140,8 @@ sure that the default branch differs from `bar-2`).
   $ git switch --quiet -
   $ cd ..
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository#bar-2"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#bar-2"
 
 Locking that branch should work and pick `bar.2.0.0`:
 
@@ -211,14 +166,8 @@ of the main branch.
 
 The repo should be using the `1.0` tag, as we don't want `bar.3.0.0`.
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository#1.0"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
+  $ rm dune-workspace
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#1.0"
 
 So we should get `bar.1.0.0` when locking.
 

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -11,19 +11,7 @@ Thus we first create a repo:
   $ git add -A
   $ git commit --quiet -m "Initial commit"
   $ cd ..
-
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository"))
-  > (lock_dir
-  >  (repositories mock))
-  > (context
-  >  (default
-  >   (name default)
-  >   (lock_dir dune.lock)))
-  > EOF
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
 
 We set the project up to depend on `foo`
 

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -14,18 +14,7 @@ To start with we create a repository in with a `foo` package.
 
 We set this repository as sole source for opam repositories.
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository"))
-  > (context
-  >  (default
-  >   (name default)
-  >   (lock_dir dune.lock)))
-  > EOF
+  $ add_mock_repo_if_needed
 
 We set the project up to depend on `foo`
 

--- a/test/blackbox-tests/test-cases/pkg/submodules.t
+++ b/test/blackbox-tests/test-cases/pkg/submodules.t
@@ -58,14 +58,7 @@ In our mock repository, we make sure to add the package submodule as
 
 We'll use the mock repository as source and depend on `bar`:
 
-  $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
-  > (repository
-  >  (name mock)
-  >  (url "git+file://$(pwd)/mock-opam-repository"))
-  > (lock_dir
-  >  (repositories mock))
-  > EOF
+  $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
   $ cat > dune-project <<EOF
   > (lang dune 3.10)
   > (package


### PR DESCRIPTION
A lot of tests just do the very basic addition of the mock-repo into the workspace with the repo overridden sometimes, so this applies the helper function wherever that's easily possible.

Follow-up from #11183, this PR contains the test improvements.