### PR TITLE
Check for parameterised libraries from the compiler config

### DIFF
--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -187,8 +187,7 @@ let modules_rules sctx kind expander ~dir scope modules =
     | Executables _ | Library _ | Melange _ -> Memo.return ()
     | Parameter _ ->
       let* ocaml = Super_context.context sctx |> Context.ocaml in
-      let ocaml_version = Ocaml_config.version_string ocaml.ocaml_config in
-      if Ocaml.Version.supports_parametrized_library ocaml_version
+      if Ocaml_config.parameterised_modules ocaml.ocaml_config
       then Memo.return ()
       else
         User_error.raise

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -137,6 +137,7 @@ type t =
   ; supports_shared_libraries : bool
   ; windows_unicode : bool
   ; ox : bool
+  ; parameterised_modules : bool
   }
 
 let version t = t.version
@@ -192,6 +193,7 @@ let natdynlink_supported t = t.natdynlink_supported
 let supports_shared_libraries t = t.supports_shared_libraries
 let windows_unicode t = t.windows_unicode
 let ox t = t.ox
+let parameterised_modules t = t.parameterised_modules
 
 let to_list
       { version = _
@@ -247,6 +249,7 @@ let to_list
       ; supports_shared_libraries
       ; windows_unicode
       ; ox
+      ; parameterised_modules
       }
   : (string * Value.t) list
   =
@@ -302,6 +305,7 @@ let to_list
   ; "supports_shared_libraries", Bool supports_shared_libraries
   ; "windows_unicode", Bool windows_unicode
   ; "ox", Bool ox
+  ; "parameterised_modules", Bool parameterised_modules
   ]
 ;;
 
@@ -362,6 +366,7 @@ let by_name
       ; supports_shared_libraries
       ; windows_unicode
       ; ox
+      ; parameterised_modules
       }
       name
   : Value.t option
@@ -419,6 +424,7 @@ let by_name
   | "supports_shared_libraries" -> Some (Bool supports_shared_libraries)
   | "windows_unicode" -> Some (Bool windows_unicode)
   | "ox" -> Some (Bool ox)
+  | "parameterised_modules" -> Some (Bool parameterised_modules)
   | _ -> None
 ;;
 
@@ -636,6 +642,7 @@ let make vars =
     let cmxs_magic_number = get vars "cmxs_magic_number" in
     let cmt_magic_number = get vars "cmt_magic_number" in
     let windows_unicode = get_bool vars "windows_unicode" in
+    let parameterised_modules = get_bool vars "parameterised_modules" in
     let natdynlink_supported =
       let lib = "dynlink.cmxa" in
       let lib = if version >= (5, 0, 0) then Filename.concat "dynlink" lib else lib in
@@ -707,6 +714,7 @@ let make vars =
     ; supports_shared_libraries
     ; windows_unicode
     ; ox
+    ; parameterised_modules
     }
   with
   | t -> Ok t

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -119,6 +119,7 @@ val natdynlink_supported : t -> bool
 val supports_shared_libraries : t -> bool
 val windows_unicode : t -> bool
 val ox : t -> bool
+val parameterised_modules : t -> bool
 
 (** {1 Values} *)
 

--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -39,9 +39,3 @@ let supports_oxcaml version =
   Stdune.String.is_suffix ~suffix:jst version
   || Stdune.String.is_suffix ~suffix:ox version
 ;;
-
-let supports_parametrized_library version =
-  (* We create the alias to make sure it is easy to distinguish the
-     functionality from the compiler variant. *)
-  supports_oxcaml version
-;;

--- a/src/ocaml/version.mli
+++ b/src/ocaml/version.mli
@@ -85,8 +85,5 @@ val add_std_cxx_flag : t -> bool
 (* Whether the compiler supports OxCaml *)
 val supports_oxcaml : string -> bool
 
-(* Whether the compiler supports the parametrized library *)
-val supports_parametrized_library : string -> bool
-
 (** Whether the compiler supports the [-cmi-file] flag *)
 val supports_cmi_file : t -> bool


### PR DESCRIPTION
Changes the check for parameterised libraries to the flag emitted by the OxCaml compiler, rather than relying on parsing the compiler version string. This way, we rely on the implementation and not the compiler version, as this feature could get upstreamed to ocaml/ocaml. The OxCaml compiler config (`ocamlc -config`) emits `parameterised_modules: true`, which is being checked to detect whether parameterised libraries are available.