### PR TITLE
fix(rpc): fix formatting of message in rpc status

### DIFF
--- a/bin/rpc/status.ml
+++ b/bin/rpc/status.ml
@@ -125,21 +125,14 @@ let term =
         in
         let message =
           match (menu : Dune_rpc_impl.Decl.Status.Menu.t) with
-          | Uninitialized ->
-            User_message.make
-              [ Pp.textf "Client [%s], conducting version negotiation" id ]
+          | Uninitialized -> [ Pp.textf "Client [%s], conducting version negotiation" id ]
           | Menu menu ->
-            User_message.make
-              [ Pp.vbox
-                  ~indent:2
-                  (Pp.concat
-                     ~sep:Pp.space
-                     (Pp.textf "Client [%s] with the following RPC versions:" id
-                      :: List.map menu ~f:(fun (method_, version) ->
-                        Pp.textf "%s: %d" method_ version)))
-              ]
+            [ Pp.textf "Client [%s] with the following RPC versions:" id
+            ; Pp.enumerate menu ~f:(fun (method_, version) ->
+                Pp.textf "%s: %d" method_ version)
+            ]
         in
-        Console.print_user_message message))
+        Console.print message))
     >>| function
     | Ok () -> ()
     | Error e -> Printf.printf "Error: %s\n" e)


### PR DESCRIPTION
Looks like:
```
$ _build/install/default/bin/dune rpc status
Server is listening on unix:path=_build/.rpc/dune
Connected clients (including this one):
Client [(ocamllsp 0)] with the following RPC versions:
- build_dir: 1
- cancel-poll/diagnostic: 1
- cancel-poll/progress: 1
- cancel-poll/running-jobs: 1
- diagnostics: 2
- format-dune-file: 1
- notify/abort: 1
- notify/log: 1
- ping: 1
- poll/diagnostic: 2
- poll/progress: 2
- poll/running-jobs: 1
- promote: 1
- shutdown: 1
Client [status] with the following RPC versions:
- build: 2
- build_dir: 1
- cancel-poll/diagnostic: 1
- cancel-poll/progress: 1
- cancel-poll/running-jobs: 1
- diagnostics: 2
- format-dune-file: 1
- notify/abort: 1
- notify/log: 1
- ping: 1
- poll/diagnostic: 2
- poll/progress: 2
- poll/running-jobs: 1
- promote: 1
- shutdown: 1
- status: 1
```

fix #11950