### PR TITLE
[3.17] `(no_dynlink)`: do not build `.cmxs` (#11176)

### DIFF
--- a/doc/changes/11176.md
+++ b/doc/changes/11176.md
@@ -1,0 +1,2 @@
+- #11176: when a library declares `(no_dynlink)`, then the `.cmxs` file for it
+  is no longer built. (@nojb)

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -378,6 +378,7 @@ let orig_src_dir t = t.orig_src_dir
 let best_src_dir t = Option.value ~default:t.src_dir t.orig_src_dir
 let set_version t version = { t with version }
 let entry_modules t = t.entry_modules
+let dynlink_supported t = Mode.Dict.get t.plugins Native <> []
 
 let eval_native_archives_exn (type path) (t : path t) ~modules =
   match t.native_archives, modules with

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -155,6 +155,7 @@ val enabled : _ t -> Enabled_status.t Memo.t
 val orig_src_dir : 'path t -> 'path option
 val version : _ t -> Package_version.t option
 val dune_version : _ t -> Dune_lang.Syntax.Version.t option
+val dynlink_supported : _ t -> bool
 
 (** Directory where the source files for the library are located. Returns the
     original src dir when it exists *)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -490,7 +490,9 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
           Super_context.add_rule sctx ~dir ~loc:lib.buildable.loc rule)))
   in
   Memo.when_
-    (Dynlink_supported.By_the_os.get natdynlink_supported && modes.ocaml.native)
+    (Lib_info.dynlink_supported lib_info
+     && Dynlink_supported.By_the_os.get natdynlink_supported
+     && modes.ocaml.native)
     (fun () -> build_shared ~native_archives ~sctx lib ~dir ~flags)
 ;;
 

--- a/test/blackbox-tests/test-cases/no_dynlink.t
+++ b/test/blackbox-tests/test-cases/no_dynlink.t
@@ -1,0 +1,62 @@
+This test checks that if a library is declared with `(no_dynlink)`, then the
+corresponding `.cmxs` file is *not* built.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.17)
+  > EOF
+
+First we check the behaviour when `(no_dynlink)` is not present.
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+
+  $ touch a.ml
+
+  $ dune build _build/default/mylib.cmxs
+
+Now with `(no_dynlink)`.
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (no_dynlink))
+  > EOF
+
+  $ dune clean
+
+  $ dune build _build/default/mylib.cmxs
+  Error: Don't know how to build _build/default/mylib.cmxs
+  Hint: did you mean _build/default/mylib.cma or _build/default/mylib.cmxa?
+  [1]
+
+Next, we check that the .cmxs is installed without `(no_dynlink)`:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.17)
+  > (package (name mylib))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name mylib))
+  > EOF
+
+  $ dune build _build/default/mylib.install
+
+  $ grep cmxs _build/default/mylib.install
+    "_build/install/default/lib/mylib/mylib.cmxs"
+
+And *not* installed with `(no_dynlink)`:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name mylib)
+  >  (no_dynlink))
+  > EOF
+
+  $ dune build _build/default/mylib.install
+
+  $ grep cmxs _build/default/mylib.install
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -16,6 +16,8 @@ Test that shows what happens when dune.lock is ignored.
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml
   > +++ b/foo.ml
+  > @@ -0,0 +1 @@
+  > +let () = print_endline "Hello, World!"
   > EOF
 
   $ mkdir src


### PR DESCRIPTION
Cherry-pick of #11176 to 3.17. cc @maiste 