### PR TITLE
Fix promotion of directory targets without files in them

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/github10609/run.t
+++ b/test/blackbox-tests/test-cases/directory-targets/github10609/run.t
@@ -1,0 +1,23 @@
+We test that a directory target with only other subdirs can be
+properly promoted.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir foo))
+  >  (mode (promote (until-clean)))
+  >  (action
+  >    (progn
+  >      (run mkdir -p foo/bar)
+  >      (run touch foo/bar/file1)
+  >      (run mkdir -p foo/bar/baz/qux)
+  >      (run touch foo/bar/baz/qux/file2))))
+  > EOF
+
+  $ dune build foo
+  $ ls foo/bar/baz/qux
+  file2


### PR DESCRIPTION
Replaces #10931.
On that PR, my colleague @moyodiallo made some comments with significant requested changes. He finally proposed something that seemed to work [here](https://github.com/moyodiallo/dune/commit/b00b92e1fbc1007736677436d3b9b56be3f089fc). Since then however, he left the company. I am here making a PR with his code.
This may fix #10609, cc @ejgallego.
