### PR TITLE
test: move cram stanza to correct location

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -61,10 +61,6 @@
   (applies_to error)
   (enabled_if false)))
 
-(cram
- (applies_to sandboxing)
- (deps %{bin:file}))
-
 ; CONDITIONALLY DISABLED TESTS
 
 (cram
@@ -133,14 +129,6 @@
  (enabled_if
   (not %{arch_sixtyfour}))
  (deps %{bin:ocaml}))
-
-(cram
- (applies_to interfere-sandbox-deletion)
- (deps %{bin:bash}))
-
-(cram
- (applies_to sandboxing-stale-directory-target)
- (deps %{bin:bash}))
 
 (cram
  (applies_to hidden-deps-supported)

--- a/test/blackbox-tests/test-cases/sandbox/dune
+++ b/test/blackbox-tests/test-cases/sandbox/dune
@@ -1,0 +1,11 @@
+(cram
+ (applies_to sandboxing)
+ (deps %{bin:file}))
+
+(cram
+ (applies_to sandboxing-stale-directory-target)
+ (deps %{bin:bash}))
+
+(cram
+ (applies_to interfere-sandbox-deletion)
+ (deps %{bin:bash}))


### PR DESCRIPTION
It should be in the same directory as the test