### PR TITLE
chore: comply with LGPL-2

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1,3 +1,17 @@
+(*
+   This file includes code from the 0install library. It is distributed under
+   the LGPL-2.1-or-later licence. See src/sdune_pkg/COPYING.md for the full
+   license.
+
+   Copyright (C) 2013, Thomas Leonard
+   See the README file for details, or visit http://0install.net.
+
+   Files:
+   - Includes solver_core.ml and solver_core.mli files
+   - Includes diagnostics.ml and diagnostics.mli
+   - Remove usage from the S module from the s.ml file
+*)
+
 open Import
 open Fiber.O
 

--- a/src/sat/hash_set.ml
+++ b/src/sat/hash_set.ml
@@ -1,3 +1,11 @@
+(*
+   This file is distributed under LGPL-2.1-or-later. It is extracted from the
+   0install library. See src/sat/COPYING.md for the full license.
+
+   Copyright (C) 2013, Thomas Leonard
+   See the README file for details, or visit http://0install.net.
+*)
+
 module List = Stdlib.ListLabels
 
 let ( = ) = Int.equal

--- a/src/sat/hash_set.mli
+++ b/src/sat/hash_set.mli
@@ -1,3 +1,11 @@
+(*
+   This file is extracted from the 0install library. It is distributed under
+   the LGPL-2.1-or-later licence. See src/sat/COPYING.md for the full license.
+
+   Copyright (C) 2013, Thomas Leonard
+   See the README file for details, or visit http://0install.net.
+*)
+
 type t
 
 val create : unit -> t

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -1,5 +1,9 @@
-(* Copyright (C) 2013, Thomas Leonard
- * See the README file for details, or visit http://0install.net.
+(*
+   This file is extracted from the 0install library. It is distributed under
+   the LGPL-2.1-or-later licence. See src/sat/COPYING.md for the full license.
+
+   Copyright (C) 2013, Thomas Leonard
+   See the README file for details, or visit http://0install.net.
 *)
 
 (** A general purpose SAT solver. *)

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -1,5 +1,9 @@
-(* Copyright (C) 2013, Thomas Leonard
- * See the README file for details, or visit http://0install.net.
+(*
+   This file is extracted from the 0install library. It is distributed under
+   the LGPL-2.1-or-later licence. See src/sat/COPYING.md for the full license.
+
+   Copyright (C) 2013, Thomas Leonard
+   See the README file for details, or visit http://0install.net.
 *)
 
 (** A general purpose SAT solver. *)


### PR DESCRIPTION
This PR adds headers to the files from the 0install solver under LGPL2. I have added a pointer to the full notice and list the files that were diluted in `opam_solver.ml` from the `0install`.

I didn't add the changes at the top of the file as any user is able to track the changes through `git`. I don't know if it would be sufficient to comply.

Should fix #11603.
