### PR TITLE
Disable binary dev tools by default in the preview build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,6 @@
           [
             "--pkg-build-progress" "enable"
             "--lock-dev-tool" "enable"
-            "--bin-dev-tools" "enable"
             "--portable-lock-dir" "enable"
           ];
       };


### PR DESCRIPTION
It seems to continue to create issues, so disabling it by default might for now be the way forward.