### PR TITLE
test(melange): use a different flag for forwards-compat

### DIFF
--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -66,7 +66,7 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   $ cat >dune <<EOF
   > (melange.emit
   >  (target "$target")
-  >  (compile_flags :standard -mel-g )
+  >  (compile_flags :standard --mel-noassertfalse)
   >  (emit_stdlib false)
   >  (modules main))
   > EOF
@@ -91,7 +91,7 @@ Dump-dot-merlin includes the melange flags
   S /MELC_STDLIB/__private__/melange_mini_stdlib
   S /MELC_STDLIB
   S $TESTCASE_ROOT
-  # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -mel-g
+  # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g --mel-noassertfalse
   
 Check for flag directives ordering when another preprocessor is defined
 


### PR DESCRIPTION
we're removing `--mel-g` in https://github.com/melange-re/melange/pull/1234

this change tests the same behavior -- that custom flags are passed on to merlin -- but with a flag that we have no plans of removing.