### PR TITLE
dune-pkg: Better error messages on extract fail

### DIFF
--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -77,12 +77,13 @@ let extract t ~archive ~target =
   let prefix = Path.basename target in
   let suffix = Path.basename archive in
   let target_in_temp = Temp_dir.dir_for_target ~target ~prefix ~suffix in
+  let temp_stderr_path = Temp.create File ~prefix ~suffix:"stderr" in
   Fiber.finalize ~finally:(fun () ->
     Temp.destroy Dir target_in_temp;
+    Temp.destroy File temp_stderr_path;
     Fiber.return ())
   @@ fun () ->
   Path.mkdir_p target_in_temp;
-  let temp_stderr_path = Temp.create File ~prefix ~suffix:"stderr" in
   let stderr_to = Process.Io.file temp_stderr_path Out in
   let stdout_to = Process.Io.make_stdout ~output_on_success:Swallow ~output_limit in
   let args = command.make_args ~archive ~target_in_temp in

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -112,10 +112,12 @@ let extract t ~archive ~target =
       let stderr_lines = Io.input_lines err_channel in
       User_error.raise
         [ Pp.textf "failed to extract '%s'" (Path.basename archive)
-        ; Pp.textf
-            "Reason: %s failed with non-zero exit code '%d' and output:"
-            (Path.basename command.bin)
-            exit_code
+        ; Pp.concat
+            ~sep:Pp.space
+            [ Pp.text "Reason:"
+            ; User_message.command @@ Path.basename command.bin
+            ; Pp.textf "failed with non-zero exit code '%d' and output:" exit_code
+            ]
         ; Pp.enumerate stderr_lines ~f:Pp.text
         ])
 ;;

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -108,15 +108,14 @@ let extract t ~archive ~target =
     Path.rename target_in_temp target;
     Ok ())
   else
-    In_channel.with_open_text (Path.to_absolute_filename temp_stderr_path)
-    @@ fun err_channel ->
-    let stderr_lines = In_channel.input_lines err_channel in
-    User_error.raise
-      [ Pp.textf "failed to extract '%s'" (Path.basename archive)
-      ; Pp.textf
-          "Reason: %s failed with non-zero exit code '%d' and output:"
-          (Path.basename command.bin)
-          exit_code
-      ; Pp.enumerate stderr_lines ~f:Pp.text
-      ]
+    Io.with_file_in temp_stderr_path ~f:(fun err_channel ->
+      let stderr_lines = Io.input_lines err_channel in
+      User_error.raise
+        [ Pp.textf "failed to extract '%s'" (Path.basename archive)
+        ; Pp.textf
+            "Reason: %s failed with non-zero exit code '%d' and output:"
+            (Path.basename command.bin)
+            exit_code
+        ; Pp.enumerate stderr_lines ~f:Pp.text
+        ])
 ;;

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -59,11 +59,20 @@
 
 (cram
  (deps %{bin:tar})
- (applies_to source-caching tarball pin-depends extra-sources))
+ (applies_to
+  source-caching
+  tarball
+  pin-depends
+  extra-sources
+  pkg-extract-fail))
 
 (cram
  (deps %{bin:ocaml_index})
  (applies_to gh10985))
+
+(cram
+ (deps %{bin:unzip})
+ (applies_to pkg-extract-fail))
 
 ;; disabled for flakiness
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -14,10 +14,7 @@ build this package and check for sufficient error handling
   $ solve foo
   Solution for dune.lock:
   - foo.0.0.1
-
-  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
-  File "dune.lock/foo.pkg", line 6
-  6 |    file://PWD/corrupted.tar)))
+  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' 
   Error: failed to extract 'corrupted.tar'
   Reason: tar failed with non-zero exit code '2' and output:
   - /usr/bin/tar: This does not look like a tar archive
@@ -38,9 +35,7 @@ captured
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
-  File "dune.lock/foo.pkg", line 6
-  6 |    file://PWD/corrupted.tar.gz)))
+  $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' 
   Error: failed to extract 'corrupted.tar.gz'
   Reason: tar failed with non-zero exit code '2' and output:
   - /usr/bin/tar: This does not look like a tar archive
@@ -66,9 +61,7 @@ unzip error message a bit less clear
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
-  File "dune.lock/foo.pkg", line 6
-  6 |    file://PWD/corrupted.zip)))
+  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' 
   Error: failed to extract 'corrupted.zip'
   Reason: unzip failed with non-zero exit code '9' and output:
   -   End-of-central-directory signature not found.  Either this file is not
@@ -76,10 +69,10 @@ unzip error message a bit less clear
   -   latter case the central directory and zipfile comment will be found on
   -   the last disk(s) of this archive.
   - unzip:  cannot find zipfile directory in one of
-    PWD/corrupted.zip
+    $TESTCASE_ROOT/corrupted.zip
     or
   -        
-    PWD/corrupted.zip.zip,
+    $TESTCASE_ROOT/corrupted.zip.zip,
     and cannot find
-    PWD/corrupted.zip.ZIP,
+    $TESTCASE_ROOT/corrupted.zip.ZIP,
     period.

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -1,3 +1,6 @@
+Note that test output here is heavily sanitized due to tools using different
+exit codes and error messages, see #11560 for example output
+
 Create a mock package whose url is a corrupted/invalid tar file attempt to
 build this package and check for sufficient error handling
 
@@ -14,11 +17,9 @@ build this package and check for sufficient error handling
   $ solve foo
   Solution for dune.lock:
   - foo.0.0.1
-  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' 
+  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.tar'
-  Reason: tar failed with non-zero exit code '2' and output:
-  - /usr/bin/tar: This does not look like a tar archive
-  - /usr/bin/tar: Exiting with failure status due to previous errors
+  Reason: tar failed with non-zero exit code X and output:
 
 Repeat the same test as above but ensure that error output from gzip is
 captured
@@ -35,14 +36,9 @@ captured
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' 
+  $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.tar.gz'
-  Reason: tar failed with non-zero exit code '2' and output:
-  - /usr/bin/tar: This does not look like a tar archive
-  - 
-  - gzip: stdin: not in gzip format
-  - /usr/bin/tar: Child returned status 1
-  - /usr/bin/tar: Error is not recoverable: exiting now
+  Reason: tar failed with non-zero exit code X and output:
 
 Now try another local package but this time of zip format to test if stderr is
 captured from the unzip tool. Note that preprocessing with sed here makes the
@@ -61,18 +57,6 @@ unzip error message a bit less clear
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' 
+  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.zip'
-  Reason: unzip failed with non-zero exit code '9' and output:
-  -   End-of-central-directory signature not found.  Either this file is not
-  -   a zipfile, or it constitutes one disk of a multi-part archive.  In the
-  -   latter case the central directory and zipfile comment will be found on
-  -   the last disk(s) of this archive.
-  - unzip:  cannot find zipfile directory in one of
-    $TESTCASE_ROOT/corrupted.zip
-    or
-  -        
-    $TESTCASE_ROOT/corrupted.zip.zip,
-    and cannot find
-    $TESTCASE_ROOT/corrupted.zip.ZIP,
-    period.
+  Reason: unzip failed with non-zero exit code X and output:

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -17,9 +17,9 @@ build this package and check for sufficient error handling
   $ solve foo
   Solution for dune.lock:
   - foo.0.0.1
-  $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
+  $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.tar'
-  Reason: tar failed with non-zero exit code X and output:
+  Reason: 'tar' failed with non-zero exit code X and output:
 
 Repeat the same test as above but ensure that error output from gzip is
 captured
@@ -38,7 +38,7 @@ captured
 
   $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.tar.gz'
-  Reason: tar failed with non-zero exit code X and output:
+  Reason: 'tar' failed with non-zero exit code X and output:
 
 Now try another local package but this time of zip format to test if stderr is
 captured from the unzip tool. Note that preprocessing with sed here makes the
@@ -59,4 +59,4 @@ unzip error message a bit less clear
 
   $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.zip'
-  Reason: unzip failed with non-zero exit code X and output:
+  Reason: 'unzip' failed with non-zero exit code X and output:

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -26,7 +26,6 @@ build this package and check for sufficient error handling
 Repeat the same test as above but ensure that error output from gzip is
 captured
 
-  $ rm -rd dune.lock
   $ echo "corrupted tar.gz" > corrupted.tar.gz
 
   $ mkpkg foo <<EOF
@@ -49,3 +48,38 @@ captured
   - gzip: stdin: not in gzip format
   - /usr/bin/tar: Child returned status 1
   - /usr/bin/tar: Error is not recoverable: exiting now
+
+Now try another local package but this time of zip format to test if stderr is
+captured from the unzip tool. Note that preprocessing with sed here makes the
+unzip error message a bit less clear
+
+  $ echo "corrupted zip" > corrupted.zip
+
+  $ mkpkg foo <<EOF
+  > url {
+  >  src: "corrupted.zip"
+  > }
+  > EOF
+
+  $ add_mock_repo_if_needed
+  $ solve foo
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
+  File "dune.lock/foo.pkg", line 6
+  6 |    file://PWD/corrupted.zip)))
+  Error: failed to extract 'corrupted.zip'
+  Reason: unzip failed with non-zero exit code '9' and output:
+  -   End-of-central-directory signature not found.  Either this file is not
+  -   a zipfile, or it constitutes one disk of a multi-part archive.  In the
+  -   latter case the central directory and zipfile comment will be found on
+  -   the last disk(s) of this archive.
+  - unzip:  cannot find zipfile directory in one of
+    PWD/corrupted.zip
+    or
+  -        
+    PWD/corrupted.zip.zip,
+    and cannot find
+    PWD/corrupted.zip.ZIP,
+    period.

--- a/test/blackbox-tests/test-cases/pkg/tarball-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/tarball-extract-fail.t
@@ -1,0 +1,51 @@
+Create a mock package whose url is a corrupted/invalid tar file attempt to
+build this package and check for sufficient error handling
+
+  $ . ./helpers.sh
+  $ echo "corrupted tar" > corrupted.tar
+
+  $ mkpkg foo <<EOF
+  > url {
+  >  src: "corrupted.tar"
+  > }
+  > EOF
+
+  $ add_mock_repo_if_needed
+  $ solve foo
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
+  File "dune.lock/foo.pkg", line 6
+  6 |    file://PWD/corrupted.tar)))
+  Error: failed to extract 'corrupted.tar'
+  Reason: tar failed with non-zero exit code '2' and output:
+  - /usr/bin/tar: This does not look like a tar archive
+  - /usr/bin/tar: Exiting with failure status due to previous errors
+
+Repeat the same test as above but ensure that error output from gzip is
+captured
+
+  $ rm -rd dune.lock
+  $ echo "corrupted tar.gz" > corrupted.tar.gz
+
+  $ mkpkg foo <<EOF
+  > url {
+  >  src: "corrupted.tar.gz"
+  > }
+  > EOF
+
+  $ solve foo
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ build_pkg foo 2>&1 | sed "s#\^##g; s#$(pwd)#PWD#; s#, characters.*##" | awk 'NF'
+  File "dune.lock/foo.pkg", line 6
+  6 |    file://PWD/corrupted.tar.gz)))
+  Error: failed to extract 'corrupted.tar.gz'
+  Reason: tar failed with non-zero exit code '2' and output:
+  - /usr/bin/tar: This does not look like a tar archive
+  - 
+  - gzip: stdin: not in gzip format
+  - /usr/bin/tar: Child returned status 1
+  - /usr/bin/tar: Error is not recoverable: exiting now

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -36,9 +36,9 @@ Git
 
 HTTP
 
-  $ runtest "(fetch (url \"https://0.0.0.0:35000\"))" 2>&1 | sed -ne '/Error:/,$ p' | sed -e 's/".*"/"<PATH>"/'
-  Error:
-  failed to unpack archive downloaded from https://0.0.0.0:35000
-  reason:
-  unable to extract "<PATH>"
-  
+  $ runtest "(fetch (url \"https://0.0.0.0:35000\"))" 2>&1 | sed -ne '/Error:/,$ p' | sed "s#\.temp/[^/]*/download#.temp/TMP/download#g"
+  Error: failed to extract 'download'
+  Reason: tar failed with non-zero exit code '2' and output:
+  - /usr/bin/tar: _build/.temp/TMP/download: Cannot
+    open: No such file or directory
+  - /usr/bin/tar: Error is not recoverable: exiting now

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -36,9 +36,6 @@ Git
 
 HTTP
 
-  $ runtest "(fetch (url \"https://0.0.0.0:35000\"))" 2>&1 | sed -ne '/Error:/,$ p' | sed "s#\.temp/[^/]*/download#.temp/TMP/download#g"
+  $ runtest "(fetch (url \"https://0.0.0.0:35000\"))" 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'download'
-  Reason: tar failed with non-zero exit code '2' and output:
-  - /usr/bin/tar: _build/.temp/TMP/download: Cannot
-    open: No such file or directory
-  - /usr/bin/tar: Error is not recoverable: exiting now
+  Reason: tar failed with non-zero exit code X and output:

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -38,4 +38,4 @@ HTTP
 
   $ runtest "(fetch (url \"https://0.0.0.0:35000\"))" 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'download'
-  Reason: tar failed with non-zero exit code X and output:
+  Reason: 'tar' failed with non-zero exit code X and output:


### PR DESCRIPTION
This pull request is in reference to and would close #11549 *(as well as possibly other related issues)* by capturing the output of commands such as `tar`, `gzip`, and `unzip` when dune attempts to install a package and reporting a corresponding error message. The following is an example of the tool `tar` encountering a corrupted file:

```
File "dune.lock/foo.pkg", line 6, characters 3-136:
6 |    file:///DIR_NOT_INCLUDED_FOR_BREVITY/corrupted.tar)))
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Error: failed to extract 'corrupted.tar'
  Reason: tar failed with non-zero exit code '2' and output:
  - /usr/bin/tar: This does not look like a tar archive
  - /usr/bin/tar: Exiting with failure status due to previous errors
```
One note, relating to the original issue was that I was unable to test behavior when a corresponding tool did not exist on the system. If any guidance on how to check this case could be provided I would be more than willing to add additional handling and tests for this case :)