### PR TITLE
refactor(fiber): switch [Fiber.Var] to be array backed

### DIFF
--- a/src/dune_async_io/async_io.ml
+++ b/src/dune_async_io/async_io.ml
@@ -248,7 +248,7 @@ module T_var : sig
   val get_exn : unit -> t Fiber.t
   val setup : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
 end = struct
-  let t_var = Fiber.Var.create ()
+  let t_var = Fiber.Var.create None
 
   let get_exn () =
     let+ t = Fiber.Var.get_exn t_var in
@@ -260,7 +260,7 @@ end = struct
   ;;
 
   let setup t f =
-    Fiber.Var.set t_var t (fun () ->
+    Fiber.Var.set t_var (Some t) (fun () ->
       Fiber.finalize f ~finally:(fun () ->
         if t.started
         then (

--- a/src/dune_engine/rpc.ml
+++ b/src/dune_engine/rpc.ml
@@ -13,7 +13,7 @@ type t =
   ; mutable state : [ `Awaiting_start | `Running | `Stopped ]
   }
 
-let t = Fiber.Var.create ()
+let t = Fiber.Var.create None
 
 let stop ({ state; server; pool } as t) =
   let* () = Fiber.return () in
@@ -28,7 +28,7 @@ let stop ({ state; server; pool } as t) =
 let with_background_rpc server f =
   let pool = Fiber.Pool.create () in
   let v = { state = `Awaiting_start; server; pool } in
-  Fiber.Var.set t v (fun () ->
+  Fiber.Var.set t (Some v) (fun () ->
     Fiber.fork_and_join_unit
       (fun () -> Fiber.Pool.run pool)
       (fun () -> Fiber.finalize f ~finally:(fun () -> stop v)))

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -829,8 +829,8 @@ type t =
   ; thread_pool : Thread_pool.t
   }
 
-let t : t Fiber.Var.t = Fiber.Var.create ()
-let set x f = Fiber.Var.set t x f
+let t : t option Fiber.Var.t = Fiber.Var.create None
+let set x f = Fiber.Var.set t (Some x) f
 let t_opt () = Fiber.Var.get t
 let t () = Fiber.Var.get_exn t
 

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -123,13 +123,13 @@ module Var : sig
   type 'a t
 
   (** Create a new variable *)
-  val create : unit -> 'a t
+  val create : 'a -> 'a t
 
   (** [get var] reads the value of [var]. *)
-  val get : 'a t -> 'a option fiber
+  val get : 'a t -> 'a fiber
 
   (** Same as [get] but raises if [var] is unset. *)
-  val get_exn : 'a t -> 'a fiber
+  val get_exn : 'a option t -> 'a fiber
 
   (** [set var value fiber] sets [var] to [value] during the execution of
       [fiber].
@@ -141,7 +141,9 @@ module Var : sig
       ]} *)
   val set : 'a t -> 'a -> (unit -> 'b fiber) -> 'b fiber
 
-  val unset : 'a t -> (unit -> 'b fiber) -> 'b fiber
+  (** [update var ~f fiber] runs [fiber] with [var] updated by applying [f] to its current
+      value. Warning: do not use a lot of stack space in [f]. *)
+  val update : 'a t -> f:('a -> 'a) -> (unit -> 'b fiber) -> 'b fiber
 end
 
 (** {1 Error handling} *)

--- a/src/fiber/src/var_map.ml
+++ b/src/fiber/src/var_map.ml
@@ -1,0 +1,51 @@
+(* This module is an unsafe implementation of [Univ_map] that should be faster for
+   small-sized maps. The principle is that copying a small array is, in fact, faster and
+   requires less allocation than updating a persistent map.
+
+   We represent the map as an [Obj.t array], and inserting and retrieval are performed by
+   coercing to and from the expected types, thus allowing the collection to contain values
+   of different types.
+
+   The interface of this module ensures type safety by requiring each index to be created
+   at a specific type. A value can only be retrieved using the same index that was used to
+   store it, which means that the type of the value will be what the caller expects. *)
+
+type t = Obj.t array
+
+let empty = [||]
+
+module Key = struct
+  type 'a t = int
+
+  let next_key = ref 0
+  let initial_values : Obj.t array ref = ref [||]
+
+  let create initial_value =
+    let key = !next_key in
+    incr next_key;
+    initial_values
+    := Array.init (key + 1) (fun i ->
+         if i < key then !initial_values.(i) else Obj.repr initial_value);
+    key
+  ;;
+end
+
+let get (type a) (t : t) key : a =
+  if key < Array.length t
+  then (Obj.magic : Obj.t -> a) t.(key)
+  else (Obj.magic : Obj.t -> a) !Key.initial_values.(key)
+;;
+
+let set (type a) (t : t) (key : a Key.t) (x : a) : t =
+  let copy =
+    if key < Array.length t then Array.copy t else Array.init (key + 1) (fun i -> get t i)
+  in
+  copy.(key) <- Obj.repr x;
+  copy
+;;
+
+let update (type a) (t : t) (key : a Key.t) ~(f : a -> a) : t =
+  let old = get t key in
+  let new_ = f old in
+  set t key new_
+;;

--- a/src/fiber/src/var_map.mli
+++ b/src/fiber/src/var_map.mli
@@ -1,0 +1,27 @@
+(** A heterogeneous total map data structure optimized for small collections. *)
+type t
+
+module Key : sig
+  (** A key to a map. *)
+  type 'a t
+
+  (** Create a new key for use in a map. This function is expensive and should be called
+      sparingly: the map is optimized for a small number of keys created at startup.
+
+      The input value will be used as the initial value of the key in the map. You can
+      pick ['a = 'b option] and pass [None] if the key has no reasonable initial value. *)
+  val create : 'a -> 'a t
+end
+
+(** The map with no entries. *)
+val empty : t
+
+(** Update or insert an entry. *)
+val set : t -> 'a Key.t -> 'a -> t
+
+(** Retrieve the value stored at a key. Returns the initial value if the key has never
+    been [set]. *)
+val get : t -> 'a Key.t -> 'a
+
+(** [update t key f] is a shortcut for [set t key (f (get t key))]. *)
+val update : t -> 'a Key.t -> f:('a -> 'a) -> t


### PR DESCRIPTION
This turns out to be faster as there's few elements in the array