### PR TITLE
refactor: Make CLI return lock dir path as `Path.Source.t`

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -342,6 +342,7 @@ let lock ~version_preference ~lock_dirs_arg ~print_perf_stats ~portable_lock_dir
   in
   let lock_dirs =
     Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
+    |> List.map ~f:Path.source
   in
   solve
     workspace

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -7,6 +7,7 @@ let find_outdated_packages ~transitive ~lock_dirs_arg () =
     let* workspace = Memo.run (Workspace.workspace ()) in
     Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace
     |> Fiber.parallel_map ~f:(fun lock_dir_path ->
+      let lock_dir_path = Path.source lock_dir_path in
       (* updating makes sense when checking for outdated packages *)
       let* repos =
         get_repos

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -196,33 +196,34 @@ module Lock_dirs_arg = struct
   ;;
 
   let lock_dirs_of_workspace t (workspace : Workspace.t) =
-    let default_path = Lazy.force Lock_dir.default_path in
+    let module Set = Path.Source.Set in
+    let default_path = Dune_rules.Lock_dir.default_source_path in
     let workspace_lock_dirs =
       default_path
       :: List.map workspace.lock_dirs ~f:(fun (lock_dir : Workspace.Lock_dir.t) ->
-        lock_dir.path |> Path.source)
-      |> Path.Set.of_list
-      |> Path.Set.to_list
+        lock_dir.path)
+      |> Set.of_list
+      |> Set.to_list
     in
     match t with
     | All -> workspace_lock_dirs
     | Selected [] -> [ default_path ]
     | Selected chosen_lock_dirs ->
-      let workspace_lock_dirs_set = Path.Set.of_list workspace_lock_dirs in
-      let chosen_lock_dirs = List.map ~f:Path.source chosen_lock_dirs in
-      let chosen_lock_dirs_set = Path.Set.of_list chosen_lock_dirs in
-      if Path.Set.is_subset chosen_lock_dirs_set ~of_:workspace_lock_dirs_set
+      let workspace_lock_dirs_set = Set.of_list workspace_lock_dirs in
+      let chosen_lock_dirs_set = Set.of_list chosen_lock_dirs in
+      if Set.is_subset chosen_lock_dirs_set ~of_:workspace_lock_dirs_set
       then chosen_lock_dirs
       else (
         let unknown_lock_dirs =
-          Path.Set.diff chosen_lock_dirs_set workspace_lock_dirs_set |> Path.Set.to_list
+          Set.diff chosen_lock_dirs_set workspace_lock_dirs_set |> Set.to_list
         in
+        let f x = Path.pp (Path.source x) in
         User_error.raise
           [ Pp.text
               "The following directories are not lock directories in this workspace:"
-          ; Pp.enumerate unknown_lock_dirs ~f:Path.pp
+          ; Pp.enumerate unknown_lock_dirs ~f
           ; Pp.text "This workspace contains the following lock directories:"
-          ; Pp.enumerate workspace_lock_dirs ~f:Path.pp
+          ; Pp.enumerate workspace_lock_dirs ~f
           ])
   ;;
 end

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -81,7 +81,7 @@ module Lock_dirs_arg : sig
 
       A user error is raised if the list of positional arguments used when
       creating [t] is not a subset of the lock directories of the workspace. *)
-  val lock_dirs_of_workspace : t -> Workspace.t -> Path.t list
+  val lock_dirs_of_workspace : t -> Workspace.t -> Path.Source.t list
 end
 
 (** [pp_packages lock_dir] returns a list of pretty-printed packages occurring in

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -13,7 +13,9 @@ let term =
         Pkg_common.Lock_dirs_arg.all
         workspace
     in
-    let any_lockdir_exists = List.exists lock_dir_paths ~f:Path.exists in
+    let any_lockdir_exists =
+      List.exists lock_dir_paths ~f:(fun p -> Path.exists (Path.source p))
+    in
     (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
        directories in the source tree *)
     let enabled =

--- a/bin/pkg/print_solver_env.ml
+++ b/bin/pkg/print_solver_env.ml
@@ -30,9 +30,9 @@ let print_solver_env ~lock_dirs_arg =
     >>| Option.some
   in
   let lock_dirs = Lock_dirs_arg.lock_dirs_of_workspace lock_dirs_arg workspace in
-  List.iter
-    lock_dirs
-    ~f:(print_solver_env_for_lock_dir workspace ~solver_env_from_current_system)
+  List.iter lock_dirs ~f:(fun lock_dir ->
+    let lock_dir = Path.source lock_dir in
+    print_solver_env_for_lock_dir workspace ~solver_env_from_current_system lock_dir)
 ;;
 
 let term =

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -21,9 +21,9 @@ let enumerate_lock_dirs_by_path ~lock_dirs () =
     Workspace.workspace () >>| Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace lock_dirs
   in
   List.filter_map per_contexts ~f:(fun lock_dir_path ->
-    if Path.exists lock_dir_path
+    if Path.exists (Path.source lock_dir_path)
     then (
-      match Lock_dir.read_disk_exn lock_dir_path with
+      match Lock_dir.read_disk_exn (Path.source lock_dir_path) with
       | lock_dir -> Some (Ok (lock_dir_path, lock_dir))
       | exception User_error.E e -> Some (Error (lock_dir_path, `Parse_error e)))
     else None)
@@ -42,8 +42,9 @@ let validate_lock_dirs ~lock_dirs () =
   else
     let+ universes =
       Fiber.parallel_map lock_dirs_by_path ~f:(function
-        | Error e -> Fiber.return (Some e)
+        | Error (p, e) -> Fiber.return (Some (Path.source p, e))
         | Ok (lock_dir_path, lock_dir) ->
+          let lock_dir_path = Path.source lock_dir_path in
           let+ platform = solver_env_from_system_and_context ~lock_dir_path in
           (match Package_universe.create ~platform local_packages lock_dir with
            | Ok _ -> None

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1124,7 +1124,6 @@ let dev_tool_lock_dir_path dev_tool =
   Path.relative dev_tools_path (Package_name.to_string (Dev_tool.package_name dev_tool))
 ;;
 
-let default_path = lazy Path.(relative root "dune.lock")
 let metadata_filename = "lock.dune"
 
 module Metadata = Dune_sexp.Versioned_file.Make (Unit)

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -117,8 +117,6 @@ val create_latest_version
        (* TODO: make this non-optional when portable lockdirs becomes the default *)
   -> t
 
-val default_path : Path.t Lazy.t
-
 (** Returns the path to the lockdir that will be used to lock the
     given dev tool *)
 val dev_tool_lock_dir_path : Dev_tool.t -> Path.t

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -136,7 +136,9 @@ let select_lock_dir lock_dir_selection =
   Workspace.Lock_dir_selection.eval lock_dir_selection ~dir:workspace.dir ~f:expander
 ;;
 
-let default_source_path = Path.Source.(relative root "dune.lock")
+let default_dir = "dune.lock"
+let default_path = lazy Path.(relative root default_dir)
+let default_source_path = Path.Source.(relative root default_dir)
 
 let get_path ctx =
   let* workspace = Workspace.workspace () in

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -136,6 +136,8 @@ let select_lock_dir lock_dir_selection =
   Workspace.Lock_dir_selection.eval lock_dir_selection ~dir:workspace.dir ~f:expander
 ;;
 
+let default_source_path = Path.Source.(relative root "dune.lock")
+
 let get_path ctx =
   let* workspace = Workspace.workspace () in
   match

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -10,6 +10,9 @@ val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.t option Memo.t
 
+(** The default filesystem location where the lock dir is going to get created *)
+val default_path : Path.t Lazy.t
+
 (** The default path where the lock dir will be written to manually *)
 val default_source_path : Path.Source.t
 

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -10,6 +10,9 @@ val of_dev_tool : Dune_pkg.Dev_tool.t -> t Memo.t
 val lock_dir_active : Context_name.t -> bool Memo.t
 val get_path : Context_name.t -> Path.t option Memo.t
 
+(** The default path where the lock dir will be written to manually *)
+val default_source_path : Path.Source.t
+
 module Sys_vars : sig
   type t =
     { os : string option Memo.Lazy.t


### PR DESCRIPTION
Factored out of #12394, this PR makes `Pkg_common.lock_dirs_of_workspace` return a `Path.Source.t` again. As the workspace definition is always a `Path.Source.t`, the CLI always refers to source paths and in #12394 it has proven to be a more sensible API.

Converting a source path to a path is fairly trivial, converting the other way requires pattern matching and handling invalid cases, so restricting the type here is most likely an improvement overall.