### PR TITLE
ci: check bootstrap script in 4.02

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -82,6 +82,23 @@ jobs:
         env:
           LC_ALL: C
 
+  bootstrap:
+    name: Bootstrap
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
+
 #
 # Stage 2
 #

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ bootstrap:
 test-bootstrap:
 	@ocaml boot/bootstrap.ml --boot-dir _test_boot
 
+.PHONY: test-bootstrap-script
+test-bootstrap-script:
+	@ocamlc -i boot/bootstrap.ml
+
 .PHONY: release
 release: $(BIN)
 	@$(BIN) build @install -p dune --profile dune-bootstrap

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -2,7 +2,7 @@ open StdLabels
 open Printf
 
 (* This program performs version checking of the compiler and switches to the
-   secondary compiler if necessary. The script should execute in OCaml 4.08! *)
+   secondary compiler if necessary. The script should execute in OCaml 4.02! *)
 
 let min_supported_natively = 4, 08, 0
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,9 +55,12 @@
       add-experimental-configure-flags = pkg: pkg.overrideAttrs {
         configureFlags =
           [
-            "--pkg-build-progress" "enable"
-            "--lock-dev-tool" "enable"
-            "--portable-lock-dir" "enable"
+            "--pkg-build-progress"
+            "enable"
+            "--lock-dev-tool"
+            "enable"
+            "--portable-lock-dir"
+            "enable"
           ];
       };
 
@@ -256,6 +259,17 @@
                 that can build Dune and the Coq testsuite.
               '';
             };
+
+          bootstrap-check =
+            pkgs.mkShell {
+              inherit INSIDE_NIX;
+              buildInputs = with pkgs; [ gnumake ocaml-ng.ocamlPackages_4_02.ocaml ];
+              meta.description = ''
+                Provides a minimal shell environment in order to test the
+                bootstrapping script.
+              '';
+            };
+
           microbench = makeDuneDevShell {
             extraBuildInputs = pkgs: [
               pkgs.ocamlPackages.core_bench


### PR DESCRIPTION
We can use `ocamlc -i` (infer interface) to interpret the script without running or generating artefacts. It will output any errors we get.

fix https://github.com/ocaml/dune/issues/12178

The CI job doesn't use the `make` target because we don't (need to) have `make` installed.