### PR TITLE
Add pins of dune-project to Dyn representation

### DIFF
--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -103,7 +103,7 @@ let to_dyn
   ; subst_config
   ; strict_package_deps
   ; allow_approximate_merlin
-  ; pins = _
+  ; pins
   ; cram
   ; expand_aliases_in_sandbox
   ; opam_file_location
@@ -135,6 +135,7 @@ let to_dyn
     ; "format_config", option Format_config.to_dyn format_config
     ; "subst_config", option Toggle.to_dyn (Option.map ~f:snd subst_config)
     ; "strict_package_deps", bool strict_package_deps
+    ; "pins", Dune_pkg.Pin_stanza.DB.to_dyn pins
     ; "cram", bool cram
     ; "allow_approximate_merlin", opaque allow_approximate_merlin
     ; "expand_aliases_in_sandbox", bool expand_aliases_in_sandbox


### PR DESCRIPTION
While working on #11186 I noticed that the `Dyn.t` representation of `Dune_project.t` discards the sources/pins, unlike the `Workspace.t` which converts them.

This PR adds the code to call the right conversion function, which already exists.