### PR TITLE
chore: remove coverage job and instrumentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,6 @@ test-all: $(BIN)
 test-all-sans-melange: $(BIN)
 	$(BIN) build @runtest @runtest-js @runtest-coq
 
-test-coverage: $(BIN)
-	- $(BIN) build --instrument-with bisect_ppx --force @runtest
-	bisect-ppx-report send-to Coveralls
-
 .PHONY: check
 check: $(BIN)
 	@$(BIN) build @check

--- a/otherlibs/chrome-trace/src/dune
+++ b/otherlibs/chrome-trace/src/dune
@@ -1,6 +1,4 @@
 (library
  (name chrome_trace)
  (public_name chrome-trace)
- (synopsis "Emit catapult trace files, compatible with chrome://tracing")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Emit catapult trace files, compatible with chrome://tracing"))

--- a/otherlibs/chrome-trace/test/dune
+++ b/otherlibs/chrome-trace/test/dune
@@ -13,6 +13,4 @@
   base
   ppx_inline_test.config)
  (preprocess
-  (pps ppx_expect))
- (instrumentation
-  (backend bisect_ppx)))
+  (pps ppx_expect)))

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -11,9 +11,7 @@
    (:include flags/flags.sexp)))
  (special_builtin_support
   (configurator
-   (api_version 1)))
- (instrumentation
-  (backend bisect_ppx)))
+   (api_version 1))))
 
 (documentation
  (package dune-configurator))

--- a/otherlibs/dune-action-plugin/src/dune
+++ b/otherlibs/dune-action-plugin/src/dune
@@ -3,6 +3,4 @@
  (public_name dune-action-plugin)
  (libraries stdune csexp dune-glob unix dune-rpc.private)
  (synopsis
-  "[Internal] Monadic interface for defining scripts with dynamic or complex sets of dependencies.")
- (instrumentation
-  (backend bisect_ppx)))
+  "[Internal] Monadic interface for defining scripts with dynamic or complex sets of dependencies."))

--- a/otherlibs/dune-build-info/src/dune
+++ b/otherlibs/dune-build-info/src/dune
@@ -5,9 +5,7 @@
  (special_builtin_support
   (build_info
    (data_module build_info_data)
-   (api_version 1)))
- (instrumentation
-  (backend bisect_ppx)))
+   (api_version 1))))
 
 (documentation
  (package dune-build-info))

--- a/otherlibs/dune-glob/src/dune
+++ b/otherlibs/dune-glob/src/dune
@@ -4,8 +4,6 @@
  (libraries stdune dune-private-libs.dune_re dyn ordering)
  (flags
   (:standard -w -50))
- (synopsis "The glob language as understood by dune.")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "The glob language as understood by dune."))
 
 (ocamllex lexer)

--- a/otherlibs/dune-glob/test/dune
+++ b/otherlibs/dune-glob/test/dune
@@ -11,6 +11,4 @@
   base
   ppx_inline_test.config)
  (preprocess
-  (pps ppx_expect))
- (instrumentation
-  (backend bisect_ppx)))
+  (pps ppx_expect)))

--- a/otherlibs/dune-private-libs/meta_parser/dune
+++ b/otherlibs/dune-private-libs/meta_parser/dune
@@ -1,8 +1,6 @@
 (library
  (name dune_meta_parser)
  (public_name dune-private-libs.meta_parser)
- (synopsis "[Internal] findlib META parser")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "[Internal] findlib META parser"))
 
 (ocamllex meta_lexer)

--- a/otherlibs/dune-private-libs/section/dune
+++ b/otherlibs/dune-private-libs/section/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_section)
  (public_name dune-private-libs.dune-section)
- (synopsis "[Internal] section definition")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "[Internal] section definition"))

--- a/otherlibs/dune-rpc-lwt/src/dune
+++ b/otherlibs/dune-rpc-lwt/src/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_rpc_lwt)
  (public_name dune-rpc-lwt)
- (libraries csexp dune_rpc lwt lwt.unix unix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries csexp dune_rpc lwt lwt.unix unix))

--- a/otherlibs/dune-rpc/dune
+++ b/otherlibs/dune-rpc/dune
@@ -8,6 +8,4 @@
   xdg
   ordering
   pp
-  (re_export dune_rpc_private))
- (instrumentation
-  (backend bisect_ppx)))
+  (re_export dune_rpc_private)))

--- a/otherlibs/dune-rpc/private/dune
+++ b/otherlibs/dune-rpc/private/dune
@@ -2,8 +2,6 @@
  (name dune_rpc_private)
  (public_name dune-rpc.private)
  (libraries stdune ordering pp csexp dyn xdg unix)
- (synopsis "for internal use only")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "for internal use only"))
 
 (ocamllex dbus_address)

--- a/otherlibs/dune-site/src/dune
+++ b/otherlibs/dune-site/src/dune
@@ -8,6 +8,4 @@
    (data_module dune_site_data)))
  (libraries
   (re_export dune-private-libs.dune-section)
-  dune-site.private)
- (instrumentation
-  (backend bisect_ppx)))
+  dune-site.private))

--- a/otherlibs/dune-site/src/plugins/dune
+++ b/otherlibs/dune-site/src/plugins/dune
@@ -6,6 +6,4 @@
   (dune_site
    (plugins)
    (data_module dune_site_plugins_data)))
- (libraries dune-site dune-private-libs.meta_parser dune-site.linker)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries dune-site dune-private-libs.meta_parser dune-site.linker))

--- a/otherlibs/dune-site/src/private/dune
+++ b/otherlibs/dune-site/src/private/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_site_private)
  (libraries dune-private-libs.dune-section)
- (public_name dune-site.private)
- (instrumentation
-  (backend bisect_ppx)))
+ (public_name dune-site.private))

--- a/otherlibs/dyn/dune
+++ b/otherlibs/dyn/dune
@@ -1,5 +1,3 @@
 (library
  (public_name dyn)
- (libraries pp ordering)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries pp ordering))

--- a/otherlibs/ocamlc-loc/src/dune
+++ b/otherlibs/ocamlc-loc/src/dune
@@ -1,8 +1,6 @@
 (library
  (name ocamlc_loc)
  (public_name ocamlc-loc)
- (libraries dyn)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries dyn))
 
 (ocamllex lexer)

--- a/otherlibs/ordering/dune
+++ b/otherlibs/ordering/dune
@@ -1,6 +1,4 @@
 (library
  (name ordering)
  (public_name ordering)
- (synopsis "Element ordering.")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Element ordering."))

--- a/otherlibs/stdune/dune_filesystem_stubs/dune
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune
@@ -4,6 +4,4 @@
  (libraries unix)
  (foreign_stubs
   (language c)
-  (names readdir))
- (instrumentation
-  (backend bisect_ppx)))
+  (names readdir)))

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -14,6 +14,4 @@
   (:include flags/sexp))
  (foreign_stubs
   (language c)
-  (names wait4_stubs platform_stubs copyfile_stubs signal_stubs))
- (instrumentation
-  (backend bisect_ppx)))
+  (names wait4_stubs platform_stubs copyfile_stubs signal_stubs)))

--- a/otherlibs/xdg/dune
+++ b/otherlibs/xdg/dune
@@ -11,9 +11,7 @@
  (foreign_stubs
   (language c)
   (names xdg_stubs))
- (synopsis "[Internal] XDG base directories specification implementation")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "[Internal] XDG base directories specification implementation"))
 
 (documentation
  (package xdg))

--- a/src/async_inotify_for_dune/dune
+++ b/src/async_inotify_for_dune/dune
@@ -1,5 +1,3 @@
 (library
  (name async_inotify_for_dune)
- (libraries stdune unix ocaml_inotify threads.posix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune unix ocaml_inotify threads.posix))

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -13,6 +13,4 @@
   (re_export unix))
  (foreign_stubs
   (language c)
-  (names csexp_rpc_stubs))
- (instrumentation
-  (backend bisect_ppx)))
+  (names csexp_rpc_stubs)))

--- a/src/dag/dune
+++ b/src/dag/dune
@@ -1,6 +1,4 @@
 (library
  (name dag)
  (libraries stdune incremental_cycles)
- (synopsis "Directed Acyclic Graph library")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Directed Acyclic Graph library"))

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -10,6 +10,4 @@
   dune_targets
   fiber
   stdune
-  unix)
- (instrumentation
-  (backend bisect_ppx)))
+  unix))

--- a/src/dune_cache_storage/dune
+++ b/src/dune_cache_storage/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_cache_storage)
  (synopsis "[Internal] Dune cache storage, used for local and cloud caches")
- (libraries csexp dune_util dune_digest fiber fiber_util stdune xdg unix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries csexp dune_util dune_digest fiber fiber_util stdune xdg unix))

--- a/src/dune_config_file/dune
+++ b/src/dune_config_file/dune
@@ -15,6 +15,4 @@
   dune_tui
   dune_util
   dune_spawn)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_console/dune
+++ b/src/dune_console/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_console)
- (libraries stdune)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune))

--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -3,6 +3,4 @@
  (libraries dune_metrics dune_stats dune_console dune_util stdune unix)
  (foreign_stubs
   (names dune_digest_stubs)
-  (language c))
- (instrumentation
-  (backend bisect_ppx)))
+  (language c)))

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -34,6 +34,4 @@
   dune_filesystem_stubs
   dune_digest
   dune_metrics)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -11,6 +11,4 @@
   async_inotify_for_dune
   dune_re
   fswatch_win)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_graph/dune
+++ b/src/dune_graph/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_graph)
- (libraries stdune)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune))

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -13,8 +13,6 @@
   ordering
   predicate_lang
   dune_section
-  (re_export dune_sexp))
- (instrumentation
-  (backend bisect_ppx)))
+  (re_export dune_sexp)))
 
 (ocamllex dune_file_script)

--- a/src/dune_metrics/dune
+++ b/src/dune_metrics/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_metrics)
- (libraries stdune unix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune unix))

--- a/src/dune_output_truncation/dune
+++ b/src/dune_output_truncation/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_output_truncation)
- (libraries stdune)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune))

--- a/src/dune_patch/dune
+++ b/src/dune_patch/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_patch)
- (libraries stdune fiber dune_engine dune_lang action_ext dune_re)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune fiber dune_engine dune_lang action_ext dune_re))

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -19,6 +19,4 @@
   opam_format
   build_info
   sat
-  xdg)
- (instrumentation
-  (backend bisect_ppx)))
+  xdg))

--- a/src/dune_pkg_outdated/dune
+++ b/src/dune_pkg_outdated/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_pkg_outdated)
  (synopsis "[Internal] Implementation of dune pkg outdated")
- (libraries stdune dune_lang dune_pkg opam_format fiber)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune dune_lang dune_pkg opam_format fiber))

--- a/src/dune_rpc_client/dune
+++ b/src/dune_rpc_client/dune
@@ -1,6 +1,4 @@
 (library
  (name dune_rpc_client)
  (libraries stdune unix fiber csexp_rpc dune_util xdg dune_rpc_private)
- (synopsis "Dune's rpc server + a usable client")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Dune's rpc server + a usable client"))

--- a/src/dune_rpc_impl/dune
+++ b/src/dune_rpc_impl/dune
@@ -13,6 +13,4 @@
   dune_rpc_private
   dune_rpc_server
   dune_engine)
- (synopsis "Dune's rpc server + a usable client")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Dune's rpc server + a usable client"))

--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -10,6 +10,4 @@
   dune_stats
   dune_util
   dune_rpc_private
-  unix)
- (instrumentation
-  (backend bisect_ppx)))
+  unix))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -42,9 +42,7 @@
   fs
   unix
   xdg)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))
 
 (ocamllex ocamlobjinfo)
 

--- a/src/dune_rules_rpc/dune
+++ b/src/dune_rules_rpc/dune
@@ -10,6 +10,4 @@
   dune_rpc_impl
   dune_rpc_private
   dune_rpc_server
-  dune_rules)
- (instrumentation
-  (backend bisect_ppx)))
+  dune_rules))

--- a/src/dune_sexp/dune
+++ b/src/dune_sexp/dune
@@ -1,8 +1,6 @@
 (library
  (name dune_sexp)
  (synopsis "[Internal] S-expression library")
- (libraries stdune dune_uutf)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune dune_uutf))
 
 (ocamllex lexer versioned_file_first_line)

--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -3,6 +3,4 @@
  (foreign_stubs
   (language c)
   (names dune_stats_stubs))
- (libraries stdune chrome_trace dune_spawn unix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune chrome_trace dune_spawn unix))

--- a/src/dune_thread_pool/dune
+++ b/src/dune_thread_pool/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_thread_pool)
- (libraries stdune threads.posix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune threads.posix))

--- a/src/dune_threaded_console/dune
+++ b/src/dune_threaded_console/dune
@@ -1,5 +1,3 @@
 (library
  (name dune_threaded_console)
- (libraries stdune dune_util dune_console dune_engine threads.posix)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune dune_util dune_console dune_engine threads.posix))

--- a/src/dune_tui/dune
+++ b/src/dune_tui/dune
@@ -10,8 +10,6 @@
   dune_config
   dune_console
   dune_threaded_console
-  threads.posix)
- (instrumentation
-  (backend bisect_ppx)))
+  threads.posix))
 
 (include_subdirs unqualified)

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -16,6 +16,4 @@
   dune_sexp
   dune_config
   memo
-  (re_export unix))
- (instrumentation
-  (backend bisect_ppx)))
+  (re_export unix)))

--- a/src/fiber_event_bus/dune
+++ b/src/fiber_event_bus/dune
@@ -1,6 +1,4 @@
 (library
  (name fiber_event_bus)
  (libraries fiber stdune)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))

--- a/src/fiber_util/dune
+++ b/src/fiber_util/dune
@@ -1,6 +1,4 @@
 (library
  (name fiber_util)
  (libraries stdune fiber)
- (synopsis "Utilities for working with the Fiber library")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Utilities for working with the Fiber library"))

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,6 +1,4 @@
 (library
  (name memo)
  (libraries stdune dyn dune_graph dag fiber dune_console unix)
- (synopsis "Incremental computation library that powers Dune")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Incremental computation library that powers Dune"))

--- a/src/ocaml-config/dune
+++ b/src/ocaml-config/dune
@@ -1,6 +1,4 @@
 (library
  (name ocaml_config)
  (libraries stdune)
- (synopsis "[Internal] Interpret the output of 'ocamlc -config'")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "[Internal] Interpret the output of 'ocamlc -config'"))

--- a/src/ocaml/dune
+++ b/src/ocaml/dune
@@ -1,5 +1,3 @@
 (library
  (name ocaml)
- (libraries stdune dune_sexp ocaml_config)
- (instrumentation
-  (backend bisect_ppx)))
+ (libraries stdune dune_sexp ocaml_config))

--- a/src/scheme/dune
+++ b/src/scheme/dune
@@ -1,5 +1,3 @@
 (library
  (name scheme)
- (instrumentation
-  (backend bisect_ppx))
  (libraries stdune dune_engine memo))

--- a/src/upgrader/dune
+++ b/src/upgrader/dune
@@ -9,6 +9,4 @@
   dune_engine
   dune_rules
   fiber)
- (synopsis "Internal Dune library, do not use!")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Internal Dune library, do not use!"))

--- a/vendor/fiber/src/dune
+++ b/vendor/fiber/src/dune
@@ -1,6 +1,4 @@
 (library
  (name fiber)
  (libraries stdune dyn)
- (synopsis "Monadic concurrency library")
- (instrumentation
-  (backend bisect_ppx)))
+ (synopsis "Monadic concurrency library"))


### PR DESCRIPTION
We completely remove the instrumentation fields from all the stanzas. If we ever wish to add it back, we should do so after implementing a project-wide instrumentation field rather than having to annotate every stanza.

We also remove a leftover `Makefile` target.