### PR TITLE
tests: Fix breakage on macOS with BSD `sed`

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -58,7 +58,7 @@ mkpkg() {
 set_pkg_to () {
   local value="${1}"
   if grep "(pkg .*)" dune-workspace > /dev/null; then
-    sed -i'' "s/(pkg .*)/(pkg ${value})/" dune-workspace
+    sed -i.bak "s/(pkg .*)/(pkg ${value})/" dune-workspace
   else
     echo "(pkg ${value})" >> dune-workspace
   fi
@@ -73,7 +73,7 @@ disable_pkg() {
 }
 
 unset_pkg() {
-  sed -i'' "/(pkg/d" dune-workspace
+  sed -i.bak "/(pkg/d" dune-workspace
 }
 
 add_mock_repo_if_needed() {


### PR DESCRIPTION
In #12488 I missed the fact that `sed` on macOS was failing, this PR aims to fix the issue.