### PR TITLE
test: demonstrate cram test adding new commands

### DIFF
--- a/test/blackbox-tests/test-cases/cram/recursive-promote.t
+++ b/test/blackbox-tests/test-cases/cram/recursive-promote.t
@@ -1,0 +1,45 @@
+Demonstrate that cram tests that add new commands are correctly executed:
+
+  $  cat >dune-project <<EOF
+  > (lang dune 3.17)
+  > EOF
+
+  $ cat >test.t <<EOF
+  >   $ echo "$ echo foo"
+  > EOF
+
+  $ runTest() {
+  > dune runtest test.t
+  > dune promote
+  > cat test.t
+  > }
+
+  $ runTest
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  Promoting _build/default/test.t.corrected to test.t.
+    $ echo "$ echo foo"
+    $ echo foo
+
+  $ runTest
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  Promoting _build/default/test.t.corrected to test.t.
+    $ echo "$ echo foo"
+    $ echo foo
+    $ echo foo
+    foo
+
+  $ runTest
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  Promoting _build/default/test.t.corrected to test.t.
+    $ echo "$ echo foo"
+    $ echo foo
+    $ echo foo
+    foo
+    $ echo foo
+    foo


### PR DESCRIPTION
When such a cram test executes, it produces a new command in the test file. This means that we need to execute it after promoting to get the final result.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>