### PR TITLE
Update trunk for next OCaml release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
           - 5.1.x
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.3.0+trunk
+          - ocaml-compiler: ocaml-variants.5.4.0+trunk
             os: ubuntu-latest
             skip_test: true
           # OCaml 4:


### PR DESCRIPTION
CI keeps breaking because `ocaml-variants.5.3.0+trunk` is gone, now that 5.3.0 was released. This PR updates it to 5.4.0.

I don't think this is good in general, since this will keep breaking every time a release is cut and the old `+trunk` removed from opam-repository and will require someone to come in and fix CI while all PRs fail CI due to unrelated failures. I think we should drop this particular solution and if we want to keep testing against `trunk`, use the trunk from git instead of going through opam releases.