### PR TITLE
fix(melange): build time benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ci-bench/fix-after-ocaml51
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -85,6 +84,7 @@ jobs:
       - name: Install all deps
         working-directory: pupilfirst
         run: |
+          opam pin add --no-action .
           opam install -y . --deps-only
 
       - name: Run pupilfirst benchmark


### PR DESCRIPTION
These seem to be failing with:

```
[WARNING] Failed checks on pupilfirst package definition from source at
git+file:///home/runner/work/dune/dune/pupilfirst#master: warning 74:
Field 'pin-depends' contains packages that are neither in 'depends' nor
in 'depopts': "reason-react-ppx"
```


not entirely sure that the pin-depends are being respected.