### PR TITLE
pkg: minor fix is sys_poll library

### DIFF
--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -98,7 +98,7 @@ let os ~path =
 let maybe_read_lines p =
   match Io.String_path.lines_of_file p with
   | s -> Some s
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
+  | exception Sys_error _ -> None
 ;;
 
 let os_release_fields () =


### PR DESCRIPTION
`Io.String_path.lines_of_file` raises `Sys_error` rather than `Unix_error`, so the way we were handling errors in sys_poll would not correctly handle cases where files are missing. Since `Sys_error` does not provide information about the nature of the error, explicitly check that the file exists and is a regular file rather than relying on exceptions.