### PR TITLE
nix: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739019272,
-        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
+        "lastModified": 1743076231,
+        "narHash": "sha256-yQugdVfi316qUfqzN8JMaA2vixl+45GxNm4oUfXlbgw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
+        "rev": "6c5963357f3c1c840201eda129a99d455074db04",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738777743,
-        "narHash": "sha256-l2eEAvqeBcpIRf75GyTasMZdSpP1wcJzGDdHZuUpa3U=",
+        "lastModified": 1742787740,
+        "narHash": "sha256-6q1v+TN+xFYr/+OgQxZ2fiPmnxatzlDGwjMJZiI4kag=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "578dae4718747c751e5f39fa7d155f35d9e0775c",
+        "rev": "dbe213c8d7b52b0995c549fc7a2123fef3af85d6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,14 @@
         [ file mercurial ]
         ++ lib.optionals stdenv.isLinux [ strace ];
       testNativeBuildInputs = with pkgs; [ nodejs-slim pkg-config opam ocamlformat ];
+      
+      docInputs = with pkgs.python3.pkgs; [
+        sphinx-autobuild
+        furo
+        sphinx-copybutton
+        sphinx-design
+        myst-parser
+      ];
     in
     {
       formatter = pkgs.nixpkgs-fmt;
@@ -124,14 +132,8 @@
                 else pkgs;
 
               inherit (pkgs') writeScriptBin stdenv;
+              inherit docInputs;
 
-              docInputs = with pkgs'.python3.pkgs; [
-                sphinx-autobuild
-                furo
-                sphinx-copybutton
-                sphinx-design
-                myst-parser
-              ];
               duneScript =
                 writeScriptBin "dune" ''
                   #!${stdenv.shell}
@@ -166,17 +168,7 @@
         {
           doc =
             pkgs.mkShell {
-              buildInputs = (with pkgs;
-                let pythonPackages = python311Packages; in
-                [
-                  sphinx
-                  sphinx-autobuild
-                  pythonPackages.sphinx-copybutton
-                  pythonPackages.furo
-                  pythonPackages.sphinx-design
-                  pythonPackages.myst-parser
-                ]
-              );
+              buildInputs = docInputs;
               meta.description = ''
                 Provides a shell environment suitable for building the Dune
                 documentation website (e.g. `make doc`).

--- a/flake.nix
+++ b/flake.nix
@@ -167,13 +167,14 @@
           doc =
             pkgs.mkShell {
               buildInputs = (with pkgs;
+                let pythonPackages = python310Packages; in
                 [
                   sphinx
                   sphinx-autobuild
-                  python310Packages.sphinx-copybutton
-                  python310Packages.furo
-                  python310Packages.sphinx-design
-                  python310Packages.myst-parser
+                  pythonPackages.sphinx-copybutton
+                  pythonPackages.furo
+                  pythonPackages.sphinx-design
+                  pythonPackages.myst-parser
                 ]
               );
               meta.description = ''

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,7 @@
           doc =
             pkgs.mkShell {
               buildInputs = (with pkgs;
-                let pythonPackages = python310Packages; in
+                let pythonPackages = python311Packages; in
                 [
                   sphinx
                   sphinx-autobuild


### PR DESCRIPTION
In this PR we update the nix flake. This requires python 3.11 due to a newer version of Sphinx, so we consolidate the python packages required for documentation and the `.#doc` flake output.

- [ ] `nix develop` tested locally.
- [x] `nix develop .#doc` test locally.
- [x] `nix flake check`