### PR TITLE
chore: Bump ocaml version used in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ DEV_DEPS := \
 core_bench \
 patdiff
 
-TEST_OCAMLVERSION := 5.2.1
+TEST_OCAMLVERSION := 5.3.0
+# When updating this version, don't forget to also bump the number in the docs.
 
 -include Makefile.dev
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -54,10 +54,10 @@ Here are the most common commands you'll be running:
    $ ./dune.exe build @foo
 
 
-Note that tests are currently written for version 5.1.1 of the OCaml compiler.
+Note that tests are currently written for version 5.3.0 of the OCaml compiler.
 Some tests depend on the specific wording of compilation errors which can change
 between compiler versions, so to reliably run the tests make sure that
-``ocaml.5.1.1`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
+``ocaml.5.3.0`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
 the root of the Dune repo contains the current compiler version for which tests
 are written.
 

--- a/doc/tutorials/developing-with-dune/introduction.md
+++ b/doc/tutorials/developing-with-dune/introduction.md
@@ -44,7 +44,7 @@ Let's create a local switch: `cd` to this directory and run the following comman
 This can take a few minutes.
 
 ```sh
-opam switch create ./ 5.1.1
+opam switch create ./ 5.3.0
 ```
 
 This command has created a directory named `_opam` in the current directory.


### PR DESCRIPTION
The ocaml version used in tests at the moment seems in-between releases as
- The Makefile says `5.2.1`
- The documentation says `5.1.1`
- The output of the tests suggests `5.3.x`:
Running the test suite with `5.2.1` yields numerous errors like this
```diff
- The constant 123 has type...
+ This expression has type...
```
These errors disappear when running with `5.3.0`, so in this PR I am bumping the version to that.

References:
- in #11708 the version in the Makefile was updated to `5.2.1`
- in #11788 the version actually used by tests was updated to `5.3.x`
- [Here](https://discuss.ocaml.org/t/ocaml-5-3-0-released/15916#p-67819-compiler-user-interface-and-warnings-14) is the discuss announcement of the release of `5.3.0`, which has a formatted changelog. The link above points directly to the changes in error messages.