### PR TITLE
[3.20] backport #12251

### DIFF
--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -122,6 +122,11 @@ let runtest_term =
           let+ res = Action_builder.of_memo (disambiguate_test_name dir) in
           [ context ], res
         | In_source_dir dir ->
+          (* We need to adjust the path here to make up for the current working directory. *)
+          let { Workspace_root.to_cwd; _ } = Common.root common in
+          let dir =
+            Path.Source.L.relative Path.Source.root (to_cwd @ Path.Source.explode dir)
+          in
           let+ res = Action_builder.of_memo (disambiguate_test_name dir) in
           contexts, res
         | In_private_context _ | In_install_dir _ ->

--- a/doc/changes/12251.md
+++ b/doc/changes/12251.md
@@ -1,0 +1,2 @@
+- Fix the interpretation of paths in `dune runtest` when running from within a
+  subdirectory. (#12251, fixes #12250, @Alizter)

--- a/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
@@ -22,7 +22,6 @@ Reproduction case for https://github.com/ocaml/dune/issues/12250
 dune runtest should be able to run in a subdirectory and the arguments passed
 to it should be adjusted accordingly.
 
-This is currently not the case:
 
   $ (cd somelib && unset INSIDE_DUNE; dune runtest --diff-command=- my/path/)
   Entering directory '$TESTCASE_ROOT'

--- a/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
@@ -26,7 +26,9 @@ This is currently not the case:
 
   $ (cd somelib && unset INSIDE_DUNE; dune runtest --diff-command=- my/path/)
   Entering directory '$TESTCASE_ROOT'
-  Error: "my/path" does not match any known test.
+  File "somelib/my/path/test.t", line 1, characters 0-0:
+  Error: Files _build/default/somelib/my/path/test.t and
+  _build/default/somelib/my/path/test.t.corrected differ.
   Leaving directory '$TESTCASE_ROOT'
   [1]
 

--- a/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-subdir.t
@@ -1,0 +1,33 @@
+Reproduction case for https://github.com/ocaml/dune/issues/12250
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.19)
+  > EOF
+
+  $ mkdir -p somelib/my/path
+  $ cat > somelib/my/path/test.t <<EOF
+  >   $ echo hi
+  > EOF
+
+  $ dune runtest somelib/my/path/
+  File "somelib/my/path/test.t", line 1, characters 0-0:
+  Error: Files _build/default/somelib/my/path/test.t and
+  _build/default/somelib/my/path/test.t.corrected differ.
+  [1]
+
+dune runtest should be able to run in a subdirectory and the arguments passed
+to it should be adjusted accordingly.
+
+This is currently not the case:
+
+  $ (cd somelib && unset INSIDE_DUNE; dune runtest --diff-command=- my/path/)
+  Entering directory '$TESTCASE_ROOT'
+  Error: "my/path" does not match any known test.
+  Leaving directory '$TESTCASE_ROOT'
+  [1]
+
+


### PR DESCRIPTION
- **test: dune runtest in subdirectory**
- **fix(runtest): path interpretation in subdirectory**
