### PR TITLE
test(cram): make timeout test less racy + tweak formatting

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -413,6 +413,8 @@ let run_cram_test env ~src ~script ~cram_stanzas ~temp_dir ~cwd ~timeout =
       [ Pp.textf "A time limit of %.2fs has been set in " timeout
       ; Pp.tag User_message.Style.Loc @@ Loc.pp_file_colon_line timeout_loc
       ]
+      |> Pp.concat
+      |> Pp.hovbox
     in
     let timeout_msg =
       match
@@ -441,7 +443,7 @@ let run_cram_test env ~src ~script ~cram_stanzas ~temp_dir ~cwd ~timeout =
     in
     User_error.raise
       ~loc:(Loc.in_file (Path.drop_optional_build_context_maybe_sandboxed src))
-      (timeout_msg @ timeout_set_message)
+      (timeout_msg @ [ timeout_set_message ])
 ;;
 
 let run_produce_correction ~src ~env ~script ~timeout lexbuf =

--- a/test/blackbox-tests/test-cases/cram/timeout-no-command.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-no-command.t
@@ -26,8 +26,7 @@ which specific command caused the timeout:
   File "test.t", line 1, characters 0-0:
   Error: Cram test timed out while running command:
     $ echo "This is the problematic command" && sleep 2
-  A time limit of 0.10s has been set in 
-  dune:2
+  A time limit of 0.10s has been set in dune:2
   [1]
 
 The error message above shows that we get a generic timeout message but no

--- a/test/blackbox-tests/test-cases/cram/timeout.t
+++ b/test/blackbox-tests/test-cases/cram/timeout.t
@@ -39,11 +39,9 @@ The cram test will take 2 seconds to run unless it is killed. We make sure this
 fails earlier by passing a timeout command in front of dune. Our expected
 behaviour is for dune to kill the cram test immediately.
 
-  $ timeout 1 dune test test.t
+  $ timeout 1 dune test test.t 2>&1 | sed 's/echo hi/first command/'
   File "test.t", line 1, characters 0-0:
   Error: Cram test timed out while running command:
-    $ echo hi
-  A time limit of 0.00s has been set in 
-  dune:2
-  [1]
+    $ first command
+  A time limit of 0.00s has been set in dune:2
 


### PR DESCRIPTION
Sometimes it fails on `echo` sometimes on `sleep`. This makes it more likely to fail on `sleep`.