### PR TITLE
pkg: defer evaluating platform vars in commands

### DIFF
--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -53,6 +53,10 @@ let post = of_string "post"
 let one_of t xs = List.mem xs ~equal t
 let dev = of_string "dev"
 
+let platform_specific =
+  Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]
+;;
+
 module Project = struct
   let encode name = Dune_sexp.Encoder.string (":" ^ to_string name)
 

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -32,6 +32,10 @@ val build : t
 val dev : t
 val one_of : t -> t list -> bool
 
+(** The set of variable names whose values are expected to differ depending on
+    the current platform. *)
+val platform_specific : Set.t
+
 module Project : sig
   val encode : t Dune_sexp.Encoder.t
   val decode : t Dune_sexp.Decoder.t

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -21,5 +21,8 @@ val extend : t -> t -> t
 val with_defaults : t
 
 val pp : t -> 'a Pp.t
+
+(** Remove a set of bindings from the env *)
 val unset_multi : t -> Package_variable_name.Set.t -> t
+
 val to_env : t -> OpamFilter.env

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -140,11 +140,18 @@ stored in the lockdir metadata:
   (version 0.0.1)
   
   (install
-   (run echo qux))
+   (when
+    (= %{arch} arm)
+    (run echo qux)))
   
   (build
    (progn
-    (run echo foo)
+    (when
+     (= %{os} linux)
+     (run echo foo))
+    (when
+     (= %{os} macos)
+     (run echo bar))
     (run echo baz)))
   $ cat dune.lock/lock.dune
   (lang package 0.1)
@@ -154,9 +161,3 @@ stored in the lockdir metadata:
   (repositories
    (complete false)
    (used))
-  
-  (expanded_solver_variable_bindings
-   (variable_values
-    (os linux)
-    (arch arm))
-   (unset_variables x))


### PR DESCRIPTION
Package build and install commands are expressions that generate the command to run by evaluating a series of conditional statements. This allows the commands to be tailored to the current machine where the command is being run. Previously dune would evaluate platform-specific variables (e.g. os, arch) in these expressions at solve-time, producing lockfiles specialized to the machine where they are solved. This change defers evaluation of these variables until build-time.

The consequence of deferring evaluation of platform variables to build time is that lockfiles will preserve more of the conditional logic found in the corresponding opam file. Note that some variables are still evaluated, such as `with-test`, as these variables are not based on the platform. The benefit of deferring evaluation of platform variables is that users of computers that differ from the computer where the lockfile was generated will be able to run the build/install commands specialized for their computer, which is more likely to work than attempting to run the build/install commands specialized for the computer where the lockfile was generated.

Note that this change alone is not sufficient for making lockfiles portable, as it doesn't address the fact that the dependencies of a package can also vary depending on platform-specific variables.