### PR TITLE
cram: rename conflict -> conflict_marker

### DIFF
--- a/doc/changes/added/12538.md
+++ b/doc/changes/added/12538.md
@@ -1,4 +1,4 @@
-- Add a `(conflict error|ignore)` option to the cram stanza. When `(conflict
-  error)` is set, the cram test will fail in the presence of conflict markers.
-  Git, diff3 and jujutsu conflict markers are detected. (#12538, #12617, fixes
-  #12512, @rgrinberg, @Alizter)
+- Add a `(conflict_markers error|ignore)` option to the cram stanza. When
+  `(conflict_markers error)` is set, the cram test will fail in the presence of
+  conflict markers. Git, diff3 and jujutsu conflict markers are detected.
+  (#12538, #12617, fixes #12512, @rgrinberg, @Alizter)

--- a/doc/reference/dune/cram.rst
+++ b/doc/reference/dune/cram.rst
@@ -110,7 +110,7 @@ Cram
 
       This limits each selected test to at most 2.5 seconds of execution time.
 
-   .. describe:: (conflict <ignore|error>)
+   .. describe:: (conflict_markers <ignore|error>)
 
       .. versionadded:: 3.21
 

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -55,10 +55,12 @@ let cram_stanzas =
       (* CR-someday rgrinberg for alizter: insert a location spanning the
          entire once we start extracting it *)
       User_error.raise
-        [ Pp.text "Conflict found. Please remove it or set (conflict allow)" ]
+        [ Pp.text
+            "Conflict marker found. Please remove it or set (conflict_markers allow)"
+        ]
     | _ -> state
   in
-  fun ~(conflict : Cram_stanza.Conflict.t) lexbuf ->
+  fun ~(conflict_markers : Cram_stanza.Conflict_markers.t) lexbuf ->
     let rec loop acc conflict_state =
       match Cram_lexer.block lexbuf with
       | None -> List.rev acc
@@ -67,7 +69,7 @@ let cram_stanzas =
           match s with
           | Command _ -> conflict_state
           | Comment lines ->
-            (match conflict with
+            (match conflict_markers with
              | Ignore -> conflict_state
              | Error -> List.fold_left lines ~init:conflict_state ~f:find_conflict)
         in
@@ -77,7 +79,7 @@ let cram_stanzas =
 ;;
 
 module For_tests = struct
-  let cram_stanzas lexbuf = cram_stanzas lexbuf ~conflict:Ignore
+  let cram_stanzas lexbuf = cram_stanzas lexbuf ~conflict_markers:Ignore
 
   let dyn_of_block = function
     | Cram_lexer.Comment lines -> Dyn.variant "Comment" [ Dyn.list Dyn.string lines ]
@@ -482,9 +484,9 @@ let run_cram_test env ~src ~script ~cram_stanzas ~temp_dir ~cwd ~timeout =
       (timeout_msg @ [ timeout_set_message ])
 ;;
 
-let run_produce_correction ~conflict ~src ~env ~script ~timeout lexbuf =
+let run_produce_correction ~conflict_markers ~src ~env ~script ~timeout lexbuf =
   let temp_dir = make_temp_dir ~script in
-  let cram_stanzas = cram_stanzas lexbuf ~conflict in
+  let cram_stanzas = cram_stanzas lexbuf ~conflict_markers in
   let cwd = Path.parent_exn script in
   let env = make_run_env env ~temp_dir ~cwd in
   let open Fiber.O in
@@ -501,11 +503,11 @@ module Script = Persistent.Make (struct
     let test_example () = []
   end)
 
-let run_and_produce_output ~conflict ~src ~env ~dir:cwd ~script ~dst ~timeout =
+let run_and_produce_output ~conflict_markers ~src ~env ~dir:cwd ~script ~dst ~timeout =
   let script_contents = Io.read_file ~binary:false script in
   let lexbuf = Lexbuf.from_string script_contents ~fname:(Path.to_string script) in
   let temp_dir = make_temp_dir ~script in
-  let cram_stanzas = cram_stanzas lexbuf ~conflict in
+  let cram_stanzas = cram_stanzas lexbuf ~conflict_markers in
   (* We don't want the ".cram.run.t" dir around when executing the script. *)
   Path.rm_rf (Path.parent_exn script);
   let env = make_run_env env ~temp_dir ~cwd in
@@ -552,7 +554,7 @@ module Run = struct
 
     let action { src; dir; script; output; timeout } ~ectx:_ ~(eenv : Action.env) =
       run_and_produce_output
-        ~conflict:Ignore
+        ~conflict_markers:Ignore
         ~src
         ~env:eenv.env
         ~dir
@@ -574,7 +576,7 @@ module Make_script = struct
     type ('path, 'target) t =
       { script : 'path
       ; target : 'target
-      ; conflict : Cram_stanza.Conflict.t
+      ; conflict_markers : Cram_stanza.Conflict_markers.t
       }
 
     let name = "cram-generate"
@@ -582,22 +584,22 @@ module Make_script = struct
     let bimap t f g = { t with script = f t.script; target = g t.target }
     let is_useful_to ~memoize:_ = true
 
-    let encode { script = src; target = dst; conflict } path target : Sexp.t =
+    let encode { script = src; target = dst; conflict_markers } path target : Sexp.t =
       List
         [ path src
         ; target dst
         ; Atom
-            (match conflict with
+            (match conflict_markers with
              | Error -> "error"
              | Ignore -> "ignore")
         ]
     ;;
 
-    let action { script = src; target = dst; conflict } ~ectx:_ ~eenv:_ =
+    let action { script = src; target = dst; conflict_markers } ~ectx:_ ~eenv:_ =
       let commands =
         Io.read_file ~binary:false src
         |> Lexbuf.from_string ~fname:(Path.to_string src)
-        |> cram_stanzas ~conflict
+        |> cram_stanzas ~conflict_markers
         |> List.filter_map ~f:(function
           | Cram_lexer.Comment _ -> None
           | Command s -> Some s)
@@ -611,8 +613,8 @@ module Make_script = struct
   include Action_ext.Make (Spec)
 end
 
-let make_script ~src ~script ~conflict =
-  Make_script.action { script = src; target = script; conflict }
+let make_script ~src ~script ~conflict_markers =
+  Make_script.action { script = src; target = script; conflict_markers }
 ;;
 
 module Diff = struct
@@ -640,7 +642,7 @@ module Diff = struct
         in
         let current_stanzas =
           Lexbuf.from_string ~fname:(Path.to_string script) current
-          |> cram_stanzas ~conflict:Ignore
+          |> cram_stanzas ~conflict_markers:Ignore
         in
         let rec loop acc current expected =
           match current with
@@ -683,7 +685,7 @@ module Action = struct
         script
         ~f:
           (run_produce_correction
-             ~conflict:Ignore
+             ~conflict_markers:Ignore
              ~src:script
              ~env:eenv.env
              ~script

--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -4,7 +4,7 @@ open Import
 val make_script
   :  src:Path.t
   -> script:Path.Build.t
-  -> conflict:Cram_stanza.Conflict.t
+  -> conflict_markers:Cram_stanza.Conflict_markers.t
   -> Action.t
 
 (** Runs the script created in [make_script] *)

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -20,7 +20,7 @@ let decode_applies_to =
   subtree <|> predicate
 ;;
 
-module Conflict = struct
+module Conflict_markers = struct
   type t =
     | Error
     | Ignore
@@ -41,7 +41,7 @@ type t =
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
   ; locks : Locks.t
-  ; conflict : Conflict.t option
+  ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
   ; timeout : (Loc.t * float) option
@@ -96,10 +96,10 @@ let decode =
             User_error.raise
               ~loc
               [ Pp.text "Timeout value must be a non-negative float." ])
-     and+ conflict =
+     and+ conflict_markers =
        field_o
-         "conflict"
-         (Dune_lang.Syntax.since Stanza.syntax (3, 21) >>> Conflict.decode)
+         "conflict_markers"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 21) >>> Conflict_markers.decode)
      in
      { loc
      ; alias
@@ -110,6 +110,6 @@ let decode =
      ; package
      ; runtest_alias
      ; timeout
-     ; conflict
+     ; conflict_markers
      })
 ;;

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -4,7 +4,7 @@ type applies_to =
   | Whole_subtree
   | Files_matching_in_this_dir of Predicate_lang.Glob.t
 
-module Conflict : sig
+module Conflict_markers : sig
   type t =
     | Error
     | Ignore
@@ -19,7 +19,7 @@ type t =
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
   ; locks : Locks.t
-  ; conflict : Conflict.t option
+  ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
   ; timeout : (Loc.t * float) option

--- a/test/blackbox-tests/test-cases/cram/conflict-markers-diff3.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers-diff3.t
@@ -5,7 +5,7 @@ Cram tests can forbid git diff3 conflicts:
   > EOF
 
   $ cat >dune <<EOF
-  > (cram (conflict error))
+  > (cram (conflict_markers error))
   > EOF
 
 Full diff3 conflict without command and output interleaving:
@@ -22,7 +22,8 @@ Full diff3 conflict without command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test
@@ -42,7 +43,8 @@ Full diff3 conflict with command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test

--- a/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
@@ -5,7 +5,7 @@ Cram tests can forbid jujutsu conflicts:
   > EOF
 
   $ cat >dune <<EOF
-  > (cram (conflict error))
+  > (cram (conflict_markers error))
   > EOF
 
 Full jujutsu conflict without command and output interleaving:
@@ -20,7 +20,8 @@ Full jujutsu conflict without command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test
@@ -38,7 +39,8 @@ Full jujutsu conflict with command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test
@@ -59,7 +61,8 @@ Jujutsu default style conflict (diff + snapshot):
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test
@@ -80,7 +83,8 @@ Jujutsu snapshot style conflict:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test

--- a/test/blackbox-tests/test-cases/cram/conflict-markers.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers.t
@@ -5,7 +5,7 @@ Cram tests can forbid conflicts:
   > EOF
 
   $ cat >dune <<EOF
-  > (cram (conflict error))
+  > (cram (conflict_markers error))
   > EOF
 
 Full conflict without command and output interleaving:
@@ -20,7 +20,8 @@ Full conflict without command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test
@@ -38,7 +39,8 @@ Full conflict with command and output interleaving:
   > EOF
 
   $ dune runtest test.t
-  Error: Conflict found. Please remove it or set (conflict allow)
+  Error: Conflict marker found. Please remove it or set (conflict_markers
+  allow)
   -> required by _build/default/.cram.test.t/cram.sh
   -> required by _build/default/.cram.test.t/cram.out
   -> required by alias test

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -26,7 +26,7 @@
   %{bin:dune_cmd}
   (package dune))
  ;; We don't allow conflict markers in tests
- (conflict error)
+ (conflict_markers error)
  ;; Tests shouldn't take longer than 60s
  (timeout 60))
 


### PR DESCRIPTION
This is a more deliberate name to avoid confusion in the future.