### PR TITLE
Add fs-io as a dependency on stdune

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -202,11 +202,12 @@ understood by dune language."))
  (depends
   (ocaml (>= 4.08.0))
   base-unix
-  (top-closure (= :version))
+  (csexp (>= 1.5.0))
   (dyn (= :version))
+  (fs-io (= :version))
   (ordering (= :version))
   (pp (>= 2.0.0))
-  (csexp (>= 1.5.0)))
+  (top-closure (= :version)))
  (maintenance_intent none)
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 

--- a/stdune.opam
+++ b/stdune.opam
@@ -13,11 +13,12 @@ depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "4.08.0"}
   "base-unix"
-  "top-closure" {= version}
+  "csexp" {>= "1.5.0"}
   "dyn" {= version}
+  "fs-io" {= version}
   "ordering" {= version}
   "pp" {>= "2.0.0"}
-  "csexp" {>= "1.5.0"}
+  "top-closure" {= version}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"


### PR DESCRIPTION
Following #12176, `fs-io` is a new package that used to be part of stdune, and that stdune should depend upon.

Thanks to and cc @Alizter 