### PR TITLE
Add support for Tangled ATproto-based code repositories

### DIFF
--- a/doc/changes/12197.md
+++ b/doc/changes/12197.md
@@ -1,0 +1,1 @@
+- Add support for Tangled ATproto-based code repositories (#12197, @avsm)

--- a/doc/reference/dune-project/source.rst
+++ b/doc/reference/dune-project/source.rst
@@ -28,6 +28,8 @@ source
        - ``(sourcehut user/repo)``
      * - `Codeberg <https://codeberg.org>`_
        - ``(codeberg user/repo)`` *(New in 3.17)*
+     * - `Tangled <https://tangled.sh>`_
+       - ``(tangled @user.domain/repo)`` *(New in 3.21)*
 
    Examples:
 

--- a/src/dune_lang/source_kind.ml
+++ b/src/dune_lang/source_kind.ml
@@ -20,6 +20,7 @@ module Host = struct
     | Gitlab of gitlab_repo
     | Sourcehut of user_repo
     | Codeberg of user_repo
+    | Tangled of user_repo
 
   let kind_string = function
     | Github _ -> "github"
@@ -27,6 +28,7 @@ module Host = struct
     | Gitlab _ -> "gitlab"
     | Sourcehut _ -> "sourcehut"
     | Codeberg _ -> "codeberg"
+    | Tangled _ -> "tangled"
   ;;
 
   let dyn_of_user_repo kind { user; repo } =
@@ -46,8 +48,11 @@ module Host = struct
     let kind = Dyn.string (kind_string repo) in
     match repo with
     | Gitlab gitlab_repo -> dyn_of_gitlab_repo kind gitlab_repo
-    | Github user_repo | Bitbucket user_repo | Sourcehut user_repo | Codeberg user_repo ->
-      dyn_of_user_repo kind user_repo
+    | Github user_repo
+    | Bitbucket user_repo
+    | Sourcehut user_repo
+    | Codeberg user_repo
+    | Tangled user_repo -> dyn_of_user_repo kind user_repo
   ;;
 
   let host_of_repo = function
@@ -56,6 +61,7 @@ module Host = struct
     | Gitlab _ -> "gitlab.com"
     | Sourcehut _ -> "sr.ht"
     | Codeberg _ -> "codeberg.org"
+    | Tangled _ -> "tangled.sh"
   ;;
 
   let base_uri repo =
@@ -65,6 +71,7 @@ module Host = struct
     | Sourcehut { user; repo } -> sprintf "%s/~%s/%s" host user repo
     | Github { user; repo }
     | Bitbucket { user; repo }
+    | Tangled { user; repo }
     | Gitlab (User_repo { user; repo })
     | Codeberg { user; repo } -> sprintf "%s/%s/%s" host user repo
   ;;
@@ -78,6 +85,7 @@ module Host = struct
     | Gitlab _ as repo -> homepage repo ^ "/-/issues"
     | Sourcehut _ as repo -> add_https ("todo." ^ base_uri repo)
     | Codeberg _ as repo -> homepage repo ^ "/issues"
+    | Tangled _ as repo -> homepage repo ^ "/issues"
   ;;
 
   let enum k =
@@ -88,6 +96,7 @@ module Host = struct
     ; Bitbucket stub_user_repo
     ; Sourcehut stub_user_repo
     ; Codeberg stub_user_repo
+    ; Tangled stub_user_repo
     ; Gitlab (User_repo stub_user_repo)
     ; Gitlab stub_org_repo
     ]
@@ -99,6 +108,7 @@ module Host = struct
         | Bitbucket _, [ user; repo ] -> Bitbucket { user; repo }, Some ((2, 8), name)
         | Sourcehut _, [ user; repo ] -> Sourcehut { user; repo }, Some ((3, 1), name)
         | Codeberg _, [ user; repo ] -> Codeberg { user; repo }, Some ((3, 17), name)
+        | Tangled _, [ user; repo ] -> Tangled { user; repo }, Some ((3, 21), name)
         | Gitlab _, [ user; repo ] ->
           Gitlab (User_repo { user; repo }), Some ((2, 8), name)
         | Gitlab _, [ org; proj; repo ] ->
@@ -139,6 +149,7 @@ module Host = struct
       | Bitbucket { user; repo }
       | Gitlab (User_repo { user; repo })
       | Sourcehut { user; repo }
+      | Tangled { user; repo }
       | Codeberg { user; repo } -> sprintf "%s/%s" user repo
     in
     let open Encoder in
@@ -151,6 +162,7 @@ module Host = struct
       let base = base_uri repo in
       match repo with
       | Sourcehut _ -> "git." ^ base
+      | Tangled _ -> base
       | _ -> base ^ ".git"
     in
     "git+https://" ^ base_uri

--- a/src/dune_lang/source_kind.mli
+++ b/src/dune_lang/source_kind.mli
@@ -20,6 +20,7 @@ module Host : sig
     | Gitlab of gitlab_repo
     | Sourcehut of user_repo
     | Codeberg of user_repo
+    | Tangled of user_repo
 
   val homepage : t -> string
   val bug_reports : t -> string

--- a/test/blackbox-tests/test-cases/project-source/source-stanza.t
+++ b/test/blackbox-tests/test-cases/project-source/source-stanza.t
@@ -4,7 +4,7 @@ the supported 'github', 'gitlab', 'sourcehut', and 'bitbucket'.
 Test a generated 'github' user repo
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.17)
+  > (lang dune 3.21)
   > (name foo)
   > (generate_opam_files true)
   > (source (github user/repo))
@@ -63,6 +63,15 @@ Test a generated 'codeberg' user repo
   homepage: "https://codeberg.org/user/repo"
   bug-reports: "https://codeberg.org/user/repo/issues"
   dev-repo: "git+https://codeberg.org/user/repo.git"
+
+Test a generated 'tangled' user repo
+
+  $ sed -i -e '4s|.*|(source (tangled @user.domain/repo))|' dune-project
+  $ dune build
+  $ cat foo.opam | grep -i tangled.sh
+  homepage: "https://tangled.sh/@user.domain/repo"
+  bug-reports: "https://tangled.sh/@user.domain/repo/issues"
+  dev-repo: "git+https://tangled.sh/@user.domain/repo"
 
 Test that the creation of a source stanza of the form 'org/project/repo' is
 disallowed by any forge type other than gitlab and that associated error

--- a/test/blackbox-tests/test-cases/project-source/tangled.t
+++ b/test/blackbox-tests/test-cases/project-source/tangled.t
@@ -1,0 +1,29 @@
+Test the tangled source type in project files.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (name foo)
+  > (generate_opam_files true)
+  > (source (tangled @anil.recoil.org/foo))
+  > (package
+  >  (allow_empty)
+  >  (name foo))
+  > EOF
+
+  $ dune build
+  $ cat foo.opam | grep -i tangled.sh
+  homepage: "https://tangled.sh/@anil.recoil.org/foo"
+  bug-reports: "https://tangled.sh/@anil.recoil.org/foo/issues"
+  dev-repo: "git+https://tangled.sh/@anil.recoil.org/foo"
+
+The 'tangled' source kind is only supported in Dune lang >=3.21; check that
+Dune errors as expected with earlier Dune lang versions.
+
+  $ sed -i -e '1s|.*|(lang dune 3.16)|' dune-project
+  $ dune build
+  File "dune-project", line 4, characters 8-38:
+  4 | (source (tangled @anil.recoil.org/foo))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Tangled is only available since version 3.21 of the dune language.
+  Please update your dune-project file to have (lang dune 3.21).
+  [1]


### PR DESCRIPTION
First OCaml package using this service is up in opam-repo at: https://github.com/ocaml/opam-repository/pull/28338