### PR TITLE
Rename lockdirs to discourage checking them into version control

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -246,7 +246,7 @@ module Options_implied_by_dash_p = struct
         & opt_all ~vopt:true bool [ false ]
         & info [ "require-dune-project-file" ] ~docs ~doc)
     and+ ignore_lock_dir =
-      let doc = "Ignore dune.lock/ directory." in
+      let doc = "Ignore .dune-solution-cache/ directory." in
       Arg.(value & flag & info [ "ignore-lock-dir" ] ~docs ~doc)
     in
     { root

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -93,7 +93,7 @@ let info =
     ; `P "For example:"
     ; `Pre "    \\$ dune pkg outdated"
     ; `Noblank
-    ; `Pre "    1/2 packages in dune.lock are outdated."
+    ; `Pre "    1/2 packages in .dune-solution-cache are outdated."
     ; `Noblank
     ; `Pre "    - ocaml 4.14.1 < 5.1.0"
     ; `Noblank

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -181,7 +181,8 @@ module Lock_dirs_arg = struct
                []
                ~docv:"LOCKDIRS"
                ~doc:
-                 "Lock directories to check for outdated packages. Defaults to dune.lock.")
+                 "Lock directories to check for outdated packages. Defaults to \
+                  .dune-solution-cache.")
        in
        Selected (List.map arg ~f:Path.Source.of_string))
       (let+ _all =

--- a/doc/explanation/package-management.md
+++ b/doc/explanation/package-management.md
@@ -101,7 +101,7 @@ archives to download (since there is no central location for all archives), the
 build instructions (since each package can use its own way of building), and
 additional metadata like the system packages it depends upon.
 
-The information is stored in a directory (`dune.lock` by default) as separate
+The information is stored in a directory (`.dune-solution-cache` by default) as separate
 files, to reduce potential merge conflicts and simplify code review. Storing
 additional files like patches is also simpler this way.
 

--- a/doc/reference/dune-workspace/context.rst
+++ b/doc/reference/dune-workspace/context.rst
@@ -17,7 +17,7 @@ the description of an opam switch, as follows:
 
 -  ``(lock_dir <path>)`` specifies the lock directory that will be used for
    building this context (if any). If no lock directory is specified
-   ``dune.lock`` will be used. See the
+   ``.dune-solution-cache`` will be used. See the
    :doc:`/reference/dune-workspace/lock_dir` stanza for lock directory
    configuration options.
 

--- a/doc/reference/dune-workspace/lock_dir.rst
+++ b/doc/reference/dune-workspace/lock_dir.rst
@@ -19,7 +19,7 @@ changed if desired.
    .. describe:: (path <string>)
 
       The location in the source tree where the lock directory will be
-      created or read from. If not specified defaults to ``dune.lock``.
+      created or read from. If not specified defaults to ``.dune-solution-cache``.
 
    .. describe:: (repositories <name list>)
 

--- a/doc/tutorials/dune-package-management/dependencies.md
+++ b/doc/tutorials/dune-package-management/dependencies.md
@@ -26,7 +26,7 @@ to update our lock directory with the new packages.
 
 ```
 $ dune pkg lock
-Solution for dune.lock:
+Solution for .dune-solution-cache:
 - base-unix.base
 - fmt.0.9.0
 - ocaml.5.2.0
@@ -112,7 +112,7 @@ package is locked:
 
 ```
 $ dune pkg lock
-Solution for dune.lock:
+Solution for .dune-solution-cache:
 - base-unix.base
 - fmt.0.9.0
 - ocaml.5.2.0

--- a/doc/tutorials/dune-package-management/pinning.md
+++ b/doc/tutorials/dune-package-management/pinning.md
@@ -31,7 +31,7 @@ the information from the selected package repositories.
 
 ```
 $ dune pkg lock
-Solution for dune.lock:
+Solution for .dune-solution-cache:
 - base-unix.base
 - fmt.dev
 - ocaml.5.0.0

--- a/doc/tutorials/dune-package-management/repos.md
+++ b/doc/tutorials/dune-package-management/repos.md
@@ -35,7 +35,7 @@ dependencies changes accordingly:
 
 ```
 $ dune pkg lock
-Solution for dune.lock:
+Solution for .dune-solution-cache:
 - base-unix.base
 - fmt.0.9.0
 - ocaml.5.0.0

--- a/doc/tutorials/dune-package-management/setup.md
+++ b/doc/tutorials/dune-package-management/setup.md
@@ -63,7 +63,7 @@ This is easily done with a new Dune command:
 
 ```
 $ dune pkg lock
-Solution for dune.lock:
+Solution for .dune-solution-cache:
 - ocaml.5.2.0
 - ocaml-base-compiler.5.2.0
 - ocaml-config.3

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -19,7 +19,7 @@ val debug_artifact_substitution : bool ref
 (** Print package output when building with package management *)
 val debug_package_logs : bool ref
 
-(** Whether we are ignoring "dune.lock/". *)
+(** Whether we are ignoring ".dune-solution-cache/". *)
 val ignore_lock_dir : bool ref
 
 val concurrency : int ref

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -131,7 +131,7 @@ let select_lock_dir lock_dir_selection =
   Workspace.Lock_dir_selection.eval lock_dir_selection ~dir:workspace.dir ~f:expander
 ;;
 
-let default_dir = "dune.lock"
+let default_dir = ".dune-solution-cache"
 
 (* location where project lock dirs are stored *)
 let path_prefix =
@@ -148,7 +148,7 @@ let dev_tool_to_path_segment dev_tool =
 ;;
 
 let dev_tool_source_lock_dir dev_tool =
-  let dev_tools_path = Path.Source.(relative root "dev-tools.locks") in
+  let dev_tools_path = Path.Source.(relative root ".dune-tools-solution-cache") in
   let dev_tool_segment = dev_tool_to_path_segment dev_tool in
   Path.Source.append_local dev_tools_path dev_tool_segment
 ;;

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1534,7 +1534,7 @@ end = struct
               [ "dir", Path.External.to_dyn e ]
           | In_source_tree s ->
             (match Path.Source.explode s with
-             | [ "dev-tools.locks"; dev_tool; files_dir ] ->
+             | [ ".dune-tools-solution-cache"; dev_tool; files_dir ] ->
                Path.Build.L.relative
                  Private_context.t.build_dir
                  [ "default"; ".dev-tool-locks"; dev_tool; files_dir ]

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -131,7 +131,7 @@ module Lock_dir = struct
     let decode =
       let+ loc = loc
       and+ path =
-        let+ path = field ~default:"dune.lock" "path" string in
+        let+ path = field ~default:".dune-solution-cache" "path" string in
         Path.Source.relative dir path
       and+ solver_env = field_o "solver_env" Solver_env.decode
       and+ unset_solver_vars =

--- a/test/blackbox-tests/test-cases/describe/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe/describe_location.t
@@ -26,7 +26,7 @@ An executable from the current project:
 
 Test that executables from dependencies are located correctly:
 
-  $ source_lock_dir="dune.lock"
+  $ source_lock_dir=".dune-solution-cache"
   $ mkdir -p "${source_lock_dir}"
   $ cat > "${source_lock_dir}"/lock.dune <<EOF
   > (lang package 0.1)

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
@@ -35,7 +35,7 @@ A package that depends on ocaml:
 Try solving without additional constraints:
   $ add_mock_repo_if_needed
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml.0.0.1
   - ocaml-base-compiler.0.0.1
 
@@ -52,6 +52,6 @@ Now make a workspace file adding the constarint on ocaml-system:
 
 Solve again. This time ocaml-system is chosen.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml.0.0.1
   - ocaml-system.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints.t
@@ -27,7 +27,7 @@ Notice that the constraints field doesn't introduce additional packages. The
   >  (name x)
   >  (depends foo bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.1.0.0
 
@@ -52,7 +52,7 @@ There are no valid version of foo at the moment:
   >  (depends foo bar))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: bar.1.9.1 x.dev
   - foo -> (problem)
@@ -70,6 +70,6 @@ If we add one:
   >  (name x)
   >  (depends foo bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.9.1
   - foo.0.9.0

--- a/test/blackbox-tests/test-cases/pkg/build-package-logs.t
+++ b/test/blackbox-tests/test-cases/pkg/build-package-logs.t
@@ -22,7 +22,7 @@ Create a package with a failing command that throws an error:
 Building the package should fail and print an error:
 
   $ build_pkg x 2>&1 | sed -E 's#/.*/cat#cat#g'
-  File "dune.lock/x.pkg", line 4, characters 11-14:
+  File ".dune-solution-cache/x.pkg", line 4, characters 11-14:
   4 |       (run cat i_dont_exist)))
                  ^^^
   Error: Logs for package x

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -13,7 +13,7 @@ Start with a project with a single package with no dependencies:
   > (package
   >  (name foo))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
@@ -31,13 +31,13 @@ Add a dependency to the project:
   >  (depends a))
   > EOF
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
   Error: This project has at least one non-local dependency but the lockdir
   doesn't contain a dependency hash.
   An example of a non-local dependency of this project is: a
   Hint: Regenerate the lockdir by running 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Add a non-local dependency to the package:
@@ -47,7 +47,7 @@ Add a non-local dependency to the package:
   >  (name foo)
   >  (depends a))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
@@ -67,8 +67,8 @@ Add a second dependency to the project:
   >  (depends a b))
   > EOF
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
-  File "dune.lock/lock.dune", line 3, characters 17-49:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
+  File ".dune-solution-cache/lock.dune", line 3, characters 17-49:
   Error: Dependency hash in lockdir does not match the hash of non-local
   dependencies of this project. The lockdir expects the the non-local
   dependencies to hash to:
@@ -77,7 +77,7 @@ Add a second dependency to the project:
   d18946fdd9833ae312d309f654f11c1b
   Hint: Regenerate the lockdir by running 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Remove all dependencies from the project:
@@ -87,13 +87,13 @@ Remove all dependencies from the project:
   >  (name foo))
   > EOF
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
-  File "dune.lock/lock.dune", line 3, characters 17-49:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
+  File ".dune-solution-cache/lock.dune", line 3, characters 17-49:
   Error: This project has no non-local dependencies yet the lockfile contains a
   dependency hash: 7ba1cacd46bb2609d7b9735909c3b8a5
   Hint: Regenerate the lockdir by running 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Exercise handling invalid dependency hashes.
@@ -110,32 +110,32 @@ Exercise handling invalid dependency hashes.
 Case where the label ("md5") is missing:
   $ make_lock_metadata_with_hash badhash
   $ dune pkg validate-lockdir
-  Failed to parse lockdir dune.lock:
-  File "dune.lock/lock.dune", line 2, characters 17-24:
+  Failed to parse lockdir .dune-solution-cache:
+  File ".dune-solution-cache/lock.dune", line 2, characters 17-24:
   Error: Dependency hash is not a valid md5 hash: badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Case where the label is not "md5":
   $ make_lock_metadata_with_hash foo=badhash
   $ dune pkg validate-lockdir
-  Failed to parse lockdir dune.lock:
-  File "dune.lock/lock.dune", line 2, characters 17-28:
+  Failed to parse lockdir .dune-solution-cache:
+  File ".dune-solution-cache/lock.dune", line 2, characters 17-28:
   Error: Dependency hash is not a valid md5 hash: foo=badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Case where the the hash is not a valid md5 hash:
   $ make_lock_metadata_with_hash md5=badhash
   $ dune pkg validate-lockdir
-  Failed to parse lockdir dune.lock:
-  File "dune.lock/lock.dune", line 2, characters 17-28:
+  Failed to parse lockdir .dune-solution-cache:
+  File ".dune-solution-cache/lock.dune", line 2, characters 17-28:
   Error: Dependency hash is not a valid md5 hash: md5=badhash
   
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]

--- a/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
+++ b/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
@@ -15,7 +15,7 @@ Make sure that we verify archives of local archives
   > EOF
 
   $ build_pkg foo
-  File "dune.lock/foo.pkg", line 4, characters 12-48:
+  File ".dune-solution-cache/foo.pkg", line 4, characters 12-48:
   4 |   (checksum md5=069aa55d40e548280f92af693f6c625a)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Invalid checksum, got

--- a/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
@@ -23,6 +23,6 @@ documentation-only deps are omitted from the solution.
 Dune will also not include dependencies marked `post` in the lock directory.
 
   $ solve "(test :with-test) (doc :with-doc) (dev-setup :with-dev-setup) (dev :with-dev) (build :build) (post :post)"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - build.0.0.1
   - test.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
@@ -7,7 +7,7 @@ Exercise dune resolving the post dependencies found in compiler packages.
   > (lang dune 3.20)
   > (pkg enabled)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock)
   >  (solver_env
   >   (os linux)))
@@ -44,7 +44,7 @@ lists to prevent circular dependencies at package build time.
   > EOF
 
   $ solve ocaml-base-compiler 
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml-base-compiler.0.0.1
 
 Ensure that packages can be resolved at build time. This checks that

--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -21,7 +21,7 @@ A file that will comprise the package source:
   Package "foo" has source archive which lacks a checksum.
   The source archive will be downloaded from: http://0.0.0.0:1
   Dune will compute its own checksum for this source archive.
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 Replace the path in the lockfile as it would otherwise include the sandbox
@@ -52,7 +52,7 @@ Recreate the foo package with a fake port number to signal that the file will
   The source archive will be downloaded from: http://0.0.0.0:9000
   Dune will compute its own checksum for this source archive.
   Warning: Download failed with code 404
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)
@@ -71,7 +71,7 @@ Check that no checksum is computed for a local source file:
   > }
   > EOF
   $ solve foo 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 Check that no checksum is computed for a local source directory:
@@ -83,7 +83,7 @@ Check that no checksum is computed for a local source directory:
   > }
   > EOF
   $ solve foo 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 
@@ -124,7 +124,7 @@ asserted by the fact that the webserver will only serve the file a single time.
   Package "foo" has source archive which lacks a checksum.
   The source archive will be downloaded from: http://0.0.0.0:2
   Dune will compute its own checksum for this source archive.
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - baz.0.0.1
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/conflict-class.t
+++ b/test/blackbox-tests/test-cases/pkg/conflict-class.t
@@ -31,7 +31,7 @@ Local conflict class defined in a local package:
 
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev x.dev foo&x
   - bar -> (problem)
@@ -50,7 +50,7 @@ Now the conflict class comes from the opam repository
 
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.0.0.1 x.dev
   - bar -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -18,7 +18,7 @@ The solver should say no solution rather than just ignoring the conflict.
   >  (depends bar))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: bar.0.0.1 x.dev
   - foo -> (problem)
@@ -43,7 +43,7 @@ There could be more than one conflict and they can have version constraints:
   >  (depends bar bar2))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: bar.0.0.1 bar2.0.0.1 x.dev
   - foo -> (problem)
@@ -70,7 +70,7 @@ disjunction, either package is problematic:
   $ mkpkg dune 3.11
   $ echo '(lang dune 3.11)' | solve_project 2>&1 | sed -E 's/3.[0-9]+/3.XX/'
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: bar.0.0.1 bar2.0.0.1 x.dev
   - dune -> dune.3.XX
@@ -87,7 +87,7 @@ Adding a new version of `foo` only resolves one conflict:
   $ mkpkg foo 0.2
   $ echo '(lang dune 3.11)' | solve_project 2>&1 | sed -E 's/3.[0-9]+/3.XX/'
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: bar.0.0.1 bar2.0.0.1 foo.0.2 x.dev
   - dune -> dune.3.XX
@@ -102,7 +102,7 @@ Addition of `foo2` to solve the last remaining conflict:
   $ solve_project <<EOF
   > (lang dune 3.11)
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - bar2.0.0.1
   - foo.0.2
@@ -120,7 +120,7 @@ due to the version constraints conflicts:
   >  (conflicts (foo (>= 0.2)) (foo2 (>= 0.2)))
   >  (depends bar bar2))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - bar2.0.0.1
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
+++ b/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
@@ -13,7 +13,7 @@ constraints.
   > EOF
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - foo.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -86,7 +86,7 @@ Package which has boolean where string was expected. This should be caught while
   > EOF
 
   $ solve standard-dune with-interpolation with-percent-sign variable-types
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - standard-dune.0.0.1
   - variable-types.0.0.1
   - with-interpolation.0.0.1
@@ -141,7 +141,7 @@ Package which has boolean where string was expected. This should be caught while
   [1]
 
   $ solve exercise-filters
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - exercise-filters.0.0.1
 
   $ cat ${default_lock_dir}/exercise-filters.pkg
@@ -191,7 +191,7 @@ Package which has boolean where string was expected. This should be caught while
 
 Test that if opam filter translation is disabled the output doesn't contain any translated filters:
   $ solve exercise-filters
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - exercise-filters.0.0.1
   $ cat ${default_lock_dir}/exercise-filters.pkg
   (version 0.0.1)
@@ -239,7 +239,7 @@ Test that if opam filter translation is disabled the output doesn't contain any 
      (run echo m))))
 
   $ solve exercise-term-filters
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - exercise-term-filters.0.0.1
   $ cat ${default_lock_dir}/exercise-term-filters.pkg
   (version 0.0.1)
@@ -286,7 +286,7 @@ Package with package conjunction and string selections inside variable interpola
   > (lang dune 3.8)
   > (package (name x) (depends package-conjunction-and-string-selection))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - package-conjunction-and-string-selection.0.0.1
 Note that "enable" is not a true opam variable. Opam desugars occurrences of
 "pkg:enable" into "pkg:enable?enable:disable" but if the explicit package scope

--- a/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
+++ b/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
@@ -16,7 +16,7 @@ Test the error message when curl is needed but not installed.
 
 Build the package in an environment without curl.
   $ PATH=$(dirname $(which dune)) build_pkg foo
-  File "dune.lock/foo.pkg", line 3, characters 7-28:
+  File ".dune-solution-cache/foo.pkg", line 3, characters 7-28:
   3 |   (url "http://0.0.0.0:8000")))
              ^^^^^^^^^^^^^^^^^^^^^
   Error: The program 'curl' does not appear to be installed. Dune uses 'curl'

--- a/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
@@ -45,7 +45,7 @@ With this project set up, lets depend on it.
   >  (name foo)
   >  (depends nondune))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - nondune.dev
   $ cat > dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -24,7 +24,7 @@ Make a project that uses the foo library:
   >  (libraries foo))
   > EOF
 
-Make dune.lock files with known program "dune".
+Make .dune-solution-cache files with known program "dune".
   $ make_lockdir
   $ make_lockpkg foo <<EOF
   > (version 0.0.1)
@@ -40,7 +40,7 @@ Make dune.lock files with known program "dune".
 Build the project, when it fails building 'foo' package, it shows the depexts
 error message.
   $ dune build
-  File "dune.lock/foo.pkg", line 3, characters 6-10:
+  File ".dune-solution-cache/foo.pkg", line 3, characters 6-10:
   3 |  (run dune build))
             ^^^^
   Error: Logs for package foo
@@ -52,7 +52,7 @@ error message.
   - unzip
   [1]
 
-Make dune.lock files with unknown program and unknown package.
+Make .dune-solution-cache files with unknown program and unknown package.
   $ make_lockdir
   $ make_lockpkg foo <<EOF
   > (version 0.0.1)
@@ -68,7 +68,7 @@ Make dune.lock files with unknown program and unknown package.
 Running the same build. It is supposed to show the depexts message at the end,
 when the program is not found.
   $ dune build
-  File "dune.lock/foo.pkg", line 3, characters 6-21:
+  File ".dune-solution-cache/foo.pkg", line 3, characters 6-21:
   3 |  (run unknown-program))
             ^^^^^^^^^^^^^^^
   Error: Program unknown-program not found in the tree or in PATH

--- a/test/blackbox-tests/test-cases/pkg/depexts/solve.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/solve.t
@@ -19,7 +19,7 @@ Make a project that uses the foo library:
 
 locking would add the opam 'depext' field to foo.pkg
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
@@ -19,7 +19,7 @@ Make a project that uses the foo library:
 
 Locking should succeed and not include the "unzip" package
   $ dune pkg lock 2>&1 | head -n 1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
 
   $ cat ${default_lock_dir}/foo.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
@@ -16,7 +16,7 @@ Make a package which has a regular dependency and an optional dependency.
 The optional dependency on "b" is not included in foo's dependencies because
 "b" is not part of the package solution:
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - foo.0.0.1
   $ cat ${default_lock_dir}/foo.pkg
@@ -32,7 +32,7 @@ Another package which has a regular dependency on "b":
 Solve again, this time depending on both "foo" and "bar". Now "b" is among
 the dependencies of "foo", since "b" is part of the package solution:
   $ solve foo bar
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-optional.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-optional.t
@@ -17,5 +17,5 @@ the solver.
   >  (depopts bar)
   >  (conflicts bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
@@ -16,7 +16,7 @@ prefer if any:
 We don't currently support depopts so they are both omitted.
 
   $ solve bar baz
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - baz.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-constraints.t
@@ -25,7 +25,7 @@ Here the solver could pick "bar" and "foo", and perphaps pick "optional",
 however this is not required.
 
   $ solve bar
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.1
 
@@ -34,6 +34,6 @@ excluded from the build plan if the latest version of "foo" is picked.
 
   $ mkpkg foo 2
   $ solve bar
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.2

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts.t
@@ -12,5 +12,5 @@ Selecting depopts
   >  (depends foo)
   >  (depopts bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
@@ -21,23 +21,23 @@ Handling of more than one depopt:
   $ runtest <<'EOF'
   > depopts: [ "a" "b" "c" ]
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
 
   $ runtest <<'EOF'
   > depopts: [ "a" "b" "c" "d" ]
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
 
   $ runtest <<'EOF'
   > depopts: [ ("a" | "b") "c" "d" ]
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
 
   $ runtest <<'EOF'
   > depopts: [ (("e" | "a") | ("d" | "f")) "b" "c" ]
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11698.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11698.t
@@ -27,5 +27,5 @@ Reproduce the bug in #11698
   >  (name x)
   >  (depends dep))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - dep.1.0.0

--- a/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
@@ -1,4 +1,4 @@
-We test how opam files with depopts fields are translated into dune.lock files:
+We test how opam files with depopts fields are translated into .dune-solution-cache files:
 
   $ . ../helpers.sh
   $ mkrepo
@@ -10,7 +10,7 @@ Make a package with a depopts field
   $ mkpkg foo
 
   $ solve with-depopts
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-depopts.0.0.1
 
 When depopts are supported and selected, the above lock should change and we
@@ -31,7 +31,7 @@ Depopts should not be selected if they conflict with other constraints:
   > EOF
 
   $ solve no-foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - no-foo.0.0.1
   - with-depopts.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
@@ -14,7 +14,7 @@ Demonstrate how depopts can be forced in the workspace
   >  (name x)
   >  (depopts foo bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
 
 Select just foo
@@ -30,7 +30,7 @@ Select just foo
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 Select both foo and bar
@@ -46,7 +46,7 @@ Select both foo and bar
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
 
@@ -63,7 +63,7 @@ Select a package that is not listed as depopt
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
 
 
@@ -81,7 +81,7 @@ Select garbage
 
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: z
   [1]

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -38,7 +38,7 @@ Here is the output of solving for multiple contexts:
   >  (name x)
   >  (depends A B C))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - A.1.2.0
   - B.2.1+rc1
   - C.81.0.4044.138
@@ -52,7 +52,7 @@ Here is the output of solving for multiple contexts:
   - E.3.0~alpha1
 Here is the output of dune describe pkg lock:
   $ dune describe pkg lock
-  Contents of dune.lock:
+  Contents of .dune-solution-cache:
   - A.1.2.0
   - B.2.1+rc1
   - C.81.0.4044.138
@@ -60,8 +60,8 @@ Here is the output of dune describe pkg lock:
   - E.3.0~alpha1
 
 The names of the lockfiles can also be provided:
-  $ dune describe pkg lock dune.lock foo.lock 
-  Contents of dune.lock:
+  $ dune describe pkg lock .dune-solution-cache foo.lock 
+  Contents of .dune-solution-cache:
   - A.1.2.0
   - B.2.1+rc1
   - C.81.0.4044.138

--- a/test/blackbox-tests/test-cases/pkg/duplicate-lock-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/duplicate-lock-dirs.t
@@ -16,19 +16,19 @@ We configure the same lock directory twice:
   [1]
 
 Another way to define a duplicate is by omitting the path. Since it defaults to
-dune.lock:
+.dune-solution-cache:
 
   $ cat > dune-workspace <<EOF
   > (lang dune 3.11)
   > (lock_dir)
-  > (lock_dir (path dune.lock))
+  > (lock_dir (path .dune-solution-cache))
   > EOF
 
   $ dune build
   File "dune-workspace", line 3, characters 0-27:
-  3 | (lock_dir (path dune.lock))
+  3 | (lock_dir (path .dune-solution-cache))
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Lock directory "dune.lock" is defined multiple times:
+  Error: Lock directory ".dune-solution-cache" is defined multiple times:
   - dune-workspace:2
   - dune-workspace:3
   [1]

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -73,7 +73,7 @@ Make a project that uses the library:
 Lock, build, and run the executable in the project:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ dune exec bar
   Hello, World!

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -39,7 +39,7 @@ Create a workspace config that defines separate build contexts for macos and lin
   >  (solver_env
   >   (os macos)))
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock))
   > (context
   >  (default
@@ -58,7 +58,7 @@ Now the os-specific dependencies are included on their respective systems.
   $ dune pkg lock --all
   Solution for dune.linux.lock:
   (no dependencies to lock)
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
   Solution for dune.macos.lock:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
@@ -12,7 +12,7 @@ A lock directory which does not exist in the source tree:
 
   $ cat >dune-workspace <<EOF
   > (lang dune 3.13)
-  > (lock_dir (path $PWD/dune.lock))
+  > (lock_dir (path $PWD/.dune-solution-cache))
   > EOF
 
   $ build_pkg foo 2>&1 | awk '/Internal error/,/Raised/'
@@ -21,6 +21,6 @@ A lock directory which does not exist in the source tree:
     ("Local.relative: received absolute path",
      { t = "."
      ; path =
-         "$TESTCASE_ROOT/dune.lock"
+         "$TESTCASE_ROOT/.dune-solution-cache"
      })
   Raised at Stdune__Code_error.raise in file

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -111,7 +111,7 @@ url and the extra source.
 
   $ add_mock_repo_if_needed
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - needs-patch.0.0.1
 
   $ sed -E 's/md5=[0-9a-f]+/md5=$HASH/g' ${default_lock_dir}/needs-patch.pkg
@@ -169,7 +169,7 @@ application order of them mattering:
 Lock the project to use that new package
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - needs-patch.0.0.2
 
 Running the binary should work and output the double patched message:

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -45,7 +45,7 @@ cache, it will fail, as the source is 404 now:
   $ dune clean
   $ export DUNE_CACHE=disabled
   $ build_pkg test
-  File "dune.lock/test.pkg", line 4, characters 7-25:
+  File ".dune-solution-cache/test.pkg", line 4, characters 7-25:
   4 |   (url http://localhost:1)
              ^^^^^^^^^^^^^^^^^^
   Error: Download failed with code 404

--- a/test/blackbox-tests/test-cases/pkg/fetch-local-source.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-local-source.t
@@ -17,7 +17,7 @@ Build a package that uses the archive as its source:
   > EOF
   $ add_mock_repo_if_needed
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ build_pkg foo
   $ cat _build/_private/default/.pkg/$($dune pkg print-digest foo)/source/*
@@ -34,7 +34,7 @@ Build a package that uses the src directory as its source:
   > EOF
   $ add_mock_repo_if_needed
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ build_pkg foo
   $ cat _build/_private/default/.pkg/$($dune pkg print-digest foo)/source/*

--- a/test/blackbox-tests/test-cases/pkg/gh11265.t
+++ b/test/blackbox-tests/test-cases/pkg/gh11265.t
@@ -14,7 +14,7 @@ A package which depends on a single package and also conflicts with the same pac
   >  (conflicts bar))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev
   - bar -> (problem)
@@ -32,7 +32,7 @@ Now add an additional conflict on a non-existant package "baz". Dune should cont
   >  (conflicts bar baz))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev
   - bar -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -30,7 +30,7 @@ Locking should produce the newest package from the repo
 
   $ mkdir dune-cache
   $ XDG_CACHE_HOME=$PWD/dune-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0
 
 Now let's assume a new version of foo is released.
@@ -46,7 +46,7 @@ Locking should update the git repo in our cache folder and give us the newer
 version in the lock file
 
   $ XDG_CACHE_HOME=$PWD/dune-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.1
 
 If the package selected has some additional files that are supposed to be
@@ -74,15 +74,15 @@ should also be included.
 Locking should be successful and it should include the additional file
 
   $ XDG_CACHE_HOME=$PWD/dune-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.2
 
   $ find ${default_lock_dir} | sort
-  dune.lock
-  dune.lock/foo.files
-  dune.lock/foo.files/hello.txt
-  dune.lock/foo.pkg
-  dune.lock/lock.dune
+  .dune-solution-cache
+  .dune-solution-cache/foo.files
+  .dune-solution-cache/foo.files/hello.txt
+  .dune-solution-cache/foo.pkg
+  .dune-solution-cache/lock.dune
 
 The extra-file should have the same content as the original file, we determine
 that by hashing with the checksum that we expected in the OPAM file

--- a/test/blackbox-tests/test-cases/pkg/hash-algos.t
+++ b/test/blackbox-tests/test-cases/pkg/hash-algos.t
@@ -54,7 +54,7 @@ first checksum to the lockfile for this package.
   > EOF
 
   $ solve with-md5 with-sha256 with-sha512 with-all
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-all.0.0.1
   - with-md5.0.0.1
   - with-sha256.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -13,7 +13,7 @@ dune="dune"
 
 pkg_root="_build/_private/default/.pkg"
 
-default_lock_dir="dune.lock"
+default_lock_dir=".dune-solution-cache"
 source_lock_dir="${default_lock_dir}"
 
 # Prints the directory containing the package target and source dirs within the

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -1,4 +1,4 @@
-Test that shows what happens when dune.lock is ignored.
+Test that shows what happens when .dune-solution-cache is ignored.
 
   $ . ./helpers.sh
 
@@ -31,12 +31,12 @@ Test that shows what happens when dune.lock is ignored.
   > (lang dune 3.16)
   > EOF
 
-Building test works when the dune.lock is visible to dune.
+Building test works when the .dune-solution-cache is visible to dune.
 
   $ build_pkg test
 
 Now the project is changed to only include src (which effectively ignores
-dune.lock):
+.dune-solution-cache):
 
   $ cat > dune <<EOF
   > (dirs src)

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -15,7 +15,7 @@ dependency.
 
   $ test "2.0.0" 2>&1 | sed -E 's/3.[0-9]+/3.XX/g'
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.0.0.1 x.dev
   - dune -> (problem)
@@ -24,11 +24,11 @@ dependency.
       Rejected candidates:
         dune.3.XX: Incompatible with restriction: <= 2.0.0
   $ test "4.0.0"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ test "4.0.0" 2>&1 | sed -E 's/3.[0-9]+/3.XX/g'
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 Create a fake project and ensure `dune` can be used as a dependency:
@@ -40,5 +40,5 @@ Create a fake project and ensure `dune` can be used as a dependency:
   >  (depends dune))
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -2,7 +2,7 @@ Add some build contexts with different environments
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (unset_solver_vars arch os-distribution os os-family os-version sys-ocaml-version))
   > (lock_dir
   >  (path dune.linux.lock)
@@ -60,7 +60,7 @@ Add some build contexts with different environments
   - sys-ocaml-version = 5.0
   - with-dev-setup = false
   - with-doc = false
-  Solver environment for lock directory dune.lock:
+  Solver environment for lock directory .dune-solution-cache:
   - opam-version = 2.2.0~alpha-vendored
   - post = true
   - with-dev-setup = false

--- a/test/blackbox-tests/test-cases/pkg/local-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/local-dune.t
@@ -21,6 +21,6 @@ Dune is defined in the workspace where we're solving
   >  (name foo)
   >  (depends bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - test-dep.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -8,16 +8,16 @@ Create a lock directory that didn't originally exist
   > (lock_dir
   >  (repositories mock))
   > (lock_dir
-  >  (path "dev/dune.lock")
+  >  (path "dev/.dune-solution-cache")
   >  (repositories mock))
   > EOF
   $ add_mock_repo_if_needed
 
-  $ dune pkg lock "dev/dune.lock"
-  Solution for dev/dune.lock:
+  $ dune pkg lock "dev/.dune-solution-cache"
+  Solution for dev/.dune-solution-cache:
   (no dependencies to lock)
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
@@ -28,7 +28,7 @@ Create a lock directory that didn't originally exist
 
 Re-create a lock directory in the newly created lock dir
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)
@@ -42,7 +42,7 @@ Attempt to create a lock directory inside an existing directory without a lock.d
   $ rm -rf ${default_lock_dir}
   $ cp -r dir-without-metadata ${default_lock_dir}
   $ dune pkg lock
-  Error: Refusing to regenerate lock directory dune.lock
+  Error: Refusing to regenerate lock directory .dune-solution-cache
   Specified lock dir lacks metadata file (lock.dune)
   [1]
 
@@ -51,9 +51,9 @@ Attempt to create a lock directory inside an existing directory with an invalid 
   $ rm -rf ${default_lock_dir}
   $ cp -r dir-with-invalid-metadata ${default_lock_dir}
   $ dune pkg lock
-  Error: Refusing to regenerate lock directory dune.lock
-  Unable to parse lock directory metadata file (dune.lock/lock.dune):
-  File "dune.lock/lock.dune", line 1, characters 0-12:
+  Error: Refusing to regenerate lock directory .dune-solution-cache
+  Unable to parse lock directory metadata file (.dune-solution-cache/lock.dune):
+  File ".dune-solution-cache/lock.dune", line 1, characters 0-12:
   Error: Invalid first line, expected: (lang <lang> <version>)
   
   [1]
@@ -63,6 +63,6 @@ Attempt to create a lock directory with the same name as an existing regular fil
   $ rm -rf ${default_lock_dir}
   $ touch ${default_lock_dir}
   $ dune pkg lock
-  Error: Refusing to regenerate lock directory dune.lock
-  Specified lock dir path (dune.lock) is not a directory
+  Error: Refusing to regenerate lock directory .dune-solution-cache
+  Specified lock dir path (.dune-solution-cache) is not a directory
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -131,11 +131,11 @@ Test that cond statements can have a default value:
   >   (lock_dir
   >    (cond
   >     (false non-existant)
-  >     (default dune.lock)))))
+  >     (default .dune-solution-cache)))))
   > EOF
 
-  $ dune pkg lock dune.lock
-  Solution for dune.lock:
+  $ dune pkg lock .dune-solution-cache
+  Solution for .dune-solution-cache:
   - linux-only.0.0.1
   $ dune clean
   $ build_pkg linux-only

--- a/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
@@ -23,7 +23,7 @@ Create a fake project and lock it:
   > EOF
   $ add_mock_repo_if_needed
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
 As the lock file is syncronised with `dune-pkg`, the build succeeds:
@@ -41,14 +41,14 @@ We add the bar dependency to the test package
 
 It fails as we have not regenerated the lock:
   $ dune build
-  File "dune.lock/lock.dune", line 1, characters 0-0:
+  File ".dune-solution-cache/lock.dune", line 1, characters 0-0:
   Error: The lock dir is not sync with your dune-project
   Hint: run dune pkg lock
   [1]
 
 We fix it and the build succeeds again:
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
   $ build_pkg foo

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -33,7 +33,7 @@ Without a lockdir this command prints a hint but exits successfully.
 
 Make the lockdir.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1
@@ -48,30 +48,30 @@ Add a file to the lockdir to cause the parser to fail.
   > foo
   > EOF
   $ dune pkg validate-lockdir
-  Failed to parse lockdir dune.lock:
-  File "dune.lock/bar.pkg", line 1, characters 0-3:
+  Failed to parse lockdir .dune-solution-cache:
+  File ".dune-solution-cache/bar.pkg", line 1, characters 0-3:
   Error: S-expression of the form (<name> <values>...) expected
   
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Remove the file but corrupt the lockdir metadata file.
   $ rm ${source_lock_dir}/bar.pkg
   $ echo foo >> ${source_lock_dir}/lock.dune
   $ dune pkg validate-lockdir
-  Failed to parse lockdir dune.lock:
-  File "dune.lock/lock.dune", line 8, characters 0-3:
+  Failed to parse lockdir .dune-solution-cache:
+  File ".dune-solution-cache/lock.dune", line 8, characters 0-3:
   Error: S-expression of the form (<name> <values>...) expected
   
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Regenerate the lockdir and validate the result.
   $ rm -r ${source_lock_dir}
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1
@@ -84,7 +84,7 @@ Remove a package from the lockdir.
 
 This results in an invalid lockdir due to the missing package.
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
   File "dune-project", line 2, characters 0-47:
   Error: The dependencies of local package "foo" could not be satisfied from
   the lockdir:
@@ -92,12 +92,12 @@ This results in an invalid lockdir due to the missing package.
   Hint: The lockdir no longer contains a solution for the local packages in
   this project. Regenerate the lockdir by running: 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Regenerate the lockdir and validate the result.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1
@@ -114,7 +114,7 @@ Change the version of a dependency by modifying its lockfile.
 
 Now the lockdir is invalid as it doesn't contain the right version of "b".
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
   File "dune-project", line 2, characters 0-47:
   Error: The dependencies of local package "foo" could not be satisfied from
   the lockdir:
@@ -123,12 +123,12 @@ Now the lockdir is invalid as it doesn't contain the right version of "b".
   Hint: The lockdir no longer contains a solution for the local packages in
   this project. Regenerate the lockdir by running: 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Regenerate the lockdir and validate the result.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1
@@ -143,19 +143,19 @@ Add a package to the lockdir with the same name as a local package.
 
 The lockdir is invalid as the package "b" is now defined both locally and in the lockdir.
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
   File "dune-project", line 2, characters 0-47:
   Error: A package named "foo" is defined locally but is also present in the
   lockdir
   Hint: The lockdir no longer contains a solution for the local packages in
   this project. Regenerate the lockdir by running: 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Regenerate the lockdir and validate the result.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1
@@ -170,19 +170,19 @@ Add a package to the lockdir which isn't part of the local package dependency hi
 
 The lockdir is invalid as it contains unnecessary packages.
   $ dune pkg validate-lockdir
-  Lockdir dune.lock does not contain a solution for local packages:
+  Lockdir .dune-solution-cache does not contain a solution for local packages:
   Error: The lockdir contains packages which are not among the transitive
   dependencies of any local package:
   - f.0.0.1
   Hint: The lockdir no longer contains a solution for the local packages in
   this project. Regenerate the lockdir by running: 'dune pkg lock'
   Error: Some lockdirs do not contain solutions for local packages:
-  - dune.lock
+  - .dune-solution-cache
   [1]
 
 Regenerate the lockdir and validate the result.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -19,7 +19,7 @@ package graph then it's caught when loading the lockdir.
   > EOF
 
   $ dune describe pkg lock
-  Contents of dune.lock:
+  Contents of .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - c.0.0.1
@@ -30,11 +30,11 @@ package graph then it's caught when loading the lockdir.
   > EOF
 
   $ dune describe pkg lock
-  File "dune.lock/c.pkg", line 2, characters 11-12:
+  File ".dune-solution-cache/c.pkg", line 2, characters 11-12:
   The package "c" depends on the package "d", but "d" does not appear in the
-  lockdir dune.lock.
+  lockdir .dune-solution-cache.
   Error: At least one package dependency is itself not present as a package in
-  the lockdir dune.lock.
+  the lockdir .dune-solution-cache.
   Hint: This could indicate that the lockdir is corrupted. Delete it and then
   regenerate it by running: 'dune pkg lock'
   [1]
@@ -42,14 +42,14 @@ package graph then it's caught when loading the lockdir.
   $ rm ${source_lock_dir}/a.pkg
 
   $ dune describe pkg lock
-  File "dune.lock/c.pkg", line 2, characters 9-10:
+  File ".dune-solution-cache/c.pkg", line 2, characters 9-10:
   The package "c" depends on the package "a", but "a" does not appear in the
-  lockdir dune.lock.
-  File "dune.lock/c.pkg", line 2, characters 11-12:
+  lockdir .dune-solution-cache.
+  File ".dune-solution-cache/c.pkg", line 2, characters 11-12:
   The package "c" depends on the package "d", but "d" does not appear in the
-  lockdir dune.lock.
+  lockdir .dune-solution-cache.
   Error: At least one package dependency is itself not present as a package in
-  the lockdir dune.lock.
+  the lockdir .dune-solution-cache.
   Hint: This could indicate that the lockdir is corrupted. Delete it and then
   regenerate it by running: 'dune pkg lock'
   [1]

--- a/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
@@ -27,7 +27,7 @@ rather than "a.0.0.1".
   >  (name foo)
   >  (depends c d))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.2
   - b.0.0.1
   - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -33,7 +33,7 @@ Generate a `dune-project` file.
 Run the solver and generate a lock directory.
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.5.0
   - baz.0.1.0
   - foo.0.0.1
@@ -44,21 +44,21 @@ Helper to the name and contents of each file in the lock directory separated by
 
 Print the contents of each file in the lockdir:
   $ print_all
-  dune.lock/bar.pkg:
+  .dune-solution-cache/bar.pkg:
   
   (version 0.5.0)
   
   
   ---
   
-  dune.lock/baz.pkg:
+  .dune-solution-cache/baz.pkg:
   
   (version 0.1.0)
   
   
   ---
   
-  dune.lock/foo.pkg:
+  .dune-solution-cache/foo.pkg:
   
   (version 0.0.1)
   
@@ -67,7 +67,7 @@ Print the contents of each file in the lockdir:
   
   ---
   
-  dune.lock/lock.dune:
+  .dune-solution-cache/lock.dune:
   
   (lang package 0.1)
   
@@ -83,27 +83,27 @@ Print the contents of each file in the lockdir:
 
 Run the solver again preferring oldest versions of dependencies:
   $ dune pkg lock --version-preference=oldest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.4.0
   - baz.0.1.0
   - foo.0.0.1
 
   $ print_all
-  dune.lock/bar.pkg:
+  .dune-solution-cache/bar.pkg:
   
   (version 0.4.0)
   
   
   ---
   
-  dune.lock/baz.pkg:
+  .dune-solution-cache/baz.pkg:
   
   (version 0.1.0)
   
   
   ---
   
-  dune.lock/foo.pkg:
+  .dune-solution-cache/foo.pkg:
   
   (version 0.0.1)
   
@@ -112,7 +112,7 @@ Run the solver again preferring oldest versions of dependencies:
   
   ---
   
-  dune.lock/lock.dune:
+  .dune-solution-cache/lock.dune:
   
   (lang package 0.1)
   
@@ -139,7 +139,7 @@ Regenerate the `dune-project` file introducing an unsatisfiable constraint.
 Run the solver again. This time it will fail.
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: baz.0.1.0 foo.0.0.1 lockfile_generation_test.dev
   - bar -> (problem)
@@ -173,7 +173,7 @@ After running this we expact a solution that has either `bar` or `baz` but not
 both.
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.5.0
   - bar-or-baz.0.0.1
 Top level or is simple, but does nested or work? nested-r defines nested or
@@ -197,7 +197,7 @@ After runninng we expect the solution to have quux and either baz or quz as
 well as bar or qux.
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.5.0
   - baz.0.1.0
   - nested-or.0.0.1
@@ -217,7 +217,7 @@ in between.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.5.0
   - priorities.0.0.1
   - quux.0.0.1
@@ -244,6 +244,6 @@ With versions 1 and 3 negated and version 4 removed via version constraint,
 we'd expect version 2 to be chosen:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - negation.0.0.1
   - pkg.2

--- a/test/blackbox-tests/test-cases/pkg/multi-project-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/multi-project-cycle.t
@@ -22,5 +22,5 @@ Demonstrate how dune handles project dependency cycles in the same project
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/multi-project.t
+++ b/test/blackbox-tests/test-cases/pkg/multi-project.t
@@ -20,7 +20,7 @@ Multiple projects support
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
 
 This should work without any toplevel projects as well:
@@ -28,5 +28,5 @@ This should work without any toplevel projects as well:
   $ mkdir b
   $ mv dune-project b
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
@@ -44,7 +44,7 @@ Define 1.0.0 in repo1 and 2.0.0 in repo2 for the same package:
 
   $ mkpkg repo1 1.0.0
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0.0
   (version 1.0.0)
   
@@ -53,7 +53,7 @@ Define 1.0.0 in repo1 and 2.0.0 in repo2 for the same package:
 
   $ mkpkg repo2 2.0.0
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.2.0.0
   (version 2.0.0)
   
@@ -66,7 +66,7 @@ should take priority
 
   $ mkpkg repo1 2.0.0
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.2.0.0
   (version 2.0.0)
   
@@ -78,7 +78,7 @@ be selected:
 
   $ mkpkg repo2 3.0.0
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.3.0.0
   (version 3.0.0)
   
@@ -109,7 +109,7 @@ Now we repeat the tests but with a git repo:
 
   $ mkworkspace "repo1 repo2 git-repo"
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.3.0.0
   (version 3.0.0)
   
@@ -118,7 +118,7 @@ Now we repeat the tests but with a git repo:
 
   $ mkworkspace "git-repo repo1 repo2"
   $ runtest
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.3.0.0
   (version 3.0.0)
   

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -55,7 +55,7 @@ Locking should produce the newest package from `new`
 
   $ mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.2.0
 
 If we just use `old` we should get the older `foo` package in our lockfile
@@ -79,7 +79,7 @@ solution:
  
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0
 
 If we specify both repositories to be used, we should still get the new foo
@@ -103,7 +103,7 @@ package:
 
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.2.0
 
 If we use the ordered set language format and try to exclude `new` from the
@@ -128,5 +128,5 @@ older version of foo:
 
   $ rm -r dune-workspace-cache && mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0

--- a/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
@@ -35,7 +35,7 @@ A few packages here so the errors could get large.
 
   $ dune pkg lock
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: foobar
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
@@ -19,7 +19,7 @@ Initial file:
   let () = print_endline "Hello, world"
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
@@ -40,7 +40,7 @@ attempt to build the package "foo".
   $ cat foo.ml
   let () = print_endline "Hello, world"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -62,7 +62,7 @@ Create a lockdir and define the package "bar". Note its install command is
 Now run `dune fmt` again. It attempts to build the project and its
 dependencies, and fails to install the dependency "bar".
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  File "dune.lock/bar.pkg", line 2, characters 14-19:
+  File ".dune-solution-cache/bar.pkg", line 2, characters 14-19:
   2 | (install (run false))
                     ^^^^^
   Error: Logs for package bar

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -97,7 +97,7 @@ EOF
 (lang dune 3.20)
 
 (lock_dir
- (path "dev-tools.locks/ocamlformat")
+ (path ".dune-tools-solution-cache/ocamlformat")
  (repositories mock))
 
 (lock_dir

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -29,7 +29,7 @@ Add a fake executable in the PATH
 
 Build the OCamlFormat binary dev-tool
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   File "dune", line 1, characters 0-0:
   Error: Files _build/default/dune and _build/default/.formatted/dune differ.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -28,7 +28,7 @@ Update dune-project to add the dependency on OCamlFormat.
 
 Lock and build the project to make OCamlFormat from the project dependencies available.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocamlformat.0.26.2
 
 Run "dune fmt" without the dev-tools feature enabled. This should invoke the ocamlformat
@@ -45,7 +45,7 @@ Format using the dev-tools feature, it does not invoke the OCamlFormat binary fr
 the project dependencies (0.26.2) but instead builds and runs the OCamlFormat binary as a
 dev-tool (0.26.3).
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -59,7 +59,7 @@ Retry, without dev-tools feature and without cleaning. This time it uses the OCa
 binary from the project dependencies rather than the dev-tool. This exercises the
 behavior when OCamlFormat is installed simultaneously as both a dev-tool and as a
 regular package dependency.
-  $ rm -rf dev-tools.locks/ocamlformat
+  $ rm -rf .dune-tools-solution-cache/ocamlformat
   $ dune fmt --preview
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -84,7 +84,7 @@ Add ".ocamlformat" file.
 
 Lock the to trigger package management
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - printer.2.0
 
 It shows that the project uses printer.2.0
@@ -94,7 +94,7 @@ It shows that the project uses printer.2.0
 Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with different
 versions of the same dependency.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   - printer.1.0
   File "foo.ml", line 1, characters 0-0:
@@ -117,7 +117,7 @@ dependencies of the project are isolated from one another.
 
 Relock the project.
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)
 
 There is no leak here. It is not taking the "printer" lib from dev-tools.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -13,9 +13,9 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 
 It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.4
-  File "dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
+  File ".dune-tools-solution-cache/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
   4 |  (run dune build -p %{pkg-self:name} @install))
             ^^^^
   Error: Logs for package ocamlformat

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -25,7 +25,7 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 Without a ".ocamlformat" file, "dune fmt" takes the latest version of
 OCamlFormat.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -40,13 +40,13 @@ Create .ocamlformat file
   > EOF
 
 An important cleaning here, "dune fmt" will relock and build the new version(0.26.2) of OCamlFormat.
-  $ rm -r dev-tools.locks/ocamlformat
+  $ rm -r .dune-tools-solution-cache/ocamlformat
   $ dune clean
 
 With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocamlformat"
 file.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -64,10 +64,10 @@ Formating a second time would not trigger the lock/solve.
   $ cat _build/default/.formatted/foo.ml
   formatted with version 0.26.2
 
-When "dev-tools.locks" is removed, the solving/lock is renewed
-  $ rm -r dev-tools.locks/ocamlformat
+When ".dune-tools-solution-cache" is removed, the solving/lock is renewed
+  $ rm -r .dune-tools-solution-cache/ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -28,7 +28,7 @@ Create ".ocamlformat-ignore"
 
 Check with the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -42,7 +42,7 @@ Check with the feature when ".ocamlformat-ignore" file exists.
 
 An important cleaning here, "dune fmt" takes the dev-tool when the lock directory
 exists even if the dev-tool feature is disabled.
-  $ rm -r dev-tools.locks/ocamlformat
+  $ rm -r .dune-tools-solution-cache/ocamlformat
 
 Check without the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=disabled dune fmt

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -8,7 +8,7 @@ Test `dune tools which ocamlformat`:
 
 Install ocamlformat as a dev tool:
   $ dune tools install ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -1,7 +1,7 @@
-'dune fmt' produce lock files inside "dev-tools.locks/ocamlformat" before it starts building
+'dune fmt' produce lock files inside ".dune-tools-solution-cache/ocamlformat" before it starts building
 ocamlformat and its dependencies during the same run of the "dune fmt" command. The source tree is
 loaded before the lock files are produced, this is why any 'patch' file inside
-'dev-tools.locks/ocmalformat' is not copied inside the 'build' directory when a rule depends on it.
+'.dune-tools-solution-cache/ocmalformat' is not copied inside the 'build' directory when a rule depends on it.
 
 The issue was that there is a rule that depends on an 'patch' file in order to copy the file
 inside '_private/default/..' directory, since the file could not be copied, the rule is not activated.
@@ -61,7 +61,7 @@ Make a project that uses the fake ocamlformat:
 
 First run of 'dune fmt' is supposed to format the fail.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -28,7 +28,7 @@ Initial file:
 This should choose the 0.24+foo version:
   $ echo "version=0.24" > .ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.24+foo
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -41,9 +41,9 @@ This should choose the 0.24+foo version:
 
 This should choose the 0.24+bar version:
   $ echo "version=0.25" > .ocamlformat
-  $ rm -rf dev-tools.locks
+  $ rm -rf .dune-tools-solution-cache
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.25+bar
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -57,10 +57,10 @@ This should choose the 0.24+bar version:
 
 This should fail as there is no version matching 0.24.1:
   $ echo "version=0.24.1" > .ocamlformat
-  $ rm -rf dev-tools.locks
+  $ rm -rf .dune-tools-solution-cache
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dev-tools.locks/ocamlformat:
+  Lock directory .dune-tools-solution-cache/ocamlformat:
   Couldn't solve the package dependency formula.
   Selected candidates: ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -15,7 +15,7 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
 Format, it shows the solving error.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dev-tools.locks/ocamlformat:
+  Lock directory .dune-tools-solution-cache/ocamlformat:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: ocamlformat
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -21,7 +21,7 @@ The command will fail because the dev tool is not installed:
 
 Install the dev tool:
   $ dune tools exec ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -8,7 +8,7 @@ Exercise running the ocamlformat wrapper command.
   $ make_project_with_dev_tool_lockdir
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -25,7 +25,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -24,7 +24,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
 
 Confirm that each dev tool's bin directory is now in PATH:
   $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
@@ -34,7 +34,7 @@ Test that ocamllsp can be installed while dune is running in watch mode.
   Success, waiting for filesystem changes...
 
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -10,10 +10,10 @@ Test that the ocamllsp dev tool can see the ocamlformat dev tool.
   > (lang dune 3.20)
   > (pkg enabled)
   > (lock_dir
-  >  (path "dev-tools.locks/ocaml-lsp-server")
+  >  (path ".dune-tools-solution-cache/ocaml-lsp-server")
   >  (repositories mock))
   > (lock_dir
-  >  (path "dev-tools.locks/ocamlformat")
+  >  (path ".dune-tools-solution-cache/ocamlformat")
   >  (repositories mock))
   > (lock_dir
   >   (repositories mock))
@@ -45,11 +45,11 @@ Make a fake ocamlformat
   > EOF
 
   $ dune tools install ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for .dune-tools-solution-cache/ocamlformat:
   - ocamlformat.0.0.1
 
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -29,12 +29,12 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ cat dev-tools.locks/ocaml-lsp-server/ocaml.pkg
+  $ cat .dune-tools-solution-cache/ocaml-lsp-server/ocaml.pkg
   (version 5.2.0)
 
 We can re-run "dune tools exec ocamllsp" without relocking or rebuilding.
@@ -54,10 +54,10 @@ before running. Ocamllsp now depends on ocaml.5.1.0.
   changed to 5.1.0 (formerly the compiler version was 5.2.0). The dev-tool
   "ocaml-lsp-server" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for .dune-tools-solution-cache/ocaml-lsp-server:
   - ocaml.5.1.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
   hello from fake ocamllsp
-  $ cat dev-tools.locks/ocaml-lsp-server/ocaml.pkg
+  $ cat .dune-tools-solution-cache/ocaml-lsp-server/ocaml.pkg
   (version 5.1.0)

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -4,7 +4,7 @@ setup_ocamllsp_workspace() {
   cat > dune-workspace <<EOF
 (lang dune 3.20)
 (lock_dir
- (path "dev-tools.locks/ocaml-lsp-server")
+ (path ".dune-tools-solution-cache/ocaml-lsp-server")
  (repositories mock))
  (lock_dir
   (repositories mock))

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -25,7 +25,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for dev-tools.locks/odoc:
+  Solution for .dune-tools-solution-cache/odoc:
   - ocaml.5.2.0
   - odoc.0.0.1
   hello from fake odoc

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -29,7 +29,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially odoc will be depend on ocaml.5.2.0 to match the project.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for dev-tools.locks/odoc:
+  Solution for .dune-tools-solution-cache/odoc:
   - ocaml.5.2.0
   - odoc.0.0.1
   hello from fake odoc
@@ -40,7 +40,7 @@ Initially odoc will be depend on ocaml.5.2.0 to match the project.
   Error: Rule failed to generate the following targets:
   - _doc/_odoc/pkg/foo/page-index.odoc
   [1]
-  $ cat dev-tools.locks/odoc/ocaml.pkg
+  $ cat .dune-tools-solution-cache/odoc/ocaml.pkg
   (version 5.2.0)
 
 We can re-run "dune ocaml doc" without relocking or rebuilding.
@@ -65,7 +65,7 @@ before running. Odoc now depends on ocaml.5.1.0.
   The version of the compiler package ("ocaml") in this project's lockdir has
   changed to 5.1.0 (formerly the compiler version was 5.2.0). The dev-tool
   "odoc" will be re-locked and rebuilt with this version of the compiler.
-  Solution for dev-tools.locks/odoc:
+  Solution for .dune-tools-solution-cache/odoc:
   - ocaml.5.1.0
   - odoc.0.0.1
   hello from fake odoc

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -5,7 +5,7 @@ setup_odoc_workspace() {
 (lang dune 3.20)
 (pkg enabled)
 (lock_dir
- (path "dev-tools.locks/odoc")
+ (path ".dune-tools-solution-cache/odoc")
  (repositories mock))
  (lock_dir
   (repositories mock))

--- a/test/blackbox-tests/test-cases/pkg/opam-file.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-file.t
@@ -24,7 +24,7 @@ of the disjunction to be picked for a solution:
   > ]
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
 
 With the right filters, the other side of the disjunction should get picked:
@@ -36,7 +36,7 @@ With the right filters, the other side of the disjunction should get picked:
   > ]
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - b.0.0.1
 
 Unreachable packages should not be included. In the next test, "b" should not
@@ -50,5 +50,5 @@ necessary during solving.
   > ]
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -10,7 +10,7 @@ To mark it, we use `conflict-class: "ocaml-core-compiler"`
   > EOF
 
   $ solve foocaml
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foocaml.0.0.1
 
   $ grep ocaml ${default_lock_dir}/lock.dune

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -35,13 +35,13 @@ Test that we can read package metadata from opam files.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.1
   - b.0.6
   - d.0.0.1
 
   $ dune describe pkg list-locked-dependencies
-  Dependencies of local packages locked in dune.lock
+  Dependencies of local packages locked in .dune-solution-cache
   - Immediate dependencies of local package bar.dev
     - d.0.0.1
     - foo.dev
@@ -64,14 +64,14 @@ Test that we can read package metadata from opam files.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.1
   - b.0.6
   - c.0.1
   - d.0.0.1
 
   $ dune describe pkg list-locked-dependencies
-  Dependencies of local packages locked in dune.lock
+  Dependencies of local packages locked in .dune-solution-cache
   - Immediate dependencies of local package bar.dev
     - d.0.0.1
     - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -1,5 +1,5 @@
 This test checks that the files in the files/ directory inside a package in an opam
-repository are copied correctly to the dune.lock file.
+repository are copied correctly to the .dune-solution-cache file.
 
   $ . ./helpers.sh
   $ mkrepo
@@ -20,7 +20,7 @@ Make a package with a patch
   > EOF
 
   $ solve with-patch
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-patch.0.0.1
 
 We expect that the files in the files directory of the opam repository get copied to the

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
@@ -23,7 +23,7 @@ available that avoids a cycle.
 Solver finds the invalid solution as it doesn't check cycles.
 
   $ solve c
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
@@ -16,17 +16,17 @@ Testing how the solver handles cycles in an opam repository.
 Solver doesn't complain about cycles.
 
   $ solve a
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - c.0.0.1
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - c.0.0.1
   $ solve c
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   - b.0.0.1
   - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
@@ -11,7 +11,7 @@ Make a package with only an install step
   $ mkdir -p $mock_packages/install-no-build/install-no-build.0.0.1/
 
   $ solve install-no-build
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - install-no-build.0.0.1
 The lockfile should only contain an install step.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -1,5 +1,5 @@
 We test how opam files with substs fields together with patches fields are translated into
-the dune.lock file. Opam allows substitution to happen before the patches phase, so we
+the .dune-solution-cache file. Opam allows substitution to happen before the patches phase, so we
 must do the same.
  
   $ . ./helpers.sh
@@ -15,7 +15,7 @@ Make a package with a substs and patches field field
   $ opam_repo=$mock_packages/with-substs-and-patches/with-substs-and-patches.0.0.1
 
   $ solve with-substs-and-patches
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-substs-and-patches.0.0.1
   $ append_to_lockpkg with-substs-and-patches <<EOF
   > (source (copy $PWD/source))

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
@@ -1,5 +1,5 @@
 In this test we test the translation of a package with a build-env field and no build or
-install step into a dune lock file.
+install step into a .dune-solution-cache file.
 
   $ . ./helpers.sh
   $ mkrepo
@@ -10,7 +10,7 @@ Make a package with a build-env field and no build or install step
   > EOF
 
   $ solve with-build-env
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-build-env.0.0.1
 
 When there is no build or install step the build environment does not appear in the lock

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
@@ -1,4 +1,4 @@
-In this test we test the translation of a package with a build-env field into a dune lock
+In this test we test the translation of a package with a build-env field into a .dune-solution-cache
 file.
 
   $ . ./helpers.sh
@@ -12,7 +12,7 @@ Make a package with a build-env field
   > EOF
 
   $ solve with-build-env
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-build-env.0.0.1
 The lockfile should contain a setenv action.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
@@ -13,7 +13,7 @@ In this test we demonstrate that we don't currently do anything special with tho
   > EOF
 
   $ solve with-build-test-doc
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-build-test-doc.0.0.1
 The lockfile should contain the `build-test` and `build-doc` fields inside the build
 action.

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
@@ -31,7 +31,7 @@ Make a package with an extra-source field and multiple checksums
   > EOF
 
   $ solve with-extra-source with-extra-source-md5 with-extra-source-multiple-checksums
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-extra-source.0.0.1
   - with-extra-source-md5.0.0.1
   - with-extra-source-multiple-checksums.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -22,7 +22,7 @@ Make a package with a patch behind a filter
   > EOF
 
   $ solve with-patch-filter
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-patch-filter.0.0.1
   $ append_to_lockpkg with-patch-filter <<EOF
   > (source (copy $PWD/source))

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -46,18 +46,18 @@ file and the second patches two, one of the files is in a subdirectory.:w
   > EOF
 
   $ solve with-patch
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-patch.0.0.1
   $ append_to_lockpkg with-patch <<EOF
   > (source (copy $PWD/source))
   > EOF
 
-Checking that the patch files have been copied to the dune.lock dir
+Checking that the patch files have been copied to the .dune-solution-cache dir
 
   $ [ -d ${default_lock_dir}/with-patch.files ] && ls ${default_lock_dir}/with-patch.files/foo.patch
-  dune.lock/with-patch.files/foo.patch
+  .dune-solution-cache/with-patch.files/foo.patch
   $ [ -d ${default_lock_dir}/with-patch.files/dir ] && ls ${default_lock_dir}/with-patch.files/dir/bar.patch
-  dune.lock/with-patch.files/dir/bar.patch
+  .dune-solution-cache/with-patch.files/dir/bar.patch
 
 The lockfile should contain the patch action. 
   $ cat ${default_lock_dir}/with-patch.pkg 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -23,7 +23,7 @@ Make a package with a patch
   > EOF
 
   $ solve with-patch
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-patch.0.0.1
   $ append_to_lockpkg with-patch <<EOF
   > (source (copy $PWD/source))

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -1,4 +1,4 @@
-Testing the translation of the setenv field of an opam file into the dune lock dir.
+Testing the translation of the setenv field of an opam file into the .dune-solution-cache dir.
 
   $ . ./helpers.sh
   $ mkrepo
@@ -27,7 +27,7 @@ Make another package that depends on that and outputs the exported env vars
   > ]
   > EOF
   > solve deps-on-with-setenv
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - deps-on-with-setenv.0.0.1
   - with-setenv.0.0.1
 The exported env from the first package should be in the lock dir.
@@ -101,7 +101,7 @@ difference between a propagated export_env versus the initial env.
   > ]
   > EOF
   > solve deps-on-with-setenv-2
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - deps-on-with-setenv-2.0.0.1
   - with-setenv.0.0.1
   - with-setenv-2.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -1,4 +1,4 @@
-We test how opam files with substs fields are translated into the dune.lock file.
+We test how opam files with substs fields are translated into the .dune-solution-cache file.
  
   $ . ./helpers.sh
   $ mkrepo
@@ -10,7 +10,7 @@ Make a package with a substs field
   > EOF
 
   $ solve with-substs
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-substs.0.0.1
   $ append_to_lockpkg with-substs <<EOF
   > (source (copy $PWD/source))

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -29,7 +29,7 @@ Make a mock repo tarball that will get used by dune to download the package
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
 
@@ -48,7 +48,7 @@ other systems and thus shouldn't be included.
   $ rm -r ${default_lock_dir} dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/mock-opam-repository"
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
 
@@ -70,7 +70,7 @@ in the repo and make sure it locks the older version.
   $ rm -r ${default_lock_dir} dune-workspace
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository#${REPO_HASH}"
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
   $ grep "mock-opam-repository#$REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null
@@ -81,7 +81,7 @@ repository and thus the new foo package.
   $ rm dune-workspace
   $ add_mock_repo_if_needed "git+file://$(pwd)/mock-opam-repository"
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.1.0
   $ grep "mock-opam-repository#$NEW_REPO_HASH" ${default_lock_dir}/lock.dune > /dev/null
@@ -111,7 +111,7 @@ So now the test should work as it can't access the repo:
 
   $ rm -r ${default_lock_dir}
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.1.0
 
@@ -123,7 +123,7 @@ restored the repo to where it was before)
   $ mv elsewhere mock-opam-repository
   $ rm -r ${default_lock_dir}
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.0.1.0
 
@@ -148,7 +148,7 @@ Locking that branch should work and pick `bar.2.0.0`:
 
   $ rm -r ${default_lock_dir}
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.2.0.0
   - foo.0.1.0
 
@@ -174,6 +174,6 @@ So we should get `bar.1.0.0` when locking.
 
   $ rm -r ${default_lock_dir}
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.0.1.0

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -15,7 +15,7 @@ Demonstrate the generation of the lock directory in the presence of "|"
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a1.0.0.1
   - b.0.0.1
 Only a1 or a2 should appear but not both.
@@ -34,7 +34,7 @@ packages, so comparing their version numbers is meaningless.
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a1.0.0.1
   - b.0.0.1
 
@@ -50,7 +50,7 @@ which is completely omitted from the solution).
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a2.0.0.2
   - b.0.0.2
 
@@ -61,7 +61,7 @@ Same solution if a1 only known version is excluded:
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a2.0.0.2
   - b.0.0.2
 
@@ -74,7 +74,7 @@ solver to try to find a solution which doesn't include it.
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a1.0.0.1
   - b.0.0.1
 
@@ -85,7 +85,7 @@ Update a1.0.0.1 to also be flagged as avoid-version:
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a2.0.0.1
   - b.0.0.1
 
@@ -97,7 +97,7 @@ avoid-version:
   > EOF
 
   $ solve b
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a2.0.0.2 (this version should be avoided)
   - b.0.0.2
 
@@ -151,7 +151,7 @@ latest versions of packages a and d allow it to reduce the solution to 2
 avoid-version:
 
   $ solve a
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.1
   - d.0.1 (this version should be avoided)
   - f.0.1 (this version should be avoided)

--- a/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
@@ -12,7 +12,7 @@ Test conversion of opam sources into lock dir package specifications
   > EOF
 
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
 
   $ showpkg() {
@@ -39,7 +39,7 @@ Test conversion of opam sources into lock dir package specifications
   $ rm -rf ${default_lock_dir}
 
   $ solve testpkg 2>&1 | sed -E 's#.*.sandbox/[^/]+#.sandbox/$SANDBOX#g' | sed '/File "/q'
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
 
   $ showpkg | sed -e "s#$PWD#<pwd>#"
@@ -64,7 +64,7 @@ Unsupported backends:
   > EOF
 
   $ solve testpkg 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ showpkg
   (version 0.0.1)
@@ -85,7 +85,7 @@ git+http
   > EOF
 
   $ solve testpkg 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ showpkg
   (version 0.0.1)
@@ -105,7 +105,7 @@ git+file
   > }
   > EOF
   $ solve testpkg 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ showpkg
   (version 0.0.1)
@@ -125,7 +125,7 @@ git+foobar
   > }
   > EOF
   $ solve testpkg 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ showpkg
   (version 0.0.1)
@@ -145,7 +145,7 @@ file+git
   > }
   > EOF
   $ solve testpkg 2>&1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ showpkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
@@ -24,7 +24,7 @@ Regular dependencies
   > EOF
 
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   - testpkg.1
 
@@ -33,7 +33,7 @@ Regular dependencies
   > EOF
 
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.2
 
 Depopts. We don't have proper support for depopts yet, so these don't work.
@@ -45,7 +45,7 @@ the same way as depends
   > EOF
 
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.2
 
   $ mkpkg "testpkg" 2 <<'EOF' 
@@ -53,5 +53,5 @@ the same way as depends
   > EOF
 
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.2

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
@@ -13,7 +13,7 @@ variables can be found in `opam-var-os.t`.
   > ]
   > EOF
   > solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
@@ -38,7 +38,7 @@ Therefore we modify the lockfile here to remove these from the opam file:
   > ]
   > EOF
   > solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
 The value for "jobs" should always be 1.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -22,7 +22,7 @@ unset them all.
   > ]
   > EOF
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)
@@ -53,7 +53,7 @@ separately here:
   > ]
   > EOF
   $ solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
 
   $ ocaml_version="$(ocaml -vnum)"

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -49,7 +49,7 @@ We echo each package variable.
   > mkpkg "foo" <<EOF
   > EOF
   > solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   - testpkg.0.0.1
 Inspecting the lockfile we can see how each opam package variable was translated into a
@@ -114,35 +114,35 @@ corresponding Dune version.
 The values here are not important, but Dune should be able to interpret the variables.
 
   $ build_pkg testpkg
-  File "dune.lock/testpkg.pkg", line 45, characters 15-36:
+  File ".dune-solution-cache/testpkg.pkg", line 45, characters 15-36:
   45 |   (run echo 35 %{pkg-self:with-test})
                       ^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-test"
-  File "dune.lock/testpkg.pkg", line 46, characters 15-36:
+  File ".dune-solution-cache/testpkg.pkg", line 46, characters 15-36:
   46 |   (run echo 36 %{pkg-self:with-test})
                       ^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-test"
-  File "dune.lock/testpkg.pkg", line 47, characters 15-35:
+  File ".dune-solution-cache/testpkg.pkg", line 47, characters 15-35:
   47 |   (run echo 37 %{pkg:foo:with-test})
                       ^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-test"
-  File "dune.lock/testpkg.pkg", line 48, characters 15-35:
+  File ".dune-solution-cache/testpkg.pkg", line 48, characters 15-35:
   48 |   (run echo 38 %{pkg-self:with-doc})
                       ^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-doc"
-  File "dune.lock/testpkg.pkg", line 49, characters 15-35:
+  File ".dune-solution-cache/testpkg.pkg", line 49, characters 15-35:
   49 |   (run echo 39 %{pkg-self:with-doc})
                       ^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-doc"
-  File "dune.lock/testpkg.pkg", line 50, characters 15-34:
+  File ".dune-solution-cache/testpkg.pkg", line 50, characters 15-34:
   50 |   (run echo 40 %{pkg:foo:with-doc})
                       ^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-doc"
-  File "dune.lock/testpkg.pkg", line 51, characters 15-41:
+  File ".dune-solution-cache/testpkg.pkg", line 51, characters 15-41:
   51 |   (run echo 41 %{pkg-self:with-dev-setup})
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-dev-setup"
-  File "dune.lock/testpkg.pkg", line 52, characters 15-40:
+  File ".dune-solution-cache/testpkg.pkg", line 52, characters 15-40:
   52 |   (run echo 42 %{pkg:foo:with-dev-setup})))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-dev-setup"

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -26,7 +26,7 @@ opam-var-unsupported.t
   > ]
   > EOF
   > solve testpkg
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testpkg.0.0.1
   $ cat ${default_lock_dir}/testpkg.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/outdated-with-dev-setup.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated-with-dev-setup.t
@@ -11,10 +11,10 @@ Reproduce internal error with dune pkg outdated in #11188.
   >  (name foo)
   >  (depends a (b :with-dev-setup)))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
 
 dune pkg outdated is able to handle :with-dev-setup correctly.
   $ dune pkg outdated
-  dune.lock is up to date.
+  .dune-solution-cache is up to date.
 

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -34,7 +34,7 @@
   >  (name baz)
   >  (depends bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
   Solution for dune.workspace.lock:
@@ -45,29 +45,29 @@ No package should be outdated after a fresh lock.
 
 Default behaviour is to check the default lock file.
   $ outdated
-  dune.lock is up to date.
+  .dune-solution-cache is up to date.
 
 All lock file can be check by passing --all
   $ outdated --all
-  - dune.lock is up to date.
+  - .dune-solution-cache is up to date.
   - dune.workspace.lock is up to date.
 
 Specific lock files can be given as positional arguments.
-  $ outdated dune.lock
-  dune.lock is up to date.
+  $ outdated .dune-solution-cache
+  .dune-solution-cache is up to date.
 
 Invalid lock files give an error
   $ outdated invalid_lock
   Error: The following directories are not lock directories in this workspace:
   - invalid_lock
   This workspace contains the following lock directories:
-  - dune.lock
+  - .dune-solution-cache
   - dune.workspace.lock
   [1]
 
 Multiple lock files can be given.
-  $ outdated dune.lock dune.workspace.lock
-  - dune.lock is up to date.
+  $ outdated .dune-solution-cache dune.workspace.lock
+  - .dune-solution-cache is up to date.
   - dune.workspace.lock is up to date.
 
 Adding a new version of the bar package to the repository.
@@ -79,7 +79,7 @@ Adding a new version of the bar package to the repository.
 Dune should report the new version of bar as available.
 
   $ outdated --all
-  - 1/2 packages in dune.lock are outdated.
+  - 1/2 packages in .dune-solution-cache are outdated.
     - bar 0.0.1 < 0.0.2
   - 1/2 packages in dune.workspace.lock are outdated.
     - bar 0.0.1 < 0.0.2
@@ -89,7 +89,7 @@ Dune should only report the bar package as it is an immediate dependency.
 
   $ mkpkg foo 0.0.2 
   $ outdated --all
-  - 2/2 packages in dune.lock are outdated.
+  - 2/2 packages in .dune-solution-cache are outdated.
     Showing immediate dependencies, use --transitive to see them all.
     - bar 0.0.1 < 0.0.2
   - 2/2 packages in dune.workspace.lock are outdated.
@@ -98,19 +98,19 @@ Dune should only report the bar package as it is an immediate dependency.
 
 If --transitive is also passed then both should be reported.
 
-  $ outdated --transitive dune.lock
-  2/2 packages in dune.lock are outdated.
+  $ outdated --transitive .dune-solution-cache
+  2/2 packages in .dune-solution-cache are outdated.
   - bar 0.0.1 < 0.0.2
   - foo 0.0.1 < 0.0.2
 
 If we remove packages from the repository then we should get a nice error.
 
   $ rm -rf mock-opam-repository/packages/bar
-  $ outdated dune.lock 
-  1/2 packages in dune.lock are outdated.
+  $ outdated .dune-solution-cache 
+  1/2 packages in .dune-solution-cache are outdated.
   Showing immediate dependencies, use --transitive to see the rest.
   Error: Some packages could not be found.
-  When checking dune.lock, the following packages:
+  When checking .dune-solution-cache, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -118,11 +118,11 @@ If we remove packages from the repository then we should get a nice error.
 
 When printing both successes and failures, any errors should appear afterwards.
 
-  $ outdated dune.lock --transitive
-  1/2 packages in dune.lock are outdated.
+  $ outdated .dune-solution-cache --transitive
+  1/2 packages in .dune-solution-cache are outdated.
   - foo 0.0.1 < 0.0.2
   Error: Some packages could not be found.
-  When checking dune.lock, the following packages:
+  When checking .dune-solution-cache, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -131,12 +131,12 @@ When printing both successes and failures, any errors should appear afterwards.
 Similarly for multiple lock files.
 
   $ outdated --transitive --all
-  - 1/2 packages in dune.lock are outdated.
+  - 1/2 packages in .dune-solution-cache are outdated.
     - foo 0.0.1 < 0.0.2
   - 1/2 packages in dune.workspace.lock are outdated.
     - foo 0.0.1 < 0.0.2
   Error: Some packages could not be found.
-  When checking dune.lock, the following packages:
+  When checking .dune-solution-cache, the following packages:
   - bar
   were not found in the following opam repositories:
   - None
@@ -150,10 +150,10 @@ If multiple packages are missing, the error should enumerate them. The errors sh
 appear irrespective of being a transitive dependency.
 
   $ rm -r mock-opam-repository/packages/foo
-  $ outdated --transitive dune.lock 
-  dune.lock is up to date.
+  $ outdated --transitive .dune-solution-cache 
+  .dune-solution-cache is up to date.
   Error: Some packages could not be found.
-  When checking dune.lock, the following packages:
+  When checking .dune-solution-cache, the following packages:
   - bar
   - foo
   were not found in the following opam repositories:
@@ -163,10 +163,10 @@ appear irrespective of being a transitive dependency.
 With multiple lock files, the errors should also be printed for each of them.
 
   $ outdated --all 
-  - dune.lock is up to date.
+  - .dune-solution-cache is up to date.
   - dune.workspace.lock is up to date.
   Error: Some packages could not be found.
-  When checking dune.lock, the following packages:
+  When checking .dune-solution-cache, the following packages:
   - bar
   - foo
   were not found in the following opam repositories:

--- a/test/blackbox-tests/test-cases/pkg/package-name-with-plus-character.t
+++ b/test/blackbox-tests/test-cases/pkg/package-name-with-plus-character.t
@@ -21,5 +21,5 @@ This is based on the build command of mingw-w64-shims.0.2.0
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -25,7 +25,7 @@ Declare a package which refers to some variables:
 
 Solve the package using the default solver env:
   $ solve a
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   $ cat ${default_lock_dir}/a.pkg
   (version 0.0.1)
@@ -54,7 +54,7 @@ Make a custom solver env:
   > (lang dune 3.20)
   > (pkg enabled)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock)
   >  (solver_env
   >   (dev false)
@@ -63,7 +63,7 @@ Make a custom solver env:
   > (context
   >  (default
   >   (name default)
-  >   (lock_dir dune.lock)))
+  >   (lock_dir .dune-solution-cache)))
   > (repository
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))
@@ -71,7 +71,7 @@ Make a custom solver env:
 
 Run the solver using the new env:
   $ solve a
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
   $ cat ${default_lock_dir}/a.pkg
   (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -34,7 +34,7 @@ Local pinned source.
   > opam-version: "2.0"
   > EOF
   $ runtest "file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -48,7 +48,7 @@ Local pinned source.
   > opam-version: "2.0"
   > EOF
   $ runtest "file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -62,7 +62,7 @@ Local pinned source.
   > opam-version: "2.0"
   > EOF
   $ runtest "file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -76,7 +76,7 @@ Local pinned source.
   > opam-version: "2.0"
   > EOF
   $ runtest "file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -95,7 +95,7 @@ Git pinned source:
   $ git commit --quiet -m "Initial commit"
   $ cd ..
   $ runtest "git+file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -114,7 +114,7 @@ Git pinned source with toplevel opam file:
   $ git commit --quiet -m "Initial commit"
   $ cd ..
   $ runtest "git+file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -134,7 +134,7 @@ Git pinned source with toplevel opam dir 1
   $ git commit --quiet -m "Initial commit"
   $ cd ..
   $ runtest "git+file://$PWD/$dir"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   (version 1.0.0)
   (dev)
@@ -187,7 +187,7 @@ Pin to an HTTP archive work
   $ echo tarball.tar > fake-curls
   $ PORT=1
   $ runtest "http://0.0.0.0:$PORT/tarball.tar" > output
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   $ grep "md5=$MD5_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
   Checksum matches
@@ -202,7 +202,7 @@ Pin to an HTTP archive detects wrong hash
   $ sed -i.tmp "s/$MD5_CHECKSUM/92449184682b45b5f07e811fdd61d35f/g" ${default_lock_dir}/bar.pkg
   $ rm -rf already-served
   $ dune build 2>&1 | grep -v "md5"
-  File "dune.lock/bar.pkg", line 6, characters 12-48:
+  File ".dune-solution-cache/bar.pkg", line 6, characters 12-48:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Invalid checksum, got
 
@@ -215,7 +215,7 @@ of the target again
   $ MD5_CHECKSUM=$(md5sum tarball.tar  | cut -f1 -d' ')
   $ echo tarball.tar > fake-curls
   $ runtest "http://0.0.0.0:$PORT/tarball.tar" > output
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   $ grep "md5=$MD5_CHECKSUM" output 2>&1 > /dev/null && echo "Checksum matches"
   Checksum matches

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
@@ -25,7 +25,7 @@ in any repository
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0.0
 
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -55,7 +55,7 @@ Demonstrate the build command we construct for different types of projects:
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - dune-only.dev
   - mixed.dev
   - opam-only.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
@@ -30,7 +30,7 @@ We create a repo with a fixed name for the default branch.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
 
 We create a tag that clashes with the name of the branch (hence we needed to
@@ -41,7 +41,7 @@ fix the name of the branch eariler):
 This should work without issue, as we never reference the ambiguous reference:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
 
 If we use the duplicate reference in the config
@@ -60,7 +60,7 @@ This will work as both references point at the same revision, thus aren't
 ambiguous:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
 
 If we then change the reference of the branch to point to a different revision
@@ -92,7 +92,7 @@ Git also has unambibuous namespaces tags and branches, for tags it is `refs/tags
 Locking should work, as there are no ambiguous references.
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
 
 For branches the namespace is `refs/heads/`:
@@ -110,5 +110,5 @@ For branches the namespace is `refs/heads/`:
 Likewise locking a branch this way should work as well:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
@@ -35,5 +35,5 @@ should be ignored.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
@@ -29,7 +29,7 @@ should favor the dune metadata in such a case.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.dev
   - foo.dev
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
@@ -25,6 +25,6 @@ We can pull multiple packages from a single source
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.dev
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
@@ -22,7 +22,7 @@ We try to pull an opam package that isn't a dune project
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
   $ pkg="${default_lock_dir}/foo.pkg"
   $ grep version $pkg

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
@@ -30,7 +30,7 @@ command is currently not respected when the package is pinned.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - opam-template.dev
   $ build_pkg opam-template
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
@@ -33,7 +33,7 @@ Here we demonstrate that projects override their sub projects:
   > (package (name bar))
   > EOF
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.dev
 
   $ print_source "bar"

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
@@ -36,6 +36,6 @@ We can override the sources set by packages we're fetching:
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.dev
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
@@ -31,6 +31,6 @@ respect the pin-depends
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depopts.t
@@ -27,5 +27,5 @@ package with depopts.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - pkg-with-depopts.5.2.0

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
@@ -33,6 +33,6 @@ Sources are traversed recursively (unlike pins)
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.dev
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
@@ -46,7 +46,7 @@ Make a second package depending on the first via a pin:
 
 Lock and build the second package to demonstrate that everything works so far:
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
   $ dune exec ./bar.exe
   foo

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -32,7 +32,7 @@ Make a package "foo" whose build will fail after printing a message:
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev
 
 Attempt to build the package the first time:
@@ -41,7 +41,7 @@ Attempt to build the package the first time:
   echo aaa
   aaa
   false
-  File "dune.lock/foo.pkg", line 4, characters 6-13:
+  File ".dune-solution-cache/foo.pkg", line 4, characters 6-13:
   4 |  (run %{make}))
             ^^^^^^^
   Error: Logs for package foo
@@ -59,7 +59,7 @@ The change to the package is picked up:
   echo bbb
   bbb
   false
-  File "dune.lock/foo.pkg", line 4, characters 6-13:
+  File ".dune-solution-cache/foo.pkg", line 4, characters 6-13:
   4 |  (run %{make}))
             ^^^^^^^
   Error: Logs for package foo

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
@@ -40,5 +40,5 @@ Note that sources in the projects are overriden by the workspace
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.dev

--- a/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
@@ -103,7 +103,7 @@ create the lock file:
   $ enable_pkg
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - testlib.0.0.1
 
 Now disable pkg again:

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -8,7 +8,7 @@ should be used.
   $ cat >dune-workspace <<EOF
   > (lang dune 3.20)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock))
   > (lock_dir
   >  (path dune.other.lock)

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -15,7 +15,7 @@ build this package and check for sufficient error handling
 
   $ add_mock_repo_if_needed
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
   Error: failed to extract 'corrupted.tar'
@@ -33,7 +33,7 @@ captured
   > EOF
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ build_pkg foo 2>&1 |  sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"
@@ -54,7 +54,7 @@ unzip error message a bit less clear
 
   $ add_mock_repo_if_needed
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ build_pkg foo 2>&1 | sed -ne '/Error:/,$ p' | sed '/^Reason/ q' | sed "s/'[0-9]*'/X/"

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -48,7 +48,7 @@ Helper function that creates a workspace file with a given solver env.
   >  (name foo)
   >  (depends bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - b.0.0.1
   - bar.0.0.1
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -34,7 +34,7 @@ Create a package that writes a different value to some files depending on the os
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -46,7 +46,7 @@ Create a custom dune-workspace to solve for openbsd.
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = openbsd
@@ -76,7 +76,7 @@ Build as though we were on openbsd.
 
 Now building on linux won't work:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  File "dune.lock/lock.dune", lines 10-11, characters 1-31:
+  File ".dune-solution-cache/lock.dune", lines 10-11, characters 1-31:
   10 |  ((arch x86_64)
   11 |   (os openbsd)))
   Error: The lockdir does not contain a solution compatible with the current

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -14,7 +14,7 @@ setting the variable "sys-ocaml-version":
   >  (name mock)
   >  (url "file://$(pwd)/mock-opam-repository"))
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock)
   >  (solver_env
   >   (sys-ocaml-version 5.4.0+solver-env-version-override)))
@@ -49,7 +49,7 @@ Set up a project that depends on the package:
 
 Solve the project:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux; sys-ocaml-version =

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -22,7 +22,7 @@ Demonstrate various cases representing depexts in lockfiles.
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
@@ -52,7 +52,7 @@ correct depext names can be chosen for the current distro at build time.
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = macos; os-distribution = homebrew; os-family = homebrew

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
@@ -38,7 +38,7 @@ Create a workspace with some typos in package variable names
            ^^^^^^^^^
   Warning: The package variable "os_family" looks like a typo. Did you mean
   "os-family"?
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -33,7 +33,7 @@ Make a package that is only available on macos.
 Solving will still succeed, but there'll be a warning because dune will attempt
 to solve for macos, linux, and windows by default.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = macos
@@ -97,7 +97,7 @@ No errors when you try to build the platform on macos.
 
 Building on linux fails because the lockdir doesn't contain a compatible solution.
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  File "dune.lock/lock.dune", lines 10-13, characters 1-58:
+  File ".dune-solution-cache/lock.dune", lines 10-13, characters 1-58:
   10 |  ((arch x86_64)
   11 |   (os macos))
   12 |  ((arch arm64)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -52,7 +52,7 @@ A package that conditionally depends on packages depending on the OS:
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -69,7 +69,7 @@ Define a project with a package depending on bar:
 
 Solve the project. The solution will contain extra files for both versions of foo:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -53,7 +53,7 @@ Define a package bar which conditionally depends on different versions of foo:
   > EOF
 
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
-  Solution for dune.lock
+  Solution for .dune-solution-cache
   
   This solution supports the following platforms:
   - arch = x86_64; os = linux

--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -19,7 +19,7 @@ Solving for post dependencies:
 We don't need bar, so we skip it
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/foo.pkg
@@ -37,7 +37,7 @@ Self dependency
   > EOF
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/foo.pkg
@@ -54,7 +54,7 @@ Using post to break cycle:
   > EOF
 
   $ solve bar
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1
 
@@ -75,7 +75,7 @@ post "cycle":
   > EOF
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/foo.pkg
@@ -90,5 +90,5 @@ In depopts:
   $ mkpkg bar
 
   $ solve foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/prevent-user-setting-with-test.t
+++ b/test/blackbox-tests/test-cases/pkg/prevent-user-setting-with-test.t
@@ -5,13 +5,13 @@ Add a workspace that attempts to set the "with-test" variable:
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (solver_env
   >   (with-test false)))
   > (context
   >  (default
   >   (name default)
-  >   (lock dune.lock)))
+  >   (lock .dune-solution-cache)))
   > EOF
 
   $ dune pkg print-solver-env

--- a/test/blackbox-tests/test-cases/pkg/project-package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/project-package-cycle.t
@@ -16,5 +16,5 @@ Demonstrate how dune handles project dependency cycles in the same project
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   (no dependencies to lock)

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -33,5 +33,5 @@ Creating a lock should thus work.
 
   $ mkdir dune-workspace-cache
   $ XDG_CACHE_HOME=$(pwd)/fake-xdg-cache dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.1.0

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -79,7 +79,7 @@ Generate a mock opam repository
   > }
 
   $ build_single_package foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   package: foo.0.0.1
   enable: enable
@@ -88,7 +88,7 @@ Generate a mock opam repository
   package conjunction: false
   package conjunction string selection: bar
   $ build_single_package bar
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   installed
   installed or pinned
@@ -96,41 +96,41 @@ Generate a mock opam repository
   disjunction with some undefined vars
   conjunction with some undefined vars
   $ build_single_package baz
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - baz.0.0.1
   installed
   not madeup:installed
   hello
   
   $ build_single_package error1
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - error1.0.0.1
-  File "dune.lock/error1.pkg", line 6, characters 3-16:
+  File ".dune-solution-cache/error1.pkg", line 6, characters 3-16:
   6 |    %{pkg-self:a}
          ^^^^^^^^^^^^^
   Error: Undefined package variable "a"
   [1]
   $ build_single_package error2
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - error2.0.0.1
-  File "dune.lock/error2.pkg", line 6, characters 3-16:
+  File ".dune-solution-cache/error2.pkg", line 6, characters 3-16:
   6 |    %{pkg-self:a}
          ^^^^^^^^^^^^^
   Error: Undefined package variable "a"
   [1]
   $ build_single_package error3
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - error3.0.0.1
-  File "dune.lock/error3.pkg", line 4, characters 6-19:
+  File ".dune-solution-cache/error3.pkg", line 4, characters 6-19:
   4 |  (run not-a-program echo hello))
             ^^^^^^^^^^^^^
   Error: Program not-a-program not found in the tree or in PATH
    (context: default)
   [1]
   $ build_single_package error4
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - error4.0.0.1
-  File "dune.lock/error4.pkg", line 4, characters 6-36:
+  File ".dune-solution-cache/error4.pkg", line 4, characters 6-36:
   4 |  (run not-a-program-%{pkg-self:name} echo hello))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Program not-a-program-error4 not found in the tree or in PATH

--- a/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
@@ -21,7 +21,7 @@ The version of foo that should be selected is 1.0.0
   >  (name x)
   >  (depends foo))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.1.0.0
 
@@ -35,7 +35,7 @@ constraint on `foo` will fail:
   >  (depends (foo (= :version))))
   > EOF
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - foo -> (problem)
@@ -53,7 +53,7 @@ But specifying a version for the local package `x` yields a solution:
   >  (name x)
   >  (depends (foo (= :version))))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.1.0.0
 
@@ -68,6 +68,6 @@ of the dune-project:
   $ solve_project <<EOF
   > (lang dune 3.11)
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.1.0.0
   - foo.1.0.0

--- a/test/blackbox-tests/test-cases/pkg/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/pkg/sites-plugin.t
@@ -151,7 +151,7 @@ We should observe the same behaviour that when running test above.
   > EOF
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - app.0.0.1
   - plugin1.0.0.1
   $ dune build @runtest 2>&1 | dune_cmd sanitize

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -34,7 +34,7 @@ Tests for when:
   $ test_action '(run (when (= a b) xxx) (when (and (< 41 42) (<> foo bar)) echo) foo)'
   foo
   $ test_action '(run (when invalid-condition echo) foo)'
-  File "dune.lock/test.pkg", line 2, characters 20-37:
+  File ".dune-solution-cache/test.pkg", line 2, characters 20-37:
   2 | (install (run (when invalid-condition echo) foo))
                           ^^^^^^^^^^^^^^^^^
   Error: This expression is used as a condition and so must evaluate to either
@@ -49,7 +49,7 @@ Tests for when:
   $ test_action '(run echo (concat (when true foo) (when false bar) baz))'
   foobaz
   $ test_action '(run echo (when (or %{pkg-self:not_a_variable} true) foo))'
-  File "dune.lock/test.pkg", line 2, characters 29-55:
+  File ".dune-solution-cache/test.pkg", line 2, characters 29-55:
   2 | (install (run echo (when (or %{pkg-self:not_a_variable} true) foo)))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "not_a_variable"
@@ -63,7 +63,7 @@ Tests for if:
   $ test_action '(run echo (if (if true true false) (concat foo bar) (concat baz qux)))'
   foobar
   $ test_action '(run echo (if invalid-condition foo bar))'
-  File "dune.lock/test.pkg", line 2, characters 23-40:
+  File ".dune-solution-cache/test.pkg", line 2, characters 23-40:
   2 | (install (run echo (if invalid-condition foo bar)))
                              ^^^^^^^^^^^^^^^^^
   Error: This expression is used as a condition and so must evaluate to either
@@ -86,7 +86,7 @@ Test conversion from blang to string:
 
 Test the error message when the program doesn't exist:
   $ test_action '(run madeup)'
-  File "dune.lock/test.pkg", line 2, characters 14-20:
+  File ".dune-solution-cache/test.pkg", line 2, characters 14-20:
   2 | (install (run madeup))
                     ^^^^^^
   Error: Program madeup not found in the tree or in PATH
@@ -95,14 +95,14 @@ Test the error message when the program doesn't exist:
   $ test_action '(run (concat e c h o) hello)'
   hello
   $ test_action '(run (concat m a d e u p) hello)'
-  File "dune.lock/test.pkg", line 2, characters 14-34:
+  File ".dune-solution-cache/test.pkg", line 2, characters 14-34:
   2 | (install (run (concat m a d e u p) hello))
                     ^^^^^^^^^^^^^^^^^^^^
   Error: Program madeup not found in the tree or in PATH
    (context: default)
   [1]
   $ test_action '(run (if true madeup echo) hello)'
-  File "dune.lock/test.pkg", line 2, characters 14-35:
+  File ".dune-solution-cache/test.pkg", line 2, characters 14-35:
   2 | (install (run (if true madeup echo) hello))
                     ^^^^^^^^^^^^^^^^^^^^^
   Error: Program madeup not found in the tree or in PATH

--- a/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
@@ -29,7 +29,7 @@ implementations.
 When the latest version of all packages is the same, the ocaml-base-compiler
 package is chosen, which is what we want.
   $ solve ocaml
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
 
@@ -43,7 +43,7 @@ The alpha version of the compiler is not chosen here because dune's
 solver respects the avoid-version flag between multiple versions of
 the same package.
   $ solve ocaml
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
 
@@ -67,7 +67,7 @@ of compiler packages with a higher version number than the latest
 version of ocaml-base-compiler without the avoid-version flag is
 unstable.
   $ solve ocaml
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0
 
@@ -78,7 +78,7 @@ other choices:
   > depends: [ "ocaml" {> "$CURRENT" } ]
   > EOF
   $ solve edgy
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - edgy.1.0
   - ocaml.5.3.0
   - ocaml-variants.5.3.0+trunk (this version should be avoided)
@@ -87,7 +87,7 @@ other choices:
   > depends: [ "ocaml" "ocaml-base-compiler" {> "$CURRENT" } ]
   > EOF
   $ solve edgy
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - edgy.1.0
   - ocaml.5.2.0
   - ocaml-base-compiler.5.2.0+alpha1 (this version should be avoided)

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -52,7 +52,7 @@ Make a workspace file which sets some of the variables.
   > (lang dune 3.20)
   > (pkg enabled)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock)
   >  (solver_env
   >   (os linux)
@@ -69,7 +69,7 @@ Make a workspace file which sets some of the variables.
 
 Solve the packages again, this time with the variables set.
   $ solve_all
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - no-deps-a.1.0
   - no-deps-b.1.0
   - static-deps.1.0
@@ -80,7 +80,7 @@ Solve the packages again, this time with the variables set.
   (repositories
    (complete false)
    (used))
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - dynamic-deps.1.0
   - no-deps-a.1.0
   - no-deps-b.1.0
@@ -96,7 +96,7 @@ Solve the packages again, this time with the variables set.
    (variable_values
     (os linux)
     (arch arm)))
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - dynamic-deps-lazy.1.0
   - no-deps-a.1.0
   - no-deps-b.1.0
@@ -134,7 +134,7 @@ stored in the lockdir metadata:
   >  (name foo)
   >  (depends filtered-commands))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - filtered-commands.0.0.1
 
   $ cat ${default_lock_dir}/filtered-commands.pkg

--- a/test/blackbox-tests/test-cases/pkg/submodules.t
+++ b/test/blackbox-tests/test-cases/pkg/submodules.t
@@ -70,6 +70,6 @@ We'll use the mock repository as source and depend on `bar`:
 We should be able to successfully solve the project with `foo` and `bar`:
 
   $ dune pkg lock
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - bar.0.0.1
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/test-only-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/test-only-deps.t
@@ -37,7 +37,7 @@ Test that we can identify the test-only locked dependencies of a package
   >   baz
   >   (qux :with-test)))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.2
   - b.0.0.1
   - bar.0.0.1
@@ -47,7 +47,7 @@ Test that we can identify the test-only locked dependencies of a package
   - qux.0.0.1
 List immediate dependencies in the lockdir. This should mirror the information in dune-project.
   $ dune describe pkg list-locked-dependencies
-  Dependencies of local packages locked in dune.lock
+  Dependencies of local packages locked in .dune-solution-cache
   - Immediate dependencies of local package local_1.dev
     - local_2.dev
     
@@ -58,7 +58,7 @@ List transitive dependencies. Note that only immediate test-only dependencies
 and their dependencies are included (not test-only dependencies of test-only
 dependencies).
   $ dune describe pkg list-locked-dependencies --transitive
-  Dependencies of local packages locked in dune.lock
+  Dependencies of local packages locked in .dune-solution-cache
   - Transitive dependencies of local package local_1.dev
     - b.0.0.1
     - bar.0.0.1
@@ -85,7 +85,7 @@ is run with with-test=true so the dependency won't even be in the lockdir.
   >   (foo (= :with-test false))
   >   bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - b.0.0.1
   - bar.0.0.1
   - c.0.0.1
@@ -112,7 +112,7 @@ incompatible version of the dependency will be in the lockdir.
   >   (a (or (= 0.0.1) (and :with-test (= 0.0.2))))
   >   bar))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.2
   - b.0.0.1
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -14,7 +14,7 @@ Demonstrate what happens when we try to fetch from a source that doesn't exist:
   > }
 
 Local file system
-  $ runtest "(copy \"$PWD/dummy\")" 2>&1 | sed "s#$(pwd)#PWD#" | sed '/ *^\^*$/d' | sed '\#^File ".*dune.lock/foo.pkg", line 2, characters#d'
+  $ runtest "(copy \"$PWD/dummy\")" 2>&1 | sed "s#$(pwd)#PWD#" | sed '/ *^\^*$/d' | sed '\#^File ".*.dune-solution-cache/foo.pkg", line 2, characters#d'
   2 | (source (copy "PWD/dummy"))
   Error:
   PWD/dummy

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -5,7 +5,7 @@ Set up two build contexts: a default one for linux and another for macos.
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (lock_dir
-  >  (path dune.lock)
+  >  (path .dune-solution-cache)
   >  (repositories mock)
   >  (solver_env
   >   (os linux)))
@@ -29,7 +29,7 @@ Helper shell function to generate a dune-project file and generate lockdir for b
 
   $ solve_project() {
   >   cat >dune-project
-  >   dune pkg lock dune.lock
+  >   dune pkg lock .dune-solution-cache
   >   dune pkg lock dune.macos.lock
   > }
 
@@ -81,7 +81,7 @@ A package whose oldest and newest version is only available if with-test is fals
 No solution will be available on macos as all versions of this package are only
 available on linux.
   $ solve linux-only
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - linux-only.0.0.2
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
@@ -96,7 +96,7 @@ available on linux.
 The latest version of the package will be chosen on linux but the middle
 version will be chosen on macos as that's the only version available on macos.
   $ solve macos-sometimes
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - macos-sometimes.0.0.3
   Solution for dune.macos.lock:
   - macos-sometimes.0.0.2
@@ -105,7 +105,7 @@ A warning will be printed as the undefined-var.0.0.1 package has an undefined
 variable in its `available` filter. The undefined-var.0.0.2 package has a valid
 `available` filter but is only available on linux.
   $ solve undefined-var
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - undefined-var.0.0.2
   Error: Unable to solve dependencies for the following lock directories:
   Lock directory dune.macos.lock:
@@ -121,7 +121,7 @@ Warnings will be printed and no solution will be found as the availability
 filter resolves to a string instead of to a boolean.
   $ solve availability-string
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: x.dev
   - availability-string -> (problem)
@@ -142,7 +142,7 @@ The middle version will be picked as this is the only one available if
 with-test is set. This exercises that we can handle flags in the available
 filter.
   $ solve with-test-check
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - with-test-check.0.0.2
   Solution for dune.macos.lock:
   - with-test-check.0.0.2

--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -23,7 +23,7 @@ project:
 Solve the dependencies:
   $ dune pkg lock 2>&1 | sed -E 's/"3.[0-9]+"/"3.XX"/'
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev
   - dune -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
@@ -14,7 +14,7 @@ Reproduce internal error with dune pkg validate-lockdir in #11188.
   >  (depends
   >   a))
   > EOF
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - a.0.0.1
 
 Dune is able to verify this lock directory correctly:

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -32,31 +32,31 @@ Test variable filters on dependencies
 
 Regular dependencies are resolved transitively:
   $ solve depends-on-foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - depends-on-foo.0.0.1
   - foo.0.0.1
   - foo-dependency.0.0.1
 
 Transitive test dependencies are not included:
   $ solve depends-on-foo-with-test
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - depends-on-foo-with-test.0.0.1
 
 Test dependencies of the project are included:
   $ solve "(foo :with-test)"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - foo.0.0.1
   - foo-dependency.0.0.1
 
 Test dependencies of test dependencies are excluded:
   $ solve "(depends-on-foo-with-test :with-test)"
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - depends-on-foo-with-test.0.0.1
 
 Conflicting packages can't be co-installed:
   $ solve foo conflicts-with-foo
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: foo.0.0.1 foo-dependency.0.0.1 x.dev
   - conflicts-with-foo -> (problem)
@@ -67,7 +67,7 @@ Conflicting packages can't be co-installed:
 Conflicting packages in transitive dependencies can't be co-installed:
   $ solve depends-on-foo conflicts-with-foo
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dune.lock:
+  Lock directory .dune-solution-cache:
   Couldn't solve the package dependency formula.
   Selected candidates: depends-on-foo.0.0.1 foo.0.0.1 foo-dependency.0.0.1
                        x.dev
@@ -78,7 +78,7 @@ Conflicting packages in transitive dependencies can't be co-installed:
 
 Conflicts with transitive test dependencies don't affect the solution:
   $ solve depends-on-foo-with-test conflicts-with-foo
-  Solution for dune.lock:
+  Solution for .dune-solution-cache:
   - conflicts-with-foo.0.0.1
   - depends-on-foo-with-test.0.0.1
 

--- a/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
+++ b/test/expect-tests/dune_pkg_outdated/dune_pkg_outdated_test.ml
@@ -66,7 +66,7 @@ let test_message
       number_of_transitive
       total_number_of_transitive
   in
-  let lock_dir_path = Stdune.Path.of_string "dune.lock" in
+  let lock_dir_path = Stdune.Path.of_string ".dune-solution-cache" in
   let message =
     Dune_pkg.Outdated.For_tests.explain_results ~transitive ~lock_dir_path results
   in
@@ -101,17 +101,17 @@ let test_message
 let%expect_test "transitive helper message" =
   (* Transitive dependencies, helper message in the transitive = true case. *)
   test_message ~transitive:true 0 0 10 20;
-  [%expect {| [Warning]  10/20 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  10/20 packages in .dune-solution-cache are outdated. |}];
   test_message ~transitive:false 0 0 10 20;
   [%expect
     {|
-    [Warning]  10/20 packages in dune.lock are outdated.
+    [Warning]  10/20 packages in .dune-solution-cache are outdated.
     [no style] Showing immediate dependencies, use --transitive to see the rest. |}];
   (* No transitive dependencies, no helper message in both cases. *)
   test_message ~transitive:true 10 20 0 0;
-  [%expect {| [Warning]  10/20 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  10/20 packages in .dune-solution-cache are outdated. |}];
   test_message ~transitive:false 10 20 0 0;
-  [%expect {| [Warning]  10/20 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  10/20 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* [test a b c d] prints a message saying that out of [b] immediate dependencies [a] were
@@ -137,34 +137,34 @@ let test
 (* We should always report an empty lock file as up to date. *)
 let%expect_test "no packages" =
   test 0 0 0 0;
-  [%expect {| [Success]  dune.lock is up to date. |}]
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}]
 ;;
 
 let%expect_test "single immediate package" =
   test 0 1 0 0;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 1 0 0;
-  [%expect {| [Warning]  1/1 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  1/1 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "two immediate packages" =
   test 0 2 0 0;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 2 0 0;
-  [%expect {| [Warning]  1/2 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/2 packages in .dune-solution-cache are outdated. |}];
   test 2 2 0 0;
-  [%expect {| [Warning]  2/2 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  2/2 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "three immediate packages" =
   test 0 3 0 0;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 3 0 0;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 2 3 0 0;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 3 3 0 0;
-  [%expect {| [Warning]  3/3 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  3/3 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* This case will never happen as having at least a single transitive dependency means
@@ -172,31 +172,31 @@ let%expect_test "three immediate packages" =
    this however, so for consistency we include what it would say. *)
 let%expect_test "single transitive package" =
   test 0 0 0 1;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 0 0 1 1;
-  [%expect {| [Warning]  1/1 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  1/1 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* Same as above. *)
 let%expect_test "two transitives packages" =
   test 0 0 0 2;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 0 0 1 2;
-  [%expect {| [Warning]  1/2 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/2 packages in .dune-solution-cache are outdated. |}];
   test 0 0 2 2;
-  [%expect {| [Warning]  2/2 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  2/2 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* Same as above. *)
 let%expect_test "three transitive packages" =
   test 0 0 0 3;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 0 0 1 3;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 0 0 2 3;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 0 0 3 3;
-  [%expect {| [Warning]  3/3 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  3/3 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* A lockfile with two packages, one an immediate dependency and one a transitive
@@ -204,71 +204,71 @@ let%expect_test "three transitive packages" =
    outdated. Since we only show the *)
 let%expect_test "one immediate and one transitive" =
   test 0 1 0 1;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 1 0 1;
-  [%expect {| [Warning]  1/2 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/2 packages in .dune-solution-cache are outdated. |}];
   test 0 1 1 1;
-  [%expect {| [Warning]  1/2 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/2 packages in .dune-solution-cache are outdated. |}];
   test 1 1 1 1;
-  [%expect {| [Warning]  2/2 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  2/2 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "one immediate and two transitive" =
   test 0 1 0 2;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 1 0 2;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 0 1 1 2;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 1 1 1 2;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 0 1 2 2;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 1 1 2 2;
-  [%expect {| [Warning]  3/3 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  3/3 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "two immediate and one transitive" =
   test 0 2 0 1;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 2 0 1;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 2 2 0 1;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 0 2 1 1;
-  [%expect {| [Warning]  1/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/3 packages in .dune-solution-cache are outdated. |}];
   test 1 2 1 1;
-  [%expect {| [Warning]  2/3 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/3 packages in .dune-solution-cache are outdated. |}];
   test 2 2 1 1;
-  [%expect {| [Warning]  3/3 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  3/3 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "two immediate and two transitive" =
   test 0 2 0 2;
-  [%expect {| [Success]  dune.lock is up to date. |}];
+  [%expect {| [Success]  .dune-solution-cache is up to date. |}];
   test 1 2 0 2;
-  [%expect {| [Warning]  1/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/4 packages in .dune-solution-cache are outdated. |}];
   test 2 2 0 2;
-  [%expect {| [Warning]  2/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/4 packages in .dune-solution-cache are outdated. |}];
   test 0 2 1 2;
-  [%expect {| [Warning]  1/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  1/4 packages in .dune-solution-cache are outdated. |}];
   test 1 2 1 2;
-  [%expect {| [Warning]  2/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/4 packages in .dune-solution-cache are outdated. |}];
   test 2 2 1 2;
-  [%expect {| [Warning]  3/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  3/4 packages in .dune-solution-cache are outdated. |}];
   test 0 2 2 2;
-  [%expect {| [Warning]  2/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  2/4 packages in .dune-solution-cache are outdated. |}];
   test 1 2 2 2;
-  [%expect {| [Warning]  3/4 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  3/4 packages in .dune-solution-cache are outdated. |}];
   test 2 2 2 2;
-  [%expect {| [Warning]  4/4 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  4/4 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 let%expect_test "some larger examples" =
   test 0 0 10 100;
-  [%expect {| [Warning]  10/100 packages in dune.lock are outdated. |}];
+  [%expect {| [Warning]  10/100 packages in .dune-solution-cache are outdated. |}];
   test 12 34 56 78;
-  [%expect {| [Warning]  68/112 packages in dune.lock are outdated. |}]
+  [%expect {| [Warning]  68/112 packages in .dune-solution-cache are outdated. |}]
 ;;
 
 (* [test_entire_output a b c d] prints the message from before and also all the outdated
@@ -287,7 +287,7 @@ let test_entire_output
       number_of_transitive
       total_number_of_transitive
   in
-  let lock_dir_path = Stdune.Path.of_string "dune.lock" in
+  let lock_dir_path = Stdune.Path.of_string ".dune-solution-cache" in
   let message = Dune_pkg.Outdated.For_tests.pp ~transitive ~lock_dir_path results in
   Console.print [ message ]
 ;;
@@ -297,7 +297,7 @@ let%expect_test "testing entire output" =
   test_entire_output ~transitive:false 2 3 2 3;
   [%expect
     {|
-4/6 packages in dune.lock are outdated.
+4/6 packages in .dune-solution-cache are outdated.
 Showing immediate dependencies, use --transitive to see the rest.
 - foo0 1.0.0 < 2.0.0
 - foo1 1.0.0 < 2.0.0
@@ -305,7 +305,7 @@ Showing immediate dependencies, use --transitive to see the rest.
   test_entire_output ~transitive:true 2 3 2 3;
   [%expect
     {|
-4/6 packages in dune.lock are outdated.
+4/6 packages in .dune-solution-cache are outdated.
 - foo0 1.0.0 < 2.0.0
 - foo1 1.0.0 < 2.0.0
 - bar0 1.0.0 < 2.0.0


### PR DESCRIPTION
Dune's lock directories are currently not portable. Naming them "dune.lock" might suggest to users of other packgae managers that it is safe to check them into version control and share them between developers potentially using different machines. To discourage this behaviour, lockdirs are renamed from "dune.lock" to ".dune-solution-cache". The fact that this directory begins with a period and contains the word "cache" should hopefully discourage users from checking them into version control.

For the same reason, the collection of dev tool lockdirs is renamed from "dev-tools.locks" to ".dune-tools-solution-cache".

In the future it's likely we will enable portable lock directories by default, at which point they will become safe to check into version control. At this point we can change the default lock directory name back to "dune.lock" and encourage checking them into version control.