### PR TITLE
One Directory per Package

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -430,6 +430,7 @@ module Component = struct
                 ; constraint_ = None
                 }
               ]
+            ~contents_basename:None
         in
         let packages = Package.Name.Map.singleton (Package.name package) package in
         let info =

--- a/doc/changes/added/12614.md
+++ b/doc/changes/added/12614.md
@@ -1,0 +1,5 @@
+- Introduce a `(dir ..)` field on packages defined in the `dune-project`. This
+  field allows to associate a directory with a particular package. This makes
+  dune automatically filter out all stanzas in this directory and its
+  descendants with `--only-packages`. All users are recommended to switch to
+  using this field. (#12614, fixes #3255, @rgrinberg)

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -62,6 +62,7 @@ module Mode_conf = Mode_conf
 module Oxcaml = Oxcaml
 module Modules_settings = Modules_settings
 module Stanza_pkg = Stanza_pkg
+module Package_mask = Package_mask
 
 (* CR-someday rgrinberg: perhaps wrap these under [Stanzas]? *)
 module Copy_files = Copy_files

--- a/src/dune_lang/dune_project.mli
+++ b/src/dune_lang/dune_project.mli
@@ -19,7 +19,7 @@ val packages : t -> Package.t Package.Name.Map.t
 val name : t -> Dune_project_name.t
 val version : t -> Package_version.t option
 val root : t -> Path.Source.t
-val stanza_parser : t -> Stanza.t list Decoder.t
+val stanza_parser : t -> dir:Path.Source.t -> Stanza.t list Decoder.t
 val generate_opam_files : t -> bool
 val set_generate_opam_files : bool -> t -> t
 

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -1,33 +1,6 @@
 open Import
 module Name = Package_name
-
-module Id = struct
-  module T = struct
-    type t =
-      { name : Name.t
-      ; dir : Path.Source.t
-      }
-
-    let compare { name; dir } pkg =
-      match Name.compare name pkg.name with
-      | Eq -> Path.Source.compare dir pkg.dir
-      | e -> e
-    ;;
-
-    let to_dyn { dir; name } =
-      Dyn.record [ "name", Name.to_dyn name; "dir", Path.Source.to_dyn dir ]
-    ;;
-  end
-
-  include T
-
-  let hash { name; dir } = Tuple.T2.hash Name.hash Path.Source.hash (name, dir)
-  let name t = t.name
-
-  module C = Comparable.Make (T)
-  module Set = C.Set
-  module Map = C.Map
-end
+module Id = Package_id
 
 type opam_file =
   | Exists of bool
@@ -176,7 +149,7 @@ let decode =
        and+ allow_empty = field_b "allow_empty" ~check:(Syntax.since Stanza.syntax (3, 0))
        and+ lang_version = Syntax.get_exn Stanza.syntax in
        let allow_empty = lang_version < (3, 0) || allow_empty in
-       let id = { Id.name; dir } in
+       let id = Id.create ~name ~dir in
        let opam_file = Name.file id.name ~dir:id.dir in
        { id
        ; loc
@@ -265,7 +238,7 @@ let create
       ~original_opam_file
       ~deprecated_package_names
   =
-  let id = { Id.name; dir } in
+  let id = Id.create ~name ~dir in
   { id
   ; loc
   ; version

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -20,6 +20,7 @@ val deprecated_package_names : t -> Loc.t Name.Map.t
 val sites : t -> Section.t Site.Map.t
 val name : t -> Name.t
 val dir : t -> Path.Source.t
+val exclusive_dir : t -> (Loc.t * Path.Source.t) option
 val set_inside_opam_dir : t -> dir:Path.Source.t -> t
 val encode : Name.t -> t Encoder.t
 val decode : dir:Path.Source.t -> t Decoder.t
@@ -69,6 +70,7 @@ val create
   -> tags:string list
   -> original_opam_file:original_opam_file option
   -> deprecated_package_names:Loc.t Name.Map.t
+  -> contents_basename:(Loc.t * Filename.t) option
   -> t
 
 val original_opam_file : t -> original_opam_file option

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -1,19 +1,12 @@
 (** Information about a package defined in the workspace *)
 
 open Import
+module Id : module type of Package_id with type t = Package_id.t
 
 module Name : sig
   type t = Package_name.t
 
   include module type of Package_name with type t := t
-end
-
-module Id : sig
-  type t
-
-  val name : t -> Name.t
-
-  include Comparable_intf.S with type key := t
 end
 
 type opam_file =

--- a/src/dune_lang/package_id.ml
+++ b/src/dune_lang/package_id.ml
@@ -1,0 +1,28 @@
+open Import
+
+module T = struct
+  type t =
+    { name : Package_name.t
+    ; dir : Path.Source.t
+    }
+
+  let compare { name; dir } pkg =
+    match Package_name.compare name pkg.name with
+    | Eq -> Path.Source.compare dir pkg.dir
+    | e -> e
+  ;;
+
+  let to_dyn { dir; name } =
+    Dyn.record [ "name", Package_name.to_dyn name; "dir", Path.Source.to_dyn dir ]
+  ;;
+end
+
+include T
+
+let create ~name ~dir = { name; dir }
+let hash { name; dir } = Tuple.T2.hash Package_name.hash Path.Source.hash (name, dir)
+let name t = t.name
+
+module C = Comparable.Make (T)
+module Set = C.Set
+module Map = C.Map

--- a/src/dune_lang/package_id.mli
+++ b/src/dune_lang/package_id.mli
@@ -9,5 +9,6 @@ val create : name:Package_name.t -> dir:Path.Source.t -> t
 val name : t -> Package_name.t
 val hash : t -> int
 val to_dyn : t -> Dyn.t
+val compare : t -> t -> Ordering.t
 
 include Comparable_intf.S with type key := t

--- a/src/dune_lang/package_id.mli
+++ b/src/dune_lang/package_id.mli
@@ -1,0 +1,13 @@
+open Import
+
+type t = private
+  { name : Package_name.t
+  ; dir : Path.Source.t
+  }
+
+val create : name:Package_name.t -> dir:Path.Source.t -> t
+val name : t -> Package_name.t
+val hash : t -> int
+val to_dyn : t -> Dyn.t
+
+include Comparable_intf.S with type key := t

--- a/src/dune_lang/package_mask.ml
+++ b/src/dune_lang/package_mask.ml
@@ -2,16 +2,53 @@ open Import
 
 type t =
   | Inside_package of Package_id.t
-  | Forbidden_packages of Package_id.t Path.Source.Map.t
+  | Forbidden_packages of
+      { by_dir : Package_id.t Path.Source.Map.t
+      ; by_id : Path.Source.t Package_id.Map.t
+      }
 
 let key : t Univ_map.Key.t = Univ_map.Key.create ~name:"package-mask" Dyn.opaque
+let decode () = Decoder.get key |> Decoder.map ~f:Option.value_exn
 
-let package_env ~dir ~packages =
-  if Path.Source.Map.is_empty packages
-  then Forbidden_packages packages
+let validate t ~loc pkg =
+  match t with
+  | Inside_package pkg' ->
+    if Ordering.is_eq (Package_id.compare pkg pkg')
+    then Ok ()
+    else
+      Error
+        (User_error.make
+           ~loc
+           [ Pp.textf
+               "Package %s may not be defined here"
+               (Package_name.to_string pkg.name)
+           ; Pp.textf
+               "The only package that can be defined in this directory is %s because the \
+                directory of this stanza is exclusive to this package"
+               (Package_name.to_string pkg'.name)
+           ])
+  | Forbidden_packages { by_dir = _; by_id } ->
+    (match Package_id.Map.find by_id pkg with
+     | None -> Ok ()
+     | Some dir ->
+       Error
+         (User_error.make
+            ~loc
+            [ Pp.textf
+                "Package %s may not be defined here"
+                (Package_name.to_string pkg.name)
+            ; Pp.textf
+                "That package must exist in %s"
+                (Path.Source.to_string_maybe_quoted dir)
+            ]))
+;;
+
+let package_env ~dir ~packages:by_dir =
+  if Path.Source.Map.is_empty by_dir
+  then Forbidden_packages { by_dir; by_id = Package_id.Map.empty }
   else (
     let rec find dir =
-      match Path.Source.Map.find packages dir with
+      match Path.Source.Map.find by_dir dir with
       | Some s -> Some s
       | None ->
         (match Path.Source.parent dir with
@@ -20,10 +57,15 @@ let package_env ~dir ~packages =
     in
     match find dir with
     | Some p -> Inside_package p
-    | None -> Forbidden_packages packages)
+    | None ->
+      let by_id =
+        Path.Source.Map.to_list by_dir
+        |> Package_id.Map.of_list_map_exn ~f:(fun (dir, id) -> id, dir)
+      in
+      Forbidden_packages { by_id; by_dir })
 ;;
 
-let decode : Package_id.t option Decoder.t =
+let decode_pkg : Package_id.t option Decoder.t =
   let open Decoder in
   Decoder.get key
   >>| function

--- a/src/dune_lang/package_mask.ml
+++ b/src/dune_lang/package_mask.ml
@@ -1,0 +1,33 @@
+open Import
+
+type t =
+  | Inside_package of Package_id.t
+  | Forbidden_packages of Package_id.t Path.Source.Map.t
+
+let key : t Univ_map.Key.t = Univ_map.Key.create ~name:"package-mask" Dyn.opaque
+
+let package_env ~dir ~packages =
+  if Path.Source.Map.is_empty packages
+  then Forbidden_packages packages
+  else (
+    let rec find dir =
+      match Path.Source.Map.find packages dir with
+      | Some s -> Some s
+      | None ->
+        (match Path.Source.parent dir with
+         | None -> None
+         | Some s -> find s)
+    in
+    match find dir with
+    | Some p -> Inside_package p
+    | None -> Forbidden_packages packages)
+;;
+
+let decode : Package_id.t option Decoder.t =
+  let open Decoder in
+  Decoder.get key
+  >>| function
+  | None -> None
+  | Some (Inside_package id) -> Some id
+  | Some (Forbidden_packages _) -> None
+;;

--- a/src/dune_lang/package_mask.mli
+++ b/src/dune_lang/package_mask.mli
@@ -1,9 +1,22 @@
+(** Package masks for decoding stanzas.
+
+   Package masks describe the invariants that must be respected when
+   associating a stanza with a package. *)
+
 open Import
 
 type t = private
   | Inside_package of Package_id.t
-  | Forbidden_packages of Package_id.t Path.Source.Map.t
+  (** The only valid package association is the argument *)
+  | Forbidden_packages of
+      { by_dir : Package_id.t Path.Source.Map.t
+      ; by_id : Path.Source.t Package_id.Map.t
+      }
+  (** All of the packages in either map are forbidden and may not be attached
+      to any stanza when this mask is set. *)
 
+val validate : t -> loc:Loc.t -> Package_id.t -> (unit, User_message.t) result
 val package_env : dir:Path.Source.t -> packages:Package_id.t Path.Source.Map.t -> t
 val key : t Univ_map.Key.t
-val decode : Package_id.t option Decoder.t
+val decode : unit -> (t, _) Decoder.parser
+val decode_pkg : Package_id.t option Decoder.t

--- a/src/dune_lang/package_mask.mli
+++ b/src/dune_lang/package_mask.mli
@@ -1,0 +1,9 @@
+open Import
+
+type t = private
+  | Inside_package of Package_id.t
+  | Forbidden_packages of Package_id.t Path.Source.Map.t
+
+val package_env : dir:Path.Source.t -> packages:Package_id.t Path.Source.Map.t -> t
+val key : t Univ_map.Key.t
+val decode : Package_id.t option Decoder.t

--- a/src/dune_lang/stanza.ml
+++ b/src/dune_lang/stanza.ml
@@ -14,7 +14,7 @@ module type T = sig
   val hash : t -> int
 end
 
-type t = E : 'a * (module T with type t = 'a) -> t
+type t = E : 'a * Package_id.t option * (module T with type t = 'a) -> t
 
 module Key = struct
   type stanza = t
@@ -28,13 +28,13 @@ module type S = sig
   type t
   type repr += T of t
 
-  val make_stanza : t -> stanza
+  val make_stanza : t -> Package_id.t option -> stanza
   val decode_stanza : t Decoder.t -> stanza list Decoder.t
   val decode_stanzas : t list Decoder.t -> stanza list Decoder.t
   val key : t Key.t
 end
 
-let repr (E (a, (module T))) = T.repr a
+let repr (E (a, _id, (module T))) = T.repr a
 
 module Make (S : sig
     type t
@@ -54,9 +54,21 @@ struct
     type _ witness += W : t witness
   end
 
-  let make_stanza (a : S.t) = E (a, (module T))
-  let decode_stanza d = Decoder.map d ~f:(fun x -> [ make_stanza x ])
-  let decode_stanzas d = Decoder.map d ~f:(List.map ~f:make_stanza)
+  let make_stanza (a : S.t) pkg = E (a, pkg, (module T))
+
+  let decode_stanza d =
+    let open Decoder in
+    let* mask = Decoder.get Package_mask.key in
+    let+ d = d in
+    let package =
+      match mask with
+      | Some (Forbidden_packages _) | None -> None
+      | Some (Inside_package id) -> Some id
+    in
+    [ make_stanza d package ]
+  ;;
+
+  let decode_stanzas d = Decoder.map d ~f:(List.map ~f:(fun s -> make_stanza s None))
 
   let key : S.t Key.t =
     fun t ->
@@ -68,13 +80,16 @@ struct
   include T
 end
 
-let compare (E (x, (module X))) (E (y, (module Y))) =
+let compare (E (x, px, (module X))) (E (y, py, (module Y))) =
   match X.W with
-  | Y.W -> X.compare x y
+  | Y.W -> Tuple.T2.compare X.compare (Option.compare Package_id.compare) (x, px) (y, py)
   | _ -> Id.compare X.id Y.id
 ;;
 
-let hash (E (t, (module T))) = Tuple.T2.hash Id.hash T.hash (T.id, t)
+let hash (E (t, p, (module T))) =
+  Tuple.T3.hash Id.hash (Option.hash Package_id.hash) T.hash (T.id, p, t)
+;;
+
 let equal x y = Ordering.is_eq (compare x y)
 
 module Parser = struct

--- a/src/dune_lang/stanza.ml
+++ b/src/dune_lang/stanza.ml
@@ -16,6 +16,8 @@ end
 
 type t = E : 'a * Package_id.t option * (module T with type t = 'a) -> t
 
+let package (E (_, p, _)) = p
+
 module Key = struct
   type stanza = t
   type nonrec 'a t = t -> 'a option

--- a/src/dune_lang/stanza.mli
+++ b/src/dune_lang/stanza.mli
@@ -5,6 +5,7 @@ open Import
 type repr = ..
 type t
 
+val package : t -> Package_id.t option
 val repr : t -> repr
 
 module Key : sig

--- a/src/dune_lang/stanza.mli
+++ b/src/dune_lang/stanza.mli
@@ -19,7 +19,7 @@ module type S = sig
   type t
   type repr += T of t
 
-  val make_stanza : t -> stanza
+  val make_stanza : t -> Package_id.t option -> stanza
   val decode_stanza : t Decoder.t -> stanza list Decoder.t
   val decode_stanzas : t list Decoder.t -> stanza list Decoder.t
   val key : t Key.t

--- a/src/dune_lang/stanza_pkg.mli
+++ b/src/dune_lang/stanza_pkg.mli
@@ -1,7 +1,13 @@
 open Import
 
 val decode : Package.t Decoder.t
-val resolve : Dune_project.t -> Package.Name.t -> (Package.t, User_message.t) Result.t
+
+val resolve
+  :  Dune_project.t
+  -> Package_mask.t
+  -> Loc.t * Package.Name.t
+  -> (Package.t, User_message.t) Result.t
+
 val field : stanza:string -> Package.t Decoder.fields_parser
 val field_opt : ?check:unit Decoder.t -> unit -> Package.t option Decoder.fields_parser
 val default_exn : loc:Loc.t -> Dune_project.t -> string -> Package.t

--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -291,4 +291,5 @@ let load_opam_file_with_contents ~contents:opam_file_string file name =
     ~sites:Dune_lang.Site.Map.empty
     ~allow_empty:true
     ~original_opam_file:(Some { file; contents = opam_file_string })
+    ~contents_basename:None
 ;;

--- a/src/dune_rules/coq/coq_stanza.ml
+++ b/src/dune_rules/coq/coq_stanza.ml
@@ -175,6 +175,7 @@ module Theory = struct
     }
 
   let coq_public_decode =
+    let* mask = Dune_lang.Package_mask.decode () in
     map_validate
       (let+ project = Dune_project.get_exn ()
        and+ loc_name =
@@ -196,7 +197,8 @@ module Theory = struct
             | None -> Package.Name.of_string name
             | Some (pkg, _) -> Package.Name.of_string pkg
           in
-          Stanza_pkg.resolve project pkg |> Result.map ~f:(fun pkg -> Some (loc, pkg)))
+          Stanza_pkg.resolve project mask (loc, pkg)
+          |> Result.map ~f:(fun pkg -> Some (loc, pkg)))
   ;;
 
   let merge_package_public ~package ~public =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -41,7 +41,7 @@ module Mask = struct
         | Library.T l ->
           (match Library_redirect.Local.of_private_lib l with
            | None -> Drop
-           | Some p -> Convert (Library_redirect.Local.make_stanza p))
+           | Some p -> Convert (Library_redirect.Local.make_stanza p None))
         | _ -> Drop)
   ;;
 
@@ -116,7 +116,8 @@ let parse_stanzas ~file ~(eval : eval) sexps =
         Path.Source.relative eval.dir Source.Dune_file.fname
     in
     let stanza_parser =
-      Dune_project.stanza_parser eval.project |> Warning_emit.Bag.set warnings
+      Dune_project.stanza_parser ~dir:eval.dir eval.project
+      |> Warning_emit.Bag.set warnings
     in
     parse_file_includes ~stanza_parser ~context sexps
   in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -54,7 +54,7 @@ module Mask = struct
           match Stanzas.stanza_package stanza with
           | None -> true
           | Some package ->
-            let name = Package.name package in
+            let name = Package.Id.name package in
             Package.Name.Map.mem visible_pkgs name)
   ;;
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -525,7 +525,7 @@ end = struct
         | Plugin.T t -> Plugin_rules.install_rules ~sctx ~package_db ~dir t
         | _ -> Memo.return []
       in
-      let name = Package.name package in
+      let name = Package.Id.name package in
       Some (name, entries)
   ;;
 

--- a/src/dune_rules/stanzas/public_lib.ml
+++ b/src/dune_rules/stanzas/public_lib.ml
@@ -14,7 +14,7 @@ let package t = t.package
 
 (** if [~allow_deprecated_names] is set, then we allow the package name to be
     attached to one of the deprecated packages *)
-let make ~allow_deprecated_names project ((_, s) as loc_name) =
+let make ~allow_deprecated_names project mask ((loc, s) as loc_name) =
   let pkg, rest = Lib_name.split s in
   match
     match allow_deprecated_names with
@@ -30,7 +30,7 @@ let make ~allow_deprecated_names project ((_, s) as loc_name) =
   with
   | Some x -> Ok x
   | None ->
-    Stanza_pkg.resolve project pkg
+    Stanza_pkg.resolve project mask (loc, pkg)
     |> Result.map ~f:(fun pkg ->
       { package = pkg
       ; sub_dir = (if rest = [] then None else Some (String.concat rest ~sep:"/"))
@@ -39,9 +39,10 @@ let make ~allow_deprecated_names project ((_, s) as loc_name) =
 ;;
 
 let decode ~allow_deprecated_names =
+  let* mask = Dune_lang.Package_mask.decode () in
   map_validate
     (let+ project = Dune_project.get_exn ()
      and+ loc_name = located Lib_name.decode in
      project, loc_name)
-    ~f:(fun (project, loc_name) -> make ~allow_deprecated_names project loc_name)
+    ~f:(fun (project, loc_name) -> make ~allow_deprecated_names project mask loc_name)
 ;;

--- a/src/dune_rules/stanzas/public_lib.mli
+++ b/src/dune_rules/stanzas/public_lib.mli
@@ -20,6 +20,7 @@ val package : t -> Package.t
 val make
   :  allow_deprecated_names:bool
   -> Dune_project.t
+  -> Dune_lang.Package_mask.t
   -> Loc.t * Lib_name.t
   -> (t, User_message.t) result
 

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -117,15 +117,16 @@ let of_ast (project : Dune_project.t) sexp =
 ;;
 
 let stanza_package stanza =
-  match Stanza.repr stanza with
-  | Library.T lib -> Library.package lib
-  | Alias_conf.T { package = Some package; _ }
-  | Rule_conf.T { package = Some package; _ }
-  | Install_conf.T { package; _ }
-  | Plugin.T { package; _ }
-  | Executables.T { install_conf = Some { package; _ }; _ }
-  | Documentation.T { package; _ }
-  | Tests.T { package = Some package; _ } -> Some package
-  | Coq_stanza.Theory.T { package = Some package; _ } -> Some package
-  | _ -> None
+  (match Stanza.repr stanza with
+   | Library.T lib -> Library.package lib
+   | Alias_conf.T { package = Some package; _ }
+   | Rule_conf.T { package = Some package; _ }
+   | Install_conf.T { package; _ }
+   | Plugin.T { package; _ }
+   | Executables.T { install_conf = Some { package; _ }; _ }
+   | Documentation.T { package; _ }
+   | Tests.T { package = Some package; _ } -> Some package
+   | Coq_stanza.Theory.T { package = Some package; _ } -> Some package
+   | _ -> None)
+  |> Option.map ~f:Package.id
 ;;

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -125,16 +125,22 @@ let of_ast (project : Dune_project.t) ~dir sexp =
 ;;
 
 let stanza_package stanza =
-  (match Stanza.repr stanza with
-   | Library.T lib -> Library.package lib
-   | Alias_conf.T { package = Some package; _ }
-   | Rule_conf.T { package = Some package; _ }
-   | Install_conf.T { package; _ }
-   | Plugin.T { package; _ }
-   | Executables.T { install_conf = Some { package; _ }; _ }
-   | Documentation.T { package; _ }
-   | Tests.T { package = Some package; _ } -> Some package
-   | Coq_stanza.Theory.T { package = Some package; _ } -> Some package
-   | _ -> None)
-  |> Option.map ~f:Package.id
+  match
+    (* Not clear if this check is even necessary. Shouldn't this always match
+       [Stanza.package] anyway? *)
+    (match Stanza.repr stanza with
+     | Library.T lib -> Library.package lib
+     | Alias_conf.T { package = Some package; _ }
+     | Rule_conf.T { package = Some package; _ }
+     | Install_conf.T { package; _ }
+     | Plugin.T { package; _ }
+     | Executables.T { install_conf = Some { package; _ }; _ }
+     | Documentation.T { package; _ }
+     | Tests.T { package = Some package; _ } -> Some package
+     | Coq_stanza.Theory.T { package = Some package; _ } -> Some package
+     | _ -> None)
+    |> Option.map ~f:Package.id
+  with
+  | Some _ as s -> s
+  | None -> Stanza.package stanza
 ;;

--- a/src/dune_rules/stanzas/stanzas.mli
+++ b/src/dune_rules/stanzas/stanzas.mli
@@ -12,7 +12,7 @@ module Dynamic_include : sig
   include Stanza.S with type t := t
 end
 
-val stanza_package : Stanza.t -> Package.t option
+val stanza_package : Stanza.t -> Package.Id.t option
 
 (** [of_ast project ast] is the list of [Stanza.t]s derived from decoding the
     [ast] according to the syntax given by [kind] in the context of the

--- a/src/dune_rules/stanzas/stanzas.mli
+++ b/src/dune_rules/stanzas/stanzas.mli
@@ -14,7 +14,7 @@ end
 
 val stanza_package : Stanza.t -> Package.Id.t option
 
-(** [of_ast project ast] is the list of [Stanza.t]s derived from decoding the
-    [ast] according to the syntax given by [kind] in the context of the
+(** [of_ast project ~dir ast] is the list of [Stanza.t]s derived from decoding
+    the [ast] according to the syntax given by [kind] in the context of the
     [project] *)
-val of_ast : Dune_project.t -> Dune_lang.Ast.t -> Stanza.t list
+val of_ast : Dune_project.t -> dir:Path.Source.t -> Dune_lang.Ast.t -> Stanza.t list

--- a/test/blackbox-tests/test-cases/exclusive-package-dirs.t
+++ b/test/blackbox-tests/test-cases/exclusive-package-dirs.t
@@ -1,0 +1,81 @@
+Packages can be marked as existing in a particular directory.
+
+First, demonstrate that packages cannot try to occupy the same directory:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name foo)
+  >  (dir foo))
+  > (package
+  >  (name bar)
+  >  (dir foo))
+  > EOF
+
+  $ dune build
+  File "dune-project", line 7, characters 6-9:
+  7 |  (dir foo))
+            ^^^
+  Error: package foo is already defined in "foo"
+  [1]
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name foo)
+  >  (dir foo))
+  > (package
+  >  (name bar))
+  > EOF
+
+  $ mkdir foo
+  $ cat >foo/dune <<EOF
+  > (rule (with-stdout-to x.txt (echo foo bar)))
+  > EOF
+
+  $ dune build foo/x.txt
+
+This should error because foo/x.txt is only visible to package foo
+
+  $ dune build --only-packages bar foo/x.txt
+  Error: Don't know how to build foo/x.txt
+  [1]
+
+We can try to define a rule that belongs to "foo" elsewhere, but it should not
+work:
+
+  $ mkdir bar
+  $ cat >bar/dune <<EOF
+  > (executable
+  >  (public_name bar)
+  >  (package foo))
+  > EOF
+  $ touch bar/bar.ml
+
+  $ dune build @check
+  File "bar/dune", line 3, characters 10-13:
+  3 |  (package foo))
+                ^^^
+  Error: Package foo may not be defined here
+  That package must exist in foo
+  [1]
+
+  $ rm -rf bar/
+
+It should also be impossible to add non foo stanzas to foo/
+
+  $ cat >foo/dune <<EOF
+  > (executable
+  >  (public_name foo)
+  >  (package bar))
+  > EOF
+  $ touch foo/foo.ml
+
+  $ dune build @check
+  File "foo/dune", line 3, characters 10-13:
+  3 |  (package bar))
+                ^^^
+  Error: Package bar may not be defined here
+  The only package that can be defined in this directory is foo because the
+  directory of this stanza is exclusive to this package
+  [1]

--- a/test/blackbox-tests/test-cases/missing-package.t
+++ b/test/blackbox-tests/test-cases/missing-package.t
@@ -44,9 +44,9 @@ Now we use another form instead of a library
   > EOF
 
   $ dune build @install
-  File "dune", line 4, characters 1-14:
+  File "dune", line 4, characters 10-13:
   4 |  (package foo))
-       ^^^^^^^^^^^^^
+                ^^^
   Error: The current scope doesn't define package "foo".
   The only packages for which you can declare elements to be installed in this
   directory are:
@@ -59,9 +59,9 @@ Same thing but without packages in the project
   > (lang dune 3.13)
   > EOF
   $ dune build @install
-  File "dune", line 4, characters 1-14:
+  File "dune", line 4, characters 10-13:
   4 |  (package foo))
-       ^^^^^^^^^^^^^
+                ^^^
   Error: You cannot declare items to be installed without adding a
   <package>.opam file at the root of your project.
   To declare elements to be installed as part of package "foo", add a


### PR DESCRIPTION
This PR introduces a `(dir ..)` field for packages in the dune-project file. The meaning of this field is to designate a single directory for a package.

We get two types of validation from this field:

1. Stanzas inside a package's directory may only belong to said package.
2. Stanzas outside the the package's directory may not be attached to said package.

Moreover, stanzas marked using `dir` field are excluded via `--only-packages` just like stanzas that use the `package` field.

Fixes #3255
