### PR TITLE
[3.18] backport #11619

### DIFF
--- a/doc/changes/11619.md
+++ b/doc/changes/11619.md
@@ -1,0 +1,1 @@
+- fix: pass pkg-config (extra) args in all pkgconfig invocations. A missing --personality flag would result in pkgconf not finding libraries in some contexts. (#11619, @MisterDA)

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -735,7 +735,7 @@ module Pkg_config = struct
     in
     let pc_flags = "--print-errors" in
     let { Process.exit_code; stderr; _ } =
-      Process.run_process c ~dir ?env t.pkg_config [ pc_flags; expr ]
+      Process.run_process c ~dir ?env t.pkg_config (t.pkg_config_args @ [ pc_flags; expr ])
     in
     if exit_code = 0
     then (

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -1,9 +1,11 @@
 These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config`
 
   $ dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g
-  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --print-errors dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
+   | --personality
+   | $TARGET
    | dummy-pkg
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --personality $TARGET --cflags dummy-pkg
   -> process exited with code 0
@@ -22,9 +24,10 @@ These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config
 
   $ dune clean
   $ PKG_CONFIG_ARGN="--static" dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a'
-  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --print-errors dummy-pkg
+  run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --print-errors dummy-pkg
   -> process exited with code 0
   -> stdout:
+   | --static
    | dummy-pkg
   run: $TESTCASE_ROOT/_build/default/.bin/pkgconf --static --cflags dummy-pkg
   -> process exited with code 0


### PR DESCRIPTION
This PR backports the PR to correctly pass the flag to `pkg-conf`.

cc @MisterDA 