### PR TITLE
fix(cram): do not re-run tests unnecessarily

### DIFF
--- a/doc/changes/11194.md
+++ b/doc/changes/11194.md
@@ -1,0 +1,2 @@
+- Stop re-running cram tests after promotion when it's not necessary (#11994,
+  @rgrinberg)

--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -1,3 +1,13 @@
 open Import
 
+(** Produces the script containing only the commands to run *)
+val make_script : src:Path.t -> script:Path.Build.t -> Action.t
+
+(** Runs the script created in [make_script] *)
+val run : dir:Path.t -> script:Path.t -> output:Path.Build.t -> Action.t
+
+(** Produces a diff if [src] needs to be updated *)
+val diff : src:Path.t -> output:Path.t -> Action.t
+
+(** Corresponds the user written cram action *)
 val action : Path.t -> Action.t

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -6,7 +6,7 @@ module Map_reduce =
     (Memo)
     (Monoid.Product (Monoid.Union (Path.Set)) (Monoid.Union (Path.Set)))
 
-let files dir =
+let files_with_filter dir ~filter =
   let prefix_with, dir = Path.extract_build_context_dir_exn dir in
   Source_tree.find_dir dir
   >>= function
@@ -23,6 +23,7 @@ let files dir =
             Source_tree.Dir.filenames dir
             |> String.Set.to_list
             |> Path.Set.of_list_map ~f:(fun fn -> Path.relative path fn)
+            |> Path.Set.filter ~f:filter
           in
           let empty_directories =
             if Path.Set.is_empty files then Path.Set.singleton path else Path.Set.empty
@@ -31,3 +32,5 @@ let files dir =
     in
     Dep.Set.of_source_files ~files ~empty_directories, files
 ;;
+
+let files = files_with_filter ~filter:(Fun.const true)

--- a/src/dune_rules/source_deps.mli
+++ b/src/dune_rules/source_deps.mli
@@ -1,5 +1,10 @@
 open Import
 
+val files_with_filter
+  :  Path.t
+  -> filter:(Path.t -> bool)
+  -> (Dep.Set.t * Path.Set.t) Memo.t
+
 (** [files path] returns all the source dependencies starting from [path]. If
     [path] isn't in the source, the empty dependency set and an empty path set
     is returned *)

--- a/test/blackbox-tests/test-cases/cram/cram-double-alias.t
+++ b/test/blackbox-tests/test-cases/cram/cram-double-alias.t
@@ -22,4 +22,4 @@ aliases that are being built together.
 
 Here we make sure that the cram test is only run once
   $ cat _build/log | grep dune_cram | sed 's/.*dune_cram_[0-9a-f]*_/dune_cram_HASH_/g'
-  dune_cram_HASH_.foo.t/main.sh)
+  dune_cram_HASH_.cram.sh/main.sh)

--- a/test/blackbox-tests/test-cases/cram/double-run-promote.t
+++ b/test/blackbox-tests/test-cases/cram/double-run-promote.t
@@ -24,4 +24,3 @@ side-effect should only contain a single "run":
 
   $ cat side-effect
   run
-  run

--- a/test/blackbox-tests/test-cases/cram/test-dir-contents.t
+++ b/test/blackbox-tests/test-cases/cram/test-dir-contents.t
@@ -16,6 +16,7 @@ Demonstrate the files and directories listed in a cram test:
   $ cat test.t
     $ find . | sort
     .
+    ./.cram.test.t
 
   $ ls _build/default | sort
   test.t

--- a/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
+++ b/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
@@ -34,8 +34,7 @@ Run the cram test, should fail and file should be promoted
   File "my_cram.t/run.t", line 1, characters 0-0:
   Error: Files _build/default/my_cram.t/run.t and
   _build/default/my_cram.t/run.t.corrected differ.
-  Error:
-  rename(_build/.sandbox/$SANDBOX/default/my_cram.t/run.t.corrected): Not a directory
+  Error: rename(_build/default/my_cram.t/run.t.corrected): Not a directory
   -> required by alias my_cram
   -> required by alias runtest
 

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -43,6 +43,10 @@ let%expect_test "persistent digests" =
     72eb282c39bb084e69d6bd1615b8aaec
     ---
 
+    CRAM-RESULT version 1
+    65e543aaf5ccc8148d50a1305aa3622b
+    ---
+
     merlin-conf version 7
     a14a4700929a15bb2030e36f71e66d20
     ---


### PR DESCRIPTION
## Problem

When running a cram test and then promoting its result, dune will immediately re-run the test to confirm the result is valid. This step is unnecessary when the set of commands does not change after the promotion. This PR avoids the unnecesasry re-running in exactly this case.

## How it Works?

We factor out the single cram action into 3 components:

1. An action that generates the set of commands from the cram test. This corresponds to the script we're going to execute
2. An action that executes the script in step 1. and produces the output in a serialized form.
3. An action that diffs the output produced by step 2. against the original script.