### PR TITLE
Cache: only store executable permission bit

### DIFF
--- a/doc/changes/11541.md
+++ b/doc/changes/11541.md
@@ -1,0 +1,1 @@
+- Cache: we now only store the executable permission bit for files (#11541, fixes #11533, @ElectreAAS)

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -24,7 +24,7 @@ val generic : 'a -> t
 module Stats_for_digest : sig
   type t =
     { st_kind : Unix.file_kind
-    ; st_perm : Unix.file_perm
+    ; executable : bool
     }
 
   val of_unix_stats : Unix.stats -> t

--- a/test/blackbox-tests/test-cases/directory-targets/cache-permissions.t
+++ b/test/blackbox-tests/test-cases/directory-targets/cache-permissions.t
@@ -37,20 +37,16 @@ First build: `d` (with mode 755) and `other` are stored in cache
   $ dune build other
   building d
   building other
+
+The chmod command was run, so this is expected
   $ dune_cmd stat permissions _build/default/d
   755
 
-Second build: `d` is restored but the cached `other` depends on a version of
-`d` that does not correspond to what's in `_build`, so `other` gets rebuilt.
-Both versions are stored.
+Second build: `d` is restored and `other` can use it, so no rebuild happens.
 
   $ dune clean
   $ dune build other
-  building other
+
+We'll note that the permissions are still set to the umask
   $ dune_cmd stat permissions _build/default/d
   775
-
-Third build: `d` is restored and `other` can use it, so no rebuild happens.
-
-  $ dune clean
-  $ dune build other

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -2,14 +2,14 @@ open Stdune
 module Digest = Dune_digest
 
 let%expect_test "directory digest version" =
-  (* If this test fails with a new digest value, make sure to update to update
+  (* If this test fails with a new digest value, make sure to update
      [directory_digest_version] in digest.ml.
 
      The expected value is kept outside of the expect block on purpose so that it
      must be modified manually. *)
   let expected = "a743ec66ce913ff6587a3816a8acc6ea" in
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
+  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; executable = true } in
   (match Digest.path_with_stats ~allow_dirs:true dir stats with
    | Ok digest ->
      let digest = Digest.to_string digest in
@@ -26,7 +26,7 @@ let%expect_test "directory digest version" =
 
 let%expect_test "directories with symlinks" =
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
+  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; executable = true } in
   let sub = Path.relative dir "sub" in
   Path.mkdir_p sub;
   Unix.symlink "bar" (Path.to_string (Path.relative dir "foo"));


### PR DESCRIPTION
This PR is built on top of ~~the not-yet-merged #11534~~ main!, and includes the fix proposed in #11533.
We just stop storing the read & write permissions bits, only store the executable one. The strategy is the same as in git, we check if any of the u+x/g+x/o+x bits are set.