### PR TITLE
Allow  concurrent exec with watch mode

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -221,7 +221,7 @@ let build =
             [ Pp.textf
                 "Your build request is being forwarded to a running Dune instance%s so \
                  most command-line arguments will be ignored."
-                (match (lock_held_by : Dune_util.Global_lock.Lock_held_by.t) with
+                (match lock_held_by with
                  | Unknown -> ""
                  | Pid_from_lockfile pid -> sprintf " (pid: %d)" pid)
             ];

--- a/doc/changes/11840.md
+++ b/doc/changes/11840.md
@@ -1,0 +1,2 @@
+- Allow `dune exec` to run concurrently with another instance of dune in watch
+  mode (#11840, @gridbugs)

--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -17,8 +17,9 @@
  (applies_to what-dune-watches)
  (deps %{bin:strace}))
 
-;; this test sometimes gets stuck and times out
+;; These tests sometimes get stuck and time out:
 
 (cram
- (applies_to watching-eager-concurrent-build-command)
+ (applies_to watching-eager-concurrent-build-command
+  watching-eager-concurrent-exec-command)
  (enabled_if false))

--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-exec-command.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-exec-command.t
@@ -1,0 +1,50 @@
+Demonstrate running "dune exec" concurrently with an eager rpc server.
+
+  $ echo '(lang dune 3.18)' > dune-project
+  $ echo '(executable (name foo))' > dune
+  $ echo 'let () = print_endline "foo"' > foo.ml
+  $ touch README.md
+
+Just watch the readme file so we don't accidentally build foo.exe before
+testing the --no-build option:
+  $ dune build README.md --watch &
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+
+Demonstrate handling the --no-build option:
+  $ dune exec --no-build ./foo.exe
+  Error: Program './foo.exe' isn't built yet. You need to build it first or
+  remove the '--no-build' option.
+  [1]
+
+Demonstrate running an executable from the current project:
+  $ dune exec ./foo.exe
+  foo
+
+Demonstrate running an executable from PATH:
+  $ dune exec echo "bar"
+  Warning: As this is not the main instance of Dune it is unable to locate the
+  executable "echo" within this project. Dune will attempt to resolve the
+  executable's name within your PATH only.
+  bar
+
+Demonstrate printing a warning if arguments are passed that would be ignored
+due to how Dune builds via RPC:
+  $ dune exec --force ./foo.exe 2>&1 | sed 's/pid: [0-9]*/pid: PID/g'
+  Warning: Your build request is being forwarded to a running Dune instance
+  (pid: PID). Note that certain command line arguments may be ignored.
+  foo
+
+Demonstrate trying to run exec in watch mode while another watch server is running:
+  $ dune exec ./foo.exe --watch 2>&1 | sed 's/pid: [0-9]*/pid: PID/g'
+  Error: Another instance of dune (pid: PID) has locked the _build
+  directory. Refusing to start a new watch server until no other instances of
+  dune are running.
+
+Demonstrate running an executable via an absolute path:
+  $ dune exec $(which echo) "baz"
+  baz
+
+  $ dune shutdown
+  $ wait


### PR DESCRIPTION
This change allows a limited version of `dune exec` to run at the same time as dune is running in watch mode. This allows users to run example programs without needing to stop their watch server. This works by sending messages to the RPC server to build the executable if necessary.
