### PR TITLE
Docs: Move 'dune mental model' to the top of the section

### DIFF
--- a/doc/explanation/index.rst
+++ b/doc/explanation/index.rst
@@ -7,11 +7,11 @@ the rest of the OCaml ecosystem.
 .. toctree::
    :maxdepth: 1
 
+   mental-model
    scopes
    preprocessing
    ocaml-ecosystem
    package-management
    opam-integration
    bootstrap
-   mental-model
    tour/index


### PR DESCRIPTION
Only the first commit from https://github.com/ocaml/dune/pull/12612, as it seems uncontroversial.