### PR TITLE
fix: use build and install instructions from opam on pinning

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -61,7 +61,7 @@ let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version ~extra_depe
   ; pins = Package_name.Map.empty
   ; conflict_class = []
   ; loc = Loc.none
-  ; command_source = Other { build = []; install = [] }
+  ; command_source = Opam_file { build = []; install = [] }
   }
 ;;
 

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -61,9 +61,7 @@ let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version ~extra_depe
   ; pins = Package_name.Map.empty
   ; conflict_class = []
   ; loc = Loc.none
-  ; build = []
-  ; install = []
-  ; dune_build = false
+  ; command_source = Other { build = []; install = [] }
   }
 ;;
 

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -61,6 +61,9 @@ let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version ~extra_depe
   ; pins = Package_name.Map.empty
   ; conflict_class = []
   ; loc = Loc.none
+  ; build = []
+  ; install = []
+  ; dune_build = false
   }
 ;;
 

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -13,8 +13,8 @@ type pin =
 type pins = pin Package_name.Map.t
 
 type command_source =
-  | Dune
-  | Other of
+  | Assume_defaults
+  | Opam_file of
       { build : OpamTypes.command list
       ; install : OpamTypes.command list
       }
@@ -120,8 +120,8 @@ let for_solver
   =
   let build, install =
     match command_source with
-    | Dune -> [], []
-    | Other { build; install } -> build, install
+    | Assume_defaults -> [], []
+    | Opam_file { build; install } -> build, install
   in
   { For_solver.name
   ; dependencies
@@ -150,14 +150,14 @@ let of_package (t : Dune_lang.Package.t) =
     ; loc
     ; conflict_class = []
     ; pins = Package_name.Map.empty
-    ; command_source = Dune
+    ; command_source = Assume_defaults
     }
   | Some { file; contents = opam_file_string } ->
     let opam_file =
       Opam_file.read_from_string_exn ~contents:opam_file_string (Path.source file)
     in
     let command_source =
-      Other
+      Opam_file
         { build = opam_file |> OpamFile.OPAM.build
         ; install = opam_file |> OpamFile.OPAM.install
         }

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -10,6 +10,13 @@ type pin =
 
 type pins = pin Package_name.Map.t
 
+type command_source =
+  | Dune
+  | Other of
+      { build : OpamTypes.command list
+      ; install : OpamTypes.command list
+      }
+
 (** Information about a local package that's relevant for package management.
     This is intended to represent local packages defined in a dune-project file
     (rather than packages in a lockdir). This is distinct from a
@@ -26,9 +33,7 @@ type t =
   ; depopts : Package_dependency.t list
   ; pins : pins
   ; loc : Loc.t
-  ; build : OpamTypes.command list
-  ; install : OpamTypes.command list
-  ; dune_build : bool
+  ; command_source : command_source
   }
 
 module Dependency_hash : sig

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -10,6 +10,11 @@ type pin =
 
 type pins = pin Package_name.Map.t
 
+(** Describe the commands to execute from the source. [Dune] means that no opam
+    file is available and dune will use [dune] to build the package.
+    [Other { build ; install }]  describe where there is an opam file from
+    which we extract the build and the install command. Note that both of them
+    can be empty. *)
 type command_source =
   | Dune
   | Other of

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -10,14 +10,14 @@ type pin =
 
 type pins = pin Package_name.Map.t
 
-(** Describe the commands to execute from the source. [Dune] means that no opam
-    file is available and dune will use [dune] to build the package.
-    [Other { build ; install }]  describe where there is an opam file from
-    which we extract the build and the install command. Note that both of them
-    can be empty. *)
+(** Describe the commands to execute from the source. [Assume_defaults] means
+    that no opam file is available and dune will use [dune] to build the
+    package. [Opam_file { build ; install }]  describe where there is an opam
+    file from which we extract the build and the install command. Note that
+    both of them can be empty. *)
 type command_source =
-  | Dune
-  | Other of
+  | Assume_defaults
+  | Opam_file of
       { build : OpamTypes.command list
       ; install : OpamTypes.command list
       }

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -26,6 +26,9 @@ type t =
   ; depopts : Package_dependency.t list
   ; pins : pins
   ; loc : Loc.t
+  ; build : OpamTypes.command list
+  ; install : OpamTypes.command list
+  ; dune_build : bool
   }
 
 module Dependency_hash : sig
@@ -48,6 +51,8 @@ module For_solver : sig
     ; depopts : Package_dependency.t list
     ; conflict_class : Package_name.t list
     ; pins : pins
+    ; build : OpamTypes.command list
+    ; install : OpamTypes.command list
     }
 
   (** [to_opam_file t] returns an [OpamFile.OPAM.t] whose fields are based on the

--- a/src/dune_pkg/pin_stanza.ml
+++ b/src/dune_pkg/pin_stanza.ml
@@ -361,8 +361,8 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
             (Package_name.to_opam_package_name package.name)
             (Package_version.to_opam_package_version package.version)
         in
-        Resolved_package.dune_package
-          ~dune_build:local_package.dune_build
+        Resolved_package.local_package
+          ~command_source:local_package.command_source
           package.loc
           opam_file
           opam_package

--- a/src/dune_pkg/pin_stanza.ml
+++ b/src/dune_pkg/pin_stanza.ml
@@ -349,8 +349,9 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
         ]
     | Some pkg ->
       let resolved_package =
+        let local_package = Local_package.of_package pkg in
         let opam_file =
-          Local_package.of_package pkg
+          local_package
           |> Local_package.for_solver
           |> Local_package.For_solver.to_opam_file
           |> OpamFile.OPAM.with_url (OpamFile.URL.create (snd package.url))
@@ -360,7 +361,11 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
             (Package_name.to_opam_package_name package.name)
             (Package_version.to_opam_package_version package.version)
         in
-        Resolved_package.dune_package package.loc opam_file opam_package
+        Resolved_package.dune_package
+          ~dune_build:local_package.dune_build
+          package.loc
+          opam_file
+          opam_package
       in
       resolve package.name resolved_package
   in

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -84,7 +84,12 @@ let scan_files_entries path =
          ])
 ;;
 
-let dune_package ~dune_build loc opam_file opam_package =
+let local_package ~command_source loc opam_file opam_package =
+  let dune_build =
+    match (command_source : Local_package.command_source) with
+    | Dune -> true
+    | Other _ -> false
+  in
   let opam_file = add_opam_package_to_opam_file opam_package opam_file in
   let package = OpamFile.OPAM.package opam_file in
   { dune_build; opam_file; package; loc; extra_files = Inside_files_dir None }

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -87,8 +87,8 @@ let scan_files_entries path =
 let local_package ~command_source loc opam_file opam_package =
   let dune_build =
     match (command_source : Local_package.command_source) with
-    | Dune -> true
-    | Other _ -> false
+    | Assume_defaults -> true
+    | Opam_file _ -> false
   in
   let opam_file = add_opam_package_to_opam_file opam_package opam_file in
   let package = OpamFile.OPAM.package opam_file in

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -84,10 +84,10 @@ let scan_files_entries path =
          ])
 ;;
 
-let dune_package loc opam_file opam_package =
+let dune_package ~dune_build loc opam_file opam_package =
   let opam_file = add_opam_package_to_opam_file opam_package opam_file in
   let package = OpamFile.OPAM.package opam_file in
-  { dune_build = true; opam_file; package; loc; extra_files = Inside_files_dir None }
+  { dune_build; opam_file; package; loc; extra_files = Inside_files_dir None }
 ;;
 
 open Fiber.O

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -23,5 +23,5 @@ val local_fs
   -> files_dir:Path.Local.t option
   -> t
 
-val dune_package : Loc.t -> OpamFile.OPAM.t -> OpamPackage.t -> t
+val dune_package : dune_build:bool -> Loc.t -> OpamFile.OPAM.t -> OpamPackage.t -> t
 val get_opam_package_files : t list -> File_entry.t list list Fiber.t

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -23,5 +23,11 @@ val local_fs
   -> files_dir:Path.Local.t option
   -> t
 
-val dune_package : dune_build:bool -> Loc.t -> OpamFile.OPAM.t -> OpamPackage.t -> t
+val local_package
+  :  command_source:Local_package.command_source
+  -> Loc.t
+  -> OpamFile.OPAM.t
+  -> OpamPackage.t
+  -> t
+
 val get_opam_package_files : t list -> File_entry.t list list Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -5,12 +5,12 @@ Demonstrate the build command we construct for different types of projects:
   $ mkrepo
   $ add_mock_repo_if_needed
 
-  $ mkdir _template _dune-only _mixed
+  $ mkdir _template _dune-only _mixed _opam-only
 
   $ cat >_template/dune-project <<EOF
   > (lang dune 3.13)
   > (generate_opam_files true)
-  > (package (name template))
+  > (package (name template)  (allow_empty))
   > EOF
   $ cat >_template/mixed.opam.template <<EOF
   > build: [ "echo" "template" ]
@@ -18,7 +18,7 @@ Demonstrate the build command we construct for different types of projects:
 
   $ cat >_dune-only/dune-project <<EOF
   > (lang dune 3.13)
-  > (package (name dune-only))
+  > (package (name dune-only)  (allow_empty))
   > EOF
 
   $ cat >_mixed/dune-project <<EOF
@@ -27,6 +27,11 @@ Demonstrate the build command we construct for different types of projects:
   $ cat >_mixed/mixed.opam <<EOF
   > opam-version: "2.0"
   > build: [ "echo" "mixed" ]
+  > EOF
+
+  $ cat > _opam-only/opam-only.opam <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "opam only" ]
   > EOF
 
   $ cat >dune-project <<EOF
@@ -40,15 +45,20 @@ Demonstrate the build command we construct for different types of projects:
   > (pin
   >  (url "$PWD/_mixed")
   >  (package (name mixed)))
+  > (pin
+  >  (url "$PWD/_opam-only")
+  >  (package (name opam-only)))
   > (package
   >  (name main)
-  >  (depends dune-only mixed template))
+  >  (allow_empty)
+  >  (depends dune-only mixed template opam-only))
   > EOF
 
   $ dune pkg lock
   Solution for dune.lock:
   - dune-only.dev
   - mixed.dev
+  - opam-only.dev
   - template.dev
   $ build_command() {
   > grep "$1" dune.lock/$2.pkg
@@ -59,3 +69,11 @@ Demonstrate the build command we construct for different types of projects:
   (dune)
   $ build_command "(build" mixed
   (build
+  $ build_command "(build" opam-only
+  (build
+
+If we build the deps, everything works fine and we see the output of the opam
+pins:
+  $ dune build @pkg-install
+  mixed
+  opam only

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -51,11 +51,11 @@ Demonstrate the build command we construct for different types of projects:
   - mixed.dev
   - template.dev
   $ build_command() {
-  > grep "(dune)" dune.lock/$1.pkg
+  > grep "$1" dune.lock/$2.pkg
   > }
-  $ build_command dune-only
+  $ build_command "(dune)" dune-only
   (dune)
-  $ build_command mixed
+  $ build_command "(dune)" template
   (dune)
-  $ build_command template
-  (dune)
+  $ build_command "(build" mixed
+  (build


### PR DESCRIPTION
When building instructions with package management, pinning packages relied on dune for all the cases. This PR changes this behavior: if there is an opam file, it extracts the instructions from it. It doesn't change behaviors outside of pinning.

This avoids having pinning packages with no dependencies to OCaml from failing because `ocamlc` is not available (for example).

This PR is necessary for projects where the OPAM file install elements without Dune. Indeed, it would try to execute Dune and fails because there is no dependency to `ocamlc` (because using package management and no deps to OCaml is declared).
