### PR TITLE
chore: restore maintenance intent

### DIFF
--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -26,7 +26,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/dune-project
+++ b/dune-project
@@ -79,6 +79,7 @@ executable was built.
   (dyn (= :version))
   (stdune (= :version))
   (ocaml (>= 4.08)))
+ (maintenance_intent none)
  (description "\
 !!!!!!!!!!!!!!!!!!!!!!
 !!!!! DO NOT USE !!!!!
@@ -169,6 +170,7 @@ understood by dune language."))
   (ocaml (>= 4.08.0))
   (ordering (= :version))
   (pp (>= 1.1.0)))
+ (maintenance_intent none)
  (description "Dynamic type"))
 
 (package
@@ -176,6 +178,7 @@ understood by dune language."))
  (synopsis "Element ordering")
  (depends
   (ocaml (>= 4.08.0)))
+ (maintenance_intent none)
  (description "Element ordering"))
 
 (package
@@ -195,6 +198,7 @@ understood by dune language."))
   (ordering (= :version))
   (pp (>= 2.0.0))
   (csexp (>= 1.5.0)))
+ (maintenance_intent none)
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 
 (package
@@ -205,6 +209,7 @@ understood by dune language."))
  (depends
   (ocaml (>= 4.08.0))
   (dyn (= :version)))
+ (maintenance_intent none)
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 
 (package

--- a/dyn.opam
+++ b/dyn.opam
@@ -16,7 +16,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/ocamlc-loc.opam
+++ b/ocamlc-loc.opam
@@ -19,7 +19,7 @@ conflicts: [
   "ocaml-lsp-server" {< "1.15.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/ordering.opam
+++ b/ordering.opam
@@ -14,7 +14,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]

--- a/stdune.opam
+++ b/stdune.opam
@@ -20,7 +20,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   ["rm" "-rf" "vendor/csexp"]


### PR DESCRIPTION
This PR restores the maintenance intent. It seems the change in the `dune-project` file has been lost between the PRs about it.
This fix avoids having to modify the file manually in opam.
