### PR TITLE
Change lock dir path type to `Path.t`

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -19,7 +19,7 @@ module Show_lock = struct
       Pp.concat
         ~sep:Pp.space
         [ Pp.hovbox
-          @@ Pp.textf "Contents of %s:" (Path.Source.to_string_maybe_quoted lock_dir_path)
+          @@ Pp.textf "Contents of %s:" (Path.to_string_maybe_quoted lock_dir_path)
         ; Pkg_common.pp_packages packages
         ]
       |> Pp.vbox)
@@ -123,14 +123,14 @@ module List_locked_dependencies = struct
   let enumerate_lock_dirs_by_path workspace ~lock_dirs =
     let lock_dirs = Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs workspace in
     List.filter_map lock_dirs ~f:(fun lock_dir_path ->
-      if Path.exists (Path.source lock_dir_path)
+      if Path.exists lock_dir_path
       then (
         try Some (lock_dir_path, Lock_dir.read_disk_exn lock_dir_path) with
         | User_error.E e ->
           User_warning.emit
             [ Pp.textf
                 "Failed to parse lockdir %s:"
-                (Path.Source.to_string_maybe_quoted lock_dir_path)
+                (Path.to_string_maybe_quoted lock_dir_path)
             ; User_message.pp e
             ];
           None)
@@ -158,7 +158,7 @@ module List_locked_dependencies = struct
              [ Pp.hbox
                  (Pp.textf
                     "Dependencies of local packages locked in %s"
-                    (Path.Source.to_string_maybe_quoted lock_dir_path))
+                    (Path.to_string_maybe_quoted lock_dir_path))
              ; Pp.enumerate
                  (Package_name.Map.keys local_packages)
                  ~f:(package_deps_in_lock_dir_pp package_universe ~transitive)

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -28,7 +28,7 @@ module Progress_indicator = struct
     end
 
     type t =
-      { lockdir_path : Path.Source.t
+      { lockdir_path : Path.t
       ; state : State.t option ref
       }
 
@@ -45,7 +45,7 @@ module Progress_indicator = struct
     List.find_map t ~f:(fun { Per_lockdir.lockdir_path; state } ->
       Option.map !state ~f:(fun state ->
         Pp.concat
-          [ Pp.textf "Locking %s: " (Path.Source.to_string_maybe_quoted lockdir_path)
+          [ Pp.textf "Locking %s: " (Path.to_string_maybe_quoted lockdir_path)
           ; Per_lockdir.State.pp state
           ]))
     |> Option.value ~default:Pp.nop
@@ -247,9 +247,7 @@ let solve_lock_dir
       User_message.make
         ((Pp.tag
             User_message.Style.Success
-            (Pp.textf
-               "Solution for %s:"
-               (Path.Source.to_string_maybe_quoted lock_dir_path))
+            (Pp.textf "Solution for %s:" (Path.to_string_maybe_quoted lock_dir_path))
           :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
               | [] ->
                 Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
@@ -311,7 +309,7 @@ let solve
     User_error.raise
       ([ Pp.text "Unable to solve dependencies for the following lock directories:" ]
        @ List.concat_map errors ~f:(fun (path, messages) ->
-         [ Pp.textf "Lock directory %s:" (Path.Source.to_string_maybe_quoted path)
+         [ Pp.textf "Lock directory %s:" (Path.to_string_maybe_quoted path)
          ; Pp.hovbox (Pp.concat ~sep:Pp.newline messages)
          ]))
   | Ok write_disks_with_summaries ->

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -6,7 +6,7 @@ val solve
   -> project_pins:Dune_pkg.Pin.DB.t
   -> solver_env_from_current_system:Dune_pkg.Solver_env.t option
   -> version_preference:Dune_pkg.Version_preference.t option
-  -> lock_dirs:Path.Source.t list
+  -> lock_dirs:Path.t list
   -> print_perf_stats:bool
   -> portable_lock_dir:bool
   -> unit Fiber.t

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -38,7 +38,7 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
           ~sep:Pp.space
           [ Pp.textf
               "When checking %s, the following packages:"
-              (Path.Source.to_string_maybe_quoted lock_dir_path)
+              (Path.to_string_maybe_quoted lock_dir_path)
             |> Pp.hovbox
           ; Pp.concat
               ~sep:Pp.space

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -15,7 +15,7 @@ val solver_env
 val poll_solver_env_from_current_system : unit -> Dune_pkg.Solver_env.t Fiber.t
 
 val solver_env_from_system_and_context
-  :  lock_dir_path:Path.Source.t
+  :  lock_dir_path:Path.t
   -> Dune_pkg.Solver_env.t Fiber.t
 
 module Version_preference : sig
@@ -27,7 +27,7 @@ end
 
 val unset_solver_vars_of_workspace
   :  Workspace.t
-  -> lock_dir_path:Path.Source.t
+  -> lock_dir_path:Path.t
   -> Dune_lang.Package_variable_name.Set.t option
 
 val repositories_of_workspace
@@ -36,18 +36,15 @@ val repositories_of_workspace
 
 val repositories_of_lock_dir
   :  Workspace.t
-  -> lock_dir_path:Path.Source.t
+  -> lock_dir_path:Path.t
   -> (Loc.t * Dune_pkg.Pkg_workspace.Repository.Name.t) list
 
 val constraints_of_workspace
   :  Workspace.t
-  -> lock_dir_path:Path.Source.t
+  -> lock_dir_path:Path.t
   -> Dune_lang.Package_dependency.t list
 
-val depopts_of_workspace
-  :  Workspace.t
-  -> lock_dir_path:Path.Source.t
-  -> Package_name.t list
+val depopts_of_workspace : Workspace.t -> lock_dir_path:Path.t -> Package_name.t list
 
 val get_repos
   :  Dune_pkg.Pkg_workspace.Repository.t Dune_pkg.Pkg_workspace.Repository.Name.Map.t
@@ -84,7 +81,7 @@ module Lock_dirs_arg : sig
 
       A user error is raised if the list of positional arguments used when
       creating [t] is not a subset of the lock directories of the workspace. *)
-  val lock_dirs_of_workspace : t -> Workspace.t -> Path.Source.t list
+  val lock_dirs_of_workspace : t -> Workspace.t -> Path.t list
 end
 
 (** [pp_packages lock_dir] returns a list of pretty-printed packages occurring in

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -13,10 +13,7 @@ let term =
         Pkg_common.Lock_dirs_arg.all
         workspace
     in
-    let any_lockdir_exists =
-      List.exists lock_dir_paths ~f:(fun lock_dir_path ->
-        Path.exists (Path.source lock_dir_path))
-    in
+    let any_lockdir_exists = List.exists lock_dir_paths ~f:Path.exists in
     (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
        directories in the source tree *)
     let enabled = any_lockdir_exists || workspace.config.pkg_enabled in

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -16,7 +16,7 @@ let print_solver_env_for_lock_dir workspace ~solver_env_from_current_system lock
   Console.print
     [ Pp.textf
         "Solver environment for lock directory %s:"
-        (Path.Source.to_string_maybe_quoted lock_dir_path)
+        (Path.to_string_maybe_quoted lock_dir_path)
     ; Dune_pkg.Solver_env.pp solver_env
     ]
 ;;

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -69,17 +69,10 @@ module Pkg : sig
   val to_dyn : t -> Dyn.t
 
   val decode
-    : (lock_dir:Path.Source.t
-       -> solved_for_platforms:Solver_env.t list
-       -> Package_name.t
-       -> t)
+    : (lock_dir:Path.t -> solved_for_platforms:Solver_env.t list -> Package_name.t -> t)
         Decoder.t
 
-  val files_dir
-    :  Package_name.t
-    -> Package_version.t option
-    -> lock_dir:Path.Source.t
-    -> Path.Source.t
+  val files_dir : Package_name.t -> Package_version.t option -> lock_dir:Path.t -> Path.t
 end
 
 module Repositories : sig
@@ -128,11 +121,11 @@ val create_latest_version
        (* TODO: make this non-optional when portable lockdirs becomes the default *)
   -> t
 
-val default_path : Path.Source.t
+val default_path : Path.t Lazy.t
 
 (** Returns the path to the lockdir that will be used to lock the
     given dev tool *)
-val dev_tool_lock_dir_path : Dev_tool.t -> Path.Source.t
+val dev_tool_lock_dir_path : Dev_tool.t -> Path.t
 
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 
@@ -144,7 +137,7 @@ module Write_disk : sig
 
   val prepare
     :  portable_lock_dir:bool
-    -> lock_dir_path:Path.Source.t
+    -> lock_dir_path:Path.t
     -> files:File_entry.t Package_version.Map.Multi.t Package_name.Map.t
     -> lock_dir
     -> t
@@ -152,19 +145,19 @@ module Write_disk : sig
   val commit : t -> unit
 end
 
-val read_disk : Path.Source.t -> (t, User_message.t) result
-val read_disk_exn : Path.Source.t -> t
+val read_disk : Path.t -> (t, User_message.t) result
+val read_disk_exn : Path.t -> t
 
 module Make_load (Io : sig
     include Monad.S
 
     val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
-    val readdir_with_kinds : Path.Source.t -> (Filename.t * Unix.file_kind) list t
-    val with_lexbuf_from_file : Path.Source.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
-    val stats_kind : Path.Source.t -> (File_kind.t, Unix_error.Detailed.t) result t
+    val readdir_with_kinds : Path.t -> (Filename.t * Unix.file_kind) list t
+    val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
+    val stats_kind : Path.t -> (File_kind.t, Unix_error.Detailed.t) result t
   end) : sig
-  val load : Path.Source.t -> (t, User_message.t) result Io.t
-  val load_exn : Path.Source.t -> t Io.t
+  val load : Path.t -> (t, User_message.t) result Io.t
+  val load_exn : Path.t -> t Io.t
 end
 
 (** [transitive_dependency_closure t ~platform names] returns the set of package names

--- a/src/dune_pkg/outdated.ml
+++ b/src/dune_pkg/outdated.ml
@@ -66,14 +66,14 @@ let explain_results_to_user results ~transitive ~lock_dir_path =
           "%d/%d packages in %s are outdated."
           count
           total_number_of_deps
-          (Path.Source.to_string_maybe_quoted lock_dir_path))
+          (Path.to_string_maybe_quoted lock_dir_path))
     :: transitive_helper ~all_of
   in
   match transitive_status with
   (* If there are no outdated transitive deps then everything is up to date. *)
   | `No_transitive_deps_outdated ->
     [ Pp.tag User_message.Style.Success
-      @@ Pp.textf "%s is up to date." (Path.Source.to_string_maybe_quoted lock_dir_path)
+      @@ Pp.textf "%s is up to date." (Path.to_string_maybe_quoted lock_dir_path)
     ]
   | `All_transitive_deps_outdated ->
     packages_in_lockdir_are ~all_of:true number_of_outdated_deps

--- a/src/dune_pkg/outdated.mli
+++ b/src/dune_pkg/outdated.mli
@@ -22,7 +22,7 @@ val find
       command to see them.
 
     - [lock_dir_path] is the path to the lock directory that will appear in the messages. *)
-val pp : t -> transitive:bool -> lock_dir_path:Path.Source.t -> User_message.Style.t Pp.t
+val pp : t -> transitive:bool -> lock_dir_path:Path.t -> User_message.Style.t Pp.t
 
 val packages_that_were_not_found : t -> Package_name.t list
 
@@ -43,12 +43,12 @@ module For_tests : sig
   val explain_results
     :  result list
     -> transitive:bool
-    -> lock_dir_path:Path.Source.t
+    -> lock_dir_path:Path.t
     -> User_message.Style.t Pp.t list
 
   val pp
     :  result list
     -> transitive:bool
-    -> lock_dir_path:Path.Source.t
+    -> lock_dir_path:Path.t
     -> User_message.Style.t Pp.t
 end

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -321,7 +321,7 @@ end = struct
       Pkg_rules.lock_dir_path (Context_name.of_string ctx)
       >>| (function
        | None -> false
-       | Some of_ -> Path.Source.is_descendant ~of_ src_dir)
+       | Some of_ -> Path.is_descendant ~of_ (Path.source src_dir))
       >>= (function
        | true -> Memo.return (Lock_dir st_dir)
        | false ->

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -189,7 +189,8 @@ let find_checksum, find_url =
           ~init:(Checksum.Map.empty, Digest.Map.empty)
           ~f:(fun acc dev_tool ->
             Fs_memo.dir_exists
-              (In_source_dir (Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool))
+              (Path.as_outside_build_dir_exn
+                 (Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool))
             >>= function
             | false -> Memo.return acc
             | true -> Lock_dir.of_dev_tool dev_tool >>| add_checksums_and_urls acc)

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -34,7 +34,7 @@ end
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
     let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Ocamlformat in
-    Fs_memo.dir_exists (Path.source path |> Path.as_outside_build_dir_exn)
+    path |> Path.as_outside_build_dir_exn |> Fs_memo.dir_exists
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -677,7 +677,7 @@ let raise_on_lock_dir_out_of_sync =
         with
         | `Valid -> ()
         | `Invalid ->
-          let loc = Loc.in_file (Path.source (Path.Source.relative path "lock.dune")) in
+          let loc = Loc.in_file (Path.relative path "lock.dune") in
           let hints = Pp.[ text "run dune pkg lock" ] in
           User_error.raise
             ~loc

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -3,12 +3,12 @@ module Pkg = Dune_pkg.Lock_dir.Pkg
 
 type t := Dune_pkg.Lock_dir.t
 
-val get_with_path : Context_name.t -> (Path.Source.t * t, User_message.t) result Memo.t
+val get_with_path : Context_name.t -> (Path.t * t, User_message.t) result Memo.t
 val get : Context_name.t -> (t, User_message.t) result Memo.t
 val get_exn : Context_name.t -> t Memo.t
 val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
-val get_path : Context_name.t -> Path.Source.t option Memo.t
+val get_path : Context_name.t -> Path.t option Memo.t
 
 module Sys_vars : sig
   type t =

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -256,7 +256,7 @@ let odoc_base_flags quiet build_dir =
 
 let odoc_dev_tool_lock_dir_exists () =
   let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Odoc in
-  Fs_memo.dir_exists (Path.Outside_build_dir.In_source_dir path)
+  Fs_memo.dir_exists (Path.as_outside_build_dir_exn path)
 ;;
 
 let odoc_dev_tool_exe_path_building_if_necessary () =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1166,14 +1166,17 @@ end = struct
             Dune_pkg.Lock_dir.Pkg.files_dir info.name (Some info.version) ~lock_dir
           in
           let+ path_with_version_exists =
-            Fs_memo.dir_exists
-              (Path.source path_with_version |> Path.as_outside_build_dir_exn)
+            path_with_version |> Path.as_outside_build_dir_exn |> Fs_memo.dir_exists
           in
           if path_with_version_exists then path_with_version else path_without_version
         in
-        Path.Build.append_source
-          (Context_name.build_dir (Package_universe.context_name package_universe))
-          files_dir
+        let build_path =
+          Context_name.build_dir (Package_universe.context_name package_universe)
+        in
+        match files_dir with
+        | External _ -> Code_error.raise "TODO" []
+        | In_source_tree s -> Path.Build.append_source build_path s
+        | In_build_dir s -> Path.Build.append build_path s
       in
       let id = Pkg.Id.gen () in
       let write_paths = Paths.make package_universe name ~relative:Path.Build.relative in

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -18,7 +18,7 @@ val setup_rules
   -> Context_name.t
   -> Build_config.Gen_rules.t Memo.t
 
-val lock_dir_path : Context_name.t -> Path.Source.t option Memo.t
+val lock_dir_path : Context_name.t -> Path.t option Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val ocaml_toolchain : Context_name.t -> Ocaml_toolchain.t Action_builder.t option Memo.t
 val which : Context_name.t -> (Filename.t -> Path.t option Memo.t) Staged.t

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -150,7 +150,7 @@ let requires ~loc ~db ~libs =
 let utop_dev_tool_lock_dir_exists =
   Memo.Lazy.create (fun () ->
     let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Utop in
-    Fs_memo.dir_exists (Path.Outside_build_dir.In_source_dir path))
+    Fs_memo.dir_exists (Path.as_outside_build_dir_exn path))
 ;;
 
 let utop_findlib_conf = Filename.concat utop_dir_basename "findlib.conf"

--- a/src/source/workspace.mli
+++ b/src/source/workspace.mli
@@ -8,7 +8,7 @@ module Lib_name := Dune_lang.Lib_name
 
 module Lock_dir : sig
   type t =
-    { path : Path.Source.t
+    { path : Path.t
     ; version_preference : Dune_pkg.Version_preference.t option
     ; solver_env : Dune_pkg.Solver_env.t option
     ; unset_solver_vars : Dune_lang.Package_variable_name.Set.t option
@@ -32,7 +32,7 @@ module Lock_dir_selection : sig
     :  t
     -> dir:Path.Source.t
     -> f:Value.t list Memo.t String_with_vars.expander
-    -> Path.Source.t Memo.t
+    -> Path.t Memo.t
 end
 
 module Context : sig
@@ -129,7 +129,7 @@ type t = private
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 val hash : t -> int
-val find_lock_dir : t -> Path.Source.t -> Lock_dir.t option
+val find_lock_dir : t -> Path.t -> Lock_dir.t option
 val add_repo : t -> Dune_pkg.Pkg_workspace.Repository.t -> t
 val default_repositories : Dune_pkg.Pkg_workspace.Repository.t list
 

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -65,16 +65,14 @@ module Update = struct
 end
 
 let lock_dir_encode_decode_round_trip_test ?commit ~lock_dir_path ~lock_dir () =
-  let lock_dir_path = Path.Source.of_string lock_dir_path in
+  let lock_dir_path = Path.of_string lock_dir_path in
   Lock_dir.Write_disk.(
     prepare ~portable_lock_dir:false ~lock_dir_path ~files:Package_name.Map.empty lock_dir
     |> commit);
   let lock_dir_round_tripped =
     try Lock_dir.read_disk_exn lock_dir_path with
     | User_error.E _ as exn ->
-      let metadata_path =
-        Path.Source.relative lock_dir_path Lock_dir.metadata_filename |> Path.source
-      in
+      let metadata_path = Path.relative lock_dir_path Lock_dir.metadata_filename in
       let metadata_file_contents = Io.read_file metadata_path in
       print_endline
         "Failed to parse lockdir. Dumping raw metadata file to assist debugging.";

--- a/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
+++ b/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
@@ -1,6 +1,8 @@
 open Stdune
 module Console = Dune_console
 
+let () = Dune_tests_common.init ()
+
 (** [dummy_results a b c d] creates a dummy result with [a]/[b] immediate dependencies and
     [c]/[d] transitive dependencies. The total number of dependencies will be [b] + [d]
     of which [a] + [b] will be outdated. *)
@@ -64,7 +66,7 @@ let test_message
       number_of_transitive
       total_number_of_transitive
   in
-  let lock_dir_path = Stdune.Path.Source.of_string "dune.lock" in
+  let lock_dir_path = Stdune.Path.of_string "dune.lock" in
   let message =
     Dune_pkg.Outdated.For_tests.explain_results ~transitive ~lock_dir_path results
   in
@@ -285,7 +287,7 @@ let test_entire_output
       number_of_transitive
       total_number_of_transitive
   in
-  let lock_dir_path = Stdune.Path.Source.of_string "dune.lock" in
+  let lock_dir_path = Stdune.Path.of_string "dune.lock" in
   let message = Dune_pkg.Outdated.For_tests.pp ~transitive ~lock_dir_path results in
   Console.print [ message ]
 ;;


### PR DESCRIPTION
Given we plan to move the lock dirs into the build directory, we can't continue to use `Path.Source.t`. We can either move them to `Path.Build.t` or `Path.t`.

The former has the advantage that it restricts the system from writing the lock dir to any place that isn't the build dir, however it requires a lot more changes that can't meaningfully be unbundled from #11775.

This PR is more conservative and only moves it to `Path.t`. It still relies on the fact that the `Path.t` is not an `Path.Build.t` but most of them are backed by a `Path.Source.t`. It also adds a bit of lazy-loading as `Path.of_string` requires `Fgetcl` to be initialized so the parsing can't happen at CLI parse time, but the complication is quite marginal.