### PR TITLE
pkg: enroll dune-release and opam-publish as dev tools

### DIFF
--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -8,7 +8,7 @@ module Exec = struct
     Cmd.group
       info
       (List.map
-         [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig ]
+         [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig; Opam_publish; Dune_release ]
          ~f:Tools_common.exec_command)
   ;;
 end

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -7,6 +7,8 @@ type t =
   | Utop
   | Ocamlearlybird
   | Odig
+  | Opam_publish
+  | Dune_release
 
 let to_dyn = function
   | Ocamlformat -> Dyn.variant "Ocamlformat" []
@@ -15,9 +17,13 @@ let to_dyn = function
   | Utop -> Dyn.variant "Utop" []
   | Ocamlearlybird -> Dyn.variant "Ocamlearlybird" []
   | Odig -> Dyn.variant "Odig" []
+  | Opam_publish -> Dyn.variant "Opam_publish" []
+  | Dune_release -> Dyn.variant "Dune_release" []
 ;;
 
-let all = [ Ocamlformat; Odoc; Ocamllsp; Utop; Ocamlearlybird; Odig ]
+let all =
+  [ Ocamlformat; Odoc; Ocamllsp; Utop; Ocamlearlybird; Odig; Opam_publish; Dune_release ]
+;;
 
 let equal a b =
   match a, b with
@@ -32,6 +38,11 @@ let equal a b =
   | Ocamlearlybird, Ocamlearlybird -> true
   | Ocamlearlybird, _ | _, Ocamlearlybird -> false
   | Odig, Odig -> true
+  | Odig, _ | _, Odig -> false
+  | Opam_publish, Opam_publish -> true
+  | Opam_publish, _ -> false
+  | _, Opam_publish -> false
+  | Dune_release, Dune_release -> true
 ;;
 
 let hash = Poly.hash
@@ -43,6 +54,8 @@ let package_name = function
   | Utop -> Package_name.of_string "utop"
   | Ocamlearlybird -> Package_name.of_string "earlybird"
   | Odig -> Package_name.of_string "odig"
+  | Opam_publish -> Package_name.of_string "opam-publish"
+  | Dune_release -> Package_name.of_string "dune-release"
 ;;
 
 let of_package_name package_name =
@@ -53,6 +66,8 @@ let of_package_name package_name =
   | "utop" -> Utop
   | "earlybird" -> Ocamlearlybird
   | "odig" -> Odig
+  | "opam-publish" -> Opam_publish
+  | "dune-release" -> Dune_release
   | other -> User_error.raise [ Pp.textf "No such dev tool: %s" other ]
 ;;
 
@@ -63,6 +78,8 @@ let exe_name = function
   | Utop -> "utop"
   | Ocamlearlybird -> "ocamlearlybird"
   | Odig -> "odig"
+  | Opam_publish -> "opam-publish"
+  | Dune_release -> "dune-release"
 ;;
 
 let exe_path_components_within_package t = [ "bin"; exe_name t ]
@@ -74,5 +91,7 @@ let needs_to_build_with_same_compiler_as_project = function
        the debugger is expected to print identifiers. In any case,
        ocamlearlybird isn't going to work well due to relocation issues *)
     false
+  | Opam_publish -> false
+  | Dune_release -> false
   | Utop | Odoc | Ocamllsp | Odig -> true
 ;;

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -7,6 +7,8 @@ type t =
   | Utop
   | Ocamlearlybird
   | Odig
+  | Opam_publish
+  | Dune_release
 
 val to_dyn : t -> Dyn.t
 val all : t list

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -17,6 +17,12 @@ Output the help text:
          dune tools exec COMMAND …
   
   COMMANDS
+         dune-release [OPTION]… [ARGS]…
+             Wrapper for running dune-release intended to be run automatically
+             by a text editor. All positional arguments will be passed to the
+             dune-release executable (pass flags to dune-release after the '--'
+             argument, such as 'dune tools exec dune-release -- --help').
+  
          ocamlearlybird [OPTION]… [ARGS]…
              Wrapper for running ocamlearlybird intended to be run
              automatically by a text editor. All positional arguments will be
@@ -41,6 +47,12 @@ Output the help text:
              text editor. All positional arguments will be passed to the odig
              executable (pass flags to odig after the '--' argument, such as
              'dune tools exec odig -- --help').
+  
+         opam-publish [OPTION]… [ARGS]…
+             Wrapper for running opam-publish intended to be run automatically
+             by a text editor. All positional arguments will be passed to the
+             opam-publish executable (pass flags to opam-publish after the '--'
+             argument, such as 'dune tools exec opam-publish -- --help').
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -28,6 +28,8 @@ Confirm that each dev tool's bin directory is now in PATH:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/dune-release/dune-release/target/bin
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/opam-publish/opam-publish/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/odig/odig/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/earlybird/earlybird/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/utop/utop/target/bin


### PR DESCRIPTION
Adding `opam-publish` and `dune-release` as dev tools. This addresses #12099. Both tools solve the same purpose, i.e. to make releases of new packages. Essentially, they automate to a varying degree what could be done manually when we make new releases to `opam-repository`. They have different approaches to doing so, hence it's perhaps useful to provide both as dev tools. 