### PR TITLE
refactor(boot): remove useless directory name

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1245,7 +1245,7 @@ let sort_files dependencies ~main =
 
 let common_build_args name ~external_includes ~external_libraries =
   List.concat
-    [ [ "-o"; Filename.concat "../_boot" (name ^ ".exe"); "-g" ]
+    [ [ "-o"; name ^ ".exe"; "-g" ]
     ; (match Config.mode with
        | Byte -> [ Config.output_complete_obj_arg ]
        | Native -> [])


### PR DESCRIPTION
We're already in _boot, so ../_boot is just .

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>