### PR TITLE
fix(boot): allow groups without group intf module

### DIFF
--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
@@ -16,17 +16,12 @@ Currently doesn't work because it is not implemented.
   > EOF
 
   $ create_dune a <<EOF
-  > module M1 = A.B.X
+  > module M1 = A.B
+  > module M2 = A.B.X
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  Fatal error: exception File "boot/duneboot.ml", line 1461, characters 20-26: Assertion failed
-  Called from unknown location
-  Called from unknown location
-  Called from unknown location
-  Called from unknown location
-  Called from unknown location
-  Called from unknown location
-  [2]
+  Hello from wrapped a/b/x.ml
+  Hello from bootstrapped binary!
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -34,8 +34,8 @@ Currently doesn't work because it is not implemented.
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  Hello from unwrapped a/x.ml
   Hello from wrapped a/b/c/c.ml
   Hello from wrapped a/b/b.ml
+  Hello from unwrapped a/x.ml
   Hello from bootstrapped binary!
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -31,8 +31,8 @@ Testing the bootstrap of a wrapped include subdirs unqualified.
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  Hello from unwrapped a/x.ml
-  Hello from wrapped a/b/c/c.ml
   Hello from wrapped a/b/b.ml
+  Hello from wrapped a/b/c/c.ml
+  Hello from unwrapped a/x.ml
   Hello from bootstrapped binary!
 

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -20,10 +20,6 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
-  cd _boot && /OCAMLOPT -c -g -no-alias-deps -w -49-23-53 -alert -unstable dune_exe__Main.ml
-  File "dune_exe__Main.ml", line 1, characters 5-6:
-  1 | open A
-           ^
-  Error: Unbound module A
-  [2]
+  Hello from wrapped non-interface module a/b.ml
+  Hello from bootstrapped binary!
 


### PR DESCRIPTION
In such a situation, the dependency on such a group must be converted to a dependency of every module in the group (in the absence of precise dep analysis).