### PR TITLE
Allow dev tools to be installed while watch server runs

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -138,11 +138,7 @@ let run_build_command ~(common : Common.t) ~config ~request =
     ~request
 ;;
 
-(* Instruct the specified RPC server to build the specified targets, waiting
-   for a response from the server indicating that the build succeeded or failed
-   and print error messages if the build failed.
-*)
-let build_via_rpc_server targets =
+let build_via_rpc_server ~print_on_success ~targets =
   let open Fiber.O in
   let+ response = Rpc.Build.build ~wait:true targets in
   match response with
@@ -151,8 +147,10 @@ let build_via_rpc_server targets =
       "Error: %s\n%!"
       (Dyn.to_string (Dune_rpc_private.Response.Error.to_dyn error))
   | Ok Success ->
-    Console.print_user_message
-      (User_message.make [ Pp.text "Success" |> Pp.tag User_message.Style.Success ])
+    if print_on_success
+    then
+      Console.print_user_message
+        (User_message.make [ Pp.text "Success" |> Pp.tag User_message.Style.Success ])
   | Ok (Failure errors) ->
     List.iter errors ~f:(fun { Dune_engine.Compound_user_error.main; _ } ->
       Console.print_user_message main);
@@ -217,7 +215,7 @@ let build =
          perform the RPC call.
       *)
       Scheduler.go_without_rpc_server ~common ~config (fun () ->
-        build_via_rpc_server targets)
+        build_via_rpc_server ~print_on_success:true ~targets)
     | Ok () ->
       let request setup =
         Target.interpret_targets (Common.root common) config setup targets

--- a/bin/build_cmd.mli
+++ b/bin/build_cmd.mli
@@ -1,5 +1,15 @@
 open Import
 
+(** Connect to an RPC server (waiting for the server to start if necessary) and
+    then send a request to the server to build the specified targets. If the
+    build fails then a diagnostic error message is printed. If
+    [print_on_success] is true then this function will also print a message
+    after the build succeeds. *)
+val build_via_rpc_server
+  :  print_on_success:bool
+  -> targets:Dune_lang.Dep_conf.t list
+  -> unit Fiber.t
+
 val run_build_system
   :  common:Common.t
   -> request:(Dune_rules.Main.build_system -> unit Action_builder.t)

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -22,7 +22,7 @@ let lock_ocamlformat () =
        this logic remain outside of `dune build`, as `dune
        build` is intended to only build targets, and generating
        a lockdir is not building a target. *)
-    Lock_dev_tool.lock_ocamlformat () |> Memo.run
+    Lock_dev_tool.lock_dev_tool Ocamlformat |> Memo.run
   else Fiber.return ()
 ;;
 

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -205,7 +205,11 @@ let lockdir_status dev_tool =
                   ]))))
 ;;
 
-let lock_dev_tool dev_tool version =
+(* [lock_dev_tool_at_version dev_tool version] generates the lockdir for the
+   dev tool [dev_tool]. If [version] is [Some v] then version [v] of the tool
+   will be chosen by the solver. Otherwise the solver is free to choose the
+   appropriate version of the tool to install. *)
+let lock_dev_tool_at_version dev_tool version =
   let open Memo.O in
   let* need_to_solve =
     lockdir_status dev_tool
@@ -240,8 +244,15 @@ let lock_dev_tool dev_tool version =
 
 let lock_ocamlformat () =
   let version = Dune_pkg.Ocamlformat.version_of_current_project's_ocamlformat_config () in
-  lock_dev_tool Ocamlformat version
+  lock_dev_tool_at_version Ocamlformat version
 ;;
 
-let lock_odoc () = lock_dev_tool Odoc None
-let lock_ocamllsp () = lock_dev_tool Ocamllsp None
+let lock_odoc () = lock_dev_tool_at_version Odoc None
+let lock_ocamllsp () = lock_dev_tool_at_version Ocamllsp None
+
+let lock_dev_tool dev_tool =
+  match (dev_tool : Dune_pkg.Dev_tool.t) with
+  | Ocamlformat -> lock_ocamlformat ()
+  | Odoc -> lock_odoc ()
+  | Ocamllsp -> lock_ocamllsp ()
+;;

--- a/bin/lock_dev_tool.mli
+++ b/bin/lock_dev_tool.mli
@@ -1,6 +1,4 @@
 open! Import
 
 val is_enabled : bool Lazy.t
-val lock_ocamlformat : unit -> unit Memo.t
-val lock_odoc : unit -> unit Memo.t
-val lock_ocamllsp : unit -> unit Memo.t
+val lock_dev_tool : Dune_pkg.Dev_tool.t -> unit Memo.t

--- a/bin/ocaml/doc.ml
+++ b/bin/ocaml/doc.ml
@@ -16,7 +16,7 @@ let info = Cmd.info "doc" ~doc ~man
 let lock_odoc_if_dev_tool_enabled () =
   match Lazy.force Lock_dev_tool.is_enabled with
   | false -> Action_builder.return ()
-  | true -> Action_builder.of_memo (Lock_dev_tool.lock_odoc ())
+  | true -> Action_builder.of_memo (Lock_dev_tool.lock_dev_tool Odoc)
 ;;
 
 let term =

--- a/bin/tools/ocamlformat.ml
+++ b/bin/tools/ocamlformat.ml
@@ -2,47 +2,13 @@ open! Import
 module Pkg_dev_tool = Dune_rules.Pkg_dev_tool
 
 let exe_path = Path.build @@ Pkg_dev_tool.exe_path Ocamlformat
-let exe_name = Pkg_dev_tool.exe_name Ocamlformat
-
-let run_dev_tool workspace_root ~args =
-  let exe_path_string = Path.to_string exe_path in
-  Console.print_user_message
-    (Dune_rules.Pkg_build_progress.format_user_message
-       ~verb:"Running"
-       ~object_:(User_message.command (String.concat ~sep:" " (exe_name :: args))));
-  Console.finish ();
-  restore_cwd_and_execve workspace_root exe_path_string args Env.initial
-;;
-
-let dev_tool_exe_exists () = Path.exists exe_path
-
-let build_dev_tool common =
-  match dev_tool_exe_exists () with
-  | true ->
-    (* Avoid running the build system if the executable already exists
-       to reduce unnecessary latency in the common case. *)
-    Fiber.return ()
-  | false ->
-    let open Fiber.O in
-    let+ result =
-      Build_cmd.run_build_system ~common ~request:(fun _build_system ->
-        Action_builder.path exe_path)
-    in
-    (match result with
-     | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
-     | Ok () -> ())
-;;
 
 module Exec = struct
   let term =
     let+ builder = Common.Builder.term
     and+ args = Arg.(value & pos_all string [] (info [] ~docv:"ARGS")) in
     let common, config = Common.init builder in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      let open Fiber.O in
-      let* () = Lock_dev_tool.lock_ocamlformat () |> Memo.run in
-      let+ () = build_dev_tool common in
-      run_dev_tool (Common.root common) ~args)
+    Tools_common.lock_build_and_run_dev_tool ~common ~config Ocamlformat ~args
   ;;
 
   let info =

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -1,0 +1,56 @@
+open! Import
+module Pkg_dev_tool = Dune_rules.Pkg_dev_tool
+
+let dev_tool_exe_path dev_tool = Path.build @@ Pkg_dev_tool.exe_path dev_tool
+
+let dev_tool_build_target dev_tool =
+  Dune_lang.Dep_conf.File
+    (Dune_lang.String_with_vars.make_text
+       Loc.none
+       (Path.to_string (dev_tool_exe_path dev_tool)))
+;;
+
+let build_dev_tool_directly common dev_tool =
+  let open Fiber.O in
+  let+ result =
+    Build_cmd.run_build_system ~common ~request:(fun _build_system ->
+      Action_builder.path (dev_tool_exe_path dev_tool))
+  in
+  match result with
+  | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
+  | Ok () -> ()
+;;
+
+let build_dev_tool_via_rpc dev_tool =
+  let target = dev_tool_build_target dev_tool in
+  Build_cmd.build_via_rpc_server ~print_on_success:false ~targets:[ target ]
+;;
+
+let lock_and_build_dev_tool ~common ~config dev_tool =
+  let open Fiber.O in
+  match Dune_util.Global_lock.lock ~timeout:None with
+  | Error () ->
+    Scheduler.go_without_rpc_server ~common ~config (fun () ->
+      let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in
+      build_dev_tool_via_rpc dev_tool)
+  | Ok () ->
+    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+      let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in
+      build_dev_tool_directly common dev_tool)
+;;
+
+let run_dev_tool workspace_root dev_tool ~args =
+  let exe_name = Pkg_dev_tool.exe_name dev_tool in
+  let exe_path_string = Path.to_string (dev_tool_exe_path dev_tool) in
+  Console.print_user_message
+    (Dune_rules.Pkg_build_progress.format_user_message
+       ~verb:"Running"
+       ~object_:(User_message.command (String.concat ~sep:" " (exe_name :: args))));
+  Console.finish ();
+  restore_cwd_and_execve workspace_root exe_path_string args Env.initial
+;;
+
+let lock_build_and_run_dev_tool ~common ~config dev_tool ~args =
+  lock_and_build_dev_tool ~common ~config dev_tool;
+  run_dev_tool (Common.root common) dev_tool ~args
+;;

--- a/bin/tools/tools_common.mli
+++ b/bin/tools/tools_common.mli
@@ -1,0 +1,11 @@
+open! Import
+
+(** Generate a lockdir for a dev tool, build the dev tool, then run the dev
+    tool. If a step is unnecessary then it is skipped. This function does not
+    return, but starts running the dev tool in place of the current process. *)
+val lock_build_and_run_dev_tool
+  :  common:Common.t
+  -> config:Dune_config_file.Dune_config.t
+  -> Dune_pkg.Dev_tool.t
+  -> args:string list
+  -> 'a

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
@@ -1,0 +1,44 @@
+Test that ocamllsp can be installed while dune is running in watch mode.
+
+  $ . ../helpers.sh
+  $ . ./helpers.sh
+
+  $ mkrepo
+  $ make_mock_ocamllsp_package
+  $ mkpkg ocaml 5.2.0
+
+  $ setup_ocamllsp_workspace
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > 
+  > (package
+  >  (name foo))
+  > EOF
+
+  $ make_lockdir
+  $ cat > dune.lock/ocaml.pkg <<EOF
+  > (version 5.2.0)
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let () = print_endline "hi"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (public_name foo))
+  > EOF
+
+  $ dune build --watch &
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+
+  $ dune tools exec ocamllsp
+  Solution for dev-tools.locks/ocaml-lsp-server:
+  - ocaml.5.2.0
+  - ocaml-lsp-server.0.0.1
+       Running 'ocamllsp'
+  hello from fake ocamllsp
+
+  $ dune shutdown
+  $ wait


### PR DESCRIPTION
If `dune tools exec ocamllsp` is executed while the watch server is running, dune will now build ocamllsp in the instance of dune where the watch server is running rather than failing due to the build directory being locked.