### PR TITLE
feat(exec): support absolute paths for dune exec

### DIFF
--- a/doc/changes/12094.md
+++ b/doc/changes/12094.md
@@ -1,0 +1,2 @@
+- `dune exec` now accepts absolute paths inside the workspace. (#12094,
+  @Alizter)

--- a/test/blackbox-tests/test-cases/exec/exec-abs.t
+++ b/test/blackbox-tests/test-cases/exec/exec-abs.t
@@ -16,9 +16,23 @@ Testing interaction of dune exec and absolute directories.
   $ dune exec ./foo.exe
   hi
 
+Dune exec is able to handle absolute executable paths.
+
   $ dune exec $PWD/foo.exe
-  Error: Program
-  '$TESTCASE_ROOT/foo.exe'
-  not found!
+  hi
+
+Lets check some validation:
+
+  $ dune exec ..
+  Error: Program '..' not found!
+  [1]
+  $ dune exec .
+  Error: Program '.' not found!
+  [1]
+  $ dune exec /.
+  Error: Program '/.' not found!
+  [1]
+  $ dune exec /
+  Error: Program '/' not found!
   [1]
 

--- a/test/blackbox-tests/test-cases/exec/exec-abs.t
+++ b/test/blackbox-tests/test-cases/exec/exec-abs.t
@@ -1,0 +1,24 @@
+Testing interaction of dune exec and absolute directories.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name foo))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let () = print_endline "hi" ;;
+  > EOF
+
+  $ dune exec ./foo.exe
+  hi
+
+  $ dune exec $PWD/foo.exe
+  Error: Program
+  '$TESTCASE_ROOT/foo.exe'
+  not found!
+  [1]
+


### PR DESCRIPTION
We add support for `dune exec` to work with absolute paths to files in the workspace.

- [x] changelog
- fixes #10536 
- [ ] get working for rpc?
- [ ] check windows