### PR TITLE
reimplementation of dune exec -w

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -64,106 +64,46 @@ module Cmd_arg = struct
   let conv = Arg.conv ((fun s -> Ok (parse s)), pp)
 end
 
-module Command_to_exec = struct
-  (* A command to execute, which knows how to (re)build the program and then
-     run it with some arguments in an environment *)
-
-  type command_env =
-    { path : Path.t
-    ; env : Env.t
-    }
-
-  type t =
-    { get_env_and_build_if_necessary :
-        string -> (command_env, [ `Already_reported ]) result Fiber.t
-    ; prog : string
-    ; args : string list
-    }
-
-  (* Helper function to spawn a new process running a command in an
-     environment, returning the new process' pid *)
-  let spawn_process ~root path ~args ~env =
-    let pid =
-      let prog = string_path_relative_to_specified_root root (Path.to_string path) in
-      let env = Env.to_unix env |> Spawn.Env.of_list in
-      let argv = prog :: args in
-      let cwd = Spawn.Working_dir.Path Fpath.initial_cwd in
-      Spawn.spawn ~prog ~env ~cwd ~argv ()
-    in
-    Pid.of_int pid
-  ;;
-
-  (* Run the command, first (re)building the program which the command is
-     invoking *)
-  let build_and_run_in_child_process
-        ~root
-        ~config
-        { get_env_and_build_if_necessary; prog; args }
-    =
-    get_env_and_build_if_necessary prog
-    |> Fiber.map
-         ~f:
-           (Result.map ~f:(fun { path; env } ->
-              Scheduler.maybe_clear_screen ~details_hum:[] config;
-              spawn_process ~root ~args ~env path))
-  ;;
-end
-
 module Watch = struct
-  (* When running `dune exec` in watch mode, this will keep track of the pid of
-     the process created to run the program in the previous iteration so that
-     it can be killed (for long running programs, e.g. servers) and restarted
-     when its source is changed. *)
-
-  type state = { currently_running_pid : Pid.t option ref }
-
-  let init_state () = { currently_running_pid = ref None }
-
-  let kill_process pid =
-    let pid_int = Pid.to_int pid in
-    (* TODO This logic should exist in one place. Currently it's here and in
-       the scheduler *)
-    let signal = if Sys.win32 then Sys.sigkill else Sys.sigterm in
-    (* FIXME Since we're reaping in a different thread, this can technically
-       cause pid reuse *)
-    Unix.kill pid_int signal;
-    let do_wait () =
-      Scheduler.wait_for_process ~timeout_seconds:1. pid
-      |> Fiber.map ~f:(fun (_ : Proc.Process_info.t) -> ())
-    in
-    let on_error (e : Exn_with_backtrace.t) =
-      (* Ignore [Build_cancelled] exception we expect the build to be cancelled
-         if the source is changed during compilation. *)
-      match e.exn with
-      | Memo.Non_reproducible Scheduler.Run.Build_cancelled -> Fiber.return ()
-      | _ -> Exn_with_backtrace.reraise e
-    in
-    Fiber.map_reduce_errors (module Monoid.Unit) ~on_error do_wait
-    |> Fiber.map ~f:(function Ok () | Error () -> ())
+  let on_error (e : Exn_with_backtrace.t) =
+    (* Ignore [Build_cancelled] exception we expect the build to be cancelled if the
+       source is changed during compilation. *)
+    match e.exn with
+    | Memo.Non_reproducible Scheduler.Run.Build_cancelled -> Fiber.return ()
+    | _ -> Exn_with_backtrace.reraise e
   ;;
 
-  let kill_currently_running_process { currently_running_pid } =
-    match !currently_running_pid with
-    | None -> Fiber.return ()
-    | Some pid ->
-      currently_running_pid := None;
-      kill_process pid
-  ;;
-
-  (* Kills the currently running process, then runs the given command after
-     (re)building the program which it will invoke *)
-  let run ~root ~config state ~command_to_exec =
+  let step ~root ~sctx ~env ~prog ~args ~get_path_and_build_if_necessary =
     let open Fiber.O in
-    let* () = Fiber.return () in
-    let* () = kill_currently_running_process state in
-    let* command_to_exec = command_to_exec () in
-    Command_to_exec.build_and_run_in_child_process ~root ~config command_to_exec
-    >>| Result.map ~f:(fun pid -> state.currently_running_pid := Some pid)
-  ;;
-
-  let loop ~root ~config ~command_to_exec =
-    let state = init_state () in
-    Scheduler.Run.poll (run ~root ~config state ~command_to_exec)
+    let* get_env_and_build_if_necessary, args =
+      Memo.run
+      @@
+      let open Memo.O in
+      let* sctx = sctx in
+      let expand = Cmd_arg.expand ~root ~sctx in
+      let+ prog = expand prog
+      and+ args = Memo.parallel_map args ~f:expand in
+      ( build (fun () ->
+          let+ env = env
+          and+ path = get_path_and_build_if_necessary ~prog in
+          path, env)
+      , args )
+    in
+    get_env_and_build_if_necessary
+    >>= function
+    | Ok (path, env) ->
+      Fiber.map ~f:(function Ok () | Error () -> Ok ())
+      @@ Fiber.map_reduce_errors (module Monoid.Unit) ~on_error
+      @@ fun () ->
+      Dune_engine.Process.run_external_in_out
+        ~dir:(Path.of_string Fpath.initial_cwd)
+        ~env
+        path
+        args
+      >>| (function
+       | 0 -> ()
+       | exit_code -> Console.print [ Pp.textf "Program exited with code [%d]" exit_code ])
+    | Error `Already_reported as e -> Fiber.return e
   ;;
 end
 
@@ -297,12 +237,12 @@ module Exec_context = struct
         let open Memo.O in
         let* env = env
         and* sctx = sctx in
-        let root = Common.root common in
+        let expand = Cmd_arg.expand ~root:(Common.root common) ~sctx in
         let* path =
-          let* prog = Cmd_arg.expand prog ~root ~sctx in
+          let* prog = expand prog in
           get_path_and_build_if_necessary ~prog
         in
-        let+ args = Memo.parallel_map ~f:(Cmd_arg.expand ~root ~sctx) args in
+        let+ args = Memo.parallel_map ~f:expand args in
         path, args, env)
     in
     let prog = Path.to_string path in
@@ -313,30 +253,18 @@ module Exec_context = struct
   let run_eager_watch t common config =
     Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config
     @@ fun () ->
-    let command_to_exec () =
-      let open Fiber.O in
-      let* { sctx; env; prog; args; get_path_and_build_if_necessary } = t in
-      Memo.run
-      @@
-      let open Memo.O in
-      let* sctx = sctx in
-      let expand = Cmd_arg.expand ~root:(Common.root common) ~sctx in
-      let* prog = expand prog in
-      let+ args = Memo.parallel_map args ~f:expand in
-      { Command_to_exec.get_env_and_build_if_necessary =
-          (fun prog ->
-            (* TODO we should release the dune lock. But we aren't doing it
-               because we don't unload the database files we've marshalled.
-            *)
-            build (fun () ->
-              let+ env = env
-              and+ path = get_path_and_build_if_necessary ~prog in
-              { Command_to_exec.path; env }))
-      ; prog
-      ; args
-      }
-    in
-    Watch.loop ~root:(Common.root common) ~config ~command_to_exec
+    let open Fiber.O in
+    let* { sctx; env; prog; args; get_path_and_build_if_necessary } = t in
+    Scheduler.Run.poll
+    @@
+    let* () = Fiber.return @@ Scheduler.maybe_clear_screen ~details_hum:[] config in
+    Watch.step
+      ~root:(Common.root common)
+      ~sctx
+      ~env
+      ~prog
+      ~args
+      ~get_path_and_build_if_necessary
   ;;
 end
 

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -162,3 +162,10 @@ val run_capture_zero_separated
   -> Path.t
   -> string list
   -> 'a Fiber.t
+
+val run_external_in_out
+  :  ?dir:Path.t
+  -> ?env:Env.t
+  -> Path.t
+  -> string list
+  -> int Fiber.t

--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -9,7 +9,7 @@
   ;; unreliable to depend on in a test so these tests are disabled on macos.
   ;; (<> "macosx" %{ocaml-config:system})
   ;; disabled until it works in CI
-  false))
+  true))
 
 (cram
  (deps wait-for-file.sh))

--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -7,9 +7,7 @@
   ;; sometimes go undetected. Adding a delay (e.g. `sleep 1`) before modifying the
   ;; program seems to guarantee a rebuild will be triggered, but that is too
   ;; unreliable to depend on in a test so these tests are disabled on macos.
-  ;; (<> "macosx" %{ocaml-config:system})
-  ;; disabled until it works in CI
-  true))
+  (<> "macosx" %{ocaml-config:system})))
 
 (cram
  (deps wait-for-file.sh))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-segfault.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-segfault.t
@@ -1,0 +1,61 @@
+Here we test what happens if there is a segfault in the program we are running with dune
+exec. Segfaults are determined and signalled from the operating system. It is usually
+impossible for a program to recover after recieving such a signal.
+
+For dune exec -w, we are indifferent to what the process we are running is actually doing
+since it shouldn't affect dune's other functions.
+
+TODO: It would be nice for Dune to indicate to the user that the subprocess was terminated
+in this way. But for now we fail and stop the program silently.
+  $ DONE_FLAG=_build/done_flag
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (libraries unix))
+  > EOF
+
+  $ cat > touch.ml <<EOF
+  > let touch path =
+  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  Unix.close fd
+  > ;;
+  > EOF
+
+This first program will cause a segfault by using Obj.magic and calling an integer like it
+is a function.
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   let f = Obj.magic 0 in
+  >   Touch.touch "$DONE_FLAG";
+  >   print_endline "about to segfault";
+  >   f 1  (* Segfault: calling an int as if it is a function *)
+  >   [@@warning "-20"]
+  > ;;
+  > EOF
+
+When we start ./foo.exe with dune exec -w we note that we haven't exited, but simply
+finished a build.
+  $ dune exec -w ./foo.exe &
+  about to segfault
+  fixed segfault
+  Success, waiting for filesystem changes...
+  $ PID=$!
+  $ ./wait-for-file.sh $DONE_FLAG
+
+We can now start a new build by modifying the original program and removing the segfault.
+This rebuilds successfully as indicated by the above output.
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   Touch.touch "$DONE_FLAG";
+  >   print_endline "fixed segfault";
+  > ;;
+  > EOF
+
+  $ ./wait-for-file.sh $DONE_FLAG
+
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
@@ -1,0 +1,64 @@
+Testing stdin for watch mode dune exec
+ 
+We use the done flag as a signal that the program has finished.
+  $ DONE_FLAG=_build/done_flag
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (libraries unix))
+  > EOF
+
+  $ cat > touch.ml <<EOF
+  > let touch path =
+  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  Unix.close fd
+  > ;;
+  > EOF
+ 
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   print_endline "what is your name?";
+  >   let name = read_line () in
+  >   print_endline ("hello " ^ name ^ "!");
+  >   Touch.touch "$DONE_FLAG"
+  > ;;
+  > EOF
+
+Our program takes in some input from stdin, so we need to make sure dune passes this along
+correctly. To simulate giving this input later we use a pipe.
+  $ mkfifo input.pipe
+  $ dune exec -w -- ./foo.exe < input.pipe &
+  what is your name?
+  hello John Doe!
+  Success, waiting for filesystem changes...
+  (2) what is your name?
+  (2) hello Alice Johnson!
+  Success, waiting for filesystem changes...
+  $ PID=$!
+
+  $ cat > input.pipe <<EOF
+  > John Doe
+  > EOF
+  $ ./wait-for-file.sh $DONE_FLAG
+
+We can trigger arebuild and give another input.
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   print_endline "(2) what is your name?";
+  >   let name = read_line () in
+  >   print_endline ("(2) hello " ^ name ^ "!");
+  >   Touch.touch "$DONE_FLAG"
+  > ;;
+  > EOF
+  $ cat > input.pipe <<EOF
+  > Alice Johnson
+  > EOF
+
+  $ ./wait-for-file.sh $DONE_FLAG
+
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
@@ -10,17 +10,17 @@ between each change to its code.
   > EOF
 
   $ dune exec --watch ./foo.exe &
-  Success, waiting for filesystem changes...
   foo
   Success, waiting for filesystem changes...
   bar
+  Success, waiting for filesystem changes...
   File "foo.ml", line 1, characters 23-24:
   1 | let () = print_endline "baz
                              ^
   Error: String literal not terminated
   Had 1 error, waiting for filesystem changes...
-  Success, waiting for filesystem changes...
   baz
+  Success, waiting for filesystem changes...
   $ PID=$!
 
 Wait for the $DONE_FLAG file to exist, then delete the file. This file is

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
@@ -1,0 +1,39 @@
+Here we test what happens if the program we are running with dune exec -w exits with a
+non-zero exit code.
+
+  $ DONE_FLAG=_build/done_flag
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (libraries unix))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let touch path =
+  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  Unix.close fd
+  > ;;
+  > 
+  > let () =
+  >   touch "$DONE_FLAG";
+  >   Printf.eprintf "oh no!\n";
+  >   exit 1
+  > ;;
+  > EOF
+
+The build will still be considered successful even if the program being run fails. We
+output the exit code of the program to be clear to the user. It's not useful anyway since
+we are in watch mode.
+  $ dune exec -w -- ./foo.exe &
+  oh no!
+  Program exited with code [1]
+  Success, waiting for filesystem changes...
+  $ PID=$!
+  $ ./wait-for-file.sh $DONE_FLAG
+
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
@@ -1,9 +1,7 @@
 Test exec --watch with a program that ignores sigterm.
 
   $ dune exec --watch ./foo.exe &
-  Success, waiting for filesystem changes...
   1: before
-  Success, waiting for filesystem changes...
   2: before
   $ PID=$!
 

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
@@ -4,8 +4,8 @@ project root directory.
 "dune exec --watch" works fine when invoked at the root level
   $ DONE_FLAG=_build/done_flag
   $ dune exec --watch ./bin/main.exe $DONE_FLAG &
-  Success, waiting for filesystem changes...
   foo
+  Success, waiting for filesystem changes...
   $ PID=$!
 
 Wait for the $DONE_FLAG file to exist, then delete the file. This file is
@@ -19,8 +19,8 @@ Perform the same test above but first enter the "bin" directory.
   $ cd bin
   $ dune exec --root .. --watch ./bin/main.exe ../$DONE_FLAG &
   Entering directory '..'
-  Success, waiting for filesystem changes...
   foo
+  Success, waiting for filesystem changes...
   Leaving directory '..'
   $ PID=$!
   $ cd ..

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -49,3 +49,13 @@ Change the program so that it no longer terminates immediately.
 
 Prevent the test from leaking the dune process.
   $ kill $PID
+
+Checking for the child process
+  $ pgrep -c "foo.exe" || true
+  1
+
+Killing the child process manually
+  $ kill $(pidof ./_build/default/foo.exe)
+
+  $ pgrep -c "foo.exe" || true
+  0

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -14,9 +14,7 @@ between each change to its code.
   > EOF
 
   $ dune exec --watch ./foo.exe &
-  Success, waiting for filesystem changes...
   0: before
-  Success, waiting for filesystem changes...
   1: before
   1: after
   Success, waiting for filesystem changes...
@@ -51,11 +49,5 @@ Prevent the test from leaking the dune process.
   $ kill $PID
 
 Checking for the child process
-  $ pgrep -c "foo.exe" || true
-  1
-
-Killing the child process manually
-  $ kill $(pidof ./_build/default/foo.exe)
-
   $ pgrep -c "foo.exe" || true
   0


### PR DESCRIPTION
This PR is left as a draft for the moment as I iterate over it.

In this PR we reimplement `dune exec -w` to use `Dune_engine.Process` rather than `Spawn` directly. This has a number of advantages, mainly we no longer have to juggle the difficult job of keeping track of sub-processes.

Doing this has some unintended side-effects, such as all output being redirected to stderr due to how dune display messages. We therefore offer a small tweak to `Dune_engine.Process` in order to have access to the usual stdout and stderr.

- Fixes https://github.com/ocaml/dune/issues/11089
