### PR TITLE
Add doc string for `Common.x`

### DIFF
--- a/bin/common.mli
+++ b/bin/common.mli
@@ -3,6 +3,8 @@ open Stdune
 
 type t
 
+(* [x t] returns the [Context_name.t] of of the cross-compilation context, if
+  there is any *)
 val x : t -> Dune_engine.Context_name.t option
 val capture_outputs : t -> bool
 val root : t -> Workspace_root.t


### PR DESCRIPTION
It was unclear to me what it was for, so after learning about it I thought it might make sense to document it.