### PR TITLE
 fix: avoid killing process group when not applicable 

### DIFF
--- a/doc/changes/fixed/12360.md
+++ b/doc/changes/fixed/12360.md
@@ -1,0 +1,2 @@
+- Fix issue where `dune exec -w` was unable to kill running programs on
+  rebuild. (#12360, fixes #12323, @Alizter)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -718,6 +718,7 @@ end
 type t =
   { started_at : Time.t
   ; pid : Pid.t
+  ; is_process_group_leader : bool
   ; response_file : Path.t option
   ; stdout : Path.t option
   ; stderr : Path.t option
@@ -871,9 +872,9 @@ let report_process_finished
 
 let set_temp_dir_when_running_actions = ref true
 
-let await ~timeout { response_file; pid; _ } =
+let await ~timeout { response_file; pid; is_process_group_leader; _ } =
   let+ process_info, termination_reason =
-    Scheduler.wait_for_build_process ?timeout pid ~is_process_group_leader:true
+    Scheduler.wait_for_build_process ?timeout pid ~is_process_group_leader
   in
   Option.iter response_file ~f:(fun path -> path |> Path.to_string |> Fpath.unlink_exn);
   process_info, termination_reason
@@ -1004,6 +1005,7 @@ let spawn
   Io.release stderr;
   { started_at
   ; pid
+  ; is_process_group_leader = Option.is_some setpgid
   ; response_file
   ; stdout = stdout_capture
   ; stderr = stderr_capture

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -2,10 +2,17 @@ open Stdune
 
 type job =
   { pid : Pid.t
+  ; is_process_group_leader : bool
   ; ivar : Proc.Process_info.t Fiber.Ivar.t
   }
 
-let dyn_of_job { pid; ivar = _ } = Dyn.record [ "pid", Dyn.int (Pid.to_int pid) ]
+let dyn_of_job { pid; is_process_group_leader; ivar } =
+  Dyn.record
+    [ "pid", Dyn.int (Pid.to_int pid)
+    ; "is_process_group_leader", Dyn.bool is_process_group_leader
+    ; "ivar", Dyn.opaque ivar
+    ]
+;;
 
 type build_input_change =
   | Fs_event of File_watcher.Fs_memo_event.t

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -2,6 +2,7 @@ open Stdune
 
 type job =
   { pid : Pid.t
+  ; is_process_group_leader : bool
   ; ivar : Proc.Process_info.t Fiber.Ivar.t
   }
 

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -1,6 +1,6 @@
 open Stdune
 
-val kill_process_group : Pid.t -> int -> unit
+val kill_process_group : Pid.t -> int -> is_process_group_leader:bool -> unit
 
 (** Initialize the process watcher thread. *)
 type t

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -96,7 +96,7 @@ val with_job_slot : (Fiber.Cancel.t -> Config.t -> 'a Fiber.t) -> 'a Fiber.t
     timeout. *)
 val wait_for_process
   :  ?timeout:Time.Span.t
-  -> ?is_process_group_leader:bool
+  -> is_process_group_leader:bool
   -> Pid.t
   -> Proc.Process_info.t Fiber.t
 
@@ -107,7 +107,7 @@ type termination_reason =
 
 val wait_for_build_process
   :  ?timeout:Time.Span.t
-  -> ?is_process_group_leader:bool
+  -> is_process_group_leader:bool
   -> Pid.t
   -> (Proc.Process_info.t * termination_reason) Fiber.t
 

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -18,7 +18,6 @@ Below, 0: after should *not* be appearing.
 
   $ dune exec --watch ./foo.exe &
   0: before
-  0: after
   1: before
   1: after
   Success, waiting for filesystem changes...

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -109,7 +109,12 @@ let run ?env ~prog ~argv () =
   Unix.close stdout_w;
   Unix.close stderr_w;
   ( pid
-  , (let+ proc = Scheduler.wait_for_process ~timeout:(Time.Span.of_secs 3.0) pid in
+  , (let+ proc =
+       Scheduler.wait_for_process
+         ~timeout:(Time.Span.of_secs 3.0)
+         ~is_process_group_leader:false
+         pid
+     in
      if proc.status <> Unix.WEXITED 0
      then (
        let name =

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -56,7 +56,10 @@ let%expect_test "run process with timeout" =
          Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int
        in
        let+ (_ : Proc.Process_info.t) =
-         Scheduler.wait_for_process ~timeout:(Time.Span.of_secs 0.1) pid
+         Scheduler.wait_for_process
+           ~timeout:(Time.Span.of_secs 0.1)
+           ~is_process_group_leader:false
+           pid
        in
        print_endline "sleep timed out");
   [%expect


### PR DESCRIPTION
We add a way of tracking whether a job is a process group leader to the
scheduler. This allows us to avoid sending a signal to a process group
when it isn't needed.

Doing so fixes an issue with dune exec -w where rebuilds would send a
kill signal to a non-existant process group assumed to be attached to
the process we were execing.

- [x] depends on #12361 
- [x] changelog
- fixes #12323 