### PR TITLE
Don't solve for windows arm64 by default

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -176,7 +176,6 @@ let popular_platform_envs =
   ; make ~os:"macos" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
   ; make ~os:"macos" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
   ; make ~os:"win32" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
-  ; make ~os:"win32" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
   ]
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -42,7 +42,6 @@ Create a package that writes a different value to some files depending on the os
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1
@@ -66,8 +65,6 @@ Create a package that writes a different value to some files depending on the os
    ((arch arm64)
     (os macos))
    ((arch x86_64)
-    (os win32))
-   ((arch arm64)
     (os win32)))
 
   $ cat ${default_lock_dir}/foo.0.0.1.pkg
@@ -108,13 +105,7 @@ Create a package that writes a different value to some files depending on the os
        (progn
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64) (os win32)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo arm64 > %{share}/machine")))))))
+        (run sh -c "echo x86_64 > %{share}/machine")))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -62,8 +62,6 @@ Solve the project:
     5.4.0+solver-env-version-override
   - arch = x86_64; os = win32; sys-ocaml-version =
     5.4.0+solver-env-version-override
-  - arch = arm64; os = win32; sys-ocaml-version =
-    5.4.0+solver-env-version-override
   
   Dependencies on all supported platforms:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -30,7 +30,6 @@ Demonstrate various cases representing depexts in lockfiles.
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -48,7 +48,6 @@ to solve for macos, linux, and windows by default.
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   See the log or run with --verbose for more details. Configure platforms to
   solve for in the dune-workspace file.
@@ -70,14 +69,6 @@ The log file will contain errors about the package being unavailable.
   #       foo.0.0.1: Availability condition not satisfied
   # Failed to find package solution for platform:
   # - arch = x86_64
-  # - os = win32
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Failed to find package solution for platform:
-  # - arch = arm64
   # - os = win32
   # Couldn't solve the package dependency formula.
   # Selected candidates: x.dev

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -60,7 +60,6 @@ A package that conditionally depends on packages depending on the OS:
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1
@@ -82,7 +81,7 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/
-  foo.0.0.1-2703cce578216454b58a01492e99e039
+  foo.0.0.1-f25d4bdb5ae54b8ba819b6837709d5bc
   linux-only.0.0.1-f1f7456a7bf1c70f9203f8caadf79f6d
 
   $ dune clean
@@ -90,5 +89,5 @@ Build the project as if we were on linux and confirm that only the linux-specifi
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/
-  foo.0.0.1-c5f5594e192bc07c61ccef9d837bd2c0
+  foo.0.0.1-03f41d0caa9112c45e024836d778d225
   macos-only.0.0.1-45b66a146d607b34b06be6c1cafeeb83

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -77,7 +77,6 @@ Solve the project. The solution will contain extra files for both versions of fo
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   Dependencies on all supported platforms:
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -61,7 +61,6 @@ Define a package bar which conditionally depends on different versions of foo:
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
   - arch = x86_64; os = win32
-  - arch = arm64; os = win32
   
   Dependencies on all supported platforms:
   - bar.0.0.1


### PR DESCRIPTION
Windows arm64 is not widely used. Currently generating portable lockdirs requires running the solver for each of a configurable list of platforms. Removing windows arm64 from the default platform list will speed up solving for most users by avoiding generating a solution that few people will be able to use.