### PR TITLE
refactor: remove wonky use of [simple_rules] in the test stanza rules

### DIFF
--- a/src/dune_rules/simple_rules.mli
+++ b/src/dune_rules/simple_rules.mli
@@ -39,3 +39,9 @@ val alias
   -> expander:Expander.t
   -> Alias_conf.t
   -> unit Memo.t
+
+val interpret_and_add_locks
+  :  expander:Expander.t
+  -> Locks.t
+  -> Action.Full.t Action_builder.t
+  -> Action.Full.t Action_builder.t


### PR DESCRIPTION
Just use the direct api for alias creation

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>