### PR TITLE
chore: Promote change of `unix; threads` -> `threads.posix`

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,4 +1,4 @@
-let external_libraries = [ "unix"; "threads" ]
+let external_libraries = [ "threads.posix" ]
 
 let local_libraries =
   [ ("otherlibs/ordering", Some "Ordering", false, None)


### PR DESCRIPTION
When calling `dune build` it promotes this change (at least on my machine). I don't know why this is happening or whether this is correct. From my cursory understandin `threads` will always pick `threads.posix` as `threads.vm` is deprecated but I don't know which change on caused this and whether this is the right thing to do.

Thus I am opening this PR as a to open a discussion but I am not sure if the proposed solution is the correct one.