### PR TITLE
fix(pkg): use available local package version to satisfy =version opam constraints

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -53,7 +53,7 @@ let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version ~extra_depe
     Package_name.of_string (Package_name.to_string dev_tool_pkg_name ^ "_dev_tool_wrapper")
   in
   { Dune_pkg.Local_package.name = local_package_name
-  ; version = None
+  ; version = Dune_pkg.Lock_dir.Pkg_info.default_version
   ; dependencies =
       Dune_pkg.Dependency_formula.of_dependencies (dependency :: extra_dependencies)
   ; conflicts = []

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -21,7 +21,7 @@ type command_source =
 
 type t =
   { name : Package_name.t
-  ; version : Package_version.t option
+  ; version : Package_version.t
   ; dependencies : Dependency_formula.t
   ; conflicts : Package_dependency.t list
   ; conflict_class : Package_name.t list
@@ -59,6 +59,7 @@ end
 module For_solver = struct
   type t =
     { name : Package_name.t
+    ; version : Package_version.t
     ; dependencies : Dependency_formula.t
     ; conflicts : Package_dependency.t list
     ; depopts : Package_dependency.t list
@@ -70,6 +71,7 @@ module For_solver = struct
 
   let to_opam_file
         { name
+        ; version
         ; dependencies
         ; conflicts
         ; conflict_class
@@ -83,6 +85,7 @@ module For_solver = struct
        them *)
     OpamFile.OPAM.empty
     |> OpamFile.OPAM.with_name (Package_name.to_opam_package_name name)
+    |> OpamFile.OPAM.with_version (Package_version.to_opam_package_version version)
     |> OpamFile.OPAM.with_depends (Dependency_formula.to_filtered_formula dependencies)
     |> OpamFile.OPAM.with_conflicts
          (List.map conflicts ~f:Package_dependency.to_opam_filtered_formula
@@ -108,7 +111,7 @@ end
 
 let for_solver
       { name
-      ; version = _
+      ; version
       ; dependencies
       ; conflicts
       ; conflict_class
@@ -124,6 +127,7 @@ let for_solver
     | Opam_file { build; install } -> build, install
   in
   { For_solver.name
+  ; version
   ; dependencies
   ; conflicts
   ; conflict_class
@@ -137,7 +141,7 @@ let for_solver
 let of_package (t : Dune_lang.Package.t) =
   let module Package = Dune_lang.Package in
   let loc = Package.loc t in
-  let version = Package.version t in
+  let version = Package.version t |> Option.value ~default:Package_version.dev in
   let name = Package.name t in
   match Package.original_opam_file t with
   | None ->

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -31,7 +31,7 @@ type command_source =
     it can use to represent local packages. *)
 type t =
   { name : Package_name.t
-  ; version : Package_version.t option
+  ; version : Package_version.t
   ; dependencies : Dependency_formula.t
   ; conflicts : Package_dependency.t list
   ; conflict_class : Package_name.t list
@@ -56,6 +56,7 @@ module For_solver : sig
   (** The minimum set of fields about a package needed by the solver. *)
   type t =
     { name : Package_name.t
+    ; version : Package_version.t
     ; dependencies : Dependency_formula.t
     ; conflicts : Package_dependency.t list
     ; depopts : Package_dependency.t list

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -42,7 +42,7 @@ module Pkg_info = struct
       ]
   ;;
 
-  let default_version = Package_version.of_string "dev"
+  let default_version = Package_version.dev
 
   let variables t =
     let module Variable = OpamVariable in

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1987,7 +1987,7 @@ let reject_unreachable_packages =
             "package is both local and returned by solver"
             [ "name", Package_name.to_dyn name ]
         | Some (lock_dir_pkg : Lock_dir.Pkg.t), None -> Some lock_dir_pkg.info.version
-        | None, Some _pkg -> Some Package_version.dev)
+        | None, Some (pkg : Local_package.For_solver.t) -> Some pkg.version)
     in
     let pkgs_by_name =
       Package_name.Map.merge pkgs_by_name local_packages ~f:(fun name lhs rhs ->
@@ -2005,8 +2005,7 @@ let reject_unreachable_packages =
                 let opam_package =
                   OpamPackage.create
                     (Package_name.to_opam_package_name pkg.name)
-                    (* Use [dev] because at this point we don't have any version *)
-                    (Package_version.to_opam_package_version Package_version.dev)
+                    (Package_version.to_opam_package_version pkg.version)
                 in
                 Solver_env.to_env solver_env |> add_self_to_filter_env opam_package
               in

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -21,7 +21,7 @@ let lockdir_regenerate_hints =
 let version_by_package_name local_packages (lock_dir : Lock_dir.t) =
   let from_local_packages =
     Package_name.Map.map local_packages ~f:(fun (local_package : Local_package.t) ->
-      Option.value local_package.version ~default:Lock_dir.Pkg_info.default_version)
+      local_package.version)
   in
   let from_lock_dir =
     Package_name.Map.map lock_dir.packages ~f:(fun pkg -> pkg.info.version)

--- a/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
@@ -24,3 +24,50 @@ The version of foo that should be selected is 1.0.0
   Solution for dune.lock:
   - bar.1.0.0
   - foo.1.0.0
+
+By default, local packages have version `dev` so the following version
+constraint on `foo` will fail:
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (depends (foo (= :version))))
+  > EOF
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  Selected candidates: x.dev
+  - foo -> (problem)
+      No usable implementations:
+        foo.1.0.0: Package does not satisfy constraints of local package x
+  [1]
+
+But specifying a version for the local package `x` yields a solution:
+
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > (generate_opam_files true)
+  > (version 1.0.0)
+  > (package
+  >  (name x)
+  >  (depends (foo (= :version))))
+  > EOF
+  Solution for dune.lock:
+  - bar.1.0.0
+  - foo.1.0.0
+
+Same result if the version of package `x` is specified by the opam file instead
+of the dune-project:
+
+  $ dune build x.opam
+  $ grep '^version' x.opam
+  version: "1.0.0"
+
+  $ mkpkg dune 3.11
+  $ solve_project <<EOF
+  > (lang dune 3.11)
+  > EOF
+  Solution for dune.lock:
+  - bar.1.0.0
+  - foo.1.0.0


### PR DESCRIPTION
The solver currently assumes that local packages always have version `dev` even when the `dune-project` or `.opam` file specifies a different version. This leads to solver failure when a local package depends on a non-local package with a `{= version}` constraint, since we won't find a `dev` version of the dependency in that case (as we should have used the locally specified version instead). cc @Leonidas-from-XIV 