### PR TITLE
refactor: move `Modules{.With_vlib,}.entry_modules`

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -330,9 +330,8 @@ let entry_module_names sctx t =
   match Lib_info.entry_modules (Lib.info t) with
   | External d -> Resolve.Memo.of_result d
   | Local ->
-    let+ modules = Dir_contents.modules_of_lib sctx t in
-    let modules = Option.value_exn modules in
-    Resolve.return (Modules.With_vlib.entry_modules modules |> List.map ~f:Module.name)
+    let+ modules = Dir_contents.modules_of_local_lib sctx (Lib.Local.of_lib_exn t) in
+    modules |> Modules.entry_modules |> List.map ~f:Module.name |> Resolve.return
 ;;
 
 let root_module_entries t =

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -250,10 +250,8 @@ module Lib = struct
          let virtual_ =
            if virtual_ then Some (Lib_info.Source.External modules) else None
          in
+         let entry_modules = Modules.entry_modules modules |> List.map ~f:Module.name in
          let modules = Modules.With_vlib.modules modules in
-         let entry_modules =
-           Modules.With_vlib.entry_modules modules |> List.map ~f:Module.name
-         in
          let wrapped =
            Some (Lib_info.Inherited.This (Modules.With_vlib.wrapped modules))
          in

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -930,6 +930,18 @@ let compat_for_exn t m =
      | Some (Group g) -> Group.lib_interface g)
 ;;
 
+let entry_modules t =
+  List.filter
+    ~f:(fun m -> Module.visibility m = Public)
+    (match t.modules with
+     | Stdlib w -> Stdlib.lib_interface w |> Option.to_list
+     | Singleton m -> [ m ]
+     | Unwrapped m -> Unwrapped.entry_modules m
+     | Wrapped m ->
+       (* we assume this is never called for implementations *)
+       [ Wrapped.lib_interface m ])
+;;
+
 module With_vlib = struct
   type impl =
     { obj_map : Sourced_module.t Module_name.Unique.Map.t Lazy.t
@@ -1230,23 +1242,6 @@ module With_vlib = struct
     match t with
     | Modules t -> Modules (map t)
     | Impl w -> Impl { w with impl = map w.impl }
-  ;;
-
-  let entry_modules = function
-    | Impl i ->
-      Code_error.raise
-        "entry_modules: not defined for implementations"
-        [ "impl", dyn_of_impl i ]
-    | Modules t ->
-      List.filter
-        ~f:(fun m -> Module.visibility m = Public)
-        (match t.modules with
-         | Stdlib w -> Stdlib.lib_interface w |> Option.to_list
-         | Singleton m -> [ m ]
-         | Unwrapped m -> Unwrapped.entry_modules m
-         | Wrapped m ->
-           (* we assume this is never called for implementations *)
-           [ Wrapped.lib_interface m ])
   ;;
 
   let wrapped = function

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -57,6 +57,11 @@ val wrapped : t -> Wrapped.t
 val source_dirs : t -> Path.Set.t
 val compat_for_exn : t -> Module.t -> Module.t
 
+(** List of entry modules visible to users of the library. For wrapped
+    libraries, this is always one module. For unwrapped libraries, this could
+    be more than one. *)
+val entry_modules : t -> Module.t list
+
 module With_vlib : sig
   type modules := t
   type t
@@ -95,11 +100,6 @@ module With_vlib : sig
 
   (** Returns all the compatibility modules. *)
   val wrapped_compat : t -> Module.Name_map.t
-
-  (** List of entry modules visible to users of the library. For wrapped
-      libraries, this is always one module. For unwrapped libraries, this could be
-      more than one. *)
-  val entry_modules : t -> Module.t list
 
   (** Returns the main module name if it exists. It exist for libraries with
       [(wrapped true)] or one module libraries. *)

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -608,9 +608,7 @@ let libs_of_pkg ctx ~pkg =
 ;;
 
 let entry_modules_by_lib sctx lib =
-  Dir_contents.modules_of_local_lib sctx lib
-  >>| Modules.With_vlib.modules
-  >>| Modules.With_vlib.entry_modules
+  Dir_contents.modules_of_local_lib sctx lib >>| Modules.entry_modules
 ;;
 
 let entry_modules sctx ~pkg =

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -1211,9 +1211,9 @@ let lib_artifacts ctx all index lib modules =
     | Melange -> Melange Cmi
   in
   let obj_dir = Lib_info.obj_dir info in
-  let entry_modules = Modules.With_vlib.entry_modules modules in
+  let modules = Modules.With_vlib.drop_vlib modules in
+  let entry_modules = Modules.entry_modules modules in
   modules
-  |> Modules.With_vlib.drop_vlib
   |> Modules.fold ~init:[] ~f:(fun m acc ->
     let visible =
       let visible =


### PR DESCRIPTION
It was a `Code_error` to use `entry_modules` on a `Impl` branch, so there's no point in having that function in the `With_vlib` submodule. This simplifies some of the other code, which doesn't have to create a `Modules.With_vlib.Modules ..` just to call this function.