### PR TITLE
ci: run tests with nix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,7 +54,7 @@ jobs:
           extra_nix_config: |
             extra-substituters = https://anmonteiro.nix-cache.workers.dev
             extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
-      - run: nix develop -i --set-env-var NIX_CI true -c make test
+      - run: nix develop -i -c make test
 
   fmt:
     name: Format

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,8 +16,80 @@ permissions:
   contents: read
 
 jobs:
+
+#
+# Stage 1
+#
+
+  nix-build:
+    name: Nix Build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - run: nix build
+
+  nix-test:
+    name: Nix Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - run: nix develop -i --set-env-var NIX_CI true -c make test
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - run: nix develop .#fmt -c make fmt
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - run: nix develop .#doc -c make doc
+        env:
+          LC_ALL: C
+
+#
+# Stage 2
+#
+
   build:
     name: Build
+    # we only start building our other jobs, once our main tests have passed
+    needs: nix-test
     strategy:
       fail-fast: false
       matrix:
@@ -115,52 +187,9 @@ jobs:
         run: opam install ./dune-configurator.opam
         if: ${{ matrix.configurator == true }}
 
-  nix:
-    name: Nix
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://anmonteiro.nix-cache.workers.dev
-            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
-      - run: nix build
-
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://anmonteiro.nix-cache.workers.dev
-            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
-      - run: nix develop .#fmt -c make fmt
-
-  doc:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://anmonteiro.nix-cache.workers.dev
-            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
-      - run: nix develop .#doc -c make doc
-        env:
-          LC_ALL: C
-
   coq:
     name: Coq 8.16.1
+    needs: nix-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -176,6 +205,7 @@ jobs:
 
   wasm:
     name: Wasm_of_ocaml
+    needs: nix-build
     runs-on: ubuntu-latest
     steps:
       - name: Install Node
@@ -213,6 +243,7 @@ jobs:
 
   create-local-opam-switch:
     name: Create local opam switch
+    needs: nix-build
     strategy:
       fail-fast: true
       matrix:
@@ -238,6 +269,7 @@ jobs:
 
   build-microbench:
     name: Build microbenchmarks
+    needs: nix-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -102,43 +102,41 @@ jobs:
           # OCaml trunk:
           - ocaml-compiler: ocaml-variants.5.4.0+trunk
             os: ubuntu-latest
-            skip_test: true
           # OCaml 5:
           ## ubuntu (x86)
           - ocaml-compiler: 5.3.x
             os: ubuntu-latest
+            run_tests: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 5.3.x
             os: macos-latest
+            run_tests: true
           ## macos (x86)
           - ocaml-compiler: 5.3.x
             os: macos-13
-            skip_test: true
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.3.0,system-msvc
             os: windows-latest
+            run_tests: true
           ## mingw
           - ocaml-compiler: ocaml-base-compiler.5.3.0,system-mingw
             os: windows-latest
+            run_tests: true
           # OCaml 4:
           ## ubuntu (x86)
           - ocaml-compiler: 4.14.x
             os: ubuntu-latest
-            skip_test: true
           ## ubuntu (x86-32)
           - ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
             os: ubuntu-latest
-            skip_test: true
             apt_update: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 4.14.x
             os: macos-latest
-            skip_test: true
           # OCaml 4.08:
           ## ubuntu (x86)
           - ocaml-compiler: 4.08.x
             os: ubuntu-latest
-            skip_test: true
 
     runs-on: ${{ matrix.os }}
 
@@ -172,15 +170,15 @@ jobs:
         run: |
           opam install . --deps-only --with-test
           opam exec -- make dev-deps
-        if: ${{ matrix.skip_test == false }}
+        if: ${{ matrix.run_tests }}
 
       - name: Run test suite on Unix
         run: opam exec -- make test
-        if: ${{ matrix.os != 'windows-latest' && matrix.skip_test == false }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.run_tests }}
 
       - name: Run test suite on Win32
         run: opam exec -- make test-windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.skip_test == false }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.run_tests }}
 
       # We never build configurator
       - name: Build configurator

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,6 +110,7 @@ jobs:
         run: opam exec -- make test-windows
         if: ${{ matrix.os == 'windows-latest' && matrix.skip_test == false }}
 
+      # We never build configurator
       - name: Build configurator
         run: opam install ./dune-configurator.opam
         if: ${{ matrix.configurator == true }}

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,7 @@
 
       devShells =
         let
+          INSIDE_NIX = "true";
           makeDuneDevShell =
             { extraBuildInputs ? (pkgs: [ ])
             , meta ? null
@@ -188,11 +189,13 @@
                 lwt
                 patdiff
               ] ++ (extraBuildInputs pkgs'));
+              inherit INSIDE_NIX;
             };
         in
         {
           doc =
             pkgs.mkShell {
+              inherit INSIDE_NIX;
               buildInputs = docInputs;
               meta.description = ''
                 Provides a shell environment suitable for building the Dune
@@ -202,6 +205,7 @@
 
           fmt =
             pkgs.mkShell {
+              inherit INSIDE_NIX;
               nativeBuildInputs = [ ocamlformat ];
               inputsFrom = [ pkgs.dune_3 ];
               meta.description = ''
@@ -226,6 +230,7 @@
             '';
           };
           slim-opam = with pkgs; mkShell {
+            inherit INSIDE_NIX;
             nativeBuildInputs = lib.remove pkgs.ocamlformat (testNativeBuildInputs pkgs);
             buildInputs = lib.optionals stdenv.isDarwin [
               darwin.apple_sdk.frameworks.CoreServices
@@ -238,6 +243,7 @@
 
           coq =
             pkgs.mkShell {
+              inherit INSIDE_NIX;
               nativeBuildInputs = (testNativeBuildInputs pkgs);
               # Coq requires OCaml 4.x
               inputsFrom = [ pkgs.ocaml-ng.ocamlPackages_4_14.dune_3 ];

--- a/otherlibs/dune-site/test/dune
+++ b/otherlibs/dune-site/test/dune
@@ -4,10 +4,13 @@
   (package dune)
   (package dune-site)))
 
+; The test being broken on CI, we deactivate it when
+; we detect that the CI environment variable is not
+; set. Most CI systems set it.
+
 (cram
  (applies_to run_2_9 run)
  (enabled_if
   (and
-   (<> %{os_distribution} nixos)
    (not %{env:CI=false})
-   (not %{env:NIX_CI=false}))))
+   (not %{env:INSIDE_NIX=false}))))

--- a/otherlibs/dune-site/test/dune
+++ b/otherlibs/dune-site/test/dune
@@ -4,13 +4,10 @@
   (package dune)
   (package dune-site)))
 
-; The test being broken on CI, we deactivate it when
-; we detect that the CI environment variable is not
-; set. Most CI systems set it.
-
 (cram
  (applies_to run_2_9 run)
  (enabled_if
   (and
    (<> %{os_distribution} nixos)
-   (not %{env:CI=false}))))
+   (not %{env:CI=false})
+   (not %{env:NIX_CI=false}))))

--- a/test/blackbox-tests/test-cases/melange/dune
+++ b/test/blackbox-tests/test-cases/melange/dune
@@ -11,9 +11,7 @@
 (cram
  (deps %{bin:melc_stdlib_prefix})
  (enabled_if
-  (and
-   (<> %{os_distribution} nixos)
-   (not %{env:NIX_CI=false})))
+  (not %{env:INSIDE_NIX=false}))
  (applies_to merlin))
 
 (cram

--- a/test/blackbox-tests/test-cases/melange/dune
+++ b/test/blackbox-tests/test-cases/melange/dune
@@ -11,7 +11,9 @@
 (cram
  (deps %{bin:melc_stdlib_prefix})
  (enabled_if
-  (<> %{os_distribution} nixos))
+  (and
+   (<> %{os_distribution} nixos)
+   (not %{env:NIX_CI=false})))
  (applies_to merlin))
 
 (cram

--- a/test/blackbox-tests/test-cases/merlin/dune
+++ b/test/blackbox-tests/test-cases/merlin/dune
@@ -8,9 +8,7 @@
 
 (cram
  (enabled_if
-  (and
-   (<> %{os_distribution} nixos)
-   (not %{env:NIX_CI=false})))
+  (not %{env:INSIDE_NIX=false}))
  (applies_to github4125)
  (deps %{bin:opam}))
 
@@ -27,8 +25,6 @@
 (cram
  (applies_to dialect)
  (enabled_if
-  (and
-   (<> %{os_distribution} nixos)
-   (not %{env:NIX_CI=false})))
+  (not %{env:INSIDE_NIX=false}))
  (deps %{bin:melc})
  (alias runtest-melange))

--- a/test/blackbox-tests/test-cases/merlin/dune
+++ b/test/blackbox-tests/test-cases/merlin/dune
@@ -8,7 +8,9 @@
 
 (cram
  (enabled_if
-  (<> %{os_distribution} nixos))
+  (and
+   (<> %{os_distribution} nixos)
+   (not %{env:NIX_CI=false})))
  (applies_to github4125)
  (deps %{bin:opam}))
 
@@ -25,6 +27,8 @@
 (cram
  (applies_to dialect)
  (enabled_if
-  (<> %{os_distribution} nixos))
+  (and
+   (<> %{os_distribution} nixos)
+   (not %{env:NIX_CI=false})))
  (deps %{bin:melc})
  (alias runtest-melange))


### PR DESCRIPTION
In this PR we introduce CI jobs for running the tests with nix. We also introduce a dependency order to the rest of the CI.

Many of the platform specific tests won't run unless the main nix tests pass. The nix tests act as a point of early failure. It is a fast job since much of it is cached.

Similarly for the build jobs, many rely on the nix build. If the nix build doesn't work, then there is no point attempting to build the other jobs anyway.

This also stops the useless running of CI runners and availability issues when there is a lot of activity in the repository.

I've also noted that at some point we have stopped building dune configurator separately. I believe that this step was intended for OCaml jobs such as 4.08 to still be able to use it. It might be worth reintroducing that, but otherwise our usual configurator tests are run in more recent versions of OCaml.