### PR TITLE
Terminate process group after cram execution

### DIFF
--- a/doc/changes/11841.md
+++ b/doc/changes/11841.md
@@ -1,0 +1,4 @@
+- Kill all processes in the process group after the main process has
+  terminated; in particular this avoids background processes in cram tests to
+  stick around after the test finished (#11841, fixes #11820, @Alizter,
+  @Leonidas-from-XIV)

--- a/test/blackbox-tests/test-cases/cram/subprocess.t
+++ b/test/blackbox-tests/test-cases/cram/subprocess.t
@@ -7,8 +7,7 @@ project with a single cram test.
 
 We create a file for tracking the PID of a subprocess.
 
-  $ cat > pid.txt
-  $ export FILE=$(realpath ./pid.txt)
+  $ FILE=$(realpath ./pid.txt)
 
 We create a cram test that spawns a subprocess and records its PID in the file
 we gave before.
@@ -20,10 +19,12 @@ we gave before.
 
 We can now run this test, which will record its PID in the file.
 
-  $ dune build @mycram
+  $ dune runtest mycram.t
 
 The test finished successfully, now we make sure that the PID was correctly
 terminated.
 
+  $ [ -s $FILE ] && echo pid file created
+  pid file created
   $ ps -p $(cat $FILE) > /dev/null || echo "Process terminated"
   Process terminated

--- a/test/blackbox-tests/test-cases/cram/subprocess.t
+++ b/test/blackbox-tests/test-cases/cram/subprocess.t
@@ -1,0 +1,29 @@
+Testing the termination of subprocesses in cram tests. We first create a dune
+project with a single cram test.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+We create a file for tracking the PID of a subprocess.
+
+  $ cat > pid.txt
+  $ export FILE=$(realpath ./pid.txt)
+
+We create a cram test that spawns a subprocess and records its PID in the file
+we gave before.
+  $ cat > mycram.t <<EOF
+  >   $ sleep 5 &
+  >   $ echo \$! > $FILE
+  > EOF
+
+We can now run this test, which will record its PID.
+  $ dune build @mycram
+
+We can now check if this PID is running. Since it suceeded, it means our
+subprocess is still around and has *not* been killed by dune.
+  $ kill -0 $(cat $FILE) 2> /dev/null
+
+We manually kill it ourselves by this point.
+  $ kill -9 $(cat $FILE)
+

--- a/test/blackbox-tests/test-cases/cram/subprocess.t
+++ b/test/blackbox-tests/test-cases/cram/subprocess.t
@@ -12,18 +12,18 @@ We create a file for tracking the PID of a subprocess.
 
 We create a cram test that spawns a subprocess and records its PID in the file
 we gave before.
+
   $ cat > mycram.t <<EOF
   >   $ sleep 5 &
   >   $ echo \$! > $FILE
   > EOF
 
-We can now run this test, which will record its PID.
+We can now run this test, which will record its PID in the file.
+
   $ dune build @mycram
 
-We can now check if this PID is running. Since it suceeded, it means our
-subprocess is still around and has *not* been killed by dune.
-  $ kill -0 $(cat $FILE) 2> /dev/null
+The test finished successfully, now we make sure that the PID was correctly
+terminated.
 
-We manually kill it ourselves by this point.
-  $ kill -9 $(cat $FILE)
-
+  $ ps -p $(cat $FILE) > /dev/null || echo "Process terminated"
+  Process terminated


### PR DESCRIPTION
After discussing an alternate solution for #11827 with @rgrinberg we agreed that the best course of action is to just terminate the entire process group of the cram test after execution.

This PR reuses @Alizter's cram test repro case.

It introduces a slight race condition that we might be terminating an unrelated process group that accidentally got the same PID as the cram test. I am unaware of a way to avoid it, the chance is not substantial as OSes usually increment PIDs until they wrap around. In any case the engine is already terminating process groups if the process to be waited on has a timeout, so this code just extends it to the case where there is no timeout.

Fixes #11820