### PR TITLE
Revert "pkg: add repro for gh11375"

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -77,16 +77,3 @@ Lock, build, and run the executable in the project:
   - foo.0.0.1
   $ dune exec bar
   Hello, World!
-
-Rebuild the executable, this time in the release profile:
-  $ dune clean
-  $ dune exec --release bar
-  File "dune", line 3, characters 12-15:
-  3 |  (libraries foo))
-                  ^^^
-  Error: Library "foo" not found.
-  -> required by _build/default/.bar.eobjs/byte/dune__exe__Bar.cmi
-  -> required by _build/default/.bar.eobjs/native/dune__exe__Bar.cmx
-  -> required by _build/default/bar.exe
-  -> required by _build/install/default/bin/bar
-  [1]


### PR DESCRIPTION
Reverts ocaml/dune#11376

As @rgrinberg points out, we already have a test for this so to keep test run duration manageable I'd suggest reverting the addition of the new test.