### PR TITLE
test: regression with --force and cram tests

### DIFF
--- a/test/blackbox-tests/test-cases/cram/double-run-promote.t
+++ b/test/blackbox-tests/test-cases/cram/double-run-promote.t
@@ -24,3 +24,12 @@ side-effect should only contain a single "run":
 
   $ cat side-effect
   run
+
+However, if passing --force, we should still be able to re-run cram tests:
+
+  $ dune runtest foo.t --force
+
+There should be two "run"s here, however there is only one:
+  $ cat side-effect
+  run
+


### PR DESCRIPTION
Previously, --force would re-run already run cram tests. However this is no longer the case. 

Here is the test with 3.19 before #11994: 

```
 |side-effect should only contain a single "run":
 |
 |  $ cat side-effect
 |  run
+|  run
 |
 |However, if passing --force, we should still be able to re-run cram tests:
 |
 |  $ dune runtest foo.t --force
 |
 |There should be two "run"s here, however there is only one:
 |  $ cat side-effect
 |  run
+|  run
+|  run
```