### PR TITLE
fix(oxcaml): generate merlin config for library parameters

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -309,6 +309,7 @@ let executables_rules
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names))
       ~modes:`Exe
+      ~parameters:(Resolve.return [])
   in
   cctx, merlin
 ;;

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -622,7 +622,8 @@ let library_rules
     Sub_system.gen_rules
       { super_context = sctx; dir; stanza = lib; scope; source_modules; compile_info }
   and+ merlin =
-    let+ requires_hidden = Compilation_context.requires_hidden cctx in
+    let+ requires_hidden = Compilation_context.requires_hidden cctx
+    and+ parameters = Compilation_context.parameters cctx in
     let flags = Compilation_context.flags cctx in
     Merlin.make
       ~requires_compile
@@ -636,6 +637,7 @@ let library_rules
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Merlin_ident.for_lib (Library.best_name lib))
       ~modes:(`Lib (Lib_info.modes lib_info))
+      ~parameters (* ["-parameter"; "A"; "-parameter"; "B"] *)
   in
   merlin
 ;;

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -637,7 +637,7 @@ let library_rules
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Merlin_ident.for_lib (Library.best_name lib))
       ~modes:(`Lib (Lib_info.modes lib_info))
-      ~parameters (* ["-parameter"; "A"; "-parameter"; "B"] *)
+      ~parameters
   in
   merlin
 ;;

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -482,7 +482,8 @@ let setup_emit_cmj_rules
         ~obj_dir
         ~ident:merlin_ident
         ~dialects:(Dune_project.dialects (Scope.project scope))
-        ~modes:`Melange_emit )
+        ~modes:`Melange_emit
+        ~parameters:(Resolve.return []) )
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir in
   Buildable_rules.with_lib_deps ctx merlin_ident ~dir ~f

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -127,7 +127,7 @@ module Processed = struct
     type nonrec t = t
 
     let name = "merlin-conf"
-    let version = 7
+    let version = 8
     let to_dyn _ = Dyn.String "Use [dune ocaml dump-dot-merlin] instead"
 
     let test_example () =

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -61,6 +61,7 @@ module Processed = struct
     ; flags : string list
     ; extensions : string option Ml_kind.Dict.t list
     ; indexes : Path.t list
+    ; parameters : Module_name.t list
     }
 
   let dyn_of_config
@@ -73,6 +74,7 @@ module Processed = struct
         ; flags
         ; extensions
         ; indexes
+        ; parameters
         }
     =
     let open Dyn in
@@ -86,6 +88,7 @@ module Processed = struct
       ; "flags", list string flags
       ; "extensions", list (Ml_kind.Dict.to_dyn (Dyn.option string)) extensions
       ; "indexes", list Path.to_dyn indexes
+      ; "parameters", list Module_name.to_dyn parameters
       ]
   ;;
 
@@ -138,6 +141,7 @@ module Processed = struct
           ; flags = [ "-x" ]
           ; extensions = [ { Ml_kind.Dict.intf = None; impl = Some "ext" } ]
           ; indexes = []
+          ; parameters = []
           }
       ; per_file_config = Path.Build.Map.empty
       ; pp_config =
@@ -191,6 +195,7 @@ module Processed = struct
         ; flags
         ; extensions
         ; indexes
+        ; parameters
         }
     =
     let make_directive tag value = Sexp.List [ Atom tag; value ] in
@@ -240,7 +245,20 @@ module Processed = struct
           in
           Some (make_directive "FLG" (Sexp.List open_flags))
       in
-      List.filter_opt [ base_flags; pp_flags; open_flags ]
+      let parameter_flags =
+        match parameters with
+        | [] -> None
+        | params ->
+          Some
+            (make_directive
+               "FLG"
+               (Sexp.List
+                  (List.concat_map
+                     ~f:(fun m ->
+                       [ Sexp.Atom "-parameter"; Sexp.Atom (Module_name.to_string m) ])
+                     params)))
+      in
+      List.filter_opt [ base_flags; pp_flags; open_flags; parameter_flags ]
     in
     let unit_name = [ make_directive "UNIT_NAME" (Sexp.Atom unit_name) ] in
     let suffixes =
@@ -297,6 +315,7 @@ module Processed = struct
         hidden_src_dirs
         extensions
         indexes
+        parameters
     =
     let b = Buffer.create 256 in
     let printf = Printf.bprintf b in
@@ -327,6 +346,14 @@ module Processed = struct
         print "# FLG";
         List.iter flags ~f:(fun f -> printf " %s" (quote_for_dot_merlin f));
         print "\n");
+    let () =
+      match parameters with
+      | [] -> ()
+      | params ->
+        print "# FLG";
+        List.iter params ~f:(fun f -> printf " -parameter %s" (Module_name.to_string f));
+        print "\n"
+    in
     Buffer.contents b
   ;;
 
@@ -428,6 +455,7 @@ module Processed = struct
                   ; flags
                   ; extensions
                   ; indexes
+                  ; parameters = _
                   }
               }
             ->
@@ -452,7 +480,8 @@ module Processed = struct
            hidden_obj_dirs
            hidden_src_dirs
            extensions
-           indexes)
+           indexes
+           init.config.parameters)
   ;;
 end
 
@@ -482,6 +511,7 @@ module Unprocessed = struct
     ; extensions : string option Ml_kind.Dict.t list
     ; readers : string list String.Map.t
     ; mode : Lib_mode.t
+    ; parameters : Module_name.t list Resolve.t
     }
 
   type t =
@@ -502,6 +532,7 @@ module Unprocessed = struct
         ~dialects
         ~ident
         ~modes
+        ~parameters
     =
     (* Merlin shouldn't cause the build to fail, so we just ignore errors *)
     let mode =
@@ -526,6 +557,7 @@ module Unprocessed = struct
       ; objs_dirs
       ; extensions
       ; readers
+      ; parameters
       }
     in
     { ident; config; modules }
@@ -654,6 +686,7 @@ module Unprocessed = struct
              ; preprocess = _
              ; libname = _
              ; mode
+             ; parameters
              }
          } as t)
         sctx
@@ -713,6 +746,7 @@ module Unprocessed = struct
         let requires_hidden = Resolve.peek requires_hidden |> Result.value ~default:[] in
         add_lib_dirs sctx mode requires_hidden
       in
+      let parameters = Resolve.peek parameters |> Result.value ~default:[] in
       let src_dirs =
         Path.Set.of_list_map ~f:Path.source more_src_dirs |> Path.Set.union deps_src_dirs
       in
@@ -727,6 +761,7 @@ module Unprocessed = struct
       ; flags
       ; extensions
       ; indexes
+      ; parameters
       }
     and+ pp_config = pp_config t (Super_context.context sctx) ~expander in
     let per_file_config =

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -53,6 +53,9 @@ val make
   -> ident:Merlin_ident.t
   -> modes:[ `Lib of Lib_mode.Map.Set.t | `Exe | `Melange_emit ]
   -> parameters:Module_name.t list Resolve.t
+       (** The `parameters` argument takes the list of parameters from the
+       compilation context and stores it in the form of `["-parameter"; "P1";
+       "-parameter"; "P2"]` where P1 and P2 are the parameters. *)
   -> t
 
 val more_src_dirs : Dir_contents.t -> source_dirs:Path.Source.t list -> Path.Source.t list

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -52,6 +52,7 @@ val make
   -> dialects:Dialect.DB.t
   -> ident:Merlin_ident.t
   -> modes:[ `Lib of Lib_mode.Map.Set.t | `Exe | `Melange_emit ]
+  -> parameters:Module_name.t list Resolve.t
   -> t
 
 val more_src_dirs : Dir_contents.t -> source_dirs:Path.Source.t list -> Path.Source.t list

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -380,3 +380,79 @@ A library can have more parameters than its dependencies:
   > EOF
 
   $ dune build
+  $ dune ocaml dump-dot-merlin lib2
+  EXCLUDE_QUERY_DIR
+  STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml
+  SOURCE_ROOT $TESTCASE_ROOT
+  B $TESTCASE_ROOT/_build/default/a/.a.objs/byte
+  B $TESTCASE_ROOT/_build/default/b/.b.objs/byte
+  B $TESTCASE_ROOT/_build/default/c/.c.objs/byte
+  B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte
+  B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte
+  B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte
+  S $TESTCASE_ROOT/a
+  S $TESTCASE_ROOT/b
+  S $TESTCASE_ROOT/c
+  S $TESTCASE_ROOT/lib
+  S $TESTCASE_ROOT/lib2
+  S $TESTCASE_ROOT/utils
+  INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index
+  # FLG -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g
+  # FLG -parameter A -parameter B -parameter C
+  
+  $ dune ocaml merlin dump-config lib2
+  Lib2: _build/default/lib2/lib2
+  ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
+   (STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/b/.b.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/c/.c.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte)
+   (S $TESTCASE_ROOT/a)
+   (S $TESTCASE_ROOT/b)
+   (S $TESTCASE_ROOT/c)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib2)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
+   (FLG (-parameter A -parameter B -parameter C))
+   (UNIT_NAME lib2))
+  Lib2: _build/default/lib2/lib2.ml
+  ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
+   (STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/b/.b.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/c/.c.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte)
+   (S $TESTCASE_ROOT/a)
+   (S $TESTCASE_ROOT/b)
+   (S $TESTCASE_ROOT/c)
+   (S $TESTCASE_ROOT/lib)
+   (S $TESTCASE_ROOT/lib2)
+   (S $TESTCASE_ROOT/utils)
+   (FLG (-w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
+   (FLG (-parameter A -parameter B -parameter C))
+   (UNIT_NAME lib2))

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -1,3 +1,7 @@
+Set up path masking
+
+  $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$(ocamlc -where)":$BUILD_PATH_PREFIX_MAP
+
 Testing the `parameters` field in library stanzas.
 
   $ cat >> dune-project <<EOF
@@ -382,7 +386,7 @@ A library can have more parameters than its dependencies:
   $ dune build
   $ dune ocaml dump-dot-merlin lib2
   EXCLUDE_QUERY_DIR
-  STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml
+  STDLIB /OCAMLC_WHERE
   SOURCE_ROOT $TESTCASE_ROOT
   B $TESTCASE_ROOT/_build/default/a/.a.objs/byte
   B $TESTCASE_ROOT/_build/default/b/.b.objs/byte
@@ -413,7 +417,7 @@ A library can have more parameters than its dependencies:
    (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
-   (STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml)
+   (STDLIB /OCAMLC_WHERE)
    (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
    (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)
@@ -438,7 +442,7 @@ A library can have more parameters than its dependencies:
    (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
-   (STDLIB /home/sudha/.opam/oxcaml2/lib/ocaml)
+   (STDLIB /OCAMLC_WHERE)
    (SOURCE_ROOT $TESTCASE_ROOT)
    (EXCLUDE_QUERY_DIR)
    (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -388,79 +388,9 @@ A library can have more parameters than its dependencies:
   $ melc_compiler="$(which melc)" &> /dev/null
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
   $ dune build
-  $ dune ocaml dump-dot-merlin lib2
-  EXCLUDE_QUERY_DIR
-  STDLIB /OCAMLC_WHERE
-  SOURCE_ROOT $TESTCASE_ROOT
-  B $TESTCASE_ROOT/_build/default/a/.a.objs/byte
-  B $TESTCASE_ROOT/_build/default/b/.b.objs/byte
-  B $TESTCASE_ROOT/_build/default/c/.c.objs/byte
-  B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte
-  B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte
-  B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte
-  S $TESTCASE_ROOT/a
-  S $TESTCASE_ROOT/b
-  S $TESTCASE_ROOT/c
-  S $TESTCASE_ROOT/lib
-  S $TESTCASE_ROOT/lib2
-  S $TESTCASE_ROOT/utils
-  INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index
-  INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index
-  INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index
-  INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index
-  INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index
-  INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index
-  # FLG -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g
+  $ dune ocaml dump-dot-merlin lib2 | grep 'parameter'
   # FLG -parameter A -parameter B -parameter C
-  
-  $ dune ocaml merlin dump-config lib2
-  Lib2: _build/MELC_COMPILER/default/lib2/lib2
-  ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/b/.b.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/c/.c.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte)
-   (S $TESTCASE_ROOT/a)
-   (S $TESTCASE_ROOT/b)
-   (S $TESTCASE_ROOT/c)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib2)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
+
+  $ dune ocaml merlin dump-config lib2 | grep 'parameter'
    (FLG (-parameter A -parameter B -parameter C))
-   (UNIT_NAME lib2))
-  Lib2: _build/MELC_COMPILER/default/lib2/lib2.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.lib.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/utils/.utils.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/a/.a.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/b/.b.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/c/.c.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib/.lib.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/utils/.utils.objs/byte)
-   (S $TESTCASE_ROOT/a)
-   (S $TESTCASE_ROOT/b)
-   (S $TESTCASE_ROOT/c)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib2)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (FLG (-parameter A -parameter B -parameter C))
-   (UNIT_NAME lib2))

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -383,6 +383,10 @@ A library can have more parameters than its dependencies:
   > (library (name lib2) (parameters a b c) (libraries lib))
   > EOF
 
+  $ ocamlc_where="$(ocamlc -where)"
+  $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
+  $ melc_compiler="$(which melc)" &> /dev/null
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
   $ dune build
   $ dune ocaml dump-dot-merlin lib2
   EXCLUDE_QUERY_DIR
@@ -410,7 +414,7 @@ A library can have more parameters than its dependencies:
   # FLG -parameter A -parameter B -parameter C
   
   $ dune ocaml merlin dump-config lib2
-  Lib2: _build/default/lib2/lib2
+  Lib2: _build/MELC_COMPILER/default/lib2/lib2
   ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)
@@ -435,7 +439,7 @@ A library can have more parameters than its dependencies:
    (FLG (-w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
    (FLG (-parameter A -parameter B -parameter C))
    (UNIT_NAME lib2))
-  Lib2: _build/default/lib2/lib2.ml
+  Lib2: _build/MELC_COMPILER/default/lib2/lib2.ml
   ((INDEX $TESTCASE_ROOT/_build/default/a/.a.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/b/.b.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/c/.c.objs/cctx.ocaml-index)

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -48,7 +48,7 @@ let%expect_test "persistent digests" =
     ---
 
     merlin-conf version 7
-    a14a4700929a15bb2030e36f71e66d20
+    699a5c5c686662da218d0be3cb2f161c
     ---
 
     INCREMENTAL-DB version 6

--- a/test/expect-tests/persistent_tests.ml
+++ b/test/expect-tests/persistent_tests.ml
@@ -47,7 +47,7 @@ let%expect_test "persistent digests" =
     65e543aaf5ccc8148d50a1305aa3622b
     ---
 
-    merlin-conf version 7
+    merlin-conf version 8
     699a5c5c686662da218d0be3cb2f161c
     ---
 


### PR DESCRIPTION
Fixes #12546.

With @art-w, we discovered the library parameter flag `-parameter` was being added to the compilation context but did not propagate to the merlin config. This takes the information from compilation context and feeds into the merlin config generation.