### PR TITLE
pkg: remove broken symlinks from package sources

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -194,8 +194,8 @@ let rm_rf fn =
   | _ -> unlink_exn fn
 ;;
 
-let traverse =
-  let rec loop on_file on_dir on_broken_symlink root stack acc =
+let traverse ~dir ~init ~on_file ~on_dir ~on_broken_symlink =
+  let rec loop root stack acc =
     match stack with
     | [] -> acc
     | dir :: dirs ->
@@ -218,10 +218,9 @@ let traverse =
                 | _ -> stack, acc)
              | _ -> stack, acc)
          in
-         loop on_file on_dir on_broken_symlink root stack acc)
+         loop root stack acc)
   in
-  fun ~dir ~init ~on_file ~on_dir ~on_broken_symlink ->
-    loop on_file on_dir on_broken_symlink dir [ "" ] init
+  loop dir [ "" ] init
 ;;
 
 let traverse_files ~dir ~init ~f =

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -57,6 +57,7 @@ val traverse
   -> init:'acc
   -> on_file:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> on_dir:(dir:string -> Filename.t -> 'acc -> 'acc)
+  -> on_broken_symlink:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> 'acc
 
 val traverse_files
@@ -64,3 +65,8 @@ val traverse_files
   -> init:'acc
   -> f:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> 'acc
+
+(** [is_broken_simlink path] returns [true] iff [path] refers to a symlink
+    whose target does not exist.  Returns false if [path] is not a symlink, or
+    is a symlink whose target exists. *)
+val is_broken_symlink : string -> bool

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -496,6 +496,7 @@ module External : sig
   val as_local : t -> string
   val append_local : t -> Local.t -> t
   val of_filename_relative_to_initial_cwd : string -> t
+  val is_broken_symlink : t -> bool
 end = struct
   module Table = String.Table
 
@@ -570,6 +571,8 @@ end = struct
   let of_filename_relative_to_initial_cwd fn =
     if Filename.is_relative fn then relative initial_cwd fn else of_string fn
   ;;
+
+  let is_broken_symlink = Fpath.is_broken_symlink
 
   include (
     Comparator.Operators (struct
@@ -1467,6 +1470,14 @@ let drop_prefix_exn t ~prefix =
   | None ->
     Code_error.raise "Path.drop_prefix_exn" [ "t", to_dyn t; "prefix", to_dyn prefix ]
   | Some p -> p
+;;
+
+let is_broken_symlink = function
+  | External e -> External.is_broken_symlink e
+  | In_source_tree _ | In_build_dir _ ->
+    (* Paths within the source tree and build dir are always fully-expanded,
+       so there's no possibility for them to be broken symlinks. *)
+    false
 ;;
 
 module Expert = struct

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -434,6 +434,7 @@ val drop_prefix_exn : t -> prefix:t -> Local.t
 val drop_prefix : t -> prefix:t -> Local.t option
 
 val make_local_path : Local.t -> t
+val is_broken_symlink : t -> bool
 
 module Expert : sig
   (** Attempt to convert external paths to source/build paths. Don't use this

--- a/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
@@ -1,0 +1,77 @@
+Test that dune can handle the case where a dependency's source contains a
+symlink with a missing destination.
+
+  $ . ./helpers.sh
+
+Define a package foo containing a broken symlink.
+  $ mkdir foo
+  $ touch foo/a.txt
+  $ ln -s non_existent foo/b.txt
+
+Define a package bar containing a broken symlink.
+  $ mkdir bar
+  $ touch bar/a.txt
+  $ ln -s non_existent bar/b.txt
+  $ tar czf bar.tar.gz bar
+
+Make a directory to contain a test project and change to it.
+  $ mkdir project
+  $ cd project
+
+Create a lockdir for the project.
+  $ mkdir dune.lock
+  $ cat > dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+
+The package "foo" exercises copying package sources from a local directory.
+  $ cat > dune.lock/foo.pkg <<EOF
+  > (version 0.0.1)
+  > (source
+  >  (fetch
+  >   (url
+  >    file:///$PWD/../foo)))
+  > EOF
+
+The package "bar" exercises extracting a source archive from a local file.
+  $ cat > dune.lock/bar.pkg <<EOF
+  > (version 0.0.1)
+  > (source
+  >  (fetch
+  >   (url
+  >    file:///$PWD/../bar.tar.gz)))
+  > EOF
+
+The package "bar" exercises extracting a source archive from a downloaded file.
+  $ cat > dune.lock/baz.pkg <<EOF
+  > (version 0.0.1)
+  > (source
+  >  (fetch
+  >   (url http://0.0.0.0:1)
+  >   (checksum md5=$(md5sum $PWD/../bar.tar.gz | cut -f1 -d' '))))
+  > EOF
+
+Set up a fake web server to serve the source archive for the package "bar".
+  $ echo $PWD/../bar.tar.gz >> fake-curls
+
+Make a project file that depends on all the packages.
+  $ cat > dune-project <<EOF
+  > (lang dune 3.17)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo bar baz))
+  > EOF
+
+Build the packages.
+  $ build_pkg foo
+  $ build_pkg bar
+  $ build_pkg baz
+
+All files were copied except for the broken symlinks:
+  $ ls _build/_private/default/.pkg/foo/source
+  a.txt
+  $ ls _build/_private/default/.pkg/bar/source
+  a.txt
+  $ ls _build/_private/default/.pkg/baz/source
+  a.txt

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -47,7 +47,8 @@
   source-caching
   tarball
   pin-depends
-  extra-sources))
+  extra-sources
+  broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:md5sum})
@@ -55,7 +56,8 @@
   source-caching
   extra-sources
   ocamlformat-dev-tool
-  dev-tool-conflict-test))
+  dev-tool-conflict-test
+  broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:tar})
@@ -64,7 +66,8 @@
   tarball
   pin-depends
   extra-sources
-  pkg-extract-fail))
+  pkg-extract-fail
+  broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:ocaml_index})


### PR DESCRIPTION
Dune cannot handle symlinks with missing targets. Package source archives may contain such broken symlinks. This can be due to packaging errors on the part of the package author which are benign to the correct operation of the package when installed with opam, but render packages uninstallable with dune.

It's assumed that all opam packages can be installed with opam, so if a package contains a broken symlink then the symlink must not be necessary for the correct operation of the package. Thus the fix is to remove broken symlinks from extracted source archives, and to avoid copying broken symlinks from local package source directories.

A less conservative approach than this might attempt to allow dune to handle broken symlinks in general, but this would be a much larger change, and has been attempted and abandoned several times before.