### PR TITLE
refactor: remove unnecessary [dir] in some rules

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -333,7 +333,8 @@ let compile_info ~scope (exes : Executables.t) =
     ~forbidden_libraries:exes.forbidden_libraries
 ;;
 
-let rules ~sctx ~dir ~dir_contents ~scope ~expander (exes : Executables.t) =
+let rules ~sctx ~dir_contents ~scope ~expander (exes : Executables.t) =
+  let dir = Dir_contents.dir dir_contents in
   let* compile_info = compile_info ~scope exes in
   let f () =
     executables_rules

--- a/src/dune_rules/exe_rules.mli
+++ b/src/dune_rules/exe_rules.mli
@@ -1,10 +1,7 @@
-open Import
-
 val compile_info : scope:Scope.t -> Executables.t -> Lib.Compile.t Memo.t
 
 val rules
   :  sctx:Super_context.t
-  -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> scope:Scope.t
   -> expander:Expander.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -118,7 +118,7 @@ end = struct
       in
       if_available_buildable
         ~loc:lib.buildable.loc
-        (fun () -> Lib_rules.rules lib ~sctx ~dir ~scope ~dir_contents ~expander)
+        (fun () -> Lib_rules.rules lib ~sctx ~scope ~dir_contents ~expander)
         enabled_if
     | Foreign_library.T lib ->
       Expander.eval_blang expander lib.enabled_if
@@ -130,9 +130,7 @@ end = struct
       >>= if_available (fun () ->
         let+ () =
           Memo.Option.iter exes.install_conf ~f:(install_stanza_rules ~expander ~ctx_dir)
-        and+ cctx_merlin =
-          Exe_rules.rules exes ~sctx ~dir ~scope ~expander ~dir_contents
-        in
+        and+ cctx_merlin = Exe_rules.rules exes ~sctx ~scope ~expander ~dir_contents in
         { (with_cctx_merlin ~loc:exes.buildable.loc cctx_merlin) with
           js =
             Some
@@ -179,7 +177,7 @@ end = struct
     | Melange_stanzas.Emit.T mel ->
       Expander.eval_blang expander mel.enabled_if
       >>= if_available_buildable ~loc:mel.loc (fun () ->
-        Melange_rules.setup_emit_cmj_rules ~dir_contents ~dir ~scope ~sctx ~expander mel)
+        Melange_rules.setup_emit_cmj_rules ~dir_contents ~scope ~sctx ~expander mel)
     | _ -> Memo.return empty_none
   ;;
 

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -624,7 +624,8 @@ let library_rules
   merlin
 ;;
 
-let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
+let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
+  let dir = Dir_contents.dir dir_contents in
   let buildable = lib.buildable in
   let libs = Scope.libs scope in
   let lib_id =

--- a/src/dune_rules/lib_rules.mli
+++ b/src/dune_rules/lib_rules.mli
@@ -12,7 +12,6 @@ val rules
   :  Library.t
   -> sctx:Super_context.t
   -> dir_contents:Dir_contents.t
-  -> dir:Path.Build.t
   -> expander:Expander.t
   -> scope:Scope.t
   -> (Compilation_context.t * Merlin.t) Memo.t

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -270,7 +270,6 @@ let melange_compile_flags ~sctx ~dir (mel : Melange_stanzas.Emit.t) =
 
 let setup_emit_cmj_rules
       ~sctx
-      ~dir
       ~scope
       ~expander
       ~dir_contents
@@ -279,6 +278,7 @@ let setup_emit_cmj_rules
   let* compile_info = compile_info ~scope mel in
   let ctx = Super_context.context sctx in
   let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
+  let dir = Dir_contents.dir dir_contents in
   let f () =
     let* modules, obj_dir =
       Dir_contents.ocaml dir_contents

--- a/src/dune_rules/melange/melange_rules.mli
+++ b/src/dune_rules/melange/melange_rules.mli
@@ -2,7 +2,6 @@ open Import
 
 val setup_emit_cmj_rules
   :  sctx:Super_context.t
-  -> dir:Path.Build.t
   -> scope:Scope.t
   -> expander:Expander.t
   -> dir_contents:Dir_contents.t

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -151,5 +151,5 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
                 in
                 ()))
   in
-  Exe_rules.rules t.exes ~sctx ~dir ~scope ~expander ~dir_contents
+  Exe_rules.rules t.exes ~sctx ~scope ~expander ~dir_contents
 ;;

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -43,18 +43,10 @@ let find_module sctx src =
          drop_rules
          @@ fun () ->
          match origin with
-         | Executables exes ->
-           Exe_rules.rules ~sctx ~dir:stanza_dir ~dir_contents ~scope ~expander exes
-         | Library lib ->
-           Lib_rules.rules lib ~sctx ~dir_contents ~dir:stanza_dir ~expander ~scope
+         | Executables exes -> Exe_rules.rules ~sctx ~dir_contents ~scope ~expander exes
+         | Library lib -> Lib_rules.rules lib ~sctx ~dir_contents ~expander ~scope
          | Melange mel ->
-           Melange_rules.setup_emit_cmj_rules
-             ~sctx
-             ~dir_contents
-             ~dir:stanza_dir
-             ~expander
-             ~scope
-             mel
+           Melange_rules.setup_emit_cmj_rules ~sctx ~dir_contents ~expander ~scope mel
        in
        let module_ =
          let modules = Compilation_context.modules cctx in


### PR DESCRIPTION
Whenever we pass [dir_contents], the directory is the root of this value. There's no need to pass an additional directory

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>