### PR TITLE
fix(pkg): pkg disabled now disables package management

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -362,6 +362,9 @@ let term =
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    let open Fiber.O in
+    Pkg_common.check_pkg_management_enabled ()
+    >>>
     let portable_lock_dir =
       match Config.get Dune_rules.Compile_time.portable_lock_dir with
       | `Enabled -> true

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -75,8 +75,10 @@ let term =
   and+ lock_dirs_arg = Pkg_common.Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go_with_rpc_server ~common ~config
-  @@ find_outdated_packages ~transitive ~lock_dirs_arg
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    let open Fiber.O in
+    Pkg_common.check_pkg_management_enabled ()
+    >>> find_outdated_packages ~transitive ~lock_dirs_arg ())
 ;;
 
 let info =

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -226,3 +226,21 @@ module Lock_dirs_arg = struct
           ])
   ;;
 end
+
+let check_pkg_management_enabled () =
+  Memo.run
+  @@
+  let open Memo.O in
+  let+ workspace = Workspace.workspace () in
+  match workspace.config.pkg_enabled with
+  | Set (_, `Enabled) | Unset -> ()
+  | Set (loc, `Disabled) ->
+    User_error.raise
+      ~loc
+      [ Pp.text "Package management is disabled in workspace configuration." ]
+      ~hints:
+        [ Pp.text
+            "To enable package management, remove the explicit (pkg disabled) setting \
+             from your dune-workspace file."
+        ]
+;;

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -87,3 +87,7 @@ end
 (** [pp_packages lock_dir] returns a list of pretty-printed packages occurring in
     [lock_dir]. *)
 val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
+
+(** [check_pkg_management_enabled ()] checks if package management is enabled in the
+    workspace configuration. Raises a user error if it is explicitly disabled. *)
+val check_pkg_management_enabled : unit -> unit Fiber.t

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -16,7 +16,12 @@ let term =
     let any_lockdir_exists = List.exists lock_dir_paths ~f:Path.exists in
     (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
        directories in the source tree *)
-    let enabled = any_lockdir_exists || workspace.config.pkg_enabled in
+    let enabled =
+      match workspace.config.pkg_enabled with
+      | Set (_, `Enabled) -> true
+      | Set (_, `Disabled) -> false
+      | Unset -> any_lockdir_exists
+    in
     match enabled with
     | true -> ()
     | false -> exit 1)

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -80,7 +80,9 @@ let term =
   and+ lock_dirs = Pkg_common.Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
-  Scheduler.go_with_rpc_server ~common ~config @@ validate_lock_dirs ~lock_dirs
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    let open Fiber.O in
+    Pkg_common.check_pkg_management_enabled () >>> validate_lock_dirs ~lock_dirs ())
 ;;
 
 let command = Cmd.v info term

--- a/doc/reference/config/index.rst
+++ b/doc/reference/config/index.rst
@@ -22,6 +22,7 @@ The ``config`` file can contain the following stanzas:
   cache_storage_mode
   display
   jobs
+  pkg
   project_defaults
   sandboxing_preference
   terminal_persistence

--- a/doc/reference/config/pkg.rst
+++ b/doc/reference/config/pkg.rst
@@ -1,0 +1,26 @@
+pkg
+---
+
+Controls whether Dune's package management features are enabled. Package
+management includes dependency locking, package resolution, and building 
+dependencies from source.
+
+.. code:: dune
+
+    (pkg <setting>)
+
+where ``<setting>`` is one of:
+
+- ``enabled`` forces package management to be enabled, even if no lock
+  directories are present.
+
+- ``disabled`` forces package management to be disabled, even if lock
+  directories are present. When disabled, Dune will not load package rules
+  and all ``dune pkg`` commands will fail with an error.
+
+If no ``(pkg ...)`` setting is specified, Dune will auto-detect whether to
+enable package management based on the presence of lock directories in the
+workspace. This usage is not currently recommended, since lock directories 
+are not stabilized or portable.
+
+.. versionadded:: 3.20

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -29,6 +29,13 @@ module Toggle = struct
 
   let all : (string * t) list = [ "enabled", `Enabled; "disabled", `Disabled ]
 
+  let equal x y =
+    match x, y with
+    | `Enabled, `Enabled -> true
+    | `Enabled, _ | _, `Enabled -> false
+    | `Disabled, `Disabled -> true
+  ;;
+
   let to_string t =
     List.find_map all ~f:(fun (k, v) -> if Poly.equal v t then Some k else None)
     |> Option.value_exn

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -17,6 +17,7 @@ module Toggle : sig
     ]
 
   val all : (string * t) list
+  val equal : t -> t -> bool
   val of_string : string -> (t, string) result
   val to_string : t -> string
   val to_dyn : t -> Dyn.t

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -55,7 +55,18 @@ module Dune_config : sig
   end
 
   module Pkg_enabled : sig
-    type t = bool
+    (** Configuration for Dune's package management features.
+        
+        - [Set (loc, `Enabled)]: Package management is explicitly enabled. Forces package 
+          management to be active even if no lock directories are present.
+
+        - [Set (loc, `Disabled)]: Package management is explicitly disabled. Forces package 
+          management to be inactive even if lock directories are present.
+
+        - [Unset]: Package management enablement is not explicitly configured.  *)
+    type t =
+      | Set of Loc.t * Dune_config.Config.Toggle.t
+      | Unset
   end
 
   module Terminal_persistence : sig

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -62,7 +62,7 @@ add_mock_repo_if_needed() {
   if [ ! -e dune-workspace ]
   then
       cat >dune-workspace <<EOF
-(lang dune 3.10)
+(lang dune 3.20)
 (lock_dir
  (repositories mock))
 (repository
@@ -92,6 +92,19 @@ EOF
   
     fi
   fi
+}
+
+create_mock_repo() {
+  # Always create a fresh workspace with mock repository configuration
+  repo="${1:-file://$(pwd)/mock-opam-repository}"
+  cat >dune-workspace <<EOF
+(lang dune 3.20)
+(lock_dir
+ (repositories mock))
+(repository
+ (name mock)
+ (url "${repo}"))
+EOF
 }
 
 make_lockpkg() {
@@ -128,7 +141,7 @@ EOF
 
 make_project() {
   cat <<EOF
-(lang dune 3.11)
+(lang dune 3.20)
  (package
   (name x)
   (allow_empty)

--- a/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
@@ -1,0 +1,187 @@
+Exercise the workflow when package management is explicitly disabled.
+
+When (pkg disabled) is set, dune should behave as if no lock directory exists.
+This tests the three-state logic: None (auto-detect), Some true (force enable),
+Some false (force disable).
+
+This means that:
+1. Package rules should not be loaded during the build.
+2. All pkg commands should fail with appropriate errors.
+3. This should work even when lock directories are present.
+4. Explicit settings should override auto-detection.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+First, create a dummy library package in a subdirectory that we can depend on:
+
+  $ mkdir -p external_sources/testlib_src
+  $ cat > external_sources/testlib_src/dune-project << EOF
+  > (lang dune 3.20)
+  > (package (name testlib))
+  > EOF
+
+  $ cat > external_sources/testlib_src/dune << EOF
+  > (library
+  >  (public_name testlib)
+  >  (name testlib))
+  > EOF
+
+  $ cat > external_sources/testlib_src/testlib.ml << EOF
+  > let greet name = Printf.printf "Hello %s from testlib!\n" name
+  > EOF
+
+Create a mock opam package for our library:
+
+  $ mkpkg testlib << EOF
+  > build: [
+  >   ["dune" "build" "-p" name "@install"]
+  > ]
+  > EOF
+
+Setup a project with dependencies that would normally require package
+management:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.20)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends testlib))
+  > EOF
+
+  $ cat > dune << EOF
+  > (dirs (:standard \ external_sources))
+  > (executable
+  >  (public_name foo)
+  >  (name foo)
+  >  (libraries testlib))
+  > EOF
+
+  $ cat > foo.ml << EOF
+  > let () = Testlib.greet "world"
+  > EOF
+
+Create a workspace configuration that explicitly disables package management:
+
+  $ add_mock_repo_if_needed
+  $ cat >> dune-workspace << EOF
+  > (pkg disabled)
+  > EOF
+
+Test that dune pkg enabled reports disabled:
+
+  $ dune pkg enabled
+  [1]
+
+Test that pkg commands fail when disabled:
+
+  $ dune pkg lock
+  File "dune-workspace", line 7, characters 5-13:
+  7 | (pkg disabled)
+           ^^^^^^^^
+  Error: Package management is disabled in workspace configuration.
+  Hint: To enable package management, remove the explicit (pkg disabled)
+  setting from your dune-workspace file.
+  [1]
+
+  $ dune pkg outdated 2>&1 | grep "Error:"
+  Error: Package management is disabled in workspace configuration.
+
+  $ dune pkg validate-lockdir 2>&1 | grep "Error:"
+  Error: Package management is disabled in workspace configuration.
+
+Test that dune build fails appropriately when trying to use unavailable
+packages, proving we did not install the needed dependency:
+
+  $ dune build 2>&1 | grep -E "(Error|Library.*not found)" | head -5
+  Error: Library "testlib" not found.
+
+Now create a lock directory with our testlib package to simulate the case
+where lockdirs exist but pkg is disabled. First, temporarily enable pkg to
+create the lock file:
+
+  $ create_mock_repo
+  $ cat >> dune-workspace << EOF
+  > (pkg enabled)
+  > EOF
+
+  $ dune pkg lock
+  Solution for dune.lock:
+  - testlib.0.0.1
+
+Now disable pkg again:
+
+  $ create_mock_repo  
+  $ cat >> dune-workspace << EOF
+  > (pkg disabled)
+  > EOF
+
+Even with a proper lock directory present, pkg should still be reported as
+disabled:
+
+  $ dune pkg enabled
+  [1]
+
+And dune build should still fail to find the library because pkg rules are not
+loaded:
+
+  $ dune build 2>&1 | grep -E "(Error|Library.*not found)" | head -5
+  Error: Library "testlib" not found.
+
+This behavior is identical to having no lock directory. When pkg is disabled,
+the build system does not load package rules, so it does not know about the
+packages.
+
+Test enabling package management again - it should work normally:
+
+  $ create_mock_repo
+  $ cat >> dune-workspace << EOF
+  > (pkg enabled)
+  > EOF
+
+  $ dune pkg enabled
+
+With pkg enabled and a lock directory present, package management is now
+active.
+
+Now test the default (auto-detect) behavior:
+
+  $ create_mock_repo
+
+With lockdir present, auto-detect should enable pkg management:
+
+  $ dune pkg enabled
+
+Remove lockdir, auto-detect should disable pkg management:
+
+  $ rm -rf ${default_lock_dir}
+  $ dune pkg enabled
+  [1]
+
+Test that auto-detect can be overridden by explicit workspace settings:
+
+  $ mkdir -p ${default_lock_dir}
+  $ cat > ${default_lock_dir}/lock.dune << EOF
+  > (lang package-lock 0.1)
+  > EOF
+
+  $ create_mock_repo
+  $ cat >> dune-workspace << EOF
+  > (pkg disabled)
+  > EOF
+
+Even with lockdir present, explicit disabled should take precedence:
+
+  $ dune pkg enabled
+  [1]
+
+And explicit enabled should work even without lockdir:
+
+  $ rm -rf ${default_lock_dir}
+  $ create_mock_repo
+  $ cat >> dune-workspace << EOF
+  > (pkg enabled)
+  > EOF
+
+  $ dune pkg enabled

--- a/test/expect-tests/dune_config_file/dune_config_test.ml
+++ b/test/expect-tests/dune_config_file/dune_config_test.ml
@@ -33,7 +33,7 @@ let%expect_test "cache-check-probability 0.1" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
-    ; pkg_enabled = false
+    ; pkg_enabled = Unset
     ; experimental = []
     }
     |}]
@@ -58,7 +58,7 @@ let%expect_test "cache-storage-mode copy" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
-    ; pkg_enabled = false
+    ; pkg_enabled = Unset
     ; experimental = []
     }
     |}]
@@ -83,7 +83,7 @@ let%expect_test "cache-storage-mode hardlink" =
         ; maintenance_intent = None
         ; license = Some [ "LICENSE" ]
         }
-    ; pkg_enabled = false
+    ; pkg_enabled = Unset
     ; experimental = []
     }
     |}]


### PR DESCRIPTION
The option `(pkg disabled)` didn't actually disable any package management features other than changing the value of the `dune pkg enabled` command. This PR introduces that functionality and adds a further test making sure it behaves as intended. We also document the field which was previously undocumented.

Since it was undocumented and buggy, it might be worth warning users on 3.20 and bump the versions to 3.21.

- [ ] introduced in 3.20 but didn't really work, bump to 3.21 and add warning?
- [x] docs
- [x] changelog
- [x] tests