### PR TITLE
test(boot): test bootstrap procedure

### DIFF
--- a/test/blackbox-tests/test-cases/boot/cycle.t
+++ b/test/blackbox-tests/test-cases/boot/cycle.t
@@ -1,0 +1,30 @@
+Testing cycle detection in bootstrap.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+  $ cat > src/a/a.ml <<EOF
+  > open B
+  > EOF
+
+  $ cat > src/a/b.ml <<EOF
+  > open A
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  cycle:
+  - a__B.ml
+  - a.ml
+  - main.ml
+  dependency cycle compiling a.ml
+  [2]
+

--- a/test/blackbox-tests/test-cases/boot/dune
+++ b/test/blackbox-tests/test-cases/boot/dune
@@ -1,0 +1,11 @@
+(cram
+ (deps
+  helpers.sh
+  %{project_root}/boot/types.ml
+  %{project_root}/boot/duneboot.ml
+  %{bin:bootstrap.exe}))
+
+(env
+ (_
+  (binaries
+   (%{project_root}/boot/bootstrap.exe as bootstrap.exe))))

--- a/test/blackbox-tests/test-cases/boot/helpers.sh
+++ b/test/blackbox-tests/test-cases/boot/helpers.sh
@@ -1,0 +1,33 @@
+
+mkdir boot
+cp ../../../../boot/types.ml boot/types.ml
+cp ../../../../boot/duneboot.ml boot/duneboot.ml
+
+cat > dune-project <<EOF
+(lang dune 3.21)
+(using dune-bootstrap-info 0.1)
+EOF
+
+# These libraries are hardcoded and expected to exist:
+mkdir -p vendor/re/src
+mkdir -p vendor/spawn/src
+mkdir -p vendor/uutf
+
+mkdir bin
+
+# Creates a fake dune executable that depends on [$1] and emits bootstrap info
+# which is then used to bootstrap the fake dune.
+create_dune() {
+  cat > bin/main.ml 
+  cat > bin/dune <<EOF
+(executable
+ (name main)
+ (libraries $1)
+ (bootstrap_info bootstrap-info))
+EOF
+  dune build bin/bootstrap-info 
+  cp _build/default/bin/bootstrap-info boot/libs.ml
+  bootstrap.exe || return $?
+  _boot/dune.exe
+}
+

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -1,0 +1,38 @@
+Testing the bootstrap of an unwrapped include subdirs qualified.
+
+Currently doesn't work because it is not implemented.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a/b/c
+
+  $ cat > src/a/x.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
+  > EOF
+
+  $ cat > src/a/b/b.ml <<EOF
+  > let () = Printf.printf "Hello form unwrapped a/b/b.ml\n"
+  > EOF
+
+  $ cat > src/a/b/c/c.ml <<EOF
+  > let () = Printf.printf "Hello form unwrapped a/b/c/c.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a)
+  >  (wrapped false))
+  > (include_subdirs qualified)
+  > EOF
+
+  $ create_dune a <<EOF
+  > open X
+  > open B
+  > open C
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Fatal error: exception Failure("failed to find [B]")
+  [2]
+

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -1,0 +1,38 @@
+Testing the bootstrap of a wrapped include subdirs qualified.
+
+Currently doesn't work because it is not implemented.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a/b/c
+
+  $ cat > src/a/x.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
+  > EOF
+
+  $ cat > src/a/b/b.ml <<EOF
+  > let () = Printf.printf "Hello form wrapped a/b/b.ml\n"
+  > EOF
+
+  $ cat > src/a/b/c/c.ml <<EOF
+  > let () = Printf.printf "Hello form wrapped a/b/c/c.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > (include_subdirs qualified)
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > open X
+  > open B
+  > open C
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Fatal error: exception Failure("failed to find [B;A]")
+  [2]
+

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
@@ -1,0 +1,38 @@
+Testing the bootstrap of an unwrapped include subdirs unqualified.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a/b/c
+
+  $ cat > src/a/x.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
+  > EOF
+
+  $ cat > src/a/b/b.ml <<EOF
+  > let () = Printf.printf "Hello form unwrapped a/b/b.ml\n"
+  > EOF
+
+  $ cat > src/a/b/c/c.ml <<EOF
+  > let () = Printf.printf "Hello form unwrapped a/b/c/c.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a)
+  >  (wrapped false))
+  > (include_subdirs unqualified)
+  > EOF
+
+  $ create_dune a <<EOF
+  > open X
+  > open B
+  > open C
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello form unwrapped a/b/b.ml
+  Hello form unwrapped a/b/c/c.ml
+  Hello from unwrapped a/x.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -1,0 +1,38 @@
+Testing the bootstrap of a wrapped include subdirs unqualified.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a/b/c
+
+  $ cat > src/a/x.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
+  > EOF
+
+  $ cat > src/a/b/b.ml <<EOF
+  > let () = Printf.printf "Hello form wrapped a/b/b.ml\n"
+  > EOF
+
+  $ cat > src/a/b/c/c.ml <<EOF
+  > let () = Printf.printf "Hello form wrapped a/b/c/c.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > (include_subdirs unqualified)
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > open X
+  > open B
+  > open C
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello form wrapped a/b/b.ml
+  Hello form wrapped a/b/c/c.ml
+  Hello from unwrapped a/x.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
@@ -1,0 +1,25 @@
+Testing the bootstrap of singleton unwrapped libraries.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/b.ml <<EOF
+  > let () = Printf.printf "Hello from singleton unwrapped a/b.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a)
+  >  (wrapped false))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open B
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from singleton unwrapped a/b.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
@@ -1,0 +1,24 @@
+Testing the bootstrap of singleton wrapped libraries.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/a.ml <<EOF
+  > let () = Printf.printf "Hello from singleton wrapped a/a.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from singleton wrapped a/a.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/unwrapped.t
@@ -1,0 +1,30 @@
+Testing the bootstrap of unwrapped libraries.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+  $ cat > src/a/a.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/a.ml\n"
+  > EOF
+
+  $ cat > src/a/b.ml <<EOF
+  > let () = Printf.printf "Hello from unwrapped a/b.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a)
+  >  (wrapped false))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > open B
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from unwrapped a/a.ml
+  Hello from unwrapped a/b.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -1,0 +1,25 @@
+Testing the bootstrap of wrapped libraries without interface moodule.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/b.ml <<EOF
+  > let () = Printf.printf "Hello from wrapped non-interface module a/b.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > open B
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from wrapped non-interface module a/b.ml
+  Hello from bootstrapped binary!
+

--- a/test/blackbox-tests/test-cases/boot/wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped.t
@@ -1,0 +1,31 @@
+Testing the bootstrap of wrapped libraries.
+
+  $ . ./helpers.sh
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/a.ml <<EOF
+  > module B = B
+  > let () = Printf.printf "Hello from wrapped interface module a/a.ml\n"
+  > EOF
+
+  $ cat > src/a/b.ml <<EOF
+  > let () = Printf.printf "Hello from wrapped module a/b.ml\n"
+  > EOF
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+  $ create_dune a <<EOF
+  > open A
+  > open B
+  > let () = Printf.printf "Hello from bootstrapped binary!"
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from wrapped module a/b.ml
+  Hello from wrapped interface module a/a.ml
+  Hello from bootstrapped binary!
+


### PR DESCRIPTION
We test the bootstrap procedure inside a cram test. This exercises the bootstrap_info extension to output a bootstrapped version of a stripped down dune binary. We can add parts to this library accordingly.