### PR TITLE
Allow concurrent build with RPC server

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -125,7 +125,7 @@ let run_build_command_once ~(common : Common.t) ~config ~request =
     | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
     | Ok () -> ()
   in
-  Scheduler.go ~common ~config once
+  Scheduler.go_with_rpc_server ~common ~config once
 ;;
 
 let run_build_command ~(common : Common.t) ~config ~request =

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -42,7 +42,7 @@ let term =
   in
   let coq_file_arg = Common.prefix_target common coq_file_arg |> Path.Local.of_string in
   let coqtop, args, env =
-    Scheduler.go ~common ~config
+    Scheduler.go_with_rpc_server ~common ~config
     @@ fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in

--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -82,7 +82,7 @@ let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
     Console.print
       [ Pp.vbox @@ Pp.concat_map ~f:Pp.vbox paragraphs ~sep:(Pp.seq Pp.space Pp.space) ]
   in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   Build_cmd.run_build_system ~common ~request

--- a/bin/describe/describe_contexts.ml
+++ b/bin/describe/describe_contexts.ml
@@ -3,7 +3,7 @@ open Import
 let term =
   let+ builder = Common.Builder.term in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   let* setup = Import.Main.setup () in

--- a/bin/describe/describe_depexts.ml
+++ b/bin/describe/describe_depexts.ml
@@ -38,7 +38,7 @@ let term =
   and+ lock_dirs_arg = Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () -> print_depexts ~lock_dirs_arg)
+  Scheduler.go_with_rpc_server ~common ~config (fun () -> print_depexts ~lock_dirs_arg)
 ;;
 
 let info =

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -207,7 +207,7 @@ let term =
   and+ _ = Describe_lang_compat.arg
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   let* setup = Import.Main.setup () in

--- a/bin/describe/describe_opam_files.ml
+++ b/bin/describe/describe_opam_files.ml
@@ -5,7 +5,7 @@ let term =
   and+ format = Describe_format.arg
   and+ _ = Describe_lang_compat.arg in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   build_exn
   @@ fun () ->

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -27,7 +27,7 @@ module Show_lock = struct
     and+ lock_dir_arg = Pkg_common.Lock_dirs_arg.term in
     let builder = Common.Builder.forbid_builds builder in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config @@ print_lock lock_dir_arg
+    Scheduler.go_with_rpc_server ~common ~config @@ print_lock lock_dir_arg
   ;;
 
   let command =
@@ -60,7 +60,7 @@ module Dependency_hash = struct
     let+ builder = Common.Builder.term in
     let builder = Common.Builder.forbid_builds builder in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config print_local_packages_hash
+    Scheduler.go_with_rpc_server ~common ~config print_local_packages_hash
   ;;
 
   let info =
@@ -180,7 +180,8 @@ module List_locked_dependencies = struct
     and+ lock_dirs = Pkg_common.Lock_dirs_arg.term in
     let builder = Common.Builder.forbid_builds builder in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config @@ list_locked_dependencies ~transitive ~lock_dirs
+    Scheduler.go_with_rpc_server ~common ~config
+    @@ list_locked_dependencies ~transitive ~lock_dirs
   ;;
 
   let command = Cmd.v info term

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -161,7 +161,7 @@ let term =
   and+ _ = Describe_lang_compat.arg
   and+ file = Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"FILE")) in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   let* setup = Import.Main.setup () in

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -655,7 +655,7 @@ let term : unit Term.t =
     in
     Dune_lang.Decoder.parse parse Univ_map.empty ast
   in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   let* setup = Import.Main.setup () in

--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -5,7 +5,7 @@ let term =
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config
+  Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->
   let open Fiber.O in
   let* setup = Import.Main.setup () in

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -228,7 +228,7 @@ module Exec_context = struct
   ;;
 
   let run_once t common config =
-    Scheduler.go ~common ~config
+    Scheduler.go_with_rpc_server ~common ~config
     @@ fun () ->
     let open Fiber.O in
     let* path, args, env =

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -40,7 +40,7 @@ let run_fmt_command ~(common : Common.t) ~config =
     | Ok () -> ()
     | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
   in
-  Scheduler.go ~common ~config once
+  Scheduler.go_with_rpc_server ~common ~config once
 ;;
 
 let command =

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -200,7 +200,7 @@ module Scheduler = struct
     Run.go config ~on_event:(on_event dune_config) f
   ;;
 
-  let go ~common ~config f =
+  let go_with_rpc_server ~common ~config f =
     let f =
       match Common.rpc common with
       | `Allow server -> fun () -> Dune_engine.Rpc.with_background_rpc (rpc server) f

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -79,7 +79,7 @@ let context_cwd : Init_context.t Term.t =
   let builder = Common.Builder.set_default_root_is_cwd builder true in
   let common, config = Common.init builder in
   let project_defaults = config.project_defaults in
-  Scheduler.go ~common ~config (fun () ->
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
     Memo.run (Init_context.make path project_defaults))
 ;;
 
@@ -279,7 +279,8 @@ let project =
        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p root in
        let common, config = Common.init builder in
        let project_defaults = config.project_defaults in
-       Scheduler.go ~common ~config (fun () -> Memo.run @@ init_context project_defaults)
+       Scheduler.go_with_rpc_server ~common ~config (fun () ->
+         Memo.run @@ init_context project_defaults)
      in
      Component.init
        (Project { context; common; options = { template; inline_tests; pkg } });

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -816,7 +816,7 @@ let make ~what =
     let builder = Common.Builder.forbid_builds builder in
     let builder = Common.Builder.disable_log_file builder in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config (fun () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let from_command_line =
         { Install.Roots.lib_root = libdir_from_command_line
         ; etc_root = etcdir_from_command_line

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -14,7 +14,7 @@ let term =
           ~doc:"List libraries that are not available and explain why")
   in
   let common, config = Common.init builder in
-  Scheduler.go
+  Scheduler.go_with_rpc_server
     ~common
     ~config
     (let run () =

--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -227,7 +227,8 @@ module Dump_config = struct
       in
       Common.init builder
     in
-    Scheduler.go ~common ~config (fun () -> Server.dump ~selected_context dir)
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+      Server.dump ~selected_context dir)
   ;;
 
   let command = Cmd.v info term
@@ -258,7 +259,7 @@ let start_session_term =
     in
     Common.init builder
   in
-  Scheduler.go ~common ~config (Server.start ~selected_context)
+  Scheduler.go_with_rpc_server ~common ~config (Server.start ~selected_context)
 ;;
 
 let command = Cmd.v (start_session_info "ocaml-merlin") start_session_term
@@ -300,7 +301,7 @@ module Dump_dot_merlin = struct
       in
       Common.init builder
     in
-    Scheduler.go ~common ~config (fun () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
       match path with
       | Some s -> Server.dump_dot_merlin ~selected_context s
       | None -> Server.dump_dot_merlin ~selected_context ".")

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -42,7 +42,7 @@ let term =
   and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
   and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () ->
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in
     build_exn (fun () ->
@@ -213,7 +213,7 @@ module Module = struct
         & Arg.info [] ~docv:"MODULE" ~doc:"Path to an OCaml module.")
     and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config (fun () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in
       build_exn (fun () ->

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -22,7 +22,7 @@ let term =
   if not (Path.is_directory (Path.of_string dir))
   then User_error.raise [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
   let env, lib_config, utop_path, requires =
-    Scheduler.go ~common ~config (fun () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in
       build_exn (fun () ->

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -249,7 +249,7 @@ let term =
   and+ print_perf_stats = Arg.(value & flag & info [ "print-perf-stats" ]) in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () ->
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
     lock ~version_preference ~lock_dirs_arg ~print_perf_stats)
 ;;
 

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -73,7 +73,8 @@ let term =
   and+ lock_dirs_arg = Pkg_common.Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config @@ find_outdated_packages ~transitive ~lock_dirs_arg
+  Scheduler.go_with_rpc_server ~common ~config
+  @@ find_outdated_packages ~transitive ~lock_dirs_arg
 ;;
 
 let info =

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -40,7 +40,7 @@ let term =
   and+ lock_dirs_arg = Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () -> print_solver_env ~lock_dirs_arg)
+  Scheduler.go_with_rpc_server ~common ~config (fun () -> print_solver_env ~lock_dirs_arg)
 ;;
 
 let info =

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -76,7 +76,7 @@ let term =
   and+ lock_dirs = Pkg_common.Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config @@ validate_lock_dirs ~lock_dirs
+  Scheduler.go_with_rpc_server ~common ~config @@ validate_lock_dirs ~lock_dirs
 ;;
 
 let command = Cmd.v info term

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -278,7 +278,7 @@ let term =
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
   let common, config = Common.init builder in
   let out = Option.map ~f:Path.of_string out in
-  Scheduler.go ~common ~config (fun () ->
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in
     build_exn (fun () ->

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -85,7 +85,7 @@ let term =
              multiple fields.")
   in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () ->
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in
     let* setup = Memo.run setup in

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -69,7 +69,8 @@ module Diff = struct
     and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
-    Scheduler.go ~common ~config (fun () -> Diff_promotion.display files_to_promote)
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+      Diff_promotion.display files_to_promote)
   ;;
 
   let command = Cmd.v info term
@@ -83,7 +84,8 @@ module Files = struct
     and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
-    Scheduler.go ~common ~config (fun () -> display_files files_to_promote)
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+      display_files files_to_promote)
   ;;
 
   let command = Cmd.v info term

--- a/bin/rpc/build.ml
+++ b/bin/rpc/build.ml
@@ -46,6 +46,31 @@ let establish_client_session ~wait =
   establish_connection_or_raise ~wait once
 ;;
 
+(* Sends a request to build [targets] to the RPC server at [where]. The targets
+   are specified as strings containing sexp-encoded targets that are passed to
+   this command as arguments on the command line. *)
+let build_sexp_string_targets ~wait ~targets =
+  let open Fiber.O in
+  let* connection = establish_client_session ~wait in
+  Dune_rpc_impl.Client.client
+    connection
+    (Dune_rpc.Initialize.Request.create ~id:(Dune_rpc.Id.make (Sexp.Atom "build")))
+    ~f:(fun session ->
+      Rpc_common.request_exn
+        session
+        (Dune_rpc_private.Decl.Request.witness Dune_rpc_impl.Decl.build)
+        targets)
+;;
+
+let build ~wait targets =
+  let targets =
+    List.map targets ~f:(fun target ->
+      let sexp = Dune_lang.Dep_conf.encode target in
+      Dune_lang.to_string sexp)
+  in
+  build_sexp_string_targets ~wait ~targets
+;;
+
 let term =
   let name_ = Arg.info [] ~docv:"TARGET" in
   let+ (builder : Common.Builder.t) = Common.Builder.term
@@ -54,25 +79,14 @@ let term =
   Rpc_common.client_term builder
   @@ fun _common ->
   let open Fiber.O in
-  let* conn = establish_client_session ~wait in
-  Dune_rpc_impl.Client.client
-    conn
-    (Dune_rpc.Initialize.Request.create ~id:(Dune_rpc.Id.make (Sexp.Atom "build")))
-    ~f:(fun session ->
-      let open Fiber.O in
-      let+ response =
-        Rpc_common.request_exn
-          session
-          (Dune_rpc_private.Decl.Request.witness Dune_rpc_impl.Decl.build)
-          targets
-      in
-      match response with
-      | Error (error : Dune_rpc_private.Response.Error.t) ->
-        Printf.printf
-          "Error: %s\n%!"
-          (Dyn.to_string (Dune_rpc_private.Response.Error.to_dyn error))
-      | Ok Success -> print_endline "Success"
-      | Ok Failure -> print_endline "Failure")
+  let+ response = build_sexp_string_targets ~wait ~targets in
+  match response with
+  | Error (error : Dune_rpc_private.Response.Error.t) ->
+    Printf.eprintf
+      "Error: %s\n%!"
+      (Dyn.to_string (Dune_rpc_private.Response.Error.to_dyn error))
+  | Ok Success -> print_endline "Success"
+  | Ok (Failure _) -> print_endline "Failure"
 ;;
 
 let info =

--- a/bin/rpc/build.mli
+++ b/bin/rpc/build.mli
@@ -1,2 +1,16 @@
+open! Import
+
+(** Sends a command to an RPC server to build the specified targets and wait
+    for the build to complete or fail. If [wait] is true then wait until an RPC
+    server is running before making the request. Otherwise if no RPC server is
+    running then raise a [User_error].  *)
+val build
+  :  wait:bool
+  -> Dune_lang.Dep_conf.t list
+  -> ( Dune_rpc_impl.Decl.Build_outcome_with_diagnostics.t
+       , Dune_rpc.Response.Error.t )
+       result
+       Fiber.t
+
 (** dune rpc build command *)
 val cmd : unit Cmdliner.Cmd.t

--- a/bin/rpc/rpc.ml
+++ b/bin/rpc/rpc.ml
@@ -12,3 +12,5 @@ let info =
 ;;
 
 let group = Cmd.group info [ Status.cmd; Build.cmd; Ping.cmd ]
+
+module Build = Build

--- a/bin/rpc/rpc.mli
+++ b/bin/rpc/rpc.mli
@@ -1,2 +1,4 @@
 (** dune rpc command group *)
 val group : unit Cmdliner.Cmd.t
+
+module Build = Build

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -33,7 +33,7 @@ let client_term builder f =
   let builder = Common.Builder.forbid_builds builder in
   let builder = Common.Builder.disable_log_file builder in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config f
+  Scheduler.go_with_rpc_server ~common ~config f
 ;;
 
 let wait_term =

--- a/bin/tools/ocamlformat.ml
+++ b/bin/tools/ocamlformat.ml
@@ -38,7 +38,7 @@ module Exec = struct
     let+ builder = Common.Builder.term
     and+ args = Arg.(value & pos_all string [] (info [] ~docv:"ARGS")) in
     let common, config = Common.init builder in
-    Scheduler.go ~common ~config (fun () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in
       let* () = Lock_dev_tool.lock_ocamlformat () |> Memo.run in
       let+ () = build_dev_tool common in

--- a/bin/tools/ocamllsp.ml
+++ b/bin/tools/ocamllsp.ml
@@ -48,7 +48,7 @@ module Exec = struct
         ]
     | true ->
       let common, config = Common.init builder in
-      Scheduler.go ~common ~config (fun () ->
+      Scheduler.go_with_rpc_server ~common ~config (fun () ->
         let open Fiber.O in
         let* () = Lock_dev_tool.lock_ocamllsp () |> Memo.run in
         let+ () = build_ocamllsp common in

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -16,7 +16,7 @@ let info = Cmd.info "upgrade" ~doc ~man
 let term =
   let+ builder = Common.Builder.term in
   let common, config = Common.init builder in
-  Scheduler.go ~common ~config (fun () -> Dune_upgrader.upgrade ())
+  Scheduler.go_with_rpc_server ~common ~config (fun () -> Dune_upgrader.upgrade ())
 ;;
 
 let command = Cmd.v info term

--- a/doc/changes/11712.md
+++ b/doc/changes/11712.md
@@ -1,0 +1,1 @@
+- Allow concurrent build with RPC server (#11712, @gridbugs)

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -23,7 +23,16 @@ val triple
   -> ('a * 'b * 'c, values) t
 
 val enum : (string * 'a) list -> ('a, values) t
+
+(** [iso t to_ from] creates a parser for a type ['b] out of a parser for a
+    type ['a], where ['a] and ['b] are isomorphic to one another. The functions
+    [to_] and [from] convert between the two types ['a] and ['b]. A typical
+    approach for parsing record types is to convert them to/from tuples (via the
+    [three], [four], etc. combinators) which can be parsed with [record], and
+    then use [iso] to convert the parser for a tuple type into a parser for the
+    original record type. *)
 val iso : ('a, 'k) t -> ('a -> 'b) -> ('b -> 'a) -> ('b, 'k) t
+
 val iso_result : ('a, 'k) t -> ('a -> ('b, exn) result) -> ('b -> 'a) -> ('b, 'k) t
 val version : ?until:int * int -> ('a, 'k) t -> since:int * int -> ('a, 'k) t
 
@@ -118,5 +127,12 @@ val error : error -> 'a
 val dyn_of_error : error -> Dyn.t
 val to_sexp : ('a, values) t -> 'a -> Sexp.t
 val of_sexp : ('a, values) t -> version:int * int -> Sexp.t -> ('a, error) result
+
+(** [fixpoint f] is a helper for creating parsers of recursive data structures
+    such as ASTs. [f] is a function which returns a parser for a single node in
+    the hierarchy, and [f] is passed a parser which it can use for parsing
+    children of the current node. [fixpoint f] then returns a parser for the
+    recursive data structure. *)
 val fixpoint : (('a, 'k) t -> ('a, 'k) t) -> ('a, 'k) t
+
 val sexp_for_digest : ('a, 'k) t -> Sexp.t

--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -81,6 +81,13 @@ module User_message : sig
       | Success
       | Ansi_styles of Ansi_color.Style.t list
   end
+
+  type t = Stdune.User_message.t
+
+  (** (De)serializer for [User_message.t] which ignores the [annots] field. The
+      [annots] field is non-trivial to serialize and is not necessary for
+      formatting messages, so it's not handled here. *)
+  val sexp_without_annots : t Conv.value
 end
 
 module Diagnostic : sig

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -2,6 +2,11 @@ module Promote = struct
   type t =
     | Automatically
     | Never
+
+  let to_dyn = function
+    | Automatically -> Dyn.variant "Automatically" []
+    | Never -> Dyn.variant "Never" []
+  ;;
 end
 
 let report_errors_config = ref Report_errors_config.default

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -21,6 +21,8 @@ module Promote : sig
   type t =
     | Automatically
     | Never
+
+  val to_dyn : t -> Dyn.t
 end
 
 (** explicit promotion mode is set *)

--- a/src/dune_engine/compound_user_error.mli
+++ b/src/dune_engine/compound_user_error.mli
@@ -9,6 +9,7 @@ type t = private
   ; related : User_message.t list
   }
 
+val to_dyn : t -> Dyn.t
 val annot : t list User_message.Annots.Key.t
 val make : main:User_message.t -> related:User_message.t list -> t
 val parse_output : dir:Path.t -> string -> t list

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -1,20 +1,47 @@
 open Import
 open Dune_rpc
 
-module Build_outcome = struct
-  type t = Scheduler.Run.Build_outcome.t =
-    | Success
-    | Failure
+module Compound_user_error = struct
+  include Dune_engine.Compound_user_error
 
   let sexp =
     let open Conv in
+    let from { main; related } = main, related in
+    let to_ (main, related) = make ~main ~related in
+    let main = field "main" (required User_message.sexp_without_annots) in
+    let related = field "related" (required (list User_message.sexp_without_annots)) in
+    iso (record (both main related)) to_ from
+  ;;
+end
+
+module Build_outcome_with_diagnostics = struct
+  type t =
+    | Success
+    | Failure of Dune_engine.Compound_user_error.t list
+
+  let sexp_v1 =
+    let open Conv in
     let success = constr "Success" unit (fun () -> Success) in
-    let failure = constr "Failure" unit (fun () -> Failure) in
+    let failure = constr "Failure" unit (fun () -> Failure []) in
     let variants = [ econstr success; econstr failure ] in
     sum variants (function
       | Success -> case () success
-      | Failure -> case () failure)
+      | Failure _ -> case () failure)
   ;;
+
+  let sexp_v2 =
+    let open Conv in
+    let success = constr "Success" unit (fun () -> Success) in
+    let failure =
+      constr "Failure" (list Compound_user_error.sexp) (fun errors -> Failure errors)
+    in
+    let variants = [ econstr success; econstr failure ] in
+    sum variants (function
+      | Success -> case () success
+      | Failure errors -> case errors failure)
+  ;;
+
+  let sexp = sexp_v2
 end
 
 module Status = struct
@@ -51,11 +78,18 @@ module Build = struct
   let v1 =
     Decl.Request.make_current_gen
       ~req:(Conv.list Conv.string)
-      ~resp:Build_outcome.sexp
+      ~resp:Build_outcome_with_diagnostics.sexp_v1
       ~version:1
   ;;
 
-  let decl = Decl.Request.make ~method_:"build" ~generations:[ v1 ]
+  let v2 =
+    Decl.Request.make_current_gen
+      ~req:(Conv.list Conv.string)
+      ~resp:Build_outcome_with_diagnostics.sexp_v2
+      ~version:2
+  ;;
+
+  let decl = Decl.Request.make ~method_:"build" ~generations:[ v1; v2 ]
 end
 
 let build = Build.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -3,10 +3,10 @@ open Dune_rpc
 
 (** Internal RPC requests *)
 
-module Build_outcome : sig
-  type t = Scheduler.Run.Build_outcome.t =
+module Build_outcome_with_diagnostics : sig
+  type t =
     | Success
-    | Failure
+    | Failure of Dune_engine.Compound_user_error.t list
 
   val sexp : (t, Conv.values) Conv.t
 end
@@ -25,5 +25,5 @@ module Status : sig
   val sexp : (t, Conv.values) Conv.t
 end
 
-val build : (string list, Build_outcome.t) Decl.Request.t
+val build : (string list, Build_outcome_with_diagnostics.t) Decl.Request.t
 val status : (unit, Status.t) Decl.Request.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -10,7 +10,8 @@ val create
   -> parse_build:(string -> 'a)
   -> 'a t
 
-type 'a pending_build_action = Build of 'a list * Decl.Build_outcome.t Fiber.Ivar.t
+type 'a pending_build_action =
+  | Build of 'a list * Dune_engine.Scheduler.Run.Build_outcome.t Fiber.Ivar.t
 
 val pending_build_action : 'a t -> 'a pending_build_action Fiber.t
 

--- a/src/dune_util/global_lock.mli
+++ b/src/dune_util/global_lock.mli
@@ -3,7 +3,10 @@
     Before starting rpc, writing to the build dir, this lock should be locked. *)
 
 (** attempt to acquire a lock. once a lock is locked, subsequent locks always
-    succeed *)
+    succeed. Returns [Ok ()] if the lock is acquired within [timeout] seconds,
+    and [Error ()] otherwise. *)
+val lock : timeout:float option -> (unit, unit) result
+
 val lock_exn : timeout:float option -> unit
 
 (** release a lock and allow it be re-acquired *)

--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-build-command.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-build-command.t
@@ -1,0 +1,42 @@
+Demonstrate running "dune build" concurrently with an eager rpc server.
+
+  $ echo '(lang dune 3.18)' > dune-project
+  $ echo '(executable (name foo))' > dune
+  $ echo 'let () = print_endline "Hello, World!"' > foo.ml
+
+Build the project once before starting the watch server so the watch server starts immediately.
+  $ dune build
+  $ dune build --watch &
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  File "foo.ml", line 1, characters 9-21:
+  1 | let () = print_endlin "Hello, World!"
+               ^^^^^^^^^^^^
+  Error: Unbound value print_endlin
+  Hint: Did you mean print_endline?
+  Had 1 error, waiting for filesystem changes...
+  File "foo.ml", line 1, characters 9-21:
+  1 | let () = print_endlin "Hello, World!"
+               ^^^^^^^^^^^^
+  Error: Unbound value print_endlin
+  Hint: Did you mean print_endline?
+  Had 1 error, waiting for filesystem changes...
+
+Demonstrate that we can run "dune build" while the watch server is running.
+  $ dune build
+  Success
+
+Demonstrate that error messages are still printed by "dune build" when it's
+acting as an RPC client while running concurrently with an RPC server.
+  $ echo 'let () = print_endlin "Hello, World!"' > foo.ml
+  $ dune build
+  File "$TESTCASE_ROOT/foo.ml", line 1, characters 9-21:
+  1 | let () = print_endlin "Hello, World!"
+               ^^^^^^^^^^^^
+  Unbound value print_endlin
+  Hint: Did you mean print_endline?
+  Error: Build failed with 1 error.
+  [1]
+
+  $ dune shutdown
+  $ wait

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -148,7 +148,7 @@ let dune_build client what =
       what
       (match res with
        | Success -> "succeeded"
-       | Failure -> "failed")
+       | Failure _ -> "failed")
 ;;
 
 let with_dune_watch ?watch_mode_args ?env f =


### PR DESCRIPTION
Allow the `dune build` command to be run concurrently with an RPC server (in either passive or eager watch mode). This works by having the second instance of dune send RPC build command to the RPC server, and the RPC server then sends diagnostic messages back to the first instance of dune.

Currently this is only implemented for the `dune build` command, and promoting changes into source files is not supported. There are also some subtle differences between the output of `dune build` is performing the build itself and when it's acting as an RPC client, such as file paths being absolute rather than relative and the underline under code errors losing its color.