### PR TITLE
fix(dune_cache): use [binary:true] to write atomically

### DIFF
--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -59,7 +59,7 @@ let write_atomically ~mode ~content dst : Write_result.t =
   Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune" ~suffix:"write" ~f:(function
     | Error e -> Write_result.Error e
     | Ok temp_file ->
-      (match Io.write_file ~binary:false temp_file content with
+      (match Io.write_file ~binary:true temp_file content with
        | exception e -> Error e
        | () -> add_atomically ~mode ~src:temp_file ~dst))
 ;;


### PR DESCRIPTION
We're writing files that are used by dune, we don't need any line ending conversion here.

Same thing is done upstream

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>