### PR TITLE
feat(runtest): --alias and --alias-rec for dune runtest

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -163,9 +163,8 @@ let build =
   let term =
     let+ builder = Common.Builder.term
     and+ targets = Arg.(value & pos_all dep [] name_)
-    and+ aliases_rec = Arg.(value & opt_all Dep.alias_rec_arg [] & info [ "alias-rec" ])
-    and+ aliases = Arg.(value & opt_all Dep.alias_arg [] & info [ "alias" ]) in
-    let targets = List.concat [ targets; aliases; aliases_rec ] in
+    and+ aliases = Common.alias_flags_term in
+    let targets = List.concat [ targets; aliases ] in
     let targets =
       match targets with
       | [] -> [ Common.Builder.default_target builder ]

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -91,6 +91,12 @@ let one_of term1 term2 =
        `Error (true, sprintf "Cannot use %s and %s simultaneously" arg1 arg2)
 ;;
 
+let alias_flags_term =
+  let+ aliases_rec = Arg.(value & opt_all Arg.Dep.alias_rec_arg [] & info [ "alias-rec" ])
+  and+ aliases = Arg.(value & opt_all Arg.Dep.alias_arg [] & info [ "alias" ]) in
+  List.concat [ aliases; aliases_rec ]
+;;
+
 let build_info =
   let+ build_info =
     Arg.(

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -91,3 +91,5 @@ end
 (** [one_of term1 term2] allows options from [term1] or exclusively options from
     [term2]. If the user passes options from both terms, an error is reported. *)
 val one_of : 'a Cmdliner.Term.t -> 'a Cmdliner.Term.t -> 'a Cmdliner.Term.t
+
+val alias_flags_term : Arg.Dep.t list Cmdliner.Term.t

--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -36,30 +36,72 @@ let runtest_info =
 let runtest_term =
   let name = Arg.info [] ~docv:"TEST" in
   let+ builder = Common.Builder.term
-  and+ dir_or_cram_test_paths = Arg.(value & pos_all string [ "." ] name) in
+  and+ tests_to_run = Arg.(value & pos_all string [] name)
+  and+ aliases = Common.alias_flags_term in
   let common, config = Common.init builder in
+  let tests_to_run =
+    match tests_to_run, aliases with
+    | [], [] -> [ "." ]
+    | _ -> tests_to_run
+  in
   match Dune_util.Global_lock.lock ~timeout:None with
   | Ok () ->
-    Build.run_build_command
-      ~common
-      ~config
-      ~request:
-        (Runtest_common.make_request
-           ~dir_or_cram_test_paths
-           ~to_cwd:(Common.root common).to_cwd)
+    let request setup =
+      Action_builder.all_unit
+        [ Runtest_common.make_request
+            ~dir_or_cram_test_paths:tests_to_run
+            ~to_cwd:(Common.root common).to_cwd
+            setup
+        ; Target.interpret_targets (Common.root common) config setup aliases
+        ]
+    in
+    Build.run_build_command ~common ~config ~request
   | Error lock_held_by ->
-    Scheduler.go_without_rpc_server
-      ~common
-      ~config
-      (Rpc.Rpc_common.wrap_build_outcome_exn
-         ~print_on_success:true
-         (Rpc.Rpc_common.fire_request
+    let combined_request () =
+      (* CR-someday Alizter: We should be able to fire multiple requests at the
+         same time. *)
+      let open Fiber.O in
+      (* CR-someday Alizter: Find out the best value for this or fix the buggy
+         behaviouir. Polling forever causes issues that become apparent here
+         due to our double request. We therefore diable it here. *)
+      let wait = false in
+      let runtest_request =
+        if List.is_empty tests_to_run
+        then Fiber.return (Ok Dune_rpc.Build_outcome_with_diagnostics.Success)
+        else
+          Rpc.Rpc_common.fire_request
             ~name:"runtest"
-            ~wait:false
+            ~wait
             ~lock_held_by
             builder
-            Dune_rpc.Procedures.Public.runtest)
-         dir_or_cram_test_paths)
+            Dune_rpc.Procedures.Public.runtest
+            tests_to_run
+      in
+      let build_request =
+        if List.is_empty aliases
+        then Fiber.return (Ok Dune_rpc.Build_outcome_with_diagnostics.Success)
+        else
+          Rpc.Rpc_common.fire_request
+            ~name:"build"
+            ~wait
+            ~lock_held_by
+            builder
+            Dune_rpc_impl.Decl.build
+            (Rpc.Rpc_common.prepare_targets aliases)
+      in
+      let+ runtest_result = runtest_request
+      and+ build_result = build_request in
+      match runtest_result, build_result with
+      | Ok Success, Ok Success -> Ok Dune_rpc.Build_outcome_with_diagnostics.Success
+      | Ok (Failure errors1), Ok (Failure errors2) -> Ok (Failure (errors1 @ errors2))
+      | Ok (Failure errors), Ok Success | Ok Success, Ok (Failure errors) ->
+        Ok (Failure errors)
+      (* CR-someday Alizter: This is wrong and we drop errors here. Find a way
+         to combine them. *)
+      | Error e, _ | _, Error e -> Error e
+    in
+    Rpc.Rpc_common.wrap_build_outcome_exn ~print_on_success:true combined_request ()
+    |> Scheduler.go_without_rpc_server ~common ~config
 ;;
 
 let commands =

--- a/test/blackbox-tests/test-cases/runtest-cmd-alias.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-alias.t
@@ -1,0 +1,74 @@
+Test the --alias and --alias-rec flags in the dune runtest command
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+Set up cram tests that will fail so we can test running them with --alias
+
+  $ make_failing_test() {
+  >   cat >$1 <<EOF
+  >   \$ echo "actual $1 output"
+  >   expected $1 output
+  > EOF
+  > }
+
+  $ make_failing_test test-1.t
+  $ make_failing_test test-2.t
+  $ make_failing_test test-3.t
+
+  $ mkdir subdir
+  $ make_failing_test subdir/test-1.t
+  $ make_failing_test subdir/test-2.t
+
+  $ test() {
+  >   dune runtest "$@" 2>&1 | grep -E "^File.*\.t"
+  > }
+
+Test running a specific cram test alias with --alias
+
+  $ test --alias test-1
+  File "test-1.t", line 1, characters 0-0:
+
+Test running multiple specific cram test aliases with --alias
+
+  $ test --alias test-1 --alias test-2
+  File "test-1.t", line 1, characters 0-0:
+  File "test-2.t", line 1, characters 0-0:
+
+Test running specific cram test alias recursively with --alias-rec
+
+  $ test --alias-rec test-1
+  File "subdir/test-1.t", line 1, characters 0-0:
+  File "test-1.t", line 1, characters 0-0:
+
+Test running multiple cram test aliases recursively
+
+  $ test --alias-rec test-1 --alias-rec test-2
+  File "subdir/test-1.t", line 1, characters 0-0:
+  File "subdir/test-2.t", line 1, characters 0-0:
+  File "test-1.t", line 1, characters 0-0:
+  File "test-2.t", line 1, characters 0-0:
+
+Test combining --alias and --alias-rec
+
+  $ test --alias test-3 --alias-rec test-1
+  File "subdir/test-1.t", line 1, characters 0-0:
+  File "test-1.t", line 1, characters 0-0:
+  File "test-3.t", line 1, characters 0-0:
+
+Test combining path with --alias
+
+  $ test subdir --alias test-3
+  File "subdir/test-1.t", line 1, characters 0-0:
+  File "subdir/test-2.t", line 1, characters 0-0:
+  File "test-3.t", line 1, characters 0-0:
+
+Test that --alias and --alias-rec work the same as build command
+
+  $ dune build --alias test-1 2>&1 | grep -E "^File.*\.t"
+  File "test-1.t", line 1, characters 0-0:
+
+  $ dune build --alias-rec test-1 2>&1 | grep -E "^File.*\.t"
+  File "subdir/test-1.t", line 1, characters 0-0:
+  File "test-1.t", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/watching/runtest-combined-dirs-aliases.t
+++ b/test/blackbox-tests/test-cases/watching/runtest-combined-dirs-aliases.t
@@ -1,0 +1,54 @@
+Test that "dune runtest" with both directories and aliases fails gracefully
+when another dune instance is running.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+Set up failing cram tests for testing the combined case
+
+  $ make_failing_test() {
+  >   cat >$1 <<EOF
+  >   \$ echo "actual $1 output"
+  >   expected $1 output
+  > EOF
+  > }
+
+  $ make_failing_test test-main.t
+  $ mkdir subdir
+  $ make_failing_test subdir/test-sub.t
+
+  $ test() {
+  >   dune runtest "$@" 2>&1 | grep -E "^File.*\.t"
+  > }
+
+Start dune in passive watch mode:
+  $ dune build --passive-watch 2>&1 | echo > /dev/null &
+
+  $ dune rpc ping --wait
+  Server appears to be responding normally
+
+Running tests in a directory:
+  $ test subdir
+  [1]
+
+Running a test:
+  $ test test-main.t
+  File "test-main.t", line 1, characters 0-0:
+
+Building an alias:
+  $ test --alias test-main
+  File "test-main.t", line 1, characters 0-0:
+
+Default target:
+  $ test 2>&1 | sort
+  File "subdir/test-sub.t", line 1, characters 0-0:
+  File "test-main.t", line 1, characters 0-0:
+
+Both an alias and a test:
+  $ test --alias test-main subdir/test-sub.t 2>&1 | sort
+  File "subdir/test-sub.t", line 1, characters 0-0:
+  File "test-main.t", line 1, characters 0-0:
+
+Clean up:
+  $ wait


### PR DESCRIPTION
We add the `--alias` and `--alias-rec` flags to `dune runtest`. They work the same as they do for `dune build`.

This is convenient to have, since you might want to do `--alias-rec check` in addition to running tests etc.

I've also made sure that it works when connecting over RPC. cc @ElectreAAS 