### PR TITLE
refactor: remove pointless backtracking

### DIFF
--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -102,8 +102,13 @@ module Mode_conf = struct
   ;;
 
   let decode =
-    enum [ "byte", Byte; "js", Jsoo JS; "native", Native; "best", Best ]
-    <|> sum [ "wasm", Syntax.since Stanza.syntax (3, 17) >>> return (Jsoo Wasm) ]
+    enum'
+      [ "byte", return Byte
+      ; "js", return (Jsoo JS)
+      ; "native", return Native
+      ; "best", return Best
+      ; "wasm", Syntax.since Stanza.syntax (3, 17) >>> return (Jsoo Wasm)
+      ]
   ;;
 
   module O = Comparable.Make (T)

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -263,8 +263,9 @@ module Link_mode = struct
   let simple_representations_including_wasm = ("wasm", wasm) :: simple_representations
 
   let simple =
-    Dune_lang.Decoder.enum simple_representations
-    <|> sum [ "wasm", Syntax.since Stanza.syntax (3, 17) >>> return wasm ]
+    ("wasm", Syntax.since Stanza.syntax (3, 17) >>> return wasm)
+    :: List.map simple_representations ~f:(fun (x, y) -> x, return y)
+    |> enum'
   ;;
 
   let decode =


### PR DESCRIPTION
We shouldn't be using `<|>` when it can be avoided