### PR TITLE
Require minimal ppxlib version

### DIFF
--- a/dune.opam
+++ b/dune.opam
@@ -57,7 +57,7 @@ depends: [
   "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
-  "ppxlib" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.0.0-51" & os != "win32" }

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -19,7 +19,7 @@ depends: [
   "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
-  "ppxlib" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.0.0-51" & os != "win32" }


### PR DESCRIPTION
Otherwise the `describe` test is failing because the description does not match.

Similar reasoning as #11487.