### PR TITLE
`Loc.t` mapping API

### DIFF
--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -198,9 +198,7 @@ let blang_map = Blang.Ast.map_string
 
 let rec map_loc ~f = function
   | Nil -> Nil
-  | Literal sw ->
-    let loc = f (String_with_vars.loc sw) in
-    Literal (String_with_vars.with_loc ~loc sw)
+  | Literal sw -> Literal (String_with_vars.map_loc ~f sw)
   | Form (loc, form) ->
     let loc = f loc in
     let form = map_form_loc ~f form in

--- a/src/dune_lang/slang.mli
+++ b/src/dune_lang/slang.mli
@@ -40,6 +40,7 @@ val decode : t Decoder.t
 val encode : t Encoder.t
 val to_dyn : t -> Dyn.t
 val loc : t -> Loc.t
+val map_loc : f:(Loc.t -> Loc.t) -> t -> t
 val concat : ?loc:Loc.t -> t list -> t
 val when_ : ?loc:Loc.t -> blang -> t -> t
 val if_ : ?loc:Loc.t -> blang -> then_:t -> else_:t -> t
@@ -66,7 +67,8 @@ module Blang : sig
   val equal : t -> t -> bool
 
   val to_dyn : t -> Dyn.t
-  val remove_locs : blang -> blang
+  val remove_locs : t -> t
+  val map_loc : f:(Loc.t -> Loc.t) -> t -> t
   val true_ : t
   val false_ : t
   val decode : t Decoder.t

--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -114,6 +114,11 @@ let decode_manually f =
 let decode = decode_manually Pform.Env.parse
 let loc t = t.loc
 
+let map_loc t ~f =
+  let loc = f t.loc in
+  { t with loc }
+;;
+
 let virt_pform ?quoted pos pform =
   let loc = Loc.of_pos pos in
   make_pform ?quoted loc pform

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -16,8 +16,8 @@ val equal_no_loc : t -> t -> bool
 (** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 
-(** [with_loc t ~f] transforms the value to update the location. *)
-val with_loc : t -> f:(Loc.t -> Loc.t) -> t
+(** [map_loc t ~f] transforms the value to update the location. *)
+val map_loc : t -> f:(Loc.t -> Loc.t) -> t
 
 val to_dyn : t Dyn.builder
 

--- a/src/dune_lang/string_with_vars.mli
+++ b/src/dune_lang/string_with_vars.mli
@@ -16,6 +16,9 @@ val equal_no_loc : t -> t -> bool
 (** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 
+(** [with_loc t ~f] transforms the value to update the location. *)
+val with_loc : t -> f:(Loc.t -> Loc.t) -> t
+
 val to_dyn : t Dyn.builder
 
 include Conv.S with type t := t


### PR DESCRIPTION
If we need to adjust locations on Slang expressions (as we need in the copy rules PR) then we need an API to apply these API changes.

Matching some other functions, this PR implements the `map_loc` function that recursively maps locations.