### PR TITLE
pkg: precompute directory descendants in rev_store

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -66,6 +66,8 @@ module Local : sig
   val split_first_component : t -> (Filename.t * t) option
   val explode : t -> Filename.t list
   val descendant : t -> of_:t -> t option
+
+  module Table : Hashtbl.S with type key = t
 end
 
 module External : sig


### PR DESCRIPTION
Previously dune would do a linear search through all files in the rev store in order to compute the descendants of a single directory. This change precomputes all descendants of each directory in a single pass.

I've benchmarked this by running `dune pkg lock` in https://github.com/gridbugs/climate and it went from ~4.2s to ~3.6s on average (including the time taken to update the repos).