### PR TITLE
chore(test): get rid of timeout in watching tests

### DIFF
--- a/test/blackbox-tests/test-cases/actions/stray-process.t
+++ b/test/blackbox-tests/test-cases/actions/stray-process.t
@@ -20,7 +20,7 @@ Shows what happens when Dune tries to kill an action that has sub-processes.
 sub_process.exe spawns a sub-process that creates $BEACON_FILE. We
 wait for the beacon to be notified that the sub-process has started:
 
-  $ with_timeout dune_cmd wait-for-file-to-appear $BEACON_FILE
+  $ dune_cmd wait-for-file-to-appear $BEACON_FILE
   $ CHILD_PID=`cat $BEACON_FILE`
 
 Now we stop Dune, which should normally kill all sub-processes:

--- a/test/blackbox-tests/test-cases/watching/basic.t
+++ b/test/blackbox-tests/test-cases/watching/basic.t
@@ -57,7 +57,7 @@ Basic tests for the file-watching mode.
   $ cat _build/default/y
   new-contents3
 
-  $ with_timeout dune shutdown
+  $ dune shutdown
   $ cat .#dune-output
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...

--- a/test/blackbox-tests/test-cases/watching/helpers.sh
+++ b/test/blackbox-tests/test-cases/watching/helpers.sh
@@ -6,22 +6,8 @@ start_dune () {
     DUNE_RUNNING=1;
 }
 
-timeout="$(command -v timeout || echo gtimeout)"
-
-with_timeout () {
-    $timeout 2 "$@"
-    exit_code=$?
-    if [ "$exit_code" = 124 ]
-    then
-        echo Timed out
-        cat .#dune-output
-    else
-        return "$exit_code"
-    fi
-}
-
 stop_dune () {
-    with_timeout dune shutdown;
+    dune shutdown;
     # On Linux, we may run into a bash pid aliasing bug that causes wait to
     # reject the pid. Therefore we use tail to wait instead.
     if [ "$(uname -s)" = "Linux" ]
@@ -36,5 +22,5 @@ stop_dune () {
 }
 
 build () {
-    with_timeout dune rpc build --wait "$@"
+    dune rpc build --wait "$@"
 }

--- a/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
+++ b/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
@@ -30,7 +30,7 @@ memoization).
   $ build test
   Success
 
-  $ with_timeout dune shutdown
+  $ dune shutdown
   $ cat .#dune-output | sed -e 's#.sandbox/[^/]*/default/test/subdir#.sandbox/<hash>/default/test/subdir#'
   $TESTCASE_ROOT/_build/.sandbox/<hash>/default/test/subdir
   Success, waiting for filesystem changes...


### PR DESCRIPTION
We already have a cram timeout for all cram tests, so a specific mechanism here isn't needed. It was also a little flaky when the test took longer than 2 seconds. The parent cram timeout is much more forgiving.