### PR TITLE
doc: Fix markup and URL targets of wasm_of_ocaml docs

### DIFF
--- a/doc/wasmoo.rst
+++ b/doc/wasmoo.rst
@@ -8,9 +8,10 @@ Wasm Compilation With Wasm_of_ocaml
 
    This is an how-to guide.
 
-Wasm_of_ocaml_ is a compiler from OCaml to WebAssembly (Wasm for
-short). The compiler works by translating OCaml bytecode to Wasm code.
-The compiler can currently be installed from [its Github repository](https://github.com/ocaml-wasm/wasm_of_ocaml).
+Wasm_of_ocaml is a compiler from OCaml to WebAssembly (Wasm for short). The
+compiler works by translating OCaml bytecode to Wasm code. The compiler is
+available in the `js_of_ocaml Github repository
+<https://github.com/ocsigen/js_of_ocaml>`_.
 
 Compiling to Wasm
 =================
@@ -100,5 +101,3 @@ Wasm_of_ocaml can generate sourcemaps for the generated Wasm code.
 By default, they are generated when using the ``dev`` build profile and are not generated otherwise.
 The behavior can explicitly be specified in an ``env`` stanza (see :doc:`/reference/dune/env`)
 or per executable inside ``(wasm_of_ocaml (sourcemap ...))`` (see :doc:`/reference/dune/executable`)
-
-.. _wasm_of_ocaml: https://github.com/ocaml-wasm/wasm_of_ocaml


### PR DESCRIPTION
As I was reading [this discuss post](https://discuss.ocaml.org/t/ann-js-of-ocaml-6-0-1-wasm-of-ocaml/16160) I noticed that the [wasmoo docs](https://dune.readthedocs.io/en/stable/wasmoo.html) are in a bit of a messy state:

The markup used Markdown syntax which didn't render correctly. Also, it pointed to the old location of the compiler which still exists but points to js_of_ocaml since it was merged into js_of_ocaml some months ago.

This PR fixes some low-hanging fruits.