### PR TITLE
[3.17] backport 11204 - remove errors message from `dune subst` with empty dir

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -332,6 +332,10 @@ let subst vcs =
                  |> Memo.return)
        in
        Some (None, None, Path.Source.Set.to_list files))
+  >>| Option.bind ~f:(fun ((_, _, files) as s) ->
+    match files with
+    | [] -> None
+    | _ :: _ -> Some s)
   >>= Memo.Option.iter ~f:(fun (version, commit, files) ->
     let+ (dune_project : Dune_project.t) =
       (* CR-soon rgrinberg: unify this check with the above version check *)

--- a/doc/changes/11204.md
+++ b/doc/changes/11204.md
@@ -1,0 +1,2 @@
+- Remove useless error message when running `$ dune subst` in empty projects.
+  (@rgrinberg, #11204, fixes #11200)

--- a/test/blackbox-tests/test-cases/github11200.t
+++ b/test/blackbox-tests/test-cases/github11200.t
@@ -1,0 +1,4 @@
+Running `dune subst` should succeed in an empty directory.
+Regression test for https://github.com/ocaml/dune/issues/11200
+
+  $ dune subst


### PR DESCRIPTION
Backport for the 3.17.1 release.