### PR TITLE
test: enable wasmoo inline-tests on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test: $(BIN)
 	$(BIN) runtest
 
 test-windows: $(BIN)
-	$(BIN) build @runtest-windows
+	DUNE_WASM_TEST=enable $(BIN) build @runtest-windows
 
 test-js: $(BIN)
 	$(BIN) build @runtest-js

--- a/test/blackbox-tests/test-cases/wasmoo/dune
+++ b/test/blackbox-tests/test-cases/wasmoo/dune
@@ -6,6 +6,10 @@
   (= %{env:DUNE_WASM_TEST=disable} enable)))
 
 (cram
+ (applies_to inline-tests)
+ (alias runtest-windows))
+
+(cram
  (applies_to build-info)
  (deps
   (package dune-build-info)))


### PR DESCRIPTION
TODO
- enable wasmoo tests with env var on windows (currently not set)