### PR TITLE
pkg: simpler default platforms for solver

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -121,7 +121,11 @@ let popular_platform_envs =
   let make ~os ~arch ~os_distribution ~os_family () =
     let env = empty in
     let env = set env Package_variable_name.os (Variable_value.string os) in
-    let env = set env Package_variable_name.arch (Variable_value.string arch) in
+    let env =
+      match arch with
+      | Some arch -> set env Package_variable_name.arch (Variable_value.string arch)
+      | None -> env
+    in
     let env =
       match os_distribution with
       | Some os_distribution ->
@@ -139,56 +143,9 @@ let popular_platform_envs =
     in
     env
   in
-  [ make
-      ~os:"linux"
-      ~arch:"x86_64"
-      ~os_distribution:(Some "ubuntu")
-      ~os_family:(Some "debian")
-      ()
-  ; make
-      ~os:"linux"
-      ~arch:"arm64"
-      ~os_distribution:(Some "ubuntu")
-      ~os_family:(Some "debian")
-      ()
-  ; make
-      ~os:"linux"
-      ~arch:"x86_64"
-      ~os_distribution:(Some "alpine")
-      ~os_family:(Some "alpine")
-      ()
-  ; make
-      ~os:"linux"
-      ~arch:"arm64"
-      ~os_distribution:(Some "alpine")
-      ~os_family:(Some "alpine")
-      ()
-  ; make ~os:"linux" ~arch:"x86_64" ~os_distribution:None ~os_family:None ()
-  ; make ~os:"linux" ~arch:"arm64" ~os_distribution:None ~os_family:None ()
-  ; make
-      ~os:"macos"
-      ~arch:"x86_64"
-      ~os_distribution:(Some "homebrew")
-      ~os_family:(Some "homebrew")
-      ()
-  ; make
-      ~os:"macos"
-      ~arch:"arm64"
-      ~os_distribution:(Some "homebrew")
-      ~os_family:(Some "homebrew")
-      ()
-  ; make
-      ~os:"win32"
-      ~arch:"x86_64"
-      ~os_distribution:(Some "cygwin")
-      ~os_family:(Some "windows")
-      ()
-  ; make
-      ~os:"win32"
-      ~arch:"arm64"
-      ~os_distribution:(Some "cygwin")
-      ~os_family:(Some "windows")
-      ()
+  [ make ~os:"linux" ~arch:None ~os_distribution:None ~os_family:None ()
+  ; make ~os:"macos" ~arch:None ~os_distribution:None ~os_family:None ()
+  ; make ~os:"win32" ~arch:None ~os_distribution:None ~os_family:None ()
   ]
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -46,107 +46,36 @@ Create a package that writes a different value to some files depending on the os
    (complete false)
    (used))
   
-  (solved_for_platforms
-   ((arch x86_64)
-    (os linux)
-    (os-distribution ubuntu)
-    (os-family debian))
-   ((arch arm64)
-    (os linux)
-    (os-distribution ubuntu)
-    (os-family debian))
-   ((arch x86_64)
-    (os linux)
-    (os-distribution alpine)
-    (os-family alpine))
-   ((arch arm64)
-    (os linux)
-    (os-distribution alpine)
-    (os-family alpine))
-   ((arch x86_64)
-    (os linux))
-   ((arch arm64)
-    (os linux))
-   ((arch x86_64)
-    (os macos)
-    (os-distribution homebrew)
-    (os-family homebrew))
-   ((arch arm64)
-    (os macos)
-    (os-distribution homebrew)
-    (os-family homebrew))
-   ((arch x86_64)
-    (os win32)
-    (os-distribution cygwin)
-    (os-family windows))
-   ((arch arm64)
-    (os win32)
-    (os-distribution cygwin)
-    (os-family windows)))
+  (solved_for_platforms ((os linux)) ((os macos)) ((os win32)))
 
   $ cat dune.lock/foo.0.0.1.pkg
   (version 0.0.1)
   
   (build
    (choice
-    ((((arch x86_64)
-       (os linux)
-       (os-distribution ubuntu)
-       (os-family debian))
-      ((arch x86_64)
-       (os linux)
-       (os-distribution alpine)
-       (os-family alpine))
-      ((arch x86_64)
-       (os linux)))
+    ((((os linux)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
         (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64)
-       (os linux)
-       (os-distribution ubuntu)
-       (os-family debian))
-      ((arch arm64)
-       (os linux)
-       (os-distribution alpine)
-       (os-family alpine))
-      ((arch arm64)
-       (os linux)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))
-    ((((arch x86_64) (os macos) (os-distribution homebrew) (os-family homebrew)))
+        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
+        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))
+    ((((os macos)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
         (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64) (os macos) (os-distribution homebrew) (os-family homebrew)))
+        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
+        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))
+    ((((os win32)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))
-    ((((arch x86_64) (os win32) (os-distribution cygwin) (os-family windows)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64) (os win32) (os-distribution cygwin) (os-family windows)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo arm64 > %{share}/machine")))))))
+        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
+        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/foo/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -51,36 +51,6 @@ The log file will contain errors about the package being unavailable.
   # - foo -> (problem)
   #     No usable implementations:
   #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
 
 The lockdir will contain a list of the platforms where solving succeeded.
   $ cat dune.lock/lock.dune
@@ -92,30 +62,16 @@ The lockdir will contain a list of the platforms where solving succeeded.
    (complete false)
    (used))
   
-  (solved_for_platforms
-   ((arch x86_64)
-    (os macos)
-    (os-distribution homebrew)
-    (os-family homebrew))
-   ((arch arm64)
-    (os macos)
-    (os-distribution homebrew)
-    (os-family homebrew)))
+  (solved_for_platforms ((os macos)))
 
 No errors when you try to build the platform on macos.
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
 
 Building on linux fails because the lockdir doesn't contain a compatible solution.
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  File "dune.lock/lock.dune", lines 10-17, characters 1-162:
-  10 |  ((arch x86_64)
-  11 |   (os macos)
-  12 |   (os-distribution homebrew)
-  13 |   (os-family homebrew))
-  14 |  ((arch arm64)
-  15 |   (os macos)
-  16 |   (os-distribution homebrew)
-  17 |   (os-family homebrew)))
+  File "dune.lock/lock.dune", line 9, characters 22-34:
+  9 | (solved_for_platforms ((os macos)))
+                            ^^^^^^^^^^^^
   Error: The lockdir does not contain a solution compatible with the current
   platform.
   The current platform is:


### PR DESCRIPTION
Simplify the default set of platforms dune will try to solve projects for. This speeds up solving in the common case since the solver will run fewer times, and hopefully generates more general solutions since the distribution and architecture are never constrained by default. If this leads to problems with common packages on common platforms we can always add more cases to the default so the common experience using Dune is smooth.