### PR TITLE
feat:Buildable stanza ocamldep_flags

### DIFF
--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -21,6 +21,14 @@ let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
     Ocaml_flags.with_vendored_flags ~ocaml_version flags
 ;;
 
+let ocamldep_flags t ~dir spec =
+  let* expander = Super_context.expander t ~dir in
+  let expanded_flags =
+    Expander.expand_and_eval_set expander spec ~standard:(Action_builder.return [])
+  in
+  Memo.return expanded_flags
+;;
+
 let gen_select_rules sctx ~dir compile_info =
   Lib.Compile.resolved_selects compile_info
   |> Resolve.Memo.read_memo

--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -46,3 +46,11 @@ val ocaml_flags
   -> dir:Path.Build.t
   -> Ocaml_flags.Spec.t
   -> Ocaml_flags.t Memo.t
+
+(** Compute the ocamldep flags based on the directory environment and a buildable
+    stanza *)
+val ocamldep_flags
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Ordered_set_lang.Unexpanded.t
+  -> string list Action_builder.t Memo.t

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -180,6 +180,7 @@ let gen_rules sctx t ~dir ~scope =
       ~requires_compile
       ~requires_link
       ~flags:(Ocaml_flags.of_list [ "-w"; "-24" ])
+      ~ocamldep_flags:Ocaml_flags.Ocamldep_flags.none
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None
       ~package:None

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -134,6 +134,7 @@ let create
       ~obj_dir
       ~modules
       ~flags
+      ~ocamldep_flags
       ~requires_compile
       ~requires_link
       ?(preprocessing = Pp_spec.dummy)
@@ -192,7 +193,7 @@ let create
     ; stdlib
     }
   in
-  let+ dep_graphs = Dep_rules.rules ocamldep_modules_data
+  let+ dep_graphs = Dep_rules.rules ocamldep_modules_data ~ocamldep_flags
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -25,6 +25,7 @@ val create
   -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
   -> flags:Ocaml_flags.t
+  -> ocamldep_flags:string list Action_builder.t
   -> requires_compile:Lib.t list Resolve.Memo.t
   -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
   -> ?preprocessing:Pp_spec.t

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -53,7 +53,7 @@ let ooi_deps
   read
 ;;
 
-let deps_of_module ({ modules; _ } as md) ~ml_kind m =
+let deps_of_module ({ modules; _ } as md) ~ml_kind ~ocamldep_flags m =
   match Module.kind m with
   | Wrapped_compat ->
     let interface_module =
@@ -63,7 +63,7 @@ let deps_of_module ({ modules; _ } as md) ~ml_kind m =
     in
     List.singleton interface_module |> Action_builder.return |> Memo.return
   | _ ->
-    let+ deps = Ocamldep.deps_of md ~ml_kind m in
+    let+ deps = Ocamldep.deps_of md m ~ml_kind ~ocamldep_flags in
     (match Modules.With_vlib.alias_for modules m with
      | [] -> deps
      | aliases ->
@@ -95,7 +95,7 @@ let deps_of_vlib_module ({ obj_dir; vimpl; dir; sctx; _ } as md) ~ml_kind source
     Ocamldep.read_deps_of ~obj_dir:vlib_obj_dir ~modules ~ml_kind m
 ;;
 
-let rec deps_of md ~ml_kind (m : Modules.Sourced_module.t) =
+let rec deps_of md ~ml_kind ~ocamldep_flags (m : Modules.Sourced_module.t) =
   let is_alias =
     match m with
     | Impl_of_virtual_module _ -> false
@@ -115,9 +115,9 @@ let rec deps_of md ~ml_kind (m : Modules.Sourced_module.t) =
     in
     match m with
     | Imported_from_vlib _ -> skip_if_source_absent (deps_of_vlib_module md ~ml_kind) m
-    | Normal m -> skip_if_source_absent (deps_of_module md ~ml_kind) m
+    | Normal m -> skip_if_source_absent (deps_of_module md ~ml_kind ~ocamldep_flags) m
     | Impl_of_virtual_module impl_or_vlib ->
-      deps_of md ~ml_kind
+      deps_of md ~ml_kind ~ocamldep_flags
       @@
       let m = Ml_kind.Dict.get impl_or_vlib ml_kind in
       (match ml_kind with
@@ -150,9 +150,11 @@ let dict_of_func_concurrently f =
   Ml_kind.Dict.make ~impl ~intf
 ;;
 
-let for_module md module_ = dict_of_func_concurrently (deps_of md (Normal module_))
+let for_module md ~ocamldep_flags module_ =
+  dict_of_func_concurrently (deps_of ~ocamldep_flags md (Normal module_))
+;;
 
-let rules md =
+let rules md ~ocamldep_flags =
   let modules = md.modules in
   match Modules.With_vlib.as_singleton modules with
   | Some m -> Memo.return (Dep_graph.Ml_kind.dummy m)
@@ -161,7 +163,7 @@ let rules md =
       let+ per_module =
         Modules.With_vlib.obj_map modules
         |> Module_name.Unique.Parallel_map.parallel_map ~f:(fun _obj_name m ->
-          deps_of md ~ml_kind m)
+          deps_of ~ml_kind ~ocamldep_flags md m)
       in
       Dep_graph.make ~dir:md.dir ~per_module)
 ;;

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -4,6 +4,7 @@ open Import
 
 val for_module
   :  Ocamldep.Modules_data.t
+  -> ocamldep_flags:string list Action_builder.t
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.t
 
@@ -14,4 +15,7 @@ val immediate_deps_of
   -> ml_kind:Ml_kind.t
   -> Module.t list Action_builder.t
 
-val rules : Ocamldep.Modules_data.t -> Dep_graph.t Ml_kind.Dict.t Memo.t
+val rules
+  :  Ocamldep.Modules_data.t
+  -> ocamldep_flags:string list Action_builder.t
+  -> Dep_graph.t Ml_kind.Dict.t Memo.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -176,6 +176,9 @@ let executables_rules
       ~jsoo_is_whole_program
   in
   let* flags = Buildable_rules.ocaml_flags sctx ~dir exes.buildable.flags in
+  let* ocamldep_flags =
+    Buildable_rules.ocamldep_flags sctx ~dir exes.buildable.ocamldep_flags
+  in
   let* modules, pp =
     let+ modules, pp =
       Buildable_rules.modules_rules
@@ -208,6 +211,7 @@ let executables_rules
       ~obj_dir
       ~modules
       ~flags
+      ~ocamldep_flags
       ~requires_link
       ~requires_compile
       ~preprocessing:pp

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -153,6 +153,7 @@ include Sub_system.Register_end_point (struct
           Buildable_rules.ocaml_flags sctx ~dir info.executable_ocaml_flags
         in
         let flags = Ocaml_flags.append_common ocaml_flags [ "-w"; "-24"; "-g" ] in
+        let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
         Compilation_context.create
           ()
           ~super_context:sctx
@@ -163,6 +164,7 @@ include Sub_system.Register_end_point (struct
           ~requires_compile:runner_libs
           ~requires_link:(Memo.lazy_ (fun () -> runner_libs))
           ~flags
+          ~ocamldep_flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
           ~melange_package_name:None
           ~package

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -497,6 +497,8 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
 
 let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_info =
   let* flags = Buildable_rules.ocaml_flags sctx ~dir lib.buildable.flags
+  and* ocamldep_flags =
+    Buildable_rules.ocamldep_flags sctx ~dir lib.buildable.ocamldep_flags
   and* vimpl = Virtual_rules.impl sctx ~lib ~scope in
   let obj_dir = Library.obj_dir ~dir lib in
   let* modules, pp =
@@ -539,6 +541,7 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_
     ~obj_dir
     ~modules
     ~flags
+    ~ocamldep_flags
     ~requires_compile
     ~requires_link
     ~preprocessing:pp

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -472,12 +472,14 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       |> Modules.With_vlib.singleton_exe
     in
     let flags = Ocaml_flags.default ~dune_version ~profile:Release in
+    let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
     Compilation_context.create
       ~super_context:sctx
       ~scope
       ~obj_dir
       ~modules
       ~flags
+      ~ocamldep_flags
       ~requires_compile
       ~requires_link
       ~opaque:(Explicit false)

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -307,6 +307,7 @@ let setup_emit_cmj_rules
     in
     let requires_link = Lib.Compile.requires_link compile_info in
     let* flags = melange_compile_flags ~sctx ~dir mel in
+    let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
     let* cctx =
       let direct_requires = Lib.Compile.direct_requires compile_info in
       Compilation_context.create
@@ -317,6 +318,7 @@ let setup_emit_cmj_rules
         ~obj_dir
         ~modules
         ~flags
+        ~ocamldep_flags
         ~requires_link
         ~requires_compile:direct_requires
         ~preprocessing:pp

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -274,7 +274,10 @@ module Run (P : PARAMS) = struct
       |> Compilation_context.without_bin_annot
     in
     let* deps =
-      Dep_rules.for_module (Compilation_context.ocamldep_modules_data cctx) mock_module
+      Dep_rules.for_module
+        (Compilation_context.ocamldep_modules_data cctx)
+        ~ocamldep_flags:Ocaml_flags.Ocamldep_flags.none
+        mock_module
     in
     let* () =
       Module_compilation.ocamlc_i ~deps cctx mock_module ~output:(inferred_mli base)

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -193,3 +193,7 @@ let allow_only_melange t =
 let open_flags modules =
   List.concat_map modules ~f:(fun name -> [ "-open"; Module_name.to_string name ])
 ;;
+
+module Ocamldep_flags = struct
+  let none = Action_builder.return []
+end

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -36,3 +36,8 @@ val with_vendored_alerts : t -> t
 val dump : t -> Dune_lang.t list Action_builder.t
 val with_vendored_flags : t -> ocaml_version:Version.t -> t
 val open_flags : Module_name.t list -> string list
+
+module Ocamldep_flags : sig
+  (** Returns a [string list Action_builder.t] with no flags. *)
+  val none : string list Action_builder.t
+end

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -127,6 +127,7 @@ let transitive_deps =
 let deps_of
       ({ sandbox; modules; sctx; dir; obj_dir; vimpl = _; stdlib = _ } as md)
       ~ml_kind
+      ~ocamldep_flags
       unit
   =
   let source = Option.value_exn (Module.source unit ~ml_kind) in
@@ -151,7 +152,8 @@ let deps_of
          ocamldep
          ~dir:(Path.build (Context.build_dir context))
          ~stdout_to:ocamldep_output
-         [ A "-modules"
+         [ Command.Args.dyn ocamldep_flags
+         ; A "-modules"
          ; Command.Args.dyn flags
          ; Command.Ml_kind.flag ml_kind
          ; Dep (Module.File.path source)

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -22,6 +22,7 @@ end
 val deps_of
   :  Modules_data.t
   -> ml_kind:Ml_kind.t
+  -> ocamldep_flags:string list Action_builder.t
   -> Module.t
   -> Module.t list Action_builder.t Memo.t
 

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -313,6 +313,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
     let requires_compile = Resolve.map driver_and_libs ~f:snd in
     let requires_link = Memo.lazy_ (fun () -> Memo.return requires_compile) in
     let flags = Ocaml_flags.of_list [ "-g"; "-w"; "-24" ] in
+    let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
     let opaque = Compilation_context.Explicit false in
     let modules = Modules.With_vlib.singleton_exe module_ in
     Compilation_context.create
@@ -321,6 +322,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
       ~obj_dir
       ~modules
       ~flags
+      ~ocamldep_flags
       ~requires_compile:(Memo.return requires_compile)
       ~requires_link
       ~opaque

--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -17,6 +17,7 @@ type t =
   ; preprocessor_deps : Dep_conf.t list
   ; lint : Preprocess.Without_instrumentation.t Preprocess.Per_module.t
   ; flags : Ocaml_flags.Spec.t
+  ; ocamldep_flags : Ordered_set_lang.Unexpanded.t
   ; js_of_ocaml : Js_of_ocaml.In_buildable.t Js_of_ocaml.Mode.Pair.t
   ; allow_overlapping_dependencies : bool
   ; ctypes : Ctypes_field.t option
@@ -87,6 +88,10 @@ let decode (for_ : for_) =
   and+ libraries =
     field "libraries" (Lib_dep.L.decode ~allow_re_export:in_library) ~default:[]
   and+ flags = Ocaml_flags.Spec.decode
+  and+ ocamldep_flags_opt =
+    field_o
+      "ocamldep_flags"
+      (Dune_lang.Syntax.since Stanza.syntax (3, 18) >>> Ordered_set_lang.Unexpanded.decode)
   and+ js_of_ocaml =
     field
       "js_of_ocaml"
@@ -109,6 +114,9 @@ let decode (for_ : for_) =
     field_b
       "empty_module_interface_if_absent"
       ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
+  in
+  let ocamldep_flags =
+    Option.value ~default:Ordered_set_lang.Unexpanded.standard ocamldep_flags_opt
   in
   let preprocess =
     let init =
@@ -169,6 +177,7 @@ let decode (for_ : for_) =
   ; extra_objects
   ; libraries
   ; flags
+  ; ocamldep_flags
   ; js_of_ocaml = { js = js_of_ocaml; wasm = wasm_of_ocaml }
   ; allow_overlapping_dependencies
   ; ctypes

--- a/src/dune_rules/stanzas/buildable.mli
+++ b/src/dune_rules/stanzas/buildable.mli
@@ -16,6 +16,7 @@ type t =
   ; preprocessor_deps : Dep_conf.t list
   ; lint : Lint.t
   ; flags : Ocaml_flags.Spec.t
+  ; ocamldep_flags : Ordered_set_lang.Unexpanded.t
   ; js_of_ocaml : Js_of_ocaml.In_buildable.t Js_of_ocaml.Mode.Pair.t
   ; allow_overlapping_dependencies : bool
   ; ctypes : Ctypes_field.t option

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -222,6 +222,7 @@ module Stanza = struct
         (Ocaml_flags.default ~dune_version ~profile)
         [ "-w"; "-24" ]
     in
+    let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
     let* modules = Source.modules source preprocessing in
     let* cctx =
       Compilation_context.create
@@ -234,6 +235,7 @@ module Stanza = struct
         ~requires_compile
         ~requires_link
         ~flags
+        ~ocamldep_flags
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None
         ~package:None

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -174,6 +174,7 @@ let setup sctx ~dir =
     let profile = Super_context.context sctx |> Context.profile in
     Ocaml_flags.append_common (Ocaml_flags.default ~dune_version ~profile) [ "-w"; "-24" ]
   in
+  let ocamldep_flags = Ocaml_flags.Ocamldep_flags.none in
   let* cctx =
     let requires_link = Memo.lazy_ (fun () -> requires) in
     Compilation_context.create
@@ -186,6 +187,7 @@ let setup sctx ~dir =
       ~requires_link
       ~requires_compile:requires
       ~flags
+      ~ocamldep_flags
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None
       ~package:None


### PR DESCRIPTION
This PR in a work in progress but addresses issue #11419.

As I have never contributed to Dune before I'd like some feedback on my implementation and any changes which could be made to make my contribution fit better into the Dune code base :).

I'll add to the documentation and push it to my branch as well before this is ready to be merged.

Right now `ocamldep_flags` is only supported in buildable stanzas as that made the most sense to me and I implemented the flag parsing by reusing the functionality used by `ocamlc_flags` and `ocamlopt_flags`.

The additions didn't feel enough to warrant thir own file and implementing it alongside the flags for ocamlc, ocamlopt and melange (in the `Ocaml_flags.t`) felt like adding a lot of bloat to those functions to support this which currently doesn't need all of that functionality. Hence I added `Ocaml_flags.Ocamldep_flags`.