### PR TITLE
tests: Use `make_lockpkg` to create a package in lock dir

### DIFF
--- a/test/blackbox-tests/test-cases/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe_location.t
@@ -26,12 +26,12 @@ An executable from the current project:
 
 Test that executables from dependencies are located correctly:
 
-  $ default_lock_dir="dune.lock"
-  $ mkdir -p "${default_lock_dir}"
-  $ cat > "${default_lock_dir}"/lock.dune <<EOF
+  $ source_lock_dir="dune.lock"
+  $ mkdir -p "${source_lock_dir}"
+  $ cat > "${source_lock_dir}"/lock.dune <<EOF
   > (lang package 0.1)
   > EOF
-  $ cat > ${default_lock_dir}/bar.pkg << EOF
+  $ cat > ${source_lock_dir}/bar.pkg << EOF
   > (version 0.1)
   > (install
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -3,8 +3,7 @@ Test that section pforms are substituted with absolute paths.
   $ . ./helpers.sh
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (install (progn
   >  (run echo --prefix %{prefix})

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -21,7 +21,7 @@ Ensure the alias is not available outside of the package manamgent context:
 
 Create a fake package which echoes information to stdout when build:
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg << EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (build
   >  (run echo "Build package foo"))

--- a/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
@@ -22,7 +22,7 @@ Create a lockdir for the project.
   $ make_lockdir
 
 The package "foo" exercises copying package sources from a local directory.
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch
@@ -31,7 +31,7 @@ The package "foo" exercises copying package sources from a local directory.
   > EOF
 
 The package "bar" exercises extracting a source archive from a local file.
-  $ cat > ${default_lock_dir}/bar.pkg <<EOF
+  $ make_lockpkg bar <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch
@@ -40,7 +40,7 @@ The package "bar" exercises extracting a source archive from a local file.
   > EOF
 
 The package "bar" exercises extracting a source archive from a downloaded file.
-  $ cat > ${default_lock_dir}/baz.pkg <<EOF
+  $ make_lockpkg baz <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -98,7 +98,7 @@ Remove all dependencies from the project:
 
 Exercise handling invalid dependency hashes.
   $ make_lock_metadata_with_hash() {
-  >   cat > ${default_lock_dir}/lock.dune <<EOF
+  >   cat > ${source_lock_dir}/lock.dune <<EOF
   > (lang package 0.1)
   > (dependency_hash $1)
   > (repositories

--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -13,7 +13,7 @@ Create a directory containing a shell script and add the directory to PATH.
 
 Create a lockdir with a lockfile that runs the shell script in a build command.
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build (run hello))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -3,8 +3,10 @@ Some environment variables are automatically exported by packages:
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ echo "(version 0.0.1)" > ${default_lock_dir}/test.pkg
-  $ cat > ${default_lock_dir}/usetest.pkg <<'EOF'
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > EOF
+  $ make_lockpkg usetest <<'EOF'
   > (version 0.0.1)
   > (depends test)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -26,7 +26,7 @@ Make a project that uses the foo library:
 
 Make dune.lock files with known program "dune".
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (build
   >  (run dune build))
@@ -54,7 +54,7 @@ error message.
 
 Make dune.lock files with unknown program and unknown package.
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (build
   >  (run unknown-program))

--- a/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
@@ -12,7 +12,7 @@ Make a project:
 Create a lockdir with a package that features some depexts.
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (depexts unzip gnupg)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
@@ -2,8 +2,7 @@ Test for packages with no source field but with extra_sources.
 
   $ . ./helpers.sh
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 1)
   > (extra_sources
   >  (foo.txt

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -3,7 +3,7 @@ Packages can export environment variables
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (exported_env
   >  (= FOO bar)
@@ -12,7 +12,7 @@ Packages can export environment variables
   >  (:= BAR zzz))
   > EOF
 
-  $ cat > ${default_lock_dir}/usetest.pkg <<'EOF'
+  $ make_lockpkg usetest <<'EOF'
   > (depends test)
   > (version 1.2.3)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
@@ -5,7 +5,7 @@ A lock directory which does not exist in the source tree:
   $ mkdir project
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (build (run echo foo))
   > (version 1.0.0)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -6,7 +6,7 @@ Test that can fetch the sources from an external dir
   $ echo "y" > foo/x
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/foo))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
@@ -3,8 +3,7 @@ file in the package's source.
 
   $ . ./helpers.sh
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 1)
   > (source
   >  (copy $PWD/foo-source))

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -13,7 +13,7 @@ Fetch from more than one source
   > this is baz
   > EOF
 
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/foo))
   > (extra_sources (mybaz (copy $PWD/baz)))

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -18,7 +18,7 @@ Set up a project that depends on a package that is being downloaded
   $ echo test.tar > fake-curls
   $ SRC_PORT=1
   $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source
   >  (fetch

--- a/test/blackbox-tests/test-cases/pkg/file-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/file-depends.t
@@ -6,9 +6,7 @@ the files found in files-depend.
 
   $ . ./helpers.sh
   $ make_lockdir
-
-  $ foo=$PWD/foo
-  > cat > ${default_lock_dir}/file-depends.pkg <<EOF
+  $ foo=$PWD/foo make_lockpkg file-depends <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| echo Building file-depends
@@ -24,7 +22,7 @@ checksum is not parsable.
 
 Now we make a package depending on file-depends.
 
-  $ cat > ${default_lock_dir}/dep.pkg <<EOF
+  $ make_lockpkg dep <<EOF
   > (version 0.0.1)
   > (depends file-depends)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
+++ b/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
@@ -35,11 +35,7 @@ Reproduces #11405
 
   $ make_lockdir
 
-  $ cat > ${default_lock_dir}/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
-
-  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
+  $ make_lockpkg mypkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/gh10959.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10959.t
@@ -23,11 +23,7 @@ Now we set up a lock file with this package and then attempt to use it:
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/lock.dune <<EOF
-  > (lang package 0.1)
-  > EOF
-
-  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
+  $ make_lockpkg mypkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/gh10985.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10985.t
@@ -31,7 +31,7 @@ Now we set up a lock file with this package and then attempt to use it:
   $ . ../helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
+  $ make_lockpkg mypkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/../external_sources))
   > (build (run dune build --release --promote-install-file=true . @install))

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -7,7 +7,7 @@ Things should be the same whether dependencies are specified or not.
 If we have a package we depend on
 
   $ mkdir dependency-source
-  $ cat > ${default_lock_dir}/dependency.pkg <<EOF
+  $ make_lockpkg dependency <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/dependency-source))
   > EOF
@@ -15,7 +15,7 @@ If we have a package we depend on
 And we have a package we want to build
 
   $ mkdir test-source
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -23,9 +23,9 @@ And we have a package we want to build
   > EOF
   $ build_pkg test
 
-Now it fails since adding the dependency modified PATH.
+It should continue to work even if `dependency` modifies `PATH`:
 
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > ; adding deps breaks cat

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -15,7 +15,7 @@ Test fetching from git
 
   $ mkdir foo && cd foo
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$MYGITREPO")))
   > (build (run cat foo))

--- a/test/blackbox-tests/test-cases/pkg/git-submodule.t
+++ b/test/blackbox-tests/test-cases/pkg/git-submodule.t
@@ -31,7 +31,7 @@ someotherrepo as a submodule.
 
   $ mkdir foo && cd foo
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$SOMEREPO")))
   > (build (progn (run cat foo) (run cat mysubmodule/bar)))
@@ -43,10 +43,10 @@ not the case and only somerepo is pulled.
   $ build_pkg test 2>&1 | sed -E 's|.*/cat|cat|'
   hello
   world
+
 When the above works it should act like:
 
-  $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (fetch (url "git+file://$SOMEREPO")))
   > (build 

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -14,6 +14,7 @@ dune="dune"
 pkg_root="_build/_private/default/.pkg"
 
 default_lock_dir="dune.lock"
+source_lock_dir="${default_lock_dir}"
 
 build_pkg() {
   $dune build $pkg_root/$1/target/
@@ -94,10 +95,21 @@ EOF
 }
 
 make_lockpkg() {
-  local dir="${default_lock_dir}"
-  mkdir -p "$dir"
-  local f="$dir/$1.pkg"
+  mkdir -p "${source_lock_dir}"
+  local f="${source_lock_dir}/$1.pkg"
   cat > "$f"
+}
+
+append_to_lockpkg() {
+  local pkg="${1}"
+  cat >> "${source_lock_dir}/${pkg}.pkg"
+}
+
+make_lockpkg_file() {
+  local pkg="${1}"
+  local filename="${2}"
+  mkdir -p "${source_lock_dir}/${pkg}.files"
+  cat > "${source_lock_dir}/${pkg}.files/${filename}"
 }
 
 solve_project() {
@@ -107,8 +119,8 @@ solve_project() {
 }
 
 make_lockdir() {
-  mkdir -p "${default_lock_dir}"
-  cat > "${default_lock_dir}"/lock.dune <<EOF
+  mkdir -p "${source_lock_dir}"
+  cat > "${source_lock_dir}"/lock.dune <<EOF
 (lang package 0.1)
 (repositories (complete true))
 EOF

--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
@@ -5,8 +5,7 @@ without using locked dependencies.
   $ . ./helpers.sh
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (build
   >  (run echo "I have not been ignored."))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -3,15 +3,14 @@ Test that shows what happens when dune.lock is ignored.
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (progn
   >   (run touch foo.ml)
   >   (patch foo.patch)))
   > EOF
-  $ mkdir ${default_lock_dir}/test.files
-  $ cat > ${default_lock_dir}/test.files/foo.patch <<EOF
+  $ make_lockpkg_file test foo.patch <<EOF
   > diff --git a/foo.ml b/foo.ml
   > index b69a69a5a..ea988f6bd 100644
   > --- a/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -3,7 +3,7 @@ Install actions should have the switch directory prepared:
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (install (system "find %{prefix} | sort"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -3,7 +3,7 @@ Testing install actions
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (install (system "echo foobar; mkdir -p %{lib}; touch %{lib}/xxx"))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
@@ -3,8 +3,7 @@ Use build paths in the install entries of a package
   $ . ./helpers.sh
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.install <<EOF

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -4,7 +4,7 @@ Test missing entries in the .install file
 
   $ make_lockdir
   $ lockfile() {
-  > cat > ${default_lock_dir}/test.pkg <<EOF
+  > make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (system "echo 'lib: [ \"$1\" ]' > test.install"))

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -3,7 +3,7 @@ Test that installed binaries are visible in dependent packages
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| echo "#!/bin/sh\necho from test package" > foo;
@@ -18,7 +18,7 @@ Test that installed binaries are visible in dependent packages
   >  ))
   > EOF
 
-  $ cat > ${default_lock_dir}/usetest.pkg <<EOF
+  $ make_lockpkg usetest <<EOF
   > (version 0.0.1)
   > (depends test)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/libraries.t
+++ b/test/blackbox-tests/test-cases/pkg/libraries.t
@@ -26,8 +26,7 @@ Now we set up a lock file with this package and then attempt to use it:
   > EOF
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/mypkg.pkg <<EOF
+  $ make_lockpkg mypkg <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build (run dune build --release --promote-install-file=true . @install))

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -44,7 +44,9 @@ Initially the lockdir will be valid.
   $ dune pkg validate-lockdir
 
 Add a file to the lockdir to cause the parser to fail.
-  $ echo foo > ${default_lock_dir}/bar.pkg
+  $ make_lockpkg bar <<EOF
+  > foo
+  > EOF
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/bar.pkg", line 1, characters 0-3:
@@ -55,8 +57,8 @@ Add a file to the lockdir to cause the parser to fail.
   [1]
 
 Remove the file but corrupt the lockdir metadata file.
-  $ rm ${default_lock_dir}/bar.pkg
-  $ echo foo >> ${default_lock_dir}/lock.dune
+  $ rm ${source_lock_dir}/bar.pkg
+  $ echo foo >> ${source_lock_dir}/lock.dune
   $ dune pkg validate-lockdir
   Failed to parse lockdir dune.lock:
   File "dune.lock/lock.dune", line 8, characters 0-3:
@@ -67,7 +69,7 @@ Remove the file but corrupt the lockdir metadata file.
   [1]
 
 Regenerate the lockdir and validate the result.
-  $ rm -r ${default_lock_dir}
+  $ rm -r ${source_lock_dir}
   $ dune pkg lock
   Solution for dune.lock:
   - a.0.0.1
@@ -78,7 +80,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Remove a package from the lockdir.
-  $ rm ${default_lock_dir}/a.pkg
+  $ rm ${source_lock_dir}/a.pkg
 
 This results in an invalid lockdir due to the missing package.
   $ dune pkg validate-lockdir
@@ -106,7 +108,7 @@ Regenerate the lockdir and validate the result.
   $ cat ${default_lock_dir}/b.pkg
   (version 0.0.2)
 Change the version of a dependency by modifying its lockfile.
-  $ cat > ${default_lock_dir}/b.pkg <<EOF
+  $ make_lockpkg b <<EOF
   > (version 0.0.1)
   > EOF
 
@@ -135,7 +137,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Add a package to the lockdir with the same name as a local package.
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > EOF
 
@@ -162,7 +164,7 @@ Regenerate the lockdir and validate the result.
   $ dune pkg validate-lockdir
 
 Add a package to the lockdir which isn't part of the local package dependency hierarchy.
-  $ cat > ${default_lock_dir}/f.pkg <<EOF
+  $ make_lockpkg f <<EOF
   > (version 0.0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -5,16 +5,15 @@ package graph then it's caught when loading the lockdir.
 
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/a.pkg <<EOF
+  $ make_lockpkg a <<EOF
   > (version 0.0.1)
   > (depends b)
   > EOF
-  $ cat > ${default_lock_dir}/b.pkg <<EOF
+  $ make_lockpkg b <<EOF
   > (version 0.0.1)
   > (depends c)
   > EOF
-  $ cat > ${default_lock_dir}/c.pkg <<EOF
+  $ make_lockpkg c <<EOF
   > (version 0.0.1)
   > (depends a)
   > EOF
@@ -25,7 +24,7 @@ package graph then it's caught when loading the lockdir.
   - b.0.0.1
   - c.0.0.1
 
-  $ cat > ${default_lock_dir}/c.pkg <<EOF
+  $ make_lockpkg c <<EOF
   > (version 0.0.1)
   > (depends a d)
   > EOF
@@ -40,7 +39,7 @@ package graph then it's caught when loading the lockdir.
   regenerate it by running: 'dune pkg lock'
   [1]
 
-  $ rm ${default_lock_dir}/a.pkg
+  $ rm ${source_lock_dir}/a.pkg
 
   $ dune describe pkg lock
   File "dune.lock/c.pkg", line 2, characters 9-10:

--- a/test/blackbox-tests/test-cases/pkg/make.t
+++ b/test/blackbox-tests/test-cases/pkg/make.t
@@ -8,7 +8,7 @@ Build a package with make
   > foo: ; @echo running makefile
   > EOF
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (build (run %{make}))
   > (source (copy $PWD/foo))

--- a/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
@@ -73,10 +73,10 @@ use the system OCaml for this.
 Now we finally make the OCaml package for testing through the lock file:
 
   $ make_lockdir
-  $ cat >> ${default_lock_dir}/lock.dune <<EOF
+  $ cat >> ${source_lock_dir}/lock.dune <<EOF
   > (ocaml mycaml)
   > EOF
-  $ cat > ${default_lock_dir}/mycaml.pkg <<EOF
+  $ make_lockpkg mycaml <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/mycamlsources))
   > (build

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
@@ -54,7 +54,7 @@ attempt to build the package "foo".
 Create a lockdir and define the package "bar". Note its install command is
 `false` so it will fail to install.
   $ make_lockdir
-  $ cat > ${default_lock_dir}/bar.pkg <<EOF
+  $ make_lockpkg bar <<EOF
   > (version 0.0.1)
   > (install (run false))
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -20,7 +20,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -18,7 +18,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
@@ -17,7 +17,7 @@ Test that ocamllsp can be installed while dune is running in watch mode.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -39,7 +39,7 @@ Make a fake ocamlformat
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -23,7 +23,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 
@@ -43,7 +43,7 @@ We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
   hello from fake ocamllsp
 
 Change the version of ocaml that the project depends on.
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.1.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -20,7 +20,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -23,7 +23,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.2.0)
   > EOF
 
@@ -55,7 +55,7 @@ We can re-run "dune ocaml doc" without relocking or rebuilding.
   [1]
 
 Change the version of ocaml that the project depends on.
-  $ cat > ${default_lock_dir}/ocaml.pkg <<EOF
+  $ make_lockpkg ocaml <<EOF
   > (version 5.1.0)
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -17,7 +17,7 @@ Make a package with a substs and patches field field
   $ solve with-substs-and-patches
   Solution for dune.lock:
   - with-substs-and-patches.0.0.1
-  $ cat >> ${default_lock_dir}/with-substs-and-patches.pkg <<EOF
+  $ append_to_lockpkg with-substs-and-patches <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
@@ -35,7 +35,7 @@ Make a package with an extra-source field and multiple checksums
   - with-extra-source.0.0.1
   - with-extra-source-md5.0.0.1
   - with-extra-source-multiple-checksums.0.0.1
-  $ cat >> ${default_lock_dir}/with-extra-source.pkg <<EOF
+  $ append_to_lockpkg with-extra-source <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -24,7 +24,7 @@ Make a package with a patch behind a filter
   $ solve with-patch-filter
   Solution for dune.lock:
   - with-patch-filter.0.0.1
-  $ cat >> ${default_lock_dir}/with-patch-filter.pkg <<EOF
+  $ append_to_lockpkg with-patch-filter <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -48,7 +48,7 @@ file and the second patches two, one of the files is in a subdirectory.:w
   $ solve with-patch
   Solution for dune.lock:
   - with-patch.0.0.1
-  $ cat >> ${default_lock_dir}/with-patch.pkg <<EOF
+  $ append_to_lockpkg with-patch <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -25,7 +25,7 @@ Make a package with a patch
   $ solve with-patch
   Solution for dune.lock:
   - with-patch.0.0.1
-  $ cat >> ${default_lock_dir}/with-patch.pkg <<EOF
+  $ append_to_lockpkg with-patch <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -12,7 +12,7 @@ Make a package with a substs field
   $ solve with-substs
   Solution for dune.lock:
   - with-substs.0.0.1
-  $ cat >> ${default_lock_dir}/with-substs.pkg <<EOF
+  $ append_to_lockpkg with-substs <<EOF
   > (source (copy $PWD/source))
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/package-cycle.t
@@ -3,16 +3,15 @@ Package resolution creating a cycle
   $ . ./helpers.sh
 
   $ make_lockdir
-
-  $ cat > ${default_lock_dir}/a.pkg <<EOF
+  $ make_lockpkg a <<EOF
   > (version 0.0.1)
   > (depends b)
   > EOF
-  $ cat > ${default_lock_dir}/b.pkg <<EOF
+  $ make_lockpkg b <<EOF
   > (version 0.0.1)
   > (depends c)
   > EOF
-  $ cat > ${default_lock_dir}/c.pkg <<EOF
+  $ make_lockpkg c <<EOF
   > (version 0.0.1)
   > (depends a)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -7,7 +7,7 @@ Additional files overlaid on top of the source can be found in the
   $ touch test-source/foo
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source
   >  (copy $PWD/test-source))
@@ -15,11 +15,10 @@ Additional files overlaid on top of the source can be found in the
   >  (system "echo foo:; cat foo; echo bar:; cat bar"))
   > EOF
 
-  $ mkdir ${default_lock_dir}/test.files
-  $ cat > ${default_lock_dir}/test.files/foo <<EOF
+  $ make_lockpkg_file test foo <<EOF
   > foo from test.files
   > EOF
-  $ cat > ${default_lock_dir}/test.files/bar <<EOF
+  $ make_lockpkg_file test bar <<EOF
   > bar from test.files
   > EOF
 

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -4,7 +4,7 @@ Applying patches
 
   $ mkdir test-source
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -13,8 +13,7 @@ Applying patches
   >   (system "cat foo.ml")))
   > EOF
 
-  $ mkdir ${default_lock_dir}/test.files
-  $ cat > ${default_lock_dir}/test.files/foo.patch <<EOF
+  $ make_lockpkg_file test foo.patch <<EOF
   > diff --git a/foo.ml b/foo.ml
   > new file mode 100644
   > index 0000000..557db03

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
@@ -6,7 +6,7 @@ Testing the when action in lockfiles
 
 Case with a mix of uncoditional and conditional actions in a progn action
 
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (install
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps.t
@@ -7,7 +7,7 @@ We should be able to specify (package ..) deps on locally built packages.
   > EOF
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (install
   >  (progn
@@ -46,7 +46,7 @@ Now we define the external package using a dune project:
   > print_endline "Hello from foo.ml!"
   > EOF
 
-  $ cat > ${default_lock_dir}/foo.pkg <<EOF
+  $ make_lockpkg foo <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/external_sources))
   > (build (run dune build @install --promote-install-files))

--- a/test/blackbox-tests/test-cases/pkg/run-local.t
+++ b/test/blackbox-tests/test-cases/pkg/run-local.t
@@ -5,7 +5,7 @@ they could have been created or modified by previous build commands (such as
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -3,7 +3,7 @@ install and build commands.
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build (run sh -c "echo [build] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))
   > (install (run sh -c "echo [install] OCAMLFIND_DESTDIR=$OCAMLFIND_DESTDIR"))

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -3,7 +3,7 @@ Test that we run the build command
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (progn

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -5,7 +5,7 @@
 Helper function to create a lockfile with a given install action and then build it, running the action.
   $ test_action() {
   >   dune clean || true
-  >   cat > ${default_lock_dir}/test.pkg <<EOF
+  >   make_lockpkg test <<EOF
   > (version 0.0.1)
   > (install $1)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
@@ -3,11 +3,7 @@ Test the %{pkg:installed}% form inside file substitution:
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ mkdir source
-  $ cat >source/foo.in <<EOF
-  > foo: %{somepkg:installed}%
-  > EOF
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/source))
   > (build
@@ -15,6 +11,10 @@ Test the %{pkg:installed}% form inside file substitution:
   >   (system "echo somepkg installation %{pkg:somepkg:installed}")
   >   (substitute foo.in foo)
   >   (system "cat foo")))
+  > EOF
+  $ mkdir source
+  $ cat >source/foo.in <<EOF
+  > foo: %{somepkg:installed}%
   > EOF
 
   $ build_pkg test

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -7,7 +7,7 @@ The test-source folder has a file to use substitution on.
   > This file will be fed to the substitution mechanism
   > EOF
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -31,7 +31,7 @@ This should also work with any other filename combination:
   $ cat >test-source/foo.ml.template <<EOF
   > This is using a different file suffix
   > EOF
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -51,7 +51,7 @@ Undefined variables, how do they substitute?
   $ cat >test-source/variables.ml.in <<EOF
   > We substitute this '%%{var}%%' into '%{var}%'
   > EOF
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -81,7 +81,7 @@ Now with variables set
   > %%{with-test}%% is '%{with-test}%'
   > %%{os}%% is '%{os}%'
   > EOF
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (build
@@ -109,11 +109,11 @@ Now with variables set
 It is also possible to use variables of your dependencies:
 
   $ mkdir dependency-source
-  $ cat > ${default_lock_dir}/dependency.pkg <<EOF
+  $ make_lockpkg dependency <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/dependency-source))
   > EOF
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (source (copy $PWD/test-source))
   > (depends dependency)

--- a/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
@@ -37,7 +37,7 @@ the appropriate location, respecting the DESTDIR variable.
   > EOF
 
 Lockfile for the fake compiler package:
-  $ cat > ${default_lock_dir}/ocaml-base-compiler.pkg << EOF
+  $ make_lockpkg ocaml-base-compiler << EOF
   > (version 1)
   > 
   > (build

--- a/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
@@ -40,7 +40,7 @@ location
 
 We generate the lockfile for the fake compiler
 
-  $ cat > ${default_lock_dir}/ocaml-base-compiler.pkg << EOF
+  $ make_lockpkg ocaml-base-compiler << EOF
   > (version 1)
   > (build
   >  (run ./configure %{prefix}))
@@ -54,7 +54,7 @@ We generate the lock file for the package to demonstrate the variable is
 replaced with the path to the sandbox inside of the path to the non-relocatable
 location.
 
-  $ cat > ${default_lock_dir}/baz.pkg << EOF
+  $ make_lockpkg baz << EOF
   > (version 1)
   > (build
   >  (run sh -exc "echo %{pkg:ocaml-base-compiler:share}"))

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -3,7 +3,7 @@ Test that we can set variables
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.config <<EOF
@@ -18,7 +18,7 @@ Test that we can set variables
   >  ))
   > EOF
 
-  $ cat > ${default_lock_dir}/usetest.pkg <<EOF
+  $ make_lockpkg usetest <<EOF
   > (version 0.0.1)
   > (depends test)
   > (build
@@ -51,7 +51,7 @@ Test that we can set variables
 
 Now we demonstrate we get a proper error from invalid .config files:
 
-  $ cat > ${default_lock_dir}/test.pkg <<EOF
+  $ make_lockpkg test <<EOF
   > (version 0.0.1)
   > (build
   >  (system "\| cat >test.config <<EOF

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -9,15 +9,15 @@ This path is system-specific so we need to be able to remove it from the output.
   $ make_lockdir
 
 Make some packages so that the test package can have dependencies:
-  $ cat > ${default_lock_dir}/hello1.pkg <<'EOF'
+  $ make_lockpkg hello1 <<EOF
   > (version 0.0.1)
   > EOF
-  $ cat > ${default_lock_dir}/hello2.pkg <<'EOF'
+  $ make_lockpkg hello2.pkg <<EOF
   > (version 0.0.1)
   > EOF
 
 Printing out PATH without setting it:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build
   >  (system "echo PATH=$PATH"))
@@ -27,7 +27,7 @@ Printing out PATH without setting it:
   PATH=DUNE_PATH:/bin
 
 Setting PATH to a specific value:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -39,7 +39,7 @@ Setting PATH to a specific value:
   PATH=/tmp/bin
 
 Attempting to add a path to PATH replaces the entire PATH:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -51,7 +51,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   PATH=/tmp/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv
@@ -65,7 +65,7 @@ Try adding multiple paths to PATH:
   PATH=/bar/bin:/foo/bin:/tmp/bin:DUNE_PATH:/bin
 
 Printing out PATH without setting it when the package has a dependency:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -76,7 +76,7 @@ Printing out PATH without setting it when the package has a dependency:
   PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -89,7 +89,7 @@ Setting PATH to a specific value:
   PATH=/tmp/bin
 
 Attempting to add a path to PATH replaces the entire PATH:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build
@@ -102,7 +102,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (depends hello1 hello2)
   > (build

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -3,7 +3,7 @@ Setting environment variables in actions
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ cat > ${default_lock_dir}/test.pkg <<'EOF'
+  $ make_lockpkg test <<'EOF'
   > (version 0.0.1)
   > (build
   >  (withenv


### PR DESCRIPTION
This variable refers to the lock dir that is meant to be in the users source folder and potentially later be copied to the _build folder. For now it is identical to the default build directory.