### PR TITLE
test: disable exec watch tests

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -13,7 +13,7 @@
 
 (cram
  (applies_to exec-watch-basic exec-watch-server exec-watch-ignore-sigterm
-  exec-signal)
+  exec-signal exec-watch-fail exec-stdin)
  (enabled_if false))
 
 (cram


### PR DESCRIPTION
Since we kill subprocesses there is a race condition when killing dune inside a cram test. We therefore disable these tests for now.