### PR TITLE
chore(ci): remove coveralls

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -136,41 +136,6 @@ jobs:
       - uses: cachix/install-nix-action@v18
       - run: nix develop .#fmt -c make fmt
 
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ocaml-compiler:
-          - 5.1.x
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          opam-depext: false
-
-      - name: Set git user
-        run: |
-          git config --global user.name github-actions[bot]
-          git config --global user.email github-actions[bot]@users.noreply.github.com
-
-      # Install ocamlfind-secondary and ocaml-secondary-compiler, if needed
-      - run: opam install ./dune.opam --deps-only --with-test
-
-      - name: Install deps on Unix
-        run: |
-          opam install . --deps-only
-          opam exec -- make dev-deps
-          opam exec -- make coverage-deps
-      - run: opam exec -- make test-coverage
-        continue-on-error: true
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NUMBER: ${{ github.event.number }}
-
   doc:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes the stage that pushes the report to Coveralls. Regarding the CI, we don't take advantage of the coverage in our case. Removing would make the CI green again and reduce computing time.

If we find reasons to get the coverage back, we can still reintroduce it.
