### PR TITLE
refactor(boot): move ocamlfind output to temp file

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -76,9 +76,10 @@ let () =
     then "ocamlc", None
     else (
       let compiler = "ocamlfind -toolchain secondary ocamlc" in
-      let output_fn = duneboot ^ ".ocamlfind-output" in
+      let output_fn, out = Filename.open_temp_file "duneboot" "ocamlfind-output" in
       let n = runf "%s 2>%s" compiler output_fn in
       let s = read_file output_fn in
+      close_out out;
       prerr_endline s;
       if n <> 0 || s <> ""
       then (


### PR DESCRIPTION
There's no need for this generated file to be created in the source