### PR TITLE
Update benchmark Docker file to supported Debian version

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-10-ocaml-4.14
+FROM ocaml/opam:debian-12-ocaml-4.14
 RUN opam depext -u patdiff.v0.15.0
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir


### PR DESCRIPTION
The benchmark builds are failing because Debian 10 is not on the release mirrors anymore, maybe updating to Debian 12 will solve this.