### PR TITLE
chore: ignore start file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ result
 
 .DS_Store
 nix/profiles/
+start/dune


### PR DESCRIPTION
The start file is the recommended way of keeping track of the set of active goals. It is customary to start dune in watch mode as in `$ dune build -w @start/build` and maintain the current set of goals as an alias in `start/dune`. Therefore, this file should not be committed.