### PR TITLE
test: enable pkg-config tests on nixos and fix

### DIFF
--- a/otherlibs/configurator/test/blackbox-tests/dune
+++ b/otherlibs/configurator/test/blackbox-tests/dune
@@ -11,7 +11,3 @@
  (enabled_if
   (<> %{ocaml-config:system} win))
  (applies_to configurator.t))
-
-(cram
- (enabled_if
-  (<> %{os_distribution} nixos)))

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-args.t/run.t
@@ -1,3 +1,6 @@
+  $ unset PKG_CONFIG_ARGN
+  $ unset PKG_CONFIG
+
 These tests show that setting `PKG_CONFIG_ARGN` passes extra args to `pkg-config`
 
   $ dune build 2>&1 | awk '/run:.*bin\/pkgconf/{a=1}/stderr/{a=0}a' | sed s/$(ocamlc -config | sed -n "/^target:/ {s/target: //; p; }")/\$TARGET/g


### PR DESCRIPTION
Our nixos derivation had the pkg-config variables set which was messing with the beginning of the test. The fix is to simply unset it in the beginning.