### PR TITLE
refactor(melange): avoid dead code path

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -22,9 +22,11 @@ let output_of_lib =
 ;;
 
 let lib_output_path ~output_dir ~lib_dir src =
-  match Path.drop_prefix_exn src ~prefix:lib_dir |> Path.Local.to_string with
-  | "" -> output_dir
-  | dir -> Path.Build.relative output_dir dir
+  if Path.equal lib_dir src
+  then output_dir
+  else (
+    let src_dir = Path.drop_prefix_exn src ~prefix:lib_dir in
+    Path.Build.append_local output_dir src_dir)
 ;;
 
 let make_js_name ~js_ext ~output m =


### PR DESCRIPTION
when `prefix = path`, `Path.drop_prefix_exn` returns `Local.root` (which is `"."`):

https://github.com/ocaml/dune/blob/422986440edc34d847f632e00824611360452b27/otherlibs/stdune/src/path.ml#L1457

Therefore, the `match` branch for `""` never gets hit.