### PR TITLE
pkg: add argument to pkg lock to print perf stats

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -81,6 +81,7 @@ let solve ~dev_tool ~local_packages =
        ~solver_env_from_current_system
        ~version_preference:None
        ~lock_dirs:[ lock_dir ]
+       ~print_perf_stats:false
 ;;
 
 let compiler_package_name = Package_name.of_string "ocaml"

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -7,6 +7,7 @@ val solve
   -> solver_env_from_current_system:Dune_pkg.Solver_env.t option
   -> version_preference:Dune_pkg.Version_preference.t option
   -> lock_dirs:Path.Source.t list
+  -> print_perf_stats:bool
   -> unit Fiber.t
 
 (** Command to create lock directory *)

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -5,6 +5,7 @@ module Solver_result : sig
     { lock_dir : Lock_dir.t
     ; files : File_entry.t Package_name.Map.Multi.t
     ; pinned_packages : Package_name.Set.t
+    ; num_expanded_packages : int
     }
 end
 


### PR DESCRIPTION
When doing performance work on the solver it's helpful to see a breakdown of the time spent running the solver vs the time spent updating the package repos. I've also found the number of expanded packages to be both much higher than I expected and highly correlated to the performance runtime (unsurprisingly) so it's included in the stats too.