### PR TITLE
feat(cram): detect diff3 and jujutsu conflicts

### DIFF
--- a/doc/changes/added/12538.md
+++ b/doc/changes/added/12538.md
@@ -1,3 +1,4 @@
 - Add a `(conflict error|ignore)` option to the cram stanza. When `(conflict
   error)` is set, the cram test will fail in the presence of conflict markers.
-  (#12538, fixes #12512, @rgrinberg)
+  Git, diff3 and jujutsu conflict markers are detected. (#12538, #12617, fixes
+  #12512, @rgrinberg, @Alizter)

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -41,11 +41,17 @@ let quote_for_sh fn =
 ;;
 
 let cram_stanzas =
+  let is_conflict_marker line =
+    match line with
+    | "=======" | "%%%%%%%" | "+++++++" | "-------" | "|||||||" -> true
+    | _ -> false
+  in
   let find_conflict state line =
     match state with
-    | `No_conflict when line = "<<<<<<<" -> `Start
-    | `Start when line = "=======" -> `Split
-    | `Split when line = ">>>>>>>" ->
+    | `No_conflict when line = "<<<<<<<" -> `Started
+    | `Started when is_conflict_marker line -> `Has_markers
+    | `Has_markers when is_conflict_marker line -> `Has_markers
+    | `Has_markers when line = ">>>>>>>" ->
       (* CR-someday rgrinberg for alizter: insert a location spanning the
          entire once we start extracting it *)
       User_error.raise

--- a/test/blackbox-tests/test-cases/cram/conflict-markers-diff3.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers-diff3.t
@@ -1,0 +1,77 @@
+Cram tests can forbid git diff3 conflicts:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (cram (conflict error))
+  > EOF
+
+Full diff3 conflict without command and output interleaving:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  > Left side
+  > |||||||
+  > Original
+  > =======
+  > Right side
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Full diff3 conflict with command and output interleaving:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo left
+  > |||||||
+  >   $ foo original
+  > =======
+  >   > bar right
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Partial diff3 conflicts are ignored:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo
+  >   > bar
+  > |||||||
+  > EOF
+
+  $ dune runtest test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  [1]
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo
+  > |||||||
+  >   > original
+  > EOF
+
+  $ dune runtest test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  [1]

--- a/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
@@ -1,0 +1,115 @@
+Cram tests can forbid jujutsu conflicts:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (cram (conflict error))
+  > EOF
+
+Full jujutsu conflict without command and output interleaving:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  > A Small
+  > %%%%%%%
+  > Conflict
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Full jujutsu conflict with command and output interleaving:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo
+  > %%%%%%%
+  >   > bar
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Jujutsu default style conflict (diff + snapshot):
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  > %%%%%%%
+  > -apple
+  > +grapefruit
+  > +++++++
+  > APPLE
+  > GRAPE
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Jujutsu snapshot style conflict:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  > +++++++
+  > Left side
+  > -------
+  > Original
+  > +++++++
+  > Right side
+  > >>>>>>>
+  > $ echo tada
+  > EOF
+
+  $ dune runtest test.t
+  Error: Conflict found. Please remove it or set (conflict allow)
+  -> required by _build/default/.cram.test.t/cram.sh
+  -> required by _build/default/.cram.test.t/cram.out
+  -> required by alias test
+  [1]
+
+Partial jujutsu conflicts are ignored:
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo
+  >   > bar
+  > >>>>>>>
+  > EOF
+
+  $ dune runtest test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  [1]
+
+  $ cat >test.t <<EOF
+  > <<<<<<<
+  >   $ foo
+  > %%%%%%%
+  >   > bar
+  > EOF
+
+  $ dune runtest test.t
+  File "test.t", line 1, characters 0-0:
+  Error: Files _build/default/test.t and _build/default/test.t.corrected
+  differ.
+  [1]


### PR DESCRIPTION
We add support for both diff3 and jujutsu conflict markers to the conflict detection added in #12538.