### PR TITLE
chore(ci): disable test in CI

### DIFF
--- a/otherlibs/dune-site/test/dune
+++ b/otherlibs/dune-site/test/dune
@@ -7,6 +7,8 @@
 ; The test being broken on CI, we deactivate it when
 ; we detect that the CI environment variable is not
 ; set. Most CI systems set it.
+
 (cram
-  (applies_to run)
-  (enabled_if (not %{env:CI=false})))
+ (applies_to run)
+ (enabled_if
+  (not %{env:CI=false})))

--- a/otherlibs/dune-site/test/dune
+++ b/otherlibs/dune-site/test/dune
@@ -3,3 +3,10 @@
  (deps
   (package dune)
   (package dune-site)))
+
+; The test being broken on CI, we deactivate it when
+; we detect that the CI environment variable is not
+; set. Most CI systems set it.
+(cram
+  (applies_to run)
+  (enabled_if (not %{env:CI=false})))


### PR DESCRIPTION
This PR is an attempt to fix the broken CI test. None of the maintainers is able to reproduce the bug locally. As a result, this PR only disabled the when it detects the CI environment variable set by GitHub Actions (see [the documentation](https://docs.github.com/fr/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables)).
