### PR TITLE
refactor: move action plugin out of the engine

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -71,7 +71,6 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
       ; Predicate_lang.encode Dune_sexp.Encoder.int pred
       ; encode t
       ]
-  | Dynamic_run (a, xs) -> List (atom "run_dynamic" :: program a :: List.map xs ~f:string)
   | Chdir (a, r) -> List [ atom "chdir"; path a; encode r ]
   | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode r ]
   | Redirect_out (outputs, fn, perm, r) ->

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -418,6 +418,12 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
+  ; { path = "src/action_plugin"
+    ; main_module_name = Some "Action_plugin"
+    ; include_subdirs_unqualified = false
+    ; special_builtin_support = None
+    ; root_module = None
+    }
   ; { path = "src/dune_threaded_console"
     ; main_module_name = Some "Dune_threaded_console"
     ; include_subdirs_unqualified = false

--- a/src/action_plugin/action_plugin.mli
+++ b/src/action_plugin/action_plugin.mli
@@ -1,0 +1,3 @@
+open Import
+
+val action : prog:Action.Prog.t -> args:string list -> Action.t

--- a/src/action_plugin/dune
+++ b/src/action_plugin/dune
@@ -1,0 +1,11 @@
+(library
+ (name action_plugin)
+ (libraries
+  stdune
+  dune_engine
+  dune_targets
+  predicate_lang
+  fiber
+  csexp
+  dune-glob
+  dune_action_plugin))

--- a/src/action_plugin/import.ml
+++ b/src/action_plugin/import.ml
@@ -1,0 +1,14 @@
+include struct
+  open Dune_engine
+  module Action = Action
+  module Dep = Dep
+  module File_selector = File_selector
+  module Rpc = Rpc
+  module Process = Process
+  module Clflags = Clflags
+  module Done_or_more_deps = Done_or_more_deps
+  module Exec = Action.Ext.Exec
+end
+
+include Stdune
+module Glob = Dune_glob.V1

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -183,7 +183,6 @@ let fold_one_step t ~init:acc ~f =
   | With_accepted_exit_codes (_, t) -> f acc t
   | Progn l | Pipe (_, l) | Concurrent l -> List.fold_left l ~init:acc ~f
   | Run _
-  | Dynamic_run _
   | Echo _
   | Cat _
   | Copy _
@@ -220,7 +219,6 @@ let chdirs =
 let empty = Progn []
 
 let rec is_dynamic = function
-  | Dynamic_run _ -> true
   | Chdir (_, t)
   | Setenv (_, _, t)
   | Redirect_out (_, _, _, t)
@@ -289,7 +287,6 @@ let is_useful_to memoize =
     | Remove_tree _ -> false
     | Mkdir _ -> false
     | Run _ -> true
-    | Dynamic_run _ -> true
     | Bash _ -> true
     | Extension (module A) -> A.Spec.is_useful_to ~memoize
   in

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -193,9 +193,6 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Produce.t =
       { eenv with exit_codes }
     in
     exec t ~ectx ~eenv
-  | Dynamic_run (Error e, _) -> Action.Prog.Not_found.raise e
-  | Dynamic_run (Ok prog, args) ->
-    Produce.of_fiber (Action_plugin.exec ~ectx ~eenv prog args)
   | Chdir (dir, t) -> exec t ~ectx ~eenv:{ eenv with working_dir = dir }
   | Setenv (var, value, t) ->
     exec t ~ectx ~eenv:{ eenv with env = Env.add eenv.env ~var ~value }

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -28,7 +28,6 @@ module type Ast = sig
   type t =
     | Run of program * string Array.Immutable.t
     | With_accepted_exit_codes of int Predicate_lang.t * t
-    | Dynamic_run of program * string list
     | Chdir of path * t
     | Setenv of string * string * t
     (* It's not possible to use a build path here since jbuild supports

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -19,8 +19,6 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     | Run (prog, args) ->
       Run (f_program ~dir prog, Array.Immutable.map args ~f:(f_string ~dir))
     | With_accepted_exit_codes (pred, t) -> With_accepted_exit_codes (pred, f t ~dir)
-    | Dynamic_run (prog, args) ->
-      Dynamic_run (f_program ~dir prog, List.map args ~f:(f_string ~dir))
     | Chdir (fn, t) -> Chdir (f_path ~dir fn, f t ~dir:fn)
     | Setenv (var, value, t) -> Setenv (f_string ~dir var, f_string ~dir value, f t ~dir)
     | Redirect_out (outputs, fn, perm, t) ->

--- a/src/dune_engine/action_plugin.mli
+++ b/src/dune_engine/action_plugin.mli
@@ -1,8 +1,0 @@
-open Import
-
-val exec
-  :  ectx:Action_intf.Exec.context
-  -> eenv:Action_intf.Exec.env
-  -> Path.t
-  -> string list
-  -> Done_or_more_deps.t Fiber.t

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -48,7 +48,6 @@ let simplify act =
     match act with
     | Run (prog, args) -> Run (prog, Array.Immutable.to_list args) :: acc
     | With_accepted_exit_codes (_, t) -> loop t acc
-    | Dynamic_run (prog, args) -> Run (prog, args) :: acc
     | Chdir (p, act) -> loop act (Chdir p :: mkdir p :: acc)
     | Setenv (k, v, act) -> loop act (Setenv (k, v) :: acc)
     | Redirect_out (outputs, fn, perm, act) ->

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -454,7 +454,7 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
     O.With_accepted_exit_codes (pred, t)
   | Dynamic_run (prog, args) ->
     let+ prog, args = expand_run prog args in
-    O.Dynamic_run (prog, args)
+    Action_plugin.action ~prog ~args
   | Chdir (fn, t) ->
     E.At_rule_eval_stage.path fn ~f:(fun dir ->
       A.chdir

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -7,6 +7,7 @@
   build_path_prefix_map
   chrome_trace
   csexp
+  action_plugin
   dune_action_plugin
   dune_cache
   dune_cache_storage

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,9 +40,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [2eb3625df15d127fd24d71cb12a0c110] (_build/default/source): not found in cache
+  Shared cache miss [7ce0a4c4f9bbe747387f65b1a6c78ffa] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [5bd79a21d9a54fa9f8d991ad45109d1e] (_build/default/target1): not found in cache
+  Shared cache miss [de4b3699518e527f0bb1bf1385ef4262] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [055e127f555b3fafe95f560290795689] (_build/default/source): not found in cache
+  Shared cache miss [7bd743d84a8dd5da167a7f16422ab75a] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [03f7dfdb12ee66311712e0aa5c65de08] (_build/default/target1): not found in cache
+  Shared cache miss [768fcf94a7fec561d6da578d39f6fdaf] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [78f2c7a1ca2fb3c739b6adc7c2310f3d]: ((in_cache
+  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -120,7 +120,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [78f2c7a1ca2fb3c739b6adc7c2310f3d]: ((in_cache
+  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -132,7 +132,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [78f2c7a1ca2fb3c739b6adc7c2310f3d]: ((in_cache
+  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./23/2342c7575f2061e6e3396d6dcf8f0d5f:((8:metadata)(5:files(8:target_a32:7b362c0c7d2035084c9fc2d0e6815be5)))
-  ./f5/f54153a11ae41a60aa095c4671180b84:((8:metadata)(5:files(8:target_b32:d5b73f7b5d75090e1da54099e4458db3)))
+  ./62/62b3d3204298795e1dc06d2ad898320c:((8:metadata)(5:files(8:target_b32:d5b73f7b5d75090e1da54099e4458db3)))
+  ./92/9205b2a6c2a50c99556a20c05b6471f8:((8:metadata)(5:files(8:target_a32:7b362c0c7d2035084c9fc2d0e6815be5)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 


### PR DESCRIPTION
Now that custom actions can ask for more dependencies, there's no need for the action plugin to live inside the engine.

This better aligns the implementation with upstream.
