### PR TITLE
debug broken CI cache

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,6 +69,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
         env:
           OPAMVERBOSE: 3
+          XXXXXXXXXXX: 1
 
       # git user needs to be configured for the following tests:
       # otherlibs/build-info/test/run.t

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
+        uses: kit-ty-kate/setup-ocaml@test-macos
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -67,6 +67,8 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+        env:
+          OPAMVERBOSE: 3
 
       # git user needs to be configured for the following tests:
       # otherlibs/build-info/test/run.t

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,12 +64,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: kit-ty-kate/setup-ocaml@test-macos
+        uses: kit-ty-kate/setup-ocaml@workaround-gpatch-macos
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-        env:
-          OPAMVERBOSE: 3
-          XXXXXXXXXXX: 1
 
       # git user needs to be configured for the following tests:
       # otherlibs/build-info/test/run.t


### PR DESCRIPTION
Sorry to open such a debug PR for opam issues such as https://github.com/ocaml/dune/actions/runs/13189768488/job/36820198222?pr=11453 but i've tried everything and i'm unable to reproduce either locally or an a custom github action so my only choice is to debug at the source with the only lead i have so far: something somehow got wrong with setup-ocaml's cache