### PR TITLE
Alternative to #11437: warn, do not fail, if sandbox cannot be deleted

### DIFF
--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -317,7 +317,7 @@ let move_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Validated
 ;;
 
 let failed_to_delete_sandbox dir reason =
-  User_error.raise
+  User_warning.emit
     [ Pp.textf "failed to delete sandbox in %s" (Path.Build.to_string_maybe_quoted dir)
     ; Pp.text "Reason:"
     ; reason


### PR DESCRIPTION
An alternative to #11437: simply warn if the sandbox cannot be deleted, instead of failing.

Yet another possibility could be to warn and retry (as is done in #11437) the `Path.rm_rf` operation.

For discussion.