### PR TITLE
chore(ci): pin switch to local version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -221,7 +221,12 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - uses: actions/checkout@v4
-      - run: opam switch create . -y
+      - name: Create an empty switch
+        run: opam switch create . --empty
+      - name: Pin local packages to local dependencies
+        run: opam pin add . -n --with-version=dev
+      - name: Install external dependencies
+        run: opam install .
 
   build-microbench:
     name: Build microbenchmarks


### PR DESCRIPTION
Following the discussion regarding the CI and the fact that it was using the latest, I have updated the CI to use the `dev` version instead of the previous version. It means the CI wouldn't break when bumping to latest and developing new feature on latest. It would remove the needs to do a release just to be able to call new features.
I pin to `dev` because if we put the latest version it will need to be updated every time. The rest of the CI use the local source with Nix so it does not suffer from the same issue.
