### PR TITLE
Regression test for #11200: `dune subst` fails on an empty directory

### DIFF
--- a/test/blackbox-tests/test-cases/github11200.t
+++ b/test/blackbox-tests/test-cases/github11200.t
@@ -1,0 +1,9 @@
+Running `dune subst` should succeed in an empty directory.
+Regression test for https://github.com/ocaml/dune/issues/11200
+
+  $ dune subst
+  File ".", line 1, characters 0-0:
+  Error: There is no dune-project file in the current directory, please add one
+  with a (name <name>) field in it.
+  Hint: 'dune subst' must be executed from the root of the project.
+  [1]


### PR DESCRIPTION
Adds a regression test for #11200 

With dune 3.16 this command succeeds with no output. Dune 3.17 gives

```
+|  File ".", line 1, characters 0-0:
+|  Error: There is no dune-project file in the current directory, please add one
+|  with a (name <name>) field in it.
+|  Hint: 'dune subst' must be executed from the root of the project.
+|  [1]
```