### PR TITLE
test(cram): make timeout test less flaky

### DIFF
--- a/test/blackbox-tests/test-cases/cram/timeout.t
+++ b/test/blackbox-tests/test-cases/cram/timeout.t
@@ -39,9 +39,9 @@ The cram test will take 2 seconds to run unless it is killed. We make sure this
 fails earlier by passing a timeout command in front of dune. Our expected
 behaviour is for dune to kill the cram test immediately.
 
-  $ timeout 1 dune test test.t 2>&1 | sed 's/echo hi/first command/'
+  $ timeout 1 dune test test.t 2>&1 | sed 's/echo hi/command/' | sed 's/sleep 2/command/'
   File "test.t", line 1, characters 0-0:
   Error: Cram test timed out while running command:
-    $ first command
+    $ command
   A time limit of 0.00s has been set in dune:2
 


### PR DESCRIPTION
We forgot to sanitize the second command if it ever happens.