### PR TITLE
Avoid using Poly.hash on Set and Map in pkg_rules

### DIFF
--- a/otherlibs/stdune/src/loc0.ml
+++ b/otherlibs/stdune/src/loc0.ml
@@ -65,6 +65,7 @@ let stop = function
 
 let compare = Poly.compare
 let equal = Poly.equal
+let hash = Poly.hash
 let none = No_loc
 
 let is_none = function

--- a/otherlibs/stdune/src/loc0.mli
+++ b/otherlibs/stdune/src/loc0.mli
@@ -11,6 +11,7 @@ val set_start : t -> Lexing.position -> t
 val stop : t -> Lexing.position
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
+val hash : t -> int
 val none : t
 val is_none : t -> bool
 val to_dyn : t -> Dyn.t

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -28,6 +28,7 @@ include (
   end) :
     Dune_util.Stringlike with type t := t)
 
+let hash t = String.hash (to_string t)
 let arch = of_string "arch"
 let os = of_string "os"
 let os_version = of_string "os-version"

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -15,6 +15,7 @@ module Set : Set.S with type elt = t and type 'a map = 'a Map.t
 
 val of_string : string -> t
 val to_string : t -> string
+val hash : t -> int
 val arch : t
 val os : t
 val os_version : t

--- a/src/dune_lang/package_version.mli
+++ b/src/dune_lang/package_version.mli
@@ -7,6 +7,7 @@ val of_string_opt : string -> t option
 val of_string_user_error : Loc.t * string -> (t, User_message.t) result
 val to_string : t -> string
 val equal : t -> t -> bool
+val hash : t -> int
 val to_dyn : t -> Dyn.t
 val encode : t Encoder.t
 val decode : t Decoder.t

--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -29,6 +29,7 @@ let pp v =
 ;;
 
 let equal = OpamHash.equal
+let hash = Poly.hash
 
 include Comparable.Make (struct
     type nonrec t = t

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -18,5 +18,6 @@ val of_md5 : Md5.t -> t
 
 val pp : t -> 'a Pp.t
 val equal : t -> t -> bool
+val hash : t -> int
 
 module Map : Map.S with type key = t

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -34,6 +34,8 @@ let equal a b =
   | Odig, Odig -> true
 ;;
 
+let hash = Poly.hash
+
 let package_name = function
   | Ocamlformat -> Package_name.of_string "ocamlformat"
   | Odoc -> Package_name.of_string "odoc"

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -11,6 +11,7 @@ type t =
 val to_dyn : t -> Dyn.t
 val all : t list
 val equal : t -> t -> bool
+val hash : t -> int
 val package_name : t -> Package_name.t
 val of_package_name : Package_name.t -> t
 val exe_name : t -> string

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -66,6 +66,7 @@ module Pkg : sig
 
   val remove_locs : t -> t
   val equal : t -> t -> bool
+  val hash : t -> int
   val to_dyn : t -> Dyn.t
 
   val decode

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -6,6 +6,7 @@ val of_string : string -> t
 val of_string_user_error : Loc.t * string -> (t, User_message.t) result
 val to_string : t -> string
 val equal : t -> t -> bool
+val hash : t -> int
 val to_dyn : t -> Dyn.t
 val encode : t Dune_lang.Encoder.t
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -11,6 +11,15 @@ end
 include T
 include Comparable.Make (T)
 
+let hash t =
+  Package_variable_name.Map.foldi t ~init:0 ~f:(fun key value running_hash ->
+    Tuple.T3.hash
+      Package_variable_name.hash
+      Variable_value.hash
+      Int.hash
+      (key, value, running_hash))
+;;
+
 let empty = Package_variable_name.Map.empty
 let is_empty = Package_variable_name.Map.is_empty
 

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -4,6 +4,7 @@ type t
 
 val empty : t
 val equal : t -> t -> bool
+val hash : t -> int
 val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val is_empty : t -> bool

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -31,6 +31,13 @@ let to_dyn { url = _loc, url; checksum } =
     ]
 ;;
 
+let hash { url; checksum } =
+  Tuple.T2.hash
+    (Tuple.T2.hash Loc.hash OpamUrl.hash)
+    (Option.hash (Tuple.T2.hash Loc.hash Checksum.hash))
+    (url, checksum)
+;;
+
 let fetch_archive_cached =
   let cache = Single_run_file_cache.create () in
   fun (url_loc, url) ->

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -9,6 +9,7 @@ val equal : t -> t -> bool
 val decode : (Path.External.t -> t) Dune_sexp.Decoder.t
 val encode : t -> Dune_sexp.t
 val to_dyn : t -> Dyn.t
+val hash : t -> int
 val remove_locs : t -> t
 val compute_missing_checksum : t -> Package_name.t -> pinned:bool -> t Fiber.t
 val external_copy : Loc.t * Path.External.t -> t

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -17,6 +17,7 @@ let true_ = "true"
 let false_ = "false"
 let string = Fun.id
 let equal = String.equal
+let hash = String.hash
 let compare = String.compare
 let to_dyn = Dyn.string
 let to_string = Fun.id

--- a/src/dune_pkg/variable_value.mli
+++ b/src/dune_pkg/variable_value.mli
@@ -9,6 +9,7 @@ val false_ : t
 val string : string -> t
 
 val equal : t -> t -> bool
+val hash : t -> int
 val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t


### PR DESCRIPTION
If two values are equal then their hashes must also be equal. `Hashtbl.hash` (or `Poly.hash` as its known in dune) can compute a hash for an arbitrary value by traversing its representation in memory, the so-called "structure" of the value. Thus if two values differ in their structure, their hashes will likely also differ.

Some OCaml types have a notion of equality which is looser than structural equality. That is, two values may be considered equal even if their representations differ. Common examples are Sets and Maps, which are implemented by self-balancing binary trees. The representation in memory of such data structures is dependent on the order in which values are inserted into them, however their equality is based entirely upon their contents. Using Sets of ints as an example `(add 1 (add 2 empty))` may be structurally different from `(add 2 (add 1 empty))` even though these values are considered to be equal.

Thus it is incorrect to use `Poly.hash` to compute the hash of a Set or Map.

This change updates the hash computation for the `Pkg_rules.DB.t` type to avoid the use of `Poly.hash` as well as several other types which comprise it.

Possibly related to https://github.com/ocaml/dune/issues/12244