### PR TITLE
Document that executables using `dune-configurator` depend on config file

### DIFF
--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -66,7 +66,8 @@ example:
         [ "HAS_CLOCK_GETTIME", Switch has_clock_gettime ]);
 
 Usually, the module above would be named ``discover.ml``. The next step is to
-invoke it as an executable and tell Dune about the targets that it produces:
+invoke it as an executable and tell Dune about the targets that it produces and
+that it depends on ``dune-configurator``'s configuration file:
 
 .. code-block:: dune
 
@@ -76,6 +77,8 @@ invoke it as an executable and tell Dune about the targets that it produces:
 
   (rule
    (targets config.h)
+   (deps
+    (glob_files %{workspace_root}/.dune/configurator*))
    (action (run ./discover.exe)))
 
 Another common pattern is to produce a flags file with Configurator and then


### PR DESCRIPTION
This PR proposes to document in the example of a program using `dune-configurator` that it depends on the configuration file it will read so that dune will know it must run the program again if and when the configuration changes. The proposed approach uses a glob to make it a bit more robust to changes (of file names or paths and `dune-configurator` versions).

The corresponding issue, namely a case in which the program should be run again and wasn’t, came up with the [mirage-crypto] project which uses `dune-configurator` to detect some C flags that are specific to the target architecture: a change of the target architecture from `x86_64` to `arm64` didn’t trigger a re-run of the configure program; then the build failed when trying to pass `x86_64`-specific flags to the `arm64` gcc compiler.

The explicit dependency suggested by this PR fixes that issue. The question that arose in the [mirage-crypto] PR is whether that’s the proper way to express that dependency, as it is referring to files that are created implicitly by dune. What do you think about that?

[mirage-crypto]: https://github.com/mirage/mirage-crypto/pull/267