### PR TITLE
docs: Improve the manpage docs for `dune ocaml top`

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -51,8 +51,8 @@ include struct
 
     let default_exits = List.map ~f:Exit_code.info Exit_code.all
 
-    let info ?docs ?doc ?man ?envs ?version name =
-      info ?docs ?doc ?man ?envs ?version ~exits:default_exits name
+    let info ?docs ?doc ?man_xrefs ?man ?envs ?version name =
+      info ?docs ?doc ?man_xrefs ?man ?envs ?version ~exits:default_exits name
     ;;
   end
 end

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -43,7 +43,7 @@ let files_to_load_of_requires sctx requires =
 let term =
   let+ builder = Common.Builder.term
   and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
-  and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
+  and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run top.|} in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
@@ -214,7 +214,7 @@ module Module = struct
         required
         & pos 0 (some string) None
         & Arg.info [] ~docv:"MODULE" ~doc:"Path to an OCaml module.")
-    and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|} in
+    and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run top.|} in
     let common, config = Common.init builder in
     Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -10,7 +10,10 @@ let man =
       {|Print a list of toplevel directives for including directories and loading cma files.|}
   ; `P
       {|The output of $(b,dune ocaml top) should be evaluated in a toplevel
-          to make a library available there.|}
+        to make the libraries available there.|}
+  ; `P
+      {|In many toplevels this can be achieved by using the $(b,#use_output) command,
+        e.g. $(b,#use_output "dune ocaml top").|}
   ; `Blocks Common.help_secs
   ]
 ;;

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -9,7 +9,7 @@ let man =
   ; `P
       {|Print a list of toplevel directives for including directories and loading cma files.|}
   ; `P
-      {|The output of $(b,dune top) should be evaluated in a toplevel
+      {|The output of $(b,dune ocaml top) should be evaluated in a toplevel
           to make a library available there.|}
   ; `Blocks Common.help_secs
   ]
@@ -91,7 +91,7 @@ module Module = struct
         "The module's source is evaluated in the toplevel without being sealed by the \
          mli."
     ; `P
-        {|The output of $(b,dune top) should be evaluated in a toplevel
+        {|The output of $(b,dune ocaml top) should be evaluated in a toplevel
           to make the module available there.|}
     ; `Blocks Common.help_secs
     ]

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -10,7 +10,8 @@ let man =
   ]
 ;;
 
-let info = Cmd.info "utop" ~doc ~man
+let man_xrefs = [ `Cmd "top" ]
+let info = Cmd.info "utop" ~man_xrefs ~doc ~man
 
 let lock_utop_if_dev_tool_enabled () =
   match Lazy.force Lock_dev_tool.is_enabled with


### PR DESCRIPTION
I am unsure between `dune ocaml top` and `dune top` as the xrefs only accepts the latter but they seem to be equivalent anyway.

Fixes #12493