### PR TITLE
chore(ci): remove opam unsupported compilers

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,13 +56,6 @@ jobs:
           - ocaml-compiler: 4.08.x
             os: ubuntu-latest
             skip_test: true
-          - ocaml-compiler: 4.04.x
-            os: ubuntu-latest
-            skip_test: true
-            configurator: true
-          - ocaml-compiler: 4.02.x
-            os: ubuntu-latest
-            skip_test: true
 
     runs-on: ${{ matrix.os }}
 

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -2,7 +2,7 @@ open StdLabels
 open Printf
 
 (* This program performs version checking of the compiler and switches to the
-   secondary compiler if necessary. The script should execute in OCaml 4.02! *)
+   secondary compiler if necessary. The script should execute in OCaml 4.08! *)
 
 let min_supported_natively = 4, 08, 0
 

--- a/doc/reference/dune-workspace/index.rst
+++ b/doc/reference/dune-workspace/index.rst
@@ -21,9 +21,9 @@ The ``dune-workspace`` file uses the S-expression syntax. This is what a typical
 .. code:: dune
 
     (lang dune 3.14)
-    (context (opam (switch 4.07.1)))
     (context (opam (switch 4.08.1)))
     (context (opam (switch 4.11.1)))
+    (context (opam (switch 4.14.2)))
 
 The rest of this section describe the stanzas available.
 

--- a/doc/reference/ordered-set-language.rst
+++ b/doc/reference/ordered-set-language.rst
@@ -25,7 +25,7 @@ future so that one may write:
 
 .. code::
 
-   (flags (if (>= %{ocaml_version} 4.06) ...))
+   (flags (if (>= %{ocaml_version} 4.08) ...))
 
 This restriction will allow you to add this feature without introducing
 breaking changes. If you want to write a list where the first element

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -19,7 +19,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -89,7 +89,7 @@ no stability guarantee.
  (name dune-configurator)
  (synopsis "Helper library for gathering system configuration")
  (depends
-  (ocaml (>= 4.04.0))
+  (ocaml (>= 4.08.0))
   base-unix
   (csexp (>= 1.5.0)))
  (description "\

--- a/dune.opam
+++ b/dune.opam
@@ -43,7 +43,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "ocaml" {>= "4.08"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -5,7 +5,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "ocaml" {>= "4.08"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/test/blackbox-tests/test-cases/bigarray.t/run.t
+++ b/test/blackbox-tests/test-cases/bigarray.t/run.t
@@ -1,16 +1,6 @@
 This tests the support for the bigarray atom in the dune libraries stanza.
 
 History:
-- OCaml 4.05 ([ocaml/ocaml#997](https://github.com/ocaml/ocaml/pull/997) and
-[ocaml/ocaml#1077](https://github.com/ocaml/ocaml/pull/1077)) add
-`Unix.map_file` allowing the `map_file` functions in `Bigarray` to be
-deprecated. Bigarray remains a separate library.
-- OCaml 4.07 ([ocaml/ocaml#1685](https://github.com/ocaml/ocaml/pull/1685))
-adds `Stdlib.Bigarray`, but without the `map_file` functions (since these
-required `Unix.file_descr`. The separate library remains with those
-functions (but still marked as deprecated). Code can be updated to use
-Unix.map_file and then Stdlib.Bigarray and not require the separate library
-at all, but the separate remains compatible with OCaml 4.06.
 - OCaml 4.08 ([ocaml/ocaml#2263](https://github.com/ocaml/ocaml/pull/2263))
 deletes the `map_file` functions completely, requiring _all_ code to be
 updated to use `Unix.map_file`, if appropriate. From this release, it is

--- a/test/blackbox-tests/test-cases/utop/dune
+++ b/test/blackbox-tests/test-cases/utop/dune
@@ -1,5 +1,3 @@
 (cram
  (deps
-  (package utop))
- (enabled_if
-  (>= %{ocaml_version} 4.08.0)))
+  (package utop)))

--- a/test/blackbox-tests/test-cases/utop/dune
+++ b/test/blackbox-tests/test-cases/utop/dune
@@ -2,4 +2,4 @@
  (deps
   (package utop))
  (enabled_if
-  (>= %{ocaml_version} 4.05.0)))
+  (>= %{ocaml_version} 4.08.0)))


### PR DESCRIPTION
Following the [recent updates](https://discuss.ocaml.org/t/opam-repository-archival-phase-2-ocaml-4-08-is-the-lower-bound/15965) on the opam side, the `4.08` is now considered the lower bound. As a result this PR removes two tests on `4.02` and `4.04` that are not relevant anymore, regarding this new policy.
