### PR TITLE
Warn about some common typos in package variables

### DIFF
--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -328,3 +328,7 @@ let contains_double_underscore =
 ;;
 
 let last s = if length s > 0 then Some s.[length s - 1] else None
+
+let replace_char s ~from ~to_ =
+  String.map (fun c -> if Char.equal c from then to_ else c) s
+;;

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -123,3 +123,4 @@ val quote_list_for_shell : string list -> string
 val filter_map : string -> f:(char -> char option) -> string
 val contains_double_underscore : string -> bool
 val last : string -> char option
+val replace_char : string -> from:char -> to_:char -> string

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -28,13 +28,6 @@ include (
   end) :
     Dune_util.Stringlike with type t := t)
 
-let encode t = Encoder.string (to_string t)
-
-let decode =
-  let open Decoder in
-  string >>| of_string
-;;
-
 let arch = of_string "arch"
 let os = of_string "os"
 let os_version = of_string "os-version"
@@ -49,11 +42,71 @@ let version = of_string "version"
 let name = of_string "name"
 let build = of_string "build"
 let post = of_string "post"
-let one_of t xs = List.mem xs ~equal t
 let dev = of_string "dev"
+let one_of t xs = List.mem xs ~equal t
 
 let platform_specific =
   Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]
+;;
+
+(* Users are free to refer to arbitrarily-named variables, but these are the
+   common variables that are widely in circulation. *)
+let all_known =
+  [ arch
+  ; os
+  ; os_version
+  ; os_distribution
+  ; os_family
+  ; opam_version
+  ; sys_ocaml_version
+  ; with_test
+  ; with_doc
+  ; with_dev_setup
+  ; version
+  ; name
+  ; build
+  ; post
+  ; dev
+  ]
+;;
+
+let encode t = Encoder.string (to_string t)
+
+let check_typo_underscore_instead_of_dash =
+  let possible_typos =
+    List.filter_map all_known ~f:(fun t ->
+      let t_string = to_string t in
+      if String.contains t_string '-'
+      then Some (String.replace_char t_string ~from:'-' ~to_:'_')
+      else None)
+  in
+  fun loc t ->
+    let string = to_string t in
+    if List.mem possible_typos string ~equal:String.equal
+    then
+      List.iter all_known ~f:(fun v ->
+        (* Many of dune's pform variables use underscores to separate words, but
+           package variables use underscores for compatibility with opam. Thus we
+           expect users to often mistakenly use underscores for package variables,
+           so warn in this case. *)
+        let v_string = to_string v in
+        let possible_typo = String.replace_char v_string ~from:'-' ~to_:'_' in
+        if String.equal string possible_typo
+        then
+          User_warning.emit
+            ~loc
+            [ Pp.textf
+                "The package variable %S looks like a typo. Did you mean %S?"
+                string
+                v_string
+            ])
+;;
+
+let decode =
+  let open Decoder in
+  let+ loc, t = located (string >>| of_string) in
+  check_typo_underscore_instead_of_dash loc t;
+  t
 ;;
 
 module Project = struct

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -29,8 +29,7 @@ let sentinel_value_of_variable_name variable_name =
   let uppercase_replacing_dash_with_underscore =
     Package_variable_name.to_string variable_name
     |> String.uppercase
-    |> String.split_on_char ~sep:'-'
-    |> String.concat ~sep:"_"
+    |> String.replace_char ~from:'-' ~to_:'_'
   in
   string (String.concat ~sep:"" [ "__"; uppercase_replacing_dash_with_underscore ])
 ;;

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
@@ -1,0 +1,41 @@
+Detect common typos with package variables when describing platforms to solve for.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a workspace with some typos in package variable names
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.18)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (repositories mock)
+  >  (solve_for_platforms
+  >   ((arch x86_64)
+  >    (os linux)
+  >    (os_distribution debian)
+  >    (os_family debian))))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (allow_empty))
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  File "dune-workspace", line 10, characters 4-19:
+  10 |    (os_distribution debian)
+           ^^^^^^^^^^^^^^^
+  Warning: The package variable "os_distribution" looks like a typo. Did you
+  mean "os-distribution"?
+  File "dune-workspace", line 11, characters 4-13:
+  11 |    (os_family debian))))
+           ^^^^^^^^^
+  Warning: The package variable "os_family" looks like a typo. Did you mean
+  "os-family"?
+  Solution for dune.lock:
+  (no dependencies to lock)


### PR DESCRIPTION
Dune uses underscores to separate words in pform variables but package variables use dashes for compatibility with opam. This will probably lead to typos. Technically arbitrarily-named solver variables are allowed by opam so typos in variable names have the potential to be silently accepted by dune while having no effect on the solution. This change prints a warning when dune encounters a package variable name that is identical to a known variable except with dashes replaced with underscores.