### PR TITLE
add melange to `@ocaml-index` alias

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -415,6 +415,10 @@ let setup_emit_cmj_rules
           { ocaml = { byte = None; native = None }; melange = Some (Requested mel.loc) }
     in
     let* () = Module_compilation.build_all cctx in
+    let* () =
+      Memo.when_ (Compilation_context.bin_annot cctx) (fun () ->
+        Ocaml_index.cctx_rules cctx)
+    in
     let* requires_compile = Compilation_context.requires_compile cctx in
     let* requires_hidden = Compilation_context.requires_hidden cctx in
     let stdlib_dir = (Compilation_context.ocaml cctx).lib_config.stdlib_dir in

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -64,7 +64,12 @@ let cctx_rules cctx =
     in
     (* Indexation also depends on the current stanza's modules *)
     let modules_deps =
-      let cm_kind = Lib_mode.Cm_kind.(Ocaml Cmi) in
+      let modes = Compilation_context.modes cctx in
+      let cm_kind =
+        if modes.ocaml.native || modes.ocaml.byte
+        then Lib_mode.Cm_kind.(Ocaml Cmi)
+        else Lib_mode.Cm_kind.(Melange Cmi)
+      in
       (* We only index occurrences in user-written modules *)
       Compilation_context.modules cctx
       |> Modules.With_vlib.drop_vlib
@@ -104,6 +109,8 @@ let context_indexes sctx =
       match Stanza.repr stanza with
       | Executables.T exes | Tests.T { exes; _ } -> Some (Executables.obj_dir ~dir exes)
       | Library.T lib -> Some (Library.obj_dir ~dir lib)
+      | Melange_stanzas.Emit.T { target; _ } ->
+        Some (Obj_dir.make_melange_emit ~dir ~name:target)
       | _ -> None
     in
     match obj with

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -74,7 +74,9 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
   $ touch main.ml
   $ dune build @check
   $ dune ocaml merlin dump-config $PWD | grep -i "$target"
+  ((INDEX $TESTCASE_ROOT/_build/default/.output.mobjs/cctx.ocaml-index)
    (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
+  ((INDEX $TESTCASE_ROOT/_build/default/.output.mobjs/cctx.ocaml-index)
    (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
 
 Dump-dot-merlin includes the melange flags
@@ -91,6 +93,7 @@ Dump-dot-merlin includes the melange flags
   S /MELC_STDLIB/__private__/melange_mini_stdlib
   S /MELC_STDLIB
   S $TESTCASE_ROOT
+  INDEX $TESTCASE_ROOT/_build/default/.output.mobjs/cctx.ocaml-index
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g --mel-noassertfalse
   
 Check for flag directives ordering when another preprocessor is defined


### PR DESCRIPTION
This change makes `@ocaml-index` alias aware of Melange by making the alias aware of the Melange stanza and making the cctx rule correctly resolve the Melange path