### PR TITLE
test(melange): show melange emits the (empty) module group wrapper

### DIFF
--- a/test/blackbox-tests/test-cases/melange/melange-wrapper-module.t
+++ b/test/blackbox-tests/test-cases/melange/melange-wrapper-module.t
@@ -1,0 +1,34 @@
+Show that Dune shouldn't emit a JS file for the `melange.emit` module group
+wrapper
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias dist)
+  >  (target dist)
+  >  (emit_stdlib false))
+  > EOF
+
+If there's more than 1 module, we currently emit the module group wrapper,
+`.dist.mobjs/melange.js`
+
+  $ cat > x.ml <<EOF
+  > let () = print_endline "x"
+  > EOF
+  $ cat > y.ml <<EOF
+  > let () = print_endline "y"
+  > EOF
+
+  $ dune build @dist --display=short 2>&1 | grep 'melange\.js'
+          melc dist/.dist.mobjs/melange.js
+  $ ls -a _build/default/dist
+  .
+  ..
+  .dist.mobjs
+  x.js
+  y.js
+


### PR DESCRIPTION
the empty wrapper shouldn't be emitted, as
1. it'll always be empty
2. uses a hidden directory
3. confuses users