### PR TITLE
feature: depopt selection in the workspace

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -120,6 +120,7 @@ let solve_lock_dir
     ~local_packages:
       (Package_name.Map.map local_packages ~f:Dune_pkg.Local_package.for_solver)
     ~constraints:(constraints_of_workspace workspace ~lock_dir_path)
+    ~selected_depopts:(depopts_of_workspace workspace ~lock_dir_path)
   >>= function
   | Error (`Diagnostic_message message) -> Fiber.return (Error (lock_dir_path, message))
   | Ok { lock_dir; files; pinned_packages; num_expanded_packages } ->

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -58,6 +58,12 @@ let constraints_of_workspace (workspace : Workspace.t) ~lock_dir_path =
   | Some lock_dir -> lock_dir.constraints
 ;;
 
+let depopts_of_workspace (workspace : Workspace.t) ~lock_dir_path =
+  match Workspace.find_lock_dir workspace lock_dir_path with
+  | None -> []
+  | Some lock_dir -> lock_dir.depopts |> List.map ~f:snd
+;;
+
 let repositories_of_lock_dir workspace ~lock_dir_path =
   match Workspace.find_lock_dir workspace lock_dir_path with
   | Some lock_dir -> lock_dir.repositories

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -38,6 +38,11 @@ val constraints_of_workspace
   -> lock_dir_path:Path.Source.t
   -> Dune_lang.Package_dependency.t list
 
+val depopts_of_workspace
+  :  Workspace.t
+  -> lock_dir_path:Path.Source.t
+  -> Package_name.t list
+
 val get_repos
   :  Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
   -> repositories:(Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1604,6 +1604,7 @@ let solve_lock_dir
       ~local_packages
       ~pins:pinned_packages
       ~constraints
+      ~selected_depopts
   =
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
@@ -1638,8 +1639,8 @@ let solve_lock_dir
     in
     Lazy.force context
   in
-  Package_name.Map.to_list_map local_packages ~f:(fun name _ ->
-    Package_name.to_opam_package_name name)
+  Package_name.Map.keys local_packages @ selected_depopts
+  |> List.map ~f:Package_name.to_opam_package_name
   |> solve_package_list ~context
   >>= function
   | Error _ as e -> Fiber.return e

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -16,5 +16,6 @@ val solve_lock_dir
   -> local_packages:Local_package.For_solver.t Package_name.Map.t
   -> pins:Resolved_package.t Package_name.Map.t
   -> constraints:Dune_lang.Package_dependency.t list
+  -> selected_depopts:Package_name.t list
   -> (Solver_result.t, [ `Diagnostic_message of User_message.Style.t Pp.t ]) result
        Fiber.t

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -11,6 +11,7 @@ module Lock_dir : sig
     ; repositories : (Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list
     ; constraints : Dune_lang.Package_dependency.t list
     ; pins : (Loc.t * string) list
+    ; depopts : (Loc.t * Package.Name.t) list
     }
 
   val equal : t -> t -> bool

--- a/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
@@ -1,0 +1,87 @@
+Demonstrate how depopts can be forced in the workspace
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+
+  $ mkpkg foo
+  $ mkpkg bar
+  $ mkpkg baz
+
+  $ solve_project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depopts foo bar))
+  > EOF
+  Solution for dune.lock:
+  (no dependencies to lock)
+
+Select just foo
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (lock_dir
+  >  (depopts foo)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+Select both foo and bar
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (lock_dir
+  >  (depopts foo bar)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1
+
+Select a package that is not listed as depopt
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (lock_dir
+  >  (depopts baz)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  (no dependencies to lock)
+
+
+Select garbage
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.10)
+  > (lock_dir
+  >  (depopts z)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+  $ dune pkg lock
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: z
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -15,7 +15,7 @@ Set up two build contexts: a default one for linux and another for macos.
   >  (solver_env
   >   (os macos)))
   > (context
-  >  (default)) 
+  >  (default))
   > (context
   >  (default
   >   (name macos)


### PR DESCRIPTION
Add a [deopts] field to allow users to select depopts.

The depopts are selected globally for all packages that list them. This is inline with how opam does things.

Fixes #11643

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>