### PR TITLE
refactor: remove unused ocaml function

### DIFF
--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -55,16 +55,6 @@ let is_compiler_and_toolchains_enabled name =
   | `Disabled -> false
 ;;
 
-let ocaml context env ~bin_dir =
-  let which prog =
-    let path = Path.Outside_build_dir.relative bin_dir prog in
-    let+ exists = Fs_memo.file_exists path in
-    if exists then Some (Path.outside_build_dir path) else None
-  in
-  let get_ocaml_tool ~dir:_ prog = which prog in
-  Ocaml_toolchain.make context ~which ~env ~get_ocaml_tool
-;;
-
 (* Returns the path to the directory containing the artifacts within the
    temporary install directory. When installing with the DESTDIR variable, the
    absolute path to the final installation directory is concatenated to the

--- a/src/dune_rules/pkg_toolchain.mli
+++ b/src/dune_rules/pkg_toolchain.mli
@@ -30,12 +30,6 @@ val pkg_dir : Dune_pkg.Lock_dir.Pkg.t -> Path.Outside_build_dir.t
     script. *)
 val installation_prefix : pkg_dir:Path.Outside_build_dir.t -> Path.Outside_build_dir.t
 
-val ocaml
-  :  Context_name.t
-  -> Env.t
-  -> bin_dir:Path.Outside_build_dir.t
-  -> Ocaml_toolchain.t Memo.t
-
 (** Rewrite the OCaml compiler install action so that it installs the compiler
     package to the users toolchain directory. If the compiler is found to be
     already installed in the users toolchain directory, the action is instead


### PR DESCRIPTION
This PR removes a function that was there but not used by Dune. It was discovered when working on #11310.
