### PR TITLE
feat(oxcaml): add the library_parameter stanza

### DIFF
--- a/doc/changes/11963.md
+++ b/doc/changes/11963.md
@@ -1,0 +1,4 @@
+## Added
+
+- (Experimental): Introduce the `library_parameter` stanza. It allows users to declare a parameter when
+  using the OxCaml compiler (#11963, implements #12084, @maiste) 

--- a/doc/reference/dune/index.rst
+++ b/doc/reference/dune/index.rst
@@ -76,6 +76,12 @@ The following pages describe the available stanzas and their meanings.
       ocamlyacc
 
     .. toctree::
+      :caption: Experimental
+      :maxdepth: 1
+
+      library_parameter
+
+    .. toctree::
       :caption: Deprecated
       :maxdepth: 1
 

--- a/doc/reference/dune/library_parameter.rst
+++ b/doc/reference/dune/library_parameter.rst
@@ -1,0 +1,109 @@
+library_parameter
+-----------------
+
+.. warning::
+
+   This feature is experimental and requires the compiler you are using to
+   support parameterized libraries.
+
+The ``library_parameter`` stanza describes a parameter interface defined in a single ``.mli`` file. To enable this feature,
+you need to add ``(using oxcaml 0.1)`` :doc:`extension
+</reference/dune-project/using>` in your ``dune-project`` file.
+
+.. describe:: (library_parameter ...)
+
+  .. versionadded:: 3.20
+
+  Define a parameter.
+
+  .. describe:: (name <parameter-name>)
+
+    ``parameter-name`` is the name of the library parameter. It must be a valid
+    OCaml module name as for :doc:`/reference/dune/library`. 
+
+    This must be specified if no `public_name` is specified.
+
+  .. describe:: (public_name ...)
+
+    The name under which the library parameter can be referred as a dependency
+    when it's not part of the current workspace, i.e., when it is installed.
+    Without a ``(public_name ...)`` field, the library parameter won't be
+    installed by Dune. The public name must start with the package name it's
+    part of and optionally followed by a dot, then anything else you want. The
+    package name must also be one of the packages that Dune knows about, as
+    determined by the logic described in :doc:`/reference/packages`.
+
+  .. describe:: (package <package>)
+
+    Installs a private library parameter under the specified package. Such a
+    parameter is now usable by public libraries defined in the same project.
+
+  .. describe:: (synopsis <string>)
+
+    A one-line description of the library parameter.
+
+  .. describe:: (modules <modules>)
+
+    Specifies a specific module to select as a `library_parameter`.
+
+    ``<modules>`` uses the :doc:`/reference/ordered-set-language`, where
+    elements are module names and don't need to start with an uppercase letter.
+
+    The library parameter **must** only declare one ``mli`` file as part of its
+    modules.
+
+  .. describe:: (libraries <library-dependencies>)
+
+    Specifies the library parameter's dependencies.
+
+    See :doc:`/reference/library-dependencies` for more details.
+
+  .. describe:: (preprocesss <preprocess-spec>)
+
+    Specifies how to preprocess files when needed.
+
+    The default is ``no_preprocessing``, and other options are described
+    in :doc:`/reference/preprocessing-spec`.
+
+  .. describe:: (preprocessor_deps (<deps-conf list>))
+
+    Specifies extra preprocessor dependencies preprocessor, i.e., if the
+    preprocessor reads a generated file.
+
+    The specification of dependencies is described in
+    :doc:`/concepts/dependency-spec`.
+
+
+  .. describe:: (flags ...)
+
+    See :doc:`/concepts/ocaml-flags`.
+
+  .. describe:: (ocamlc_flags ...)
+
+    See :doc:`/concepts/ocaml-flags`.
+
+  .. describe:: (ocamlopt_flags ...)
+
+   See :doc:`/concepts/ocaml-flags`.
+
+  .. describe:: (optional)
+
+    If present, it indicates that the library parameter should only be built
+    and installed if all the dependencies are available, either in the
+    workspace or in the installed world.
+
+  .. describe:: (enabled_if <blang expression>)
+
+    Conditionally disables a library parameter.
+
+    A disabled library parameter cannot be built and will not be installed.
+
+    The condition is specified using the :doc:`/reference/boolean-language`, and
+    the field allows for the ``%{os_type}`` variable, which is expanded to the
+    type of OS being targeted by the current build. Its value is the same as the
+    value of the ``os_type`` parameter in the output of ``ocamlc -config``.
+
+  .. describe:: (allow_overlapping_dependencies)
+
+    Allows external dependencies to overlap with libraries that are present in
+    the workspace.

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -59,6 +59,7 @@ module Js_of_ocaml = Js_of_ocaml
 module Menhir = Menhir
 module Rule_mode_decoder = Rule_mode_decoder
 module Mode_conf = Mode_conf
+module Oxcaml = Oxcaml
 
 (* CR-someday rgrinberg: perhaps wrap these under [Stanzas]? *)
 module Copy_files = Copy_files

--- a/src/dune_lang/lib_kind.ml
+++ b/src/dune_lang/lib_kind.ml
@@ -62,6 +62,7 @@ type t =
   | Normal
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
+  | Parameter
 
 let equal = Poly.equal
 
@@ -69,6 +70,7 @@ let to_dyn x =
   let open Dyn in
   match x with
   | Normal -> variant "Normal" []
+  | Parameter -> variant "Parameter" []
   | Ppx_deriver args -> variant "Ppx_deriver" [ Ppx_args.to_dyn args ]
   | Ppx_rewriter args -> variant "Ppx_rewriter" [ Ppx_args.to_dyn args ]
 ;;
@@ -77,6 +79,7 @@ let decode =
   let open Decoder in
   sum
     [ "normal", return Normal
+    ; "parameter", return Parameter
     ; ( "ppx_deriver"
       , let+ args = Ppx_args.decode in
         Ppx_deriver args )
@@ -90,6 +93,7 @@ let encode t =
   match
     match t with
     | Normal -> Dune_sexp.atom "normal"
+    | Parameter -> Dune_sexp.atom "parameter"
     | Ppx_deriver x -> List (Dune_sexp.atom "ppx_deriver" :: Ppx_args.encode x)
     | Ppx_rewriter x -> List (Dune_sexp.atom "ppx_rewriter" :: Ppx_args.encode x)
   with

--- a/src/dune_lang/lib_kind.mli
+++ b/src/dune_lang/lib_kind.mli
@@ -17,6 +17,7 @@ type t =
   | Normal
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
+  | Parameter
 
 val to_dyn : t Dyn.builder
 val equal : t -> t -> bool

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -55,6 +55,7 @@ let with_lib_deps (t : Context.t) merlin_ident ~dir ~f =
 type kind =
   | Executables of Buildable.t * (Loc.t * string) list
   | Library of Buildable.t * Lib_name.Local.t
+  | Parameter of Buildable.t * Lib_name.Local.t
   | Melange of
       { preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
       ; preprocessor_deps : Dep_conf.t list
@@ -147,7 +148,7 @@ let modules_rules
 let modules_rules sctx kind expander ~dir scope modules =
   let preprocess, preprocessor_deps, lint, empty_module_interface_if_absent =
     match kind with
-    | Executables (buildable, _) | Library (buildable, _) ->
+    | Executables (buildable, _) | Library (buildable, _) | Parameter (buildable, _) ->
       ( buildable.preprocess
       , buildable.preprocessor_deps
       , buildable.lint
@@ -158,12 +159,12 @@ let modules_rules sctx kind expander ~dir scope modules =
   let lib_name =
     match kind with
     | Executables _ | Melange _ -> None
-    | Library (_, name) -> Some name
+    | Library (_, name) | Parameter (_, name) -> Some name
   in
   let empty_intf_modules =
     match kind with
     | Executables (_, modules) -> Some modules
-    | Library _ | Melange _ -> None
+    | Library _ | Melange _ | Parameter _ -> None
   in
   modules_rules
     ~preprocess

--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -23,6 +23,7 @@ val with_lib_deps
 type kind =
   | Executables of Buildable.t * (Loc.t * string) list
   | Library of Buildable.t * Lib_name.Local.t
+  | Parameter of Buildable.t * Lib_name.Local.t
   | Melange of
       { preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
       ; preprocessor_deps : Dep_conf.t list

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -76,7 +76,7 @@ let gen_lib pub_name lib ~version =
   in
   let preds =
     match kind with
-    | Normal -> []
+    | Normal | Parameter -> []
     | Ppx_rewriter _ | Ppx_deriver _ -> [ Pos "ppx_driver" ]
   in
   let name lib =
@@ -127,7 +127,7 @@ let gen_lib pub_name lib ~version =
          ; ppx_runtime_deps ppx_rt_deps
          ])
     ; (match kind with
-       | Normal -> []
+       | Normal | Parameter -> []
        | Ppx_rewriter _ | Ppx_deriver _ ->
          (* Deprecated ppx method support *)
          let no_ppx_driver = Neg "ppx_driver"
@@ -139,7 +139,7 @@ let gen_lib pub_name lib ~version =
              ; requires ~preds:[ no_ppx_driver ] ppx_runtime_deps_for_deprecated_method
              ]
            ; (match kind with
-              | Normal -> assert false
+              | Normal | Parameter -> assert false
               | Ppx_rewriter _ ->
                 [ rule "ppx" [ no_ppx_driver; no_custom_ppx ] Set "./ppx.exe --as-ppx"
                 ; rule "library_kind" [] Set "ppx_rewriter"

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -79,7 +79,7 @@ module Stanzas_to_entries : sig
 end = struct
   let lib_ppxs ctx ~scope ~(lib : Library.t) =
     match lib.kind with
-    | Normal | Ppx_deriver _ -> Memo.return []
+    | Normal | Parameter | Ppx_deriver _ -> Memo.return []
     | Ppx_rewriter _ ->
       Library.best_name lib
       |> Ppx_driver.ppx_exe ctx ~scope
@@ -266,6 +266,7 @@ end = struct
     let { Lib_mode.Map.ocaml = { Mode.Dict.byte; native } as ocaml; melange } =
       Mode_conf.Lib.Set.eval lib.modes ~has_native
     in
+    let is_parameter = Library.is_parameter lib in
     let+ melange_runtime_entries = additional_deps lib.melange_runtime_deps
     and+ public_headers = additional_deps lib.public_headers
     and+ module_files =
@@ -297,16 +298,21 @@ end = struct
         fun m ->
           let cm_file kind = Obj_dir.Module.cm_file obj_dir m ~kind in
           let open Lib_mode.Cm_kind in
-          [ if_ (native || byte) (Ocaml Cmi, cm_file (Ocaml Cmi))
-          ; if_ native (Ocaml Cmx, cm_file (Ocaml Cmx))
-          ; if_ (byte && virtual_library) (Ocaml Cmo, cm_file (Ocaml Cmo))
-          ; if_
-              (native && virtual_library)
-              (Ocaml Cmx, Obj_dir.Module.o_file obj_dir m ~ext_obj)
-          ; if_ melange (Melange Cmi, cm_file (Melange Cmi))
-          ; if_ melange (Melange Cmj, cm_file (Melange Cmj))
-          ]
-          |> List.rev_concat
+          let cmi = if_ (native || byte) (Ocaml Cmi, cm_file (Ocaml Cmi)) in
+          let rest =
+            if is_parameter
+            then []
+            else
+              [ if_ native (Ocaml Cmx, cm_file (Ocaml Cmx))
+              ; if_ (byte && virtual_library) (Ocaml Cmo, cm_file (Ocaml Cmo))
+              ; if_
+                  (native && virtual_library)
+                  (Ocaml Cmx, Obj_dir.Module.o_file obj_dir m ~ext_obj)
+              ; if_ melange (Melange Cmi, cm_file (Melange Cmi))
+              ; if_ melange (Melange Cmj, cm_file (Melange Cmj))
+              ]
+          in
+          cmi :: rest |> List.rev_concat
       in
       let set_dir m = List.rev_map ~f:(fun (cm_kind, p) -> cm_dir m cm_kind, p) in
       let+ modules_impl =
@@ -348,11 +354,16 @@ end = struct
       [ sources
       ; melange_runtime_entries
       ; List.rev_map module_files ~f:(fun (sub_dir, file) -> make_entry ?sub_dir Lib file)
-      ; List.rev_map lib_files ~f:(fun (section, file) -> make_entry section file)
-      ; List.rev_map execs ~f:(make_entry Libexec)
-      ; dll_files
-      ; install_c_headers
-      ; public_headers
+      ; (match is_parameter with
+         | true -> []
+         | false ->
+           List.rev_concat
+             [ List.rev_map lib_files ~f:(fun (section, file) -> make_entry section file)
+             ; List.rev_map execs ~f:(make_entry Libexec)
+             ; dll_files
+             ; install_c_headers
+             ; public_headers
+             ])
       ]
   ;;
 

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -660,16 +660,16 @@ module Vlib : sig
   (** Make sure that for every virtual library in the list there is at most one
       corresponding implementation.
 
-      Additionally, if linking is [true], ensures that every virtual library as
-      an implementation and re-arrange the list so that implementations replaces
-      virtual libraries. *)
+      Additionally, if linking is [true], ensures that every virtual library as an
+      implementation and re-arrange the list so that implementations replaces virtual
+      libraries. *)
   val associate
     :  (t * Dep_stack.t) list
     -> [ `Compile | `Link | `Partial_link ]
     -> t list Resolve.Memo.t
 
   module Unimplemented : sig
-    (** set of unimplemented libraries*)
+    (** set of unimplemented libraries *)
     type t
 
     val empty : t

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -367,6 +367,7 @@ let kind t = t.kind
 let default_implementation t = t.default_implementation
 let obj_dir t = t.obj_dir
 let virtual_ t = t.virtual_
+let is_parameter t = t.kind = Parameter
 let implements t = t.implements
 let synopsis t = t.synopsis
 let wrapped t = t.wrapped

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -140,6 +140,7 @@ val wasmoo_runtime : 'path t -> 'path list
 val melange_runtime_deps : 'path t -> 'path File_deps.t
 val obj_dir : 'path t -> 'path Obj_dir.t
 val virtual_ : _ t -> bool
+val is_parameter : _ t -> bool
 val entry_modules : _ t -> (Module_name.t list, User_message.t) result Source.t
 val main_module_name : _ t -> Main_module_name.t
 val wrapped : _ t -> Wrapped.t Inherited.t option

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -92,7 +92,7 @@ let build_lib
          Expander.expand_and_eval_set expander lib.library_flags ~standard)
     ; As
         (match lib.kind with
-         | Normal -> []
+         | Normal | Parameter -> []
          | Ppx_deriver _ | Ppx_rewriter _ -> [ "-linkall" ])
     ; Dyn
         (Cm_files.top_sorted_cms cm_files ~mode
@@ -439,18 +439,21 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
     Lib_info.eval_native_archives_exn lib_info ~modules:(Some modules)
   in
   let* () =
-    let cm_files =
-      let excluded_modules =
-        (* ctypes type_gen and function_gen scripts should not be included in the
+    if Library.is_parameter lib
+    then Memo.return ()
+    else (
+      let cm_files =
+        let excluded_modules =
+          (* ctypes type_gen and function_gen scripts should not be included in the
            library. Otherwise they will spew stuff to stdout on library load. *)
-        match lib.buildable.ctypes with
-        | Some ctypes -> Ctypes_field.non_installable_modules ctypes
-        | None -> []
+          match lib.buildable.ctypes with
+          | Some ctypes -> Ctypes_field.non_installable_modules ctypes
+          | None -> []
+        in
+        Cm_files.make ~excluded_modules ~obj_dir ~ext_obj ~modules ~top_sorted_modules ()
       in
-      Cm_files.make ~excluded_modules ~obj_dir ~ext_obj ~modules ~top_sorted_modules ()
-    in
-    iter_modes_concurrently modes.ocaml ~f:(fun mode ->
-      build_lib lib ~native_archives ~dir ~sctx ~expander ~flags ~mode ~cm_files)
+      iter_modes_concurrently modes.ocaml ~f:(fun mode ->
+        build_lib lib ~native_archives ~dir ~sctx ~expander ~flags ~mode ~cm_files))
   and* () =
     (* Build *.cma.js / *.wasma *)
     Memo.when_ modes.ocaml.byte (fun () ->

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -376,7 +376,7 @@ let make_lib_modules
       in
       let kind : Modules_field_evaluator.kind =
         match lib.virtual_modules with
-        | None -> Exe_or_normal_lib
+        | None -> if lib.kind = Parameter then Parameter else Exe_or_normal_lib
         | Some virtual_modules -> Virtual { virtual_modules }
       in
       Memo.return (Resolve.return (kind, main_module_name, wrapped))
@@ -434,6 +434,17 @@ let make_lib_modules
       in
       User_error.raise ~annots ~loc:loc_include_subdirs [ main_message ]
     | _, _ -> ()
+  in
+  let () =
+    if Library.is_parameter lib
+    then (
+      match Module_trie.as_singleton modules with
+      | Some _ -> ()
+      | None ->
+        User_error.raise
+          ~loc:lib.buildable.loc
+          [ Pp.text "a library_parameter can't declare more than one module." ])
+    else ()
   in
   let implements = Option.is_some lib.implements in
   let _loc, lib_name = lib.name in

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -1,7 +1,6 @@
 (** OCaml sources *)
 
-(** This module encapsulates the structure of source files in a particular
-    directory. *)
+(** This module encapsulates the structure of source files in a particular directory. *)
 
 open Import
 
@@ -33,7 +32,7 @@ val modules_and_obj_dir
   -> for_:for_
   -> (Modules.t * Path.Build.t Obj_dir.t) Memo.t
 
-(** Modules attached to a library, executable, or melange.emit stanza.*)
+(** Modules attached to a library, executable, or melange.emit stanza. *)
 val modules : t -> libs:Lib.DB.t -> for_:for_ -> Modules.t Memo.t
 
 (** Find out the origin of the stanza for a given module *)
@@ -41,12 +40,12 @@ val find_origin : t -> libs:Lib.DB.t -> Module_name.Path.t -> Origin.t option Me
 
 val empty : t
 
-(** This [lookup_vlib] argument is required for constructing the collection of
-    modules for an implementation of a virtual library.
+(** This [lookup_vlib] argument is required for constructing the collection of modules for
+    an implementation of a virtual library.
 
-    We need to know the contents of the virtual library to: - verify conditions
-    all virtual modules are implemented - make sure that we construct [Module.t]
-    with the correct [kind] *)
+    We need to know the contents of the virtual library to: - verify conditions all
+    virtual modules are implemented - make sure that we construct [Module.t] with the
+    correct [kind] *)
 
 val include_subdirs : t -> Include_subdirs.t
 
@@ -62,3 +61,10 @@ val make
   -> include_subdirs:Loc.t * Include_subdirs.t
   -> dirs:Source_file_dir.t list
   -> t Memo.t
+
+val modules_of_files
+  :  path:Module_name.t list
+  -> dialects:Dialect.DB.t
+  -> dir:Path.Build.t
+  -> files:Import.String.Set.t
+  -> Module.Source.t Module_name.Map.t

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -19,6 +19,7 @@ module Kind : sig
     | Impl_vmodule
     | Wrapped_compat
     | Root
+    | Parameter
 
   include Dune_lang.Conv.S with type t := t
 

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -217,6 +217,7 @@ let build_cm
      then A "-opaque"
      else Command.Args.empty
    in
+   let as_parameter_arg = if Module.kind m = Parameter then [ "-as-parameter" ] else [] in
    let flags, sandbox =
      let flags =
        Command.Args.dyn (Ocaml_flags.get (Compilation_context.flags cctx) mode)
@@ -269,6 +270,7 @@ let build_cm
             ; Command.Args.as_any
                 (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
             ; extra_args
+            ; As as_parameter_arg
             ; S (melange_args cctx cm_kind m)
             ; A "-no-alias-deps"
             ; opaque_arg

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -16,6 +16,7 @@ type kind =
   | Virtual of Virtual.t
   | Implementation of Implementation.t
   | Exe_or_normal_lib
+  | Parameter
 
 let eval0 =
   let key = function
@@ -106,6 +107,7 @@ let find_errors
       ~private_modules
       ~existing_virtual_modules
       ~allow_new_public_modules
+      ~is_parameter
   =
   let all =
     (* We expect that [modules] is big and all the other ones are small, that's
@@ -148,7 +150,7 @@ let find_errors
            (add_if has_impl Spurious_module_virtual
             ++ add_if !?intf_only Virt_intf_overlap
             ++ add_if !?private_ Private_virt_module
-            ++ add_if (not !?modules) Undeclared_virtual_module)
+            ++ add_if ((not !?modules) && not is_parameter) Undeclared_virtual_module)
       @@ with_property
            modules
            (add_if
@@ -180,6 +182,7 @@ let check_invalid_module_listing
       ~existing_virtual_modules
       ~allow_new_public_modules
       ~is_vendored
+      ~is_parameter
       ~version
   =
   let { errors; unimplemented_virt_modules } =
@@ -190,6 +193,7 @@ let check_invalid_module_listing
       ~private_modules
       ~existing_virtual_modules
       ~allow_new_public_modules
+      ~is_parameter
   in
   if
     List.is_non_empty errors
@@ -346,12 +350,12 @@ let eval
   let eval = eval0 ~expander ~loc:stanza_loc ~all_modules in
   let allow_new_public_modules =
     match kind with
-    | Exe_or_normal_lib | Virtual _ -> true
+    | Exe_or_normal_lib | Virtual _ | Parameter -> true
     | Implementation { allow_new_public_modules; _ } -> allow_new_public_modules
   in
   let existing_virtual_modules =
     match kind with
-    | Exe_or_normal_lib | Virtual _ -> Module_name.Path.Set.empty
+    | Exe_or_normal_lib | Virtual _ | Parameter -> Module_name.Path.Set.empty
     | Implementation { existing_virtual_modules; _ } -> existing_virtual_modules
   in
   let+ intf_only = eval ~standard:Module_trie.empty modules_without_implementation
@@ -359,7 +363,13 @@ let eval
     match kind with
     | Exe_or_normal_lib | Implementation _ -> Memo.return Module_trie.empty
     | Virtual { virtual_modules } -> eval ~standard:Module_trie.empty virtual_modules
+    | Parameter -> Memo.return (Module_trie.map ~f:(fun v -> stanza_loc, v) all_modules)
   and+ private_modules = eval ~standard:Module_trie.empty private_modules in
+  let is_parameter =
+    match kind with
+    | Parameter -> true
+    | Virtual _ | Exe_or_normal_lib | Implementation _ -> false
+  in
   check_invalid_module_listing
     ~stanza_loc
     ~modules_without_implementation
@@ -370,6 +380,7 @@ let eval
     ~existing_virtual_modules
     ~allow_new_public_modules
     ~is_vendored
+    ~is_parameter
     ~version;
   let all_modules =
     Module_trie.mapi modules ~f:(fun _path (_, m) ->
@@ -378,8 +389,10 @@ let eval
         if Module_trie.mem private_modules name then Visibility.Private else Public
       in
       let kind =
-        if Module_trie.mem virtual_modules name
-        then Module.Kind.Virtual
+        if is_parameter
+        then Module.Kind.Parameter
+        else if Module_trie.mem virtual_modules name
+        then Virtual
         else if Module.Source.has m ~ml_kind:Impl
         then (
           let name = Module.Source.name m in

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -18,6 +18,7 @@ type kind =
   | Virtual of Virtual.t
   | Implementation of Implementation.t
   | Exe_or_normal_lib
+  | Parameter
 
 val eval
   :  expander:Expander.t

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -370,7 +370,7 @@ let get_cookies ~loc ~expander ~lib_name libs =
       let info = Lib.info t in
       let kind = Lib_info.kind info in
       match kind with
-      | Normal -> Memo.return []
+      | Normal | Parameter -> Memo.return []
       | Ppx_rewriter { cookies } | Ppx_deriver { cookies } ->
         Memo.List.map cookies ~f:(fun { Lib_kind.Ppx_args.Cookie.name; value } ->
           let+ value = Expander.No_deps.expand_str expander value in

--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -65,8 +65,8 @@ let decode (for_ : for_) =
       Foreign.Stubs.make ~loc ~language ~names ~flags :: foreign_stubs
   in
   let+ loc = loc
-  and+ preprocess, preprocessor_deps = Preprocess.preprocess_fields
-  and+ lint = field "lint" Lint.decode ~default:Lint.default
+  and+ preprocess, preprocessor_deps = decode_preprocess
+  and+ lint = decode_lint
   and+ foreign_stubs =
     multi_field
       "foreign_stubs"
@@ -93,7 +93,7 @@ let decode (for_ : for_) =
   and+ cxx_names_loc, cxx_names =
     located
       (only_in_library (field_o "cxx_names" (use_foreign >>> Ordered_set_lang.decode)))
-  and+ modules = Stanza_common.Modules_settings.decode
+  and+ modules = decode_modules
   and+ self_build_stubs_archive_loc, self_build_stubs_archive =
     located
       (only_in_library
@@ -105,9 +105,8 @@ let decode (for_ : for_) =
                (2, 0)
                ~extra_info:"Use the (foreign_archives ...) field instead."
              >>> enter (maybe string))))
-  and+ libraries =
-    field "libraries" (Lib_dep.L.decode ~allow_re_export:in_library) ~default:[]
-  and+ flags = Ocaml_flags.Spec.decode
+  and+ libraries = decode_libraries ~allow_re_export:in_library
+  and+ flags = decode_ocaml_flags
   and+ js_of_ocaml =
     field
       "js_of_ocaml"
@@ -119,24 +118,16 @@ let decode (for_ : for_) =
       (Dune_lang.Syntax.since Stanza.syntax (3, 17)
        >>> Js_of_ocaml.In_buildable.decode ~in_library ~mode:Wasm)
       ~default:Js_of_ocaml.In_buildable.default
-  and+ allow_overlapping_dependencies = field_b "allow_overlapping_dependencies"
+  and+ allow_overlapping_dependencies = decode_allow_overlapping
   and+ version = Dune_lang.Syntax.get_exn Stanza.syntax
   and+ ctypes =
     field_o
       "ctypes"
       (Dune_lang.Syntax.since Ctypes_field.syntax (0, 1) >>> Ctypes_field.decode)
-  and+ instrumentation = Preprocess.Instrumentation.instrumentation
   and+ empty_module_interface_if_absent =
     field_b
       "empty_module_interface_if_absent"
       ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
-  in
-  let preprocess =
-    let init =
-      let f libname = Preprocess.With_instrumentation.Ordinary libname in
-      Module_name.Per_item.map preprocess ~f:(Preprocess.map ~f)
-    in
-    List.fold_left instrumentation ~init ~f:Preprocess.Per_module.add_instrumentation
   in
   let foreign_stubs =
     foreign_stubs

--- a/src/dune_rules/stanzas/buildable.mli
+++ b/src/dune_rules/stanzas/buildable.mli
@@ -31,3 +31,26 @@ val has_foreign_cxx : t -> bool
 val has_mode_dependent_foreign_stubs : t -> bool
 val decode : for_ -> t Dune_lang.Decoder.fields_parser
 val has_foreign_stubs : t -> bool
+
+(** Parser for the libraries fields *)
+val decode_libraries : allow_re_export:bool -> Lib_dep.L.t Dune_lang.Decoder.fields_parser
+
+(** Parser for the preprocesss *)
+val decode_preprocess
+  : ( Preprocess.With_instrumentation.t Preprocess.Per_module.t * Dep_conf.t list
+      , Dune_lang.Decoder.fields )
+      Dune_lang.Decoder.parser
+
+(** Parser for the ocaml flags *)
+val decode_ocaml_flags : Ocaml_flags.Spec.t Dune_lang.Decoder.fields_parser
+
+(* Parser for the modules field *)
+val decode_modules : Stanza_common.Modules_settings.t Dune_lang.Decoder.fields_parser
+
+(* Parser for the lint field *)
+val decode_lint
+  : Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+      Dune_lang.Decoder.fields_parser
+
+(* Parser for allow_overlapping_dependencies *)
+val decode_allow_overlapping : bool Dune_lang.Decoder.fields_parser

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -369,6 +369,7 @@ let best_name t =
   | Public p -> snd p.name
 ;;
 
+let is_parameter t = t.kind = Parameter
 let is_virtual t = Option.is_some t.virtual_modules
 let is_impl t = Option.is_some t.implements
 
@@ -421,7 +422,9 @@ let to_lib_info
   let archive ?(dir = dir) ext = archive conf ~dir ~ext in
   let modes = Mode_conf.Lib.Set.eval ~has_native conf.modes in
   let archive_for_mode ~f_ext ~mode =
-    if Mode.Dict.get modes.ocaml mode then Some (archive (f_ext mode)) else None
+    if Mode.Dict.get modes.ocaml mode && not (is_parameter conf)
+    then Some (archive (f_ext mode))
+    else None
   in
   let archives_for_mode ~f_ext =
     Mode.Dict.of_func (fun ~mode -> archive_for_mode ~f_ext ~mode |> Option.to_list)

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -73,6 +73,7 @@ val archive : t -> dir:Path.Build.t -> ext:string -> Path.Build.t
 
 val best_name : t -> Lib_name.t
 val is_virtual : t -> bool
+val is_parameter : t -> bool
 val is_impl : t -> bool
 val obj_dir : dir:Path.Build.t -> t -> Path.Build.t Obj_dir.t
 val main_module_name : t -> Lib_info.Main_module_name.t

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -1,0 +1,110 @@
+open Import
+open! Dune_lang.Decoder
+
+type t =
+  { name : Loc.t * Lib_name.Local.t
+  ; project : Dune_project.t
+  ; visibility : Library.visibility
+  ; buildable : Buildable.t
+  ; stdlib : Ocaml_stdlib.t option
+  ; enabled_if : Blang.t
+  ; optional : bool
+  ; synopsis : string option
+  ; loc : Loc.t
+  ; dune_version : Dune_lang.Syntax.Version.t
+  }
+
+let to_library t =
+  let loc, _ = t.name in
+  { Library.name = t.name
+  ; visibility = t.visibility
+  ; synopsis = t.synopsis
+  ; install_c_headers = []
+  ; public_headers = loc, []
+  ; ppx_runtime_libraries = []
+  ; modes = Mode_conf.Lib.Set.of_list [ Ocaml Byte, Inherited ]
+  ; kind = Lib_kind.Parameter
+  ; library_flags = Ordered_set_lang.Unexpanded.standard
+  ; c_library_flags = Ordered_set_lang.Unexpanded.standard
+  ; virtual_deps = []
+  ; wrapped = This (Simple false)
+  ; buildable = t.buildable
+  ; dynlink = Dynlink_supported.of_bool false
+  ; project = t.project
+  ; sub_systems = Sub_system_name.Map.empty
+  ; dune_version = t.dune_version
+  ; virtual_modules = None
+  ; implements = None
+  ; default_implementation = None
+  ; private_modules = None
+  ; stdlib = t.stdlib
+  ; special_builtin_support = None
+  ; enabled_if = t.enabled_if
+  ; instrumentation_backend = None
+  ; melange_runtime_deps = loc, []
+  ; optional = t.optional
+  }
+;;
+
+let decode =
+  fields
+    (let* stanza_loc = loc in
+     let wrapped = None in
+     (* Wrapped.Simple true in *)
+     let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
+     let* project = Dune_project.get_exn () in
+     let+ buildable = Buildable.decode (Library (Option.map ~f:snd wrapped))
+     and+ name = field_o "name" Lib_name.Local.decode_loc
+     and+ public = field_o "public_name" (Public_lib.decode ~allow_deprecated_names:false)
+     and+ package = field_o "package" (located Stanza_common.Pkg.decode)
+     and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
+     and+ synopsis = field_o "synopsis" string
+     and+ optional = field_b "optional" in
+     let name =
+       match name, public with
+       | Some (loc, res), _ -> loc, res
+       | None, Some { Public_lib.name = loc, name; _ } ->
+         (match Lib_name.to_local (loc, name) with
+          | Ok m -> loc, m
+          | Error user_message ->
+            User_error.raise
+              ~loc
+              [ Pp.textf "Invalid library_parameter name."
+              ; Pp.text
+                  "Public library_parameter names don't have this restriction. You can \
+                   either change this public name to be a valid library_parameter name \
+                   or add a \"name\" field with a valid library_parameter name."
+              ]
+              ~hints:(Lib_name.Local.valid_format_doc :: user_message.hints))
+       | None, None ->
+         User_error.raise
+           ~loc:stanza_loc
+           [ Pp.text "supply at least one of name or public_name fields" ]
+     in
+     let visibility =
+       match public, package with
+       | None, None -> Library.Private None
+       | Some public, None -> Public public
+       | None, Some (_loc, package) -> Private (Some package)
+       | Some public, Some (loc, _) ->
+         User_error.raise
+           ~loc
+           [ Pp.textf
+               "This library parameter has a public_name, it already belongs to the \
+                package %s"
+               (Package.Name.to_string (Package.name public.package))
+           ]
+     in
+     to_library
+       { name
+       ; visibility
+       ; buildable
+       ; project
+       ; stdlib = None
+       ; enabled_if
+       ; optional
+       ; synopsis
+       ; loc = stanza_loc
+       ; dune_version
+       })
+;;

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -49,11 +49,34 @@ let to_library t =
 let decode =
   fields
     (let* stanza_loc = loc in
-     let wrapped = None in
-     (* Wrapped.Simple true in *)
      let* project = Dune_project.get_exn () in
      let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
-     let+ buildable = Buildable.decode (Library (Option.map ~f:snd wrapped))
+     let+ buildable : Buildable.t =
+       let+ loc = loc
+       and+ libraries = Buildable.decode_libraries ~allow_re_export:true
+       and+ preprocess, preprocessor_deps = Buildable.decode_preprocess
+       and+ lint = Buildable.decode_lint
+       and+ flags = Buildable.decode_ocaml_flags
+       and+ allow_overlapping_dependencies = Buildable.decode_allow_overlapping
+       and+ modules = Buildable.decode_modules in
+       { Buildable.loc
+       ; modules
+       ; empty_module_interface_if_absent = false
+       ; libraries
+       ; foreign_archives = []
+       ; extra_objects = Foreign.Objects.empty
+       ; foreign_stubs = []
+       ; preprocess
+       ; preprocessor_deps
+       ; lint
+       ; flags
+       ; js_of_ocaml =
+           { js = Js_of_ocaml.In_buildable.default
+           ; wasm = Js_of_ocaml.In_buildable.default
+           }
+       ; allow_overlapping_dependencies
+       ; ctypes = None
+       }
      and+ name = field_o "name" Lib_name.Local.decode_loc
      and+ public = field_o "public_name" (Public_lib.decode ~allow_deprecated_names:false)
      and+ package = field_o "package" (located Stanza_common.Pkg.decode)

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -51,8 +51,8 @@ let decode =
     (let* stanza_loc = loc in
      let wrapped = None in
      (* Wrapped.Simple true in *)
-     let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
      let* project = Dune_project.get_exn () in
+     let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
      let+ buildable = Buildable.decode (Library (Option.map ~f:snd wrapped))
      and+ name = field_o "name" Lib_name.Local.decode_loc
      and+ public = field_o "public_name" (Public_lib.decode ~allow_deprecated_names:false)

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -62,6 +62,12 @@ let stanzas : constructors =
         match Library_redirect.Local.of_lib x with
         | None -> base
         | Some r -> Library_redirect.Local.make_stanza r :: base )
+    ; ( "library_parameter"
+      , let+ x = Parameter.decode in
+        let base = [ Library.make_stanza x ] in
+        match Library_redirect.Local.of_lib x with
+        | None -> base
+        | Some r -> Library_redirect.Local.make_stanza r :: base )
     ; ( "foreign_library"
       , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
         and+ x = Foreign_library.decode in

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -63,7 +63,9 @@ let stanzas : constructors =
         | None -> base
         | Some r -> Library_redirect.Local.make_stanza r :: base )
     ; ( "library_parameter"
-      , let+ x = Parameter.decode in
+      , let+ () = Dune_lang.Syntax.since Stanza.syntax (3, 20)
+        and+ () = Dune_lang.Syntax.since Dune_lang.Oxcaml.syntax (0, 1)
+        and+ x = Parameter.decode in
         let base = [ Library.make_stanza x ] in
         match Library_redirect.Local.of_lib x with
         | None -> base

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -57,6 +57,10 @@ let add_stanza db ~dir (acc, pps) stanza =
        then (
          match Lib_info.kind info with
          | Normal -> Appendable_list.cons lib acc, pps
+         | Parameter -> Appendable_list.cons lib acc, pps
+         (* CR @maiste or @art-w: the parametrized libraries in utop follows
+             the same schema as Normal library but it needs to be verified once
+             parametrized libraries are fully supported. *)
          | Lib_kind.Ppx_rewriter _ | Ppx_deriver _ ->
            ( Appendable_list.cons lib acc
            , Appendable_list.cons (Lib_info.loc info, Lib_info.name info) pps ))
@@ -95,6 +99,10 @@ let add_stanza db ~dir (acc, pps) stanza =
          let info = Lib.info lib in
          match Lib_info.kind info with
          | Normal -> Appendable_list.cons lib acc, pps
+         | Parameter -> Appendable_list.cons lib acc, pps
+         (* CR @maiste or @art-w: the parametrized libraries in utop follows
+             the same schema as Normal library but it needs to be verified once
+             parametrized libraries are fully supported. *)
          | Ppx_rewriter _ | Ppx_deriver _ ->
            ( Appendable_list.cons lib acc
            , Appendable_list.cons (Lib_info.loc info, Lib_info.name info) pps )))

--- a/test/blackbox-tests/test-cases/oxcaml/dune
+++ b/test/blackbox-tests/test-cases/oxcaml/dune
@@ -1,3 +1,7 @@
 (cram
  (applies_to :whole_subtree)
  (enabled_if %{oxcaml_supported}))
+
+(cram
+ (deps helpers.sh)
+ (applies_to :whole_subtree))

--- a/test/blackbox-tests/test-cases/oxcaml/helpers.sh
+++ b/test/blackbox-tests/test-cases/oxcaml/helpers.sh
@@ -1,0 +1,22 @@
+export XDG_CACHE_HOME="$PWD/.cache"
+
+init_project() {
+  cat > "dune-project" <<EOF
+(lang dune 3.20)
+(using oxcaml 0.1)
+EOF
+}
+
+make_dir_with_dune() {
+  path="$1"
+  mkdir -p $path
+  cat > "$path/dune"
+}
+
+target_cmi() {
+  echo "./$1/.$1.objs/byte/$1.cmi"
+}
+
+build_target_cmi() {
+  echo "./_build/default/$1/.$1.objs/byte/$1.cmi"
+}

--- a/test/blackbox-tests/test-cases/oxcaml/library_parameter.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library_parameter.t
@@ -1,0 +1,189 @@
+This test verifies that the `library_parameter` stanza works as expected.
+
+  $ . ./helpers.sh
+  $ cat > "dune-project" <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ echo "(package (name param))" >> "dune-project"
+
+We create our first parameter. We use the `public_name` to prevent dune from
+being lazy.
+
+  $ mkdir param
+  $ echo "type t = int" > param/param_intf.mli
+  $ cat > "param/dune" <<EOF
+  > (library_parameter
+  >  (public_name param.intf)
+  >  (name param_intf))
+  > EOF
+
+The test build should fails because the oxcaml extension is not available.
+
+  $ dune build
+  File "param/dune", lines 1-3, characters 0-64:
+  1 | (library_parameter
+  2 |  (public_name param.intf)
+  3 |  (name param_intf))
+  Error: 'library_parameter' is available only when oxcaml is enabled in the
+  dune-project file. You must enable it using (using oxcaml 0.1) in your
+  dune-project file.
+  Note however that oxcaml is experimental and might change without notice in
+  the future.
+  [1]
+
+Adding the extension in the dune project solve the problem.
+
+  $ echo "(using oxcaml 0.1)" >> dune-project
+  $ dune build
+  $ ocamlobjinfo _build/default/param/.param_intf.objs/byte/param_intf.cmi | grep 'Is parameter'
+  Is parameter: YES
+
+We create a second parameter in the same directory. We rewrite the dune file to
+use the `modules` field.
+
+  $ cat > "param/dune" <<EOF
+  > (library_parameter
+  >  (public_name param.intf)
+  >  (name param_intf)
+  >  (modules param_intf))
+  > (library_parameter
+  >  (public_name param.intf2)
+  >  (name param_intf2)
+  >  (modules param_intf2))
+  > EOF
+
+  $ echo "type t = string" > param/param_intf2.mli
+
+We rebuild it and ensure we have the new parameter available.
+
+  $ dune build
+  $ ocamlobjinfo _build/default/param/.param_intf2.objs/byte/param_intf2.cmi | grep "Is parameter"
+  Is parameter: YES
+
+We create a third parameter with multiple modules. The test should fail as we
+limit the parameter to one module now.
+
+  $ echo "(package (name multiple_param))" >> "dune-project"
+  $ mkdir multiple
+  $ cat > "multiple/dune" << EOF
+  > (library_parameter
+  >  (public_name multiple_param)
+  >  (name multiple_param)
+  >  (modules multiple_param data))
+  > EOF
+  $ cat > "multiple/data.mli" << EOF
+  > type t = int
+  > EOF
+  $ cat > "multiple/multiple_param.mli" << EOF
+  > type t = string
+  > EOF
+
+  $ dune build
+  File "multiple/dune", lines 1-4, characters 0-103:
+  1 | (library_parameter
+  2 |  (public_name multiple_param)
+  3 |  (name multiple_param)
+  4 |  (modules multiple_param data))
+  Error: a library_parameter can't declare more than one module.
+  [1]
+
+We make sure the same happened if multiple modules exists in one directory.
+
+  $ cat > "multiple/dune" << EOF
+  > (library_parameter
+  >  (public_name multiple_param)
+  >  (name multiple_param))
+  > EOF
+  $ dune build
+  File "multiple/dune", lines 1-3, characters 0-72:
+  1 | (library_parameter
+  2 |  (public_name multiple_param)
+  3 |  (name multiple_param))
+  Error: a library_parameter can't declare more than one module.
+  [1]
+
+We build the installable version to ensure we have generated the correct
+information to access the parameter through different packages.
+
+  $ rm -rf multiple
+  $ cat > "dune-project" << EOF
+  > (lang dune 3.20)
+  > (package (name param))
+  > (using oxcaml 0.1)
+  > EOF
+  $ dune build @install
+
+We check the META files exist.
+
+  $ cat _build/install/default/lib/param/META
+  package "intf" (
+    directory = "intf"
+    description = ""
+    requires = ""
+    archive(byte) = ""
+    archive(native) = ""
+    plugin(byte) = ""
+    plugin(native) = ""
+  )
+  package "intf2" (
+    directory = "intf2"
+    description = ""
+    requires = ""
+    archive(byte) = ""
+    archive(native) = ""
+    plugin(byte) = ""
+    plugin(native) = ""
+  )
+
+We ensure we have access to the `dune-package` and it contains the two
+parameters.
+
+  $ cat _build/install/default/lib/param/dune-package | grep -v "lang dune"
+  (name param)
+  (sections (lib .))
+  (files
+   (lib
+    (META
+     dune-package
+     intf/param_intf.cmi
+     intf/param_intf.cmti
+     intf/param_intf.mli
+     intf2/param_intf2.cmi
+     intf2/param_intf2.cmti
+     intf2/param_intf2.mli)))
+  (library
+   (name param.intf)
+   (kind parameter)
+   (modes byte)
+   (modules
+    (singleton
+     (obj_name param_intf)
+     (visibility public)
+     (kind parameter)
+     (source (path Param_intf) (intf (path intf/param_intf.mli))))))
+  (library
+   (name param.intf2)
+   (kind parameter)
+   (modes byte)
+   (modules
+    (singleton
+     (obj_name param_intf2)
+     (visibility public)
+     (kind parameter)
+     (source (path Param_intf2) (intf (path intf2/param_intf2.mli))))))
+
+We verify it will install the data to the correct location.
+
+  $ cat _build/default/param.install
+  lib: [
+    "_build/install/default/lib/param/META"
+    "_build/install/default/lib/param/dune-package"
+    "_build/install/default/lib/param/intf/param_intf.cmi" {"intf/param_intf.cmi"}
+    "_build/install/default/lib/param/intf/param_intf.cmti" {"intf/param_intf.cmti"}
+    "_build/install/default/lib/param/intf/param_intf.mli" {"intf/param_intf.mli"}
+    "_build/install/default/lib/param/intf2/param_intf2.cmi" {"intf2/param_intf2.cmi"}
+    "_build/install/default/lib/param/intf2/param_intf2.cmti" {"intf2/param_intf2.cmti"}
+    "_build/install/default/lib/param/intf2/param_intf2.mli" {"intf2/param_intf2.mli"}
+  ]
+

--- a/test/blackbox-tests/test-cases/oxcaml/parameter-deps.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameter-deps.t
@@ -1,0 +1,38 @@
+Test that the parameters support access to the dependencies
+
+  $ . ./helpers.sh
+  $ init_project
+
+Creates a library that exports a module we can later import as part of the library
+
+  $ make_dir_with_dune "signature" <<EOF
+  > (library
+  >  (name signature))
+  > EOF
+  $ cat > "signature/signature.ml" <<EOF
+  > module type S = sig
+  >  val some_int: int
+  > end
+  > EOF
+
+Use the library in a library_parameter.
+
+  $ make_dir_with_dune "param_intf" <<EOF
+  > (library_parameter
+  >  (name param_intf)
+  >  (libraries signature))
+  > EOF
+  $ cat > "param_intf/param_intf.mli" <<EOF
+  > module M : Signature.S
+  > EOF
+
+We build the expected `cmi` and check if it is available from the _build dir.
+This test will be extended later to support the implementation and the
+parametrized library.
+
+  $ dune build $(target_cmi "param_intf")
+
+We ensure it built the parameter.
+
+  $ ocamlobjinfo "$(build_target_cmi 'param_intf')" | grep "Is parameter"
+  Is parameter: YES


### PR DESCRIPTION
This PR is the first of a set of four PRs related to the introduction of Parameterized Libraries in Dune.

This feature is only available with OxCaml until it is upstream to the compiler. 

It contains multiples changes:
- Support for the `library_parameter` stanza
- Test of the newly introduced stanza. The tests will be updated with the next PRs.
- The documentation related to the new stanza.

Closes #12084 
