### PR TITLE
pkg: add dev tools to PATH when running dev tools

### DIFF
--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -1,6 +1,12 @@
 open! Import
 module Pkg_dev_tool = Dune_rules.Pkg_dev_tool
 
+let add_dev_tools_to_path env =
+  List.fold_left Pkg_dev_tool.all ~init:env ~f:(fun acc tool ->
+    let dir = Pkg_dev_tool.exe_path tool |> Path.Build.parent_exn |> Path.build in
+    Env_path.cons acc ~dir)
+;;
+
 let dev_tool_exe_path dev_tool = Path.build @@ Pkg_dev_tool.exe_path dev_tool
 
 let dev_tool_build_target dev_tool =
@@ -47,7 +53,8 @@ let run_dev_tool workspace_root dev_tool ~args =
        ~verb:"Running"
        ~object_:(User_message.command (String.concat ~sep:" " (exe_name :: args))));
   Console.finish ();
-  restore_cwd_and_execve workspace_root exe_path_string args Env.initial
+  let env = add_dev_tools_to_path Env.initial in
+  restore_cwd_and_execve workspace_root exe_path_string args env
 ;;
 
 let lock_build_and_run_dev_tool ~common ~config dev_tool ~args =

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -1,0 +1,35 @@
+Test that the ocamllsp dev tool executes in an environment where other dev
+tools are in PATH.
+
+  $ . ../helpers.sh
+  $ . ./helpers.sh
+
+  $ mkrepo
+  $ mkpkg ocaml 5.2.0
+  $ setup_ocamllsp_workspace
+
+Make a fake ocamllsp package that prints out the PATH variable:
+  $ mkpkg ocaml-lsp-server <<EOF
+  > install: [
+  >   [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamllsp" ]
+  >   [ "sh" "-c" "echo 'echo \$PATH' >> %{bin}%/ocamllsp" ]
+  >   [ "sh" "-c" "chmod a+x %{bin}%/ocamllsp" ]
+  > ]
+  > EOF
+
+  $ make_lockdir
+  $ cat > dune.lock/ocaml.pkg <<EOF
+  > (version 5.2.0)
+  > EOF
+
+Confirm that each dev tool's bin directory is now in PATH:
+  $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
+  Solution for dev-tools.locks/ocaml-lsp-server:
+  - ocaml.5.2.0
+  - ocaml-lsp-server.0.0.1
+       Running 'ocamllsp'
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/earlybird/earlybird/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/utop/utop/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/ocaml-lsp-server/ocaml-lsp-server/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/odoc/odoc/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -1,0 +1,58 @@
+Test that the ocamllsp dev tool can see the ocamlformat dev tool.
+
+  $ . ../helpers.sh
+  $ . ./helpers.sh
+
+  $ mkrepo
+  $ mkpkg ocaml 5.2.0
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.16)
+  > (lock_dir
+  >  (path "dev-tools.locks/ocaml-lsp-server")
+  >  (repositories mock))
+  > (lock_dir
+  >  (path "dev-tools.locks/ocamlformat")
+  >  (repositories mock))
+  > (lock_dir
+  >   (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$(pwd)/mock-opam-repository"))
+  > EOF
+
+Make a fake ocamllsp package that prints out the PATH variable:
+  $ mkpkg ocaml-lsp-server <<EOF
+  > install: [
+  >   [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamllsp" ]
+  >   [ "sh" "-c" "echo 'echo fake ocamllsp will now run fake ocamlformat:' >> %{bin}%/ocamllsp" ]
+  >   [ "sh" "-c" "echo 'ocamlformat' >> %{bin}%/ocamllsp" ]
+  >   [ "sh" "-c" "chmod a+x %{bin}%/ocamllsp" ]
+  > ]
+  > EOF
+
+Make a fake ocamlformat
+  $ mkpkg ocamlformat <<EOF
+  > install: [
+  >   [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamlformat" ]
+  >   [ "sh" "-c" "echo 'echo hello from fake ocamlformat' >> %{bin}%/ocamlformat" ]
+  >   [ "sh" "-c" "chmod a+x %{bin}%/ocamlformat" ]
+  > ]
+  > EOF
+
+  $ make_lockdir
+  $ cat > dune.lock/ocaml.pkg <<EOF
+  > (version 5.2.0)
+  > EOF
+
+  $ dune tools install ocamlformat
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.0.1
+
+  $ dune tools exec ocamllsp
+  Solution for dev-tools.locks/ocaml-lsp-server:
+  - ocaml.5.2.0
+  - ocaml-lsp-server.0.0.1
+       Running 'ocamllsp'
+  fake ocamllsp will now run fake ocamlformat:
+  hello from fake ocamlformat


### PR DESCRIPTION
This allows the ocamllsp dev tool to run the ocamlformat dev tool, assuming the latter is installed.

Addresses https://github.com/ocaml/dune/issues/10964

cc @pitag-ha 