### PR TITLE
fix: pass pkg-config (extra) args when evaluating the expression

### DIFF
--- a/doc/changes/11619.md
+++ b/doc/changes/11619.md
@@ -1,0 +1,1 @@
+- fix: pass pkg-config (extra) args in all pkgconfig invocations. A missing --personality flag would result in pkgconf not finding libraries in some contexts. (#11619, @MisterDA)

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -735,7 +735,7 @@ module Pkg_config = struct
     in
     let pc_flags = "--print-errors" in
     let { Process.exit_code; stderr; _ } =
-      Process.run_process c ~dir ?env t.pkg_config [ pc_flags; expr ]
+      Process.run_process c ~dir ?env t.pkg_config (t.pkg_config_args @ [ pc_flags; expr ])
     in
     if exit_code = 0
     then (

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -1,9 +1,11 @@
 These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config`
 
   $ dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
-  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --print-errors dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
+   | --personality
+   | $TARGET
    | dummy-pkg
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --cflags dummy-pkg
   -> process exited with code 0
@@ -22,9 +24,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
 
   $ dune clean
   $ PKG_CONFIG_ARGN="--static" dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a'
-  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --print-errors dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
+   | --static
    | dummy-pkg
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --cflags dummy-pkg
   -> process exited with code 0


### PR DESCRIPTION
pkgconf uses the personality to locate the correct library when the library can be found with multiple toolchains. For instance, on Cygwin, pkgconf could detect libcurl (built with cygwin1.dll), licurl (built with x86_64-w64-mingw32), or libcurl (built with i686-w64-mingw32). It needs the right `--personality` flag to select between these libraries, which we pass when asking for the `--cflags` or `--libs`. We also need it when validating the expression, or pkgconf returns an error:

```console
$ (cd _build/default && config/discover.exe)
which: pkgconf
-> found: C:\Users\Antonin\AppData\Local\opam\default-2\bin\pkgconf.exe
run: C:\Users\Antonin\AppData\Local\opam\default-2\bin\pkgconf.exe --print-errors "libcurl >= 7.28.0"
-> process exited with code 1
-> stdout:
-> stderr:
| Package libcurl was not found in the pkg-config search path.
| Perhaps you should add the directory containing `libcurl.pc'
| to the PKG_CONFIG_PATH environment variable
| Package 'libcurl' not found
Error: Package libcurl was not found in the pkg-config search path.
Perhaps you should add the directory containing `libcurl.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libcurl' not found
$ ~/AppData/Local/opam/default-2/bin/pkgconf.exe --personality x86_64-w64-mingw32 --print-errors "libcurl >= 7.28.0
```

This is a nasty bug for me, as there's no way of passing the personality flag to pkgconf outsite of Dune: the `PKG_CONFIG_ARGN` is just exposed by Dune and CMake and isn't actually recognized by pkgconf.

cf #10937 