### PR TITLE
pkg: don't expand deps of restricting deps

### DIFF
--- a/src/0install-solver/solver_core.ml
+++ b/src/0install-solver/solver_core.ml
@@ -238,7 +238,8 @@ module Make (Model : S.SOLVER_INPUT) = struct
          not process any transitive dependencies here since the dependencies of
          restricting dependencies are irrelevant to solving the dependency
          problem. *)
-      Fiber.sequential_iter !conflicts ~f:(fun (impl_var, dep) ->
+      List.rev !conflicts
+      |> Fiber.sequential_iter ~f:(fun (impl_var, dep) ->
         process_dep `No_expand impl_var dep)
       (* All impl_candidates have now been added, so snapshot the cache. *)
     in


### PR DESCRIPTION
Previously dune would expand dependencies of packages that are only ever marked as conflicting with packages in the solution. This led to the expansion of far more packages that necessary. Expanding a package requires reading an opam file and so is a relatively expensive operation.

For packages that only depend on the compiler (ocaml-base-compiler), this reduces the number of expanded packages from 8376 to 1841 at the time of writing.

Consider this to be a proof of concept demonstrating the problem and a potential solution. "Better" solutions might avoid the additional mutable state I've added here but would probably be more invasive. Since we've discussed eventually rewriting the solver anyway, I'm happy for this to be merged if my approach is deemed acceptable.

Here are the performance stats (using [this](https://github.com/ocaml/dune/pull/11263) feature) before and after this change on my machine (also including https://github.com/ocaml/dune/pull/11254 as it removes a large constant factor (technically `O(num-pkgs-in-repo)`) from the solver runtime). The project being locked has a single dependency on `ocaml-base-compiler`.
```
# before
$ dune pkg lock --print-perf-stats
Solution for dune.lock:
- ocaml-base-compiler.5.2.1

Expanded packages: 8376
Updated repos in: 0.91s
Solved dependencies in: 2.73s

# after
$ dune pkg lock --print-perf-stats
Solution for dune.lock:
- ocaml-base-compiler.5.2.1

Expanded packages: 1841
Updated repos in: 0.90s
Solved dependencies in: 0.45s
```