### PR TITLE
feature: tests stanzas produce aliases

### DIFF
--- a/doc/changes/11558.md
+++ b/doc/changes/11558.md
@@ -1,0 +1,2 @@
+- `(tests)` stanzas now generate aliases with the test name. To run `(test (name a))` you
+  can do `dune build @a`. (#11558, grants part of #10239, @Alizter)

--- a/doc/reference/dune/test.rst
+++ b/doc/reference/dune/test.rst
@@ -27,8 +27,8 @@ can define two tests at once with:
     <optional fields>)
 
 This defines an executable named ``mytest.exe``. These tests can be run by
-building the aliases ``mytest`` and ``expect_test`` respectively. They will also
-be added to the ``runtest`` alias.
+building the aliases ``runtest-mytest`` and ``runtest-expect_test``
+respectively. They will also be added to the ``runtest`` alias.
 
 If the directory also contains an ``expect_test.expected`` file, then
 ``expect_test`` will be used to define an expect test. That is, the test will be

--- a/doc/reference/dune/test.rst
+++ b/doc/reference/dune/test.rst
@@ -26,11 +26,13 @@ can define two tests at once with:
     (names mytest expect_test)
     <optional fields>)
 
-This defines an executable named ``mytest.exe`` that will be executed as part of
-the ``runtest`` alias. If the directory also contains an
-``expect_test.expected`` file, then ``expect_test`` will be used to define an
-expect test. That is, the test will be executed and its output will be compared
-to ``expect_test.expected``.
+This defines an executable named ``mytest.exe``. These tests can be run by
+building the aliases ``mytest`` and ``expect_test`` respectively. They will also
+be added to the ``runtest`` alias.
+
+If the directory also contains an ``expect_test.expected`` file, then
+``expect_test`` will be used to define an expect test. That is, the test will be
+executed and its output will be compared to ``expect_test.expected``.
 
 The optional fields supported are a subset of the alias and executables fields.
 In particular, all fields except for ``public_names`` are supported from the

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -115,7 +115,7 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           in
           let add_alias =
             let expander = Expander.add_bindings expander ~bindings:extra_bindings in
-            let alias = Alias.make ~dir (Alias.Name.of_string s) in
+            let alias = Alias.make ~dir (Alias.Name.of_string ("runtest-" ^ s)) in
             fun ~loc ~action ->
               let action =
                 let chdir = Expander.dir expander in

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -1,10 +1,11 @@
 open Import
 open Memo.O
 
-let alias mode ~dir =
-  match mode with
-  | `js mode -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir ~mode
-  | `exe | `bc -> Memo.return Alias0.runtest
+let runtest_alias mode ~dir =
+  (match mode with
+   | `js mode -> Jsoo_rules.js_of_ocaml_runtest_alias ~dir ~mode
+   | `exe | `bc -> Memo.return Alias0.runtest)
+  >>| Alias.make ~dir
 ;;
 
 let test_kind dir_contents (loc, name, ext) =
@@ -68,8 +69,7 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
     | false ->
       let loc = Nonempty_list.hd t.exes.names |> fst in
       Memo.parallel_iter runtest_modes ~f:(fun mode ->
-        let* alias_name = alias mode ~dir in
-        let alias = Alias.make alias_name ~dir in
+        let* alias = runtest_alias mode ~dir in
         Simple_rules.Alias_rules.add_empty sctx ~loc ~alias)
     | true ->
       Nonempty_list.to_list t.exes.names
@@ -97,7 +97,7 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
             in
             Pform.Map.singleton test_pform [ Value.Path test_exe_path ]
           in
-          let* runtest_alias = alias runtest_mode ~dir in
+          let* runtest_alias = runtest_alias runtest_mode ~dir in
           let deps =
             (* is this useless? we are going to infer the dependency anyway *)
             match custom_runner with
@@ -115,6 +115,7 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           in
           let add_alias =
             let expander = Expander.add_bindings expander ~bindings:extra_bindings in
+            let alias = Alias.make ~dir (Alias.Name.of_string s) in
             fun ~loc ~action ->
               let action =
                 let chdir = Expander.dir expander in
@@ -127,10 +128,10 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
                   ~what:"aliases"
               in
               Simple_rules.interpret_and_add_locks ~expander t.locks action
-              |> Simple_rules.Alias_rules.add
-                   sctx
-                   ~loc
-                   ~alias:(Alias.make ~dir runtest_alias)
+              |> Simple_rules.Alias_rules.add sctx ~loc ~alias
+              >>> (Dep.alias alias
+                   |> Action_builder.dep
+                   |> Rules.Produce.Alias.add_deps runtest_alias)
           in
           match test_kind dir_contents (loc, s, ext) with
           | `Regular -> add_alias ~loc ~action:run_action

--- a/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
+++ b/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
@@ -1,0 +1,22 @@
+Tests stanzas produce aliases with the executable names
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.17)
+  > EOF
+
+  $ cat > dune << EOF
+  > (tests
+  >  (names a b))
+  > EOF
+
+  $ cat > a.ml << EOF
+  > let () = print_endline "a"
+  > EOF
+
+  $ cat > b.ml << EOF
+  > let () = print_endline "b"
+  > EOF
+
+  $ dune build @a @b
+  a
+  b

--- a/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
+++ b/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
@@ -17,7 +17,7 @@ Tests stanzas produce aliases with the executable names
   > let () = print_endline "b"
   > EOF
 
-  $ dune build @a @b
+  $ dune build @runtest-a @runtest-b
   a
   b
 

--- a/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
+++ b/test/blackbox-tests/test-cases/stanzas/tests/tests-stanza-alias.t
@@ -20,3 +20,19 @@ Tests stanzas produce aliases with the executable names
   $ dune build @a @b
   a
   b
+
+Checking interaction with enabled_if
+
+  $ cat > dune << EOF
+  > (tests
+  >  (names a b)
+  >  (enabled_if false))
+  > EOF
+
+  $ dune build @a @b
+  Error: Alias "a" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  Hint: did you mean all?
+  Error: Alias "b" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  [1]

--- a/test/blackbox-tests/test-cases/test-build-if/feature.t
+++ b/test/blackbox-tests/test-cases/test-build-if/feature.t
@@ -13,20 +13,34 @@ the test runs as part of @runtest
   >  (enabled_if %{env:ENABLED=false}))
   > EOF
 
-  $ touch t.ml
+  $ compiled_flag="t compiled"
+  $ ran_flag="t ran"
+
+  $ cat > t.ml <<EOF
+  > module T : sig
+  >   val message : string
+  >   [@@alert message "$compiled_flag"]
+  > end = struct
+  >   let message = "$ran_flag"
+  > end
+  > 
+  > let () =
+  >   Printf.printf "%s" T.message
+  > ;;
+  > EOF
 
 We test the various combinations:
 
   $ test_one () {
   >   dune clean
-  >   output=$( dune build "$1" --display short 2>&1 )
+  >   output=$( dune build "$1" 2>&1 )
   >   echo When building $1 with ENABLED=${ENABLED:-unset}:
-  >   if echo $output|grep -q ocamlopt ; then
+  >   if echo $output | grep -q "$compiled_flag" ; then
   >     echo '  build was done: YES'
   >   else
   >     echo '  build was done: NO'
   >   fi
-  >   if echo $output|grep -q "alias t" ; then
+  >   if echo $output | grep -q "$ran_flag" ; then
   >     echo '  test did run:   YES'
   >   else
   >     echo '  test did run:   NO'

--- a/test/blackbox-tests/test-cases/test-build-if/feature.t
+++ b/test/blackbox-tests/test-cases/test-build-if/feature.t
@@ -26,7 +26,7 @@ We test the various combinations:
   >   else
   >     echo '  build was done: NO'
   >   fi
-  >   if echo $output|grep -q "alias runtest" ; then
+  >   if echo $output|grep -q "alias t" ; then
   >     echo '  test did run:   YES'
   >   else
   >     echo '  test did run:   NO'


### PR DESCRIPTION
We add a way to run tests defined in `tests` stanzas by creating an alias with the same name. The basic idea is that:

```
(tests
 (names a b))
```

produces aliases `@a` and `@b` that can be run.

This addresses the other part of #10239 not addressed in #11109. 

- [x] changelog
- [x] docs
- [x] work out a way to do this for `(enabled_if false)`.
