### PR TITLE
Add with-dev-setup to package dependency specification.

### DIFF
--- a/doc/reference/dune-project/package.rst
+++ b/doc/reference/dune-project/package.rst
@@ -116,7 +116,7 @@ opam's own language. The syntax is a list of the following elements:
 
 .. productionlist:: pkg-dep
    op : '=' | '<' | '>' | '<>' | '>=' | '<='
-   filter : :dev | :build | :with-test | :with-doc | :post
+   filter : :dev | :build | :with-test | :with-doc | :with-dev-setup | :post
    constr : (<op> <version>)
    logop : or | and
    dep : <name>


### PR DESCRIPTION
Minor update to the documentation to indicate that `:with-dev-setup` is also a valid filter. The :with-test, :with-doc, and :with-dev-setup have all been available since opam 2.2.

