### PR TITLE
Allow `dune subst` to work inside a subfolder of a Git repository

### DIFF
--- a/doc/changes/11760.md
+++ b/doc/changes/11760.md
@@ -1,0 +1,2 @@
+- Fix `$ dune subst` in sub directories of a git repository (#11760, fixes
+  #11045, @Richard-Degenne)

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -182,8 +182,27 @@ let files =
   in
   let f run args t =
     let open Fiber.O in
-    let+ l = run t args in
-    List.map l ~f:Path.Source.of_string
+    let f =
+      let prefix =
+        Path.to_absolute_filename t.root |> Path.External.of_string |> Path.external_
+      in
+      let source_root =
+        Path.to_absolute_filename (Path.source Path.Source.root)
+        |> Path.External.of_string
+        |> Path.external_
+      in
+      match Path.drop_prefix source_root ~prefix with
+      | None -> fun p -> Some (Path.Source.of_string p)
+      | Some prefix ->
+        fun p ->
+          (match
+             let p = Path.Local.of_string p in
+             Path.Local.descendant p ~of_:prefix
+           with
+           | None -> None
+           | Some p -> Some (Path.Source.of_local p))
+    in
+    run t args >>| List.filter_map ~f
   in
   Staged.unstage
   @@ make_fun

--- a/test/blackbox-tests/test-cases/subst/git-subfolder.t
+++ b/test/blackbox-tests/test-cases/subst/git-subfolder.t
@@ -14,6 +14,8 @@ Regression test for https://github.com/ocaml/dune/issues/11045
   $ git add -A && git commit --quiet --message "Initial commit"
   $ cd subfolder
   $ dune subst
-  File "subfolder.opam", line 1, characters 0-0:
-  Error: repository does not contain any version information
+  File ".", line 1, characters 0-0:
+  Error: There is no dune-project file in the current directory, please add one
+  with a (name <name>) field in it.
+  Hint: 'dune subst' must be executed from the root of the project.
   [1]

--- a/test/blackbox-tests/test-cases/subst/git-subfolder.t
+++ b/test/blackbox-tests/test-cases/subst/git-subfolder.t
@@ -14,8 +14,3 @@ Regression test for https://github.com/ocaml/dune/issues/11045
   $ git add -A && git commit --quiet --message "Initial commit"
   $ cd subfolder
   $ dune subst
-  File ".", line 1, characters 0-0:
-  Error: There is no dune-project file in the current directory, please add one
-  with a (name <name>) field in it.
-  Hint: 'dune subst' must be executed from the root of the project.
-  [1]

--- a/test/blackbox-tests/test-cases/subst/git-subfolder.t
+++ b/test/blackbox-tests/test-cases/subst/git-subfolder.t
@@ -1,0 +1,32 @@
+Running `dune subst` in a subfolder of a Git repository should work.
+Regression test for https://github.com/ocaml/dune/issues/11045
+
+  $ git init --quiet
+  $ dune init proj subfolder
+  Entering directory 'subfolder'
+  Success: initialized project component named subfolder
+  Leaving directory 'subfolder'
+
+  $ unset INSIDE_DUNE
+
+`dune subst` requires at least one commit in the repository.
+
+  $ git add -A && git commit --quiet --message "Initial commit"
+  $ cd subfolder
+  $ dune subst
+  Raised when trying to print location { pos_fname = "subfolder.opam"
+  ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 10 }
+  ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 25 }
+  }
+  /-----------------------------------------------------------------------
+  | Internal error: Uncaught exception.
+  | End_of_file
+  | Raised at Stdlib.input_line.scan in file "stdlib.ml", line 456, characters 14-31
+  | Called from Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line 10, characters 8-11
+  | Re-raised at Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line 16, characters 4-11
+  | Called from Stdune__Result.try_with in file "otherlibs/stdune/src/result.ml", line 30, characters 8-12
+  \-----------------------------------------------------------------------
+  
+  File "subfolder.opam", line 1, characters 10-25:
+  Error: repository does not contain any version information
+  [1]

--- a/test/blackbox-tests/test-cases/subst/git-subfolder.t
+++ b/test/blackbox-tests/test-cases/subst/git-subfolder.t
@@ -14,19 +14,6 @@ Regression test for https://github.com/ocaml/dune/issues/11045
   $ git add -A && git commit --quiet --message "Initial commit"
   $ cd subfolder
   $ dune subst
-  Raised when trying to print location { pos_fname = "subfolder.opam"
-  ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 10 }
-  ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 25 }
-  }
-  /-----------------------------------------------------------------------
-  | Internal error: Uncaught exception.
-  | End_of_file
-  | Raised at Stdlib.input_line.scan in file "stdlib.ml", line 456, characters 14-31
-  | Called from Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line 10, characters 8-11
-  | Re-raised at Stdune__Exn.protectx in file "otherlibs/stdune/src/exn.ml", line 16, characters 4-11
-  | Called from Stdune__Result.try_with in file "otherlibs/stdune/src/result.ml", line 30, characters 8-12
-  \-----------------------------------------------------------------------
-  
-  File "subfolder.opam", line 1, characters 10-25:
+  File "subfolder.opam", line 1, characters 0-0:
   Error: repository does not contain any version information
   [1]


### PR DESCRIPTION
I gave my best shot at fixing #11045, but tests fail with a runtime error that I have a hard time understanding. If anyone could give me some pointers or complete the fix, that would be awesome.

```
Internal error, please report upstream including the contents of _build/log.
Description:
  ("Fdecl.get: not set", {})
Raised at Stdune__Code_error.raise in file
  "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
Called from Dune_rules__Only_packages.Clflags.t in file
  "src/dune_rules/only_packages.ml" (inlined), line 25, characters 13-24
Called from Dune_rules__Only_packages.filter_packages_in_project in file
  "src/dune_rules/only_packages.ml", line 68, characters 8-20
Called from Fiber__Core.O.(>>|).(fun) in file "vendor/fiber/src/core.ml",
  line 253, characters 36-41
Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
  line 76, characters 8-11
Re-raised at Stdune__Exn.raise_with_backtrace in file
  "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
  line 76, characters 8-11
Re-raised at Stdune__Exn.raise_with_backtrace in file
  "otherlibs/stdune/src/exn.ml", line 38, characters 27-56
Called from Fiber__Scheduler.exec in file "vendor/fiber/src/scheduler.ml",
  line 76, characters 8-11
-> required by ("find-dir-raw", In_source_tree ".")
```