### PR TITLE
feature: add --alias as an argument for building aliases

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -116,6 +116,16 @@ module Dep = struct
 
   let conv = conv' (parser, printer)
   let to_string_maybe_quoted t = String.maybe_quoted (Format.asprintf "%a" printer t)
+
+  let alias_arg =
+    let parse x = Ok (Dep_conf.Alias (String_with_vars.make_text Loc.none x)) in
+    conv' (parse, printer)
+  ;;
+
+  let alias_rec_arg =
+    let parse x = Ok (Dep_conf.Alias_rec (String_with_vars.make_text Loc.none x)) in
+    conv' (parse, printer)
+  ;;
 end
 
 let dep = Dep.conv

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -26,6 +26,8 @@ module Dep : sig
   val alias : dir:Stdune.Path.Local.t -> Dune_engine.Alias.Name.t -> t
   val alias_rec : dir:Stdune.Path.Local.t -> Dune_engine.Alias.Name.t -> t
   val to_string_maybe_quoted : t -> string
+  val alias_arg : t conv
+  val alias_rec_arg : t conv
 end
 
 val bytes : int64 conv

--- a/bin/build.ml
+++ b/bin/build.ml
@@ -184,7 +184,10 @@ let build =
   let name_ = Arg.info [] ~docv:"TARGET" in
   let term =
     let+ builder = Common.Builder.term
-    and+ targets = Arg.(value & pos_all dep [] name_) in
+    and+ targets = Arg.(value & pos_all dep [] name_)
+    and+ aliases_rec = Arg.(value & opt_all Dep.alias_rec_arg [] & info [ "alias-rec" ])
+    and+ aliases = Arg.(value & opt_all Dep.alias_arg [] & info [ "alias" ]) in
+    let targets = List.concat [ targets; aliases; aliases_rec ] in
     let targets =
       match targets with
       | [] -> [ Common.Builder.default_target builder ]

--- a/doc/changes/12043.md
+++ b/doc/changes/12043.md
@@ -1,0 +1,2 @@
+- Add `--alias` and `--alias-rec` flags as an alternative to the `@` and `@@`
+  syntax in the command line (#12043, fixes #5775, @rgrinberg)

--- a/test/blackbox-tests/test-cases/alias-arg.t
+++ b/test/blackbox-tests/test-cases/alias-arg.t
@@ -1,0 +1,33 @@
+Demonstrate the --alias argument to build aliases in the command
+line without the @ syntax
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action (echo "root: foo\n")))
+  > (rule
+  >  (alias bar)
+  >  (action (echo "root: bar\n")))
+  > EOF
+
+  $ mkdir x
+
+  $ cat >x/dune <<EOF
+  > (rule
+  >  (alias bar)
+  >  (action (echo "x: bar\n")))
+  > EOF
+
+  $ dune build --alias foo --alias x/bar
+  root: foo
+  x: bar
+
+  $ dune clean
+
+  $ dune build --alias-rec bar
+  root: bar
+  x: bar


### PR DESCRIPTION
Turns out that typing `@` in the command line can be problematic on Windows. This PR adds an alternative way to specify aliases in the command line using the `--alias` and the `--alias-rec` flags.

Fixes https://github.com/ocaml/dune/issues/5775