### PR TITLE
Copy the lock directories to the build folder and read package rules from there

### DIFF
--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -10,6 +10,7 @@ module Show_lock = struct
       >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dir_arg
     in
     Fiber.parallel_map lock_dir_paths ~f:(fun lock_dir_path ->
+      let lock_dir_path = Path.source lock_dir_path in
       let+ platform = Pkg_common.solver_env_from_system_and_context ~lock_dir_path in
       let lock_dir = Lock_dir.read_disk_exn lock_dir_path in
       let packages =
@@ -123,14 +124,14 @@ module List_locked_dependencies = struct
   let enumerate_lock_dirs_by_path workspace ~lock_dirs =
     let lock_dirs = Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs workspace in
     List.filter_map lock_dirs ~f:(fun lock_dir_path ->
-      if Path.exists lock_dir_path
+      if Path.exists (Path.source lock_dir_path)
       then (
-        try Some (lock_dir_path, Lock_dir.read_disk_exn lock_dir_path) with
+        try Some (lock_dir_path, Lock_dir.read_disk_exn (Path.source lock_dir_path)) with
         | User_error.E e ->
           User_warning.emit
             [ Pp.textf
                 "Failed to parse lockdir %s:"
-                (Path.to_string_maybe_quoted lock_dir_path)
+                (Path.Source.to_string_maybe_quoted lock_dir_path)
             ; User_message.pp e
             ];
           None)
@@ -148,6 +149,7 @@ module List_locked_dependencies = struct
     in
     let+ pp =
       Fiber.parallel_map lock_dirs_by_path ~f:(fun (lock_dir_path, lock_dir) ->
+        let lock_dir_path = Path.source lock_dir_path in
         let+ platform = Pkg_common.solver_env_from_system_and_context ~lock_dir_path in
         let package_universe =
           Package_universe.create ~platform local_packages lock_dir |> User_error.ok_exn

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -79,7 +79,7 @@ let solve ~dev_tool ~local_packages =
       Workspace.add_repo workspace Dune_pkg.Pkg_workspace.Repository.binary_packages
     | `Disabled -> workspace
   in
-  let lock_dir = Lock_dir.dev_tool_lock_dir_path dev_tool in
+  let lock_dir = Dune_rules.Lock_dir.dev_tool_lock_dir dev_tool in
   Memo.of_reproducible_fiber
   @@ Lock.solve
        workspace
@@ -173,7 +173,7 @@ let extra_dependencies dev_tool =
 
 let lockdir_status dev_tool =
   let open Memo.O in
-  let dev_tool_lock_dir = Lock_dir.dev_tool_lock_dir_path dev_tool in
+  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_lock_dir dev_tool in
   match Lock_dir.read_disk dev_tool_lock_dir with
   | Error _ -> Memo.return `No_lockdir
   | Ok { packages; _ } ->

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -79,7 +79,8 @@ let solve ~dev_tool ~local_packages =
       Workspace.add_repo workspace Dune_pkg.Pkg_workspace.Repository.binary_packages
     | `Disabled -> workspace
   in
-  let lock_dir = Dune_rules.Lock_dir.dev_tool_lock_dir dev_tool in
+  (* as we want to write to the source, we're using the source lock dir here *)
+  let lock_dir = Dune_rules.Lock_dir.dev_tool_source_lock_dir dev_tool |> Path.source in
   Memo.of_reproducible_fiber
   @@ Lock.solve
        workspace
@@ -113,6 +114,7 @@ let locked_ocaml_compiler_version () =
     (* Dev tools are only ever built with the default context. *)
     Context_name.default
   in
+  (* TODO make sure this doesn't run when there is no lock dir *)
   let* result = Dune_rules.Lock_dir.get context
   and* platform =
     Pkg_common.poll_solver_env_from_current_system () |> Memo.of_reproducible_fiber
@@ -173,36 +175,45 @@ let extra_dependencies dev_tool =
 
 let lockdir_status dev_tool =
   let open Memo.O in
-  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_lock_dir dev_tool in
-  match Lock_dir.read_disk dev_tool_lock_dir with
-  | Error _ -> Memo.return `No_lockdir
-  | Ok { packages; _ } ->
-    (match Dune_pkg.Dev_tool.needs_to_build_with_same_compiler_as_project dev_tool with
-     | false -> Memo.return `Lockdir_ok
-     | true ->
-       let* platform =
-         Pkg_common.poll_solver_env_from_current_system () |> Memo.of_reproducible_fiber
-       in
-       let packages = Lock_dir.Packages.pkgs_on_platform_by_name packages ~platform in
-       (match Package_name.Map.find packages compiler_package_name with
-        | None -> Memo.return `No_compiler_lockfile_in_lockdir
-        | Some { info; _ } ->
-          let+ ocaml_compiler_version = locked_ocaml_compiler_version () in
-          (match Package_version.equal info.version ocaml_compiler_version with
-           | true -> `Lockdir_ok
-           | false ->
-             `Dev_tool_needs_to_be_relocked_because_project_compiler_version_changed
-               (User_message.make
-                  [ Pp.textf
-                      "The version of the compiler package (%S) in this project's \
-                       lockdir has changed to %s (formerly the compiler version was %s). \
-                       The dev-tool %S will be re-locked and rebuilt with this version \
-                       of the compiler."
-                      (Package_name.to_string compiler_package_name)
-                      (Package_version.to_string ocaml_compiler_version)
-                      (Package_version.to_string info.version)
-                      (Dune_pkg.Dev_tool.package_name dev_tool |> Package_name.to_string)
-                  ]))))
+  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_source_lock_dir dev_tool in
+  let* lock_dir_exists =
+    Dune_engine.Fs_memo.dir_exists (In_source_dir dev_tool_lock_dir)
+  in
+  match lock_dir_exists with
+  | false -> Memo.return `No_lockdir
+  | true ->
+    let dev_tool_lock_dir = Path.source dev_tool_lock_dir in
+    (match Lock_dir.read_disk dev_tool_lock_dir with
+     | Error _ -> Memo.return `No_lockdir
+     | Ok { packages; _ } ->
+       (match Dune_pkg.Dev_tool.needs_to_build_with_same_compiler_as_project dev_tool with
+        | false -> Memo.return `Lockdir_ok
+        | true ->
+          let* platform =
+            Pkg_common.poll_solver_env_from_current_system ()
+            |> Memo.of_reproducible_fiber
+          in
+          let packages = Lock_dir.Packages.pkgs_on_platform_by_name packages ~platform in
+          (match Package_name.Map.find packages compiler_package_name with
+           | None -> Memo.return `No_compiler_lockfile_in_lockdir
+           | Some { info; _ } ->
+             let+ ocaml_compiler_version = locked_ocaml_compiler_version () in
+             (match Package_version.equal info.version ocaml_compiler_version with
+              | true -> `Lockdir_ok
+              | false ->
+                `Dev_tool_needs_to_be_relocked_because_project_compiler_version_changed
+                  (User_message.make
+                     [ Pp.textf
+                         "The version of the compiler package (%S) in this project's \
+                          lockdir has changed to %s (formerly the compiler version was \
+                          %s). The dev-tool %S will be re-locked and rebuilt with this \
+                          version of the compiler."
+                         (Package_name.to_string compiler_package_name)
+                         (Package_version.to_string ocaml_compiler_version)
+                         (Package_version.to_string info.version)
+                         (Dune_pkg.Dev_tool.package_name dev_tool
+                          |> Package_name.to_string)
+                     ])))))
 ;;
 
 (* [lock_dev_tool_at_version dev_tool version] generates the lockdir for the

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -342,6 +342,7 @@ let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir
   in
   let lock_dirs =
     Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
+    |> List.map ~f:Path.source
   in
   solve
     workspace

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -7,6 +7,7 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
     let* workspace = Memo.run (Workspace.workspace ()) in
     Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
     |> Fiber.parallel_map ~f:(fun lock_dir_path ->
+      let lock_dir_path = Path.source lock_dir_path in
       (* updating makes sense when checking for outdated packages *)
       let* repos =
         get_repos

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -196,7 +196,7 @@ module Lock_dirs_arg = struct
   ;;
 
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
-    let default_path = Lazy.force Lock_dir.default_path in
+    let default_path = Dune_rules.Lock_dir.default_path in
     let workspace_lock_dirs =
       default_path
       :: List.map workspace.lock_dirs ~f:(fun (lock_dir : Workspace.Lock_dir.t) ->

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -196,33 +196,35 @@ module Lock_dirs_arg = struct
   ;;
 
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
-    let default_path = Dune_rules.Lock_dir.default_path in
+    let default_path = Dune_rules.Lock_dir.default_source_path in
     let workspace_lock_dirs =
       default_path
       :: List.map workspace.lock_dirs ~f:(fun (lock_dir : Workspace.Lock_dir.t) ->
-        lock_dir.path |> Path.source)
-      |> Path.Set.of_list
-      |> Path.Set.to_list
+        lock_dir.path)
+      |> Path.Source.Set.of_list
+      |> Path.Source.Set.to_list
     in
     match t with
     | All -> workspace_lock_dirs
     | Selected [] -> [ default_path ]
     | Selected chosen_lock_dirs ->
-      let workspace_lock_dirs_set = Path.Set.of_list workspace_lock_dirs in
-      let chosen_lock_dirs = List.map ~f:Path.source chosen_lock_dirs in
-      let chosen_lock_dirs_set = Path.Set.of_list chosen_lock_dirs in
-      if Path.Set.is_subset chosen_lock_dirs_set ~of_:workspace_lock_dirs_set
+      let workspace_lock_dirs_set = Path.Source.Set.of_list workspace_lock_dirs in
+      (* let chosen_lock_dirs = List.map ~f:Path.source chosen_lock_dirs in *)
+      let chosen_lock_dirs_set = Path.Source.Set.of_list chosen_lock_dirs in
+      if Path.Source.Set.is_subset chosen_lock_dirs_set ~of_:workspace_lock_dirs_set
       then chosen_lock_dirs
       else (
         let unknown_lock_dirs =
-          Path.Set.diff chosen_lock_dirs_set workspace_lock_dirs_set |> Path.Set.to_list
+          Path.Source.Set.diff chosen_lock_dirs_set workspace_lock_dirs_set
+          |> Path.Source.Set.to_list
         in
+        let f x = Path.pp (Path.source x) in
         User_error.raise
           [ Pp.text
               "The following directories are not lock directories in this workspace:"
-          ; Pp.enumerate unknown_lock_dirs ~f:Path.pp
+          ; Pp.enumerate unknown_lock_dirs ~f
           ; Pp.text "This workspace contains the following lock directories:"
-          ; Pp.enumerate workspace_lock_dirs ~f:Path.pp
+          ; Pp.enumerate workspace_lock_dirs ~f
           ])
   ;;
 end

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -209,7 +209,6 @@ module Lock_dirs_arg = struct
     | Selected [] -> [ default_path ]
     | Selected chosen_lock_dirs ->
       let workspace_lock_dirs_set = Path.Source.Set.of_list workspace_lock_dirs in
-      (* let chosen_lock_dirs = List.map ~f:Path.source chosen_lock_dirs in *)
       let chosen_lock_dirs_set = Path.Source.Set.of_list chosen_lock_dirs in
       if Path.Source.Set.is_subset chosen_lock_dirs_set ~of_:workspace_lock_dirs_set
       then chosen_lock_dirs

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -81,7 +81,7 @@ module Lock_dirs_arg : sig
 
       A user error is raised if the list of positional arguments used when
       creating [t] is not a subset of the lock directories of the workspace. *)
-  val lock_dirs_of_workspace : t -> Workspace.t -> Path.t list
+  val lock_dirs_of_workspace : t -> Workspace.t -> Path.Source.t list
 end
 
 (** [pp_packages lock_dir] returns a list of pretty-printed packages occurring in

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -13,7 +13,9 @@ let term =
         Pkg_common.Lock_dirs_arg.all
         workspace
     in
-    let any_lockdir_exists = List.exists lock_dir_paths ~f:Path.exists in
+    let any_lockdir_exists =
+      List.exists lock_dir_paths ~f:(fun p -> Path.exists (Path.source p))
+    in
     (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
        directories in the source tree *)
     let enabled = any_lockdir_exists || workspace.config.pkg_enabled in

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -30,9 +30,9 @@ let print_solver_env ~lock_dirs_arg =
     >>| Option.some
   in
   let lock_dirs = Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace in
-  List.iter
-    lock_dirs
-    ~f:(print_solver_env_for_lock_dir workspace ~solver_env_from_current_system)
+  List.iter lock_dirs ~f:(fun lock_dir ->
+    let lock_dir = Path.source lock_dir in
+    print_solver_env_for_lock_dir workspace ~solver_env_from_current_system lock_dir)
 ;;
 
 let term =

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -21,9 +21,9 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
     Workspace.workspace () >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
   in
   List.filter_map per_contexts ~f:(fun lock_dir_path ->
-    if Path.exists lock_dir_path
+    if Path.exists (Path.source lock_dir_path)
     then (
-      match Lock_dir.read_disk_exn lock_dir_path with
+      match Lock_dir.read_disk_exn (Path.source lock_dir_path) with
       | lock_dir -> Some (Ok (lock_dir_path, lock_dir))
       | exception User_error.E e -> Some (Error (lock_dir_path, `Parse_error e)))
     else None)
@@ -42,8 +42,9 @@ let validate_lock_dirs ~lock_dirs () =
   else
     let+ universes =
       Fiber.parallel_map lock_dirs_by_path ~f:(function
-        | Error e -> Fiber.return (Some e)
+        | Error (p, e) -> Fiber.return (Some (Path.source p, e))
         | Ok (lock_dir_path, lock_dir) ->
+          let lock_dir_path = Path.source lock_dir_path in
           let+ platform = solver_env_from_system_and_context ~lock_dir_path in
           (match Package_universe.create ~platform local_packages lock_dir with
            | Ok _ -> None

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -20,7 +20,17 @@ let build_dev_tool_directly common dev_tool =
   let open Fiber.O in
   let+ result =
     Build.run_build_system ~common ~request:(fun _build_system ->
-      Action_builder.path (dev_tool_exe_path dev_tool))
+      let d = dev_tool_exe_path dev_tool in
+      Printf.eprintf "Dev_tool_exe %S\n" (Path.to_string d);
+      let lock_dir_path = Dune_rules.Lock_dir.dev_tool_lock_dir dev_tool in
+      Printf.eprintf "Lock dir path for dev tool is %S\n" (Path.to_string lock_dir_path);
+      let open Action_builder.O in
+      dev_tool
+      |> Lock_dev_tool.lock_dev_tool
+      |> Action_builder.of_memo
+      (* probably the dev_tool_exe_path should have a dependency on lock_dir_path *)
+      >>> Action_builder.path lock_dir_path
+      >>> Action_builder.path (dev_tool_exe_path dev_tool))
   in
   match result with
   | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
@@ -41,7 +51,6 @@ let lock_and_build_dev_tool ~common ~config dev_tool =
       build_dev_tool_via_rpc dev_tool)
   | Ok () ->
     Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in
       build_dev_tool_directly common dev_tool)
 ;;
 
@@ -58,7 +67,9 @@ let run_dev_tool workspace_root dev_tool ~args =
 ;;
 
 let lock_build_and_run_dev_tool ~common ~config dev_tool ~args =
+  Printf.eprintf "Attempting to lock dev tool\n";
   lock_and_build_dev_tool ~common ~config dev_tool;
+  Printf.eprintf "Done locking & building dev tool\n";
   run_dev_tool (Common.root common) dev_tool ~args
 ;;
 

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -200,7 +200,6 @@ let remove_old_artifacts
         Path.Build.Map.mem rules_here.by_file_targets path
         || Path.Build.Map.mem rules_here.by_directory_targets path
       in
-      Printf.eprintf "Considering %S? Target %B Keep? %B\n" (Path.Build.to_string path) path_is_a_target (Subdir_set.mem subdirs_to_keep fn);
       if not path_is_a_target
       then (
         match kind with

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -200,6 +200,7 @@ let remove_old_artifacts
         Path.Build.Map.mem rules_here.by_file_targets path
         || Path.Build.Map.mem rules_here.by_directory_targets path
       in
+      Printf.eprintf "Considering %S? Target %B Keep? %B\n" (Path.Build.to_string path) path_is_a_target (Subdir_set.mem subdirs_to_keep fn);
       if not path_is_a_target
       then (
         match kind with
@@ -855,6 +856,7 @@ end = struct
         ~dir
         ~real_directory_targets:(Rules.directory_targets rules_produced)
         ~directory_targets;
+      (* Printf.eprintf "Descendants to keep %S\n" (Dir_set.to_dyn (Path.Local_gen.to_dyn) descendants_to_keep); *)
       (let subdirs_to_keep = Subdir_set.of_dir_set descendants_to_keep in
        remove_old_artifacts ~dir ~rules_here ~subdirs_to_keep;
        remove_old_sub_dirs_in_anonymous_actions_dir

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -818,8 +818,36 @@ module Pkg = struct
   let files_dir package_name maybe_package_version ~lock_dir =
     match files_dir_generic package_name maybe_package_version ~lock_dir with
     | In_source_tree _ as path -> path
-    | other ->
-      Code_error.raise "file_dir is not a source path" [ "path", Path.to_dyn other ]
+    | In_build_dir _ as path -> path
+    | External e ->
+      Code_error.raise
+        "file_dir is an external path, this is unsupported"
+        [ "path", Path.External.to_dyn e ]
+  ;;
+
+  (* TODO: deduplicate this function *)
+  let source_path_of_lock_dir_path path =
+    match (path : Path.t) with
+    | In_source_tree s -> s
+    | In_build_dir b ->
+      (match Path.Build.explode b with
+       | [ _; _; ".lock"; lock_dir; "content" ] -> Path.Source.of_string lock_dir
+       | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
+    | External e ->
+      Code_error.raise
+        "External lock dir path is unsupported"
+        [ "dir", Path.External.to_dyn e ]
+  ;;
+
+  let source_files_dir package_name package_version ~lock_dir =
+    let source = source_path_of_lock_dir_path lock_dir in
+    let extension = ".files" in
+    Path.Source.relative
+      source
+      (Package_name.to_string package_name
+       ^ "."
+       ^ Package_version.to_string package_version
+       ^ extension)
   ;;
 
   (* Combine the platform-specific parts of a pair of [t]s, raising a code

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1115,12 +1115,6 @@ let create_latest_version
   }
 ;;
 
-let dev_tool_lock_dir_path dev_tool =
-  let dev_tools_path = Path.(relative root "dev-tools.locks") in
-  Path.relative dev_tools_path (Package_name.to_string (Dev_tool.package_name dev_tool))
-;;
-
-let default_path = lazy Path.(relative root "dune.lock")
 let metadata_filename = "lock.dune"
 
 module Metadata = Dune_sexp.Versioned_file.Make (Unit)

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -831,7 +831,7 @@ module Pkg = struct
     | In_source_tree s -> s
     | In_build_dir b ->
       (match Path.Build.explode b with
-       | [ _; _; ".lock"; lock_dir; ] -> Path.Source.of_string lock_dir
+       | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
        | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
     | External e ->
       Code_error.raise

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -831,7 +831,7 @@ module Pkg = struct
     | In_source_tree s -> s
     | In_build_dir b ->
       (match Path.Build.explode b with
-       | [ _; _; ".lock"; lock_dir; "content" ] -> Path.Source.of_string lock_dir
+       | [ _; _; ".lock"; lock_dir; ] -> Path.Source.of_string lock_dir
        | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
     | External e ->
       Code_error.raise

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -832,6 +832,9 @@ module Pkg = struct
     | In_build_dir b ->
       (match Path.Build.explode b with
        | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
+       | [ _; _; ".dev-tool-locks"; dev_tool ] ->
+         (* TODO nicer *)
+         Path.Source.(relative (of_string "dev-tools.lock") dev_tool)
        | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
     | External e ->
       Code_error.raise

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1405,7 +1405,6 @@ module Make_load (Io : sig
     val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
     val readdir_with_kinds : Path.t -> (Filename.t * Unix.file_kind) list t
     val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
-    val stats_kind : Path.t -> (File_kind.t, Unix_error.Detailed.t) result t
   end) =
 struct
   let load_metadata metadata_file_path =
@@ -1487,36 +1486,6 @@ struct
       package_name
   ;;
 
-  let check_path lock_dir_path =
-    let open Io.O in
-    Io.stats_kind lock_dir_path
-    >>| function
-    | Ok S_DIR -> Ok ()
-    | Error (Unix.ENOENT, _, _) ->
-      Error
-        (User_error.make
-           ~hints:
-             [ Pp.concat
-                 ~sep:Pp.space
-                 [ Pp.text "Run"
-                 ; User_message.command "dune pkg lock"
-                 ; Pp.text "to generate it."
-                 ]
-               |> Pp.hovbox
-             ]
-           [ Pp.textf "%s does not exist." (Path.to_string lock_dir_path) ])
-    | Error e ->
-      Error
-        (User_error.make
-           [ Pp.textf "%s is not accessible" (Path.to_string lock_dir_path)
-           ; Pp.textf "reason: %s" (Unix_error.Detailed.to_string_hum e)
-           ])
-    | _ ->
-      Error
-        (User_error.make
-           [ Pp.textf "%s is not a directory." (Path.to_string lock_dir_path) ])
-  ;;
-
   let check_packages packages ~lock_dir_path =
     match validate_packages packages with
     | Ok () -> Ok ()
@@ -1553,50 +1522,46 @@ struct
 
   let load lock_dir_path =
     let open Io.O in
-    let* result = check_path lock_dir_path in
-    match result with
-    | Error e -> Io.return (Error e)
-    | Ok () ->
-      let* ( version
-           , dependency_hash
-           , ocaml
-           , repos
-           , expanded_solver_variable_bindings
-           , solved_for_platforms )
-        =
-        load_metadata (Path.relative lock_dir_path metadata_filename)
-      in
-      let+ packages =
-        Io.readdir_with_kinds lock_dir_path
-        >>| List.filter_map ~f:(fun (name, (kind : Unix.file_kind)) ->
-          match kind with
-          | S_REG -> Package_filename.to_package_name_and_version name |> Result.to_option
-          | _ ->
-            (* TODO *)
-            None)
-        >>= Io.parallel_map ~f:(fun (package_name, maybe_package_version) ->
-          let _loc, solved_for_platforms = solved_for_platforms in
-          let+ pkg =
-            load_pkg
-              ~version
-              ~lock_dir_path
-              ~solved_for_platforms
-              package_name
-              maybe_package_version
-          in
-          pkg)
-        >>| Packages.of_pkg_list
-      in
-      check_packages packages ~lock_dir_path
-      |> Result.map ~f:(fun () ->
-        { version
-        ; dependency_hash
-        ; packages
-        ; ocaml
-        ; repos
-        ; expanded_solver_variable_bindings
-        ; solved_for_platforms
-        })
+    let* ( version
+         , dependency_hash
+         , ocaml
+         , repos
+         , expanded_solver_variable_bindings
+         , solved_for_platforms )
+      =
+      load_metadata (Path.relative lock_dir_path metadata_filename)
+    in
+    let+ packages =
+      Io.readdir_with_kinds lock_dir_path
+      >>| List.filter_map ~f:(fun (name, (kind : Unix.file_kind)) ->
+        match kind with
+        | S_REG -> Package_filename.to_package_name_and_version name |> Result.to_option
+        | _ ->
+          (* TODO *)
+          None)
+      >>= Io.parallel_map ~f:(fun (package_name, maybe_package_version) ->
+        let _loc, solved_for_platforms = solved_for_platforms in
+        let+ pkg =
+          load_pkg
+            ~version
+            ~lock_dir_path
+            ~solved_for_platforms
+            package_name
+            maybe_package_version
+        in
+        pkg)
+      >>| Packages.of_pkg_list
+    in
+    check_packages packages ~lock_dir_path
+    |> Result.map ~f:(fun () ->
+      { version
+      ; dependency_hash
+      ; packages
+      ; ocaml
+      ; repos
+      ; expanded_solver_variable_bindings
+      ; solved_for_platforms
+      })
   ;;
 
   let load_exn lock_dir_path =
@@ -1607,10 +1572,6 @@ end
 
 module Load_immediate = Make_load (struct
     include Monad.Id
-
-    let stats_kind file =
-      file |> Path.stat |> Result.map ~f:(fun { Unix.st_kind; _ } -> st_kind)
-    ;;
 
     let parallel_map xs ~f = List.map xs ~f
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -149,7 +149,6 @@ module Make_load (Io : sig
     val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
     val readdir_with_kinds : Path.t -> (Filename.t * Unix.file_kind) list t
     val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a t
-    val stats_kind : Path.t -> (File_kind.t, Unix_error.Detailed.t) result t
   end) : sig
   val load : Path.t -> (t, User_message.t) result Io.t
   val load_exn : Path.t -> t Io.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -74,6 +74,14 @@ module Pkg : sig
         Decoder.t
 
   val files_dir : Package_name.t -> Package_version.t option -> lock_dir:Path.t -> Path.t
+
+  (** [source_files_dir p v l] returns the path of the versioned files dir. Might return
+      a path that does not exist. *)
+  val source_files_dir
+    :  Package_name.t
+    -> Package_version.t
+    -> lock_dir:Path.t
+    -> Path.Source.t
 end
 
 module Repositories : sig

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -122,12 +122,6 @@ val create_latest_version
        (* TODO: make this non-optional when portable lockdirs becomes the default *)
   -> t
 
-val default_path : Path.t Lazy.t
-
-(** Returns the path to the lockdir that will be used to lock the
-    given dev tool *)
-val dev_tool_lock_dir_path : Dev_tool.t -> Path.t
-
 module Metadata : Dune_sexp.Versioned_file.S with type data := unit
 
 val metadata_filename : Filename.t

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -189,8 +189,7 @@ let find_checksum, find_url =
           ~init:(Checksum.Map.empty, Digest.Map.empty)
           ~f:(fun acc dev_tool ->
             Fs_memo.dir_exists
-              (Path.as_outside_build_dir_exn
-                 (Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool))
+              (In_source_dir (Lock_dir.dev_tool_source_lock_dir dev_tool))
             >>= function
             | false -> Memo.return acc
             | true -> Lock_dir.of_dev_tool dev_tool >>| add_checksums_and_urls acc)

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -188,14 +188,18 @@ let find_checksum, find_url =
           Dune_pkg.Dev_tool.all
           ~init:(Checksum.Map.empty, Digest.Map.empty)
           ~f:(fun acc dev_tool ->
-            Fs_memo.dir_exists
-              (In_source_dir (Lock_dir.dev_tool_source_lock_dir dev_tool))
+            Source_tree.find_dir (Lock_dir.dev_tool_source_lock_dir dev_tool)
             >>= function
-            | false -> Memo.return acc
-            | true -> Lock_dir.of_dev_tool dev_tool >>| add_checksums_and_urls acc)
+            | None -> Memo.return acc
+            | Some _ -> Lock_dir.of_dev_tool dev_tool >>| add_checksums_and_urls acc)
       in
       Per_context.list ()
-      >>= Memo.parallel_map ~f:Lock_dir.get
+      >>= Memo.parallel_map ~f:(fun ctx_name ->
+        let* active = Lock_dir.lock_dir_active ctx_name in
+        match active with
+        | true -> Lock_dir.get ctx_name
+        | false ->
+          Memo.return @@ Error (User_message.make [ Pp.text "Context has no lock dir" ]))
       >>| List.filter_map ~f:Result.to_option
       >>| List.fold_left ~init ~f:add_checksums_and_urls)
   in

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -33,8 +33,8 @@ end
 
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
-    let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Ocamlformat in
-    path |> Path.as_outside_build_dir_exn |> Fs_memo.dir_exists
+    let path = Lock_dir.dev_tool_source_lock_dir Ocamlformat in
+    Fs_memo.dir_exists (In_source_dir path)
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -34,7 +34,8 @@ end
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
     let path = Lock_dir.dev_tool_source_lock_dir Ocamlformat in
-    Fs_memo.dir_exists (In_source_dir path)
+    let+ exists = Source_tree.find_dir path >>| Option.is_some in
+    exists
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -648,7 +648,10 @@ let private_context ~dir components _ctx =
   analyze_private_context_path components
   >>= function
   | `Invalid_context -> Memo.return Gen_rules.unknown_context
-  | `Valid (ctx, components) -> Pkg_rules.setup_rules ctx ~dir ~components
+  | `Valid (ctx, components) ->
+    let+ lock_rules = Lock_rules.setup_rules ~dir ~components
+    and+ pkg_rules = Pkg_rules.setup_rules ctx ~dir ~components in
+    Gen_rules.combine lock_rules pkg_rules
   | `Root ->
     let+ contexts = Per_context.list () in
     let build_dir_only_sub_dirs =

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -184,6 +184,7 @@ let get_workspace_lock_dir ctx =
 
 let get_with_path ctx =
   let* path = get_path ctx >>| Option.value_exn in
+  let* () = Build_system.build_dir path in
   Load.load path
   >>= function
   | Error e -> Memo.return (Error e)

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -136,7 +136,7 @@ let default_path =
   let ctx_name = "default" in
   Path.Build.L.relative
     Private_context.t.build_dir
-    [ ctx_name; ".lock"; "dune.lock"; "content" ]
+    [ ctx_name; ".lock"; "dune.lock" ]
   |> Path.build
 ;;
 
@@ -158,7 +158,6 @@ let dev_tool_lock_dir dev_tool =
     Path.Build.L.relative Private_context.t.build_dir [ ctx_name; ".dev-tool-locks" ]
   in
   let lock_dir = Path.Build.append_local lock_dir l in
-  let lock_dir = Path.Build.relative lock_dir "content" in
   Path.build lock_dir
 ;;
 

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -136,6 +136,37 @@ let select_lock_dir lock_dir_selection =
   Workspace.Lock_dir_selection.eval lock_dir_selection ~dir:workspace.dir ~f:expander
 ;;
 
+let default_path =
+  (* TODO remove ctx_name *)
+  let ctx_name = "default" in
+  Path.Build.L.relative
+    Private_context.t.build_dir
+    [ ctx_name; ".lock"; "dune.lock"; "content" ]
+  |> Path.build
+;;
+
+let dev_tool_to_path_segment dev_tool =
+  dev_tool |> Dev_tool.package_name |> Package_name.to_string |> Path.Local.of_string
+;;
+
+let dev_tool_source_lock_dir dev_tool =
+  let dev_tools_path = Path.Source.(relative root "dev-tools.locks") in
+  let dev_tool_segment = dev_tool_to_path_segment dev_tool in
+  Path.Source.append_local dev_tools_path dev_tool_segment
+;;
+
+let dev_tool_lock_dir dev_tool =
+  (* dev tools always live in default *)
+  let ctx_name = "default" in
+  let l = dev_tool_to_path_segment dev_tool in
+  let lock_dir =
+    Path.Build.L.relative Private_context.t.build_dir [ ctx_name; ".lock" ]
+  in
+  let lock_dir = Path.Build.append_local lock_dir l in
+  let lock_dir = Path.Build.relative lock_dir "content" in
+  Path.build lock_dir
+;;
+
 let get_path ctx =
   let* workspace = Workspace.workspace () in
   match
@@ -144,10 +175,9 @@ let get_path ctx =
       | false -> None
       | true -> Some ctx')
   with
-  | None -> Memo.return (Some (Lazy.force default_path))
+  | None | Some (Default { lock_dir = None; _ }) -> Memo.return (Some default_path)
   | Some (Default { lock_dir = Some lock_dir_selection; _ }) ->
     select_lock_dir lock_dir_selection >>| Option.some
-  | Some (Default { lock_dir = None; _ }) -> Memo.return (Some (Lazy.force default_path))
   | Some (Opam _) -> Memo.return None
 ;;
 
@@ -177,12 +207,17 @@ let get ctx = get_with_path ctx >>| Result.map ~f:snd
 let get_exn ctx = get ctx >>| User_error.ok_exn
 
 let of_dev_tool dev_tool =
-  let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool in
-  Fs_memo.dir_exists (Path.as_outside_build_dir_exn path)
+  let source_path = dev_tool_source_lock_dir dev_tool in
+  Fs_memo.dir_exists (In_source_dir source_path)
   >>= function
-  | true -> Load.load_exn path
+  | true ->
+    (* if it exists, load it from the build location by triggering the
+         copy rules *)
+    let lock_dir_path = dev_tool_lock_dir dev_tool in
+    Load.load_exn lock_dir_path
   | false ->
-    User_error.raise [ Pp.textf "%s does not exist" (Path.to_string_maybe_quoted path) ]
+    User_error.raise
+      [ Pp.textf "%s does not exist" (Path.Source.to_string_maybe_quoted source_path) ]
 ;;
 
 let lock_dir_active ctx =

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -101,21 +101,16 @@ module Load = Make_load (struct
     include Memo
 
     let readdir_with_kinds path =
-      Fs_memo.dir_contents (Path.as_outside_build_dir_exn path)
-      >>| function
+      Readdir.read_directory_with_kinds (Path.to_string path)
+      |> function
       | Error _ ->
         (* CR-someday rgrinberg: add some proper message here *)
         User_error.raise [ Pp.text "" ]
-      | Ok content -> Fs_cache.Dir_contents.to_list content
+      | Ok content -> return content
     ;;
 
     let with_lexbuf_from_file path ~f =
-      Fs_memo.with_lexbuf_from_file (Path.as_outside_build_dir_exn path) ~f
-    ;;
-
-    let stats_kind p =
-      Fs_memo.path_stat (Path.as_outside_build_dir_exn p)
-      >>| Stdune.Result.map ~f:(fun { Fs_cache.Reduced_stats.st_kind; _ } -> st_kind)
+      Io.Untracked.with_lexbuf_from_file path ~f |> return
     ;;
   end)
 
@@ -160,7 +155,7 @@ let dev_tool_lock_dir dev_tool =
   let ctx_name = "default" in
   let l = dev_tool_to_path_segment dev_tool in
   let lock_dir =
-    Path.Build.L.relative Private_context.t.build_dir [ ctx_name; ".lock" ]
+    Path.Build.L.relative Private_context.t.build_dir [ ctx_name; ".dev-tool-locks" ]
   in
   let lock_dir = Path.Build.append_local lock_dir l in
   let lock_dir = Path.Build.relative lock_dir "content" in
@@ -221,13 +216,7 @@ let of_dev_tool dev_tool =
 ;;
 
 let lock_dir_active ctx =
-  if !Clflags.ignore_lock_dir
-  then Memo.return false
-  else
-    get_path ctx
-    >>= function
-    | None -> Memo.return false
-    | Some path -> Fs_memo.dir_exists (Path.as_outside_build_dir_exn path)
+  if !Clflags.ignore_lock_dir then Memo.return false else get_path ctx >>| Option.is_some
 ;;
 
 let source_kind (source : Dune_pkg.Source.t) =

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -163,8 +163,9 @@ let dev_tool_lock_dir dev_tool =
 ;;
 
 let get_path ctx =
+  (* TODO check if lock dir was ignored *)
   let* workspace = Workspace.workspace () in
-  match
+  let* v = match
     List.find_map workspace.contexts ~f:(fun ctx' ->
       match Context_name.equal (Workspace.Context.name ctx') ctx with
       | false -> None
@@ -174,17 +175,38 @@ let get_path ctx =
   | Some (Default { lock_dir = Some lock_dir_selection; _ }) ->
     select_lock_dir lock_dir_selection >>| Option.some
   | Some (Opam _) -> Memo.return None
+  in
+  match v with
+  | None -> Memo.return None
+  | Some p ->
+      let temp = Path.Source.of_string "dune.lock" in
+      let* dir = Source_tree.find_dir temp in
+      match dir with
+      | None ->
+          Printf.eprintf "Not part of the source tree\n";
+          Memo.return (Some p)
+      | Some _ ->
+          Printf.eprintf "We got a path\n";
+          Memo.return (Some p)
 ;;
 
 let get_workspace_lock_dir ctx =
   let* workspace = Workspace.workspace () in
-  let+ path = get_path ctx >>| Option.value_exn in
+  let+ path = get_path ctx in
+  let open Option.O in
+  let* path in
   Workspace.find_lock_dir workspace path
 ;;
 
 let get_with_path ctx =
   let* path = get_path ctx >>| Option.value_exn in
-  let* () = Build_system.build_dir path in
+  let temp = Path.Source.of_string "dune.lock" in
+  let* dir = Source_tree.find_dir temp in
+  let* () = match dir with
+    (* | None -> Memo.return () *)
+    | None
+    | Some _ -> Build_system.build_dir path
+  in
   Load.load path
   >>= function
   | Error e -> Memo.return (Error e)

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -134,9 +134,7 @@ let select_lock_dir lock_dir_selection =
 let default_path =
   (* TODO remove ctx_name *)
   let ctx_name = "default" in
-  Path.Build.L.relative
-    Private_context.t.build_dir
-    [ ctx_name; ".lock"; "dune.lock" ]
+  Path.Build.L.relative Private_context.t.build_dir [ ctx_name; ".lock"; "dune.lock" ]
   |> Path.build
 ;;
 
@@ -164,7 +162,7 @@ let dev_tool_lock_dir dev_tool =
 let get_path ctx =
   (* TODO check if lock dir was ignored *)
   let* workspace = Workspace.workspace () in
-  let* v = match
+  match
     List.find_map workspace.contexts ~f:(fun ctx' ->
       match Context_name.equal (Workspace.Context.name ctx') ctx with
       | false -> None
@@ -174,38 +172,19 @@ let get_path ctx =
   | Some (Default { lock_dir = Some lock_dir_selection; _ }) ->
     select_lock_dir lock_dir_selection >>| Option.some
   | Some (Opam _) -> Memo.return None
-  in
-  match v with
-  | None -> Memo.return None
-  | Some p ->
-      let temp = Path.Source.of_string "dune.lock" in
-      let* dir = Source_tree.find_dir temp in
-      match dir with
-      | None ->
-          Printf.eprintf "Not part of the source tree\n";
-          Memo.return (Some p)
-      | Some _ ->
-          Printf.eprintf "We got a path\n";
-          Memo.return (Some p)
 ;;
 
 let get_workspace_lock_dir ctx =
   let* workspace = Workspace.workspace () in
   let+ path = get_path ctx in
   let open Option.O in
-  let* path in
+  let* path = path in
   Workspace.find_lock_dir workspace path
 ;;
 
 let get_with_path ctx =
   let* path = get_path ctx >>| Option.value_exn in
-  let temp = Path.Source.of_string "dune.lock" in
-  let* dir = Source_tree.find_dir temp in
-  let* () = match dir with
-    (* | None -> Memo.return () *)
-    | None
-    | Some _ -> Build_system.build_dir path
-  in
+  let* () = Build_system.build_dir path in
   Load.load path
   >>= function
   | Error e -> Memo.return (Error e)

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -138,6 +138,8 @@ let default_path =
   |> Path.build
 ;;
 
+let default_source_path = Path.Source.(relative root "dune.lock")
+
 let dev_tool_to_path_segment dev_tool =
   dev_tool |> Dev_tool.package_name |> Package_name.to_string |> Path.Local.of_string
 ;;
@@ -159,19 +161,31 @@ let dev_tool_lock_dir dev_tool =
   Path.build lock_dir
 ;;
 
-let get_path ctx =
+let get_path ctx_name =
   (* TODO check if lock dir was ignored *)
   let* workspace = Workspace.workspace () in
-  match
-    List.find_map workspace.contexts ~f:(fun ctx' ->
-      match Context_name.equal (Workspace.Context.name ctx') ctx with
+  let ctx =
+    List.find_map workspace.contexts ~f:(fun ctx ->
+      match Context_name.equal (Workspace.Context.name ctx) ctx_name with
       | false -> None
-      | true -> Some ctx')
-  with
-  | None | Some (Default { lock_dir = None; _ }) -> Memo.return (Some default_path)
-  | Some (Default { lock_dir = Some lock_dir_selection; _ }) ->
-    select_lock_dir lock_dir_selection >>| Option.some
-  | Some (Opam _) -> Memo.return None
+      | true -> Some ctx)
+  in
+  let* lock_dir_paths =
+    match ctx with
+    | None | Some (Default { lock_dir = None; _ }) ->
+      Memo.return (Some (default_source_path, default_path))
+    | Some (Default { lock_dir = Some lock_dir_selection; _ }) ->
+      let+ source_lock_dir = select_lock_dir lock_dir_selection in
+      Some (source_lock_dir, Path.of_string "TODO")
+    | Some (Opam _) -> Memo.return None
+  in
+  match lock_dir_paths with
+  | None -> Memo.return None
+  | Some (source_path, lock_dir_path) ->
+    let* in_source_tree = Source_tree.find_dir source_path in
+    (match in_source_tree with
+     | Some _ -> Memo.return (Some lock_dir_path)
+     | None -> Memo.return None)
 ;;
 
 let get_workspace_lock_dir ctx =

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -197,7 +197,15 @@ let get_workspace_lock_dir ctx =
 ;;
 
 let get_with_path ctx =
-  let* path = get_path ctx >>| Option.value_exn in
+  let* path =
+    get_path ctx
+    >>| function
+    | Some p -> p
+    | None ->
+      Code_error.raise
+        "No lock dir path for context availabled"
+        [ "context", Context_name.to_dyn ctx ]
+  in
   let* () = Build_system.build_dir path in
   Load.load path
   >>= function
@@ -218,14 +226,15 @@ let get_exn ctx = get ctx >>| User_error.ok_exn
 
 let of_dev_tool dev_tool =
   let source_path = dev_tool_source_lock_dir dev_tool in
-  Fs_memo.dir_exists (In_source_dir source_path)
+  Source_tree.find_dir source_path
   >>= function
-  | true ->
+  | Some _ ->
     (* if it exists, load it from the build location by triggering the
-         copy rules *)
+         copy rules before loading it *)
     let lock_dir_path = dev_tool_lock_dir dev_tool in
+    let* () = Build_system.build_dir lock_dir_path in
     Load.load_exn lock_dir_path
-  | false ->
+  | None ->
     User_error.raise
       [ Pp.textf "%s does not exist" (Path.Source.to_string_maybe_quoted source_path) ]
 ;;

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -10,6 +10,16 @@ val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.t option Memo.t
 
+(** The default filesystem location where the lock dir is going to get created *)
+val default_path : Path.t
+
+(** The location in the source tree where a dev tool lock dir is expected *)
+val dev_tool_source_lock_dir : Dune_pkg.Dev_tool.t -> Path.Source.t
+
+(** Returns the path to the lockdir that will be used to lock the
+    given dev tool *)
+val dev_tool_lock_dir : Dune_pkg.Dev_tool.t -> Path.t
+
 module Sys_vars : sig
   type t =
     { os : string option Memo.Lazy.t

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -13,6 +13,9 @@ val get_path : Context_name.t -> Path.t option Memo.t
 (** The default filesystem location where the lock dir is going to get created *)
 val default_path : Path.t
 
+(** The default path where the lock dir will be written to manually *)
+val default_source_path : Path.Source.t
+
 (** The location in the source tree where a dev tool lock dir is expected *)
 val dev_tool_source_lock_dir : Dune_pkg.Dev_tool.t -> Path.Source.t
 

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -34,10 +34,12 @@ module Copy = struct
       let+ () = Fiber.return () in
       Path.mkdir_p (Path.build target);
       Path.Source.Set.iter files ~f:(fun src ->
-        (* let src = Path.Source.relative lock_dir filename in *)
         let dst =
           match Path.Source.explode src with
-          | [] -> Code_error.raise "meh" []
+          | [] ->
+            Code_error.raise
+              "Somehow the path is unexpected"
+              [ "src", Path.Source.to_dyn src ]
           | _ :: components -> Path.Build.L.relative target components
         in
         let parent = Path.Build.parent_exn dst in
@@ -81,18 +83,32 @@ let copy_lock_dir ~target ~lock_dir ~files =
 
 let setup_copy_rules ~dir ~lock_dir =
   let target = Path.Build.relative dir "content" in
-  let rules =
-    Rules.collect_unit (fun () ->
-      let* files = files lock_dir in
-      let copy_rule = copy_lock_dir ~target ~lock_dir ~files in
-      rule ~loc:Loc.none copy_rule)
+  let+ _deps, file_set = Source_deps.files (Path.source lock_dir) in
+  let directory_targets, rules =
+    match Path.Set.is_empty file_set with
+    | false ->
+      let directory_targets = Some (Path.Build.Map.singleton target Loc.none) in
+      ( directory_targets
+      , Rules.collect_unit (fun () ->
+          let* _files = files lock_dir in
+          let files =
+            Path.Set.fold
+              ~init:Path.Source.Set.empty
+              ~f:(fun e acc ->
+                match (e : Path.t) with
+                | In_source_tree p -> Path.Source.Set.add acc p
+                | _ -> Code_error.raise "Whatsup" [])
+              file_set
+          in
+          let copy_rule = copy_lock_dir ~target ~lock_dir ~files in
+          rule ~loc:Loc.none copy_rule) )
+    | true -> None, Memo.return Rules.empty
   in
-  let directory_targets = Path.Build.Map.singleton target Loc.none in
-  Gen_rules.make ~directory_targets rules
+  Gen_rules.make ?directory_targets rules
 ;;
 
 let setup_lock_rules ~dir ~lock_dir =
-  let+ workspace = Workspace.workspace () in
+  let* workspace = Workspace.workspace () in
   let lock_dir = Path.Source.relative workspace.dir lock_dir in
   setup_copy_rules ~dir ~lock_dir
 ;;

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -11,7 +11,7 @@ module Copy = struct
     type ('path, 'target) t =
       { target : 'target
       ; lock_dir : Path.Source.t
-      ; contents : Fs_cache.Dir_contents.t
+      ; files : Path.Source.Set.t
       }
 
     let name = "copy-lock-dir"
@@ -19,24 +19,30 @@ module Copy = struct
     let bimap t _ g = { t with target = g t.target }
     let is_useful_to ~memoize = memoize
 
-    let encode { target; lock_dir; contents } _encode_path encode_target : Sexp.t =
+    let encode { target; lock_dir; files } _encode_path encode_target : Sexp.t =
       let contents : Sexp.t list =
-        contents
-        |> Fs_cache.Dir_contents.to_list
-        |> List.map ~f:(fun (filename, filekind) ->
-          Sexp.List
-            [ Atom filename; Atom (filekind |> File_kind.to_dyn |> Dyn.to_string) ])
+        files
+        |> Path.Source.Set.to_list
+        |> List.sort ~compare:Path.Source.compare
+        |> List.map ~f:(fun p -> Sexp.Atom (Path.Source.to_string p))
       in
       List [ encode_target target; Atom (Path.Source.to_string lock_dir); List contents ]
     ;;
 
-    let action { target; lock_dir; contents } ~ectx:_ ~eenv:_ =
+    let action { target; lock_dir = _; files } ~ectx:_ ~eenv:_ =
       let open Fiber.O in
       let+ () = Fiber.return () in
       Path.mkdir_p (Path.build target);
-      Fs_cache.Dir_contents.iter contents ~f:(fun (filename, _file_kind) ->
-        let src = Path.Source.relative lock_dir filename in
-        let dst = Path.Build.relative target filename in
+      Path.Source.Set.iter files ~f:(fun src ->
+        (* let src = Path.Source.relative lock_dir filename in *)
+        let dst =
+          match Path.Source.explode src with
+          | [] -> Code_error.raise "meh" []
+          | _ :: components -> Path.Build.L.relative target components
+        in
+        let parent = Path.Build.parent_exn dst in
+        (* Printf.eprintf "Source to copy %S => %S (parent %S)\n" (Path.Source.to_string src) (Path.Build.to_string dst) (Path.Build.to_string parent); *)
+        Path.mkdir_p (Path.build parent);
         Io.copy_file ~src:(Path.source src) ~dst:(Path.build dst) ())
     ;;
   end
@@ -44,8 +50,30 @@ module Copy = struct
   module A = Action_ext.Make (Spec)
 end
 
-let copy_lock_dir ~target ~lock_dir ~contents =
-  Copy.A.action { Copy.Spec.target; lock_dir; contents }
+let rec files p =
+  let open Memo.O in
+  let* dir_contents = Fs_memo.dir_contents (Path.Outside_build_dir.In_source_dir p) in
+  let dir_contents =
+    match dir_contents with
+    | Ok dir_contents -> dir_contents
+    | Error _ -> User_error.raise [ Pp.text "meh" ]
+  in
+  let dir_contents = Fs_cache.Dir_contents.to_list dir_contents in
+  Memo.List.fold_left
+    dir_contents
+    ~f:(fun acc (file_name, file_kind) ->
+      let p = Path.Source.relative p file_name in
+      match file_kind with
+      | S_REG -> Memo.return (Path.Source.Set.add acc p)
+      | S_DIR ->
+        let* recursive = files p in
+        Path.Source.Set.union acc recursive |> Memo.return
+      | _ -> User_error.raise [ Pp.text "lock dir is problematique" ])
+    ~init:Path.Source.Set.empty
+;;
+
+let copy_lock_dir ~target ~lock_dir ~files =
+  Copy.A.action { Copy.Spec.target; lock_dir; files }
   |> Action.Full.make ~can_go_in_shared_cache:false
   |> Action_builder.With_targets.return
   |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
@@ -55,19 +83,8 @@ let setup_copy_rules ~dir ~lock_dir =
   let target = Path.Build.relative dir "content" in
   let rules =
     Rules.collect_unit (fun () ->
-      let* dir_contents =
-        Fs_memo.dir_contents (Path.Outside_build_dir.In_source_dir lock_dir)
-      in
-      let contents =
-        match dir_contents with
-        | Ok dir_contents -> dir_contents
-        | Error unix_error ->
-          User_error.raise
-            [ Pp.text "Failed to read lock directory from source tree"
-            ; Pp.text (Unix_error.Detailed.to_string_hum unix_error)
-            ]
-      in
-      let copy_rule = copy_lock_dir ~target ~lock_dir ~contents in
+      let* files = files lock_dir in
+      let copy_rule = copy_lock_dir ~target ~lock_dir ~files in
       rule ~loc:Loc.none copy_rule)
   in
   let directory_targets = Path.Build.Map.singleton target Loc.none in

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -81,8 +81,7 @@ let copy_lock_dir ~target ~lock_dir ~files =
   |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
 ;;
 
-let setup_copy_rules ~dir ~lock_dir =
-  let target = Path.Build.relative dir "content" in
+let setup_copy_rules ~dir:target ~lock_dir =
   let+ _deps, file_set = Source_deps.files (Path.source lock_dir) in
   let directory_targets, rules =
     match Path.Set.is_empty file_set with
@@ -90,6 +89,7 @@ let setup_copy_rules ~dir ~lock_dir =
       let directory_targets = Some (Path.Build.Map.singleton target Loc.none) in
       ( directory_targets
       , Rules.collect_unit (fun () ->
+          (* TODO use Source_deps.files here too *)
           let* _files = files lock_dir in
           let files =
             Path.Set.fold
@@ -111,6 +111,7 @@ let setup_copy_rules ~dir ~lock_dir =
 
 let setup_lock_rules ~dir ~lock_dir =
   let* workspace = Workspace.workspace () in
+  let dir = Path.Build.relative dir lock_dir in
   let lock_dir = Path.Source.relative workspace.dir lock_dir in
   setup_copy_rules ~dir ~lock_dir
 ;;
@@ -118,12 +119,8 @@ let setup_lock_rules ~dir ~lock_dir =
 let setup_rules ~components ~dir =
   match components with
   | [ ".lock" ] ->
-    Gen_rules.make
-      ~build_dir_only_sub_dirs:
-        (Gen_rules.Build_only_sub_dirs.singleton ~dir Subdir_set.all)
-      (Memo.return Rules.empty)
-    |> Memo.return
-  | [ ".lock"; lock_dir ] -> setup_lock_rules ~dir ~lock_dir
+     (* TODO enable other lock dirs too, by reading them from the workspace *)
+    setup_lock_rules ~dir ~lock_dir:"dune.lock"
   | [] ->
     let sub_dirs = [ ".lock" ] in
     let build_dir_only_sub_dirs =

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -1,0 +1,99 @@
+open Import
+open Memo.O
+module Gen_rules = Build_config.Gen_rules
+
+let rule ?loc { Action_builder.With_targets.build; targets } =
+  Rule.make ~info:(Rule.Info.of_loc_opt loc) ~targets build |> Rules.Produce.rule
+;;
+
+module Copy = struct
+  module Spec = struct
+    type ('path, 'target) t =
+      { target : 'target
+      ; lock_dir : Path.Source.t
+      ; contents : Fs_cache.Dir_contents.t
+      }
+
+    let name = "copy-lock-dir"
+    let version = 1
+    let bimap t _ g = { t with target = g t.target }
+    let is_useful_to ~memoize = memoize
+
+    let encode { target; lock_dir; contents } _encode_path encode_target : Sexp.t =
+      let contents : Sexp.t list =
+        contents
+        |> Fs_cache.Dir_contents.to_list
+        |> List.map ~f:(fun (filename, filekind) ->
+          Sexp.List
+            [ Atom filename; Atom (filekind |> File_kind.to_dyn |> Dyn.to_string) ])
+      in
+      List [ encode_target target; Atom (Path.Source.to_string lock_dir); List contents ]
+    ;;
+
+    let action { target; lock_dir; contents } ~ectx:_ ~eenv:_ =
+      let open Fiber.O in
+      let+ () = Fiber.return () in
+      Path.mkdir_p (Path.build target);
+      Fs_cache.Dir_contents.iter contents ~f:(fun (filename, _file_kind) ->
+        let src = Path.Source.relative lock_dir filename in
+        let dst = Path.Build.relative target filename in
+        Io.copy_file ~src:(Path.source src) ~dst:(Path.build dst) ())
+    ;;
+  end
+
+  module A = Action_ext.Make (Spec)
+end
+
+let copy_lock_dir ~target ~lock_dir ~contents =
+  Copy.A.action { Copy.Spec.target; lock_dir; contents }
+  |> Action.Full.make ~can_go_in_shared_cache:false
+  |> Action_builder.With_targets.return
+  |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
+;;
+
+let setup_copy_rules ~dir ~lock_dir =
+  let target = Path.Build.relative dir "content" in
+  let rules =
+    Rules.collect_unit (fun () ->
+      let* dir_contents =
+        Fs_memo.dir_contents (Path.Outside_build_dir.In_source_dir lock_dir)
+      in
+      let contents =
+        match dir_contents with
+        | Ok dir_contents -> dir_contents
+        | Error unix_error ->
+          User_error.raise
+            [ Pp.text "Failed to read lock directory from source tree"
+            ; Pp.text (Unix_error.Detailed.to_string_hum unix_error)
+            ]
+      in
+      let copy_rule = copy_lock_dir ~target ~lock_dir ~contents in
+      rule ~loc:Loc.none copy_rule)
+  in
+  let directory_targets = Path.Build.Map.singleton target Loc.none in
+  Gen_rules.make ~directory_targets rules
+;;
+
+let setup_lock_rules ~dir ~lock_dir =
+  let+ workspace = Workspace.workspace () in
+  let lock_dir = Path.Source.relative workspace.dir lock_dir in
+  setup_copy_rules ~dir ~lock_dir
+;;
+
+let setup_rules ~components ~dir =
+  match components with
+  | [ ".lock" ] ->
+    Gen_rules.make
+      ~build_dir_only_sub_dirs:
+        (Gen_rules.Build_only_sub_dirs.singleton ~dir Subdir_set.all)
+      (Memo.return Rules.empty)
+    |> Memo.return
+  | [ ".lock"; lock_dir ] -> setup_lock_rules ~dir ~lock_dir
+  | [] ->
+    let sub_dirs = [ ".lock" ] in
+    let build_dir_only_sub_dirs =
+      Gen_rules.Build_only_sub_dirs.singleton ~dir @@ Subdir_set.of_list sub_dirs
+    in
+    Memo.return @@ Gen_rules.make ~build_dir_only_sub_dirs (Memo.return Rules.empty)
+  | _ -> Memo.return @@ Gen_rules.rules_here Gen_rules.Rules.empty
+;;

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -85,10 +85,11 @@ let setup_copy_rules ~dir:target ~lock_dir =
   let+ _deps, file_set = Source_deps.files (Path.source lock_dir) in
   let directory_targets, rules =
     match Path.Set.is_empty file_set with
+    | true -> Path.Build.Map.empty, Memo.return Rules.empty
     | false ->
-      let directory_targets = Some (Path.Build.Map.singleton target Loc.none) in
-      ( directory_targets
-      , Rules.collect_unit (fun () ->
+      let directory_targets = Path.Build.Map.singleton target Loc.none in
+      let rules =
+        Rules.collect_unit (fun () ->
           (* TODO use Source_deps.files here too *)
           let* _files = files lock_dir in
           let files =
@@ -101,12 +102,11 @@ let setup_copy_rules ~dir:target ~lock_dir =
               file_set
           in
           let copy_rule = copy_lock_dir ~target ~lock_dir ~files in
-          rule ~loc:Loc.none copy_rule) )
-    | true ->
-        Printf.eprintf "No rules here\n";
-        Some (Path.Build.Map.empty), Memo.return Rules.empty
+          rule ~loc:Loc.none copy_rule)
+      in
+      directory_targets, rules
   in
-  Gen_rules.make ?directory_targets rules
+  Gen_rules.make ~directory_targets rules
 ;;
 
 let setup_lock_rules ~dir ~lock_dir =
@@ -119,7 +119,7 @@ let setup_lock_rules ~dir ~lock_dir =
 let setup_rules ~components ~dir =
   match components with
   | [ ".lock" ] ->
-     (* TODO enable other lock dirs too, by reading them from the workspace *)
+    (* TODO enable other lock dirs too, by reading them from the workspace *)
     setup_lock_rules ~dir ~lock_dir:"dune.lock"
   | [] ->
     let sub_dirs = [ ".lock" ] in

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -102,7 +102,9 @@ let setup_copy_rules ~dir ~lock_dir =
           in
           let copy_rule = copy_lock_dir ~target ~lock_dir ~files in
           rule ~loc:Loc.none copy_rule) )
-    | true -> None, Memo.return Rules.empty
+    | true ->
+        Printf.eprintf "No rules here\n";
+        Some (Path.Build.Map.empty), Memo.return Rules.empty
   in
   Gen_rules.make ?directory_targets rules
 ;;

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -52,28 +52,6 @@ module Copy = struct
   module A = Action_ext.Make (Spec)
 end
 
-let rec files p =
-  let open Memo.O in
-  let* dir_contents = Fs_memo.dir_contents (Path.Outside_build_dir.In_source_dir p) in
-  let dir_contents =
-    match dir_contents with
-    | Ok dir_contents -> dir_contents
-    | Error _ -> User_error.raise [ Pp.text "meh" ]
-  in
-  let dir_contents = Fs_cache.Dir_contents.to_list dir_contents in
-  Memo.List.fold_left
-    dir_contents
-    ~f:(fun acc (file_name, file_kind) ->
-      let p = Path.Source.relative p file_name in
-      match file_kind with
-      | S_REG -> Memo.return (Path.Source.Set.add acc p)
-      | S_DIR ->
-        let* recursive = files p in
-        Path.Source.Set.union acc recursive |> Memo.return
-      | _ -> User_error.raise [ Pp.text "lock dir is problematique" ])
-    ~init:Path.Source.Set.empty
-;;
-
 let copy_lock_dir ~target ~lock_dir ~files =
   Copy.A.action { Copy.Spec.target; lock_dir; files }
   |> Action.Full.make ~can_go_in_shared_cache:false
@@ -90,15 +68,20 @@ let setup_copy_rules ~dir:target ~lock_dir =
       let directory_targets = Path.Build.Map.singleton target Loc.none in
       let rules =
         Rules.collect_unit (fun () ->
-          (* TODO use Source_deps.files here too *)
-          let* _files = files lock_dir in
           let files =
             Path.Set.fold
               ~init:Path.Source.Set.empty
               ~f:(fun e acc ->
                 match (e : Path.t) with
                 | In_source_tree p -> Path.Source.Set.add acc p
-                | _ -> Code_error.raise "Whatsup" [])
+                | In_build_dir b ->
+                  Code_error.raise
+                    "Source deps returned build paths"
+                    [ "path", Path.Build.to_dyn b ]
+                | External e ->
+                  Code_error.raise
+                    "Source deps returned external path"
+                    [ "path", Path.External.to_dyn e ])
               file_set
           in
           let copy_rule = copy_lock_dir ~target ~lock_dir ~files in

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -104,18 +104,23 @@ let setup_dev_tool_lock_rules ~dir dev_tool =
 ;;
 
 let setup_rules ~components ~dir =
+  let empty = Gen_rules.rules_here Gen_rules.Rules.empty in
   match components with
   | [ ".lock" ] ->
     (* TODO enable other lock dirs too, by reading them from the workspace *)
     setup_lock_rules ~dir ~lock_dir:"dune.lock"
   | [ ".dev-tool-locks" ] ->
-    (* TODO properly set up copy dev tool lock rules *)
-    setup_dev_tool_lock_rules ~dir Ocamlformat
+    Memo.List.fold_left
+      Dune_pkg.Dev_tool.all
+      ~f:(fun rules dev_tool ->
+        let+ dev_tool_rules = setup_dev_tool_lock_rules ~dir dev_tool in
+        Gen_rules.combine rules dev_tool_rules)
+      ~init:empty
   | [] ->
     let sub_dirs = [ ".lock"; ".dev-tool-locks" ] in
     let build_dir_only_sub_dirs =
       Gen_rules.Build_only_sub_dirs.singleton ~dir @@ Subdir_set.of_list sub_dirs
     in
     Memo.return @@ Gen_rules.make ~build_dir_only_sub_dirs (Memo.return Rules.empty)
-  | _ -> Memo.return @@ Gen_rules.rules_here Gen_rules.Rules.empty
+  | _ -> Memo.return empty
 ;;

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -100,6 +100,7 @@ let setup_dev_tool_lock_rules ~dir dev_tool =
   let dev_tool_name = Dune_lang.Package_name.to_string package_name in
   let dir = Path.Build.relative dir dev_tool_name in
   let lock_dir = Lock_dir.dev_tool_source_lock_dir dev_tool in
+  Printf.eprintf "Lock rules on %S (from %S)\n" (Path.Build.to_string dir) (Path.Source.to_string lock_dir);
   setup_copy_rules ~dir ~lock_dir
 ;;
 

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -29,19 +29,15 @@ module Copy = struct
       List [ encode_target target; Atom (Path.Source.to_string lock_dir); List contents ]
     ;;
 
-    let action { target; lock_dir = _; files } ~ectx:_ ~eenv:_ =
+    let action { target; lock_dir; files } ~ectx:_ ~eenv:_ =
       let open Fiber.O in
       let+ () = Fiber.return () in
       Path.mkdir_p (Path.build target);
       Path.Source.Set.iter files ~f:(fun src ->
-        let dst =
-          match Path.Source.explode src with
-          | [] ->
-            Code_error.raise
-              "Somehow the path is unexpected"
-              [ "src", Path.Source.to_dyn src ]
-          | _ :: components -> Path.Build.L.relative target components
+        let suffix =
+          Path.drop_prefix_exn (Path.source src) ~prefix:(Path.source lock_dir)
         in
+        let dst = Path.Build.append_local target suffix in
         let parent = Path.Build.parent_exn dst in
         (* Printf.eprintf "Source to copy %S => %S (parent %S)\n" (Path.Source.to_string src) (Path.Build.to_string dst) (Path.Build.to_string parent); *)
         Path.mkdir_p (Path.build parent);
@@ -99,13 +95,24 @@ let setup_lock_rules ~dir ~lock_dir =
   setup_copy_rules ~dir ~lock_dir
 ;;
 
+let setup_dev_tool_lock_rules ~dir dev_tool =
+  let package_name = Dune_pkg.Dev_tool.package_name dev_tool in
+  let dev_tool_name = Dune_lang.Package_name.to_string package_name in
+  let dir = Path.Build.relative dir dev_tool_name in
+  let lock_dir = Lock_dir.dev_tool_source_lock_dir dev_tool in
+  setup_copy_rules ~dir ~lock_dir
+;;
+
 let setup_rules ~components ~dir =
   match components with
   | [ ".lock" ] ->
     (* TODO enable other lock dirs too, by reading them from the workspace *)
     setup_lock_rules ~dir ~lock_dir:"dune.lock"
+  | [ ".dev-tool-locks" ] ->
+    (* TODO properly set up copy dev tool lock rules *)
+    setup_dev_tool_lock_rules ~dir Ocamlformat
   | [] ->
-    let sub_dirs = [ ".lock" ] in
+    let sub_dirs = [ ".lock"; ".dev-tool-locks" ] in
     let build_dir_only_sub_dirs =
       Gen_rules.Build_only_sub_dirs.singleton ~dir @@ Subdir_set.of_list sub_dirs
     in

--- a/src/dune_rules/lock_rules.mli
+++ b/src/dune_rules/lock_rules.mli
@@ -1,0 +1,6 @@
+open Import
+
+val setup_rules
+  :  components:string list
+  -> dir:Path.Build.t
+  -> Build_config.Gen_rules.t Memo.t

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -255,8 +255,8 @@ let odoc_base_flags quiet build_dir =
 ;;
 
 let odoc_dev_tool_lock_dir_exists () =
-  let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Odoc in
-  Fs_memo.dir_exists (Path.as_outside_build_dir_exn path)
+  let path = Lock_dir.dev_tool_source_lock_dir Odoc in
+  Fs_memo.dir_exists (In_source_dir path)
 ;;
 
 let odoc_dev_tool_exe_path_building_if_necessary () =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1209,7 +1209,9 @@ end = struct
             "Package files directory is external source directory, this is unsupported"
             [ "dir", Path.External.to_dyn e ]
         | In_source_tree s -> Path.Build.append_source build_path s
-        | In_build_dir s -> Path.Build.append build_path s
+        | In_build_dir b ->
+          (* it's already a build path, no need to do anything *)
+          b
       in
       let id = Pkg.Id.gen () in
       let write_paths = Paths.make package_universe name ~relative:Path.Build.relative in
@@ -1739,17 +1741,69 @@ let source_rules (pkg : Pkg.t) =
   source_deps, Memo.parallel_iter copy_rules ~f:(fun (loc, copy) -> rule ~loc copy)
 ;;
 
+let source_path_of_files_dir file_dir =
+  match Path.Build.explode file_dir with
+  | [ _; _; ".lock"; name; "content"; dir ] ->
+    Path.Source.L.relative Path.Source.root [ name; dir ]
+  | components ->
+    Code_error.raise "Invalid path" [ "components", Dyn.list Dyn.string components ]
+;;
+
+let rec scan_contents p =
+  let dir_contents =
+    match Readdir.read_directory_with_kinds (Path.Build.to_string p) with
+    | Ok dir_contents -> dir_contents
+    | Error e ->
+      Code_error.raise
+        "Failure to enumerate files"
+        [ "error", Unix_error.Detailed.to_dyn e ]
+  in
+  List.fold_left
+    dir_contents
+    ~f:(fun (files, empty_directories) (file_name, file_kind) ->
+      let p = Path.Build.relative p file_name in
+      match (file_kind : Unix.file_kind) with
+      | S_REG -> Path.Build.Set.add files p, empty_directories
+      | S_DIR ->
+        let recursive_files, recursive_empty_dir = scan_contents p in
+        (match
+           ( Path.Build.Set.is_empty recursive_files
+           , Path.Build.Set.is_empty recursive_empty_dir )
+         with
+         | true, true ->
+           recursive_files, Path.Build.Set.union empty_directories recursive_empty_dir
+         | true, false ->
+           files, Path.Build.Set.union empty_directories recursive_empty_dir
+         | false, _ -> Path.Build.Set.union files recursive_files, empty_directories)
+      | _ -> User_error.raise [ Pp.text "lock dir is problematique" ])
+    ~init:(Path.Build.Set.empty, Path.Build.Set.empty)
+;;
+
+let files p =
+  let files, empty_directories = scan_contents p in
+  let tp s =
+    Path.Build.Set.fold
+      s
+      ~f:(fun e acc -> Path.Set.add acc (Path.build e))
+      ~init:Path.Set.empty
+  in
+  let files = tp files in
+  let empty_directories = tp empty_directories in
+  Dep.Set.of_source_files ~files ~empty_directories, files
+;;
+
 let build_rule context_name ~source_deps (pkg : Pkg.t) =
   let+ build_action =
     let+ copy_action, build_action, install_action =
       let+ copy_action =
         let+ copy_action =
-          Fs_memo.dir_exists
-            (In_source_dir (Path.Build.drop_build_context_exn pkg.files_dir))
+          let path_in_source = source_path_of_files_dir pkg.files_dir in
+          Fs_memo.dir_exists (In_source_dir path_in_source)
           >>= function
           | false -> Memo.return []
           | true ->
-            let+ deps, source_deps = Source_deps.files (Path.build pkg.files_dir) in
+            let+ () = Memo.return () in
+            let deps, source_deps = files pkg.files_dir in
             let open Action_builder.O in
             [ Action_builder.with_no_targets
               @@ (Action_builder.deps deps

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2026,6 +2026,7 @@ let setup_rules ~components ~dir ctx =
   assert (String.equal Pkg_dev_tool.install_path_base_dir_name ".dev-tool");
   match Context_name.is_default ctx, components with
   | true, [ ".dev-tool"; pkg_name; pkg_dep_name ] ->
+    Printf.eprintf "Dev tool Rules for .dev-tool/%s/%s\n" pkg_name pkg_dep_name;
     setup_package_rules
       ~package_universe:
         (Dev_tool (Package.Name.of_string pkg_name |> Dune_pkg.Dev_tool.of_package_name))

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1743,7 +1743,7 @@ let source_rules (pkg : Pkg.t) =
 
 let source_path_of_files_dir file_dir =
   match Path.Build.explode file_dir with
-  | [ _; _; ".lock"; name; "content"; dir ] ->
+  | [ _; _; ".lock"; name; dir ] ->
     Path.Source.L.relative Path.Source.root [ name; dir ]
   | components ->
     Code_error.raise "Invalid path" [ "components", Dyn.list Dyn.string components ]

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -88,6 +88,7 @@ module Package_universe = struct
     match t with
     | Project_dependencies ctx -> Lock_dir.get_path ctx
     | Dev_tool dev_tool ->
+      (* CR-Leonidas-from-XIV: It probably isn't always [Some] *)
       dev_tool |> Lock_dir.dev_tool_lock_dir |> Option.some |> Memo.return
   ;;
 end
@@ -1744,6 +1745,8 @@ let source_rules (pkg : Pkg.t) =
 let source_path_of_files_dir file_dir =
   match Path.Build.explode file_dir with
   | [ _; _; ".lock"; name; dir ] -> Path.Source.L.relative Path.Source.root [ name; dir ]
+  | [ _; _; ".dev-tool-locks"; dev_tool; dir ] ->
+    Path.Source.L.relative (Path.Source.of_string "dev-tool.locks") [ dev_tool; dir ]
   | components ->
     Code_error.raise "Invalid path" [ "components", Dyn.list Dyn.string components ]
 ;;

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1189,16 +1189,16 @@ end = struct
              solution may have multiple versions of the same package
              necessitating version numbers in files dirs to prevent
              collisions). *)
-          let path_without_version =
-            Dune_pkg.Lock_dir.Pkg.files_dir info.name None ~lock_dir
-          in
           let path_with_version =
-            Dune_pkg.Lock_dir.Pkg.files_dir info.name (Some info.version) ~lock_dir
+            Dune_pkg.Lock_dir.Pkg.source_files_dir info.name info.version ~lock_dir
           in
           let+ path_with_version_exists =
-            path_with_version |> Path.as_outside_build_dir_exn |> Fs_memo.dir_exists
+            Fs_memo.dir_exists (Path.Outside_build_dir.In_source_dir path_with_version)
           in
-          if path_with_version_exists then path_with_version else path_without_version
+          match path_with_version_exists with
+          | true ->
+            Dune_pkg.Lock_dir.Pkg.files_dir info.name (Some info.version) ~lock_dir
+          | false -> Dune_pkg.Lock_dir.Pkg.files_dir info.name None ~lock_dir
         in
         let build_path =
           Context_name.build_dir (Package_universe.context_name package_universe)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1743,8 +1743,7 @@ let source_rules (pkg : Pkg.t) =
 
 let source_path_of_files_dir file_dir =
   match Path.Build.explode file_dir with
-  | [ _; _; ".lock"; name; dir ] ->
-    Path.Source.L.relative Path.Source.root [ name; dir ]
+  | [ _; _; ".lock"; name; dir ] -> Path.Source.L.relative Path.Source.root [ name; dir ]
   | components ->
     Code_error.raise "Invalid path" [ "components", Dyn.list Dyn.string components ]
 ;;

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -88,7 +88,7 @@ module Package_universe = struct
     match t with
     | Project_dependencies ctx -> Lock_dir.get_path ctx
     | Dev_tool dev_tool ->
-      Memo.return (Some (Dune_pkg.Lock_dir.dev_tool_lock_dir_path dev_tool))
+      dev_tool |> Lock_dir.dev_tool_lock_dir |> Option.some |> Memo.return
   ;;
 end
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2041,7 +2041,12 @@ let setup_rules ~components ~dir ctx =
       (Memo.return Rules.empty)
     |> Memo.return
   | _, [ ".pkg"; pkg_name ] ->
-    setup_package_rules ~package_universe:(Project_dependencies ctx) ~dir ~pkg_name
+    (* Only generate pkg rules if there is a lock dir for that context *)
+    let* lock_dir_active = Lock_dir.lock_dir_active ctx in
+    (match lock_dir_active with
+     | false -> Memo.return @@ Gen_rules.make (Memo.return Rules.empty)
+     | true ->
+       setup_package_rules ~package_universe:(Project_dependencies ctx) ~dir ~pkg_name)
   | _, ".pkg" :: _ :: _ ->
     Memo.return @@ Gen_rules.redirect_to_parent Gen_rules.Rules.empty
   | true, ".dev-tool" :: _ :: _ :: _ ->

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -7,7 +7,11 @@ module Map_reduce =
     (Monoid.Product (Monoid.Union (Path.Set)) (Monoid.Union (Path.Set)))
 
 let files_with_filter dir ~filter =
-  let prefix_with, dir = Path.extract_build_context_dir_exn dir in
+  let prefix_with, dir =
+    match (dir : Path.t) with
+    | In_source_tree dir -> Path.of_string "", dir
+    | otherwise -> Path.extract_build_context_dir_exn otherwise
+  in
   Source_tree.find_dir dir
   >>= function
   | None -> Memo.return (Dep.Set.empty, Path.Set.empty)

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -147,8 +147,8 @@ let requires ~loc ~db ~libs =
 
 let utop_dev_tool_lock_dir_exists =
   Memo.Lazy.create (fun () ->
-    let path = Dune_pkg.Lock_dir.dev_tool_lock_dir_path Utop in
-    Fs_memo.dir_exists (Path.as_outside_build_dir_exn path))
+    let path = Lock_dir.dev_tool_source_lock_dir Utop in
+    Fs_memo.dir_exists (In_source_dir path))
 ;;
 
 let utop_findlib_conf = Filename.concat utop_dir_basename "findlib.conf"

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -726,8 +726,22 @@ let hash { merlin_context; contexts; env; config; repos; lock_dirs; dir; pins } 
     , Pin_stanza.Workspace.hash pins )
 ;;
 
+let source_path_of_lock_dir_path path =
+  match (path : Path.t) with
+  | In_source_tree s -> s
+  | In_build_dir b ->
+    (match Path.Build.explode b with
+     | [ _; _; ".lock"; lock_dir; "content" ] -> Path.Source.of_string lock_dir
+     | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
+  | External e ->
+    Code_error.raise
+      "External lock dir path is unsupported"
+      [ "dir", Path.External.to_dyn e ]
+;;
+
 let find_lock_dir t path =
-  List.find t.lock_dirs ~f:(fun lock_dir -> Path.equal (Path.source lock_dir.path) path)
+  let path = source_path_of_lock_dir_path path in
+  List.find t.lock_dirs ~f:(fun lock_dir -> Path.Source.equal lock_dir.path path)
 ;;
 
 let add_repo t repo = { t with repos = repo :: t.repos }

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -731,7 +731,7 @@ let source_path_of_lock_dir_path path =
   | In_source_tree s -> s
   | In_build_dir b ->
     (match Path.Build.explode b with
-     | [ _; _; ".lock"; lock_dir; "content" ] -> Path.Source.of_string lock_dir
+     | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
      | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
   | External e ->
     Code_error.raise

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -267,7 +267,7 @@ module Lock_dir_selection = struct
   let eval t ~dir ~f =
     let open Memo.O in
     match t with
-    | Name name -> Path.Source.relative dir name |> Path.source |> Memo.return
+    | Name name -> Path.Source.relative dir name |> Memo.return
     | Cond cond ->
       let+ value = Cond_expand.eval cond ~dir:(Path.source dir) ~f in
       (match (value : Value.t option) with
@@ -275,8 +275,9 @@ module Lock_dir_selection = struct
          User_error.raise
            ~loc:cond.loc
            [ Pp.text "None of the conditions matched so no lockdir could be chosen." ]
-       | Some (String s) -> Path.Source.relative dir s |> Path.source
-       | Some (Dir p | Path p) -> Path.reach ~from:(Path.source dir) p |> Path.of_string)
+       | Some (String s) -> Path.Source.relative dir s
+       | Some (Dir p | Path p) ->
+         Path.reach ~from:(Path.source dir) p |> Path.Source.of_string)
   ;;
 end
 

--- a/src/source/workspace.mli
+++ b/src/source/workspace.mli
@@ -24,7 +24,7 @@ module Lock_dir : sig
 end
 
 module Lock_dir_selection : sig
-  (** A dsl for selecting a lockdir either by literally naming it or using a
+  (** A DSL for selecting a lockdir either by literally naming it or using a
       cond expression to select a lockdir based on blangs *)
   type t
 
@@ -32,7 +32,7 @@ module Lock_dir_selection : sig
     :  t
     -> dir:Path.Source.t
     -> f:Value.t list Memo.t String_with_vars.expander
-    -> Path.t Memo.t
+    -> Path.Source.t Memo.t
 end
 
 module Context : sig

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -34,6 +34,8 @@ Test that shows what happens when dune.lock is ignored.
 Building test works when the dune.lock is visible to dune.
 
   $ build_pkg test
+  $ tree dune.lock
+  $ tree _build/_private/default/.lock/dune.lock/content
 
 Now the project is changed to only include src (which effectively ignores
 dune.lock):
@@ -52,4 +54,6 @@ Building fails as the patch cannot be found anymore
 And the backage cannot be shown:
 
   $ show_pkg test
-  
+
+  $ tree $pkg_root
+  $ tree -a _build/_private/default

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -34,8 +34,6 @@ Test that shows what happens when dune.lock is ignored.
 Building test works when the dune.lock is visible to dune.
 
   $ build_pkg test
-  $ tree dune.lock
-  $ tree _build/_private/default/.lock/dune.lock/content
 
 Now the project is changed to only include src (which effectively ignores
 dune.lock):
@@ -54,6 +52,3 @@ Building fails as the patch cannot be found anymore
 And the backage cannot be shown:
 
   $ show_pkg test
-
-  $ tree $pkg_root
-  $ tree -a _build/_private/default

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -44,11 +44,10 @@ dune.lock):
 
 Building fails as the patch cannot be found anymore
 
-  $ build_pkg test 2>&1 | sed 's|\.sandbox/[a-f0-9]*/|.sandbox/<hash>/|'
-  Error:
-  open(_build/.sandbox/<hash>/_private/default/.pkg/test/source/foo.patch): No such file or directory
-  -> required by _build/_private/default/.pkg/test/target
+  $ build_pkg test
+  Error: Don't know how to build _build/_private/default/.pkg/test/target/
+  [1]
 
-And the backage cannot be shown:
+And the package cannot be shown:
 
   $ show_pkg test

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -94,7 +94,7 @@ EOF
  (public_name foo))
 EOF
   cat > dune-workspace <<EOF
-(lang dune 3.13)
+(lang dune 3.20)
 
 (lock_dir
  (path "dev-tools.locks/ocamlformat")
@@ -106,6 +106,8 @@ EOF
 (repository
  (name mock)
  (url "file://$(pwd)/mock-opam-repository"))
+
+(pkg enabled)
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -2,7 +2,7 @@
 # project and the ocamllsp lockdir.
 setup_ocamllsp_workspace() {
   cat > dune-workspace <<EOF
-(lang dune 3.16)
+(lang dune 3.20)
 (lock_dir
  (path "dev-tools.locks/ocaml-lsp-server")
  (repositories mock))
@@ -11,6 +11,7 @@ setup_ocamllsp_workspace() {
 (repository
  (name mock)
  (url "file://$(pwd)/mock-opam-repository"))
+(pkg enabled)
 EOF
 }
 


### PR DESCRIPTION
This is a WIP PR to implement rules that copy the lock dirs (project lock dirs and dev-tool lock dirs) into the build folder before the package rules. It's a a prerequisite for #11775 which changes the logic to directly generate the lock directories in the build directory.