### PR TITLE
Windows: retry a file remove - a virus checker might lock files

### DIFF
--- a/doc/changes/11437.md
+++ b/doc/changes/11437.md
@@ -1,0 +1,1 @@
+- Fix #11425 by retrying a file delete operation up 30x with 1s sleep in case of an EACCESS error (Windows only)

--- a/doc/changes/11437.md
+++ b/doc/changes/11437.md
@@ -1,1 +1,3 @@
-- Fix #11425 by retrying a file delete operation up 30x with 1s sleep in case of an EACCESS error (Windows only)
+- On Windows, under heavy load, file delete operations can sometimes fail due to
+  AV programs, etc. Guard against it by retrying the operation up to 30x with a
+  1s waiting gap (#11437, fixes #11425, @MSoegtropIMC)

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -118,12 +118,14 @@ let win32_unlink fn =
        Unix.unlink fn
      with
      | Unix.Unix_error (Unix.EACCES, _, _) ->
-      (* On Windows a virus scanner frequently has a lock on new executables for a short while - just retry *)
-      let rec retry_loop cnt =
-        Unix.sleep 1;
-        (try Unix.unlink fn
-         with Unix.Unix_error (Unix.EACCES, _, _) -> if cnt>0 then retry_loop (cnt-1) else raise e)
-      in retry_loop 30)
+       (* On Windows a virus scanner frequently has a lock on new executables for a short while - just retry *)
+       let rec retry_loop cnt =
+         Unix.sleep 1;
+         try Unix.unlink fn with
+         | Unix.Unix_error (Unix.EACCES, _, _) ->
+           if cnt > 0 then retry_loop (cnt - 1) else raise e
+       in
+       retry_loop 30)
 ;;
 
 let unlink_exn = if Stdlib.Sys.win32 then win32_unlink else Unix.unlink

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -117,7 +117,13 @@ let win32_unlink fn =
        Unix.chmod fn 0o666;
        Unix.unlink fn
      with
-     | _ -> raise e)
+     | Unix.Unix_error (Unix.EACCES, _, _) ->
+      (* On Windows a virus scanner frequently has a lock on new executables for a short while - just retry *)
+      let rec retry_loop cnt =
+        Unix.sleep 1;
+        (try Unix.unlink fn
+         with Unix.Unix_error (Unix.EACCES, _, _) -> if cnt>0 then retry_loop (cnt-1) else raise e)
+      in retry_loop 30)
 ;;
 
 let unlink_exn = if Stdlib.Sys.win32 then win32_unlink else Unix.unlink


### PR DESCRIPTION
Fixes #11425

A few notes: the Windows error in this situation is "file lockaed" and not "permission denied", but afaik the Unix error codes do not distinguish these cases.

One could be more restrictive in further with blocks also handling only `EACCESS´ - I am not sure what is best.

Regarding the retry time of 30x1s: this might be excessive, but 10s may happen on a heavily loaded machine. Usually a virus scanner should require less than 1s.

I tested this in a large opam meta project (Coq Platform) where without this patch 3 builds fail. With this patch, this worked reliably (tested with dune 3.16.1 because dune 3.17.X has other issues on Windows I didn't research in detail as yet, but e.g. cariro doesn't find cairo.h with 3.17.2 but it does with 3.16.1.