### PR TITLE
tests: Enable dev-tool flag when running dev-tools

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -7,10 +7,10 @@ Test `dune tools which ocamlformat`:
   $ make_project_with_dev_tool_lockdir
 
 Install ocamlformat as a dev tool:
-  $ dune tools install ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools install ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:
-  $ dune tools which ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
   _build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin/ocamlformat

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -12,7 +12,7 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
   > EOF
 
 The command will fail because the dev tool is not installed:
-  $ dune tools which ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
   Error: ocamlformat is not installed as a dev tool
   [1]
 
@@ -20,14 +20,14 @@ The command will fail because the dev tool is not installed:
   _build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin/ocamlformat
 
 Install the dev tool:
-  $ dune tools exec ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2
 
 Now the command will succeed because the tool has been installed:
-  $ dune tools which ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
   _build/_private/default/.dev-tool/ocamlformat/ocamlformat/target/bin/ocamlformat
 
 Make sure the file is actually there:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -7,7 +7,7 @@ Exercise running the ocamlformat wrapper command.
   $ make_ocamlformat_opam_pkg "0.26.2"
   $ make_project_with_dev_tool_lockdir
 
-  $ dune tools exec ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -24,7 +24,7 @@ a lockdir containing an "ocaml" lockfile.
   > (version 5.2.0)
   > EOF
 
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -23,7 +23,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
   > EOF
 
 Confirm that each dev tool's bin directory is now in PATH:
-  $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
@@ -13,7 +13,7 @@ doesn't contain a lockfile for the "ocaml" package.
 
   $ make_lockdir
 
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
   Error: The lockdir doesn't contain a lockfile for the package "ocaml".
   Hint: Add a dependency on "ocaml" to one of the packages in dune-project and
   then run 'dune pkg lock'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -43,11 +43,11 @@ Make a fake ocamlformat
   > (version 5.2.0)
   > EOF
 
-  $ dune tools install ocamlformat
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools install ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.0.1
 
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -28,7 +28,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
 Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
@@ -38,7 +38,7 @@ Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
   (version 5.2.0)
 
 We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
        Running 'ocamllsp'
   hello from fake ocamllsp
 
@@ -49,7 +49,7 @@ Change the version of ocaml that the project depends on.
 
 Running "dune tools exec ocamllsp" causes ocamllsp to be relocked and rebuilt
 before running. Ocamllsp now depends on ocaml.5.1.0.
-  $ dune tools exec ocamllsp
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
   The version of the compiler package ("ocaml") in this project's lockdir has
   changed to 5.1.0 (formerly the compiler version was 5.2.0). The dev-tool
   "ocaml-lsp-server" will be re-locked and rebuilt with this version of the


### PR DESCRIPTION
This is factored out of #12394 and makes sure that the dev tool flag is set when attempting to use dev-tool functionality.