### PR TITLE
Download the latest release for a manual trigger of Docker image generation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,3 +1,4 @@
+
 name: Docker Release
 
 on:
@@ -36,14 +37,25 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Download release assets
+      - name: Download release assets (current ref)
+        if: ${{ github.ref_name != '' }}
         env:
-            GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-             mkdir -p docker-context
-             gh release download ${{ github.ref_name }} \
-             --pattern "*.tbz" \
-             --dir docker-context
+          mkdir -p docker-context
+          gh release download "${{ github.ref_name }}" \
+          --pattern "*.tbz" \
+          --dir docker-context
+
+      - name: Download release assets (latest if ref is not present)
+        if: ${{ github.ref_name == '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p docker-context
+          gh release download \
+          --pattern "*.tbz" \
+          --dir docker-context
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Per the discussion in #12252, this PR adds an additional step to download release assets from the latest release if the current tag number doesn't exist, i.e., in the case of a manual trigger of the GitHub Actions job.