### PR TITLE
test: building pform exes has incorrect root

### DIFF
--- a/test/blackbox-tests/test-cases/pform-exe.t
+++ b/test/blackbox-tests/test-cases/pform-exe.t
@@ -1,0 +1,28 @@
+Testing the building of executables specified by pforms in Dune.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > (package (name foo-pkg))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name foo))
+  > EOF
+
+  $ cat > foo.ml
+
+dune build is able to expand pforms, but it appears that the root is incorrect.
+
+  $ dune build %{bin:foo}
+  Error: File unavailable:
+  $TESTCASE_ROOT/../install/default/bin/foo
+  [1]
+
+This can be mitigated by specifying a build path:
+
+  $ dune build _build/default/%{bin:foo}
+
+dune exec has special support for expanding pforms for bin.
+
+  $ dune exec -- %{bin:foo}


### PR DESCRIPTION
When building `%{bin:foo}` with `dune build` we are expanding the pform relative to the wrong root. It's not even clear what the correct root here would be since we would need to know the intended build context.

I think we could do something a bit more sensible however. Not quite sure just yet.