### PR TITLE
refactor: get rid of dummy ocamlobjinfo targets

### DIFF
--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -137,13 +137,13 @@ let run ~dir ?sandbox ?stdout_to prog args =
   run_dyn_prog ~dir ?sandbox ?stdout_to (Action_builder.return prog) args
 ;;
 
-let run' ~dir prog args =
+let run' ?sandbox ~dir prog args =
   let open Action_builder.O in
   let+ () = dep_prog prog
   and+ args = expand_no_targets ~dir (S args) in
   Action.Run (prog, Appendable_list.to_immutable_array args)
   |> Action.chdir dir
-  |> Action.Full.make
+  |> Action.Full.make ?sandbox
 ;;
 
 let quote_args =

--- a/src/dune_rules/command.mli
+++ b/src/dune_rules/command.mli
@@ -90,7 +90,8 @@ val run
 
 (** Same as [run], but for actions that don't produce targets *)
 val run'
-  :  dir:Path.t
+  :  ?sandbox:Sandbox_config.t
+  -> dir:Path.t
   -> Action.Prog.t
   -> Args.without_targets Args.t list
   -> Action.Full.t Action_builder.t

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -20,7 +20,7 @@ let ooi_deps
       (sourced_module : Modules.Sourced_module.t)
   =
   let m = Modules.Sourced_module.to_module sourced_module in
-  let* write, read =
+  let* read =
     let unit =
       let cm_kind =
         match ml_kind with
@@ -50,8 +50,7 @@ let ooi_deps
          then None
          else Module_name.Unique.Map.find vlib_obj_map dep))
   in
-  let+ () = add_rule write
-  and+ () =
+  let+ () =
     add_rule
       (let target =
          Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind)) |> Option.value_exn

--- a/src/dune_rules/ocamlobjinfo.mli
+++ b/src/dune_rules/ocamlobjinfo.mli
@@ -11,7 +11,7 @@ val rules
   -> dir:Path.Build.t
   -> sandbox:Sandbox_config.t option
   -> unit:Path.t
-  -> Action.Full.t Action_builder.With_targets.t * t Action_builder.t
+  -> t Action_builder.t
 
 (** For testing only *)
 val parse : string -> t


### PR DESCRIPTION
Now they're invisible to the user. No change in behavior otherwise.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>
