### PR TITLE
refactor(pkg): do not pass all pinned packages to [Lock_pkg]

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -337,7 +337,7 @@ let opam_package_to_lock_file_pkg
       stats_updater
       version_by_package_name
       opam_package
-      ~pinned_package_names
+      ~pinned
       ~candidates_cache
   =
   let name = Package_name.of_opam_package_name (OpamPackage.name opam_package) in
@@ -375,7 +375,7 @@ let opam_package_to_lock_file_pkg
         { Source.url; checksum })
     in
     let dev =
-      Package_name.Set.mem pinned_package_names name
+      pinned
       ||
       match url with
       | None -> false

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -12,6 +12,6 @@ val opam_package_to_lock_file_pkg
   -> Solver_stats.Updater.t
   -> Package_version.t Package_name.Map.t
   -> OpamPackage.t
-  -> pinned_package_names:Package_name.Set.t
+  -> pinned:bool
   -> candidates_cache:(Package_name.t -> Resolved_package.t OpamPackage.Version.Map.t)
   -> [> `Compiler | `Non_compiler ] * Lock_dir.Pkg.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1668,8 +1668,11 @@ let solve_lock_dir
             stats_updater
             version_by_package_name
             opam_package
-            ~pinned_package_names
-            ~candidates_cache)
+            ~candidates_cache
+            ~pinned:
+              (OpamPackage.name opam_package
+               |> Package_name.of_opam_package_name
+               |> Package_name.Set.mem pinned_package_names))
       in
       let ocaml =
         (* This doesn't allow the compiler to live in the source tree. Oh


### PR DESCRIPTION
we only need to know if our own package is pinned

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>