### PR TITLE
test: disable exec-watch-basic.t

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -12,7 +12,11 @@
 ; These tests are explicitly disabled due to flakiness
 
 (cram
- (applies_to exec-watch-server exec-watch-ignore-sigterm exec-signal)
+ (applies_to
+  exec-watch-server
+  exec-watch-ignore-sigterm
+  exec-signal
+  exec-watch-basic)
  (enabled_if false))
 
 (cram


### PR DESCRIPTION
it flakes with:

```
File "test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t _build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t.corrected
diff --git a/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t b/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t.corrected
index 056c13f..898f8e3 100644
--- a/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
+++ b/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t.corrected
@@ -11,7 +11,6 @@ between each change to its code.
 
   $ dune exec --watch ./foo.exe &
   foo
-  Success, waiting for filesystem changes...
   bar
   Success, waiting for filesystem changes...
   File "foo.ml", line 1, characters 23-24:
make: *** [Makefile:92: test] Error 1
Error: Process completed with exit code 2.
```