### PR TITLE
fix: add missing thread flag to support Mutex

### DIFF
--- a/vendor/opam-file-format/dune
+++ b/vendor/opam-file-format/dune
@@ -1,6 +1,7 @@
 (library
  (name opam_file_format)
- (wrapped false))
+ (wrapped false)
+ (flags :standard -thread))
 
 (ocamllex opamLexer)
 (ocamlyacc opamBaseParser)


### PR DESCRIPTION
This PR fixes the `Unbound module Mutex` by adding the `-thread` flag to the compiler. It is not necessary (but harmless) with `5.X` version but required for `4.X`.

Closes #11450
