### PR TITLE
chore: Promote change due to #11172

### DIFF
--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -11,7 +11,7 @@ let roots : string option Install.Roots.t =
   ; libexec_root = None
   }
 
+let prefix : string option = None
 let toolchains = `Enabled
 let pkg_build_progress = `Disabled
 let lock_dev_tool = `Disabled
-let prefix = None


### PR DESCRIPTION
When building dune after #11172 this change gets promoted when rebuilding. To prevent it leaking into unrelated PRs this PR adds it explicitely.