### PR TITLE
pkg: improve performance of null builds (#12248)

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -71,6 +71,8 @@ module Package_universe = struct
     | Dev_tool dev_tool -> Tuple.T2.hash Int.hash Dune_pkg.Dev_tool.hash (1, dev_tool)
   ;;
 
+  let to_dyn = Dyn.opaque
+
   let context_name = function
     | Project_dependencies context_name -> context_name
     | Dev_tool _ ->
@@ -1096,7 +1098,10 @@ module DB = struct
     ; system_provided : Package.Name.Set.t
     }
 
-  let equal t { all; system_provided } =
+  let equal t t2 =
+    phys_equal t t2
+    ||
+    let { all; system_provided } = t2 in
     Package.Name.Map.equal ~equal:Lock_dir.Pkg.equal t.all all
     && Package.Name.Set.equal t.system_provided system_provided
   ;;
@@ -1114,12 +1119,21 @@ module DB = struct
       Tuple.T2.hash Package.Name.hash Int.hash (name, running_hash))
   ;;
 
-  let get package_universe =
-    let dune = Package.Name.Set.singleton (Package.Name.of_string "dune") in
-    let+ lock_dir = Package_universe.lock_dir package_universe
-    and+ solver_env = Lock_dir.Sys_vars.solver_env () in
-    let all = Dune_pkg.Lock_dir.packages_on_platform lock_dir ~platform:solver_env in
-    { all; system_provided = dune }
+  let get =
+    let memo =
+      Memo.create
+        "DB.get"
+        ~input:(module Package_universe)
+        (fun package_universe ->
+           let dune = Package.Name.Set.singleton (Package.Name.of_string "dune") in
+           let+ lock_dir = Package_universe.lock_dir package_universe
+           and+ solver_env = Lock_dir.Sys_vars.solver_env () in
+           let all =
+             Dune_pkg.Lock_dir.packages_on_platform lock_dir ~platform:solver_env
+           in
+           { all; system_provided = dune })
+    in
+    fun packages_universe -> Memo.exec memo packages_universe
   ;;
 end
 
@@ -1140,9 +1154,9 @@ end = struct
       }
 
     let equal { db; package; universe } t =
-      DB.equal db t.db
-      && Package.Name.equal package t.package
+      Package.Name.equal package t.package
       && Package_universe.equal universe t.universe
+      && DB.equal db t.db
     ;;
 
     let hash { db; package; universe } =


### PR DESCRIPTION
Between now and the investigation of this slowness described in the issue, I have forgotten what's happening exactly, but regardless this Pkg_rules.DB.t type is large, which makes comparing it with itself costly. By avoiding recomputing the same datastructure multiple times, we can cutoff the comparison with physical equality.

`dune build -j 1` in the test repo from the issue goes from 4s to 2s or so.