### PR TITLE
fix(pkg): handle empty ID_LIKE

### DIFF
--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -195,6 +195,7 @@ let os_family ~os_distribution ~os_release_fields ~os =
   | Some "linux" ->
     (match List.assoc (Lazy.force os_release_fields) "ID_LIKE" with
      | None -> os_distribution
+     | Some "" -> os_distribution
      | Some s ->
        (* first word *)
        (match Scanf.sscanf s " %s" Fun.id with


### PR DESCRIPTION
On NixOS for whatever reason `ID_LIKE` was an empty string. In this case we shouldn't use it to find the `os_family` and instead fallback to the `os_distribution`.