### PR TITLE
refactor: simpler tracking of `Lib_info.virtual_`

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -105,7 +105,7 @@ module Lib = struct
     let melange_runtime_deps = additional_paths (Lib_info.melange_runtime_deps info) in
     let jsoo_runtime = Lib_info.jsoo_runtime info in
     let wasmoo_runtime = Lib_info.wasmoo_runtime info in
-    let virtual_ = Option.is_some (Lib_info.virtual_ info) in
+    let virtual_ = Lib_info.virtual_ info in
     let instrumentation_backend = Lib_info.instrumentation_backend info in
     let native_archives =
       match Lib_info.native_archives info with
@@ -247,9 +247,6 @@ module Lib = struct
          let preprocess = Preprocess.Per_module.no_preprocessing () in
          let virtual_deps = [] in
          let dune_version = None in
-         let virtual_ =
-           if virtual_ then Some (Lib_info.Source.External modules) else None
-         in
          let entry_modules = Modules.entry_modules modules |> List.map ~f:Module.name in
          let modules = Modules.With_vlib.modules modules in
          let wrapped =

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -168,7 +168,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
     let wasmoo_runtime = Findlib.Package.wasmoo_runtime t in
     let melange_runtime_deps = Lib_info.File_deps.External [] in
     let preprocess = Preprocess.Per_module.no_preprocessing () in
-    let virtual_ = None in
+    let virtual_ = false in
     let default_implementation = None in
     let wrapped = None in
     let foreign_archives, native_archives =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -98,8 +98,8 @@ end = struct
       >>| Option.some
     and+ foreign_archives =
       match Lib_info.virtual_ lib with
-      | None -> Memo.return (Mode.Map.Multi.to_flat_list @@ Lib_info.foreign_archives lib)
-      | Some _ ->
+      | false -> Memo.return (Mode.Map.Multi.to_flat_list @@ Lib_info.foreign_archives lib)
+      | true ->
         let+ foreign_sources = Dir_contents.foreign_sources dir_contents in
         let name = Lib_info.name lib in
         let files = Foreign_sources.for_lib foreign_sources ~name in
@@ -823,7 +823,7 @@ end = struct
           match
             List.find_map libraries ~f:(fun lib ->
               let info = Lib.Local.info lib in
-              Option.some_if (Option.is_some (Lib_info.virtual_ info)) lib)
+              Option.some_if (Lib_info.virtual_ info) lib)
           with
           | None -> Action_builder.lines_of meta_template
           | Some vlib ->

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -324,7 +324,7 @@ type 'path t =
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; dune_version : Dune_lang.Syntax.Version.t option
   ; sub_systems : Sub_system_info.t Sub_system_name.Map.t
-  ; virtual_ : Modules.t Source.t option
+  ; virtual_ : bool
   ; entry_modules : (Module_name.t list, User_message.t) result Source.t
   ; implements : (Loc.t * Lib_name.t) option
   ; default_implementation : (Loc.t * Lib_name.t) option
@@ -597,7 +597,7 @@ let to_dyn
     ; "virtual_deps", list (snd Lib_name.to_dyn) virtual_deps
     ; "dune_version", option Dune_lang.Syntax.Version.to_dyn dune_version
     ; "sub_systems", Sub_system_name.Map.to_dyn Dyn.opaque sub_systems
-    ; "virtual_", option (Source.to_dyn Modules.to_dyn) virtual_
+    ; "virtual_", bool virtual_
     ; ( "entry_modules"
       , Source.to_dyn
           (Result.to_dyn (list Module_name.to_dyn) string)

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -139,7 +139,7 @@ val jsoo_runtime : 'path t -> 'path list
 val wasmoo_runtime : 'path t -> 'path list
 val melange_runtime_deps : 'path t -> 'path File_deps.t
 val obj_dir : 'path t -> 'path Obj_dir.t
-val virtual_ : _ t -> Modules.t Source.t option
+val virtual_ : _ t -> bool
 val entry_modules : _ t -> (Module_name.t list, User_message.t) result Source.t
 val main_module_name : _ t -> Main_module_name.t
 val wrapped : _ t -> Wrapped.t Inherited.t option
@@ -217,7 +217,7 @@ val create
   -> enabled:Enabled_status.t Memo.t
   -> virtual_deps:(Loc.t * Lib_name.t) list
   -> dune_version:Dune_lang.Syntax.Version.t option
-  -> virtual_:Modules.t Source.t option
+  -> virtual_:bool
   -> entry_modules:(Module_name.t list, User_message.t) result Source.t
   -> implements:(Loc.t * Lib_name.t) option
   -> default_implementation:(Loc.t * Lib_name.t) option

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -328,8 +328,10 @@ let modules t ~libs ~for_ = modules_and_obj_dir t ~libs ~for_ >>| fst
 let virtual_modules ~lookup_vlib ~libs vlib =
   let info = Lib.info vlib in
   let+ modules =
-    match Option.value_exn (Lib_info.virtual_ info) with
-    | External modules -> Memo.return modules
+    match Lib_info.modules info with
+    | External modules ->
+      let modules = Option.value_exn modules in
+      Memo.return (Modules_group.With_vlib.drop_vlib modules)
     | Local ->
       let src_dir = Lib_info.src_dir info |> Path.as_in_build_dir_exn in
       let* t = lookup_vlib ~dir:src_dir in

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -440,7 +440,7 @@ let to_lib_info
     | Private pkg -> Lib_info.Status.Private (conf.project, pkg)
     | Public p -> Public (conf.project, p.package)
   in
-  let virtual_library = is_virtual conf in
+  let virtual_ = is_virtual conf in
   let foreign_archives =
     let init =
       Mode.Map.Multi.create_for_all_modes
@@ -456,7 +456,7 @@ let to_lib_info
   in
   let native_archives =
     let archive = archive ext_lib in
-    if virtual_library || not modes.ocaml.native
+    if virtual_ || not modes.ocaml.native
     then Lib_info.Files []
     else if
       Option.is_some conf.implements
@@ -467,10 +467,9 @@ let to_lib_info
   in
   let foreign_dll_files = foreign_dll_files conf ~dir ~ext_dll in
   let exit_module = Option.bind conf.stdlib ~f:(fun x -> x.exit_module) in
-  let virtual_ = Option.map conf.virtual_modules ~f:(fun _ -> Lib_info.Source.Local) in
   let foreign_objects = Lib_info.Source.Local in
   let archives, plugins =
-    if virtual_library
+    if virtual_
     then Mode.Dict.make_both [], Mode.Dict.make_both []
     else (
       let plugins =


### PR DESCRIPTION
- `Lib_info.virtual_` at most tracks the modules that are already tracked in `Lib_info.modules lib.info`
- It can just be a `bool` instead of pointing to redundant information, which simplifies the implementation of #10630 a little bit


the diff is best viewed [without the whitespace diff](https://github.com/ocaml/dune/pull/11713/files?w=1)