### PR TITLE
pkg: add command to install dev tools

### DIFF
--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -6,6 +6,15 @@ module Exec = struct
   let group = Cmd.group info [ Ocamlformat.Exec.command; Ocamllsp.Exec.command ]
 end
 
+module Install = struct
+  let doc = "Command group for installing wrapped tools."
+  let info = Cmd.info ~doc "install"
+
+  let group =
+    Cmd.group info (List.map [ Ocamlformat; Ocamllsp ] ~f:Tools_common.install_command)
+  ;;
+end
+
 module Which = struct
   let doc = "Command group for printing the path to wrapped tools."
   let info = Cmd.info ~doc "which"
@@ -17,4 +26,4 @@ end
 
 let doc = "Command group for wrapped tools."
 let info = Cmd.info ~doc "tools"
-let group = Cmd.group info [ Exec.group; Which.group ]
+let group = Cmd.group info [ Exec.group; Install.group; Which.group ]

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -88,3 +88,17 @@ let which_command dev_tool =
   in
   Cmd.v info term
 ;;
+
+let install_command dev_tool =
+  let exe_name = Pkg_dev_tool.exe_name dev_tool in
+  let term =
+    let+ builder = Common.Builder.term in
+    let common, config = Common.init builder in
+    lock_and_build_dev_tool ~common ~config dev_tool
+  in
+  let info =
+    let doc = sprintf "Install %s as a dev tool" exe_name in
+    Cmd.info exe_name ~doc
+  in
+  Cmd.v info term
+;;

--- a/bin/tools/tools_common.mli
+++ b/bin/tools/tools_common.mli
@@ -11,3 +11,4 @@ val lock_build_and_run_dev_tool
   -> 'a
 
 val which_command : Dune_pkg.Dev_tool.t -> unit Cmd.t
+val install_command : Dune_pkg.Dev_tool.t -> unit Cmd.t

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -1,0 +1,16 @@
+Test `dune tools which ocamlformat`:
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.2"
+  $ make_ocamlformat_opam_pkg "0.26.2"
+  $ make_project_with_dev_tool_lockdir
+
+Install ocamlformat as a dev tool:
+  $ dune tools install ocamlformat
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+
+Verify that ocamlformat is installed:
+  $ dune tools which ocamlformat
+  _build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin/ocamlformat


### PR DESCRIPTION
Formerly the only way to install dev tools was by running them, leading to people coming up with workarounds for installing tools, such as running dev tools with "--version". This change adds a dedicated command for install dev tools without running them.

CC @pitag-ha