### PR TITLE
pkg: enroll odig as a dev-tool

### DIFF
--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -7,7 +7,7 @@ module Exec = struct
   let group =
     Cmd.group
       info
-      (List.map [ Ocamlformat; Ocamllsp; Ocamlearlybird ] ~f:Tools_common.exec_command)
+      (List.map [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig ] ~f:Tools_common.exec_command)
   ;;
 end
 

--- a/bin/tools/tools.ml
+++ b/bin/tools/tools.ml
@@ -7,7 +7,9 @@ module Exec = struct
   let group =
     Cmd.group
       info
-      (List.map [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig ] ~f:Tools_common.exec_command)
+      (List.map
+         [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig ]
+         ~f:Tools_common.exec_command)
   ;;
 end
 

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -33,7 +33,7 @@ let equal a b =
   | Ocamlearlybird, _ -> false
   | _, Ocamlearlybird -> true
   | Odig, Odig -> true
-
+;;
 
 let package_name = function
   | Ocamlformat -> Package_name.of_string "ocamlformat"
@@ -71,7 +71,7 @@ let exe_path_components_within_package t =
   | Ocamllsp -> [ "bin"; exe_name t ]
   | Utop -> [ "bin"; exe_name t ]
   | Ocamlearlybird -> [ "bin"; exe_name t ]
-  | Odig -> [ "bin"; exe_name t]
+  | Odig -> [ "bin"; exe_name t ]
 ;;
 
 let needs_to_build_with_same_compiler_as_project = function

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -30,8 +30,7 @@ let equal a b =
   | Utop, Utop -> true
   | Utop, _ | _, Utop -> false
   | Ocamlearlybird, Ocamlearlybird -> true
-  | Ocamlearlybird, _ -> false
-  | _, Ocamlearlybird -> true
+  | Ocamlearlybird, _ | _, Ocamlearlybird -> false
   | Odig, Odig -> true
 ;;
 

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -6,6 +6,7 @@ type t =
   | Ocamllsp
   | Utop
   | Ocamlearlybird
+  | Odig
 
 let to_dyn = function
   | Ocamlformat -> Dyn.variant "Ocamlformat" []
@@ -13,9 +14,10 @@ let to_dyn = function
   | Ocamllsp -> Dyn.variant "Ocamllsp" []
   | Utop -> Dyn.variant "Utop" []
   | Ocamlearlybird -> Dyn.variant "Ocamlearlybird" []
+  | Odig -> Dyn.variant "Odig" []
 ;;
 
-let all = [ Ocamlformat; Odoc; Ocamllsp; Utop; Ocamlearlybird ]
+let all = [ Ocamlformat; Odoc; Ocamllsp; Utop; Ocamlearlybird; Odig ]
 
 let equal a b =
   match a, b with
@@ -28,7 +30,10 @@ let equal a b =
   | Utop, Utop -> true
   | Utop, _ | _, Utop -> false
   | Ocamlearlybird, Ocamlearlybird -> true
-;;
+  | Ocamlearlybird, _ -> false
+  | _, Ocamlearlybird -> true
+  | Odig, Odig -> true
+
 
 let package_name = function
   | Ocamlformat -> Package_name.of_string "ocamlformat"
@@ -36,6 +41,7 @@ let package_name = function
   | Ocamllsp -> Package_name.of_string "ocaml-lsp-server"
   | Utop -> Package_name.of_string "utop"
   | Ocamlearlybird -> Package_name.of_string "earlybird"
+  | Odig -> Package_name.of_string "odig"
 ;;
 
 let of_package_name package_name =
@@ -45,6 +51,7 @@ let of_package_name package_name =
   | "ocaml-lsp-server" -> Ocamllsp
   | "utop" -> Utop
   | "earlybird" -> Ocamlearlybird
+  | "odig" -> Odig
   | other -> User_error.raise [ Pp.textf "No such dev tool: %s" other ]
 ;;
 
@@ -54,6 +61,7 @@ let exe_name = function
   | Ocamllsp -> "ocamllsp"
   | Utop -> "utop"
   | Ocamlearlybird -> "ocamlearlybird"
+  | Odig -> "odig"
 ;;
 
 let exe_path_components_within_package t =
@@ -63,6 +71,7 @@ let exe_path_components_within_package t =
   | Ocamllsp -> [ "bin"; exe_name t ]
   | Utop -> [ "bin"; exe_name t ]
   | Ocamlearlybird -> [ "bin"; exe_name t ]
+  | Odig -> [ "bin"; exe_name t]
 ;;
 
 let needs_to_build_with_same_compiler_as_project = function
@@ -71,4 +80,5 @@ let needs_to_build_with_same_compiler_as_project = function
   | Ocamllsp -> true
   | Utop -> false
   | Ocamlearlybird -> false
+  | Odig -> false
 ;;

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -6,6 +6,7 @@ type t =
   | Ocamllsp
   | Utop
   | Ocamlearlybird
+  | Odig
 
 val to_dyn : t -> Dyn.t
 val all : t list

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -36,6 +36,12 @@ Output the help text:
              ocamllsp executable (pass flags to ocamllsp after the '--'
              argument, such as 'dune tools exec ocamllsp -- --help').
   
+         odig [OPTION]… [ARGS]…
+             Wrapper for running odig intended to be run automatically by a
+             text editor. All positional arguments will be passed to the odig
+             executable (pass flags to odig after the '--' argument, such as
+             'dune tools exec odig -- --help').
+  
   COMMON OPTIONS
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -28,6 +28,7 @@ Confirm that each dev tool's bin directory is now in PATH:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/odig/odig/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/earlybird/earlybird/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/utop/utop/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/ocaml-lsp-server/ocaml-lsp-server/target/bin


### PR DESCRIPTION
This PR enrolls `odig` as a dev-tool, to help calling from [vscode-ocaml-platform](https://github.com/ocamllabs/vscode-ocaml-platform), as `vscode-ocaml-platfrom` calls `odig` rather than `odoc`. (cc @pitag-ha @PizieDust)