### PR TITLE
pkg: command to check if project intends to use dune package management

### DIFF
--- a/bin/pkg/pkg.ml
+++ b/bin/pkg/pkg.ml
@@ -8,7 +8,12 @@ let man =
 ;;
 
 let subcommands =
-  [ Lock.command; Print_solver_env.command; Outdated.command; Validate_lock_dir.command ]
+  [ Lock.command
+  ; Print_solver_env.command
+  ; Outdated.command
+  ; Validate_lock_dir.command
+  ; Pkg_enabled.command
+  ]
 ;;
 
 let info name =

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -169,6 +169,8 @@ module Lock_dirs_arg = struct
     | All
     | Selected of Path.Source.t list
 
+  let all = All
+
   let term =
     Common.one_of
       (let+ arg =

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -62,6 +62,9 @@ module Lock_dirs_arg : sig
       [Lock_dirs_arg.lock_dirs_of_workspace]. *)
   type t
 
+  (** Select all lockdirs *)
+  val all : t
+
   (** [Lock_dirs_arg.term] is a command-line argument that can be used to
       specify the lock directories to consider. This can then be passed to
       [Lock_dirs_arg.lock_dirs_of_workspace].

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -1,0 +1,31 @@
+open Import
+
+let term =
+  let+ builder = Common.Builder.term in
+  let common, config = Common.init builder in
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    Memo.run
+    @@
+    let open Memo.O in
+    let+ workspace = Workspace.workspace () in
+    let lock_dir_paths =
+      Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace
+        Pkg_common.Lock_dirs_arg.all
+        workspace
+    in
+    let any_lockdir_exists =
+      List.exists lock_dir_paths ~f:(fun lock_dir_path ->
+        Path.exists (Path.source lock_dir_path))
+    in
+    if any_lockdir_exists then () else exit 1)
+;;
+
+let info =
+  let doc =
+    "Check if the project indicates that dune's package management features should be \
+     enabled. Exits with 0 if package management is enabled and 1 otherwise."
+  in
+  Cmd.info "enabled" ~doc
+;;
+
+let command = Cmd.v info term

--- a/bin/pkg/pkg_enabled.mli
+++ b/bin/pkg/pkg_enabled.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -1,0 +1,41 @@
+Exercise the "dune pkg enabled" command which checks whether package management
+should be used.
+
+  $ . ./helpers.sh
+
+  $ mkrepo
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (lock_dir
+  >  (path dune.lock)
+  >  (repositories mock))
+  > (lock_dir
+  >  (path dune.other.lock)
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (allow_empty)
+  >  (name foo))
+  > EOF
+
+When no lockdir is present pkg is not enabled:
+  $ dune pkg enabled
+  [1]
+
+When the default lockdir is present pkg is enabled:
+  $ dune pkg lock > /dev/null 2> /dev/null
+
+  $ dune pkg enabled
+
+  $ rm -r dune.lock
+
+When a non-default lockdir is present, pkg is still enabled:
+  $ dune pkg lock dune.other.lock > /dev/null 2> /dev/null
+  $ dune pkg enabled


### PR DESCRIPTION
Some users have been using the presence of the dune.lock directory to determine whether a project is locked. This is brittle as other lockdir names are possible. It also doesn't align with the mental model for lockdirs in dune in that dune projects may have multiple lockdirs, so the "lockedness" of a project depends on which lockdir you are interested in. Finally, there's no guarantee that the current default lockdir name or location is not stable; it may change in a future dune version.

This change introduces a new command `dune pkg is-locked` which prints whether each specified lockdir exists (using the same lockdir selection logic as `dune pkg lock`) and exits 0 only if all specified lockdirs exist. Using this command should be more stable than checking for the existence of dune.lock.