### PR TITLE
refactor(pkg): stop passing the entire candidates cache as a function

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -338,15 +338,11 @@ let opam_package_to_lock_file_pkg
       version_by_package_name
       opam_package
       ~pinned
-      ~candidates_cache
+      resolved_package
   =
   let name = Package_name.of_opam_package_name (OpamPackage.name opam_package) in
   let version =
     OpamPackage.version opam_package |> Package_version.of_opam_package_version
-  in
-  let resolved_package =
-    candidates_cache name
-    |> OpamPackage.Version.Map.find (Package_version.to_opam_package_version version)
   in
   let opam_file = Resolved_package.opam_file resolved_package in
   let loc = Resolved_package.loc resolved_package in

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -13,5 +13,5 @@ val opam_package_to_lock_file_pkg
   -> Package_version.t Package_name.Map.t
   -> OpamPackage.t
   -> pinned:bool
-  -> candidates_cache:(Package_name.t -> Resolved_package.t OpamPackage.Version.Map.t)
+  -> Resolved_package.t
   -> [> `Compiler | `Non_compiler ] * Lock_dir.Pkg.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1659,20 +1659,17 @@ let solve_lock_dir
             ( Package_name.of_opam_package_name (OpamPackage.name package)
             , Package_version.of_opam_package_version (OpamPackage.version package) ))
         in
-        let candidates_cache package_name =
-          (Table.find_exn candidates_cache package_name).resolved
-        in
         List.map opam_packages_to_lock ~f:(fun opam_package ->
+          let name = OpamPackage.name opam_package |> Package_name.of_opam_package_name in
           Lock_pkg.opam_package_to_lock_file_pkg
             solver_env
             stats_updater
             version_by_package_name
             opam_package
-            ~candidates_cache
-            ~pinned:
-              (OpamPackage.name opam_package
-               |> Package_name.of_opam_package_name
-               |> Package_name.Set.mem pinned_package_names))
+            ~pinned:(Package_name.Set.mem pinned_package_names name)
+            (let version = OpamPackage.version opam_package in
+             (Table.find_exn candidates_cache name).resolved
+             |> OpamPackage.Version.Map.find version))
       in
       let ocaml =
         (* This doesn't allow the compiler to live in the source tree. Oh


### PR DESCRIPTION
Just passing the package in question is enough