### PR TITLE
fix(boot): don't clear status line when disabled

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -484,8 +484,12 @@ module Status_line = struct
       displayed := new_displayed)
   ;;
 
-  let clear () = Printf.printf "\r*s\r%!"
-  let () = at_exit (fun () -> Printf.printf "\r%*s\r" (String.length !displayed) "")
+  let clear () = if display_status_line then Printf.printf "\r*s\r%!"
+
+  let () =
+    at_exit (fun () ->
+      if display_status_line then Printf.printf "\r%*s\r" (String.length !displayed) "")
+  ;;
 end
 
 module Io = struct


### PR DESCRIPTION
We shouldn't be clearing the line when `display_status_line` is disabled.