### PR TITLE
pkg: allow pkg for release builds

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -242,7 +242,6 @@ module Options_implied_by_dash_p = struct
       ; "--always-show-command-line"
       ; "--promote-install-files"
       ; "--require-dune-project-file"
-      ; "--ignore-lock-dir"
       ; "--default-target"
       ; "@install"
       ]
@@ -294,7 +293,7 @@ module Options_implied_by_dash_p = struct
     Term.with_used_args
       Arg.(
         value
-        & alias_opt (fun s -> [ "--release"; "--only-packages"; s ])
+        & alias_opt (fun s -> [ "--release"; "--ignore-lock-dir"; "--only-packages"; s ])
         & info
             [ "p"; "for-release-of-packages" ]
             ~docs

--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
@@ -1,4 +1,6 @@
-When building a project in release mode we should ignore the lock directory.
+When building a project with -p we should ignore the lock directory. This is so
+that packages with lockdirs in their source archive can be built by opam
+without using locked dependencies.
 
   $ . ./helpers.sh
 
@@ -17,4 +19,4 @@ When building a project in release mode we should ignore the lock directory.
   >  (depends test))
   > EOF
 
-  $ dune build @install --release
+  $ dune build @install -p foo


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/11375

@rgrinberg do you remember why "--ignore-lock-dir" was added to the arguments passed by "--release"? Is it now safe to remove?