### PR TITLE
Looking up paths to executables with `dune describe location`

### DIFF
--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -21,6 +21,7 @@ let subcommands =
   ; Describe_pkg.command
   ; Describe_contexts.command
   ; Describe_depexts.command
+  ; Describe_location.command
   ]
 ;;
 

--- a/bin/describe/describe_location.ml
+++ b/bin/describe/describe_location.ml
@@ -36,7 +36,7 @@ let term : unit Term.t =
   let open Memo.O in
   let* sctx = setup >>| Import.Main.find_scontext_exn ~name:context in
   let* prog = Exec.Cmd_arg.expand ~root:(Common.root common) ~sctx prog in
-  let+ path = Exec.get_path common context ~prog >>| Path.to_string in
+  let+ path = Exec.get_path common sctx ~prog >>| Path.to_string in
   Dune_console.printf "%s" path
 ;;
 

--- a/bin/describe/describe_location.ml
+++ b/bin/describe/describe_location.ml
@@ -1,0 +1,43 @@
+open! Import
+
+let doc =
+  "Print the path to the executable using the same resolution logic as [dune exec]."
+;;
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|$(b,dune describe location NAME) prints the path to the executable NAME using the same logic as:
+          |}
+  ; `Pre "$ dune exec NAME"
+  ; `P
+      "Dune will first try to resolve the executable within the public executables in \
+       the current project, then inside the \"bin\" directory of each package among the \
+       project's  dependencies (when using dune package management), and finally within \
+       the  directories listed in the $PATH environment variable."
+  ]
+;;
+
+let info = Cmd.info "location" ~doc ~man
+
+let term : unit Term.t =
+  let+ builder = Common.Builder.term
+  and+ context = Common.context_arg ~doc:{|Run the command in this build context.|}
+  and+ prog =
+    Arg.(required & pos 0 (some Exec.Cmd_arg.conv) None (Arg.info [] ~docv:"PROG"))
+  in
+  let common, config = Common.init builder in
+  Scheduler.go_with_rpc_server ~common ~config
+  @@ fun () ->
+  let open Fiber.O in
+  let* setup = Import.Main.setup () in
+  build_exn
+  @@ fun () ->
+  let open Memo.O in
+  let* sctx = setup >>| Import.Main.find_scontext_exn ~name:context in
+  let* prog = Exec.Cmd_arg.expand ~root:(Common.root common) ~sctx prog in
+  let+ path = Exec.get_path common context ~prog >>| Path.to_string in
+  Dune_console.printf "%s" path
+;;
+
+let command = Cmd.v info term

--- a/bin/describe/describe_location.mli
+++ b/bin/describe/describe_location.mli
@@ -1,0 +1,3 @@
+open! Import
+
+val command : unit Cmd.t

--- a/bin/exec.mli
+++ b/bin/exec.mli
@@ -1,3 +1,24 @@
 open Import
 
+module Cmd_arg : sig
+  type t
+
+  val conv : t Arg.conv
+  val expand : t -> root:Workspace_root.t -> sctx:Super_context.t -> string Memo.t
+end
+
+(** Returns the path to the executable [prog] as it will be resolved by dune:
+  - if [prog] is the name of an executable defined by the project then the path
+    to that executable will be returned, and evaluating the returned memo will
+    build the executable if necessary.
+  - otherwise if [prog] is the name of an executable in the "bin" directory of
+    a package in this project's dependency cone then the path to that executable
+    file will be returned. Note that for this reason all dependencies of the
+    project will be built when the returned memo is evaluated (unless the first
+    case is hit).
+  - otherwise if [prog] is the name of an executable in one of the directories
+    listed in the PATH environment variable, the path to that executable will be
+    returned. *)
+val get_path : Common.t -> Context_name.t -> prog:string -> Path.t Memo.t
+
 val command : unit Cmd.t

--- a/bin/exec.mli
+++ b/bin/exec.mli
@@ -19,6 +19,6 @@ end
   - otherwise if [prog] is the name of an executable in one of the directories
     listed in the PATH environment variable, the path to that executable will be
     returned. *)
-val get_path : Common.t -> Context_name.t -> prog:string -> Path.t Memo.t
+val get_path : Common.t -> Super_context.t -> prog:string -> Path.t Memo.t
 
 val command : unit Cmd.t

--- a/doc/changes/11905.md
+++ b/doc/changes/11905.md
@@ -1,0 +1,2 @@
+- Add `dune describe location` for printing the path to the executable that
+  would be run (#11905, @gridbugs)

--- a/test/blackbox-tests/test-cases/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe_location.t
@@ -1,0 +1,65 @@
+Exercise the various ways of resolving executable names with `dune exec`.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.20)
+  > 
+  > (package
+  >  (name foo))
+  > EOF
+
+  $ cat > dune << EOF
+  > (executable
+  >  (public_name foo))
+  > EOF
+
+  $ cat > foo.ml << EOF
+  > let () = print_endline "hello foo"
+  > EOF
+
+An executable that would be installed by the current package:
+  $ dune describe location foo
+  _build/install/default/bin/foo
+
+An executable from the current project:
+  $ dune describe location ./foo.exe
+  _build/default/foo.exe
+
+Test that executables from dependencies are located correctly:
+  $ mkdir dune.lock
+  $ cat > dune.lock/lock.dune << EOF
+  > (lang package 0.1)
+  > EOF
+  $ cat > dune.lock/bar.pkg << EOF
+  > (version 0.1)
+  > (install
+  >  (progn
+  >   (write-file %{bin}/bar "#!/bin/sh\necho hello bar")
+  >   (run chmod a+x %{bin}/bar)))
+  > EOF
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.20)
+  > 
+  > (package
+  >  (name foo)
+  >  (depends bar))
+  > EOF
+
+  $ dune describe location bar
+  _build/_private/default/.pkg/bar/target/bin/bar
+
+Test that executables from PATH are located correctly:
+  $ mkdir bin
+  $ cat > bin/baz << EOF
+  > #!/bin/sh
+  > echo hello baz
+  > EOF
+
+  $ chmod a+x bin/baz
+  $ export PATH=$PWD/bin:$PATH
+
+  $ dune describe location baz
+  $TESTCASE_ROOT/bin/baz
+
+  $ dune exec echo '%{bin:foo}'
+  _build/install/default/bin/foo


### PR DESCRIPTION
The "dune exec" command has three different ways of resolving the names of executables to paths to executables:
 - public executables defined in the current project
 - executables in the "bin" directories of dependencies
 - executables in directories listed in $PATH

This can lead to unexpected shadowing, especially in the case of executables from dependecies, as users may not be aware that one of the packages in their project's dependency cone defines an executable with the same name of an executable that's also insalled system-wide.

Short of fixing the problem for now, this change introduces a tool for helping investigate specifically which executable will be run by "dune exec". This adds a command "dune which" which prints the path to the executable.