### PR TITLE
Dune Pins itself

### DIFF
--- a/src/dune_pkg/dune_dep.ml
+++ b/src/dune_pkg/dune_dep.ml
@@ -6,3 +6,6 @@ let version =
   let major, minor = Dune_lang.Stanza.latest_version in
   OpamPackage.Version.of_string @@ sprintf "%d.%d" major minor
 ;;
+
+let package = OpamPackage.create (Package_name.to_opam_package_name name) version
+let opam_file = OpamFile.OPAM.create package

--- a/src/dune_pkg/dune_dep.mli
+++ b/src/dune_pkg/dune_dep.mli
@@ -1,2 +1,4 @@
 val name : Package_name.t
 val version : OpamPackage.Version.t
+val package : OpamPackage.t
+val opam_file : OpamFile.OPAM.t

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -134,7 +134,7 @@ let load_opam_package_from_dir ~(dir : Path.t) package =
   | false -> None
   | true ->
     let files_dir = Some (Paths.files_dir package) in
-    Some (Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir)
+    Some (Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir ~url:None)
 ;;
 
 let load_packages_from_git rev_store opam_packages =
@@ -151,7 +151,8 @@ let load_packages_from_git rev_store opam_packages =
         ~opam_file:(Rev_store.File.path opam_file)
         ~opam_file_contents
         rev
-        ~files_dir:(Some files_dir))
+        ~files_dir:(Some files_dir)
+        ~url:None)
 ;;
 
 let all_packages_versions_in_dir loc ~dir opam_package_name =

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -5,7 +5,6 @@ type t
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t
-val set_url : t -> OpamUrl.t -> t
 val dune_build : t -> bool
 
 val git_repo
@@ -14,6 +13,7 @@ val git_repo
   -> opam_file_contents:string
   -> Rev_store.At_rev.t
   -> files_dir:Path.Local.t option
+  -> url:OpamUrl.t option
   -> t
 
 val local_fs
@@ -21,6 +21,7 @@ val local_fs
   -> dir:Path.t
   -> opam_file_path:Path.Local.t
   -> files_dir:Path.Local.t option
+  -> url:OpamUrl.t option
   -> t
 
 val local_package

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -6,6 +6,7 @@ val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t
 val dune_build : t -> bool
+val dune : t
 
 val git_repo
   :  OpamPackage.t

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -17,18 +17,19 @@ dependency.
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
   Couldn't solve the package dependency formula.
-  Selected candidates: foo.0.0.1 x.dev
-  - dune -> (problem)
-      User requested = 3.XX
-      Rejected candidates:
-        dune.3.XX.0: Incompatible with restriction: = 3.XX
+  The following packages couldn't be found: dune
   $ test "4.0.0"
-  Solution for dune.lock:
-  - foo.0.0.1
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: dune
+  [1]
 
   $ test "4.0.0" 2>&1 | sed -E 's/3.[0-9]+/3.XX/g'
-  Solution for dune.lock:
-  - foo.0.0.1
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: dune
 
 Create a fake project and ensure `dune` can be used as a dependency:
   $ cat > dune-project <<EOF
@@ -39,5 +40,8 @@ Create a fake project and ensure `dune` can be used as a dependency:
   >  (depends dune))
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
-  (no dependencies to lock)
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  The following packages couldn't be found: dune
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -17,19 +17,19 @@ dependency.
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.lock:
   Couldn't solve the package dependency formula.
-  The following packages couldn't be found: dune
+  Selected candidates: foo.0.0.1 x.dev
+  - dune -> (problem)
+      User requested = 3.XX
+      foo 0.0.1 requires <= 2.0.0
+      Rejected candidates:
+        dune.3.XX: Incompatible with restriction: <= 2.0.0
   $ test "4.0.0"
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
-  Couldn't solve the package dependency formula.
-  The following packages couldn't be found: dune
-  [1]
+  Solution for dune.lock:
+  - foo.0.0.1
 
   $ test "4.0.0" 2>&1 | sed -E 's/3.[0-9]+/3.XX/g'
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
-  Couldn't solve the package dependency formula.
-  The following packages couldn't be found: dune
+  Solution for dune.lock:
+  - foo.0.0.1
 
 Create a fake project and ensure `dune` can be used as a dependency:
   $ cat > dune-project <<EOF
@@ -40,8 +40,5 @@ Create a fake project and ensure `dune` can be used as a dependency:
   >  (depends dune))
   > EOF
   $ dune pkg lock
-  Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
-  Couldn't solve the package dependency formula.
-  The following packages couldn't be found: dune
-  [1]
+  Solution for dune.lock:
+  (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -6,9 +6,6 @@ dependency.
   $ . ./helpers.sh
   $ mkrepo
 
-  $ mkpkg dune 3.11.0 <<EOF
-  > EOF
-
   $ test() {
   > mkpkg foo <<EOF
   > depends: [ "dune" {<= "$1"} ]
@@ -26,6 +23,10 @@ dependency.
       Rejected candidates:
         dune.3.XX.0: Incompatible with restriction: = 3.XX
   $ test "4.0.0"
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ test "4.0.0" 2>&1 | sed -E 's/3.[0-9]+/3.XX/g'
   Solution for dune.lock:
   - foo.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-dune.t
@@ -1,0 +1,34 @@
+Pinning dune itself
+
+  $ . ../helpers.sh
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+# CR-someday rgrinberg: ideally, this source shouldn't be necessary and we
+# should disqualify this pin without resolving any sources
+
+  $ mkdir _extra_source
+  $ cat >_extra_source/dune-project <<EOF
+  > (lang dune 3.12)
+  > (package (name dune))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "file://$PWD/_extra_source")
+  >  (package (name dune)))
+  > (package
+  >   (name main))
+  > EOF
+
+For now, pinning dune is not allowed:
+
+  $ dune pkg lock
+  File "dune-project", line 4, characters 1-22:
+  4 |  (package (name dune)))
+       ^^^^^^^^^^^^^^^^^^^^^
+  Error: Dune cannot be pinned. The currently running version is the only one
+  that may be used
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -22,8 +22,12 @@ project:
 
 Solve the dependencies:
   $ dune pkg lock 2>&1 | sed -E 's/"3.[0-9]+"/"3.XX"/'
-  Error: The current version of Dune does not satisfy the version constraints
-  for Dune in this project's dependencies.
-  Details:
-  Found version "3.XX" of package "dune" which doesn't satisfy the required
-  version constraint "< 3.0"
+  Error: Unable to solve dependencies for the following lock directories:
+  Lock directory dune.lock:
+  Couldn't solve the package dependency formula.
+  Selected candidates: foo.dev
+  - dune -> (problem)
+      User requested = 3.21
+      foo dev requires < 3.0
+      Rejected candidates:
+        dune.3.21: Incompatible with restriction: < 3.0


### PR DESCRIPTION
From the commit that fixes the issue:

Automatically make dune pin itself. We're going to assume that the dune
we're using right now is the one that will be used to run the build
plan.

Perhaps this behavior isn't always deired. We could imagine wanting to
produce build plans for older or newer dunes. For now, this is a good
default though.

A separate commit is made for a small preliminary refactoring to ease reviewing.

Fixes #12381 