### PR TITLE
chore(ci): remove --with-test from installing dune

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -158,7 +158,7 @@ jobs:
       # Install ocamlfind-secondary and ocaml-secondary-compiler, if needed
       - run: |
           opam pin -n . --with-version=3.20
-          opam install ./dune.opam --deps-only --with-test
+          opam install ./dune.opam --deps-only
 
       - name: Install system deps on macOS
         run: brew install coreutils pkg-config file


### PR DESCRIPTION
If the goal is to check that dune is building, we don't need its test deps.

Dune has no test-deps, so this is useless anyway

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>