### PR TITLE
doc: update wasm_of_ocaml installation instructions

### DIFF
--- a/doc/wasmoo.rst
+++ b/doc/wasmoo.rst
@@ -9,9 +9,12 @@ Wasm Compilation With Wasm_of_ocaml
    This is an how-to guide.
 
 Wasm_of_ocaml is a compiler from OCaml to WebAssembly (Wasm for short). The
-compiler works by translating OCaml bytecode to Wasm code. The compiler is
-available in the `js_of_ocaml Github repository
-<https://github.com/ocsigen/js_of_ocaml>`_.
+compiler works by translating OCaml bytecode to Wasm code. The compiler can
+be installed with opam:
+
+.. code:: console
+
+   $ opam install wasm_of_ocaml-compiler
 
 Compiling to Wasm
 =================

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -175,6 +175,7 @@ module Version = struct
 end
 
 let install_jsoo_hint = "opam install js_of_ocaml-compiler"
+let install_wasmoo_hint = "opam install wasm_of_ocaml-compiler"
 
 let in_build_dir (ctx : Build_context.t) ~config args =
   Path.Build.L.relative ctx.build_dir (".js" :: Config.path config :: args)
@@ -209,8 +210,12 @@ let jsoo ~dir sctx =
 ;;
 
 let wasmoo ~dir sctx =
-  (* TODO add a hint when wasm_of_ocaml released on opam *)
-  Super_context.resolve_program sctx ~dir ~loc:None "wasm_of_ocaml"
+  Super_context.resolve_program
+    sctx
+    ~dir
+    ~loc:None
+    ~hint:install_wasmoo_hint
+    "wasm_of_ocaml"
 ;;
 
 type sub_command =


### PR DESCRIPTION
This PR updates the installation instructions for wasm_of_ocaml, which is now officially available via opam as part of the js_of_ocaml 6.0.1 release.