### PR TITLE
fix(oxcaml): CI dev version conflict

### DIFF
--- a/.github/workflows/oxcaml.yml
+++ b/.github/workflows/oxcaml.yml
@@ -26,9 +26,11 @@ jobs:
           opam-repositories: |
             oxcaml: "git+https://github.com/oxcaml/opam-repository.git"
             default: "git+https://github.com/ocaml/opam-repository.git"
+          opam-pin: false
 
       - name: Install deps
         run: |
+          opam pin add . -n --with-version=3.20.2+ox
           opam install . --deps-only
           opam install re spawn uutf
 


### PR DESCRIPTION
As found by @Alizter, the [OxCaml opam-repo has recently added a constraint on dune version to be exactly `3.20.2+ox`](https://github.com/oxcaml/opam-repository/commit/26cb9899ece2c113b2703b1757d02b0b8cb86d96), which breaks the dune CI where the version was set to `dev` (cc @d-kalinichenko ).