### PR TITLE
chore: rename internal spawn to dune_spawn

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -48,7 +48,7 @@
   dune_rules_rpc
   dune_rpc_private
   dune_rpc_client
-  spawn
+  dune_spawn
   opam_format
   xdg)
  (bootstrap_info bootstrap-info))

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -100,7 +100,7 @@ let local_libraries =
     ; special_builtin_support = None
     }
   ; { path = "vendor/spawn/src"
-    ; main_module_name = None
+    ; main_module_name = Some "Dune_spawn"
     ; include_subdirs_unqualified = false
     ; special_builtin_support = None
     }

--- a/dune.opam
+++ b/dune.opam
@@ -56,6 +56,7 @@ depends: [
   "ocamlfind" { with-dev-setup & os != "win32" }
   "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
   "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind" { with-dev-setup & os != "win32" }
   "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
   "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }

--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,7 @@
                 merlin
                 ocaml-index
                 ppx_expect
+                spawn
                 ctypes
                 integers
                 mdx

--- a/src/dune_config_file/dune
+++ b/src/dune_config_file/dune
@@ -14,7 +14,7 @@
   dune_stats
   dune_tui
   dune_util
-  spawn)
+  dune_spawn)
  (synopsis "Internal Dune library, do not use!")
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -1,6 +1,7 @@
 module Dune_config = struct
   open Stdune
   open Dune_lang.Decoder
+  module Spawn = Dune_spawn.Spawn
   module Display = Display
   module Scheduler = Dune_engine.Scheduler
   module Sandbox_mode = Dune_engine.Sandbox_mode

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -28,7 +28,7 @@
   dune_rpc_private
   dune_rpc_client
   dune_thread_pool
-  spawn
+  dune_spawn
   ocamlc_loc
   dune_file_watcher
   dune_filesystem_stubs

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -8,6 +8,7 @@ module Stringlike = Dune_util.Stringlike
 
 module type Stringlike = Dune_util.Stringlike
 
+module Spawn = Dune_spawn.Spawn
 module Persistent = Dune_util.Persistent
 module Execution_env = Dune_util.Execution_env
 module Glob = Dune_glob.V1

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -1,7 +1,7 @@
 (library
  (name dune_file_watcher)
  (libraries
-  spawn
+  dune_spawn
   fsevents
   dune_console
   unix

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -1,4 +1,5 @@
 open! Stdune
+open Import
 module Inotify_lib = Async_inotify_for_dune.Async_inotify
 module Console = Dune_console
 

--- a/src/dune_file_watcher/import.ml
+++ b/src/dune_file_watcher/import.ml
@@ -1,0 +1,1 @@
+module Spawn = Dune_spawn.Spawn

--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -3,6 +3,6 @@
  (foreign_stubs
   (language c)
   (names dune_stats_stubs))
- (libraries stdune chrome_trace spawn unix)
+ (libraries stdune chrome_trace dune_spawn unix)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -1,4 +1,5 @@
 open Stdune
+module Spawn = Dune_spawn.Spawn
 module Timestamp = Chrome_trace.Event.Timestamp
 module Event = Chrome_trace.Event
 

--- a/vendor/spawn/src/dune
+++ b/vendor/spawn/src/dune
@@ -1,5 +1,5 @@
 (library
- (name spawn)
+ (name dune_spawn)
  (foreign_stubs
   (language c)
   (flags (:standard (:include flags.sexp)))


### PR DESCRIPTION
We shouldn't be using the internal vendored library for anything but bootstrapping dune. For everything else, spawn from opam should be preferred.