### PR TITLE
refactor: remove force lazy from findlib

### DIFF
--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -490,15 +490,13 @@ type t = DB.t
 
 let create =
   Per_context.create_by_name ~name:"findlib" (fun context ->
-    Memo.lazy_ (fun () ->
-      let* context = Context.DB.get context in
-      let* paths = Context.findlib_paths context
-      and* lib_config =
-        let+ ocaml = Context.ocaml context in
-        ocaml.lib_config
-      in
-      DB.create ~paths ~lib_config)
-    |> Memo.Lazy.force)
+    let* context = Context.DB.get context in
+    let* paths = Context.findlib_paths context
+    and* lib_config =
+      let+ ocaml = Context.ocaml context in
+      ocaml.lib_config
+    in
+    DB.create ~paths ~lib_config)
   |> Staged.unstage
 ;;
 


### PR DESCRIPTION
As far as I understand, the `lazy_ |> force` isn't doing anything interesting (but I'm curious to know if it's actually useful?)