### PR TITLE
test: internal cyclic module error exposed

### DIFF
--- a/test/blackbox-tests/test-cases/cyclic-dep-executable.t
+++ b/test/blackbox-tests/test-cases/cyclic-dep-executable.t
@@ -1,0 +1,33 @@
+  $ cat > dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name foo))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > open Bar
+  > open Baz
+  > EOF
+
+  $ cat > bar.ml <<EOF
+  > open Baz
+  > EOF
+
+  $ cat > baz.ml <<EOF
+  > open Bar
+  > EOF
+
+  $ dune build
+  Error: Dependency cycle between:
+     _build/default/.foo.eobjs/dune__exe__Baz.impl.all-deps
+  -> _build/default/.foo.eobjs/dune__exe__Bar.impl.all-deps
+  -> _build/default/.foo.eobjs/dune__exe__Baz.impl.all-deps
+  -> required by _build/default/.foo.eobjs/dune__exe__Foo.impl.all-deps
+  -> required by _build/default/foo.exe
+  -> required by alias all
+  -> required by alias default
+  [1]
+
+

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -37,6 +37,7 @@
  (libraries
   fiber
   stdune
+  dune_re
   dune_rpc_client
   dune_rpc_e2e
   dune_rpc_private


### PR DESCRIPTION
Here we demonstrate a cycle error that ends up staying internal causing problems when communicated over RPC. The cram test demonstrates the minimal set up to achieve it and the expect test compares the error with a similar one which gets reported nicely to the user.

I would expect this message to also get reported nicely to the user, but we must be missing it's detection somewhere.