### PR TITLE
nix: fix flake warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     melange = {
       url = "github:melange-re/melange/refs/tags/5.0.0-52";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
     };
     ocaml-overlays = {
       url = "github:nix-ocaml/nix-overlays";


### PR DESCRIPTION
`melange` no longer has inpupt `flake-utils` so nix was spitting out a warning. This fixes that warning by removing that follow.