### PR TITLE
refactor(boot): fix path computation

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1350,13 +1350,18 @@ module Library = struct
         let paths = Io.readdir dir in
         List.partition_map paths ~f:(fun fn ->
           let path = Filename.concat dir fn in
+          let is_dir = Sys.is_directory path in
           let module_path =
-            match include_subdirs with
-            | Qualified -> fn :: module_path
-            | No | Unqualified -> module_path
+            match
+              match include_subdirs with
+              | No | Unqualified -> false
+              | Qualified -> is_dir
+            with
+            | true -> fn :: module_path
+            | false -> module_path
           in
           let arg = path, fn, module_path in
-          if Sys.is_directory path then Left arg else Right arg)
+          if is_dir then Left arg else Right arg)
       in
       let files =
         List.filter_map files ~f:(fun (path, fn, module_path) ->

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -33,6 +33,10 @@ Currently doesn't work because it is not implemented.
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  Fatal error: exception Failure("failed to find [B]")
+  cd _boot && /OCAMLOPT -c -g -no-alias-deps -w -49-23-53 -alert -unstable main.ml
+  File "main.ml", line 3, characters 5-6:
+  3 | open C
+           ^
+  Error: Unbound module C
   [2]
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -33,6 +33,10 @@ Currently doesn't work because it is not implemented.
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  Fatal error: exception Failure("failed to find [B;A]")
+  cd _boot && /OCAMLOPT -c -g -no-alias-deps -w -49-23-53 -alert -unstable main.ml
+  File "main.ml", line 3, characters 5-6:
+  3 | open B
+           ^
+  Error: Unbound module B
   [2]
 


### PR DESCRIPTION
This has no effect since we aren't using `(include_subdirs qualified)`