### PR TITLE
Publish Dune Docker images during release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: Docker Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,66 @@
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.8.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Download release assets
+        env:
+            GH_TOKEN: ${{ github.token }}
+        run: |
+             mkdir -p docker-context
+             gh release download ${{ github.ref_name }} \
+             --pattern "*.tbz" \
+             --dir docker-context
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker-context
+          file: ./docker/release.Dockerfile
+          push: true
+        #   tags: ${{ secrets.DOCKERHUB_USERNAME }}/dune:${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=debian:13
 FROM ${BASE_IMAGE} AS build
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser build-essential curl ocaml
+RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser build-essential ocaml
 
 RUN addgroup --gid 1000 dune && adduser --uid 1000 --ingroup dune dune
 

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -1,0 +1,26 @@
+ARG BASE_IMAGE=debian:latest
+FROM ${BASE_IMAGE}
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y build-essential curl git sudo ocaml wget
+
+RUN git config --global user.email "docker@example.com"
+RUN git config --global user.name "Docker"
+
+RUN addgroup --system --gid 1000 dune
+RUN adduser --system --uid 1000 --ingroup dune dune
+WORKDIR /home/dune
+
+# Use release assets from Docker context
+RUN tar -xvjf dune*.tbz
+RUN mv dune-[0-9]*/ dune
+WORKDIR /home/dune/dune
+
+# Build and install dune
+RUN ./configure --prefix=/usr/local
+RUN make bootstrap
+RUN make release
+RUN make install
+
+# Verify installation
+RUN dune --version


### PR DESCRIPTION
This change is in line with #12177, which proposed to add a GitHub action that publishes a minimal Dune Docker image on every release. I've tried to keep the Docker file very minimal by building it with the OCaml compiler that comes with the distribution (on Debian this is currently 5.3.0, but it's possible the distribution OCaml compiler version is updated much later than the compiler release).

This GitHub Action essentially builds and pushes the Docker image on every new release to the GitHub container registry. This can be pushed to other registries such as Docker Hub, but it's perhaps easiest to start with GitHub itself. If we decide to go ahead with this approach, we may need to update `secrets.GITHUB_TOKEN`.

Fixes #12177