### PR TITLE
refactor(boot): move boot types to separate module

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -25,7 +25,7 @@ let keep_generated_files =
   !keep_generated_files
 ;;
 
-let modules = [ "boot/libs"; "boot/duneboot" ]
+let modules = [ "boot/types"; "boot/libs"; "boot/duneboot" ]
 let duneboot = ".duneboot"
 let prog = duneboot ^ ".exe"
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -29,10 +29,12 @@ let concurrency, verbose, debug, secondary, force_byte_compilation, static, buil
 
 (** {2 General configuration} *)
 
+open Types
+
 type task =
   { target : string * string
   ; external_libraries : string list
-  ; local_libraries : Libs.library list
+  ; local_libraries : library list
   }
 
 let task =
@@ -791,7 +793,7 @@ module Build_info = struct
        | Some v -> sprintf "Some %S" v);
     pr "\n";
     let libs =
-      List.map task.local_libraries ~f:(fun (lib : Libs.library) -> lib.path, "version")
+      List.map task.local_libraries ~f:(fun (lib : library) -> lib.path, "version")
       @ List.map task.external_libraries ~f:(fun name ->
         name, {|Some "[distributed with OCaml]"|})
       |> List.sort ~cmp:(fun (a, _) (b, _) -> String.compare a b)
@@ -1041,7 +1043,7 @@ module Library = struct
   ;;
 
   let process
-        { Libs.path = dir
+        { path = dir
         ; main_module_name = namespace
         ; include_subdirs_unqualified = scan_subdirs
         ; special_builtin_support = build_info_module
@@ -1069,7 +1071,7 @@ module Library = struct
       in
       match root_module with
       | None -> modules
-      | Some { Libs.name; entries = _ } ->
+      | Some { name; entries = _ } ->
         String.Set.add (String.capitalize_ascii name) modules
     in
     let wrapper = Wrapper.make ~namespace ~modules in
@@ -1086,7 +1088,7 @@ module Library = struct
     in
     let root_module =
       Option.map
-        (fun { Libs.name; entries } ->
+        (fun { name; entries } ->
            let src =
              let fn = String.uncapitalize_ascii name ^ ".ml" in
              { file = fn; kind = Ml }
@@ -1270,7 +1272,7 @@ let assemble_libraries { local_libraries; target = _, main; _ } ~ocaml_config =
     let namespace =
       String.capitalize_ascii (Filename.chop_extension (Filename.basename main))
     in
-    { Libs.path = dir
+    { path = dir
     ; main_module_name = Some namespace
     ; include_subdirs_unqualified = true
     ; special_builtin_support = None

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,17 +1,4 @@
-
-type root_module =
-  { name : string
-  ; entries : string list
-  }
-
-type library =
-  { path : string
-  ; main_module_name : string option
-  ; include_subdirs_unqualified : bool
-  ; special_builtin_support : string option
-  ; root_module : root_module option
-  }
-
+open Types
 let external_libraries = [ "unix"; "threads" ]
 
 let local_libraries =

--- a/boot/libs.mli
+++ b/boot/libs.mli
@@ -5,18 +5,7 @@
    undone and bootstrap to be done again.
 *)
 
-type root_module =
-  { name : string
-  ; entries : string list
-  }
-
-type library =
-  { path : string
-  ; main_module_name : string option
-  ; include_subdirs_unqualified : bool
-  ; special_builtin_support : string option
-  ; root_module : root_module option
-  }
+open Types
 
 val external_libraries : string list
 val local_libraries : library list

--- a/boot/types.ml
+++ b/boot/types.ml
@@ -1,0 +1,12 @@
+type root_module =
+  { name : string
+  ; entries : string list
+  }
+
+type library =
+  { path : string
+  ; main_module_name : string option
+  ; include_subdirs_unqualified : bool
+  ; special_builtin_support : string option
+  ; root_module : root_module option
+  }

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -20,23 +20,6 @@ module Root_module_data = struct
   ;;
 end
 
-let type_def =
-  {|
-type root_module =
-  { name : string
-  ; entries : string list
-  }
-
-type library =
-  { path : string
-  ; main_module_name : string option
-  ; include_subdirs_unqualified : bool
-  ; special_builtin_support : string option
-  ; root_module : root_module option
-  }
-|}
-;;
-
 let local_library
       ~root_module
       ~special_builtin_support
@@ -132,7 +115,7 @@ let rule sctx ~requires_link =
     Pp.to_fmt
     (Pp.concat
        ~sep:Pp.cut
-       [ Pp.verbatim type_def
+       [ Pp.verbatim "open Types"
        ; def "external_libraries" (Dyn.list Lib_name.to_dyn externals)
        ; Pp.nop
        ; def "local_libraries" (List locals)


### PR DESCRIPTION
No need to generate these. They're always constant.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>