### PR TITLE
fix: remove dune-re

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -248,7 +248,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1"
+        run: opam install "wasm_of_ocaml-compiler>=6.1" re
 
       - name: Set Git User
         run: |

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,4 +1,5 @@
 FROM ocaml/opam:debian-12-ocaml-4.14
 RUN opam depext -u patdiff.v0.15.0
+RUN opam install re
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1217,11 +1217,12 @@ type status =
 let resolve_externals external_libraries =
   let external_libraries, external_includes =
     let convert = function
-      | "threads" -> "threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ]
-      | "unix" -> "unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags
+      | "threads" -> Some ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
+      | "unix" -> Some ("unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags)
+      | "seq" | "re" -> None
       | s -> fatal "unhandled external library %s" s
     in
-    List.map ~f:convert external_libraries |> List.split
+    List.filter_map ~f:convert external_libraries |> List.split
   in
   let external_includes = List.concat external_includes in
   external_libraries, external_includes

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -9,7 +9,12 @@ type library =
 let external_libraries = [ "unix"; "threads" ]
 
 let local_libraries =
-  [ { path = "otherlibs/top-closure"
+  [ { path = "vendor/re/src"
+    ; main_module_name = Some "Re"
+    ; include_subdirs_unqualified = false
+    ; special_builtin_support = None
+    }
+  ; { path = "otherlibs/top-closure"
     ; main_module_name = Some "Top_closure"
     ; include_subdirs_unqualified = false
     ; special_builtin_support = None
@@ -81,11 +86,6 @@ let local_libraries =
     }
   ; { path = "src/dune_async_io"
     ; main_module_name = Some "Dune_async_io"
-    ; include_subdirs_unqualified = false
-    ; special_builtin_support = None
-    }
-  ; { path = "vendor/re/src"
-    ; main_module_name = Some "Dune_re"
     ; include_subdirs_unqualified = false
     ; special_builtin_support = None
     }

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -13,8 +13,8 @@ depends: [
   "dune" {>= "3.20"}
   "stdune" {= version}
   "dyn"
+  "re"
   "ordering"
-  "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-project
+++ b/dune-project
@@ -135,8 +135,8 @@ execution of the action.
  (depends
   (stdune (= :version))
   dyn
-  ordering
-  (dune-private-libs (= :version)))
+  re
+  ordering)
  (description "\
 dune-glob provides a parser and interpreter for globs as \
 understood by dune language."))

--- a/flake.nix
+++ b/flake.nix
@@ -178,6 +178,7 @@
                 ++ [ duneScript ];
               inputsFrom = [ pkgs'.ocamlPackages.dune_3 ];
               buildInputs = testBuildInputs ++ (with pkgs'.ocamlPackages; [
+                re
                 ocaml-lsp
                 merlin
                 ocaml-index
@@ -210,7 +211,14 @@
             pkgs.mkShell {
               inherit INSIDE_NIX;
               nativeBuildInputs = [ ocamlformat ];
-              inputsFrom = [ pkgs.dune_3 ];
+              # re shouldn't be needed. this is an issue with the fmt rules
+              inputsFrom = [
+                pkgs.dune_3
+              ];
+              buildInputs = [
+                pkgs.ocamlPackages.re
+                pkgs.ocamlPackages.findlib
+              ];
               meta.description = ''
                 Provides a shell environment suitable for formatting the Dune
                 codebase source code (e.g. with `make fmt`).
@@ -249,8 +257,11 @@
               inherit INSIDE_NIX;
               nativeBuildInputs = (testNativeBuildInputs pkgs);
               # Coq requires OCaml 4.x
-              inputsFrom = [ pkgs.ocaml-ng.ocamlPackages_4_14.dune_3 ];
+              inputsFrom = [
+                pkgs.ocaml-ng.ocamlPackages_4_14.dune_3
+              ];
               buildInputs = with pkgs; [
+                ocaml-ng.ocamlPackages_4_14.re
                 coq_8_16_native
                 coq_8_16_native.ocamlPackages.findlib
               ];

--- a/otherlibs/dune-glob/src/dune
+++ b/otherlibs/dune-glob/src/dune
@@ -1,7 +1,7 @@
 (library
  (name dune_glob)
  (public_name dune-glob)
- (libraries stdune dune-private-libs.dune_re dyn ordering)
+ (libraries stdune re dyn ordering)
  (flags
   (:standard -w -50))
  (synopsis "The glob language as understood by dune."))

--- a/otherlibs/dune-glob/src/glob.ml
+++ b/otherlibs/dune-glob/src/glob.ml
@@ -1,5 +1,4 @@
 open Stdune
-module Re = Dune_re
 
 type t =
   | Re of

--- a/otherlibs/dune-glob/src/lexer.mli
+++ b/otherlibs/dune-glob/src/lexer.mli
@@ -2,6 +2,6 @@ open Stdune
 
 type t =
   | Literal of string
-  | Re of Dune_re.t
+  | Re of Re.t
 
 val parse_string : string -> (t, int * string) Result.result

--- a/otherlibs/dune-glob/src/lexer.mll
+++ b/otherlibs/dune-glob/src/lexer.mll
@@ -1,11 +1,10 @@
 {
 open! Stdune
-module Re = Dune_re
 open Re
 
 type t =
   | Literal of string
-  | Re of Dune_re.t
+  | Re of Re.t
 
 let no_slash        = diff any (char '/')
 let no_slash_no_dot = diff any (set "./")

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -1,5 +1,5 @@
 (library
  (name dune_file_watcher)
  (libraries dune_spawn fsevents dune_console unix stdune threads.posix
-  ocaml_inotify async_inotify_for_dune dune_re fswatch_win)
+  ocaml_inotify async_inotify_for_dune re fswatch_win)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -158,8 +158,6 @@ type t =
     (* Pending fs sync operations indexed by the special sync filename. *)
   }
 
-module Re = Dune_re
-
 let create_should_exclude_predicate ~watch_exclusions =
   (* TODO we should really take the predicate directly and not depend on
      regular expressions in our file watching component *)

--- a/src/dune_patch/dune
+++ b/src/dune_patch/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_patch)
- (libraries stdune fiber dune_engine dune_lang action_ext dune_re))
+ (libraries stdune fiber dune_engine dune_lang action_ext re))

--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -1,5 +1,4 @@
 open Stdune
-module Re = Dune_re
 
 include struct
   open Dune_engine

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -5,5 +5,5 @@
   (names md5_stubs)
   (language c))
  (libraries stdune fiber fiber_util chrome_trace dune_engine dune_util
-  dune_stats dune_lang dune_console dune_re dune_vcs dune_config opam_format
+  dune_stats dune_lang dune_console re dune_vcs dune_config opam_format
   build_info sat xdg))

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -1,6 +1,5 @@
 include Stdune
 module Stringlike = Dune_util.Stringlike
-module Re = Dune_re
 
 module type Stringlike = Dune_util.Stringlike
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -3,7 +3,6 @@ open Dune_vcs
 module Process = Dune_engine.Process
 module Display = Dune_engine.Display
 module Scheduler = Dune_engine.Scheduler
-module Re = Dune_re
 open Fiber.O
 
 module Object : sig

--- a/src/dune_rules/coq/coq_config.ml
+++ b/src/dune_rules/coq/coq_config.ml
@@ -94,7 +94,7 @@ module Version = struct
       }
 
     let make version_string =
-      let open Dune_re in
+      let module Group = Re.Group in
       let regex =
         let open Re in
         seq [ rep digit |> group; char '.'; rep digit |> group; rep any |> group ]

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -5,7 +5,7 @@
  (libraries action_ext build_path_prefix_map chrome_trace csexp
   dune_action_plugin dune_cache dune_cache_storage dune_config
   dune_config_file dune_console dune_digest dune_engine dune_findlib
-  dune_glob dune_lang dune_meta_parser dune_patch dune_pkg dune_re
+  dune_glob dune_lang dune_meta_parser dune_patch dune_pkg re
   dune_rpc_private dune_section dune_site_private dune_stats dune_targets
   dune_util dune_vcs fiber fs install memo ocaml ocaml_config opam_format
   predicate_lang promote scheme source stdune unix xdg)

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -73,7 +73,6 @@ include struct
   module Version = Version
 end
 
-module Re = Dune_re
 module Syntax = Dune_sexp.Syntax
 
 include struct

--- a/src/source/dune
+++ b/src/source/dune
@@ -1,7 +1,6 @@
 (library
  (name source)
  (libraries chrome_trace dune_config dune_config_file dune_console
-  dune_digest dune_engine dune_glob dune_lang dune_pkg dune_re
-  dune_rpc_private dune_stats dune_util dune_vcs memo ocaml_config
-  predicate_lang stdune)
+  dune_digest dune_engine dune_glob dune_lang dune_pkg re dune_rpc_private
+  dune_stats dune_util dune_vcs memo ocaml_config predicate_lang stdune)
  (synopsis "Internal Dune library, do not use!"))

--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -1,8 +1,7 @@
 (executable
  (name dune_cmd)
  (modules dune_cmd)
- (libraries stdune dune-private-libs.dune_re dune-configurator
-  build_path_prefix_map str unix))
+ (libraries stdune re dune-configurator build_path_prefix_map str unix))
 
 (ocamllex dunepp)
 

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -1,5 +1,4 @@
 open Stdune
-module Re = Dune_re
 
 let commands = Table.create (module String) 10
 

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -37,7 +37,7 @@
  (libraries
   fiber
   stdune
-  dune_re
+  re
   dune_rpc_client
   dune_rpc_e2e
   dune_rpc_private

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -7,7 +7,6 @@ module Sub = Dune_rpc.Sub
 module Diagnostic = Dune_rpc.Diagnostic
 module Request = Dune_rpc.Public.Request
 module Response = Dune_rpc.Response
-module Re = Dune_re
 
 let%expect_test "turn on and shutdown" =
   let test () =

--- a/test/expect-tests/dune_rpc_impl/dune
+++ b/test/expect-tests/dune_rpc_impl/dune
@@ -9,7 +9,7 @@
   dune_rpc_private
   dune_rpc_impl
   dune_engine
-  dune_re
+  re
   stdune
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
+++ b/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
@@ -1,6 +1,5 @@
 open Stdune
 module Dune_rpc = Dune_rpc_private
-module Re = Dune_re
 
 let () =
   Stdune.Path.set_root (Stdune.Path.External.of_filename_relative_to_initial_cwd ".");

--- a/test/unit-tests/artifact_substitution/artifact_substitution.ml
+++ b/test/unit-tests/artifact_substitution/artifact_substitution.ml
@@ -1,6 +1,5 @@
 open Stdune
 open Dune_rules
-module Re = Dune_re
 
 let () =
   Path.set_root (Path.External.cwd ());

--- a/test/unit-tests/artifact_substitution/dune
+++ b/test/unit-tests/artifact_substitution/dune
@@ -1,4 +1,4 @@
 (test
  (name artifact_substitution)
  (package dune-private-libs)
- (libraries stdune dune_engine dune_rules fiber dune_re memo))
+ (libraries stdune dune_engine dune_rules fiber re memo))

--- a/vendor/opam/src/core/dune
+++ b/vendor/opam/src/core/dune
@@ -4,5 +4,5 @@
  (foreign_stubs
   (language c)
   (names custom_opamStubs))
- (libraries dune_re unix sha dune_uutf)
+ (libraries re unix sha dune_uutf)
  (wrapped false))

--- a/vendor/opam/src/core/opamStd.ml
+++ b/vendor/opam/src/core/opamStd.ml
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Re = Dune_re
-
 module type SET = sig
   include Set.S
   val map: (elt -> elt) -> t -> t

--- a/vendor/opam/src/core/opamStd.mli
+++ b/vendor/opam/src/core/opamStd.mli
@@ -278,7 +278,7 @@ module String : sig
   val for_all: (char -> bool) -> string -> bool
   val contains_char: string -> char -> bool
   val contains: sub:string -> string -> bool
-  val exact_match: Dune_re.re -> string -> bool
+  val exact_match: Re.re -> string -> bool
   val find_from: (char -> bool) -> string -> int -> int
 
   (** Like [String.compare], but with lowercase/uppercase variants ordered next

--- a/vendor/opam/src/core/opamUrl.ml
+++ b/vendor/opam/src/core/opamUrl.ml
@@ -11,8 +11,6 @@
 
 open OpamStd.Op
 
-module Re = Dune_re
-
 type version_control = [ `git | `darcs | `hg ]
 
 type backend = [ `http | `rsync | version_control ]

--- a/vendor/opam/src/format/dune
+++ b/vendor/opam/src/format/dune
@@ -2,7 +2,7 @@
   (name        opam_format)
   (synopsis    "OCaml Package Manager file format handling library")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   unix (re_export opam_core) (re_export opam_file_format) dune_re)
+  (libraries   unix (re_export opam_core) (re_export opam_file_format) re)
   (modules_without_implementation OpamTypes)
   (wrapped     false))
 

--- a/vendor/opam/src/format/opamFile.ml
+++ b/vendor/opam/src/format/opamFile.ml
@@ -18,7 +18,6 @@
       a string list list. These are mostly used internally
     - files using the "opam syntax" and lexer, parsed using OpamFormat.Pp.V
 *)
-module Re = Dune_re
 
 open OpamParserTypes.FullPos
 open OpamTypes

--- a/vendor/opam/src/format/opamFilter.ml
+++ b/vendor/opam/src/format/opamFilter.ml
@@ -8,8 +8,6 @@
 (*  exception on linking described in the file LICENSE.                   *)
 (*                                                                        *)
 (**************************************************************************)
-module Re = Dune_re
-
 open OpamTypes
 open OpamTypesBase
 open OpamStd.Op

--- a/vendor/opam/src/format/opamFilter.mli
+++ b/vendor/opam/src/format/opamFilter.mli
@@ -8,7 +8,6 @@
 (*  exception on linking described in the file LICENSE.                   *)
 (*                                                                        *)
 (**************************************************************************)
-module Re = Dune_re
 
 (** Formulas on variables, as used in opam files build scripts
 

--- a/vendor/opam/src/format/opamFormula.ml
+++ b/vendor/opam/src/format/opamFormula.ml
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Re = Dune_re
-
 type relop = [`Eq|`Neq|`Geq|`Gt|`Leq|`Lt]
 
 let neg_relop = function

--- a/vendor/opam/src/format/opamSwitch.ml
+++ b/vendor/opam/src/format/opamSwitch.ml
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Re = Dune_re
-
 include OpamStd.AbstractString
 
 let unset = of_string "#unset#"

--- a/vendor/re/src/dune
+++ b/vendor/re/src/dune
@@ -1,4 +1,0 @@
-(library
- (name dune_re)
- (public_name dune-private-libs.dune_re)
- (synopsis "Internal Dune library, do not use!"))

--- a/vendor/re/src/dune_re.ml
+++ b/vendor/re/src/dune_re.ml
@@ -1,1 +1,0 @@
-include Re

--- a/vendor/update-re.sh
+++ b/vendor/update-re.sh
@@ -22,12 +22,4 @@ SRC=$TMP/ocaml-re
 cp -v $SRC/LICENSE.md re
 cp -v $SRC/lib/*.{ml,mli} re/src/
 
-echo "include Re" > re/src/dune_re.ml
-cat >re/src/dune <<EOF
-(library
- (name dune_re)
- (public_name dune-private-libs.dune_re)
- (synopsis "Internal Dune library, do not use!"))
-EOF
-
 git add -A .


### PR DESCRIPTION
Use regular re in development. The benefits are two fold:

* dune-glob no longer needs our private fork of re to be installed

* we don't need the useless dune_re module
