### PR TITLE
feature: allow custom actions to ask for more dependencies

### DIFF
--- a/src/action_ext/action_ext.ml
+++ b/src/action_ext/action_ext.ml
@@ -1,13 +1,38 @@
 open Stdune
 module Action = Dune_engine.Action
+module Done_or_more_deps = Dune_engine.Done_or_more_deps
+open Dune_engine.Action.Ext
 
-module Make (S : Action.Ext.Spec) = struct
+module Make (S : sig
+    type ('path, 'target) t
+
+    val name : string
+    val version : int
+    val is_useful_to : memoize:bool -> bool
+    val encode : ('p, 't) t -> ('p -> Sexp.t) -> ('t -> Sexp.t) -> Sexp.t
+    val bimap : ('a, 'b) t -> ('a -> 'x) -> ('b -> 'y) -> ('x, 'y) t
+
+    val action
+      :  (Path.t, Path.Build.t) t
+      -> ectx:Exec.context
+      -> eenv:Exec.env
+      -> unit Fiber.t
+  end) =
+struct
   module Spec = struct
     include S
+
+    let is_dynamic = false
 
     let encode t f g =
       let open Sexp in
       List [ Atom name; Atom (Int.to_string version); S.encode t f g ]
+    ;;
+
+    let action a ~ectx ~eenv =
+      let open Fiber.O in
+      let+ () = action a ~ectx ~eenv in
+      Done_or_more_deps.Done
     ;;
   end
 

--- a/src/action_ext/action_ext.mli
+++ b/src/action_ext/action_ext.mli
@@ -1,5 +1,20 @@
 open Stdune
+open Dune_engine.Action.Ext
 
-module Make (S : Dune_engine.Action.Ext.Spec) : sig
+module Make (S : sig
+    type ('path, 'target) t
+
+    val name : string
+    val version : int
+    val is_useful_to : memoize:bool -> bool
+    val encode : ('p, 't) t -> ('p -> Sexp.t) -> ('t -> Sexp.t) -> Sexp.t
+    val bimap : ('a, 'b) t -> ('a -> 'x) -> ('b -> 'y) -> ('x, 'y) t
+
+    val action
+      :  (Path.t, Path.Build.t) t
+      -> ectx:Exec.context
+      -> eenv:Exec.env
+      -> unit Fiber.t
+  end) : sig
   val action : (Path.t, Path.Build.t) S.t -> Dune_engine.Action.t
 end

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -238,8 +238,8 @@ let rec is_dynamic = function
   | Write_file _
   | Rename _
   | Remove_tree _
-  | Mkdir _
-  | Extension _ -> false
+  | Mkdir _ -> false
+  | Extension (module A) -> A.Spec.is_dynamic
 ;;
 
 let maybe_sandbox_path sandbox p =

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -105,12 +105,15 @@ module Exec = struct
 end
 
 module Ext = struct
+  module Exec = Exec
+
   module type Spec = sig
     type ('path, 'target) t
 
     val name : string
     val version : int
     val is_useful_to : memoize:bool -> bool
+    val is_dynamic : bool
     val encode : ('p, 't) t -> ('p -> Sexp.t) -> ('t -> Sexp.t) -> Sexp.t
     val bimap : ('a, 'b) t -> ('a -> 'x) -> ('b -> 'y) -> ('x, 'y) t
 
@@ -122,7 +125,7 @@ module Ext = struct
             known dependencies. In the future, we may generalize this to return
             an [Action_exec.done_or_more_deps], but that may be trickier to get
             right, and is a bridge we can cross when we get there. *)
-      unit Fiber.t
+      Done_or_more_deps.t Fiber.t
   end
 
   module type Instance = sig

--- a/src/dune_engine/action_plugin.mli
+++ b/src/dune_engine/action_plugin.mli
@@ -1,19 +1,8 @@
 open Import
-module Dependency = Dune_action_plugin.Private.Protocol.Dependency
-
-type done_or_more_deps =
-  | Done
-  (* This code assumes that there can be at most one 'dynamic-run' within single
-     action. [DAP.Dependency.t] stores relative paths so name clash would be
-     possible if multiple 'dynamic-run' would be executed in different
-     subdirectories that contains targets having the same name. *)
-  | Need_more_deps of (Dependency.Set.t * Dep.Set.t)
-
-val done_or_more_deps_union : done_or_more_deps -> done_or_more_deps -> done_or_more_deps
 
 val exec
   :  ectx:Action_intf.Exec.context
   -> eenv:Action_intf.Exec.env
   -> Path.t
   -> string list
-  -> done_or_more_deps Fiber.t
+  -> Done_or_more_deps.t Fiber.t

--- a/src/dune_engine/done_or_more_deps.ml
+++ b/src/dune_engine/done_or_more_deps.ml
@@ -1,0 +1,13 @@
+module Dependency = Dune_action_plugin.Private.Protocol.Dependency
+
+type t =
+  | Done
+  | Need_more_deps of (Dependency.Set.t * Dep.Set.t)
+
+let union (x : t) (y : t) =
+  match x, y with
+  | Done, Done -> Done
+  | Done, Need_more_deps x | Need_more_deps x, Done -> Need_more_deps x
+  | Need_more_deps (deps1, dyn_deps1), Need_more_deps (deps2, dyn_deps2) ->
+    Need_more_deps (Dependency.Set.union deps1 deps2, Dep.Set.union dyn_deps1 dyn_deps2)
+;;

--- a/src/dune_engine/done_or_more_deps.mli
+++ b/src/dune_engine/done_or_more_deps.mli
@@ -1,0 +1,11 @@
+module Dependency := Dune_action_plugin.Private.Protocol.Dependency
+
+type t =
+  | Done
+  (* This code assumes that there can be at most one 'dynamic-run' within single
+      action. [DAP.Dependency.t] stores relative paths so name clash would be
+      possible if multiple 'dynamic-run' would be executed in different
+      subdirectories that contains targets having the same name. *)
+  | Need_more_deps of (Dependency.Set.t * Dep.Set.t)
+
+val union : t -> t -> t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -3,6 +3,7 @@ module Context_name = Context_name
 module Action_builder = Action_builder
 module Dep = Dep
 module Action = Action
+module Done_or_more_deps = Done_or_more_deps
 module Utils = Utils
 module Dir_set = Dir_set
 module Subdir_set = Subdir_set


### PR DESCRIPTION
The goal of this change is to extract minimal interface of the dune action plugin so that its current implementation can be moved out of the engine.

To do this, we just allow custom actions to return the [Done_or_more_deps.t] type just like every other "built-in" action can. There was no good reason for this limitation anyway. The only reason for the inconsistency was that custom actions were added without much thought for DAP.
