### PR TITLE
fix(pkg): do include files from unreachable packages

### DIFF
--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1752,10 +1752,9 @@ let solve_lock_dir
         ~expanded_solver_variable_bindings
     in
     let+ files =
-      List.map opam_packages_to_lock ~f:(fun package ->
-        let name = Package_name.of_opam_package_name (OpamPackage.name package) in
-        let version = OpamPackage.version package in
-        resolve_package name version)
+      Package_name.Map.to_list_map pkgs_by_name ~f:(fun name (package : Lock_dir.Pkg.t) ->
+        Package_version.to_opam_package_version package.info.version
+        |> resolve_package name)
       |> files
     in
     Ok

--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -28,7 +28,7 @@ We don't need bar, so we skip it
 We should also skip any artifacts that bar references:
 
   $ [ -d dune.lock/bar.files ] && ls -1 -x dune.lock/bar.files
-  bar.file
+  [1]
 
 Self dependency
 


### PR DESCRIPTION
The solver correctly removes unnecessary `{post}` dependencies, but keeps their artifacts around. This is because we do the reachability analysis after computing the files we copy the lock directory. Reversing the two steps fixes the bug.

One of @gridbugs or @Leonidas-from-XIV please