### PR TITLE
ci: update for ocaml 5.4 release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -164,7 +164,7 @@ jobs:
         # 4.02.x and 4.07.x in other environments
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.4.0+trunk
+          - ocaml-compiler: ocaml-variants.5.5.0+trunk
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)
@@ -176,7 +176,7 @@ jobs:
             os: macos-latest
             run_tests: true
           ## macos (x86)
-          - ocaml-compiler: 5.3.x
+          - ocaml-compiler: 5.4.x
             os: macos-15-intel
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.3.0,system-msvc


### PR DESCRIPTION
Update the CI workflows to track the current major version trunk and latest release.

As per https://github.com/ocaml/opam-repository/pull/28683

This should fix the breakage on the main: https://github.com/ocaml/dune/actions/runs/18416316858/job/52481101066