### PR TITLE
test: child process is not terminated by termination of dune exec -w

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -9,7 +9,7 @@
   ;; unreliable to depend on in a test so these tests are disabled on macos.
   ;; (<> "macosx" %{ocaml-config:system})
   ;; disabled until it works in CI
-  false))
+  true))
 
 (cram
  (deps wait-for-file.sh))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -49,3 +49,13 @@ Change the program so that it no longer terminates immediately.
 
 Prevent the test from leaking the dune process.
   $ kill $PID
+
+Checking for the child process
+  $ pgrep -c "foo.exe" || true
+  1
+
+Killing the child preocess manually
+  $ kill $(pidof ./_build/default/foo.exe)
+
+  $ pgrep -c "foo.exe" || true
+  0


### PR DESCRIPTION
Reproduction for #11089.