### PR TITLE
pkg: don't depend on dune_digest

### DIFF
--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -21,7 +21,7 @@ include (
 
 let to_opam_hash v = v
 let of_opam_hash v = v
-let of_dune_digest dune_digest = OpamHash.md5 (Dune_digest.to_string dune_digest)
+let of_md5 md5 = md5 |> Md5.to_string |> OpamHash.md5
 
 let pp v =
   let s = to_string v in

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -21,7 +21,7 @@ include (
 
 let to_opam_hash v = v
 let of_opam_hash v = v
-let of_md5 md5 = md5 |> Md5.to_string |> OpamHash.md5
+let of_md5 md5 = md5 |> Md5.to_hex_string |> OpamHash.md5
 
 let pp v =
   let s = to_string v in

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -21,7 +21,7 @@ include (
 
 let to_opam_hash v = v
 let of_opam_hash v = v
-let of_md5 md5 = md5 |> Md5.to_hex_string |> OpamHash.md5
+let of_md5 md5 = md5 |> Md5.to_hex |> OpamHash.md5
 
 let pp v =
   let s = to_string v in

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -13,8 +13,8 @@ val to_opam_hash : t -> OpamHash.t
 (** [of_opam_hash h] converts [h] from the representation used by OPAM to Dune's *)
 val of_opam_hash : OpamHash.t -> t
 
-(** Convert an MD5 [Dune_digest.t] into OPAM's checksum representation *)
-val of_dune_digest : Dune_digest.t -> t
+(** Convert an [Md5.t] into OPAM's checksum representation *)
+val of_md5 : Md5.t -> t
 
 val pp : t -> 'a Pp.t
 val equal : t -> t -> bool

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -1,13 +1,15 @@
 (library
  (name dune_pkg)
  (synopsis "[Internal] Dune's packaging support")
+ (foreign_stubs
+  (names md5_stubs)
+  (language c))
  (libraries
   stdune
   fiber
   fiber_util
   chrome_trace
   dune_engine
-  dune_digest
   dune_util
   dune_stats
   dune_lang

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -35,13 +35,13 @@ module Dependency_hash = struct
 
   let equal = Md5.equal
   let to_dyn = Md5.to_dyn
-  let to_string = Md5.to_string
+  let to_string = Md5.to_hex_string
   let encode t = to_string t |> Encoder.string
 
   let decode =
     let open Decoder in
     let+ loc, hash = located string in
-    match Md5.from_hex hash with
+    match Md5.of_hex_string hash with
     | Some hash -> hash
     | None ->
       User_error.raise

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -31,17 +31,17 @@ type t =
   }
 
 module Dependency_hash = struct
-  type t = Dune_digest.t
+  type t = Md5.t
 
-  let equal = Dune_digest.equal
-  let to_dyn = Dune_digest.to_dyn
-  let to_string = Dune_digest.to_string
+  let equal = Md5.equal
+  let to_dyn = Md5.to_dyn
+  let to_string = Md5.to_string
   let encode t = to_string t |> Encoder.string
 
   let decode =
     let open Decoder in
     let+ loc, hash = located string in
-    match Dune_digest.Digest.from_hex hash with
+    match Md5.from_hex hash with
     | Some hash -> hash
     | None ->
       User_error.raise
@@ -54,7 +54,7 @@ module Dependency_hash = struct
     | false -> None
     | true ->
       let hashable = formula |> Dependency_formula.to_dyn |> Dyn.to_string in
-      Some (Dune_digest.string hashable)
+      Some (Md5.string hashable)
   ;;
 end
 

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -35,13 +35,13 @@ module Dependency_hash = struct
 
   let equal = Md5.equal
   let to_dyn = Md5.to_dyn
-  let to_string = Md5.to_hex_string
+  let to_string = Md5.to_hex
   let encode t = to_string t |> Encoder.string
 
   let decode =
     let open Decoder in
     let+ loc, hash = located string in
-    match Md5.of_hex_string hash with
+    match Md5.of_hex hash with
     | Some hash -> hash
     | None ->
       User_error.raise

--- a/src/dune_pkg/md5.ml
+++ b/src/dune_pkg/md5.ml
@@ -2,9 +2,17 @@ open Stdune
 
 type t = string
 
-external md5_fd : Unix.file_descr -> string = "dune_pkg_md5_fd"
+let equal = String.equal
+let to_hex_string = Stdlib.Digest.to_hex
+let to_dyn s = Dyn.variant "digest" [ String (to_hex_string s) ]
 
-module D = Stdlib.Digest
+let of_hex_string s =
+  match Stdlib.Digest.from_hex s with
+  | s -> Some s
+  | exception Invalid_argument _ -> None
+;;
+
+external md5_fd : Unix.file_descr -> string = "dune_pkg_md5_fd"
 
 let file file =
   (* On Windows, if this function is invoked in a background thread, if can happen that
@@ -21,13 +29,4 @@ let file file =
   Exn.protectx fd ~f:md5_fd ~finally:Unix.close
 ;;
 
-let string = D.string
-let equal = String.equal
-let to_string = D.to_hex
-let to_dyn s = Dyn.variant "digest" [ String (to_string s) ]
-
-let from_hex s =
-  match D.from_hex s with
-  | s -> Some s
-  | exception Invalid_argument _ -> None
-;;
+let string = Stdlib.Digest.string

--- a/src/dune_pkg/md5.ml
+++ b/src/dune_pkg/md5.ml
@@ -6,41 +6,23 @@ external md5_fd : Unix.file_descr -> string = "dune_pkg_md5_fd"
 
 module D = Stdlib.Digest
 
-module type Digest_impl = sig
-  val file : string -> t
-  val string : string -> t
-end
+let file file =
+  (* On Windows, if this function is invoked in a background thread, if can happen that
+     the file is not properly closed. [O_SHARE_DELETE] ensures that the main thread can
+     delete it even if it is still open. See #8243. *)
+  let file = Path.to_string file in
+  let fd =
+    match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE; O_CLOEXEC ] 0 with
+    | fd -> fd
+    | exception Unix.Unix_error (Unix.EACCES, _, _) ->
+      raise (Sys_error (sprintf "%s: Permission denied" file))
+    | exception exn -> reraise exn
+  in
+  Exn.protectx fd ~f:md5_fd ~finally:Unix.close
+;;
 
-module Direct_impl : Digest_impl = struct
-  let file file =
-    (* On Windows, if this function is invoked in a background thread,
-       if can happen that the file is not properly closed.
-       [O_SHARE_DELETE] ensures that the main thread can delete it even if it
-       is still open. See #8243. *)
-    let fd =
-      match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE; O_CLOEXEC ] 0 with
-      | fd -> fd
-      | exception Unix.Unix_error (Unix.EACCES, _, _) ->
-        raise (Sys_error (sprintf "%s: Permission denied" file))
-      | exception exn -> reraise exn
-    in
-    Exn.protectx fd ~f:md5_fd ~finally:Unix.close
-  ;;
-
-  let string = D.string
-end
-
-module Mutable_impl = struct
-  let file_ref = ref Direct_impl.file
-  let string_ref = ref D.string
-  let file f = !file_ref f
-  let string s = !string_ref s
-end
-
-module Impl : Digest_impl = Mutable_impl
-
+let string = D.string
 let equal = String.equal
-let file p = Impl.file (Path.to_string p)
 let to_string = D.to_hex
 let to_dyn s = Dyn.variant "digest" [ String (to_string s) ]
 
@@ -49,5 +31,3 @@ let from_hex s =
   | s -> Some s
   | exception Invalid_argument _ -> None
 ;;
-
-let string = Impl.string

--- a/src/dune_pkg/md5.ml
+++ b/src/dune_pkg/md5.ml
@@ -3,10 +3,10 @@ open Stdune
 type t = string
 
 let equal = String.equal
-let to_hex_string = Stdlib.Digest.to_hex
-let to_dyn s = Dyn.variant "digest" [ String (to_hex_string s) ]
+let to_hex = Stdlib.Digest.to_hex
+let to_dyn s = Dyn.variant "digest" [ String (to_hex s) ]
 
-let of_hex_string s =
+let of_hex s =
   match Stdlib.Digest.from_hex s with
   | s -> Some s
   | exception Invalid_argument _ -> None

--- a/src/dune_pkg/md5.ml
+++ b/src/dune_pkg/md5.ml
@@ -1,0 +1,53 @@
+open Stdune
+
+type t = string
+
+external md5_fd : Unix.file_descr -> string = "dune_pkg_md5_fd"
+
+module D = Stdlib.Digest
+
+module type Digest_impl = sig
+  val file : string -> t
+  val string : string -> t
+end
+
+module Direct_impl : Digest_impl = struct
+  let file file =
+    (* On Windows, if this function is invoked in a background thread,
+       if can happen that the file is not properly closed.
+       [O_SHARE_DELETE] ensures that the main thread can delete it even if it
+       is still open. See #8243. *)
+    let fd =
+      match Unix.openfile file [ Unix.O_RDONLY; O_SHARE_DELETE; O_CLOEXEC ] 0 with
+      | fd -> fd
+      | exception Unix.Unix_error (Unix.EACCES, _, _) ->
+        raise (Sys_error (sprintf "%s: Permission denied" file))
+      | exception exn -> reraise exn
+    in
+    Exn.protectx fd ~f:md5_fd ~finally:Unix.close
+  ;;
+
+  let string = D.string
+end
+
+module Mutable_impl = struct
+  let file_ref = ref Direct_impl.file
+  let string_ref = ref D.string
+  let file f = !file_ref f
+  let string s = !string_ref s
+end
+
+module Impl : Digest_impl = Mutable_impl
+
+let equal = String.equal
+let file p = Impl.file (Path.to_string p)
+let to_string = D.to_hex
+let to_dyn s = Dyn.variant "digest" [ String (to_string s) ]
+
+let from_hex s =
+  match D.from_hex s with
+  | s -> Some s
+  | exception Invalid_argument _ -> None
+;;
+
+let string = Impl.string

--- a/src/dune_pkg/md5.mli
+++ b/src/dune_pkg/md5.mli
@@ -17,10 +17,9 @@ val file : Path.t -> t
 (** [Md5.string s] returns the [Md5.t] digest of the string [s]. *)
 val string : string -> t
 
-(** [Md5.to_hex_string t] returns the printable hexadecimal representation of the given
-    digest [t]. *)
-val to_hex_string : t -> string
+(** [Md5.to_hex t] returns the hexadecimal representation of the given digest [t]. *)
+val to_hex : t -> string
 
-(** [Md5.of_hex_string s] convert a hexadecimal representation back into the corresponding
+(** [Md5.of_hex s] converts a hexadecimal representation back into the corresponding
     digest. *)
-val of_hex_string : string -> t option
+val of_hex : string -> t option

--- a/src/dune_pkg/md5.mli
+++ b/src/dune_pkg/md5.mli
@@ -1,0 +1,14 @@
+(** This is a temporary partial copy of the old [Dune_digest] module based on MD5. It is
+    used in package management to compute checksums and will be replaced accordingly in
+    the future. *)
+open Import
+
+(** Digests (MD5) *)
+type t
+
+val to_dyn : t -> Dyn.t
+val equal : t -> t -> bool
+val to_string : t -> string
+val from_hex : string -> t option
+val file : Path.t -> t
+val string : string -> t

--- a/src/dune_pkg/md5.mli
+++ b/src/dune_pkg/md5.mli
@@ -1,14 +1,26 @@
-(** This is a temporary partial copy of the old [Dune_digest] module based on MD5. It is
-    used in package management to compute checksums and will be replaced accordingly in
-    the future. *)
 open Import
 
-(** Digests (MD5) *)
+(** This module serves as a wrapper around the C implementation of MD5 found in the OCaml
+    compiler libraries. We use this implementation to avoid holding the GC lock whilst
+    digesting. *)
+
+(** MD5 Digests *)
 type t
 
 val to_dyn : t -> Dyn.t
 val equal : t -> t -> bool
-val to_string : t -> string
-val from_hex : string -> t option
+
+(** [Md5.file path] returns the [Md5.t] digest of the contents of the given file at
+    [path]. *)
 val file : Path.t -> t
+
+(** [Md5.string s] returns the [Md5.t] digest of the string [s]. *)
 val string : string -> t
+
+(** [Md5.to_hex_string t] returns the printable hexadecimal representation of the given
+    digest [t]. *)
+val to_hex_string : t -> string
+
+(** [Md5.of_hex_string s] convert a hexadecimal representation back into the corresponding
+    digest. *)
+val of_hex_string : string -> t option

--- a/src/dune_pkg/md5_stubs.c
+++ b/src/dune_pkg/md5_stubs.c
@@ -1,0 +1,48 @@
+#define CAML_INTERNALS  // needed to access md5.h functions
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/bigarray.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+#include <errno.h>
+#include <caml/md5.h>
+
+/* yanked from:
+ * https://github.com/janestreet/core/blob/master/core/src/md5_stubs.c
+ */
+CAMLprim value dune_pkg_md5_fd(value v_fd) {
+  CAMLparam1(v_fd);
+  CAMLlocal1(v_res);
+#ifdef _WIN32
+  int fd = win_CRT_fd_of_filedescr(v_fd);
+#else
+  int fd = Int_val(v_fd);
+#endif
+  struct MD5Context ctx;
+  caml_release_runtime_system();
+  {
+    char buffer[UNIX_BUFFER_SIZE];
+
+    intnat bytes_read;
+    caml_MD5Init(&ctx);
+    while (1) {
+      bytes_read = read(fd, buffer, sizeof(buffer));
+      if (bytes_read == 0) {
+        break;
+      } else if (bytes_read < 0) {
+        if (errno == EINTR)
+          continue;
+        caml_acquire_runtime_system();
+        uerror("read", Nothing);
+      } else {
+        caml_MD5Update(&ctx, (unsigned char *)buffer, bytes_read);
+      }
+    }
+  }
+  caml_acquire_runtime_system();
+  v_res = caml_alloc_string(16);
+  caml_MD5Final(&Byte_u(v_res, 0), &ctx);
+  CAMLreturn(v_res);
+}

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -42,7 +42,7 @@ let fetch_and_hash_archive_cached (url_loc, url) =
   let open Fiber.O in
   fetch_archive_cached (url_loc, url)
   >>| function
-  | Ok target -> Some (Dune_digest.file target |> Checksum.of_dune_digest)
+  | Ok target -> Some (Md5.file target |> Checksum.of_md5)
   | Error message_opt ->
     let message =
       Option.value


### PR DESCRIPTION
`Dune_digest` used md5 but this is an implementation detail we shouldn't rely on for computing md5 checksums in package management. We therefore copy and strip down the important parts, renaming any C stubs.
