### PR TITLE
pkg: include sys_ocaml_version in solver env

### DIFF
--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -79,15 +79,14 @@ module Sys_vars = struct
   let solver_env () =
     let open Memo.O in
     let module V = Package_variable_name in
-    let { os; os_version; os_distribution; os_family; arch; sys_ocaml_version = _ } =
-      poll
-    in
+    let { os; os_version; os_distribution; os_family; arch; sys_ocaml_version } = poll in
     let+ var_value_pairs =
       [ V.os, os
       ; V.os_version, os_version
       ; V.os_distribution, os_distribution
       ; V.os_family, os_family
       ; V.arch, arch
+      ; V.sys_ocaml_version, sys_ocaml_version
       ]
       |> Memo.List.filter_map ~f:(fun (var, value) ->
         let+ value = Memo.Lazy.force value in


### PR DESCRIPTION
This fixes a problem when using the "ocaml-system" compiler package and setting the "sys-ocaml-version" variable in the solver environment. Without including sys_ocaml_version in the solver environment at build time, the presence of sys_ocaml_version in the solver environment recorded in the lockdir causes dune to incorrectly believe that the solver environment is incompatible with the current system, even if the version of the currently-installed system compiler is the same as the one in the solver environment recorded in the lockdir.