### PR TITLE
test(pkg): demonstrate an issue with post deps

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -5,6 +5,13 @@ Solving for post dependencies:
 
   $ mkpkg bar
 
+  $ barfile="bar.file"
+  $ bardir="$mock_packages/bar/bar.0.0.1"
+  $ mkdir -p $bardir/files/dir
+  $ cat >$bardir/files/$barfile <<EOF
+  > foo patch
+  > EOF
+
   $ mkpkg foo <<EOF
   > depends: [ "bar" {post} ]
   > EOF
@@ -17,6 +24,11 @@ We don't need bar, so we skip it
 
   $ cat dune.lock/foo.pkg
   (version 0.0.1)
+
+We should also skip any artifacts that bar references:
+
+  $ [ -d dune.lock/bar.files ] && ls -1 -x dune.lock/bar.files
+  bar.file
 
 Self dependency
 


### PR DESCRIPTION
When post deps are ignored due to reachability, any files that they reference still end up being included in the solver.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>