### PR TITLE
Rename Find_closest_source_dir.find_by_dir

### DIFF
--- a/src/dune_rules/coq/coq_scope.ml
+++ b/src/dune_rules/coq/coq_scope.ml
@@ -25,7 +25,9 @@ let coq_scopes_by_dir
       coq_stanzas_by_project_dir
   =
   let parent = Some public_theories in
-  let find_db dir = snd (Find_closest_source_dir.find_by_dir db_by_project_dir ~dir) in
+  let find_db dir =
+    snd (Find_closest_source_dir.find_by_dir_exn db_by_project_dir ~dir)
+  in
   Path.Source.Map.merge
     projects_by_dir
     coq_stanzas_by_project_dir

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -126,7 +126,7 @@ let load =
 
 let find_project ~dir =
   let+ { projects_by_root; _ } = load () in
-  Find_closest_source_dir.find_by_dir projects_by_root ~dir
+  Find_closest_source_dir.find_by_dir_exn projects_by_root ~dir
 ;;
 
 let stanzas_in_dir dir =

--- a/src/dune_rules/find_closest_source_dir.ml
+++ b/src/dune_rules/find_closest_source_dir.ml
@@ -1,6 +1,6 @@
 open Import
 
-let find_by_dir map (dir : Path.Source.t) =
+let find_by_dir_exn map (dir : Path.Source.t) =
   let rec loop d =
     match Path.Source.Map.find map d with
     | Some s -> s
@@ -21,14 +21,14 @@ let invalid_path dir =
     [ "dir", Path.Build.to_dyn dir ]
 ;;
 
-let find_by_dir map ~dir =
+let find_by_dir_exn map ~dir =
   if Path.Build.is_root dir
   then invalid_path dir
   else (
     match Dune_engine.Dpath.analyse_target dir with
     | Regular (name, src) ->
       (match Install.Context.analyze_path name src with
-       | Normal (_, path) -> find_by_dir map path
+       | Normal (_, path) -> find_by_dir_exn map path
        | _ -> invalid_path dir)
     | _ -> invalid_path dir)
 ;;

--- a/src/dune_rules/find_closest_source_dir.mli
+++ b/src/dune_rules/find_closest_source_dir.mli
@@ -1,3 +1,3 @@
 open Import
 
-val find_by_dir : 'a Path.Source.Map.t -> dir:Path.Build.t -> 'a
+val find_by_dir_exn : 'a Path.Source.Map.t -> dir:Path.Build.t -> 'a

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -17,7 +17,7 @@ module DB = struct
   type scope = t
   type t = { by_dir : scope Path.Source.Map.t }
 
-  let find_by_dir t dir = Find_closest_source_dir.find_by_dir t.by_dir ~dir
+  let find_by_dir t dir = Find_closest_source_dir.find_by_dir_exn t.by_dir ~dir
 
   let find_by_project t project =
     Path.Source.Map.find_exn t.by_dir (Dune_project.root project)


### PR DESCRIPTION
Ad the _exn prefix because this function can raise if misused.