### PR TITLE
pkg: set arch variable when solving portable lockdir

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -143,9 +143,12 @@ let popular_platform_envs =
     in
     env
   in
-  [ make ~os:"linux" ~arch:None ~os_distribution:None ~os_family:None ()
-  ; make ~os:"macos" ~arch:None ~os_distribution:None ~os_family:None ()
-  ; make ~os:"win32" ~arch:None ~os_distribution:None ~os_family:None ()
+  [ make ~os:"linux" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
+  ; make ~os:"linux" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
+  ; make ~os:"macos" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
+  ; make ~os:"macos" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
+  ; make ~os:"win32" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
+  ; make ~os:"win32" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
   ]
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -46,36 +46,65 @@ Create a package that writes a different value to some files depending on the os
    (complete false)
    (used))
   
-  (solved_for_platforms ((os linux)) ((os macos)) ((os win32)))
+  (solved_for_platforms
+   ((arch x86_64)
+    (os linux))
+   ((arch arm64)
+    (os linux))
+   ((arch x86_64)
+    (os macos))
+   ((arch arm64)
+    (os macos))
+   ((arch x86_64)
+    (os win32))
+   ((arch arm64)
+    (os win32)))
 
   $ cat dune.lock/foo.0.0.1.pkg
   (version 0.0.1)
   
   (build
    (choice
-    ((((os linux)))
+    ((((arch x86_64) (os linux)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
         (run sh -c "echo Linux > %{share}/kernel")
-        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
-        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))
-    ((((os macos)))
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64) (os linux)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo Linux > %{share}/kernel")
+        (run sh -c "echo arm64 > %{share}/machine")))))
+    ((((arch x86_64) (os macos)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
         (run sh -c "echo Darwin > %{share}/kernel")
-        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
-        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))
-    ((((os win32)))
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64) (os macos)))
      ((action
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
-        (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
-        (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine"))))))))
+        (run sh -c "echo Darwin > %{share}/kernel")
+        (run sh -c "echo arm64 > %{share}/machine")))))
+    ((((arch x86_64) (os win32)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo x86_64 > %{share}/machine")))))
+    ((((arch arm64) (os win32)))
+     ((action
+       (progn
+        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+        (run touch %{lib}/%{pkg-self:name}/META)
+        (run sh -c "echo arm64 > %{share}/machine")))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/foo/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -51,6 +51,16 @@ The log file will contain errors about the package being unavailable.
   # - foo -> (problem)
   #     No usable implementations:
   #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
+  # Couldn't solve the package dependency formula.
+  # Selected candidates: x.dev
+  # - foo -> (problem)
+  #     No usable implementations:
+  #       foo.0.0.1: Availability condition not satisfied
 
 The lockdir will contain a list of the platforms where solving succeeded.
   $ cat dune.lock/lock.dune
@@ -62,16 +72,22 @@ The lockdir will contain a list of the platforms where solving succeeded.
    (complete false)
    (used))
   
-  (solved_for_platforms ((os macos)))
+  (solved_for_platforms
+   ((arch x86_64)
+    (os macos))
+   ((arch arm64)
+    (os macos)))
 
 No errors when you try to build the platform on macos.
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
 
 Building on linux fails because the lockdir doesn't contain a compatible solution.
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  File "dune.lock/lock.dune", line 9, characters 22-34:
-  9 | (solved_for_platforms ((os macos)))
-                            ^^^^^^^^^^^^
+  File "dune.lock/lock.dune", lines 10-13, characters 1-58:
+  10 |  ((arch x86_64)
+  11 |   (os macos))
+  12 |  ((arch arm64)
+  13 |   (os macos)))
   Error: The lockdir does not contain a solution compatible with the current
   platform.
   The current platform is:


### PR DESCRIPTION
Without the `arch` variable set to a known architecture the `ocaml-compiler` package only installs the bytecode compiler. This change sets `arch` to `x86_64` and `arm64` in the default solver environments.

Fixes https://github.com/ocaml/dune/issues/11926