### PR TITLE
Fix #10999

### DIFF
--- a/doc/changes/11729.md
+++ b/doc/changes/11729.md
@@ -1,0 +1,2 @@
+- Fix $ dune describe pp for libraries in the presence of `(include_subdirs
+  unqualified)` (#11729, fixes #10999, @rgrinberg)

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -31,8 +31,9 @@ let find_module sctx src =
   | None -> Memo.return None
   | Some module_name ->
     let* dir_contents = drop_rules @@ fun () -> Dir_contents.get sctx ~dir in
+    let stanza_dir = Dir_contents.dir dir_contents in
     let* ocaml = Dir_contents.ocaml dir_contents
-    and* scope = Scope.DB.find_by_dir dir in
+    and* scope = Scope.DB.find_by_dir stanza_dir in
     Ml_sources.find_origin ocaml ~libs:(Scope.libs scope) [ module_name ]
     >>= (function
      | None -> Memo.return None
@@ -43,13 +44,14 @@ let find_module sctx src =
          @@ fun () ->
          match origin with
          | Executables exes ->
-           Exe_rules.rules ~sctx ~dir ~dir_contents ~scope ~expander exes
-         | Library lib -> Lib_rules.rules lib ~sctx ~dir_contents ~dir ~expander ~scope
+           Exe_rules.rules ~sctx ~dir:stanza_dir ~dir_contents ~scope ~expander exes
+         | Library lib ->
+           Lib_rules.rules lib ~sctx ~dir_contents ~dir:stanza_dir ~expander ~scope
          | Melange mel ->
            Melange_rules.setup_emit_cmj_rules
              ~sctx
              ~dir_contents
-             ~dir
+             ~dir:stanza_dir
              ~expander
              ~scope
              mel

--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/lib/dune
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/lib/dune
@@ -1,0 +1,4 @@
+(include_subdirs unqualified)
+
+(library
+ (name foo))

--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
@@ -24,3 +24,32 @@ This also works for reason code
   # 1 "src/main_re.pp.re.ml"
   # 1 "src/main_re.pp.re"
   Util.log ("Hello, world!")
+
+  $ dune describe pp lib/subdir/bazy.ml
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("Lib.DB.get_compile_info got library that doesn't exist",
+     { lib_id =
+         Local
+           { name = "foo"
+           ; loc = "lib/dune:4"
+           ; src_dir = In_source_tree "lib/subdir"
+           }
+     })
+  Raised at Stdune__Code_error.raise in file
+    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
+    line 259, characters 36-41
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 79, characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
+  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
+    line 79, characters 8-11
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
+  [1]

--- a/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/describe-pp/describe-pp.t/run.t
@@ -26,30 +26,4 @@ This also works for reason code
   Util.log ("Hello, world!")
 
   $ dune describe pp lib/subdir/bazy.ml
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Lib.DB.get_compile_info got library that doesn't exist",
-     { lib_id =
-         Local
-           { name = "foo"
-           ; loc = "lib/dune:4"
-           ; src_dir = In_source_tree "lib/subdir"
-           }
-     })
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
-  Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
-    line 259, characters 36-41
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 79, characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
-  Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
-    line 79, characters 8-11
   
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  [1]


### PR DESCRIPTION
Use the correct directory when looking up the stanza of a module.

Previously, the directory of the module source was used. This breaks in the presence of `(include_subdirs ..)`