### PR TITLE
pkg: don't set %{jobs} variable from -j in deps

### DIFF
--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -135,6 +135,9 @@ module Dune_config : sig
   val hash : t -> int
   val equal : t -> t -> bool
 
+  (** The degree of concurrency dune will use by default. *)
+  val auto_concurrency : int lazy_t
+
   (** [for_scheduler config ?watch_exclusions stats_opt ~signal_watcher]
       creates a configuration for a scheduler from the user-visible Dune
       [config]. *)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -662,7 +662,14 @@ module Action_expander = struct
       | Build -> Memo.return [ Value.Dir paths.source_dir ]
       | Prefix -> Memo.return [ Value.Dir paths.prefix ]
       | User -> Memo.return [ Value.String (Unix.getlogin ()) ]
-      | Jobs -> Memo.return [ Value.String (Int.to_string !Clflags.concurrency) ]
+      | Jobs ->
+        (* Note that here we intentionally don't set %{jobs} based on dune's
+           "-j" argument. Doing so would mean that each time a different
+           value is passed to "-j", all the dependencies of the project that
+           reference %{jobs} would be rebuilt (including the OCaml compiler
+           itself which takes several minutes). *)
+        Memo.return
+          [ Value.String (Int.to_string (Lazy.force Dune_config.auto_concurrency)) ]
       | Arch -> sys_poll_var (fun { arch; _ } -> arch)
       | Group ->
         let group = Unix.getgid () |> Unix.getgrgid in


### PR DESCRIPTION
When building a project's dependencies, setting the value of %{jobs} from the value of -j means that each time a different value is passed to ${jobs}, each dependency of the project that references the %{jobs} variable in its dependency cone is rebuilt. This includes the compiler which can take several minutes to build. Setting the %{jobs} variable to a fixed value (chosen as the default degree of concurrency used by dune) avoids this issue. Passing a value to -j still affects the degree of concurrency used when building the project itself (as opposed to its dependencies).

Fixes https://github.com/ocaml/dune/issues/12103