### PR TITLE
Enable package management for more (pkg) tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/build-single-package.t
+++ b/test/blackbox-tests/test-cases/pkg/build-single-package.t
@@ -8,6 +8,11 @@ Requesting to build a single package should not build unrelated things:
   > (lang dune 3.12)
   > EOF
 
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
+  > EOF
+
   $ pkg() {
   > make_lockpkg $1 <<EOF
   > (build (run echo building $1))

--- a/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
@@ -4,7 +4,8 @@ Exercise dune resolving the post dependencies found in compiler packages.
   $ mkrepo
 
   $ cat >dune-workspace << EOF
-  > (lang dune 3.16)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (path dune.lock)
   >  (repositories mock)

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -13,7 +13,8 @@ First we setup a repo.
   > mkpkg E 3.0~alpha1
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.11)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (context
   >  (default))
   > (context

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -3,7 +3,8 @@ Create a lock directory that didn't originally exist
   $ . ../helpers.sh
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories mock))
   > (lock_dir

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
@@ -26,7 +26,8 @@ Multiple opam repositories that define the same package:
   > `
 
   $ cat >dune-workspace <<EOF
-  > (lang dune 3.11)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories repo1 repo2))
   > $repos12

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -29,7 +29,8 @@ Create a new mock repo, with a different foo package
 We have to define both repositories in the workspace, but will only use `new`.
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories new))
   > (repository
@@ -61,7 +62,8 @@ If we just use `old` we should get the older `foo` package in our lockfile
 solution:
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories old))
   > (repository
@@ -84,7 +86,8 @@ If we specify both repositories to be used, we should still get the new foo
 package:
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories old new))
   > (repository
@@ -108,7 +111,8 @@ set, we should get a solution that only has `old` and will thus include the
 older version of foo:
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.10)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (repository
   >  (name new)
   >  (url "git+file://$(pwd)/mock-opam-repository"))

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -7,7 +7,8 @@ Test that the ocamllsp dev tool can see the ocamlformat dev tool.
   $ mkpkg ocaml 5.2.0
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.16)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (path "dev-tools.locks/ocaml-lsp-server")
   >  (repositories mock))

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -2,7 +2,8 @@
 # project and the odoc lockdir.
 setup_odoc_workspace() {
   cat > dune-workspace <<EOF
-(lang dune 3.16)
+(lang dune 3.20)
+(pkg enabled)
 (lock_dir
  (path "dev-tools.locks/odoc")
  (repositories mock))

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -52,7 +52,8 @@ Test that we can read package metadata from opam files.
     
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.12)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories mock)
   >  (solver_env

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -11,7 +11,8 @@
   > depends: [ "foo" {>= "0.0.1"} ]
   > EOF
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.11)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories mock))
   > (lock_dir

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -50,8 +50,9 @@ Solve the package using the default solver env:
      @install)))
 
 Make a custom solver env:
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (path dune.lock)
   >  (repositories mock)

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -20,7 +20,8 @@ Test that we validate lockdirs before using them to build a package.
 Helper function that creates a workspace file with a given solver env.
   $ generate_workspace() {
   >  cat <<EOF
-  > (lang dune 3.12)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (repositories mock)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -16,7 +16,7 @@ Create a package that writes a different value to some files depending on the os
 
 Create a custom dune-workspace to solve for openbsd.
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.18)
+  > (lang dune 3.20)
   > (repository
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))
@@ -25,6 +25,7 @@ Create a custom dune-workspace to solve for openbsd.
   >  (solve_for_platforms
   >   ((arch x86_64)
   >    (os openbsd))))
+  > (pkg enabled)
   > EOF
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -7,8 +7,9 @@ environment that affects the solution.
 
 Create a workspace that defines a lockdir with a custom solver environment,
 setting the variable "sys-ocaml-version":
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (repository
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
@@ -24,7 +24,8 @@ will demonstrate that even though the project isn't solved for a particular
 linux distribution, enough information is stored in the lockdir so that the
 correct depext names can be chosen for the current distro at build time.
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.18)
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (repository
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
@@ -6,7 +6,7 @@ Detect common typos with package variables when describing platforms to solve fo
 
 Create a workspace with some typos in package variable names
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.18)
+  > (lang dune 3.20)
   > (repository
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))
@@ -17,6 +17,7 @@ Create a workspace with some typos in package variable names
   >    (os linux)
   >    (os_distribution debian)
   >    (os_family debian))))
+  > (pkg enabled)
   > EOF
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -48,8 +48,9 @@ the logic which stores solver vars in lockdir metadata in this case.
   > }
 
 Make a workspace file which sets some of the variables.
-  $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
   > (lock_dir
   >  (path dune.lock)
   >  (repositories mock)

--- a/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
@@ -3,6 +3,7 @@ a mock compiler package using dune's toolchain mechanism.
 
   $ . ./helpers.sh
   $ make_lockdir
+  $ add_mock_repo_if_needed
 
 We create a fake compiler by creating a configure file.
 


### PR DESCRIPTION
Going forward the signal to use package management is `(pkg enabled)` so the tests that currently rely on it always enabled/autodetected need to opt in.

Fortunately, on `main` the meaning of "unset" and `enabled` are identical in cases where package management is used, so it can be just enabled.

Pulled out of #11775 (which requires the change) to reduce the scope of changes in the PR.