### PR TITLE
Avoid formatting read-only files

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -217,3 +217,11 @@ let traverse =
 let traverse_files ~dir ~init ~f =
   traverse ~dir ~init ~on_dir:(fun ~dir:_ _fname acc -> acc) ~on_file:f
 ;;
+
+let is_rw p =
+  try
+    Unix.access p Unix.[ R_OK; W_OK ];
+    true
+  with
+  | Unix.Unix_error _ -> false
+;;

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -64,3 +64,6 @@ val traverse_files
   -> init:'acc
   -> f:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> 'acc
+
+(** Is readable and writable. *)
+val is_rw : string -> bool

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1436,6 +1436,7 @@ module Source = struct
 
   let is_in_build_dir s = is_in_build_dir (path_of_local s)
   let to_local t = t
+  let is_rw t = Fpath.is_rw (to_string t)
 end
 
 let set_of_source_paths set = Source.Set.to_list set |> Set.of_list_map ~f:source

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -109,6 +109,9 @@ module Source : sig
   val descendant : t -> of_:t -> t option
   val to_local : t -> Local.t
 
+  (** Whether the file at the given path is readable and writable. *)
+  val is_rw : t -> bool
+
   module Table : Hashtbl.S with type key = t
 end
 

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -138,6 +138,9 @@ let gen_rules_output
      let* dialect, kind =
        Path.Source.extension file |> Dialect.DB.find_by_extension dialects
      in
+     (* Avoid setting up rules that will fail during promotion due to the
+        source file not being writable. *)
+     let* () = Option.some_if (Path.Source.is_rw file) () in
      let* () =
        Option.some_if (Format_config.includes config (Dialect (Dialect.name dialect))) ()
      in

--- a/test/blackbox-tests/test-cases/dialects/good.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/good.t/run.t
@@ -2,6 +2,8 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune exec ./main.exe
 
+  $ chmod a+w *
+
   $ dune build @fmt
   Formatting main.mf
   Formatting main.mfi

--- a/test/blackbox-tests/test-cases/dialects/no_impl.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/no_impl.t/run.t
@@ -2,6 +2,8 @@ Test the (dialect ...) stanza inside the `dune-project` file.
 
   $ dune exec ./main.exe
 
+  $ chmod a+w *
+
   $ dune build @fmt
   fake ocamlformat is running: "--impl" "fmt.ml"
   fake ocamlformat is running: "--impl" "main.ml"

--- a/test/blackbox-tests/test-cases/dialects/no_intf_good.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/no_intf_good.t/run.t
@@ -2,6 +2,8 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune exec ./main.exe
 
+  $ chmod a+w *
+
   $ dune build @fmt
   fake ocamlformat is running: "--impl" "fmt.ml"
   Formatting main.mf

--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -3,6 +3,10 @@ Note about versioning:
 - in (lang dune 1.x), no formatting rules are set up by default.
 - (lang dune 2.0) behaves as if (using fmt 1.2) is set.
 
+Turn every symlinks into writable files belonging to the sandbox as formatting
+rules are not generated for read-only files:
+  $ find . -type l | while read f; do (rm "$f"; cat > $f) < $f; done
+
 Formatting can be checked using the @fmt target:
 
   $ touch .ocamlformat

--- a/test/blackbox-tests/test-cases/read-only-symlink-target.t/run.t
+++ b/test/blackbox-tests/test-cases/read-only-symlink-target.t/run.t
@@ -6,20 +6,9 @@ Nix can leave a symlink to a store path in the tree, often called 'result'.
   $ chmod -R a-w "$RESULT"
   $ ln -s "$RESULT" result
 
-This command should succeed:
+Formatting 'foo.ml' shouldn't be attempted and this command should succeed:
 
   $ dune fmt
-  File "ocamlformat.ml", line 1, characters 0-0:
-  Error: Files _build/default/ocamlformat.ml and
-  _build/default/.formatted/ocamlformat.ml differ.
-  File "result/foo.ml", line 1, characters 0-0:
-  Error: Files _build/default/result/foo.ml and
-  _build/default/result/.formatted/foo.ml differ.
-  Promoting _build/default/.formatted/ocamlformat.ml to ocamlformat.ml.
-  Promoting _build/default/result/.formatted/foo.ml to result/foo.ml.
-  Error: failed to promote result/foo.ml
-  Permission denied
-  [1]
 
 Allow Dune to remove temporary files (calling Dune crashes without this):
 


### PR DESCRIPTION
This follows the discussion in https://github.com/ocaml/dune/pull/11202

Formatting a read-only file might succeed but the promotion step will fail and disturb the workflow. This checks each source file access before setting up the formatting rule.

This happens often with Nix's 'result' links, which might contain .ml files when an OCaml project was built.
Ideally, Dune wouldn't look inside 'result' links as they often contain outdated installables for the local packages but changing that might interfere with symlinks to other dune workspaces.