### PR TITLE
refactor(pkg): speed up opam file parsing

### DIFF
--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -25,10 +25,11 @@ let loc_of_opam_pos
 ;;
 
 let read_from_string_exn ~contents path =
+  let filename = Path.to_absolute_filename path |> OpamFilename.raw in
+  let pos = OpamTypesBase.pos_file filename in
   try
-    OpamFile.OPAM.read_from_string
-      contents
-      ~filename:(Path.to_absolute_filename path |> OpamFilename.raw |> OpamFile.make)
+    let syntax = OpamFile.Syntax.of_string (OpamFile.make filename) contents in
+    OpamPp.parse OpamFile.OPAM.pp_raw_fields ~pos syntax.file_contents
   with
   | OpamPp.Bad_version (_, message) ->
     User_error.raise


### PR DESCRIPTION
Since we are reading opam files direclty from strings, their paths are meaningless and we shouldn't try to infer anything about the file from the filename we've passed.

Before:
```
[nix-shell:/Users/rgrinberg/github/mirage/irmin]$ hyperfine --style basic "~/github/ocaml/dune/_build/default/bin/main.exe pkg lock"
Benchmark 1: ~/github/ocaml/dune/_build/default/bin/main.exe pkg lock
  Time (mean ¬± œÉ):      1.654 s ¬±  0.098 s    [User: 0.948 s, System: 0.465 s]
  Range (min ‚Ä¶ max):    1.534 s ‚Ä¶  1.876 s    10 runs
```

After:

```
[nix-shell:/Users/rgrinberg/github/mirage/irmin]$ hyperfine --style basic "~/github/ocaml/dune/_build/default/bin/main.exe pkg lock"
Benchmark 1: ~/github/ocaml/dune/_build/default/bin/main.exe pkg lock
  Time (mean ¬± œÉ):      1.516 s ¬±  0.113 s    [User: 0.929 s, System: 0.315 s]
  Range (min ‚Ä¶ max):    1.398 s ‚Ä¶  1.723 s    10 runs
```

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>