### PR TITLE
[3.20] backport #12324

### DIFF
--- a/doc/changes/12324.md
+++ b/doc/changes/12324.md
@@ -1,2 +1,2 @@
 - Fix `runtest-js` mistakenly using wrong dependencies (#12324,
-  @vouillon and @Alizter)
+  @vouillon)

--- a/doc/changes/12324.md
+++ b/doc/changes/12324.md
@@ -1,0 +1,2 @@
+- Fix `runtest-js` mistakenly using wrong dependencies (#12324,
+  @vouillon and @Alizter)

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/js-alias/dune
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/js-alias/dune
@@ -1,0 +1,8 @@
+(library
+ (name inline_tests_js_alias)
+ (inline_tests (modes byte js) (backend fake_backend)))
+
+(env
+ (_
+  (js_of_ocaml
+   (runtest_alias runtest-js))))

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/js-alias/js.ml
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/js-alias/js.ml
@@ -1,0 +1,8 @@
+let _ =
+  Printf.eprintf
+    "inline tests (%s - alias)\n"
+    (match Sys.backend_type with
+     | Native -> "Native"
+     | Bytecode -> "Byte"
+     | Other _ -> "JS")
+;;

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
@@ -1,7 +1,7 @@
 Run inline tests using node js
 
   $ cat >dune-project <<EOF
-  > (lang dune 2.6)
+  > (lang dune 3.0)
   > EOF
 
 (With the dev profile on OCaml 5, the warning is expected)
@@ -9,6 +9,8 @@ Run inline tests using node js
   $ dune runtest
   inline tests (Byte)
   inline tests (Byte)
+  inline tests (Byte - alias)
+  inline tests (Byte - alias)
   inline tests (Native)
   inline tests (Native)
   Warning [missing-effects-backend]: your program contains effect handlers; you should probably run js_of_ocaml with option '--effects=cps'
@@ -28,3 +30,8 @@ CR-Alizter: This test has a different behaviour for the macos-latest in the CI a
   Error: Don't know how to build
   js/.inline_tests_js.inline-tests/inline_test_runner_inline_tests_js.bc
   [1]
+
+  $ dune build @runtest-js
+  Warning [missing-effects-backend]: your program contains effect handlers; you should probably run js_of_ocaml with option '--effects=cps'
+  inline tests (JS - alias)
+  inline tests (JS - alias)


### PR DESCRIPTION
- **fix(jsoo): runtest-js alias now depends on runtest-js-name for (inline-tests)**
- **test: make sure runtest_alias works properly for inline tests**
- **doc: add changelog entry**
