### PR TITLE
refactor(rev_store): enforce typing of objects

### DIFF
--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -105,4 +105,4 @@ let fetch_revision t ~loc resolve rev_store =
      | Some rev -> Ok rev)
 ;;
 
-let set_rev (t : t) rev = { t with hash = Some (Rev_store.Object.to_string rev) }
+let set_rev (t : t) rev = { t with hash = Some (Rev_store.Object.to_hex rev) }

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -115,7 +115,7 @@ let of_git_repo loc url =
       (sprintf
          "%s#%s"
          (OpamUrl.base_url url)
-         (Rev_store.Object.to_string (Rev_store.At_rev.rev at_rev))
+         (Rev_store.Object.to_hex (Rev_store.At_rev.rev at_rev))
        |> OpamUrl.of_string
        |> OpamUrl.to_string)
   in

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -11,7 +11,7 @@ module Object : sig
   type resolved = private t
 
   val of_sha1 : string -> t option
-  val to_string : t -> string
+  val to_hex : t -> string
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
 end


### PR DESCRIPTION
We enforce the typing of `Object.t` which was a bit loose before and move some things around in preperation for #12188.