### PR TITLE
fix: disable bin-annot for cinaps binaries

### DIFF
--- a/doc/changes/12350.md
+++ b/doc/changes/12350.md
@@ -1,0 +1,1 @@
+- Fix: stop generating `cmt` files for cinaps binaries (#12530, @rgrinberg)

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -184,6 +184,7 @@ let gen_rules sctx t ~dir ~scope =
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None
         ~package:None
+        ~bin_annot:false
     in
     let link_args =
       let open Action_builder.O in


### PR DESCRIPTION
Such binaries are generated from hidden sources. We don't need cmt's for them