### PR TITLE
tests: Make `dune.lock` a configurable location

### DIFF
--- a/test/blackbox-tests/test-cases/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe_location.t
@@ -25,11 +25,13 @@ An executable from the current project:
   _build/default/foo.exe
 
 Test that executables from dependencies are located correctly:
-  $ mkdir dune.lock
-  $ cat > dune.lock/lock.dune << EOF
+
+  $ default_lock_dir="dune.lock"
+  $ mkdir -p "${default_lock_dir}"
+  $ cat > "${default_lock_dir}"/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat > dune.lock/bar.pkg << EOF
+  $ cat > ${default_lock_dir}/bar.pkg << EOF
   > (version 0.1)
   > (install
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -4,7 +4,7 @@ Test that section pforms are substituted with absolute paths.
 
   $ make_lockdir
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (install (progn
   >  (run echo --prefix %{prefix})

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -21,7 +21,7 @@ Ensure the alias is not available outside of the package manamgent context:
 
 Create a fake package which echoes information to stdout when build:
   $ make_lockdir
-  $ cat > dune.lock/foo.pkg << EOF
+  $ cat > ${default_lock_dir}/foo.pkg << EOF
   > (version 0.0.1)
   > (build
   >  (run echo "Build package foo"))

--- a/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
@@ -19,13 +19,10 @@ Make a directory to contain a test project and change to it.
   $ cd project
 
 Create a lockdir for the project.
-  $ mkdir dune.lock
-  $ cat > dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ make_lockdir
 
 The package "foo" exercises copying package sources from a local directory.
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch
@@ -34,7 +31,7 @@ The package "foo" exercises copying package sources from a local directory.
   > EOF
 
 The package "bar" exercises extracting a source archive from a local file.
-  $ cat > dune.lock/bar.pkg <<EOF
+  $ cat > ${default_lock_dir}/bar.pkg <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch
@@ -43,7 +40,7 @@ The package "bar" exercises extracting a source archive from a local file.
   > EOF
 
 The package "bar" exercises extracting a source archive from a downloaded file.
-  $ cat > dune.lock/baz.pkg <<EOF
+  $ cat > ${default_lock_dir}/baz.pkg <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -15,7 +15,7 @@ Start with a project with a single package with no dependencies:
   > EOF
   Solution for dune.lock:
   (no dependencies to lock)
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (repositories
@@ -49,7 +49,7 @@ Add a non-local dependency to the package:
   > EOF
   Solution for dune.lock:
   - a.0.0.1
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (dependency_hash 7ba1cacd46bb2609d7b9735909c3b8a5)
@@ -98,7 +98,7 @@ Remove all dependencies from the project:
 
 Exercise handling invalid dependency hashes.
   $ make_lock_metadata_with_hash() {
-  >   cat >dune.lock/lock.dune <<EOF
+  >   cat > ${default_lock_dir}/lock.dune <<EOF
   > (lang package 0.1)
   > (dependency_hash $1)
   > (repositories

--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -13,7 +13,7 @@ Create a directory containing a shell script and add the directory to PATH.
 
 Create a lockdir with a lockfile that runs the shell script in a build command.
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build (run hello))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -26,7 +26,7 @@ A file that will comprise the package source:
 
 Replace the path in the lockfile as it would otherwise include the sandbox
 path.
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (source
@@ -54,7 +54,7 @@ Recreate the foo package with a fake port number to signal that the file will
   Warning: download failed with code 404
   Solution for dune.lock:
   - foo.0.0.1
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (source

--- a/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
+++ b/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
@@ -17,7 +17,7 @@ constraints.
   - a.0.0.1
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (depends a)

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -92,7 +92,7 @@ Package which has boolean where string was expected. This should be caught while
   - with-interpolation.0.0.1
   - with-percent-sign.0.0.1
 
-  $ cat dune.lock/standard-dune.pkg
+  $ cat ${default_lock_dir}/standard-dune.pkg
   (version 0.0.1)
   
   (install
@@ -105,7 +105,7 @@ Package which has boolean where string was expected. This should be caught while
      (run dune subst))
     (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
 
-  $ cat dune.lock/with-interpolation.pkg
+  $ cat ${default_lock_dir}/with-interpolation.pkg
   (version 0.0.1)
   
   (install
@@ -116,13 +116,13 @@ Package which has boolean where string was expected. This should be caught while
     (run ./configure --prefix=%{prefix} --docdir=%{doc}/ocaml)
     (run %{make} -j%{jobs})))
 
-  $ cat dune.lock/with-percent-sign.pkg
+  $ cat ${default_lock_dir}/with-percent-sign.pkg
   (version 0.0.1)
   
   (build
    (run printf %d 42))
 
-  $ cat dune.lock/variable-types.pkg
+  $ cat ${default_lock_dir}/variable-types.pkg
   (version 0.0.1)
   
   (build
@@ -144,7 +144,7 @@ Package which has boolean where string was expected. This should be caught while
   Solution for dune.lock:
   - exercise-filters.0.0.1
 
-  $ cat dune.lock/exercise-filters.pkg
+  $ cat ${default_lock_dir}/exercise-filters.pkg
   (version 0.0.1)
   
   (build
@@ -193,7 +193,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
   $ solve exercise-filters
   Solution for dune.lock:
   - exercise-filters.0.0.1
-  $ cat dune.lock/exercise-filters.pkg
+  $ cat ${default_lock_dir}/exercise-filters.pkg
   (version 0.0.1)
   
   (build
@@ -241,7 +241,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
   $ solve exercise-term-filters
   Solution for dune.lock:
   - exercise-term-filters.0.0.1
-  $ cat dune.lock/exercise-term-filters.pkg
+  $ cat ${default_lock_dir}/exercise-term-filters.pkg
   (version 0.0.1)
   
   (build
@@ -301,7 +301,7 @@ to a dune if-statement that checks the "enable" variable (rather than the
 It's probably an error for opam packages to use the "enable" in ways that opam
 doesn't desugar but these tests are included so we can check that behaviour is
 preserved between opam and dune.
-  $ cat dune.lock/package-conjunction-and-string-selection.pkg
+  $ cat ${default_lock_dir}/package-conjunction-and-string-selection.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -3,8 +3,8 @@ Some environment variables are automatically exported by packages:
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ echo "(version 0.0.1)" > dune.lock/test.pkg
-  $ cat >dune.lock/usetest.pkg <<'EOF'
+  $ echo "(version 0.0.1)" > ${default_lock_dir}/test.pkg
+  $ cat > ${default_lock_dir}/usetest.pkg <<'EOF'
   > (version 0.0.1)
   > (depends test)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -26,7 +26,7 @@ Make a project that uses the foo library:
 
 Make dune.lock files with known program "dune".
   $ make_lockdir
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (run dune build))
@@ -54,7 +54,7 @@ error message.
 
 Make dune.lock files with unknown program and unknown package.
   $ make_lockdir
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (run unknown-program))

--- a/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
@@ -12,7 +12,7 @@ Make a project:
 Create a lockdir with a package that features some depexts.
 
   $ make_lockdir
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (depexts unzip gnupg)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/depexts/solve.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/solve.t
@@ -21,7 +21,7 @@ locking would add the opam 'depext' field to foo.pkg
   $ dune pkg lock
   Solution for dune.lock:
   - foo.0.0.1
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (depexts unzip gnupg)

--- a/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
@@ -21,5 +21,5 @@ Locking should succeed and not include the "unzip" package
   $ dune pkg lock 2>&1 | head -n 1
   Solution for dune.lock:
 
-  $ [ -e dune.lock/foo.pkg ] && cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
@@ -19,7 +19,7 @@ The optional dependency on "b" is not included in foo's dependencies because
   Solution for dune.lock:
   - a.0.0.1
   - foo.0.0.1
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (depends a)
@@ -37,7 +37,7 @@ the dependencies of "foo", since "b" is part of the package solution:
   - b.0.0.1
   - bar.0.0.1
   - foo.0.0.1
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
   
   (depends a b)

--- a/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
@@ -16,7 +16,7 @@ Make a package with a depopts field
 When depopts are supported and selected, the above lock should change and we
 should also be able to see a deps field in the lock file:
 
-  $ cat dune.lock/with-depopts.pkg
+  $ cat ${default_lock_dir}/with-depopts.pkg
   (version 0.0.1)
 
 We should also be able to validate the lock directory:

--- a/test/blackbox-tests/test-cases/pkg/duplicate-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/duplicate-packages.t
@@ -10,11 +10,8 @@ shouldn't be allowed (for now)
   $ cat > mypkg.opam <<EOF
   > opam-version: "2.0"
   > EOF
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
-  $ touch dune.lock/mypkg.lock
+  $ make_lockdir
+  $ touch ${default_lock_dir}/mypkg.lock
 
   $ dune build
 

--- a/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
@@ -3,7 +3,7 @@ Test for packages with no source field but with extra_sources.
   $ . ./helpers.sh
   $ make_lockdir
 
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 1)
   > (extra_sources
   >  (foo.txt

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -3,7 +3,7 @@ Packages can export environment variables
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (exported_env
   >  (= FOO bar)
@@ -12,7 +12,7 @@ Packages can export environment variables
   >  (:= BAR zzz))
   > EOF
 
-  $ cat >dune.lock/usetest.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/usetest.pkg <<'EOF'
   > (depends test)
   > (version 1.2.3)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
@@ -2,8 +2,10 @@ A lock directory which does not exist in the source tree:
 
   $ . ./helpers.sh
 
-  $ mkdir dune.lock project
-  $ cat >dune.lock/foo.pkg <<EOF
+  $ mkdir project
+
+  $ make_lockdir
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (build (run echo foo))
   > (version 1.0.0)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -6,7 +6,7 @@ Test that can fetch the sources from an external dir
   $ echo "y" > foo/x
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/foo))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
@@ -4,7 +4,7 @@ file in the package's source.
   $ . ./helpers.sh
   $ make_lockdir
 
-  $ cat > dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 1)
   > (source
   >  (copy $PWD/foo-source))

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -13,7 +13,7 @@ Fetch from more than one source
   > this is baz
   > EOF
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/foo))
   > (extra_sources (mybaz (copy $PWD/baz)))
@@ -114,7 +114,7 @@ url and the extra source.
   Solution for dune.lock:
   - needs-patch.0.0.1
 
-  $ sed -E 's/md5=[0-9a-f]+/md5=$HASH/g' dune.lock/needs-patch.pkg
+  $ sed -E 's/md5=[0-9a-f]+/md5=$HASH/g' ${default_lock_dir}/needs-patch.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -18,7 +18,7 @@ Set up a project that depends on a package that is being downloaded
   $ echo test.tar > fake-curls
   $ SRC_PORT=1
   $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch

--- a/test/blackbox-tests/test-cases/pkg/file-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/file-depends.t
@@ -8,7 +8,7 @@ the files found in files-depend.
   $ make_lockdir
 
   $ foo=$PWD/foo
-  > cat > dune.lock/file-depends.pkg <<EOF
+  > cat > ${default_lock_dir}/file-depends.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| echo Building file-depends
@@ -24,7 +24,7 @@ checksum is not parsable.
 
 Now we make a package depending on file-depends.
 
-  $ cat > dune.lock/dep.pkg <<EOF
+  $ cat > ${default_lock_dir}/dep.pkg <<EOF
   > (version 0.0.1)
   > (depends file-depends)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
+++ b/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
@@ -33,13 +33,13 @@ Reproduces #11405
   > (lang dune 3.17)
   > EOF
 
-  $ mkdir dune.lock
+  $ make_lockdir
 
-  $ cat >dune.lock/lock.dune <<EOF
+  $ cat > ${default_lock_dir}/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
 
-  $ cat >dune.lock/mypkg.pkg <<EOF
+  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/gh10959.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10959.t
@@ -22,12 +22,12 @@ Now we set up a lock file with this package and then attempt to use it:
   > (lang dune 3.11)
   > EOF
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
+  $ make_lockdir
+  $ cat > ${default_lock_dir}/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
 
-  $ cat >dune.lock/mypkg.pkg <<EOF
+  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/gh10985.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10985.t
@@ -24,16 +24,14 @@ the package directory in the dune file:
 
 Now we set up a lock file with this package and then attempt to use it:
 
-  $ cat >dune-project <<EOF
+  $ cat > dune-project <<EOF
   > (lang dune 3.11)
   > EOF
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ . ../helpers.sh
 
-  $ cat >dune.lock/mypkg.pkg <<EOF
+  $ make_lockdir
+  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/../external_sources))
   > (build (run dune build --release --promote-install-file=true . @install))

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -7,7 +7,7 @@ Things should be the same whether dependencies are specified or not.
 If we have a package we depend on
 
   $ mkdir dependency-source
-  $ cat >dune.lock/dependency.pkg <<EOF
+  $ cat > ${default_lock_dir}/dependency.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/dependency-source))
   > EOF
@@ -15,7 +15,7 @@ If we have a package we depend on
 And we have a package we want to build
 
   $ mkdir test-source
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -25,7 +25,7 @@ And we have a package we want to build
 
 Now it fails since adding the dependency modified PATH.
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > ; adding deps breaks cat

--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -77,7 +77,7 @@ Locking should be successful and it should include the additional file
   Solution for dune.lock:
   - foo.1.2
 
-  $ find dune.lock | sort
+  $ find ${default_lock_dir} | sort
   dune.lock
   dune.lock/foo.files
   dune.lock/foo.files/hello.txt
@@ -87,7 +87,7 @@ Locking should be successful and it should include the additional file
 The extra-file should have the same content as the original file, we determine
 that by hashing with the checksum that we expected in the OPAM file
 
-  $ cmp -s dune.lock/foo.files/$FILES_NAME "$FILES_FOLDER/$FILES_NAME" && echo "The contents match"
+  $ cmp -s ${default_lock_dir}/foo.files/$FILES_NAME "$FILES_FOLDER/$FILES_NAME" && echo "The contents match"
   The contents match
 
 The git repos support repo should also be able to handle unusual objects in our

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -15,7 +15,7 @@ Test fetching from git
 
   $ mkdir foo && cd foo
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$MYGITREPO")))
   > (build (run cat foo))

--- a/test/blackbox-tests/test-cases/pkg/git-submodule.t
+++ b/test/blackbox-tests/test-cases/pkg/git-submodule.t
@@ -31,7 +31,7 @@ someotherrepo as a submodule.
 
   $ mkdir foo && cd foo
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$SOMEREPO")))
   > (build (progn (run cat foo) (run cat mysubmodule/bar)))
@@ -46,7 +46,7 @@ not the case and only somerepo is pulled.
 When the above works it should act like:
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$SOMEREPO")))
   > (build 

--- a/test/blackbox-tests/test-cases/pkg/hash-algos.t
+++ b/test/blackbox-tests/test-cases/pkg/hash-algos.t
@@ -60,7 +60,7 @@ first checksum to the lockfile for this package.
   - with-sha256.0.0.1
   - with-sha512.0.0.1
 
-  $ cat dune.lock/*
+  $ cat ${default_lock_dir}/*
   (lang package 0.1)
   
   (dependency_hash 32180cf311133b30d0b5be2a40c89f43)

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -13,6 +13,8 @@ dune="dune"
 
 pkg_root="_build/_private/default/.pkg"
 
+default_lock_dir="dune.lock"
+
 build_pkg() {
   $dune build $pkg_root/$1/target/
 }
@@ -92,10 +94,10 @@ EOF
 }
 
 make_lockpkg() {
-  local dir="dune.lock"
-  mkdir -p $dir
+  local dir="${default_lock_dir}"
+  mkdir -p "$dir"
   local f="$dir/$1.pkg"
-  cat >$f
+  cat > "$f"
 }
 
 solve_project() {
@@ -105,8 +107,8 @@ solve_project() {
 }
 
 make_lockdir() {
-  mkdir -p dune.lock
-  cat >dune.lock/lock.dune <<EOF
+  mkdir -p "${default_lock_dir}"
+  cat > "${default_lock_dir}"/lock.dune <<EOF
 (lang package 0.1)
 (repositories (complete true))
 EOF
@@ -123,7 +125,7 @@ EOF
 }
 
 print_source() {
-  cat dune.lock/$1.pkg | sed -n "/source/,//p" | sed "s#$PWD#PWD#g" | tr '\n' ' '| tr -s " "
+  cat "${default_lock_dir}"/"$1".pkg | sed -n "/source/,//p" | sed "s#$PWD#PWD#g" | tr '\n' ' '| tr -s " "
 }
 
 solve() {

--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
@@ -6,7 +6,7 @@ without using locked dependencies.
 
   $ make_lockdir
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (build
   >  (run echo "I have not been ignored."))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -3,15 +3,15 @@ Test that shows what happens when dune.lock is ignored.
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (progn
   >   (run touch foo.ml)
   >   (patch foo.patch)))
   > EOF
-  $ mkdir dune.lock/test.files
-  $ cat > dune.lock/test.files/foo.patch <<EOF
+  $ mkdir ${default_lock_dir}/test.files
+  $ cat > ${default_lock_dir}/test.files/foo.patch <<EOF
   > diff --git a/foo.ml b/foo.ml
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -3,7 +3,7 @@ Install actions should have the switch directory prepared:
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (install (system "find %{prefix} | sort"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -3,7 +3,7 @@ Testing install actions
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (install (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
@@ -4,7 +4,7 @@ Use build paths in the install entries of a package
 
   $ make_lockdir
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.install <<EOF

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -4,7 +4,7 @@ Test missing entries in the .install file
 
   $ make_lockdir
   $ lockfile() {
-  > cat >dune.lock/test.pkg <<EOF
+  > cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "echo 'lib: [ \"$1\" ]' > test.install"))

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -3,7 +3,7 @@ Test that installed binaries are visible in dependent packages
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| echo "#!/bin/sh\necho from test package" > foo;
@@ -18,7 +18,7 @@ Test that installed binaries are visible in dependent packages
   >  ))
   > EOF
 
-  $ cat >dune.lock/usetest.pkg <<EOF
+  $ cat > ${default_lock_dir}/usetest.pkg <<EOF
   > (version 0.0.1)
   > (depends test)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/libraries.t
+++ b/test/blackbox-tests/test-cases/pkg/libraries.t
@@ -25,12 +25,9 @@ Now we set up a lock file with this package and then attempt to use it:
   > (lang dune 3.11)
   > EOF
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ make_lockdir
 
-  $ cat >dune.lock/mypkg.pkg <<EOF
+  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build (run dune build --release --promote-install-file=true . @install))

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -1,23 +1,24 @@
 Create a lock directory that didn't originally exist
 
-  $ cat >dune-workspace <<EOF
+  $ . ../helpers.sh
+
+  $ cat > dune-workspace <<EOF
   > (lang dune 3.10)
   > (lock_dir
   >  (repositories mock))
   > (lock_dir
   >  (path "dev/dune.lock")
   >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
+  $ add_mock_repo_if_needed
+
   $ dune pkg lock "dev/dune.lock"
   Solution for dev/dune.lock:
   (no dependencies to lock)
   $ dune pkg lock
   Solution for dune.lock:
   (no dependencies to lock)
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (repositories
@@ -28,7 +29,7 @@ Re-create a lock directory in the newly created lock dir
   $ dune pkg lock
   Solution for dune.lock:
   (no dependencies to lock)
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (repositories
@@ -36,16 +37,18 @@ Re-create a lock directory in the newly created lock dir
    (used))
 
 Attempt to create a lock directory inside an existing directory without a lock.dune file
-  $ rm -rf dune.lock
-  $ cp -r dir-without-metadata dune.lock
+
+  $ rm -rf ${default_lock_dir}
+  $ cp -r dir-without-metadata ${default_lock_dir}
   $ dune pkg lock
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir lacks metadata file (lock.dune)
   [1]
 
 Attempt to create a lock directory inside an existing directory with an invalid lock.dune file
-  $ rm -rf dune.lock
-  $ cp -r dir-with-invalid-metadata dune.lock
+
+  $ rm -rf ${default_lock_dir}
+  $ cp -r dir-with-invalid-metadata ${default_lock_dir}
   $ dune pkg lock
   Error: Refusing to regenerate lock directory dune.lock
   Unable to parse lock directory metadata file (dune.lock/lock.dune):
@@ -55,8 +58,9 @@ Attempt to create a lock directory inside an existing directory with an invalid 
   [1]
 
 Attempt to create a lock directory with the same name as an existing regular file
-  $ rm -rf dune.lock
-  $ touch dune.lock
+
+  $ rm -rf ${default_lock_dir}
+  $ touch ${default_lock_dir}
   $ dune pkg lock
   Error: Refusing to regenerate lock directory dune.lock
   Specified lock dir path (dune.lock) is not a directory

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -44,7 +44,7 @@ Initially the lockdir will be valid.
   $ dune pkg validate-lockdir
 
 Add a file to the lockdir to cause the parser to fail.
-  $ echo foo > dune.lock/bar.pkg
+  $ echo foo > ${default_lock_dir}/bar.pkg
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/bar.pkg", line 1, characters 0-3:
@@ -55,8 +55,8 @@ Add a file to the lockdir to cause the parser to fail.
   [1]
 
 Remove the file but corrupt the lockdir metadata file.
-  $ rm dune.lock/bar.pkg
-  $ echo foo >> dune.lock/lock.dune
+  $ rm ${default_lock_dir}/bar.pkg
+  $ echo foo >> ${default_lock_dir}/lock.dune
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/lock.dune", line 8, characters 0-3:
@@ -67,7 +67,7 @@ Remove the file but corrupt the lockdir metadata file.
   [1]
 
 Regenerate the lockdir and validate the result.
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - a.0.0.1
@@ -78,7 +78,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Remove a package from the lockdir.
-  $ rm dune.lock/a.pkg
+  $ rm ${default_lock_dir}/a.pkg
 
 This results in an invalid lockdir due to the missing package.
   $ dune pkg validate-lockdir
@@ -103,10 +103,10 @@ Regenerate the lockdir and validate the result.
   - e.0.0.1
   $ dune pkg validate-lockdir
 
-  $ cat dune.lock/b.pkg
+  $ cat ${default_lock_dir}/b.pkg
   (version 0.0.2)
 Change the version of a dependency by modifying its lockfile.
-  $ cat >dune.lock/b.pkg <<EOF
+  $ cat > ${default_lock_dir}/b.pkg <<EOF
   > (version 0.0.1)
   > EOF
 
@@ -135,7 +135,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Add a package to the lockdir with the same name as a local package.
-  $ cat >dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > EOF
 
@@ -162,7 +162,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Add a package to the lockdir which isn't part of the local package dependency hierarchy.
-  $ cat >dune.lock/f.pkg <<EOF
+  $ cat > ${default_lock_dir}/f.pkg <<EOF
   > (version 0.0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -6,15 +6,15 @@ package graph then it's caught when loading the lockdir.
 
   $ make_lockdir
 
-  $ cat >dune.lock/a.pkg <<EOF
+  $ cat > ${default_lock_dir}/a.pkg <<EOF
   > (version 0.0.1)
   > (depends b)
   > EOF
-  $ cat >dune.lock/b.pkg <<EOF
+  $ cat > ${default_lock_dir}/b.pkg <<EOF
   > (version 0.0.1)
   > (depends c)
   > EOF
-  $ cat >dune.lock/c.pkg <<EOF
+  $ cat > ${default_lock_dir}/c.pkg <<EOF
   > (version 0.0.1)
   > (depends a)
   > EOF
@@ -25,7 +25,7 @@ package graph then it's caught when loading the lockdir.
   - b.0.0.1
   - c.0.0.1
 
-  $ cat >dune.lock/c.pkg <<EOF
+  $ cat > ${default_lock_dir}/c.pkg <<EOF
   > (version 0.0.1)
   > (depends a d)
   > EOF
@@ -40,7 +40,7 @@ package graph then it's caught when loading the lockdir.
   regenerate it by running: 'dune pkg lock'
   [1]
 
-  $ rm dune.lock/a.pkg
+  $ rm ${default_lock_dir}/a.pkg
 
   $ dune describe pkg lock
   File "dune.lock/c.pkg", line 2, characters 9-10:

--- a/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
@@ -34,12 +34,12 @@ rather than "a.0.0.1".
   - d.0.0.1
 
 Confirm that we locked "a.0.0.2".
-  $ cat dune.lock/a.pkg
+  $ cat ${default_lock_dir}/a.pkg
   (version 0.0.2)
 
 The deps in the lockfile for "c" shouldn't contain "a" since the only version
 of "a" that "c" could depend on is "a.0.0.1" which isn't part of the solution.
-  $ cat dune.lock/c.pkg
+  $ cat ${default_lock_dir}/c.pkg
   (version 0.0.1)
   
   (depends b)

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -40,7 +40,7 @@ Run the solver and generate a lock directory.
 
 Helper to the name and contents of each file in the lock directory separated by
 "---", sorting by filename for consistency.
-  $ print_all() { find dune.lock -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"; }
+  $ print_all() { find ${default_lock_dir} -type f | sort | xargs -I{} sh -c "printf '{}:\n\n'; cat {}; printf '\n\n---\n\n'"; }
 
 Print the contents of each file in the lockdir:
   $ print_all

--- a/test/blackbox-tests/test-cases/pkg/make.t
+++ b/test/blackbox-tests/test-cases/pkg/make.t
@@ -8,7 +8,7 @@ Build a package with make
   > foo: ; @echo running makefile
   > EOF
   $ make_lockdir
-  $ cat >dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (build (run %{make}))
   > (source (copy $PWD/foo))

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
@@ -35,8 +35,8 @@ Multiple opam repositories that define the same package:
   $ make_project foo | cat >dune-project
 
   $ runtest () {
-  > dune pkg lock
-  > cat dune.lock/foo.pkg
+  >   dune pkg lock
+  >   cat ${default_lock_dir}/foo.pkg
   > }
 
 Define 1.0.0 in repo1 and 2.0.0 in repo2 for the same package:

--- a/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
@@ -72,12 +72,11 @@ use the system OCaml for this.
 
 Now we finally make the OCaml package for testing through the lock file:
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
+  $ make_lockdir
+  $ cat >> ${default_lock_dir}/lock.dune <<EOF
   > (ocaml mycaml)
   > EOF
-  $ cat >dune.lock/mycaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/mycaml.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/mycamlsources))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
@@ -27,7 +27,7 @@ Dune file in OCaml syntax and a files directory should work
 
   $ dune build
 
-  $ mkdir dune.lock/ocamlfind.files
-  $ touch dune.lock/ocamlfind.files/foo.patch
+  $ mkdir ${default_lock_dir}/ocamlfind.files
+  $ touch ${default_lock_dir}/ocamlfind.files/foo.patch
 
   $ dune build

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
@@ -53,11 +53,8 @@ attempt to build the package "foo".
 
 Create a lockdir and define the package "bar". Note its install command is
 `false` so it will fail to install.
-  $ mkdir dune.lock
-  $ cat > dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
-  $ cat > dune.lock/bar.pkg <<EOF
+  $ make_lockdir
+  $ cat > ${default_lock_dir}/bar.pkg <<EOF
   > (version 0.0.1)
   > (install (run false))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -95,14 +95,17 @@ EOF
 EOF
   cat > dune-workspace <<EOF
 (lang dune 3.13)
- (lock_dir
-  (path "dev-tools.locks/ocamlformat")
+
+(lock_dir
+ (path "dev-tools.locks/ocamlformat")
+ (repositories mock))
+
+(lock_dir
   (repositories mock))
-  (lock_dir
-   (repositories mock))
- (repository
-  (name mock)
-  (url "file://$(pwd)/mock-opam-repository"))
+
+(repository
+ (name mock)
+ (url "file://$(pwd)/mock-opam-repository"))
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -20,7 +20,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -18,7 +18,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
@@ -17,7 +17,7 @@ Test that ocamllsp can be installed while dune is running in watch mode.
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -16,10 +16,8 @@ Test that the ocamllsp dev tool can see the ocamlformat dev tool.
   >  (repositories mock))
   > (lock_dir
   >   (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$(pwd)/mock-opam-repository"))
   > EOF
+  $ add_mock_repo_if_needed
 
 Make a fake ocamllsp package that prints out the PATH variable:
   $ mkpkg ocaml-lsp-server <<EOF
@@ -41,7 +39,7 @@ Make a fake ocamlformat
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -23,7 +23,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 
@@ -43,7 +43,7 @@ We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   hello from fake ocamllsp
 
 Change the version of ocaml that the project depends on.
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.1.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -20,7 +20,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -23,7 +23,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
   $ make_lockdir
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.2.0)
   > EOF
 
@@ -55,7 +55,7 @@ We can re-run "dune ocaml doc" without relocking or rebuilding.
   [1]
 
 Change the version of ocaml that the project depends on.
-  $ cat > dune.lock/ocaml.pkg <<EOF
+  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
   > (version 5.1.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -13,5 +13,5 @@ To mark it, we use `conflict-class: "ocaml-core-compiler"`
   Solution for dune.lock:
   - foocaml.0.0.1
 
-  $ grep ocaml dune.lock/lock.dune
+  $ grep ocaml ${default_lock_dir}/lock.dune
   (ocaml foocaml)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -26,7 +26,7 @@ Make a package with a patch
 We expect that the files in the files directory of the opam repository get copied to the
 lock file. 
 
-  $ lock_dir="dune.lock/with-patch.files"
+  $ lock_dir="${default_lock_dir}/with-patch.files"
   $ [ -d $lock_dir ] && cat $lock_dir/$fname1
   foo
   $ [ -d $lock_dir ] && cat $lock_dir/$fname2

--- a/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
@@ -15,7 +15,7 @@ Make a package with only an install step
   - install-no-build.0.0.1
 The lockfile should only contain an install step.
 
-  $ cat dune.lock/install-no-build.pkg 
+  $ cat ${default_lock_dir}/install-no-build.pkg 
   (version 0.0.1)
   
   (install

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -17,13 +17,13 @@ Make a package with a substs and patches field field
   $ solve with-substs-and-patches
   Solution for dune.lock:
   - with-substs-and-patches.0.0.1
-  $ cat >>dune.lock/with-substs-and-patches.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-substs-and-patches.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 The lockfile should contain the substitute and patch actions.
 
-  $ cat dune.lock/with-substs-and-patches.pkg 
+  $ cat ${default_lock_dir}/with-substs-and-patches.pkg 
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
@@ -16,5 +16,5 @@ Make a package with a build-env field and no build or install step
 When there is no build or install step the build environment does not appear in the lock
 file.
 
-  $ cat dune.lock/with-build-env.pkg 
+  $ cat ${default_lock_dir}/with-build-env.pkg 
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
@@ -16,7 +16,7 @@ Make a package with a build-env field
   - with-build-env.0.0.1
 The lockfile should contain a setenv action.
 
-  $ cat dune.lock/with-build-env.pkg 
+  $ cat ${default_lock_dir}/with-build-env.pkg 
   (version 0.0.1)
   
   (install

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
@@ -20,7 +20,7 @@ action.
 
 This is currently not the case. 
 
-  $ cat dune.lock/with-build-test-doc.pkg 
+  $ cat ${default_lock_dir}/with-build-test-doc.pkg 
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
@@ -35,13 +35,13 @@ Make a package with an extra-source field and multiple checksums
   - with-extra-source.0.0.1
   - with-extra-source-md5.0.0.1
   - with-extra-source-multiple-checksums.0.0.1
-  $ cat >>dune.lock/with-extra-source.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-extra-source.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 The lockfile should contain the fetching of extra sources.
 
-  $ cat dune.lock/with-extra-source.pkg 
+  $ cat ${default_lock_dir}/with-extra-source.pkg 
   (version 0.0.1)
   
   (extra_sources
@@ -55,7 +55,7 @@ The lockfile should contain the fetching of extra sources.
 
 The lockfile should contain the fetching of extra sources with md5 checksums.
 
-  $ cat dune.lock/with-extra-source-md5.pkg 
+  $ cat ${default_lock_dir}/with-extra-source-md5.pkg 
   (version 0.0.1)
   
   (extra_sources
@@ -67,7 +67,7 @@ The lockfile should contain the fetching of extra sources with md5 checksums.
 The lockfile should contain the fetching of extra sources with the first checksum from the
 list of checksums.
 
-  $ cat dune.lock/with-extra-source-multiple-checksums.pkg 
+  $ cat ${default_lock_dir}/with-extra-source-multiple-checksums.pkg 
   (version 0.0.1)
   
   (extra_sources

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
@@ -3,13 +3,11 @@ file copying step rather than the build step.
 
   $ . ./helpers.sh
 
-  $ mkdir -p dune.lock/foo.files
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ make_lockdir
+  $ mkdir -p ${default_lock_dir}/foo.files
 
-  $ touch dune.lock/foo.files/foo.install
-  $ echo "(version 0.0.1)" > dune.lock/foo.pkg
+  $ touch ${default_lock_dir}/foo.files/foo.install
+  $ echo "(version 0.0.1)" > ${default_lock_dir}/foo.pkg
 
 The foo.install file in files/ should have been copied over.
   $ build_pkg foo 2>&1 | sed 's/copyfile/open/'

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
@@ -26,7 +26,7 @@ Demonstrate the translation of filtered dependencies
 
   $ solve bar 2>/dev/null
 
-  $ cat dune.lock/bar.pkg
+  $ cat ${default_lock_dir}/bar.pkg
   (version 0.0.1)
   
   (depends pkg-build)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -24,13 +24,13 @@ Make a package with a patch behind a filter
   $ solve with-patch-filter
   Solution for dune.lock:
   - with-patch-filter.0.0.1
-  $ cat >>dune.lock/with-patch-filter.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-patch-filter.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 The lockfile should contain the patch action with the appropriate filter. 
 
-  $ cat dune.lock/with-patch-filter.pkg 
+  $ cat ${default_lock_dir}/with-patch-filter.pkg 
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -48,19 +48,19 @@ file and the second patches two, one of the files is in a subdirectory.:w
   $ solve with-patch
   Solution for dune.lock:
   - with-patch.0.0.1
-  $ cat >>dune.lock/with-patch.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-patch.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 Checking that the patch files have been copied to the dune.lock dir
 
-  $ [ -d dune.lock/with-patch.files ] && ls dune.lock/with-patch.files/foo.patch
+  $ [ -d ${default_lock_dir}/with-patch.files ] && ls ${default_lock_dir}/with-patch.files/foo.patch
   dune.lock/with-patch.files/foo.patch
-  $ [ -d dune.lock/with-patch.files/dir ] && ls dune.lock/with-patch.files/dir/bar.patch
+  $ [ -d ${default_lock_dir}/with-patch.files/dir ] && ls ${default_lock_dir}/with-patch.files/dir/bar.patch
   dune.lock/with-patch.files/dir/bar.patch
 
 The lockfile should contain the patch action. 
-  $ cat dune.lock/with-patch.pkg 
+  $ cat ${default_lock_dir}/with-patch.pkg 
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -25,13 +25,13 @@ Make a package with a patch
   $ solve with-patch
   Solution for dune.lock:
   - with-patch.0.0.1
-  $ cat >>dune.lock/with-patch.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-patch.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 The lockfile should contain the patch action. 
 
-  $ cat dune.lock/with-patch.pkg 
+  $ cat ${default_lock_dir}/with-patch.pkg 
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -32,7 +32,7 @@ Make another package that depends on that and outputs the exported env vars
   - with-setenv.0.0.1
 The exported env from the first package should be in the lock dir.
 
-  $ cat dune.lock/with-setenv.pkg
+  $ cat ${default_lock_dir}/with-setenv.pkg
   (version 0.0.1)
   
   (exported_env
@@ -41,7 +41,7 @@ The exported env from the first package should be in the lock dir.
    (+= prepend_without_trailing_sep "Prepended without trailing sep")
    (=+ append_without_leading_sep "Appended without leading sep")
    (=: append_with_leading_sep "Appended with leading sep"))
-  $ cat dune.lock/deps-on-with-setenv.pkg
+  $ cat ${default_lock_dir}/deps-on-with-setenv.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -12,12 +12,12 @@ Make a package with a substs field
   $ solve with-substs
   Solution for dune.lock:
   - with-substs.0.0.1
-  $ cat >>dune.lock/with-substs.pkg <<EOF
+  $ cat >> ${default_lock_dir}/with-substs.pkg <<EOF
   > (source (copy $PWD/source))
   > EOF
 
 The lockfile should contain the substitute action.
-  $ cat dune.lock/with-substs.pkg
+  $ cat ${default_lock_dir}/with-substs.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -40,19 +40,19 @@ Our cache folder should be populated with a revision store:
 
 Make sure lock.dune contains the repo hash:
 
-  $ grep "mock-opam-repository#$REPO_HASH" dune.lock/lock.dune > /dev/null
+  $ grep "mock-opam-repository#$REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null
 
 Now try it with an a path. Given it is not a git URL, it can't be reproduced on
 other systems and thus shouldn't be included.
 
-  $ rm -r dune.lock dune-workspace
+  $ rm -r ${default_lock_dir} dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/mock-opam-repository"
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
   - foo.0.0.1
 
-  $ grep "mock-opam-repository#$REPO_HASH" dune.lock/lock.dune > /dev/null || echo "not found"
+  $ grep "mock-opam-repository#$REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null || echo "not found"
   not found
 
 We also test that it is possible to specify a specific commit when locking a
@@ -67,13 +67,13 @@ in the repo and make sure it locks the older version.
   $ NEW_REPO_HASH=$(git rev-parse HEAD)
   $ cd ..
 
-  $ rm -r dune.lock dune-workspace
+  $ rm -r ${default_lock_dir} dune-workspace
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
   - foo.0.0.1
-  $ grep "mock-opam-repository#$REPO_HASH" dune.lock/lock.dune > /dev/null
+  $ grep "mock-opam-repository#$REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null
 
 If we specify no branch however, it should be using the latest commit in the
 repository and thus the new foo package.
@@ -84,7 +84,7 @@ repository and thus the new foo package.
   Solution for dune.lock:
   - bar.0.0.1
   - foo.0.1.0
-  $ grep "mock-opam-repository#$NEW_REPO_HASH" dune.lock/lock.dune > /dev/null
+  $ grep "mock-opam-repository#$NEW_REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null
 
 A new package is released in the repo:
 
@@ -109,7 +109,7 @@ To be safe it doesn't access the repo, we make sure to move the mock-repo away
 
 So now the test should work as it can't access the repo:
 
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - bar.0.0.1
@@ -121,7 +121,7 @@ restored the repo to where it was before)
   $ rm -r dune-workspace
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${NEWEST_REPO_HASH}"
   $ mv elsewhere mock-opam-repository
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - bar.1.0.0
@@ -146,7 +146,7 @@ sure that the default branch differs from `bar-2`).
 
 Locking that branch should work and pick `bar.2.0.0`:
 
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - bar.2.0.0
@@ -172,7 +172,7 @@ The repo should be using the `1.0` tag, as we don't want `bar.3.0.0`.
 
 So we should get `bar.1.0.0` when locking.
 
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - bar.1.0.0

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -20,7 +20,7 @@ Demonstrate the generation of the lock directory in the presence of "|"
   - b.0.0.1
 Only a1 or a2 should appear but not both.
 
-  $ cat dune.lock/b.pkg
+  $ cat ${default_lock_dir}/b.pkg
   (version 0.0.1)
   
   (depends a1)

--- a/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
@@ -16,8 +16,8 @@ Test conversion of opam sources into lock dir package specifications
   - testpkg.0.0.1
 
   $ showpkg() {
-  > local f=dune.lock/testpkg.pkg
-  > [ -e $f ] && cat $f
+  >   local f="${default_lock_dir}"/testpkg.pkg
+  >   [ -e $f ] && cat $f
   > }
  
   $ showpkg
@@ -36,7 +36,7 @@ Test conversion of opam sources into lock dir package specifications
   > }
   > EOF
 
-  $ rm -rf dune.lock
+  $ rm -rf ${default_lock_dir}
 
   $ solve testpkg 2>&1 | sed -E 's#.*.sandbox/[^/]+#.sandbox/$SANDBOX#g' | sed '/File "/q'
   Solution for dune.lock:
@@ -54,7 +54,7 @@ Test conversion of opam sources into lock dir package specifications
 
 Unsupported backends:
 
-  $ rm -rf dune.lock
+  $ rm -rf ${default_lock_dir}
 
   $ mkpkg testpkg <<EOF
   > url {
@@ -76,7 +76,7 @@ Unsupported backends:
 
 git+http
 
-  $ rm -rf dune.lock
+  $ rm -rf ${default_lock_dir}
   $ mkpkg testpkg <<EOF
   > url {
   >   src: "git+http://github.com/foo"
@@ -97,7 +97,7 @@ git+http
 
 git+file
 
-  $ rm -rf dune.lock
+  $ rm -rf ${default_lock_dir}
   $ mkpkg testpkg <<EOF
   > url {
   >   src: "git+file://here"
@@ -116,7 +116,8 @@ git+file
     (checksum md5=069aa55d40e548280f92af693f6c625a)))
 
 git+foobar
-  $ rm -rf dune.lock
+
+  $ rm -rf ${default_lock_dir}
   $ mkpkg testpkg <<EOF
   > url {
   >   src: "git+foobar://random-thing-here"
@@ -135,7 +136,8 @@ git+foobar
     (checksum md5=069aa55d40e548280f92af693f6c625a)))
 
 file+git
-  $ rm -rf dune.lock
+
+  $ rm -rf ${default_lock_dir}
   $ mkpkg testpkg <<EOF
   > url {
   >   src: "file+git://random-thing-here"

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
@@ -15,7 +15,7 @@ variables can be found in `opam-var-os.t`.
   > solve testpkg
   Solution for dune.lock:
   - testpkg.0.0.1
-  $ cat dune.lock/testpkg.pkg
+  $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -24,7 +24,7 @@ unset them all.
   > solve testpkg
   Solution for dune.lock:
   - testpkg.0.0.1
-  $ cat dune.lock/testpkg.pkg 
+  $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -55,7 +55,7 @@ We echo each package variable.
 Inspecting the lockfile we can see how each opam package variable was translated into a
 corresponding Dune version.
 
-  $ cat dune.lock/testpkg.pkg
+  $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -28,7 +28,7 @@ opam-var-unsupported.t
   > solve testpkg
   Solution for dune.lock:
   - testpkg.0.0.1
-  $ cat dune.lock/testpkg.pkg
+  $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/package-cycle.t
@@ -4,15 +4,15 @@ Package resolution creating a cycle
 
   $ make_lockdir
 
-  $ cat >dune.lock/a.pkg <<EOF
+  $ cat > ${default_lock_dir}/a.pkg <<EOF
   > (version 0.0.1)
   > (depends b)
   > EOF
-  $ cat >dune.lock/b.pkg <<EOF
+  $ cat > ${default_lock_dir}/b.pkg <<EOF
   > (version 0.0.1)
   > (depends c)
   > EOF
-  $ cat >dune.lock/c.pkg <<EOF
+  $ cat > ${default_lock_dir}/c.pkg <<EOF
   > (version 0.0.1)
   > (depends a)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -7,7 +7,7 @@ Additional files overlaid on top of the source can be found in the
   $ touch test-source/foo
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source
   >  (copy $PWD/test-source))
@@ -15,11 +15,11 @@ Additional files overlaid on top of the source can be found in the
   >  (system "echo foo:; cat foo; echo bar:; cat bar"))
   > EOF
 
-  $ mkdir dune.lock/test.files
-  $ cat >dune.lock/test.files/foo <<EOF
+  $ mkdir ${default_lock_dir}/test.files
+  $ cat > ${default_lock_dir}/test.files/foo <<EOF
   > foo from test.files
   > EOF
-  $ cat >dune.lock/test.files/bar <<EOF
+  $ cat > ${default_lock_dir}/test.files/bar <<EOF
   > bar from test.files
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -27,7 +27,7 @@ Solve the package using the default solver env:
   $ solve a
   Solution for dune.lock:
   - a.0.0.1
-  $ cat dune.lock/a.pkg
+  $ cat ${default_lock_dir}/a.pkg
   (version 0.0.1)
   
   (build
@@ -72,7 +72,7 @@ Run the solver using the new env:
   $ solve a
   Solution for dune.lock:
   - a.0.0.1
-  $ cat dune.lock/a.pkg
+  $ cat ${default_lock_dir}/a.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -4,7 +4,7 @@ Applying patches
 
   $ mkdir test-source
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -13,8 +13,8 @@ Applying patches
   >   (system "cat foo.ml")))
   > EOF
 
-  $ mkdir dune.lock/test.files
-  $ cat >dune.lock/test.files/foo.patch <<EOF
+  $ mkdir ${default_lock_dir}/test.files
+  $ cat > ${default_lock_dir}/test.files/foo.patch <<EOF
   > diff --git a/foo.ml b/foo.ml
   > new file mode 100644
   > index 0000000..557db03

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -11,16 +11,16 @@ Demonstrate our support for pin-depends.
   $ mkpkg bar 0.0.1
 
   $ runtest() {
-  > cat >foo.opam <<EOF
-  > opam-version: "2.0"
-  > depends: [ "bar" ]
-  > pin-depends: [ "bar.1.0.0" "$1" ]
+  >   cat > foo.opam <<EOF
+  >   opam-version: "2.0"
+  >   depends: [ "bar" ]
+  >   pin-depends: [ "bar.1.0.0" "$1" ]
   > EOF
-  > dune pkg lock && {
-  >   local pkg="dune.lock/bar.pkg";
-  >   grep version $pkg;
-  >   grep dev $pkg;
-  >   print_source "bar";
+  >   dune pkg lock && {
+  >     local pkg="${default_lock_dir}/bar.pkg"
+  >     grep version $pkg
+  >     grep dev $pkg
+  >     print_source "bar"
   >   } 
   > }
 
@@ -199,7 +199,7 @@ Pin to an HTTP archive detects wrong hash
   >  (name foo)
   >  (libraries bar))
   > EOF
-  $ sed -i.tmp "s/$MD5_CHECKSUM/92449184682b45b5f07e811fdd61d35f/g" dune.lock/bar.pkg
+  $ sed -i.tmp "s/$MD5_CHECKSUM/92449184682b45b5f07e811fdd61d35f/g" ${default_lock_dir}/bar.pkg
   $ rm -rf already-served
   $ dune build 2>&1 | grep -v "md5"
   File "dune.lock/bar.pkg", line 6, characters 12-48:

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
@@ -33,7 +33,7 @@ Now we verify the metadata we generated for the package. First we verify the
 build instructions and version are set correctly.
 
 We print the source separately for ease of post processing the output.
-  $ cat dune.lock/foo.pkg | sed "/source/,//d"
+  $ cat ${default_lock_dir}/foo.pkg | sed "/source/,//d"
   (version 1.0.0)
   
   (dune)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -61,7 +61,7 @@ Demonstrate the build command we construct for different types of projects:
   - opam-only.dev
   - template.dev
   $ build_command() {
-  > grep "$1" dune.lock/$2.pkg
+  > grep "$1" "${default_lock_dir}/$2.pkg"
   > }
   $ build_command "(dune)" dune-only
   (dune)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
@@ -33,14 +33,14 @@ should favor the dune metadata in such a case.
   - bar.dev
   - foo.dev
 
-  $  cat dune.lock/bar.pkg | sed "/source/,//d"
+  $ cat ${default_lock_dir}/bar.pkg | sed "/source/,//d"
   (version dev)
   
   (dune)
   
   
   (dev)
-  $  cat dune.lock/foo.pkg | sed "/source/,//d"
+  $ cat ${default_lock_dir}/foo.pkg | sed "/source/,//d"
   (version dev)
   
   (dune)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
@@ -24,7 +24,7 @@ We try to pull an opam package that isn't a dune project
   $ dune pkg lock
   Solution for dune.lock:
   - foo.dev
-  $ pkg="dune.lock/foo.pkg"
+  $ pkg="${default_lock_dir}/foo.pkg"
   $ grep version $pkg
   (version dev)
   $ grep dev $pkg

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
@@ -34,7 +34,7 @@ command is currently not respected when the package is pinned.
   - opam-template.dev
   $ build_pkg opam-template
 
-  $ cat dune.lock/opam-template.pkg | sed "/source/,//d"
+  $ cat ${default_lock_dir}/opam-template.pkg | sed "/source/,//d"
   (version dev)
   
   (dune)

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
@@ -5,7 +5,8 @@ Testing the when action in lockfiles
   $ make_lockdir
 
 Case with a mix of uncoditional and conditional actions in a progn action
-  $ cat >dune.lock/test.pkg <<'EOF'
+
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (install
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps.t
@@ -7,7 +7,7 @@ We should be able to specify (package ..) deps on locally built packages.
   > EOF
 
   $ make_lockdir
-  $ cat >dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (install
   >  (progn
@@ -46,7 +46,7 @@ Now we define the external package using a dune project:
   > print_endline "Hello from foo.ml!"
   > EOF
 
-  $ cat >dune.lock/foo.pkg <<EOF
+  $ cat > ${default_lock_dir}/foo.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build (run dune build @install --promote-install-files))

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -34,7 +34,7 @@ When the default lockdir is present pkg is enabled:
 
   $ dune pkg enabled
 
-  $ rm -r dune.lock
+  $ rm -r ${default_lock_dir}
 
 When a non-default lockdir is present, pkg is still enabled:
   $ dune pkg lock dune.other.lock > /dev/null 2> /dev/null

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -37,7 +37,7 @@ Create a package that writes a different value to some files depending on the os
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)
@@ -60,7 +60,7 @@ Create a package that writes a different value to some files depending on the os
    ((arch arm64)
     (os win32)))
 
-  $ cat dune.lock/foo.0.0.1.pkg
+  $ cat ${default_lock_dir}/foo.0.0.1.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -48,7 +48,7 @@ Create a custom dune-workspace to solve for openbsd.
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -52,7 +52,7 @@ Solve the project:
   - foo.0.0.1
 
 Confirming that the build action creates the conditional file:
-  $ cat dune.lock/foo.0.0.1.pkg
+  $ cat ${default_lock_dir}/foo.0.0.1.pkg
   (version 0.0.1)
   
   (build

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -25,7 +25,7 @@ Demonstrate various cases representing depexts in lockfiles.
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/foo.0.0.1.pkg
+  $ cat ${default_lock_dir}/foo.0.0.1.pkg
   (version 0.0.1)
   
   (depexts

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -63,7 +63,7 @@ The log file will contain errors about the package being unavailable.
   #       foo.0.0.1: Availability condition not satisfied
 
 The lockdir will contain a list of the platforms where solving succeeded.
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (dependency_hash 36e640fbcda71963e7e2f689f6c96c3e)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -75,19 +75,19 @@ Solve the project. The solution will contain extra files for both versions of fo
   - foo.2
 
 Verify the contents of the extra files for each version of foo:
-  $ cat dune.lock/foo.1.files/version.txt
+  $ cat ${default_lock_dir}/foo.1.files/version.txt
   version_1
-  $ cat dune.lock/foo.2.files/version.txt
+  $ cat ${default_lock_dir}/foo.2.files/version.txt
   version_2
 
 Build as if we're on linux and verify that the appropriate extra file was copied into _build:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  $ cat _build/default/dune.lock/foo.1.files/version.txt
+  $ cat ${default_lock_dir}/foo.1.files/version.txt
   version_1
 
   $ dune clean
 
 Build as if we're on macos and verify that the appropriate extra file was copied into _build:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
-  $ cat _build/default/dune.lock/foo.2.files/version.txt
+  $ cat ${default_lock_dir}/foo.2.files/version.txt
   version_2

--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -22,12 +22,12 @@ We don't need bar, so we skip it
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
 
 We should also skip any artifacts that bar references:
 
-  $ [ -d dune.lock/bar.files ] && ls -1 -x dune.lock/bar.files
+  $ [ -d ${default_lock_dir}/bar.files ] && ls -1 -x ${default_lock_dir}/bar.files
   [1]
 
 Self dependency
@@ -40,7 +40,7 @@ Self dependency
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
 
 Using post to break cycle:
@@ -58,7 +58,7 @@ Using post to break cycle:
   - bar.0.0.1
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg dune.lock/bar.pkg
+  $ cat ${default_lock_dir}/foo.pkg ${default_lock_dir}/bar.pkg
   (version 0.0.1)
   (version 0.0.1)
   
@@ -78,7 +78,7 @@ post "cycle":
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ cat dune.lock/foo.pkg
+  $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
 
 In depopts:

--- a/test/blackbox-tests/test-cases/pkg/run-local.t
+++ b/test/blackbox-tests/test-cases/pkg/run-local.t
@@ -5,7 +5,7 @@ they could have been created or modified by previous build commands (such as
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -3,7 +3,7 @@ install and build commands.
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build (run sh -c "echo [build] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))
   > (install (run sh -c "echo [install] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -3,7 +3,7 @@ Test that we run the build command
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -1,14 +1,11 @@
   $ . ./helpers.sh
 
-  $ mkdir dune.lock
-  $ cat >dune.lock/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
+  $ make_lockdir
 
 Helper function to create a lockfile with a given install action and then build it, running the action.
   $ test_action() {
   >   dune clean || true
-  >   cat > dune.lock/test.pkg <<EOF
+  >   cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (install $1)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -38,13 +38,13 @@ the logic which stores solver vars in lockdir metadata in this case.
   $ solve_all() {
   > 
   >  solve static-deps
-  >  cat dune.lock/lock.dune
+  >  cat ${default_lock_dir}/lock.dune
   > 
   >  solve dynamic-deps
-  >  cat dune.lock/lock.dune
+  >  cat ${default_lock_dir}/lock.dune
   > 
   >  solve dynamic-deps-lazy
-  >  cat dune.lock/lock.dune
+  >  cat ${default_lock_dir}/lock.dune
   > }
 
 Make a workspace file which sets some of the variables.
@@ -136,7 +136,7 @@ stored in the lockdir metadata:
   Solution for dune.lock:
   - filtered-commands.0.0.1
 
-  $ cat dune.lock/filtered-commands.pkg
+  $ cat ${default_lock_dir}/filtered-commands.pkg
   (version 0.0.1)
   
   (install
@@ -146,7 +146,7 @@ stored in the lockdir metadata:
    (progn
     (run echo foo)
     (run echo baz)))
-  $ cat dune.lock/lock.dune
+  $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
   
   (dependency_hash e99c6a04197fafe2e8b7153de21bba97)

--- a/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
@@ -7,7 +7,7 @@ Test the %{pkg:installed}% form inside file substitution:
   $ cat >source/foo.in <<EOF
   > foo: %{somepkg:installed}%
   > EOF
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/source))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -7,7 +7,7 @@ The test-source folder has a file to use substitution on.
   > This file will be fed to the substitution mechanism
   > EOF
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -31,7 +31,7 @@ This should also work with any other filename combination:
   $ cat >test-source/foo.ml.template <<EOF
   > This is using a different file suffix
   > EOF
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -51,7 +51,7 @@ Undefined variables, how do they substitute?
   $ cat >test-source/variables.ml.in <<EOF
   > We substitute this '%%{var}%%' into '%{var}%'
   > EOF
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -81,7 +81,7 @@ Now with variables set
   > %%{with-test}%% is '%{with-test}%'
   > %%{os}%% is '%{os}%'
   > EOF
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -109,11 +109,11 @@ Now with variables set
 It is also possible to use variables of your dependencies:
 
   $ mkdir dependency-source
-  $ cat >dune.lock/dependency.pkg <<EOF
+  $ cat > ${default_lock_dir}/dependency.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/dependency-source))
   > EOF
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (depends dependency)

--- a/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
@@ -37,7 +37,7 @@ the appropriate location, respecting the DESTDIR variable.
   > EOF
 
 Lockfile for the fake compiler package:
-  $ cat > dune.lock/ocaml-base-compiler.pkg << EOF
+  $ cat > ${default_lock_dir}/ocaml-base-compiler.pkg << EOF
   > (version 1)
   > 
   > (build

--- a/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
@@ -40,7 +40,7 @@ location
 
 We generate the lockfile for the fake compiler
 
-  $ cat > dune.lock/ocaml-base-compiler.pkg << EOF
+  $ cat > ${default_lock_dir}/ocaml-base-compiler.pkg << EOF
   > (version 1)
   > (build
   >  (run ./configure %{prefix}))
@@ -54,7 +54,7 @@ We generate the lock file for the package to demonstrate the variable is
 replaced with the path to the sandbox inside of the path to the non-relocatable
 location.
 
-  $ cat > dune.lock/baz.pkg << EOF
+  $ cat > ${default_lock_dir}/baz.pkg << EOF
   > (version 1)
   > (build
   >  (run sh -exc "echo %{pkg:ocaml-base-compiler:share}"))

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -3,7 +3,7 @@ Test that we can set variables
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.config <<EOF
@@ -18,7 +18,7 @@ Test that we can set variables
   >  ))
   > EOF
 
-  $ cat >dune.lock/usetest.pkg <<EOF
+  $ cat > ${default_lock_dir}/usetest.pkg <<EOF
   > (version 0.0.1)
   > (depends test)
   > (build
@@ -51,7 +51,7 @@ Test that we can set variables
 
 Now we demonstrate we get a proper error from invalid .config files:
 
-  $ cat >dune.lock/test.pkg <<EOF
+  $ cat > ${default_lock_dir}/test.pkg <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.config <<EOF

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -9,15 +9,15 @@ This path is system-specific so we need to be able to remove it from the output.
   $ make_lockdir
 
 Make some packages so that the test package can have dependencies:
-  $ cat >dune.lock/hello1.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/hello1.pkg <<'EOF'
   > (version 0.0.1)
   > EOF
-  $ cat >dune.lock/hello2.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/hello2.pkg <<'EOF'
   > (version 0.0.1)
   > EOF
 
 Printing out PATH without setting it:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
   >  (system "echo PATH=$PATH"))
@@ -27,7 +27,7 @@ Printing out PATH without setting it:
   PATH=DUNE_PATH:/bin
 
 Setting PATH to a specific value:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -39,7 +39,7 @@ Setting PATH to a specific value:
   PATH=/tmp/bin
 
 Attempting to add a path to PATH replaces the entire PATH:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -51,7 +51,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   PATH=/tmp/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -65,7 +65,7 @@ Try adding multiple paths to PATH:
   PATH=/bar/bin:/foo/bin:/tmp/bin:DUNE_PATH:/bin
 
 Printing out PATH without setting it when the package has a dependency:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -76,7 +76,7 @@ Printing out PATH without setting it when the package has a dependency:
   PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -89,7 +89,7 @@ Setting PATH to a specific value:
   PATH=/tmp/bin
 
 Attempting to add a path to PATH replaces the entire PATH:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -102,7 +102,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -3,7 +3,7 @@ Setting environment variables in actions
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat >dune.lock/test.pkg <<'EOF'
+  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv


### PR DESCRIPTION
Given that we plan to move the location, this PR makes the location configurable in the helpers script.