### PR TITLE
pkg: implement a package search command

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -49,7 +49,8 @@
   spawn
   opam_format
   source
-  xdg)
+  xdg
+  re)
  (bootstrap_info bootstrap-info))
 
 ; Installing the dune binary depends on the kind of build:

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -76,6 +76,14 @@ include struct
   module Dune_project = Dune_project
 end
 
+include struct
+  open Dune_pkg
+  module Opam_repo = Opam_repo
+  module Lock_dir = Lock_dir
+  module Rev_store = Rev_store
+  module Resolved_package = Resolved_package
+end
+
 module Log = Dune_util.Log
 module Dune_rpc = Dune_rpc_private
 module Graph = Dune_graph.Graph

--- a/bin/pkg/group.ml
+++ b/bin/pkg/group.ml
@@ -14,6 +14,7 @@ let subcommands =
   ; Validate_lock_dir.command
   ; Pkg_enabled.command
   ; Print_digest.command
+  ; Search.command
   ]
 ;;
 

--- a/bin/pkg/pkg.ml
+++ b/bin/pkg/pkg.ml
@@ -4,4 +4,5 @@ module Outdated = Outdated
 module Pkg_common = Pkg_common
 module Pkg_enabled = Pkg_enabled
 module Print_solver_env = Print_solver_env
+module Search = Search
 module Validate_lock_dir = Validate_lock_dir

--- a/bin/pkg/search.ml
+++ b/bin/pkg/search.ml
@@ -1,0 +1,133 @@
+open Import
+
+let get_default_lock_dir_path () = Dune_rules.Lock_dir.default_source_path |> Path.source
+
+let packages_in_repo ~query repo =
+  let package_names = Opam_repo.packages_in_repo repo in
+  let filtered_packages =
+    match query with
+    | None -> package_names
+    | Some re ->
+      List.filter package_names ~f:(fun name ->
+        Re.execp re (OpamPackage.Name.to_string name))
+  in
+  filtered_packages
+  |> Fiber.parallel_map ~f:(fun name ->
+    let open Fiber.O in
+    let* versions = Opam_repo.load_all_versions [ repo ] name in
+    let versions =
+      OpamPackage.Version.Map.filter
+        (fun _version resolved_pkg ->
+           let opam_file = Resolved_package.opam_file resolved_pkg in
+           let avoid = List.mem opam_file.flags Pkgflag_AvoidVersion ~equal:Poly.equal in
+           not avoid)
+        versions
+    in
+    Fiber.return (name, OpamPackage.Version.Map.max_binding_opt versions))
+;;
+
+let search_packages ~query () =
+  let open Fiber.O in
+  let* workspace = Memo.run (Workspace.workspace ()) in
+  let* lock_dir_path = Dune_rules.Lock_dir.get_path Context_name.default |> Memo.run in
+  let lock_dir_path =
+    match lock_dir_path with
+    | Some p -> p
+    | None -> get_default_lock_dir_path ()
+  in
+  let* repos =
+    Pkg_common.get_repos
+      (Pkg_common.repositories_of_workspace workspace)
+      ~repositories:(Pkg_common.repositories_of_lock_dir workspace ~lock_dir_path)
+  in
+  let re = Option.map ~f:(fun q -> Re.str q |> Re.no_case |> Re.compile) query in
+  let* filtered = Fiber.parallel_map ~f:(packages_in_repo ~query:re) repos in
+  let results =
+    filtered
+    |> List.concat
+    |> List.filter_map ~f:(fun (name, version_pkg) ->
+      Option.map ~f:(fun data -> name, data) version_pkg)
+    |> List.fold_left
+         ~init:OpamPackage.Name.Map.empty
+         ~f:(fun acc (name, ((v2, _pkg) as data)) ->
+           if OpamPackage.Name.Map.mem name acc
+           then (
+             let v1, _ = OpamPackage.Name.Map.find name acc in
+             (* Replace with next repository's package only if it's a newer
+             version, to respect the repository order. *)
+             if OpamPackage.Version.compare v1 v2 < 0
+             then OpamPackage.Name.Map.add name data acc
+             else acc)
+           else OpamPackage.Name.Map.add name data acc)
+  in
+  if OpamPackage.Name.Map.is_empty results
+  then (
+    let msg =
+      match query with
+      | Some q -> Pp.textf "No packages found matching %S." q
+      | None -> Pp.text "No packages found."
+    in
+    User_error.raise [ msg ])
+  else (
+    let results =
+      OpamPackage.Name.Map.bindings results
+      |> List.sort ~compare:(fun (a, _) (b, _) ->
+        (* Sort exact matches before substring matches *)
+        let order =
+          match query with
+          | Some q ->
+            let a_str = OpamPackage.Name.to_string a in
+            let b_str = OpamPackage.Name.to_string b in
+            if String.equal a_str q
+            then -1
+            else if String.equal b_str q
+            then 1
+            else OpamPackage.Name.compare a b
+          | None -> OpamPackage.Name.compare a b
+        in
+        Ordering.of_int order)
+    in
+    [ Pp.enumerate results ~f:(fun (name, (version, resolved_pkg)) ->
+        let synopsis =
+          resolved_pkg |> Resolved_package.opam_file |> OpamFile.OPAM.synopsis
+        in
+        Pp.concat
+          ~sep:Pp.space
+          [ Pp.tag User_message.Style.Kwd (Pp.verbatim (OpamPackage.Name.to_string name))
+          ; Pp.verbatim (OpamPackage.Version.to_string version)
+            |> Pp.tag User_message.Style.Hint
+          ; Option.value ~default:"(no synopsis)" synopsis
+            |> Pp.text
+            |> Pp.tag User_message.Style.Details
+          ])
+    ]
+    |> Console.print
+    |> Fiber.return)
+;;
+
+let term =
+  let+ builder = Common.Builder.term
+  and+ query = Arg.(value & pos 0 (some string) None & info [] ~docv:"QUERY") in
+  let builder = Common.Builder.forbid_builds builder in
+  let common, config = Common.init builder in
+  Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    let open Fiber.O in
+    Pkg_common.check_pkg_management_enabled () >>> search_packages ~query ())
+;;
+
+let info =
+  let doc = "Search for packages through repositories in workspace." in
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P
+        "Searches through all the repositories configured in the default context's \
+         workdir and prints the names of packages that match the given QUERY. QUERY can \
+         also be a glob pattern as documented and used in the dependency specifications."
+    ; `S "EXAMPLES"
+    ; `Pre "  dune pkg search dune"
+    ]
+  in
+  Cmd.info "search" ~doc ~man
+;;
+
+let command = Cmd.v info term

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -32,6 +32,8 @@ module Key : sig
   val opam_package : t -> OpamPackage.t
 end
 
+val packages_in_repo : t -> OpamPackage.Name.t list
+
 val all_packages_versions_map
   :  t list
   -> OpamPackage.Name.t

--- a/test/blackbox-tests/test-cases/pkg/search/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/search/basic.t
@@ -1,0 +1,43 @@
+  $ . ../helpers.sh
+
+We setup a simple mock repository directory with a couple of packages.
+
+  $ mkrepo
+  $ mkpkg foo
+  $ mkpkg bar <<EOF
+  > depends: [ "foo" {>= "0.0.1"} ]
+  > synopsis: "Mock bar package that depends on foo."
+  > EOF
+
+Create a dune-workspace with a the mock repository added
+
+  $ add_mock_repo_if_needed
+
+Search without any query arguments
+
+  $ dune pkg search
+  - bar 0.0.1 Mock bar package that depends on foo.
+  - foo 0.0.1 (no synopsis)
+
+Search with a query argument -- exact name
+
+  $ dune pkg search foo
+  - foo 0.0.1 (no synopsis)
+
+Another search with a query argument - substring of package name, upper-cased
+since the search is caseless.
+
+  $ dune pkg search 'ar'
+  - bar 0.0.1 Mock bar package that depends on foo.
+
+Search with no results
+
+  $ dune pkg search baz
+  Error: No packages found matching "baz".
+  [1]
+
+Search for all packages
+
+  $ dune pkg search
+  - bar 0.0.1 Mock bar package that depends on foo.
+  - foo 0.0.1 (no synopsis)

--- a/test/blackbox-tests/test-cases/pkg/search/dune
+++ b/test/blackbox-tests/test-cases/pkg/search/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps helpers.sh))

--- a/test/blackbox-tests/test-cases/pkg/search/empty-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/search/empty-repo.t
@@ -1,0 +1,33 @@
+  $ . ../helpers.sh
+
+We use an empty repository with no packages for this test.
+
+  $ mkrepo
+
+Create a dune-workspace with a the mock repository added
+
+  $ add_mock_repo_if_needed
+
+Search with a query argument -- exact name
+
+  $ dune pkg search foo
+  Error: No packages found matching "foo".
+  [1]
+
+Another search with a query argument - substring of package name
+
+  $ dune pkg search ar
+  Error: No packages found matching "ar".
+  [1]
+
+Search with no results
+
+  $ dune pkg search baz
+  Error: No packages found matching "baz".
+  [1]
+
+Search for all packages
+
+  $ dune pkg search '.*'
+  Error: No packages found matching ".*".
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/search/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/search/helpers.sh
@@ -1,0 +1,51 @@
+. ../helpers.sh
+
+mkrepo_other() {
+  local mock_packages
+  mock_packages="other-opam-repository/packages"
+  mkrepo
+}
+
+mkpkg_other() {
+  local mock_packages
+  mock_packages="other-opam-repository/packages"
+  mkpkg "$@"
+}
+
+create_dune_workspace_with_mock_repos() {
+  # Always create a fresh workspace with mock repository configuration
+  repo1="file://$(pwd)/mock-opam-repository"
+  repo2="file://$(pwd)/other-opam-repository"
+  cat >dune-workspace <<EOF
+(lang dune 3.20)
+(pkg enabled)
+(lock_dir
+ (repositories other mock))
+(repository
+ (name mock)
+ (url "${repo1}"))
+(repository
+ (name other)
+ (url "${repo2}"))
+EOF
+}
+
+mk_multiple_packages() {
+  packages="dune utop merlin ocamlformat ppxlib yojson cmdliner eio alcotest core base bos notty js_of_ocaml atdgen owl re reason spectre"
+  versions="0.2 0.3 0.5 1.0 1.3 2.0 3.0~alpha1"
+  for pkg in $packages;
+  do
+    for version in $versions;
+    do
+      if [ "${#pkg}" -gt 4 ]; then
+        prefix="This is just a very very very very very long synopsis for the excellent"
+      else
+        prefix="Short synopsis for"
+      fi
+      mkpkg "$pkg" "$version" <<EOF
+depends: [ "ocaml" {>= "4.12.0"} ]
+synopsis: "$prefix package: '$pkg' version: '$version'"
+EOF
+    done
+  done
+}

--- a/test/blackbox-tests/test-cases/pkg/search/many-results.t
+++ b/test/blackbox-tests/test-cases/pkg/search/many-results.t
@@ -1,0 +1,86 @@
+  $ . ../helpers.sh
+
+Load search/helpers.sh for helper to create many packages
+  $ . ./helpers.sh
+
+We setup a simple mock repository directory with a couple of packages.
+
+  $ mkrepo
+
+Create multiple packages in the mock repo
+
+  $ mk_multiple_packages
+
+Create a dune-workspace with a the mock repository added
+
+  $ add_mock_repo_if_needed
+
+Search for all packages
+
+  $ dune pkg search
+  - alcotest 3.0~alpha1 This is just a very very very very very long synopsis
+    for the excellent package: 'alcotest' version: '3.0~alpha1'
+  - atdgen 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'atdgen' version: '3.0~alpha1'
+  - base 3.0~alpha1 Short synopsis for package: 'base' version: '3.0~alpha1'
+  - bos 3.0~alpha1 Short synopsis for package: 'bos' version: '3.0~alpha1'
+  - cmdliner 3.0~alpha1 This is just a very very very very very long synopsis
+    for the excellent package: 'cmdliner' version: '3.0~alpha1'
+  - core 3.0~alpha1 Short synopsis for package: 'core' version: '3.0~alpha1'
+  - dune 3.0~alpha1 Short synopsis for package: 'dune' version: '3.0~alpha1'
+  - eio 3.0~alpha1 Short synopsis for package: 'eio' version: '3.0~alpha1'
+  - js_of_ocaml 3.0~alpha1 This is just a very very very very very long
+    synopsis for the excellent package: 'js_of_ocaml' version: '3.0~alpha1'
+  - merlin 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'merlin' version: '3.0~alpha1'
+  - notty 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'notty' version: '3.0~alpha1'
+  - ocamlformat 3.0~alpha1 This is just a very very very very very long
+    synopsis for the excellent package: 'ocamlformat' version: '3.0~alpha1'
+  - owl 3.0~alpha1 Short synopsis for package: 'owl' version: '3.0~alpha1'
+  - ppxlib 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'ppxlib' version: '3.0~alpha1'
+  - re 3.0~alpha1 Short synopsis for package: 're' version: '3.0~alpha1'
+  - reason 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'reason' version: '3.0~alpha1'
+  - spectre 3.0~alpha1 This is just a very very very very very long synopsis
+    for the excellent package: 'spectre' version: '3.0~alpha1'
+  - utop 3.0~alpha1 Short synopsis for package: 'utop' version: '3.0~alpha1'
+  - yojson 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'yojson' version: '3.0~alpha1'
+
+Search with a query argument -- exact name
+
+  $ dune pkg search dune
+  - dune 3.0~alpha1 Short synopsis for package: 'dune' version: '3.0~alpha1'
+
+Another search with a query argument - substring of package name.
+
+  $ dune pkg search 'o'
+  - alcotest 3.0~alpha1 This is just a very very very very very long synopsis
+    for the excellent package: 'alcotest' version: '3.0~alpha1'
+  - bos 3.0~alpha1 Short synopsis for package: 'bos' version: '3.0~alpha1'
+  - core 3.0~alpha1 Short synopsis for package: 'core' version: '3.0~alpha1'
+  - eio 3.0~alpha1 Short synopsis for package: 'eio' version: '3.0~alpha1'
+  - js_of_ocaml 3.0~alpha1 This is just a very very very very very long
+    synopsis for the excellent package: 'js_of_ocaml' version: '3.0~alpha1'
+  - notty 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'notty' version: '3.0~alpha1'
+  - ocamlformat 3.0~alpha1 This is just a very very very very very long
+    synopsis for the excellent package: 'ocamlformat' version: '3.0~alpha1'
+  - owl 3.0~alpha1 Short synopsis for package: 'owl' version: '3.0~alpha1'
+  - reason 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'reason' version: '3.0~alpha1'
+  - utop 3.0~alpha1 Short synopsis for package: 'utop' version: '3.0~alpha1'
+  - yojson 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'yojson' version: '3.0~alpha1'
+
+Another search with a query argument - substring of package name.
+
+  $ dune pkg search 're'
+  - re 3.0~alpha1 Short synopsis for package: 're' version: '3.0~alpha1'
+  - core 3.0~alpha1 Short synopsis for package: 'core' version: '3.0~alpha1'
+  - reason 3.0~alpha1 This is just a very very very very very long synopsis for
+    the excellent package: 'reason' version: '3.0~alpha1'
+  - spectre 3.0~alpha1 This is just a very very very very very long synopsis
+    for the excellent package: 'spectre' version: '3.0~alpha1'

--- a/test/blackbox-tests/test-cases/pkg/search/multiple-repos-conflicting-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/search/multiple-repos-conflicting-packages.t
@@ -1,0 +1,64 @@
+  $ . ../helpers.sh
+
+Source helpers for creating another repo, etc.
+  $ . ./helpers.sh
+
+We setup a couple of different mock repositories. First, create
+mock-opam-repository with a couple of packages
+
+  $ mkrepo
+  $ mkpkg foo "0.0.2"
+  $ mkpkg bar <<EOF
+  > depends: [ "foo" {>= "0.0.1"} ]
+  > synopsis: "Mock bar package that depends on foo."
+  > EOF
+  $ mkpkg blah
+
+Create dune-workspace with mock repo configured
+
+  $ add_mock_repo_if_needed
+
+Search for all packages
+
+  $ dune pkg search
+  - bar 0.0.1 Mock bar package that depends on foo.
+  - blah 0.0.1 (no synopsis)
+  - foo 0.0.2 (no synopsis)
+
+Next, create other-opam-repository with a couple of conflicting packages
+
+  $ mkrepo_other
+  $ mkpkg_other baz
+  $ mkpkg_other foo "0.0.1" <<EOF
+  > synopsis: "Foo package in other repo with a synopsis, but lower version."
+  > EOF
+  $ mkpkg_other bar "0.0.1" <<EOF
+  > depends: [ "foo" {>= "0.0.1"} ]
+  > synopsis: "Mock bar package in other repo that depends on foo."
+  > EOF
+  $ mkpkg_other blah <<EOF
+  > flags: [avoid-version]
+  > synopsis: "Mock blah package that should be avoided!!"
+  > EOF
+
+Create a dune-workspace with both the mock repositories added
+
+  $ create_dune_workspace_with_mock_repos
+
+Search for all packages
+
+  $ dune pkg search
+  - bar 0.0.1 Mock bar package in other repo that depends on foo.
+  - baz 0.0.1 (no synopsis)
+  - blah 0.0.1 (no synopsis)
+  - foo 0.0.2 (no synopsis)
+
+Search with a query argument -- exact name
+
+  $ dune pkg search bar
+  - bar 0.0.1 Mock bar package in other repo that depends on foo.
+
+Another search with a query argument - substring of package name
+
+  $ dune pkg search ar
+  - bar 0.0.1 Mock bar package in other repo that depends on foo.

--- a/test/blackbox-tests/test-cases/pkg/search/multiple-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/search/multiple-repos.t
@@ -1,0 +1,57 @@
+  $ . ../helpers.sh
+
+Source helpers for creating another repo, etc.
+  $ . ./helpers.sh
+
+We setup a couple of different mock repositories. First, create
+mock-opam-repository with a couple of packages
+
+  $ mkrepo
+  $ mkpkg foo
+  $ mkpkg bar <<EOF
+  > depends: [ "foo" {>= "0.0.1"} ]
+  > synopsis: "Mock bar package that depends on foo."
+  > EOF
+
+Next, create other-opam-repository with a package
+
+  $ mkrepo_other
+  $ mkpkg_other baz
+
+Create a dune-workspace with both the mock repositories added
+
+  $ create_dune_workspace_with_mock_repos
+
+Search for all packages
+
+  $ dune pkg search
+  - bar 0.0.1 Mock bar package that depends on foo.
+  - baz 0.0.1 (no synopsis)
+  - foo 0.0.1 (no synopsis)
+
+Search with a query argument -- exact name
+
+  $ dune pkg search foo
+  - foo 0.0.1 (no synopsis)
+
+Another search with a query argument - substring of package name
+
+  $ dune pkg search ar
+  - bar 0.0.1 Mock bar package that depends on foo.
+
+Search for package in other repo
+
+  $ dune pkg search baz
+  - baz 0.0.1 (no synopsis)
+
+Search with results from both repos
+
+  $ dune pkg search ba
+  - bar 0.0.1 Mock bar package that depends on foo.
+  - baz 0.0.1 (no synopsis)
+
+Search with no results
+
+  $ dune pkg search dune
+  Error: No packages found matching "dune".
+  [1]


### PR DESCRIPTION
This PR adds an initial version of `dune pkg search <query>` in an attempt to address #12106. 

- Adds a command `dune pkg search >query>`. `<query>` is a required parameter which can be a Perl regular expression that is used to search package names.

- The command only works in a dune workspace, since it would require
  repositories to be configured to perform the search.

- Currently, search looks through valid package directory names in a repository and lists the maximum version that has not been marked as `avoid-version` along with the synopsis.

- Currently, we only search in the repositories configured in the lock dir for the default context. 

**NOTE:** I'm new to the `dune` codebase and this is my first "significant" code contribution. Please do point me to things to read and learn about, if there are things that can help with building missing conceptual understanding, etc.