### PR TITLE
test: fix exec-watch-server test and demonstrate issue

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -1,4 +1,10 @@
 (cram
+ (deps wait-for-file.sh))
+
+(cram
+ (timeout 5))
+
+(cram
  (enabled_if
   ;; On macos it looks like dune has a chance to miss filesystem events if they
   ;; occur too close together in time. Tests of `dune exec -w` run a program with a
@@ -12,12 +18,5 @@
 ; These tests are explicitly disabled due to flakiness
 
 (cram
- (applies_to
-  exec-watch-server
-  exec-watch-ignore-sigterm
-  exec-signal
-  exec-watch-basic)
+ (applies_to exec-watch-ignore-sigterm exec-signal exec-watch-basic)
  (enabled_if false))
-
-(cram
- (deps wait-for-file.sh))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -1,20 +1,24 @@
-Test exec --watch with a program that doesn't terminate immediately.
+Test exec --watch with a program that does not terminate immediately.
 
-File created by the program being exec'd. In between each experiment we'll wait
-until the file exists so that dune has enough time to build and run the program
-between each change to its code.
+File created by the program being execed. In between each experiment we will
+wait until the file exists so that dune has enough time to build and run the
+program between each change to its code.
+
   $ export DONE_FLAG=_build/done_flag
 
   $ cat >foo.ml <<EOF
   > let () =
   >   print_endline "0: before";
   >   Touch.touch "$DONE_FLAG";
-  >   Unix.sleep 1000;
+  >   Unix.sleep 1;
   >   print_endline "0: after"
   > EOF
 
+Below, 0: after should *not* be appearing.
+
   $ dune exec --watch ./foo.exe &
   0: before
+  0: after
   1: before
   1: after
   Success, waiting for filesystem changes...
@@ -39,15 +43,9 @@ Change the program so that it no longer terminates immediately.
   > let () =
   >   print_endline "2: before";
   >   Touch.touch "$DONE_FLAG";
-  >   Unix.sleep 1000;
+  >   Unix.sleep 1;
   >   print_endline "2: after"
   > EOF
 
   $ ../wait-for-file.sh $DONE_FLAG
 
-Prevent the test from leaking the dune process.
-  $ kill $PID
-
-Checking for the child process
-  $ pgrep -c "foo.exe" || true
-  0


### PR DESCRIPTION
The sleep time set in this test was way too high. I set it back to a sensible level so that when it fails it doesn't stall. I've also added a timeout to the exec-watch tests in general, since there shouldn't be any slow tests.

The exec-watch-server test has been re-enabled and the issue in https://github.com/ocaml/dune/issues/12323 is demonstrated.