### PR TITLE
feat: use extension inside of syntax

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -72,7 +72,7 @@ module Dep = struct
       Stanza.syntax
       (Active Stanza.latest_version)
       (String_with_vars.set_decoding_env
-         (Pform.Env.initial Stanza.latest_version)
+         (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
          Dep_conf.decode)
   ;;
 

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -580,7 +580,9 @@ module Dune_config = struct
 
   let load_config_file p =
     load_exn p ~f:(fun lang ->
-      String_with_vars.set_decoding_env (Pform.Env.initial lang.version) decode)
+      String_with_vars.set_decoding_env
+        (Pform.Env.initial ~stanza:lang.version ~extensions:[])
+        decode)
   ;;
 
   let load_user_config_file () =

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -333,7 +333,21 @@ let interpret_lang_and_extensions ~(lang : Lang.Instance.t) ~explicit_extensions
   let parsing_context =
     let init =
       let init = Univ_map.singleton (Syntax.key lang.syntax) (Active lang.version) in
-      Univ_map.set init String_with_vars.decoding_env_key (Pform.Env.initial lang.version)
+      let extensions =
+        List.fold_left extensions ~init:[] ~f:(fun acc (ext : Extension.automatic) ->
+          match ext with
+          | Not_selected _ -> acc
+          | Selected ext ->
+            let syntax =
+              let (Extension.Packed ext) = ext.extension in
+              ext.syntax
+            in
+            (syntax, ext.version) :: acc)
+      in
+      Univ_map.set
+        init
+        String_with_vars.decoding_env_key
+        (Pform.Env.initial ~stanza:lang.version ~extensions)
     in
     List.fold_left extensions ~init ~f:(fun acc (ext : Extension.automatic) ->
       let syntax =
@@ -820,7 +834,8 @@ let parse_packages
 ;;
 
 let parse ~dir ~(lang : Lang.Instance.t) ~file =
-  String_with_vars.set_decoding_env (Pform.Env.initial lang.version)
+  String_with_vars.set_decoding_env
+    (Pform.Env.initial ~stanza:lang.version ~extensions:[])
   @@ fields
   @@ let+ name = field_o "name" Dune_project_name.decode
      and+ version = field_o "version" Package_version.decode

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -518,23 +518,23 @@ let describe_kind = function
 module With_versioning_info = struct
   type 'a t =
     | No_info of 'a
-    | Since of 'a * Syntax.Version.t
+    | Since of 'a * Syntax.t * Syntax.Version.t
     | Deleted_in of 'a * Syntax.Version.t * User_message.Style.t Pp.t list
     | Renamed_in of 'a * Syntax.Version.t * string
 
   let get_data = function
-    | No_info x | Since (x, _) | Deleted_in (x, _, _) | Renamed_in (x, _, _) -> x
+    | No_info x | Since (x, _, _) | Deleted_in (x, _, _) | Renamed_in (x, _, _) -> x
   ;;
 
   let renamed_in x ~new_name ~version = Renamed_in (x, version, new_name)
   let deleted_in ~version ?(repl = []) kind = Deleted_in (kind, version, repl)
-  let since ~version v = Since (v, version)
+  let since ?(what = Stanza.syntax) ~version v = Since (v, what, version)
 
   let to_dyn f =
     let open Dyn in
     function
     | No_info x -> variant "No_info" [ f x ]
-    | Since (x, v) -> variant "Since" [ f x; Syntax.Version.to_dyn v ]
+    | Since (x, _, v) -> variant "Since" [ f x; Syntax.Version.to_dyn v ]
     | Deleted_in (x, v, repl) ->
       variant
         "Deleted_in"
@@ -555,7 +555,9 @@ module Env = struct
   type 'a map = 'a With_versioning_info.t String.Map.t
 
   type t =
-    { syntax_version : Syntax.Version.t
+    { extensions : Syntax.Version.t Syntax.Map.t
+    ; syntax_lang : Syntax.t
+    ; syntax_version : Syntax.Version.t
     ; vars : Var.t map
     ; macros : Macro.t map
     }
@@ -592,7 +594,13 @@ module Env = struct
       in
       String.Map.of_list_exn vars
     in
-    fun syntax_version -> { vars; macros; syntax_version }
+    fun syntax_lang syntax_version ->
+      { vars
+      ; macros
+      ; syntax_lang
+      ; syntax_version
+      ; extensions = Syntax.Map.singleton syntax_lang syntax_version
+      }
   ;;
 
   let initial =
@@ -707,7 +715,11 @@ module Env = struct
       in
       String.Map.of_list_exn (List.concat [ lowercased; uppercased; other; os ])
     in
-    fun syntax_version -> { syntax_version; vars; macros }
+    fun ~stanza:syntax_version ~extensions ->
+      let extensions =
+        Syntax.Map.of_list_exn ((Stanza.syntax, syntax_version) :: extensions)
+      in
+      { syntax_version; syntax_lang = Stanza.syntax; vars; macros; extensions }
   ;;
 
   let lt_renamed_input_file t =
@@ -720,6 +732,18 @@ module Env = struct
     }
   ;;
 
+  let find_extension ~loc defined extension =
+    match Syntax.Map.find defined extension with
+    | Some version -> version
+    | None ->
+      User_error.raise
+        ~loc
+        [ Pp.textf
+            "cannoot use pform without enabling extension %s"
+            (Syntax.name extension)
+        ]
+  ;;
+
   let parse map syntax_version (pform : Template.Pform.t) =
     let module P = Template.Pform in
     match String.Map.find map pform.name with
@@ -730,16 +754,15 @@ module Env = struct
     | Some v ->
       (match v with
        | No_info v -> v
-       | Since (v, min_version) ->
+       | Since (v, what, min_version) ->
+         let syntax_version = find_extension ~loc:pform.loc syntax_version what in
          if syntax_version >= min_version
          then v
-         else
-           Syntax.Error.since
-             (P.loc pform)
-             Stanza.syntax
-             min_version
-             ~what:(P.describe pform)
+         else Syntax.Error.since (P.loc pform) what min_version ~what:(P.describe pform)
        | Renamed_in (v, in_version, new_name) ->
+         let syntax_version =
+           find_extension ~loc:pform.loc syntax_version Stanza.syntax
+         in
          if syntax_version < in_version
          then v
          else
@@ -750,6 +773,9 @@ module Env = struct
              ~what:(P.describe pform)
              ~to_:(P.describe { pform with name = new_name })
        | Deleted_in (v, in_version, repl) ->
+         let syntax_version =
+           find_extension ~loc:pform.loc syntax_version Stanza.syntax
+         in
          if syntax_version < in_version
          then v
          else
@@ -763,8 +789,8 @@ module Env = struct
 
   let parse t (pform : Template.Pform.t) =
     match pform.payload with
-    | None -> Var (parse t.vars t.syntax_version pform)
-    | Some payload -> Macro { macro = parse t.macros t.syntax_version pform; payload }
+    | None -> Var (parse t.vars t.extensions pform)
+    | Some payload -> Macro { macro = parse t.macros t.extensions pform; payload }
   ;;
 
   let unsafe_parse_without_checking_version map (pform : Template.Pform.t) =
@@ -784,10 +810,10 @@ module Env = struct
       Macro { macro = unsafe_parse_without_checking_version t.macros pform; payload }
   ;;
 
-  let to_dyn { syntax_version; vars; macros } =
+  let to_dyn { syntax_lang = _; syntax_version = _; extensions; vars; macros } =
     let open Dyn in
     record
-      [ "syntax_version", Syntax.Version.to_dyn syntax_version
+      [ "extensions", Syntax.Map.to_dyn Syntax.Version.to_dyn extensions
       ; "vars", String.Map.to_dyn (to_dyn Var.to_dyn) vars
       ; "macros", String.Map.to_dyn (to_dyn Macro.to_dyn) macros
       ]
@@ -802,15 +828,15 @@ module Env = struct
   ;;
 
   type stamp =
-    Syntax.Version.t
+    Syntax.Version.t Syntax.Map.t
     * (string * Var.t With_versioning_info.t) list
     * (string * Macro.t With_versioning_info.t) list
 
-  let to_stamp { syntax_version; vars; macros } : stamp =
-    syntax_version, String.Map.to_list vars, String.Map.to_list macros
+  let to_stamp { extensions; vars; macros; _ } : stamp =
+    extensions, String.Map.to_list vars, String.Map.to_list macros
   ;;
 
-  let all_known { syntax_version = _; vars; macros } =
+  let all_known { vars; macros; _ } =
     String.Map.union
       (String.Map.map vars ~f:(fun x -> Var (With_versioning_info.get_data x)))
       (String.Map.map macros ~f:(fun x ->

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -744,7 +744,9 @@ module Env = struct
             (Syntax.name extension)
         ]
         ~hints:
-          [ Pp.textf "Try enabling the extension with (using %s <version>)" (Syntax.name extension)
+          [ Pp.textf
+              "Try enabling the extension with (using %s <version>)"
+              (Syntax.name extension)
           ]
   ;;
 

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -739,12 +739,12 @@ module Env = struct
       User_error.raise
         ~loc
         [ Pp.textf
-            "Can't parse the variable %s without the extension %s"
+            "Can't parse the variable %s without the %s extension"
             name
             (Syntax.name extension)
         ]
         ~hints:
-          [ Pp.textf "Try enabling the extension with (using %s)" (Syntax.name extension)
+          [ Pp.textf "Try enabling the extension with (using %s <version>)" (Syntax.name extension)
           ]
   ;;
 

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -838,11 +838,11 @@ module Env = struct
     * (string * Var.t With_versioning_info.t) list
     * (string * Macro.t With_versioning_info.t) list
 
-  let to_stamp { extensions; vars; macros; _ } : stamp =
+  let to_stamp { extensions; vars; macros; syntax_version = _; syntax_lang = _ } : stamp =
     extensions, String.Map.to_list vars, String.Map.to_list macros
   ;;
 
-  let all_known { vars; macros; _ } =
+  let all_known { vars; macros; extensions = _; syntax_version = _; syntax_lang = _ } =
     String.Map.union
       (String.Map.map vars ~f:(fun x -> Var (With_versioning_info.get_data x)))
       (String.Map.map macros ~f:(fun x ->

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -188,8 +188,13 @@ module Env : sig
   (** Decoding environment *)
   type t
 
-  val pkg : Syntax.Version.t -> t
-  val initial : Syntax.Version.t -> t
+  val pkg : Syntax.t -> Syntax.Version.t -> t
+
+  val initial
+    :  stanza:Syntax.Version.t
+    -> extensions:(Syntax.t * Syntax.Version.t) list
+    -> t
+
   val add_user_vars : t -> string list -> t
   val parse : t -> Template.Pform.t -> pform
 

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1459,7 +1459,7 @@ struct
       Io.with_lexbuf_from_file pkg_file_path ~f:(Dune_sexp.Parser.parse ~mode:Many)
     in
     let parser =
-      let env = Pform.Env.pkg version in
+      let env = Pform.Env.pkg Dune_lang.Pkg.syntax version in
       let decode =
         Syntax.set Dune_lang.Pkg.syntax (Active version) Pkg.decode
         |> Syntax.set Dune_lang.Stanza.syntax (Active Dune_lang.Stanza.latest_version)

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -86,7 +86,8 @@ let expand_include ~dir ~project s =
         Stanza.syntax
         (Active (Dune_project.dune_version project))
         (String_with_vars.set_decoding_env
-           (Pform.Env.initial Stanza.latest_version)
+           (* CR-someday rgrinberg: this environment looks fishy *)
+           (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
            (Bindings.decode Dep_conf.decode))
     in
     List.concat_map ~f:(Dune_lang.Decoder.parse dep_parser Univ_map.empty) asts

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -595,7 +595,7 @@ module Or_meta = struct
     match
       Vfile.parse_contents lexbuf ~f:(fun lang ->
         String_with_vars.set_decoding_env
-          (Pform.Env.initial lang.version)
+          (Pform.Env.initial ~stanza:lang.version ~extensions:[])
           (decode ~lang ~dir))
     with
     | contents -> Ok contents

--- a/src/dune_rules_rpc/dune_rules_rpc.ml
+++ b/src/dune_rules_rpc/dune_rules_rpc.ml
@@ -61,6 +61,6 @@ let parse_build_arg s =
        (* CR-someday aalekseyev: hardcoding the version here is not
           ideal, but it will do for now since this command is not
           stable and we're only using it in tests. *)
-       (Pform.Env.initial (3, 0)))
+       (Pform.Env.initial ~stanza:(3, 0) ~extensions:[]))
     (Dune_lang.Parser.parse_string ~fname:"dune rpc" ~mode:Dune_lang.Parser.Mode.Single s)
 ;;

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -222,6 +222,13 @@ and key =
       ; dune_lang_ver : Version.t
       }
 
+module Map = Map.Make (struct
+    type nonrec t = t
+
+    let to_dyn = Dyn.opaque
+    let compare (x : t) y = String.compare x.name y.name
+  end)
+
 let to_dyn { name; desc; key = _; supported_versions; experimental } =
   let open Dyn in
   record

--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -133,3 +133,5 @@ val set : t -> Key.t -> ('a, 'k) Decoder.parser -> ('a, 'k) Decoder.parser
 val key : t -> Key.t Univ_map.Key.t
 val get_exn : t -> (Version.t, 'k) Decoder.parser
 val experimental : t -> bool
+
+module Map : Map.S with type key = t

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -1034,7 +1034,9 @@ let load_step1 clflags p =
     then default_step1 clflags
     else
       parse_contents lb ~f:(fun lang ->
-        String_with_vars.set_decoding_env (Pform.Env.initial lang.version) (step1 clflags)))
+        String_with_vars.set_decoding_env
+          (Pform.Env.initial ~stanza:lang.version ~extensions:[])
+          (step1 clflags)))
 ;;
 
 let filename = "dune-workspace"


### PR DESCRIPTION
This PR is a spinoff of #11826. It extracts the necessary code to use syntax extension with `since ~what`. 
