### PR TITLE
pkg: relock ocamlformat when version changes

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
@@ -1,0 +1,28 @@
+When installing a dev tool which already has a lockdir, detect the case where
+the tool's lockfile is absent from the lockdir and relock.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a fake ocamlformat package
+  $ make_fake_ocamlformat "0.26.0"
+  $ make_ocamlformat_opam_pkg "0.26.0"
+
+  $ make_project_with_dev_tool_lockdir
+
+Install ocamlformat once to generate the lockdir.
+  $ dune tools install ocamlformat
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.0
+
+Delete ocamlformat's lockfile.
+  $ rm dev-tools.locks/ocamlformat/ocamlformat.pkg
+
+Reinstall ocamlformat.
+  $ dune tools install ocamlformat
+  Warning: The lock directory for the tool "ocamlformat" exists but does not
+  contain a lockfile for the package "ocamlformat". This may indicate that the
+  lock directory has been tampered with. Please avoid making manual changes to
+  tool lock directories. The tool will now be relocked.
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
@@ -1,0 +1,39 @@
+When the version in .ocamlformat changes, automatically relock ocamlformat with
+the new version.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ make_fake_ocamlformat "0.26.0"
+  $ echo ocamlformat-0.26.0.tar > fake-curls
+  $ make_ocamlformat_opam_pkg "0.26.0" 1
+
+  $ make_fake_ocamlformat "0.27.0"
+  $ echo ocamlformat-0.27.0.tar >> fake-curls
+  $ make_ocamlformat_opam_pkg "0.27.0" 2
+
+Make dune-project that uses the mocked dev-tool opam-reposiotry.
+  $ make_project_with_dev_tool_lockdir
+
+Create .ocamlformat file
+  $ cat > .ocamlformat <<EOF
+  > version = 0.26.0
+  > EOF
+
+Install ocamlformat. 0.26.0 should be installed because that's the version in .ocamlformat.
+  $ dune tools install ocamlformat
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.0
+
+Change the version in .ocamlformat.
+  $ cat > .ocamlformat <<EOF
+  > version = 0.27.0
+  > EOF
+
+Install ocamlformat again. Dune should detect that the version has changed and relock:
+  $ dune tools install ocamlformat
+  The lock directory for the tool "ocamlformat" exists but contains a solution
+  for 0.26.0 of the tool, whereas version 0.27.0 now needs to be installed. The
+  tool will now be re-locked.
+  Solution for dev-tools.locks/ocamlformat:
+  - ocamlformat.0.27.0


### PR DESCRIPTION
The .ocamlformat file can contain the version of ocamlformat which a project uses for autoformatting. Previously this file was used to determine which version of ocamlformat to install initially, but changes to the version specified in .ocamlformat did not cause dune to relock the tool with the new version, leading to a mismatch between the specified and installed versions of ocamlformat within a project.

This change allows dune to detect when the specified and locked versions of ocamlformat differ, and relocks (and re-installs) ocamlformat in this case.

Possibly related to https://github.com/ocaml/dune/issues/12588