### PR TITLE
Shorter path for inline-tests

### DIFF
--- a/doc/changes/11307.md
+++ b/doc/changes/11307.md
@@ -1,0 +1,2 @@
+- Use shorter path for inline-tests artifacts.
+  (@hhugo, #11307)

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -178,12 +178,15 @@ let directory_targets_of_library
              | false -> Path.Build.Map.empty
              | true ->
                let dir_target =
-                 let lib_name = Lib_name.Local.to_string (snd name) in
+                 let lib_name = snd name in
                  let inline_test_dir =
-                   let inline_test_name = sprintf "%s.inline-tests" lib_name in
-                   Path.Build.relative dir ("." ^ inline_test_name)
+                   Path.Build.relative
+                     dir
+                     (Inline_tests_info.inline_test_dirname lib_name)
                  in
-                 Path.Build.relative inline_test_dir ("run" ^ Js_of_ocaml.Ext.wasm_dir)
+                 Path.Build.relative
+                   inline_test_dir
+                   (Inline_tests_info.inline_test_runner ^ Js_of_ocaml.Ext.wasm_dir)
                in
                Path.Build.Map.singleton dir_target loc)
       >>= when_enabled ~dir ~enabled_if

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -178,8 +178,8 @@ let directory_targets_of_library
              | false -> Path.Build.Map.empty
              | true ->
                let dir_target =
-                 let lib_name = snd name in
                  let inline_test_dir =
+                   let lib_name = snd name in
                    Path.Build.relative
                      dir
                      (Inline_tests_info.inline_test_dirname lib_name)

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -179,12 +179,11 @@ let directory_targets_of_library
              | true ->
                let dir_target =
                  let lib_name = Lib_name.Local.to_string (snd name) in
-                 let name = sprintf "inline_test_runner_%s" lib_name in
                  let inline_test_dir =
                    let inline_test_name = sprintf "%s.inline-tests" lib_name in
                    Path.Build.relative dir ("." ^ inline_test_name)
                  in
-                 Path.Build.relative inline_test_dir (name ^ Js_of_ocaml.Ext.wasm_dir)
+                 Path.Build.relative inline_test_dir ("run" ^ Js_of_ocaml.Ext.wasm_dir)
                in
                Path.Build.Map.singleton dir_target loc)
       >>= when_enabled ~dir ~enabled_if

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -81,14 +81,13 @@ include Sub_system.Register_end_point (struct
       in
       let loc = lib.buildable.loc in
       let lib_name = snd lib.name in
-      let inline_test_name =
-        sprintf "%s.inline-tests" (Lib_name.Local.to_string lib_name)
+      let inline_test_dir =
+        Path.Build.relative dir (Inline_tests_info.inline_test_dirname lib_name)
       in
-      let inline_test_dir = Path.Build.relative dir ("." ^ inline_test_name) in
-      let name = "run" in
-      let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir ~name in
+      let runner_name = Inline_tests_info.inline_test_runner in
+      let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir ~name:"t" in
       let main_module =
-        let name = Module_name.of_string name in
+        let name = Module_name.of_string "main" in
         Module.generated ~kind:Impl ~src_dir:inline_test_dir [ name ]
       in
       let modules = Modules.With_vlib.singleton_exe main_module in
@@ -212,7 +211,7 @@ include Sub_system.Register_end_point (struct
         in
         Exe.build_and_link
           cctx
-          ~program:{ name; main_module_name = Module.name main_module; loc }
+          ~program:{ name = runner_name; main_module_name = Module.name main_module; loc }
           ~linkages
           ~link_args
           ~promote:None
@@ -269,7 +268,7 @@ include Sub_system.Register_end_point (struct
           | Native | Best | Byte -> None
           | Jsoo _ -> Some Jsoo_rules.runner
         in
-        let exe = Path.build (Path.Build.relative inline_test_dir (name ^ ext)) in
+        let exe = Path.build (Path.Build.relative inline_test_dir (runner_name ^ ext)) in
         let open Action_builder.O in
         let+ action =
           match custom_runner with
@@ -301,7 +300,9 @@ include Sub_system.Register_end_point (struct
           | Jsoo Wasm ->
             Action_builder.path
               (Path.build
-                 (Path.Build.relative inline_test_dir (name ^ Js_of_ocaml.Ext.wasm_dir)))
+                 (Path.Build.relative
+                    inline_test_dir
+                    (runner_name ^ Js_of_ocaml.Ext.wasm_dir)))
         in
         Action.chdir (Path.build dir) action
       in

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -85,10 +85,8 @@ include Sub_system.Register_end_point (struct
         sprintf "%s.inline-tests" (Lib_name.Local.to_string lib_name)
       in
       let inline_test_dir = Path.Build.relative dir ("." ^ inline_test_name) in
-      let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir ~name:inline_test_name in
-      let name =
-        sprintf "inline_test_runner_%s" (Lib_name.Local.to_string (snd lib.name))
-      in
+      let name = "run" in
+      let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir ~name in
       let main_module =
         let name = Module_name.of_string name in
         Module.generated ~kind:Impl ~src_dir:inline_test_dir [ name ]

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -183,3 +183,9 @@ module Tests = struct
      purposes *)
   let encode _t = assert false
 end
+
+let inline_test_dirname lib_name =
+  sprintf ".%s.inline-tests" (Lib_name.Local.to_string lib_name)
+;;
+
+let inline_test_runner = "inline-test-runner"

--- a/src/dune_rules/inline_tests_info.mli
+++ b/src/dune_rules/inline_tests_info.mli
@@ -52,3 +52,6 @@ module Tests : sig
 
   include Sub_system_info.S with type t := t
 end
+
+val inline_test_dirname : Lib_name.Local.t -> string
+val inline_test_runner : string

--- a/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
@@ -5,14 +5,14 @@ First, build silently to avoid some noise
 See that `test1/runtest`, which uses `fake_backend_1, only runs one inline test runner
 
   $ dune build --display short @test1/runtest 2>&1 | grep alias
-  inline_test_runner_test_lib1 alias test1/runtest
+           run alias test1/runtest
 
 See that `test2/runtest`, which uses `fake_backend_2`, runs one inline test runner per partition
 
   $ dune build --display short @test2/runtest 2>&1 | grep alias
-  inline_test_runner_test_lib2 alias test2/runtest
-  inline_test_runner_test_lib2 alias test2/runtest
-  inline_test_runner_test_lib2 alias test2/runtest
+           run alias test2/runtest
+           run alias test2/runtest
+           run alias test2/runtest
 
 See that we indeed have 3 partitions
 

--- a/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/parallel.t/run.t
@@ -5,14 +5,14 @@ First, build silently to avoid some noise
 See that `test1/runtest`, which uses `fake_backend_1, only runs one inline test runner
 
   $ dune build --display short @test1/runtest 2>&1 | grep alias
-           run alias test1/runtest
+  inline-test-runner alias test1/runtest
 
 See that `test2/runtest`, which uses `fake_backend_2`, runs one inline test runner per partition
 
   $ dune build --display short @test2/runtest 2>&1 | grep alias
-           run alias test2/runtest
-           run alias test2/runtest
-           run alias test2/runtest
+  inline-test-runner alias test2/runtest
+  inline-test-runner alias test2/runtest
+  inline-test-runner alias test2/runtest
 
 See that we indeed have 3 partitions
 

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t
@@ -27,7 +27,7 @@
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Fatal error: exception File ".foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
+  Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 
 The expected behavior for the following three tests is to output nothing: the tests are disabled or ignored.
@@ -41,5 +41,5 @@ The expected behavior for the following three tests is to output nothing: the te
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Fatal error: exception File ".foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
+  Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
   [1]

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t
@@ -27,7 +27,7 @@
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed
+  Fatal error: exception File ".foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 
 The expected behavior for the following three tests is to output nothing: the tests are disabled or ignored.
@@ -41,5 +41,5 @@ The expected behavior for the following three tests is to output nothing: the te
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed
+  Fatal error: exception File ".foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
   [1]


### PR DESCRIPTION
The PR uses shorter path names for inline-tests.
I believe there is little value repeating the libname information in the path under `.<LIBNAME>.inline-tests`
 
With this PR 
> _build/default/compiler/tests-jsoo/.jsoo_testsuite_parsing.inline-tests/inline_test_runner_jsoo_testsuite_parsing.bc.wasm.assets/dune__exe__Inline_test_runner_jsoo_testsuite_parsing-2efd143a.wasm.map
 
becomes
> _build/default/compiler/tests-jsoo/.jsoo_testsuite_parsing.inline-tests/run.bc.wasm.assets/dune__exe__Run-65ca7159.wasm.map

and
> _build/default/compiler/tests-jsoo/.jsoo_testsuite_parsing.inline-tests/.jsoo_testsuite_parsing.inline-tests.eobjs/jsoo/dune__exe__Inline_test_runner_jsoo_testsuite_parsing.wasmo

becomes
> _build/default/compiler/tests-jsoo/.jsoo_testsuite_parsing.inline-tests/.run.eobjs/jsoo/dune__exe__Run.wasmo
