### PR TITLE
doc: clarify generic type in rpc server

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1157,7 +1157,7 @@ let build (builder : Builder.t) =
              ~registry
              ~root:root.dir
              ~handle:Dune_rules_rpc.register
-             ~parse_build:Dune_rules_rpc.parse_build
+             ~parse_build_arg:Dune_rules_rpc.parse_build_arg
              stats))
     else `Forbid_builds
   in

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -1,4 +1,7 @@
-type 'a t
+(** An RPC handler which is abstract over the handling of the "Build" request
+    type. The type argument allows instances to choose different
+    representations of build targets. *)
+type 'build_arg t
 
 val create
   :  lock_timeout:float option
@@ -7,13 +10,18 @@ val create
   -> handle:(unit Dune_rpc_server.Handler.t -> unit)
        (** register additional requests or notifications *)
   -> Dune_stats.t option
-  -> parse_build:(string -> 'a)
-  -> 'a t
+  -> parse_build_arg:(string -> 'build_arg)
+  -> 'build_arg t
 
-type 'a pending_build_action =
-  | Build of 'a list * Dune_engine.Scheduler.Run.Build_outcome.t Fiber.Ivar.t
+(** This type allows the build request handler to be defined externally to the
+    RPC server. The ivar is expected to be filled with the outcome of the build
+    by the build request handler when the build completes (successfully or not)
+    and triggers the RPC server to reply to the client with the outcome of their
+    request. *)
+type 'build_arg pending_build_action =
+  | Build of 'build_arg list * Dune_engine.Scheduler.Run.Build_outcome.t Fiber.Ivar.t
 
-val pending_build_action : 'a t -> 'a pending_build_action Fiber.t
+val pending_build_action : 'build_arg t -> 'build_arg pending_build_action Fiber.t
 
 (** Stop accepting new rpc connections. Fiber returns when all existing
     connections terminate *)

--- a/src/dune_rules_rpc/dune_rules_rpc.ml
+++ b/src/dune_rules_rpc/dune_rules_rpc.ml
@@ -52,7 +52,7 @@ let dep_parser =
   Dune_lang.Syntax.set Stanza.syntax (Active Stanza.latest_version) Dep_conf.decode
 ;;
 
-let parse_build s =
+let parse_build_arg s =
   Dune_lang.Decoder.parse
     dep_parser
     (Univ_map.set

--- a/src/dune_rules_rpc/dune_rules_rpc.mli
+++ b/src/dune_rules_rpc/dune_rules_rpc.mli
@@ -1,2 +1,2 @@
 val register : _ Dune_rpc_server.Handler.t -> unit
-val parse_build : string -> Dune_lang.Dep_conf.t
+val parse_build_arg : string -> Dune_lang.Dep_conf.t


### PR DESCRIPTION
In my travels working on the RPC server I found I often forget exactly how the interface to the RPC server works, why it's generic, etc. I've renamed some things and written some documentation to hopefully help clarify this.