### PR TITLE
feat: add Melange Syntax version 1.0 and `Dune_project.find_extension_version`

### DIFF
--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -200,8 +200,15 @@ let to_dyn
     ]
 ;;
 
-let find_extension_args t key = Univ_map.find t.extension_args key
 let is_extension_set t key = Univ_map.mem t.extension_args key
+
+let find_extension_version t syntax =
+  match Univ_map.find t.parsing_context (Syntax.key syntax) with
+  | None | Some (Inactive _) -> None
+  | Some (Active v) -> Some v
+;;
+
+let find_extension_args t key = Univ_map.find t.extension_args key
 
 include Versioned_file.Make (struct
     type t = Stanza.Parser.t list

--- a/src/dune_lang/dune_project.mli
+++ b/src/dune_lang/dune_project.mli
@@ -102,6 +102,7 @@ val get : unit -> (t option, 'k) Decoder.parser
     written in dune-project. *)
 val find_extension_args : t -> 'a Extension.t -> 'a option
 
+val find_extension_version : t -> Syntax.t -> Syntax.Version.t option
 val is_extension_set : t -> 'a Extension.t -> bool
 val set_parsing_context : t -> 'a Decoder.t -> 'a Decoder.t
 val implicit_transitive_deps : t -> Ocaml.Version.t -> Implicit_transitive_deps.t

--- a/src/dune_lang/melange.ml
+++ b/src/dune_lang/melange.ml
@@ -36,5 +36,5 @@ let syntax =
   Syntax.create
     ~name:Dune_project.Melange_syntax.name
     ~desc:"the Melange extension"
-    [ (0, 1), `Since (3, 8) ]
+    [ (0, 1), `Since (3, 8); (1, 0), `Since (3, 20) ]
 ;;


### PR DESCRIPTION
Goal here is to:

- fix https://github.com/ocaml/dune/issues/8371
- finalize the Melange integration with #10630 + in-source promotion