### PR TITLE
Prefer `int main(void)` to `int main()` in C examples

### DIFF
--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -24,7 +24,7 @@ Configurator allows you to query for the following features:
 
 * Extract compile time information such as ``#define`` variables.
 
-Configurator is designed to be cross-compilation friendly and avoids _running_
+Configurator is designed to be cross-compilation friendly and avoids *running*
 any compiled code to extract any of the information above.
 
 Configurator started as an `independent library
@@ -49,7 +49,7 @@ example:
   let clock_gettime_code = {|
   #include <time.h>
 
-  int main()
+  int main(void)
   {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/otherlibs/configurator/test/blackbox-tests/configurator.t/c_test/run.ml
+++ b/otherlibs/configurator/test/blackbox-tests/configurator.t/c_test/run.ml
@@ -5,7 +5,7 @@ let () =
     let c_result =
       Configurator.c_test t {c|
 #include <stdio.h>
-int main()
+int main(void)
 {
    printf("Hello, World!");
    return 0;


### PR DESCRIPTION
Functions without any parameter are a pre-ANSI C construct, that is deprecated until C23 and compilers may warn about it. Since C23, `main(void)` and `main()` are equivalent (as in C++), but as the standard is quite recent it's better to a-void this old style prototype.