### PR TITLE
nix: devShell for oxcaml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "melange": {
       "inputs": {
         "melange-compiler-libs": "melange-compiler-libs",
@@ -61,6 +79,27 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "oxcaml",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1752012998,
@@ -97,15 +136,70 @@
         "type": "github"
       }
     },
+    "oxcaml": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1760541218,
+        "narHash": "sha256-eZ2Nx8eXmiTurtJVBlC+MU45N6qFF76LDAa/aum4ZTk=",
+        "owner": "oxcaml",
+        "repo": "oxcaml",
+        "rev": "eea9697287f10719188cfd82d667caaeba346e87",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxcaml",
+        "repo": "oxcaml",
+        "type": "github"
+      }
+    },
+    "oxcaml-opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760195033,
+        "narHash": "sha256-qWWJ4WiV3hnOw4dFUq363BVejLwkxTk6OaZHUSkHylg=",
+        "owner": "oxcaml",
+        "repo": "opam-repository",
+        "rev": "eeedfd918e54a8741d26af1a4ff2991b21c1045f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxcaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "melange": "melange",
         "nixpkgs": "nixpkgs",
-        "ocaml-overlays": "ocaml-overlays"
+        "ocaml-overlays": "ocaml-overlays",
+        "oxcaml": "oxcaml",
+        "oxcaml-opam-repository": "oxcaml-opam-repository"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix/ox-patches.nix
+++ b/nix/ox-patches.nix
@@ -1,0 +1,76 @@
+{ pkgs, lib, oxcamlOpamRepo }:
+
+let
+  packagesDir = "${oxcamlOpamRepo}/packages";
+
+  # Gets all patch files from a package version directory
+  getPatchesFromDir = pkgName: version:
+    let
+      filesDir = "${packagesDir}/${pkgName}/${version}/files";
+      files =
+        if builtins.pathExists filesDir
+        then builtins.attrNames (builtins.readDir filesDir)
+        else [ ];
+      patchFiles = lib.filter (f: lib.hasSuffix ".patch" f) files;
+    in
+    map (patchFile: "${filesDir}/${patchFile}") patchFiles;
+
+  oxcamlPatches = {
+    base = {
+      patches = getPatchesFromDir "base" "base.v0.18~preview.130.55+197";
+    };
+    core = {
+      patches = getPatchesFromDir "core" "core.v0.18~preview.130.55+197";
+    };
+    core_kernel = {
+      patches = getPatchesFromDir "core_kernel" "core_kernel.v0.18~preview.130.55+197";
+    };
+    dune_3 = {
+      patches = getPatchesFromDir "dune" "dune.3.20.2+ox";
+    };
+    ocaml-compiler-libs = {
+      patches = getPatchesFromDir "ocaml-compiler-libs" "ocaml-compiler-libs.v0.17.0+ox";
+    };
+    ocamlbuild = {
+      patches = getPatchesFromDir "ocamlbuild" "ocamlbuild.0.15.0+ox";
+    };
+    # ppxlib = {
+    #   patches = getPatchesFromDir "ppxlib" "ppxlib.0.33.0+ox";
+    # };
+    topkg = {
+      patches = getPatchesFromDir "topkg" "topkg.1.0.8+ox";
+    };
+  };
+
+  # Applies patches to a package if configured
+  applyPatchesIfExists = pkgName: pkg:
+    if oxcamlPatches ? ${pkgName} && lib.isDerivation pkg && pkg ? overrideAttrs then
+      let
+        patchConfig = oxcamlPatches.${pkgName};
+        numPatches = builtins.length patchConfig.patches;
+      in
+      if numPatches > 0 then
+        pkg.overrideAttrs
+          (old: {
+            postPatch = (old.postPatch or "") + ''
+              ${lib.concatMapStringsSep "\n" (patch: ''
+                if patch -p1 --no-backup-if-mismatch < ${patch} 2>&1 | grep -q "FAILED"; then
+                  echo "oxcaml: patch failed for ${pkgName}: ${builtins.baseNameOf patch}" >&2
+                fi
+              '') patchConfig.patches}
+            '';
+          })
+      else
+        pkg
+    else
+      pkg;
+
+in
+oself: osuper:
+lib.mapAttrs
+  (name: pkg:
+  if lib.isDerivation pkg && pkg ? overrideAttrs
+  then applyPatchesIfExists name pkg
+  else pkg
+  )
+  osuper


### PR DESCRIPTION
We add 3 new dev shells for OxCaml:

- bootstrap-ox: For testing the bootstrap process with OxCaml
- ox-minimal: For building dune with OxCaml and running the OxCaml test-cases
- ox: For attempting to build a dev shell with OxCaml

In order to do this, we need to fetch the latest patches from the OxCaml opam repo, however not all of them can be applied to the package versions found in nixpkgs. Because of this we cannot build a full devShell, but we can get pretty close. The File `nix/ox-patches.nix` deals with the fetching and application of the patches.

Tldr: This works:
```
nix develop .#ox-minimal -c dune runtest test/blackbox-tests/test-cases/oxcaml
```