### PR TITLE
Display Windows `NTSTATUS` exit codes in hex

### DIFF
--- a/doc/changes/11504.md
+++ b/doc/changes/11504.md
@@ -1,0 +1,2 @@
+- Display negative error codes on Windows in hex which is the more customary
+  way to display `NTSTATUS` codes (#11504, @MisterDA)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -652,7 +652,15 @@ end = struct
                (* If the command has no output, we need to say something.
                   Otherwise it's not clear what's going on. *)
                (match error with
-                | Failed n -> [ Pp.textf "Command exited with code %d." n ]
+                | Failed exitcode ->
+                  (* When debugging segfaults, 0xc0000005 is a slightly easier
+                     random number to pattern match and 🤦 than -1073741819! *)
+                  let exitcode =
+                    if Sys.win32 && exitcode < 0
+                    then Printf.sprintf "0x%08lx" (Int32.of_int exitcode)
+                    else string_of_int exitcode
+                  in
+                  [ Pp.textf "Command exited with code %s." exitcode ]
                 | Signaled signame ->
                   [ Pp.textf "Command got signal %s." (Signal.name signame) ]))
       in


### PR DESCRIPTION
On Windows, "negative" exit codes are probably `NTSTATUS` values. For example, if a program accesses an invalid memory location, Unix sends a `SIGSEGV` signal which, if unhandled, will terminate the process (setting some kind of non-zero exit code - for example, Linux sets the exit code to 128 + signal number to give a fairly memorable 139). In the equivalent scenario, Windows throws an `EXCEPTION_ACCESS_VIOLATION` which, if handled by the default exception handler, will terminate the process with exit code `STATUS_ACCESS_VIOLATION`. These codes are large negative numbers, which are not terribly memorable in decimal, so for negative exit codes we instead display them in hexadecimal as `0xc0000005` is slightly more memorable than `-1073741819`.