### PR TITLE
chore: disable timing out test

### DIFF
--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -24,3 +24,9 @@
 (cram
  (applies_to what-dune-watches)
  (deps %{bin:strace}))
+
+;; Disabled due to timeouts
+
+(cram
+ (enabled_if false)
+ (applies_to watching-eager-concurrent-build-command))


### PR DESCRIPTION
cc @ElectreAAS 

There are timeouts on the second `dune build` after the `dune rpc ping`. I think this might be the issue where the server fails to respond to a request.