### PR TITLE
fix(ci): build doc with LC_ALL=C

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -136,6 +136,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
       - run: nix develop .#doc -c make doc
+        env:
+          LC_ALL: C
 
   coq:
     name: Coq 8.16.1


### PR DESCRIPTION
The installed locales in the github runner can act weirdly and in
particular `C.UTF-8` has a different name; downgrading to `LC_ALL=C`
fixes the build.
