### PR TITLE
feat(tui): click to go to file

### DIFF
--- a/src/dune_tui/dune
+++ b/src/dune_tui/dune
@@ -9,7 +9,9 @@
   dune_notty_unix
   dune_config
   dune_console
+  dune_spawn
   dune_threaded_console
+  ocamlc_loc
   threads.posix))
 
 (include_subdirs unqualified)


### PR DESCRIPTION
If a user message has an associated location, we can now click on messages to open the users `EDITOR` at that location.

TODO:
- [x] mouse events are not handed back to tui after exiting the `EDITOR`.
- [x] Some messages, especially from the OCaml compiler, don't have locations. -- Compiler messages have embedded locations. We can detect these and do a bit more work to extract a workable location.
- [ ] Better user feedback when editor is not set or the file cannot be opened
- [x] Instruct editor to go to location?