### PR TITLE
chore(version): bump to 3.20 (latest)

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,15 +1,8 @@
 (executable
  (name bench)
  (modules bench metrics)
- (libraries
-  dune_stats
-  dune_console
-  chrome_trace
-  stdune
-  fiber
-  dune_lang
-  dune_engine
-  dune_util))
+ (libraries dune_stats dune_console chrome_trace stdune fiber dune_lang
+  dune_engine dune_util))
 
 (rule
  (alias bench)

--- a/chrome-trace.opam
+++ b/chrome-trace.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]

--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "dune-glob" {= version}
   "csexp" {>= "1.5.0"}
   "ppx_expect" {with-test}

--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "stdune" {= version}
   "dyn"
   "ordering"

--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "csexp" {>= "1.5.0"}
   "pp" {>= "1.1.0"}
   "dyn" {= version}

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.19)
+(lang dune 3.20)
 ;          ^^^^
 ; When changing the version, don't forget to regenerate *.opam files
 ; by running [dune build].

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "dune-rpc" {= version}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.6.0"}

--- a/dune-rpc.opam
+++ b/dune-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "csexp"
   "ordering"
   "dyn"

--- a/dune-site.opam
+++ b/dune-site.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]

--- a/dyn.opam
+++ b/dyn.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}

--- a/ocamlc-loc.opam
+++ b/ocamlc-loc.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "dyn" {= version}
   "odoc" {with-doc}

--- a/ordering.opam
+++ b/ordering.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -1,13 +1,5 @@
 (library
  (name dune_cache)
  (synopsis "[Internal] Dune's local and cloud build cache")
- (libraries
-  csexp
-  dune_digest
-  dune_cache_storage
-  dune_util
-  dune_console
-  dune_targets
-  fiber
-  stdune
-  unix))
+ (libraries csexp dune_digest dune_cache_storage dune_util dune_console
+  dune_targets fiber stdune unix))

--- a/src/dune_config_file/dune
+++ b/src/dune_config_file/dune
@@ -1,18 +1,6 @@
 (library
  (name dune_config_file)
- (libraries
-  stdune
-  xdg
-  dune_config
-  dune_console
-  dune_threaded_console
-  dune_lang
-  dune_cache
-  dune_cache_storage
-  dune_engine
-  dune_rpc_private
-  dune_stats
-  dune_tui
-  dune_util
-  dune_spawn)
+ (libraries stdune xdg dune_config dune_console dune_threaded_console
+  dune_lang dune_cache dune_cache_storage dune_engine dune_rpc_private
+  dune_stats dune_tui dune_util dune_spawn)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -1,10 +1,4 @@
 (library
  (name dune_digest)
- (libraries
-  dune_metrics
-  blake3_mini
-  dune_stats
-  dune_console
-  dune_util
-  stdune
+ (libraries dune_metrics blake3_mini dune_stats dune_console dune_util stdune
   unix))

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -2,35 +2,10 @@
 
 (library
  (name dune_engine)
- (libraries
-  unix
-  csexp
-  stdune
-  dune_config
-  dune_console
-  dyn
-  fiber
-  memo
-  dune_async_io
-  threads.posix
-  predicate_lang
-  dune_cache
-  dune_cache_storage
-  dune_glob
-  dune_targets
-  chrome_trace
-  dune_stats
-  dune_action_plugin
-  dune_util
-  build_path_prefix_map
-  dune_output_truncation
-  csexp_rpc
-  dune_rpc_private
-  dune_rpc_client
-  dune_thread_pool
-  dune_spawn
-  ocamlc_loc
-  dune_file_watcher
-  dune_digest
-  dune_metrics)
+ (libraries unix csexp stdune dune_config dune_console dyn fiber memo
+  dune_async_io threads.posix predicate_lang dune_cache dune_cache_storage
+  dune_glob dune_targets chrome_trace dune_stats dune_action_plugin dune_util
+  build_path_prefix_map dune_output_truncation csexp_rpc dune_rpc_private
+  dune_rpc_client dune_thread_pool dune_spawn ocamlc_loc dune_file_watcher
+  dune_digest dune_metrics)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -1,14 +1,5 @@
 (library
  (name dune_file_watcher)
- (libraries
-  dune_spawn
-  fsevents
-  dune_console
-  unix
-  stdune
-  threads.posix
-  ocaml_inotify
-  async_inotify_for_dune
-  dune_re
-  fswatch_win)
+ (libraries dune_spawn fsevents dune_console unix stdune threads.posix
+  ocaml_inotify async_inotify_for_dune dune_re fswatch_win)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -4,20 +4,6 @@
  (foreign_stubs
   (names md5_stubs)
   (language c))
- (libraries
-  stdune
-  fiber
-  fiber_util
-  chrome_trace
-  dune_engine
-  dune_util
-  dune_stats
-  dune_lang
-  dune_console
-  dune_re
-  dune_vcs
-  dune_config
-  opam_format
-  build_info
-  sat
-  xdg))
+ (libraries stdune fiber fiber_util chrome_trace dune_engine dune_util
+  dune_stats dune_lang dune_console dune_re dune_vcs dune_config opam_format
+  build_info sat xdg))

--- a/src/dune_rpc_impl/dune
+++ b/src/dune_rpc_impl/dune
@@ -1,16 +1,5 @@
 (library
  (name dune_rpc_impl)
- (libraries
-  stdune
-  promote
-  unix
-  fiber
-  csexp_rpc
-  dune_stats
-  dune_rpc_client
-  dune_console
-  dune_util
-  dune_rpc_private
-  dune_rpc_server
-  dune_engine)
+ (libraries stdune promote unix fiber csexp_rpc dune_stats dune_rpc_client
+  dune_console dune_util dune_rpc_private dune_rpc_server dune_engine)
  (synopsis "Dune's rpc server + a usable client"))

--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -1,13 +1,5 @@
 (library
  (name dune_rpc_server)
  (synopsis "Private API to define a dune rpc server")
- (libraries
-  fiber
-  stdune
-  chrome_trace
-  dyn
-  ordering
-  dune_stats
-  dune_util
-  dune_rpc_private
-  unix))
+ (libraries fiber stdune chrome_trace dyn ordering dune_stats dune_util
+  dune_rpc_private unix))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -2,45 +2,12 @@
 
 (library
  (name dune_rules)
- (libraries
-  stdune
-  csexp
-  fiber
-  memo
-  ocaml
-  dune_re
-  predicate_lang
-  dune_console
-  dune_digest
-  install
-  dune_lang
-  dune_glob
-  ocaml_config
-  dune_action_plugin
-  chrome_trace
-  dune_stats
-  dune_site_private
-  dune_util
-  dune_meta_parser
-  dune_section
-  opam_format
-  dune_cache
-  dune_pkg
-  dune_targets
-  promote
-  action_ext
-  build_path_prefix_map
-  dune_engine
-  dune_vcs
-  dune_cache_storage
-  dune_config
-  dune_config_file
-  dune_findlib
-  dune_patch
-  source
-  scheme
-  fs
-  unix
+ (libraries stdune csexp fiber memo ocaml dune_re predicate_lang dune_console
+  dune_digest install dune_lang dune_glob ocaml_config dune_action_plugin
+  chrome_trace dune_stats dune_site_private dune_util dune_meta_parser
+  dune_section opam_format dune_cache dune_pkg dune_targets promote
+  action_ext build_path_prefix_map dune_engine dune_vcs dune_cache_storage
+  dune_config dune_config_file dune_findlib dune_patch source scheme fs unix
   xdg)
  (synopsis "Internal Dune library, do not use!"))
 

--- a/src/dune_rules_rpc/dune
+++ b/src/dune_rules_rpc/dune
@@ -1,13 +1,5 @@
 (library
  (name dune_rules_rpc)
  (synopsis "rpc functionality that depends on dune's public rules")
- (libraries
-  stdune
-  fiber
-  memo
-  dune_lang
-  dune_engine
-  source
-  dune_rpc_impl
-  dune_rpc_private
-  dune_rpc_server))
+ (libraries stdune fiber memo dune_lang dune_engine source dune_rpc_impl
+  dune_rpc_private dune_rpc_server))

--- a/src/dune_tui/dune
+++ b/src/dune_tui/dune
@@ -1,15 +1,6 @@
 (library
  (name dune_tui)
- (libraries
-  stdune
-  dune_lwd
-  dune_util
-  dune_nottui
-  dune_notty
-  dune_notty_unix
-  dune_config
-  dune_console
-  dune_threaded_console
-  threads.posix))
+ (libraries stdune dune_lwd dune_util dune_nottui dune_notty dune_notty_unix
+  dune_config dune_console dune_threaded_console threads.posix))
 
 (include_subdirs unqualified)

--- a/src/install/dune
+++ b/src/install/dune
@@ -1,15 +1,5 @@
 (library
  (name install)
  (synopsis "the handling of installation paths")
- (libraries
-  stdune
-  dyn
-  opam_file_format
-  ocaml
-  dune_util
-  dune_findlib
-  dune_pkg
-  dune_engine
-  dune_section
-  dune_lang
-  dune_sexp))
+ (libraries stdune dyn opam_file_format ocaml dune_util dune_findlib dune_pkg
+  dune_engine dune_section dune_lang dune_sexp))

--- a/src/promote/dune
+++ b/src/promote/dune
@@ -1,10 +1,4 @@
 (library
  (name promote)
- (libraries
-  stdune
-  dune_engine
-  action_ext
-  dune_sexp
-  dune_console
-  dune_util
+ (libraries stdune dune_engine action_ext dune_sexp dune_console dune_util
   fiber))

--- a/src/source/dune
+++ b/src/source/dune
@@ -1,21 +1,6 @@
 (library
  (name source)
- (libraries
-  stdune
-  memo
-  dune_re
-  predicate_lang
-  dune_console
-  dune_config_file
-  dune_digest
-  dune_lang
-  dune_glob
-  ocaml_config
-  chrome_trace
-  dune_stats
-  dune_util
-  dune_pkg
-  dune_engine
-  dune_vcs
-  dune_config)
+ (libraries stdune memo dune_re predicate_lang dune_console dune_config_file
+  dune_digest dune_lang dune_glob ocaml_config chrome_trace dune_stats
+  dune_util dune_pkg dune_engine dune_vcs dune_config)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/upgrader/dune
+++ b/src/upgrader/dune
@@ -1,12 +1,5 @@
 (library
  (name dune_upgrader)
- (libraries
-  stdune
-  dune_console
-  memo
-  source
-  opam_file_format
-  dune_lang
-  dune_engine
-  fiber)
+ (libraries stdune dune_console memo source opam_file_format dune_lang
+  dune_engine fiber)
  (synopsis "Internal Dune library, do not use!"))

--- a/stdune.opam
+++ b/stdune.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
   "dyn" {= version}

--- a/test/blackbox-tests/test-cases/ctypes/dune
+++ b/test/blackbox-tests/test-cases/ctypes/dune
@@ -26,13 +26,8 @@
   (package integers)))
 
 (cram
- (applies_to
-  bytecode-stubs-external-lib
-  lib-pkg_config
-  lib-pkg_config-multiple-fd
-  lib-external-name-need-mangling
-  exe-pkg_config-multiple-fd
-  lib-return-errno
-  github-5561-name-mangle
+ (applies_to bytecode-stubs-external-lib lib-pkg_config
+  lib-pkg_config-multiple-fd lib-external-name-need-mangling
+  exe-pkg_config-multiple-fd lib-return-errno github-5561-name-mangle
   exe-pkg_config)
  (deps %{bin:pkg-config}))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -3,14 +3,9 @@
   (env-vars
    (DUNE_CONFIG__BACKGROUND_SANDBOXES disabled)
    (DUNE_CONFIG__BACKGROUND_DIGESTS disabled))
-  (binaries
-   ../utils/dune_cmd.exe
-   ../utils/dunepp.exe
-   ../utils/melc_stdlib_prefix.exe
-   ../utils/refmt.exe
-   ../utils/curl
-   ../utils/sherlodoc.exe
-   ../utils/ocaml_index.exe)))
+  (binaries ../utils/dune_cmd.exe ../utils/dunepp.exe
+   ../utils/melc_stdlib_prefix.exe ../utils/refmt.exe ../utils/curl
+   ../utils/sherlodoc.exe ../utils/ocaml_index.exe)))
 
 (cram
  (applies_to pp-cwd)

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -39,35 +39,19 @@
 
 (cram
  (deps %{bin:curl})
- (applies_to
-  unavailable-source-package
-  compute-checksums-when-missing
-  e2e
-  ocamlformat-dev-tool
-  source-caching
-  tarball
-  pin-depends
-  extra-sources
+ (applies_to unavailable-source-package compute-checksums-when-missing e2e
+  ocamlformat-dev-tool source-caching tarball pin-depends extra-sources
   broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:md5sum})
- (applies_to
-  source-caching
-  extra-sources
-  ocamlformat-dev-tool
-  dev-tool-conflict-test
-  broken-symlink-in-dependency))
+ (applies_to source-caching extra-sources ocamlformat-dev-tool
+  dev-tool-conflict-test broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:tar})
- (applies_to
-  source-caching
-  tarball
-  pin-depends
-  extra-sources
-  pkg-extract-fail
-  broken-symlink-in-dependency))
+ (applies_to source-caching tarball pin-depends extra-sources
+  pkg-extract-fail broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:ocaml_index})

--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -1,13 +1,8 @@
 (executable
  (name dune_cmd)
  (modules dune_cmd)
- (libraries
-  stdune
-  dune-private-libs.dune_re
-  dune-configurator
-  build_path_prefix_map
-  str
-  unix))
+ (libraries stdune dune-private-libs.dune_re dune-configurator
+  build_path_prefix_map str unix))
 
 (ocamllex dunepp)
 

--- a/test/expect-tests/dune_action_plugin/dune
+++ b/test/expect-tests/dune_action_plugin/dune
@@ -4,12 +4,7 @@
  (name dune_action_unit_tests)
  (inline_tests
   (deps some_dir/some_file))
- (libraries
-  dune_action_plugin
-  ppx_expect.config
-  ppx_expect.config_types
-  base
-  ppx_inline_test.config
-  dune-glob)
+ (libraries dune_action_plugin ppx_expect.config ppx_expect.config_types base
+  ppx_inline_test.config dune-glob)
  (preprocess
   (pps ppx_expect)))

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -13,18 +13,9 @@
     (= %{system} macosx)))
   (deps
    (sandbox always)))
- (libraries
-  unix
-  dune_file_watcher
-  dune_file_watcher_tests_lib
-  ppx_expect.config
-  ppx_expect.config_types
-  base
-  stdune
-  ppx_inline_test.config
-  threads.posix
-  stdio
-  spawn)
+ (libraries unix dune_file_watcher dune_file_watcher_tests_lib
+  ppx_expect.config ppx_expect.config_types base stdune
+  ppx_inline_test.config threads.posix stdio spawn)
  (preprocess
   (pps ppx_expect)))
 
@@ -36,18 +27,9 @@
    (= %{system} linux))
   (deps
    (sandbox always)))
- (libraries
-  dune_file_watcher
-  dune_file_watcher_tests_lib
-  ppx_expect.config
-  ppx_expect.config_types
-  base
-  stdune
-  ppx_inline_test.config
-  threads.posix
-  stdio
-  spawn
-  unix)
+ (libraries dune_file_watcher dune_file_watcher_tests_lib ppx_expect.config
+  ppx_expect.config_types base stdune ppx_inline_test.config threads.posix
+  stdio spawn unix)
  (preprocess
   (pps ppx_expect)))
 
@@ -57,12 +39,7 @@
  (inline_tests
   (deps
    (sandbox always)))
- (libraries
-  base
-  dune_config_file
-  dune_file_watcher
-  ppx_expect.config
-  ppx_expect.config_types
-  ppx_inline_test.config)
+ (libraries base dune_config_file dune_file_watcher ppx_expect.config
+  ppx_expect.config_types ppx_inline_test.config)
  (preprocess
   (pps ppx_expect)))

--- a/test/expect-tests/inotify_tests/dune
+++ b/test/expect-tests/inotify_tests/dune
@@ -5,17 +5,8 @@
    (= %{system} linux))
   (deps
    (sandbox always)))
- (libraries
-  async_inotify_for_dune
-  threads
-  ppx_expect.config
-  ppx_expect.config_types
-  base
-  stdune
-  ppx_inline_test.config
-  threads.posix
-  stdio
-  spawn
-  unix)
+ (libraries async_inotify_for_dune threads ppx_expect.config
+  ppx_expect.config_types base stdune ppx_inline_test.config threads.posix
+  stdio spawn unix)
  (preprocess
   (pps ppx_expect)))

--- a/xdg.opam
+++ b/xdg.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This PR should be rebased on #11883 before being merged. With the previous PR, it removes the problem with using the latest version inside of Dune (it only requires to rebuild bootstrapped dune).
It first bumps the version to the latest (3.20) and apply the new formatter. If having the latest version inside of the `dune-project` file is OK, I will also update the information in the release documentation to not forget to update the value on each release.
