### PR TITLE
Fix package validation when portable lockdirs is enabled

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
@@ -1,0 +1,65 @@
+Exercise the `dune pkg validate-lockdir` command on portable lockdirs.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Define some interdependent opam packages:
+  $ mkpkg a 0.0.1 <<EOF
+  > depends: [ "c" "d" ]
+  > EOF
+  $ mkpkg b 0.0.1 <<EOF
+  > EOF
+  $ mkpkg b 0.0.2 <<EOF
+  > EOF
+  $ mkpkg c <<EOF
+  > depends: [ "e" ]
+  > EOF
+  $ mkpkg d <<EOF
+  > EOF
+  $ mkpkg e <<EOF
+  > EOF
+
+Define some local packages.
+  $ cat >dune-project <<EOF
+  > (lang dune 3.20)
+  > (package (name foo) (depends a (b (>= 0.0.2))))
+  > (package (name bar) (depends foo c))
+  > EOF
+
+Solve dependencies:
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Solution for dune.lock
+  
+  This solution supports the following platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  - arch = x86_64; os = win32
+  
+  Dependencies on all supported platforms:
+  - a.0.0.1
+  - b.0.0.2
+  - c.0.0.1
+  - d.0.0.1
+  - e.0.0.1
+
+Validate the lockdir. This will succeed because dune generates valid lockdirs.
+  $ dune pkg validate-lockdir
+
+Remove a package from the lockdir.
+  $ rm ${source_lock_dir}/a.0.0.1.pkg
+
+Validate the lockdir. This time dune detects that a required lockfile is missing.
+  $ dune pkg validate-lockdir
+  Lockdir dune.lock does not contain a solution for local packages:
+  File "dune-project", line 2, characters 0-47:
+  Error: The dependencies of local package "foo" could not be satisfied from
+  the lockdir:
+  Package "a" is missing
+  Hint: The lockdir no longer contains a solution for the local packages in
+  this project. Regenerate the lockdir by running: 'dune pkg lock'
+  Error: Some lockdirs do not contain solutions for local packages:
+  - dune.lock
+  [1]


### PR DESCRIPTION
The `dune pkg validate-lockdir` command checks that the lockdir contains the transitive dependency closure of all local packages. When run with portable lockdirs enabled, some packages were omitted from the dependency closure because the wrong solver environment was being treated as the current platform. This change fixes the issue by using the correct solver environment to represent the current platform, and does a minor refactor so the validation logic isn't juggling two different solver environments (the second environment is the one stored in the lockdir capturing the opam solver variables used to generate the solution).