### PR TITLE
fix: stop hiding the root module

### DIFF
--- a/doc/changes/12239.md
+++ b/doc/changes/12239.md
@@ -1,0 +1,1 @@
+- Stop hiding the `root_module` from the include path (#12239, @rgrinberg)

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -213,7 +213,7 @@ let install_as t = t.install_as
 let of_source ~install_as ~obj_name ~visibility ~(kind : Kind.t) (source : Source.t) =
   (match kind, visibility with
    | (Alias _ | Impl_vmodule | Virtual | Wrapped_compat), Visibility.Public
-   | Root, Private
+   | Root, Public
    | (Impl | Intf_only | Parameter), _ -> ()
    | _, _ ->
      Code_error.raise
@@ -420,9 +420,16 @@ let generated ?install_as ?obj_name ~(kind : Kind.t) ~src_dir (path : Module_nam
     Source.make ~impl:(Some impl) ~intf:None path
   in
   let visibility : Visibility.t =
-    match kind with
-    | Root -> Private
-    | _ -> Public
+    Public
+    (* CR-someday rgrinberg: This used to be;:
+      {[
+        match kind with
+        | Root -> Private
+        | _ -> Public
+      ]}
+
+      But this currently triggers module hiding via [-I]. We need to fix that.
+    *)
   in
   of_source ~install_as ~visibility ~kind ~obj_name:(Some obj_name) source
 ;;

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -385,8 +385,17 @@ let obj_dir ~dir t =
       ((* TODO instead of this fragile approximation, we should be looking at
           [Modules.t] and deciding. Unfortunately, [Obj_dir.t] is currently
           used in some places where [Modules.t] is not yet constructed. *)
-       t.private_modules <> None
-       || t.buildable.modules.root_module <> None)
+       t.private_modules
+       <> None
+          (* CR-someday rgrinberg: The following check used to be here:
+
+            {[
+              || t.buildable.modules.root_module <> None
+            ]}
+
+            but it doesn't work correctly. We need to always pass the
+            root_module with [ -H ] at least *)
+      )
     ~private_lib
     (snd t.name)
 ;;


### PR DESCRIPTION
Fix an obscure issue found in https://github.com/ocaml/dune/pull/12238

It's a bit hard to write a test for this as it relies on some fairly obscure properties of OCaml compilation. I guess this a reminder to  ourselves to switch to using `-H` everywhere.