### PR TITLE
chore: bump dune version to 3.18

### DIFF
--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -134,6 +134,7 @@ RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tag
 RUN opam init --disable-sandboxing --auto-setup
 
 # make an opam switch for running benchmarks
+RUN echo "Cache busting to update the opam cache which serves no additional purpose besides this"
 RUN opam update && opam switch create bench 4.14.2
 RUN opam install -y dune ocamlbuild
 

--- a/chrome-trace.opam
+++ b/chrome-trace.opam
@@ -10,11 +10,12 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/chrome-trace.opam
+++ b/chrome-trace.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]

--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "dune-glob" {= version}
   "csexp" {>= "1.5.0"}
   "ppx_expect" {with-test}

--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "dune-glob" {= version}
   "csexp" {>= "1.5.0"}
   "ppx_expect" {with-test}
@@ -28,6 +28,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -16,11 +16,12 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -18,13 +18,14 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "stdune" {= version}
   "dyn"
   "ordering"

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "stdune" {= version}
   "dyn"
   "ordering"
@@ -18,6 +18,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "csexp" {>= "1.5.0"}
   "pp" {>= "1.1.0"}
   "dyn" {= version}
@@ -26,6 +26,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "csexp" {>= "1.5.0"}
   "pp" {>= "1.1.0"}
   "dyn" {= version}

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.17)
+(lang dune 3.18)
 ;          ^^^^
 ; When changing the version, don't forget to regenerate *.opam files
 ; by running [dune build].

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.12)
+(lang dune 3.17)
 ;          ^^^^
 ; When changing the version, don't forget to regenerate *.opam files
 ; by running [dune build].

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "dune-rpc" {= version}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.6.0"}

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "dune-rpc" {= version}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.6.0"}
@@ -17,6 +17,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-rpc.opam
+++ b/dune-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "csexp"
   "ordering"
   "dyn"

--- a/dune-rpc.opam
+++ b/dune-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "csexp"
   "ordering"
   "dyn"
@@ -19,6 +19,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-site.opam
+++ b/dune-site.opam
@@ -9,11 +9,12 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-site.opam
+++ b/dune-site.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]

--- a/dune.opam
+++ b/dune.opam
@@ -36,6 +36,7 @@ conflicts: [
   "jbuilder" {= "transition"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["ocaml" "boot/bootstrap.ml" "-j" jobs]
   ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]

--- a/dyn.opam
+++ b/dyn.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}

--- a/dyn.opam
+++ b/dyn.opam
@@ -9,13 +9,14 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/ocamlc-loc.opam
+++ b/ocamlc-loc.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "dyn" {= version}
   "odoc" {with-doc}

--- a/ocamlc-loc.opam
+++ b/ocamlc-loc.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "dyn" {= version}
   "odoc" {with-doc}
@@ -19,6 +19,7 @@ conflicts: [
   "ocaml-lsp-server" {< "1.15.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/ordering.opam
+++ b/ordering.opam
@@ -9,11 +9,12 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/ordering.opam
+++ b/ordering.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]

--- a/stdune.opam
+++ b/stdune.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "dyn" {= version}
@@ -20,6 +20,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/stdune.opam
+++ b/stdune.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "dyn" {= version}

--- a/xdg.opam
+++ b/xdg.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/xdg.opam
+++ b/xdg.opam
@@ -10,11 +10,12 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]


### PR DESCRIPTION
This PR is intended to be merged before #11275. The idea is to update the version of the dune lang first, as it implies new changes in terms of formatting. Then we can merge the PR that supports the maintenance fields on top of it.

cc @art-w 
