### PR TITLE
fix(cram): allow text after conflict markers

### DIFF
--- a/doc/changes/added/12538.md
+++ b/doc/changes/added/12538.md
@@ -1,4 +1,4 @@
 - Add a `(conflict_markers error|ignore)` option to the cram stanza. When
   `(conflict_markers error)` is set, the cram test will fail in the presence of
   conflict markers. Git, diff3 and jujutsu conflict markers are detected.
-  (#12538, #12617, fixes #12512, @rgrinberg, @Alizter)
+  (#12538, #12617, #12655, fixes #12512, @rgrinberg, @Alizter)

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -42,16 +42,15 @@ let quote_for_sh fn =
 
 let cram_stanzas =
   let is_conflict_marker line =
-    match line with
-    | "=======" | "%%%%%%%" | "+++++++" | "-------" | "|||||||" -> true
-    | _ -> false
+    [ "======="; "%%%%%%%"; "+++++++"; "-------"; "|||||||" ]
+    |> List.exists ~f:(fun prefix -> String.is_prefix line ~prefix)
   in
   let find_conflict state line =
     match state with
-    | `No_conflict when line = "<<<<<<<" -> `Started
+    | `No_conflict when String.is_prefix ~prefix:"<<<<<<<" line -> `Started
     | `Started when is_conflict_marker line -> `Has_markers
     | `Has_markers when is_conflict_marker line -> `Has_markers
-    | `Has_markers when line = ">>>>>>>" ->
+    | `Has_markers when String.is_prefix ~prefix:">>>>>>>" line ->
       (* CR-someday rgrinberg for alizter: insert a location spanning the
          entire once we start extracting it *)
       User_error.raise

--- a/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-markers-jj.t
@@ -11,11 +11,11 @@ Cram tests can forbid jujutsu conflicts:
 Full jujutsu conflict without command and output interleaving:
 
   $ cat >test.t <<EOF
-  > <<<<<<<
+  > <<<<<<< Conflict 1 of 2
   > A Small
   > %%%%%%%
   > Conflict
-  > >>>>>>>
+  > >>>>>>> Conflict 1 of 2 ends
   > $ echo tada
   > EOF
 
@@ -30,11 +30,11 @@ Full jujutsu conflict without command and output interleaving:
 Full jujutsu conflict with command and output interleaving:
 
   $ cat >test.t <<EOF
-  > <<<<<<<
+  > <<<<<<< Conflict 2 of 2
   >   $ foo
   > %%%%%%%
   >   > bar
-  > >>>>>>>
+  > >>>>>>> Conflict 2 of 2 ends
   > $ echo tada
   > EOF
 
@@ -49,14 +49,14 @@ Full jujutsu conflict with command and output interleaving:
 Jujutsu default style conflict (diff + snapshot):
 
   $ cat >test.t <<EOF
-  > <<<<<<<
-  > %%%%%%%
+  > <<<<<<< Conflict 1 of 1
+  > %%%%%%% Changes from base to side #1
   > -apple
   > +grapefruit
-  > +++++++
+  > +++++++ Contents of side #2
   > APPLE
   > GRAPE
-  > >>>>>>>
+  > >>>>>>> Conflict 1 of 1 ends
   > $ echo tada
   > EOF
 
@@ -71,14 +71,14 @@ Jujutsu default style conflict (diff + snapshot):
 Jujutsu snapshot style conflict:
 
   $ cat >test.t <<EOF
-  > <<<<<<<
-  > +++++++
+  > <<<<<<< Conflict 1 of 1
+  > +++++++ Contents of side #1
   > Left side
-  > -------
+  > ------- Contents of base
   > Original
-  > +++++++
+  > +++++++ Contents of side #2
   > Right side
-  > >>>>>>>
+  > >>>>>>> Conflict 1 of 1 ends
   > $ echo tada
   > EOF
 


### PR DESCRIPTION
Noticed when rebasing that this wasn't being detected correctly.