### PR TITLE
chore: Fix wasm_of_ocaml in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -211,16 +211,8 @@ jobs:
         working-directory: ./dune
         run: opam pin add -n dune . --with-version 3.17.0
 
-      - name: Checkout Wasm_of_ocaml
-        uses: actions/checkout@v4
-        with:
-          repository: ocsigen/js_of_ocaml
-          path: wasm_of_ocaml
-
       - name: Install Wasm_of_ocaml
-        working-directory: ./wasm_of_ocaml
         run: |
-           opam pin add -n . --with-version `< VERSION`
            opam install wasm_of_ocaml-compiler
 
       - name: Set Git User

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -164,9 +164,6 @@ jobs:
         with:
           token: ${{ github.token }}
 
-      - name: Install Ninja
-        run: sudo apt-get install ninja-build
-
       - name: Checkout Code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -159,43 +159,13 @@ jobs:
         with:
           node-version: latest
 
-      - name: Restore Cached Binaryen
-        id: cache-binaryen
-        uses: actions/cache/restore@v4
+      - name: Set-up Binaryen
+        uses: Aandreba/setup-binaryen@v1.0.0
         with:
-          path: binaryen
-          key: ${{ runner.os }}-binaryen-version_119
-
-      - name: Checkout Binaryen
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: WebAssembly/binaryen
-          path: binaryen
-          submodules: true
-          ref: version_119
+          token: ${{ github.token }}
 
       - name: Install Ninja
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: sudo apt-get install ninja-build
-
-      - name: Build Binaryen
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
-        working-directory: ./binaryen
-        run: |
-          cmake -G Ninja .
-          ninja
-
-      - name: Cache Binaryen
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: binaryen
-          key: ${{ runner.os }}-binaryen-version_119
-
-      - name: Set Binaryen's Path
-        run: |
-          echo "$GITHUB_WORKSPACE/binaryen/bin" >> $GITHUB_PATH
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -206,6 +176,10 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.x
+
+      - name: Install faked binaryen-bin package
+        # It's faster to use a cached version
+        run: opam install --fake binaryen-bin
 
       - name: Update Dune
         working-directory: ./dune


### PR DESCRIPTION
It doesn't need to be pinned anymore and the current development version fails. Better use a released version for stability.