### PR TITLE
Concurrent fiber solver

### DIFF
--- a/otherlibs/stdune/src/hashtbl.ml
+++ b/otherlibs/stdune/src/hashtbl.ml
@@ -75,6 +75,8 @@ struct
        |> List.sort ~compare:(fun (k, _) (k', _) -> Dyn.compare k k'))
   ;;
 
+  let to_list t = foldi t ~init:[] ~f:(fun key v acc -> (key, v) :: acc)
+
   let filteri_inplace t ~f =
     filter_map_inplace t ~f:(fun ~key ~data ->
       match f ~key ~data with

--- a/otherlibs/stdune/src/hashtbl_intf.ml
+++ b/otherlibs/stdune/src/hashtbl_intf.ml
@@ -21,4 +21,5 @@ module type S = sig
   val to_dyn : ('v -> Dyn.t) -> 'v t -> Dyn.t
   val filteri_inplace : 'a t -> f:(key:key -> data:'a -> bool) -> unit
   val length : _ t -> int
+  val to_list : 'a t -> (key * 'a) list
 end

--- a/otherlibs/stdune/src/table.ml
+++ b/otherlibs/stdune/src/table.ml
@@ -96,6 +96,7 @@ let filteri_inplace (type input output) ((module T) : (input, output) t) ~f =
 ;;
 
 let length (type input output) ((module T) : (input, output) t) = T.H.length T.value
+let to_list (type input output) ((module T) : (input, output) t) = T.H.to_list T.value
 
 module Multi = struct
   let cons t x v =

--- a/otherlibs/stdune/src/table.mli
+++ b/otherlibs/stdune/src/table.mli
@@ -40,6 +40,7 @@ val iter : (_, 'v) t -> f:('v -> unit) -> unit
 val filteri_inplace : ('a, 'b) t -> f:(key:'a -> data:'b -> bool) -> unit
 val length : (_, _) t -> int
 val values : (_, 'a) t -> 'a list
+val to_list : ('a, 'b) t -> ('a * 'b) list
 
 module Multi : sig
     type ('k, 'v) t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -710,13 +710,13 @@ module Solver = struct
               clause)
           in
           let+ () =
-            Fiber.sequential_iter !impls ~f:(fun { var = impl_var; impl } ->
+            Fiber.parallel_iter !impls ~f:(fun { var = impl_var; impl } ->
               Conflict_classes.process conflict_classes impl_var impl;
               match expand_deps with
               | `No_expand -> Fiber.return ()
               | `Expand_and_collect_conflicts deferred ->
                 Input.Impl.requires role impl
-                |> Fiber.sequential_iter ~f:(fun (dep : Input.dependency) ->
+                |> Fiber.parallel_iter ~f:(fun (dep : Input.dependency) ->
                   match dep.importance with
                   | Ensure -> process_dep expand_deps impl_var dep
                   | Prevent ->
@@ -778,7 +778,7 @@ module Solver = struct
            restricting dependencies are irrelevant to solving the dependency
            problem. *)
         List.rev !conflicts
-        |> Fiber.sequential_iter ~f:(fun (impl_var, dep) ->
+        |> Fiber.parallel_iter ~f:(fun (impl_var, dep) ->
           process_dep `No_expand impl_var dep)
         (* All impl_candidates have now been added, so snapshot the cache. *)
       in


### PR DESCRIPTION
Switch to parallel iteration from sequential iteration. This required switching to a fiber aware cache.

This gives a small but nice boost:

Before:
```
Benchmark 1: ~/github/ocaml/dune/_build/default/bin/main.exe pkg lock
  Time (mean ¬± œÉ):      1.962 s ¬±  0.069 s    [User: 1.285 s, System: 0.444 s]
  Range (min ‚Ä¶ max):    1.882 s ‚Ä¶  2.086 s    10 runs
```

After:
```
Benchmark 1: ~/github/ocaml/dune/_build/default/bin/main.exe pkg lock
  Time (mean ¬± œÉ):      1.752 s ¬±  0.315 s    [User: 1.284 s, System: 0.464 s]
  Range (min ‚Ä¶ max):    1.535 s ‚Ä¶  2.606 s    10 runs
```