### PR TITLE
chore(test): disable flaky test

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -9,8 +9,10 @@
   ;; unreliable to depend on in a test so these tests are disabled on macos.
   (<> "macosx" %{ocaml-config:system})))
 
+; These tests are explicitly disabled due to flakiness
+
 (cram
- (applies_to exec-watch-server)
+ (applies_to exec-watch-server exec-watch-ignore-sigterm)
  (enabled_if false))
 
 (cram


### PR DESCRIPTION
I've seen this fail a few time in CI. No point keeping it enabled.