### PR TITLE
fix(cram): make sure directory is empty during cram execution

### DIFF
--- a/doc/changes/12329.md
+++ b/doc/changes/12329.md
@@ -1,0 +1,2 @@
+- Remove empty `.cram.test.t` directory during the running of a cram test.
+  (#12329, fixes #12321, @Alizter)

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -470,14 +470,19 @@ let run_and_produce_output ~src ~env ~dir:cwd ~script ~dst ~timeout =
   let lexbuf = Lexbuf.from_string script_contents ~fname:(Path.to_string script) in
   let temp_dir = make_temp_dir ~script in
   let cram_stanzas = cram_stanzas lexbuf in
-  Path.unlink_exn script;
+  (* We don't want the ".cram.run.t" dir around when executing the script. *)
+  Path.rm_rf (Path.parent_exn script);
   let env = make_run_env env ~temp_dir ~cwd in
   let open Fiber.O in
-  run_cram_test env ~src ~script ~cram_stanzas ~temp_dir ~cwd ~timeout
-  >>| List.filter_map ~f:(function
-    | Cram_lexer.Command c -> Some c
-    | Comment _ -> None)
-  >>| Script.dump (Path.build dst)
+  let+ commands =
+    run_cram_test env ~src ~script ~cram_stanzas ~temp_dir ~cwd ~timeout
+    >>| List.filter_map ~f:(function
+      | Cram_lexer.Command c -> Some c
+      | Comment _ -> None)
+  in
+  let dst = Path.build dst in
+  Path.mkdir_p (Path.parent_exn dst);
+  Script.dump dst commands
 ;;
 
 module Run = struct

--- a/test/blackbox-tests/test-cases/cram/test-dir-contents.t
+++ b/test/blackbox-tests/test-cases/cram/test-dir-contents.t
@@ -16,7 +16,6 @@ Demonstrate the files and directories listed in a cram test:
   $ cat test.t
     $ find . | sort
     .
-    ./.cram.test.t
 
   $ ls _build/default | sort
   test.t
@@ -24,14 +23,20 @@ Demonstrate the files and directories listed in a cram test:
 Now repeat the test for a test defined using a directory:
 
   $ mkdir foo.t
-  $ touch foo.t/run.t
-  $ cat >test.t <<EOF
+  $ cat >foo.t/run.t <<EOF
   >   $ find . | sort
   > EOF
 
   $ dune runtest foo.t
+  File "foo.t/run.t", line 1, characters 0-0:
+  Error: Files _build/default/foo.t/run.t and
+  _build/default/foo.t/run.t.corrected differ.
+  [1]
   $ dune promote
+  Promoting _build/default/foo.t/run.t.corrected to foo.t/run.t.
   $ cat foo.t/run.t
+    $ find . | sort
+    .
   $ ( cd _build/default/foo.t && find . | sort )
   .
   ./run.t


### PR DESCRIPTION
- fix https://github.com/ocaml/dune/issues/12321
- [x] changelog
