### PR TITLE
tests: Do not print internal package structure

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -48,8 +48,3 @@ Building fails as the patch cannot be found anymore
   Error:
   open(_build/.sandbox/<hash>/_private/default/.pkg/test/source/foo.patch): No such file or directory
   -> required by _build/_private/default/.pkg/test/target
-
-And the backage cannot be shown:
-
-  $ show_pkg test
-  


### PR DESCRIPTION
As discussed with @rgrinberg on Slack, we shouldn't rely in the cram tests on the internal representation of packages and expose them as expected result. It would be better to expose this via `dune describe`

Given this tests already proves that the package is not being built in the step before, I think it is acceptable to just remove the `show_pkg`.

In the future, it would probably make sense to have `show_pkg` call `dune describe pkg` or something of that sort but in any case in this case we just want to show that `test` is not being built.