### PR TITLE
test(pkg): don't use (pkg enabled) by default

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -105,7 +105,6 @@ add_mock_repo_if_needed() {
   then
       cat >dune-workspace <<EOF
 (lang dune 3.20)
-(pkg enabled)
 (lock_dir
  (repositories mock))
 (repository
@@ -140,7 +139,6 @@ create_mock_repo() {
   repo="${1:-file://$(pwd)/mock-opam-repository}"
   cat >dune-workspace <<EOF
 (lang dune 3.20)
-(pkg enabled)
 (lock_dir
  (repositories mock))
 (repository

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -19,8 +19,8 @@ Test the error cases for invalid opam repositories
   > }
 
   $ lock
-  File "dune-workspace", line 7, characters X-X:
-  7 |  (url ..))
+  File "dune-workspace", line 6, characters X-X:
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/directory-that-does-not-exist
   does not exist
@@ -30,8 +30,8 @@ Test the error cases for invalid opam repositories
   $ rm dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/empty"
   $ lock
-  File "dune-workspace", line 7, characters X-X:
-  7 |  (url ..))
+  File "dune-workspace", line 6, characters X-X:
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/empty
   is not a directory
@@ -40,8 +40,8 @@ Test the error cases for invalid opam repositories
   $ rm dune-workspace
   $ add_mock_repo_if_needed "file://$(pwd)/no-packages-dir"
   $ lock
-  File "dune-workspace", line 7, characters X-X:
-  7 |  (url ..))
+  File "dune-workspace", line 6, characters X-X:
+  6 |  (url ..))
   Error:
   $TESTCASE_ROOT/no-packages-dir
   doesn't look like a path to an opam repository as it lacks a subdirectory

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -106,8 +106,6 @@ EOF
 (repository
  (name mock)
  (url "file://$(pwd)/mock-opam-repository"))
-
-(pkg enabled)
 EOF
 }
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
@@ -75,8 +75,8 @@ Test that dune pkg enabled reports disabled:
 Test that pkg commands fail when disabled:
 
   $ dune pkg lock
-  File "dune-workspace", line 2, characters 5-13:
-  2 | (pkg disabled)
+  File "dune-workspace", line 7, characters 5-13:
+  7 | (pkg disabled)
            ^^^^^^^^
   Error: Package management is disabled in workspace configuration.
   Hint: To enable package management, remove the explicit (pkg disabled)


### PR DESCRIPTION
These were added but it makes it difficult to change later. Let's always test the default behaviour and opt in when needed. The direction in #11775 won't be followed anyway.