### PR TITLE
fix: empty alias check for 3.20

### DIFF
--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -9,7 +9,7 @@ module Alias_rules = struct
       | Lt | Gt -> Memo.return ()
       | Eq ->
         let* project = Dune_load.find_project ~dir in
-        if Dune_project.dune_version project >= (3, 21)
+        if Dune_project.dune_version project >= (3, 20)
         then
           User_error.raise
             ~loc

--- a/test/blackbox-tests/test-cases/alias-empty.t
+++ b/test/blackbox-tests/test-cases/alias-empty.t
@@ -7,20 +7,29 @@ Testing the empty alias
 Building the empty alias does nothing
   $ dune build @empty
 
-We should check that a user hasn't added anything to an empty alias
+We should check that a user has not added anything to an empty alias:
   $ cat > dune <<EOF
   > (rule
   >  (alias empty)
   >  (action
-  >   (echo "I shouldn't be added!")))
+  >   (echo "I should not be added!")))
   > EOF
 
-This fails as expected
+For versions prior to 3.20 this does not fail:
   $ dune build @empty
-  File "dune", lines 1-4, characters 0-64:
+  I should not be added!
+
+For versions 3.20 and after this fails:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ dune build @empty
+  File "dune", lines 1-4, characters 0-65:
   1 | (rule
   2 |  (alias empty)
   3 |  (action
-  4 |   (echo "I shouldn't be added!")))
+  4 |   (echo "I should not be added!")))
   Error: User-defined rules cannot be added to the 'empty' alias
   [1]
+


### PR DESCRIPTION
We want the empty alias to be populatable for Dune versions < 3.20 but
afterwards we wish to disallow it.