### PR TITLE
Fix `dune install --create-install-files` not being able to overwrite opam files

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -680,14 +680,7 @@ let run
                 ~findlib_toolchain:(Context.findlib_toolchain context)
                 package
             in
-            let contents = Install.Entry.gen_install_file entries in
-            let path = Path.source fn in
-            try Io.write_file path contents with
-            | Unix.Unix_error (Unix.EACCES, _, _) ->
-              let Unix.{ st_perm; _ } = Path.stat_exn path in
-              Path.chmod path ~mode:(Path.Permissions.add Path.Permissions.write st_perm);
-              Io.write_file path contents;
-              Path.chmod path ~mode:st_perm)))
+            Install.Entry.gen_install_file entries |> Io.overwrite_file (Path.source fn))))
   in
   Path.Set.to_list !files_deleted_in
   (* This [List.rev] is to ensure we process children directories before

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -153,15 +153,7 @@ let subst_file path ~map opam_package_files =
       | None, Some x -> Some x
       | Some x, Some y -> Some (x ^ "\n" ^ y)
     in
-    (match contents with
-     | None -> ()
-     | Some contents ->
-       (try Io.write_file path contents with
-        | Unix.Unix_error (Unix.EACCES, _, _) ->
-          let Unix.{ st_perm; _ } = Path.stat_exn path in
-          Path.chmod path ~mode:(Path.Permissions.add Path.Permissions.write st_perm);
-          Io.write_file path contents;
-          Path.chmod path ~mode:st_perm))
+    Option.iter ~f:(Io.overwrite_file path) contents
 ;;
 
 (* Extending the Dune_project APIs, but adding capability to modify *)

--- a/doc/changes/changed/12519.md
+++ b/doc/changes/changed/12519.md
@@ -1,1 +1,1 @@
-- Make promoted files read-only. (#12519, #12465, @MisterDA)
+- Make promoted files read-only. (#12542, #12540, #12519, #12465, @MisterDA)

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -282,6 +282,18 @@ struct
     else with_file_out ~binary ?perm fn ~f:(fun oc -> output_string oc data)
   ;;
 
+  let overwrite_file ?binary fn data =
+    let path = Path.to_string fn in
+    try write_file ?binary fn data with
+    | Unix.Unix_error (Unix.EACCES, _, _) ->
+      let Unix.{ st_perm; _ } = Unix.stat path in
+      let user_write = 0o200 in
+      Unix.chmod path (st_perm lor user_write);
+      Fun.protect
+        ~finally:(fun () -> Unix.chmod path st_perm)
+        (fun () -> write_file ?binary fn data)
+  ;;
+
   let write_lines ?binary ?perm fn lines =
     with_file_out ?binary ?perm fn ~f:(fun oc ->
       List.iter

--- a/otherlibs/stdune/src/io_intf.ml
+++ b/otherlibs/stdune/src/io_intf.ml
@@ -25,6 +25,10 @@ module type S = sig
   val write_lines : ?binary:bool -> ?perm:int -> path -> string list -> unit
   val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
 
+  (** Try to write the file. On failure, temporarily set the write
+      permission, and retry writing once. *)
+  val overwrite_file : ?binary:bool -> path -> string -> unit
+
   val setup_copy
     :  ?chmod:(int -> int)
     -> src:path

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -72,6 +72,7 @@ when calling dune subst:
       "@doc" {with-doc}
     ]
   ]
+  $ dune build -p foo @install
 
 When the version of the language >= 2.7, odoc is automatically added to
 the doc dependencies:
@@ -191,13 +192,16 @@ the doc dependencies:
     ]
     ["dune" "install" "-p" name "--create-install-files" name]
   ]
+  $ dune subst
+  $ dune build -p foo --promote-install-files=false @install
+  $ dune install -p foo --create-install-files foo
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (name foo)
   > (generate_opam_files true)
   > (subst disabled)
-  > (package (name foo) (depends (odoc :with-test) something))
+  > (package (name foo) (depends (odoc :with-test) something) (allow_empty))
   > EOF
 
   $ dune build foo.opam
@@ -215,13 +219,14 @@ the doc dependencies:
       "@doc" {with-doc}
     ]
   ]
+  $ dune build -p foo @install
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (name foo)
   > (generate_opam_files true)
   > (subst enabled)
-  > (package (name foo) (depends (odoc :with-test) something))
+  > (package (name foo) (depends (odoc :with-test) something) (allow_empty))
   > EOF
 
   $ dune build foo.opam
@@ -240,3 +245,5 @@ the doc dependencies:
       "@doc" {with-doc}
     ]
   ]
+  $ dune subst
+  $ dune build -p foo @install

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -194,7 +194,7 @@ the doc dependencies:
   ]
   $ dune subst
   $ dune build -p foo --promote-install-files=false @install
-  $ dune install -p foo --create-install-files foo
+  $ dune install -p foo --create-install-files foo --prefix=$PWD/local
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)


### PR DESCRIPTION
See #12519 and #12465.
Fixes #12540. 