### PR TITLE
fix(pkg): fallback to gpatch when patch isn't available

### DIFF
--- a/src/dune_patch/dune_patch.ml
+++ b/src/dune_patch/dune_patch.ml
@@ -90,9 +90,11 @@ let patches_of_string patch_string =
 
 let prog =
   lazy
-    (match Bin.which ~path:(Env_path.path Env.initial) "patch" with
+    (let path = Env_path.path Env.initial in
+     let bins = [ "gpatch"; "patch" ] in
+     match List.find_map bins ~f:(Bin.which ~path) with
      | Some p -> p
-     | None -> User_error.raise [ Pp.text "patch not found" ])
+     | None -> User_error.raise [ Pp.textf "%s not found." (String.enumerate_and bins) ])
 ;;
 
 let exec display ~patch ~dir ~stderr =


### PR DESCRIPTION
We add a fallback to gpatch when searching for patch. This won't be necessary when we have an OCaml implementation of dune_patch, but that is still some time away.

- fix https://github.com/ocaml/dune/issues/12232