### PR TITLE
[3.18] fix: missing keyword in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 3.18.1 (2025-04-15)
 -------------------
 
+### Fixed
+
 - fix: pass pkg-config (extra) args in all pkgconfig invocations. A missing
   `--personality` flag would result in pkgconf not finding libraries in some
   contexts. (#11619, @MisterDA)


### PR DESCRIPTION
While doing the PR to the ocaml.org changelog, I have seen I forgot to add the `### Fixed` section title to the changelog. This is not a big problem and we won't redo the release because of it. However, I still reintroduce it in the changelog with this PR for consistency.
