### PR TITLE
fix: package management working with ocaml.5.3.0

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1931,14 +1931,23 @@ let ocaml_toolchain context =
   | `System_provided -> None
   | `Inside_lock_dir pkg ->
     let toolchain =
-      let cookie = (Pkg_installed.of_paths pkg.paths).cookie in
       let open Action_builder.O in
-      let* cookie = cookie in
-      (* TODO we should use the closure of [pkg] *)
-      let binaries =
-        Section.Map.find cookie.files Bin |> Option.value ~default:[] |> Path.Set.of_list
+      let transitive_deps = pkg :: Pkg.deps_closure pkg in
+      let* env, binaries =
+        Action_builder.List.fold_left
+          ~init:(Global.env (), Path.Set.empty)
+          ~f:(fun (env, binaries) pkg ->
+            let env = Env.extend_env env (Pkg.exported_env pkg) in
+            let+ cookie = (Pkg_installed.of_paths pkg.paths).cookie in
+            let binaries =
+              Section.Map.find cookie.files Bin
+              |> Option.value ~default:[]
+              |> Path.Set.of_list
+              |> Path.Set.union binaries
+            in
+            env, binaries)
+          transitive_deps
       in
-      let env = Env.extend_env (Global.env ()) (Pkg.exported_env pkg) in
       let path = Env_path.path (Global.env ()) in
       Action_builder.of_memo @@ Ocaml_toolchain.of_binaries ~path context env binaries
     in

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -49,8 +49,10 @@ let is_compiler_and_toolchains_enabled name =
       (* TODO don't hardcode these names here *)
       [ Package_name.of_string "ocaml-base-compiler"
       ; Package_name.of_string "ocaml-variants"
-      ; Package_name.of_string
-          "ocaml-compiler" (* HACK: This is required for ocaml.5.3.0 *)
+      ; Package_name.of_string "ocaml-compiler"
+        (* The [ocaml-compiler] package is required to include all the
+           packages that might install a compiler, starting from ocaml.5.3.0.
+        *)
       ]
     in
     List.mem compiler_package_names name ~equal:Package_name.equal
@@ -163,25 +165,19 @@ let modify_install_action ~prefix ~suffix action =
   else modify_install_action action ~installation_prefix:prefix ~suffix
 ;;
 
-(* Create an empty config.cache file so other packages see that the
-   compiler package is installed. *)
-let touch_config_cache =
-  Dune_lang.Action.Progn
-    [ Dune_lang.Action.Run
-        [ Slang.text "touch"
-        ; Slang.concat
-            [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build))
-            ; Slang.text "/config.cache"
-            ]
-        ]
-    ; Dune_lang.Action.Run
-        [ Slang.text "touch"
-        ; Slang.concat
-            [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build))
-            ; Slang.text "/config.status"
-            ]
-        ]
+let touch file =
+  Dune_lang.Action.Run
+    [ Slang.text "touch"
+    ; Slang.concat
+        [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build)); Slang.text file ]
     ]
+;;
+
+(* Create an empty config.cache and config.status files so other packages see
+   that the compiler package is installed.
+   TODO: extract this from the .install *)
+let touch_compiler_install =
+  Dune_lang.Action.Progn [ touch "/config.cache"; touch "/config.status" ]
 ;;
 
 let modify_build_action ~prefix action =
@@ -190,7 +186,7 @@ let modify_build_action ~prefix action =
   then
     (* If the toolchain is already installed, just create config.cache file.
        TODO(steve): Move this check to action execution time *)
-    touch_config_cache
+    touch_compiler_install
   else action
 ;;
 

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -49,6 +49,8 @@ let is_compiler_and_toolchains_enabled name =
       (* TODO don't hardcode these names here *)
       [ Package_name.of_string "ocaml-base-compiler"
       ; Package_name.of_string "ocaml-variants"
+      ; Package_name.of_string
+          "ocaml-compiler" (* HACK: This is required for ocaml.5.3.0 *)
       ]
     in
     List.mem compiler_package_names name ~equal:Package_name.equal
@@ -164,11 +166,20 @@ let modify_install_action ~prefix ~suffix action =
 (* Create an empty config.cache file so other packages see that the
    compiler package is installed. *)
 let touch_config_cache =
-  Dune_lang.Action.Run
-    [ Slang.text "touch"
-    ; Slang.concat
-        [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build))
-        ; Slang.text "/config.cache"
+  Dune_lang.Action.Progn
+    [ Dune_lang.Action.Run
+        [ Slang.text "touch"
+        ; Slang.concat
+            [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build))
+            ; Slang.text "/config.cache"
+            ]
+        ]
+    ; Dune_lang.Action.Run
+        [ Slang.text "touch"
+        ; Slang.concat
+            [ Slang.pform (Pform.Var (Pform.Var.Pkg Pform.Var.Pkg.Build))
+            ; Slang.text "/config.status"
+            ]
         ]
     ]
 ;;


### PR DESCRIPTION
The release of `ocaml.5.3.0` introduces a new transitive dependency for the compiler: `ocaml` -> `ocaml-base-compiler` -> `ocaml-compiler`. Consequently the solution is to mark `ocaml-compiler` as a toolchain element and compute the transitive dependencies to be able to fetch the binaries before installing. It also creates a new `config.status` file to make the target understand the compiler is already installed (file required by `5.3.0`).

Fixes #11309 (with the deep help of @Leonidas-from-XIV and @art-w)

(Take the opportunity to remove the unused `ocaml` function at the same time).

This PR will require to release a new version of Dune to make package management work with it.

@rgrinberg should we start to log this kind of changes in a lock file, it would be important for this release. WDTY?

