### PR TITLE
test: showcase impact of cache disabled

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
@@ -1,0 +1,130 @@
+Set up project and cache directory
+
+  $ echo "(lang dune 3.20)" > dune-project
+ 
+  $ cat > config <<EOF
+  > (lang dune 3.20)
+  > (cache enabled)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name foo))
+  > EOF
+
+  $ cat > foo.ml << EOF
+  > let f x y = x + y
+  > EOF
+
+  $ export DUNE_CACHE_ROOT=$(pwd)/dune_test_cache
+  $ mkdir $DUNE_CACHE_ROOT
+
+Initial build, populating cache
+
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  31 _build/log
+  $ ls $DUNE_CACHE_ROOT
+  files
+  meta
+  temp
+  values
+
+Second build, no-op as cache is warm
+
+  $ dune clean --config-file config
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+Build with --cache=disabled, which should be a no-op as _build is already populated
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  22 _build/log
+
+Second build with --cache=disabled, should be the same
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+Run the tests with cache except user rules
+
+  $ rm config
+  $ rm -rf $DUNE_CACHE_ROOT
+  $ mkdir $DUNE_CACHE_ROOT
+  $ cat > config <<EOF
+  > (lang dune 3.20)
+  > (cache enabled-except-user-rules)
+  > EOF
+
+Initial build, populating shared cache
+
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+  $ ls $DUNE_CACHE_ROOT
+  files
+  meta
+  temp
+  values
+
+Second build, no-op as cache is warm
+
+  $ dune clean --config-file config
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  22 _build/log
+
+Build with --cache=disabled, which should be a no-op as _build is already populated
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+Second build with --cache=disabled, should be the same
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+Run the tests without cache 
+
+  $ rm config
+  $ rm -rf $DUNE_CACHE_ROOT
+  $ mkdir $DUNE_CACHE_ROOT
+  $ cat > config <<EOF
+  > (lang dune 3.20)
+  > (cache enabled-except-user-rules)
+  > EOF
+
+Initial build, populating local cache
+
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+  $ ls $DUNE_CACHE_ROOT
+  files
+  meta
+  temp
+  values
+
+Second build, no-op as cache is warm
+
+  $ dune clean --config-file config
+  $ dune build --config-file config
+  $ wc -l _build/log 
+  22 _build/log
+
+Build with --cache=disabled, which should be a no-op as _build is already populated
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+Second build with --cache=disabled, should be the same
+
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log

--- a/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
@@ -37,13 +37,13 @@ Second build, no-op as cache is warm
   $ wc -l _build/log 
   17 _build/log
 
-Build with --cache=disabled, which should be a no-op as _build is already populated
+Build with --cache=disabled, which should be a no-op as _build is already populated. But unfortunately it is not.
 
   $ dune build --cache=disabled --config-file config
   $ wc -l _build/log 
   22 _build/log
 
-Second build with --cache=disabled, should be the same
+Second build with --cache=disabled, should be the same. Here we see it is really a no-op
 
   $ dune build --cache=disabled --config-file config
   $ wc -l _build/log 

--- a/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-disabled.t
@@ -49,6 +49,14 @@ Second build with --cache=disabled, should be the same
   $ wc -l _build/log 
   17 _build/log
 
+  $ dune clean
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  22 _build/log
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
 Run the tests with cache except user rules
 
   $ rm config
@@ -85,6 +93,14 @@ Build with --cache=disabled, which should be a no-op as _build is already popula
 
 Second build with --cache=disabled, should be the same
 
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+
+  $ dune clean
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  22 _build/log
   $ dune build --cache=disabled --config-file config
   $ wc -l _build/log 
   17 _build/log
@@ -128,3 +144,12 @@ Second build with --cache=disabled, should be the same
   $ dune build --cache=disabled --config-file config
   $ wc -l _build/log 
   17 _build/log
+
+  $ dune clean
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  22 _build/log
+  $ dune build --cache=disabled --config-file config
+  $ wc -l _build/log 
+  17 _build/log
+


### PR DESCRIPTION
Adding a test to show the different behaviors of `dune build --cache=disabled` depending on how the shared cache is setup.