### PR TITLE
feat(oxcaml): add parameters field for libraries

### DIFF
--- a/doc/reference/dune/library.rst
+++ b/doc/reference/dune/library.rst
@@ -217,6 +217,14 @@ order to declare a multi-directory library, you need to use the
 
    See :doc:`/virtual-libraries` or :doc:`/reference/dune/library_parameter`.
 
+.. describe:: (parameters <library-parameter-names>)
+
+   List the library parameters used by the library and its dependencies.
+
+   This feature is experimental and requires the compiler you are using to
+   support parameterized libraries.
+   See :doc:`/reference/dune/library_parameter`.
+
 .. describe:: (js_of_ocaml ...)
 
    Sets options for JavaScript compilation, see :ref:`jsoo-field`.

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -88,6 +88,7 @@ type t =
   ; requires_hidden : Lib.t list Resolve.Memo.t
   ; requires_link : Lib.t list Resolve.t Memo.Lazy.t
   ; implements : Virtual_rules.t
+  ; parameters : Module_name.t list Resolve.Memo.t
   ; includes : Includes.t
   ; preprocessing : Pp_spec.t
   ; opaque : bool
@@ -112,6 +113,7 @@ let flags t = t.flags
 let requires_compile t = t.requires_compile
 let requires_hidden t = t.requires_hidden
 let requires_link t = Memo.Lazy.force t.requires_link
+let parameters t = t.parameters
 let includes t = t.includes
 let preprocessing t = t.preprocessing
 let opaque t = t.opaque
@@ -128,6 +130,19 @@ let context t = Super_context.context t.super_context
 let dep_graphs t = t.modules.dep_graphs
 let ocaml t = t.ocaml
 
+let parameters_main_modules parameters =
+  let open Resolve.Memo.O in
+  let* parameters = parameters in
+  Resolve.Memo.List.map parameters ~f:(fun param ->
+    let+ main = Lib.main_module_name param in
+    match main with
+    | Some main -> main
+    | None ->
+      Code_error.raise
+        "Expected library parameter to have a main module"
+        [ "param", Lib.to_dyn param ])
+;;
+
 let create
       ~super_context
       ~scope
@@ -143,6 +158,7 @@ let create
       ~package
       ~melange_package_name
       ?(implements = Virtual_rules.no_implements)
+      ?parameters
       ?modes
       ?bin_annot
       ?loc
@@ -165,6 +181,11 @@ let create
         List.filter requires_link ~f:(fun l -> not (Table.mem requires_table l))
       in
       requires_compile, requires_hidden
+  in
+  let parameters =
+    match parameters with
+    | None -> Resolve.Memo.return []
+    | Some parameters -> parameters_main_modules parameters
   in
   let sandbox = Sandbox_config.no_special_requirements in
   let modes =
@@ -201,6 +222,7 @@ let create
   ; requires_hidden = hidden_requires
   ; requires_link
   ; implements
+  ; parameters
   ; includes =
       Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
   ; preprocessing

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -34,6 +34,7 @@ val create
   -> package:Package.t option
   -> melange_package_name:Lib_name.t option
   -> ?implements:Virtual_rules.t
+  -> ?parameters:Lib.t list Resolve.Memo.t
   -> ?modes:Mode_conf.Set.Details.t Lib_mode.Map.t
   -> ?bin_annot:bool
   -> ?loc:Loc.t
@@ -57,6 +58,7 @@ val flags : t -> Ocaml_flags.t
 val requires_link : t -> Lib.t list Resolve.Memo.t
 val requires_hidden : t -> Lib.t list Resolve.Memo.t
 val requires_compile : t -> Lib.t list Resolve.Memo.t
+val parameters : t -> Module_name.t list Resolve.Memo.t
 val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 val preprocessing : t -> Pp_spec.t
 val opaque : t -> bool

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -92,6 +92,7 @@ module Lib = struct
     let sub_systems = Lib_info.sub_systems info in
     let plugins = Lib_info.plugins info in
     let requires = Lib_info.requires info in
+    let parameters = Lib_info.parameters info in
     let foreign_objects =
       match Lib_info.foreign_objects info with
       | External e -> e
@@ -138,6 +139,7 @@ module Lib = struct
        ; paths "jsoo_runtime" jsoo_runtime
        ; paths "wasmoo_runtime" wasmoo_runtime
        ; Lib_dep.L.field_encode requires ~name:"requires"
+       ; field_l "parameters" (no_loc Lib_name.encode) parameters
        ; libs "ppx_runtime_deps" ppx_runtime_deps
        ; field_o "implements" (no_loc Lib_name.encode) implements
        ; field_o "default_implementation" (no_loc Lib_name.encode) default_implementation
@@ -228,6 +230,7 @@ module Lib = struct
        and+ wasmoo_runtime = paths "wasmoo_runtime"
        and+ melange_runtime_deps = paths "melange_runtime_deps"
        and+ requires = field_l "requires" (Lib_dep.decode ~allow_re_export:true)
+       and+ parameters = field "parameters" ~default:[] (repeat (located Lib_name.decode))
        and+ ppx_runtime_deps = libs "ppx_runtime_deps"
        and+ sub_systems = Sub_system_info.record_parser
        and+ orig_src_dir = field_o "orig_src_dir" path
@@ -280,6 +283,7 @@ module Lib = struct
            ~main_module_name
            ~sub_systems
            ~requires
+           ~parameters
            ~foreign_objects
            ~public_headers
            ~plugins

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -141,6 +141,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
     let dune_version = None in
     let virtual_deps = [] in
     let implements = None in
+    let parameters = [] in
     let orig_src_dir = None in
     let main_module_name : Lib_info.Main_module_name.t = This None in
     let enabled = Memo.return Lib_info.Enabled_status.Normal in
@@ -253,6 +254,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
       ~main_module_name
       ~sub_systems
       ~requires
+      ~parameters
       ~foreign_objects
       ~public_headers
       ~plugins

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -12,6 +12,7 @@ val to_dyn : t -> Dyn.t
 val name : t -> Lib_name.t
 
 val implements : t -> t Resolve.Memo.t option
+val parameters : t -> t list Resolve.Memo.t
 
 (** [is_local t] returns [true] whenever [t] is defined in the local workspace *)
 val is_local : t -> bool

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -318,6 +318,7 @@ type 'path t =
   ; jsoo_runtime : 'path list
   ; wasmoo_runtime : 'path list
   ; requires : Lib_dep.t list
+  ; parameters : (Loc.t * Lib_name.t) list
   ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
   ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
   ; enabled : Enabled_status.t Memo.t
@@ -345,6 +346,7 @@ let version t = t.version
 let dune_version t = t.dune_version
 let loc t = t.loc
 let requires t = t.requires
+let parameters t = t.parameters
 let preprocess t = t.preprocess
 let ppx_runtime_deps t = t.ppx_runtime_deps
 let sub_systems t = t.sub_systems
@@ -404,6 +406,7 @@ let create
       ~main_module_name
       ~sub_systems
       ~requires
+      ~parameters
       ~foreign_objects
       ~public_headers
       ~plugins
@@ -441,6 +444,7 @@ let create
   ; version
   ; synopsis
   ; requires
+  ; parameters
   ; main_module_name
   ; foreign_objects
   ; public_headers
@@ -537,6 +541,7 @@ let to_dyn
       ; version
       ; synopsis
       ; requires
+      ; parameters
       ; main_module_name
       ; foreign_objects
       ; public_headers
@@ -589,6 +594,7 @@ let to_dyn
     ; "jsoo_runtime", list path jsoo_runtime
     ; "wasmoo_runtime", list path wasmoo_runtime
     ; "requires", list Lib_dep.to_dyn requires
+    ; "parameters", list (snd Lib_name.to_dyn) parameters
     ; "ppx_runtime_deps", list (snd Lib_name.to_dyn) ppx_runtime_deps
     ; "virtual_deps", list (snd Lib_name.to_dyn) virtual_deps
     ; "dune_version", option Dune_lang.Syntax.Version.to_dyn dune_version
@@ -627,6 +633,7 @@ let for_dune_package
       ~foreign_objects
       ~obj_dir
       ~implements
+      ~parameters
       ~default_implementation
       ~sub_systems
       ~melange_runtime_deps
@@ -658,6 +665,7 @@ let for_dune_package
   ; foreign_objects
   ; obj_dir
   ; implements
+  ; parameters
   ; default_implementation
   ; sub_systems
   ; orig_src_dir

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -149,6 +149,7 @@ val modes : _ t -> Lib_mode.Map.Set.t
 val modules : _ t -> Modules.With_vlib.t option Source.t
 val implements : _ t -> (Loc.t * Lib_name.t) option
 val requires : _ t -> Lib_dep.t list
+val parameters : _ t -> (Loc.t * Lib_name.t) list
 val ppx_runtime_deps : _ t -> (Loc.t * Lib_name.t) list
 val preprocess : _ t -> Preprocess.With_instrumentation.t Preprocess.Per_module.t
 val sub_systems : _ t -> Sub_system_info.t Sub_system_name.Map.t
@@ -177,6 +178,7 @@ val for_dune_package
   -> foreign_objects:Path.t list
   -> obj_dir:Path.t Obj_dir.t
   -> implements:(Loc.t * Lib_name.t) option
+  -> parameters:(Loc.t * Lib_name.t) list
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
   -> melange_runtime_deps:Path.t list
@@ -203,6 +205,7 @@ val create
   -> main_module_name:Main_module_name.t
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
   -> requires:Lib_dep.t list
+  -> parameters:(Loc.t * Lib_name.t) list
   -> foreign_objects:'a list Source.t
   -> public_headers:'a File_deps.t
   -> plugins:'a list Mode.Dict.t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -487,7 +487,16 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
     (fun () -> build_shared ~native_archives ~sctx lib ~dir ~flags)
 ;;
 
-let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_info =
+let cctx
+      (lib : Library.t)
+      ~sctx
+      ~source_modules
+      ~dir
+      ~expander
+      ~scope
+      ~parameters
+      ~compile_info
+  =
   let* flags = Buildable_rules.ocaml_flags sctx ~dir lib.buildable.flags
   and* implements = Virtual_rules.impl sctx ~lib ~scope in
   let obj_dir = Library.obj_dir ~dir lib in
@@ -534,6 +543,7 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope ~compile_
     ~requires_compile
     ~requires_link
     ~implements
+    ~parameters
     ~preprocessing:pp
     ~opaque:Inherit_from_settings
     ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
@@ -648,7 +658,10 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
     let* source_modules =
       Dir_contents.ocaml dir_contents >>= Ml_sources.modules ~libs ~for_:(Library lib_id)
     in
-    let* cctx = cctx lib ~sctx ~source_modules ~dir ~scope ~expander ~compile_info in
+    let parameters = Lib.parameters local_lib in
+    let* cctx =
+      cctx lib ~sctx ~source_modules ~dir ~scope ~expander ~parameters ~compile_info
+    in
     let* () =
       match buildable.ctypes with
       | None -> Memo.return ()

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -247,6 +247,12 @@ let build_cm
         | None -> []
         | Some parameter -> [ "-as-argument-for"; Module_name.to_string parameter ])
    in
+   let parameters =
+     Command.Args.dyn
+       (let open Action_builder.O in
+        Resolve.Memo.read (Compilation_context.parameters cctx)
+        >>| List.concat_map ~f:(fun m -> [ "-parameter"; Module_name.to_string m ]))
+   in
    let flags, sandbox =
      let flags =
        Command.Args.dyn (Ocaml_flags.get (Compilation_context.flags cctx) mode)
@@ -301,6 +307,7 @@ let build_cm
             ; extra_args
             ; As as_parameter_arg
             ; as_argument_for
+            ; parameters
             ; S (melange_args cctx cm_kind m)
             ; A "-no-alias-deps"
             ; opaque_arg

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -76,6 +76,7 @@ type t =
   ; dune_version : Dune_lang.Syntax.Version.t
   ; virtual_modules : Ordered_set_lang.Unexpanded.t option
   ; implements : (Loc.t * Lib_name.t) option
+  ; parameters : (Loc.t * Lib_name.t) list
   ; default_implementation : (Loc.t * Lib_name.t) option
   ; private_modules : Ordered_set_lang.Unexpanded.t option
   ; stdlib : Ocaml_stdlib.t option
@@ -170,6 +171,12 @@ let decode =
        field_o
          "implements"
          (Dune_lang.Syntax.since Stanza.syntax (1, 7) >>> located Lib_name.decode)
+     and+ parameters =
+       field
+         "parameters"
+         (Dune_lang.Syntax.since Dune_lang.Oxcaml.syntax (0, 1)
+          >>> repeat (located Lib_name.decode))
+         ~default:[]
      and+ default_implementation =
        field_o
          "default_implementation"
@@ -298,6 +305,7 @@ let decode =
      ; dune_version
      ; virtual_modules
      ; implements
+     ; parameters
      ; default_implementation
      ; private_modules
      ; stdlib
@@ -563,6 +571,7 @@ let to_lib_info
     | Installed_private | Installed | Private _ -> None
   in
   let requires = conf.buildable.libraries in
+  let parameters = conf.parameters in
   let loc = conf.buildable.loc in
   let kind = conf.kind in
   let src_dir = dir in
@@ -602,6 +611,7 @@ let to_lib_info
     ~main_module_name
     ~sub_systems
     ~requires
+    ~parameters
     ~foreign_objects
     ~public_headers
     ~plugins

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -30,6 +30,7 @@ type t =
   ; dune_version : Dune_lang.Syntax.Version.t
   ; virtual_modules : Ordered_set_lang.Unexpanded.t option
   ; implements : (Loc.t * Lib_name.t) option
+  ; parameters : (Loc.t * Lib_name.t) list
   ; default_implementation : (Loc.t * Lib_name.t) option
   ; private_modules : Ordered_set_lang.Unexpanded.t option
   ; stdlib : Ocaml_stdlib.t option

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -37,6 +37,7 @@ let to_library t =
   ; dune_version = t.dune_version
   ; virtual_modules = None
   ; implements = None
+  ; parameters = []
   ; default_implementation = None
   ; private_modules = None
   ; stdlib = t.stdlib

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -63,8 +63,7 @@ let stanzas : constructors =
         | None -> base
         | Some r -> Library_redirect.Local.make_stanza r :: base )
     ; ( "library_parameter"
-      , let+ () = Dune_lang.Syntax.since Stanza.syntax (3, 20)
-        and+ () = Dune_lang.Syntax.since Dune_lang.Oxcaml.syntax (0, 1)
+      , let+ () = Dune_lang.Syntax.since Dune_lang.Oxcaml.syntax (0, 1)
         and+ x = Parameter.decode in
         let base = [ Library.make_stanza x ] in
         match Library_redirect.Local.of_lib x with

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -1,0 +1,382 @@
+Testing the `parameters` field in library stanzas.
+
+  $ cat >> dune-project <<EOF
+  > (lang dune 3.20)
+  > EOF
+
+It should fail because the syntax extension wasn't enabled in `dune-project`:
+
+  $ mkdir lib
+  $ echo 'let test () = print_endline A.foo' > lib/lib.ml
+  $ cat >lib/dune <<EOF
+  > (library (name lib) (parameters a))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 1, characters 20-34:
+  1 | (library (name lib) (parameters a))
+                          ^^^^^^^^^^^^^^
+  Error: 'parameters' is available only when oxcaml is enabled in the
+  dune-project file. You must enable it using (using oxcaml 0.1) in your
+  dune-project file.
+  Note however that oxcaml is experimental and might change without notice in
+  the future.
+  [1]
+
+After enabling the feature, it should fail reporting an unknown library
+parameter `a`:
+
+  $ cat >> dune-project <<EOF
+  > (using oxcaml 0.1)
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 1, characters 32-33:
+  1 | (library (name lib) (parameters a))
+                                      ^
+  Error: Library "a" not found.
+  -> required by alias default
+  [1]
+
+We introduce a package to also test the public names:
+
+  $ cat >> dune-project <<EOF
+  > (package (name project))
+  > EOF
+
+It should work once we define the library parameter `a`:
+
+  $ mkdir a
+  $ echo 'val foo : string' > a/a.mli
+  $ cat >a/dune <<EOF
+  > (library_parameter (public_name project.a) (name a))
+  > EOF
+
+  $ dune build
+
+It should fail if `parameters` list libraries that are not parameters:
+
+  $ mkdir b
+  $ echo 'let b = "not a parameter"' > b/b.ml
+  $ cat >b/dune <<EOF
+  > (library (name b))
+  > EOF
+
+  $ cat >lib/dune <<EOF
+  > (library (name lib) (parameters project.a b))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 1, characters 42-43:
+  1 | (library (name lib) (parameters project.a b))
+                                                ^
+  Error: Expected "b" to be a library parameter.
+  -> required by alias default
+  [1]
+
+It should work if `b` is defined as a parameter:
+
+  $ rm b/b.ml
+  $ echo 'val bar : string' > b/b.mli
+  $ cat >b/dune <<EOF
+  > (library_parameter (name b))
+  > EOF
+
+  $ dune build
+
+It should fail on duplicate parameters:
+
+  $ cat >lib/dune <<EOF
+  > (library (name lib) (parameters project.a b a))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 1, characters 44-45:
+  1 | (library (name lib) (parameters project.a b a))
+                                                  ^
+  Error: Duplicate library parameters: "project.a" and "a".
+  -> required by alias default
+  [1]
+
+Once the error is fixed, it should work:
+
+  $ cat >lib/dune <<EOF
+  > (library (name lib) (parameters b project.a))
+  > EOF
+
+  $ dune build
+
+A library can have multiple modules, and each one must be compiled with the
+parameters:
+
+  $ echo 'let foo_bar = A.foo ^ B.bar' > lib/lib_util.ml
+  $ echo 'let test () = B.bar, Lib_util.foo_bar' > lib/lib.ml
+  $ dune build
+
+We can by inspecting the `ocamlobjinfo` for the "Runtime parameters:" field,
+which lists the parameters on the following indented lines:
+
+  $ alias runtime_parameters="sed -ne '/parameter/,/^[^\t]/{/^\t/p}'"
+
+  $ ocamlobjinfo _build/default/lib/.lib.objs/native/lib__Lib_util.cmx | runtime_parameters
+  	Lib__
+  	A
+  	B
+
+  $ ocamlobjinfo _build/default/lib/.lib.objs/byte/lib__Lib_util.cmo | runtime_parameters
+  	Lib__
+  	A
+  	B
+
+The output of `ocamlobjinfo` is not exactly 1:1 with the flags given to the
+compiler.  It only lists the parameters that are actually used (`A` is not used
+by `Lib`), but also the parameterized modules that are depended upon,
+`Lib_util` and `Lib__`:
+
+  $ ocamlobjinfo _build/default/lib/.lib.objs/native/lib.cmx | runtime_parameters
+  	Lib__
+  	Lib__Lib_util
+  	B
+
+  $ ocamlobjinfo _build/default/lib/.lib.objs/byte/lib.cmo | runtime_parameters
+  	Lib__
+  	Lib__Lib_util
+  	B
+
+It's an error for a public library to depend on a private parameter:
+
+  $ cat >lib/dune <<EOF
+  > (library (public_name project.lib) (name lib) (parameters project.a b))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 1, characters 68-69:
+  1 | (library (public_name project.lib) (name lib) (parameters project.a b))
+                                                                          ^
+  Error: Library "b" is private, it cannot be a dependency of a public library.
+  You need to give "b" a public name.
+  [1]
+
+Giving a public name to `b` fixes the error:
+
+  $ cat >b/dune <<EOF
+  > (library_parameter (public_name project.b) (name b))
+  > EOF
+
+  $ dune build
+
+A library parameter can depend on other libraries when defining its interface:
+
+  $ mkdir utils
+  $ cat > utils/utils.ml <<EOF
+  > type t = string
+  > let to_string x = x
+  > EOF
+  $ cat > utils/utils.mli <<EOF
+  > type t
+  > val to_string : t -> string
+  > EOF
+  $ cat > utils/dune <<EOF
+  > (library (public_name project.utils) (name utils))
+  > EOF
+
+  $ echo 'val foo : Utils.t' > a/a.mli
+  $ cat > a/dune <<EOF
+  > (library_parameter (public_name project.a) (name a) (libraries utils))
+  > EOF
+
+Since the type of `A.foo` has changed, we must update `lib_util` before we
+attempt to build:
+
+  $ echo 'let foo_bar = Utils.to_string A.foo ^ B.bar' > lib/lib_util.ml
+
+  $ dune build
+
+We check that the opam installation will preserve the parameters metadata, both
+at the level of the library `project.lib` and for each of its parameterized
+modules:
+
+  $ dune build @install
+  $ cat _build/install/default/lib/project/dune-package | grep -v 'lang dune'
+  (name project)
+  (sections (lib .) (libexec .))
+  (files
+   (lib
+    (META
+     a/a.cmi
+     a/a.cmti
+     a/a.mli
+     b/b.cmi
+     b/b.cmti
+     b/b.mli
+     dune-package
+     lib/lib.a
+     lib/lib.cma
+     lib/lib.cmi
+     lib/lib.cmt
+     lib/lib.cmx
+     lib/lib.cmxa
+     lib/lib.ml
+     lib/lib__.cmi
+     lib/lib__.cmt
+     lib/lib__.cmx
+     lib/lib__.ml
+     lib/lib__Lib_util.cmi
+     lib/lib__Lib_util.cmt
+     lib/lib__Lib_util.cmx
+     lib/lib_util.ml
+     utils/utils.a
+     utils/utils.cma
+     utils/utils.cmi
+     utils/utils.cmt
+     utils/utils.cmti
+     utils/utils.cmx
+     utils/utils.cmxa
+     utils/utils.ml
+     utils/utils.mli))
+   (libexec (lib/lib.cmxs utils/utils.cmxs)))
+  (library
+   (name project.a)
+   (kind parameter)
+   (requires project.utils)
+   (main_module_name A)
+   (modes byte)
+   (modules
+    (singleton
+     (obj_name a)
+     (visibility public)
+     (kind parameter)
+     (source (path A) (intf (path a/a.mli))))))
+  (library
+   (name project.b)
+   (kind parameter)
+   (main_module_name B)
+   (modes byte)
+   (modules
+    (singleton
+     (obj_name b)
+     (visibility public)
+     (kind parameter)
+     (source (path B) (intf (path b/b.mli))))))
+  (library
+   (name project.lib)
+   (kind normal)
+   (archives (byte lib/lib.cma) (native lib/lib.cmxa))
+   (plugins (byte lib/lib.cma) (native lib/lib.cmxs))
+   (native_archives lib/lib.a)
+   (requires project.a project.b)
+   (parameters project.a project.b)
+   (main_module_name Lib)
+   (modes byte native)
+   (modules
+    (wrapped
+     (group
+      (alias
+       (obj_name lib__)
+       (visibility public)
+       (kind alias)
+       (source (path Lib__) (impl (path lib/lib__.ml-gen))))
+      (name Lib)
+      (modules
+       (module
+        (obj_name lib)
+        (visibility public)
+        (source (path Lib) (impl (path lib/lib.ml))))
+       (module
+        (obj_name lib__Lib_util)
+        (visibility public)
+        (source (path Lib_util) (impl (path lib/lib_util.ml))))))
+     (wrapped true))))
+  (library
+   (name project.utils)
+   (kind normal)
+   (archives (byte utils/utils.cma) (native utils/utils.cmxa))
+   (plugins (byte utils/utils.cma) (native utils/utils.cmxs))
+   (native_archives utils/utils.a)
+   (main_module_name Utils)
+   (modes byte native)
+   (modules
+    (singleton
+     (obj_name utils)
+     (visibility public)
+     (source
+      (path Utils)
+      (intf (path utils/utils.mli))
+      (impl (path utils/utils.ml))))))
+
+It's not possible to use the `parameters` fields in other stanzas than
+`(library)`:
+
+  $ mkdir bin
+  $ echo 'let () = Lib.test ()' > bin/bin.ml
+  $ cat > bin/dune <<EOF
+  > (executable (name bin) (parameters a b) (libraries lib))
+  > EOF
+
+  $ dune build
+  File "bin/dune", line 1, characters 24-34:
+  1 | (executable (name bin) (parameters a b) (libraries lib))
+                              ^^^^^^^^^^
+  Error: Unknown field "parameters"
+  [1]
+
+It's incorrect to depend on a parameterized library without providing the
+required parameters.
+
+  $ cat > bin/dune <<EOF
+  > (executable (name bin) (libraries lib))
+  > EOF
+
+  $ dune build
+  File "bin/dune", line 1, characters 34-37:
+  1 | (executable (name bin) (libraries lib))
+                                        ^^^
+  Error: Parameter "project.a" is missing.
+  -> required by _build/default/bin/.bin.eobjs/native/dune__exe__Bin.cmx
+  -> required by _build/default/bin/bin.exe
+  -> required by alias bin/all
+  -> required by alias default
+  Hint: Add (parameters project.a)
+  [1]
+
+  $ rm -r bin
+
+Same for libraries:
+
+  $ mkdir lib2
+  $ echo 'let test2 = Lib.test ()' > lib2/lib2.ml
+  $ cat > lib2/dune <<EOF
+  > (library (name lib2) (libraries lib))
+  > EOF
+  $ dune build
+  File "lib2/dune", line 1, characters 32-35:
+  1 | (library (name lib2) (libraries lib))
+                                      ^^^
+  Error: Parameter "project.a" is missing.
+  -> required by library "lib2" in _build/default/lib2
+  -> required by _build/default/lib2/.lib2.objs/native/lib2.cmx
+  -> required by _build/default/lib2/lib2.a
+  -> required by alias lib2/all
+  -> required by alias default
+  Hint: Add (parameters project.a)
+  [1]
+
+It works if `lib2` is itself parameterized with the same parameters as `lib`:
+
+  $ cat > lib2/dune <<EOF
+  > (library (name lib2) (parameters a b) (libraries lib))
+  > EOF
+
+A library can have more parameters than its dependencies:
+
+  $ mkdir c
+  $ echo 'val c : string' > c/c.mli
+  $ cat > c/dune <<EOF
+  > (library_parameter (public_name project.c) (name c))
+  > EOF
+
+  $ cat > lib2/dune <<EOF
+  > (library (name lib2) (parameters a b c) (libraries lib))
+  > EOF
+
+  $ dune build

--- a/test/blackbox-tests/test-cases/oxcaml/parameter-deps.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameter-deps.t
@@ -13,6 +13,7 @@ Creates a library that exports a module we can later import as part of the libra
   > module type S = sig
   >  val some_int: int
   > end
+  > let do_something (module X : S) = print_int X.some_int
   > EOF
 
 Use the library in a library_parameter.
@@ -36,3 +37,43 @@ We ensure it built the parameter.
 
   $ ocamlobjinfo "$(build_target_cmi 'param_intf')" | grep "Is parameter"
   Is parameter: YES
+
+A library parameterized by this parameter has transitive access to the `signature`
+library by default:
+
+  $ make_dir_with_dune "mylib" <<EOF
+  > (library
+  >   (name mylib)
+  >   (parameters param_intf))
+  > EOF
+  $ cat > mylib/mylib.ml <<EOF
+  > let test () = Signature.do_something (module Param_intf.M)
+  > EOF
+
+  $ dune build
+
+Unless the dune-project disables transitive dependencies:
+
+  $ cat >> dune-project <<EOF
+  > (implicit_transitive_deps false)
+  > EOF
+
+  $ dune build
+  File "mylib/mylib.ml", line 1, characters 14-36:
+  1 | let test () = Signature.do_something (module Param_intf.M)
+                    ^^^^^^^^^^^^^^^^^^^^^^
+  Error: Unbound module Signature
+  [1]
+
+In which case the parameter should explicitly re-export `signature`:
+
+  $ cat > param_intf/dune <<EOF
+  > (library_parameter
+  >  (name param_intf)
+  >  (libraries (re_export signature)))
+  > EOF
+
+  $ dune build
+
+  $ ocamlobjinfo "$(build_target_cmi 'mylib')" | grep -o Signature
+  Signature


### PR DESCRIPTION
This PR adds a new `(parameters ...)` field to the library stanza, to define a parameterized library (see https://github.com/ocaml/dune/pull/11963). Parameterized libraries are currently only available with the OxCaml compiler, since they require a new compiler flag `-parameter Name_of_parameter` (for each specified parameter) to compile the modules of the parameterized library.

Fixes https://github.com/ocaml/dune/issues/12086