### PR TITLE
Improve include doc to reference dynamic_include for generated files

### DIFF
--- a/doc/reference/dune/dynamic_include.rst
+++ b/doc/reference/dune/dynamic_include.rst
@@ -1,3 +1,5 @@
+.. _dynamic_include:
+
 dynamic_include
 ---------------
 

--- a/doc/reference/dune/include.rst
+++ b/doc/reference/dune/include.rst
@@ -2,9 +2,10 @@ include
 -------
 
 The ``include`` stanza allows including the contents of another file in the
-current ``dune`` file. Currently, the included file cannot be generated and must
-be present in the source tree. This feature is intended for use in conjunction
-with promotion, when parts of a ``dune`` file are to be generated.
+current ``dune`` file. The included file cannot be generated and must
+be present in the source tree. To include generated files, 
+use the :ref:`dynamic_include` stanza instead. This feature is intended 
+for use in conjunction with promotion, when parts of a ``dune`` file are to be generated.
 
 For instance:
 


### PR DESCRIPTION
To address https://github.com/ocaml/dune/issues/11525


New doc:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/bd135b6f-76cb-4ba9-a36f-1bc7585936f7" />