### PR TITLE
simplify implementation of dune exec further

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -64,71 +64,6 @@ module Cmd_arg = struct
   let conv = Arg.conv ((fun s -> Ok (parse s)), pp)
 end
 
-module Watch = struct
-  let on_error (e : Exn_with_backtrace.t) =
-    (* Ignore [Build_cancelled] exception we expect the build to be cancelled if the
-       source is changed during compilation. *)
-    match e.exn with
-    | Memo.Non_reproducible Scheduler.Run.Build_cancelled -> Fiber.return ()
-    | _ -> Exn_with_backtrace.reraise e
-  ;;
-
-  let step ~root ~sctx ~env ~prog ~args ~get_path_and_build_if_necessary =
-    let open Fiber.O in
-    let* get_env_and_build_if_necessary, args =
-      Memo.run
-      @@
-      let open Memo.O in
-      let* sctx = sctx in
-      let expand = Cmd_arg.expand ~root ~sctx in
-      let+ prog = expand prog
-      and+ args = Memo.parallel_map args ~f:expand in
-      ( build (fun () ->
-          let+ env = env
-          and+ path = get_path_and_build_if_necessary ~prog in
-          path, env)
-      , args )
-    in
-    get_env_and_build_if_necessary
-    >>= function
-    | Ok (path, env) ->
-      Fiber.map ~f:(function Ok () | Error () -> Ok ())
-      @@ Fiber.map_reduce_errors (module Monoid.Unit) ~on_error
-      @@ fun () ->
-      Dune_engine.Process.run_external_in_out
-        ~dir:(Path.of_string Fpath.initial_cwd)
-        ~env
-        path
-        args
-      >>| (function
-       | 0 -> ()
-       | exit_code -> Console.print [ Pp.textf "Program exited with code [%d]" exit_code ])
-    | Error `Already_reported as e -> Fiber.return e
-  ;;
-end
-
-let build_prog ~no_rebuild ~prog p =
-  if no_rebuild
-  then
-    if Path.exists p
-    then Memo.return p
-    else
-      User_error.raise
-        [ Pp.concat
-            ~sep:Pp.space
-            [ Pp.text "Program"
-            ; User_message.command prog
-            ; Pp.text "isn't built yet. You need to build it first or remove the"
-            ; User_message.command "--no-build"
-            ; Pp.text "option."
-            ]
-        ]
-  else
-    let open Memo.O in
-    let+ () = Build_system.build_file p in
-    p
-;;
-
 let not_found ~dir ~prog =
   let open Memo.O in
   let+ hints =
@@ -152,6 +87,28 @@ let not_found ~dir ~prog =
         ~sep:Pp.space
         [ Pp.text "Program"; User_message.command prog; Pp.text "not found!" ]
     ]
+;;
+
+let build_prog ~no_rebuild ~prog p =
+  if no_rebuild
+  then
+    if Path.exists p
+    then Memo.return p
+    else
+      User_error.raise
+        [ Pp.concat
+            ~sep:Pp.space
+            [ Pp.text "Program"
+            ; User_message.command prog
+            ; Pp.text "isn't built yet. You need to build it first or remove the"
+            ; User_message.command "--no-build"
+            ; Pp.text "option."
+            ]
+        ]
+  else
+    let open Memo.O in
+    let+ () = Build_system.build_file p in
+    p
 ;;
 
 let get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog =
@@ -194,80 +151,103 @@ let get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog =
      | None -> not_found ~dir ~prog)
 ;;
 
-module Exec_context = struct
-  type t =
-    { prog : Cmd_arg.t
-    ; args : Cmd_arg.t list
-    ; env : Env.t Memo.t
-    ; sctx : Super_context.t Memo.t
-    ; get_path_and_build_if_necessary : prog:string -> Path.t Memo.t
-    }
-
-  let init ~common ~context ~no_rebuild ~prog ~args =
-    (* The initialization of some fields is deferred until the fiber scheduler
-       has been started. *)
-    let open Fiber.O in
-    let+ setup = Import.Main.setup () in
-    let open Memo.O in
-    let sctx =
-      let+ setup = setup in
-      Import.Main.find_scontext_exn setup ~name:context
-    in
-    let dir =
-      let+ sctx = sctx in
-      let context = Dune_rules.Super_context.context sctx in
-      Path.Build.relative (Context.build_dir context) (Common.prefix_target common "")
-    in
-    let env = Memo.bind sctx ~f:Super_context.context_env in
-    let get_path_and_build_if_necessary ~prog =
-      let* sctx = sctx
-      and+ dir = dir in
-      get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog
-    in
-    { sctx; env; prog; args; get_path_and_build_if_necessary }
+module Watch = struct
+  let on_error (e : Exn_with_backtrace.t) =
+    (* Ignore [Build_cancelled] exception we expect the build to be cancelled if the
+       source is changed during compilation. *)
+    match e.exn with
+    | Memo.Non_reproducible Scheduler.Run.Build_cancelled -> Fiber.return ()
+    | _ -> Exn_with_backtrace.reraise e
   ;;
 
-  let run_once t common config =
-    Scheduler.go_with_rpc_server ~common ~config
-    @@ fun () ->
+  let step ~root ~prog ~args ~common ~no_rebuild ~context =
     let open Fiber.O in
-    let* path, args, env =
-      let* { sctx; env; prog; args; get_path_and_build_if_necessary } = t in
-      build_exn (fun () ->
-        let open Memo.O in
-        let* env = env
-        and* sctx = sctx in
-        let expand = Cmd_arg.expand ~root:(Common.root common) ~sctx in
-        let* path =
-          let* prog = expand prog in
-          get_path_and_build_if_necessary ~prog
-        in
-        let+ args = Memo.parallel_map ~f:expand args in
-        path, args, env)
+    let* setup = Import.Main.setup () in
+    let* get_env_and_build_if_necessary, args =
+      Memo.run
+      @@
+      let open Memo.O in
+      let sctx =
+        let+ setup = setup in
+        Import.Main.find_scontext_exn setup ~name:context
+      in
+      let* sctx = sctx in
+      let expand = Cmd_arg.expand ~root ~sctx in
+      let+ prog = expand prog
+      and+ args = Memo.parallel_map args ~f:expand in
+      ( build (fun () ->
+          let+ env = Super_context.context_env sctx
+          and+ path =
+            let dir =
+              let context = Dune_rules.Super_context.context sctx in
+              Path.Build.relative
+                (Context.build_dir context)
+                (Common.prefix_target common "")
+            in
+            get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog
+          in
+          path, env)
+      , args )
     in
-    let prog = Path.to_string path in
-    restore_cwd_and_execve (Common.root common) prog args env
-  ;;
-
-  let run_eager_watch t common config =
-    Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config
-    @@ fun () ->
-    let open Fiber.O in
-    let* { sctx; env; prog; args; get_path_and_build_if_necessary } = t in
-    Scheduler.Run.poll
-    @@
-    let* () = Fiber.return @@ Scheduler.maybe_clear_screen ~details_hum:[] config in
-    Watch.step
-      ~root:(Common.root common)
-      ~sctx
-      ~env
-      ~prog
-      ~args
-      ~get_path_and_build_if_necessary
+    get_env_and_build_if_necessary
+    >>= function
+    | Ok (path, env) ->
+      Fiber.map ~f:(function Ok () | Error () -> Ok ())
+      @@ Fiber.map_reduce_errors (module Monoid.Unit) ~on_error
+      @@ fun () ->
+      Dune_engine.Process.run_external_in_out
+        ~dir:(Path.of_string Fpath.initial_cwd)
+        ~env
+        path
+        args
+      >>| (function
+       | 0 -> ()
+       | exit_code -> Console.print [ Pp.textf "Program exited with code [%d]" exit_code ])
+    | Error `Already_reported as e -> Fiber.return e
   ;;
 end
 
-let term =
+let run_once config ~prog ~args ~common ~no_rebuild ~context =
+  Scheduler.go_with_rpc_server ~common ~config
+  @@ fun () ->
+  let open Fiber.O in
+  let* setup = Import.Main.setup () in
+  let* path, args, env =
+    build_exn (fun () ->
+      let open Memo.O in
+      let sctx =
+        let+ setup = setup in
+        Import.Main.find_scontext_exn setup ~name:context
+      in
+      let* env = Memo.bind sctx ~f:Super_context.context_env
+      and* sctx = sctx in
+      let expand = Cmd_arg.expand ~root:(Common.root common) ~sctx in
+      let* path =
+        let* prog = expand prog in
+        let dir =
+          let context = Dune_rules.Super_context.context sctx in
+          Path.Build.relative (Context.build_dir context) (Common.prefix_target common "")
+        in
+        get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog
+      in
+      let+ args = Memo.parallel_map ~f:expand args in
+      path, args, env)
+  in
+  let prog = Path.to_string path in
+  restore_cwd_and_execve (Common.root common) prog args env
+;;
+
+let run_eager_watch config ~prog ~args ~common ~no_rebuild ~context =
+  Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config
+  @@ fun () ->
+  let open Fiber.O in
+  Scheduler.Run.poll
+  @@
+  let* () = Fiber.return @@ Scheduler.maybe_clear_screen ~details_hum:[] config in
+  Watch.step ~root:(Common.root common) ~prog ~args ~common ~no_rebuild ~context
+;;
+
+let term : unit Term.t =
   let+ builder = Common.Builder.term
   and+ context = Common.context_arg ~doc:{|Run the command in this build context.|}
   and+ prog = Arg.(required & pos 0 (some Cmd_arg.conv) None (Arg.info [] ~docv:"PROG"))
@@ -278,15 +258,14 @@ let term =
      For watch mode, we should finalize the backend and then restart it in between
      runs. *)
   let common, config = Common.init builder in
-  let exec_context = Exec_context.init ~common ~context ~no_rebuild ~prog ~args in
   let f =
     match Common.watch common with
     | Yes Passive ->
       User_error.raise [ Pp.textf "passive watch mode is unsupported by exec" ]
-    | Yes Eager -> Exec_context.run_eager_watch
-    | No -> Exec_context.run_once
+    | Yes Eager -> run_eager_watch
+    | No -> run_once
   in
-  f exec_context common config
+  f config ~prog ~args ~common ~no_rebuild ~context
 ;;
 
 let command = Cmd.v info term

--- a/otherlibs/dune-site/test/run_2_9.t
+++ b/otherlibs/dune-site/test/run_2_9.t
@@ -343,7 +343,6 @@ Test compiling an external plugin
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH PATH=$PWD/_install/bin:$PATH dune exec  --root=e -- c
   Entering directory 'e'
-  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -357,6 +356,7 @@ Test compiling an external plugin
   e: $TESTCASE_ROOT/e/_build/install/default/share/e/data
   info.txt is found: true
   run c: registered:e,b.
+  Leaving directory 'e'
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH dune install --root=e --prefix $PWD/_install
 

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -409,8 +409,8 @@ We can build and run the resulting executable:
 
   $ dune exec --root new_exec_proj ./bin/main.exe
   Entering directory 'new_exec_proj'
-  Leaving directory 'new_exec_proj'
   Hello, World!
+  Leaving directory 'new_exec_proj'
 
 We can build and run the project's tests:
 

--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -12,7 +12,7 @@
 ; These tests are explicitly disabled due to flakiness
 
 (cram
- (applies_to exec-watch-server exec-watch-ignore-sigterm)
+ (applies_to exec-watch-server exec-watch-ignore-sigterm exec-signal)
  (enabled_if false))
 
 (cram

--- a/test/blackbox-tests/test-cases/exec-watch/exec-segfault.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-segfault.t
@@ -36,27 +36,34 @@ This first program will cause a segfault:
   > ;;
   > EOF
 
+  $ LOG_FILE=_build/log_file
+  $ mkdir _build
+
 When reaching a signal like SEGV dune exec -w will exit.
-  $ dune exec -w ./foo.exe &
+  $ dune exec -w ./foo.exe 2> >(tee "$LOG_FILE" >&2) &
   about to segfault
   Command got signal SEGV.
+  Had 1 error, waiting for filesystem changes...
+  fixed segfault
+  Success, waiting for filesystem changes...
   $ PID=$!
   $ ./wait-for-file.sh $DONE_FLAG
 
-  $ wait $PID
-  [1]
-
-Ideally we should be able to restart the build after a segfault.
+Waiting for SEGV
+  $ tail -f "$LOG_FILE" | while read line; do
+  >   echo "$line" | grep 'SEGV' && break
+  > done
+  Command got signal SEGV.
 
 We can now start a new build by modifying the original program and removing the segfault.
 This rebuilds successfully as indicated by the above output.
-$ cat > foo.ml <<EOF
-> let () =
->   Touch.touch "$DONE_FLAG";
->   print_endline "fixed segfault";
-> ;;
-> EOF
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   Touch.touch "$DONE_FLAG";
+  >   print_endline "fixed segfault";
+  > ;;
+  > EOF
 
-$ ./wait-for-file.sh $DONE_FLAG
+  $ ./wait-for-file.sh $DONE_FLAG
 
-$ kill $PID
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
@@ -30,5 +30,5 @@ Perform the same test above but first enter the "bin" directory.
 Test that the behaviour is the same when not running with "--watch"
   $ cd bin && dune exec --root .. ./bin/main.exe
   Entering directory '..'
-  Leaving directory '..'
   foo
+  Leaving directory '..'

--- a/test/blackbox-tests/test-cases/exec/exec-bin.t
+++ b/test/blackbox-tests/test-cases/exec/exec-bin.t
@@ -23,7 +23,7 @@ By default, e is executed with the program name and arguments in argv.
 
   $ dune exec ./e.exe a b c
   Hello
-  argv[0] = ./_build/default/e.exe
+  argv[0] = $TESTCASE_ROOT/_build/default/e.exe
   argv[1] = a
   argv[2] = b
   argv[3] = c
@@ -32,7 +32,7 @@ The special form %{bin:public_name} is supported.
 
   $ dune exec %{bin:e} a b c
   Hello
-  argv[0] = ./_build/install/default/bin/e
+  argv[0] = $TESTCASE_ROOT/_build/install/default/bin/e
   argv[1] = a
   argv[2] = b
   argv[3] = c

--- a/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
@@ -23,8 +23,8 @@
 
   $ (cd test; dune exec --root .. -- dunetestbar)
   Entering directory '..'
-  Leaving directory '..'
   Bar
+  Leaving directory '..'
 
   $ ls -a test/_build
   .

--- a/test/blackbox-tests/test-cases/exec/exec-fail.t
+++ b/test/blackbox-tests/test-cases/exec/exec-fail.t
@@ -20,7 +20,7 @@ If a program exits with a non-zero exit code, we should return that code.
 
   $ dune exec -- ./foo.exe
   oh no!
-  Program exited with code [1]
+  [1]
 
 If a program encounters an exception, we should return a non-zero exit code.
 
@@ -32,7 +32,7 @@ If a program encounters an exception, we should return a non-zero exit code.
 
   $ dune exec -- ./foo.exe
   Fatal error: exception Failure("oh no!")
-  Program exited with code [2]
+  [2]
 
 If a program segfaults, we should return a non-zero exit code.
 

--- a/test/blackbox-tests/test-cases/exec/exec-fail.t
+++ b/test/blackbox-tests/test-cases/exec/exec-fail.t
@@ -1,0 +1,69 @@
+Testing how dune exec handles errors in the program being run.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo))
+  > EOF
+
+If a program exits with a non-zero exit code, we should return that code.
+
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   Printf.eprintf "oh no!\n";
+  >   exit 1
+  > ;;
+  > EOF
+
+  $ dune exec -- ./foo.exe
+  oh no!
+  [1]
+
+If a program encounters an exception, we should return a non-zero exit code.
+
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   raise (Failure "oh no!")
+  > ;;
+  > EOF
+
+  $ dune exec -- ./foo.exe
+  Fatal error: exception Failure("oh no!")
+  [2]
+
+If a program segfaults, we should return a non-zero exit code.
+
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   let f = Obj.magic 0 in
+  >   f 1
+  >   [@@warning "-20"]
+  > ;;
+  > EOF
+
+Note that 128 + 11 (SEGV) = 139
+  $ $(dune exec -- ./foo.exe)
+  [139]
+
+If a program is killed by a signal before it terminates, we should return a non-zero exit
+code.
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (libraries unix))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   let pid = Unix.getpid () in
+  >   Printf.printf "Killing self";
+  >   Unix.kill pid Sys.sigkill
+  > ;;
+  > EOF
+
+  $ $(dune exec -- ./foo.exe)
+  [137]

--- a/test/blackbox-tests/test-cases/exec/exec-fail.t
+++ b/test/blackbox-tests/test-cases/exec/exec-fail.t
@@ -20,7 +20,7 @@ If a program exits with a non-zero exit code, we should return that code.
 
   $ dune exec -- ./foo.exe
   oh no!
-  [1]
+  Program exited with code [1]
 
 If a program encounters an exception, we should return a non-zero exit code.
 
@@ -32,7 +32,7 @@ If a program encounters an exception, we should return a non-zero exit code.
 
   $ dune exec -- ./foo.exe
   Fatal error: exception Failure("oh no!")
-  [2]
+  Program exited with code [2]
 
 If a program segfaults, we should return a non-zero exit code.
 
@@ -46,7 +46,8 @@ If a program segfaults, we should return a non-zero exit code.
 
 Note that 128 + 11 (SEGV) = 139
   $ $(dune exec -- ./foo.exe)
-  [139]
+  Command got signal SEGV.
+  [1]
 
 If a program is killed by a signal before it terminates, we should return a non-zero exit
 code.
@@ -66,4 +67,5 @@ code.
   > EOF
 
   $ $(dune exec -- ./foo.exe)
-  [137]
+  Command got signal KILL.
+  [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
@@ -740,8 +740,8 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ export OCAMLPATH=$PWD/external/install/lib; dune exec ./main.exe --root=some/dir
   Entering directory 'some/dir'
-  Leaving directory 'some/dir'
   Answer = 42
+  Leaving directory 'some/dir'
 
 ----------------------------------------------------------------------------------
 * External library directories in (include_dir ...)

--- a/test/blackbox-tests/test-cases/foreign-stubs/link-includes.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/link-includes.t
@@ -35,6 +35,6 @@ First we create an external library and implementation
 Then we make sure that it works fine.
   $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
   Entering directory 'exe'
-  Leaving directory 'exe'
   lib1: 42
+  Leaving directory 'exe'
 

--- a/test/blackbox-tests/test-cases/github11527.t
+++ b/test/blackbox-tests/test-cases/github11527.t
@@ -21,14 +21,14 @@ and argv.(0) can be concatenated to get a valid path.
 When running dune exec from the root this is true.
   $ dune exec -- ./bug.exe
   pwd: $TESTCASE_ROOT
-  exe: ./_build/default/bug.exe
+  exe: $TESTCASE_ROOT/_build/default/bug.exe
 
   $ mkdir subdir
 
 As expected, the `exe:` argument shows the correct path
   $ (cd subdir && dune exec --root .. -- ./bug.exe)
   Entering directory '..'
-  Leaving directory '..'
   pwd: $TESTCASE_ROOT/subdir
-  exe: ../_build/default/bug.exe
+  exe: $TESTCASE_ROOT/_build/default/bug.exe
+  Leaving directory '..'
  

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -46,5 +46,5 @@ custom version:
 
   $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
   Entering directory 'external'
-  Leaving directory 'external'
   foobarlib
+  Leaving directory 'external'

--- a/test/blackbox-tests/test-cases/private-package-lib/main.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/main.t
@@ -158,8 +158,8 @@ Now we make sure such libraries are transitively usable when installed:
   $ export OCAMLPATH=$PWD/_build/install/default/lib
   $ dune exec --root use -- ./run.exe
   Entering directory 'use'
-  Leaving directory 'use'
   Using library foo: from library foo secret string
+  Leaving directory 'use'
 
 But we cannot use such libraries directly:
 

--- a/test/blackbox-tests/test-cases/rule/dependency-external.t
+++ b/test/blackbox-tests/test-cases/rule/dependency-external.t
@@ -206,22 +206,22 @@ rules with dependencies outside the build dir are allowed
 
   $ dune exec --root=a/b -- $PWD/a/script.sh
   Entering directory 'a/b'
-  Leaving directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 ## Test dune exec 1 level below
   $ dune exec --root=a/b -- ../script.sh
   Entering directory 'a/b'
-  Leaving directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 ## Test dune exec 2 level below
   $ mv a/script.sh .
 
   $ dune exec --root=a/b -- ../../script.sh
   Entering directory 'a/b'
-  Leaving directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Regression test for #5572
   $ dune exec --root=a/b -- ../


### PR DESCRIPTION
We simplify the implementation of `dune exec` further and now `dune exec` and `dune exec -w` share the same implementation.

One difference with before (which can be observed in the tests) is that `arg[0]` is now set to an absolute path. This is still valid within the `arg[0]` convention, but we could think about changing it back to a relative path.

- [ ] Might be a good time to improve some of the doc here?