### PR TITLE
test: disable exec-watch tests

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -15,5 +15,10 @@
  (applies_to exec-watch-server exec-watch-ignore-sigterm exec-signal)
  (enabled_if false))
 
+; CR Alizter: renable all tests again, work out what causes the CI to hang
+
+(cram 
+ (enabled_if false))
+
 (cram
  (deps wait-for-file.sh))


### PR DESCRIPTION
Let's disable this again until we work out exactly what is causing the CI to hang.