### PR TITLE
[3.19] backport #11879

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -204,7 +204,20 @@ let term : unit Term.t =
     @@ fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup () in
-    build_exn @@ step ~setup ~prog ~args ~common ~no_rebuild ~context ~on_exit:exit
+    build_exn (fun () ->
+      let open Memo.O in
+      let* sctx = setup >>| Import.Main.find_scontext_exn ~name:context in
+      let* env = Super_context.context_env sctx in
+      let expand = Cmd_arg.expand ~root:(Common.root common) ~sctx in
+      let* prog =
+        let dir =
+          let context = Dune_rules.Super_context.context sctx in
+          Path.Build.relative (Context.build_dir context) (Common.prefix_target common "")
+        in
+        let* prog = expand prog in
+        get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog >>| Path.to_string
+      and* args = Memo.parallel_map ~f:expand args in
+      restore_cwd_and_execve (Common.root common) prog args env)
 ;;
 
 let command = Cmd.v info term

--- a/doc/changes/11879.md
+++ b/doc/changes/11879.md
@@ -1,0 +1,3 @@
+- Revert changes in `dune exec` behaviour introduced in 3.19.0. (#11879, fixes
+  #11870, #11867 and #11881, @Alizter)
+

--- a/otherlibs/dune-site/test/run_2_9.t
+++ b/otherlibs/dune-site/test/run_2_9.t
@@ -343,6 +343,7 @@ Test compiling an external plugin
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH PATH=$PWD/_install/bin:$PATH dune exec  --root=e -- c
   Entering directory 'e'
+  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -356,7 +357,6 @@ Test compiling an external plugin
   e: $TESTCASE_ROOT/e/_build/install/default/share/e/data
   info.txt is found: true
   run c: registered:e,b.
-  Leaving directory 'e'
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH dune install --root=e --prefix $PWD/_install
 

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -409,8 +409,8 @@ We can build and run the resulting executable:
 
   $ dune exec --root new_exec_proj ./bin/main.exe
   Entering directory 'new_exec_proj'
-  Hello, World!
   Leaving directory 'new_exec_proj'
+  Hello, World!
 
 We can build and run the project's tests:
 

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
@@ -30,5 +30,5 @@ Perform the same test above but first enter the "bin" directory.
 Test that the behaviour is the same when not running with "--watch"
   $ cd bin && dune exec --root .. ./bin/main.exe
   Entering directory '..'
-  foo
   Leaving directory '..'
+  foo

--- a/test/blackbox-tests/test-cases/exec/exec-bin.t
+++ b/test/blackbox-tests/test-cases/exec/exec-bin.t
@@ -23,7 +23,7 @@ By default, e is executed with the program name and arguments in argv.
 
   $ dune exec ./e.exe a b c
   Hello
-  argv[0] = $TESTCASE_ROOT/_build/default/e.exe
+  argv[0] = ./_build/default/e.exe
   argv[1] = a
   argv[2] = b
   argv[3] = c
@@ -32,7 +32,7 @@ The special form %{bin:public_name} is supported.
 
   $ dune exec %{bin:e} a b c
   Hello
-  argv[0] = $TESTCASE_ROOT/_build/install/default/bin/e
+  argv[0] = ./_build/install/default/bin/e
   argv[1] = a
   argv[2] = b
   argv[3] = c

--- a/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
@@ -23,8 +23,8 @@
 
   $ (cd test; dune exec --root .. -- dunetestbar)
   Entering directory '..'
-  Bar
   Leaving directory '..'
+  Bar
 
   $ ls -a test/_build
   .

--- a/test/blackbox-tests/test-cases/exec/exec-fail.t
+++ b/test/blackbox-tests/test-cases/exec/exec-fail.t
@@ -34,6 +34,10 @@ If a program encounters an exception, we should return a non-zero exit code.
   Fatal error: exception Failure("oh no!")
   [2]
 
+Disable shell monitoring (of jobs) so that we do not get spurious messages
+about signals.
+  $ set +m
+
 If a program segfaults, we should return a non-zero exit code.
 
   $ cat > foo.ml <<EOF
@@ -45,9 +49,8 @@ If a program segfaults, we should return a non-zero exit code.
   > EOF
 
 Note that 128 + 11 (SEGV) = 139
-  $ $(dune exec -- ./foo.exe)
-  Command got signal SEGV.
-  [1]
+  $ { dune exec -- ./foo.exe; } 2> /dev/null
+  [139]
 
 If a program is killed by a signal before it terminates, we should return a non-zero exit
 code.
@@ -66,6 +69,5 @@ code.
   > ;;
   > EOF
 
-  $ $(dune exec -- ./foo.exe)
-  Command got signal KILL.
-  [1]
+  $ { dune exec -- ./foo.exe; } 2> /dev/null
+  [137]

--- a/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/foreign-library.t
@@ -740,8 +740,8 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ export OCAMLPATH=$PWD/external/install/lib; dune exec ./main.exe --root=some/dir
   Entering directory 'some/dir'
-  Answer = 42
   Leaving directory 'some/dir'
+  Answer = 42
 
 ----------------------------------------------------------------------------------
 * External library directories in (include_dir ...)

--- a/test/blackbox-tests/test-cases/foreign-stubs/link-includes.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/link-includes.t
@@ -35,6 +35,6 @@ First we create an external library and implementation
 Then we make sure that it works fine.
   $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
   Entering directory 'exe'
-  lib1: 42
   Leaving directory 'exe'
+  lib1: 42
 

--- a/test/blackbox-tests/test-cases/github11527.t
+++ b/test/blackbox-tests/test-cases/github11527.t
@@ -21,14 +21,14 @@ and argv.(0) can be concatenated to get a valid path.
 When running dune exec from the root this is true.
   $ dune exec -- ./bug.exe
   pwd: $TESTCASE_ROOT
-  exe: $TESTCASE_ROOT/_build/default/bug.exe
+  exe: ./_build/default/bug.exe
 
   $ mkdir subdir
 
 As expected, the `exe:` argument shows the correct path
   $ (cd subdir && dune exec --root .. -- ./bug.exe)
   Entering directory '..'
-  pwd: $TESTCASE_ROOT/subdir
-  exe: $TESTCASE_ROOT/_build/default/bug.exe
   Leaving directory '..'
+  pwd: $TESTCASE_ROOT/subdir
+  exe: ../_build/default/bug.exe
  

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -46,5 +46,5 @@ custom version:
 
   $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
   Entering directory 'external'
-  foobarlib
   Leaving directory 'external'
+  foobarlib

--- a/test/blackbox-tests/test-cases/private-package-lib/main.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/main.t
@@ -158,8 +158,8 @@ Now we make sure such libraries are transitively usable when installed:
   $ export OCAMLPATH=$PWD/_build/install/default/lib
   $ dune exec --root use -- ./run.exe
   Entering directory 'use'
-  Using library foo: from library foo secret string
   Leaving directory 'use'
+  Using library foo: from library foo secret string
 
 But we cannot use such libraries directly:
 

--- a/test/blackbox-tests/test-cases/rule/dependency-external.t
+++ b/test/blackbox-tests/test-cases/rule/dependency-external.t
@@ -206,22 +206,22 @@ rules with dependencies outside the build dir are allowed
 
   $ dune exec --root=a/b -- $PWD/a/script.sh
   Entering directory 'a/b'
-  txt1
   Leaving directory 'a/b'
+  txt1
 
 ## Test dune exec 1 level below
   $ dune exec --root=a/b -- ../script.sh
   Entering directory 'a/b'
-  txt1
   Leaving directory 'a/b'
+  txt1
 
 ## Test dune exec 2 level below
   $ mv a/script.sh .
 
   $ dune exec --root=a/b -- ../../script.sh
   Entering directory 'a/b'
-  txt1
   Leaving directory 'a/b'
+  txt1
 
 # Regression test for #5572
   $ dune exec --root=a/b -- ../


### PR DESCRIPTION
This PR imports the fix to set back the behavior of `dune exec` to its past behavior (before `3.19.0`).
