### PR TITLE
[3.20] backport #12320

### DIFF
--- a/doc/changes/12320.md
+++ b/doc/changes/12320.md
@@ -1,0 +1,1 @@
+- Fix jsoo separate compilation with modules_without_implementation. Regression introduced in #10767. (fixes #12306 @hhugo)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -668,6 +668,7 @@ let build_cm cctx ~dir ~in_context ~mode ~src ~obj_dir ~deps ~config:config_opt 
         |> Action_builder.map ~f:Config.of_flags
       | Some config -> Action_builder.return config
     in
+    let deps = List.filter deps ~f:(fun m -> Module.has m ~ml_kind:Impl) in
     (Path.build (in_build_dir ctx ~config [ "stdlib"; with_js_ext ~mode "stdlib.cma" ])
      :: List.concat_map libs ~f:(fun lib -> jsoo_archives ~mode ctx config lib))
     @ List.map deps ~f:(fun m ->

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -18,6 +18,3 @@
   > EOF
 
   $ dune build
-  File ".main.eobjs/jsoo/_unknown_", line 1, characters 0-0:
-  Error: No rule found for .main.eobjs/jsoo/dune__exe__Interface.cmo.js
-  [1]

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -1,0 +1,23 @@
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modes js)
+  >  (modules_without_implementation interface))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let _ = Interface.Foo
+  > EOF
+
+  $ cat > interface.mli <<EOF
+  > type t = Foo
+  > EOF
+
+  $ dune build
+  File ".main.eobjs/jsoo/_unknown_", line 1, characters 0-0:
+  Error: No rule found for .main.eobjs/jsoo/dune__exe__Interface.cmo.js
+  [1]

--- a/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/without_implem.t/run.t
@@ -1,5 +1,5 @@
   $ cat > dune-project <<EOF
-  > (lang dune 3.21)
+  > (lang dune 3.20)
   > EOF
 
   $ cat > dune <<EOF


### PR DESCRIPTION
- **fix(jsoo): runtest-js alias now depends on runtest-js-name for (inline-tests)**
- **test: make sure runtest_alias works properly for inline tests**
- **doc: add changelog entry**
- **Add regression test for gh#12306**
- **Fix 12306**
- **Changes**
