### PR TITLE
Fix handling of missing optional directories in findlib

### DIFF
--- a/src/fs/fs.ml
+++ b/src/fs/fs.ml
@@ -16,8 +16,9 @@ let dir_contents (dir : Path.t) =
     >>| Result.map ~f:(fun contents ->
       Fs_cache.Dir_contents.to_list contents |> List.map ~f:fst)
   | `Inside _ ->
-    let* () = Build_system.build_dir dir in
-    Memo.return (Path.readdir_unsorted dir)
+    let* already_exists = Build_system.file_exists dir in
+    let+ () = if already_exists then Build_system.build_dir dir else Memo.return () in
+    Path.readdir_unsorted dir
 ;;
 
 let exists path kind =

--- a/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
+++ b/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
@@ -7,18 +7,27 @@ Reproduces #11405
   $ mkdir external_sources
 
   $ cat >external_sources/META <<EOF
-  > package "sub" (
-  >   directory = "sub"
+  > package "yes" (
+  >   directory = "yes"
   >   version = "0.0.1"
-  >   exists_if = "sub.cma"
+  >   exists_if = "yes.cma"
+  > )
+  > package "no" (
+  >   directory = "no"
+  >   version = "0.0.1"
+  >   exists_if = "no.cma"
   > )
   > EOF
 
   $ cat >external_sources/mypkg.install <<EOF
   > lib: [
   >  "META"
+  >  "yes/yes.cma" {"yes/yes.cma"}
   > ]
   > EOF
+
+  $ mkdir external_sources/yes
+  $ touch external_sources/yes/yes.cma
 
   $ cat >dune-project <<EOF
   > (lang dune 3.17)
@@ -35,14 +44,30 @@ Reproduces #11405
   > (source (copy $PWD/external_sources))
   > EOF
 
+  $ touch foo.ml
+
   $ cat >dune <<EOF
   > (executable
-  >  (libraries mypkg.sub)
+  >  (libraries mypkg.yes)
   >  (name foo))
   > EOF
 
   $ dune build foo.exe
   Error: This rule defines a directory target "default/.pkg/mypkg/target" that
-  matches the requested path "default/.pkg/mypkg/target/lib/mypkg/sub" but the
+  matches the requested path "default/.pkg/mypkg/target/lib/mypkg/no" but the
+  rule's action didn't produce it
+  [1]
+
+No difference between below and above even though 'yes' actually exists.
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (libraries mypkg.no)
+  >  (name foo))
+  > EOF
+
+  $ dune build foo.exe
+  Error: This rule defines a directory target "default/.pkg/mypkg/target" that
+  matches the requested path "default/.pkg/mypkg/target/lib/mypkg/no" but the
   rule's action didn't produce it
   [1]

--- a/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
+++ b/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
@@ -52,13 +52,8 @@ Reproduces #11405
   >  (name foo))
   > EOF
 
+No errors here as 'yes' actually exists
   $ dune build foo.exe
-  Error: This rule defines a directory target "default/.pkg/mypkg/target" that
-  matches the requested path "default/.pkg/mypkg/target/lib/mypkg/no" but the
-  rule's action didn't produce it
-  [1]
-
-No difference between below and above even though 'yes' actually exists.
 
   $ cat >dune <<EOF
   > (executable
@@ -66,8 +61,15 @@ No difference between below and above even though 'yes' actually exists.
   >  (name foo))
   > EOF
 
+Clearer error here as we really depend on non-existing 'no'
   $ dune build foo.exe
-  Error: This rule defines a directory target "default/.pkg/mypkg/target" that
-  matches the requested path "default/.pkg/mypkg/target/lib/mypkg/no" but the
-  rule's action didn't produce it
+  File "dune", line 2, characters 12-20:
+  2 |  (libraries mypkg.no)
+                  ^^^^^^^^
+  Error: Library "mypkg.no" in
+  _build/_private/default/.pkg/mypkg/target/lib/mypkg/no is hidden (unsatisfied
+  'exists_if').
+  -> required by _build/default/.foo.eobjs/byte/dune__exe__Foo.cmi
+  -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
+  -> required by _build/default/foo.exe
   [1]


### PR DESCRIPTION
Fixes #11405.
The first commit is a clarification of the test case, the second is the fix.

The problem wasn't easy to pin down, but actually simple to fix: the function `dir_contents` didn't check that the directory actually existed and crashed. It now checks for existence beforehand.

Found with the help of the cool @art-w :sunglasses: