### PR TITLE
refactor: use optimized write file

### DIFF
--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -77,7 +77,5 @@ let%expect_test _ =
   in
   run_action_expect_throws action;
   [%expect
-    {|
-    write_file: directory_that_does_not_exist/some_file: No such file or directory
-  |}]
+    {| write_file: open(directory_that_does_not_exist/some_file): No such file or directory |}]
 ;;


### PR DESCRIPTION
* Do not create a channel
* Try writing everything in a single syscall

This optimization was also pretty important internally. This is a more portable re-implementation

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>