### PR TITLE
ci: add timeout of 60s

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -19,7 +19,9 @@
  (deps
   (env_var OCAML_COLOR)
   %{bin:dune_cmd}
-  (package dune)))
+  (package dune))
+ ; Tests shouldn't take longer than 60s
+ (timeout 60))
 
 (cram
  (applies_to meta-template-version-bug version-corruption)


### PR DESCRIPTION
We add a timeout for all the cram tests in `test/blackbox-tests/test-cases`. The limit is 60s which is plenty of time for most of our tests. We can bump this if needed.

On very rare occasions a test may hang. This timeout will allow us to catch it in CI.