### PR TITLE
feat: add extra_objects field to foreign_library stanza

### DIFF
--- a/doc/changes/11683.md
+++ b/doc/changes/11683.md
@@ -1,0 +1,2 @@
+- Added `(extra_objects)` field to `(foreign_library)` stanza with `(:include)` support.
+  (#11683, @Alizter)

--- a/doc/reference/foreign-archives.rst
+++ b/doc/reference/foreign-archives.rst
@@ -33,6 +33,7 @@ described in :ref:`foreign-sandboxing`, or ask Dune to build it via the
      (language c)
      (enabled_if true)
      (names src4 src5)
+     (extra_objects obj1)
      (include_dir headers))
 
 This asks Dune to compile C source files ``src4`` and ``src5`` with
@@ -47,3 +48,6 @@ to the same archive name from multiple OCaml libraries and executables, so a
 foreign archive is a bit like a foreign library, hence the name of the stanza.
 The ``enabled_if`` field has the same meaning as in the :doc:`dune/library`
 stanza.
+The ``extra_objects`` field specifies additional object files to be included.
+Dune will look for ``obj1.o`` in this case. ``extra_objects`` uses the
+:doc:`/reference/ordered-set-language` and supports ``(:include ...)`` forms.

--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -28,8 +28,9 @@ let add_files sctx ~dir files =
   if Super_context.context sctx |> Context.merlin
   then (
     let alias = Alias.make Alias0.check ~dir in
-    let files = Path.Set.of_list files in
-    Rules.Produce.Alias.add_deps alias (Action_builder.path_set files))
+    (let open Action_builder.O in
+     files >>| Dep.Set.of_files >>= Action_builder.deps)
+    |> Rules.Produce.Alias.add_deps alias)
   else Memo.return ()
 ;;
 

--- a/src/dune_rules/check_rules.mli
+++ b/src/dune_rules/check_rules.mli
@@ -6,7 +6,11 @@ val add_obj_dir
   -> Lib_mode.t
   -> unit Memo.t
 
-val add_files : Super_context.t -> dir:Path.Build.t -> Path.t list -> unit Memo.t
+val add_files
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Path.t list Action_builder.t
+  -> unit Memo.t
 
 val add_cycle_check
   :  Super_context.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -252,7 +252,11 @@ let executables_rules
       let* o_files =
         o_files sctx ~dir ~expander ~exes ~linkages ~dir_contents ~requires_compile
       in
-      let* () = Check_rules.add_files sctx ~dir @@ Mode.Map.Multi.to_flat_list o_files in
+      let* () =
+        Mode.Map.Multi.to_flat_list o_files
+        |> Action_builder.return
+        |> Check_rules.add_files sctx ~dir
+      in
       let buildable = exes.buildable in
       match buildable.ctypes with
       | None ->

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -108,7 +108,7 @@ let o_files
       let first_exe = first_exe exes in
       Foreign_sources.for_exes foreign_sources ~first_exe
     in
-    let* foreign_o_files =
+    let* extra_o_files =
       let+ { Lib_config.ext_obj; _ } =
         let+ ocaml = Super_context.context sctx |> Context.ocaml in
         ocaml.lib_config
@@ -124,8 +124,8 @@ let o_files
         ~dir_contents
         ~foreign_sources
     in
-    (* [foreign_o_files] are not mode-dependent *)
-    Mode.Map.Multi.add_all o_files All foreign_o_files)
+    (* [extra_o_files] are not mode-dependent *)
+    Mode.Map.Multi.add_all o_files All extra_o_files)
 ;;
 
 let executables_rules

--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -56,9 +56,10 @@ let decode (for_ : for_) =
       (Dune_lang.Syntax.since Stanza.syntax (2, 0)
        >>> repeat (located Foreign.Archive.decode))
   and+ extra_objects =
-    field_o
+    field
       "extra_objects"
       (Dune_lang.Syntax.since Stanza.syntax (3, 5) >>> Foreign.Objects.decode)
+      ~default:Foreign.Objects.empty
   and+ c_flags =
     only_in_library
       (field_o "c_flags" (use_foreign >>> Ordered_set_lang.Unexpanded.decode))
@@ -156,7 +157,6 @@ let decode (for_ : for_) =
          the "lib" prefix, however, since standard linkers require it). *)
       | Some name -> (loc, Foreign.Archive.stubs name) :: foreign_archives)
   in
-  let extra_objects = Option.value ~default:Foreign.Objects.empty extra_objects in
   { loc
   ; preprocess
   ; preprocessor_deps

--- a/src/dune_rules/stanzas/foreign_library.ml
+++ b/src/dune_rules/stanzas/foreign_library.ml
@@ -5,7 +5,7 @@ type t =
   ; archive_name_loc : Loc.t
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
-  ; extra_objects : Foreign.Objects.t
+  ; extra_objects : Ordered_set_lang.Unexpanded.t
   }
 
 let decode =
@@ -16,10 +16,9 @@ let decode =
      and+ stubs = Foreign.Stubs.decode_stubs ~for_library:true
      and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (3, 14)) ()
      and+ extra_objects =
-       field
+       Ordered_set_lang.Unexpanded.field
          "extra_objects"
-         (Dune_lang.Syntax.since Stanza.syntax (3, 19) >>> Foreign.Objects.decode)
-         ~default:Foreign.Objects.empty
+         ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 19))
      in
      { archive_name; archive_name_loc; stubs; enabled_if; extra_objects })
 ;;

--- a/src/dune_rules/stanzas/foreign_library.ml
+++ b/src/dune_rules/stanzas/foreign_library.ml
@@ -5,6 +5,7 @@ type t =
   ; archive_name_loc : Loc.t
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
+  ; extra_objects : Foreign.Objects.t
   }
 
 let decode =
@@ -13,8 +14,14 @@ let decode =
     (let+ archive_name_loc, archive_name =
        located (field "archive_name" Foreign.Archive.Name.decode)
      and+ stubs = Foreign.Stubs.decode_stubs ~for_library:true
-     and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (3, 14)) () in
-     { archive_name; archive_name_loc; stubs; enabled_if })
+     and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (3, 14)) ()
+     and+ extra_objects =
+       field
+         "extra_objects"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 19) >>> Foreign.Objects.decode)
+         ~default:Foreign.Objects.empty
+     in
+     { archive_name; archive_name_loc; stubs; enabled_if; extra_objects })
 ;;
 
 include Stanza.Make (struct

--- a/src/dune_rules/stanzas/foreign_library.mli
+++ b/src/dune_rules/stanzas/foreign_library.mli
@@ -25,7 +25,7 @@ type t =
   ; archive_name_loc : Loc.t
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
-  ; extra_objects : Foreign.Objects.t
+  ; extra_objects : Ordered_set_lang.Unexpanded.t
   }
 
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/stanzas/foreign_library.mli
+++ b/src/dune_rules/stanzas/foreign_library.mli
@@ -1,34 +1,31 @@
-(** Foreign libraries.
-
-    This data type represents the contents of the top-level stanza
-    [foreign_library].
-
-    The fields have the following semantics.
-
-    [language] selects the compiler. At the moment, we support only [c] and
-    [cxx] settings, but in future other languages/compilers could be supported,
-    e.g. Rust and Clang.
-
-    [archive_name] determines the names of the resulting [.a] archive files.
-
-    [names] are names of source files. The full paths to the files are
-    determined by scanning package directories. Duplicate file names are
-    disallowed to avoid conflicting object names in the resulting archive file.
-
-    [flags] are passed when compiling source files.
-
-    [include_dirs] are tracked as dependencies and passed to the compiler via
-    the "-I" flag.
-
-    [extra_deps] are tracked as dependencies. *)
-
 open Import
 
+(** Foreign libraries.
+
+    This data type represents the contents of the top-level stanza [foreign_library].
+
+    The fields have the following semantics:
+
+    - [archive_name] determines the names of the resulting [.a] archive files.
+    
+    - [archive_name_loc] is the location of the [archive_name] field in the
+      Dune file. This is used for error reporting.
+
+    - [names] are names of source files. The full paths to the files are determined by
+      scanning package directories. Duplicate file names are disallowed to avoid
+      conflicting object names in the resulting archive file. 
+    
+    - [stubs] collects the language-specific compilation options.
+    
+    - [enabled_if] is a condition that determines whether the stanza is enabled.
+    
+    - [extra_objects] are additional object files to be linked in the archive. *)
 type t =
   { archive_name : Foreign.Archive.Name.t
   ; archive_name_loc : Loc.t
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
+  ; extra_objects : Foreign.Objects.t
   }
 
 val decode : t Dune_lang.Decoder.t

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
@@ -1,0 +1,45 @@
+Testing extra_objects in foreign libraries
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+First we create a foreign library that uses an extra object file containing our message.
+
+  $ cat > dune <<EOF
+  > (foreign_library
+  >  (archive_name foo)
+  >  (names foo)
+  >  (language c)
+  >  (extra_objects message))
+  > EOF
+
+  $ cat > foo.c <<EOF
+  > #include <stdio.h>
+  > extern char *message;
+  > int f() { printf("%s\n", message); return 0; }
+  > EOF
+
+Our message is compiled separately from the foreign library and the object file is
+included in the (extra_objects) field.
+  $ cat > message.c <<EOF
+  > char *message = "Hello from C!";
+  > EOF
+  $ ocamlopt -c message.c -o message.o
+
+We create a test executable that links against the foreign library to check everything is
+working as intended.
+  $ cat > test.c <<EOF
+  > #include <stdio.h>
+  > extern int f();
+  > int main() { return f(); }
+  > EOF
+
+  $ dune build _build/default/libfoo.a
+
+  $ ocamlopt test.c _build/default/libfoo.a -o test.exe
+  $ chmod +x test.exe
+
+Our test executable works as intended and prints the message from the object file.
+  $ ./test.exe
+  Hello from C!

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
@@ -73,3 +73,34 @@ Testing that (:include) works
   $ chmod +x test.exe
   $ ./test.exe
   Hello from C with an (:include)!
+
+Testing how (:include) interacts with a non-existant file.
+  $ rm message.in test.exe test.o
+
+  $ dune build _build/default/libfoo.a
+  File "dune", lines 1-6, characters 0-105:
+  1 | (foreign_library
+  2 |  (archive_name foo)
+  3 |  (names foo)
+  4 |  (language c)
+  5 |  (extra_objects
+  6 |   (:include message.in)))
+  Error: No rule found for message.in
+  [1]
+
+Testing how (:include) interacts when returning a non-existent object file.
+
+  $ cat > message.in <<EOF
+  > foobar
+  > EOF
+
+  $ dune build _build/default/libfoo.a
+  File "dune", lines 1-6, characters 0-105:
+  1 | (foreign_library
+  2 |  (archive_name foo)
+  3 |  (names foo)
+  4 |  (language c)
+  5 |  (extra_objects
+  6 |   (:include message.in)))
+  Error: No rule found for foobar.o
+  [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library-extra-objects.t
@@ -43,3 +43,33 @@ working as intended.
 Our test executable works as intended and prints the message from the object file.
   $ ./test.exe
   Hello from C!
+
+  $ rm test.exe
+  $ rm test.o
+  $ rm message.o
+
+Testing that (:include) works
+
+  $ cat > dune <<EOF
+  > (foreign_library
+  >  (archive_name foo)
+  >  (names foo)
+  >  (language c)
+  >  (extra_objects
+  >   (:include message.in)))
+  > EOF
+
+  $ cat > message.in <<EOF
+  > message
+  > EOF
+
+  $ cat > message.c <<EOF
+  > char *message = "Hello from C with an (:include)!";
+  > EOF
+  $ ocamlopt -c message.c -o message.o
+
+  $ dune build _build/default/libfoo.a
+  $ ocamlopt test.c _build/default/libfoo.a -o test.exe
+  $ chmod +x test.exe
+  $ ./test.exe
+  Hello from C with an (:include)!


### PR DESCRIPTION
We add support for the `extra_objects` field in the `foreign_library` stanza. This allows extra object files to be linked to foreign libraries.

- [x] Update docs
- [x] Changelog
- [x] Dune lang bump (we should be 3.19 not 3.18)?