### PR TITLE
boot: remove warning 24 from bootstrap

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -96,7 +96,7 @@ let () =
   in
   exit_if_non_zero
     (runf
-       "%s %s -w -24 -g -o %s -I boot %sunix.cma %s"
+       "%s %s -g -o %s -I boot %sunix.cma %s"
        compiler
        (* Make sure to produce a self-contained binary as dlls tend to cause
           issues *)


### PR DESCRIPTION
This warning is about the source file being a bad OCaml module name. This clearly isn't the case so we don't need this warning.