### PR TITLE
fix: bootstrap

### DIFF
--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -67,7 +67,7 @@ let rule sctx ~requires_link =
   let externals =
     List.filter_map externals ~f:(fun lib ->
       let name = Lib.name lib in
-      Option.some_if (Lib_name.equal name (Lib_name.of_string "threads.posix")) name)
+      Option.some_if (not (Lib_name.equal name (Lib_name.of_string "threads.posix"))) name)
   in
   Format.asprintf
     "%a@."


### PR DESCRIPTION
In 153fcd1 the filter on external libraries was flipped. This fixes that issue.

This fixes issues with bootstrap on newer OCaml versions.

Thanks @nojb!