### PR TITLE
Remove some unused logic from exec

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -123,19 +123,8 @@ let get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog =
     let path = Path.relative_to_source_in_build_or_external ~dir prog in
     Build_system.file_exists path
     >>= (function
-     | true -> Memo.return (Some path)
-     | false ->
-       if not (Filename.check_suffix prog ".exe")
-       then Memo.return None
-       else (
-         let path = Path.extend_basename path ~suffix:".exe" in
-         Build_system.file_exists path
-         >>| function
-         | true -> Some path
-         | false -> None))
-    >>= (function
-     | Some path -> build_prog ~no_rebuild ~prog path
-     | None -> not_found ~dir ~prog)
+     | true -> build_prog ~no_rebuild ~prog path
+     | false -> not_found ~dir ~prog)
   | Absolute ->
     (match
        let prog = Path.of_string prog in


### PR DESCRIPTION
This removes some code related to automatically adding a missing ".exe" suffix from a relative path to an executable passed as the program argument to `dune exec ...` if doing so would result in the name of an executable build target. However the condition is seemingly inverted from what is should be; the suffix is only added if the suffix already exists. Since nobody seems to complain about this bug, let's take the opportunity to delete the code altogether.