### PR TITLE
Portable lockdirs respects custom solver_env

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -65,6 +65,7 @@ module Pkg : sig
 
   val remove_locs : t -> t
   val equal : t -> t -> bool
+  val to_dyn : t -> Dyn.t
 
   val decode
     : (lock_dir:Path.Source.t

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -61,6 +61,7 @@ module Config_override_variables = struct
   let os_distribution = string_option_config "os_distribution"
   let os_family = string_option_config "os_family"
   let os_version = string_option_config "os_version"
+  let sys_ocaml_version = string_option_config "sys_ocaml_version"
 end
 
 (* CR-rgrinberg: do we need to call [uname] for every single option? Can't we
@@ -216,6 +217,12 @@ let os_family ~os_distribution ~os_release_fields ~os =
      | _ -> os_distribution)
 ;;
 
+let sys_ocaml_version ~path =
+  match Config_override_variables.sys_ocaml_version () with
+  | Some sys_ocaml_version -> Fiber.return (Some sys_ocaml_version)
+  | None -> run_capture_line ~path ~prog:"ocamlc" ~args:[ "-vnum" ]
+;;
+
 let make_lazy f = Fiber_lazy.create f |> Fiber_lazy.force
 
 let make ~path =
@@ -235,9 +242,7 @@ let make ~path =
   let os_family =
     make_lazy (fun () -> os_family ~os_release_fields ~os_distribution ~os)
   in
-  let sys_ocaml_version =
-    make_lazy (fun () -> run_capture_line ~path ~prog:"ocamlc" ~args:[ "-vnum" ])
-  in
+  let sys_ocaml_version = make_lazy (fun () -> sys_ocaml_version ~path) in
   { arch; os; os_version; os_distribution; os_family; sys_ocaml_version }
 ;;
 

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -79,15 +79,14 @@ module Sys_vars = struct
   let solver_env () =
     let open Memo.O in
     let module V = Package_variable_name in
-    let { os; os_version; os_distribution; os_family; arch; sys_ocaml_version = _ } =
-      poll
-    in
+    let { os; os_version; os_distribution; os_family; arch; sys_ocaml_version } = poll in
     let+ var_value_pairs =
       [ V.os, os
       ; V.os_version, os_version
       ; V.os_distribution, os_distribution
       ; V.os_family, os_family
       ; V.arch, arch
+      ; V.sys_ocaml_version, sys_ocaml_version
       ]
       |> Memo.List.filter_map ~f:(fun (var, value) ->
         let+ value = Memo.Lazy.force value in

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -7,6 +7,7 @@ export DUNE_CONFIG__ARCH=x86_64
 export DUNE_CONFIG__OS_FAMILY=debian
 export DUNE_CONFIG__OS_DISTRIBUTION=ubuntu
 export DUNE_CONFIG__OS_VERSION=24.11
+export DUNE_CONFIG__SYS_OCAML_VERSION=5.4.0+fake
 
 dune="dune"
 

--- a/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
@@ -107,5 +107,5 @@ Now we finally make the OCaml package for testing through the lock file:
 
 This should display the ocaml from the lock file rather than shadowsystemocaml
 
-  $ dune build @foo
+  $ DUNE_CONFIG__SYS_OCAML_VERSION=4.14.1 dune build @foo
   $TESTCASE_ROOT/_build/_private/default/.pkg/mycaml/target/bin/ocamlc

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -9,7 +9,7 @@ to compare their values.
 These variables are usually set to keep tests consistent across different
 platforms but for this test we need to expose the real platform to dune, so
 unset them all.
-  $ unset DUNE_CONFIG__OS DUNE_CONFIG__ARCH DUNE_CONFIG__OS_FAMILY DUNE_CONFIG__OS_DISTRIBUTION DUNE_CONFIG__OS_VERSION
+  $ unset DUNE_CONFIG__OS DUNE_CONFIG__ARCH DUNE_CONFIG__OS_FAMILY DUNE_CONFIG__OS_DISTRIBUTION DUNE_CONFIG__OS_VERSION DUNE_CONFIG__SYS_OCAML_VERSION
 
   $ mkrepo
   > mkpkg testpkg <<EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -79,6 +79,7 @@ Now building on linux won't work:
   - os-distribution = ubuntu
   - os-family = debian
   - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
   Hint: Try adding the following to dune-workspace:
   Hint: (lock_dir (solve_for_platforms ((arch x86_64) (os linux))))
   Hint: ...and then rerun 'dune pkg lock'

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -1,0 +1,75 @@
+Exercise solving with portable lockdirs when there is a custom solver
+environment that affects the solution.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a workspace that defines a lockdir with a custom solver environment,
+setting the variable "sys-ocaml-version":
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.8)
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > (lock_dir
+  >  (path dune.lock)
+  >  (repositories mock)
+  >  (solver_env
+  >   (sys-ocaml-version 5.4.0+solver-env-version-override)))
+  > EOF
+
+Create a package that creates a file only if "sys-ocaml-version" has a particular value:
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["mkdir" "-p" share "%{lib}%/%{name}%"]
+  >   ["touch" "%{lib}%/%{name}%/META"] # needed for dune to recognize this as a library
+  >   ["sh" "-c" "echo %{sys-ocaml-version}% > %{share}%/sys-ocaml-version"] { sys-ocaml-version = "5.4.0+solver-env-version-override" }
+  > ]
+  > EOF
+
+Set up a project that depends on the package:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "Hello, World!"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+Solve the project:
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+Confirming that the build action creates the conditional file:
+  $ cat dune.lock/foo.0.0.1.pkg
+  (version 0.0.1)
+  
+  (build
+   (all_platforms
+    ((action
+      (progn
+       (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+       (run touch %{lib}/%{pkg-self:name}/META)
+       (run sh -c "echo %{sys_ocaml_version} > %{share}/sys-ocaml-version"))))))
+
+Build and print the file that was conditionally added. Note that the value of
+"sys-ocaml-version" at solve-time may be different from "sys-ocaml-version" at
+build-time, since at solve-time variables are taken from the portable lockdir
+platform config and custom solver env, while at build-time variables are taken
+from the current system. For platform variables like sys-ocaml-version, an
+environment variable can be used to override the value that would otherwise be
+read from the current system.
+  $ DUNE_CONFIG__SYS_OCAML_VERSION=5.4.0+solver-env-version-override dune build
+  $ cat _build/_private/default/.pkg/foo/target/share/sys-ocaml-version
+  5.4.0+solver-env-version-override

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -96,6 +96,7 @@ Building on linux fails because the lockdir doesn't contain a compatible solutio
   - os-distribution = ubuntu
   - os-family = debian
   - os-version = 24.11
+  - sys-ocaml-version = 5.4.0+fake
   Hint: Try adding the following to dune-workspace:
   Hint: (lock_dir (solve_for_platforms ((arch arm64) (os linux))))
   Hint: ...and then rerun 'dune pkg lock'


### PR DESCRIPTION
Previously when using portable lockdirs, custom solver variables set in the "solver_env" field of the "lock_dir" stanza in dune-workspace would be ignored. After this change the custom variables are added to the solver env, though they are overriden by settings from the "solve_for_platforms" field.