### PR TITLE
[Docs] Add 'edit on github' button to all pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,13 @@ html_theme = 'furo'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {}
+html_theme_options = {
+    "top_of_page_buttons": ["edit", "view"],
+
+    "source_repository": "https://github.com/ocaml/dune/",
+    "source_branch": "main",
+    "source_directory": "doc/",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -188,11 +194,3 @@ texinfo_documents = [
      author, 'dune', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-html_context = {
-    'display_github': True,
-    'github_user': 'ocaml',
-    'github_repo': 'dune',
-    'github_version': 'main',
-    'conf_py_path': '/doc/',
-}


### PR DESCRIPTION
Closes #12387
Code is from [the furo documentation](https://github.com/pradyunsg/furo/blob/426ea05d879ee7dfdf74ba7c8b089f73081abbfd/docs/conf.py#L89-L105)

Preview over [here](https://dune--12398.org.readthedocs.build/en/12398/)

One thing of note is that the 'edit' link at the top of the page will always link to the main branch instead of the branch that the doc is running on. We decided to leave it at that for now.