### PR TITLE
Rollback dune file formatting change in 3.20.0

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,8 +1,15 @@
 (executable
  (name bench)
  (modules bench metrics)
- (libraries dune_stats dune_console chrome_trace stdune fiber dune_lang
-  dune_engine dune_util))
+ (libraries
+  dune_stats
+  dune_console
+  chrome_trace
+  stdune
+  fiber
+  dune_lang
+  dune_engine
+  dune_util))
 
 (rule
  (alias bench)

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -15,5 +15,10 @@
   (:include flags/sexp))
  (foreign_stubs
   (language c)
-  (names dune_flock readdir wait4_stubs platform_stubs copyfile_stubs
+  (names
+   dune_flock
+   readdir
+   wait4_stubs
+   platform_stubs
+   copyfile_stubs
    signal_stubs)))

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -1,5 +1,13 @@
 (library
  (name dune_cache)
  (synopsis "[Internal] Dune's local and cloud build cache")
- (libraries csexp dune_digest dune_cache_storage dune_util dune_console
-  dune_targets fiber stdune unix))
+ (libraries
+  csexp
+  dune_digest
+  dune_cache_storage
+  dune_util
+  dune_console
+  dune_targets
+  fiber
+  stdune
+  unix))

--- a/src/dune_config_file/dune
+++ b/src/dune_config_file/dune
@@ -1,6 +1,18 @@
 (library
  (name dune_config_file)
- (libraries stdune xdg dune_config dune_console dune_threaded_console
-  dune_lang dune_cache dune_cache_storage dune_engine dune_rpc_private
-  dune_stats dune_tui dune_util dune_spawn)
+ (libraries
+  stdune
+  xdg
+  dune_config
+  dune_console
+  dune_threaded_console
+  dune_lang
+  dune_cache
+  dune_cache_storage
+  dune_engine
+  dune_rpc_private
+  dune_stats
+  dune_tui
+  dune_util
+  dune_spawn)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -1,4 +1,10 @@
 (library
  (name dune_digest)
- (libraries dune_metrics blake3_mini dune_stats dune_console dune_util stdune
+ (libraries
+  dune_metrics
+  blake3_mini
+  dune_stats
+  dune_console
+  dune_util
+  stdune
   unix))

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -2,10 +2,35 @@
 
 (library
  (name dune_engine)
- (libraries unix csexp stdune dune_config dune_console dyn fiber memo
-  dune_async_io threads.posix predicate_lang dune_cache dune_cache_storage
-  dune_glob dune_targets chrome_trace dune_stats dune_action_plugin dune_util
-  build_path_prefix_map dune_output_truncation csexp_rpc dune_rpc_private
-  dune_rpc_client dune_thread_pool dune_spawn ocamlc_loc dune_file_watcher
-  dune_digest dune_metrics)
+ (libraries
+  unix
+  csexp
+  stdune
+  dune_config
+  dune_console
+  dyn
+  fiber
+  memo
+  dune_async_io
+  threads.posix
+  predicate_lang
+  dune_cache
+  dune_cache_storage
+  dune_glob
+  dune_targets
+  chrome_trace
+  dune_stats
+  dune_action_plugin
+  dune_util
+  build_path_prefix_map
+  dune_output_truncation
+  csexp_rpc
+  dune_rpc_private
+  dune_rpc_client
+  dune_thread_pool
+  dune_spawn
+  ocamlc_loc
+  dune_file_watcher
+  dune_digest
+  dune_metrics)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -1,5 +1,14 @@
 (library
  (name dune_file_watcher)
- (libraries dune_spawn fsevents dune_console unix stdune threads.posix
-  ocaml_inotify async_inotify_for_dune re fswatch_win)
+ (libraries
+  dune_spawn
+  fsevents
+  dune_console
+  unix
+  stdune
+  threads.posix
+  ocaml_inotify
+  async_inotify_for_dune
+  re
+  fswatch_win)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_lang/format.ml
+++ b/src/dune_lang/format.ml
@@ -25,10 +25,7 @@ let print_wrapped_list ~version x =
   let inner = Pp.concat_map ~sep:Pp.space ~f:pp_simple x in
   if version < (2, 8)
   then Pp.char '(' ++ Pp.hovbox ~indent:1 inner ++ Pp.char ')'
-  else
-    (if version < (3, 20) then Pp.hvbox else Pp.hovbox)
-      ~indent:1
-      (Pp.char '(' ++ inner ++ Pp.char ')')
+  else Pp.hvbox ~indent:1 (Pp.char '(' ++ inner ++ Pp.char ')')
 ;;
 
 let pp_comment_line l = Pp.char ';' ++ Pp.verbatim l

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -4,6 +4,20 @@
  (foreign_stubs
   (names md5_stubs)
   (language c))
- (libraries stdune fiber fiber_util chrome_trace dune_engine dune_util
-  dune_stats dune_lang dune_console re dune_vcs dune_config opam_format
-  build_info sat xdg))
+ (libraries
+  stdune
+  fiber
+  fiber_util
+  chrome_trace
+  dune_engine
+  dune_util
+  dune_stats
+  dune_lang
+  dune_console
+  re
+  dune_vcs
+  dune_config
+  opam_format
+  build_info
+  sat
+  xdg))

--- a/src/dune_rpc_impl/dune
+++ b/src/dune_rpc_impl/dune
@@ -1,5 +1,16 @@
 (library
  (name dune_rpc_impl)
- (libraries stdune promote unix fiber csexp_rpc dune_stats dune_rpc_client
-  dune_console dune_util dune_rpc_private dune_rpc_server dune_engine)
+ (libraries
+  stdune
+  promote
+  unix
+  fiber
+  csexp_rpc
+  dune_stats
+  dune_rpc_client
+  dune_console
+  dune_util
+  dune_rpc_private
+  dune_rpc_server
+  dune_engine)
  (synopsis "Dune's rpc server + a usable client"))

--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -1,5 +1,13 @@
 (library
  (name dune_rpc_server)
  (synopsis "Private API to define a dune rpc server")
- (libraries fiber stdune chrome_trace dyn ordering dune_stats dune_util
-  dune_rpc_private unix))
+ (libraries
+  fiber
+  stdune
+  chrome_trace
+  dyn
+  ordering
+  dune_stats
+  dune_util
+  dune_rpc_private
+  unix))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -2,13 +2,47 @@
 
 (library
  (name dune_rules)
- (libraries action_ext build_path_prefix_map chrome_trace csexp
-  dune_action_plugin dune_cache dune_cache_storage dune_config
-  dune_config_file dune_console dune_digest dune_engine dune_findlib
-  dune_glob dune_lang dune_meta_parser dune_patch dune_pkg re
-  dune_rpc_private dune_section dune_site_private dune_stats dune_targets
-  dune_util dune_vcs fiber fs install memo ocaml ocaml_config opam_format
-  predicate_lang promote scheme source stdune unix xdg)
+ (libraries
+  action_ext
+  build_path_prefix_map
+  chrome_trace
+  csexp
+  dune_action_plugin
+  dune_cache
+  dune_cache_storage
+  dune_config
+  dune_config_file
+  dune_console
+  dune_digest
+  dune_engine
+  dune_findlib
+  dune_glob
+  dune_lang
+  dune_meta_parser
+  dune_patch
+  dune_pkg
+  re
+  dune_rpc_private
+  dune_section
+  dune_site_private
+  dune_stats
+  dune_targets
+  dune_util
+  dune_vcs
+  fiber
+  fs
+  install
+  memo
+  ocaml
+  ocaml_config
+  opam_format
+  predicate_lang
+  promote
+  scheme
+  source
+  stdune
+  unix
+  xdg)
  (synopsis "Internal Dune library, do not use!"))
 
 (ocamllex ocamlobjinfo)

--- a/src/dune_rules_rpc/dune
+++ b/src/dune_rules_rpc/dune
@@ -1,5 +1,13 @@
 (library
  (name dune_rules_rpc)
  (synopsis "rpc functionality that depends on dune's public rules")
- (libraries stdune fiber memo dune_lang dune_engine source dune_rpc_impl
-  dune_rpc_private dune_rpc_server))
+ (libraries
+  stdune
+  fiber
+  memo
+  dune_lang
+  dune_engine
+  source
+  dune_rpc_impl
+  dune_rpc_private
+  dune_rpc_server))

--- a/src/dune_tui/dune
+++ b/src/dune_tui/dune
@@ -1,6 +1,15 @@
 (library
  (name dune_tui)
- (libraries stdune dune_lwd dune_util dune_nottui dune_notty dune_notty_unix
-  dune_config dune_console dune_threaded_console threads.posix))
+ (libraries
+  stdune
+  dune_lwd
+  dune_util
+  dune_nottui
+  dune_notty
+  dune_notty_unix
+  dune_config
+  dune_console
+  dune_threaded_console
+  threads.posix))
 
 (include_subdirs unqualified)

--- a/src/install/dune
+++ b/src/install/dune
@@ -1,5 +1,15 @@
 (library
  (name install)
  (synopsis "the handling of installation paths")
- (libraries stdune dyn opam_file_format ocaml dune_util dune_findlib dune_pkg
-  dune_engine dune_section dune_lang dune_sexp))
+ (libraries
+  stdune
+  dyn
+  opam_file_format
+  ocaml
+  dune_util
+  dune_findlib
+  dune_pkg
+  dune_engine
+  dune_section
+  dune_lang
+  dune_sexp))

--- a/src/promote/dune
+++ b/src/promote/dune
@@ -1,4 +1,11 @@
 (library
  (name promote)
- (libraries action_ext dune_console dune_engine dune_rpc_private dune_sexp
-  dune_util fiber stdune))
+ (libraries
+  action_ext
+  dune_console
+  dune_engine
+  dune_rpc_private
+  dune_sexp
+  dune_util
+  fiber
+  stdune))

--- a/src/source/dune
+++ b/src/source/dune
@@ -1,6 +1,22 @@
 (library
  (name source)
- (libraries chrome_trace dune_config dune_config_file dune_console
-  dune_digest dune_engine dune_glob dune_lang dune_pkg re dune_rpc_private
-  dune_stats dune_util dune_vcs memo ocaml_config predicate_lang stdune)
+ (libraries
+  chrome_trace
+  dune_config
+  dune_config_file
+  dune_console
+  dune_digest
+  dune_engine
+  dune_glob
+  dune_lang
+  dune_pkg
+  re
+  dune_rpc_private
+  dune_stats
+  dune_util
+  dune_vcs
+  memo
+  ocaml_config
+  predicate_lang
+  stdune)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/upgrader/dune
+++ b/src/upgrader/dune
@@ -1,5 +1,12 @@
 (library
  (name dune_upgrader)
- (libraries stdune dune_console memo source opam_file_format dune_lang
-  dune_engine fiber)
+ (libraries
+  stdune
+  dune_console
+  memo
+  source
+  opam_file_format
+  dune_lang
+  dune_engine
+  fiber)
  (synopsis "Internal Dune library, do not use!"))

--- a/test/blackbox-tests/test-cases/ctypes/dune
+++ b/test/blackbox-tests/test-cases/ctypes/dune
@@ -26,8 +26,13 @@
   (package integers)))
 
 (cram
- (applies_to bytecode-stubs-external-lib lib-pkg_config
-  lib-pkg_config-multiple-fd lib-external-name-need-mangling
-  exe-pkg_config-multiple-fd lib-return-errno github-5561-name-mangle
+ (applies_to
+  bytecode-stubs-external-lib
+  lib-pkg_config
+  lib-pkg_config-multiple-fd
+  lib-external-name-need-mangling
+  exe-pkg_config-multiple-fd
+  lib-return-errno
+  github-5561-name-mangle
   exe-pkg_config)
  (deps %{bin:pkg-config}))

--- a/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
+++ b/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
@@ -104,13 +104,20 @@ not stable across different setups.
    (executables
     ((names (exe))
      (requires
-      (25fa301af563256248c5dadd60078c6e b3f1696f67e77afbbf90bbd4ff4db3f7
-       3238f110cc121b8de5fb94811b5395f0 aa150dea272f13137145f9b1336e6f89
-       dc50e9309dbe56e9ba5a145dd0c7d272 c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e 9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1 b6a38388b521e9d788bf8c241c8b7131
-       e7b78a2ef3334358a41a86855c8739c2 1513262a352b79a04ff483cd84ebd966
-       2c25d00eb24f552a85fba122b2d45dd1 12c434f04237f2f66660cf4ef9d28bac
+      (25fa301af563256248c5dadd60078c6e
+       b3f1696f67e77afbbf90bbd4ff4db3f7
+       3238f110cc121b8de5fb94811b5395f0
+       aa150dea272f13137145f9b1336e6f89
+       dc50e9309dbe56e9ba5a145dd0c7d272
+       c1f4a4a8fcca6a7045ebee5b639dc729
+       5df1715b4499126654748a00e0142c5e
+       9087f2ff68e06ebafea537cd921b2b75
+       3e0806da37ceb5ee0d783c15826db0e1
+       b6a38388b521e9d788bf8c241c8b7131
+       e7b78a2ef3334358a41a86855c8739c2
+       1513262a352b79a04ff483cd84ebd966
+       2c25d00eb24f552a85fba122b2d45dd1
+       12c434f04237f2f66660cf4ef9d28bac
        d4bbc5a64c5463ce6eb84f54a61aa8b8))
      (modules
       (((name Exe)
@@ -140,7 +147,8 @@ not stable across different setups.
      (uid d4bbc5a64c5463ce6eb84f54a61aa8b8)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 2c25d00eb24f552a85fba122b2d45dd1
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       2c25d00eb24f552a85fba122b2d45dd1
        12c434f04237f2f66660cf4ef9d28bac))
      (source_dir _build/default/dummy_ppx)
      (modules
@@ -179,11 +187,16 @@ not stable across different setups.
      (uid 2c25d00eb24f552a85fba122b2d45dd1)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89 9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1 b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966 dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       5df1715b4499126654748a00e0142c5e
+       aa150dea272f13137145f9b1336e6f89
+       9087f2ff68e06ebafea537cd921b2b75
+       3e0806da37ceb5ee0d783c15826db0e1
+       b6a38388b521e9d788bf8c241c8b7131
+       1513262a352b79a04ff483cd84ebd966
+       dc50e9309dbe56e9ba5a145dd0c7d272
+       e7b78a2ef3334358a41a86855c8739c2
+       b3f1696f67e77afbbf90bbd4ff4db3f7))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
@@ -284,7 +297,8 @@ not stable across different setups.
      (uid d4bbc5a64c5463ce6eb84f54a61aa8b8)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 2c25d00eb24f552a85fba122b2d45dd1
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       2c25d00eb24f552a85fba122b2d45dd1
        12c434f04237f2f66660cf4ef9d28bac))
      (source_dir _build/default/dummy_ppx)
      (modules
@@ -336,11 +350,16 @@ not stable across different setups.
      (uid 2c25d00eb24f552a85fba122b2d45dd1)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89 9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1 b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966 dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       5df1715b4499126654748a00e0142c5e
+       aa150dea272f13137145f9b1336e6f89
+       9087f2ff68e06ebafea537cd921b2b75
+       3e0806da37ceb5ee0d783c15826db0e1
+       b6a38388b521e9d788bf8c241c8b7131
+       1513262a352b79a04ff483cd84ebd966
+       dc50e9309dbe56e9ba5a145dd0c7d272
+       e7b78a2ef3334358a41a86855c8739c2
+       b3f1696f67e77afbbf90bbd4ff4db3f7))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))

--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -546,11 +546,16 @@ not stable across different setups.
      (uid 2c25d00eb24f552a85fba122b2d45dd1)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89 9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1 b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966 dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       5df1715b4499126654748a00e0142c5e
+       aa150dea272f13137145f9b1336e6f89
+       9087f2ff68e06ebafea537cd921b2b75
+       3e0806da37ceb5ee0d783c15826db0e1
+       b6a38388b521e9d788bf8c241c8b7131
+       1513262a352b79a04ff483cd84ebd966
+       dc50e9309dbe56e9ba5a145dd0c7d272
+       e7b78a2ef3334358a41a86855c8739c2
+       b3f1696f67e77afbbf90bbd4ff4db3f7))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
@@ -1116,11 +1121,16 @@ not stable across different setups.
      (uid 2c25d00eb24f552a85fba122b2d45dd1)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89 9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1 b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966 dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      (c1f4a4a8fcca6a7045ebee5b639dc729
+       5df1715b4499126654748a00e0142c5e
+       aa150dea272f13137145f9b1336e6f89
+       9087f2ff68e06ebafea537cd921b2b75
+       3e0806da37ceb5ee0d783c15826db0e1
+       b6a38388b521e9d788bf8c241c8b7131
+       1513262a352b79a04ff483cd84ebd966
+       dc50e9309dbe56e9ba5a145dd0c7d272
+       e7b78a2ef3334358a41a86855c8739c2
+       b3f1696f67e77afbbf90bbd4ff4db3f7))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -6,9 +6,14 @@
    ; We set ocaml to always be colored since it changes the output of
    ; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144
    (OCAML_COLOR always))
-  (binaries ../utils/dune_cmd.exe ../utils/dunepp.exe
-   ../utils/melc_stdlib_prefix.exe ../utils/refmt.exe ../utils/curl
-   ../utils/sherlodoc.exe ../utils/ocaml_index.exe)))
+  (binaries
+   ../utils/dune_cmd.exe
+   ../utils/dunepp.exe
+   ../utils/melc_stdlib_prefix.exe
+   ../utils/refmt.exe
+   ../utils/curl
+   ../utils/sherlodoc.exe
+   ../utils/ocaml_index.exe)))
 
 (cram
  (applies_to pp-cwd)

--- a/test/blackbox-tests/test-cases/formatting/format-dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/format-dune-file.t/run.t
@@ -73,8 +73,17 @@ The same file, but in the current version:
   $ echo '(library (name dune) (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang ocaml_config which_program) (synopsis "Internal Dune library, do not use!") (preprocess  (action (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))' | dune format-dune-file
   (library
    (name dune)
-   (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang
-    ocaml_config which_program)
+   (libraries
+    unix
+    stdune
+    fiber
+    xdg
+    dune_re
+    threads
+    opam_file_format
+    dune_lang
+    ocaml_config
+    which_program)
    (synopsis "Internal Dune library, do not use!")
    (preprocess
     (action

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -16,8 +16,12 @@ It builds on its own (with a warning) when lang dune is 3.2 or below:
   $ dune printenv --root=inner --field flags
   Entering directory 'inner'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'inner'
   $ dune build --root=inner
   Entering directory 'inner'
@@ -37,8 +41,12 @@ Note that in versions of lang dune above 3.2 this warning becomes an error:
   $ dune printenv --root=inner --field flags
   Entering directory 'inner'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'inner'
   $ dune build --root=inner
   Entering directory 'inner'
@@ -60,8 +68,12 @@ Building the outer project works when lang dune is 3.2 or below:
   $ dune printenv --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
 
   $ dune build --root=outer
@@ -77,14 +89,22 @@ But when lang dune is 3.3 or higher the warning becomes an error:
   $ dune printenv --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
   $ dune printenv outer/vendored/inner --root=outer --field flags
   Entering directory 'outer'
   (flags
-   (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence
-    -strict-formats -short-paths -keep-locs))
+   (-w
+    @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+    -strict-sequence
+    -strict-formats
+    -short-paths
+    -keep-locs))
   Leaving directory 'outer'
 
   $ dune build --root=outer

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -35,19 +35,35 @@
 
 (cram
  (deps %{bin:curl})
- (applies_to unavailable-source-package compute-checksums-when-missing e2e
-  ocamlformat-dev-tool source-caching tarball pin-depends extra-sources
+ (applies_to
+  unavailable-source-package
+  compute-checksums-when-missing
+  e2e
+  ocamlformat-dev-tool
+  source-caching
+  tarball
+  pin-depends
+  extra-sources
   broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:md5sum})
- (applies_to source-caching extra-sources ocamlformat-dev-tool
-  dev-tool-conflict-test broken-symlink-in-dependency))
+ (applies_to
+  source-caching
+  extra-sources
+  ocamlformat-dev-tool
+  dev-tool-conflict-test
+  broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:tar})
- (applies_to source-caching tarball pin-depends extra-sources
-  pkg-extract-fail broken-symlink-in-dependency))
+ (applies_to
+  source-caching
+  tarball
+  pin-depends
+  extra-sources
+  pkg-extract-fail
+  broken-symlink-in-dependency))
 
 (cram
  (deps %{bin:ocaml_index})

--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -20,6 +20,7 @@
 ;; These tests sometimes get stuck and time out:
 
 (cram
- (applies_to watching-eager-concurrent-build-command
+ (applies_to
+  watching-eager-concurrent-build-command
   watching-eager-concurrent-exec-command)
  (enabled_if false))

--- a/test/expect-tests/dune_action_plugin/dune
+++ b/test/expect-tests/dune_action_plugin/dune
@@ -4,7 +4,12 @@
  (name dune_action_unit_tests)
  (inline_tests
   (deps some_dir/some_file))
- (libraries dune_action_plugin ppx_expect.config ppx_expect.config_types base
-  ppx_inline_test.config dune-glob)
+ (libraries
+  dune_action_plugin
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config
+  dune-glob)
  (preprocess
   (pps ppx_expect)))

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -13,9 +13,18 @@
     (= %{system} macosx)))
   (deps
    (sandbox always)))
- (libraries unix dune_file_watcher dune_file_watcher_tests_lib
-  ppx_expect.config ppx_expect.config_types base stdune
-  ppx_inline_test.config threads.posix stdio spawn)
+ (libraries
+  unix
+  dune_file_watcher
+  dune_file_watcher_tests_lib
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  stdune
+  ppx_inline_test.config
+  threads.posix
+  stdio
+  spawn)
  (preprocess
   (pps ppx_expect)))
 
@@ -27,9 +36,18 @@
    (= %{system} linux))
   (deps
    (sandbox always)))
- (libraries dune_file_watcher dune_file_watcher_tests_lib ppx_expect.config
-  ppx_expect.config_types base stdune ppx_inline_test.config threads.posix
-  stdio spawn unix)
+ (libraries
+  dune_file_watcher
+  dune_file_watcher_tests_lib
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  stdune
+  ppx_inline_test.config
+  threads.posix
+  stdio
+  spawn
+  unix)
  (preprocess
   (pps ppx_expect)))
 
@@ -39,7 +57,12 @@
  (inline_tests
   (deps
    (sandbox always)))
- (libraries base dune_config_file dune_file_watcher ppx_expect.config
-  ppx_expect.config_types ppx_inline_test.config)
+ (libraries
+  base
+  dune_config_file
+  dune_file_watcher
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_inline_test.config)
  (preprocess
   (pps ppx_expect)))

--- a/test/expect-tests/inotify_tests/dune
+++ b/test/expect-tests/inotify_tests/dune
@@ -5,8 +5,17 @@
    (= %{system} linux))
   (deps
    (sandbox always)))
- (libraries async_inotify_for_dune threads ppx_expect.config
-  ppx_expect.config_types base stdune ppx_inline_test.config threads.posix
-  stdio spawn unix)
+ (libraries
+  async_inotify_for_dune
+  threads
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  stdune
+  ppx_inline_test.config
+  threads.posix
+  stdio
+  spawn
+  unix)
  (preprocess
   (pps ppx_expect)))


### PR DESCRIPTION
The formatting change introduced in 3.20.0 (see #10892) has resulted in a number of complaints because of its unversioned nature (it does not depend on the version of the Dune language of the file being formatted). After discussion with @Alizter mainly we think that it may be a good idea to revert this change until we have a good versioning story.

The point of this PR is to have a patch ready in case we decide to do so in time for 3.20.1.