### PR TITLE
fix(pkg): stop marshalling maps

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/build-package-logs.t
+++ b/test/blackbox-tests/test-cases/pkg/build-package-logs.t
@@ -45,4 +45,4 @@ Building the package should succeed and print no output:
 Checks the package is installed:
 
   $ show_pkg_cookie y
-  { files = map {}; variables = [] }
+  { files = []; variables = [] }

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -33,9 +33,7 @@ Testing install actions
 
   $ show_pkg_cookie test
   { files =
-      map
-        { LIB_ROOT :
-            [ In_build_dir "_private/default/.pkg/test/target/lib/xxx" ]
-        }
+      [ (LIB_ROOT, [ In_build_dir "_private/default/.pkg/test/target/lib/xxx" ])
+      ]
   ; variables = []
   }

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -43,19 +43,14 @@ Test that installed binaries are visible in dependent packages
   /share/lib_rootxxx
   $ show_pkg_cookie test
   { files =
-      map
-        { LIB :
-            [ In_build_dir "_private/default/.pkg/test/target/lib/test/libxxx"
-            ]
-        ; LIB_ROOT :
-            [ In_build_dir "_private/default/.pkg/test/target/lib/lib_rootxxx"
-            ]
-        ; BIN : [ In_build_dir "_private/default/.pkg/test/target/bin/foo" ]
-        ; SHARE_ROOT :
-            [ In_build_dir
-                "_private/default/.pkg/test/target/share/lib_rootxxx"
-            ]
-        }
+      [ (LIB,
+         [ In_build_dir "_private/default/.pkg/test/target/lib/test/libxxx" ])
+      ; (LIB_ROOT,
+         [ In_build_dir "_private/default/.pkg/test/target/lib/lib_rootxxx" ])
+      ; (BIN, [ In_build_dir "_private/default/.pkg/test/target/bin/foo" ])
+      ; (SHARE_ROOT,
+         [ In_build_dir "_private/default/.pkg/test/target/share/lib_rootxxx" ])
+      ]
   ; variables = []
   }
 

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -40,7 +40,7 @@ Test that we can set variables
   version: 1.2.3
 
   $ show_pkg_cookie test
-  { files = map {}
+  { files = []
   ; variables =
       [ ("abool", Bool true)
       ; ("astring", String "foobar")

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -31,7 +31,7 @@ let%expect_test "persistent digests" =
     48031a13035ffa6b93b6b79ce277d39c
     ---
 
-    INSTALL-COOKIE version 2
+    INSTALL-COOKIE version 3
     da4ce847dd41df462849adecfe43f4eb
     ---
 


### PR DESCRIPTION
Serialize the install cookie with a list instead.

Convert maps to lists before digesting.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>