### PR TITLE
Fix cram tests build-path-prefix-map substitutions

### DIFF
--- a/doc/changes/11366.md
+++ b/doc/changes/11366.md
@@ -1,0 +1,1 @@
+- Fix cram tests build-path-prefix-map substitutions (#11366, @art-w)

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -712,9 +712,9 @@ the standard BUILD_PATH_PREFIX_MAP_ environment variable. For example:
 
 .. code:: console
 
-   $ export BUILD_PATH_PREFIX_MAP="HOME=$HOME:$BUILD_PATH_PREFIX_MAP"
+   $ export BUILD_PATH_PREFIX_MAP="/HOME=$HOME:$BUILD_PATH_PREFIX_MAP"
    $ echo $HOME
-   $HOME
+   /HOME
 
 Note: Unlike Dune's version of Cram, the original specification for Cram
 supports regular expression and glob filtering for matching output. We chose

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -98,6 +98,7 @@ val set_temp_dir_when_running_actions : bool ref
     termination. [stdout_to] [stderr_to] are released *)
 val run
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stdout_to:Io.output Io.t
   -> ?stderr_to:Io.output Io.t
@@ -111,6 +112,7 @@ val run
 
 val run_with_times
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stdout_to:Io.output Io.t
   -> ?stderr_to:Io.output Io.t
@@ -125,6 +127,7 @@ val run_with_times
 (** Run a command and capture its output *)
 val run_capture
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
@@ -137,6 +140,7 @@ val run_capture
 
 val run_capture_line
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
@@ -149,6 +153,7 @@ val run_capture_line
 
 val run_capture_lines
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
@@ -161,6 +166,7 @@ val run_capture_lines
 
 val run_capture_zero_separated
   :  ?dir:Path.t
+  -> ?temp_dir:Path.t
   -> display:Display.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -586,8 +586,15 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
     let+ l = A.all (List.map l ~f:expand) in
     O.Pipe (outputs, l)
   | Cram script ->
-    let+ script = E.dep script in
-    Cram_exec.action script
+    A.with_expander (fun expander ->
+      let open Memo.O in
+      let+ version =
+        let dir = Expander.dir expander in
+        Dune_load.find_project ~dir >>| Dune_project.dune_version
+      in
+      let open Action_expander.O in
+      let+ script = E.dep script in
+      Cram_exec.action ~version script)
   | Format_dune_file (src, dst) ->
     A.with_expander (fun expander ->
       let open Memo.O in

--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -9,7 +9,8 @@ val make_script
 
 (** Runs the script created in [make_script] *)
 val run
-  :  src:Path.t
+  :  version:Dune_lang.Syntax.Version.t
+  -> src:Path.t
   -> dir:Path.t
   -> script:Path.t
   -> output:Path.Build.t
@@ -22,7 +23,7 @@ val run
 val diff : src:Path.t -> output:Path.t -> Action.t
 
 (** Corresponds the user written cram action *)
-val action : Path.t -> Action.t
+val action : version:Dune_lang.Syntax.Version.t -> Path.t -> Action.t
 
 module For_tests : sig
   val cram_stanzas : Lexing.lexbuf -> (Loc.t * string list Cram_lexer.block) list

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -53,6 +53,7 @@ let missing_run_t (error : Cram_test.t) =
 ;;
 
 let test_rule
+      ~version
       ~sctx
       ~dir
       ({ test_name_alias
@@ -144,6 +145,7 @@ let test_rule
           and+ () = Action_builder.paths setup_scripts
           and+ locks = locks >>| Path.Set.to_list in
           Cram_exec.run
+            ~version
             ~src:(Path.build script)
             ~dir:
               (Path.build
@@ -201,7 +203,7 @@ let collect_stanzas =
     | Some dir -> collect_whole_subtree [ acc ] dir
 ;;
 
-let rules ~sctx ~dir tests =
+let rules ~version ~sctx ~dir tests =
   let* stanzas = collect_stanzas ~dir
   and* with_package_mask =
     Dune_load.mask ()
@@ -346,7 +348,7 @@ let rules ~sctx ~dir tests =
       in
       { acc with extra_aliases }
     in
-    with_package_mask spec.packages (fun () -> test_rule ~sctx ~dir spec test))
+    with_package_mask spec.packages (fun () -> test_rule ~version ~sctx ~dir spec test))
 ;;
 
 let cram_tests dir =
@@ -393,5 +395,7 @@ let rules ~sctx ~dir source_dir =
   cram_tests source_dir
   >>= function
   | [] -> Memo.return ()
-  | tests -> rules ~sctx ~dir tests
+  | tests ->
+    let version = Source_tree.Dir.project source_dir |> Dune_project.dune_version in
+    rules ~version ~sctx ~dir tests
 ;;

--- a/test/blackbox-tests/test-cases/cram/build-path-prefix-map.t
+++ b/test/blackbox-tests/test-cases/cram/build-path-prefix-map.t
@@ -1,0 +1,97 @@
+Before dune 3.22, the substitution would only apply to absolute paths containing no spaces:
+
+  $ mkdir test
+  $ cd test
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (cram)
+  > EOF
+
+  $ cat >run.t <<EOF
+  >   $ export BUILD_PATH_PREFIX_MAP=LOCAL=tmp/local
+  >   $ echo /path/to/tmp/local/thing
+  >   /path/to/tmp/local/thing
+  > EOF
+
+  $ dune runtest
+
+Since dune 3.22:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >run.t <<EOF
+  >   $ export BUILD_PATH_PREFIX_MAP=LOCAL=tmp/local
+  >   $ echo /path/to/tmp/local/thing
+  >   /path/to/LOCAL/thing
+  > EOF
+
+  $ dune runtest
+
+A longer test, which could be un-nested once dune itself requires 3.18 in its dune-project:
+
+  $ export BUILD_PATH_PREFIX_MAP=parent-env=ignore
+
+  $ cat >run.t <<"EOF"
+  > The build-path-prefix-map substitutes any dynamic path in the output of
+  > commands, to help with reproducibility:
+  > 
+  >   $ PWD=$(pwd)
+  >   $ echo $PWD
+  >   $TESTCASE_ROOT
+  >   $ echo /nest/$PWD/sub/dir
+  >   /nest/$TESTCASE_ROOT/sub/dir
+  >   $ echo "[\"$PWD\",\"$PWD\"]"
+  >   ["$TESTCASE_ROOT","$TESTCASE_ROOT"]
+  > 
+  > Besides the current `$TESTCASE_ROOT` directory, an empty `$TMPDIR` is available:
+  > 
+  >   $ ls -a $TMPDIR
+  >   .
+  >   ..
+  >   $ echo $TMPDIR
+  >   $TMPDIR
+  >   $ echo $TMPDIR/sub/dir
+  >   $TMPDIR/sub/dir
+  >   $ echo The tempdir is at:$TMPDIR:
+  >   The tempdir is at:$TMPDIR:
+  > 
+  > The environment variable `$BUILD_PATH_PREFIX_MAP` can be extended with new
+  > entries, e.g. the user `$HOME` directory:
+  > 
+  >   $ export BUILD_PATH_PREFIX_MAP="HOME=$HOME:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo $HOME
+  >   HOME
+  > 
+  > Spaces in paths are supported:
+  > 
+  >   $ SPACED="path/contains spaces/.but/it's not an"
+  >   $ echo /this/$SPACED/issue
+  >   /this/path/contains spaces/.but/it's not an/issue
+  >   $ export BUILD_PATH_PREFIX_MAP="\$SPACED=$SPACED:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo /this/$SPACED/issue
+  >   /this/$SPACED/issue
+  > 
+  > Right-most entries are preferred:
+  > 
+  >   $ SUBDIR="$(pwd)/sub"
+  >   $ export BUILD_PATH_PREFIX_MAP="\$LEFT=$SUBDIR:$BUILD_PATH_PREFIX_MAP"
+  >   $ echo $SUBDIR
+  >   $TESTCASE_ROOT/sub
+  >   $ export BUILD_PATH_PREFIX_MAP="$BUILD_PATH_PREFIX_MAP:\$RIGHT=$SUBDIR"
+  >   $ echo $SUBDIR
+  >   $RIGHT
+  > 
+  > Inspecting the `$BUILD_PATH_PREFIX_MAP` should show no dynamic path as they are
+  > all replaced by their binding:
+  > 
+  >   $ echo $BUILD_PATH_PREFIX_MAP
+  >   $LEFT=$RIGHT:$SPACED=$SPACED:HOME=HOME:parent-env=parent-env:/workspace_root=$TESTCASE_ROOT:$TESTCASE_ROOT=$TESTCASE_ROOT:$TMPDIR=$TMPDIR:$RIGHT=$RIGHT
+  > EOF
+
+  $ dune runtest

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -9,8 +9,6 @@ Testing install actions
   $ build_pkg test
   foobar
 
-  $ export BUILD_PATH_PREFIX_MAP="/PKG_ROOT=test/target:$BUILD_PATH_PREFIX_MAP"
-
   $ show_pkg_targets test
   
   /bin


### PR DESCRIPTION
I ran into a tiny issue with cram tests output, where only the first `$TESTCASE_ROOT` path would be normalized to hide the dynamic path (using bindings from `$BUILD_PATH_PREFIX_MAP`), but not the other paths on the same line. It turns out that dune expected paths to be separated by whitespace, and I was producing a json list of filenames with no spaces anywhere (with `jq -c`). In retrospect this PR should also fix reproducibility issues when a parent directory contains spaces.

Furthermore, the `$TMPDIR` variable was also expected to be normalized in command outputs by the build-path-prefix-map, but it wasn't matching as `Process.run` was overriding the cram test `$TMPDIR` env var for a different path (the shared `Dtemp.temp_dir` which contains a bunch of other things).