### PR TITLE
Switch the tangled git hosting domain over to tangled.org from tangled.sh

### DIFF
--- a/doc/reference/dune-project/source.rst
+++ b/doc/reference/dune-project/source.rst
@@ -28,7 +28,7 @@ source
        - ``(sourcehut user/repo)``
      * - `Codeberg <https://codeberg.org>`_
        - ``(codeberg user/repo)`` *(New in 3.17)*
-     * - `Tangled <https://tangled.sh>`_
+     * - `Tangled <https://tangled.org>`_
        - ``(tangled @user.domain/repo)`` *(New in 3.21)*
 
    Examples:

--- a/src/dune_lang/source_kind.ml
+++ b/src/dune_lang/source_kind.ml
@@ -61,7 +61,7 @@ module Host = struct
     | Gitlab _ -> "gitlab.com"
     | Sourcehut _ -> "sr.ht"
     | Codeberg _ -> "codeberg.org"
-    | Tangled _ -> "tangled.sh"
+    | Tangled _ -> "tangled.org"
   ;;
 
   let base_uri repo =

--- a/test/blackbox-tests/test-cases/project-source/source-stanza.t
+++ b/test/blackbox-tests/test-cases/project-source/source-stanza.t
@@ -68,10 +68,10 @@ Test a generated 'tangled' user repo
 
   $ sed -i -e '4s|.*|(source (tangled @user.domain/repo))|' dune-project
   $ dune build
-  $ cat foo.opam | grep -i tangled.sh
-  homepage: "https://tangled.sh/@user.domain/repo"
-  bug-reports: "https://tangled.sh/@user.domain/repo/issues"
-  dev-repo: "git+https://tangled.sh/@user.domain/repo"
+  $ cat foo.opam | grep -i tangled.org
+  homepage: "https://tangled.org/@user.domain/repo"
+  bug-reports: "https://tangled.org/@user.domain/repo/issues"
+  dev-repo: "git+https://tangled.org/@user.domain/repo"
 
 Test that the creation of a source stanza of the form 'org/project/repo' is
 disallowed by any forge type other than gitlab and that associated error

--- a/test/blackbox-tests/test-cases/project-source/tangled.t
+++ b/test/blackbox-tests/test-cases/project-source/tangled.t
@@ -11,10 +11,10 @@ Test the tangled source type in project files.
   > EOF
 
   $ dune build
-  $ cat foo.opam | grep -i tangled.sh
-  homepage: "https://tangled.sh/@anil.recoil.org/foo"
-  bug-reports: "https://tangled.sh/@anil.recoil.org/foo/issues"
-  dev-repo: "git+https://tangled.sh/@anil.recoil.org/foo"
+  $ cat foo.opam | grep -i tangled.org
+  homepage: "https://tangled.org/@anil.recoil.org/foo"
+  bug-reports: "https://tangled.org/@anil.recoil.org/foo/issues"
+  dev-repo: "git+https://tangled.org/@anil.recoil.org/foo"
 
 The 'tangled' source kind is only supported in Dune lang >=3.21; check that
 Dune errors as expected with earlier Dune lang versions.


### PR DESCRIPTION
Followup to #12197; the old domain still works but the new one is the default and should be used in generated opam files.