### PR TITLE
Allow rpc-triggered builds in eager watch mode

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1155,7 +1155,6 @@ let build (builder : Builder.t) =
              ~registry
              ~root:root.dir
              ~handle:Dune_rules_rpc.register
-             ~watch_mode_config:builder.watch
              ~parse_build:Dune_rules_rpc.parse_build
              stats))
     else `Forbid_builds

--- a/doc/changes/11622.md
+++ b/doc/changes/11622.md
@@ -1,0 +1,2 @@
+- Allow build RPC messages to be handled by dune's RPC server in eager watch
+  mode (#11622, @gridbugs)

--- a/doc/rpc.rst
+++ b/doc/rpc.rst
@@ -56,10 +56,17 @@ uses the ``dune-rpc`` and ``dune-rpc-lwt`` packages.
 Connecting
 ==========
 
-To connect to Dune's RPC server, it needs to be started in watch mode. It is
-possible to use ``dune build --passive-watch-mode`` to start an RPC server which
-will listen for requests without starting a build by itself. Then ``dune rpc
-build .`` will connect to it, trigger a build, and report status.
+To connect to Dune's RPC server, it needs to be started in watch mode. There
+are two ways of doing this:
+
+- Run ``dune build --passive-watch-mode`` to start an RPC server which will
+  listen for requests without starting a build by itself...
+- Or run ``dune build --watch`` to start a build server that rebuilds the
+  project's default target when source files change and *also* starts an RPC
+  server that listens for requests.
+
+Then ``dune rpc build .`` will connect to it, trigger a build, and report
+status.
 
 .. _lwt: https://github.com/ocsigen/lwt
 .. _Dune_rpc: https://github.com/ocaml/dune/blob/main/otherlibs/dune-rpc/dune_rpc.mli

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -4,7 +4,6 @@ val create
   :  lock_timeout:float option
   -> registry:[ `Add | `Skip ]
   -> root:string
-  -> watch_mode_config:Watch_mode_config.t
   -> handle:(unit Dune_rpc_server.Handler.t -> unit)
        (** register additional requests or notifications *)
   -> Dune_stats.t option

--- a/test/blackbox-tests/test-cases/watching/watching-eager-with-rpc.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-with-rpc.t
@@ -1,4 +1,4 @@
-Show error when trying to build through rpc when server is running eager watch
+Demonstrate building through rpc when server is running in eager watch
 
   $ echo '(lang dune 3.8)' > dune-project
   $ mkdir src
@@ -9,13 +9,10 @@ Show error when trying to build through rpc when server is running eager watch
   $ dune build @all
   $ dune build --watch &
   Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
 
   $ dune rpc build --wait .
-  Error: { payload = None
-  ; message =
-      "the rpc server is running with eager watch mode using --watch. to run builds through an rpc client, start the server using --passive-watch-mode"
-  ; kind = Invalid_request
-  }
+  Success
 
   $ dune shutdown
   $ wait


### PR DESCRIPTION
When dune is started in eager watch mode (e.g. by running `dune build --watch`) it starts an RPC server, but prior to this change it would reject RPC requests to build targets. This is a step towards being able to run dune commands that trigger build (e.g. `build`, `exec`, `test`) while watch mode is running.

Kind of testing the waters with this change as there may be consequences I'm unaware of of running the entire build system concurrently in two different fibers. Conceptually I think it makes sense, as the task of rebuilding targets named on the command line in response to file changes is unrelated to the task of rebuilding targets in response to RPC messages. Do we need to take extra care to prevent the two fibers from interfering with each other?