### PR TITLE
Better error message for old versions of Git

### DIFF
--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -4,6 +4,7 @@
  (libraries
   stdune
   fiber
+  fiber_util
   chrome_trace
   dune_engine
   dune_digest

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -196,7 +196,9 @@ let run_with_exit_code { dir; _ } ~allow_codes ~display args =
              minimum supported version is Git 2.29."
         ]
         ~hints:[ User_message.command "Please update your git version." ]
-    | _ -> Error { Git_error.dir; args; exit_code; output = [] })
+    | _ ->
+      Dune_console.print [ Pp.verbatim stderr ];
+      Error { Git_error.dir; args; exit_code; output = [] })
 ;;
 
 let run t ~display args =

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -171,17 +171,17 @@ let run_with_exit_code { dir; _ } ~allow_codes ~display args =
   let git = Lazy.force Vcs.git in
   let+ stderr, exit_code =
     Fiber_util.Temp.with_temp_file
-      ~f:(function
-        | Error exn -> raise exn
-        | Ok path ->
-          let stderr_to = Process.Io.file path Out in
-          let+ (), exit_code =
-            Process.run ~dir ~display ~stdout_to ~stderr_to ~env failure_mode git args
-          in
-          Stdune.Io.read_file path, exit_code)
       ~prefix:"dune"
       ~suffix:"run_with_exit_code"
       ~dir:(Path.of_string (Filename.get_temp_dir_name ()))
+      ~f:(function
+        | Error exn -> raise exn
+        | Ok path ->
+          let+ (), exit_code =
+            let stderr_to = Process.Io.file path Out in
+            Process.run ~dir ~display ~stdout_to ~stderr_to ~env failure_mode git args
+          in
+          Io.read_file path, exit_code)
   in
   if allow_codes exit_code
   then Ok exit_code

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -191,11 +191,12 @@ let run_with_exit_code { dir; _ } ~allow_codes ~display args =
       when String.is_prefix ~prefix:"error: unknown option `no-write-fetch-head'" stderr
       ->
       User_error.raise
-        [ Pp.text "Your git version doesn't support the '--no-write-fetch-head' flag." ]
-        ~hints:[ Pp.text "Please update your git version." ]
-    | _ ->
-      ();
-      Error { Git_error.dir; args; exit_code; output = [] })
+        [ User_message.command
+            "Your git version doesn't support the '--no-write-fetch-head' flag. The \
+             minimum supported version is Git 2.29."
+        ]
+        ~hints:[ User_message.command "Please update your git version." ]
+    | _ -> Error { Git_error.dir; args; exit_code; output = [] })
 ;;
 
 let run t ~display args =


### PR DESCRIPTION
Old versions of git don't support the `--no-write-fetch-head` flag. This patch detects this particular failure and prints an error message hinting that. Fixes #10976. Prints the following error message --

```
Error: Your git version doesn't support the '--no-write-fetch-head' flag.
Hint: Please update your git version.
```