### PR TITLE
fix(boot): allow [root_module] for main exe

### DIFF
--- a/src/dune_rules/bootstrap_info.mli
+++ b/src/dune_rules/bootstrap_info.mli
@@ -10,6 +10,6 @@ val gen_rules
   :  Super_context.t
   -> Executables.t
   -> dir:Path.Build.t
-  -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
+  -> Lib.Compile.t
   -> Dir_contents.t
   -> unit Memo.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -348,10 +348,7 @@ let rules ~sctx ~dir_contents ~scope ~expander (exes : Executables.t) =
       ~embed_in_plugin_libraries:exes.embed_in_plugin_libraries
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir
-  and* () =
-    let requires_link = Lib.Compile.requires_link compile_info in
-    Bootstrap_info.gen_rules sctx exes ~dir ~requires_link dir_contents
-  in
+  and* () = Bootstrap_info.gen_rules sctx exes ~dir compile_info dir_contents in
   let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
   Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
 ;;


### PR DESCRIPTION
Now we can use `root_module` everywhere in dune