### PR TITLE
chore: add dir field to dune-project

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -298,7 +298,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1" re spawn uutf
+        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf
 
       - name: Set Git User
         run: |

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-12-ocaml-4.14
 RUN opam depext -u patdiff.v0.15.0
-RUN opam install re spawn uutf
+RUN opam install csexp pp re spawn uutf
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1024,7 +1024,19 @@ module Libs = struct
   ;;
 
   let local_libraries =
-    [ { path = "vendor/re/src"
+    [ { path = "vendor/csexp/src"
+      ; main_module_name = Some "Csexp"
+      ; include_subdirs = No
+      ; special_builtin_support = None
+      ; root_module = None
+      }
+    ; { path = "vendor/pp/src"
+      ; main_module_name = Some "Pp"
+      ; include_subdirs = No
+      ; special_builtin_support = None
+      ; root_module = None
+      }
+    ; { path = "vendor/re/src"
       ; main_module_name = Some "Re"
       ; include_subdirs = No
       ; special_builtin_support = None
@@ -2017,7 +2029,7 @@ let resolve_externals external_libraries =
     let convert = function
       | "threads" -> Some ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
       | "unix" -> Some ("unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags)
-      | "seq" | "re" | "spawn" | "uutf" -> None
+      | "csexp" | "pp" | "re" | "seq" | "spawn" | "uutf" -> None
       | s -> fatal "unhandled external library %s" s
     in
     List.filter_map ~f:convert external_libraries |> List.split

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,5 +1,5 @@
 open Types
-let external_libraries = [ "unix"; "threads" ]
+let external_libraries = [ "pp"; "unix"; "csexp"; "threads" ]
 
 let local_libraries =
   [ { path = "otherlibs/top-closure"
@@ -14,20 +14,8 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
-  ; { path = "vendor/pp/src"
-    ; main_module_name = Some "Pp"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
   ; { path = "otherlibs/dyn"
     ; main_module_name = Some "Dyn"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
-  ; { path = "vendor/csexp/src"
-    ; main_module_name = Some "Csexp"
     ; include_subdirs = No
     ; special_builtin_support = None
     ; root_module = None

--- a/dune-project
+++ b/dune-project
@@ -58,6 +58,7 @@ for free.
 
 (package
  (name dune-build-info)
+ (dir otherlibs/dune-build-info)
  (synopsis "Embed build information inside executable")
  (depends
   (ocaml (>= 4.08)))
@@ -72,6 +73,7 @@ executable was built.
 
 (package
  (name dune-private-libs)
+ (dir otherlibs/dune-private-libs)
  (synopsis "Private libraries of Dune")
  (depends
   (csexp (>= 1.5.0))
@@ -92,6 +94,7 @@ no stability guarantee.
 
 (package
  (name dune-configurator)
+ (dir otherlibs/configurator)
  (synopsis "Helper library for gathering system configuration")
  (depends
   (ocaml (>= 4.08.0))
@@ -110,6 +113,7 @@ Among other things, dune-configurator allows one to:
 
 (package
  (name dune-action-plugin)
+ (dir otherlibs/dune-action-plugin)
  (synopsis "[experimental] API for writing dynamic Dune actions")
  (depends
   (dune-glob (= :version))
@@ -131,6 +135,7 @@ execution of the action.
 
 (package
  (name dune-glob)
+ (dir otherlibs/dune-glob)
  (synopsis "Glob string matching language supported by dune")
  (depends
   (stdune (= :version))
@@ -143,18 +148,21 @@ understood by dune language."))
 
 (package
  (name dune-site)
+ (dir otherlibs/dune-site)
  (synopsis "Embed locations information inside executable and libraries")
  (depends (dune-private-libs (= :version)))
  (description ""))
 
 (package
  (name dune-rpc)
+ (dir otherlibs/dune-rpc)
  (synopsis "Communicate with dune using rpc")
  (depends ocamlc-loc csexp ordering dyn xdg (stdune (= :version)) (pp (>= 1.1.0)))
  (description "Library to connect and control a running dune instance"))
 
 (package
  (name dune-rpc-lwt)
+ (dir otherlibs/dune-rpc-lwt)
  (synopsis "Communicate with dune using rpc and Lwt")
  (depends
   (dune-rpc (= :version))
@@ -165,6 +173,7 @@ understood by dune language."))
 
 (package
  (name dyn)
+ (dir otherlibs/dyn)
  (synopsis "Dynamic type")
  (depends
   (ocaml (>= 4.08.0))
@@ -175,6 +184,7 @@ understood by dune language."))
 
 (package
  (name ordering)
+ (dir otherlibs/ordering)
  (synopsis "Element ordering")
  (depends
   (ocaml (>= 4.08.0)))
@@ -183,6 +193,7 @@ understood by dune language."))
 
 (package
  (name xdg)
+ (dir otherlibs/xdg)
  (synopsis "XDG Base Directory Specification")
  (depends
   (ocaml (>= 4.08)))
@@ -190,6 +201,7 @@ understood by dune language."))
 
 (package
  (name top-closure)
+ (dir otherlibs/top-closure)
  (synopsis "Topological Closure")
  (depends
   (ocaml (>= 4.08)))
@@ -198,6 +210,7 @@ understood by dune language."))
 
 (package
  (name stdune)
+ (dir otherlibs/stdune)
  (synopsis "Dune's unstable standard library")
  (depends
   (ocaml (>= 4.08.0))
@@ -213,6 +226,7 @@ understood by dune language."))
 
 (package
  (name ocamlc-loc)
+ (dir otherlibs/ocamlc-loc)
  (synopsis "Parse ocaml compiler output into structured form")
  (conflicts
   (ocaml-lsp-server (< 1.15.0)))
@@ -224,6 +238,7 @@ understood by dune language."))
 
 (package
  (name chrome-trace)
+ (dir otherlibs/chrome-trace)
  (synopsis "Chrome trace event generation library")
  (depends
   (ocaml (>= 4.08.0)))
@@ -231,6 +246,7 @@ understood by dune language."))
 
 (package
  (name fs-io)
+ (dir otherlibs/fs-io)
  (synopsis "File System Operations")
  (depends
   base-unix

--- a/flake.nix
+++ b/flake.nix
@@ -249,6 +249,7 @@
                       ocaml-lsp
                       odoc
                       patdiff
+                      pp
                       ppx_expect
                       re
                       spawn
@@ -293,6 +294,8 @@
                 pkgs.dune_3
               ];
               buildInputs = with pkgs.ocamlPackages; [
+                csexp
+                pp
                 re
                 spawn
                 uutf
@@ -338,6 +341,8 @@
                 pkgs.ocaml-ng.ocamlPackages_4_14.dune_3
               ];
               buildInputs = with pkgs; [
+                ocaml-ng.ocamlPackages_4_14.csexp
+                ocaml-ng.ocamlPackages_4_14.pp
                 ocaml-ng.ocamlPackages_4_14.re
                 ocaml-ng.ocamlPackages_4_14.spawn
                 ocaml-ng.ocamlPackages_4_14.uutf
@@ -400,9 +405,17 @@
                   spawn = osuper.spawn.overrideAttrs (old: {
                     doCheck = false;
                   });
+                  csexp = osuper.csexp.overrideAttrs (old: {
+                    doCheck = false;
+                  });
+                  pp = osuper.pp.overrideAttrs (old: {
+                    doCheck = false;
+                  });
                 };
               extraBuildInputs =
                 pkgs: with pkgs.ocamlPackages; [
+                  csexp
+                  pp
                   re
                   spawn
                   uutf

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -118,7 +118,7 @@ let rule sctx ~requires_link ~main =
   in
   let externals =
     let available =
-      [ "threads.posix"; "re"; "spawn"; "seq"; "uutf" ]
+      [ "csexp"; "pp"; "re"; "seq"; "spawn"; "threads.posix"; "uutf" ]
       |> List.rev_map ~f:Lib_name.of_string
     in
     List.filter_map externals ~f:(fun lib ->

--- a/test/blackbox-tests/test-cases/boot/helpers.sh
+++ b/test/blackbox-tests/test-cases/boot/helpers.sh
@@ -9,13 +9,11 @@ cat > dune-project <<EOF
 EOF
 
 # These libraries are hardcoded and expected to exist:
+mkdir -p vendor/csexp/src
+mkdir -p vendor/pp/src
 mkdir -p vendor/re/src
 mkdir -p vendor/spawn/src
 mkdir -p vendor/uutf
-
-touch vendor/re/src/re.ml
-touch vendor/spawn/src/spawn.ml
-touch vendor/uutf/uutf.ml
 
 mkdir bin
 

--- a/test/unit-tests/artifact_substitution/dune
+++ b/test/unit-tests/artifact_substitution/dune
@@ -1,4 +1,3 @@
 (test
  (name artifact_substitution)
- (package dune-private-libs)
  (libraries stdune dune_engine dune_rules fiber re memo))

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -1,10 +1,4 @@
-(executable
+(test
  (name sexp_tests)
  (modules sexp_tests)
  (libraries stdune dune_lang))
-
-(rule
- (alias runtest)
- (package dune-private-libs)
- (action
-  (run ./sexp_tests.exe)))

--- a/test/unit-tests/ocaml-config/dune
+++ b/test/unit-tests/ocaml-config/dune
@@ -1,5 +1,4 @@
 (test
  (name gh637)
- (package dune-private-libs)
  (libraries stdune ocaml_config)
  (deps Makefile.config))

--- a/vendor/csexp/src/dune
+++ b/vendor/csexp/src/dune
@@ -1,5 +1,0 @@
-(library
- (name csexp)
- ;; note that this library is deleted in release mode so that the one from opam
- ;; is used
- (public_name stdune.csexp))

--- a/vendor/pp/src/dune
+++ b/vendor/pp/src/dune
@@ -1,3 +1,0 @@
-(library
- (name pp)
- (public_name dyn.pp))

--- a/vendor/update-csexp.sh
+++ b/vendor/update-csexp.sh
@@ -22,5 +22,4 @@ SRC=$TMP/csexp
 cp -v $SRC/src/csexp.{ml,mli} csexp/src
 cp -v $SRC/LICENSE.md csexp/
 
-git checkout csexp/src/dune
 git add -A .

--- a/vendor/update-pp.sh
+++ b/vendor/update-pp.sh
@@ -22,6 +22,5 @@ SRC=$TMP/pp
 cp -v $SRC/src/pp.{ml,mli} pp/src
 cp -v $SRC/LICENSE.md pp/
 
-git checkout pp/src/dune
 git checkout pp/LICENSE.md
 git add -A .


### PR DESCRIPTION
We add `dir` fields to most packages in `dune-project`. For this to work, we stop building the vendored version of `pp` and `csexp` in the main build and leave it only for the bootstrap as we have done for other vendored packages.

This should lessen the impact of the various race conditions we keep getting in the opam CI.