### PR TITLE
pkg: allow arbitrary opam repo layouts

### DIFF
--- a/src/dune_lang/package_version.mli
+++ b/src/dune_lang/package_version.mli
@@ -10,3 +10,5 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val encode : t Dune_sexp.Encoder.t
 val decode : t Dune_sexp.Decoder.t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -3,19 +3,6 @@ open Fiber.O
 
 module Paths = struct
   let packages = Path.Local.of_string "packages"
-
-  let package_root package_name =
-    OpamPackage.Name.to_string package_name |> Path.Local.relative packages
-  ;;
-
-  let package_dir package =
-    Path.Local.relative
-      (package_root (OpamPackage.name package))
-      (OpamPackage.to_string package)
-  ;;
-
-  let files_dir package = Path.Local.relative (package_dir package) "files"
-  let opam_file package = Path.Local.relative (package_dir package) "opam"
 end
 
 module Serializable = struct
@@ -41,24 +28,220 @@ module Serializable = struct
   ;;
 end
 
+(* Module for keeping track of the location of each opam file in an opam
+   repository. Note that the opam spec allows for arbitrary directory
+   hierarchies. *)
+module Opam_file_table = struct
+  module Entry = struct
+    type t =
+      { opam_file_path_relative_to_repo_root : Path.Local.t
+      ; rev_store_file_if_loaded_from_git_repo : Rev_store.File.t option
+        (* If this data was sourced from a git repo, this field retains a
+           reference to the representation of this opam file in the repo because
+           it's expensive to look up the file from its path when it's needed
+           later. *)
+      }
+
+    let to_dyn t =
+      Dyn.record
+        [ ( "opam_file_path_relative_to_repo_root"
+          , Path.Local.to_dyn t.opam_file_path_relative_to_repo_root )
+        ; ( "rev_store_file_if_loaded_from_git_repo"
+          , Dyn.option Rev_store.File.to_dyn t.rev_store_file_if_loaded_from_git_repo )
+        ]
+    ;;
+
+    let equal
+          t
+          { opam_file_path_relative_to_repo_root; rev_store_file_if_loaded_from_git_repo }
+      =
+      Path.Local.equal
+        t.opam_file_path_relative_to_repo_root
+        opam_file_path_relative_to_repo_root
+      && Option.equal
+           Rev_store.File.equal
+           t.rev_store_file_if_loaded_from_git_repo
+           rev_store_file_if_loaded_from_git_repo
+    ;;
+  end
+
+  module Version_to_entry = struct
+    type t = Entry.t Package_version.Map.t
+
+    let to_dyn = Package_version.Map.to_dyn Entry.to_dyn
+    let equal = Package_version.Map.equal ~equal:Entry.equal
+  end
+
+  type t = Version_to_entry.t Package_name.Map.t
+
+  let empty = Package_name.Map.empty
+  let to_dyn = Package_name.Map.to_dyn Version_to_entry.to_dyn
+  let equal = Package_name.Map.equal ~equal:Version_to_entry.equal
+
+  let opam_file_path_of_package (t : t) package =
+    let name = Package_name.of_opam_package_name (OpamPackage.name package) in
+    Option.bind (Package_name.Map.find t name) ~f:(fun version_to_entry ->
+      let version =
+        Package_version.of_opam_package_version (OpamPackage.version package)
+      in
+      Option.map
+        (Package_version.Map.find version_to_entry version)
+        ~f:(fun (entry : Entry.t) -> entry.opam_file_path_relative_to_repo_root))
+  ;;
+
+  let files_dir_path_of_package (t : t) package =
+    Option.map (opam_file_path_of_package t package) ~f:(fun opam_file_path ->
+      Path.Local.relative (Path.Local.parent_exn opam_file_path) "files")
+  ;;
+
+  let all_package_versions_of_name (t : t) package_name =
+    match Package_name.Map.find t package_name with
+    | None -> []
+    | Some version_to_entry ->
+      Package_version.Map.keys version_to_entry
+      |> List.map ~f:(fun package_version ->
+        OpamPackage.create
+          (Package_name.to_opam_package_name package_name)
+          (Package_version.to_opam_package_version package_version))
+  ;;
+
+  let add t name version entry ~repo_name_for_messages ~loc =
+    Package_name.Map.update t name ~f:(function
+      | None -> Some (Package_version.Map.singleton version entry)
+      | Some version_to_entry ->
+        Some
+          (Package_version.Map.update version_to_entry version ~f:(function
+             | None -> Some entry
+             | Some existing_entry ->
+               User_warning.emit
+                 ~loc
+                 [ Pp.textf
+                     "Multiple occurrences of package %s.%s in repo %S:"
+                     (Package_name.to_string name)
+                     (Package_version.to_string version)
+                     repo_name_for_messages
+                 ; Pp.textf
+                     " - %s"
+                     (Path.Local.to_string
+                        existing_entry.Entry.opam_file_path_relative_to_repo_root)
+                 ; Pp.textf
+                     " - %s"
+                     (Path.Local.to_string entry.opam_file_path_relative_to_repo_root)
+                 ; Pp.newline
+                 ; Pp.textf
+                     "Dune will use the metadata in %s"
+                     (Path.Local.to_string
+                        existing_entry.opam_file_path_relative_to_repo_root)
+                 ];
+               Some existing_entry)))
+  ;;
+
+  (* Traverse a directory hierarchy looking for files named "opam". *)
+  let of_repo_dir_path opam_repo_dir_path ~loc : t =
+    let repo_name_for_messages = Path.to_absolute_filename opam_repo_dir_path in
+    try
+      Fpath.traverse_files
+        ~dir:
+          (Path.to_absolute_filename
+             (Path.append_local opam_repo_dir_path Paths.packages))
+        ~init:empty
+        ~f:(fun ~dir file acc ->
+          if String.equal file "opam"
+          then (
+            let opam_file_path_relative_to_repo_root =
+              Path.Local.relative (Path.Local.relative Paths.packages dir) file
+            in
+            match OpamPackage.of_string_opt (Filename.basename dir) with
+            | None ->
+              User_warning.emit
+                ~loc
+                [ Pp.textf
+                    "The repo %S contains an opam file at location %S which cannot be \
+                     interpreted as an opam package. Opam files must be contained in \
+                     directories named like <name>.<version>."
+                    repo_name_for_messages
+                    (Path.Local.relative Paths.packages dir |> Path.Local.to_string)
+                ];
+              acc
+            | Some package ->
+              let name = Package_name.of_opam_package_name (OpamPackage.name package) in
+              let version =
+                Package_version.of_opam_package_version (OpamPackage.version package)
+              in
+              let entry =
+                { Entry.opam_file_path_relative_to_repo_root
+                ; rev_store_file_if_loaded_from_git_repo = None
+                }
+              in
+              add acc name version entry ~repo_name_for_messages ~loc)
+          else acc)
+    with
+    | Unix.Unix_error (err, a, e) ->
+      User_error.raise
+        ~loc
+        [ Pp.textf
+            "Unable to scan the contents of the opam repo %S:"
+            repo_name_for_messages
+        ; Unix_error.Detailed.pp (err, a, e)
+        ]
+  ;;
+
+  (* Traverse the set of files in the given rev store revision looking for
+     files named "opam". *)
+  let of_rev_store_at_rev at_rev ~repo_name_for_messages ~loc : t =
+    Rev_store.At_rev.directory_entries ~recursive:true at_rev Paths.packages
+    |> Rev_store.File.Set.fold ~init:empty ~f:(fun file acc ->
+      let path = Rev_store.File.path file in
+      if String.equal (Path.Local.basename path) "opam"
+      then (
+        let dir = Path.Local.parent_exn path in
+        match OpamPackage.of_string_opt (Path.Local.basename dir) with
+        | None ->
+          User_warning.emit
+            [ Pp.textf
+                "The repo %S contains an opam file at location %S which cannot be \
+                 interpreted as an opam package. Opam files must be contained in \
+                 directories named like <name>.<version>."
+                repo_name_for_messages
+                (Path.Local.to_string dir)
+            ];
+          acc
+        | Some package ->
+          let name = Package_name.of_opam_package_name (OpamPackage.name package) in
+          let version =
+            Package_version.of_opam_package_version (OpamPackage.version package)
+          in
+          let entry =
+            { Entry.opam_file_path_relative_to_repo_root = path
+            ; rev_store_file_if_loaded_from_git_repo = Some file
+            }
+          in
+          add acc name version entry ~repo_name_for_messages ~loc)
+      else acc)
+  ;;
+end
+
 type t =
   { source : Source_backend.t
   ; loc : Loc.t
   ; serializable : Serializable.t option
+  ; opam_file_table : Opam_file_table.t
   }
 
-let to_dyn { source; loc; serializable } =
+let to_dyn { source; loc; serializable; opam_file_table } =
   Dyn.record
     [ "source", Source_backend.to_dyn source
     ; "loc", Loc.to_dyn loc
     ; "serializable", Dyn.option Serializable.to_dyn serializable
+    ; "opam_table", Opam_file_table.to_dyn opam_file_table
     ]
 ;;
 
-let equal { source; serializable; loc } t =
+let equal { source; serializable; loc; opam_file_table } t =
   Source_backend.equal source t.source
   && Option.equal Serializable.equal serializable t.serializable
   && Loc.equal loc t.loc
+  && Opam_file_table.equal opam_file_table t.opam_file_table
 ;;
 
 let serializable { serializable; _ } = serializable
@@ -98,7 +281,8 @@ let of_opam_repo_dir_path loc opam_repo_dir_path =
      User_error.raise
        ~loc
        [ Pp.textf "could not read %s" (Path.to_string_maybe_quoted opam_repo_dir_path) ]);
-  { source = Directory opam_repo_dir_path; serializable = None; loc }
+  let opam_file_table = Opam_file_table.of_repo_dir_path opam_repo_dir_path ~loc in
+  { source = Directory opam_repo_dir_path; serializable = None; loc; opam_file_table }
 ;;
 
 let of_git_repo loc url =
@@ -119,7 +303,13 @@ let of_git_repo loc url =
        |> OpamUrl.of_string
        |> OpamUrl.to_string)
   in
-  { source = Repo at_rev; serializable; loc }
+  let opam_file_table =
+    Opam_file_table.of_rev_store_at_rev
+      at_rev
+      ~repo_name_for_messages:(OpamUrl.to_string url)
+      ~loc
+  in
+  { source = Repo at_rev; serializable; loc; opam_file_table }
 ;;
 
 let revision t =
@@ -128,13 +318,14 @@ let revision t =
   | Directory _ -> Code_error.raise "not a git repo" []
 ;;
 
-let load_opam_package_from_dir ~(dir : Path.t) package =
-  let opam_file_path = Paths.opam_file package in
-  match Path.exists (Path.append_local dir opam_file_path) with
-  | false -> None
-  | true ->
-    let files_dir = Some (Paths.files_dir package) in
-    Some (Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir)
+let load_opam_package_from_dir ~(dir : Path.t) opam_file_table package =
+  Opam_file_table.opam_file_path_of_package opam_file_table package
+  |> Option.bind ~f:(fun opam_file_path ->
+    match Path.exists (Path.append_local dir opam_file_path) with
+    | false -> None
+    | true ->
+      let files_dir = Opam_file_table.files_dir_path_of_package opam_file_table package in
+      Some (Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir))
 ;;
 
 let load_packages_from_git rev_store opam_packages =
@@ -154,36 +345,25 @@ let load_packages_from_git rev_store opam_packages =
         ~files_dir:(Some files_dir))
 ;;
 
-let all_packages_versions_in_dir loc ~dir opam_package_name =
-  let dir = Path.append_local dir (Paths.package_root opam_package_name) in
-  match Path.readdir_unsorted dir with
-  | Ok version_dirs -> List.map version_dirs ~f:OpamPackage.of_string
-  | Error (Unix.ENOENT, _, _) -> []
-  | Error e ->
-    User_error.raise
-      ~loc
-      [ Pp.textf
-          "Unable to read package versions from %s: %s"
-          (Path.to_string_maybe_quoted dir)
-          (Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e)
-      ]
-;;
-
-let all_packages_versions_at_rev rev opam_package_name =
-  Paths.package_root opam_package_name
-  |> Rev_store.At_rev.directory_entries rev ~recursive:true
-  |> Rev_store.File.Set.to_list
-  |> List.filter_map ~f:(fun file ->
-    let path = Rev_store.File.path file in
-    let open Option.O in
-    Path.Local.basename_opt path
-    >>= function
-    | "opam" ->
-      let+ package =
-        Path.Local.parent path >>| Path.Local.basename >>| OpamPackage.of_string
-      in
-      file, package
-    | _ -> None)
+let all_packages_versions_at_rev opam_file_table opam_package_name =
+  match
+    Package_name.Map.find
+      opam_file_table
+      (Package_name.of_opam_package_name opam_package_name)
+  with
+  | None -> []
+  | Some version_to_entry ->
+    Package_version.Map.to_list_map
+      version_to_entry
+      ~f:(fun package_version (entry : Opam_file_table.Entry.t) ->
+        Option.map entry.rev_store_file_if_loaded_from_git_repo ~f:(fun file ->
+          let package =
+            OpamPackage.create
+              opam_package_name
+              (Package_version.to_opam_package_version package_version)
+          in
+          file, package))
+    |> List.filter_opt
 ;;
 
 module Key = struct
@@ -198,14 +378,16 @@ end
 
 let all_package_versions t opam_package_name : Key.t list =
   match t.source with
-  | Directory dir ->
-    all_packages_versions_in_dir t.loc ~dir opam_package_name
+  | Directory _ ->
+    Opam_file_table.all_package_versions_of_name
+      t.opam_file_table
+      (Package_name.of_opam_package_name opam_package_name)
     |> List.map ~f:(fun pkg -> Key.Directory pkg)
   | Repo rev ->
-    all_packages_versions_at_rev rev opam_package_name
-    |> List.map ~f:(fun (file, pkg) ->
-      let files_dir = Paths.files_dir pkg in
-      Key.Git (file, pkg, rev, files_dir))
+    all_packages_versions_at_rev t.opam_file_table opam_package_name
+    |> List.filter_map ~f:(fun (file, pkg) ->
+      Opam_file_table.files_dir_path_of_package t.opam_file_table pkg
+      |> Option.map ~f:(fun files_dir -> Key.Git (file, pkg, rev, files_dir)))
 ;;
 
 let all_packages_versions_map ts opam_package_name =
@@ -237,7 +419,7 @@ let load_all_versions_by_keys ts =
           "impossible because all elements in from_dirs are from a directory"
           []
       | Directory dir ->
-        load_opam_package_from_dir ~dir pkg
+        load_opam_package_from_dir ~dir repo.opam_file_table pkg
         |> Option.map ~f:(fun resolved_package -> pkg, resolved_package))
   in
   let+ from_git =
@@ -262,6 +444,10 @@ let load_all_versions ts opam_package_name =
 module Private = struct
   let create ~source:serializable =
     let packages_dir_path = Path.of_string "/" in
-    { source = Directory packages_dir_path; serializable; loc = Loc.none }
+    { source = Directory packages_dir_path
+    ; serializable
+    ; loc = Loc.none
+    ; opam_file_table = Opam_file_table.empty
+    }
   ;;
 end

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -12,3 +12,5 @@ val decode : t Dune_lang.Decoder.t
 val of_opam_package_version : OpamPackage.Version.t -> t
 val to_opam_package_version : t -> OpamPackage.Version.t
 val dev : t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -391,6 +391,7 @@ module File = struct
           }
 
     let compare = Poly.compare
+    let equal = Poly.equal
 
     let to_dyn = function
       | Redirect _ -> Dyn.opaque ()

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -21,6 +21,7 @@ module File : sig
 
   val path : t -> Path.Local.t
   val to_dyn : t -> Dyn.t
+  val equal : t -> t -> bool
 
   module Set : Set.S with type elt = t
 end

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -30,7 +30,7 @@ This does not currently seem to be the case.
   > (dirs * \ mock-opam-repository)
   > EOF
 
-  $ solve with-patch
+  $ solve with-patch 2>&1 | sed -n '/^Error:/,$p'
   File "$TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files", line 1, characters 0-0:
   Error: Unable to read file in opam repository:
   opendir($TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/dir): Permission denied

--- a/test/blackbox-tests/test-cases/pkg/opam-repo-layouts.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repo-layouts.t
@@ -1,0 +1,105 @@
+Test that dune can solve dependencies with opam repos using a layout other than
+the one used by the official opam repo. Opam allows arbitrary dependency
+hierarchies inside the "package" directory.
+
+Make a custom opam repo:
+  $ mkdir -p custom-opam-repo/packages
+  $ cat > custom-opam-repo/repo <<EOF
+  > opam-version: "2.0"
+  > EOF
+
+Make some packgaes at various depths in the directory hierarchy:
+  $ mkdir -p custom-opam-repo/packages/a.1
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/a.1/opam
+
+  $ mkdir -p custom-opam-repo/packages/b/b.2
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/b/b.2/opam
+
+  $ mkdir -p custom-opam-repo/packages/foo/bar/baz/c.3
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/foo/bar/baz/c.3/opam
+
+Set up the workspace to use only the custom repo:
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.18)
+  > (repository
+  >  (name custom)
+  >  (url file://$PWD/custom-opam-repo))
+  > (lock_dir
+  >  (repositories custom))
+  > EOF
+
+Project to depend on some packages from the custom repo:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (allow_empty)
+  >  (name x)
+  >  (depends a b c))
+  > EOF
+
+Test that dune can solve the project:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - a.1
+  - b.2
+  - c.3
+
+
+Now test that dune can handle some degenerate cases.
+
+Make a copy of the c.3 package at a different location within the repo:
+
+  $ mkdir -p custom-opam-repo/packages/foo/bar/baz/qux/c.3
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/foo/bar/baz/qux/c.3/opam
+
+  $ dune pkg lock 2>&1 | sed -n '/^Warning:/,$p'
+  Warning: Multiple occurrences of package c.3 in repo
+  "$TESTCASE_ROOT/custom-opam-repo":
+   - packages/foo/bar/baz/qux/c.3/opam
+   - packages/foo/bar/baz/c.3/opam
+  
+  
+  Dune will use the metadata in packages/foo/bar/baz/qux/c.3/opam
+  Solution for dune.lock:
+  - a.1
+  - b.2
+  - c.3
+
+  $ rm -r custom-opam-repo/packages/foo/bar/baz/qux/c.3
+
+Create an opam file in a directory that doesn't have a version number. There's
+no way to refer to this package in dune-project but dune should still be able
+to parse the repo with crashing.
+
+  $ mkdir -p custom-opam-repo/packages/foo/
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/foo/opam
+
+  $ dune pkg lock 2>&1 | sed -n '/^Warning:/,$p'
+  Warning: The repo
+  "$TESTCASE_ROOT/custom-opam-repo"
+  contains an opam file at location "packages/foo" which cannot be interpreted
+  as an opam package. Opam files must be contained in directories named like
+  <name>.<version>.
+  Solution for dune.lock:
+  - a.1
+  - b.2
+  - c.3
+
+  $ rm custom-opam-repo/packages/foo/opam
+
+Put an opam file directly inside the "packages" directory:
+
+  $ echo 'opam-version: "2.0"' > custom-opam-repo/packages/opam
+
+  $ dune pkg lock 2>&1 | sed -n '/^Warning:/,$p'
+  Warning: The repo
+  "$TESTCASE_ROOT/custom-opam-repo"
+  contains an opam file at location "packages" which cannot be interpreted as
+  an opam package. Opam files must be contained in directories named like
+  <name>.<version>.
+  Solution for dune.lock:
+  - a.1
+  - b.2
+  - c.3
+
+  $ rm custom-opam-repo/packages/opam


### PR DESCRIPTION
Opam repos can have fairly arbitrary directory layouts. The only requirement is that all package manifests are under the top-level "packages" directory, and each manifest is in a file named "opam" whose parent directory is named like "<name>.<version>".

Prior to this change dune assumed a layout similar to the official opam-repository, where manifests are at
"packages/<name>/<name>.<version>/opam".

This generalizes dune's expectations of opam repositories such that arbitrary directory layouts are supported.

Fixes https://github.com/ocaml/dune/issues/11615