### PR TITLE
Execute commands in `opam-var-os.t`

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -12,7 +12,7 @@ unset them all.
   $ unset DUNE_CONFIG__OS DUNE_CONFIG__ARCH DUNE_CONFIG__OS_FAMILY DUNE_CONFIG__OS_DISTRIBUTION DUNE_CONFIG__OS_VERSION DUNE_CONFIG__SYS_OCAML_VERSION
 
   $ mkrepo
-  > mkpkg testpkg <<EOF
+  $ mkpkg testpkg <<EOF
   > build: [
   >   ["echo" arch]
   >   ["echo" os]
@@ -21,7 +21,7 @@ unset them all.
   >   ["echo" os-version]
   > ]
   > EOF
-  > solve testpkg
+  $ solve testpkg
   Solution for dune.lock:
   - testpkg.0.0.1
   $ cat ${default_lock_dir}/testpkg.pkg
@@ -52,7 +52,7 @@ separately here:
   >   ["echo" sys-ocaml-version]
   > ]
   > EOF
-  > solve testpkg
+  $ solve testpkg
   Solution for dune.lock:
   - testpkg.0.0.1
 


### PR DESCRIPTION
The cram test accidentally used `>` instead of `$` in prompts to execute commands. Somehow it still worked, but I am unsure why it worked.