### PR TITLE
Use copy_file_range when supported

### DIFF
--- a/doc/changes/12074.md
+++ b/doc/changes/12074.md
@@ -1,0 +1,2 @@
+- Use copy-on-write (COW) when copying files on filesystems that support it
+  (Btrfs, ZFS, XFS, etc), under Linux. (#12074, fixes #12071, @nojb)

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -92,7 +92,7 @@ static ssize_t dune_sendfile(int in, int out, size_t length) {
 static ssize_t dune_copy_file_range(int in, int out, size_t length) {
   ssize_t ret;
   while (length > 0) {
-    ret = copy_file_range(out, NULL, in, NULL, length, 0);
+    ret = copy_file_range(in, NULL, out, NULL, length, 0);
     if (ret < 0) {
       return ret;
     }

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -99,7 +99,7 @@ static ssize_t dune_copy_file_range(int in, int out, size_t length) {
   while (length > 0) {
     ret = copy_file_range_fn(in, NULL, out, NULL, length, 0);
     if (ret < 0) {
-      return ret;
+      return dune_sendfile(in, out, length);
     }
     length = length - ret;
   }

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -67,6 +67,7 @@ CAMLprim value stdune_sendfile(value v_in, value v_out, value v_size) {
 #include <sys/sendfile.h>
 #include <sys/utsname.h>
 #include <linux/version.h>
+#include <stdio.h>
 
 #define FD_val(value) Int_val(value)
 

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
@@ -63,7 +65,8 @@ CAMLprim value stdune_sendfile(value v_in, value v_out, value v_size) {
 #include <caml/unixsupport.h>
 
 #include <sys/sendfile.h>
-#include <unistd.h>
+#include <sys/utsname.h>
+#include <linux/version.h>
 
 #define FD_val(value) Int_val(value)
 
@@ -73,7 +76,7 @@ CAMLprim value stdune_copyfile(value v_from, value v_to) {
   caml_failwith("copyfile: only on macos");
 }
 
-static int dune_sendfile(int in, int out, size_t length) {
+static ssize_t dune_sendfile(int in, int out, size_t length) {
   ssize_t ret;
   while (length > 0) {
     ret = sendfile(out, in, NULL, length);
@@ -85,12 +88,43 @@ static int dune_sendfile(int in, int out, size_t length) {
   return length;
 }
 
+static ssize_t dune_copy_file_range(int in, int out, size_t length) {
+  ssize_t ret;
+  while (length > 0) {
+    ret = copy_file_range(out, NULL, in, NULL, length, 0);
+    if (ret < 0) {
+      return ret;
+    }
+    length = length - ret;
+  }
+  return length;
+}
+
+static int kernel_version(void) {
+  struct utsname uts;
+  int major, minor, patch;
+
+  if (uname(&uts) < 0)
+    return -1;
+
+  if (sscanf(uts.release, "%d.%d.%d", &major, &minor, &patch) != 3)
+    return -1;
+
+  return KERNEL_VERSION(major, minor, patch);
+}
+
 CAMLprim value stdune_sendfile(value v_in, value v_out, value v_size) {
+  static ssize_t (*dune_copyfile)(int, int, size_t) = NULL;
+  if (dune_copyfile == NULL) {
+    if (kernel_version() < KERNEL_VERSION(5, 19, 0)) {
+      dune_copyfile = &dune_sendfile;
+    } else {
+      dune_copyfile = &dune_copy_file_range;
+    }
+  }
   CAMLparam3(v_in, v_out, v_size);
   caml_release_runtime_system();
-  /* TODO Use copy_file_range once we have a good mechanism to test for its
-   * existence */
-  int ret = dune_sendfile(FD_val(v_in), FD_val(v_out), Long_val(v_size));
+  ssize_t ret = dune_copyfile(FD_val(v_in), FD_val(v_out), Long_val(v_size));
   caml_acquire_runtime_system();
   if (ret < 0) {
     uerror("sendfile", Nothing);


### PR DESCRIPTION
Use `copy_file_range` when supported (Linux kernel >= 5.19). We check the kernel version at runtime (but we still require the `copy_file_range` function to be available at compile-time; we could avoid this by loading the symbol with `dlsym`).

Fixes #12071