### PR TITLE
Crashes on invalid config files

### DIFF
--- a/test/blackbox-tests/test-cases/config/invalid-config-file.t
+++ b/test/blackbox-tests/test-cases/config/invalid-config-file.t
@@ -1,0 +1,3 @@
+  $ export XDG_CONFIG_HOME=$PWD
+  $ '(cache enabled)' > config
+  $ dune --version


### PR DESCRIPTION
Trying to set up a repro for behavior I encountered on my machine with an invalid config in the default location, but I haven't been able to capture it in the cram test yet.