### PR TITLE
Experimental portable lockdirs

### DIFF
--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -8,6 +8,7 @@ val solve
   -> version_preference:Dune_pkg.Version_preference.t option
   -> lock_dirs:Path.Source.t list
   -> print_perf_stats:bool
+  -> portable_lock_dir:bool
   -> unit Fiber.t
 
 (** Command to create lock directory *)

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -14,9 +14,13 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
         get_repos
           (repositories_of_workspace workspace)
           ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
-      and+ local_packages = Memo.run find_local_packages in
+      and+ local_packages = Memo.run find_local_packages
+      and+ platform = solver_env_from_system_and_context ~lock_dir_path in
       let lock_dir = Lock_dir.read_disk_exn lock_dir_path in
-      let+ results = Dune_pkg_outdated.find ~repos ~local_packages lock_dir.packages in
+      let packages =
+        Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform
+      in
+      let+ results = Dune_pkg_outdated.find ~repos ~local_packages packages in
       ( Dune_pkg_outdated.pp ~transitive ~lock_dir_path results
       , ( Dune_pkg_outdated.packages_that_were_not_found results
           |> Package_name.Set.of_list

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -12,6 +12,12 @@ val solver_env
   -> unset_solver_vars_from_context:Dune_lang.Package_variable_name.Set.t option
   -> Dune_pkg.Solver_env.t
 
+val poll_solver_env_from_current_system : unit -> Dune_pkg.Solver_env.t Fiber.t
+
+val solver_env_from_system_and_context
+  :  lock_dir_path:Path.Source.t
+  -> Dune_pkg.Solver_env.t Fiber.t
+
 module Version_preference : sig
   type t := Dune_pkg.Version_preference.t
 

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -22,6 +22,7 @@ let default_toggles : (string * [ `Disabled | `Enabled ]) list =
   ; "pkg_build_progress", `Disabled
   ; "lock_dev_tool", `Disabled
   ; "bin_dev_tools", `Disabled
+  ; "portable_lock_dir", `Disabled
   ]
 ;;
 
@@ -110,6 +111,10 @@ let () =
       , " Enable obtaining dev-tools binarys from the binary package opam repository. \
          Allows fast installation of dev-tools. \n\
         \      This flag is experimental and shouldn't be relied on by packagers." )
+    ; ( "--portable-lock-dir"
+      , toggle "portable_lock_dir"
+      , "Generate portable lock dirs. If this feature is disabled then lock dirs will be \
+         specialized to the machine where they are generated." )
     ]
   in
   let anon s = bad "Don't know what to do with %s" s in

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             "--pkg-build-progress" "enable"
             "--lock-dev-tool" "enable"
             "--bin-dev-tools" "enable"
+            "--portable-lock-dir" "enable"
           ];
       };
 

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -52,6 +52,10 @@ let post = of_string "post"
 let one_of t xs = List.mem xs ~equal t
 let dev = of_string "dev"
 
+let platform_specific =
+  Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]
+;;
+
 module Project = struct
   let encode name = Encoder.string (":" ^ to_string name)
 

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -32,6 +32,10 @@ val build : t
 val dev : t
 val one_of : t -> t list -> bool
 
+(** The set of variable names whose values are expected to differ depending on
+    the current platform. *)
+val platform_specific : Set.t
+
 module Project : sig
   val encode : t Encoder.t
   val decode : t Decoder.t

--- a/src/dune_lang/package_version.mli
+++ b/src/dune_lang/package_version.mli
@@ -10,3 +10,5 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val encode : t Encoder.t
 val decode : t Decoder.t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_pkg/file_entry.ml
+++ b/src/dune_pkg/file_entry.ml
@@ -4,7 +4,28 @@ type source =
   | Path of Path.t
   | Content of string
 
+let source_equal a b =
+  match a, b with
+  | Path a, Path b -> Path.equal a b
+  | Content a, Content b -> String.equal a b
+  | Path _, Content _ | Content _, Path _ -> false
+;;
+
+let dyn_of_source = function
+  | Path path -> Dyn.variant "Path" [ Path.to_dyn path ]
+  | Content content -> Dyn.variant "Content" [ Dyn.string content ]
+;;
+
 type t =
   { original : source
   ; local_file : Path.Local.t
   }
+
+let equal { original; local_file } t =
+  source_equal original t.original && Path.Local.equal local_file t.local_file
+;;
+
+let to_dyn { original; local_file } =
+  Dyn.record
+    [ "original", dyn_of_source original; "local_file", Path.Local.to_dyn local_file ]
+;;

--- a/src/dune_pkg/file_entry.mli
+++ b/src/dune_pkg/file_entry.mli
@@ -8,3 +8,6 @@ type t =
   { original : source
   ; local_file : Path.Local.t
   }
+
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -20,36 +20,74 @@ module Build_command : sig
   type t =
     | Action of Action.t
     | Dune (** pinned dune packages do not need to define a command *)
+
+  val to_dyn : t -> Dyn.t
+end
+
+module Dependency : sig
+  type t =
+    { loc : Loc.t
+    ; name : Package_name.t
+    }
+
+  val to_dyn : t -> Dyn.t
+end
+
+module Conditional_choice : sig
+  (** A sequence of values, each conditional on an environment. *)
+  type 'a t
+
+  val empty : 'a t
+  val singleton : Solver_env.t -> 'a -> 'a t
+
+  (** Returns the first value whose associated environment is a subset of the
+      specified environment. *)
+  val choose_for_platform : 'a t -> platform:Solver_env.t -> 'a option
 end
 
 module Pkg : sig
   type t =
-    { build_command : Build_command.t option
-    ; install_command : Action.t option
-    ; depends : (Loc.t * Package_name.t) list
-    ; depexts : string list
+    { build_command : Build_command.t Conditional_choice.t
+    ; install_command : Action.t Conditional_choice.t
+    ; depends : Dependency.t list Conditional_choice.t
+    ; depexts : string list Conditional_choice.t
     ; info : Pkg_info.t
     ; exported_env : String_with_vars.t Action.Env_update.t list
+    ; enabled_on_platforms : Solver_env.t list
     }
 
   val remove_locs : t -> t
   val equal : t -> t -> bool
-  val decode : (lock_dir:Path.Source.t -> Package_name.t -> t) Decoder.t
-  val files_dir : Package_name.t -> lock_dir:Path.Source.t -> Path.Source.t
-end
 
-module Package_filename : sig
-  val of_package_name : Package_name.t -> string
+  val decode
+    : (lock_dir:Path.Source.t
+       -> solved_for_platforms:Solver_env.t list
+       -> Package_name.t
+       -> t)
+        Decoder.t
+
+  val files_dir
+    :  Package_name.t
+    -> Package_version.t option
+    -> lock_dir:Path.Source.t
+    -> Path.Source.t
 end
 
 module Repositories : sig
   type t
 end
 
+module Packages : sig
+  type t
+
+  val to_pkg_list : t -> Pkg.t list
+  val pkgs_on_platform_by_name : t -> platform:Solver_env.t -> Pkg.t Package_name.Map.t
+end
+
 type t = private
   { version : Syntax.Version.t
   ; dependency_hash : (Loc.t * Local_package.Dependency_hash.t) option
-  ; packages : Pkg.t Package_name.Map.t
+  ; packages : Packages.t
     (** It's guaranteed that this map will contain an entry for all dependencies
       of all packages in this map. That is, the set of packages is closed under
       the "depends on" relationship between packages. *)
@@ -59,6 +97,7 @@ type t = private
     (** Stores the solver variables that were evaluated while solving
       dependencies. Can be used to determine if a lockdir is compatible
       with a particular system. *)
+  ; solved_for_platforms : Loc.t * Solver_env.t list
   }
 
 val remove_locs : t -> t
@@ -76,6 +115,8 @@ val create_latest_version
   -> ocaml:(Loc.t * Package_name.t) option
   -> repos:Opam_repo.t list option
   -> expanded_solver_variable_bindings:Solver_stats.Expanded_variable_bindings.t
+  -> solved_for_platform:Solver_env.t option
+       (* TODO: make this non-optional when portable lockdirs becomes the default *)
   -> t
 
 val default_path : Path.Source.t
@@ -93,8 +134,9 @@ module Write_disk : sig
   type t
 
   val prepare
-    :  lock_dir_path:Path.Source.t
-    -> files:File_entry.t Package_name.Map.Multi.t
+    :  portable_lock_dir:bool
+    -> lock_dir_path:Path.Source.t
+    -> files:File_entry.t Package_version.Map.Multi.t Package_name.Map.t
     -> lock_dir
     -> t
 
@@ -116,16 +158,27 @@ module Make_load (Io : sig
   val load_exn : Path.Source.t -> t Io.t
 end
 
-(** [transitive_dependency_closure t names] returns the set of package names
+(** [transitive_dependency_closure t ~platform names] returns the set of package names
     making up the transitive closure of dependencies of the set [names], or
     [Error (`Missing_packages missing_packages)] if if any element of [names]
     is not found in the lockdir. [missing_packages] is a subset of [names]
-    not present in the lockdir. *)
+    not present in the lockdir. As a package's dependencies may vary between
+    platforms, a description of the current platform must also be provided. *)
 val transitive_dependency_closure
   :  t
+  -> platform:Solver_env.t
   -> Package_name.Set.t
   -> (Package_name.Set.t, [ `Missing_packages of Package_name.Set.t ]) result
 
 (** Attempt to download and compute checksums for packages that have source
     archive urls but no checksum. *)
 val compute_missing_checksums : t -> pinned_packages:Package_name.Set.t -> t Fiber.t
+
+(** Combine the platform-specific parts of a pair of lockdirs, throwing a code
+    error if the lockdirs differ in a non-platform-specific way. *)
+val merge_conditionals : t -> t -> t
+
+(** Returns the packages contained in the solution on the given platform. If
+    the lockdir does not contain a solution compatible with the given platform
+    then a [User_error] is raised. *)
+val packages_on_platform : t -> platform:Solver_env.t -> Pkg.t Package_name.Map.t

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -3,10 +3,12 @@ open Import
 module Solver_result : sig
   type t =
     { lock_dir : Lock_dir.t
-    ; files : File_entry.t Package_name.Map.Multi.t
+    ; files : File_entry.t Package_version.Map.Multi.t Package_name.Map.t
     ; pinned_packages : Package_name.Set.t
     ; num_expanded_packages : int
     }
+
+  val merge : t -> t -> t
 end
 
 val solve_lock_dir

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -3,6 +3,7 @@ open! Import
 type t =
   { local_packages : Local_package.t Package_name.Map.t
   ; lock_dir : Lock_dir.t
+  ; platform : Solver_env.t
   ; version_by_package_name : Package_version.t Package_name.Map.t
   ; solver_env : Solver_env.t
   }
@@ -18,13 +19,14 @@ let lockdir_regenerate_hints =
   ]
 ;;
 
-let version_by_package_name local_packages (lock_dir : Lock_dir.t) =
+let version_by_package_name ~platform local_packages (lock_dir : Lock_dir.t) =
   let from_local_packages =
     Package_name.Map.map local_packages ~f:(fun (local_package : Local_package.t) ->
       local_package.version)
   in
   let from_lock_dir =
-    Package_name.Map.map lock_dir.packages ~f:(fun pkg -> pkg.info.version)
+    Lock_dir.Packages.pkgs_on_platform_by_name ~platform lock_dir.packages
+    |> Package_name.Map.map ~f:(fun (pkg : Lock_dir.Pkg.t) -> pkg.info.version)
   in
   let exception Duplicate_package of Package_name.t in
   try
@@ -85,14 +87,18 @@ let all_non_local_dependencies_of_local_packages t =
 ;;
 
 let check_for_unnecessary_packges_in_lock_dir
-      lock_dir
+      ~platform
+      (lock_dir : Lock_dir.t)
+      solver_env
       all_non_local_dependencies_of_local_packages
   =
+  let packages = Lock_dir.Packages.pkgs_on_platform_by_name lock_dir.packages ~platform in
   let unneeded_packages_in_lock_dir =
     let locked_transitive_closure_of_local_package_dependencies =
       match
         Lock_dir.transitive_dependency_closure
           lock_dir
+          ~platform:solver_env
           all_non_local_dependencies_of_local_packages
       with
       | Ok x -> x
@@ -102,7 +108,7 @@ let check_for_unnecessary_packges_in_lock_dir
           "Missing packages from lockdir after confirming no missing packages in lockdir"
           [ "missing package", Package_name.Set.to_dyn missing_packages ]
     in
-    let all_locked_packages = Package_name.Set.of_keys lock_dir.packages in
+    let all_locked_packages = Package_name.Set.of_keys packages in
     Package_name.Set.diff
       all_locked_packages
       locked_transitive_closure_of_local_package_dependencies
@@ -112,7 +118,7 @@ let check_for_unnecessary_packges_in_lock_dir
   else (
     let packages =
       Package_name.Set.to_list unneeded_packages_in_lock_dir
-      |> List.map ~f:(Package_name.Map.find_exn lock_dir.packages)
+      |> List.map ~f:(Package_name.Map.find_exn packages)
     in
     User_error.raise
       ~hints:lockdir_regenerate_hints
@@ -215,23 +221,25 @@ let validate_dependency_hash local_packages ~saved_dependency_hash =
         ]
 ;;
 
-let validate t =
+let validate ~platform t =
   validate_dependency_hash
     t.local_packages
     ~saved_dependency_hash:t.lock_dir.dependency_hash;
   all_non_local_dependencies_of_local_packages t
-  |> check_for_unnecessary_packges_in_lock_dir t.lock_dir
+  |> check_for_unnecessary_packges_in_lock_dir ~platform t.lock_dir t.solver_env
 ;;
 
-let create local_packages lock_dir =
+let create ~platform local_packages lock_dir =
   try
-    let version_by_package_name = version_by_package_name local_packages lock_dir in
+    let version_by_package_name =
+      version_by_package_name ~platform local_packages lock_dir
+    in
     let solver_env =
       Solver_stats.Expanded_variable_bindings.to_solver_env
         lock_dir.expanded_solver_variable_bindings
     in
-    let t = { local_packages; lock_dir; version_by_package_name; solver_env } in
-    validate t;
+    let t = { local_packages; lock_dir; platform; version_by_package_name; solver_env } in
+    validate ~platform t;
     Ok t
   with
   | User_error.E e -> Error e
@@ -273,6 +281,7 @@ let transitive_dependency_closure_without_test t start =
     match
       Lock_dir.transitive_dependency_closure
         t.lock_dir
+        ~platform:t.solver_env
         Package_name.Set.(
           union
             non_local_immediate_dependencies_of_local_transitive_dependency_closure
@@ -293,7 +302,10 @@ let transitive_dependency_closure_without_test t start =
 
 let contains_package t package_name =
   let in_local_packages = Package_name.Map.mem t.local_packages package_name in
-  let in_lock_dir = Package_name.Map.mem t.lock_dir.packages package_name in
+  let lock_dir_packages =
+    Lock_dir.Packages.pkgs_on_platform_by_name ~platform:t.platform t.lock_dir.packages
+  in
+  let in_lock_dir = Package_name.Map.mem lock_dir_packages package_name in
   in_local_packages || in_lock_dir
 ;;
 

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -1,17 +1,21 @@
 open! Import
 
-(** All of the packages in a dune project including local packages and packages
-    in a lockdir. The lockdir is guaranteed to contain a valid dependency
-    solution for the local packages. *)
+(** all of the packages in a dune project under the constraints of a given
+    platform, including local packages and packages in a lockdir. the lockdir
+    is guaranteed to contain a valid dependency solution for the local
+    packages. *)
 type t
 
+(** Create a universe for a given platform.
+    TODO: Consider changing this to cover all platforms simultaneously. *)
 val create
-  :  Local_package.t Package_name.Map.t
+  :  platform:Solver_env.t
+  -> Local_package.t Package_name.Map.t
   -> Lock_dir.t
   -> (t, User_message.t) result
 
 (** Verifies if the dependencies described in the project file are still
-    synchronize with the dependencies selected in the lock directroy. If it is
+    synchronized with the dependencies selected in the lock directroy. If it is
     not the case, it returns the hash of the new dependency set. *)
 val up_to_date
   :  Local_package.t Package_name.Map.t

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -12,3 +12,5 @@ val decode : t Dune_lang.Decoder.t
 val of_opam_package_version : OpamPackage.Version.t -> t
 val to_opam_package_version : t -> OpamPackage.Version.t
 val dev : t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -1,11 +1,23 @@
 open Import
 
-type t = Variable_value.t Package_variable_name.Map.t
+module T = struct
+  type t = Variable_value.t Package_variable_name.Map.t
+
+  let to_dyn = Package_variable_name.Map.to_dyn Variable_value.to_dyn
+  let equal = Package_variable_name.Map.equal ~equal:Variable_value.equal
+  let compare = Package_variable_name.Map.compare ~compare:Variable_value.compare
+end
+
+include T
+include Comparable.Make (T)
 
 let empty = Package_variable_name.Map.empty
-let equal = Package_variable_name.Map.equal ~equal:Variable_value.equal
-let to_dyn = Package_variable_name.Map.to_dyn Variable_value.to_dyn
 let is_empty = Package_variable_name.Map.is_empty
+
+let is_subset =
+  Package_variable_name.Map.is_subset ~f:(fun value ~of_ ->
+    Variable_value.equal value of_)
+;;
 
 let validate t ~loc =
   if Package_variable_name.Map.mem t Package_variable_name.with_test
@@ -18,6 +30,12 @@ let validate t ~loc =
           Package_variable_name.(to_string with_test)
           Package_variable_name.(to_string with_test)
       ]
+;;
+
+let encode t =
+  let open Encoder in
+  Package_variable_name.Map.to_list t
+  |> list (pair Package_variable_name.encode Variable_value.encode)
 ;;
 
 let decode =
@@ -48,6 +66,7 @@ let set t variable_name variable_value =
 
 let get = Package_variable_name.Map.find
 let extend a b = Package_variable_name.Map.superpose b a
+let contains = Package_variable_name.Map.mem
 
 let with_defaults =
   [ ( Package_variable_name.opam_version
@@ -77,6 +96,17 @@ let unset_multi t variable_names =
     unset t variable_name)
 ;;
 
+let remove_all_except t variable_names =
+  Package_variable_name.Map.foldi t ~init:t ~f:(fun variable_name _value acc ->
+    if Package_variable_name.Set.mem variable_names variable_name
+    then acc
+    else unset acc variable_name)
+;;
+
+let remove_all_except_platform_specific t =
+  remove_all_except t Package_variable_name.platform_specific
+;;
+
 let to_env t variable =
   match OpamVariable.Full.scope variable with
   | Self | Package _ -> None
@@ -85,4 +115,89 @@ let to_env t variable =
       OpamVariable.Full.variable variable |> Package_variable_name.of_opam
     in
     get t variable_name |> Option.map ~f:Variable_value.to_opam_variable_contents
+;;
+
+let popular_platform_envs =
+  let make ~os ~arch ~os_distribution ~os_family () =
+    let env = empty in
+    let env = set env Package_variable_name.os (Variable_value.string os) in
+    let env = set env Package_variable_name.arch (Variable_value.string arch) in
+    let env =
+      match os_distribution with
+      | Some os_distribution ->
+        set
+          env
+          Package_variable_name.os_distribution
+          (Variable_value.string os_distribution)
+      | None -> env
+    in
+    let env =
+      match os_family with
+      | Some os_family ->
+        set env Package_variable_name.os_family (Variable_value.string os_family)
+      | None -> env
+    in
+    env
+  in
+  [ make
+      ~os:"linux"
+      ~arch:"x86_64"
+      ~os_distribution:(Some "ubuntu")
+      ~os_family:(Some "debian")
+      ()
+  ; make
+      ~os:"linux"
+      ~arch:"arm64"
+      ~os_distribution:(Some "ubuntu")
+      ~os_family:(Some "debian")
+      ()
+  ; make
+      ~os:"linux"
+      ~arch:"x86_64"
+      ~os_distribution:(Some "alpine")
+      ~os_family:(Some "alpine")
+      ()
+  ; make
+      ~os:"linux"
+      ~arch:"arm64"
+      ~os_distribution:(Some "alpine")
+      ~os_family:(Some "alpine")
+      ()
+  ; make ~os:"linux" ~arch:"x86_64" ~os_distribution:None ~os_family:None ()
+  ; make ~os:"linux" ~arch:"arm64" ~os_distribution:None ~os_family:None ()
+  ; make
+      ~os:"macos"
+      ~arch:"x86_64"
+      ~os_distribution:(Some "homebrew")
+      ~os_family:(Some "homebrew")
+      ()
+  ; make
+      ~os:"macos"
+      ~arch:"arm64"
+      ~os_distribution:(Some "homebrew")
+      ~os_family:(Some "homebrew")
+      ()
+  ; make
+      ~os:"win32"
+      ~arch:"x86_64"
+      ~os_distribution:(Some "cygwin")
+      ~os_family:(Some "windows")
+      ()
+  ; make
+      ~os:"win32"
+      ~arch:"arm64"
+      ~os_distribution:(Some "cygwin")
+      ~os_family:(Some "windows")
+      ()
+  ]
+;;
+
+let add_sentinel_values_for_unset_platform_vars solver_env =
+  Package_variable_name.Set.fold
+    Package_variable_name.platform_specific
+    ~init:solver_env
+    ~f:(fun name acc ->
+      if contains acc name
+      then acc
+      else set acc name (Variable_value.sentinel_value_of_variable_name name))
 ;;

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -4,8 +4,14 @@ type t
 
 val empty : t
 val equal : t -> t -> bool
+val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val is_empty : t -> bool
+
+(** [is_subset t ~of_] is true iff each binding in [t] is also present in [of_] *)
+val is_subset : t -> of_:t -> bool
+
+val encode : t Encoder.t
 val decode : t Decoder.t
 val set : t -> Package_variable_name.t -> Variable_value.t -> t
 val get : t -> Package_variable_name.t -> Variable_value.t option
@@ -22,4 +28,26 @@ val with_defaults : t
 
 val pp : t -> 'a Pp.t
 val unset_multi : t -> Package_variable_name.Set.t -> t
+
+(** [remove_all_except t names] returns an environment with the same bindings
+    as those in [t] whose names also appear in [names]. *)
+val remove_all_except : t -> Package_variable_name.Set.t -> t
+
+(** Remove all bindings from the environment except for those which are
+    platform-specific. *)
+val remove_all_except_platform_specific : t -> t
+
 val to_env : t -> OpamFilter.env
+
+(** A list of environments comprising the most common platforms. Dune will
+    solve dependencies for these platforms unless alternative platforms are
+    specified in dune-workspace. *)
+val popular_platform_envs : t list
+
+(** Assign each unset platform variable in [t] to a sentinel value. For a
+    description of how sentinel values are chosen and why they are necessary,
+    see the documentation of [Variable_value.sentinel_value_of_variable_name]. *)
+val add_sentinel_values_for_unset_platform_vars : t -> t
+
+module Map : Map.S with type key = t
+module Set : Set.S with type elt = t and type 'a map = 'a Map.t

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -17,9 +17,20 @@ let true_ = "true"
 let false_ = "false"
 let string = Fun.id
 let equal = String.equal
+let compare = String.compare
 let to_dyn = Dyn.string
 let to_string = Fun.id
 let decode = Decoder.string
 let encode = Encoder.string
 let to_opam_filter t = OpamTypes.FString t
 let to_opam_variable_contents t = OpamTypes.S t
+
+let sentinel_value_of_variable_name variable_name =
+  let uppercase_replacing_dash_with_underscore =
+    Package_variable_name.to_string variable_name
+    |> String.uppercase
+    |> String.split_on_char ~sep:'-'
+    |> String.concat ~sep:"_"
+  in
+  string (String.concat ~sep:"" [ "__"; uppercase_replacing_dash_with_underscore ])
+;;

--- a/src/dune_pkg/variable_value.mli
+++ b/src/dune_pkg/variable_value.mli
@@ -9,9 +9,36 @@ val false_ : t
 val string : string -> t
 
 val equal : t -> t -> bool
+val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t
 val encode : t Encoder.t
 val to_string : t -> string
 val to_opam_filter : t -> OpamTypes.filter
 val to_opam_variable_contents : t -> OpamTypes.variable_contents
+
+(** [sentinel_value_of_variable_name name] is a value based on [name] that is
+    very unlikely to be seen in the wild as a value of the given variable. A
+    variable may be assigned a sentinel value in situations where it would
+    otherwise be undefined, and when an undefined value would lead to
+    undesirable consequences.
+
+    For example the "os-version" opam variable rarely has an impact on solving
+    in practice, however some package declare that they are unavailable for old
+    versions of particular operating systems distros, such as:
+
+      available: (os-distribution != "ubuntu" | os-version >= "18.04")
+
+    This states that the package is unavailable on versions of ubuntu earlier
+    than 18.04. Undefined values in opam are propagated through operators, so
+    if os-version (or os-distribution) were unset, the entire availability
+    condition would evaluate to an undefined value, which is coerced into
+    "false". That is to say that this package would be considered unavailable
+    unless os-version and os-distribution have values. Setting these variables
+    to sentinel values is sufficient for this package to be considered
+    available.
+
+    The value is a string made up of the variable's name converted to all caps,
+    with dashes replaced with underscores and prepended with "__". For example
+    "os-version" would become "__OS_VERSION". *)
+val sentinel_value_of_variable_name : Package_variable_name.t -> t

--- a/src/dune_rules/compile_time.ml
+++ b/src/dune_rules/compile_time.ml
@@ -8,3 +8,7 @@ let pkg_build_progress =
 
 let lock_dev_tools = Config.make_toggle ~name:"lock_dev_tool" ~default:Setup.lock_dev_tool
 let bin_dev_tools = Config.make_toggle ~name:"bin_dev_tools" ~default:Setup.bin_dev_tools
+
+let portable_lock_dir =
+  Config.make_toggle ~name:"portable_lock_dir" ~default:Setup.portable_lock_dir
+;;

--- a/src/dune_rules/compile_time.mli
+++ b/src/dune_rules/compile_time.mli
@@ -22,3 +22,4 @@ val pkg_build_progress : Config.Toggle.t Config.t
 val lock_dev_tools : Config.Toggle.t Config.t
 
 val bin_dev_tools : Config.Toggle.t Config.t
+val portable_lock_dir : Config.Toggle.t Config.t

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -66,6 +66,27 @@ module Sys_vars = struct
                (Dune_sexp.Template.Pform.describe source)
            ])
   ;;
+
+  let solver_env () =
+    let open Memo.O in
+    let module V = Package_variable_name in
+    let { os; os_version; os_distribution; os_family; arch; sys_ocaml_version = _ } =
+      poll
+    in
+    let+ var_value_pairs =
+      [ V.os, os
+      ; V.os_version, os_version
+      ; V.os_distribution, os_distribution
+      ; V.os_family, os_family
+      ; V.arch, arch
+      ]
+      |> Memo.List.filter_map ~f:(fun (var, value) ->
+        let+ value = Memo.Lazy.force value in
+        Option.map value ~f:(fun value -> var, Variable_value.string value))
+    in
+    List.fold_left var_value_pairs ~init:Solver_env.empty ~f:(fun acc (var, value) ->
+      Solver_env.set acc var value)
+  ;;
 end
 
 module Load = Make_load (struct

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -21,6 +21,7 @@ module Sys_vars : sig
     }
 
   val poll : t
+  val solver_env : unit -> Dune_pkg.Solver_env.t Memo.t
 end
 
 val source_kind

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -16,3 +16,4 @@ let toolchains = `Enabled
 let pkg_build_progress = `Disabled
 let lock_dev_tool = `Disabled
 let bin_dev_tools = `Disabled
+let portable_lock_dir = `Disabled

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -14,4 +14,5 @@ val toolchains : Dune_config.Config.Toggle.t
 val pkg_build_progress : Dune_config.Config.Toggle.t
 val lock_dev_tool : Dune_config.Config.Toggle.t
 val bin_dev_tools : Dune_config.Config.Toggle.t
+val portable_lock_dir : Dune_config.Config.Toggle.t
 val prefix : string option

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -13,6 +13,7 @@ module Lock_dir : sig
     ; constraints : Dune_lang.Package_dependency.t list
     ; pins : (Loc.t * string) list
     ; depopts : (Loc.t * Package.Name.t) list
+    ; solve_for_platforms : Dune_pkg.Solver_env.t list
     }
 
   val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/dune
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/dune
@@ -1,0 +1,2 @@
+(cram
+ (applies_to :whole_subtree))

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -1,0 +1,161 @@
+Basic usage of portable lockdirs.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a package that writes a different value to some files depending on the os and arch.
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo Darwin > %{share}%/kernel"] { os = "macos" }
+  >   ["sh" "-c" "echo Linux > %{share}%/kernel"] { os = "linux" }
+  >   ["sh" "-c" "echo x86_64 > %{share}%/machine"] { arch = "x86_64" }
+  >   ["sh" "-c" "echo arm64 > %{share}%/machine"] { arch = "arm64" }
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ cat dune.lock/lock.dune
+  (lang package 0.1)
+  
+  (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)
+  
+  (repositories
+   (complete false)
+   (used))
+  
+  (solved_for_platforms
+   ((arch x86_64)
+    (os linux)
+    (os-distribution ubuntu)
+    (os-family debian))
+   ((arch arm64)
+    (os linux)
+    (os-distribution ubuntu)
+    (os-family debian))
+   ((arch x86_64)
+    (os linux)
+    (os-distribution alpine)
+    (os-family alpine))
+   ((arch arm64)
+    (os linux)
+    (os-distribution alpine)
+    (os-family alpine))
+   ((arch x86_64)
+    (os linux))
+   ((arch arm64)
+    (os linux))
+   ((arch x86_64)
+    (os macos)
+    (os-distribution homebrew)
+    (os-family homebrew))
+   ((arch arm64)
+    (os macos)
+    (os-distribution homebrew)
+    (os-family homebrew))
+   ((arch x86_64)
+    (os win32)
+    (os-distribution cygwin)
+    (os-family windows))
+   ((arch arm64)
+    (os win32)
+    (os-distribution cygwin)
+    (os-family windows)))
+
+  $ cat dune.lock/foo.0.0.1.pkg
+  (version 0.0.1)
+  
+  (build
+   (choice
+    ((((arch x86_64)
+       (os linux)
+       (os-distribution ubuntu)
+       (os-family debian))
+      ((arch x86_64)
+       (os linux)
+       (os-distribution alpine)
+       (os-family alpine))
+      ((arch x86_64)
+       (os linux)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo Linux > %{share}/kernel")
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64)
+       (os linux)
+       (os-distribution ubuntu)
+       (os-family debian))
+      ((arch arm64)
+       (os linux)
+       (os-distribution alpine)
+       (os-family alpine))
+      ((arch arm64)
+       (os linux)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo Linux > %{share}/kernel")
+        (run sh -c "echo arm64 > %{share}/machine")))))
+    ((((arch x86_64) (os macos) (os-distribution homebrew) (os-family homebrew)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo Darwin > %{share}/kernel")
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64) (os macos) (os-distribution homebrew) (os-family homebrew)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo Darwin > %{share}/kernel")
+        (run sh -c "echo arm64 > %{share}/machine")))))
+    ((((arch x86_64) (os win32) (os-distribution cygwin) (os-family windows)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64) (os win32) (os-distribution cygwin) (os-family windows)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo arm64 > %{share}/machine")))))))
+
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  $ cat $pkg_root/foo/target/share/kernel
+  Linux
+  $ cat $pkg_root/foo/target/share/machine
+  arm64
+
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
+  $ cat $pkg_root/foo/target/share/kernel
+  Darwin
+  $ cat $pkg_root/foo/target/share/machine
+  x86_64

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -1,0 +1,108 @@
+Specifying custom platforms to solve for.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a package that writes a different value to some files depending on the os, with a non-defaut os.
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo OpenBSD > %{share}%/kernel"] { os = "openbsd" }
+  >   ["sh" "-c" "echo Other > %{share}%/kernel"] { os != "openbsd" }
+  > ]
+  > EOF
+
+Create a custom dune-workspace to solve for openbsd.
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.18)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os openbsd))))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ cat dune.lock/lock.dune
+  (lang package 0.1)
+  
+  (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)
+  
+  (repositories
+   (complete false)
+   (used))
+  
+  (solved_for_platforms
+   ((arch x86_64)
+    (os openbsd)))
+
+Build as though we were on openbsd.
+  $ DUNE_CONFIG__OS=openbsd DUNE_CONFIG__ARCH=x86_64 dune build
+  $ cat $pkg_root/foo/target/share/kernel
+  OpenBSD
+
+Now building on linux won't work:
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  File "dune.lock/lock.dune", lines 10-11, characters 1-31:
+  10 |  ((arch x86_64)
+  11 |   (os openbsd)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = x86_64
+  - os = linux
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch x86_64) (os linux))))
+  Hint: ...and then rerun 'dune pkg lock'
+  [1]
+  $ cat $pkg_root/foo/target/share/kernel
+  OpenBSD
+
+Update dune-workspace again, this time listing no platforms to demonstrate the
+error case.
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.18)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  File "dune-workspace", line 7, characters 1-22:
+  7 |  (solve_for_platforms))
+       ^^^^^^^^^^^^^^^^^^^^^
+  Error: No platforms were specified for solving dependencies.
+  Hint: Specify at least one platform here, or remove this field to solve for
+  the default platforms.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -1,0 +1,130 @@
+Demonstrate the case where a project can only be solved for a subset of platforms.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Make a package that is only available on macos.
+  $ mkpkg foo <<EOF
+  > available: os = "macos"
+  > build: [
+  >   ["mkdir" "-p" "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+Solving will still succeed, but there'll be a warning because dune will attempt
+to solve for macos, linux, and windows by default.
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+  
+  No solution was found for some platforms. See the log or run with --verbose
+  for more details.
+
+The log file will contain errors about the package being unavailable.
+  $ sed -n -e "/Couldn't solve the package dependency formula./,\$p" _build/log
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+
+The lockdir will contain a list of the platforms where solving succeeded.
+  $ cat dune.lock/lock.dune
+  (lang package 0.1)
+  
+  (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)
+  
+  (repositories
+   (complete false)
+   (used))
+  
+  (solved_for_platforms
+   ((arch x86_64)
+    (os macos)
+    (os-distribution homebrew)
+    (os-family homebrew))
+   ((arch arm64)
+    (os macos)
+    (os-distribution homebrew)
+    (os-family homebrew)))
+
+No errors when you try to build the platform on macos.
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
+
+Building on linux fails because the lockdir doesn't contain a compatible solution.
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  File "dune.lock/lock.dune", lines 10-17, characters 1-162:
+  10 |  ((arch x86_64)
+  11 |   (os macos)
+  12 |   (os-distribution homebrew)
+  13 |   (os-family homebrew))
+  14 |  ((arch arm64)
+  15 |   (os macos)
+  16 |   (os-distribution homebrew)
+  17 |   (os-family homebrew)))
+  Error: The lockdir does not contain a solution compatible with the current
+  platform.
+  The current platform is:
+  - arch = arm64
+  - os = linux
+  - os-distribution = ubuntu
+  - os-family = debian
+  - os-version = 24.11
+  Hint: Try adding the following to dune-workspace:
+  Hint: (lock_dir (solve_for_platforms ((arch arm64) (os linux))))
+  Hint: ...and then rerun 'dune pkg lock'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -1,0 +1,72 @@
+Test for a project whose dependencies are different depending on the platform.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+A package that's only available on linux:
+  $ mkpkg linux-only <<EOF
+  > available: os = "linux"
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > EOF
+
+A package that's only available on macos:
+  $ mkpkg macos-only <<EOF
+  > available: os = "macos"
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > EOF
+
+A package that conditionally depends on packages depending on the OS:
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > depends: [
+  >  "linux-only" { os = "linux" }
+  >  "macos-only" { os = "macos" }
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+  - linux-only.0.0.1
+  - macos-only.0.0.1
+
+Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  $ ls $pkg_root/
+  foo
+  linux-only
+
+  $ dune clean
+
+Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
+  $ ls $pkg_root/
+  foo
+  macos-only

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -1,0 +1,93 @@
+Test that extra files associated with a package are handled correctly when
+multiple different versions of the package are present in the lockdir.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Define 2 versions of the package foo that write their version number to a file
+during their build so we can validate which version was built.
+
+  $ VERSION1_FILE=mock-opam-repository/packages/foo/foo.1/files/version.txt
+  $ VERSION2_FILE=mock-opam-repository/packages/foo/foo.2/files/version.txt
+
+  $ mkdir -p $(dirname $VERSION1_FILE)
+  $ echo version_1 > $VERSION1_FILE
+
+  $ mkdir -p $(dirname $VERSION2_FILE)
+  $ echo version_2 > $VERSION2_FILE
+
+  $ mkpkg foo 1 <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > extra-files: [
+  >   ["version.txt" "md5=$(md5sum $VERSION1_FILE | cut -f1 -d' ')"]
+  > ]
+  > EOF
+  $ mkpkg foo 2 <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > extra-files: [
+  >   ["version.txt" "md5=$(md5sum $VERSION2_FILE | cut -f1 -d' ')"]
+  > ]
+  > EOF
+
+Define a package bar which conditionally depends on different versions of foo:
+
+  $ mkpkg bar <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > depends: [
+  >   "foo" {= "1" & os = "linux"}
+  >   "foo" {= "2" & os = "macos"}
+  > ]
+  > EOF
+
+Define a project with a package depending on bar:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends bar))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+Solve the project. The solution will contain extra files for both versions of foo:
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.1
+  - foo.2
+
+Verify the contents of the extra files for each version of foo:
+  $ cat dune.lock/foo.1.files/version.txt
+  version_1
+  $ cat dune.lock/foo.2.files/version.txt
+  version_2
+
+Build as if we're on linux and verify that the appropriate extra file was copied into _build:
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  $ cat _build/default/dune.lock/foo.1.files/version.txt
+  version_1
+
+  $ dune clean
+
+Build as if we're on macos and verify that the appropriate extra file was copied into _build:
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
+  $ cat _build/default/dune.lock/foo.2.files/version.txt
+  version_2

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -1,0 +1,72 @@
+Test for a project which depends on different versions of the same package depending on the platform.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Define 2 versions of the package foo that write their version number to a file
+during their build so we can validate which version was built.
+
+  $ mkpkg foo 1 <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo %{version}% > %{share}%/version"]
+  > ]
+  > EOF
+  $ mkpkg foo 2 <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo %{version}% > %{share}%/version"]
+  > ]
+  > EOF
+
+Define a package bar which conditionally depends on different versions of foo:
+
+  $ mkpkg bar <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  > ]
+  > depends: [
+  >   "foo" {= "1" & os = "linux"}
+  >   "foo" {= "2" & os = "macos"}
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends bar))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.1
+  - foo.2
+
+Build the project as if we were on linux and confirm that version 1 of foo was built:
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
+  $ cat $pkg_root/foo/target/share/version
+  1
+
+  $ dune clean
+
+Build the project as if we were on macos and confirm that version 2 of foo was built:
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
+  $ cat $pkg_root/foo/target/share/version
+  2
+

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -1,6 +1,7 @@
 open Stdune
 module Checksum = Dune_pkg.Checksum
 module Lock_dir = Dune_pkg.Lock_dir
+module Dependency = Dune_pkg.Lock_dir.Dependency
 module Opam_repo = Dune_pkg.Opam_repo
 module Expanded_variable_bindings = Dune_pkg.Solver_stats.Expanded_variable_bindings
 module Package_variable_name = Dune_lang.Package_variable_name
@@ -66,7 +67,8 @@ end
 let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   let lock_dir_path = Path.Source.of_string lock_dir_path in
   Lock_dir.Write_disk.(
-    prepare ~lock_dir_path ~files:Package_name.Map.empty lock_dir |> commit);
+    prepare ~portable_lock_dir:false ~lock_dir_path ~files:Package_name.Map.empty lock_dir
+    |> commit);
   let lock_dir_round_tripped =
     try Lock_dir.read_disk_exn lock_dir_path with
     | User_error.E _ as exn ->
@@ -84,7 +86,9 @@ let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
   in
   if Lock_dir.equal lock_dir_round_tripped' lock_dir'
   then print_endline "lockdir matches after roundtrip:"
-  else print_endline "lockdir doesn't match after roundtrip:";
+  else (
+    print_endline "lockdir doesn't match after roundtrip:";
+    print_endline (Lock_dir.to_dyn lock_dir |> Dyn.to_string));
   let dyn_lock_dir = Lock_dir.to_dyn lock_dir_round_tripped in
   let dyn_lock_dir =
     match commit with
@@ -111,7 +115,8 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
          ~local_packages:[]
          ~ocaml:None
          ~repos:None
-         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty)
+         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+         ~solved_for_platform:None)
     ();
   [%expect
     {|
@@ -123,14 +128,16 @@ let%expect_test "encode/decode round trip test for lockdir with no deps" =
     ; repos = { complete = true; used = None }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
-    } |}]
+    ; solved_for_platforms = ("<none>:1", [])
+    }
+    |}]
 ;;
 
 let empty_package name ~version =
-  { Lock_dir.Pkg.build_command = None
-  ; install_command = None
-  ; depends = []
-  ; depexts = []
+  { Lock_dir.Pkg.build_command = Lock_dir.Conditional_choice.empty
+  ; install_command = Lock_dir.Conditional_choice.empty
+  ; depends = Lock_dir.Conditional_choice.empty
+  ; depexts = Lock_dir.Conditional_choice.empty
   ; info =
       { Lock_dir.Pkg_info.name
       ; version
@@ -140,6 +147,7 @@ let empty_package name ~version =
       ; extra_sources = []
       }
   ; exported_env = []
+  ; enabled_on_platforms = []
   }
 ;;
 
@@ -160,6 +168,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
                [ Package_variable_name.os, Variable_value.string "linux" ]
            ; unset_variables = [ Package_variable_name.os_family ]
            }
+         ~solved_for_platform:None
          (Package_name.Map.of_list_exn
             [ mk_pkg_basic ~name:"foo" ~version:(Package_version.of_string "0.1.0")
             ; mk_pkg_basic ~name:"bar" ~version:(Package_version.of_string "0.2.0")
@@ -173,35 +182,43 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
     ; packages =
         map
           { "bar" :
-              { build_command = None
-              ; install_command = None
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "bar"
-                  ; version = "0.2.0"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = None
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "0.2.0" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "bar"
+                        ; version = "0.2.0"
+                        ; dev = false
+                        ; avoid = false
+                        ; source = None
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           ; "foo" :
-              { build_command = None
-              ; install_command = None
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "foo"
-                  ; version = "0.1.0"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = None
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "0.1.0" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "foo"
+                        ; version = "0.1.0"
+                        ; dev = false
+                        ; avoid = false
+                        ; source = None
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           }
     ; ocaml = Some ("simple_lock_dir/lock.dune:3", "ocaml")
     ; repos = { complete = true; used = None }
@@ -209,6 +226,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
         { variable_values = [ ("os", "linux") ]
         ; unset_variables = [ "os-family" ]
         }
+    ; solved_for_platforms = ("<none>:1", [])
     }
     |}]
 ;;
@@ -216,6 +234,9 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
 let%expect_test "encode/decode round trip test for lockdir with complex deps" =
   let module Action = Dune_lang.Action in
   let module String_with_vars = Dune_lang.String_with_vars in
+  let make_conditional value =
+    Lock_dir.Conditional_choice.singleton Dune_pkg.Solver_env.empty value
+  in
   let lock_dir =
     let pkg_a =
       let name = Package_name.of_string "a" in
@@ -226,11 +247,11 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       , let pkg = empty_package name ~version:(Package_version.of_string "0.1.0") in
         { pkg with
           build_command =
-            Some
-              (Action
+            make_conditional
+              (Lock_dir.Build_command.Action
                  Action.(Progn [ Echo [ String_with_vars.make_text Loc.none "hello" ] ]))
         ; install_command =
-            Some
+            make_conditional
               (Action.System
                  (* String_with_vars.t doesn't round trip so we have to set
                     [quoted] if the string would be quoted *)
@@ -260,8 +281,8 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ( name
       , let pkg = empty_package name ~version:(Package_version.of_string "dev") in
         { pkg with
-          install_command = None
-        ; depends = [ Loc.none, fst pkg_a ]
+          install_command = Lock_dir.Conditional_choice.empty
+        ; depends = make_conditional [ { Dependency.loc = Loc.none; name = fst pkg_a } ]
         ; info =
             { pkg.info with
               dev = true
@@ -283,7 +304,11 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ( name
       , let pkg = empty_package name ~version:(Package_version.of_string "0.2") in
         { pkg with
-          depends = [ Loc.none, fst pkg_a; Loc.none, fst pkg_b ]
+          depends =
+            make_conditional
+              [ { Dependency.loc = Loc.none; name = fst pkg_a }
+              ; { Dependency.loc = Loc.none; name = fst pkg_b }
+              ]
         ; info =
             { pkg.info with
               dev = false
@@ -304,6 +329,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
       ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
       ~repos:(Some [ opam_repo ])
       ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+      ~solved_for_platform:None
       (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
   in
   lock_dir_encode_decode_round_trip_test ~lock_dir_path:"complex_lock_dir" ~lock_dir ();
@@ -315,63 +341,98 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
     ; packages =
         map
           { "a" :
-              { build_command = Some (Action [ "progn"; [ "echo"; "hello" ] ])
-              ; install_command = Some [ "system"; "echo 'world'" ]
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "a"
-                  ; version = "0.1.0"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = Some { url = "file:///tmp/a"; checksum = None }
-                  ; extra_sources =
-                      [ ("one", { url = "file:///tmp/a"; checksum = None })
-                      ; ("two", { url = "file://randomurl"; checksum = None })
-                      ]
-                  }
-              ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
-              }
-          ; "b" :
-              { build_command = None
-              ; install_command = None
-              ; depends = [ ("complex_lock_dir/b.pkg:3", "a") ]
-              ; depexts = []
-              ; info =
-                  { name = "b"
-                  ; version = "dev"
-                  ; dev = true
-                  ; avoid = false
-                  ; source =
-                      Some
-                        { url = "https://github.com/foo/b"
-                        ; checksum =
-                            Some
-                              "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+              map
+                { "0.1.0" :
+                    { build_command =
+                        [ { condition = [ map {} ]
+                          ; value = Action [ "progn"; [ "echo"; "hello" ] ]
+                          }
+                        ]
+                    ; install_command =
+                        [ { condition = [ map {} ]
+                          ; value = [ "system"; "echo 'world'" ]
+                          }
+                        ]
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "a"
+                        ; version = "0.1.0"
+                        ; dev = false
+                        ; avoid = false
+                        ; source =
+                            Some { url = "file:///tmp/a"; checksum = None }
+                        ; extra_sources =
+                            [ ("one", { url = "file:///tmp/a"; checksum = None })
+                            ; ("two",
+                               { url = "file://randomurl"; checksum = None })
+                            ]
                         }
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+                    ; exported_env = [ { op = "="; var = "foo"; value = "bar" } ]
+                    ; enabled_on_platforms = []
+                    }
+                }
+          ; "b" :
+              map
+                { "dev" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends =
+                        [ { condition = [ map {} ]
+                          ; value =
+                              [ { loc = "complex_lock_dir/b.pkg:3"; name = "a" }
+                              ]
+                          }
+                        ]
+                    ; depexts = []
+                    ; info =
+                        { name = "b"
+                        ; version = "dev"
+                        ; dev = true
+                        ; avoid = false
+                        ; source =
+                            Some
+                              { url = "https://github.com/foo/b"
+                              ; checksum =
+                                  Some
+                                    "sha256=adfc38f14c0188a2ad80d61451d011d27ab8839b717492d7ad42f7cb911c54c3"
+                              }
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           ; "c" :
-              { build_command = None
-              ; install_command = None
-              ; depends =
-                  [ ("complex_lock_dir/c.pkg:3", "a")
-                  ; ("complex_lock_dir/c.pkg:3", "b")
-                  ]
-              ; depexts = []
-              ; info =
-                  { name = "c"
-                  ; version = "0.2"
-                  ; dev = false
-                  ; avoid = false
-                  ; source =
-                      Some { url = "https://github.com/foo/c"; checksum = None }
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "0.2" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends =
+                        [ { condition = [ map {} ]
+                          ; value =
+                              [ { loc = "complex_lock_dir/c.pkg:3"; name = "a" }
+                              ; { loc = "complex_lock_dir/c.pkg:3"; name = "b" }
+                              ]
+                          }
+                        ]
+                    ; depexts = []
+                    ; info =
+                        { name = "c"
+                        ; version = "0.2"
+                        ; dev = false
+                        ; avoid = false
+                        ; source =
+                            Some
+                              { url = "https://github.com/foo/c"
+                              ; checksum = None
+                              }
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           }
     ; ocaml = Some ("complex_lock_dir/lock.dune:3", "ocaml")
     ; repos =
@@ -380,6 +441,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
+    ; solved_for_platforms = ("<none>:1", [])
     }
     |}]
 ;;
@@ -414,6 +476,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         ~ocaml:(Some (Loc.none, Package_name.of_string "ocaml"))
         ~repos:(Some [ opam_repo ])
         ~expanded_solver_variable_bindings:Expanded_variable_bindings.empty
+        ~solved_for_platform:None
         (Package_name.Map.of_list_exn [ pkg_a; pkg_b; pkg_c ])
     in
     lock_dir_encode_decode_round_trip_test
@@ -429,50 +492,62 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
     ; packages =
         map
           { "a" :
-              { build_command = None
-              ; install_command = None
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "a"
-                  ; version = "0.1.0"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = None
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "0.1.0" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "a"
+                        ; version = "0.1.0"
+                        ; dev = false
+                        ; avoid = false
+                        ; source = None
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           ; "b" :
-              { build_command = None
-              ; install_command = None
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "b"
-                  ; version = "dev"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = None
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "dev" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "b"
+                        ; version = "dev"
+                        ; dev = false
+                        ; avoid = false
+                        ; source = None
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           ; "c" :
-              { build_command = None
-              ; install_command = None
-              ; depends = []
-              ; depexts = []
-              ; info =
-                  { name = "c"
-                  ; version = "0.2"
-                  ; dev = false
-                  ; avoid = false
-                  ; source = None
-                  ; extra_sources = []
-                  }
-              ; exported_env = []
-              }
+              map
+                { "0.2" :
+                    { build_command = []
+                    ; install_command = []
+                    ; depends = []
+                    ; depexts = []
+                    ; info =
+                        { name = "c"
+                        ; version = "0.2"
+                        ; dev = false
+                        ; avoid = false
+                        ; source = None
+                        ; extra_sources = []
+                        }
+                    ; exported_env = []
+                    ; enabled_on_platforms = []
+                    }
+                }
           }
     ; ocaml = Some ("complex_lock_dir/lock.dune:3", "ocaml")
     ; repos =
@@ -485,6 +560,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
         }
     ; expanded_solver_variable_bindings =
         { variable_values = []; unset_variables = [] }
+    ; solved_for_platforms = ("<none>:1", [])
     }
     |}]
 ;;


### PR DESCRIPTION
Adds a feature flag for enabling portable lockdirs. This is a proof of concept implementation of portable lockdirs where the entire solver runs for each of a set of platforms (combinations of architecture, OS, and in some cases the OS distribution) which most people are expected to use. This can easily be extended in the future to add more platforms or to allow projects to specify more platforms.

To make lockdirs portable, the build/install commands and dependencies of each package are transformed into match statements, where the appropriate value for each platform is enumerated. At solve-time, the solver runs once for each platform, populating these fields. At build-time, the command/dependencies appropriate for the current platform are used.

When the feature flag is not enabled dune's behaviour is unchanged.

Related to https://github.com/ocaml/dune/issues/11476