### PR TITLE
feat(tui): wrap long messages

### DIFF
--- a/src/dune_tui/drawing.ml
+++ b/src/dune_tui/drawing.ml
@@ -125,9 +125,9 @@ let detab_pp =
   fun pp -> Pp.to_ast pp |> detab_pp_ast |> Pp.of_ast
 ;;
 
-let pp_to_image pp =
+let pp_to_image ~w pp =
   detab_pp pp
-  |> Notty.I.strf "%a" (Pp.to_fmt_with_tags ~tag_handler:attr_of_user_message_style)
+  |> Notty.I.strf ~w "%a" (Pp.to_fmt_with_tags ~tag_handler:attr_of_user_message_style)
 ;;
 
 module Unicode = struct

--- a/src/dune_tui/drawing.mli
+++ b/src/dune_tui/drawing.mli
@@ -4,7 +4,7 @@ open Import
 
 (** [Drawing.pp_to_image pp] converts a [pp] to a [I.t] converting the
     [User_message.Style.t] tags into appropriate Notty [A.t]s. *)
-val pp_to_image : User_message.Style.t Pp.t -> I.t
+val pp_to_image : w:int -> User_message.Style.t Pp.t -> I.t
 
 (** [horizontal_rule ~attr ~w] draws a horizontal line with [attr] of length [w]. *)
 val horizontal_rule : attr:A.t -> w:int -> I.t

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -57,8 +57,9 @@ module Message_viewer = struct
   let is_message_hidden = Lwd.var (fun _ -> false)
 
   let message_images =
-    let+ messages = Lwd.get messages in
-    List.map messages ~f:(fun x -> Drawing.pp_to_image (User_message.pp x))
+    let+ messages = Lwd.get messages
+    and+ w, _ = Lwd.get term_size in
+    List.map messages ~f:(fun x -> Drawing.pp_to_image ~w (User_message.pp x))
   ;;
 
   (* We calculate the max message length from all the messages. This is used to keep the
@@ -228,8 +229,8 @@ let help_box =
 
 (* The status bar shows the build status and includes a help button. *)
 let status_bar =
-  let+ w, _ = Lwd.get term_size
-  and+ help_button =
+  let* w, _ = Lwd.get term_size in
+  let+ help_button =
     let+ { toggle; _ } = help_box in
     let image =
       I.hcat
@@ -243,7 +244,7 @@ let status_bar =
     Lwd.get status_line
     >>| function
     | None -> I.empty
-    | Some message -> Drawing.pp_to_image message
+    | Some message -> Drawing.pp_to_image ~w message
   in
   let status =
     I.hcat [ I.char helper_attr ' ' 1 1; status; I.char helper_attr ' ' 1 1 ]


### PR DESCRIPTION
We leverage the underlying format mechanism to allow for word wrapping. Previously, a user would have to rely on the scroll bars in order to view wide text. For most breakable text we can do better by breaking up the text with Format. Verbatim strings that are longer than the width will still trigger the horizontal scroll bar as usual.

[Screencast From 2025-08-07 00-59-45.webm](https://github.com/user-attachments/assets/9838cc7e-828c-4e8b-9eb5-7ff99bb15567)

The flickering here is from the integrated terminal inside `nvim`.