### PR TITLE
fix(exec): Spawn dune exec processes in inherited process group

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -154,7 +154,7 @@ let step ~setup ~prog ~args ~common ~no_rebuild ~context ~on_exit () =
     get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog
   and* args = Memo.parallel_map args ~f:expand in
   Memo.of_non_reproducible_fiber
-  @@ Dune_engine.Process.run_external_in_out
+  @@ Dune_engine.Process.run_inherit_std_in_out
        ~dir:(Path.of_string Fpath.initial_cwd)
        ~env
        path

--- a/doc/changes/11876.md
+++ b/doc/changes/11876.md
@@ -1,0 +1,2 @@
+- Fix `dune exec`'s ability to read stdin interactively. (#11876,
+  fixes #11870 and #11867, @Alizter)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -1240,7 +1240,7 @@ let run_capture_line
              ]))
 ;;
 
-let run_external_in_out =
+let run_inherit_std_in_out =
   let external_ ch =
     let fd = Io.descr_of_channel ch in
     { Io.kind = External; fd = lazy fd; channel = lazy ch; status = Keep_open }

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -163,6 +163,16 @@ val run_capture_zero_separated
   -> string list
   -> 'a Fiber.t
 
+(** [run_external_in_out] differs from the other [run] functions in the
+    followings ways:
+
+    - The process group ID is inherited by the parent process rather than
+    creating a new one.
+
+    - The input and output file descriptors are the standard ones.
+
+    This version is intended for running external processes at the end of a
+    build such as the ones spawned with "dune exec". *)
 val run_external_in_out
   :  ?dir:Path.t
   -> ?env:Env.t

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -163,7 +163,7 @@ val run_capture_zero_separated
   -> string list
   -> 'a Fiber.t
 
-(** [run_external_in_out] differs from the other [run] functions in the
+(** [run_inherit_std_in_out] differs from the other [run] functions in the
     followings ways:
 
     - The process group ID is inherited by the parent process rather than
@@ -173,7 +173,7 @@ val run_capture_zero_separated
 
     This version is intended for running external processes at the end of a
     build such as the ones spawned with "dune exec". *)
-val run_external_in_out
+val run_inherit_std_in_out
   :  ?dir:Path.t
   -> ?env:Env.t
   -> Path.t


### PR DESCRIPTION
In dune 3.18 we invoked Spawn directly to start a process and in turn we defaulted to inheriting the process group. In 3.19 this was changed to use the process managment given by Dune_engine.Process however here we always spawn processes in a new process group.

Terminal sessions typically rely on the process group when doing interactive things like reading lines from the user. This meant we ran into issues such as #11870 and #11867.

The fix here is to revert back to inheriting the process group.

- [x] changelog
- [x] fixes #11867
- [x] fixes #11870