### PR TITLE
add `dune describe tests` subcommand

### DIFF
--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -22,6 +22,7 @@ let subcommands =
   ; Describe_contexts.command
   ; Describe_depexts.command
   ; Describe_location.command
+  ; Describe_tests.command
   ]
 ;;
 

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -1,0 +1,159 @@
+open Import
+open Dune_rules
+
+module Test_description = struct
+  type t =
+    { name : string
+    ; source_dir : string
+    ; package : string option
+    ; enabled : bool
+    ; location : string
+    ; target : string
+    }
+
+  let to_dyn { name; source_dir; package; enabled; location; target } =
+    let open Dyn in
+    record
+      [ "name", string name
+      ; "source_dir", string source_dir
+      ; "package", option string package
+      ; "enabled", bool enabled
+      ; "location", string location
+      ; "target", string target
+      ]
+  ;;
+end
+
+module Crawl = struct
+  open Memo.O
+
+  (* Collect all (stanza, dir, expander) for test-related stanzas *)
+  let collect_test_stanzas
+        ({ Import.Main.contexts = _; scontexts } : Import.Main.build_system)
+        (context : Context.t)
+    : (Stanza.t * Path.Build.t * Expander.t) list Memo.t
+    =
+    let context_name = Context.name context in
+    let sctx = Context_name.Map.find_exn scontexts context_name in
+    let* dune_files = Dune_load.dune_files context_name in
+    Memo.parallel_map dune_files ~f:(fun (dune_file : Dune_file.t) ->
+      Dune_file.stanzas dune_file
+      >>= fun stanzas ->
+      let dir =
+        Path.Build.append_source (Context.build_dir context) (Dune_file.dir dune_file)
+      in
+      let* expander = Super_context.expander sctx ~dir in
+      Memo.return
+        (List.filter_map stanzas ~f:(fun stanza ->
+           match Stanza.repr stanza with
+           | Tests.T _ | Cram_stanza.T _ -> Some (stanza, dir, expander)
+           | Library.T lib ->
+             (match
+                Sub_system_name.Map.find lib.sub_systems Inline_tests_info.Tests.name
+              with
+              | Some (Dune_rules.Inline_tests_info.Tests.T _) ->
+                Some (stanza, dir, expander)
+              | _ -> None)
+           | _ -> None)))
+    >>| List.concat
+  ;;
+
+  (* Transform a stanza into a list of Test_description.t *)
+  let describe_stanza stanza dir expander : Test_description.t list Memo.t =
+    match Stanza.repr stanza with
+    | Tests.T (tests : Tests.t) ->
+      let* enabled = Expander.eval_blang expander tests.enabled_if in
+      let names = List.map ~f:snd (Nonempty_list.to_list tests.exes.names) in
+      let package =
+        Option.map tests.package ~f:(fun p ->
+          Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)
+      in
+      let location = Loc.to_file_colon_line tests.exes.buildable.loc in
+      let source_dir = Path.Build.drop_build_context_exn dir |> Path.Source.to_string in
+      let descs =
+        List.map names ~f:(fun name ->
+          let target = Path.Build.relative dir (name ^ ".exe") |> Path.Build.to_string in
+          { Test_description.name; source_dir; package; enabled; location; target })
+      in
+      Memo.return descs
+    | Cram_stanza.T cram ->
+      let* enabled = Expander.eval_blang expander cram.enabled_if in
+      let package =
+        Option.map cram.package ~f:(fun p ->
+          Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)
+      in
+      let location = Loc.to_file_colon_line cram.loc in
+      let source_dir = Path.Build.drop_build_context_exn dir |> Path.Source.to_string in
+      let name = "cram" in
+      (* Use the runtest alias as target, which is the actual executable target *)
+      let target = "@" ^ source_dir ^ "/runtest" in
+      let description =
+        { Test_description.name; source_dir; package; enabled; location; target }
+      in
+      Memo.return [ description ]
+    | Library.T lib ->
+      let* enabled =
+        let inline_tests =
+          match Sub_system_name.Map.find lib.sub_systems Inline_tests_info.Tests.name with
+          | Some (Dune_rules.Inline_tests_info.Tests.T t) -> t
+          | _ -> assert false
+        in
+        Expander.eval_blang expander inline_tests.enabled_if
+      in
+      let name = Lib_name.Local.to_string (snd lib.name) in
+      let package =
+        Option.map (Library.package lib) ~f:(fun p ->
+          Dune_lang.Package.name p |> Dune_lang.Package_name.to_string)
+      in
+      let location = Loc.to_file_colon_line lib.buildable.loc in
+      let source_dir = Path.Build.drop_build_context_exn dir |> Path.Source.to_string in
+      let target =
+        "@" ^ source_dir ^ "/runtest-" ^ Lib_name.Local.to_string (snd lib.name)
+      in
+      let description =
+        { Test_description.name; source_dir; package; enabled; location; target }
+      in
+      Memo.return [ description ]
+    | _ -> Memo.return []
+  ;;
+
+  (* Main entry: crawl and describe all test stanzas *)
+  let tests build_system context : Test_description.t list Memo.t =
+    let* stanzas = collect_test_stanzas build_system context in
+    Memo.parallel_map stanzas ~f:(fun (stanza, dir, expander) ->
+      describe_stanza stanza dir expander)
+    >>| List.concat
+  ;;
+end
+
+let term : unit Term.t =
+  let+ builder = Common.Builder.term
+  and+ context_name = Common.context_arg ~doc:"Build context to use."
+  and+ format = Describe_format.arg in
+  let common, config = Common.init builder in
+  Scheduler.go_with_rpc_server ~common ~config
+  @@ fun () ->
+  let open Fiber.O in
+  let* setup = Import.Main.setup () in
+  build_exn
+  @@ fun () ->
+  let open Memo.O in
+  let* setup = setup in
+  let super_context = Import.Main.find_scontext_exn setup ~name:context_name in
+  let context = Super_context.context super_context in
+  let* tests_data = Crawl.tests setup context in
+  let dyn_data =
+    List.map tests_data ~f:Test_description.to_dyn |> fun list -> Dyn.List list
+  in
+  Describe_format.print_dyn format dyn_data;
+  Memo.return ()
+;;
+
+let command =
+  let doc =
+    "Print out the tests defined in the project. The output format of this command is \
+     experimental and is subject to change without warning"
+  in
+  let info = Cmd.info ~doc "tests" in
+  Cmd.v info term
+;;

--- a/bin/describe/describe_tests.mli
+++ b/bin/describe/describe_tests.mli
@@ -1,0 +1,4 @@
+open Import
+
+(** Dune command to describe the tests in the workspace *)
+val command : unit Cmd.t

--- a/doc/changes/added/12545.md
+++ b/doc/changes/added/12545.md
@@ -1,0 +1,2 @@
+- Add `$ dune describe tests` to describe the tests in the workspace
+  (@Gromototo, #12545, fixes #12030)

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -63,7 +63,10 @@ module Pkg_dev_tool = Pkg_dev_tool
 module Pkg_build_progress = Pkg_build_progress
 module Compile_time = Compile_time
 module Cram_rules = Cram_rules
+module Cram_stanza = Cram_stanza
 module Instrumentation = Instrumentation
+module Sub_system_name = Sub_system_name
+module Inline_tests_info = Inline_tests_info
 
 module Install_rules = struct
   let install_file = Install_rules.install_file

--- a/test/blackbox-tests/test-cases/describe/describe-tests.t
+++ b/test/blackbox-tests/test-cases/describe/describe-tests.t
@@ -1,0 +1,310 @@
+Test for the `dune describe tests` command
+==========================================
+
+Setup with various test configurations
+--------------------------------------
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (package (name test-pkg))
+  > EOF
+
+Simple test
+-----------
+
+  $ cat >dune <<EOF
+  > (test
+  >  (name simple_test))
+  > EOF
+
+  $ touch simple_test.ml
+
+Test with all fields and in a subdirectory
+--------------------
+
+  $ mkdir -p subdir
+
+  $ cat >subdir/dune <<EOF
+  > (test
+  >  (name complex_test)
+  >  (package test-pkg)
+  >  (deps test_data.txt)
+  >  (locks /tmp/test.lock)
+  >  (enabled_if true)
+  >  (action (run echo "custom action")))
+  > EOF
+
+  $ touch subdir/complex_test.ml
+  $ echo "test data" > subdir/test_data.txt
+
+Disabled test
+-------------
+
+  $ mkdir -p disabled
+
+  $ cat >disabled/dune <<EOF
+  > (test
+  >  (name disabled_test)
+  >  (enabled_if false))
+  > EOF
+
+  $ touch disabled/disabled_test.ml
+
+Test with dependencies
+---------------------
+
+  $ mkdir -p with_deps
+
+  $ cat >with_deps/dune <<EOF
+  > (test
+  >  (name deps_test)
+  >  (deps 
+  >   (file ../subdir/test_data.txt)
+  >   (file dune)))
+  > EOF
+
+  $ touch with_deps/deps_test.ml
+
+Test with multiple tests in one stanza
+---------------------------------------
+
+  $ mkdir -p multi_tests
+
+  $ cat >multi_tests/dune <<EOF
+  > (tests
+  >  (names test_a test_b test_c)
+  >  (package test-pkg))
+  > EOF
+
+  $ touch multi_tests/test_a.ml
+  $ touch multi_tests/test_b.ml
+  $ touch multi_tests/test_c.ml
+
+Testing unit tests (Tests.T)
+=============================
+
+Test sexp format for unit tests only:
+
+  $ dune describe tests
+  (((name deps_test)
+    (source_dir with_deps)
+    (package ())
+    (enabled true)
+    (location with_deps/dune:1)
+    (target _build/default/with_deps/deps_test.exe))
+   ((name complex_test)
+    (source_dir subdir)
+    (package (test-pkg))
+    (enabled true)
+    (location subdir/dune:1)
+    (target _build/default/subdir/complex_test.exe))
+   ((name test_a)
+    (source_dir multi_tests)
+    (package (test-pkg))
+    (enabled true)
+    (location multi_tests/dune:1)
+    (target _build/default/multi_tests/test_a.exe))
+   ((name test_b)
+    (source_dir multi_tests)
+    (package (test-pkg))
+    (enabled true)
+    (location multi_tests/dune:1)
+    (target _build/default/multi_tests/test_b.exe))
+   ((name test_c)
+    (source_dir multi_tests)
+    (package (test-pkg))
+    (enabled true)
+    (location multi_tests/dune:1)
+    (target _build/default/multi_tests/test_c.exe))
+   ((name disabled_test)
+    (source_dir disabled)
+    (package ())
+    (enabled false)
+    (location disabled/dune:1)
+    (target _build/default/disabled/disabled_test.exe))
+   ((name simple_test)
+    (source_dir .)
+    (package ())
+    (enabled true)
+    (location dune:1)
+    (target _build/default/simple_test.exe)))
+
+Test csexp format for unit tests:
+
+  $ dune describe tests --format csexp
+  (((4:name9:deps_test)(10:source_dir9:with_deps)(7:package())(7:enabled4:true)(8:location16:with_deps/dune:1)(6:target38:_build/default/with_deps/deps_test.exe))((4:name12:complex_test)(10:source_dir6:subdir)(7:package(8:test-pkg))(7:enabled4:true)(8:location13:subdir/dune:1)(6:target38:_build/default/subdir/complex_test.exe))((4:name6:test_a)(10:source_dir11:multi_tests)(7:package(8:test-pkg))(7:enabled4:true)(8:location18:multi_tests/dune:1)(6:target37:_build/default/multi_tests/test_a.exe))((4:name6:test_b)(10:source_dir11:multi_tests)(7:package(8:test-pkg))(7:enabled4:true)(8:location18:multi_tests/dune:1)(6:target37:_build/default/multi_tests/test_b.exe))((4:name6:test_c)(10:source_dir11:multi_tests)(7:package(8:test-pkg))(7:enabled4:true)(8:location18:multi_tests/dune:1)(6:target37:_build/default/multi_tests/test_c.exe))((4:name13:disabled_test)(10:source_dir8:disabled)(7:package())(7:enabled5:false)(8:location15:disabled/dune:1)(6:target41:_build/default/disabled/disabled_test.exe))((4:name11:simple_test)(10:source_dir1:.)(7:package())(7:enabled4:true)(8:location6:dune:1)(6:target30:_build/default/simple_test.exe)))
+
+Verify that disabled tests are still shown:
+
+  $ dune describe tests | grep -A 5 disabled_test | head -6
+   ((name disabled_test)
+    (source_dir disabled)
+    (package ())
+    (enabled false)
+    (location disabled/dune:1)
+    (target _build/default/disabled/disabled_test.exe))
+
+Clean up unit test files
+-------------------------
+
+Now remove all unit test files to prepare for CRAM tests:
+
+  $ rm -rf with_deps subdir disabled multi_tests simple_test.ml dune
+
+Testing CRAM tests (Cram_stanza.T)
+===================================
+
+Setup CRAM tests
+----------------
+
+Simple CRAM test:
+
+  $ mkdir -p cram_tests
+
+  $ cat >cram_tests/dune <<EOF
+  > (cram
+  >  (deps some_file.txt))
+  > EOF
+
+  $ touch cram_tests/some_file.txt
+
+  $ cat >cram_tests/test.t <<EOF
+  > Simple cram test
+  >   \$ echo "hello"
+  >   hello
+  > EOF
+
+CRAM test with package:
+
+  $ mkdir -p cram_with_pkg
+
+  $ cat >cram_with_pkg/dune <<EOF
+  > (cram
+  >  (package test-pkg))
+  > EOF
+
+  $ cat >cram_with_pkg/example.t <<EOF
+  > Example test
+  >   \$ echo "test"
+  >   test
+  > EOF
+
+Disabled CRAM test:
+
+  $ mkdir -p cram_disabled
+
+  $ cat >cram_disabled/dune <<EOF
+  > (cram
+  >  (enabled_if false))
+  > EOF
+
+  $ cat >cram_disabled/disabled.t <<EOF
+  > This should not run
+  >   \$ echo "disabled"
+  >   disabled
+  > EOF
+
+Test sexp format for CRAM tests:
+
+  $ dune describe tests
+  (((name cram)
+    (source_dir cram_with_pkg)
+    (package (test-pkg))
+    (enabled true)
+    (location cram_with_pkg/dune:1)
+    (target @cram_with_pkg/runtest))
+   ((name cram)
+    (source_dir cram_tests)
+    (package ())
+    (enabled true)
+    (location cram_tests/dune:1)
+    (target @cram_tests/runtest))
+   ((name cram)
+    (source_dir cram_disabled)
+    (package ())
+    (enabled false)
+    (location cram_disabled/dune:1)
+    (target @cram_disabled/runtest)))
+
+Test csexp format for CRAM tests:
+
+  $ dune describe tests --format csexp
+  (((4:name4:cram)(10:source_dir13:cram_with_pkg)(7:package(8:test-pkg))(7:enabled4:true)(8:location20:cram_with_pkg/dune:1)(6:target22:@cram_with_pkg/runtest))((4:name4:cram)(10:source_dir10:cram_tests)(7:package())(7:enabled4:true)(8:location17:cram_tests/dune:1)(6:target19:@cram_tests/runtest))((4:name4:cram)(10:source_dir13:cram_disabled)(7:package())(7:enabled5:false)(8:location20:cram_disabled/dune:1)(6:target22:@cram_disabled/runtest)))
+
+Verify that disabled CRAM tests are still shown:
+
+  $ dune describe tests | grep -A 5 cram_disabled | head -6
+    (source_dir cram_disabled)
+    (package ())
+    (enabled false)
+    (location cram_disabled/dune:1)
+    (target @cram_disabled/runtest)))
+
+Inline tests generated by ppx_expect
+
+  $ mkdir -p inline_lib_test
+
+  $ cat >inline_lib_test/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (inline_tests)
+  >  (preprocess (pps ppx_expect)))
+  > EOF
+
+  $ cat >inline_lib_test/mylib.ml <<EOF
+  > let%expect_test _ =
+  >   print_endline "Hello from ppx_expect!";
+  >   [%expect {|
+  >     Hello from ppx_expect!
+  >   |}]
+  > EOF
+
+Test sexp format should include the inline-test runner alias for the library:
+
+  $ dune describe tests | grep -A 5 mylib | head -6
+  (((name mylib)
+    (source_dir inline_lib_test)
+    (package ())
+    (enabled true)
+    (location inline_lib_test/dune:1)
+    (target @inline_lib_test/runtest-mylib))
+
+  $ rm -rf inline_lib_test
+
+Inline tests with ppx_inline_test
+---------------------------------
+
+  $ mkdir -p inline_ppx_test
+
+  $ cat >inline_ppx_test/dune <<EOF
+  > (library
+  >  (name my_ppx_lib)
+  >  (package test-pkg)
+  >  (inline_tests)
+  >  (preprocess (pps ppx_inline_test)))
+  > EOF
+
+  $ cat >inline_ppx_test/my_ppx_lib.ml <<EOF
+  > let%test "my ppx test" = 1 + 1 = 2
+  > EOF
+
+Test sexp format for ppx_inline_test:
+
+  $ dune describe tests | grep -A 5 my_ppx_lib | head -6
+  (((name my_ppx_lib)
+    (source_dir inline_ppx_test)
+    (package (test-pkg))
+    (enabled true)
+    (location inline_ppx_test/dune:1)
+    (target @inline_ppx_test/runtest-my_ppx_lib))
+
+  $ rm -rf inline_ppx_test
+
+Test error cases
+----------------
+
+Test invalid context:
+
+  $ dune describe tests --context nonexistent
+  Error: Context "nonexistent" not found!
+  [1]


### PR DESCRIPTION
## Objective

Add a new `dune describe tests` subcommand to display information about test and cram stanzas defined in the current project.

This information includes metadata such as:
- **name**: The test name
- **source_dir**: Directory containing the test stanza
- **package**: Associated package (if any)
- **enabled**: Whether the test is enabled (respects `enabled_if` conditions)
- **location**: Source location of the stanza definition
- **target**: Actionable build target (`.exe` for unit tests, `@dir/runtest` alias for CRAM tests)

## Implementation

### Core Architecture
- **Dual stanza support**: Handles both `Tests.T` (unit tests) and `Cram_stanza.T` (CRAM tests)
- **Refactored logic**: Separates collection (`collect_test_stanzas`) from transformation (`describe_stanza`) for clarity and maintainability
- **Actionable targets**: 
  - Unit tests: `_build/default/<dir>/<name>.exe`
  - CRAM tests: `@<source_dir>/runtest` (alias target)
  - Inline tests: `@<source_dir>/runtest-<lib_name>` (alias target, e.g., for `ppx_expect`)
- **Crawl pattern**: Uses existing Dune crawl infrastructure and `Dyn` serialization for consistency with other describe subcommands
- **Output formats**: Supports both human-readable S-expression and canonical S-expression (`--format=csexp`)
- **Complete reporting**: Includes all tests regardless of `enabled` status (the boolean value indicates whether the test would run)

### Technical Details
- Added logic to inspect the `sub_systems` field of `Library.T` for `Inline_tests_info.Tests.name`.
- Exposed `Cram_stanza` via `dune_rules` module for type matching
- Resolved namespace conflicts (`Context_name.Map`, `Import.Main`)
- Scoped `Memo.O` usage to avoid operator conflicts with `Cmdliner.Term`

## Testing

Added comprehensive blackbox test coverage in `test/blackbox-tests/test-cases/describe/describe-tests.t`:

### Phase 1: Unit Tests (Tests.T)
- Simple tests with basic metadata
- Complex tests with full metadata (package, dependencies)
- Multiple tests in a single stanza
- Disabled tests (via `enabled_if`)
- Tests with dependencies

### Phase 2: CRAM Tests (Cram_stanza.T)
- Simple CRAM tests
- CRAM tests with package association
- Disabled CRAM tests

### Phase 3: Inline Tests (Library.T / ppx_expect)
- Tests for libraries with `(inline_tests)`.

## Fixes

Closes #12030