### PR TITLE
dune init: use source path

### DIFF
--- a/bin/dune_init.mli
+++ b/bin/dune_init.mli
@@ -7,7 +7,7 @@ module Init_context : sig
   open Dune_config_file
 
   type t =
-    { dir : Path.t
+    { dir : Path.Source.t
     ; project : Dune_project.t
     ; defaults : Dune_config.Project_defaults.t
     }

--- a/doc/changes/fixed/12601.md
+++ b/doc/changes/fixed/12601.md
@@ -1,0 +1,2 @@
+- Allow `$ dune init` to work on absolute paths (#12601, fixes #7806,
+  @rgrinberg)

--- a/test/blackbox-tests/test-cases/dune-init/github7806.t
+++ b/test/blackbox-tests/test-cases/dune-init/github7806.t
@@ -1,9 +1,2 @@
-  $ dune init project name $PWD 2>&1 | head -n 8
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("[as_in_source_tree_exn] called on something not in source tree",
-     { t =
-         External
-           "$TESTCASE_ROOT"
-     })
-  Raised at Stdune__Code_error.raise in file
+  $ dune init project name $PWD
+  Success: initialized project component named name


### PR DESCRIPTION
Saves us from using `as_in_source_tree_exn` and also prepares us from passing this directory to the stanza parser.

As a side effect, let's fix the issue of turning absolute paths into source paths and allow dune init to work on absolute paths