### PR TITLE
fix: make Dune_util.xdg lazier

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1352,7 +1352,7 @@ let init (builder : Builder.t) =
   Log.info
     [ Pp.textf
         "Shared cache location: %s"
-        (Path.to_string Dune_cache_storage.Layout.root_dir)
+        (Path.to_string (Lazy.force Dune_cache_storage.Layout.root_dir))
     ];
   Dune_rules.Main.init
     ~stats:c.stats

--- a/src/dune_cache/trimmer.ml
+++ b/src/dune_cache/trimmer.ml
@@ -25,7 +25,9 @@ let trim_broken_metadata_entries ~trimmed_so_far =
     Version.Metadata.all
     ~init:trimmed_so_far
     ~f:(fun trimmed_so_far version ->
-      let metadata_entries = Layout.Versioned.list_metadata_entries version in
+      let metadata_entries =
+        Lazy.force (Layout.Versioned.list_metadata_entries version)
+      in
       let file_path =
         Layout.Versioned.file_path (Version.Metadata.file_version version)
       in
@@ -51,7 +53,7 @@ let trim_broken_metadata_entries ~trimmed_so_far =
                | Metadata.Artifacts { entries; _ } ->
                  List.exists entries ~f:(function
                    | { Artifacts.Metadata_entry.digest = Some file_digest; path = _ } ->
-                     let reference = file_path ~file_digest in
+                     let reference = Lazy.force (file_path ~file_digest) in
                      not (Path.exists reference)
                      (* no digest means it's a directory. *)
                    | { digest = None; path = _ } -> false))
@@ -79,7 +81,7 @@ let garbage_collect () =
 
 let files_in_cache_for_all_supported_versions () =
   List.concat_map Version.File.all ~f:(fun file_version ->
-    Layout.Versioned.list_file_entries file_version)
+    Lazy.force (Layout.Versioned.list_file_entries file_version))
 ;;
 
 (* We call a cached file "unused" if there are currently no hard links to it

--- a/src/dune_cache_storage/layout.mli
+++ b/src/dune_cache_storage/layout.mli
@@ -9,7 +9,7 @@ open Stdune
 open Import
 
 (** The path to the root directory of the cache. *)
-val root_dir : Path.t
+val root_dir : Path.t Lazy.t
 
 (** Create a few subdirectories in [root_dir]. We expose this function because
     we don't want to modify the file system when the cache is disabled.
@@ -29,20 +29,20 @@ val create_cache_directories : unit -> (unit, Path.t * Unix.error) result
 
     A metadata file corresponding to an output-producing action is named by the
     action digest and stores the content digest of the resulting output. *)
-val metadata_storage_dir : Path.t
+val metadata_storage_dir : Path.t Lazy.t
 
 (** Path to the metadata file corresponding to a build action or rule with the
     given [rule_or_action_digest]. *)
-val metadata_path : rule_or_action_digest:Digest.t -> Path.t
+val metadata_path : rule_or_action_digest:Digest.t -> Path.t Lazy.t
 
 (** This is a storage for artifacts, where files named by content digests store
     the matching contents. We will create hard links to these files from build
     directories and rely on the hard link count, as well as on the last access
     time as useful metrics during cache trimming. *)
-val file_storage_dir : Path.t
+val file_storage_dir : Path.t Lazy.t
 
 (** Path to the artifact corresponding to a given [file_digest]. *)
-val file_path : file_digest:Digest.t -> Path.t
+val file_path : file_digest:Digest.t -> Path.t Lazy.t
 
 (** This is a storage for outputs and, more generally, other values that the
     build system might choose to store in the cache in future. As in
@@ -50,34 +50,39 @@ val file_path : file_digest:Digest.t -> Path.t
     digests. However, these files will always have the hard link count equal to
     one because they do not appear anywhere in build directories. By storing
     them in a separate directory, we simplify the job of the cache trimmer. *)
-val value_storage_dir : Path.t
+val value_storage_dir : Path.t Lazy.t
 
 (** Path to the value corresponding to a given [value_digest]. *)
-val value_path : value_digest:Digest.t -> Path.t
+val value_path : value_digest:Digest.t -> Path.t Lazy.t
 
 (** This directory contains temporary files used for atomic file operations
     needed when storing new artifacts in the cache. See [write_atomically]. *)
-val temp_dir : Path.t
+val temp_dir : Path.t Lazy.t
 
 (** Support for all versions of the layout, used by the cache trimmer. The
     functions provided by the top module are obtained by a partial application
     of the corresponding function defined here to a suitable current version. *)
 module Versioned : sig
-  val metadata_storage_dir : Version.Metadata.t -> Path.t
-  val metadata_path : Version.Metadata.t -> rule_or_action_digest:Digest.t -> Path.t
-  val file_storage_dir : Version.File.t -> Path.t
-  val file_path : Version.File.t -> file_digest:Digest.t -> Path.t
-  val value_storage_dir : Version.Value.t -> Path.t
-  val value_path : Version.Value.t -> value_digest:Digest.t -> Path.t
+  val metadata_storage_dir : Version.Metadata.t -> Path.t Lazy.t
+
+  val metadata_path
+    :  Version.Metadata.t
+    -> rule_or_action_digest:Digest.t
+    -> Path.t Lazy.t
+
+  val file_storage_dir : Version.File.t -> Path.t Lazy.t
+  val file_path : Version.File.t -> file_digest:Digest.t -> Path.t Lazy.t
+  val value_storage_dir : Version.Value.t -> Path.t Lazy.t
+  val value_path : Version.Value.t -> value_digest:Digest.t -> Path.t Lazy.t
 
   (** List all metadata entries currently stored in the cache. Note that there
       is no guarantee that the result is up-to-date, since files can be added or
       removed concurrently by other processes. *)
-  val list_metadata_entries : Version.Metadata.t -> (Path.t * Digest.t) list
+  val list_metadata_entries : Version.Metadata.t -> (Path.t * Digest.t) list Lazy.t
 
   (** List [list_metadata_entries] but for file entries. *)
-  val list_file_entries : Version.File.t -> (Path.t * Digest.t) list
+  val list_file_entries : Version.File.t -> (Path.t * Digest.t) list Lazy.t
 
   (** List [list_metadata_entries] but for value entries. *)
-  val list_value_entries : Version.Value.t -> (Path.t * Digest.t) list
+  val list_value_entries : Version.Value.t -> (Path.t * Digest.t) list Lazy.t
 end

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -56,7 +56,11 @@ let add_atomically ~mode ~src ~dst : Write_result.t =
 (* CR-someday amokhov: Switch to [renameat2] to go from two operations to
    one. *)
 let write_atomically ~mode ~content dst : Write_result.t =
-  Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune" ~suffix:"write" ~f:(function
+  Temp.with_temp_file
+    ~dir:(Lazy.force Layout.temp_dir)
+    ~prefix:"dune"
+    ~suffix:"write"
+    ~f:(function
     | Error e -> Write_result.Error e
     | Ok temp_file ->
       (match Io.write_file ~binary:true temp_file content with

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -585,8 +585,9 @@ module Dune_config = struct
   let decode_fields_of_workspace_file = decode_generic ~min_dune_version:(3, 0)
 
   let user_config_file =
-    let config_dir = Xdg.config_dir (Lazy.force Dune_util.xdg) in
-    Path.relative (Path.of_filename_relative_to_initial_cwd config_dir) "dune/config"
+    lazy
+      (let config_dir = Xdg.config_dir (Lazy.force Dune_util.xdg) in
+       Path.relative (Path.of_filename_relative_to_initial_cwd config_dir) "dune/config")
   ;;
 
   include Dune_lang.Versioned_file.Make (struct
@@ -603,6 +604,7 @@ module Dune_config = struct
   ;;
 
   let load_user_config_file () =
+    let user_config_file = Lazy.force user_config_file in
     if Path.exists user_config_file
     then load_config_file user_config_file
     else Partial.empty

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -116,7 +116,7 @@ module Dune_config : sig
 
   val superpose : t -> Partial.t -> t
   val default : t
-  val user_config_file : Path.t
+  val user_config_file : Path.t Lazy.t
 
   (** We return a [Partial.t] here so that the result can easily be merged with
       other sources of configurations. *)

--- a/test/expect-tests/dune_util/dune
+++ b/test/expect-tests/dune_util/dune
@@ -1,5 +1,6 @@
 (library
  (name flock_tests)
+ (modules flock_tests)
  (inline_tests
   (enabled_if
    (<> %{system} win))
@@ -9,6 +10,32 @@
   dune_util
   dyn
   stdune
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))
+
+(library
+ (name xdg_tests)
+ (modules xdg_tests)
+ (inline_tests)
+ (libraries
+  dune_util
+  ;; Please add any dependenies that you wish to check are forcing XDG
+  stdune
+  dune_console
+  ;; These dependencies are currently forcing XDG
+  dune_lang
+  dune_vcs
+  dune_config_file
+  dune_cache
+  dune_rules
+  dune_engine
+  dune_pkg
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/dune_util/dune
+++ b/test/expect-tests/dune_util/dune
@@ -28,13 +28,12 @@
   ;; Please add any dependenies that you wish to check are forcing XDG
   stdune
   dune_console
-  ;; These dependencies are currently forcing XDG
   dune_lang
   dune_vcs
+  dune_engine
   dune_config_file
   dune_cache
   dune_rules
-  dune_engine
   dune_pkg
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/test/expect-tests/dune_util/xdg_tests.ml
+++ b/test/expect-tests/dune_util/xdg_tests.ml
@@ -6,5 +6,5 @@
 
 let%expect_test "check xdg has been forced" =
   Dune_util.xdg |> Lazy.is_val |> Printf.printf "forced: %b";
-  [%expect {| forced: true |}]
+  [%expect {| forced: false |}]
 ;;

--- a/test/expect-tests/dune_util/xdg_tests.ml
+++ b/test/expect-tests/dune_util/xdg_tests.ml
@@ -1,0 +1,10 @@
+(* [Dune_util.xdg] is a lazy value. Here we make sure it is un-forced when
+   simply linking with the rest of dune.
+
+   There is nothing to be changed here, only form the Dune file. See the
+   instructions there. *)
+
+let%expect_test "check xdg has been forced" =
+  Dune_util.xdg |> Lazy.is_val |> Printf.printf "forced: %b";
+  [%expect {| forced: true |}]
+;;


### PR DESCRIPTION
I would like to be able to override the value of `Dune_util.xdg` during testing, since it gives us much more control over where certain files are being placed.

An override mechanism can be added to `Dune_util.xdg`, however one quickly realises that other places in dune are forcing this value eagarly. Therefore if we could make those places lazier, we can have enough of a window to override the value of `Dune_util.xdg` for testing purposes.

The first commit consists of a tests that depends on many dune libraries and shows that the value of `Dune_util.xdg` is being forced eagrly.

The second commit threads `Lazy.t` through various places in order to delay the forcing as much as possible. This works and allows for the override mechanism to function correctly. I would like to use this mechanism in the tests for #12188. Note that the test from the first commit makes sure we aren't forcing.

