### PR TITLE
doc: replace describe by confval

### DIFF
--- a/doc/reference/config/project_defaults.rst
+++ b/doc/reference/config/project_defaults.rst
@@ -14,7 +14,7 @@ of the :doc:`../dune-project/index` file when initializing a project with
 
 ``<optional-fields>`` are:
 
-.. describe:: (authors <string(s)>)
+.. confval:: (authors <string(s)>)
 
    Specify authors.
 
@@ -27,7 +27,7 @@ of the :doc:`../dune-project/index` file when initializing a project with
          "Jane Doe <jane.doe@example.com>"
          "John Doe <john.doe@example.com>"))
 
-.. describe:: (maintainers <string(s)>)
+.. confval:: (maintainers <string(s)>)
 
    Specify maintainers.
 
@@ -40,7 +40,7 @@ of the :doc:`../dune-project/index` file when initializing a project with
          "Jane Doe <jane.doe@example.com>"
          "John Doe <john.doe@example.com>"))
 
-.. describe:: (license <string(s)>)
+.. confval:: (license <string(s)>)
 
    Specify license, ideally as an identifier from the `SPDX License List
    <https://spdx.org/licenses/>`__.

--- a/doc/reference/dune-project/dialect.rst
+++ b/doc/reference/dune-project/dialect.rst
@@ -1,24 +1,24 @@
 dialect
 -------
 
-.. describe:: (dialect ...)
+.. confval:: (dialect ...)
 
    Declare a new :term:`dialect`.
 
-   .. describe:: (name <name>)
+   .. confval:: (name <name>)
 
       The name of the dialect being defined. It must be unique in a given
       project.
 
       This field is required.
 
-   .. describe:: (implementation ...)
+   .. confval:: (implementation ...)
 
       Details related to the implementation files (corresponding to `*.ml`).
 
       .. versionchanged:: 3.9 This field is made optional.
 
-      .. describe:: (extension <string>)
+      .. confval:: (extension <string>)
 
          Specify the file extension used for this dialect.
 
@@ -29,7 +29,7 @@ dialect
 
          This field is required.
 
-      .. describe:: (preprocess <action>)
+      .. confval:: (preprocess <action>)
 
          Run `<action>` to produce a valid OCaml abstract syntax tree.
 
@@ -43,7 +43,7 @@ dialect
 
          .. seealso:: :ref:`preprocessing-actions`
 
-      .. describe:: (format <action>)
+      .. confval:: (format <action>)
 
          Run `<action>` to format source code for this dialect.
 
@@ -58,7 +58,7 @@ dialect
 
          .. seealso:: :doc:`/howto/formatting`
 
-   .. describe:: (interface ...)
+   .. confval:: (interface ...)
 
       Details related to the interface files (corresponding to `*.mli`).
 
@@ -66,7 +66,7 @@ dialect
 
       .. versionchanged:: 3.9 This field is made optional.
 
-   .. describe:: (merlin_reader <program> <args>...)
+   .. confval:: (merlin_reader <program> <args>...)
 
       Configure Merlin to use `<program> <args>...` as READER. Merlin's READER
       is a mechanism to extend Merlin to support OCaml dialects by providing

--- a/doc/reference/dune-project/package.rst
+++ b/doc/reference/dune-project/package.rst
@@ -4,104 +4,104 @@ package
 This stanza is used to specify package metadata. In particular, this information
 is used when generating OPAM files (see :doc:`generate_opam_files`).
 
-.. describe:: (package ...)
+.. confval:: (package ...)
 
    Define package-specific metadata.
 
-   .. describe:: (name <string>)
+   .. confval:: (name <string>)
 
       The name of the package.
 
       This must be specified.
 
-   .. describe:: (synopsis <string>)
+   .. confval:: (synopsis <string>)
 
       A short package description.
 
-   .. describe:: (description <string>)
+   .. confval:: (description <string>)
 
       A longer package description.
 
-   .. describe:: (depends <dep-specification>)
+   .. confval:: (depends <dep-specification>)
 
       Package dependencies, as :token:`~pkg-dep:dep_specification`.
 
-   .. describe:: (conflicts <dep-specification>)
+   .. confval:: (conflicts <dep-specification>)
 
       Package conflicts, as :token:`~pkg-dep:dep_specification`.
 
-   .. describe:: (depopts <dep-specification>)
+   .. confval:: (depopts <dep-specification>)
 
       Optional package dependencies, as :token:`~pkg-dep:dep_specification`.
 
-   .. describe:: (tags <tags>)
+   .. confval:: (tags <tags>)
 
       A list of tags.
 
-   .. describe:: (deprecated_package_names <name list>)
+   .. confval:: (deprecated_package_names <name list>)
 
       A list of names that can be used with the
       :doc:`../dune/deprecated_library_name` stanza to migrate legacy libraries
       from other build systems that do not follow Dune's convention of
       prefixing the library's public name with the package name.
 
-   .. describe:: (license ...)
+   .. confval:: (license ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`license`).
 
-   .. describe:: (authors ...)
+   .. confval:: (authors ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`authors`).
 
-   .. describe:: (maintainers ...)
+   .. confval:: (maintainers ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`maintainers`).
 
-   .. describe:: (maintenance_intent ...)
+   .. confval:: (maintenance_intent ...)
 
       .. versionadded:: 3.18
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`maintenance_intent`).
 
-   .. describe:: (source ...)
+   .. confval:: (source ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`source`).
 
-   .. describe:: (bug_reports ...)
+   .. confval:: (bug_reports ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`bug_reports`).
 
-   .. describe:: (homepage ...)
+   .. confval:: (homepage ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`homepage`).
 
-   .. describe:: (documentation ...)
+   .. confval:: (documentation ...)
 
       .. versionadded:: 2.0
 
       The same as (and takes precedences over) the corresponding global field
       (see :doc:`documentation`).
 
-   .. describe:: (sites ...)
+   .. confval:: (sites ...)
 
       Define a site.
 

--- a/doc/reference/dune-project/pin.rst
+++ b/doc/reference/dune-project/pin.rst
@@ -10,13 +10,13 @@ Pins are package overrides used in the context of package management. They
 allow to fix a package at a specific version which is not affected by the
 package repositories selected.
 
-.. describe:: (pin ...)
+.. confval:: (pin ...)
 
    .. versionadded:: 3.14
 
    Define a package override.
 
-   .. describe:: (url <string>)
+   .. confval:: (url <string>)
 
       The URL of the package source.
 
@@ -29,19 +29,19 @@ package repositories selected.
 
       This must be specified.
 
-   .. describe:: (package ...)
+   .. confval:: (package ...)
 
       Defines which package is to be pinned.
 
       This must be specified.
 
-      .. describe:: (name <string>)
+      .. confval:: (name <string>)
 
          The name of the package.
 
          This must be specified.
 
-      .. describe:: (version <string>)
+      .. confval:: (version <string>)
 
          The version that the package should be assumed to be. Defaults to
          ``dev`` if unspecified.

--- a/doc/reference/dune-workspace/lock_dir.rst
+++ b/doc/reference/dune-workspace/lock_dir.rst
@@ -10,18 +10,18 @@ This stanza configures the lock directory settings for the current workspace.
 For the default workflow no configuration is necessary, but the defaults can be
 changed if desired.
 
-.. describe:: (lock_dir ...)
+.. confval:: (lock_dir ...)
 
    .. versionadded:: 3.13
 
    Configures a specific lock directory to be created or used.
 
-   .. describe:: (path <string>)
+   .. confval:: (path <string>)
 
       The location in the source tree where the lock directory will be
       created or read from. If not specified defaults to ``dune.lock``.
 
-   .. describe:: (repositories <name list>)
+   .. confval:: (repositories <name list>)
 
       The repositories to be used for finding a package solution, specified
       in priority order. Supports ``:standard`` which contains ``upstream`` and
@@ -30,28 +30,28 @@ changed if desired.
       Additional repositories can be defined using the
       :doc:`/reference/dune-workspace/repository` stanza.
 
-   .. describe:: (solver_env ...)
+   .. confval:: (solver_env ...)
 
       The environment that is injected into the solver when creating the lock
       directory.
 
       It consists of a sequence of ``(<name> <value>)`` pairs.
 
-   .. describe:: (unset_variables <name list>)
+   .. confval:: (unset_variables <name list>)
 
       A list of variables that are used in solving that are deliberately unset
       even if the solver could provide bindings for them.
 
       The variables here cannot overlap with those defined in ``solver_env``.
 
-   .. describe:: (pins <name list>)
+   .. confval:: (pins <name list>)
 
       .. versionadded:: 3.15
 
       Define which pins are enabled for this particular lock dir. See
       :doc:`/reference/dune-workspace/pin` for details on how to define pins.
 
-   .. describe:: (version_preference <string>)
+   .. confval:: (version_preference <string>)
 
       Can be one of:
 
@@ -60,7 +60,7 @@ changed if desired.
       - ``oldest``: The solver will pick the lowest version that will satisfy
          the constraints
 
-   .. describe:: (constraints <dep-specification>)
+   .. confval:: (constraints <dep-specification>)
 
       Adds additional solver constraints that are passed to the solver. Follows
       the :token:`~pkg-dep:dep_specification` format.
@@ -72,7 +72,7 @@ changed if desired.
          additional constraints if the packages to which the constraint is
          applied are selected and don't do anything otherwise.
 
-   .. describe:: (depopts <name list>)
+   .. confval:: (depopts <name list>)
 
       .. versionadded:: 3.19
 

--- a/doc/reference/dune-workspace/pin.rst
+++ b/doc/reference/dune-workspace/pin.rst
@@ -14,20 +14,20 @@ project and used for building dependencies.
    Defining a pin does not enable it by default. It needs to be enabled in a
    lock directory using the :doc:`/reference/dune-workspace/lock_dir` stanza.
 
-.. describe:: (pin ...)
+.. confval:: (pin ...)
 
    .. versionadded:: 3.15
 
    Defines a new package source.
 
-   .. describe:: (name <string>)
+   .. confval:: (name <string>)
 
       The name of the newly defined pin. This can be anything, it does not
       have to match the package.
 
       This must be specified.
 
-   .. describe:: (url <string>)
+   .. confval:: (url <string>)
 
       This can be a path to a directory on the local file system or remote Git
       repository. Local paths can be absolute or relative, and may optionally
@@ -38,17 +38,17 @@ project and used for building dependencies.
 
       This must be specified.
 
-   .. describe:: (package ...)
+   .. confval:: (package ...)
 
       Specifies the the packages to assign this pin to.
 
-      .. describe:: (name <string>)
+      .. confval:: (name <string>)
 
          The name of the package.
 
          This must be specified.
 
-      .. describe:: (version <string>)
+      .. confval:: (version <string>)
 
          The version that the package should be assumed to be. Defaults to
          ``dev`` if unspecified.

--- a/doc/reference/dune-workspace/repository.rst
+++ b/doc/reference/dune-workspace/repository.rst
@@ -15,19 +15,19 @@ location to it.
    enabled in a lock directory using the :doc:`/reference/dune-workspace/lock_dir`
    stanza.
 
-.. describe:: (repository ...)
+.. confval:: (repository ...)
 
    .. versionadded:: 3.12
 
    Defines a named package repository.
 
-   .. describe:: (name <string>)
+   .. confval:: (name <string>)
 
       The name used to refer to the repository. Names have to be unique.
 
       This must be specified.
 
-   .. describe:: (url <string>)
+   .. confval:: (url <string>)
 
       The location from which the repository will be loaded.
 

--- a/doc/reference/dune/alias.rst
+++ b/doc/reference/dune/alias.rst
@@ -3,7 +3,7 @@
 alias
 -----
 
-.. describe:: (alias ...)
+.. confval:: (alias ...)
 
    Add dependencies to an alias.
 
@@ -28,7 +28,7 @@ alias
 
    This stanza supports the following fields:
 
-   .. describe:: (name <name>)
+   .. confval:: (name <name>)
 
       An alias name.
 
@@ -37,7 +37,7 @@ alias
 
       This field is required.
 
-   .. describe:: (deps <deps-conf list)
+   .. confval:: (deps <deps-conf list)
 
       Specifies the dependencies of the alias.
 
@@ -45,26 +45,26 @@ alias
 
       This field is required.
 
-   .. describe:: (enabled_if <blang expression>)
+   .. confval:: (enabled_if <blang expression>)
 
       Specifies the Boolean condition that must be true for the tests to run.
 
       The condition is specified using the :doc:`/reference/boolean-language`, and
       the field allows for :doc:`/concepts/variables` to appear in the expressions.
 
-   .. describe:: (action <action>)
+   .. confval:: (action <action>)
 
       .. versionremoved :: 2.0 use :doc:`rule` with the ``alias`` field instead.
 
       An :doc:`action </reference/actions/index>` for constructing the alias.
 
-   .. describe:: (package <name>)
+   .. confval:: (package <name>)
 
       Indicates that this alias stanza is part of package ``<name>`` and should be
       filtered out if ``<name>`` is filtered out from the command line, either with
       ``--only-packages <pkgs>`` or ``-p <pkgs>``.
 
-   .. describe:: (locks (<lock-names>))
+   .. confval:: (locks (<lock-names>))
 
       Specifies that the action must be run while holding the following locks. See
       :doc:`/concepts/locks` for more details.

--- a/doc/reference/dune/cram.rst
+++ b/doc/reference/dune/cram.rst
@@ -1,7 +1,7 @@
 Cram
 ----
 
-.. describe:: (cram ...)
+.. confval:: (cram ...)
 
    Configure Cram tests in the current directory (and subdirectories).
 
@@ -11,7 +11,7 @@ Cram
 
    .. seealso:: :doc:`/reference/cram`
 
-   .. describe:: (deps <dep-spec>)
+   .. confval:: (deps <dep-spec>)
 
       Specify the dependencies of the test.
 
@@ -32,7 +32,7 @@ Cram
 
       .. seealso:: :doc:`/concepts/dependency-spec`.
 
-   .. describe:: (applies_to <predicate-lang>)
+   .. confval:: (applies_to <predicate-lang>)
 
       Specify the scope of this ``cram`` stanza. By default it applies to all the
       Cram tests in the current directory. The special ``:whole_subtree`` value
@@ -50,30 +50,30 @@ Cram
 
       .. seealso:: :doc:`/reference/predicate-language`
 
-   .. describe:: (enabled_if <blang>)
+   .. confval:: (enabled_if <blang>)
 
       Control whether the tests are enabled.
 
       .. seealso:: :doc:`/reference/boolean-language`, :doc:`/concepts/variables`
 
-   .. describe:: (alias <name>)
+   .. confval:: (alias <name>)
 
       Alias that can be used to run the test. In addition to the user alias,
       every test ``foo.t`` is attached to the :doc:`/reference/aliases/runtest`
       alias and gets its own ``@foo`` alias to make it convenient to run
       individually.
 
-   .. describe:: (locks <lock-names>)
+   .. confval:: (locks <lock-names>)
 
       Specify that the tests must be run while holding the following locks.
 
       .. seealso:: :doc:`/concepts/locks`
 
-   .. describe:: (package <name>)
+   .. confval:: (package <name>)
 
       Attach the tests selected by this stanza to the specified package.
 
-   .. describe:: (runtest_alias <true|false>)
+   .. confval:: (runtest_alias <true|false>)
 
       .. versionadded:: 3.12
 
@@ -81,7 +81,7 @@ Cram
       The default is to add every Cram test to ``runtest``, but this is not
       always desired.
 
-   .. describe:: (timeout <float>)
+   .. confval:: (timeout <float>)
 
       .. versionadded:: 3.20
 

--- a/doc/reference/dune/library.rst
+++ b/doc/reference/dune/library.rst
@@ -28,7 +28,7 @@ order to declare a multi-directory library, you need to use the
 
 ``<optional-fields>`` are:
 
-.. describe:: (public_name <name>)
+.. confval:: (public_name <name>)
 
    The name under which the library can be referred as a dependency when it's
    not part of the current workspace, i.e., when it's installed. Without a
@@ -38,19 +38,19 @@ order to declare a multi-directory library, you need to use the
    be one of the packages that Dune knows about, as determined by the logic
    described in :doc:`/reference/packages`.
 
-.. describe:: (package <package>)
+.. confval:: (package <package>)
 
    Installs a private library under the specified package. Such a library is
    now usable by public libraries defined in the same project. The Findlib name
    for this library will be ``<package>.__private__.<name>``; however, the
    library's interface will be hidden from consumers outside the project.
 
-.. describe:: (synopsis <string>)
+.. confval:: (synopsis <string>)
 
    A one-line description of the library. This is used by tools that list
    installed libraries.
 
-.. describe:: (modules <modules>)
+.. confval:: (modules <modules>)
 
    Specifies what modules are part of the library. By default, Dune will use
    all the ``.ml/.re`` files in the same directory as the ``dune`` file. This
@@ -67,13 +67,13 @@ order to declare a multi-directory library, you need to use the
    the list of modules using Dune rules. The dependencies introduced in this
    way *must live in a different directory that the stanza making use of them*.
 
-.. describe:: (libraries <library-dependencies>)
+.. confval:: (libraries <library-dependencies>)
 
    Specifies the library's dependencies.
 
    See :doc:`/reference/library-dependencies` for more details.
 
-.. describe:: (wrapped <boolean>)
+.. confval:: (wrapped <boolean>)
 
    Specifies whether the library modules should be available only through the
    top-level library module, or if they should all be exposed at the top level.
@@ -87,7 +87,7 @@ order to declare a multi-directory library, you need to use the
    modules by the library name and to ease porting of existing projects to
    Dune.
 
-.. describe:: (wrapped (transition <message>))
+.. confval:: (wrapped (transition <message>))
 
    This is the same as ``(wrapped true)``, except it will also generate
    unwrapped (not prefixed by the library name) modules to preserve
@@ -97,14 +97,14 @@ order to declare a multi-directory library, you need to use the
    false)`` to ``(wrapped true)`` without breaking compatibility for users. The
    deprecation notices for the unwrapped modules will include ``<message>``.
 
-.. describe:: (preprocess <preprocess-spec>)
+.. confval:: (preprocess <preprocess-spec>)
 
    Specifies how to preprocess files when needed.
 
    The default is ``no_preprocessing``, and other options are described
    in :doc:`/reference/preprocessing-spec`.
 
-.. describe:: (preprocessor_deps (<deps-conf list>))
+.. confval:: (preprocessor_deps (<deps-conf list>))
 
    Specifies extra preprocessor dependencies preprocessor, i.e., if the
    preprocessor reads a generated file.
@@ -112,7 +112,7 @@ order to declare a multi-directory library, you need to use the
    The specification of dependencies is described in
    :doc:`/concepts/dependency-spec`.
 
-.. describe:: (optional)
+.. confval:: (optional)
 
    If present, it indicates that the library should only be built and installed
    if all the dependencies are available, either in the workspace or in the
@@ -121,7 +121,7 @@ order to declare a multi-directory library, you need to use the
    Use this to provide extra features without adding hard dependencies to your
    project.
 
-.. describe:: (foreign_stubs <foreign-stubs-spec>)
+.. confval:: (foreign_stubs <foreign-stubs-spec>)
 
    Specifies foreign source files, e.g., C or C++ stubs, to be compiled and
    packaged together with the library.
@@ -131,21 +131,21 @@ order to declare a multi-directory library, you need to use the
    This field replaces the now-deleted fields ``c_names``, ``c_flags``,
    ``cxx_names``, and ``cxx_flags``.
 
-.. describe:: (foreign_archives <foreign-archives-list>)
+.. confval:: (foreign_archives <foreign-archives-list>)
 
    Specifies archives of foreign object files to be packaged with the library.
 
    See the section :doc:`/reference/foreign-archives` for more details. This
    field replaces the now-deleted field ``self_build_stubs_archive``.
 
-.. describe:: (install_c_headers (<names>))
+.. confval:: (install_c_headers (<names>))
 
    If your library has public C header files that must be installed, you must
    list them in this field, without the ``.h`` extension.
 
    You should favor the ``public_headers`` field starting from 3.8.
 
-.. describe:: (public_headers (<files>))
+.. confval:: (public_headers (<files>))
 
    If your library has public C header files that must be installed, you must
    list them in this field. This field accepts globs in the form of
@@ -157,7 +157,7 @@ order to declare a multi-directory library, you need to use the
    Additionally, it allows to specify the extensions of the header files, which
    allows alternative extensions such as ``.hh`` or ``.hpp``.
 
-.. describe:: (modes <modes>)
+.. confval:: (modes <modes>)
 
    List modes which should be built by default.
 
@@ -167,14 +167,14 @@ order to declare a multi-directory library, you need to use the
    The following modes are available: ``byte``, ``native`` and ``best``.
    ``best`` is ``native`` or ``byte`` when native compilation isn't available.
 
-.. describe:: (no_dynlink)
+.. confval:: (no_dynlink)
 
    Disables (native) dynamic linking of the library. This means that the
    ``.cmxs`` archive of the library will neither be built nor installed.
 
    This is for advanced use only. By default, you shouldn't set this option.
 
-.. describe:: (kind <kind>)
+.. confval:: (kind <kind>)
 
    Sets the type of library.
 
@@ -193,14 +193,14 @@ order to declare a multi-directory library, you need to use the
    libraries that share cookies with the same name should agree on their
    expanded value).
 
-.. describe:: (ppx_runtime_libraries (<library-names>))
+.. confval:: (ppx_runtime_libraries (<library-names>))
 
    This field is for when the library is a ``ppx rewriter`` or a ``[@@deriving
    ...]`` plugin, and has runtime dependencies.
 
    You need to specify these runtime dependencies here.
 
-.. describe:: (virtual_deps (<opam-packages>))
+.. confval:: (virtual_deps (<opam-packages>))
 
    Sometimes opam packages enable a specific feature only if another package is
    installed. For instance, the case of ``ctypes`` will only install
@@ -210,27 +210,27 @@ order to declare a multi-directory library, you need to use the
    unless you use Dune to synthesize the ``depends`` and ``depopts`` sections
    of your opam file.
 
-.. describe:: (js_of_ocaml ...)
+.. confval:: (js_of_ocaml ...)
 
    Sets options for JavaScript compilation, see :ref:`jsoo-field`.
 
-.. describe:: (wasm_of_ocaml ...)
+.. confval:: (wasm_of_ocaml ...)
 
    Sets options for JavaScript compilation, see :ref:`wasmoo-field`.
 
-.. describe:: (flags ...)
+.. confval:: (flags ...)
 
    See :doc:`/concepts/ocaml-flags`.
 
-.. describe:: (ocamlc_flags ...)
+.. confval:: (ocamlc_flags ...)
 
    See :doc:`/concepts/ocaml-flags`.
 
-.. describe:: (ocamlopt_flags ...)
+.. confval:: (ocamlopt_flags ...)
 
    See :doc:`/concepts/ocaml-flags`.
 
-.. describe:: (library_flags (<flags>))
+.. confval:: (library_flags (<flags>))
 
    A list of flags passed to ``ocamlc`` and ``ocamlopt`` when building the
    library archive files.
@@ -239,7 +239,7 @@ order to declare a multi-directory library, you need to use the
 
    ``<flags>`` is a list of strings supporting :doc:`/concepts/variables`.
 
-.. describe:: (c_library_flags <flags>)
+.. confval:: (c_library_flags <flags>)
 
    Specifies the flags passed to the C compiler when constructing the library
    archive file for the C stubs.
@@ -251,7 +251,7 @@ order to declare a multi-directory library, you need to use the
    write ``-lbar`` here, or whatever flags are necessary to link against this
    library.
 
-.. describe:: (modules_without_implementation <modules>)
+.. confval:: (modules_without_implementation <modules>)
 
    Specifies a list of modules that have only a ``.mli`` or ``.rei`` but no ``.ml`` or ``.re`` file.
 
@@ -267,7 +267,7 @@ order to declare a multi-directory library, you need to use the
    directory has more than one stanza, and thus a ``modules`` field must be
    specified, ``<modules>`` still needs to be added in ``modules``.
 
-.. describe:: (private_modules <modules>)
+.. confval:: (private_modules <modules>)
 
    Specifies a list of modules that will be marked as private.
 
@@ -279,12 +279,12 @@ order to declare a multi-directory library, you need to use the
    than one stanza and thus a ``modules`` field must be specified,
    ``<modules>`` still need to be added in ``modules``.
 
-.. describe:: (allow_overlapping_dependencies)
+.. confval:: (allow_overlapping_dependencies)
 
    Allows external dependencies to overlap with libraries that are present in
    the workspace.
 
-.. describe:: (enabled_if <blang expression>)
+.. confval:: (enabled_if <blang expression>)
 
    Conditionally disables a library.
 
@@ -295,7 +295,7 @@ order to declare a multi-directory library, you need to use the
    type of OS being targeted by the current build. Its value is the same as the
    value of the ``os_type`` parameter in the output of ``ocamlc -config``.
 
-.. describe:: (inline_tests)
+.. confval:: (inline_tests)
 
    Enables inline tests for this library.
 
@@ -303,7 +303,7 @@ order to declare a multi-directory library, you need to use the
 
    See :ref:`inline_tests` for a reference of corresponding options.
 
-.. describe:: (root_module <module>)
+.. confval:: (root_module <module>)
 
    This field instructs Dune to generate a module that will contain module
    aliases for every library specified in dependencies.
@@ -311,7 +311,7 @@ order to declare a multi-directory library, you need to use the
    This is useful whenever a library is shadowed by a local module. The library
    may then still be accessible via this root module.
 
-.. describe:: (ctypes <ctypes field>)
+.. confval:: (ctypes <ctypes field>)
 
    Instructs Dune to use ctypes stubgen to process your type and function
    descriptions for binding system libraries, vendored libraries, or other
@@ -321,7 +321,7 @@ order to declare a multi-directory library, you need to use the
 
    This field is available since the 3.0 version of the Dune language.
 
-.. describe:: (empty_module_interface_if_absent)
+.. confval:: (empty_module_interface_if_absent)
 
    Causes the generation of empty interfaces for every module that does not
    have an interface file already.

--- a/doc/reference/dune/library_parameter.rst
+++ b/doc/reference/dune/library_parameter.rst
@@ -10,20 +10,20 @@ The ``library_parameter`` stanza describes a parameter interface defined in a si
 you need to add ``(using oxcaml 0.1)`` :doc:`extension
 </reference/dune-project/using>` in your ``dune-project`` file.
 
-.. describe:: (library_parameter ...)
+.. confval:: (library_parameter ...)
 
   .. versionadded:: 3.20
 
   Define a parameter.
 
-  .. describe:: (name <parameter-name>)
+  .. confval:: (name <parameter-name>)
 
     ``parameter-name`` is the name of the library parameter. It must be a valid
     OCaml module name as for :doc:`/reference/dune/library`. 
 
     This must be specified if no `public_name` is specified.
 
-  .. describe:: (public_name ...)
+  .. confval:: (public_name ...)
 
     The name under which the library parameter can be referred as a dependency
     when it's not part of the current workspace, i.e., when it is installed.
@@ -33,16 +33,16 @@ you need to add ``(using oxcaml 0.1)`` :doc:`extension
     package name must also be one of the packages that Dune knows about, as
     determined by the logic described in :doc:`/reference/packages`.
 
-  .. describe:: (package <package>)
+  .. confval:: (package <package>)
 
     Installs a private library parameter under the specified package. Such a
     parameter is now usable by public libraries defined in the same project.
 
-  .. describe:: (synopsis <string>)
+  .. confval:: (synopsis <string>)
 
     A one-line description of the library parameter.
 
-  .. describe:: (modules <modules>)
+  .. confval:: (modules <modules>)
 
     Specifies a specific module to select as a `library_parameter`.
 
@@ -52,20 +52,20 @@ you need to add ``(using oxcaml 0.1)`` :doc:`extension
     The library parameter **must** only declare one ``mli`` file as part of its
     modules.
 
-  .. describe:: (libraries <library-dependencies>)
+  .. confval:: (libraries <library-dependencies>)
 
     Specifies the library parameter's dependencies.
 
     See :doc:`/reference/library-dependencies` for more details.
 
-  .. describe:: (preprocesss <preprocess-spec>)
+  .. confval:: (preprocesss <preprocess-spec>)
 
     Specifies how to preprocess files when needed.
 
     The default is ``no_preprocessing``, and other options are described
     in :doc:`/reference/preprocessing-spec`.
 
-  .. describe:: (preprocessor_deps (<deps-conf list>))
+  .. confval:: (preprocessor_deps (<deps-conf list>))
 
     Specifies extra preprocessor dependencies preprocessor, i.e., if the
     preprocessor reads a generated file.
@@ -74,25 +74,25 @@ you need to add ``(using oxcaml 0.1)`` :doc:`extension
     :doc:`/concepts/dependency-spec`.
 
 
-  .. describe:: (flags ...)
+  .. confval:: (flags ...)
 
     See :doc:`/concepts/ocaml-flags`.
 
-  .. describe:: (ocamlc_flags ...)
+  .. confval:: (ocamlc_flags ...)
 
     See :doc:`/concepts/ocaml-flags`.
 
-  .. describe:: (ocamlopt_flags ...)
+  .. confval:: (ocamlopt_flags ...)
 
    See :doc:`/concepts/ocaml-flags`.
 
-  .. describe:: (optional)
+  .. confval:: (optional)
 
     If present, it indicates that the library parameter should only be built
     and installed if all the dependencies are available, either in the
     workspace or in the installed world.
 
-  .. describe:: (enabled_if <blang expression>)
+  .. confval:: (enabled_if <blang expression>)
 
     Conditionally disables a library parameter.
 
@@ -103,7 +103,7 @@ you need to add ``(using oxcaml 0.1)`` :doc:`extension
     type of OS being targeted by the current build. Its value is the same as the
     value of the ``os_type`` parameter in the output of ``ocamlc -config``.
 
-  .. describe:: (allow_overlapping_dependencies)
+  .. confval:: (allow_overlapping_dependencies)
 
     Allows external dependencies to overlap with libraries that are present in
     the workspace.


### PR DESCRIPTION
This PR tries to address some parts of #12156.

`confval` generates anchors when `describe` does not. It might generate warnings due to references existing twice. It doesn't affect our use case, but, it could be a problem at some point if we directly use the `confval` in our refs.
