### PR TITLE
Deduplicate solver errors when generating portable lockdirs

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -1,0 +1,86 @@
+Demonstrate the case where a project can't be solved at all.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Make some packages that can't be coinstalled:
+  $ mkpkg a <<EOF
+  > depends: [
+  >  "c" {= "0.1"}
+  > ]
+  > EOF
+
+  $ mkpkg b <<EOF
+  > depends: [
+  >  "c" {= "0.2"}
+  > ]
+  > EOF
+
+  $ mkpkg c "0.2"
+
+Depend on a pair of packages which can't be coinstalled:
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name foo)
+  >  (depends a b))
+  > EOF
+
+Solver error when solving fails with the same error on all platforms:
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  - arch = x86_64; os = win32
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: a.0.0.1 b.0.0.1 foo.dev
+  - c -> (problem)
+      a 0.0.1 requires = 0.1
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.1
+  [1]
+
+Modify the "a" package so the solver error is different on different platforms:
+  $ mkpkg a <<EOF
+  > depends: [
+  >  "c" {= "0.1" & os = "linux"}
+  >  "c" {= "0.3" & os != "linux"}
+  > ]
+  > EOF
+
+This time there will be two different solver errors. Both will be printed along
+with the platforms where they are relevant:
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Error:
+  Unable to solve dependencies while generating lock directory: dune.lock
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = linux
+  - arch = arm64; os = linux
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: a.0.0.1 b.0.0.1 foo.dev
+  - c -> (problem)
+      a 0.0.1 requires = 0.1
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.1
+  
+  The dependency solver failed to find a solution for the following platforms:
+  - arch = x86_64; os = macos
+  - arch = arm64; os = macos
+  - arch = x86_64; os = win32
+  ...with this error:
+  Couldn't solve the package dependency formula.
+  Selected candidates: a.0.0.1 b.0.0.1 foo.dev
+  - c -> (problem)
+      a 0.0.1 requires = 0.3
+      Rejected candidates:
+        c.0.2: Incompatible with restriction: = 0.3
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -53,23 +53,12 @@ to solve for macos, linux, and windows by default.
   solve for in the dune-workspace file.
 
 The log file will contain errors about the package being unavailable.
-  $ sed -n -e "/Couldn't solve the package dependency formula./,\$p" _build/log
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Failed to find package solution for platform:
-  # - arch = arm64
-  # - os = linux
-  # Couldn't solve the package dependency formula.
-  # Selected candidates: x.dev
-  # - foo -> (problem)
-  #     No usable implementations:
-  #       foo.0.0.1: Availability condition not satisfied
-  # Failed to find package solution for platform:
-  # - arch = x86_64
-  # - os = win32
+  $ sed -n -e "/The dependency solver failed to find a solution for the following platforms:/,\$p" _build/log
+  # The dependency solver failed to find a solution for the following platforms:
+  # - arch = x86_64; os = linux
+  # - arch = arm64; os = linux
+  # - arch = x86_64; os = win32
+  # ...with this error:
   # Couldn't solve the package dependency formula.
   # Selected candidates: x.dev
   # - foo -> (problem)


### PR DESCRIPTION
When generating portable lockdirs the solver runs multiple times. Dune collects any errors from the solver and prints them to the terminal in the event that no solution was found on any platforms, and logs them printing a warning if no solution was found on some but not all platforms. This can create a situation where the same error is printed multiple times, since many solver errors are platform agnostic.

This change groups solver errors by the contents of their message when generating portable lockdirs. Each solver error is printed a single time, along with the list of platforms on which it occurred.