### PR TITLE
Rename sources into pins

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -77,7 +77,7 @@ let solve ~dev_tool ~local_packages =
   @@ Lock.solve
        (Workspace.add_repo workspace Dune_pkg.Pkg_workspace.Repository.binary_packages)
        ~local_packages
-       ~project_sources:Dune_pkg.Pin_stanza.DB.empty
+       ~project_pins:Dune_pkg.Pin_stanza.DB.empty
        ~solver_env_from_current_system
        ~version_preference:None
        ~lock_dirs:[ lock_dir ]

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -52,24 +52,24 @@ module Progress_indicator = struct
   let add_overlay (t : t) = Console.Status_line.add_overlay (Live (fun () -> pp t))
 end
 
-let resolve_project_sources sources =
+let resolve_project_pins project_pins =
   let scan_project ~read ~files =
     let read file = Memo.of_reproducible_fiber (read file) in
     let open Memo.O in
     Dune_project.gen_load ~read ~files ~dir:Path.Source.root ~infer_from_opam_files:false
     >>| Option.map ~f:(fun project ->
-      let sources = Dune_project.sources project in
+      let pins = Dune_project.pins project in
       let packages = Dune_project.packages project in
-      sources, packages)
+      pins, packages)
     |> Memo.run
   in
-  Pin_stanza.resolve sources ~scan_project
+  Pin_stanza.resolve project_pins ~scan_project
 ;;
 
 let solve_lock_dir
   workspace
   ~local_packages
-  ~project_sources
+  ~project_pins
   version_preference
   solver_env_from_current_system
   lock_dir_path
@@ -77,14 +77,14 @@ let solve_lock_dir
   =
   let open Fiber.O in
   let lock_dir = Workspace.find_lock_dir workspace lock_dir_path in
-  let project_sources =
+  let project_pins =
     match lock_dir with
-    | None -> project_sources
+    | None -> project_pins
     | Some lock_dir ->
       let workspace =
-        Pin_stanza.DB.Workspace.extract workspace.sources ~names:lock_dir.pins
+        Pin_stanza.DB.Workspace.extract workspace.pins ~names:lock_dir.pins
       in
-      Pin_stanza.DB.combine_exn workspace project_sources
+      Pin_stanza.DB.combine_exn workspace project_pins
   in
   let solver_env =
     solver_env
@@ -104,7 +104,7 @@ let solve_lock_dir
     := Some (Progress_indicator.Per_lockdir.State.Updating_repos repo_names);
     get_repos repo_map ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
   in
-  let* pins = resolve_project_sources project_sources in
+  let* pins = resolve_project_pins project_pins in
   progress_state := Some Progress_indicator.Per_lockdir.State.Solving;
   Dune_pkg.Opam_solver.solve_lock_dir
     solver_env
@@ -141,7 +141,7 @@ let solve_lock_dir
 let solve
   workspace
   ~local_packages
-  ~project_sources
+  ~project_pins
   ~solver_env_from_current_system
   ~version_preference
   ~lock_dirs
@@ -165,7 +165,7 @@ let solve
              solve_lock_dir
                workspace
                ~local_packages
-               ~project_sources
+               ~project_pins
                version_preference
                solver_env_from_current_system
                lockdir_path
@@ -191,11 +191,11 @@ let solve
     List.iter write_disk_list ~f:Lock_dir.Write_disk.commit
 ;;
 
-let project_sources =
+let project_pins =
   let open Memo.O in
   Dune_rules.Dune_load.projects ()
   >>| List.fold_left ~init:Pin_stanza.DB.empty ~f:(fun acc project ->
-    Pin_stanza.DB.combine_exn acc (Dune_project.sources project))
+    Pin_stanza.DB.combine_exn acc (Dune_project.pins project))
 ;;
 
 let lock ~version_preference ~lock_dirs_arg =
@@ -204,14 +204,14 @@ let lock ~version_preference ~lock_dirs_arg =
     Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
     |> Dune_pkg.Sys_poll.solver_env_from_current_system
     >>| Option.some
-  and* workspace, local_packages, project_sources =
+  and* workspace, local_packages, project_pins =
     Memo.run
     @@
     let open Memo.O in
     let+ workspace = Workspace.workspace ()
     and+ local_packages = find_local_packages
-    and+ project_sources = project_sources in
-    workspace, local_packages, project_sources
+    and+ project_pins = project_pins in
+    workspace, local_packages, project_pins
   in
   let lock_dirs =
     Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
@@ -219,7 +219,7 @@ let lock ~version_preference ~lock_dirs_arg =
   solve
     workspace
     ~local_packages
-    ~project_sources
+    ~project_pins
     ~solver_env_from_current_system
     ~version_preference
     ~lock_dirs

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -3,7 +3,7 @@ open Import
 val solve
   :  Workspace.t
   -> local_packages:Dune_pkg.Local_package.t Package_name.Map.t
-  -> project_sources:Dune_pkg.Pin_stanza.DB.t
+  -> project_pins:Dune_pkg.Pin_stanza.DB.t
   -> solver_env_from_current_system:Dune_pkg.Solver_env.t option
   -> version_preference:Dune_pkg.Version_preference.t option
   -> lock_dirs:Path.Source.t list

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -42,7 +42,7 @@ type t =
   ; subst_config : (Loc.t * Subst_config.t) option
   ; strict_package_deps : bool
   ; allow_approximate_merlin : Loc.t option
-  ; sources : Dune_pkg.Pin_stanza.DB.t
+  ; pins : Dune_pkg.Pin_stanza.DB.t
   ; cram : bool
   ; expand_aliases_in_sandbox : bool
   ; opam_file_location : [ `Relative_to_project | `Inside_opam_directory ]
@@ -70,7 +70,7 @@ let file_key t = t.file_key
 let implicit_transitive_deps t = t.implicit_transitive_deps
 let generate_opam_files t = t.generate_opam_files
 let warnings t = t.warnings
-let sources t = Dune_pkg.Pin_stanza.DB.add_opam_pins t.sources t.packages
+let pins t = Dune_pkg.Pin_stanza.DB.add_opam_pins t.pins t.packages
 let set_generate_opam_files generate_opam_files t = { t with generate_opam_files }
 let use_standard_c_and_cxx_flags t = t.use_standard_c_and_cxx_flags
 let dialects t = t.dialects
@@ -103,7 +103,7 @@ let to_dyn
   ; subst_config
   ; strict_package_deps
   ; allow_approximate_merlin
-  ; sources = _
+  ; pins = _
   ; cram
   ; expand_aliases_in_sandbox
   ; opam_file_location
@@ -427,7 +427,7 @@ let infer ~dir info packages =
   let opam_file_location = opam_file_location_default ~lang in
   { name
   ; allow_approximate_merlin = None
-  ; sources = Dune_pkg.Pin_stanza.DB.empty
+  ; pins = Dune_pkg.Pin_stanza.DB.empty
   ; packages
   ; root
   ; info
@@ -463,7 +463,7 @@ let anonymous ~dir info packages = infer ~dir info packages
 let encode : t -> Dune_lang.t list =
   fun { name
       ; allow_approximate_merlin = _
-      ; sources
+      ; pins
       ; version
       ; dune_version
       ; info
@@ -575,7 +575,7 @@ let encode : t -> Dune_lang.t list =
   let version =
     Option.map ~f:(constr "version" Package_version.encode) version |> Option.to_list
   in
-  let sources = Dune_pkg.Pin_stanza.DB.encode sources in
+  let pins = Dune_pkg.Pin_stanza.DB.encode pins in
   List.concat
     [ [ lang_stanza; name ]
     ; flags
@@ -585,7 +585,7 @@ let encode : t -> Dune_lang.t list =
     ; dialects
     ; packages
     ; subst_config
-    ; sources
+    ; pins
     ]
 ;;
 
@@ -771,7 +771,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
      and+ version = field_o "version" Package_version.decode
      and+ info = Package_info.decode ()
      and+ packages = multi_field "package" (Package.decode ~dir)
-     and+ sources = Dune_pkg.Pin_stanza.DB.decode ~dir
+     and+ pins = Dune_pkg.Pin_stanza.DB.decode ~dir
      and+ explicit_extensions =
        multi_field
          "using"
@@ -951,7 +951,7 @@ let parse ~dir ~(lang : Lang.Instance.t) ~file =
        ; subst_config
        ; strict_package_deps
        ; allow_approximate_merlin
-       ; sources
+       ; pins
        ; cram
        ; expand_aliases_in_sandbox
        ; opam_file_location

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -136,7 +136,7 @@ val strict_package_deps : t -> bool
 val cram : t -> bool
 val info : t -> Package_info.t
 val warnings : t -> Warning.Settings.t
-val sources : t -> Dune_pkg.Pin_stanza.DB.t
+val pins : t -> Dune_pkg.Pin_stanza.DB.t
 
 (** Update the execution parameters according to what is written in the
     [dune-project] file. *)

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -638,10 +638,10 @@ type t =
   ; repos : Dune_pkg.Pkg_workspace.Repository.t list
   ; lock_dirs : Lock_dir.t list
   ; dir : Path.Source.t
-  ; sources : Dune_pkg.Pin_stanza.DB.Workspace.t
+  ; pins : Dune_pkg.Pin_stanza.DB.Workspace.t
   }
 
-let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs; sources; dir } =
+let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs; pins; dir } =
   let open Dyn in
   record
     [ "merlin_context", option Context_name.to_dyn merlin_context
@@ -651,11 +651,11 @@ let to_dyn { merlin_context; contexts; env; config; repos; lock_dirs; sources; d
     ; "repos", list Repository.to_dyn repos
     ; "solver", (list Lock_dir.to_dyn) lock_dirs
     ; "dir", Path.Source.to_dyn dir
-    ; "sources", Dune_pkg.Pin_stanza.DB.Workspace.to_dyn sources
+    ; "pins", Dune_pkg.Pin_stanza.DB.Workspace.to_dyn pins
     ]
 ;;
 
-let equal { merlin_context; contexts; env; config; repos; lock_dirs; dir; sources } w =
+let equal { merlin_context; contexts; env; config; repos; lock_dirs; dir; pins } w =
   Option.equal Context_name.equal merlin_context w.merlin_context
   && List.equal Context.equal contexts w.contexts
   && Option.equal Dune_env.equal env w.env
@@ -663,10 +663,10 @@ let equal { merlin_context; contexts; env; config; repos; lock_dirs; dir; source
   && List.equal Repository.equal repos w.repos
   && List.equal Lock_dir.equal lock_dirs w.lock_dirs
   && Path.Source.equal dir w.dir
-  && Dune_pkg.Pin_stanza.DB.Workspace.equal sources w.sources
+  && Dune_pkg.Pin_stanza.DB.Workspace.equal pins w.pins
 ;;
 
-let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir; sources } =
+let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir; pins } =
   Poly.hash
     ( Option.hash Context_name.hash merlin_context
     , List.hash Context.hash contexts
@@ -675,7 +675,7 @@ let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir; sources
     , List.hash Repository.hash repos
     , List.hash Lock_dir.hash lock_dirs
     , Path.Source.hash dir
-    , Dune_pkg.Pin_stanza.DB.Workspace.hash sources )
+    , Dune_pkg.Pin_stanza.DB.Workspace.hash pins )
 ;;
 
 let find_lock_dir t path =
@@ -845,7 +845,7 @@ let step1 clflags =
          ~default:(lazy []))
   and+ config_from_workspace_file = Dune_config.decode_fields_of_workspace_file
   and+ lock_dirs = multi_field "lock_dir" (Lock_dir.decode ~dir)
-  and+ sources = Dune_pkg.Pin_stanza.DB.Workspace.decode in
+  and+ pins = Dune_pkg.Pin_stanza.DB.Workspace.decode in
   let+ contexts = multi_field "context" (lazy_ Context.decode) in
   let config =
     create_final_config
@@ -918,7 +918,7 @@ let step1 clflags =
        ; repos
        ; lock_dirs
        ; dir
-       ; sources
+       ; pins
        })
   in
   { Step1.t; config }
@@ -951,7 +951,7 @@ let default clflags =
   ; repos = default_repositories
   ; lock_dirs = []
   ; dir = Path.Source.root
-  ; sources = Dune_pkg.Pin_stanza.DB.Workspace.empty
+  ; pins = Dune_pkg.Pin_stanza.DB.Workspace.empty
   }
 ;;
 

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -117,7 +117,7 @@ type t = private
   ; repos : Dune_pkg.Pkg_workspace.Repository.t list
   ; lock_dirs : Lock_dir.t list
   ; dir : Path.Source.t
-  ; sources : Dune_pkg.Pin_stanza.DB.Workspace.t
+  ; pins : Dune_pkg.Pin_stanza.DB.Workspace.t
   }
 
 val equal : t -> t -> bool


### PR DESCRIPTION
It is more consistent if the stanzas in `dune-project` and `dune-workspace` are called pins and the names reflect that.

`sources` is potentially a better name but `pin` is for better or worse the established term in OPAM so calling them pins internally is probably a good thing. No functionality changes in this PR.