### PR TITLE
Improve error message when git is not found

### DIFF
--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -55,7 +55,16 @@ let git, hg =
     lazy
       (match Bin.which ~path:(Env_path.path Env.initial) prog with
        | Some x -> x
-       | None -> Utils.program_not_found prog ~loc:None)
+       | None ->
+         let hint =
+           match prog with
+           | "git" ->
+             Some
+               "Git is required for version information in 'dune subst', build info, and \
+                package management. Install git or add it to your PATH."
+           | _ -> None
+         in
+         Utils.program_not_found prog ~loc:None ?hint)
   in
   get "git", get "hg"
 ;;


### PR DESCRIPTION
Previously when git was not available in PATH, users would see a generic 'Program git not found in the tree or in PATH' error. This change adds a helpful hint explaining why git is needed and how to resolve the issue.

The improved error now explains that git is required for:
- Version information in 'dune subst'
- Build info and artifact substitution
- Package management operations

Addresses #10393