### PR TITLE
fix(ci): pin lwt to 5.9.1 for msvc to build

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -192,7 +192,10 @@ jobs:
       - run: opam exec -- make release
 
       - name: Install deps
+        # CR-soon Alizter: Lwt 5.9.2 breaks on msvc so we pin it here. Remove
+        # this when https://github.com/ocsigen/lwt/issues/1071 is fixed.
         run: |
+          opam pin add lwt 5.9.1 --no-action
           opam install . --deps-only --with-test
           opam exec -- make dev-deps
         if: ${{ matrix.run_tests }}


### PR DESCRIPTION
Until https://github.com/ocsigen/lwt/issues/1071 is fixed, we will have to pin our version of lwt here so that we can continue to build on msvc.