### PR TITLE
test: disable flake

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -18,5 +18,9 @@
 ; These tests are explicitly disabled due to flakiness
 
 (cram
- (applies_to exec-watch-ignore-sigterm exec-signal exec-watch-basic)
+ (applies_to
+  exec-watch-server
+  exec-watch-ignore-sigterm
+  exec-signal
+  exec-watch-basic)
  (enabled_if false))


### PR DESCRIPTION
```
./_boot/dune.exe runtest
File "test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t _build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t.corrected
diff --git a/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t b/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t.corrected
index 158b2df..567a8ae 100644
--- a/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/_build/default/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t.corrected
@@ -23,6 +23,8 @@ Below, 0: after should *not* be appearing.
   1: after
   Success, waiting for filesystem changes...
   2: before
+  Command got signal TERM.
+  Had 1 error, waiting for filesystem changes...
   $ PID=$!
 
   $ ../wait-for-file.sh $DONE_FLAG
make: *** [Makefile:92: test] Error 1
Error: Process completed with exit code 2.
```