### PR TITLE
tests: Enable package management by default in test and add helpers to disable it

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -55,6 +55,27 @@ mkpkg() {
   cat >>$mock_packages/$name/$name.$version/opam
 }
 
+set_pkg_to () {
+  local value="${1}"
+  if grep "(pkg .*)" dune-workspace > /dev/null; then
+    sed -i'' "s/(pkg .*)/(pkg ${value})/" dune-workspace
+  else
+    echo "(pkg ${value})" >> dune-workspace
+  fi
+}
+
+enable_pkg() {
+  set_pkg_to "enabled"
+}
+
+disable_pkg() {
+  set_pkg_to "disabled"
+}
+
+unset_pkg() {
+  sed -i'' "/(pkg/d" dune-workspace
+}
+
 add_mock_repo_if_needed() {
   # default, but can be overridden, e.g. if git is required
   repo="${1:-file://$(pwd)/mock-opam-repository}"
@@ -63,6 +84,7 @@ add_mock_repo_if_needed() {
   then
       cat >dune-workspace <<EOF
 (lang dune 3.20)
+(pkg enabled)
 (lock_dir
  (repositories mock))
 (repository
@@ -99,6 +121,7 @@ create_mock_repo() {
   repo="${1:-file://$(pwd)/mock-opam-repository}"
   cat >dune-workspace <<EOF
 (lang dune 3.20)
+(pkg enabled)
 (lock_dir
  (repositories mock))
 (repository

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -19,8 +19,8 @@ Test the error cases for invalid opam repositories
   > }
 
   $ lock
-  File "dune-workspace", line 6, characters X-X:
-  6 |  (url ..))
+  File "dune-workspace", line 7, characters X-X:
+  7 |  (url ..))
   Error:
   $TESTCASE_ROOT/directory-that-does-not-exist
   does not exist
@@ -30,8 +30,8 @@ Test the error cases for invalid opam repositories
   $ rm dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/empty"
   $ lock
-  File "dune-workspace", line 6, characters X-X:
-  6 |  (url ..))
+  File "dune-workspace", line 7, characters X-X:
+  7 |  (url ..))
   Error:
   $TESTCASE_ROOT/empty
   is not a directory
@@ -40,8 +40,8 @@ Test the error cases for invalid opam repositories
   $ rm dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/no-packages-dir"
   $ lock
-  File "dune-workspace", line 6, characters X-X:
-  6 |  (url ..))
+  File "dune-workspace", line 7, characters X-X:
+  7 |  (url ..))
   Error:
   $TESTCASE_ROOT/no-packages-dir
   doesn't look like a path to an opam repository as it lacks a subdirectory

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -94,7 +94,7 @@ EOF
  (public_name foo))
 EOF
   cat > dune-workspace <<EOF
-(lang dune 3.13)
+(lang dune 3.20)
 
 (lock_dir
  (path "dev-tools.locks/ocamlformat")
@@ -106,6 +106,8 @@ EOF
 (repository
  (name mock)
  (url "file://$(pwd)/mock-opam-repository"))
+
+(pkg enabled)
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -2,7 +2,7 @@
 # project and the ocamllsp lockdir.
 setup_ocamllsp_workspace() {
   cat > dune-workspace <<EOF
-(lang dune 3.16)
+(lang dune 3.20)
 (lock_dir
  (path "dev-tools.locks/ocaml-lsp-server")
  (repositories mock))
@@ -11,6 +11,7 @@ setup_ocamllsp_workspace() {
 (repository
  (name mock)
  (url "file://$(pwd)/mock-opam-repository"))
+(pkg enabled)
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
@@ -65,9 +65,7 @@ management:
 Create a workspace configuration that explicitly disables package management:
 
   $ add_mock_repo_if_needed
-  $ cat >> dune-workspace << EOF
-  > (pkg disabled)
-  > EOF
+  $ disable_pkg
 
 Test that dune pkg enabled reports disabled:
 
@@ -77,8 +75,8 @@ Test that dune pkg enabled reports disabled:
 Test that pkg commands fail when disabled:
 
   $ dune pkg lock
-  File "dune-workspace", line 7, characters 5-13:
-  7 | (pkg disabled)
+  File "dune-workspace", line 2, characters 5-13:
+  2 | (pkg disabled)
            ^^^^^^^^
   Error: Package management is disabled in workspace configuration.
   Hint: To enable package management, remove the explicit (pkg disabled)
@@ -102,9 +100,7 @@ where lockdirs exist but pkg is disabled. First, temporarily enable pkg to
 create the lock file:
 
   $ create_mock_repo
-  $ cat >> dune-workspace << EOF
-  > (pkg enabled)
-  > EOF
+  $ enable_pkg
 
   $ dune pkg lock
   Solution for dune.lock:
@@ -113,9 +109,7 @@ create the lock file:
 Now disable pkg again:
 
   $ create_mock_repo  
-  $ cat >> dune-workspace << EOF
-  > (pkg disabled)
-  > EOF
+  $ disable_pkg
 
 Even with a proper lock directory present, pkg should still be reported as
 disabled:
@@ -136,9 +130,7 @@ packages.
 Test enabling package management again - it should work normally:
 
   $ create_mock_repo
-  $ cat >> dune-workspace << EOF
-  > (pkg enabled)
-  > EOF
+  $ enable_pkg
 
   $ dune pkg enabled
 
@@ -148,6 +140,7 @@ active.
 Now test the default (auto-detect) behavior:
 
   $ create_mock_repo
+  $ unset_pkg
 
 With lockdir present, auto-detect should enable pkg management:
 
@@ -167,9 +160,7 @@ Test that auto-detect can be overridden by explicit workspace settings:
   > EOF
 
   $ create_mock_repo
-  $ cat >> dune-workspace << EOF
-  > (pkg disabled)
-  > EOF
+  $ disable_pkg
 
 Even with lockdir present, explicit disabled should take precedence:
 
@@ -180,8 +171,6 @@ And explicit enabled should work even without lockdir:
 
   $ rm -rf ${default_lock_dir}
   $ create_mock_repo
-  $ cat >> dune-workspace << EOF
-  > (pkg enabled)
-  > EOF
+  $ enable_pkg
 
   $ dune pkg enabled


### PR DESCRIPTION
This is pulling out a change from #12394 to make it easier to control whether package management should be force-enabled, force-disabled or left at the default setting.