### PR TITLE
refactor(boot): remove constants from [boot.ml]

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1468,6 +1468,22 @@ let get_flags system xs =
   |> Option.value ~default:[]
 ;;
 
+let windows_system_values = [ "win32"; "win64"; "mingw"; "mingw64" ]
+
+let build_flags =
+  [ windows_system_values, [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ] ]
+;;
+
+let link_flags =
+  (* additional link flags keyed by the platform *)
+  [ ( [ "macosx" ]
+    , [ "-cclib"; "-framework CoreFoundation"; "-cclib"; "-framework CoreServices" ] )
+  ; ( windows_system_values
+    , [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ] )
+  ; [ "beos" ], [ "-cclib"; "-lbsd" ] (* flags for Haiku *)
+  ]
+;;
+
 (** {2 Bootstrap process} *)
 let main () =
   (try Io.clear build_dir with
@@ -1484,8 +1500,8 @@ let main () =
     | None -> assert false
     | Some s -> s
   in
-  let build_flags = get_flags ocaml_system Libs.build_flags in
-  let link_flags = get_flags ocaml_system Libs.link_flags in
+  let build_flags = get_flags ocaml_system build_flags in
+  let link_flags = get_flags ocaml_system link_flags in
   build ~ocaml_config ~dependencies ~asm_files ~c_files ~build_flags ~link_flags task
 ;;
 

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -528,19 +528,3 @@ let local_libraries =
     }
   ]
 
-let build_flags =
-  [ ([ "win32"; "win64"; "mingw"; "mingw64" ],
-     [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ])
-  ]
-
-let link_flags =
-  [ ([ "macosx" ],
-     [ "-cclib"
-     ; "-framework CoreFoundation"
-     ; "-cclib"
-     ; "-framework CoreServices"
-     ])
-  ; ([ "win32"; "win64"; "mingw"; "mingw64" ],
-     [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
-  ; ([ "beos" ], [ "-cclib"; "-lbsd" ])
-  ]

--- a/boot/libs.mli
+++ b/boot/libs.mli
@@ -20,5 +20,3 @@ type library =
 
 val external_libraries : string list
 val local_libraries : library list
-val build_flags : (string list * string list) list
-val link_flags : (string list * string list) list

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -5,11 +5,6 @@ let def name dyn =
   Pp.box ~indent:2 (Pp.textf "let %s = " name ++ Dyn.pp dyn)
 ;;
 
-let flags flags =
-  let open Dyn in
-  list (pair (list string) (list string)) flags
-;;
-
 module Root_module_data = struct
   type t =
     { name : Module_name.t
@@ -79,19 +74,6 @@ let rule sctx ~requires_link =
       | Some x -> Left x
       | None -> Right lib)
   in
-  let windows_system_values = [ "win32"; "win64"; "mingw"; "mingw64" ] in
-  let build_flags =
-    [ windows_system_values, [ "-ccopt"; "-D_UNICODE"; "-ccopt"; "-DUNICODE" ] ]
-  in
-  let link_flags =
-    (* additional link flags keyed by the platform *)
-    [ ( [ "macosx" ]
-      , [ "-cclib"; "-framework CoreFoundation"; "-cclib"; "-framework CoreServices" ] )
-    ; ( windows_system_values
-      , [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ] )
-    ; [ "beos" ], [ "-cclib"; "-lbsd" ] (* flags for Haiku *)
-    ]
-  in
   let+ locals =
     Action_builder.List.map locals ~f:(fun x ->
       let info = Lib.Local.info x in
@@ -155,9 +137,6 @@ let rule sctx ~requires_link =
        ; Pp.nop
        ; def "local_libraries" (List locals)
        ; Pp.nop
-       ; def "build_flags" (flags build_flags)
-       ; Pp.nop
-       ; def "link_flags" (flags link_flags)
        ]
      |> Pp.vbox)
 ;;


### PR DESCRIPTION
There's no need for constants to be generated. They can be inlined in the bootstrap script.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>