### PR TITLE
Don't solve for windows by default with portable lockdirs

### DIFF
--- a/src/dune_pkg/solver_env.ml
+++ b/src/dune_pkg/solver_env.ml
@@ -175,7 +175,6 @@ let popular_platform_envs =
   ; make ~os:"linux" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
   ; make ~os:"macos" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
   ; make ~os:"macos" ~arch:(Some "arm64") ~os_distribution:None ~os_family:None ()
-  ; make ~os:"win32" ~arch:(Some "x86_64") ~os_distribution:None ~os_family:None ()
   ]
 ;;
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -41,7 +41,6 @@ Create a package that writes a different value to some files depending on the os
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1
@@ -63,9 +62,7 @@ Create a package that writes a different value to some files depending on the os
    ((arch x86_64)
     (os macos))
    ((arch arm64)
-    (os macos))
-   ((arch x86_64)
-    (os win32)))
+    (os macos)))
 
   $ cat ${default_lock_dir}/foo.0.0.1.pkg
   (version 0.0.1)
@@ -99,13 +96,7 @@ Create a package that writes a different value to some files depending on the os
         (run mkdir -p %{share} %{lib}/%{pkg-self:name})
         (run touch %{lib}/%{pkg-self:name}/META)
         (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))
-    ((((arch x86_64) (os win32)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo x86_64 > %{share}/machine")))))))
+        (run sh -c "echo arm64 > %{share}/machine")))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -60,8 +60,6 @@ Solve the project:
     5.4.0+solver-env-version-override
   - arch = arm64; os = macos; sys-ocaml-version =
     5.4.0+solver-env-version-override
-  - arch = x86_64; os = win32; sys-ocaml-version =
-    5.4.0+solver-env-version-override
   
   Dependencies on all supported platforms:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -29,7 +29,6 @@ Demonstrate various cases representing depexts in lockfiles.
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -37,7 +37,6 @@ Solver error when solving fails with the same error on all platforms:
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: a.0.0.1 b.0.0.1 foo.dev
@@ -75,7 +74,6 @@ with the platforms where they are relevant:
   The dependency solver failed to find a solution for the following platforms:
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   ...with this error:
   Couldn't solve the package dependency formula.
   Selected candidates: a.0.0.1 b.0.0.1 foo.dev

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -47,7 +47,6 @@ to solve for macos, linux, and windows by default.
   Platforms with no solution:
   - arch = x86_64; os = linux
   - arch = arm64; os = linux
-  - arch = x86_64; os = win32
   
   See the log or run with --verbose for more details. Configure platforms to
   solve for in the dune-workspace file.
@@ -57,7 +56,6 @@ The log file will contain errors about the package being unavailable.
   # The dependency solver failed to find a solution for the following platforms:
   # - arch = x86_64; os = linux
   # - arch = arm64; os = linux
-  # - arch = x86_64; os = win32
   # ...with this error:
   # Couldn't solve the package dependency formula.
   # Selected candidates: x.dev

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -59,7 +59,6 @@ A package that conditionally depends on packages depending on the OS:
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - foo.0.0.1
@@ -81,7 +80,7 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/
-  foo.0.0.1-f25d4bdb5ae54b8ba819b6837709d5bc
+  foo.0.0.1-9b0ae1f26c9a79e6ae8bca96ec389858
   linux-only.0.0.1-f1f7456a7bf1c70f9203f8caadf79f6d
 
   $ dune clean
@@ -89,5 +88,5 @@ Build the project as if we were on linux and confirm that only the linux-specifi
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/
-  foo.0.0.1-03f41d0caa9112c45e024836d778d225
+  foo.0.0.1-dace34542257af51bf0bfc5cd45a7ece
   macos-only.0.0.1-45b66a146d607b34b06be6c1cafeeb83

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -76,7 +76,6 @@ Solve the project. The solution will contain extra files for both versions of fo
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -60,7 +60,6 @@ Define a package bar which conditionally depends on different versions of foo:
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - bar.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
@@ -36,7 +36,6 @@ Solve dependencies:
   - arch = arm64; os = linux
   - arch = x86_64; os = macos
   - arch = arm64; os = macos
-  - arch = x86_64; os = win32
   
   Dependencies on all supported platforms:
   - a.0.0.1


### PR DESCRIPTION
Dune package management doesn't work on windows yet, so exclude windows from the set of platforms we solve for by default with portable lockdirs.