### PR TITLE
fix: missing virtual implementation in top closure

### DIFF
--- a/doc/changes/fixed/12644.md
+++ b/doc/changes/fixed/12644.md
@@ -1,0 +1,2 @@
+- Fix crash when running `dune build @check` on a library with virtual modules.
+  (#12644, fixes #12636, @Alizter)

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -52,7 +52,7 @@ let top_closed_implementations t modules =
           in
           List.filter_map ~f:(fun m ->
             match Module.kind m with
-            | Virtual -> Some (Module.Obj_map.find_exn obj_map m)
+            | Virtual -> Module.Obj_map.find obj_map m
             | Intf_only -> None
             | _ -> Some m))
   |> Action_builder.memoize "top sorted implementations"

--- a/test/blackbox-tests/test-cases/virtual-libraries/github12636.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github12636.t
@@ -21,6 +21,5 @@ Test for issue https://github.com/ocaml/dune/issues/12636
 First, test that regular build works:
   $ dune build
 
-Now test @check which should work but crashes:
-  $ dune build @check 2>&1 | grep "Internal"
-  Internal error, please report upstream including the contents of _build/log.
+Now test @check which should work without crashing:
+  $ dune build @check

--- a/test/blackbox-tests/test-cases/virtual-libraries/github12636.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github12636.t
@@ -1,0 +1,26 @@
+Test for issue https://github.com/ocaml/dune/issues/12636
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name test)
+  >  (virtual_modules a))
+  > EOF
+
+  $ cat > a.mli <<EOF
+  > val compute : int -> int
+  > EOF
+
+  $ cat > test.ml <<EOF
+  > let run x = A.compute x * 2
+  > EOF
+
+First, test that regular build works:
+  $ dune build
+
+Now test @check which should work but crashes:
+  $ dune build @check 2>&1 | grep "Internal"
+  Internal error, please report upstream including the contents of _build/log.


### PR DESCRIPTION
When a virtual module doesn't have an implementation, it doesn't make sense to include it in the implementation top closure.

Fixes https://github.com/ocaml/dune/issues/12636

- [x] changelog