### PR TITLE
Do not cancel in-progress builds on `main`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
We most likely want all changes on `main` to go through CI and not cancel out early if more things are pushed. That makes tracing issues that happened due to problematic merges much harder.

It retains the cancel-on-new-commits behavior for other branches and PRs.