### PR TITLE
ci: cache nix jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,9 +37,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix build
 
   nix-test:
@@ -52,9 +52,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop -i -c make test
 
   fmt:
@@ -62,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#fmt -c make fmt
 
   doc:
@@ -72,9 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#doc -c make doc
         env:
           LC_ALL: C
@@ -89,9 +89,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
   nix-build-4-08:
@@ -104,9 +104,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop -i .#bootstrap-check_4_08 -c make release 
 
 #
@@ -219,11 +219,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: |
-            extra-substituters = https://anmonteiro.nix-cache.workers.dev
-            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#coq -c make test-coq
         env:
           # We disable the Dune cache when running the tests
@@ -316,7 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v33
         with:
-          extra_nix_config: ${{ env.EXTRA_NIX_CONFIG }}
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#microbench -c make dune build bench/micro

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,6 +40,13 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
+          gc-max-store-size-macos: 2G
       - run: nix build
 
   nix-test:
@@ -55,6 +62,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 10G
       - run: nix develop -i -c make test
 
   fmt:
@@ -65,6 +78,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
       - run: nix develop .#fmt -c make fmt
 
   doc:
@@ -75,6 +94,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
       - run: nix develop .#doc -c make doc
         env:
           LC_ALL: C
@@ -92,6 +117,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
   nix-build-4-08:
@@ -107,6 +138,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_08 -c make release 
 
 #
@@ -222,6 +259,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 5G
       - run: nix develop .#coq -c make test-coq
         env:
           # We disable the Dune cache when running the tests
@@ -317,4 +360,10 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v33
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 5G
       - run: nix develop .#microbench -c make dune build bench/micro


### PR DESCRIPTION
We add GitHub actions level caching to all the nix jobs giving a substantial improvement to the CI times. Antonio's nix-overlay cache is good, but not all derivations are cached there. Having a local caching mechanism allows us to make use of recent CI runs. 

| Job                                | Main (s) | Cold PR (s) | Hot PR (s) | Cold → Hot Speedup | Main → Hot Speedup |
|------------------------------------|----------|-------------|------------|--------------------|--------------------|
| Nix Tests (ubuntu-latest)          | 423      | 457         | 407        | 50s                | 16s                |
| Format                             | 94       | 99          | 72         | 27s                | 22s                |
| Documentation                      | 64       | 67          | 40         | 27s                | 24s                |
| Nix Build (ubuntu-latest)          | 81       | 82          | 24         | 58s                | 57s                |
| Nix Build 4.08 (ubuntu-latest)     | 318      | 317         | 47         | 270s               | 271s               |
| Bootstrap (ubuntu-latest)          | 258      | 263         | 17         | 246s               | 241s               |
| Nix Build (macos-latest)           | 192      | 203         | 49         | 154s               | 143s               |
| Coq 8.16.1                         | 779      | 783         | 129        | 654s               | 650s               |
| Build microbenchmarks              | 140      | 161         | 104        | 57s                | 36s                |

This saves us 25 minutes in CI time!