### PR TITLE
Fix difference between bootstrap & dune behaviour w.r.t include-subdirs ambiguity

### DIFF
--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -410,7 +410,9 @@ module Group = struct
     fun acc modules m -> loop acc modules (Module.path m)
   ;;
 
-  let parents (t : t) m = parents_modules [ t ] t.modules m
+  (* [parents acc modules m] returns [acc] followed by all parent groups of 
+     module [m], ordered from innermost to outermost parent. *)
+  let parents (t : t) m = parents_modules [ t ] t.modules m |> List.rev
 
   module Memo_traversals = struct
     let rec parallel_map ({ alias; modules; name = _ } as t) ~f =
@@ -485,7 +487,10 @@ module Group = struct
       Ok (if Module_name.equal name (Module.name li) then [ li ] else [])
     | _ ->
       (* TODO don't recompute this *)
-      let parents = parents t of_ |> List.map ~f:(fun g -> g.modules, Some g.name) in
+      let parents =
+        parents_modules [ t ] t.modules of_
+        |> List.map ~f:(fun g -> g.modules, Some g.name)
+      in
       Find_dep.find_dep_of_parents parents name
   ;;
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
@@ -1,0 +1,34 @@
+Testing the bootstrap of a wrapped include subdirs qualified.
+There is ambiguity between the two different foo modules.
+We show that the behaviour is correct in the bootstrap process:
+it picks up the closest one.
+
+  $ . ./helpers.sh
+  $ mkdir a
+
+  $ cat > a/foo.ml << EOF
+  > let msg = "shouldn't be printed"
+  > EOF
+
+  $ mkdir a/bar
+  $ cat > a/bar/foo.ml << EOF
+  > let msg = "the correct module"
+  > EOF
+
+  $ cat > a/bar/baz.ml << EOF
+  > let exported = Foo.msg ^ "!"
+  > EOF
+
+  $ cat > a/dune <<EOF
+  > (library
+  >  (name a))
+  > (include_subdirs qualified)
+  > EOF
+
+  $ create_dune a <<EOF
+  > module M1 = A.Bar.Baz
+  > let () = Printf.printf "Hello from %s\n" M1.exported
+  > EOF
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  Hello from the correct module!

--- a/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
@@ -1,6 +1,6 @@
 There is ambiguity between the two different foo modules.
-The behaviour is correct in the bootstrap process, but not in dune.
-It picks up the wrong one.
+The behaviour is now correct both in the bootstrap process, and in dune.
+It picks up the closest one.
 
   $ echo "(lang dune 3.21)" > dune-project
   $ cat > dune << EOF
@@ -14,7 +14,7 @@ It picks up the wrong one.
   > EOF
 
   $ cat > foo.ml << EOF
-  > let msg = "No"
+  > let msg = "Failure"
   > EOF
 
   $ mkdir bar
@@ -26,10 +26,6 @@ It picks up the wrong one.
   > let exported = Foo.msg ^ "!"
   > EOF
 
-This is wrong, it should pick the closest module named foo.
+This is now fixed.
   $ dune exec ./main.exe
-  File "bar/baz.ml", line 1, characters 15-22:
-  1 | let exported = Foo.msg ^ "!"
-                     ^^^^^^^
-  Error: The module Foo is an alias for module Dune__exe__Foo, which is missing
-  [1]
+  Success!

--- a/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ambiguous-module-name.t
@@ -1,0 +1,35 @@
+There is ambiguity between the two different foo modules.
+The behaviour is correct in the bootstrap process, but not in dune.
+It picks up the wrong one.
+
+  $ echo "(lang dune 3.21)" > dune-project
+  $ cat > dune << EOF
+  > (include_subdirs qualified)
+  > (executable
+  >  (name main))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let ()  = print_endline Bar.Baz.exported
+  > EOF
+
+  $ cat > foo.ml << EOF
+  > let msg = "No"
+  > EOF
+
+  $ mkdir bar
+  $ cat > bar/foo.ml << EOF
+  > let msg = "Success"
+  > EOF
+
+  $ cat > bar/baz.ml << EOF
+  > let exported = Foo.msg ^ "!"
+  > EOF
+
+This is wrong, it should pick the closest module named foo.
+  $ dune exec ./main.exe
+  File "bar/baz.ml", line 1, characters 15-22:
+  1 | let exported = Foo.msg ^ "!"
+                     ^^^^^^^
+  Error: The module Foo is an alias for module Dune__exe__Foo, which is missing
+  [1]

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -97,7 +97,7 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG (-open Foo -open Foo__Groupintf__))
    (UNIT_NAME foo__Groupintf__Calc))
   Calc: _build/default/groupintf/calc.ml
   ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
@@ -109,7 +109,7 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG (-open Foo -open Foo__Groupintf__))
    (UNIT_NAME foo__Groupintf__Calc))
   Groupintf: _build/default/groupintf/groupintf
   ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
@@ -121,7 +121,7 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG (-open Foo -open Foo__Groupintf__))
    (UNIT_NAME foo__Groupintf))
   Groupintf: _build/default/groupintf/groupintf.ml
   ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
@@ -133,7 +133,7 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Groupintf__ -open Foo))
+   (FLG (-open Foo -open Foo__Groupintf__))
    (UNIT_NAME foo__Groupintf))
   Main: _build/default/main
   ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
@@ -169,7 +169,7 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Utils -open Foo))
+   (FLG (-open Foo -open Foo__Utils))
    (UNIT_NAME foo__Utils__Calc))
   Calc: _build/default/utils/calc.ml
   ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
@@ -181,6 +181,6 @@
    (S $TESTCASE_ROOT/groupintf)
    (S $TESTCASE_ROOT/utils)
    (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo__Utils -open Foo))
+   (FLG (-open Foo -open Foo__Utils))
    (UNIT_NAME foo__Utils__Calc))
   $ dune ocaml merlin dump-config utils


### PR DESCRIPTION
### Initial problem
When we have 2 modules with the same name, the one that is closer should be picked up.
The behaviour is correct within the bootstrapped dune, but not normal dune.

In bin, `include_subdirs qualified` was introduced in #12478.
Working on #12585, we realized there was a bug.

### Fix
In 36b459225953b1fef0c7ee5e05f7c054363cb870, Ali fixed the bug!