### PR TITLE
Add a command to print the path of ocamllsp and ocamlformat executables

### DIFF
--- a/bin/tools/ocamlformat.mli
+++ b/bin/tools/ocamlformat.mli
@@ -1,3 +1,9 @@
 open! Import
 
-val command : unit Cmd.t
+module Exec : sig
+  val command : unit Cmd.t
+end
+
+module Which : sig
+  val command : unit Cmd.t
+end

--- a/bin/tools/ocamllsp.mli
+++ b/bin/tools/ocamllsp.mli
@@ -1,4 +1,13 @@
 open! Import
 
 (** Command to run ocamllsp, installing it if necessary *)
-val command : unit Cmd.t
+
+module Exec : sig
+  val command : unit Cmd.t
+end
+
+(** Command to print ocamllsp's path if exists *)
+
+module Which : sig
+  val command : unit Cmd.t
+end

--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -3,9 +3,15 @@ open! Import
 module Exec = struct
   let doc = "Command group for running wrapped tools."
   let info = Cmd.info ~doc "exec"
-  let group = Cmd.group info [ Ocamlformat.command; Ocamllsp.command ]
+  let group = Cmd.group info [ Ocamlformat.Exec.command; Ocamllsp.Exec.command ]
+end
+
+module Which = struct
+  let doc = "Command group for printing the path to wrapped tools."
+  let info = Cmd.info ~doc "which"
+  let group = Cmd.group info [ Ocamlformat.Which.command; Ocamllsp.Which.command ]
 end
 
 let doc = "Command group for wrapped tools."
 let info = Cmd.info ~doc "tools"
-let group = Cmd.group info [ Exec.group ]
+let group = Cmd.group info [ Exec.group; Which.group ]

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-which.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-which.t
@@ -1,0 +1,15 @@
+Tests for the `dune tools which` command.
+
+The ocamlformat case:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  $ dune tools which ocamlformat
+  _build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin/ocamlformat
+
+The ocamllsp case:
+  $ cat >dune-project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  $ dune tools which ocamllsp
+  _build/_private/default/.dev-tool/ocaml-lsp-server/ocaml-lsp-server/target/bin/ocamllsp


### PR DESCRIPTION
This PR adds a command `dune tools which` that returns the path of dev tools, `ocamlformat` and `ocamllsp`. This can be useful in and perhaps simplify scripts that require the path of dev tools, such as [this one](https://github.com/ocaml-dune/binary-distribution/blob/main/tool-wrappers/ocamllsp). Furthermore, it could be useful for text editor plugins that call these executables. (cc @gridbugs)