### PR TITLE
chore: upgrade dune-release to 2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ dune-release:
 	dune-release tag
 	dune-release distrib --skip-build --skip-lint --skip-tests
 # See https://github.com/ocamllabs/dune-release/issues/206
-	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish distrib --verbose
+	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish --verbose
 	dune-release opam pkg
 	dune-release opam submit
 

--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,7 @@
   (ocaml-lsp-server (< 1.3.0))
   (dune-configurator (< 2.3.0))
   (odoc (< 2.0.1))
-  (dune-release (< 1.3.0))
+  (dune-release (< 2.0.0))
   (js_of_ocaml-compiler (< 3.6.0))
   (jbuilder (= transition)))
  (description "

--- a/dune.opam
+++ b/dune.opam
@@ -31,7 +31,7 @@ conflicts: [
   "ocaml-lsp-server" {< "1.3.0"}
   "dune-configurator" {< "2.3.0"}
   "odoc" {< "2.0.1"}
-  "dune-release" {< "1.3.0"}
+  "dune-release" {< "2.0.0"}
   "js_of_ocaml-compiler" {< "3.6.0"}
   "jbuilder" {= "transition"}
 ]


### PR DESCRIPTION
While preparing the release of `3.18`, I discovered there was a new version of `dune-release`. As it does not publish the documentation anymore, it is necessary to change the Makefile instructions.
