### PR TITLE
chore(ci): remove 4.14 support for creating local switch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -250,7 +250,6 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - 5
-          - 4.14
     runs-on: ${{ matrix.os }}
     steps:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}


### PR DESCRIPTION
We don't support 4.14 in development

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>