### PR TITLE
Make the notes in the document use consistent markup

### DIFF
--- a/doc/virtual-libraries.rst
+++ b/doc/virtual-libraries.rst
@@ -49,10 +49,12 @@ library and may use all the other fields. A virtual library may include other
 modules (with or without implementations), which is why it's not a pure
 "interface" library.
 
-Note: the ``virtual_modules`` field is not merged in ``modules``, which
-represents the total set of modules in a library. If a directory has more than
-one stanza and thus a ``modules`` field must be specified, virtual modules
-still need to be added in ``modules``.
+.. note::
+
+   The ``virtual_modules`` field is not merged in ``modules``, which represents
+   the total set of modules in a library. If a directory has more than one
+   stanza and thus a ``modules`` field must be specified, virtual modules still
+   need to be added in ``modules``.
 
 Implementation
 ===============


### PR DESCRIPTION
It's weird that one section uses the `note` box and the other uses `Note:`, thus this PR makes it consistent.