### PR TITLE
revert regression introduced in #11126

### DIFF
--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -624,10 +624,11 @@ module Make (User : USER) = struct
 
     (* Ensure no duplicates *)
     if List.length (remove_duplicates lits) <> List.length lits
-    then
-      User_error.raise
-        [ Pp.text "at_most_one(" ++ pp_lits lits ++ Pp.paragraph "): duplicates in list!"
-        ];
+    then (
+      let msg =
+        Pp.text "at_most_one(" ++ pp_lits lits ++ Pp.paragraph "): duplicates in list!"
+      in
+      invalid_arg (Format.asprintf "%a." Pp.to_fmt msg));
     (* Ignore any literals already known to be False.
        If any are True then they're enqueued and we'll process them
        soon. *)


### PR DESCRIPTION
We need to raise invalid arg because that is what we're catching  in:

```
            (* If [user_var] is selected, don't select an incompatible version of
               the optional dependency. We don't need to do this explicitly in
               the [essential] case, because we must select a good version and we can't
               select two. *)
            (try S.at_most_one sat (user_var :: fail) |> ignore with
             | Invalid_argument reason ->
               (* Explicitly conflicts with itself! *)
               S.at_least_one sat [ S.neg user_var ] ~reason)
```



<!-- ps-id: 1ab50ba4-1de6-451d-b905-915fe79381de -->