### PR TITLE
Optimize findlib cache

### DIFF
--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -64,6 +64,12 @@ module DB = struct
     && String.equal t.ext_lib ext_lib
   ;;
 
+  let equal a b =
+    (* Since the DB is cached per context, physical equality will
+       shortcut almost all equality tests. *)
+    phys_equal a b || equal a b
+  ;;
+
   let hash { stdlib_dir; paths; builtins; ext_lib } =
     Poly.hash
       ( Path.hash stdlib_dir


### PR DESCRIPTION
The findlib DBs are used as keys in a hashtable for memoization, but we expect them to compare equal most of the time since they are created once per context, so physical equality can shortcut a lot of comparisons.

`dune build @all` on Irmin: (previously built, so nothing to do)

```
Before:
  Time (mean ± σ):     911.8 ms ±   9.0 ms    [User: 840.7 ms, System: 73.3 ms]
  Range (min … max):   897.8 ms … 923.4 ms    10 runs

After:
  Time (mean ± σ):     836.5 ms ±  10.0 ms    [User: 763.5 ms, System: 76.2 ms]
  Range (min … max):   821.6 ms … 848.1 ms    10 runs
```
 

On Tezos:

```
Before:
  Time (mean ± σ):     23.785 s ±  2.556 s    [User: 22.362 s, System: 1.502 s]
  Range (min … max):   21.948 s … 28.395 s    10 runs

After:
  Time (mean ± σ):     22.411 s ±  2.467 s    [User: 21.019 s, System: 1.473 s]
  Range (min … max):   20.620 s … 26.860 s    10 runs
```
