### PR TITLE
test: include_subdirs unqualified duplicates cram rules

### DIFF
--- a/test/blackbox-tests/test-cases/cram/include-subdirs.t
+++ b/test/blackbox-tests/test-cases/cram/include-subdirs.t
@@ -4,13 +4,41 @@ Cram tests inside (include_subdirs unqualified)
   > (lang dune 3.11)
   > EOF
 
-  $ cat >dune <<EOF
-  > (include_subdirs unqualified)
-  > EOF
+We have a file cram test inside a subdirectory and a directory cram test. When
+the (include_subdirs unqualified) is not present, both tests fail as expected.
 
   $ mkdir sub/
   $ cat >sub/foo.t <<EOF
   >   $ echo foo
   > EOF
 
+  $ mkdir bar.t
+  $ cat > bar.t/run.t <<EOF
+  >   $ echo bar
+  > EOF
+
   $ dune runtest
+  File "bar.t/run.t", line 1, characters 0-0:
+  Error: Files _build/default/bar.t/run.t and
+  _build/default/bar.t/run.t.corrected differ.
+  File "sub/foo.t", line 1, characters 0-0:
+  Error: Files _build/default/sub/foo.t and _build/default/sub/foo.t.corrected
+  differ.
+  [1]
+
+However adding (include_subdirs unqualified) highlights two issues:
+
+1. The file cram test in the subdirectory is no longer being run.
+2. Multiple rules are being generated for the directory test.
+
+  $ cat >dune <<EOF
+  > (include_subdirs unqualified)
+  > EOF
+
+  $ dune runtest
+  Error: Multiple rules generated for _build/default/.cram.bar.t/cram.sh:
+  - <none>:1
+  - <none>:1
+  -> required by alias bar
+  -> required by alias runtest
+  [1]


### PR DESCRIPTION
This regression was observed in https://github.com/ocaml/opam-repository/pull/28302. It is due to a mix of `(include_subdirs unqualified)` and directory cram tests in the same directory. 