### PR TITLE
refactor(cram): track locations inside cram lexer

### DIFF
--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -23,6 +23,6 @@ val diff : src:Path.t -> output:Path.t -> Action.t
 val action : Path.t -> Action.t
 
 module For_tests : sig
-  val cram_stanzas : Lexing.lexbuf -> string list Cram_lexer.block list
+  val cram_stanzas : Lexing.lexbuf -> (Loc.t * string list Cram_lexer.block) list
   val dyn_of_block : string list Cram_lexer.block -> Dyn.t
 end

--- a/src/dune_rules/cram/cram_lexer.mli
+++ b/src/dune_rules/cram/cram_lexer.mli
@@ -1,3 +1,5 @@
+open Import
+
 (** .t file parser *)
 
 (** A command or comment. Output blocks are skipped *)
@@ -5,4 +7,4 @@ type 'command block =
   | Command of 'command
   | Comment of string list
 
-val block : Lexing.lexbuf -> string list block option
+val block : Lexing.lexbuf -> (Loc.t * string list block) option

--- a/src/dune_rules/cram/cram_lexer.mll
+++ b/src/dune_rules/cram/cram_lexer.mll
@@ -1,67 +1,146 @@
 {
+open Import
+
 type 'command block =
   | Command of 'command
   | Comment of string list
+
+(* Creates location from lexbuf *)
+let loc lexbuf =
+  Loc.create ~start:(Lexing.lexeme_start_p lexbuf) ~stop:(Lexing.lexeme_end_p lexbuf)
+[@@inline]
+
+(* Adjusts the start position by an offset *)
+let adjust_start_cnum offset loc =
+  let start = Loc.start loc in
+  let start = { start with pos_cnum = start.pos_cnum + offset } in
+  Loc.set_start loc start
+[@@inline]
+
+(* Creates location for "  $ " pattern, adjusting past the "  $ " prefix *)
+let loc_of_dollar lexbuf =
+  loc lexbuf |> adjust_start_cnum 2
+[@@inline]
+
+(* Gets position before consuming newline *)
+let pos_before_newline lexbuf =
+  let pos = Lexing.lexeme_end_p lexbuf in
+  { pos with pos_cnum = pos.pos_cnum - 1 }
+[@@inline]
+
+(* Creates comment from string list accumulator *)
+let create_comment_from_acc loc acc =
+  match acc with
+  | [] -> None
+  | _ -> Some (loc, Comment (List.rev acc))
+[@@inline]
 }
 
-let eol = '\n' | eof
-
-let blank = [' ' '\t' '\r' '\012']
+let nonspace = [^' ' '\n']
+let not_nl  = [^'\n']
 
 rule block = parse
   | eof { None }
-  | "  $ " ([^'\n']* as str) eol
-    { Some (command_cont [str] lexbuf) }
-  | "  " [^'\n']* eol
-    { output [] lexbuf }
-  | ' '? as str eol
-    { comment [str] lexbuf }
-  | ' '? [^' ' '\n'] [^'\n']* as str eol
-    { comment [str] lexbuf }
+  | "  $ " ([^'\n']* as str)
+    { eol_then_command_or_finish (loc_of_dollar lexbuf) str lexbuf }
+  | "  > " ([^'\n']* as str)
+    { after_comment_line (loc lexbuf) [ "  > " ^ str ] lexbuf }
+  | "  >"
+    { after_comment_line (loc lexbuf) [ "  >" ] lexbuf }
+  | "  " [^'\n']*
+    { after_output_line (loc lexbuf) lexbuf }
+  | ' ' ((nonspace not_nl*) as rest)
+    { after_comment_line (loc lexbuf) [ " " ^ rest ] lexbuf }
+  | ' ' '\n'
+    { let loc = loc lexbuf in
+      let loc = Loc.set_stop loc (pos_before_newline lexbuf) in
+      Lexing.new_line lexbuf;
+      comment loc [ " " ] lexbuf }
+  | ' '
+    { comment (loc lexbuf) [ " " ] lexbuf }
+  | '\n'
+    { let loc = loc lexbuf in
+      let loc = Loc.set_stop loc (Loc.start loc) in
+      Lexing.new_line lexbuf;
+      comment loc [ "" ] lexbuf }
+  | nonspace not_nl* as str
+    { after_comment_line (loc lexbuf) [str] lexbuf }
 
-and comment acc = parse
+and after_comment_line loc content = parse
+  | '\n' { Lexing.new_line lexbuf; comment loc content lexbuf }
+  | eof  { comment loc content lexbuf }
+
+and after_output_line loc = parse
+  | '\n' { Lexing.new_line lexbuf; output loc [] lexbuf }
+  | eof  { output loc [] lexbuf }
+
+and eol_then_command_or_finish loc str = parse
+  | '\n' { Lexing.new_line lexbuf; Some (command_cont loc [ str ] lexbuf) }
+  | eof  { Some (loc, Command [ str ]) }
+
+and comment loc acc = parse
   | eof
-    { match acc with
-    | [] -> None
-    | _ -> Some (Comment (List.rev acc))
-    }
-  | ' '? as str eol
-    { comment (str :: acc) lexbuf }
-  | ' '? [^' ' '\n'] [^'\n']* as str eol
-    { comment (str :: acc) lexbuf }
-  | ""
-    { Some (Comment (List.rev acc)) }
+    { create_comment_from_acc loc acc }
+  | ' ' ((nonspace not_nl*) as rest)
+    { let loc = Loc.set_stop loc (Lexing.lexeme_end_p lexbuf) in
+      after_comment_line_in_comment loc (" " ^ rest) acc lexbuf }
+  | ' ' '\n'
+    { let loc = Loc.set_stop loc (pos_before_newline lexbuf) in
+      Lexing.new_line lexbuf;
+      comment loc (" " :: acc) lexbuf }
+  | '\n'
+    { let loc = Loc.set_stop loc (Lexing.lexeme_start_p lexbuf) in
+      Lexing.new_line lexbuf;
+      comment loc ("" :: acc) lexbuf }
+  | nonspace not_nl* as str
+    { let loc = Loc.set_stop loc (Lexing.lexeme_end_p lexbuf) in
+      after_comment_line_in_comment loc str acc lexbuf }
+  | "" { create_comment_from_acc loc acc }
 
-and output maybe_comment = parse
+and after_comment_line_in_comment loc str acc = parse
+  | '\n' { Lexing.new_line lexbuf; comment loc (str :: acc) lexbuf }
+  | eof  { comment loc (str :: acc) lexbuf }
+
+and output loc maybe_comment = parse
   | eof
-    { match maybe_comment with
-    | [] -> None
-    | l -> Some (Comment (List.rev l))
-    }
-  | ' ' eof
-    { Some (Comment (List.rev (" " :: maybe_comment))) }
-  | "  "? eof
-    { None }
-  | "  " eol
-    { output [] lexbuf }
-  | ' '? as s eol
-    { output (s :: maybe_comment) lexbuf }
-  | "  $" eol
-    { output [] lexbuf }
-  | "  " '$' [^' ' '\n'] [^'\n']* eol
-    { output [] lexbuf }
-  | "  " [^'$' '\n'] [^'\n']* eol
-    { output [] lexbuf }
+    { let loc = Loc.set_stop loc (Lexing.lexeme_start_p lexbuf) in
+      create_comment_from_acc loc maybe_comment }
+  | "  $ " ([^'\n']* as str)
+    { eol_then_command_or_finish (loc_of_dollar lexbuf) str lexbuf }
+  | ' ' ((nonspace not_nl*) as rest)
+    { check_eol_for_output loc ((" " ^ rest) :: maybe_comment) lexbuf }
+  | ' ' '\n'
+    { Lexing.new_line lexbuf;
+      output loc (" " :: maybe_comment) lexbuf }
+  | "  " [^'\n']*
+    { after_output_line_in_output loc maybe_comment lexbuf }
   | ""
     { match maybe_comment with
-    | [] -> block lexbuf
-    | l -> comment l lexbuf
-    }
+      | [] -> block lexbuf
+      | l ->
+        let loc = Loc.set_stop loc (Lexing.lexeme_start_p lexbuf) in
+        comment loc l lexbuf }
 
-and command_cont acc = parse
-  | "  > " ([^'\n']* as str) eol
-    { command_cont (str :: acc) lexbuf }
-  | "  >" eol
-    { command_cont ("" :: acc) lexbuf }
+and after_output_line_in_output loc maybe_comment = parse
+  | '\n' { Lexing.new_line lexbuf; output loc maybe_comment lexbuf }
+  | eof  { output loc maybe_comment lexbuf }
+
+and check_eol_for_output loc maybe_comment = parse
+  | '\n' { Lexing.new_line lexbuf; output loc maybe_comment lexbuf }
+  | eof  {
+    let loc = Loc.set_stop loc (Lexing.lexeme_start_p lexbuf) in
+    Some (loc, Comment (List.rev maybe_comment)) }
+
+and command_cont loc acc = parse
+  | "  > " ([^'\n']* as str)
+    { let loc = Loc.set_stop loc (Lexing.lexeme_end_p lexbuf) in
+      eol_then_continue_or_finish loc str acc lexbuf }
+  | "  >"
+    { let loc = Loc.set_stop loc (Lexing.lexeme_end_p lexbuf) in
+      eol_then_continue_or_finish loc "" acc lexbuf }
   | ""
-    { Command (List.rev acc)  }
+    { (loc, Command (List.rev acc)) }
+
+and eol_then_continue_or_finish loc content acc = parse
+  | '\n' { Lexing.new_line lexbuf; command_cont loc (content :: acc) lexbuf }
+  | eof  { (loc, Command (List.rev (content :: acc))) }

--- a/test/expect-tests/dune_rules/cram_parsing_tests.ml
+++ b/test/expect-tests/dune_rules/cram_parsing_tests.ml
@@ -3,115 +3,437 @@ open Dune_rules.For_tests.Cram_exec.For_tests
 
 let () = Dune_tests_common.init ()
 
+let with_chdir dir f =
+  let old_cwd = Sys.getcwd () in
+  Sys.chdir (Path.to_string dir);
+  Exn.protect ~f ~finally:(fun () -> Sys.chdir old_cwd)
+;;
+
 let test content =
-  Lexing.from_string content
-  |> cram_stanzas
-  |> Dyn.list dyn_of_block
-  |> Dyn.pp
-  |> List.singleton
-  |> Dune_console.print
+  Temp.with_temp_dir
+    ~parent_dir:(Path.of_string (Sys.getcwd ()))
+    ~prefix:"cram_test"
+    ~suffix:""
+    ~f:(fun temp_dir_result ->
+      let temp_dir = Result.ok_exn temp_dir_result in
+      with_chdir temp_dir
+      @@ fun () ->
+      let test_file = Path.relative temp_dir "test.t" in
+      Io.write_file test_file content;
+      let lexbuf = Lexing.from_string ~with_positions:true content in
+      Stdlib.Lexing.set_filename lexbuf (Path.basename test_file);
+      cram_stanzas lexbuf
+      |> Pp.concat_map ~sep:Pp.cut ~f:(fun (loc, block) ->
+        [ Loc.pp loc; dyn_of_block block |> Dyn.pp; Loc.to_dyn loc |> Dyn.pp ]
+        |> Pp.concat ~sep:Pp.cut
+        |> Pp.vbox)
+      |> Pp.map_tags ~f:(fun _ -> User_message.Style.Loc)
+      |> List.singleton
+      |> Dune_console.print)
 ;;
 
 let%expect_test "simple single line command" =
   test "  $ echo 'Hello world'";
-  [%expect {| [ Command [ "echo 'Hello world'" ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-22:
+    1 |   $ echo 'Hello world'
+          ^^^^^^^^^^^^^^^^^^^^
+
+    Command [ "echo 'Hello world'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 22 }
+    }
+    |}];
   test "  $ echo 'Hello world'\n";
-  [%expect {| [ Command [ "echo 'Hello world'" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-22:
+    1 |   $ echo 'Hello world'
+          ^^^^^^^^^^^^^^^^^^^^
+
+    Command [ "echo 'Hello world'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 22 }
+    }
+    |}]
 ;;
 
 let%expect_test "command with single continuation" =
   test "  $ echo 'Hello'\n  > echo 'World!'";
-  [%expect {| [ Command [ "echo 'Hello'"; "echo 'World!'" ] ] |}];
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 2-34:
+    1 |   $ echo 'Hello'
+    2 |   > echo 'World!'
+
+    Command [ "echo 'Hello'"; "echo 'World!'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 2; pos_bol = 17; pos_cnum = 34 }
+    }
+    |}];
   test "  $ echo 'Hello'\n  > echo 'World!'\n";
-  [%expect {| [ Command [ "echo 'Hello'"; "echo 'World!'" ] ] |}]
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 2-34:
+    1 |   $ echo 'Hello'
+    2 |   > echo 'World!'
+
+    Command [ "echo 'Hello'"; "echo 'World!'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 2; pos_bol = 17; pos_cnum = 34 }
+    }
+    |}]
 ;;
 
 let%expect_test "command with empty continutation" =
   test "  $ echo 'Hello..'\n  >";
-  [%expect {| [ Command [ "echo 'Hello..'"; "" ] ] |}];
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 2-22:
+    1 |   $ echo 'Hello..'
+    2 |   >
+
+    Command [ "echo 'Hello..'"; "" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 2; pos_bol = 19; pos_cnum = 22 }
+    }
+    |}];
   test "  $ echo 'Hello..'\n  >\n";
-  [%expect {| [ Command [ "echo 'Hello..'"; "" ] ] |}]
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 2-22:
+    1 |   $ echo 'Hello..'
+    2 |   >
+
+    Command [ "echo 'Hello..'"; "" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 2; pos_bol = 19; pos_cnum = 22 }
+    }
+    |}]
 ;;
 
 (* Output lines are not parsed. They are skipped. When we run a cram test, we
    re-output the results and reassemble the cram test. *)
 let%expect_test "command followed by output lines" =
   test "  $ echo 'Hi'\n  Hi";
-  [%expect {| [ Command [ "echo 'Hi'" ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-13:
+    1 |   $ echo 'Hi'
+          ^^^^^^^^^^^
+
+    Command [ "echo 'Hi'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 13 }
+    }
+    |}];
   test "  $ echo 'Hi'\n  Hi\n";
-  [%expect {| [ Command [ "echo 'Hi'" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-13:
+    1 |   $ echo 'Hi'
+          ^^^^^^^^^^^
+
+    Command [ "echo 'Hi'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 13 }
+    }
+    |}]
 ;;
 
 let%expect_test "empty output following a command" =
   test "  $ echo 'Hi'\n  ";
-  [%expect {| [ Command [ "echo 'Hi'" ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-13:
+    1 |   $ echo 'Hi'
+          ^^^^^^^^^^^
+
+    Command [ "echo 'Hi'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 13 }
+    }
+    |}];
   test "  $ echo 'Hi'\n  \n";
-  [%expect {| [ Command [ "echo 'Hi'" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-13:
+    1 |   $ echo 'Hi'
+          ^^^^^^^^^^^
+
+    Command [ "echo 'Hi'" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 13 }
+    }
+    |}]
 ;;
 
 let%expect_test "loose output lines only" =
   test "  orphan\n  output";
-  [%expect {| [] |}];
+  [%expect {| |}];
   test "  orphan\n  output\n";
-  [%expect {| [] |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "single-space and text is a comment line" =
   test " foo";
-  [%expect {| [ Comment [ " foo" ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-4:
+    1 |  foo
+        ^^^^
+
+    Comment [ " foo" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 4 }
+    }
+    |}];
   test " foo\n";
-  [%expect {| [ Comment [ " foo" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-4:
+    1 |  foo
+        ^^^^
+
+    Comment [ " foo" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 4 }
+    }
+    |}]
 ;;
 
 let%expect_test "line with a single space only" =
   test " ";
-  [%expect {| [ Comment [ " " ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-1:
+    1 |
+        ^
+
+    Comment [ " " ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 1 }
+    }
+    |}];
   test " \n";
-  [%expect {| [ Comment [ " " ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-1:
+    1 |
+        ^
+
+    Comment [ " " ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 1 }
+    }
+    |}]
 ;;
 
 let%expect_test "empty becomes empty" =
   test "";
-  [%expect {| [] |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "blank line becomes empty-string comment" =
   test "\n";
-  [%expect {| [ Comment [ "" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-0:
+
+    Comment [ "" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    }
+    |}]
 ;;
 
 let%expect_test "group consecutive comment lines" =
   test "First line\nSecond line";
-  [%expect {| [ Comment [ "First line"; "Second line" ] ] |}];
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 0-22:
+    1 | First line
+    2 | Second line
+
+    Comment [ "First line"; "Second line" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 2; pos_bol = 11; pos_cnum = 22 }
+    }
+    |}];
   test "First line\nSecond line\n";
-  [%expect {| [ Comment [ "First line"; "Second line" ] ] |}]
+  [%expect
+    {|
+    File "test.t", lines 1-2, characters 0-22:
+    1 | First line
+    2 | Second line
+
+    Comment [ "First line"; "Second line" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 2; pos_bol = 11; pos_cnum = 22 }
+    }
+    |}]
 ;;
 
 let%expect_test "comment then command" =
   test "Intro text\n  $ cmd";
-  [%expect {| [ Comment [ "Intro text" ]; Command [ "cmd" ] ] |}];
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-10:
+    1 | Intro text
+        ^^^^^^^^^^
+
+    Comment [ "Intro text" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 10 }
+    }
+    File "test.t", line 2, characters 2-7:
+    2 |   $ cmd
+          ^^^^^
+
+    Command [ "cmd" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 2; pos_bol = 11; pos_cnum = 13 }
+    ; stop = { pos_lnum = 2; pos_bol = 11; pos_cnum = 18 }
+    }
+    |}];
   test "Intro text\n  $ cmd\n";
-  [%expect {| [ Comment [ "Intro text" ]; Command [ "cmd" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-10:
+    1 | Intro text
+        ^^^^^^^^^^
+
+    Comment [ "Intro text" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 10 }
+    }
+    File "test.t", line 2, characters 2-7:
+    2 |   $ cmd
+          ^^^^^
+
+    Command [ "cmd" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 2; pos_bol = 11; pos_cnum = 13 }
+    ; stop = { pos_lnum = 2; pos_bol = 11; pos_cnum = 18 }
+    }
+    |}]
 ;;
 
 let%expect_test "orphan output lines before command" =
   test "  ignored\n  also ignored\n  $ real\n";
-  [%expect {| [ Command [ "real" ] ] |}]
+  [%expect
+    {|
+    File "test.t", line 3, characters 2-8:
+    3 |   $ real
+          ^^^^^^
+
+    Command [ "real" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 3; pos_bol = 25; pos_cnum = 27 }
+    ; stop = { pos_lnum = 3; pos_bol = 25; pos_cnum = 33 }
+    }
+    |}]
 ;;
 
 let%expect_test "mixed document" =
   test "Doc line A\nDoc line B\n  $ echo one\n  one\n\n  $ echo two\n  two\n";
   [%expect
     {|
-    [ Comment [ "Doc line A"; "Doc line B" ]
-    ; Command [ "echo one" ]
-    ; Comment [ "" ]
-    ; Command [ "echo two" ]
-    ]
+    File "test.t", lines 1-2, characters 0-21:
+    1 | Doc line A
+    2 | Doc line B
+
+    Comment [ "Doc line A"; "Doc line B" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 2; pos_bol = 11; pos_cnum = 21 }
+    }
+    File "test.t", line 3, characters 2-12:
+    3 |   $ echo one
+          ^^^^^^^^^^
+
+    Command [ "echo one" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 3; pos_bol = 22; pos_cnum = 24 }
+    ; stop = { pos_lnum = 3; pos_bol = 22; pos_cnum = 34 }
+    }
+    File "test.t", line 5, characters 0-0:
+
+    Comment [ "" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 5; pos_bol = 41; pos_cnum = 41 }
+    ; stop = { pos_lnum = 5; pos_bol = 41; pos_cnum = 41 }
+    }
+    File "test.t", line 6, characters 2-12:
+    6 |   $ echo two
+          ^^^^^^^^^^
+
+    Command [ "echo two" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 6; pos_bol = 42; pos_cnum = 44 }
+    ; stop = { pos_lnum = 6; pos_bol = 42; pos_cnum = 54 }
+    }
     |}]
 ;;
 
 let%expect_test "comments separated by new line" =
   test "Comment 1\n\nComment 2\n";
-  [%expect {| [ Comment [ "Comment 1"; ""; "Comment 2" ] ] |}]
+  [%expect
+    {|
+    File "test.t", lines 1-3, characters 0-20:
+    1 | Comment 1
+    2 |
+    3 | Comment 2
+
+    Comment [ "Comment 1"; ""; "Comment 2" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 3; pos_bol = 11; pos_cnum = 20 }
+    }
+    |}]
+;;
+
+let%expect_test "stray command continuation is a comment" =
+  test "  > stray\n  $ cmd";
+  [%expect
+    {|
+    File "test.t", line 1, characters 0-9:
+    1 |   > stray
+        ^^^^^^^^^
+
+    Comment [ "  > stray" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 9 }
+    }
+    File "test.t", line 2, characters 2-7:
+    2 |   $ cmd
+          ^^^^^
+
+    Command [ "cmd" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 2; pos_bol = 10; pos_cnum = 12 }
+    ; stop = { pos_lnum = 2; pos_bol = 10; pos_cnum = 17 }
+    }
+    |}]
 ;;


### PR DESCRIPTION
In this PR, we enrich the cram test lexer with location information. In order to do this, we need to modify how lines are being lexed so that we can increment the line count correctly.

The tests introduced in #12334 give us some guarantees that we are preserving behaviour. 

The motivation for this change is to allow for better error messages related to cram tests. For example, in a future PR we may enrich the timeout error with the exact location of the timed out command.
