### PR TITLE
Fix handling of root module dependencies

### DIFF
--- a/doc/changes/12227.md
+++ b/doc/changes/12227.md
@@ -1,0 +1,2 @@
+- Don't run ocamldep to compute false dependencies on the `root_module`
+  (#12227, @rgrinberg)

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -137,15 +137,15 @@ let rec deps_of
           ~ml_kind
           (m : Modules.Sourced_module.t)
   =
-  let is_alias =
+  let is_alias_or_root =
     match m with
     | Impl_of_virtual_module _ -> false
     | Imported_from_vlib m | Normal m ->
       (match Module.kind m with
-       | Alias _ -> true
+       | Root | Alias _ -> true
        | _ -> false)
   in
-  if is_alias
+  if is_alias_or_root
   then Memo.return (Action_builder.return [])
   else (
     let skip_if_source_absent f sourced_module =
@@ -176,7 +176,7 @@ let has_single_file modules = Option.is_some @@ Modules.With_vlib.as_singleton m
 
 let immediate_deps_of unit modules ~obj_dir ~ml_kind =
   match Module.kind unit with
-  | Alias _ -> Action_builder.return []
+  | Root | Alias _ -> Action_builder.return []
   | Wrapped_compat ->
     let interface_module =
       match Modules.With_vlib.lib_interface modules with

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -618,7 +618,7 @@ module Module = struct
     match (dep : Dep.t) with
     | Immediate (m, _) | Transitive (m, _) ->
       (match Module.kind m with
-       | Module.Kind.Alias _ -> None
+       | Module.Kind.Alias _ | Root -> None
        | _ ->
          let dir = obj_dir t in
          let name = Dep.basename dep in

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -109,7 +109,7 @@ let parse_deps_exn =
 let transitive_deps =
   let transive_dep obj_dir m =
     (match Module.kind m with
-     | Alias _ -> None
+     | Root | Alias _ -> None
      | _ -> if Module.has m ~ml_kind:Intf then Some Ml_kind.Intf else Some Impl)
     |> Option.map ~f:(fun ml_kind ->
       Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind))

--- a/test/blackbox-tests/test-cases/root-module/root-module-ocamldep.t
+++ b/test/blackbox-tests/test-cases/root-module/root-module-ocamldep.t
@@ -26,8 +26,6 @@ compilation unit.
   _build/default/.foo.objs/byte/foo__Root.cmi
   _build/default/.foo.objs/byte/foo__Root.cmo
   _build/default/.foo.objs/byte/foo__Root.cmt
-  _build/default/.foo.objs/foo__Root.impl.all-deps
-  _build/default/.foo.objs/foo__Root.impl.d
 
 Not only is running ocamldep wasteful, but it can also lead to cycles:
 
@@ -36,10 +34,3 @@ Not only is running ocamldep wasteful, but it can also lead to cycles:
   > EOF
 
   $ dune build foo.cma
-  Error: Dependency cycle between:
-     _build/default/.foo.objs/foo__Bar.impl.all-deps
-  -> _build/default/.foo.objs/foo__Root.impl.all-deps
-  -> _build/default/.foo.objs/foo__Bar.impl.all-deps
-  -> required by _build/default/.foo.objs/byte/foo__Bar.cmo
-  -> required by _build/default/foo.cma
-  [1]

--- a/test/blackbox-tests/test-cases/root-module/root-module-ocamldep.t
+++ b/test/blackbox-tests/test-cases/root-module/root-module-ocamldep.t
@@ -1,0 +1,45 @@
+Demonstrate if we're running ocamldep for the root module. There should be no
+need to do so since this module cannot depend on any other module in the same
+compilation unit.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+  $ mkdir lib/
+  $ cat >lib/dune <<EOF
+  > (library
+  >  (name bar))
+  > EOF
+  $ touch lib/bar.ml
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (libraries bar)
+  >  (root_module root))
+  > EOF
+
+  $ dune build foo.cma
+
+  $ find _build/default/.foo.objs | grep -i root | sort -u
+  _build/default/.foo.objs/byte/foo__Root.cmi
+  _build/default/.foo.objs/byte/foo__Root.cmo
+  _build/default/.foo.objs/byte/foo__Root.cmt
+  _build/default/.foo.objs/foo__Root.impl.all-deps
+  _build/default/.foo.objs/foo__Root.impl.d
+
+Not only is running ocamldep wasteful, but it can also lead to cycles:
+
+  $ cat >bar.ml <<EOF
+  > module X = Root.Bar
+  > EOF
+
+  $ dune build foo.cma
+  Error: Dependency cycle between:
+     _build/default/.foo.objs/foo__Bar.impl.all-deps
+  -> _build/default/.foo.objs/foo__Root.impl.all-deps
+  -> _build/default/.foo.objs/foo__Bar.impl.all-deps
+  -> required by _build/default/.foo.objs/byte/foo__Bar.cmo
+  -> required by _build/default/foo.cma
+  [1]


### PR DESCRIPTION
The root module is generated, therefore it should have no dependencies.

Trying to discover dependencies for it can lead to spurious cycles.

The fix for this is hacky because we have multiple places we need to remember to cut off spurious deps. Will fix this in follow up PR's.