### PR TITLE
nix: add missing test dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -273,6 +273,11 @@
               extraBuildInputs = pkgs: (with pkgs; [
                 # dev tools
                 ccls
+                # test dependencies
+                git
+                which
+                curl
+                procps
               ]) ++ (with pkgs.ocamlPackages; [
                 pkgs.ocamlPackages.ocaml-lsp
                 pkgs.ocamlPackages.melange

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -26,7 +26,7 @@
  (deps %{bin:strace}))
 
 (cram
- (deps %{bin:git} %{bin:awk} %{bin:cmp})
+ (deps %{bin:awk} %{bin:cmp})
  (applies_to git-repo))
 
 (cram


### PR DESCRIPTION
We update the nix flake with some missing dependencies needed to run the tests.