### PR TITLE
pkg: utop dev tool

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -247,12 +247,8 @@ let lock_ocamlformat () =
   lock_dev_tool_at_version Ocamlformat version
 ;;
 
-let lock_odoc () = lock_dev_tool_at_version Odoc None
-let lock_ocamllsp () = lock_dev_tool_at_version Ocamllsp None
-
 let lock_dev_tool dev_tool =
   match (dev_tool : Dune_pkg.Dev_tool.t) with
   | Ocamlformat -> lock_ocamlformat ()
-  | Odoc -> lock_odoc ()
-  | Ocamllsp -> lock_ocamllsp ()
+  | other -> lock_dev_tool_at_version other None
 ;;

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -12,6 +12,12 @@ let man =
 
 let info = Cmd.info "utop" ~doc ~man
 
+let lock_utop_if_dev_tool_enabled () =
+  match Lazy.force Lock_dev_tool.is_enabled with
+  | false -> Memo.return ()
+  | true -> Lock_dev_tool.lock_dev_tool Utop
+;;
+
 let term =
   let+ builder = Common.Builder.term
   and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
@@ -21,7 +27,7 @@ let term =
   let dir = Common.prefix_target common dir in
   if not (Path.is_directory (Path.of_string dir))
   then User_error.raise [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
-  let env, lib_config, utop_path, requires =
+  let env, utop_path =
     Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in
@@ -29,17 +35,33 @@ let term =
         let open Memo.O in
         let* setup = setup in
         let context = Import.Main.find_context_exn setup ~name:ctx_name in
-        let utop_target =
-          let utop_target = Filename.concat dir Utop.utop_exe in
-          Path.build (Path.Build.relative (Context.build_dir context) utop_target)
+        let utop_target_path filename =
+          Path.build
+            (Path.Build.relative
+               (Context.build_dir context)
+               (Filename.concat dir filename))
         in
-        Build_system.file_exists utop_target
+        let utop_exe = utop_target_path Utop.utop_exe in
+        let utop_findlib_conf = utop_target_path Utop.utop_findlib_conf in
+        Build_system.file_exists utop_exe
         >>= function
         | false ->
           User_error.raise
             [ Pp.textf "no library is defined in %s" (String.maybe_quoted dir) ]
         | true ->
-          let* () = Build_system.build_file utop_target in
+          let* () = Build_system.build_file utop_exe in
+          let* () = lock_utop_if_dev_tool_enabled () in
+          let* utop_dev_tool_lock_dir_exists =
+            Memo.Lazy.force Utop.utop_dev_tool_lock_dir_exists
+          in
+          let* () =
+            if utop_dev_tool_lock_dir_exists
+            then
+              (* Generate the custom findlib.conf file needed when utop is run
+                 as a dev tool. *)
+              Build_system.build_file utop_findlib_conf
+            else Memo.return ()
+          in
           let sctx = Import.Main.find_scontext_exn setup ~name:ctx_name in
           let* requires =
             let dir = Path.Build.relative (Context.build_dir context) dir in
@@ -50,15 +72,29 @@ let term =
             let+ ocaml = Context.ocaml context in
             ocaml.lib_config
           and+ env = Super_context.context_env sctx in
-          env, lib_config, Path.to_string utop_target, requires))
+          let env =
+            Dune_rules.Lib_flags.L.toplevel_ld_paths requires lib_config
+            |> Path.Set.fold
+                 ~f:(fun dir env ->
+                   Env_path.cons ~var:Ocaml.Env.caml_ld_library_path env ~dir)
+                 ~init:env
+          in
+          let env =
+            if utop_dev_tool_lock_dir_exists
+            then
+              (* If there's a utop lockdir then dune will have built utop as a
+                 dev tool. In order for it to run correctly dune needed to
+                 generate a custom findlib.conf that contains the locations of
+                 all of utop's dependencies within the project's _build
+                 directory. Setting this environment variable causes the custom
+                 findlib.conf file to be used instead of the default
+                 findlib.conf. *)
+              Env.add env ~var:"OCAMLFIND_CONF" ~value:(Path.to_string utop_findlib_conf)
+            else env
+          in
+          env, Path.to_string utop_exe))
   in
   Hooks.End_of_build.run ();
-  let env =
-    Dune_rules.Lib_flags.L.toplevel_ld_paths requires lib_config
-    |> Path.Set.fold
-         ~f:(fun dir env -> Env_path.cons ~var:Ocaml.Env.caml_ld_library_path env ~dir)
-         ~init:env
-  in
   restore_cwd_and_execve (Common.root common) utop_path args env
 ;;
 

--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -11,7 +11,7 @@ module Install = struct
   let info = Cmd.info ~doc "install"
 
   let group =
-    Cmd.group info (List.map [ Ocamlformat; Ocamllsp ] ~f:Tools_common.install_command)
+    Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.install_command)
   ;;
 end
 
@@ -20,7 +20,7 @@ module Which = struct
   let info = Cmd.info ~doc "which"
 
   let group =
-    Cmd.group info (List.map [ Ocamlformat; Ocamllsp ] ~f:Tools_common.which_command)
+    Cmd.group info (List.map Dune_pkg.Dev_tool.all ~f:Tools_common.which_command)
   ;;
 end
 

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -4,21 +4,31 @@ type t =
   | Ocamlformat
   | Odoc
   | Ocamllsp
+  | Utop
 
-let all = [ Ocamlformat; Odoc; Ocamllsp ]
+let to_dyn = function
+  | Ocamlformat -> Dyn.variant "Ocamlformat" []
+  | Odoc -> Dyn.variant "Odoc" []
+  | Ocamllsp -> Dyn.variant "Ocamllsp" []
+  | Utop -> Dyn.variant "Utop" []
+;;
+
+let all = [ Ocamlformat; Odoc; Ocamllsp; Utop ]
 
 let equal a b =
   match a, b with
   | Ocamlformat, Ocamlformat -> true
   | Odoc, Odoc -> true
   | Ocamllsp, Ocamllsp -> true
-  | _ -> false
+  | Utop, Utop -> true
+  | (Ocamlformat | Odoc | Ocamllsp | Utop), _ -> false
 ;;
 
 let package_name = function
   | Ocamlformat -> Package_name.of_string "ocamlformat"
   | Odoc -> Package_name.of_string "odoc"
   | Ocamllsp -> Package_name.of_string "ocaml-lsp-server"
+  | Utop -> Package_name.of_string "utop"
 ;;
 
 let of_package_name package_name =
@@ -26,6 +36,7 @@ let of_package_name package_name =
   | "ocamlformat" -> Ocamlformat
   | "odoc" -> Odoc
   | "ocaml-lsp-server" -> Ocamllsp
+  | "utop" -> Utop
   | other -> User_error.raise [ Pp.textf "No such dev tool: %s" other ]
 ;;
 
@@ -33,6 +44,7 @@ let exe_name = function
   | Ocamlformat -> "ocamlformat"
   | Odoc -> "odoc"
   | Ocamllsp -> "ocamllsp"
+  | Utop -> "utop"
 ;;
 
 let exe_path_components_within_package t =
@@ -40,10 +52,12 @@ let exe_path_components_within_package t =
   | Ocamlformat -> [ "bin"; exe_name t ]
   | Odoc -> [ "bin"; exe_name t ]
   | Ocamllsp -> [ "bin"; exe_name t ]
+  | Utop -> [ "bin"; exe_name t ]
 ;;
 
 let needs_to_build_with_same_compiler_as_project = function
   | Ocamlformat -> false
   | Odoc -> true
   | Ocamllsp -> true
+  | Utop -> false
 ;;

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -4,7 +4,9 @@ type t =
   | Ocamlformat
   | Odoc
   | Ocamllsp
+  | Utop
 
+val to_dyn : t -> Dyn.t
 val all : t list
 val equal : t -> t -> bool
 val package_name : t -> Package_name.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -12,6 +12,7 @@ module Pkg_info : sig
     ; extra_sources : (Path.Local.t * Source.t) list
     }
 
+  val to_dyn : t -> Dyn.t
   val default_version : Package_version.t
   val variables : t -> OpamVariable.variable_contents Package_variable_name.Map.t
 end

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -438,7 +438,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
         Pp.textf "loading OCAMLPATH for context %S" (Context_name.to_string builder.name))
       (fun () ->
          match kind with
-         | Lock _ -> Pkg_rules.ocamlpath builder.name
+         | Lock _ -> Pkg_rules.project_ocamlpath builder.name
          | Default | Opam _ ->
            let+ ocamlpath = builder.env >>| Findlib_config.ocamlpath_of_env in
            Kind.ocamlpath kind ~ocamlpath ~findlib_toolchain:builder.findlib_toolchain)

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -569,18 +569,23 @@ end
 
 type t = DB.t
 
-let create =
+let create_with_paths ~paths =
   Per_context.create_by_name ~name:"findlib" (fun context ->
     Memo.lazy_ (fun () ->
       let* context = Context.DB.get context in
-      let* paths = Context.findlib_paths context
-      and* lib_config =
+      let* lib_config =
         let+ ocaml = Context.ocaml context in
         ocaml.lib_config
       in
       DB.create ~paths ~lib_config)
     |> Memo.Lazy.force)
   |> Staged.unstage
+;;
+
+let create context_name =
+  let* context = Context.DB.get context_name in
+  let* paths = Context.findlib_paths context in
+  create_with_paths context_name ~paths
 ;;
 
 include Public

--- a/src/dune_rules/findlib.mli
+++ b/src/dune_rules/findlib.mli
@@ -32,6 +32,10 @@ val all_broken_packages : t -> (Package.Name.t * User_message.t) list Memo.t
 
 val create : Context_name.t -> t Memo.t
 
+(** Create a findlib database with a given list of paths corresponding to the
+    "path" field in the findlib.conf file. *)
+val create_with_paths : paths:Path.t list -> Context_name.t -> t Memo.t
+
 module For_tests : sig
   val create : paths:Path.t list -> lib_config:Lib_config.t -> t Memo.t
 end

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1954,6 +1954,18 @@ module DB = struct
           Findlib.all_packages findlib >>| List.map ~f:Dune_package.Entry.name)
   ;;
 
+  let with_parent t ~parent = { t with parent }
+
+  let of_paths context ~paths =
+    let open Memo.O in
+    let+ ocaml = Context.ocaml context
+    and+ findlib = Findlib.create_with_paths (Context.name context) ~paths in
+    create_from_findlib
+      findlib
+      ~has_bigarray_library:(Ocaml.Version.has_bigarray_library ocaml.version)
+      ~instrument_with:(Context.instrument_with context)
+  ;;
+
   let installed (context : Context.t) =
     let open Memo.O in
     let+ ocaml = Context.ocaml context

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -89,6 +89,13 @@ module DB : sig
   (** A database allow to resolve library names *)
   type t = db
 
+  val with_parent : t -> parent:t option -> t
+
+  (** Create a library database from a specified list of library paths. A
+      library path is a path to a "lib" directory such as those found in the
+      OCAMLPATH variable or the "path" field of findlib.conf. *)
+  val of_paths : Context.t -> paths:Path.t list -> t Memo.t
+
   val installed : Context.t -> t Memo.t
 
   module Resolve_result : sig

--- a/src/dune_rules/pkg_dev_tool.ml
+++ b/src/dune_rules/pkg_dev_tool.ml
@@ -28,3 +28,5 @@ let exe_path t =
     (package_install_path t)
     ("target" :: exe_path_components_within_package t)
 ;;
+
+let lib_path t = Path.Build.L.relative (package_install_path t) [ "target"; "lib" ]

--- a/src/dune_rules/pkg_dev_tool.mli
+++ b/src/dune_rules/pkg_dev_tool.mli
@@ -14,3 +14,6 @@ val package_install_path : t -> Path.Build.t
 
 (** The path to the executable for running the given dev tool *)
 val exe_path : t -> Path.Build.t
+
+(** The path to the lib directory associated with the given dev tool *)
+val lib_path : t -> Path.Build.t

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -23,7 +23,8 @@ val lock_dir_active : Context_name.t -> bool Memo.t
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t
 val exported_env : Context_name.t -> Env.t Memo.t
-val ocamlpath : Context_name.t -> Path.t list Memo.t
+val project_ocamlpath : Context_name.t -> Path.t list Memo.t
+val dev_tool_ocamlpath : Dune_pkg.Dev_tool.t -> Path.t list Memo.t
 val find_package : Context_name.t -> Package.Name.t -> unit Action_builder.t option Memo.t
 val dev_tool_env : Dune_pkg.Dev_tool.t -> Env.t Memo.t
 val all_filtered_depexts : Context_name.t -> string list Memo.t

--- a/src/dune_rules/utop.mli
+++ b/src/dune_rules/utop.mli
@@ -7,6 +7,8 @@ open Import
 val utop_exe : Filename.t
 
 val utop_dir_basename : Filename.t
+val utop_findlib_conf : Filename.t
+val utop_dev_tool_lock_dir_exists : bool Memo.Lazy.t
 val libs_under_dir : Super_context.t -> db:Lib.DB.t -> dir:Path.t -> Lib.t list Memo.t
 val setup : Super_context.t -> dir:Path.Build.t -> unit Memo.t
 


### PR DESCRIPTION
This adds utop as a dev tool. Unlike most dev tools there is no "dune tools exec utop" command, but rather the existing "dune utop" command has been modified such that if a lockdir exists for the utop dev tool, then dune will install the utop library (downloading it if necessary) within the _build directory and use that library to create the custom utop toplevel for the project.

It's possible to install utop as a dev tool without running it by running the "dune tools install utop" command.