### PR TITLE
[3.18] Backport #11639 for OCaml 5.4 support

### DIFF
--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -33,35 +33,34 @@ type t =
 external sigwinch : unit -> int = "stdune_winch_number" [@@noalloc]
 
 let all =
-  let open Sys in
-  [ Abrt, sigabrt
-  ; Alrm, sigalrm
-  ; Fpe, sigfpe
-  ; Hup, sighup
-  ; Ill, sigill
-  ; Int, sigint
-  ; Kill, sigkill
-  ; Pipe, sigpipe
-  ; Quit, sigquit
-  ; Segv, sigsegv
-  ; Term, sigterm
-  ; Usr1, sigusr1
-  ; Usr2, sigusr2
-  ; Chld, sigchld
-  ; Cont, sigcont
-  ; Stop, sigstop
-  ; Tstp, sigtstp
-  ; Ttin, sigttin
-  ; Ttou, sigttou
-  ; Vtalrm, sigvtalrm
-  ; Prof, sigprof
-  ; Bus, sigbus
-  ; Poll, sigpoll
-  ; Sys, sigsys
-  ; Trap, sigtrap
-  ; Urg, sigurg
-  ; Xcpu, sigxcpu
-  ; Xfsz, sigxfsz
+  [ Abrt, Sys.sigabrt
+  ; Alrm, Sys.sigalrm
+  ; Fpe, Sys.sigfpe
+  ; Hup, Sys.sighup
+  ; Ill, Sys.sigill
+  ; Int, Sys.sigint
+  ; Kill, Sys.sigkill
+  ; Pipe, Sys.sigpipe
+  ; Quit, Sys.sigquit
+  ; Segv, Sys.sigsegv
+  ; Term, Sys.sigterm
+  ; Usr1, Sys.sigusr1
+  ; Usr2, Sys.sigusr2
+  ; Chld, Sys.sigchld
+  ; Cont, Sys.sigcont
+  ; Stop, Sys.sigstop
+  ; Tstp, Sys.sigtstp
+  ; Ttin, Sys.sigttin
+  ; Ttou, Sys.sigttou
+  ; Vtalrm, Sys.sigvtalrm
+  ; Prof, Sys.sigprof
+  ; Bus, Sys.sigbus
+  ; Poll, Sys.sigpoll
+  ; Sys, Sys.sigsys
+  ; Trap, Sys.sigtrap
+  ; Urg, Sys.sigurg
+  ; Xcpu, Sys.sigxcpu
+  ; Xfsz, Sys.sigxfsz
   ; Winch, sigwinch ()
   ]
 ;;


### PR DESCRIPTION
This cherry-picks #11639 to the 3.18 branch