### PR TITLE
fix: blake3 build for *bsd and Haiku

### DIFF
--- a/vendor/ocaml-blake3-mini/dune
+++ b/vendor/ocaml-blake3-mini/dune
@@ -34,7 +34,10 @@
    (= %{architecture} "amd64")
    (or
     (= %{system} "linux")
-    (= %{system} "macosx"))))
+    (= %{system} "macosx")
+    (= %{system} "freebsd")
+    (= %{system} "openbsd")
+    (= %{system} "netbsd"))))
  (deps blake3_avx2_x86-64_unix.S)
  (targets blake3_avx2_x86-64%{ext_obj})
  (action
@@ -46,7 +49,10 @@
    (= %{architecture} "amd64")
    (or
     (= %{system} "linux")
-    (= %{system} "macosx"))))
+    (= %{system} "macosx")
+    (= %{system} "freebsd")
+    (= %{system} "openbsd")
+    (= %{system} "netbsd"))))
  (deps blake3_avx512_x86-64_unix.S)
  (targets blake3_avx512_x86-64%{ext_obj})
  (action
@@ -58,7 +64,10 @@
    (= %{architecture} "amd64")
    (or
     (= %{system} "linux")
-    (= %{system} "macosx"))))
+    (= %{system} "macosx")
+    (= %{system} "freebsd")
+    (= %{system} "openbsd")
+    (= %{system} "netbsd"))))
  (deps blake3_sse2_x86-64_unix.S)
  (targets blake3_sse2_x86-64%{ext_obj})
  (action
@@ -70,7 +79,10 @@
    (= %{architecture} "amd64")
    (or
     (= %{system} "linux")
-    (= %{system} "macosx"))))
+    (= %{system} "macosx")
+    (= %{system} "freebsd")
+    (= %{system} "openbsd")
+    (= %{system} "netbsd"))))
  (deps blake3_sse41_x86-64_unix.S)
  (targets blake3_sse41_x86-64%{ext_obj})
  (action
@@ -198,7 +210,10 @@
       (= %{system} "win64")
       (= %{system} "mingw64")
       (= %{system} "linux")
-      (= %{system} "macosx"))))
+      (= %{system} "macosx")
+      (= %{system} "freebsd")
+      (= %{system} "openbsd")
+      (= %{system} "netbsd"))))
    (not
     (or
      (= %{architecture} "arm64")

--- a/vendor/ocaml-blake3-mini/dune
+++ b/vendor/ocaml-blake3-mini/dune
@@ -35,6 +35,7 @@
    (or
     (= %{system} "linux")
     (= %{system} "macosx")
+    (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
     (= %{system} "netbsd"))))
@@ -50,6 +51,7 @@
    (or
     (= %{system} "linux")
     (= %{system} "macosx")
+    (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
     (= %{system} "netbsd"))))
@@ -65,6 +67,7 @@
    (or
     (= %{system} "linux")
     (= %{system} "macosx")
+    (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
     (= %{system} "netbsd"))))
@@ -80,6 +83,7 @@
    (or
     (= %{system} "linux")
     (= %{system} "macosx")
+    (= %{system} "beos")
     (= %{system} "freebsd")
     (= %{system} "openbsd")
     (= %{system} "netbsd"))))
@@ -211,6 +215,7 @@
       (= %{system} "mingw64")
       (= %{system} "linux")
       (= %{system} "macosx")
+      (= %{system} "beos")
       (= %{system} "freebsd")
       (= %{system} "openbsd")
       (= %{system} "netbsd"))))


### PR DESCRIPTION
We fix the build of Dune on FreeBSD, OpenBSD and NetBSD. This patch has been tested in a custom CI setup here: https://github.com/Alizter/dune/pull/6. I've also added `beos` which will fix the build on Haiku which I've tested manually.

cc @maiste I would appreciate if this could make it into 3.20.0, if not, then 3.20.1 would also be fine.

- fix #12087 