### PR TITLE
fix(oxcaml): remove unused stanza parameter loc

### DIFF
--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -10,7 +10,6 @@ type t =
   ; enabled_if : Blang.t
   ; optional : bool
   ; synopsis : string option
-  ; loc : Loc.t
   ; dune_version : Dune_lang.Syntax.Version.t
   }
 
@@ -130,7 +129,6 @@ let decode =
        ; enabled_if
        ; optional
        ; synopsis
-       ; loc = stanza_loc
        ; dune_version
        })
 ;;


### PR DESCRIPTION
Not sure how this slipped through, but the warning is annoying:

```
File "src/dune_rules/stanzas/parameter.ml", lines 13-14, characters 4-3:
13 | ....loc : Loc.t
14 |   ;..........................................
Error (warning 69 [unused-field]): record field loc is never read.
(However, this field is used to build or mutate values.)
```