### PR TITLE
chore(mirage): bump to setup-ocaml@v3

### DIFF
--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -14,7 +14,7 @@ jobs:
         repository: roburio/caldav
         ref: 51f0d150542348dc259b7c9f7bc70ee592243f7f
     - name: Use OCaml ${{ matrix.ocaml-compiler }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14.x
         opam-depext: false


### PR DESCRIPTION
Since last time, the mirage CI seems to be broken. It was using an old version of setup-ocaml. This PR moves to the new and stable version.