### PR TITLE
test: empty alias in alias stanza

### DIFF
--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -2,21 +2,23 @@ open Import
 open Memo.O
 
 module Alias_rules = struct
+  let check_empty ~loc ~dir alias =
+    match Alias.Name.compare (Alias.name alias) Alias0.empty with
+    | Lt | Gt -> Memo.return ()
+    | Eq ->
+      let* project = Dune_load.find_project ~dir in
+      if Dune_project.dune_version project >= (3, 20)
+      then
+        User_error.raise
+          ~loc
+          [ Pp.text "User-defined rules cannot be added to the 'empty' alias" ]
+      else Memo.return ()
+  ;;
+
   let add sctx ~alias ~loc build =
     let dir = Alias.dir alias in
-    let* () =
-      match Alias.Name.compare (Alias.name alias) Alias0.empty with
-      | Lt | Gt -> Memo.return ()
-      | Eq ->
-        let* project = Dune_load.find_project ~dir in
-        if Dune_project.dune_version project >= (3, 20)
-        then
-          User_error.raise
-            ~loc
-            [ Pp.text "User-defined rules cannot be added to the 'empty' alias" ]
-        else Memo.return ()
-    in
-    Super_context.add_alias_action sctx alias ~dir ~loc build
+    check_empty ~loc ~dir alias
+    >>> Super_context.add_alias_action sctx alias ~dir ~loc build
   ;;
 
   let add_empty sctx ~loc ~alias =
@@ -269,7 +271,8 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
   let+ () =
     Memo.Option.iter def.alias ~f:(fun alias ->
       let alias = Alias.make alias ~dir in
-      Rules.Produce.Alias.add_deps alias (Action_builder.path_set targets))
+      Alias_rules.check_empty ~loc ~dir alias
+      >>> Rules.Produce.Alias.add_deps alias (Action_builder.path_set targets))
   in
   targets
 ;;
@@ -284,7 +287,8 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
 let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
   let alias = Alias.make ~dir alias_conf.name in
   let loc = alias_conf.loc in
-  Expander.eval_blang expander alias_conf.enabled_if
+  Alias_rules.check_empty ~loc ~dir alias
+  >>> Expander.eval_blang expander alias_conf.enabled_if
   >>= function
   | false -> Alias_rules.add_empty sctx ~loc ~alias
   | true ->

--- a/test/blackbox-tests/test-cases/alias-empty.t
+++ b/test/blackbox-tests/test-cases/alias-empty.t
@@ -19,9 +19,27 @@ For versions prior to 3.20 this does not fail:
   $ dune build @empty
   I should not be added!
 
-For versions 3.20 and after this fails:
+Also creating an alias called empty is allowed prior to 3.20:
+  $ cat > dune <<EOF
+  > (alias
+  >  (name empty)
+  >  (deps foo))
+  > EOF
+  $ cat > foo
+
+  $ dune build @empty
+
+For versions 3.20 and after these should fail:
+
   $ cat > dune-project <<EOF
   > (lang dune 3.20)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias empty)
+  >  (action
+  >   (echo "I should not be added!")))
   > EOF
 
   $ dune build @empty
@@ -32,4 +50,12 @@ For versions 3.20 and after this fails:
   4 |   (echo "I should not be added!")))
   Error: User-defined rules cannot be added to the 'empty' alias
   [1]
+
+  $ cat > dune <<EOF
+  > (alias
+  >  (name empty)
+  >  (deps foo))
+  > EOF
+
+  $ dune build @empty
 

--- a/test/blackbox-tests/test-cases/alias-empty.t
+++ b/test/blackbox-tests/test-cases/alias-empty.t
@@ -58,4 +58,10 @@ For versions 3.20 and after these should fail:
   > EOF
 
   $ dune build @empty
+  File "dune", lines 1-3, characters 0-33:
+  1 | (alias
+  2 |  (name empty)
+  3 |  (deps foo))
+  Error: User-defined rules cannot be added to the 'empty' alias
+  [1]
 


### PR DESCRIPTION
We make sure that users cannot extend the `empty` alias using the `alias` stanza.