### PR TITLE
feat:Buildable stanza keywords

### DIFF
--- a/doc/concepts/ocaml-flags.rst
+++ b/doc/concepts/ocaml-flags.rst
@@ -20,3 +20,16 @@ follows:
 .. code:: dune
 
     (flags (:standard <my options>))
+
+If you would like to set the ``-keywords`` flag for Ocaml 5.3 and above,
+you can do so using the ``(keywords)`` field which is available in the
+same stanzas as the other Ocaml flags. You can set this field in the
+following ways:
+
+- ``(keywords (version <major>.<minor>))`` to set the Ocaml version to use
+  keywords from, e.g. ``(keywords (version 5.3))``.
+- ``(keywords (extra <keyword1> <keyword2>))`` to add extra keywords to the
+  currently in use Ocaml version, e.g. ``(keywords (extra atomic))``.
+- ``(keywords (version <major>.<minor>) (extra <keyword1> <keyword2>))``
+  to use the keywords from a specific version and add some extra keywords,
+  e.g. ``(keywords (version 5.2) (extra effect))``.

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -10,6 +10,7 @@ let ocaml_flags t ~dir (spec : Ocaml_flags.Spec.t) =
       ~default:ocaml_flags
       ~eval:(Expander.expand_and_eval_set expander)
   in
+  let flags = Ocaml_flags.with_keywords flags in
   Source_tree.is_vendored (Path.Build.drop_build_context_exn dir)
   >>= function
   | false -> Memo.return flags

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -192,7 +192,7 @@ let create
     ; stdlib
     }
   in
-  let+ dep_graphs = Dep_rules.rules ocamldep_modules_data
+  let+ dep_graphs = Dep_rules.rules ~flags ocamldep_modules_data
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -5,6 +5,7 @@ open Import
 val for_module
   :  Ocamldep.Modules_data.t
   -> Module.t
+  -> flags:Ocaml_flags.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.t
 
 val immediate_deps_of
@@ -14,4 +15,7 @@ val immediate_deps_of
   -> ml_kind:Ml_kind.t
   -> Module.t list Action_builder.t
 
-val rules : Ocamldep.Modules_data.t -> Dep_graph.t Ml_kind.Dict.t Memo.t
+val rules
+  :  Ocamldep.Modules_data.t
+  -> flags:Ocaml_flags.t
+  -> Dep_graph.t Ml_kind.Dict.t Memo.t

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -263,7 +263,10 @@ let add_deps_to_aliases ?(alias = Melange_stanzas.Emit.implicit_alias) ~dir deps
 
 let melange_compile_flags ~sctx ~dir (mel : Melange_stanzas.Emit.t) =
   let specific = Lib_mode.Map.make_all mel.compile_flags in
-  Ocaml_flags.Spec.make ~common:Ordered_set_lang.Unexpanded.standard ~specific
+  Ocaml_flags.Spec.make
+    ~common:Ordered_set_lang.Unexpanded.standard
+    ~keywords:Ocaml_flags.Keywords.empty
+    ~specific
   |> Ocaml_flags_db.ocaml_flags sctx ~dir
   >>| Ocaml_flags.allow_only_melange
 ;;

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -274,7 +274,10 @@ module Run (P : PARAMS) = struct
       |> Compilation_context.without_bin_annot
     in
     let* deps =
-      Dep_rules.for_module (Compilation_context.ocamldep_modules_data cctx) mock_module
+      Dep_rules.for_module
+        ~flags:Ocaml_flags.empty
+        (Compilation_context.ocamldep_modules_data cctx)
+        mock_module
     in
     let* () =
       Module_compilation.ocamlc_i ~deps cctx mock_module ~output:(inferred_mli base)

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -4,6 +4,13 @@ open! Import
 
 type t
 
+module Keywords : sig
+  val empty : string option * string list
+  val standard : string option * string list
+  val equal : string option * string list -> string option * string list -> bool
+  val to_string_list : t -> string list
+end
+
 module Spec : sig
   type t
 
@@ -13,6 +20,7 @@ module Spec : sig
 
   val make
     :  common:Ordered_set_lang.Unexpanded.t
+    -> keywords:string option * string list
     -> specific:Ordered_set_lang.Unexpanded.t Lib_mode.Map.t
     -> t
 end
@@ -36,3 +44,4 @@ val with_vendored_alerts : t -> t
 val dump : t -> Dune_lang.t list Action_builder.t
 val with_vendored_flags : t -> ocaml_version:Version.t -> t
 val open_flags : Module_name.t list -> string list
+val with_keywords : t -> t

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -127,6 +127,7 @@ let transitive_deps =
 let deps_of
       ({ sandbox; modules; sctx; dir; obj_dir; vimpl = _; stdlib = _ } as md)
       ~ml_kind
+      ~ocamlflags
       unit
   =
   let source = Option.value_exn (Module.source unit ~ml_kind) in
@@ -147,11 +148,15 @@ let deps_of
        let flags, sandbox =
          Module.pp_flags unit |> Option.value ~default:(Action_builder.return [], sandbox)
        in
+       let keywords =
+         Ocaml_flags.Keywords.to_string_list ocamlflags |> Action_builder.return
+       in
        Command.run_dyn_prog
          ocamldep
          ~dir:(Path.build (Context.build_dir context))
          ~stdout_to:ocamldep_output
-         [ A "-modules"
+         [ Command.Args.dyn keywords
+         ; A "-modules"
          ; Command.Args.dyn flags
          ; Command.Ml_kind.flag ml_kind
          ; Dep (Module.File.path source)

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -22,6 +22,7 @@ end
 val deps_of
   :  Modules_data.t
   -> ml_kind:Ml_kind.t
+  -> ocamlflags:Ocaml_flags.t
   -> Module.t
   -> Module.t list Action_builder.t Memo.t
 


### PR DESCRIPTION
# TLDR
This pull request aims to solve #11419 and is updated based on feedback I got in #11567 .

## TODO
What is left to be done on this PR beyond any review changes is that I will need to add some tests and add memoization to the keywords. Both of which I'm unsure how to do properly so I'd like some assistance as to where I should add the tests and guidance on how to implement memoziation for the keywords.

## Details
The PR adds a `keywords` field to buildable stanzas which is a `(string option, string list)` much like the `-keywords` flag for `ocamlc`, `ocamlopt` and `ocamldep`. The way it is used in the dune file is e.g. `(library ... (keywords (version 5.2) (extra effect))` which will pass the flag `-keywords 5.2+effect`.

The storing of the keywords is done in the `Ocaml_flags.t` as a member `keywords` which is a `(string option, string list)`. I added a submodule `Keywords` to `ocaml_flags.ml` which contains some helper functions and should make code more readable in other files as the path is `Ocaml_flags.Keywords.func`.

I didn't add a Keywords.t to ideally make the code less abstracted which is something I think I read in hacking.rst.

The added field has been set to only be supported in Dune stanza syntax version 3.18.

I also added some documentation for the field alongside the currently existing documentation for Ocaml flags.

As I have never contributed to Dune before I'm unsure if I have done things the most idiomatic way but am happy to revise my solution to make it better.