### PR TITLE
refactor: cleanup dependency rules

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -96,7 +96,6 @@ type t =
   ; melange_package_name : Lib_name.t option
   ; modes : Lib_mode.Map.Set.t
   ; bin_annot : bool
-  ; ocamldep_modules_data : Ocamldep.Modules_data.t
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
   }
@@ -124,7 +123,6 @@ let vimpl t = t.vimpl
 let modes t = t.modes
 let bin_annot t = t.bin_annot
 let context t = Super_context.context t.super_context
-let ocamldep_modules_data t = t.ocamldep_modules_data
 let dep_graphs t = t.modules.dep_graphs
 let ocaml t = t.ocaml
 
@@ -179,17 +177,14 @@ let create
     let profile = Context.profile context in
     eval_opaque ocaml profile opaque
   in
-  let ocamldep_modules_data : Ocamldep.Modules_data.t =
-    { dir = Obj_dir.dir obj_dir
-    ; sandbox
-    ; obj_dir
-    ; sctx = super_context
-    ; vimpl
-    ; modules
-    ; stdlib
-    }
-  in
-  let+ dep_graphs = Dep_rules.rules ocamldep_modules_data
+  let+ dep_graphs =
+    Dep_rules.rules
+      ~dir:(Obj_dir.dir obj_dir)
+      ~sandbox
+      ~obj_dir
+      ~sctx:super_context
+      ~vimpl
+      ~modules
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b
@@ -215,7 +210,6 @@ let create
   ; melange_package_name
   ; modes
   ; bin_annot
-  ; ocamldep_modules_data
   ; loc
   ; ocaml
   }

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -86,7 +86,6 @@ val root_module_entries : t -> Module_name.t list Action_builder.t
 (** The dependency graph for the modules of the library. *)
 val dep_graphs : t -> Dep_graph.t Ml_kind.Dict.t
 
-val ocamldep_modules_data : t -> Ocamldep.Modules_data.t
 val loc : t -> Loc.t option
 val set_obj_dir : t -> Path.Build.t Obj_dir.t -> t
 val set_modes : t -> modes:Lib_mode.Map.Set.t -> t

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -1,6 +1,5 @@
 open Import
 open Memo.O
-open Ocamldep.Modules_data
 module Parallel_map = Memo.Make_parallel_map (Module_name.Unique.Map)
 
 let transitive_deps_contents modules =
@@ -11,25 +10,32 @@ let transitive_deps_contents modules =
 ;;
 
 let ooi_deps
-      { vimpl; sctx; dir; obj_dir; modules = _; stdlib = _; sandbox = _ }
+      ~vimpl
+      ~sctx
+      ~dir
+      ~obj_dir
       ~dune_version
       ~vlib_obj_map
       ~(ml_kind : Ml_kind.t)
       (sourced_module : Modules.Sourced_module.t)
   =
   let m = Modules.Sourced_module.to_module sourced_module in
-  let cm_kind =
-    match ml_kind with
-    | Intf -> Cm_kind.Cmi
-    | Impl -> vimpl |> Option.value_exn |> Vimpl.impl_cm_kind
-  in
   let* write, read =
-    let ctx = Super_context.context sctx in
-    let unit = Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml cm_kind) |> Path.build in
+    let unit =
+      let cm_kind =
+        match ml_kind with
+        | Intf -> Cm_kind.Cmi
+        | Impl -> vimpl |> Vimpl.impl_cm_kind
+      in
+      Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml cm_kind) |> Path.build
+    in
     let sandbox =
       if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
     in
-    let+ ocaml = Context.ocaml ctx in
+    let+ ocaml =
+      let ctx = Super_context.context sctx in
+      Context.ocaml ctx
+    in
     Ocamlobjinfo.rules ocaml ~sandbox ~dir ~unit
   in
   let add_rule = Super_context.add_rule sctx ~dir in
@@ -54,7 +60,7 @@ let ooi_deps
   read
 ;;
 
-let deps_of_module ({ modules; _ } as md) ~ml_kind m =
+let deps_of_module ~modules ~sandbox ~sctx ~dir ~obj_dir ~ml_kind m =
   match Module.kind m with
   | Wrapped_compat ->
     let interface_module =
@@ -66,7 +72,7 @@ let deps_of_module ({ modules; _ } as md) ~ml_kind m =
     in
     List.singleton interface_module |> Action_builder.return |> Memo.return
   | _ ->
-    let+ deps = Ocamldep.deps_of md ~ml_kind m in
+    let+ deps = Ocamldep.deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind m in
     (match Modules.With_vlib.alias_for modules m with
      | [] -> deps
      | aliases ->
@@ -75,30 +81,54 @@ let deps_of_module ({ modules; _ } as md) ~ml_kind m =
        aliases @ deps)
 ;;
 
-let deps_of_vlib_module ({ obj_dir; vimpl; dir; sctx; _ } as md) ~ml_kind sourced_module =
-  let m = Modules.Sourced_module.to_module sourced_module in
-  let vimpl = Option.value_exn vimpl in
-  let vlib = Vimpl.vlib vimpl in
-  match Lib.Local.of_lib vlib with
+let deps_of_vlib_module ~obj_dir ~vimpl ~dir ~sctx ~ml_kind sourced_module =
+  match
+    let vlib = Vimpl.vlib vimpl in
+    Lib.Local.of_lib vlib
+  with
   | None ->
-    let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
-    let dune_version =
-      let impl = Vimpl.impl vimpl in
-      Dune_project.dune_version impl.project
+    let+ deps =
+      let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
+      let dune_version =
+        let impl = Vimpl.impl vimpl in
+        Dune_project.dune_version impl.project
+      in
+      ooi_deps
+        ~vimpl
+        ~sctx
+        ~dir
+        ~obj_dir
+        ~dune_version
+        ~vlib_obj_map
+        ~ml_kind
+        sourced_module
     in
-    let+ deps = ooi_deps md ~dune_version ~vlib_obj_map ~ml_kind sourced_module in
     Action_builder.map deps ~f:(List.map ~f:Modules.Sourced_module.to_module)
   | Some lib ->
+    let vlib_obj_dir =
+      let info = Lib.Local.info lib in
+      Lib_info.obj_dir info
+    in
+    let m = Modules.Sourced_module.to_module sourced_module in
+    let+ () =
+      let src = Obj_dir.Module.dep vlib_obj_dir (Transitive (m, ml_kind)) |> Path.build in
+      let dst = Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind)) in
+      Super_context.add_rule sctx ~dir (Action_builder.symlink ~src ~dst)
+    in
     let modules = Vimpl.vlib_modules vimpl |> Modules.With_vlib.modules in
-    let info = Lib.Local.info lib in
-    let vlib_obj_dir = Lib_info.obj_dir info in
-    let src = Obj_dir.Module.dep vlib_obj_dir (Transitive (m, ml_kind)) |> Path.build in
-    let dst = Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind)) in
-    let+ () = Super_context.add_rule sctx ~dir (Action_builder.symlink ~src ~dst) in
     Ocamldep.read_deps_of ~obj_dir:vlib_obj_dir ~modules ~ml_kind m
 ;;
 
-let rec deps_of md ~ml_kind (m : Modules.Sourced_module.t) =
+let rec deps_of
+          ~obj_dir
+          ~modules
+          ~sandbox
+          ~vimpl
+          ~dir
+          ~sctx
+          ~ml_kind
+          (m : Modules.Sourced_module.t)
+  =
   let is_alias =
     match m with
     | Impl_of_virtual_module _ -> false
@@ -117,10 +147,15 @@ let rec deps_of md ~ml_kind (m : Modules.Sourced_module.t) =
       else Memo.return (Action_builder.return [])
     in
     match m with
-    | Imported_from_vlib _ -> skip_if_source_absent (deps_of_vlib_module md ~ml_kind) m
-    | Normal m -> skip_if_source_absent (deps_of_module md ~ml_kind) m
+    | Imported_from_vlib _ ->
+      let vimpl = Option.value_exn vimpl in
+      skip_if_source_absent (deps_of_vlib_module ~obj_dir ~vimpl ~dir ~sctx ~ml_kind) m
+    | Normal m ->
+      skip_if_source_absent
+        (deps_of_module ~modules ~sandbox ~sctx ~dir ~obj_dir ~ml_kind)
+        m
     | Impl_of_virtual_module impl_or_vlib ->
-      deps_of md ~ml_kind
+      deps_of ~obj_dir ~modules ~sandbox ~vimpl ~dir ~sctx ~ml_kind
       @@
       let m = Ml_kind.Dict.get impl_or_vlib ml_kind in
       (match ml_kind with
@@ -155,17 +190,20 @@ let dict_of_func_concurrently f =
   Ml_kind.Dict.make ~impl ~intf
 ;;
 
-let for_module md module_ = dict_of_func_concurrently (deps_of md (Normal module_))
+let for_module ~obj_dir ~modules ~sandbox ~vimpl ~dir ~sctx module_ =
+  dict_of_func_concurrently
+    (deps_of ~obj_dir ~modules ~sandbox ~vimpl ~dir ~sctx (Normal module_))
+;;
 
-let rules md =
-  let modules = md.modules in
+let rules ~obj_dir ~modules ~sandbox ~vimpl ~sctx ~dir =
   match Modules.With_vlib.as_singleton modules with
   | Some m -> Memo.return (Dep_graph.Ml_kind.dummy m)
   | None ->
     dict_of_func_concurrently (fun ~ml_kind ->
       let+ per_module =
         Modules.With_vlib.obj_map modules
-        |> Parallel_map.parallel_map ~f:(fun _obj_name m -> deps_of md ~ml_kind m)
+        |> Parallel_map.parallel_map ~f:(fun _obj_name m ->
+          deps_of ~obj_dir ~modules ~sandbox ~vimpl ~sctx ~dir ~ml_kind m)
       in
-      Dep_graph.make ~dir:md.dir ~per_module)
+      Dep_graph.make ~dir ~per_module)
 ;;

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -3,7 +3,12 @@
 open Import
 
 val for_module
-  :  Ocamldep.Modules_data.t
+  :  obj_dir:Path.Build.t Obj_dir.t
+  -> modules:Modules.With_vlib.t
+  -> sandbox:Sandbox_config.t
+  -> vimpl:Vimpl.t option
+  -> dir:Path.Build.t
+  -> sctx:Super_context.t
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.t
 
@@ -14,4 +19,11 @@ val immediate_deps_of
   -> ml_kind:Ml_kind.t
   -> Module.t list Action_builder.t
 
-val rules : Ocamldep.Modules_data.t -> Dep_graph.t Ml_kind.Dict.t Memo.t
+val rules
+  :  obj_dir:Path.Build.t Obj_dir.t
+  -> modules:Modules.With_vlib.t
+  -> sandbox:Sandbox_config.t
+  -> vimpl:Vimpl.t option
+  -> sctx:Super_context.t
+  -> dir:Path.Build.t
+  -> Dep_graph.Ml_kind.t Memo.t

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -274,7 +274,11 @@ module Run (P : PARAMS) = struct
       |> Compilation_context.without_bin_annot
     in
     let* deps =
-      Dep_rules.for_module (Compilation_context.ocamldep_modules_data cctx) mock_module
+      let obj_dir = Compilation_context.obj_dir cctx in
+      let modules = Compilation_context.modules cctx in
+      let vimpl = Compilation_context.vimpl cctx in
+      let dir = Obj_dir.dir obj_dir in
+      Dep_rules.for_module ~obj_dir ~modules ~sandbox ~vimpl ~dir ~sctx mock_module
     in
     let* () =
       Module_compilation.ocamlc_i ~deps cctx mock_module ~output:(inferred_mli base)

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -2,25 +2,12 @@
 
 open Import
 
-module Modules_data : sig
-  (** Various information needed about a set of modules.
-
-      This is a subset of [Compilation_context]. We don't use
-      [Compilation_context] directory as this would create a circular
-      dependency. *)
-  type t =
-    { dir : Path.Build.t
-    ; obj_dir : Path.Build.t Obj_dir.t
-    ; sctx : Super_context.t
-    ; vimpl : Vimpl.t option
-    ; modules : Modules.With_vlib.t
-    ; stdlib : Ocaml_stdlib.t option
-    ; sandbox : Sandbox_config.t
-    }
-end
-
 val deps_of
-  :  Modules_data.t
+  :  sandbox:Sandbox_config.t
+  -> modules:Modules.With_vlib.t
+  -> sctx:Super_context.t
+  -> dir:Path.Build.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t Memo.t


### PR DESCRIPTION
Stop passing around this `Ocamldep.Modules_data` record as not all the fields are used anyway