### PR TITLE
refactor: specialize string functions for opam's parser string cache

### DIFF
--- a/vendor/opam-file-format/opamLexer.mll
+++ b/vendor/opam-file-format/opamLexer.mll
@@ -82,8 +82,13 @@ let char_for_hexadecimal_code lexbuf i =
   Char.chr (val1 * 16 + val2)
 
 (* Some hash-consing for strings *)
-module HS =
-  Weak.Make(struct include String let hash = Hashtbl.hash let equal = (=) end)
+module HS = Weak.Make(struct
+  include struct
+    [@@@ocaml.warning "-32"]
+    let hash = Hashtbl.hash
+  end
+  include String
+end)
 let hm = HS.create 317
 
 let buf = Buffer.create 64


### PR DESCRIPTION
do not rely on polymorphic hashing/comparison for strings

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>