### PR TITLE
Don't use Digest.generic for toolchain hash

### DIFF
--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -33,27 +33,72 @@ let equal = Blake3_mini.Digest.equal
 let hash = Poly.hash
 let file p = file (Path.to_string p)
 let from_hex s = Blake3_mini.Digest.of_hex s
-let hasher = lazy (Blake3_mini.create ())
 
-let string s =
-  let hasher = Lazy.force hasher in
-  Blake3_mini.feed_string hasher s ~pos:0 ~len:(String.length s);
-  let res = Blake3_mini.digest hasher in
-  Blake3_mini.reset hasher;
-  res
-;;
+module Hasher = struct
+  type t = Blake3_mini.t
 
+  let with_singleton =
+    let singleton = lazy (Blake3_mini.create ()) in
+    let in_use = ref false in
+    fun f ->
+      if !in_use
+      then
+        Code_error.raise
+          "[Hasher.with_singleton] called within argument function to \
+           [Hasher.with_singleton], which is not allowed."
+          []
+      else (
+        in_use := true;
+        let hasher = Lazy.force singleton in
+        f hasher;
+        let digest = Blake3_mini.digest hasher in
+        Blake3_mini.reset hasher;
+        in_use := false;
+        digest)
+  ;;
+end
+
+module Feed = struct
+  type hasher = Hasher.t
+  type 'a t = hasher -> 'a -> unit
+
+  let contramap a ~f hasher b = a hasher (f b)
+  let string hasher s = Blake3_mini.feed_string hasher s ~pos:0 ~len:(String.length s)
+  let bool = contramap string ~f:Bool.to_string
+  let int = contramap string ~f:Int.to_string
+
+  (* We use [No_sharing] to avoid generating different digests for inputs that
+       differ only in how they share internal values. Without [No_sharing], if a
+       command line contains duplicate flags, such as multiple occurrences of the
+       flag [-I], then [Marshal.to_string] will produce different digests depending
+       on whether the corresponding strings ["-I"] point to the same memory location
+       or to different memory locations. *)
+  let generic hasher x =
+    contramap string ~f:(fun x -> Marshal.to_string x [ No_sharing ]) hasher x
+  ;;
+
+  let list feed_x hasher xs = List.iter xs ~f:(feed_x hasher)
+  let option feed_x hasher option_x = Option.iter option_x ~f:(feed_x hasher)
+
+  let tuple2 feed_a feed_b hasher (a, b) =
+    feed_a hasher a;
+    feed_b hasher b
+  ;;
+
+  let tuple3 feed_a feed_b feed_c hasher (a, b, c) =
+    feed_a hasher a;
+    feed_b hasher b;
+    feed_c hasher c
+  ;;
+
+  let digest t x = Hasher.with_singleton (fun hasher -> t hasher x)
+end
+
+let string s = Feed.digest Feed.string s
 let to_string_raw s = Blake3_mini.Digest.to_binary s
 
-(* We use [No_sharing] to avoid generating different digests for inputs that
-   differ only in how they share internal values. Without [No_sharing], if a
-   command line contains duplicate flags, such as multiple occurrences of the
-   flag [-I], then [Marshal.to_string] will produce different digests depending
-   on whether the corresponding strings ["-I"] point to the same memory location
-   or to different memory locations. *)
 let generic a =
-  Metrics.Timer.record "generic_digest" ~f:(fun () ->
-    string (Marshal.to_string a [ No_sharing ]))
+  Metrics.Timer.record "generic_digest" ~f:(fun () -> Feed.digest Feed.generic a)
 ;;
 
 let path_with_executable_bit =

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -4,6 +4,33 @@ open Stdune
 
 type t
 
+module Feed : sig
+  type digest := t
+  type hasher
+
+  (** Type for incrementally building up the computation of a hash. A ['a t]
+      can consume a value of type ['a] and incorporate it into a hash value. *)
+  type 'a t = hasher -> 'a -> unit
+
+  (** Consume any value. The result is based on the in-memory representation of
+      the value, so this is unsafe to perform on types who may have different
+      in-memory representation for values which are conceptually equal, such as
+      sets and maps. *)
+  val generic : _ t
+
+  val contramap : 'a t -> f:('b -> 'a) -> 'b t
+  val string : string t
+  val bool : bool t
+  val int : int t
+  val list : 'a t -> 'a list t
+  val option : 'a t -> 'a option t
+  val tuple2 : 'a t -> 'b t -> ('a * 'b) t
+  val tuple3 : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+
+  (** Compute the digest of a value given a feed for the type of that value. *)
+  val digest : 'a t -> 'a -> digest
+end
+
 include Comparable_intf.S with type key := t
 
 val to_dyn : t -> Dyn.t

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -8,6 +8,7 @@
   dune_glob
   dune_rpc_private
   dune_config
+  dune_digest
   opam_format
   opam_core
   ocaml

--- a/src/dune_lang/package_name.ml
+++ b/src/dune_lang/package_name.ml
@@ -77,3 +77,5 @@ let of_opam_file_basename basename =
   let* name = String.drop_suffix basename ~suffix:opam_ext in
   of_string_opt name
 ;;
+
+let digest_feed = Dune_digest.Feed.string

--- a/src/dune_lang/package_name.mli
+++ b/src/dune_lang/package_name.mli
@@ -6,6 +6,7 @@ type t
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 
 include Comparable_intf.S with type key := t
 include Conv.S with type t := t

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -29,6 +29,7 @@ include (
     Dune_util.Stringlike with type t := t)
 
 let hash t = String.hash (to_string t)
+let digest_feed = Dune_digest.Feed.contramap Dune_digest.Feed.string ~f:to_string
 let arch = of_string "arch"
 let os = of_string "os"
 let os_version = of_string "os-version"

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -16,6 +16,7 @@ module Set : Set.S with type elt = t and type 'a map = 'a Map.t
 val of_string : string -> t
 val to_string : t -> string
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val arch : t
 val os : t
 val os_version : t

--- a/src/dune_lang/package_version.ml
+++ b/src/dune_lang/package_version.ml
@@ -13,3 +13,5 @@ include (
     let of_string_opt s = if s = "" then None else Some s
   end) :
     Dune_util.Stringlike with type t := t)
+
+let digest_feed = Dune_digest.Feed.string

--- a/src/dune_lang/package_version.mli
+++ b/src/dune_lang/package_version.mli
@@ -8,6 +8,7 @@ val of_string_user_error : Loc.t * string -> (t, User_message.t) result
 val to_string : t -> string
 val equal : t -> t -> bool
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val to_dyn : t -> Dyn.t
 val encode : t Encoder.t
 val decode : t Decoder.t

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -16,6 +16,7 @@
   dune_stats
   dune_lang
   dune_console
+  dune_digest
   re
   dune_vcs
   dune_config

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -67,6 +67,7 @@ module Pkg : sig
   val remove_locs : t -> t
   val equal : t -> t -> bool
   val hash : t -> int
+  val digest_feed : t Dune_digest.Feed.t
   val to_dyn : t -> Dyn.t
   val files_dir : Package_name.t -> Package_version.t option -> lock_dir:Path.t -> Path.t
 end

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -7,6 +7,7 @@ val of_string_user_error : Loc.t * string -> (t, User_message.t) result
 val to_string : t -> string
 val equal : t -> t -> bool
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val to_dyn : t -> Dyn.t
 val encode : t Dune_lang.Encoder.t
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -20,6 +20,12 @@ let hash t =
       (key, value, running_hash))
 ;;
 
+let digest_feed hasher t =
+  Package_variable_name.Map.iteri t ~f:(fun key value ->
+    Package_variable_name.digest_feed hasher key;
+    Variable_value.digest_feed hasher value)
+;;
+
 let empty = Package_variable_name.Map.empty
 let is_empty = Package_variable_name.Map.is_empty
 

--- a/src/dune_pkg/solver_env.mli
+++ b/src/dune_pkg/solver_env.mli
@@ -5,6 +5,7 @@ type t
 val empty : t
 val equal : t -> t -> bool
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val is_empty : t -> bool

--- a/src/dune_pkg/source.ml
+++ b/src/dune_pkg/source.ml
@@ -38,6 +38,8 @@ let hash { url; checksum } =
     (url, checksum)
 ;;
 
+let digest_feed = Dune_digest.Feed.generic
+
 let fetch_archive_cached =
   let cache = Single_run_file_cache.create () in
   fun (url_loc, url) ->

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -10,6 +10,7 @@ val decode : (Path.External.t -> t) Dune_sexp.Decoder.t
 val encode : t -> Dune_sexp.t
 val to_dyn : t -> Dyn.t
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val remove_locs : t -> t
 val compute_missing_checksum : t -> Package_name.t -> pinned:bool -> t Fiber.t
 val external_copy : Loc.t * Path.External.t -> t

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -18,6 +18,7 @@ let false_ = "false"
 let string = Fun.id
 let equal = String.equal
 let hash = String.hash
+let digest_feed = Dune_digest.Feed.string
 let compare = String.compare
 let to_dyn = Dyn.string
 let to_string = Fun.id

--- a/src/dune_pkg/variable_value.mli
+++ b/src/dune_pkg/variable_value.mli
@@ -10,6 +10,7 @@ val string : string -> t
 
 val equal : t -> t -> bool
 val hash : t -> int
+val digest_feed : t Dune_digest.Feed.t
 val compare : t -> t -> ordering
 val to_dyn : t -> Dyn.t
 val decode : t Decoder.t

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -27,13 +27,15 @@ let pkg_dir (pkg : Dune_pkg.Lock_dir.Pkg.t) =
      way). *)
   let dir_name =
     (* TODO should include resolved deps *)
-    let pkg_hash = Digest.generic (Lock_dir.Pkg.remove_locs pkg) in
+    let pkg_digest =
+      Dune_digest.Feed.digest Lock_dir.Pkg.digest_feed (Lock_dir.Pkg.remove_locs pkg)
+    in
     (* A hash of the fields of a package that affect its installed artifacts *)
     sprintf
       "%s.%s-%s"
       (Package.Name.to_string pkg.info.name)
       (Package_version.to_string pkg.info.version)
-      (Digest.to_string pkg_hash)
+      (Dune_digest.to_string pkg_digest)
   in
   Path.Outside_build_dir.relative (base_dir ()) dir_name
 ;;


### PR DESCRIPTION
The Digest.generic function marshals a value to a string and then hashes the string. For types which contain sets and maps, two values constructed in different orders but which are considered equal may have different in-memory representations and so marshal to different strings and hash to different hashes.

Compiler toolchain directories created by dune have the package hash appended to their names. Using Digest.generic meant that sometimes Dune would create a new toolchain directory when re-using an existing one would suffice.

Note that this change alone will not fix
https://github.com/ocaml/dune/issues/12390.