### PR TITLE
test: wait after killing subprocess

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -12,8 +12,7 @@
 ; These tests are explicitly disabled due to flakiness
 
 (cram
- (applies_to exec-watch-basic exec-watch-server exec-watch-ignore-sigterm
-  exec-signal)
+ (applies_to exec-watch-server exec-watch-ignore-sigterm exec-signal)
  (enabled_if false))
 
 (cram

--- a/test/blackbox-tests/test-cases/exec-watch/exec-pwd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-pwd.t/run.t
@@ -19,6 +19,8 @@ In watch mode, pwd is also the folder from which dune is launched.
   $ PID=$!
   $ until test -s $OUTPUT; do sleep 0.1; done;
   $ kill $PID
+  $ wait $PID
+  [130]
   $ cat $OUTPUT
   $TESTCASE_ROOT/bin
   $ rm -rf $OUTPUT

--- a/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
@@ -65,3 +65,5 @@ This rebuilds successfully as indicated by the above output.
   $ ./wait-for-file.sh $DONE_FLAG
 
   $ kill $PID
+  $ wait $PID
+  [130]

--- a/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
@@ -62,3 +62,5 @@ We can trigger arebuild and give another input.
   $ ./wait-for-file.sh $DONE_FLAG
 
   $ kill $PID
+  $ wait $PID
+  [130]

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
@@ -49,3 +49,6 @@ Wait until the error shows up in the log
 
 Prevent the test from leaking the dune process.
   $ kill $PID
+  $ wait $PID
+  [130]
+

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
@@ -37,3 +37,5 @@ we are in watch mode.
   $ ./wait-for-file.sh $DONE_FLAG
 
   $ kill $PID
+  $ wait $PID
+  [130]

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
@@ -13,3 +13,5 @@ Test exec --watch with a program that ignores sigterm.
 
 Prevent the test from leaking the dune process.
   $ kill $PID
+  $ wait $PID
+

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/run.t
@@ -13,6 +13,8 @@ created by the program being exec'd, so when it exists we know that it's safe to
 change the code and proceed with the test.
   $ ../wait-for-file.sh $DONE_FLAG
   $ kill $PID
+  $ wait $PID
+  [130]
 
 Perform the same test above but first enter the "bin" directory.
   $ dune clean
@@ -26,6 +28,8 @@ Perform the same test above but first enter the "bin" directory.
   $ cd ..
   $ ../wait-for-file.sh $DONE_FLAG
   $ kill $PID
+  $ wait $PID
+  [130]
 
 Test that the behaviour is the same when not running with "--watch"
   $ cd bin && dune exec --root .. ./bin/main.exe

--- a/test/blackbox-tests/test-cases/exec-watch/wait-for-file.sh
+++ b/test/blackbox-tests/test-cases/exec-watch/wait-for-file.sh
@@ -7,6 +7,6 @@ set -u
 FILE=$1
 until test -e $FILE
 do
-    sleep 0.1
+    sleep 0.01
 done
 rm $FILE

--- a/test/blackbox-tests/test-cases/pkg/gh10959.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10959.t
@@ -60,3 +60,4 @@ Now we set up a lock file with this package and then attempt to use it:
   Success, waiting for filesystem changes...
   hello
   $ kill $PID
+  $ wait $PID


### PR DESCRIPTION
Finishing a cram test immediately after killing a subprocess such as dune does not give it enough time to terminate. Instead, we should be `wait`ing for the subprocess to terminate. Previously, this meant we would get the Ctrl+C some of the time when trying to terminate dune, but now we have a more consistent behaviour.