### PR TITLE
Generate rules for dev tools without feature gate

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2338,16 +2338,10 @@ let setup_rules ~components ~dir ctx =
   assert (String.equal Pkg_dev_tool.install_path_base_dir_name ".dev-tool");
   match Context_name.is_default ctx, components with
   | true, [ ".dev-tool"; dev_tool_package_name ] ->
-    (* only generate rules if dev-tools should be enabled *)
-    (match Config.get Compile_time.lock_dev_tools with
-     | `Enabled ->
-       let pkg_name = Package.Name.of_string dev_tool_package_name in
-       let dev_tool = Pkg_dev_tool.of_package_name pkg_name in
-       let* db, pkg_digest =
-         DB.of_dev_tool (Dune_pkg.Dev_tool.of_package_name pkg_name)
-       in
-       setup_package_rules db ~package_universe:(Dev_tool dev_tool) ~dir ~pkg_digest
-     | `Disabled -> Memo.return @@ Gen_rules.make (Memo.return Rules.empty))
+    let pkg_name = Package.Name.of_string dev_tool_package_name in
+    let dev_tool = Pkg_dev_tool.of_package_name pkg_name in
+    let* db, pkg_digest = DB.of_dev_tool (Dune_pkg.Dev_tool.of_package_name pkg_name) in
+    setup_package_rules db ~package_universe:(Dev_tool dev_tool) ~dir ~pkg_digest
   | true, [ ".dev-tool" ] ->
     Gen_rules.make
       ~build_dir_only_sub_dirs:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -7,10 +7,10 @@ Test `dune tools which ocamlformat`:
   $ make_project_with_dev_tool_lockdir
 
 Install ocamlformat as a dev tool:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools install ocamlformat
+  $ dune tools install ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
+  $ dune tools which ocamlformat
   _build/_private/default/.dev-tool/ocamlformat/target/bin/ocamlformat

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -12,7 +12,7 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
   > EOF
 
 The command will fail because the dev tool is not installed:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
+  $ dune tools which ocamlformat
   Error: ocamlformat is not installed as a dev tool
   [1]
 
@@ -20,14 +20,14 @@ The command will fail because the dev tool is not installed:
   _build/_private/default/.dev-tool/ocamlformat/target/bin/ocamlformat
 
 Install the dev tool:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
+  $ dune tools exec ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2
 
 Now the command will succeed because the tool has been installed:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools which ocamlformat
+  $ dune tools which ocamlformat
   _build/_private/default/.dev-tool/ocamlformat/target/bin/ocamlformat
 
 Make sure the file is actually there:

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -24,7 +24,7 @@ a lockdir containing an "ocaml" lockfile.
   > (version 5.2.0)
   > EOF
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
+  $ dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -23,7 +23,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
   > EOF
 
 Confirm that each dev tool's bin directory is now in PATH:
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
+  $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
@@ -13,7 +13,7 @@ doesn't contain a lockfile for the "ocaml" package.
 
   $ make_lockdir
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
+  $ dune tools exec ocamllsp
   Error: The lockdir doesn't contain a lockfile for the package "ocaml".
   Hint: Add a dependency on "ocaml" to one of the packages in dune-project and
   then run 'dune pkg lock'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -44,11 +44,11 @@ Make a fake ocamlformat
   > (version 5.2.0)
   > EOF
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools install ocamlformat
+  $ dune tools install ocamlformat
   Solution for dev-tools.locks/ocamlformat:
   - ocamlformat.0.0.1
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
+  $ dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -28,7 +28,7 @@ same version of the ocaml compiler as the code that it's analyzing.
   > EOF
 
 Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
+  $ dune tools exec ocamllsp
   Solution for dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
@@ -38,7 +38,7 @@ Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
   (version 5.2.0)
 
 We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamllsp
+  $ dune tools exec ocamllsp
        Running 'ocamllsp'
   hello from fake ocamllsp
 


### PR DESCRIPTION
Enabling the `lock_dev_tools` feature was originally intended to cause dune to lock and install dev tools when running commands other than those commands under the `dune tools` group. If a user runs `dune tools install`, they are indicating their intention to lock the tool if necessary, as a first step to installing the tool, regardless of whether the `lock_dev_tools` feature is enabled.

This would have been caught by CI if tests of the `dune tools install` command didn't enable the `lock_dev_tools` feature. Thus this change also disables that feature (the default) for these tests.

Fixes https://github.com/ocaml/dune/issues/12574