### PR TITLE
refactor: optimize reading files

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -125,7 +125,7 @@ let read_exit_codes_and_prefix_maps file =
     | None -> ""
     | Some file ->
       (try Io.read_file ~binary:true file with
-       | Sys_error _ ->
+       | Unix.Unix_error _ | Sys_error _ ->
          (* a script where the first command immediately exits might not produce
             the metadata file *)
          "")

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -79,7 +79,7 @@ Check that the reported digests make sense
   $ dune_cmd cat $DUNE_CACHE_ROOT/files/v4/73/7378fb2d7d80dc4468d6558d864f0897
   old-content
   $ dune_cmd cat $DUNE_CACHE_ROOT/files/v4/074/074ebdc1c3853f27c68566d8d183032c
-  Fatal error: exception Sys_error("$TESTCASE_ROOT/.cache/files/v4/074/074ebdc1c3853f27c68566d8d183032c: No such file or directory")
+  Fatal error: exception Unix.Unix_error(Unix.ENOENT, "open", "$TESTCASE_ROOT/.cache/files/v4/074/074ebdc1c3853f27c68566d8d183032c")
   [2]
 
 Check that probability values less than zero and greater than one are rejected

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -47,8 +47,7 @@ Building fails as the patch cannot be found anymore
 
   $ build_pkg test 2>&1 | sed 's|\.sandbox/[a-f0-9]*/|.sandbox/<hash>/|'
   Error:
-  _build/.sandbox/<hash>/_private/default/.pkg/test/source/foo.patch:
-  No such file or directory
+  open(_build/.sandbox/<hash>/_private/default/.pkg/test/source/foo.patch): No such file or directory
   -> required by _build/_private/default/.pkg/test/target
 
 And the backage cannot be shown:

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -52,10 +52,7 @@ let%expect_test _ =
     read_file ~path:(Path.of_string "file_that_does_not_exist") |> map ~f:ignore
   in
   run_action_expect_throws action;
-  [%expect
-    {|
-    read_file: file_that_does_not_exist: No such file or directory
-  |}]
+  [%expect {| read_file: open(file_that_does_not_exist): No such file or directory |}]
 ;;
 
 let%expect_test _ =


### PR DESCRIPTION
Using channels to read a file into a string is rather slow and creates a mutex + a bunch of useless intermediate buffers.

We instead initialize the buffer once before reading.

This optimization has been used internally for ages with great success. This is an attempt to make a portable version of it.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>