### PR TITLE
Export and unset env variables in tests

### DIFF
--- a/test/blackbox-tests/test-cases/custom-cross-compilation/toolchain.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/toolchain.t
@@ -51,11 +51,14 @@ Now we create the toolchain and make sure we actually use it:
 
 We set an undefined toolchain with findlib:
 
-  $ OCAMLFIND_TOOLCHAIN=foobar buildfoo
+  $ export OCAMLFIND_TOOLCHAIN=foobar
+  $ buildfoo
   ocamlfind: [WARNING] Undefined toolchain: foobar
   ocamlfind: [WARNING] Undefined toolchain: foobar
   built foo.cma
-  $ OCAMLFIND_CONF=$PWD/etc/findlib.conf OCAMLFIND_TOOLCHAIN=foobar buildfoo
+  $ unset OCAMLFIND_TOOLCHAIN
+  $ export OCAMLFIND_CONF=$PWD/etc/findlib.conf OCAMLFIND_TOOLCHAIN=foobar
+  $ buildfoo
   from notocamlc-foobar
   from notocamlc-foobar
   from notocamlc-foobar
@@ -77,7 +80,8 @@ Now we set it in the workspace:
   $ buildfoo
   built foo.cma
 
-  $ OCAMLFIND_CONF=$PWD/etc/findlib.conf buildfoo
+  $ export OCAMLFIND_CONF=$PWD/etc/findlib.conf
+  $ buildfoo
   from notocamlc-foobar
   from notocamlc-foobar
   from notocamlc-foobar

--- a/test/blackbox-tests/test-cases/test-build-if/feature.t
+++ b/test/blackbox-tests/test-cases/test-build-if/feature.t
@@ -50,8 +50,10 @@ We test the various combinations:
   $ test_all () {
   >   test_one @all
   >   test_one @runtest
-  >   ENABLED=true test_one @all
-  >   ENABLED=true test_one @runtest
+  >   export ENABLED=true
+  >   test_one @all
+  >   test_one @runtest
+  >   unset ENABLED
   > }
 
   $ test_all


### PR DESCRIPTION
Exporting and unsetting variables in the tests hopefully makes it Unix compliant as discussed in #12104.