### PR TITLE
test: aliases field of user rules generates multiple actions

### DIFF
--- a/test/blackbox-tests/test-cases/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias-multiple.t
@@ -64,7 +64,6 @@ Updating the dune-project file to use dune 3.5 allows the build to succeed:
   $ dune build @a
   I have run
   $ dune build @b
-  I have run
 
 Also note having both the alias and aliases fields in the same rule stanza is
 not allowed
@@ -111,7 +110,6 @@ Building both aliases at the same time should only run the action once
 
   $ dune clean
   $ dune build @a @b
-  I have run
   I have run
 
 A similar test with a rule that produces a target

--- a/test/blackbox-tests/test-cases/alias-multiple.t
+++ b/test/blackbox-tests/test-cases/alias-multiple.t
@@ -101,3 +101,30 @@ Even if the aliases list is empty
   4 |  (action (echo "I have run")))
   Error: fields "alias" and "aliases" are mutually exclusive.
   [1]
+
+Building both aliases at the same time should only run the action once
+  $ cat > dune << EOF
+  > (rule
+  >  (aliases a b)
+  >  (action (echo "I have run\n")))
+  > EOF
+
+  $ dune clean
+  $ dune build @a @b
+  I have run
+  I have run
+
+A similar test with a rule that produces a target
+  $ cat > dune << EOF
+  > (rule
+  >  (targets a)
+  >  (aliases b c)
+  >  (action
+  >   (progn
+  >    (echo "I have run\n")
+  >    (with-stdout-to a (echo "foo")))))
+  > EOF
+
+  $ dune clean
+  $ dune build @b @c
+  I have run


### PR DESCRIPTION
In a similar vain to #11547 user defined rules were generating multiple actions which meant building both aliases at the same time was running the action twice. We fix this issue by making the other aliases rely on the first alias in the list. (This might be fragile lets see).

