### PR TITLE
test(pkg): make test cleanup more sturdy

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/readonly-fs.t
+++ b/test/blackbox-tests/test-cases/dune-cache/readonly-fs.t
@@ -33,7 +33,7 @@ Likewise, this should also happen if the location is set via XDG variables.
   Warning: Cache directories could not be created: $REASON: disabling cache
   Hint: Make sure the directory $TESTCASE_ROOT/readonly/xdg-cache-dir/dune/db/temp can be created
 
-  $ HOME=/homeless-shelter
+  $ export HOME=/homeless-shelter
   $ unset XDG_CACHE_HOME
   $ dune build 2>&1 | sed 's/created: .*;/created: $REASON:/'
   Warning: Cache directories could not be created: $REASON: disabling cache

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -18,8 +18,10 @@ Make a package with a patch
   $ cat >$opam_repo/files/$fname2 <<EOF
   > bar
   > EOF
-We remove the read permissions for dir/
+We remove the read permissions for dir/ making sure to add them back if we exit
+the test.
 
+  $ trap "chmod +r $opam_repo/files/dir" EXIT
   $ chmod -r $opam_repo/files/dir
 
 The error message should have a location for the opam repository.
@@ -35,7 +37,4 @@ This does not currently seem to be the case.
   Error: Unable to read file in opam repository:
   opendir($TESTCASE_ROOT/mock-opam-repository/packages/with-patch/with-patch.0.0.1/files/dir): Permission denied
   [1]
- 
-Make sure to set permissions back so the sandbox can be cleaned up.
 
-  $ chmod +r $opam_repo/files/dir


### PR DESCRIPTION
These changes make the tests more resilient and in the case of the second commit, makes sure we can clean up the sandbox after something goes wrong.