### PR TITLE
Require js_of_ocaml >= 6

### DIFF
--- a/dune.opam
+++ b/dune.opam
@@ -49,8 +49,8 @@ depends: [
   "lwt" { with-dev-setup & os != "win32" }
   "cinaps" { with-dev-setup }
   "csexp" { with-dev-setup & >= "1.3.0" }
-  "js_of_ocaml" { with-dev-setup & os != "win32" }
-  "js_of_ocaml-compiler" { with-dev-setup & os != "win32" }
+  "js_of_ocaml" { with-dev-setup & >= "6.0.1" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.0.1" & os != "win32" }
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -11,8 +11,8 @@ depends: [
   "lwt" { with-dev-setup & os != "win32" }
   "cinaps" { with-dev-setup }
   "csexp" { with-dev-setup & >= "1.3.0" }
-  "js_of_ocaml" { with-dev-setup & os != "win32" }
-  "js_of_ocaml-compiler" { with-dev-setup & os != "win32" }
+  "js_of_ocaml" { with-dev-setup & >= "6.0.1" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.0.1" & os != "win32" }
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }


### PR DESCRIPTION
It works with older versions but the error message changed in version 6, so the test fail due to the wording of the error if the person uses `jsoo.5.9.1`.

This makes sure that people updating their system using `make dev-switch` will get their possibly existing installation updated.