### PR TITLE
feat(pkg): autolocking

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -128,6 +128,13 @@ let revision t =
   | Directory _ -> Code_error.raise "not a git repo" []
 ;;
 
+let content_digest t =
+  match t.source with
+  | Repo repo ->
+    Rev_store.At_rev.rev repo |> Rev_store.Object.to_hex |> Dune_digest.string
+  | Directory path -> Path_digest.digest_with_lstat path
+;;
+
 let load_opam_package_from_dir ~(dir : Path.t) package =
   let opam_file_path = Paths.opam_file package in
   match Path.exists (Path.append_local dir opam_file_path) with

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -26,6 +26,15 @@ val of_git_repo : Loc.t -> OpamUrl.t -> t Fiber.t
 val revision : t -> Rev_store.At_rev.t
 val serializable : t -> Serializable.t option
 
+(** [content_digest t] digests the contents of an opam repository. For a Git
+    repository, this is a digest of the commit SHA. For a directory-based
+    repository, this is a digest of the directory's contents.
+
+    Raises [User_error] in the directory case if the path cannot be accessed or
+    digested due to permission errors, the directory being deleted or modified
+    between stat and digest, or other filesystem errors. *)
+val content_digest : t -> Dune_digest.t
+
 module Key : sig
   type t
 

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -134,14 +134,16 @@ let check_for_unnecessary_packges_in_lock_dir
       ])
 ;;
 
-let up_to_date local_packages ~dependency_hash:saved_dependency_hash =
+let dependency_digest local_packages =
   let local_packages =
     Package_name.Map.values local_packages |> List.map ~f:Local_package.for_solver
   in
-  let dependency_hash =
-    Local_package.For_solver.non_local_dependencies local_packages
-    |> Local_package.Dependency_hash.of_dependency_formula
-  in
+  Local_package.For_solver.non_local_dependencies local_packages
+  |> Local_package.Dependency_hash.of_dependency_formula
+;;
+
+let up_to_date local_packages ~dependency_hash:saved_dependency_hash =
+  let dependency_hash = dependency_digest local_packages in
   match saved_dependency_hash, dependency_hash with
   | None, None -> `Valid
   | Some lock_dir_dependency_hash, Some non_local_dependencies_hash

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -14,6 +14,10 @@ val create
   -> Lock_dir.t
   -> (t, User_message.t) result
 
+val dependency_digest
+  :  Local_package.t Package_name.Map.t
+  -> Local_package.Dependency_hash.t option
+
 (** Verifies if the dependencies described in the project file are still
     synchronized with the dependencies selected in the lock directroy. If it is
     not the case, it returns the hash of the new dependency set. *)

--- a/src/dune_pkg/path_digest.ml
+++ b/src/dune_pkg/path_digest.ml
@@ -1,0 +1,25 @@
+open Import
+
+let digest_with_lstat path =
+  match Path.lstat path with
+  | Error e ->
+    User_error.raise
+      [ Pp.textf "Can't stat path %S:" (Path.to_string path); Unix_error.Detailed.pp e ]
+  | Ok stats ->
+    let stats_for_digest = Dune_digest.Stats_for_digest.of_unix_stats stats in
+    (match Dune_digest.path_with_stats ~allow_dirs:true path stats_for_digest with
+     | Ok digest -> digest
+     | Error (Unix_error e) ->
+       User_error.raise
+         [ Pp.textf "Can't digest path %S:" (Path.to_string path)
+         ; Unix_error.Detailed.pp e
+         ]
+     | Error Unexpected_kind ->
+       User_error.raise
+         [ Pp.textf
+             "Can't digest path %S: Unexpected file kind %S (%s)"
+             (Path.to_string path)
+             (File_kind.to_string stats_for_digest.st_kind)
+             (File_kind.to_string_hum stats_for_digest.st_kind)
+         ])
+;;

--- a/src/dune_pkg/path_digest.mli
+++ b/src/dune_pkg/path_digest.mli
@@ -1,0 +1,10 @@
+open Import
+
+(** [digest_with_lstat path] stats the [path] using [lstat] (without following
+    symlinks) and computes a digest of its contents. Directories are allowed
+    and will be digested recursively.
+
+    Raises [User_error] if the path cannot be stat'd (e.g., does not exist or
+    permission denied), cannot be digested (e.g., I/O error during reading), or
+    has an unexpected file kind (e.g., socket, FIFO). *)
+val digest_with_lstat : Path.t -> Dune_digest.t

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -35,3 +35,12 @@ val local_package
 val get_opam_package_files
   :  t list
   -> (File_entry.t list list, User_message.t) result Fiber.t
+
+(** [digest t] computes a digest of the resolved package contents, excluding the
+    source location. For directory-based extra files, the digest of the
+    directory contents is included. For git-based extra files, the commit SHA is
+    included.
+
+    Raises [User_error] if extra files in a directory cannot be accessed or
+    digested due to permission errors, filesystem errors. *)
+val digest : t -> Dune_digest.t

--- a/src/dune_rules/lock_action.ml
+++ b/src/dune_rules/lock_action.ml
@@ -1,0 +1,198 @@
+open Import
+
+include struct
+  open Dune_pkg
+  module Solver_env = Solver_env
+  module Opam_repo = Opam_repo
+  module Local_package = Local_package
+  module Resolved_package = Resolved_package
+  module Version_preference = Version_preference
+  module Package_universe = Package_universe
+  module Package_dependency = Package_dependency
+  module Opam_solver = Opam_solver
+  module Sys_poll = Sys_poll
+end
+
+module Spec = struct
+  type ('path, 'target) t =
+    { target : 'target
+    ; lock_dir : 'path
+    ; packages : Local_package.t Package.Name.Map.t
+    ; repos : Opam_repo.t list
+    ; solver_env_from_context : Solver_env.t
+    ; unset_solver_vars : Package_variable_name.Set.t
+    ; constraints : Package_dependency.t list
+    ; selected_depopts : Package.Name.t list
+    ; pins : Resolved_package.t Package.Name.Map.t
+    ; version_preference : Version_preference.t
+    }
+
+  let name = "lock"
+  let version = 1
+  let bimap t f g = { t with lock_dir = f t.lock_dir; target = g t.target }
+  let is_useful_to ~memoize = memoize
+
+  let encode
+        { target
+        ; lock_dir
+        ; packages
+        ; repos
+        ; solver_env_from_context
+        ; unset_solver_vars
+        ; constraints
+        ; selected_depopts
+        ; pins
+        ; version_preference
+        }
+        encode_path
+        encode_target
+    =
+    Sexp.record
+      [ "target", encode_target target
+      ; "lock_dir", encode_path lock_dir
+      ; ( "packages"
+        , match Package_universe.dependency_digest packages with
+          | None -> Atom "no packages"
+          | Some hash ->
+            List [ Atom "hash"; Atom (Local_package.Dependency_hash.to_string hash) ] )
+      ; ( "repos"
+        , List
+            (List.map repos ~f:(fun repo ->
+               Sexp.Atom (Opam_repo.content_digest repo |> Dune_digest.to_string))) )
+      ; ( "solver_env_from_context"
+        , Atom
+            (Dune_digest.Feed.compute_digest
+               Solver_env.digest_feed
+               solver_env_from_context
+             |> Dune_digest.to_string) )
+      ; ( "unset_solver_vars"
+        , List
+            (Package_variable_name.Set.to_list unset_solver_vars
+             |> List.sort ~compare:Package_variable_name.compare
+             |> List.map ~f:(fun var -> Sexp.Atom (Package_variable_name.to_string var)))
+        )
+      ; ( "constraints"
+        , List
+            (List.sort constraints ~compare:(fun a b ->
+               Dune_lang.Package_name.compare
+                 a.Package_dependency.name
+                 b.Package_dependency.name)
+             |> List.map ~f:(fun { Package_dependency.name; constraint_ } ->
+               let name = Dune_lang.Package_name.to_string name in
+               let constraint_ =
+                 match constraint_ with
+                 | None -> "no constraints"
+                 | Some c -> Package_dependency.Constraint.to_dyn c |> Dyn.to_string
+               in
+               Sexp.List [ Sexp.Atom name; Sexp.Atom constraint_ ])) )
+      ; ( "selected_depopts"
+        , List
+            (List.sort selected_depopts ~compare:Dune_lang.Package_name.compare
+             |> List.map ~f:(fun pkg_name ->
+               Sexp.Atom (Dune_lang.Package_name.to_string pkg_name))) )
+      ; ( "pins"
+        , List
+            (Dune_lang.Package_name.Map.to_list pins
+             |> List.sort ~compare:(fun (a, _) (b, _) ->
+               Dune_lang.Package_name.compare a b)
+             |> List.map ~f:(fun (pkg_name, resolved_pkg) ->
+               let name = Dune_lang.Package_name.to_string pkg_name in
+               let digest =
+                 Resolved_package.digest resolved_pkg |> Dune_digest.to_string
+               in
+               Sexp.List [ Sexp.Atom name; Sexp.Atom digest ])) )
+      ; ( "version_preference"
+        , Atom
+            (match version_preference with
+             | Oldest -> "oldest"
+             | Newest -> "newest") )
+      ]
+  ;;
+
+  let action
+        { target
+        ; lock_dir = _
+        ; packages
+        ; repos
+        ; solver_env_from_context
+        ; unset_solver_vars
+        ; constraints
+        ; selected_depopts
+        ; pins
+        ; version_preference
+        }
+        ~ectx:_
+        ~eenv:{ Action.Ext.Exec.env; _ }
+    =
+    let open Fiber.O in
+    let* () = Fiber.return () in
+    let local_packages = Package.Name.Map.map packages ~f:Local_package.for_solver in
+    (* Whether or not the lock directory we are creating is portable or not
+       doesn't concern us. We therefore set it as non-portable. *)
+    let portable_lock_dir = false in
+    let* solver_env =
+      let open Fiber.O in
+      let+ solver_env_from_current_system =
+        Sys_poll.make ~path:(Env_path.path env) |> Sys_poll.solver_env_from_current_system
+      in
+      let solver_env =
+        [ solver_env_from_current_system; solver_env_from_context ]
+        |> List.fold_left ~init:Solver_env.with_defaults ~f:Solver_env.extend
+      in
+      Solver_env.unset_multi solver_env unset_solver_vars
+    in
+    let* solver_result =
+      Opam_solver.solve_lock_dir
+        solver_env
+        version_preference
+        repos
+        ~pins
+        ~local_packages
+        ~constraints
+        ~selected_depopts
+        ~portable_lock_dir
+    in
+    match solver_result with
+    | Error (`Manifest_error diagnostic) -> raise (User_error.E diagnostic)
+    | Error (`Solve_error diagnostic) -> User_error.raise [ diagnostic ]
+    | Ok { pinned_packages; files; lock_dir; _ } ->
+      let lock_dir_path = Path.build target in
+      let+ lock_dir =
+        Dune_pkg.Lock_dir.compute_missing_checksums ~pinned_packages lock_dir
+      in
+      Dune_pkg.Lock_dir.Write_disk.prepare
+        ~portable_lock_dir
+        ~lock_dir_path
+        ~files
+        lock_dir
+      |> Dune_pkg.Lock_dir.Write_disk.commit
+  ;;
+end
+
+module A = Action_ext.Make (Spec)
+
+let action
+      ~target
+      ~lock_dir
+      ~packages
+      ~repos
+      ~solver_env_from_context
+      ~unset_solver_vars
+      ~constraints
+      ~selected_depopts
+      ~pins
+      ~version_preference
+  =
+  A.action
+    { Spec.target
+    ; lock_dir
+    ; packages
+    ; repos
+    ; solver_env_from_context
+    ; unset_solver_vars
+    ; constraints
+    ; selected_depopts
+    ; pins
+    ; version_preference
+    }
+;;

--- a/src/dune_rules/lock_action.mli
+++ b/src/dune_rules/lock_action.mli
@@ -1,0 +1,14 @@
+open Import
+
+val action
+  :  target:Path.Build.t
+  -> lock_dir:Path.t
+  -> packages:Dune_pkg.Local_package.t Package.Name.Map.t
+  -> repos:Dune_pkg.Opam_repo.t list
+  -> solver_env_from_context:Dune_pkg.Solver_env.t
+  -> unset_solver_vars:Package_variable_name.Set.t
+  -> constraints:Dune_pkg.Package_dependency.t list
+  -> selected_depopts:Dune_pkg.Package_name.t list
+  -> pins:Dune_pkg.Resolved_package.t Dune_lang.Package_name.Map.t
+  -> version_preference:Dune_pkg.Version_preference.t
+  -> Action.t

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -29,6 +29,9 @@ val dev_tool_lock_dir : Dune_pkg.Dev_tool.t -> Path.t
 
 val select_lock_dir : Workspace.Lock_dir_selection.t -> Path.Source.t Memo.t
 
+(** Returns the lock directories present in the given workspace. *)
+val lock_dirs_of_workspace : Workspace.t -> Path.Source.Set.t Memo.t
+
 module Sys_vars : sig
   type t =
     { os : string option Memo.Lazy.t

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -2,27 +2,212 @@ open Import
 open Memo.O
 module Gen_rules = Build_config.Gen_rules
 
-let action_builder_with_dir_targets ~directory_targets =
-  let targets =
-    Targets.create
-      ~files:Path.Build.Set.empty
-      ~dirs:(Path.Build.Set.of_list directory_targets)
+include struct
+  open Dune_pkg
+  module Solver_env = Solver_env
+  module Package_name = Package_name
+  module Opam_repo = Opam_repo
+  module Local_package = Local_package
+  module Resolved_package = Resolved_package
+  module Version_preference = Version_preference
+  module Package_universe = Package_universe
+  module Package_dependency = Package_dependency
+  module Opam_solver = Opam_solver
+  module Pin = Pin
+  module Opam_file = Opam_file
+  module Sys_poll = Sys_poll
+  module Pkg_workspace = Pkg_workspace
+  module OpamUrl = OpamUrl
+  module Dev_tool = Dev_tool
+end
+
+let project_and_package_pins project =
+  let dir = Dune_project.root project in
+  let pins = Dune_project.pins project in
+  let packages = Dune_project.packages project in
+  Pin.DB.add_opam_pins (Pin.DB.of_stanza ~dir pins) packages
+;;
+
+let resolve_project_pins project_pins =
+  let scan_project ~read ~files =
+    let read file = Memo.of_reproducible_fiber (read file) in
+    Dune_project.gen_load
+      ~read
+      ~files
+      ~dir:Path.Source.root
+      ~infer_from_opam_files:false
+      ~load_opam_file_with_contents:Opam_file.load_opam_file_with_contents
+    >>| Option.map ~f:(fun project ->
+      let packages = Dune_project.packages project in
+      let pins = project_and_package_pins project in
+      pins, packages)
+    |> Memo.run
   in
-  Action_builder.with_targets ~targets
+  Pin.resolve project_pins ~scan_project
+;;
+
+let project_pins =
+  Dune_load.projects ()
+  >>| List.fold_left ~init:Pin.DB.empty ~f:(fun acc project ->
+    let pins = project_and_package_pins project in
+    Pin.DB.combine_exn acc pins)
+;;
+
+let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
+  let target = Path.Build.append_local dir lock_dir in
+  let lock_dir_param = lock_dir in
+  let rules =
+    let+ workspace = Workspace.workspace () in
+    let lock_dir_path = Path.of_local lock_dir_param in
+    let lock_dir = Workspace.find_lock_dir workspace lock_dir_path in
+    let constraints =
+      match lock_dir with
+      | None -> []
+      | Some lock_dir -> lock_dir.constraints
+    in
+    let selected_depopts =
+      match lock_dir with
+      | None -> []
+      | Some lock_dir -> lock_dir.depopts |> List.map ~f:snd
+    in
+    let { Action_builder.With_targets.build; targets } =
+      (let open Action_builder.O in
+       let+ packages =
+         let open Memo.O in
+         Dune_load.packages ()
+         >>| Dune_lang.Package.Name.Map.map ~f:Local_package.of_package
+         |> Action_builder.of_memo
+       and+ repos =
+         Action_builder.of_memo
+           (Memo.of_thunk (fun () ->
+              let repositories =
+                let default =
+                  Workspace.default_repositories
+                  |> List.map ~f:(fun repo ->
+                    let name = Pkg_workspace.Repository.name repo in
+                    Loc.none, name)
+                in
+                (let open Option.O in
+                 let+ lock_dir = Workspace.find_lock_dir workspace lock_dir_path in
+                 lock_dir.repositories)
+                |> Option.value ~default
+              in
+              let available_repos =
+                List.map workspace.repos ~f:(fun repo ->
+                  Pkg_workspace.Repository.name repo, repo)
+                |> Pkg_workspace.Repository.Name.Map.of_list_exn
+              in
+              let module Repository = Pkg_workspace.Repository in
+              repositories
+              |> Fiber.parallel_map ~f:(fun (loc, name) ->
+                match Repository.Name.Map.find available_repos name with
+                | None ->
+                  User_error.raise
+                    ~loc
+                    [ Pp.textf "Repository '%s' is not a known repository"
+                      @@ Repository.Name.to_string name
+                    ]
+                | Some repo ->
+                  let loc, opam_url = Repository.opam_url repo in
+                  (match OpamUrl.classify opam_url loc with
+                   | `Git -> Opam_repo.of_git_repo loc opam_url
+                   | `Path path ->
+                     Fiber.return @@ Opam_repo.of_opam_repo_dir_path loc path
+                   | `Archive ->
+                     User_error.raise
+                       ~loc
+                       [ Pp.textf
+                           "Repositories stored in archives (%s) are currently \
+                            unsupported"
+                         @@ OpamUrl.to_string opam_url
+                       ]))
+              |> Memo.of_non_reproducible_fiber))
+       and+ pins =
+         Action_builder.of_memo
+           (Memo.of_thunk (fun () ->
+              let open Memo.O in
+              let* project_pins_db = project_pins in
+              let workspace_pins_db =
+                let workspace_pins = Pin.DB.Workspace.of_stanza workspace.pins in
+                let pin_map = Dune_lang.Pin_stanza.Workspace.map workspace.pins in
+                let all_pin_names =
+                  pin_map
+                  |> String.Map.to_list
+                  |> List.fold_left ~init:[] ~f:(fun acc (_repo_name, pkg_map) ->
+                    pkg_map
+                    |> Dune_lang.Package_name.Map.to_list
+                    |> List.fold_left
+                         ~init:acc
+                         ~f:(fun acc (pkg_name, ((loc, _url), _pkg)) ->
+                           (loc, Dune_lang.Package_name.to_string pkg_name) :: acc))
+                in
+                Pin.DB.Workspace.extract workspace_pins ~names:all_pin_names
+              in
+              let combined_pins = Pin.DB.combine_exn workspace_pins_db project_pins_db in
+              Memo.return combined_pins
+              >>| resolve_project_pins
+              >>= Memo.of_reproducible_fiber))
+       in
+       let version_preference =
+         match lock_dir with
+         | None -> Version_preference.default
+         | Some { version_preference = None; _ } -> Version_preference.default
+         | Some { version_preference = Some vp; _ } -> vp
+       in
+       let solver_env_from_context =
+         match lock_dir with
+         | None -> Solver_env.with_defaults
+         | Some { solver_env = None; _ } -> Solver_env.with_defaults
+         | Some { solver_env = Some env; _ } ->
+           Solver_env.extend Solver_env.with_defaults env
+       in
+       let unset_solver_vars =
+         match lock_dir with
+         | None -> Package_variable_name.Set.empty
+         | Some { unset_solver_vars = None; _ } -> Package_variable_name.Set.empty
+         | Some { unset_solver_vars = Some vars; _ } -> vars
+       in
+       Lock_action.action
+         ~target
+         ~lock_dir:lock_dir_path
+         ~packages
+         ~repos
+         ~solver_env_from_context
+         ~unset_solver_vars
+         ~constraints
+         ~selected_depopts
+         ~pins
+         ~version_preference
+       |> Action.Full.make
+            ~can_go_in_shared_cache:false (* TODO: probably ok this allow this? *)
+            ~sandbox:Sandbox_config.needs_sandboxing)
+      |> Action_builder.with_no_targets
+      |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
+    in
+    let rule = Rule.make ~targets build in
+    Rules.of_rules [ rule ]
+  in
+  let directory_targets = Path.Build.Map.singleton target Loc.none in
+  Gen_rules.make ~directory_targets rules
 ;;
 
 let copy_lock_dir ~target ~lock_dir ~deps ~files =
   let open Action_builder.O in
   Action_builder.deps deps
   >>> (Path.Set.to_list_map files ~f:(fun src ->
-         let suffix = Path.drop_prefix_exn src ~prefix:(Path.source lock_dir) in
-         let dst = Path.Build.append_local target suffix in
-         let parent = Path.Build.parent_exn dst in
-         Action.progn [ Action.mkdir parent; Action.copy src dst ])
+         let dst =
+           Path.drop_prefix_exn src ~prefix:(Path.source lock_dir)
+           |> Path.Build.append_local target
+         in
+         Action.progn [ Action.mkdir (Path.Build.parent_exn dst); Action.copy src dst ])
        |> Action.concurrent
        |> Action.Full.make
        |> Action_builder.return)
-  |> action_builder_with_dir_targets ~directory_targets:[ target ]
+  |> Action_builder.with_targets
+       ~targets:
+         (Targets.create
+            ~files:Path.Build.Set.empty
+            ~dirs:(Path.Build.Set.singleton target))
 ;;
 
 let setup_copy_rules ~dir:target ~lock_dir =
@@ -41,38 +226,27 @@ let setup_copy_rules ~dir:target ~lock_dir =
   Gen_rules.make ~directory_targets (Memo.return rules)
 ;;
 
-let setup_lock_rules (workspace : Workspace.t) ~dir ~lock_dir =
-  let dir = Path.Build.append_local dir lock_dir in
-  let lock_dir = Path.Source.append_local workspace.dir lock_dir in
-  setup_copy_rules ~dir ~lock_dir
+let setup_lock_rules_with_source (workspace : Workspace.t) ~dir ~lock_dir =
+  let* source =
+    let lock_dir = Path.Source.append_local workspace.dir lock_dir in
+    let+ exists = Fs_memo.dir_exists (Path.Outside_build_dir.In_source_dir lock_dir) in
+    match exists with
+    | true -> `Source_tree lock_dir
+    | false -> `Generated
+  in
+  match source with
+  | `Source_tree lock_dir ->
+    let dir = Path.Build.append_source dir lock_dir in
+    setup_copy_rules ~dir ~lock_dir
+  | `Generated -> Memo.return (setup_lock_rules ~dir ~lock_dir)
 ;;
 
 let setup_dev_tool_lock_rules ~dir dev_tool =
-  let package_name = Dune_pkg.Dev_tool.package_name dev_tool in
+  let package_name = Dev_tool.package_name dev_tool in
   let dev_tool_name = Dune_lang.Package_name.to_string package_name in
   let dir = Path.Build.relative dir dev_tool_name in
   let lock_dir = Lock_dir.dev_tool_source_lock_dir dev_tool in
   setup_copy_rules ~dir ~lock_dir
-;;
-
-let lock_dirs_of_workspace (workspace : Workspace.t) =
-  let module Set = Path.Source.Set in
-  let+ lock_dirs_from_ctx =
-    Memo.List.map workspace.contexts ~f:(function
-      | Opam _ | Default { lock_dir = None; _ } -> Memo.return None
-      | Default { lock_dir = Some selection; _ } ->
-        let+ path = Lock_dir.select_lock_dir selection in
-        Some path)
-    >>| List.filter_opt
-  in
-  match lock_dirs_from_ctx, workspace.lock_dirs with
-  | [], [] -> Set.singleton Lock_dir.default_source_path
-  | lock_dirs_from_ctx, lock_dirs_from_toplevel ->
-    let lock_paths_from_toplevel =
-      List.map lock_dirs_from_toplevel ~f:(fun (lock_dir : Workspace.Lock_dir.t) ->
-        lock_dir.path)
-    in
-    Set.union (Set.of_list lock_paths_from_toplevel) (Set.of_list lock_dirs_from_ctx)
 ;;
 
 let setup_rules ~components ~dir =
@@ -80,14 +254,14 @@ let setup_rules ~components ~dir =
   match components with
   | [ ".lock" ] ->
     let* workspace = Workspace.workspace () in
-    lock_dirs_of_workspace workspace
+    Lock_dir.lock_dirs_of_workspace workspace
     >>| Path.Source.Set.to_list
     >>= Memo.List.fold_left ~init:empty ~f:(fun rules lock_dir_path ->
       let lock_dir = Path.Source.to_local lock_dir_path in
-      let+ lock_rule = setup_lock_rules workspace ~dir ~lock_dir in
+      let+ lock_rule = setup_lock_rules_with_source workspace ~dir ~lock_dir in
       Gen_rules.combine rules lock_rule)
   | [ ".dev-tool-locks" ] ->
-    Memo.List.fold_left Dune_pkg.Dev_tool.all ~init:empty ~f:(fun rules dev_tool ->
+    Memo.List.fold_left Dev_tool.all ~init:empty ~f:(fun rules dev_tool ->
       let+ dev_tool_rules = setup_dev_tool_lock_rules ~dir dev_tool in
       Gen_rules.combine rules dev_tool_rules)
   | [] ->

--- a/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
@@ -1,0 +1,110 @@
+Test that auto-locking correctly detects when to rebuild based on repository changes.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+  $ enable_pkg
+
+Make a library package:
+
+  $ mkdir foo
+  $ cd foo
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let message = "Hello from foo version 0.0.1!"
+  > EOF
+  $ cat > dune <<EOF
+  > (library
+  >  (public_name foo))
+  > EOF
+  $ cd ..
+  $ tar cf foo.tar foo
+  $ rm -rf foo
+
+Make a package for the library using a local file source:
+
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["dune" "build" "-p" name "@install"]
+  > ]
+  > url {
+  >  src: "$PWD/foo.tar"
+  > }
+  > EOF
+
+Create a project that depends on foo:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ cat > bar.ml <<EOF
+  > let () = print_endline Foo.message
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name bar)
+  >  (libraries foo))
+  > EOF
+
+Build with auto-locking:
+  $ dune exec --display short bar 2>&1 | grep "Building"
+      Building foo.0.0.1
+
+  $ dune exec bar
+  Hello from foo version 0.0.1!
+
+Add an unrelated package to the repository:
+  $ mkpkg baz <<EOF
+  > build: [ "echo" "baz" ]
+  > EOF
+
+Build again - adding unrelated package should NOT trigger rebuild:
+  $ dune exec --display short bar 2>&1 | grep "Building" || echo "no rebuilds"
+  no rebuilds
+
+  $ dune exec bar
+  Hello from foo version 0.0.1!
+
+Now add a newer version of foo to the repository:
+
+  $ mkdir foo
+  $ cd foo
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let message = "Hello from foo 0.0.2!"
+  > EOF
+  $ cat > dune <<EOF
+  > (library
+  >  (public_name foo))
+  > EOF
+  $ cd ..
+  $ tar cf foo-0.0.2.tar foo
+  $ rm -rf foo
+
+  $ mkpkg foo 0.0.2 <<EOF
+  > build: [
+  >   ["dune" "build" "-p" name "@install"]
+  > ]
+  > url {
+  >  src: "$PWD/foo-0.0.2.tar"
+  > }
+  > EOF
+
+Build again - auto-locking should detect the new version and rebuild:
+  $ dune clean
+  $ dune exec --display short bar 2>&1 | grep "Building"
+      Building foo.0.0.2
+
+  $ dune exec bar
+  Hello from foo 0.0.2!

--- a/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
@@ -1,0 +1,79 @@
+Same setup as e2e.t but this time using building without an explicit
+`dune pkg lock`.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+  $ enable_pkg
+
+Make a library:
+  $ mkdir foo
+  $ cd foo
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let foo = "Hello, World!"
+  > EOF
+  $ cat > dune <<EOF
+  > (library
+  >  (public_name foo))
+  > EOF
+  $ cd ..
+  $ tar cf foo.tar foo
+  $ rm -rf foo
+
+Configure our fake curl to serve the tarball
+
+  $ echo foo.tar >> fake-curls
+  $ PORT=1
+
+Make a package for the library:
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["dune" "subst"] {dev}
+  >   [
+  >     "dune"
+  >     "build"
+  >     "-p"
+  >     name
+  >     "-j"
+  >     jobs
+  >     "@install"
+  >     "@runtest" {with-test}
+  >     "@doc" {with-doc}
+  >   ]
+  > ]
+  > url {
+  >  src: "http://0.0.0.0:$PORT"
+  >  checksum: [
+  >   "md5=$(md5sum foo.tar | cut -f1 -d' ')"
+  >  ]
+  > }
+  > EOF
+
+Make a project that uses the library:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ cat > bar.ml <<EOF
+  > let () = print_endline Foo.foo
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name bar)
+  >  (libraries foo))
+  > EOF
+
+Lock, build, and run the executable in the project (without dune pkg lock):
+
+  $ dune exec bar
+  Hello, World!
+

--- a/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
@@ -1,0 +1,79 @@
+Test that explicit locking followed by auto-locking produces equivalent results
+and does not trigger unnecessary rebuilds.
+
+  $ . ./helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Make a library package:
+
+  $ mkdir foo
+  $ cd foo
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let message = "Hello from foo 0.0.1!"
+  > EOF
+  $ cat > dune <<EOF
+  > (library
+  >  (public_name foo))
+  > EOF
+  $ cd ..
+  $ tar cf foo.tar foo
+  $ rm -rf foo
+
+Make a package for the library using a local file source:
+
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["dune" "build" "-p" name "@install"]
+  > ]
+  > url {
+  >  src: "$PWD/foo.tar"
+  > }
+  > EOF
+
+Create a project that depends on foo:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ cat > bar.ml <<EOF
+  > let () = print_endline Foo.message
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name bar)
+  >  (libraries foo))
+  > EOF
+
+Lock and build with explicit dune pkg lock:
+  $ dune pkg lock
+  Solution for dune.lock:
+  - foo.0.0.1
+
+  $ dune exec --display short bar 2>&1 | grep "Building"
+      Building foo.0.0.1
+
+  $ dune exec bar
+  Hello from foo 0.0.1!
+
+Remove the lock directory:
+  $ rm -rf dune.lock
+
+Enable auto-locking:
+  $ enable_pkg
+
+Build again - should auto-lock internally and NOT rebuild foo:
+  $ dune exec --display short bar 2>&1 | grep "Building" || echo "no rebuilds"
+  no rebuilds
+
+  $ dune exec bar
+  Hello from foo 0.0.1!


### PR DESCRIPTION
We add support for autolocking. This works when `(pkg enabled)` is present in the `dune-workspace` and allows users to build package dependencies without having to go through `dune pkg lock`.

If a lock file is present, it will continue to build using that as is currently the case.

This started as a rough draft of the working parts of #11775 and my branch that built on that. The advantage of this approach is that we don't touch dev tools or `dune pkg lock`.

- [ ] documentation
- fixes https://github.com/ocaml/dune/issues/12098
- fixes https://github.com/ocaml/dune/issues/11614
