### PR TITLE
ci: disable 32 bit job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,10 +53,12 @@ jobs:
           - ocaml-compiler: 4.14.x
             os: ubuntu-latest
             skip_test: true
+          # !! Disabled due to issue with dependencies (gcc and g++ not found
+          # !! in ubuntu servers)
           ## ubuntu (x86-32)
-          - ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
-            os: ubuntu-latest
-            skip_test: true
+          # - ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
+          #   os: ubuntu-latest
+          #   skip_test: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 4.14.x
             os: macos-latest


### PR DESCRIPTION
We temporarily disable the 32bit job unitl we track down and fix the issue.