### PR TITLE
fix(rpc): correct exit code when encountering an rpc error

### DIFF
--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -88,11 +88,7 @@ let wrap_build_outcome_exn ~print_on_success f args () =
   let open Fiber.O in
   let+ response = f args in
   match response with
-  | Error (error : Rpc_error.t) ->
-    Console.print
-      [ Pp.paragraphf "Error: %s" (Dyn.to_string (Rpc_error.to_dyn error))
-        |> Pp.tag User_message.Style.Error
-      ]
+  | Error (error : Rpc_error.t) -> raise_rpc_error error
   | Ok Dune_rpc.Build_outcome_with_diagnostics.Success ->
     if print_on_success
     then Console.print [ Pp.text "Success" |> Pp.tag User_message.Style.Success ]

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -455,7 +455,7 @@ module Client = struct
           Response.Error.create
             ~kind:Connection_dead
             ~payload
-            ~message:"connection terminated. this request will never receive a response"
+            ~message:"Connection terminated. This request will never receive a response."
             ()
         in
         Error error

--- a/test/blackbox-tests/test-cases/watching/shutdown.t
+++ b/test/blackbox-tests/test-cases/watching/shutdown.t
@@ -1,0 +1,33 @@
+Demonstrate what happens when the server is shut down in the middle of serving
+a client.
+
+  $ cat > dune-projec <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > mytest.t <<EOF
+  >   $ sleep 1
+  >   $ echo 'took too long'
+  > EOF
+
+  $ dune build -w &
+  Success, waiting for filesystem changes...
+
+  $ dune rpc ping --wait
+  Server appears to be responding normally
+
+  $ dune build --alias runtest &
+  Error: { payload = Some [ [ "id"; [ "auto"; "0" ] ] ]
+  ; message =
+      "connection terminated. this request will never receive a response"
+  ; kind = Connection_dead
+  }
+  $ PID=$!
+
+  $ dune rpc ping
+  Server appears to be responding normally
+  $ dune shutdown
+
+This allows us to observe the exit code. Currently this is [0] which is wrong.
+  $ wait $PID
+

--- a/test/blackbox-tests/test-cases/watching/shutdown.t
+++ b/test/blackbox-tests/test-cases/watching/shutdown.t
@@ -17,17 +17,16 @@ a client.
   Server appears to be responding normally
 
   $ dune build --alias runtest &
-  Error: { payload = Some [ [ "id"; [ "auto"; "0" ] ] ]
-  ; message =
-      "connection terminated. this request will never receive a response"
-  ; kind = Connection_dead
-  }
+  Error: Server returned error: 
+  Connection terminated. This request will never receive a response. (error
+  kind: Connection_dead)
   $ PID=$!
 
   $ dune rpc ping
   Server appears to be responding normally
   $ dune shutdown
 
-This allows us to observe the exit code. Currently this is [0] which is wrong.
+This allows us to observe the exit code which should be non-zero.
   $ wait $PID
+  [1]
 

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -765,7 +765,7 @@ let%test_module "finalization" =
         | Response.E
         |   { payload = Some [ [ "id"; [ "initialize" ] ] ]
         |   ; message =
-        |       "connection terminated. this request will never receive a response"
+        |       "Connection terminated. This request will never receive a response."
         |   ; kind = Connection_dead
         |   }
         \-----------------------------------------------------------------------
@@ -781,7 +781,7 @@ let%test_module "finalization" =
         | Response.E
         |   { payload = Some [ [ "id"; [ "initialize" ] ] ]
         |   ; message =
-        |       "connection terminated. this request will never receive a response"
+        |       "Connection terminated. This request will never receive a response."
         |   ; kind = Connection_dead
         |   }
         \-----------------------------------------------------------------------
@@ -807,7 +807,8 @@ let%test_module "finalization" =
         \-----------------------------------------------------------------------
 
 
-        --------------- |}]
+        ---------------
+        |}]
     ;;
   end)
 ;;


### PR DESCRIPTION
Demonstrates and fixes the issue observed in #12445.

- fixes #12445
- changelog