### PR TITLE
fix(melange + include_qualified): track correct `.cmj` dependencies in emit

### DIFF
--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -214,3 +214,7 @@ let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir =
       in
       Dep_graph.make ~dir ~per_module)
 ;;
+
+let deps_of ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx module_ =
+  deps_of ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx (Normal module_)
+;;

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -27,3 +27,14 @@ val rules
   -> sctx:Super_context.t
   -> dir:Path.Build.t
   -> Dep_graph.Ml_kind.t Memo.t
+
+val deps_of
+  :  obj_dir:Path.Build.t Obj_dir.t
+  -> modules:Modules.With_vlib.t
+  -> sandbox:Sandbox_config.t
+  -> impl:Virtual_rules.t
+  -> dir:Path.Build.t
+  -> sctx:Super_context.t
+  -> Module.t
+  -> ml_kind:Ml_kind.t
+  -> Module.t list Action_builder.t Memo.t

--- a/test/blackbox-tests/test-cases/melange/empty-aliases-file.t
+++ b/test/blackbox-tests/test-cases/melange/empty-aliases-file.t
@@ -115,7 +115,7 @@ file, and it's not present
   > let x = "foo"
   > EOF
 
-  $ DUNE_SANDBOX=none dune build @melange
+  $ dune build @melange
 
 `foo.js` was manually written, therefore it's present. `sub.js` is an alias
 file, and it's not present


### PR DESCRIPTION
depends on https://github.com/ocaml/dune/pull/12530