### PR TITLE
stdune: define User_message.to_dyn and replace Poly.compare

### DIFF
--- a/otherlibs/stdune/src/import.ml
+++ b/otherlibs/stdune/src/import.ml
@@ -1,0 +1,31 @@
+module Pp = struct
+  include Pp
+
+  (** This version of [Pp.compare] uses [Ordering.t] rather than returning an [int]. *)
+  let compare ~compare x y =
+    Ordering.of_int (Pp.compare (fun a b -> Ordering.to_int (compare a b)) x y)
+  ;;
+
+  let to_dyn tag_to_dyn t =
+    let rec to_dyn t =
+      let open Dyn in
+      match (t : _ Pp.Ast.t) with
+      | Nop -> variant "Nop" []
+      | Seq (x, y) -> variant "Seq" [ to_dyn x; to_dyn y ]
+      | Concat (x, y) -> variant "Concat" [ to_dyn x; list to_dyn y ]
+      | Box (i, t) -> variant "Box" [ int i; to_dyn t ]
+      | Vbox (i, t) -> variant "Vbox" [ int i; to_dyn t ]
+      | Hbox t -> variant "Hbox" [ to_dyn t ]
+      | Hvbox (i, t) -> variant "Hvbox" [ int i; to_dyn t ]
+      | Hovbox (i, t) -> variant "Hovbox" [ int i; to_dyn t ]
+      | Verbatim s -> variant "Verbatim" [ string s ]
+      | Char c -> variant "Char" [ char c ]
+      | Break (x, y) ->
+        variant "Break" [ triple string int string x; triple string int string y ]
+      | Newline -> variant "Newline" []
+      | Text s -> variant "Text" [ string s ]
+      | Tag (s, t) -> variant "Tag" [ tag_to_dyn s; to_dyn t ]
+    in
+    to_dyn (Pp.to_ast t)
+  ;;
+end

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -34,39 +34,6 @@ module Ordering = Ordering
 module Flock = Flock
 module Terminal_signals = Terminal_signals
 module Execution_env = Execution_env
-
-module Pp = struct
-  include Pp
-
-  (** This version of [Pp.compare] uses [Ordering.t] rather than returning an [int]. *)
-  let compare ~compare x y =
-    Ordering.of_int (Pp.compare (fun a b -> Ordering.to_int (compare a b)) x y)
-  ;;
-
-  let to_dyn tag_to_dyn t =
-    let rec to_dyn t =
-      let open Dyn in
-      match (t : _ Pp.Ast.t) with
-      | Nop -> variant "Nop" []
-      | Seq (x, y) -> variant "Seq" [ to_dyn x; to_dyn y ]
-      | Concat (x, y) -> variant "Concat" [ to_dyn x; list to_dyn y ]
-      | Box (i, t) -> variant "Box" [ int i; to_dyn t ]
-      | Vbox (i, t) -> variant "Vbox" [ int i; to_dyn t ]
-      | Hbox t -> variant "Hbox" [ to_dyn t ]
-      | Hvbox (i, t) -> variant "Hvbox" [ int i; to_dyn t ]
-      | Hovbox (i, t) -> variant "Hovbox" [ int i; to_dyn t ]
-      | Verbatim s -> variant "Verbatim" [ string s ]
-      | Char c -> variant "Char" [ char c ]
-      | Break (x, y) ->
-        variant "Break" [ triple string int string x; triple string int string y ]
-      | Newline -> variant "Newline" []
-      | Text s -> variant "Text" [ string s ]
-      | Tag (s, t) -> variant "Tag" [ tag_to_dyn s; to_dyn t ]
-    in
-    to_dyn (Pp.to_ast t)
-  ;;
-end
-
 module Result = Result
 module Set = Set
 module Signal = Signal
@@ -99,6 +66,7 @@ module Code_error = Code_error
 module User_error = User_error
 module User_message = User_message
 module User_warning = User_warning
+module Pp = Import.Pp
 module Lexbuf = Lexbuf
 module Scanf = Scanf
 module Sys = Sys

--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -1,3 +1,5 @@
+open Import
+
 module Style = struct
   type t =
     | Loc
@@ -177,11 +179,23 @@ type t =
   ; dir : string option
   }
 
+let to_dyn { loc; paragraphs; hints; annots; context; dir } =
+  Dyn.record
+    [ "loc", Dyn.option Loc0.to_dyn loc
+    ; "paragraphs", Dyn.list (Pp.to_dyn Style.to_dyn) paragraphs
+    ; "hints", Dyn.list (Pp.to_dyn Style.to_dyn) hints
+    ; "annots", Annots.to_dyn annots
+    ; "context", Dyn.option Dyn.string context
+    ; "dir", Dyn.option Dyn.string dir
+    ]
+;;
+
 let compare { loc; paragraphs; hints; annots; context = _; dir = _ } t =
   let open Ordering.O in
   let= () = Option.compare Loc0.compare loc t.loc in
-  let= () = List.compare paragraphs t.paragraphs ~compare:Poly.compare in
-  let= () = List.compare hints t.hints ~compare:Poly.compare in
+  let compare = Pp.compare ~compare:Style.compare in
+  let= () = List.compare paragraphs t.paragraphs ~compare in
+  let= () = List.compare hints t.hints ~compare in
   Poly.compare annots t.annots
 ;;
 

--- a/otherlibs/stdune/src/user_message.mli
+++ b/otherlibs/stdune/src/user_message.mli
@@ -1,3 +1,5 @@
+open Import
+
 (** A message for the user *)
 
 (** User messages are styled document that can be printed to the console or in
@@ -73,6 +75,7 @@ type t =
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val pp : t -> Style.t Pp.t
+val to_dyn : t -> Dyn.t
 
 module Print_config : sig
   (** Associate ANSI terminal styles to symbolic styles *)


### PR DESCRIPTION
Due to dependency cycles, this useful function was omitted previously. We introduce it, since it is useful for debugging and testing. Doing so requires appending to the Pp module earlier on, which also allows us to define User_message.compare more correctly, avoiding Poly.compare.