### PR TITLE
[3.17] `Io.copy_channels`: make it reentrant (#11194)

### DIFF
--- a/doc/changes/11194.md
+++ b/doc/changes/11194.md
@@ -1,0 +1,3 @@
+- Fix bug that could result in corrupted file copies by Dune, for example when
+  using the `copy_files#` stanza or the `copy#` action. (@nojb, #11194, fixes
+  #11193)

--- a/otherlibs/stdune/src/io.mli
+++ b/otherlibs/stdune/src/io.mli
@@ -4,9 +4,6 @@ val close_in : in_channel -> unit
 val close_out : out_channel -> unit
 val close_both : in_channel * out_channel -> unit
 val input_lines : in_channel -> string list
-
-(** This function is not safe to use from multiple threads, even if operating on
-    unrelated channels because it uses a statically-allocated global buffer. *)
 val copy_channels : in_channel -> out_channel -> unit
 
 (** Try to read everything from a channel. Returns [Error ()] if the contents


### PR DESCRIPTION
Signed-off-by: Nicolás Ojeda Bär <n.oje.bar@gmail.com>
(cherry picked from commit ef02bd720abf5c60242b87c7019f8ebc8635d3e1)