### PR TITLE
fix(pkg): classify dev tools correctly

### DIFF
--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -69,9 +69,10 @@ let exe_path_components_within_package t = [ "bin"; exe_name t ]
 
 let needs_to_build_with_same_compiler_as_project = function
   | Ocamlformat -> false
-  | Odoc -> true
-  | Ocamllsp -> true
-  | Utop -> false
-  | Ocamlearlybird -> false
-  | Odig -> false
+  | Ocamlearlybird ->
+    (* CR-someday rgrinberg: I have my doubts that this is true given that
+       the debugger is expected to print identifiers. In any case,
+       ocamlearlybird isn't going to work well due to relocation issues *)
+    false
+  | Utop | Odoc | Ocamllsp | Odig -> true
 ;;


### PR DESCRIPTION
odig does depend on the version of the compiler because it uses compiler-libs to parse compiler artifacts. So does utop

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>