### PR TITLE
feat(cram): timeout for cram tests

### DIFF
--- a/doc/changes/12041.md
+++ b/doc/changes/12041.md
@@ -1,0 +1,3 @@
+- Added a `(timeout <float>)` field to the `(cram)` stanza to specify per-test
+  time limits. Tests exceeding the timeout are terminated with an error.
+  (#12041, @Alizter)

--- a/doc/reference/dune/cram.rst
+++ b/doc/reference/dune/cram.rst
@@ -80,3 +80,33 @@ Cram
       When set to ``false``, do not add the tests to the ``runtest`` alias.
       The default is to add every Cram test to ``runtest``, but this is not
       always desired.
+
+   .. describe:: (timeout <float>)
+
+      .. versionadded:: 3.20
+
+      Specify a time limit (in seconds) for each individual Cram test.
+
+      If a test takes longer than the specified timeout, Dune will terminate it
+      and report a timeout error. This can be useful to catch tests that hang
+      or take unexpectedly long.
+
+      The timeout is a floating-point number (e.g., `1.5` for 1.5 seconds).
+      Zero or negative values cause immediate failure when running the cram
+      test.
+
+      If multiple ``cram`` stanzas apply to the same test, the **lowest** of
+      all specified timeouts is used.
+
+      This field is typically used to guard against unresponsive or
+      non-terminating test cases.
+
+      Example:
+
+      .. code:: dune
+
+         (cram
+          (timeout 2.5))
+
+      This limits each selected test to at most 2.5 seconds of execution time.
+

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -5,7 +5,8 @@ module Action_output_on_success := Execution_parameters.Action_output_on_success
 module Action_output_limit := Execution_parameters.Action_output_limit
 
 module Failure_mode : sig
-  (** How to handle sub-process failures. This type controls the way in which the process we are running can fail. *)
+  (** How to handle sub-process failures. This type controls the way in which
+      the process we are running can fail. *)
   type ('a, 'b) t =
     | Strict : ('a, 'a) t (** Fail if the process exits with anything else than [0] *)
     | Accept : int Predicate.t -> ('a, ('a, int) result) t
@@ -17,7 +18,8 @@ module Failure_mode : sig
         ; failure_mode : ('a, 'b) t
         }
         -> ('a, ('b, [ `Timed_out ]) result) t
-    (** In addition to the [failure_mode], finish early if [timeout_seconds] was reached. *)
+    (** In addition to the [failure_mode], finish early if [timeout_seconds]
+        was reached. *)
 end
 
 module Io : sig

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -5,13 +5,19 @@ module Action_output_on_success := Execution_parameters.Action_output_on_success
 module Action_output_limit := Execution_parameters.Action_output_limit
 
 module Failure_mode : sig
-  (** How to handle sub-process failures *)
+  (** How to handle sub-process failures. This type controls the way in which the process we are running can fail. *)
   type ('a, 'b) t =
     | Strict : ('a, 'a) t (** Fail if the process exits with anything else than [0] *)
     | Accept : int Predicate.t -> ('a, ('a, int) result) t
     (** Accept the following non-zero exit codes, and return [Error code] if
         the process exits with one of these codes. *)
     | Return : ('a, 'a * int) t (** Accept any error code and return it. *)
+    | Timeout :
+        { timeout_seconds : float option
+        ; failure_mode : ('a, 'b) t
+        }
+        -> ('a, ('b, [ `Timed_out ]) result) t
+    (** In addition to the [failure_mode], finish early if [timeout_seconds] was reached. *)
 end
 
 module Io : sig

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -104,6 +104,7 @@ val wait_for_process
 type termination_reason =
   | Normal
   | Cancel
+  | Timeout
 
 val wait_for_build_process
   :  ?timeout_seconds:float

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -458,7 +458,7 @@ let run_and_produce_output ~src ~env ~dir:cwd ~script ~dst ~timeout =
 module Run = struct
   module Spec = struct
     type ('path, 'target) t =
-      { src : 'path
+      { src : Path.t
       ; dir : 'path
       ; script : 'path
       ; output : 'target
@@ -468,16 +468,15 @@ module Run = struct
     let name = "cram-run"
     let version = 2
 
-    let bimap { src; dir; script; output; timeout } f g =
-      { src = f src; dir = f dir; script = f script; output = g output; timeout }
+    let bimap ({ src = _; dir; script; output; timeout } as t) f g =
+      { t with dir = f dir; script = f script; output = g output; timeout }
     ;;
 
     let is_useful_to ~memoize:_ = true
 
-    let encode { src; dir; script; output; timeout } path target : Sexp.t =
+    let encode { src = _; dir; script; output; timeout } path target : Sexp.t =
       List
-        [ path src
-        ; path dir
+        [ path dir
         ; path script
         ; target output
         ; Dune_sexp.Encoder.(option float (Option.map ~f:snd timeout))

--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -4,7 +4,13 @@ open Import
 val make_script : src:Path.t -> script:Path.Build.t -> Action.t
 
 (** Runs the script created in [make_script] *)
-val run : dir:Path.t -> script:Path.t -> output:Path.Build.t -> Action.t
+val run
+  :  src:Path.t
+  -> dir:Path.t
+  -> script:Path.t
+  -> output:Path.Build.t
+  -> timeout:(Loc.t * float) option
+  -> Action.t
 
 (** Produces a diff if [src] needs to be updated *)
 val diff : src:Path.t -> output:Path.t -> Action.t

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -29,6 +29,7 @@ type t =
   ; locks : Locks.t
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
+  ; timeout : (Loc.t * float) option
   }
 
 include Stanza.Make (struct
@@ -67,8 +68,20 @@ let decode =
        field_o
          "runtest_alias"
          (Dune_lang.Syntax.since Stanza.syntax (3, 12) >>> located bool)
+     and+ timeout =
+       field_o
+         "timeout"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 20)
+          >>> located float
+          >>| fun (loc, t) ->
+          if t >= 0.
+          then loc, t
+          else
+            User_error.raise
+              ~loc
+              [ Pp.text "Timeout value must be a non-negative float." ])
      in
-     { loc; alias; deps; enabled_if; locks; applies_to; package; runtest_alias })
+     { loc; alias; deps; enabled_if; locks; applies_to; package; runtest_alias; timeout })
 ;;
 
 let stanza =

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -13,6 +13,7 @@ type t =
   ; locks : Locks.t
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
+  ; timeout : (Loc.t * float) option
   }
 
 include Stanza.S with type t := t

--- a/test/blackbox-tests/test-cases/cram/timeout-invalid.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-invalid.t
@@ -1,0 +1,125 @@
+Here we check the validation of the timeout field of the cram stanza.
+
+First we check the version guard.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 1))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 1-12:
+  2 |  (timeout 1))
+       ^^^^^^^^^^^
+  Error: 'timeout' is only available since version 3.20 of the dune language.
+  Please update your dune-project file to have (lang dune 3.20).
+  [1]
+
+Next we check some invalid values:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ cat > test.t <<EOF
+  >   $ echo hi
+  > EOF
+
+Negative values fail immediately.
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout -1.0))
+  > EOF
+
+  $ dune test test.t
+  File "dune", line 2, characters 10-14:
+  2 |  (timeout -1.0))
+                ^^^^
+  Error: Timeout value must be a non-negative float.
+  [1]
+
+Checking some currently accepted float values:
+
+  $ test() {
+  >   echo "(cram (timeout $1))" > dune
+  >   dune build 
+  > }
+
+  $ test -1
+  File "dune", line 1, characters 15-17:
+  1 | (cram (timeout -1))
+                     ^^
+  Error: Timeout value must be a non-negative float.
+  [1]
+  $ test Inf
+  $ test +Inf
+  $ test -Inf
+  File "dune", line 1, characters 15-19:
+  1 | (cram (timeout -Inf))
+                     ^^^^
+  Error: Timeout value must be a non-negative float.
+  [1]
+  $ test nan
+  File "dune", line 1, characters 15-18:
+  1 | (cram (timeout nan))
+                     ^^^
+  Error: Timeout value must be a non-negative float.
+  [1]
+  $ test .5
+  $ test 0.
+  $ test 1.
+  $ test 1.0e1
+  $ test 1e1
+  $ test 1e-1
+  $ test 1e+1
+  $ test 1e308
+  $ test 1e-324
+
+Invalid values should be vetted correctly:
+
+  $ test
+  File "dune", line 1, characters 6-16:
+  1 | (cram (timeout ))
+            ^^^^^^^^^^
+  Error: Not enough arguments for "timeout"
+  [1]
+
+  $ test foo
+  File "dune", line 1, characters 15-18:
+  1 | (cram (timeout foo))
+                     ^^^
+  Error: Float expected
+  [1]
+
+  $ test --1
+  File "dune", line 1, characters 15-18:
+  1 | (cram (timeout --1))
+                     ^^^
+  Error: Float expected
+  [1]
+
+  $ test 1..0
+  File "dune", line 1, characters 15-19:
+  1 | (cram (timeout 1..0))
+                     ^^^^
+  Error: Float expected
+  [1]
+
+  $ test 1e
+  File "dune", line 1, characters 15-17:
+  1 | (cram (timeout 1e))
+                     ^^
+  Error: Float expected
+  [1]
+
+  $ test 1.0.0
+  File "dune", line 1, characters 15-20:
+  1 | (cram (timeout 1.0.0))
+                     ^^^^^
+  Error: Float expected
+  [1]

--- a/test/blackbox-tests/test-cases/cram/timeout-redigest.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-redigest.t
@@ -1,0 +1,61 @@
+Testing how timeout affects the digest:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ cat > mytest.t
+
+This test counts the occurances of the cram script in the log.
+  $ check() {
+  >   cat _build/log | grep -c main.sh
+  > }
+
+We can observe the test is run the first time:
+
+  $ dune test mytest.t
+  $ check
+  1
+
+And is not run the second time:
+
+  $ dune test mytest.t
+  $ check
+  0
+  [1]
+
+If we add a timeout, we would not expect for the digest of the cram test to
+change.
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 1))
+  > EOF
+
+However this is currently not the case and we rerun the cram test:
+
+  $ dune test mytest.t
+  $ check
+  1
+
+  $ dune test mytest.t
+  $ check
+  0
+  [1]
+
+This is again the case on another time change:
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 2))
+  > EOF
+ 
+  $ dune test mytest.t
+  $ check
+  1
+
+  $ dune test mytest.t
+  $ check
+  0
+  [1]
+

--- a/test/blackbox-tests/test-cases/cram/timeout.t
+++ b/test/blackbox-tests/test-cases/cram/timeout.t
@@ -1,0 +1,46 @@
+Testing the timeout functionality of cram tests.
+
+First we create a cram test that will take less than our time budget. This will
+allow the test to fail. (Since "hi" needs to be promoted).
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 1))
+  > EOF
+
+  $ cat > test.t <<EOF
+  >   $ echo hi
+  > EOF
+
+  $ dune test test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  [1]
+
+Next we create a cram test that will take longer than our timeout budget which
+will cause dune to kill the test.
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 0.0))
+  > EOF
+
+  $ cat > test.t <<EOF
+  >   $ echo hi
+  >   $ sleep 2
+  > EOF
+
+The cram test will take 2 seconds to run unless it is killed. We make sure this
+fails earlier by passing a timeout command in front of dune. Our expected
+behaviour is for dune to kill the cram test immediately.
+
+  $ timeout 1 dune test test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Cram test timed out. A time limit of 0.00s has been set in dune:2.
+  [1]
+


### PR DESCRIPTION
We add a `(timeout)` field for cram stanzas allowing users to set up a time budget for cram tests to run in. If the budget is exceeded then the cram test will be cancelled.

- [ ] `dune_engine` changes are ok? 
- [x] changelog
- [x] documentation
