### PR TITLE
Remove most backtracking from lockdir parser

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -68,11 +68,6 @@ module Pkg : sig
   val equal : t -> t -> bool
   val hash : t -> int
   val to_dyn : t -> Dyn.t
-
-  val decode
-    : (lock_dir:Path.t -> solved_for_platforms:Solver_env.t list -> Package_name.t -> t)
-        Decoder.t
-
   val files_dir : Package_name.t -> Package_version.t option -> lock_dir:Path.t -> Path.t
 end
 


### PR DESCRIPTION
To parse both portable and non-portable lockdirs with mostly the same code, the parser would attempt to parse fields with the non-portable lockdir syntax and fall back to the portable syntax should parsing fail. This led to the generation of parse errors when the first attempt at parsing a field would fail, and even though these errors are discarded, generating them took a noticeable amount of time.

This changes the parsing logic to only attempt to parse fields in a single syntax, determined by the presence of the `solved_for_platforms` field in the lockdir metadata file. This field is present precisely when a lockdir is portable.

Fixes https://github.com/ocaml/dune/issues/12248