### PR TITLE
Fix #12131

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -75,7 +75,8 @@ type t =
   ; cache_config : Dune_cache.Config.t
   ; cache_debug_flags : Cache_debug_flags.t
   ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
-  ; execution_parameters : dir:Path.Build.t -> Execution_parameters.t Memo.t
+  ; execution_parameters :
+      Context_name.t -> dir:Path.Build.t -> Execution_parameters.t Memo.t
   ; source_tree : (module Source_tree)
   ; shared_cache : (module Dune_cache.Shared.S)
   ; write_error_summary : Build_system_error.Set.t -> unit Fiber.t

--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -132,7 +132,8 @@ module type Build_config = sig
     -> sandboxing_preference:Sandbox_mode.t list
     -> rule_generator:(module Gen_rules.Rule_generator)
     -> implicit_default_alias:(Path.Build.t -> unit Action_builder.t option Memo.t)
-    -> execution_parameters:(dir:Path.Build.t -> Execution_parameters.t Memo.t)
+    -> execution_parameters:
+         (Context_name.t -> dir:Path.Build.t -> Execution_parameters.t Memo.t)
     -> source_tree:(module Source_tree)
     -> shared_cache:(module Dune_cache.Shared.S)
     -> write_error_summary:(Build_system_error.Set.t -> unit Fiber.t)
@@ -152,7 +153,8 @@ module type Build_config = sig
     ; cache_config : Dune_cache.Config.t
     ; cache_debug_flags : Cache_debug_flags.t
     ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
-    ; execution_parameters : dir:Path.Build.t -> Execution_parameters.t Memo.t
+    ; execution_parameters :
+        Context_name.t -> dir:Path.Build.t -> Execution_parameters.t Memo.t
     ; source_tree : (module Source_tree)
     ; shared_cache : (module Dune_cache.Shared.S)
     ; write_error_summary : Build_system_error.Set.t -> unit Fiber.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -485,8 +485,8 @@ end = struct
     let head_target = Targets.Validated.head targets in
     let* execution_parameters =
       match Dpath.Target_dir.of_target targets.root with
-      | Regular (With_context (_, _)) | Anonymous_action (With_context (_, _)) ->
-        (Build_config.get ()).execution_parameters ~dir:targets.root
+      | Regular (With_context (context, _)) | Anonymous_action (With_context (context, _))
+        -> (Build_config.get ()).execution_parameters context ~dir:targets.root
       | Anonymous_action Root | Regular Root | Invalid _ ->
         Code_error.raise
           "invalid dir for rule execution"

--- a/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
+++ b/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
@@ -26,4 +26,3 @@ There should only be one execution here:
   foo
 
   $ makeProject false
-  foo

--- a/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
+++ b/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
@@ -1,0 +1,29 @@
+Demonstrate that there should be no dependence on the dune lang version for
+building packages:
+
+  $ . ./helpers.sh
+
+  $ make_lockdir
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (build (run echo foo))
+  > EOF
+
+  $ makeProject() {
+  > cat >dune-project <<EOF
+  > (lang dune 3.20)
+  > (expand_aliases_in_sandbox $1)
+  > (package
+  >  (name foo)
+  >  (depends test))
+  > EOF
+  > build_pkg test
+  > }
+
+There should only be one execution here:
+
+  $ makeProject true
+  foo
+
+  $ makeProject false
+  foo


### PR DESCRIPTION
Ignore project settings for rules when building packages. Packages are supposed to be built globally for the entire workspace. Individual project settings should be ignored.