### PR TITLE
test: clean up melange runtime_deps tests

### DIFF
--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
@@ -116,7 +116,7 @@ Test depending on paths that "escape" the melange.emit directory
   > let () = Js.log file_content
   > EOF
 
-Need to create the source dir first for the alias to be picked up
+Rules are created for the runtime deps
 
   $ dune rules @mel | grep .txt
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -46,13 +46,6 @@ Alias is found even if source dir "output" isn't present
    (targets ((files (_build/default/output/assets/file.txt)) (directories ())))
    (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
 
-Creating the source directory makes it appear in the alias
-
-  $ dune rules @mel | grep file.txt
-  ((deps ((File (In_build_dir _build/default/assets/file.txt))))
-   (targets ((files (_build/default/output/assets/file.txt)) (directories ())))
-   (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
-
   $ dune build @mel
 
 The runtime_dep index.txt was copied to the build folder

--- a/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
@@ -80,7 +80,8 @@ The runtime_dep index.txt was copied to the build folder
   
   Some text
   
-The same does not work for non-recursive aliases
+
+The same does not work for non-recursive aliases (no assets dir)
 
   $ dune clean
   $ dune build @@mel


### PR DESCRIPTION
follow-up to #7334, where we added support for aliases to be picked up in all directories, not just source dirs.