### PR TITLE
refactor(pkg): unrefutable constraints

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -186,39 +186,48 @@ let all_packages_versions_at_rev rev opam_package_name =
     | _ -> None)
 ;;
 
-let all_package_versions t opam_package_name =
+module Key = struct
+  type t =
+    | Directory of OpamPackage.t
+    | Git of Rev_store.File.t * OpamPackage.t * Rev_store.At_rev.t * Path.Local.t
+
+  let opam_package = function
+    | Directory p | Git (_, p, _, _) -> p
+  ;;
+end
+
+let all_package_versions t opam_package_name : Key.t list =
   match t.source with
   | Directory dir ->
     all_packages_versions_in_dir t.loc ~dir opam_package_name
-    |> List.map ~f:(fun pkg -> `Directory pkg)
+    |> List.map ~f:(fun pkg -> Key.Directory pkg)
   | Repo rev ->
     all_packages_versions_at_rev rev opam_package_name
     |> List.map ~f:(fun (file, pkg) ->
       let files_dir = Paths.files_dir pkg in
-      `Git (file, pkg, rev, files_dir))
+      Key.Git (file, pkg, rev, files_dir))
 ;;
 
-let load_all_versions ts opam_package_name =
+let all_packages_versions_map ts opam_package_name =
+  List.concat_map ts ~f:(fun t ->
+    all_package_versions t opam_package_name |> List.rev_map ~f:(fun pkg -> t, pkg))
+  |> List.fold_left ~init:OpamPackage.Version.Map.empty ~f:(fun acc (repo, pkg) ->
+    let version =
+      let pkg = Key.opam_package pkg in
+      OpamPackage.version pkg
+    in
+    if OpamPackage.Version.Map.mem version acc
+    then acc
+    else OpamPackage.Version.Map.add version (repo, pkg) acc)
+;;
+
+let load_all_versions_by_keys ts =
   let from_git, from_dirs =
-    List.concat_map ts ~f:(fun t ->
-      all_package_versions t opam_package_name |> List.rev_map ~f:(fun pkg -> t, pkg))
-    |> List.fold_left ~init:OpamPackage.Version.Map.empty ~f:(fun acc (repo, pkg) ->
-      let version =
-        let pkg =
-          match pkg with
-          | `Directory pkg -> pkg
-          | `Git (_, pkg, _, _) -> pkg
-        in
-        OpamPackage.version pkg
-      in
-      if OpamPackage.Version.Map.mem version acc
-      then acc
-      else OpamPackage.Version.Map.add version (repo, pkg) acc)
-    |> OpamPackage.Version.Map.values
-    |> List.partition_map ~f:(fun (repo, pkg) ->
+    OpamPackage.Version.Map.values ts
+    |> List.partition_map ~f:(fun (repo, (pkg : Key.t)) ->
       match pkg with
-      | `Git (file, pkg, rev, files_dir) -> Left (file, pkg, rev, files_dir)
-      | `Directory pkg -> Right (repo, pkg))
+      | Git (file, pkg, rev, files_dir) -> Left (file, pkg, rev, files_dir)
+      | Directory pkg -> Right (repo, pkg))
   in
   let from_dirs =
     List.filter_map from_dirs ~f:(fun (repo, pkg) ->
@@ -244,6 +253,10 @@ let load_all_versions ts opam_package_name =
   |> List.rev_map ~f:(fun (opam_package, resolved_package) ->
     OpamPackage.version opam_package, resolved_package)
   |> OpamPackage.Version.Map.of_list
+;;
+
+let load_all_versions ts opam_package_name =
+  all_packages_versions_map ts opam_package_name |> load_all_versions_by_keys
 ;;
 
 module Private = struct

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -26,6 +26,21 @@ val of_git_repo : Loc.t -> OpamUrl.t -> t Fiber.t
 val revision : t -> Rev_store.At_rev.t
 val serializable : t -> Serializable.t option
 
+module Key : sig
+  type t
+
+  val opam_package : t -> OpamPackage.t
+end
+
+val all_packages_versions_map
+  :  t list
+  -> OpamPackage.Name.t
+  -> (t * Key.t) OpamPackage.Version.Map.t
+
+val load_all_versions_by_keys
+  :  (t * Key.t) OpamPackage.Version.Map.t
+  -> Resolved_package.t OpamPackage.Version.Map.t Fiber.t
+
 (** Load package metadata for all versions of a package with a given name *)
 val load_all_versions
   :  t list

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -22,8 +22,7 @@ The solver should say no solution rather than just ignoring the conflict.
   Couldn't solve the package dependency formula.
   Selected candidates: bar.0.0.1 x.dev
   - foo -> (problem)
-      x dev requires conflict with all versions
-      Rejected candidates:
-        foo.0.0.1: Incompatible with restriction: conflict with all versions
+      No usable implementations:
+        foo.0.0.1: Package does not satisfy constraints of local package x
   [1]
 

--- a/test/blackbox-tests/test-cases/pkg/gh11265.t
+++ b/test/blackbox-tests/test-cases/pkg/gh11265.t
@@ -18,9 +18,8 @@ A package which depends on a single package and also conflicts with the same pac
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev
   - bar -> (problem)
-      foo dev requires conflict with all versions
-      Rejected candidates:
-        bar.0.0.1: Incompatible with restriction: conflict with all versions
+      No usable implementations:
+        bar.0.0.1: Package does not satisfy constraints of local package foo
   [1]
 
 Now add an additional conflict on a non-existant package "baz". Dune will choose the package "bar" despite it being a conflict:

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -143,12 +143,16 @@ Run the solver again. This time it will fail.
   Couldn't solve the package dependency formula.
   Selected candidates: baz.0.1.0 foo.0.0.1 lockfile_generation_test.dev
   - bar -> (problem)
-      foo 0.0.1 requires >= 0.2
-      lockfile_generation_test dev requires >= 0.6
-      Rejected candidates:
-        bar.0.5.0: Incompatible with restriction: >= 0.6
-        bar.0.4.0: Incompatible with restriction: >= 0.6
-        bar.0.0.1: Incompatible with restriction: >= 0.2
+      No usable implementations:
+        bar.0.5.0:
+          Package does not satisfy constraints of local package
+          lockfile_generation_test
+        bar.0.4.0:
+          Package does not satisfy constraints of local package
+          lockfile_generation_test
+        bar.0.0.1:
+          Package does not satisfy constraints of local package
+          lockfile_generation_test
   [1]
 
 We'll also test how the lockfile generation works with alternate solutions.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -64,11 +64,11 @@ This should fail as there is no version matching 0.24.1:
   Couldn't solve the package dependency formula.
   Selected candidates: ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)
-      ocamlformat_dev_tool_wrapper dev requires
-        >= 0.24.1 & <= 0.24.1___MAX_VERSION
-      Rejected candidates:
+      No usable implementations:
         ocamlformat.0.25+bar:
-          Incompatible with restriction: >= 0.24.1 & <= 0.24.1___MAX_VERSION
+          Package does not satisfy constraints of local package
+          ocamlformat_dev_tool_wrapper
         ocamlformat.0.24+foo:
-          Incompatible with restriction: >= 0.24.1 & <= 0.24.1___MAX_VERSION
+          Package does not satisfy constraints of local package
+          ocamlformat_dev_tool_wrapper
   [1]


### PR DESCRIPTION
Reduce loading of unnecessary opam packages by making sure that every local package must not conflict with the constraints of local packages. Such packages can never be used for a solution, and loading them is pointless.

This is a large speed improvement for repos that write many constraints (such as bonsai for example).