### PR TITLE
Refactor `Dune_lang.Package`

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -394,7 +394,7 @@ module Component = struct
       =
       let cst =
         let package =
-          Package.create
+          Dune_lang.Dune_package.create
             ~name:(Options.Common.package_name common)
             ~loc:Loc.none
             ~version:None
@@ -404,7 +404,7 @@ module Component = struct
             ~sites:Site.Map.empty
             ~allow_empty:false
             ~deprecated_package_names:Package.Name.Map.empty
-            ~original_opam_file:None
+              (* ~original_opam_file:None *)
             ~dir
             ~synopsis:(Some "A short synopsis")
             ~description:(Some "A longer description")
@@ -415,6 +415,7 @@ module Component = struct
                 }
               ]
         in
+        let package = Dune_lang.Package.of_dune_package package in
         let packages = Package.Name.Map.singleton (Package.name package) package in
         let info =
           Package_info.example

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -404,7 +404,6 @@ module Component = struct
             ~sites:Site.Map.empty
             ~allow_empty:false
             ~deprecated_package_names:Package.Name.Map.empty
-            ~has_opam_file:(Exists false)
             ~original_opam_file:None
             ~dir
             ~synopsis:(Some "A short synopsis")

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,4 +1,4 @@
-let external_libraries = [ "unix"; "threads" ]
+let external_libraries = [ "threads.posix" ]
 
 let local_libraries =
   [ ("otherlibs/ordering", Some "Ordering", false, None)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -19,6 +19,7 @@ module Package_version = Package_version
 module Package_variable_name = Package_variable_name
 module Lib_kind = Lib_kind
 module Lib_dep = Lib_dep
+module Loaded_package = Loaded_package
 module Pkg = Pkg
 module Ordered_set_lang = Ordered_set_lang
 module Format_config = Format_config

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -13,6 +13,7 @@ module Path = Path
 module Value = Value
 module Blang = Blang
 module Binary_kind = Binary_kind
+module Package_id = Package_id
 module Package_constraint = Package_constraint
 module Package_name = Package_name
 module Package_dependency = Package_dependency

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -8,6 +8,7 @@ module String_with_vars = String_with_vars
 module Pform = Pform
 module Action = Action
 module Dune_file_script = Dune_file_script
+module Dune_package = Dune_package
 module Path = Path
 module Value = Value
 module Blang = Blang

--- a/src/dune_lang/dune_package.ml
+++ b/src/dune_lang/dune_package.ml
@@ -1,0 +1,279 @@
+open Stdune
+open Dune_sexp
+module Name = Package_name
+
+module Id = struct
+  module T = struct
+    type t =
+      { name : Name.t
+      ; dir : Path.Source.t
+      }
+
+    let compare { name; dir } pkg =
+      match Name.compare name pkg.name with
+      | Eq -> Path.Source.compare dir pkg.dir
+      | e -> e
+    ;;
+
+    let to_dyn { dir; name } =
+      Dyn.record [ "name", Name.to_dyn name; "dir", Path.Source.to_dyn dir ]
+    ;;
+  end
+
+  include T
+
+  let hash { name; dir } = Tuple.T2.hash Name.hash Path.Source.hash (name, dir)
+  let name t = t.name
+
+  module C = Comparable.Make (T)
+  module Set = C.Set
+  module Map = C.Map
+end
+
+type opam_file =
+  | Exists of bool
+  | Generated
+
+(* we need the original opam file when passing it [$ dune pkg lock] we want to
+   to allow the opam library interpret the opam file directly. *)
+type original_opam_file =
+  { file : Path.Source.t
+  ; contents : string
+  }
+
+type t =
+  { id : Id.t
+  ; opam_file : Path.Source.t
+  ; loc : Loc.t
+  ; synopsis : string option
+  ; description : string option
+  ; depends : Package_dependency.t list
+  ; conflicts : Package_dependency.t list
+  ; depopts : Package_dependency.t list
+  ; info : Package_info.t
+  ; version : Package_version.t option (* ; has_opam_file : opam_file *)
+  ; tags : string list
+  ; deprecated_package_names : Loc.t Name.Map.t
+  ; sites : Section.t Site.Map.t
+  ; allow_empty : bool
+  }
+
+(* Package name are globally unique, so we can reasonably expect that there will
+   always be only a single value of type [t] with a given name in memory. That's
+   why we only hash the name. *)
+let hash t = Id.hash t.id
+let name t = t.id.name
+let dir t = t.id.dir
+let loc t = t.loc
+let deprecated_package_names t = t.deprecated_package_names
+
+(* let set_has_opam_file t has_opam_file = { t with has_opam_file } *)
+let version t = t.version
+let depends t = t.depends
+let conflicts t = t.conflicts
+let depopts t = t.depopts
+let tags t = t.tags
+let synopsis t = t.synopsis
+let info t = t.info
+let description t = t.description
+let id t = t.id
+let set_inside_opam_dir t ~dir = { t with opam_file = Name.file t.id.name ~dir }
+let set_version_and_info t ~version ~info = { t with version; info }
+
+let encode
+      (name : Name.t)
+      { id = _
+      ; loc = _
+      ; synopsis
+      ; description
+      ; depends
+      ; conflicts
+      ; depopts
+      ; info
+      ; version
+      ; tags
+      ; deprecated_package_names
+      ; sites
+      ; allow_empty
+      ; opam_file = _
+      }
+  =
+  let open Encoder in
+  let fields =
+    Package_info.encode_fields info
+    @ record_fields
+        [ field "name" Name.encode name
+        ; field_o "synopsis" string synopsis
+        ; field_o "description" string description
+        ; field_l "depends" Package_dependency.encode depends
+        ; field_l "conflicts" Package_dependency.encode conflicts
+        ; field_l "depopts" Package_dependency.encode depopts
+        ; field_o "version" Package_version.encode version
+        ; field "tags" (list string) ~default:[] tags
+        ; field_l
+            "deprecated_package_names"
+            Name.encode
+            (Name.Map.keys deprecated_package_names)
+        ; field_l "sites" (pair Site.encode Section.encode) (Site.Map.to_list sites)
+        ; field_b "allow_empty" allow_empty
+        ]
+  in
+  list sexp (string "package" :: fields)
+;;
+
+let decode_name ~version =
+  if version >= (3, 11) then Name.decode_opam_compatible else Name.decode
+;;
+
+let decode =
+  let open Decoder in
+  let name_map syntax of_list_map to_string name decode print_value error_msg =
+    let+ names = field ~default:[] name (syntax >>> repeat decode) in
+    match of_list_map names ~f:(fun (loc, s) -> s, loc) with
+    | Ok x -> x
+    | Error (name, (loc1, _), (loc2, _)) ->
+      User_error.raise
+        [ Pp.textf "%s %s is declared twice:" error_msg (to_string name)
+        ; Pp.textf "- %s" (print_value loc1)
+        ; Pp.textf "- %s" (print_value loc2)
+        ]
+  in
+  fun ~dir ->
+    fields
+    @@ let* version = Syntax.get_exn Stanza.syntax in
+       let+ loc = loc
+       and+ name = field "name" (decode_name ~version)
+       and+ synopsis = field_o "synopsis" string
+       and+ description = field_o "description" string
+       and+ version =
+         field_o "version" (Syntax.since Stanza.syntax (2, 5) >>> Package_version.decode)
+       and+ depends = field ~default:[] "depends" (repeat Package_dependency.decode)
+       and+ conflicts = field ~default:[] "conflicts" (repeat Package_dependency.decode)
+       and+ depopts = field ~default:[] "depopts" (repeat Package_dependency.decode)
+       and+ info = Package_info.decode ~since:(2, 0) ()
+       and+ tags = field "tags" (enter (repeat string)) ~default:[]
+       and+ deprecated_package_names =
+         name_map
+           (Syntax.since Stanza.syntax (2, 0))
+           Name.Map.of_list_map
+           Name.to_string
+           "deprecated_package_names"
+           (located Name.decode)
+           Loc.to_file_colon_line
+           "Deprecated package name"
+       and+ sites =
+         name_map
+           (Syntax.since Stanza.syntax (2, 8))
+           Site.Map.of_list_map
+           Site.to_string
+           "sites"
+           (pair Section.decode Site.decode)
+           Section.to_string
+           "Site location name"
+       and+ allow_empty = field_b "allow_empty" ~check:(Syntax.since Stanza.syntax (3, 0))
+       and+ lang_version = Syntax.get_exn Stanza.syntax in
+       let allow_empty = lang_version < (3, 0) || allow_empty in
+       let id = { Id.name; dir } in
+       let opam_file = Name.file id.name ~dir:id.dir in
+       Printf.eprintf "Sets to Exists false\n";
+       { id
+       ; loc
+       ; synopsis
+       ; description
+       ; depends
+       ; conflicts
+       ; depopts
+       ; info
+       ; version
+       ; tags
+       ; deprecated_package_names
+       ; sites
+       ; allow_empty
+       ; opam_file
+       }
+;;
+
+(* let dyn_of_opam_file = *)
+(*   let open Dyn in *)
+(*   function *)
+(*   | Exists b -> variant "Exists" [ bool b ] *)
+(*   | Generated -> variant "Generated" [] *)
+(* ;; *)
+
+let to_dyn
+      { id
+      ; version
+      ; synopsis
+      ; description
+      ; depends
+      ; conflicts
+      ; depopts
+      ; info (* ; has_opam_file *)
+      ; tags
+      ; loc = _
+      ; deprecated_package_names
+      ; sites
+      ; allow_empty
+      ; opam_file = _ (* ; original_opam_file = _ *)
+      }
+  =
+  let open Dyn in
+  record
+    [ "id", Id.to_dyn id
+    ; "synopsis", option string synopsis
+    ; "description", option string description
+    ; "depends", list Package_dependency.to_dyn depends
+    ; "conflicts", list Package_dependency.to_dyn conflicts
+    ; "depopts", list Package_dependency.to_dyn depopts
+    ; "info", Package_info.to_dyn info
+      (* ; "has_opam_file", dyn_of_opam_file has_opam_file *)
+    ; "tags", list string tags
+    ; "version", option Package_version.to_dyn version
+    ; "deprecated_package_names", Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names
+    ; "sites", Site.Map.to_dyn Section.to_dyn sites
+    ; "allow_empty", Bool allow_empty
+    ]
+;;
+
+let opam_file t = t.opam_file
+let sites t = t.sites
+
+(* let has_opam_file t = t.has_opam_file *)
+let allow_empty t = t.allow_empty
+let map_depends t ~f = { t with depends = f t.depends }
+
+let create
+      ~name
+      ~loc
+      ~version
+      ~conflicts
+      ~depends
+      ~depopts
+      ~info
+      (* ~has_opam_file *)
+      ~dir
+      ~sites
+      ~allow_empty
+      ~synopsis
+      ~description
+      ~tags
+      (* ~original_opam_file *)
+      ~deprecated_package_names
+  =
+  let id = { Id.name; dir } in
+  { id
+  ; loc
+  ; version
+  ; synopsis
+  ; description
+  ; depends
+  ; conflicts
+  ; info
+  ; depopts (* ; has_opam_file *)
+  ; tags
+  ; deprecated_package_names
+  ; sites
+  ; allow_empty
+  ; opam_file = Name.file name ~dir (* ; original_opam_file *)
+  }
+;;

--- a/src/dune_lang/dune_package.ml
+++ b/src/dune_lang/dune_package.ml
@@ -149,7 +149,6 @@ let decode =
        let allow_empty = lang_version < (3, 0) || allow_empty in
        let id = Package_id.create ~name ~dir in
        let opam_file = Name.file (Package_id.name id) ~dir:(Package_id.dir id) in
-       Printf.eprintf "Sets to Exists false\n";
        { id
        ; loc
        ; synopsis

--- a/src/dune_lang/dune_package.ml
+++ b/src/dune_lang/dune_package.ml
@@ -51,7 +51,7 @@ type t =
   ; conflicts : Package_dependency.t list
   ; depopts : Package_dependency.t list
   ; info : Package_info.t
-  ; version : Package_version.t option (* ; has_opam_file : opam_file *)
+  ; version : Package_version.t option
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Site.Map.t

--- a/src/dune_lang/dune_package.mli
+++ b/src/dune_lang/dune_package.mli
@@ -1,0 +1,80 @@
+(** Information about a package defined in the workspace *)
+
+open Stdune
+
+module Name : sig
+  type t = Package_name.t
+
+  include module type of Package_name with type t := t
+end
+
+module Id : sig
+  type t
+
+  val name : t -> Name.t
+
+  include Comparable_intf.S with type key := t
+end
+
+type opam_file =
+  | Exists of bool
+  | Generated
+
+type t
+
+val loc : t -> Loc.t
+val deprecated_package_names : t -> Loc.t Name.Map.t
+val sites : t -> Section.t Site.Map.t
+val name : t -> Name.t
+val dir : t -> Path.Source.t
+val set_inside_opam_dir : t -> dir:Path.Source.t -> t
+val encode : Name.t -> t Dune_sexp.Encoder.t
+val decode : dir:Path.Source.t -> t Dune_sexp.Decoder.t
+val opam_file : t -> Path.Source.t
+val to_dyn : t -> Dyn.t
+val hash : t -> int
+
+(* val set_has_opam_file : t -> opam_file -> t *)
+val version : t -> Package_version.t option
+val depends : t -> Package_dependency.t list
+val conflicts : t -> Package_dependency.t list
+val depopts : t -> Package_dependency.t list
+val tags : t -> string list
+val synopsis : t -> string option
+val info : t -> Package_info.t
+val description : t -> string option
+val id : t -> Id.t
+
+val set_version_and_info
+  :  t
+  -> version:Package_version.t option
+  -> info:Package_info.t
+  -> t
+
+(* val has_opam_file : t -> opam_file *)
+val allow_empty : t -> bool
+val map_depends : t -> f:(Package_dependency.t list -> Package_dependency.t list) -> t
+
+type original_opam_file =
+  { file : Path.Source.t
+  ; contents : string
+  }
+
+val create
+  :  name:Name.t
+  -> loc:Loc.t
+  -> version:Package_version.t option
+  -> conflicts:Package_dependency.t list
+  -> depends:Package_dependency.t list
+  -> depopts:Package_dependency.t list
+  -> info:Package_info.t (* -> has_opam_file:opam_file *)
+  -> dir:Path.Source.t
+  -> sites:Section.t Site.Map.t
+  -> allow_empty:bool
+  -> synopsis:string option
+  -> description:string option
+  -> tags:string list (* -> original_opam_file:original_opam_file option *)
+  -> deprecated_package_names:Loc.t Name.Map.t
+  -> t
+
+(* val original_opam_file : t -> original_opam_file option *)

--- a/src/dune_lang/dune_package.mli
+++ b/src/dune_lang/dune_package.mli
@@ -8,14 +8,6 @@ module Name : sig
   include module type of Package_name with type t := t
 end
 
-module Id : sig
-  type t
-
-  val name : t -> Name.t
-
-  include Comparable_intf.S with type key := t
-end
-
 type opam_file =
   | Exists of bool
   | Generated
@@ -43,7 +35,7 @@ val tags : t -> string list
 val synopsis : t -> string option
 val info : t -> Package_info.t
 val description : t -> string option
-val id : t -> Id.t
+val id : t -> Package_id.t
 
 val set_version_and_info
   :  t

--- a/src/dune_lang/loaded_package.ml
+++ b/src/dune_lang/loaded_package.ml
@@ -1,0 +1,13 @@
+type opam_file =
+  | Exists of bool
+  | Generated
+
+type t = {
+  package : Package.t;
+  has_opam_file : opam_file;
+}
+
+let package t = t.package
+let has_opam_file t = t.has_opam_file
+
+let create ~package ~has_opam_file = { package; has_opam_file }

--- a/src/dune_lang/loaded_package.ml
+++ b/src/dune_lang/loaded_package.ml
@@ -2,12 +2,11 @@ type opam_file =
   | Exists of bool
   | Generated
 
-type t = {
-  package : Package.t;
-  has_opam_file : opam_file;
-}
+type t =
+  { package : Package.t
+  ; has_opam_file : opam_file
+  }
 
 let package t = t.package
 let has_opam_file t = t.has_opam_file
-
 let create ~package ~has_opam_file = { package; has_opam_file }

--- a/src/dune_lang/loaded_package.mli
+++ b/src/dune_lang/loaded_package.mli
@@ -1,0 +1,10 @@
+type t
+
+type opam_file =
+  | Exists of bool
+  | Generated
+
+val has_opam_file : t -> opam_file
+val package : t -> Package.t
+
+val create : package:Package.t -> has_opam_file:opam_file -> t

--- a/src/dune_lang/loaded_package.mli
+++ b/src/dune_lang/loaded_package.mli
@@ -6,5 +6,4 @@ type opam_file =
 
 val has_opam_file : t -> opam_file
 val package : t -> Package.t
-
 val create : package:Package.t -> has_opam_file:opam_file -> t

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -3,8 +3,7 @@ module Name = Package_name
 
 module Opam_package = struct
   type t =
-    { name : Package_name.t
-    ; dir : Path.Source.t
+    { id : Package_id.t
     ; opam_file : Path.Source.t
     ; loc : Loc.t
     ; synopsis : string option
@@ -31,9 +30,9 @@ module Opam_package = struct
         ~tags
     =
     (* TODO fix *)
+    let id = Package_id.create ~name ~dir in
     let opam_file = dir in
-    { name
-    ; dir
+    { id
     ; opam_file
     ; loc
     ; synopsis
@@ -48,6 +47,10 @@ module Opam_package = struct
   ;;
 
   let to_dyn _t = Dyn.string "TODO"
+
+  let depends t = t.depends
+  let depopts t = t.depopts
+  let conflicts t = t.conflicts
 end
 
 type t =
@@ -59,7 +62,7 @@ let of_opam_package pkg = Opam_package pkg
 
 let name = function
   | Dune_package t -> Dune_package.name t
-  | Opam_package t -> t.name
+  | Opam_package t -> Package_id.name t.id
 ;;
 
 let info = function
@@ -99,7 +102,7 @@ let loc = function
 
 let dir = function
   | Dune_package t -> Dune_package.dir t
-  | Opam_package t -> t.dir
+  | Opam_package t -> Package_id.dir t.id
 ;;
 
 let synopsis = function
@@ -126,3 +129,20 @@ let set_version_and_info t ~version ~info =
   match t with
   | Dune_package t -> Dune_package (Dune_package.set_version_and_info t ~version ~info)
   | Opam_package t -> Opam_package { t with version; info }
+;;
+
+let id = function
+  | Dune_package t -> Dune_package.id t
+  | Opam_package t -> t.id
+;;
+
+let allow_empty = function
+  | Dune_package t -> Dune_package.allow_empty t
+  | Opam_package _ -> false
+;;
+
+let opam_package = function
+  | Dune_package _ -> None
+  | Opam_package t -> Some t
+
+(* let depends v *) 

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -52,13 +52,15 @@ type t =
   ; depopts : Package_dependency.t list
   ; info : Package_info.t
   ; version : Package_version.t option
-  ; has_opam_file : opam_file
+  (* ; has_opam_file : opam_file *)
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Site.Map.t
   ; allow_empty : bool
   ; original_opam_file : original_opam_file option
   }
+
+
 
 (* Package name are globally unique, so we can reasonably expect that there will
    always be only a single value of type [t] with a given name in memory. That's
@@ -68,7 +70,7 @@ let name t = t.id.name
 let dir t = t.id.dir
 let loc t = t.loc
 let deprecated_package_names t = t.deprecated_package_names
-let set_has_opam_file t has_opam_file = { t with has_opam_file }
+(* let set_has_opam_file t has_opam_file = { t with has_opam_file } *)
 let version t = t.version
 let depends t = t.depends
 let conflicts t = t.conflicts
@@ -86,7 +88,7 @@ let encode
       (name : Name.t)
       { id = _
       ; loc = _
-      ; has_opam_file = _
+      (* ; has_opam_file = _ *)
       ; synopsis
       ; description
       ; depends
@@ -179,6 +181,7 @@ let decode =
        let allow_empty = lang_version < (3, 0) || allow_empty in
        let id = { Id.name; dir } in
        let opam_file = Name.file id.name ~dir:id.dir in
+       Printf.eprintf "Sets to Exists false\n";
        { id
        ; loc
        ; synopsis
@@ -188,7 +191,7 @@ let decode =
        ; depopts
        ; info
        ; version
-       ; has_opam_file = Exists false
+       (* ; has_opam_file = Exists false *)
        ; tags
        ; deprecated_package_names
        ; sites
@@ -198,12 +201,12 @@ let decode =
        }
 ;;
 
-let dyn_of_opam_file =
-  let open Dyn in
-  function
-  | Exists b -> variant "Exists" [ bool b ]
-  | Generated -> variant "Generated" []
-;;
+(* let dyn_of_opam_file = *)
+(*   let open Dyn in *)
+(*   function *)
+(*   | Exists b -> variant "Exists" [ bool b ] *)
+(*   | Generated -> variant "Generated" [] *)
+(* ;; *)
 
 let to_dyn
       { id
@@ -214,7 +217,7 @@ let to_dyn
       ; conflicts
       ; depopts
       ; info
-      ; has_opam_file
+      (* ; has_opam_file *)
       ; tags
       ; loc = _
       ; deprecated_package_names
@@ -233,7 +236,7 @@ let to_dyn
     ; "conflicts", list Package_dependency.to_dyn conflicts
     ; "depopts", list Package_dependency.to_dyn depopts
     ; "info", Package_info.to_dyn info
-    ; "has_opam_file", dyn_of_opam_file has_opam_file
+    (* ; "has_opam_file", dyn_of_opam_file has_opam_file *)
     ; "tags", list string tags
     ; "version", option Package_version.to_dyn version
     ; "deprecated_package_names", Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names
@@ -244,7 +247,7 @@ let to_dyn
 
 let opam_file t = t.opam_file
 let sites t = t.sites
-let has_opam_file t = t.has_opam_file
+(* let has_opam_file t = t.has_opam_file *)
 let allow_empty t = t.allow_empty
 let map_depends t ~f = { t with depends = f t.depends }
 
@@ -256,7 +259,7 @@ let create
       ~depends
       ~depopts
       ~info
-      ~has_opam_file
+      (* ~has_opam_file *)
       ~dir
       ~sites
       ~allow_empty
@@ -276,7 +279,7 @@ let create
   ; conflicts
   ; info
   ; depopts
-  ; has_opam_file
+  (* ; has_opam_file *)
   ; tags
   ; deprecated_package_names
   ; sites

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -1,290 +1,123 @@
 open Stdune
-open Dune_sexp
 module Name = Package_name
 
-module Id = struct
-  module T = struct
-    type t =
-      { name : Name.t
-      ; dir : Path.Source.t
-      }
+module Opam_package = struct
+  type t =
+    { name : Package_name.t
+    ; dir : Path.Source.t
+    ; opam_file : Path.Source.t
+    ; loc : Loc.t
+    ; synopsis : string option
+    ; description : string option
+    ; depends : OpamTypes.filtered_formula
+    ; conflicts : Package_dependency.t list
+    ; depopts : Package_dependency.t list
+    ; info : Package_info.t
+    ; version : Package_version.t option
+    ; tags : string list
+    }
 
-    let compare { name; dir } pkg =
-      match Name.compare name pkg.name with
-      | Eq -> Path.Source.compare dir pkg.dir
-      | e -> e
-    ;;
+  let create
+        ~name
+        ~loc
+        ~version
+        ~conflicts
+        ~depends
+        ~depopts
+        ~info
+        ~dir
+        ~synopsis
+        ~description
+        ~tags
+    =
+    (* TODO fix *)
+    let opam_file = dir in
+    { name
+    ; dir
+    ; opam_file
+    ; loc
+    ; synopsis
+    ; description
+    ; depends
+    ; conflicts
+    ; depopts
+    ; info
+    ; version
+    ; tags
+    }
+  ;;
 
-    let to_dyn { dir; name } =
-      Dyn.record [ "name", Name.to_dyn name; "dir", Path.Source.to_dyn dir ]
-    ;;
-  end
-
-  include T
-
-  let hash { name; dir } = Tuple.T2.hash Name.hash Path.Source.hash (name, dir)
-  let name t = t.name
-
-  module C = Comparable.Make (T)
-  module Set = C.Set
-  module Map = C.Map
+  let to_dyn _t = Dyn.string "TODO"
 end
 
-type opam_file =
-  | Exists of bool
-  | Generated
-
-(* we need the original opam file when passing it [$ dune pkg lock] we want to
-   to allow the opam library interpret the opam file directly. *)
-type original_opam_file =
-  { file : Path.Source.t
-  ; contents : string
-  }
-
 type t =
-  { id : Id.t
-  ; opam_file : Path.Source.t
-  ; loc : Loc.t
-  ; synopsis : string option
-  ; description : string option
-  ; depends : Package_dependency.t list
-  ; conflicts : Package_dependency.t list
-  ; depopts : Package_dependency.t list
-  ; info : Package_info.t
-  ; version : Package_version.t option
-  (* ; has_opam_file : opam_file *)
-  ; tags : string list
-  ; deprecated_package_names : Loc.t Name.Map.t
-  ; sites : Section.t Site.Map.t
-  ; allow_empty : bool
-  ; original_opam_file : original_opam_file option
-  }
+  | Dune_package of Dune_package.t
+  | Opam_package of Opam_package.t
 
+let of_dune_package pkg = Dune_package pkg
+let of_opam_package pkg = Opam_package pkg
 
-
-(* Package name are globally unique, so we can reasonably expect that there will
-   always be only a single value of type [t] with a given name in memory. That's
-   why we only hash the name. *)
-let hash t = Id.hash t.id
-let name t = t.id.name
-let dir t = t.id.dir
-let loc t = t.loc
-let deprecated_package_names t = t.deprecated_package_names
-(* let set_has_opam_file t has_opam_file = { t with has_opam_file } *)
-let version t = t.version
-let depends t = t.depends
-let conflicts t = t.conflicts
-let depopts t = t.depopts
-let tags t = t.tags
-let synopsis t = t.synopsis
-let info t = t.info
-let description t = t.description
-let id t = t.id
-let original_opam_file t = t.original_opam_file
-let set_inside_opam_dir t ~dir = { t with opam_file = Name.file t.id.name ~dir }
-let set_version_and_info t ~version ~info = { t with version; info }
-
-let encode
-      (name : Name.t)
-      { id = _
-      ; loc = _
-      (* ; has_opam_file = _ *)
-      ; synopsis
-      ; description
-      ; depends
-      ; conflicts
-      ; depopts
-      ; info
-      ; version
-      ; tags
-      ; deprecated_package_names
-      ; sites
-      ; allow_empty
-      ; opam_file = _
-      ; original_opam_file = _
-      }
-  =
-  let open Encoder in
-  let fields =
-    Package_info.encode_fields info
-    @ record_fields
-        [ field "name" Name.encode name
-        ; field_o "synopsis" string synopsis
-        ; field_o "description" string description
-        ; field_l "depends" Package_dependency.encode depends
-        ; field_l "conflicts" Package_dependency.encode conflicts
-        ; field_l "depopts" Package_dependency.encode depopts
-        ; field_o "version" Package_version.encode version
-        ; field "tags" (list string) ~default:[] tags
-        ; field_l
-            "deprecated_package_names"
-            Name.encode
-            (Name.Map.keys deprecated_package_names)
-        ; field_l "sites" (pair Site.encode Section.encode) (Site.Map.to_list sites)
-        ; field_b "allow_empty" allow_empty
-        ]
-  in
-  list sexp (string "package" :: fields)
+let name = function
+  | Dune_package t -> Dune_package.name t
+  | Opam_package t -> t.name
 ;;
 
-let decode_name ~version =
-  if version >= (3, 11) then Name.decode_opam_compatible else Name.decode
+let info = function
+  | Dune_package t -> Dune_package.info t
+  | Opam_package t -> t.info
 ;;
 
-let decode =
-  let open Decoder in
-  let name_map syntax of_list_map to_string name decode print_value error_msg =
-    let+ names = field ~default:[] name (syntax >>> repeat decode) in
-    match of_list_map names ~f:(fun (loc, s) -> s, loc) with
-    | Ok x -> x
-    | Error (name, (loc1, _), (loc2, _)) ->
-      User_error.raise
-        [ Pp.textf "%s %s is declared twice:" error_msg (to_string name)
-        ; Pp.textf "- %s" (print_value loc1)
-        ; Pp.textf "- %s" (print_value loc2)
-        ]
-  in
-  fun ~dir ->
-    fields
-    @@ let* version = Syntax.get_exn Stanza.syntax in
-       let+ loc = loc
-       and+ name = field "name" (decode_name ~version)
-       and+ synopsis = field_o "synopsis" string
-       and+ description = field_o "description" string
-       and+ version =
-         field_o "version" (Syntax.since Stanza.syntax (2, 5) >>> Package_version.decode)
-       and+ depends = field ~default:[] "depends" (repeat Package_dependency.decode)
-       and+ conflicts = field ~default:[] "conflicts" (repeat Package_dependency.decode)
-       and+ depopts = field ~default:[] "depopts" (repeat Package_dependency.decode)
-       and+ info = Package_info.decode ~since:(2, 0) ()
-       and+ tags = field "tags" (enter (repeat string)) ~default:[]
-       and+ deprecated_package_names =
-         name_map
-           (Syntax.since Stanza.syntax (2, 0))
-           Name.Map.of_list_map
-           Name.to_string
-           "deprecated_package_names"
-           (located Name.decode)
-           Loc.to_file_colon_line
-           "Deprecated package name"
-       and+ sites =
-         name_map
-           (Syntax.since Stanza.syntax (2, 8))
-           Site.Map.of_list_map
-           Site.to_string
-           "sites"
-           (pair Section.decode Site.decode)
-           Section.to_string
-           "Site location name"
-       and+ allow_empty = field_b "allow_empty" ~check:(Syntax.since Stanza.syntax (3, 0))
-       and+ lang_version = Syntax.get_exn Stanza.syntax in
-       let allow_empty = lang_version < (3, 0) || allow_empty in
-       let id = { Id.name; dir } in
-       let opam_file = Name.file id.name ~dir:id.dir in
-       Printf.eprintf "Sets to Exists false\n";
-       { id
-       ; loc
-       ; synopsis
-       ; description
-       ; depends
-       ; conflicts
-       ; depopts
-       ; info
-       ; version
-       (* ; has_opam_file = Exists false *)
-       ; tags
-       ; deprecated_package_names
-       ; sites
-       ; allow_empty
-       ; opam_file
-       ; original_opam_file = None
-       }
+let version = function
+  | Dune_package t -> Dune_package.version t
+  | Opam_package t -> t.version
 ;;
 
-(* let dyn_of_opam_file = *)
-(*   let open Dyn in *)
-(*   function *)
-(*   | Exists b -> variant "Exists" [ bool b ] *)
-(*   | Generated -> variant "Generated" [] *)
-(* ;; *)
-
-let to_dyn
-      { id
-      ; version
-      ; synopsis
-      ; description
-      ; depends
-      ; conflicts
-      ; depopts
-      ; info
-      (* ; has_opam_file *)
-      ; tags
-      ; loc = _
-      ; deprecated_package_names
-      ; sites
-      ; allow_empty
-      ; opam_file = _
-      ; original_opam_file = _
-      }
-  =
-  let open Dyn in
-  record
-    [ "id", Id.to_dyn id
-    ; "synopsis", option string synopsis
-    ; "description", option string description
-    ; "depends", list Package_dependency.to_dyn depends
-    ; "conflicts", list Package_dependency.to_dyn conflicts
-    ; "depopts", list Package_dependency.to_dyn depopts
-    ; "info", Package_info.to_dyn info
-    (* ; "has_opam_file", dyn_of_opam_file has_opam_file *)
-    ; "tags", list string tags
-    ; "version", option Package_version.to_dyn version
-    ; "deprecated_package_names", Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names
-    ; "sites", Site.Map.to_dyn Section.to_dyn sites
-    ; "allow_empty", Bool allow_empty
-    ]
+let opam_file = function
+  | Dune_package t -> Dune_package.opam_file t
+  | Opam_package t -> t.opam_file
 ;;
 
-let opam_file t = t.opam_file
-let sites t = t.sites
-(* let has_opam_file t = t.has_opam_file *)
-let allow_empty t = t.allow_empty
-let map_depends t ~f = { t with depends = f t.depends }
+let tags = function
+  | Dune_package t -> Dune_package.tags t
+  | Opam_package t -> t.tags
+;;
 
-let create
-      ~name
-      ~loc
-      ~version
-      ~conflicts
-      ~depends
-      ~depopts
-      ~info
-      (* ~has_opam_file *)
-      ~dir
-      ~sites
-      ~allow_empty
-      ~synopsis
-      ~description
-      ~tags
-      ~original_opam_file
-      ~deprecated_package_names
-  =
-  let id = { Id.name; dir } in
-  { id
-  ; loc
-  ; version
-  ; synopsis
-  ; description
-  ; depends
-  ; conflicts
-  ; info
-  ; depopts
-  (* ; has_opam_file *)
-  ; tags
-  ; deprecated_package_names
-  ; sites
-  ; allow_empty
-  ; opam_file = Name.file name ~dir
-  ; original_opam_file
-  }
+let sites = function
+  | Dune_package t -> Dune_package.sites t
+  | Opam_package _ -> Site.Map.empty
+;;
+
+let deprecated_package_names = function
+  | Dune_package t -> Dune_package.deprecated_package_names t
+  | Opam_package _ -> Name.Map.empty
+;;
+
+let loc = function
+  | Dune_package t -> Dune_package.loc t
+  | Opam_package t -> t.loc
+;;
+
+let dir = function
+  | Dune_package t -> Dune_package.dir t
+  | Opam_package t -> t.dir
+;;
+
+let synopsis = function
+  | Dune_package t -> Dune_package.synopsis t
+  | Opam_package t -> t.synopsis
+;;
+
+let description = function
+  | Dune_package t -> Dune_package.description t
+  | Opam_package t -> t.description
+;;
+
+let dune_package = function
+  | Dune_package t -> Some t
+  | Opam_package _ -> None
+;;
+
+let to_dyn = function
+  | Dune_package t -> Dune_package.to_dyn t
+  | Opam_package t -> Opam_package.to_dyn t
 ;;

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -121,3 +121,8 @@ let to_dyn = function
   | Dune_package t -> Dune_package.to_dyn t
   | Opam_package t -> Opam_package.to_dyn t
 ;;
+
+let set_version_and_info t ~version ~info =
+  match t with
+  | Dune_package t -> Dune_package (Dune_package.set_version_and_info t ~version ~info)
+  | Opam_package t -> Opam_package { t with version; info }

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -29,7 +29,6 @@ module Opam_package = struct
         ~description
         ~tags
     =
-    (* TODO fix *)
     let id = Package_id.create ~name ~dir in
     let opam_file = dir in
     { id

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -24,6 +24,10 @@ module Opam_package : sig
     -> description:string option
     -> tags:string list
     -> t
+
+  val depends : t -> OpamTypes.filtered_formula
+  val depopts : t -> Package_dependency.t list
+  val conflicts : t -> Package_dependency.t list
 end
 
 val of_dune_package : Dune_package.t -> t
@@ -40,5 +44,14 @@ val dir : t -> Path.Source.t
 val synopsis : t -> string option
 val description : t -> string option
 val dune_package : t -> Dune_package.t option
+val opam_package : t -> Opam_package.t option
 val to_dyn : t -> Dyn.t
-val set_version_and_info : t -> version:Package_version.t option -> info:Package_info.t -> t
+
+val set_version_and_info
+  :  t
+  -> version:Package_version.t option
+  -> info:Package_info.t
+  -> t
+
+val id : t -> Package_id.t
+val allow_empty : t -> bool

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -1,6 +1,6 @@
-(** Information about a package defined in the workspace *)
-
 open Stdune
+
+type t
 
 module Name : sig
   type t = Package_name.t
@@ -8,74 +8,36 @@ module Name : sig
   include module type of Package_name with type t := t
 end
 
-module Id : sig
+module Opam_package : sig
   type t
 
-  val name : t -> Name.t
-
-  include Comparable_intf.S with type key := t
+  val create
+    :  name:Name.t
+    -> loc:Loc.t
+    -> version:Package_version.t option
+    -> conflicts:Package_dependency.t list
+    -> depends:OpamTypes.filtered_formula
+    -> depopts:Package_dependency.t list
+    -> info:Package_info.t
+    -> dir:Path.Source.t
+    -> synopsis:string option
+    -> description:string option
+    -> tags:string list
+    -> t
 end
 
-type opam_file =
-  | Exists of bool
-  | Generated
-
-type t
-
-val loc : t -> Loc.t
-val deprecated_package_names : t -> Loc.t Name.Map.t
-val sites : t -> Section.t Site.Map.t
-val name : t -> Name.t
-val dir : t -> Path.Source.t
-val set_inside_opam_dir : t -> dir:Path.Source.t -> t
-val encode : Name.t -> t Dune_sexp.Encoder.t
-val decode : dir:Path.Source.t -> t Dune_sexp.Decoder.t
-val opam_file : t -> Path.Source.t
-val to_dyn : t -> Dyn.t
-val hash : t -> int
-(* val set_has_opam_file : t -> opam_file -> t *)
-val version : t -> Package_version.t option
-val depends : t -> Package_dependency.t list
-val conflicts : t -> Package_dependency.t list
-val depopts : t -> Package_dependency.t list
-val tags : t -> string list
-val synopsis : t -> string option
+val of_dune_package : Dune_package.t -> t
+val of_opam_package : Opam_package.t -> t
+val name : t -> Package_name.t
 val info : t -> Package_info.t
+val version : t -> Package_version.t option
+val opam_file : t -> Stdune.Path.Source.t
+val tags : t -> string list
+val sites : t -> Section.t Site.Map.t
+val deprecated_package_names : t -> Loc.t Name.Map.t
+val loc : t -> Loc.t
+val dir : t -> Path.Source.t
+val synopsis : t -> string option
 val description : t -> string option
-val id : t -> Id.t
-
-val set_version_and_info
-  :  t
-  -> version:Package_version.t option
-  -> info:Package_info.t
-  -> t
-
-(* val has_opam_file : t -> opam_file *)
-val allow_empty : t -> bool
-val map_depends : t -> f:(Package_dependency.t list -> Package_dependency.t list) -> t
-
-type original_opam_file =
-  { file : Path.Source.t
-  ; contents : string
-  }
-
-val create
-  :  name:Name.t
-  -> loc:Loc.t
-  -> version:Package_version.t option
-  -> conflicts:Package_dependency.t list
-  -> depends:Package_dependency.t list
-  -> depopts:Package_dependency.t list
-  -> info:Package_info.t
-  (* -> has_opam_file:opam_file *)
-  -> dir:Path.Source.t
-  -> sites:Section.t Site.Map.t
-  -> allow_empty:bool
-  -> synopsis:string option
-  -> description:string option
-  -> tags:string list
-  -> original_opam_file:original_opam_file option
-  -> deprecated_package_names:Loc.t Name.Map.t
-  -> t
-
-val original_opam_file : t -> original_opam_file option
+val dune_package : t -> Dune_package.t option
+val to_dyn : t -> Dyn.t

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -33,7 +33,7 @@ val decode : dir:Path.Source.t -> t Dune_sexp.Decoder.t
 val opam_file : t -> Path.Source.t
 val to_dyn : t -> Dyn.t
 val hash : t -> int
-val set_has_opam_file : t -> opam_file -> t
+(* val set_has_opam_file : t -> opam_file -> t *)
 val version : t -> Package_version.t option
 val depends : t -> Package_dependency.t list
 val conflicts : t -> Package_dependency.t list
@@ -50,7 +50,7 @@ val set_version_and_info
   -> info:Package_info.t
   -> t
 
-val has_opam_file : t -> opam_file
+(* val has_opam_file : t -> opam_file *)
 val allow_empty : t -> bool
 val map_depends : t -> f:(Package_dependency.t list -> Package_dependency.t list) -> t
 
@@ -67,7 +67,7 @@ val create
   -> depends:Package_dependency.t list
   -> depopts:Package_dependency.t list
   -> info:Package_info.t
-  -> has_opam_file:opam_file
+  (* -> has_opam_file:opam_file *)
   -> dir:Path.Source.t
   -> sites:Section.t Site.Map.t
   -> allow_empty:bool

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -41,3 +41,4 @@ val synopsis : t -> string option
 val description : t -> string option
 val dune_package : t -> Dune_package.t option
 val to_dyn : t -> Dyn.t
+val set_version_and_info : t -> version:Package_version.t option -> info:Package_info.t -> t

--- a/src/dune_lang/package_id.ml
+++ b/src/dune_lang/package_id.ml
@@ -1,0 +1,30 @@
+open Stdune
+module Name = Package_name
+
+module T = struct
+  type t =
+    { name : Name.t
+    ; dir : Path.Source.t
+    }
+
+  let compare { name; dir } pkg =
+    match Name.compare name pkg.name with
+    | Eq -> Path.Source.compare dir pkg.dir
+    | e -> e
+  ;;
+
+  let to_dyn { dir; name } =
+    Dyn.record [ "name", Name.to_dyn name; "dir", Path.Source.to_dyn dir ]
+  ;;
+end
+
+include T
+
+let hash { name; dir } = Tuple.T2.hash Name.hash Path.Source.hash (name, dir)
+let name t = t.name
+let dir t = t.dir
+let create ~name ~dir = { name; dir }
+
+module C = Comparable.Make (T)
+module Set = C.Set
+module Map = C.Map

--- a/src/dune_lang/package_id.mli
+++ b/src/dune_lang/package_id.mli
@@ -1,0 +1,12 @@
+open Stdune
+
+type t
+
+val name : t -> Package_name.t
+val dir : t -> Path.Source.t
+val create : name:Package_name.t -> dir:Path.Source.t -> t
+val hash : t -> int
+
+include Comparable_intf.S with type key := t
+
+val to_dyn : t -> Dyn.t

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -139,8 +139,15 @@ let of_package (t : Dune_lang.Package.t) =
   let loc = Package.loc t in
   let version = Package.version t in
   let name = Package.name t in
+  (* let hof = match Package.has_opam_file t with *)
+  (* | Generated -> "Generated" *)
+  (* | Exists true -> "Exists" *)
+  (* | Exists false -> "Doesnot exist" *)
+  (* in *)
+  Printf.eprintf "Attempting to load of_package: %s\n" (Package.Name.to_string name);
   match Package.original_opam_file t with
   | None ->
+    Printf.eprintf "No original opam file\n";
     let dependencies = t |> Package.depends |> Dependency_formula.of_dependencies in
     { name
     ; version
@@ -153,6 +160,7 @@ let of_package (t : Dune_lang.Package.t) =
     ; command_source = Assume_defaults
     }
   | Some { file; contents = opam_file_string } ->
+    Printf.eprintf "Yes original opam file\n";
     let opam_file =
       Opam_file.read_from_string_exn ~contents:opam_file_string (Path.source file)
     in

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -145,6 +145,14 @@ let of_package (t : Dune_lang.Package.t) =
   (* | Exists false -> "Doesnot exist" *)
   (* in *)
   Printf.eprintf "Attempting to load of_package: %s\n" (Package.Name.to_string name);
+  (* match Package.depends t with *)
+  (* | [] -> *)
+  (*     match Loaded_package.has_opam_file with *)
+  (*     | Missing -> [] *)
+  (*     | Generated -> [] *)
+  (*     | Exists path -> (1* load & parse *1) *)
+  (* | _ -> *)
+  (*   (1* depends are in dune project *1) *)
   match Package.original_opam_file t with
   | None ->
     Printf.eprintf "No original opam file\n";

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -139,12 +139,12 @@ let of_package (t : Dune_lang.Package.t) =
   let loc = Package.loc t in
   let version = Package.version t in
   let name = Package.name t in
-  Printf.eprintf "Attempting to load of_package: %s\n" (Package.Name.to_string name);
+  (* Printf.eprintf "Attempting to load of_package: %s\n" (Package.Name.to_string name); *)
   match (Package.dune_package t, Package.opam_package t) with
   | None, None -> assert false
   | Some _, Some _ -> assert false
   | Some t, None ->
-    Printf.eprintf "No original opam file\n";
+    (* Printf.eprintf "No original opam file\n"; *)
     let dependencies = t |> Dune_lang.Dune_package.depends |> Dependency_formula.of_dependencies in
     { name
     ; version
@@ -157,7 +157,7 @@ let of_package (t : Dune_lang.Package.t) =
     ; command_source = Assume_defaults
     }
   | None, Some o ->
-    Printf.eprintf "Yes original opam file\n";
+    (* Printf.eprintf "Yes original opam file\n"; *)
     let command_source =
       (* Opam_file *)
       (*   { build = opam_file |> OpamFile.OPAM.build *)

--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -288,5 +288,4 @@ let load_opam_file_with_contents ~contents:opam_file_string file name =
     ~synopsis:(get_one "synopsis")
     ~description:(get_one "description")
     ~tags:(Option.value (get_many "tags") ~default:[])
-  |> Dune_lang.Package.of_opam_package
 ;;

--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -285,7 +285,6 @@ let load_opam_file_with_contents ~contents:opam_file_string file name =
     ~info
     ~synopsis:(get_one "synopsis")
     ~description:(get_one "description")
-    ~has_opam_file:(Exists true)
     ~tags:(Option.value (get_many "tags") ~default:[])
     ~deprecated_package_names:Package_name.Map.empty
     ~sites:Dune_lang.Site.Map.empty

--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -271,7 +271,9 @@ let load_opam_file_with_contents ~contents:opam_file_string file name =
         (let+ url = get_one "dev-repo" in
          Dune_lang.Source_kind.Url url)
   in
-  Dune_lang.Package.create
+  let opam_file = read_from_string_exn ~contents:opam_file_string (Path.source file) in
+  let depends = opam_file |> OpamFile.OPAM.depends in
+  Dune_lang.Package.Opam_package.create
     ~name
     ~dir
     ~loc
@@ -280,14 +282,11 @@ let load_opam_file_with_contents ~contents:opam_file_string file name =
        |> Option.map ~f:Package_version.of_string_user_error
        >>| User_error.ok_exn)
     ~conflicts:[]
-    ~depends:[]
+    ~depends
     ~depopts:[]
     ~info
     ~synopsis:(get_one "synopsis")
     ~description:(get_one "description")
     ~tags:(Option.value (get_many "tags") ~default:[])
-    ~deprecated_package_names:Package_name.Map.empty
-    ~sites:Dune_lang.Site.Map.empty
-    ~allow_empty:true
-    ~original_opam_file:(Some { file; contents = opam_file_string })
+  |> Dune_lang.Package.of_opam_package
 ;;

--- a/src/dune_pkg/opam_file.mli
+++ b/src/dune_pkg/opam_file.mli
@@ -37,4 +37,4 @@ val load_opam_file_with_contents
   :  contents:string
   -> Path.Source.t
   -> Package_name.t
-  -> Dune_lang.Package.t
+  -> Dune_lang.Package.Opam_package.t

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -76,14 +76,15 @@ let load () =
       ~init:(Package.Name.Map.empty, Package.Name.Set.empty)
       ~f:(fun (acc_packages, vendored) (status, (project : Dune_project.t)) ->
         let packages = Dune_project.including_hidden_packages project in
-        let loaded_packages = Dune_lang.Package_name.Map.map packages ~f:(fun package ->
-          let has_opam_file = match Dune_project.generate_opam_files project with
-          (* TODO fix up this shit by checking for opam files *)
-          | true -> Dune_lang.Loaded_package.Generated
-          | false -> Dune_lang.Loaded_package.Exists false
-          in
-          Dune_lang.Loaded_package.create ~package ~has_opam_file
-        )
+        let loaded_packages =
+          Dune_lang.Package_name.Map.map packages ~f:(fun package ->
+            let has_opam_file =
+              match Dune_project.generate_opam_files project with
+              (* TODO fix up this shit by checking for opam files *)
+              | true -> Dune_lang.Loaded_package.Generated
+              | false -> Dune_lang.Loaded_package.Exists false
+            in
+            Dune_lang.Loaded_package.create ~package ~has_opam_file)
         in
         let vendored =
           match status with
@@ -97,17 +98,26 @@ let load () =
               [ Pp.textf
                   "The package %S is defined more than once:"
                   (Package.Name.to_string name)
-              ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc (Dune_lang.Loaded_package.package a)))
-              ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc (Dune_lang.Loaded_package.package b)))
+              ; Pp.textf
+                  "- %s"
+                  (Loc.to_file_colon_line
+                     (Package.loc (Dune_lang.Loaded_package.package a)))
+              ; Pp.textf
+                  "- %s"
+                  (Loc.to_file_colon_line
+                     (Package.loc (Dune_lang.Loaded_package.package b)))
               ])
         in
         acc_packages, vendored)
   in
-  let packages = Dune_lang.Package_name.Map.map loaded_packages ~f:Dune_lang.Loaded_package.package in
+  let packages =
+    Dune_lang.Package_name.Map.map loaded_packages ~f:Dune_lang.Loaded_package.package
+  in
   let mask = Only_packages.mask packages ~vendored:vendored_packages in
   let selected_packages = Only_packages.filter_packages mask packages in
-  let loaded_packages = Dune_lang.Package_name.Map.filteri loaded_packages ~f:(fun name _lpkg ->
-    Dune_lang.Package_name.Map.mem selected_packages name)
+  let loaded_packages =
+    Dune_lang.Package_name.Map.filteri loaded_packages ~f:(fun name _lpkg ->
+      Dune_lang.Package_name.Map.mem selected_packages name)
   in
   let projects = List.rev_map projects ~f:snd in
   let dune_files =

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -11,4 +11,5 @@ val find_project : dir:Path.Build.t -> Dune_project.t Memo.t
 val stanzas_in_dir : Path.Build.t -> Dune_file.t option Memo.t
 val mask : unit -> Only_packages.t Memo.t
 val packages : unit -> Package.t Package.Name.Map.t Memo.t
+val loaded_packages : unit -> Dune_lang.Loaded_package.t Package.Name.Map.t Memo.t
 val projects : unit -> Dune_project.t list Memo.t

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -983,7 +983,7 @@ let load_dune_project ~read ~dir opam_packages : t Memo.t =
   parse_contents
     lexbuf
     ~f:(fun lang ->
-      Printf.eprintf "Parsing again with lang\n";
+      (* Printf.eprintf "Parsing again with lang\n"; *)
       parse ~dir ~lang ~file)
     opam_packages
 ;;
@@ -992,13 +992,13 @@ let gen_load ~read ~dir ~files ~infer_from_opam_files : t option Memo.t =
   let open Memo.O in
   let opam_packages =
     Filename.Set.fold files ~init:[] ~f:(fun fn acc ->
-      Printf.eprintf "Folding over %s\n" fn;
+      (* Printf.eprintf "Folding over %s\n" fn; *)
       match Package.Name.of_opam_file_basename fn with
       | None ->
-        Printf.eprintf "No, it wasn't loaded\n";
+        (* Printf.eprintf "No, it wasn't loaded\n"; *)
         acc
       | Some name ->
-        Printf.eprintf "loaded %s\n" (Dune_lang.Package_name.to_string name);
+        (* Printf.eprintf "loaded %s\n" (Dune_lang.Package_name.to_string name); *)
         let opam_file = Path.Source.relative dir fn in
         let loc = Loc.in_file (Path.source opam_file) in
         let pkg =

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -102,6 +102,7 @@ include struct
   module Dune_project_name = Dune_project_name
   module Package = Package
   module Dialect = Dialect
+  module Package_id = Package_id
 end
 
 include Dune_engine.No_io

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -9,10 +9,11 @@ let install_file ~(package : Package.Name.t) ~findlib_toolchain =
 ;;
 
 module Package_paths = struct
-  let opam_file (ctx : Build_context.t) (pkg : Package.t) =
+  let opam_file (ctx : Build_context.t) (lpkg : Dune_lang.Loaded_package.t) =
+    let pkg = Dune_lang.Loaded_package.package lpkg in
     let opam_file = Package.opam_file pkg in
     let exists =
-      match Package.has_opam_file pkg with
+      match Dune_lang.Loaded_package.has_opam_file lpkg with
       | Exists b -> b
       | Generated -> true
     in
@@ -507,10 +508,11 @@ end = struct
   let stanzas_to_entries sctx =
     let ctx = Context.build_context (Super_context.context sctx) in
     let* stanzas = Dune_load.dune_files ctx.name in
-    let* packages = Dune_load.packages () in
+    let* loaded_packages = Dune_load.loaded_packages () in
     let+ init =
-      Package_map_traversals.parallel_map packages ~f:(fun _name (pkg : Package.t) ->
+      Package_map_traversals.parallel_map loaded_packages ~f:(fun _name (pkg : Dune_lang.Loaded_package.t) ->
         let opam_file = Package_paths.opam_file ctx pkg in
+        let pkg = Dune_lang.Loaded_package.package pkg in
         let init =
           let file section local_file dst =
             Install.Entry.make section local_file ~kind:`File ~dst

--- a/src/dune_rules/opam_create.mli
+++ b/src/dune_rules/opam_create.mli
@@ -7,7 +7,11 @@ val template_file : Path.t -> Path.t
 
 (** Generate the contents of an opam file. [template] is the filename and
     contents of the template file. *)
-val generate : Dune_project.t -> Package.t -> template:(Path.t * string) option -> string
+val generate
+  :  Dune_project.t
+  -> Dune_lang.Dune_package.t
+  -> template:(Path.t * string) option
+  -> string
 
 val gen_rules
   :  Super_context.t Memo.t


### PR DESCRIPTION
While working on the bug where we ignore dependencies from OPAM file if there is a `package` definition in the `dune-project` when locking, I ran across a weird behavior:

`Dune_lang.Package.t` contains a *lot* of fields which have very little to do with parsing a `package` stanza and is overloaded with tons of stuff that is either only relevant when the `Package.t` has been created from an OPAM file or read from a `dune-project` (as evident by the `encode`/`decode` functions which ignore a lot of fields and a lot of accessor functions where data is set after the `package` stanza has been decoded).

This also leads to the strange behavior that an OPAM file is read, a `Package.t` is created with mostly invalid/empty data, containing the original `opam` file content as an attachment. When we attempt to lock, we ignore all these invalid fields and parse the opam file again.

This seemed all a bit messy, so in this PR I'm trying to split this up a bit. I've moved the `Dune_lang.Package` to `Dune_lang.Dune_package` and created a new wrapper `Package` type that can be created from either `dune-project` or an `opam` file. I generally think that whatever `Package` is doing should probably be moved to `Dune_rules.Package` (and `Dune_lang.Dune_package` should become `Dune_lang.Package` again) but I first wanted to see how big the impact is on the testsuite. There is a bit of breakage but I am reasonably certain it can be fixed fairly easily.

But before polishing it up I'd like to ask whether this direction is something that makes sense or whether I am missing something crucial and whether it creates a lot of issues. @rgrinberg could you please comment whether the plan makes sense to you?