### PR TITLE
Make promoted files read-only

### DIFF
--- a/doc/changes/12519.md
+++ b/doc/changes/12519.md
@@ -1,0 +1,1 @@
+- Make promoted files read-only. (#12519, #12465, @MisterDA)

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -82,9 +82,10 @@ let promote_target_if_not_up_to_date
         ];
       if promote_until_clean then To_delete.add dst;
       (* The file in the build directory might be read-only if it comes from the
-         shared cache. However, we want the file in the source tree to be
-         writable by the user, so we explicitly set the user writable bit. *)
-      let chmod = Path.Permissions.add Path.Permissions.write in
+         shared cache. We don't want the file in the source tree to be writable
+         by the user, since a new promotion will overwrite it, so we explicitly
+         remove the write permission. *)
+      let chmod = Path.Permissions.remove Path.Permissions.write in
       let+ () = promote_source ~chmod ~delete_dst_if_it_is_a_directory:true ~src ~dst in
       true
   in

--- a/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
@@ -20,9 +20,9 @@ Reproduction case for #3026
 Run Dune a first time to fill the cache, then delete the promoted file and run
 Dune again. At the end of the first run, the file [_build/default/file] should
 get deduplicated and so become read-only. As a result, on the second run the
-promoted file will be copied from a read-only file. However, we still want the
-user to be able to edit this file given that it is in the source tree, so Dune
-should change the permission of this file.
+promoted file will be copied from a read-only file. We don't want the user to be
+able to edit this file even if it is in the source tree, as Dune will always
+overwrite it, so Dune should ensure the file isn't writable.
 
 We check that Dune does change the permission by echoing something into the file
 after the second run.
@@ -40,4 +40,5 @@ after the second run.
   $ cat file
   Hello, world!
 
-  $ echo plop > file
+  $ dune_cmd stat permissions file
+  444

--- a/test/blackbox-tests/test-cases/ignore-promoted-rules-internal-rules.t
+++ b/test/blackbox-tests/test-cases/ignore-promoted-rules-internal-rules.t
@@ -11,6 +11,9 @@ Reported in #8417
   > EOF
 
   $ dune build foo.opam
+  $ dune_cmd stat permissions foo.opam
+  444
+  $ chmod +w foo.opam
   $ echo foobar_extra >> foo.opam
   $ grep foobar_extra foo.opam
   foobar_extra

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -125,6 +125,9 @@ Dune restores only1 if it's modified in the source tree
 
   $ cat only1
   0
+  $ dune_cmd stat permissions only1
+  444
+  $ chmod +w only1
   $ echo 1 > only1
   $ dune build only2
   $ cat only1

--- a/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
+++ b/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
@@ -22,6 +22,9 @@ Dune doesn't promote the file again if it's unchanged.
 
 Dune does promotes the file again if it's changed.
 
+  $ dune_cmd stat permissions promoted
+  444
+  $ chmod +w promoted
   $ echo hi > promoted
   $ dune build promoted --verbose 2>&1 | grep "Promoting"
   Promoting "_build/default/promoted" to "promoted"

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -50,6 +50,9 @@ Remove a directory and rebuild.
 
 Modify a file and rebuild.
 
+  $ dune_cmd stat permissions d1/b
+  444
+  $ chmod +w d1/b
   $ echo -n "*" > d1/b
   $ cat d1/a d1/b d1/d2/c
   +*+

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -50,6 +50,9 @@ Now try deleting the promoted file.
 
 Now try replacing its content.
 
+  $ dune_cmd stat permissions promoted
+  444
+  $ chmod +w promoted
   $ echo hi > promoted
   $ build result
   Success


### PR DESCRIPTION
Files promoted to the source directory should be read-only because they are generated. If they're edited, they're going to be eventually overwritten by a following build. Setting them read-only would prevent user confusion.

In this case, read-only would only be useful for humans, and Dune should make the file writable again if it needs to overwrite it.

If the user need to overwrite a promoted file, for instance before distributing a source archive, then she needs to manually set the write permission.

Fixes #12465.