### PR TITLE
refactor: Do not expose function that is unused

### DIFF
--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -25,8 +25,6 @@ val classify : t -> Loc.t -> [ `Path of Path.t | `Git | `Archive ]
 module Map : Map.S with type key = t
 module Set : Set.S with type elt = t and type 'a map = 'a Map.t
 
-val remote : t -> loc:Loc.t -> Rev_store.t -> Rev_store.Remote.t
-
 type resolve =
   | Resolved of Rev_store.Object.resolved
   | Unresolved of Rev_store.Object.t


### PR DESCRIPTION
Through a messy rebase I accidentally removed this function, but turns out it was unused, so might as well drop it if we don't need it.

(Adding @Alizter as reviewer as he's been cleaning up the fetch API lately, so this seems somewhat relevant)