### PR TITLE
doc: never break inline code in html output

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,0 +1,3 @@
+code.docutils.literal {
+  white-space : nowrap;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,10 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
+html_css_files = [
+    'css/custom.css'
+]
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
I dislike seeing inline code being broken in two lines whenever it pleases the browser, so there we go! A simple CSS rule and the browser won't wrap them, even if they're wrapped in the rst file (this happens by accident or to break at 80 cols, never on purpose).

- https://docs.readthedocs.com/platform/stable/guides/adding-custom-css.html
- https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
Don't use `preserve` as the inline code might have a break in the original rst.