### PR TITLE
pkg: minimize number of packages flagged avoid-version

### DIFF
--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -105,13 +105,19 @@ let find_local_packages =
   >>| Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
 ;;
 
-let pp_packages packages =
-  Pp.enumerate
-    packages
-    ~f:(fun { Lock_dir.Pkg.info = { Lock_dir.Pkg_info.name; version; _ }; _ } ->
-      Pp.verbatim
-        (Package_name.to_string name ^ "." ^ Dune_pkg.Package_version.to_string version))
+let pp_package { Lock_dir.Pkg.info = { Lock_dir.Pkg_info.name; version; avoid; _ }; _ } =
+  let warn =
+    if avoid
+    then Pp.tag User_message.Style.Warning (Pp.text " (this version should be avoided)")
+    else Pp.nop
+  in
+  let open Pp.O in
+  Pp.verbatim
+    (Package_name.to_string name ^ "." ^ Dune_pkg.Package_version.to_string version)
+  ++ warn
 ;;
+
+let pp_packages packages = Pp.enumerate packages ~f:pp_package
 
 module Lock_dirs_arg = struct
   type t =

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -75,4 +75,4 @@ end
 
 (** [pp_packages lock_dir] returns a list of pretty-printed packages occurring in
     [lock_dir]. *)
-val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> 'a Pp.t
+val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -7,6 +7,7 @@ module Pkg_info : sig
     { name : Package_name.t
     ; version : Package_version.t
     ; dev : bool
+    ; avoid : bool
     ; source : Source.t option
     ; extra_sources : (Path.Local.t * Source.t) list
     }

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -48,6 +48,12 @@ module Make (User : USER) : sig
       @raise Invalid_argument if the list contains duplicates. *)
   val at_most_one : lit list -> at_most_one_clause
 
+  type at_most_clause
+
+  (** Add a clause preventing more than [n] literals in the list from being [True].
+      @raise Invalid_argument if the list contains duplicates. *)
+  val at_most : int -> lit list -> at_most_clause
+
   (** [run_solver decider] tries to solve the SAT problem. It simplifies it as much as possible first. When it
       has two paths which both appear possible, it calls [decider ()] to choose which to explore first. If this
       leads to a solution, it will be used. If not, the other path will be tried. If [decider] returns [None],

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -68,12 +68,90 @@ Same solution if a1 only known version is excluded:
 Update a2.0.0.2 marking it as avoid-version which should tell the
 solver to try to find a solution which doesn't include it.
 
-For now, all avoid-version packages are excluded.
-
-$ mkpkg a2 0.0.2 <<EOF
+  $ mkpkg a2 0.0.2 <<EOF
+  > conflicts: [ "a1" ]
+  > flags: [avoid-version]
+  > EOF
 
   $ solve b
   Solution for dune.lock:
-  - a2.0.0.2
+  - a1.0.0.1
+  - b.0.0.1
+
+Update a1.0.0.1 to also be flagged as avoid-version:
+
+  $ mkpkg a1 0.0.1 <<EOF
+  > flags: [avoid-version]
+  > EOF
+
+  $ solve b
+  Solution for dune.lock:
+  - a2.0.0.1
+  - b.0.0.1
+
+Then there are no "good" solution remaining once a2.0.0.1 is also flagged
+avoid-version:
+
+  $ mkpkg a2 0.0.1 <<EOF
+  > flags: [avoid-version]
+  > EOF
+
+  $ solve b
+  Solution for dune.lock:
+  - a2.0.0.2 (this version should be avoided)
   - b.0.0.2
 
+In general, the solver should select the minimal number of avoid-version possible:
+
+  $ mkpkg a 0.2 <<EOF
+  > depends: [ "c" ]
+  > EOF
+
+  $ mkpkg a 0.1 <<EOF
+  > depends: [ "d" ]
+  > EOF
+
+  $ mkpkg c 0.2 <<EOF
+  > flags: [avoid-version]
+  > depends: [ "d" ]
+  > EOF
+
+  $ mkpkg c 0.1 <<EOF
+  > flags: [avoid-version]
+  > depends: [ "e" ]
+  > EOF
+
+  $ mkpkg d 0.2 <<EOF
+  > flags: [avoid-version]
+  > depends: [ "e" ]
+  > EOF
+
+  $ mkpkg d 0.1 <<EOF
+  > flags: [avoid-version]
+  > depends: [ "f" ]
+  > EOF
+
+  $ mkpkg e 0.1 <<EOF
+  > flags: [avoid-version]
+  > depends: [ "f" ]
+  > EOF
+
+  $ mkpkg f 0.1 <<EOF
+  > flags: [avoid-version]
+  > EOF
+
+In this example, the solver will first find a solution by DFS (always selecting
+the largest possible version of each package), which will result in 4
+avoid-version for packages c, d, e, f:
+
+a.0.2 => c.0.2 => d.0.2 => e.0.1 => f.0.1
+
+But after minimizing this upperbound, the solver will find that ignoring the
+latest versions of packages a and d allow it to reduce the solution to 2
+avoid-version:
+
+  $ solve a
+  Solution for dune.lock:
+  - a.0.1
+  - d.0.1 (this version should be avoided)
+  - f.0.1 (this version should be avoided)

--- a/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
@@ -70,3 +70,24 @@ unstable.
   Solution for dune.lock:
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
+
+A package can still force an unstable version of the compiler by leaving no
+other choices:
+
+  $ mkpkg edgy 1.0 << EOF
+  > depends: [ "ocaml" {> "$CURRENT" } ]
+  > EOF
+  $ solve edgy
+  Solution for dune.lock:
+  - edgy.1.0
+  - ocaml.5.3.0
+  - ocaml-variants.5.3.0+trunk (this version should be avoided)
+
+  $ mkpkg edgy 1.0 << EOF
+  > depends: [ "ocaml" "ocaml-base-compiler" {> "$CURRENT" } ]
+  > EOF
+  $ solve edgy
+  Solution for dune.lock:
+  - edgy.1.0
+  - ocaml.5.2.0
+  - ocaml-base-compiler.5.2.0+alpha1 (this version should be avoided)

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -132,7 +132,13 @@ let empty_package name ~version =
   ; depends = []
   ; depexts = []
   ; info =
-      { Lock_dir.Pkg_info.name; version; dev = false; source = None; extra_sources = [] }
+      { Lock_dir.Pkg_info.name
+      ; version
+      ; dev = false
+      ; avoid = false
+      ; source = None
+      ; extra_sources = []
+      }
   ; exported_env = []
   }
 ;;
@@ -175,6 +181,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
                   { name = "bar"
                   ; version = "0.2.0"
                   ; dev = false
+                  ; avoid = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -189,6 +196,7 @@ let%expect_test "encode/decode round trip test for lockdir with simple deps" =
                   { name = "foo"
                   ; version = "0.1.0"
                   ; dev = false
+                  ; avoid = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -315,6 +323,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "a"
                   ; version = "0.1.0"
                   ; dev = false
+                  ; avoid = false
                   ; source = Some { url = "file:///tmp/a"; checksum = None }
                   ; extra_sources =
                       [ ("one", { url = "file:///tmp/a"; checksum = None })
@@ -332,6 +341,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "b"
                   ; version = "dev"
                   ; dev = true
+                  ; avoid = false
                   ; source =
                       Some
                         { url = "https://github.com/foo/b"
@@ -355,6 +365,7 @@ let%expect_test "encode/decode round trip test for lockdir with complex deps" =
                   { name = "c"
                   ; version = "0.2"
                   ; dev = false
+                  ; avoid = false
                   ; source =
                       Some { url = "https://github.com/foo/c"; checksum = None }
                   ; extra_sources = []
@@ -426,6 +437,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
                   { name = "a"
                   ; version = "0.1.0"
                   ; dev = false
+                  ; avoid = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -440,6 +452,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
                   { name = "b"
                   ; version = "dev"
                   ; dev = false
+                  ; avoid = false
                   ; source = None
                   ; extra_sources = []
                   }
@@ -454,6 +467,7 @@ let%expect_test "encode/decode round trip test with locked repo revision" =
                   { name = "c"
                   ; version = "0.2"
                   ; dev = false
+                  ; avoid = false
                   ; source = None
                   ; extra_sources = []
                   }


### PR DESCRIPTION
`dune pkg lock` currently fails to find a solution when a dependency flagged as `avoid-version` is absolutely necessary (see e.g. issue #11136). PR #10668 disallowed all package versions with the avoid flag, since they can result in unwanted solutions (typically: selecting an unstable version of the compiler, when a stable version would have worked).

We discussed during the dune dev meeting that a command-line flag could be added to toggle that behavior, but I didn't really like it... To provide users with a nice error message with a suggestion to re-run `dune pkg lock --allow-avoid-version`, we would need to know when this flag would help (so why not do it by default?). Furthermore as soon as the avoid-versions are allowed in the search space, the SAT solver starts using them for unnecessary purposes (like picking an unstable compiler): Even though the avoid-version are deprioritized, the SAT solver is greedy and will happily use them to satisfy an earlier choice instead of backtracking. In practice we would like it to only pick the absolutely unavoidable packages, but stick to recommended dependencies otherwise.

This yields a simple plan to minimize the number of avoid-version packages included in the solution:
1. Run the solver with all packages flagged avoid-version disallowed. If that works, then we have an ideal solution and we are done!
2. Otherwise, re-run the solver but with all the avoid-version packages allowed. If that still fails, then there are definitively no solution.
3. But if a solution was found by using the avoid-version packages, then that solution gives us an upperbound on the number of avoid-version packages required, and a lowerbound of at least 1. We can re-run the solver with the goal of finding a better solution with less of those packages, by dichotomy on the bounds and an `at most N` SAT constraint with `lower <= N < upper`. The SAT solver already supported `at_most_one` clauses, so the `at_most N` generalization was nearly available.
  Finally the UI displays a warning for all the unavoidable avoid-version, so that the user is informed and can dig into the issue if they desire.