### PR TITLE
 feat(dune): support `+` prefixes for PPX CLI flags 

### DIFF
--- a/src/dune_rules/preprocess.ml
+++ b/src/dune_rules/preprocess.ml
@@ -12,9 +12,12 @@ module Pps_and_flags = struct
     and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in
     let pps, more_flags =
       List.partition_map l ~f:(fun s ->
-        match String_with_vars.is_prefix ~prefix:"-" s with
-        | Yes -> Right s
-        | No | Unknown _ ->
+        match
+          ( String_with_vars.is_prefix ~prefix:"-" s
+          , String_with_vars.is_prefix ~prefix:"+" s )
+        with
+        | Yes, _ | _, Yes -> Right s
+        | (No | Unknown _), _ ->
           let loc = String_with_vars.loc s in
           (match String_with_vars.text_only s with
            | None ->

--- a/src/dune_rules/preprocess.ml
+++ b/src/dune_rules/preprocess.ml
@@ -16,7 +16,8 @@ module Pps_and_flags = struct
           ( String_with_vars.is_prefix ~prefix:"-" s
           , String_with_vars.is_prefix ~prefix:"+" s )
         with
-        | Yes, _ | _, Yes -> Right s
+        | Yes, _ -> Right s
+        | _, Yes when syntax_version >= (3, 18) -> Right s
         | (No | Unknown _), _ ->
           let loc = String_with_vars.loc s in
           (match String_with_vars.text_only s with

--- a/src/dune_rules/preprocess.ml
+++ b/src/dune_rules/preprocess.ml
@@ -17,7 +17,17 @@ module Pps_and_flags = struct
           , String_with_vars.is_prefix ~prefix:"+" s )
         with
         | Yes, _ -> Right s
-        | _, Yes when syntax_version >= (3, 18) -> Right s
+        | _, Yes ->
+          if syntax_version >= (3, 18)
+          then Right s
+          else
+            User_error.raise
+              ~loc:(String_with_vars.loc s)
+              ~hints:[ Pp.text "Upgrade your dune-project to `(lang dune 3.18)'" ]
+              [ Pp.text
+                  "PPX args starting with `+' cannot be used before version 3.18 of the \
+                   dune language"
+              ]
         | (No | Unknown _), _ ->
           let loc = String_with_vars.loc s in
           (match String_with_vars.text_only s with

--- a/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
@@ -33,10 +33,3 @@ Create ppx1 and exe:
   $ touch the_exe.ml
 
   $ dune build ./the_exe.exe
-  File "dune", line 9, characters 30-35:
-  9 |  (preprocess (pps ppx --alert ++foo)))
-                                    ^^^^^
-  Error: Library "++foo" not found.
-  -> required by _build/default/.merlin-conf/exe-the_exe
-  -> required by _build/default/the_exe.exe
-  [1]

--- a/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
@@ -36,9 +36,9 @@ Create ppx1 and exe:
   File "dune", line 9, characters 30-35:
   9 |  (preprocess (pps ppx --alert ++foo)))
                                     ^^^^^
-  Error: Library "++foo" not found.
-  -> required by _build/default/.merlin-conf/exe-the_exe
-  -> required by _build/default/the_exe.exe
+  Error: PPX args starting with `+' cannot be used before version 3.18 of the
+  dune language
+  Hint: Upgrade your dune-project to `(lang dune 3.18)'
   [1]
 
 Works since Dune 3.18

--- a/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
@@ -33,3 +33,17 @@ Create ppx1 and exe:
   $ touch the_exe.ml
 
   $ dune build ./the_exe.exe
+  File "dune", line 9, characters 30-35:
+  9 |  (preprocess (pps ppx --alert ++foo)))
+                                    ^^^^^
+  Error: Library "++foo" not found.
+  -> required by _build/default/.merlin-conf/exe-the_exe
+  -> required by _build/default/the_exe.exe
+  [1]
+
+Works since Dune 3.18
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+  $ dune build ./the_exe.exe

--- a/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-flags-plus.t
@@ -1,0 +1,42 @@
+Create ppx1 and exe:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+  $ cat > dune <<EOF
+  > (library
+  >  (name ppx)
+  >  (kind ppx_rewriter)
+  >  (modules ppx)
+  >  (ppx.driver (main Ppx.main)))
+  > (executable
+  >  (name the_exe)
+  >  (modules the_exe)
+  >  (preprocess (pps ppx --alert ++foo)))
+  > EOF
+  $ cat > ppx.ml <<EOF
+  > let main () =
+  >   let out = ref "" in
+  >   let args =
+  >     [ ("-o", Arg.Set_string out, "")
+  >     ; ("--impl", Arg.Set_string (ref ""), "")
+  >     ; ("--as-ppx", Arg.Set (ref false), "")
+  >     ; ("--cookie", Arg.Set (ref false), "")
+  >     ; ("--alert", Arg.Set_string (ref ""), "")
+  >     ]
+  >   in
+  >   let anon _ = () in
+  >   Arg.parse (Arg.align args) anon "";
+  >   let out = open_out !out in
+  >   close_out out;
+  > EOF
+  $ touch the_exe.ml
+
+  $ dune build ./the_exe.exe
+  File "dune", line 9, characters 30-35:
+  9 |  (preprocess (pps ppx --alert ++foo)))
+                                    ^^^^^
+  Error: Library "++foo" not found.
+  -> required by _build/default/.merlin-conf/exe-the_exe
+  -> required by _build/default/the_exe.exe
+  [1]


### PR DESCRIPTION
this is useful for cases like `melange.ppx` which emit alerts and allow to configure them via `-alert ...`.