### PR TITLE
Add a configuration option to enable package management

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -520,6 +520,7 @@ let shared_with_config_file =
   ; action_stdout_on_success
   ; action_stderr_on_success
   ; project_defaults = None
+  ; pkg_enabled = None
   ; experimental = None
   }
 ;;

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -17,7 +17,10 @@ let term =
       List.exists lock_dir_paths ~f:(fun lock_dir_path ->
         Path.exists (Path.source lock_dir_path))
     in
-    if any_lockdir_exists then () else exit 1)
+    let enabled = any_lockdir_exists || workspace.config.pkg_enabled in
+    match enabled with
+    | true -> ()
+    | false -> exit 1)
 ;;
 
 let info =

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -17,6 +17,8 @@ let term =
       List.exists lock_dir_paths ~f:(fun lock_dir_path ->
         Path.exists (Path.source lock_dir_path))
     in
+    (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
+       directories in the source tree *)
     let enabled = any_lockdir_exists || workspace.config.pkg_enabled in
     match enabled with
     | true -> ()

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -53,6 +53,14 @@ module Dune_config = struct
     ;;
   end
 
+  module Pkg_enabled = struct
+    type t = bool
+
+    let decode = enum' [ "enabled", return true; "disabled", return false ]
+    let equal = Bool.equal
+    let to_dyn = Dyn.bool
+  end
+
   module Terminal_persistence = struct
     type t =
       | Preserve
@@ -236,6 +244,7 @@ module Dune_config = struct
       ; action_stdout_on_success : Action_output_on_success.t field
       ; action_stderr_on_success : Action_output_on_success.t field
       ; project_defaults : Project_defaults.t field
+      ; pkg_enabled : Pkg_enabled.t field
       ; experimental : (string * (Loc.t * string)) list field
       }
   end
@@ -260,6 +269,7 @@ module Dune_config = struct
           ; action_stdout_on_success
           ; action_stderr_on_success
           ; project_defaults
+          ; pkg_enabled
           ; experimental
           }
       =
@@ -287,6 +297,7 @@ module Dune_config = struct
               (Tuple.T2.equal String.equal (Tuple.T2.equal Loc.equal String.equal)))
            t.experimental
            experimental
+      && field Pkg_enabled.equal t.pkg_enabled pkg_enabled
     ;;
   end
 
@@ -314,6 +325,7 @@ module Dune_config = struct
       ; action_stderr_on_success =
           field a.action_stderr_on_success b.action_stderr_on_success
       ; project_defaults = field a.project_defaults b.project_defaults
+      ; pkg_enabled = field a.pkg_enabled b.pkg_enabled
       ; experimental = field a.experimental b.experimental
       }
     ;;
@@ -338,6 +350,7 @@ module Dune_config = struct
           ; action_stdout_on_success
           ; action_stderr_on_success
           ; project_defaults
+          ; pkg_enabled
           ; experimental
           }
       =
@@ -358,6 +371,7 @@ module Dune_config = struct
         ; ( "action_stderr_on_success"
           , field Action_output_on_success.to_dyn action_stderr_on_success )
         ; "project_defaults", field Project_defaults.to_dyn project_defaults
+        ; "pkg_enabled", field Pkg_enabled.to_dyn pkg_enabled
         ; ( "experimental"
           , field Dyn.(list (pair string (fun (_, v) -> string v))) experimental )
         ]
@@ -382,6 +396,7 @@ module Dune_config = struct
       ; action_stdout_on_success = None
       ; action_stderr_on_success = None
       ; project_defaults = None
+      ; pkg_enabled = None
       ; experimental = None
       }
     ;;
@@ -467,6 +482,7 @@ module Dune_config = struct
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
+    ; pkg_enabled = false
     ; experimental = []
     }
   ;;
@@ -533,6 +549,7 @@ module Dune_config = struct
     and+ action_stderr_on_success =
       field_o "action_stderr_on_success" (3, 0) Action_output_on_success.decode
     and+ project_defaults = field_o "project_defaults" (3, 17) Project_defaults.decode
+    and+ pkg_enabled = field_o "pkg" (3, 20) Pkg_enabled.decode
     and+ experimental =
       field_o "experimental" (3, 8) (repeat (pair string (located string)))
     in
@@ -554,6 +571,7 @@ module Dune_config = struct
     ; action_stdout_on_success
     ; action_stderr_on_success
     ; project_defaults
+    ; pkg_enabled
     ; experimental
     }
   ;;

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -54,6 +54,10 @@ module Dune_config : sig
     end
   end
 
+  module Pkg_enabled : sig
+    type t = bool
+  end
+
   module Terminal_persistence : sig
     type t =
       | Preserve
@@ -83,6 +87,7 @@ module Dune_config : sig
       ; action_stdout_on_success : Action_output_on_success.t field
       ; action_stderr_on_success : Action_output_on_success.t field
       ; project_defaults : Project_defaults.t field
+      ; pkg_enabled : Pkg_enabled.t field
       ; experimental : (string * (Loc.t * string)) list field
       }
   end

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -47,7 +47,8 @@ enabled.
   $ dune pkg enabled
   [1]
 
-Manually enable package management in the workspace
+Manually enable package management in the workspace, it should be reported as
+enabled:
 
   $ cat > dune-workspace <<EOF
   > (lang dune 3.20)
@@ -56,11 +57,16 @@ Manually enable package management in the workspace
   $ dune pkg enabled && echo "Yes, it is enabled"
   Yes, it is enabled
 
+If we remove the setting from the workspace it should go back to the default
+(disabled)
+
   $ cat > dune-workspace <<EOF
   > (lang dune 3.20)
   > EOF
   $ dune pkg enabled || echo "Package management disabled"
   Package management disabled
+
+Enable the package management globally in the users config.
 
   $ cat > config <<EOF
   > (lang dune 3.20)
@@ -68,3 +74,19 @@ Manually enable package management in the workspace
   > EOF
   $ dune pkg enabled --config-file=config && echo "Yes, it is enabled"
   Yes, it is enabled
+
+Disable it in the user config, but enable it in the workspace. Workspace is
+higher precedence so it should be enabled:
+
+  $ cat > config <<EOF
+  > (lang dune 3.20)
+  > (pkg disabled)
+  > EOF
+  $ dune pkg enabled --config-file=config || echo "Successfully disabled by config"
+  Successfully disabled by config
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
+  > EOF
+  $ dune pkg enabled --config-file=config && echo "Workspace config overrides user config"
+  Workspace config overrides user config

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -19,7 +19,7 @@ should be used.
   > EOF
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.13)
+  > (lang dune 3.20)
   > (package
   >  (allow_empty)
   >  (name foo))
@@ -39,3 +39,32 @@ When the default lockdir is present pkg is enabled:
 When a non-default lockdir is present, pkg is still enabled:
   $ dune pkg lock dune.other.lock > /dev/null 2> /dev/null
   $ dune pkg enabled
+
+Remove the other lock dir and make sure the status didn't latch to be always
+enabled.
+
+  $ rm -r dune.other.lock
+  $ dune pkg enabled
+  [1]
+
+Manually enable package management in the workspace
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
+  > EOF
+  $ dune pkg enabled && echo "Yes, it is enabled"
+  Yes, it is enabled
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > EOF
+  $ dune pkg enabled || echo "Package management disabled"
+  Package management disabled
+
+  $ cat > config <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
+  > EOF
+  $ dune pkg enabled --config-file=config && echo "Yes, it is enabled"
+  Yes, it is enabled

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -66,7 +66,7 @@ If we remove the setting from the workspace it should go back to the default
   $ dune pkg enabled || echo "Package management disabled"
   Package management disabled
 
-Enable the package management globally in the users config.
+Enable the package management globally in the user's config.
 
   $ cat > config <<EOF
   > (lang dune 3.20)

--- a/test/expect-tests/dune_config_file/dune_config_test.ml
+++ b/test/expect-tests/dune_config_file/dune_config_test.ml
@@ -33,6 +33,7 @@ let%expect_test "cache-check-probability 0.1" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
+    ; pkg_enabled = false
     ; experimental = []
     }
     |}]
@@ -57,6 +58,7 @@ let%expect_test "cache-storage-mode copy" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
+    ; pkg_enabled = false
     ; experimental = []
     }
     |}]
@@ -81,6 +83,7 @@ let%expect_test "cache-storage-mode hardlink" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
+    ; pkg_enabled = false
     ; experimental = []
     }
     |}]


### PR DESCRIPTION
As discussed in the [dune-dev meeting on the 9th of July](https://github.com/ocaml/dune/wiki/dev-meeting-2025-07-09#signal-to-enable-dune-package-management-leonidas-from-xiv) we plan to introduce an option to enable package management instead of detecting it from the presence of lock files.

This PR adds the configuration options. Lock files are currently still used if they are in the source tree (hence the code retains the check), but this will change when autolocking is merged.