### PR TITLE
chore(nix): set dune version to `3.x-n/a`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
       packages = {
         default = with pkgs; stdenv.mkDerivation {
           pname = "dune";
-          version = "n/a";
+          version = "3.x-n/a";
           src =
             let fs = lib.fileset; in
             fs.toSource {


### PR DESCRIPTION
- nixpkgs upstream has a [check](https://github.com/NixOS/nixpkgs/blob/b2e126e6cb4e09a5794e28c4dacf41257d7be4b1/pkgs/build-support/ocaml/dune.nix#L58-L59) for the dune version to set `--docdir` and `--mandir`. 
- setting `version` to something >= 2.9 allows us to run the odoc tests with the `.#scope` devShell