### PR TITLE
[3.20] backport #12242

### DIFF
--- a/doc/changes/12242.md
+++ b/doc/changes/12242.md
@@ -1,0 +1,2 @@
+- Fix `runtest-js` mistakenly depending on `byte` (fixes #12243, #12242,
+  @vouillon and @Alizter)

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -115,7 +115,12 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           in
           let add_alias =
             let expander = Expander.add_bindings expander ~bindings:extra_bindings in
-            let alias = Alias.make ~dir (Alias.Name.of_string ("runtest-" ^ s)) in
+            let alias =
+              [ Alias.Name.to_string (Alias.name runtest_alias); s ]
+              |> String.concat ~sep:"-"
+              |> Alias.Name.of_string
+              |> Alias.make ~dir
+            in
             fun ~loc ~action ->
               let action =
                 let chdir = Expander.dir expander in

--- a/test/blackbox-tests/test-cases/jsoo/tests.t/dune
+++ b/test/blackbox-tests/test-cases/jsoo/tests.t/dune
@@ -1,6 +1,6 @@
 (tests
  (names a b)
- (modes js))
+ (modes byte js))
 
 (env
  (_

--- a/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
@@ -1,5 +1,6 @@
 tests stanza with jsoo
 
+There should anly be one 'ok' here since we only want to run the js mode tests.
+
   $ dune build @default @runtest-js
-  a: ok
   a: ok

--- a/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
@@ -2,3 +2,4 @@ tests stanza with jsoo
 
   $ dune build @default @runtest-js
   a: ok
+  a: ok


### PR DESCRIPTION
- **test: make sure runtest_alias works properly**
- **fix(jsoo): runtest-js alias now depends on runtest-js-name for (tests)**
