### PR TITLE
tui: better visual delimeters

### DIFF
--- a/src/dune_tui/drawing.ml
+++ b/src/dune_tui/drawing.ml
@@ -107,8 +107,6 @@ let pp_to_image =
 ;;
 
 module Unicode = struct
-  let ogham_feather_mark = Uchar.of_int 0x169B
-  let ogham_reversed_feather_mark = Uchar.of_int 0x169C
   let horizontal_bar = Uchar.of_int 0x2015
   let box_drawings_double_horizontal = Uchar.of_int 0x2550
   let box_drawings_double_vertical = Uchar.of_int 0x2551

--- a/src/dune_tui/drawing.mli
+++ b/src/dune_tui/drawing.mli
@@ -19,12 +19,6 @@ val box_with_title : attr:A.t -> title:string -> title_attr:A.t -> I.t -> I.t
 module Unicode : sig
   (** Unicode constants useful for drawing. *)
 
-  (** ᚛ U+169B *)
-  val ogham_feather_mark : Uchar.t
-
-  (** ᚜ U+169C *)
-  val ogham_reversed_feather_mark : Uchar.t
-
   (** ― U+2015 *)
   val horizontal_bar : Uchar.t
 

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -96,27 +96,27 @@ module Message_viewer = struct
     let index_is_hidden = is_hidden index in
     let status =
       I.hcat
-        [ I.uchar divider_attr Unicode.ogham_reversed_feather_mark 1 1
+        [ I.uchar divider_attr (Uchar.of_char '[') 1 1
         ; I.string user_feedback_attr (string_of_int (index + 1))
         ; I.string divider_attr "/"
         ; I.string user_feedback_attr (string_of_int total)
-        ; I.uchar divider_attr Unicode.ogham_feather_mark 1 1
+        ; I.uchar divider_attr (Uchar.of_char ']') 1 1
         ]
     in
     let toggle_indicator =
       I.hcat
-        [ I.uchar divider_attr Unicode.ogham_reversed_feather_mark 1 1
+        [ I.uchar divider_attr (Uchar.of_char '[') 1 1
         ; (if index_is_hidden then I.string helper_attr "+" else I.string helper_attr "-")
-        ; I.uchar divider_attr Unicode.ogham_feather_mark 1 1
+        ; I.uchar divider_attr (Uchar.of_char ']') 1 1
         ]
     in
     let synopsis =
       if index_is_hidden
       then
         I.hcat
-          [ I.hpad 1 0 @@ I.uchar divider_attr Unicode.ogham_reversed_feather_mark 1 1
+          [ I.hpad 1 0 @@ I.uchar divider_attr (Uchar.of_char '[') 1 1
           ; synopsis
-          ; I.uchar divider_attr Unicode.ogham_feather_mark 1 1
+          ; I.uchar divider_attr (Uchar.of_char ']') 1 1
           ]
       else I.empty
     in
@@ -223,9 +223,9 @@ let status_bar =
     let+ { toggle; _ } = help_box in
     let image =
       I.hcat
-        [ I.uchar helper_attr Unicode.ogham_reversed_feather_mark 1 1
+        [ I.uchar helper_attr (Uchar.of_char '[') 1 1
         ; I.char user_feedback_attr '?' 1 1
-        ; I.uchar helper_attr Unicode.ogham_feather_mark 1 1
+        ; I.uchar helper_attr (Uchar.of_char ']') 1 1
         ]
     in
     Button.of_ (Ui.atom image) toggle
@@ -236,13 +236,7 @@ let status_bar =
     | Some message -> Drawing.pp_to_image message
   in
   let status =
-    I.hcat
-      [ I.uchar helper_attr Unicode.ogham_reversed_feather_mark 1 1
-      ; I.char helper_attr ' ' 1 1
-      ; status
-      ; I.char helper_attr ' ' 1 1
-      ; I.uchar helper_attr Unicode.ogham_feather_mark 1 1
-      ]
+    I.hcat [ I.char helper_attr ' ' 1 1; status; I.char helper_attr ' ' 1 1 ]
   in
   let hsnap_or_leave ~width img =
     if I.width img < width then I.hsnap ~align:`Middle width img else img


### PR DESCRIPTION
We previously used Ogham feather marks for dressing up the status bar and various buttons. This turned out to be a poor choice due to the variance in rendering styles.

We instead use square brackets since they are rendered a bit more consistently.

Before:

![Screenshot From 2025-07-06 19-08-23](https://github.com/user-attachments/assets/fd2bbab3-097e-4642-9b55-717b62050e7c)

After:

![Screenshot From 2025-07-06 19-26-05](https://github.com/user-attachments/assets/42cca9b8-2d5a-4d4f-b57e-afaac0973c2f)
