### PR TITLE
General portable depexts in lockfiles

### DIFF
--- a/bin/describe/describe_depexts.ml
+++ b/bin/describe/describe_depexts.ml
@@ -1,51 +1,19 @@
 open Import
-open Pkg_common
-module Lock_dir = Dune_pkg.Lock_dir
 
-let enumerate_lock_dirs_by_path workspace ~lock_dirs =
-  let lock_dirs = Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs workspace in
-  List.filter_map lock_dirs ~f:(fun lock_dir_path ->
-    if Path.exists (Path.source lock_dir_path)
-    then (
-      try Some (Lock_dir.read_disk_exn lock_dir_path) with
-      | User_error.E e ->
-        User_warning.emit
-          [ Pp.textf
-              "Failed to parse lockdir %s:"
-              (Path.Source.to_string_maybe_quoted lock_dir_path)
-          ; User_message.pp e
-          ];
-        None)
-    else None)
-;;
-
-let print_depexts ~lock_dirs_arg =
+let print_depexts context_name =
   let open Fiber.O in
-  let open Lock_dir in
-  let+ workspace = Memo.run (Workspace.workspace ())
-  and+ platform =
-    Dune_pkg.Sys_poll.make ~path:(Env_path.path Stdune.Env.initial)
-    |> Dune_pkg.Sys_poll.solver_env_from_current_system
-  in
-  let depexts =
-    enumerate_lock_dirs_by_path workspace ~lock_dirs:lock_dirs_arg
-    |> List.concat_map ~f:(fun lock_dir ->
-      Lock_dir.Packages.pkgs_on_platform_by_name ~platform lock_dir.packages
-      |> Package_name.Map.values
-      |> List.concat_map ~f:(fun (pkg : Lock_dir.Pkg.t) ->
-        match Lock_dir.Conditional_choice.choose_for_platform pkg.depexts ~platform with
-        | Some depexts -> depexts
-        | None -> []))
+  let+ depexts =
+    build_exn (fun () -> Dune_rules.Pkg_rules.all_filtered_depexts context_name)
   in
   Console.print [ Pp.concat_map ~sep:Pp.newline ~f:Pp.verbatim depexts ]
 ;;
 
 let term =
   let+ builder = Common.Builder.term
-  and+ lock_dirs_arg = Lock_dirs_arg.term in
+  and+ context_name = Common.context_arg ~doc:"Build context to use." in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go_with_rpc_server ~common ~config (fun () -> print_depexts ~lock_dirs_arg)
+  Scheduler.go_with_rpc_server ~common ~config (fun () -> print_depexts context_name)
 ;;
 
 let info =

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -92,6 +92,7 @@ let solve_multiple_platforms
       ~constraints
       ~selected_depopts
       ~solve_for_platforms
+      ~portable_lock_dir
   =
   let open Fiber.O in
   let solve_for_env env =
@@ -103,6 +104,7 @@ let solve_multiple_platforms
       ~local_packages
       ~constraints
       ~selected_depopts
+      ~portable_lock_dir
   in
   let portable_solver_env =
     Dune_pkg.Solver_env.unset_multi
@@ -195,6 +197,7 @@ let solve_lock_dir
       ~constraints:(constraints_of_workspace workspace ~lock_dir_path)
       ~selected_depopts:(depopts_of_workspace workspace ~lock_dir_path)
       ~solve_for_platforms
+      ~portable_lock_dir
   in
   let solver_result =
     match result with

--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -396,7 +396,7 @@ let decode_pkg =
             Withenv (ops, t) )
     ; ( "when"
       , Syntax.since Stanza.syntax (0, 1)
-        >>> let+ condition = Slang.decode_blang
+        >>> let+ condition = Slang.Blang.decode
             and+ action = t in
             When (condition, action) )
     ; ( "run"
@@ -463,7 +463,7 @@ let rec encode =
   | Withenv (ops, t) ->
     List [ atom "withenv"; List (List.map ~f:Env_update.encode ops); encode t ]
   | When (condition, action) ->
-    List [ atom "when"; Slang.encode_blang condition; encode action ]
+    List [ atom "when"; Slang.Blang.encode condition; encode action ]
   | Format_dune_file (src, dst) -> List [ atom "format-dune-file"; sw src; sw dst ]
 ;;
 

--- a/src/dune_lang/blang.ml
+++ b/src/dune_lang/blang.ml
@@ -37,6 +37,15 @@ module Ast = struct
       variant "Compare" [ Relop.to_dyn o; string_to_dyn s1; string_to_dyn s2 ]
   ;;
 
+  let rec map_string ~f = function
+    | Const b -> Const b
+    | Not t -> Not (map_string ~f t)
+    | Expr s -> Expr (f s)
+    | And ts -> And (List.map ts ~f:(map_string ~f))
+    | Or ts -> Or (List.map ts ~f:(map_string ~f))
+    | Compare (o, s1, s2) -> Compare (o, f s1, f s2)
+  ;;
+
   let decode ~override_decode_bare_literal decode_string =
     let open Decoder in
     let decode_bare_literal =

--- a/src/dune_lang/blang.mli
+++ b/src/dune_lang/blang.mli
@@ -26,6 +26,10 @@ module Ast : sig
   val true_ : 'string t
   val false_ : 'string t
   val to_dyn : 'string Dyn.builder -> 'string t -> Dyn.t
+  val equal : ('string -> 'string -> bool) -> 'string t -> 'string t -> bool
+
+  (** [map_string f t] applies [f] to each string value inside [t]. *)
+  val map_string : f:('a -> 'b) -> 'a t -> 'b t
 
   (** The [override_decode_bare_literal] argument is an alternative parser that
       if provided, will be used to parse string literals for the [Expr _]

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -25,6 +25,59 @@ and form =
   | Or_absorb_undefined_var of blang list
   | Blang of blang
 
+let rec equal a b =
+  let form_equal a b =
+    match a, b with
+    | Concat a, Concat b -> List.equal equal a b
+    | When a, When b -> Tuple.T2.equal blang_equal equal a b
+    | ( If { condition = a_condition; then_ = a_then_; else_ = a_else_ }
+      , If { condition = b_condition; then_ = b_then_; else_ = b_else_ } ) ->
+      blang_equal a_condition b_condition
+      && equal a_then_ b_then_
+      && equal a_else_ b_else_
+    | Has_undefined_var a, Has_undefined_var b -> equal a b
+    | ( Catch_undefined_var { value = a_value; fallback = a_fallback }
+      , Catch_undefined_var { value = b_value; fallback = b_fallback } ) ->
+      equal a_value b_value && equal a_fallback b_fallback
+    | And_absorb_undefined_var a, And_absorb_undefined_var b
+    | Or_absorb_undefined_var a, Or_absorb_undefined_var b -> List.equal blang_equal a b
+    | Blang a, Blang b -> blang_equal a b
+    | _, _ -> false
+  in
+  match a, b with
+  | Nil, Nil -> true
+  | Literal a, Literal b -> String_with_vars.equal a b
+  | Form a, Form b -> Tuple.T2.equal Loc.equal form_equal a b
+  | _, _ -> false
+
+and blang_equal a b = Blang.Ast.equal equal a b
+
+let rec remove_locs t =
+  let form_remove_locs = function
+    | Concat ts -> Concat (List.map ts ~f:remove_locs)
+    | When (blang, t) -> When (blang_remove_locs blang, remove_locs t)
+    | If { condition; then_; else_ } ->
+      If
+        { condition = blang_remove_locs condition
+        ; then_ = remove_locs then_
+        ; else_ = remove_locs else_
+        }
+    | Has_undefined_var t -> Has_undefined_var (remove_locs t)
+    | Catch_undefined_var { value; fallback } ->
+      Catch_undefined_var { value = remove_locs value; fallback = remove_locs fallback }
+    | And_absorb_undefined_var blangs ->
+      And_absorb_undefined_var (List.map blangs ~f:blang_remove_locs)
+    | Or_absorb_undefined_var blangs ->
+      Or_absorb_undefined_var (List.map blangs ~f:blang_remove_locs)
+    | Blang blang -> Blang (blang_remove_locs blang)
+  in
+  match t with
+  | Nil -> Nil
+  | Literal sw -> Literal (String_with_vars.remove_locs sw)
+  | Form (_loc, form) -> Form (Loc.none, form_remove_locs form)
+
+and blang_remove_locs blang = Blang.Ast.map_string ~f:remove_locs blang
+
 let decode_literal =
   let open Decoder in
   let+ x = String_with_vars.decode in
@@ -84,8 +137,6 @@ let decode =
     Form (loc, Blang x))
 ;;
 
-let decode_blang = Blang.Ast.decode ~override_decode_bare_literal:None decode
-
 let rec encode t =
   let open Encoder in
   match t with
@@ -117,31 +168,25 @@ let rec encode t =
      | Blang b -> Blang.Ast.encode encode b)
 ;;
 
-let encode_blang = Blang.Ast.encode encode
-
 let rec to_dyn = function
   | Nil -> Dyn.variant "Nil" []
   | Literal sw -> Dyn.variant "Literal" [ String_with_vars.to_dyn sw ]
   | Form (_loc, form) ->
     (match form with
      | Concat ts -> Dyn.variant "Concat" (List.map ts ~f:to_dyn)
-     | When (condition, t) ->
-       Dyn.variant "When" [ Blang.Ast.to_dyn to_dyn condition; to_dyn t ]
+     | When (condition, t) -> Dyn.variant "When" [ blang_to_dyn condition; to_dyn t ]
      | If { condition; then_; else_ } ->
        Dyn.variant "If" [ Blang.Ast.to_dyn to_dyn condition; to_dyn then_; to_dyn else_ ]
      | Has_undefined_var t -> Dyn.variant "Has_undefined_var" [ to_dyn t ]
      | Catch_undefined_var { value; fallback } ->
        Dyn.variant "Catch_undefined_var" [ to_dyn value; to_dyn fallback ]
      | And_absorb_undefined_var blangs ->
-       Dyn.variant
-         "And_absorb_undefined_var"
-         (List.map blangs ~f:(Blang.Ast.to_dyn to_dyn))
+       Dyn.variant "And_absorb_undefined_var" (List.map blangs ~f:blang_to_dyn)
      | Or_absorb_undefined_var blangs ->
-       Dyn.variant
-         "Or_absorb_undefined_var"
-         (List.map blangs ~f:(Blang.Ast.to_dyn to_dyn))
-     | Blang b -> Dyn.variant "Blang" [ Blang.Ast.to_dyn to_dyn b ])
-;;
+       Dyn.variant "Or_absorb_undefined_var" (List.map blangs ~f:blang_to_dyn)
+     | Blang b -> Dyn.variant "Blang" [ blang_to_dyn b ])
+
+and blang_to_dyn blang = Blang.Ast.to_dyn to_dyn blang
 
 let loc = function
   | Nil -> Loc.none
@@ -288,3 +333,15 @@ and simplify_blang = function
     in
     Or (List.map blangs ~f:simplify_blang)
 ;;
+
+module Blang = struct
+  type t = blang
+
+  let equal = blang_equal
+  let to_dyn = blang_to_dyn
+  let remove_locs = blang_remove_locs
+  let true_ = Blang.Const true
+  let false_ = Blang.Const false
+  let decode = Blang.Ast.decode ~override_decode_bare_literal:None decode
+  let encode = Blang.Ast.encode encode
+end

--- a/src/dune_lang/slang.mli
+++ b/src/dune_lang/slang.mli
@@ -32,10 +32,12 @@ and form =
        if none of the arguments evaluate to true *)
   | Blang of blang (** convert a boolean returned by a blang expression into a string *)
 
+(** Tests for syntactic equality of a pair of slang expressions *)
+val equal : t -> t -> bool
+
+val remove_locs : t -> t
 val decode : t Decoder.t
 val encode : t Encoder.t
-val decode_blang : blang Decoder.t
-val encode_blang : blang Encoder.t
 val to_dyn : t -> Dyn.t
 val loc : t -> Loc.t
 val concat : ?loc:Loc.t -> t list -> t
@@ -56,3 +58,17 @@ val bool : ?loc:Loc.t -> bool -> t
 val simplify : t -> t
 
 val simplify_blang : blang -> blang
+
+module Blang : sig
+  type t = blang
+
+  (** Tests for syntactic equality of a pair of blang expressions *)
+  val equal : t -> t -> bool
+
+  val to_dyn : t -> Dyn.t
+  val remove_locs : blang -> blang
+  val true_ : t
+  val false_ : t
+  val decode : t Decoder.t
+  val encode : t Encoder.t
+end

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -45,12 +45,19 @@ module Conditional_choice : sig
   val choose_for_platform : 'a t -> platform:Solver_env.t -> 'a option
 end
 
+module Depexts : sig
+  type t =
+    { external_package_names : string list
+    ; enabled_if : [ `Always | `Conditional of Slang.Blang.t ]
+    }
+end
+
 module Pkg : sig
   type t =
     { build_command : Build_command.t Conditional_choice.t
     ; install_command : Action.t Conditional_choice.t
     ; depends : Dependency.t list Conditional_choice.t
-    ; depexts : string list Conditional_choice.t
+    ; depexts : Depexts.t list
     ; info : Pkg_info.t
     ; exported_env : String_with_vars.t Action.Env_update.t list
     ; enabled_on_platforms : Solver_env.t list

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -14,4 +14,5 @@ val opam_package_to_lock_file_pkg
   -> OpamPackage.t
   -> pinned:bool
   -> Resolved_package.t
+  -> portable_lock_dir:bool
   -> Lock_dir.Pkg.t

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -1650,6 +1650,7 @@ let solve_lock_dir
       ~pins:pinned_packages
       ~constraints
       ~selected_depopts
+      ~portable_lock_dir
   =
   let pinned_package_names = Package_name.Set.of_keys pinned_packages in
   let stats_updater = Solver_stats.Updater.init () in
@@ -1720,7 +1721,8 @@ let solve_lock_dir
             version_by_package_name
             opam_package
             ~pinned:(Package_name.Set.mem pinned_package_names name)
-            resolved_package)
+            resolved_package
+            ~portable_lock_dir)
       in
       match Package_name.Map.of_list_map pkgs ~f:(fun pkg -> pkg.info.name, pkg) with
       | Error (name, _pkg1, _pkg2) ->

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -19,5 +19,14 @@ val solve_lock_dir
   -> pins:Resolved_package.t Package_name.Map.t
   -> constraints:Dune_lang.Package_dependency.t list
   -> selected_depopts:Package_name.t list
+  -> portable_lock_dir:bool
+       (** XXX(steve): Indicates that the solver should generate portable
+           lockdirs. We try to avoid having the solver behave differently
+           depending on whether we are generating portable lockdirs but
+           allowing minor changes in what information is stored in the lockdir
+           depending on this argument can greatly simplify the logic for
+           handling both portable and non-portable lockdirs with the same code.
+           Once portable lockdirs are enabled unconditionally, remove this
+           argument. *)
   -> (Solver_result.t, [ `Diagnostic_message of User_message.Style.t Pp.t ]) result
        Fiber.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -73,6 +73,10 @@ module Install_rules = struct
   let stanzas_to_entries = Install_rules.stanzas_to_entries
 end
 
+module Pkg_rules = struct
+  let all_filtered_depexts = Pkg_rules.all_filtered_depexts
+end
+
 module For_tests = struct
   module Dynlink_supported = Dynlink_supported
   module Ocamlobjinfo = Ocamlobjinfo

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -26,6 +26,7 @@ val exported_env : Context_name.t -> Env.t Memo.t
 val ocamlpath : Context_name.t -> Path.t list Memo.t
 val find_package : Context_name.t -> Package.Name.t -> unit Action_builder.t option Memo.t
 val dev_tool_env : Dune_pkg.Dev_tool.t -> Env.t Memo.t
+val all_filtered_depexts : Context_name.t -> string list Memo.t
 
 val setup_pkg_install_alias
   :  dir:Path.Build.t

--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -48,8 +48,8 @@ error message.
   Error: Invalid first line, expected: (lang <lang> <version>)
   
   Hint: You may want to verify the following depexts are installed:
-  - unzip
   - gnupg
+  - unzip
   [1]
 
 Make dune.lock files with unknown program and unknown package.

--- a/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
@@ -20,5 +20,5 @@ Create a lockdir with a package that features some depexts.
 Printing the depexts should show all the depexts that the project has:
 
   $ dune show depexts
-  unzip
   gnupg
+  unzip

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -1,0 +1,36 @@
+Demonstrate various cases representing depexts in lockfiles.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg foo <<EOF
+  > depexts: [
+  >   # unconditional depexts (these are rare but opam allows them)
+  >   ["foo" "bar" "baz"]
+  >   # depexts depending on the distro
+  >   ["foo-ubuntu" "bar-ubuntu"] {os-distribution = "ubuntu"}
+  >   ["foo-arch" "bar-arch"] {os-distribution = "archlinux"}
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ cat dune.lock/foo.0.0.1.pkg
+  (version 0.0.1)
+  
+  (depexts
+   (foo baz bar)
+   ((foo-ubuntu bar-ubuntu)
+    (= %{os_distribution} ubuntu))
+   ((foo-arch bar-arch)
+    (= %{os_distribution} archlinux)))

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
@@ -1,0 +1,65 @@
+Exercise generating depexts in portable lockdirs by solving a project that
+depends on a simplified copy of conf-pkg-config - a package whose depexts vary
+greatly depending on the platform.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a package based on the conf-pkg-config opam package. This package has a
+depext on the native pkg-config, which is named differently depending on the os
+distribution.
+  $ mkpkg conf-pkg-config <<EOF
+  > depexts: [
+  >   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
+  >   ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
+  >   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  >   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  > ]
+  > EOF
+
+Create a custom dune-workspace to constrain the number of platforms. Of note is
+the fact that when solving for linux the os distribution is omitted. This test
+will demonstrate that even though the project isn't solved for a particular
+linux distribution, enough information is stored in the lockdir so that the
+correct depext names can be chosen for the current distro at build time.
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.18)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os macos)
+  >    (os-distribution homebrew)
+  >    (os-family homebrew))
+  >   ((arch x86_64)
+  >    (os linux))
+  >   ((arch x86_64)
+  >    (os win32)
+  >    (os-distribution cygwin)
+  >    (os-family windows))))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends conf-pkg-config))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - conf-pkg-config.0.0.1
+
+Print the name of the depext on a variety of os/distro/versions:
+  $ DUNE_CONFIG__OS=macos DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew dune show depexts
+  pkgconf
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__OS_FAMILY=debian dune show depexts
+  pkg-config
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__OS_FAMILY=centos DUNE_CONFIG__OS_DISTRIBUTION=centos DUNE_CONFIG__OS_VERSION=6 dune show depexts
+  pkgconfig
+  $ DUNE_CONFIG__OS=linux DUNE_CONFIG__OS_FAMILY=centos DUNE_CONFIG__OS_DISTRIBUTION=centos DUNE_CONFIG__OS_VERSION=9 dune show depexts
+  pkgconf-pkg-config

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -137,7 +137,7 @@ let empty_package name ~version =
   { Lock_dir.Pkg.build_command = Lock_dir.Conditional_choice.empty
   ; install_command = Lock_dir.Conditional_choice.empty
   ; depends = Lock_dir.Conditional_choice.empty
-  ; depexts = Lock_dir.Conditional_choice.empty
+  ; depexts = []
   ; info =
       { Lock_dir.Pkg_info.name
       ; version


### PR DESCRIPTION
Dune stores depexts for each package in the lockdir. These are the names
of system dependencies that must be installed by the system package
manager (e.g. apt-get, homebrew) in order for the package to be used
(possibly at build time or at run time). The name of a system package
may vary between package managers, so opam package typically contain a
list of different names for a depext, along with conditions under which
that name should be used. For example the conf-pkg-config opam package
specifies that it depends on a depext named "pkg-config" on ubuntu, but
a depext named "pkgconf" on archlinux.

Dune uses depexts to provide hints when a package fails to build. If a
package with at least one depext fails to build, dune will print a
message suggesting to the user that the reason the package failed to
build might be because of a missing depext, and it will try to print the
depext name appropriate to the user's system. This is because the
expectation is that the user will the go and manually invoke their
package manager to install the package. (Unlike opam, dune does not
currently attempt to invoke the user's package manager and install
depexts automatically).

Dune can also be queried for a list of all depexts for the current
project.

Currently dune only stores the names of depexts specialized for the
system where the lockdir was generated. This creates a problem for users
working on a project with a checked-in lockdir on a computer other than
the one where the lockdir was generated. Dune will tell users possibly
incorrect names for their project's depexts, since the names will be
tailored for a different type of computer with a different package
manager where the appropriate depext has a different name.

This commit changes the behaviour of the `depext` field in lockfiles to
capture all of the depext metadata from the corresponding opam file,
converted to dune's slang dsl. This allows the choice of which depext
name to show to be deferred to build time, which means that the depext
names will always be appropriate for the current system.

This new behaviour is behind the "portable-lock-dir" feature flag.