### PR TITLE
ci: update package listing before job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,6 +57,7 @@ jobs:
           - ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
             os: ubuntu-latest
             skip_test: true
+            apt_update: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 4.14.x
             os: macos-latest
@@ -87,6 +88,12 @@ jobs:
         run: |
           git config --global user.name github-actions[bot]
           git config --global user.email github-actions[bot]@users.noreply.github.com
+
+      # The 32 bit gcc/g++ packages are by default out-of-date so we need to
+      # manually update our package listing.
+      - name: Update apt package listing
+        if: ${{ matrix.apt_update == true }}
+        run: sudo apt update
 
       # Install ocamlfind-secondary and ocaml-secondary-compiler, if needed
       - run: opam install ./dune.opam --deps-only --with-test


### PR DESCRIPTION
The 32 bit CI job has an out-of-date package listing so the 32 bit `gcc/g++` toolchain didn't have a valid mirror. We fix this issue by doing `sudo apt update` only for the 32 bit job, allowing it to build correctly.

The package listing on `ubuntu-latest` will be updated at some point in the future, after which we can remove this work-around.