### PR TITLE
Fix build issues in the release docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,14 @@
-
 name: Docker Release
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Create image for a specific tag'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -38,7 +42,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Download release assets (current ref)
-        if: ${{ github.ref_name != '' }}
+        if: ${{ github.ref_type == 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -46,16 +50,18 @@ jobs:
           gh release download "${{ github.ref_name }}" \
           --pattern "*.tbz" \
           --dir docker-context
+          mv docker-context/dune*.tbz docker-context/dune.tbz
 
       - name: Download release assets (latest if ref is not present)
-        if: ${{ github.ref_name == '' }}
+        if: ${{ github.ref_type == 'branch'}}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p docker-context
-          gh release download \
+          gh release download "${{ github.event.inputs.tag }}" \
           --pattern "*.tbz" \
           --dir docker-context
+          mv docker-context/dune*.tbz docker-context/dune.tbz
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -64,10 +70,9 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: ./docker-context
+          build-contexts: tarball=./docker-context
           file: ./docker/release.Dockerfile
           push: true
-        #   tags: ${{ secrets.DOCKERHUB_USERNAME }}/dune:${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -1,25 +1,40 @@
 ARG BASE_IMAGE=debian:13
 FROM ${BASE_IMAGE} AS build
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser build-essential ocaml
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y adduser build-essential ocaml
 
 RUN addgroup --gid 1000 dune && adduser --uid 1000 --ingroup dune dune
 
 USER dune:dune
 
-COPY --from=tarball /dune.tbz /home/dune/dune.tbz
 WORKDIR /home/dune
+COPY --from=tarball /dune.tbz /home/dune/dune.tbz
 
 # Use release assets from Docker context
 RUN tar -xf dune*.tbz && mv dune-*/ dune
 
 # Build and install dune
-RUN cd dune && ./configure --prefix=/home/dune/install && make bootstrap && make release && make install
+RUN cd dune && ./configure --prefix=/home/dune/install && \
+    make bootstrap && \
+    make release && \
+    make install
 
 FROM ${BASE_IMAGE} AS run
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser curl ocaml git sudo && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN addgroup --gid 1000 dune && adduser --uid 1000 --ingroup dune dune
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        adduser \
+        curl \
+        ocaml \
+        git \
+        sudo && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
+    addgroup --gid 1000 dune && \
+    adduser --uid 1000 --ingroup dune dune
+
 
 COPY --from=build /home/dune/install/bin/dune /usr/local/bin
 USER dune:dune

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser build-ess
 RUN addgroup --gid 1000 dune && adduser --uid 1000 --ingroup dune dune
 
 USER dune:dune
+
+COPY --from=tarball /dune.tbz /home/dune/dune.tbz
 WORKDIR /home/dune
 
 # Use release assets from Docker context
@@ -16,7 +18,7 @@ RUN cd dune && ./configure --prefix=/home/dune/install && make bootstrap && make
 
 FROM ${BASE_IMAGE} AS run
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser curl ocaml git && rm -rf /var/lib/{apt,dpkg,cache,log}/
+RUN apt-get update && apt-get upgrade -y && apt-get install -y adduser curl ocaml git sudo && rm -rf /var/lib/{apt,dpkg,cache,log}/
 RUN addgroup --gid 1000 dune && adduser --uid 1000 --ingroup dune dune
 
 COPY --from=build /home/dune/install/bin/dune /usr/local/bin


### PR DESCRIPTION
Fixes the GitHub Actions workflow for releasing Docker images. This has been tested in my local fork (https://github.com/Sudha247/dune/pkgs/container/dune), with the help of @Leonidas-from-XIV.

One change here is, a manual trigger of the job requires the version number as input. I'm inclined to keep it this way to avoid confusion on which version is being extracted, but I'm open to hear other ideas.