### PR TITLE
Disable `man` pager thus making the output more reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -1,6 +1,15 @@
 Exercise printing the help messages for dev tools commands.
 
-  $ dune tools exec --help
+Disable the pagers, as the command line parser might use a pager from the users
+system which will reformat the output if not specifically requesting `plain`
+output.
+
+  $ export PAGER=false
+  $ export MANPAGER=false
+
+Output the help text:
+
+  $ dune tools exec --help=plain
   NAME
          dune-tools-exec - Command group for running wrapped tools.
   


### PR DESCRIPTION
I've set both `PAGER` and `MANPAGER` to `false` as `false` will always trigger this: https://github.com/dbuenzli/cmdliner/blob/84a255a684c27a2906ef2cc2893cdee2773cc1b6/src/cmdliner_manpage.ml#L533

However setting `--help=plain` is actually enough. But I think it is still nice to set, in case someone forgets the `=plain` part as it works locally but will potentially fail on other systems.