### PR TITLE
nix: add wasmoo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -324,6 +324,8 @@
                 pkgs.ocamlPackages.melange
                 js_of_ocaml-compiler
                 js_of_ocaml
+                pkgs.binaryen
+                wasm_of_ocaml-compiler
                 utop
                 core_bench
               ]);

--- a/test/blackbox-tests/test-cases/wasmoo/dune
+++ b/test/blackbox-tests/test-cases/wasmoo/dune
@@ -1,6 +1,6 @@
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:node} %{bin:js_of_ocaml} %{bin:wasm_of_ocaml})
+ (deps %{bin:node} %{bin:js_of_ocaml} %{bin:wasm_of_ocaml} %{bin:wasm-merge})
  (alias runtest-wasm)
  (enabled_if
   (= %{env:DUNE_WASM_TEST=disable} enable)))


### PR DESCRIPTION
This allows us to run the wasmoo tests from the main dev flake.