### PR TITLE
test: demonstrate that we can't lock when dune is a local package

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/local-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/local-dune.t
@@ -1,0 +1,27 @@
+Dune is defined in the workspace where we're solving
+
+  $ . ./helpers.sh
+
+  $ mkrepo
+
+  $ mkpkg bar <<EOF
+  > depends: [ "dune" ]
+  > EOF
+
+  $ mkpkg test-dep <<EOF
+  > depends: [ "dune" ]
+  > EOF
+
+  $ solve_project <<EOF
+  > (lang dune 3.19)
+  > (package
+  >  (name dune)
+  >  (depends (test-dep :with-test)))
+  > (package
+  >  (name foo)
+  >  (depends bar))
+  > EOF
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "bar" is not in the workspace but it
+  depends on the package "dune" which is in the workspace.
+  [1]


### PR DESCRIPTION
This overlapping package restriction shouldn't be respected here since dune is already installed when we're locking.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>