### PR TITLE
chore: update makefile to support latest dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ dev-switch:
 	else \
 		opam switch create -y . $(TEST_OCAMLVERSION) --no-install ; \
 	fi
+	opam pin add -y . -n --with-version=dev
 	opam install -y . --deps-only --with-test --with-dev-setup
 	$(MAKE) install-ocamlformat
 	opam install -y $(DEV_DEPS)


### PR DESCRIPTION
As we updated `dune` to use the latest version, it requires `dune` to be pinned to the local version to satisfy the dependencies and be able to use `ocaml-lsp-server` without `merlin` complaining about the `dune` version not being correct.
This PR simply changes the `dev-switch` to also pin `dune` packages to the local version.
