### PR TITLE
pkg: handle undefined vars in command filters

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1686,7 +1686,18 @@ let opam_commands_to_actions
                     let filter_blang =
                       filter_to_blang ~package ~loc filter |> Slang.simplify_blang
                     in
-                    Slang.when_ filter_blang slang)))
+                    let filter_blang_handling_undefined =
+                      (* Wrap the blang filter so that if any undefined
+                         variables are expanded while evaluating the filter,
+                         the filter will return false. *)
+                      let slang =
+                        Slang.catch_undefined_var
+                          (Slang.blang filter_blang)
+                          ~fallback:(Slang.bool false)
+                      in
+                      Blang.Expr slang
+                    in
+                    Slang.when_ filter_blang_handling_undefined slang)))
       in
       if List.is_empty terms
       then None

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -248,9 +248,13 @@ Test that if opam filter translation is disabled the output doesn't contain any 
    (run
     echo
     a
-    (when %{pkg-self:foo} b)
     (when
-     (and_absorb_undefined_var %{pkg-self:bar} %{pkg-self:baz})
+     (catch_undefined_var %{pkg-self:foo} false)
+     b)
+    (when
+     (catch_undefined_var
+      (and_absorb_undefined_var %{pkg-self:bar} %{pkg-self:baz})
+      false)
      c)))
 
   $ solve filter-error-bool-where-string-expected

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -43,7 +43,9 @@ Solve the package using the default solver env:
      -j
      %{jobs}
      (when
-      (= %{pkg-self:foo} bar)
+      (catch_undefined_var
+       (= %{pkg-self:foo} bar)
+       false)
       --foobar)
      @install)))
 


### PR DESCRIPTION
Opam treats undefined variables as false when evaluating command filters. This change wraps command filters in lockfiles with `catch_undefined_var` so dune's behaviour matches.