### PR TITLE
test: set OCAML_COLOR to always

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -2,7 +2,10 @@
  (_
   (env-vars
    (DUNE_CONFIG__BACKGROUND_SANDBOXES disabled)
-   (DUNE_CONFIG__BACKGROUND_DIGESTS disabled))
+   (DUNE_CONFIG__BACKGROUND_DIGESTS disabled)
+   ; We set ocaml to always be colored since it changes the output of
+   ; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144
+   (OCAML_COLOR always))
   (binaries ../utils/dune_cmd.exe ../utils/dunepp.exe
    ../utils/melc_stdlib_prefix.exe ../utils/refmt.exe ../utils/curl
    ../utils/sherlodoc.exe ../utils/ocaml_index.exe)))
@@ -14,6 +17,7 @@
 (cram
  (applies_to :whole_subtree)
  (deps
+  (env_var OCAML_COLOR)
   %{bin:dune_cmd}
   (package dune)))
 

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -1,3 +1,10 @@
+(env
+ (_
+  (env-vars
+   ; We set ocaml to always be colored since it changes the output of
+   ; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144
+   (OCAML_COLOR always))))
+
 (library
  (name dune_rpc_e2e)
  (modules dune_rpc_e2e)


### PR DESCRIPTION
We explicitly set OCAML_COLOR to always due to the fact that OCaml 5.3
changes the content of error messages depending on this value. This
means auto-color-detection changes the content of error messages and
gives us a headache in the CI.

A related OCaml issue upstream: https://github.com/ocaml/ocaml/issues/14144