### PR TITLE
refactor(boot): parameterize Types.library by the name

### DIFF
--- a/boot/libs.mli
+++ b/boot/libs.mli
@@ -8,5 +8,5 @@
 open Types
 
 val external_libraries : string list
-val local_libraries : library list
-val main : library
+val local_libraries : string library list
+val main : string library

--- a/boot/types.ml
+++ b/boot/types.ml
@@ -1,6 +1,6 @@
-type root_module =
-  { name : string
-  ; entries : string list
+type 'name root_module =
+  { name : 'name
+  ; entries : 'name list
   }
 
 type include_subdirs =
@@ -8,10 +8,10 @@ type include_subdirs =
   | Qualified
   | No
 
-type library =
+type 'name library =
   { path : string
-  ; main_module_name : string option
+  ; main_module_name : 'name option
   ; include_subdirs : include_subdirs
-  ; special_builtin_support : string option
-  ; root_module : root_module option
+  ; special_builtin_support : 'name option
+  ; root_module : 'name root_module option
   }


### PR DESCRIPTION
To allow to use [Module_name.t]