### PR TITLE
pkg: fix opam conflicts "expected formula to be a conjunction"

### DIFF
--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -119,12 +119,12 @@ let of_package (t : Dune_lang.Package.t) =
     let opam_file =
       Opam_file.read_from_string_exn ~contents:opam_file_string (Path.source file)
     in
-    let convert_filtered_formula = Package_dependency.list_of_opam_filtered_formula loc in
+    let convert_filtered_formula = Package_dependency.list_of_opam_disjunction loc in
     let dependencies =
       opam_file |> OpamFile.OPAM.depends |> Dependency_formula.of_filtered_formula
     in
-    let conflicts = convert_filtered_formula `Or (OpamFile.OPAM.conflicts opam_file) in
-    let depopts = convert_filtered_formula `Or (OpamFile.OPAM.depopts opam_file) in
+    let conflicts = convert_filtered_formula (OpamFile.OPAM.conflicts opam_file) in
+    let depopts = convert_filtered_formula (OpamFile.OPAM.depopts opam_file) in
     let conflict_class =
       OpamFile.OPAM.conflict_class opam_file
       |> List.map ~f:Package_name.of_opam_package_name

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -119,12 +119,15 @@ let of_package (t : Dune_lang.Package.t) =
     let opam_file =
       Opam_file.read_from_string_exn ~contents:opam_file_string (Path.source file)
     in
-    let convert_filtered_formula = Package_dependency.list_of_opam_disjunction loc in
     let dependencies =
       opam_file |> OpamFile.OPAM.depends |> Dependency_formula.of_filtered_formula
     in
-    let conflicts = convert_filtered_formula (OpamFile.OPAM.conflicts opam_file) in
-    let depopts = convert_filtered_formula (OpamFile.OPAM.depopts opam_file) in
+    let conflicts =
+      OpamFile.OPAM.conflicts opam_file |> Package_dependency.list_of_opam_disjunction loc
+    in
+    let depopts =
+      OpamFile.OPAM.depopts opam_file |> Package_dependency.list_of_opam_disjunction loc
+    in
     let conflict_class =
       OpamFile.OPAM.conflict_class opam_file
       |> List.map ~f:Package_name.of_opam_package_name

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -123,7 +123,7 @@ let of_package (t : Dune_lang.Package.t) =
     let dependencies =
       opam_file |> OpamFile.OPAM.depends |> Dependency_formula.of_filtered_formula
     in
-    let conflicts = convert_filtered_formula `And (OpamFile.OPAM.conflicts opam_file) in
+    let conflicts = convert_filtered_formula `Or (OpamFile.OPAM.conflicts opam_file) in
     let depopts = convert_filtered_formula `Or (OpamFile.OPAM.depopts opam_file) in
     let conflict_class =
       OpamFile.OPAM.conflict_class opam_file

--- a/src/dune_pkg/package_dependency.ml
+++ b/src/dune_pkg/package_dependency.ml
@@ -220,13 +220,10 @@ let to_opam_filtered_formula { name; constraint_ } =
   OpamFormula.Atom (opam_package_name, condition)
 ;;
 
-let list_of_opam_filtered_formula loc kind filtered_formula =
+let list_of_opam_disjunction loc filtered_formula =
   let exception E of Convert_from_opam_error.t in
   try
-    (match kind with
-     | `And -> OpamFormula.ands_to_list
-     | `Or -> OpamFormula.ors_to_list)
-      filtered_formula
+    OpamFormula.ors_to_list filtered_formula
     |> List.map ~f:(fun (filtered_formula : OpamTypes.filtered_formula) ->
       match filtered_formula with
       | Atom (name, condition) ->
@@ -254,10 +251,8 @@ let list_of_opam_filtered_formula loc kind filtered_formula =
       | Filtered_formula_is_not_the_correct_kind { non_atom } ->
         let formula_string = OpamFilter.string_of_filtered_formula non_atom in
         sprintf
-          "Expected formula to be a %s of atoms but encountered non-atom term '%s'"
-          (match kind with
-           | `And -> "conjunction"
-           | `Or -> "disjunction")
+          "Expected formula to be a disjunction of atoms but encountered non-atom term \
+           '%s'"
           formula_string
     in
     User_error.raise ~loc [ Pp.text message ]

--- a/src/dune_pkg/package_dependency.mli
+++ b/src/dune_pkg/package_dependency.mli
@@ -28,9 +28,5 @@ val opam_depend : t -> OpamParserTypes.FullPos.value
 val to_opam_filtered_formula : t -> OpamTypes.filtered_formula
 
 (** Attempt to interpret a [OpamTypes.filtered_formula] as a list of [t]s by
-    treating the formula as a conjunction of packages with constraints. *)
-val list_of_opam_filtered_formula
-  :  Loc.t
-  -> [ `Or | `And ]
-  -> OpamTypes.filtered_formula
-  -> t list
+    treating the formula as a disjunction of packages with constraints. *)
+val list_of_opam_disjunction : Loc.t -> OpamTypes.filtered_formula -> t list

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -71,9 +71,18 @@ disjunction, either package is problematic:
   $ solve_project <<EOF
   > (lang dune 3.11)
   > EOF
-  File "x.opam", line 1, characters 0-0:
-  Error: Expected formula to be a conjunction of atoms but encountered non-atom
-  term 'foo < "0.2" | foo2 < "0.2"'
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 bar2.0.0.1 x.dev
+  - dune -> dune.3.11
+      User requested = 3.18
+  - foo -> (problem)
+      No usable implementations:
+        foo.0.0.1: Package does not satisfy constraints of local package x
+  - foo2 -> (problem)
+      No usable implementations:
+        foo2.0.0.1: Package does not satisfy constraints of local package x
   [1]
 
 Adding a new version of `foo` only resolves one conflict:
@@ -82,9 +91,15 @@ Adding a new version of `foo` only resolves one conflict:
   $ solve_project <<EOF
   > (lang dune 3.11)
   > EOF
-  File "x.opam", line 1, characters 0-0:
-  Error: Expected formula to be a conjunction of atoms but encountered non-atom
-  term 'foo < "0.2" | foo2 < "0.2"'
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 bar2.0.0.1 foo.0.2 x.dev
+  - dune -> dune.3.11
+      User requested = 3.18
+  - foo2 -> (problem)
+      No usable implementations:
+        foo2.0.0.1: Package does not satisfy constraints of local package x
   [1]
 
 And of `foo2` to solve the last remaining conflict:
@@ -93,10 +108,11 @@ And of `foo2` to solve the last remaining conflict:
   $ solve_project <<EOF
   > (lang dune 3.11)
   > EOF
-  File "x.opam", line 1, characters 0-0:
-  Error: Expected formula to be a conjunction of atoms but encountered non-atom
-  term 'foo < "0.2" | foo2 < "0.2"'
-  [1]
+  Solution for dune.lock:
+  - bar.0.0.1
+  - bar2.0.0.1
+  - foo.0.2
+  - foo2.0.2
 
 Same but checking that the latest versions of `foo` and `foo2` are not selected
 due to the versions constraints conflicts:

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -26,7 +26,7 @@ The solver should say no solution rather than just ignoring the conflict.
         foo.0.0.1: Package does not satisfy constraints of local package x
   [1]
 
-There could be more than one conflict and they can have versions constraints:
+There could be more than one conflict and they can have version constraints:
 
   $ mkpkg foo2 0.0.1
   $ mkpkg bar2 << EOF
@@ -58,7 +58,7 @@ When conflicts are obtained from an opam file instead of a dune-project,
 the behaviour should be the same:
 
   $ dune build x.opam
-  $ cat x.opam | sed -n '/conflicts/,/]/p'
+  $ sed -n '/conflicts/,/]/p' x.opam
   conflicts: [
     "foo" {< "0.2"}
     "foo2" {< "0.2"}
@@ -102,7 +102,7 @@ Adding a new version of `foo` only resolves one conflict:
         foo2.0.0.1: Package does not satisfy constraints of local package x
   [1]
 
-And of `foo2` to solve the last remaining conflict:
+Addition of `foo2` to solve the last remaining conflict:
 
   $ mkpkg foo2 0.2
   $ solve_project <<EOF
@@ -115,7 +115,7 @@ And of `foo2` to solve the last remaining conflict:
   - foo2.0.2
 
 Same but checking that the latest versions of `foo` and `foo2` are not selected
-due to the versions constraints conflicts:
+due to the version constraints conflicts:
 
   $ solve_project << EOF
   > (lang dune 3.11)

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -2,7 +2,7 @@ The solver should repsect the (conflicts) field of the (package) stanza.
 
   $ . ./helpers.sh
   $ mkrepo
-  $ mkpkg foo
+  $ mkpkg foo 0.0.1
   $ mkpkg bar << EOF
   > depends: [ "foo" ]
   > EOF
@@ -26,3 +26,92 @@ The solver should say no solution rather than just ignoring the conflict.
         foo.0.0.1: Package does not satisfy constraints of local package x
   [1]
 
+There could be more than one conflict and they can have versions constraints:
+
+  $ mkpkg foo2 0.0.1
+  $ mkpkg bar2 << EOF
+  > depends: [ "foo2" ]
+  > EOF
+
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (generate_opam_files true)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (conflicts (foo (< 0.2)) (foo2 (< 0.2)))
+  >  (depends bar bar2))
+  > EOF
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  Selected candidates: bar.0.0.1 bar2.0.0.1 x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.0.0.1: Package does not satisfy constraints of local package x
+  - foo2 -> (problem)
+      No usable implementations:
+        foo2.0.0.1: Package does not satisfy constraints of local package x
+  [1]
+
+When conflicts are obtained from an opam file instead of a dune-project,
+the behaviour should be the same:
+
+  $ dune build x.opam
+  $ cat x.opam | sed -n '/conflicts/,/]/p'
+  conflicts: [
+    "foo" {< "0.2"}
+    "foo2" {< "0.2"}
+  ]
+
+Even though the conflicts are listed by opam without a `|` to indicate a
+disjunction, either package is problematic:
+
+  $ mkpkg dune 3.11
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  File "x.opam", line 1, characters 0-0:
+  Error: Expected formula to be a conjunction of atoms but encountered non-atom
+  term 'foo < "0.2" | foo2 < "0.2"'
+  [1]
+
+Adding a new version of `foo` only resolves one conflict:
+
+  $ mkpkg foo 0.2
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  File "x.opam", line 1, characters 0-0:
+  Error: Expected formula to be a conjunction of atoms but encountered non-atom
+  term 'foo < "0.2" | foo2 < "0.2"'
+  [1]
+
+And of `foo2` to solve the last remaining conflict:
+
+  $ mkpkg foo2 0.2
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  File "x.opam", line 1, characters 0-0:
+  Error: Expected formula to be a conjunction of atoms but encountered non-atom
+  term 'foo < "0.2" | foo2 < "0.2"'
+  [1]
+
+Same but checking that the latest versions of `foo` and `foo2` are not selected
+due to the versions constraints conflicts:
+
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (generate_opam_files true)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (conflicts (foo (>= 0.2)) (foo2 (>= 0.2)))
+  >  (depends bar bar2))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+  - bar2.0.0.1
+  - foo.0.0.1
+  - foo2.0.0.1


### PR DESCRIPTION
When an opam package declares conflicts with multiple other packages (for example [`bigstringaf.opam`](https://github.com/ocaml/opam-repository/blob/master/packages/bigstringaf/bigstringaf.0.10.0/opam#L28)), `dune pkg lock` currently fails with the error `Expected formula to be a conjunction of atoms but encountered non-atom term 'a | b'`. This appears to be a small oversight as the code expects opam conflicts to be provided as a conjunction, while in practice it's a disjunction. (We could support arbitrary formulas in conflicts, but this quick fix should unstuck the vast majority of packages concerned by this... I'm not aware of packages that conflict with a simultaneous installation of two other packages)