### PR TITLE
refactor: remove open!

### DIFF
--- a/bin/describe/describe_location.ml
+++ b/bin/describe/describe_location.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 let doc =
   "Print the path to the executable using the same resolution logic as [dune exec]."

--- a/bin/describe/describe_location.mli
+++ b/bin/describe/describe_location.mli
@@ -1,3 +1,3 @@
-open! Import
+open Import
 
 val command : unit Cmd.t

--- a/bin/lock_dev_tool.mli
+++ b/bin/lock_dev_tool.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 val is_enabled : bool Lazy.t
 val lock_dev_tool : Dune_pkg.Dev_tool.t -> unit Memo.t

--- a/bin/ocaml/doc.mli
+++ b/bin/ocaml/doc.mli
@@ -1,3 +1,3 @@
-open! Import
+open Import
 
 val cmd : unit Cmd.t

--- a/bin/pkg/validate_lock_dir.ml
+++ b/bin/pkg/validate_lock_dir.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 open Pkg_common
 module Package_universe = Dune_pkg.Package_universe
 module Lock_dir = Dune_pkg.Lock_dir

--- a/bin/rpc/rpc_build.mli
+++ b/bin/rpc/rpc_build.mli
@@ -1,4 +1,2 @@
-open! Import
-
 (** dune rpc build command *)
 val cmd : unit Cmdliner.Cmd.t

--- a/bin/runtest_common.ml
+++ b/bin/runtest_common.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 let find_cram_test path ~parent_dir =
   let open Memo.O in

--- a/bin/runtest_common.mli
+++ b/bin/runtest_common.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** [make_request ~dir_or_cram_test_paths ~to_cwd] returns a function suitable
     for passing to [Build_cmd.run_build_system] which runs the tests referred

--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 module Exec = struct
   let doc = "Command group for running wrapped tools."

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 module Pkg_dev_tool = Dune_rules.Pkg_dev_tool
 
 let dev_tool_bin_dirs =

--- a/bin/tools/tools_common.mli
+++ b/bin/tools/tools_common.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** Generate a lockdir for a dev tool, build the dev tool, then run the dev
     tool. If a step is unnecessary then it is skipped. This function does not

--- a/bin/workspace_root.mli
+++ b/bin/workspace_root.mli
@@ -1,5 +1,3 @@
-open! Stdune
-
 (** Finding the root of the workspace *)
 
 module Kind : sig

--- a/otherlibs/dune-glob/src/lexer.mll
+++ b/otherlibs/dune-glob/src/lexer.mll
@@ -1,5 +1,5 @@
 {
-open! Stdune
+open Stdune
 open Re
 
 type t =

--- a/otherlibs/dune-glob/test/dune_glob_tests.ml
+++ b/otherlibs/dune-glob/test/dune_glob_tests.ml
@@ -1,4 +1,3 @@
-open! Stdune
 module Glob = Dune_glob.V1
 
 let printf = Printf.printf

--- a/otherlibs/dune-rpc/private/public.ml
+++ b/otherlibs/dune-rpc/private/public.ml
@@ -1,4 +1,3 @@
-open! Import
 open Types
 
 module Request = struct

--- a/otherlibs/stdune/src/user_message.ml
+++ b/otherlibs/stdune/src/user_message.ml
@@ -1,5 +1,3 @@
-open! Import
-
 module Style = struct
   type t =
     | Loc

--- a/otherlibs/stdune/src/user_message.mli
+++ b/otherlibs/stdune/src/user_message.mli
@@ -1,5 +1,3 @@
-open! Import
-
 (** A message for the user *)
 
 (** User messages are styled document that can be printed to the console or in

--- a/otherlibs/stdune/test/list_tests.ml
+++ b/otherlibs/stdune/test/list_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Dyn
 open Dune_tests_common
 

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Path
 open Dune_tests_common
 

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Dyn
 open Dune_tests_common
 

--- a/otherlibs/stdune/test/top_closure.ml
+++ b/otherlibs/stdune/test/top_closure.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 let deps_of_list list dep = List.assoc_opt dep list |> Option.value ~default:[]
 

--- a/src/dag/dag.ml
+++ b/src/dag/dag.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 include Dag_intf
 
 module Make (Value : Value) () : S with type value := Value.t = struct

--- a/src/dag/dag.mli
+++ b/src/dag/dag.mli
@@ -1,7 +1,5 @@
 (** Detection of cycles in dynamic dags *)
 
-open! Stdune
-
 (** Based on the work by:
 
     Michael A. Bender, Jeremy T. Fineman, Seth Gilbert, and Robert E. Tarjan.

--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -1,6 +1,6 @@
 (** Detection of cycles in dynamic dags *)
 
-open! Stdune
+open Stdune
 
 module type Value = sig
   type t

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -4,7 +4,7 @@
     execute. These usually, but not necessarily correspond to actions written by
     the user in [Dune_lang.Action.t] *)
 
-open! Import
+open Import
 open Dune_util.Action
 
 module Inputs : sig

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -1,6 +1,6 @@
 (** A collection of rules across a known finite set of directories *)
 
-open! Import
+open Import
 
 (** Represent a set of rules producing files in a given directory *)
 module Dir_rules : sig

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -1,6 +1,6 @@
 (** Scheduling *)
 
-open! Import
+open Import
 
 module Config : sig
   type t =

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (* [To_delete] is used mostly to implement [dune clean]. It is an imperfect
    heuristic, in particular it can go wrong if:

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 module Inotify_lib := Async_inotify_for_dune.Async_inotify
 
 type t

--- a/src/dune_lang/cond.ml
+++ b/src/dune_lang/cond.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Dune_sexp
 
 type t =

--- a/src/dune_lang/dune_file_script.mll
+++ b/src/dune_lang/dune_file_script.mll
@@ -1,5 +1,4 @@
 {
-open! Stdune
 }
 
 rule is_script = parse

--- a/src/dune_lang/ocaml_flags.mli
+++ b/src/dune_lang/ocaml_flags.mli
@@ -1,6 +1,6 @@
 (** OCaml flags *)
 
-open! Import
+open Import
 
 type 'a t =
   { common : 'a

--- a/src/dune_lang/rule_mode_decoder.mli
+++ b/src/dune_lang/rule_mode_decoder.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 module Rule := Dune_engine.Rule
 
 module Promote : sig

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type t =
   | Ocamlformat

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -1,5 +1,3 @@
-open! Import
-
 type t =
   | Ocamlformat
   | Odoc

--- a/src/dune_pkg/fiber_cache.ml
+++ b/src/dune_pkg/fiber_cache.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type ('k, 'v) t =
   { (* The cache stores results so that if an exception was raised while

--- a/src/dune_pkg/fiber_cache.mli
+++ b/src/dune_pkg/fiber_cache.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** Associates asynchronously-computed values of type ['v] with keys of type ['k] *)
 type ('k, 'v) t

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 module Package_constraint = Dune_lang.Package_constraint
 
 type pin =

--- a/src/dune_pkg/local_package.mli
+++ b/src/dune_pkg/local_package.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type pin =
   { loc : Loc.t

--- a/src/dune_pkg/ocamlformat.mli
+++ b/src/dune_pkg/ocamlformat.mli
@@ -1,5 +1,3 @@
-open! Import
-
 (** Returns the version from the current project's .ocamlformat file,
     if it exists *)
 val version_of_current_project's_ocamlformat_config : unit -> Package_version.t option

--- a/src/dune_pkg/opam_dyn.ml
+++ b/src/dune_pkg/opam_dyn.ml
@@ -1,5 +1,3 @@
-open! Import
-
 let rec formula atom_to_dyn (formula_ : _ OpamFormula.formula) =
   match formula_ with
   | Empty -> Dyn.variant "Empty" []

--- a/src/dune_pkg/opam_dyn.mli
+++ b/src/dune_pkg/opam_dyn.mli
@@ -1,5 +1,3 @@
-open! Import
-
 val package_name : OpamTypes.name -> Dyn.t
 val package : OpamPackage.t -> Dyn.t
 val relop : OpamTypes.relop -> Dyn.t

--- a/src/dune_pkg/package_dependency.mli
+++ b/src/dune_pkg/package_dependency.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Constraint : sig
   module Op : sig

--- a/src/dune_pkg/package_name.ml
+++ b/src/dune_pkg/package_name.ml
@@ -1,4 +1,3 @@
-open! Stdune
 include Dune_lang.Package_name
 
 let of_opam_package_name opam_package_name =

--- a/src/dune_pkg/package_name.mli
+++ b/src/dune_pkg/package_name.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type t = Dune_lang.Package_name.t
 

--- a/src/dune_pkg/package_universe.ml
+++ b/src/dune_pkg/package_universe.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type t =
   { local_packages : Local_package.t Package_name.Map.t

--- a/src/dune_pkg/package_universe.mli
+++ b/src/dune_pkg/package_universe.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** all of the packages in a dune project under the constraints of a given
     platform, including local packages and packages in a lockdir. the lockdir

--- a/src/dune_pkg/package_version.ml
+++ b/src/dune_pkg/package_version.ml
@@ -1,4 +1,3 @@
-open! Stdune
 include Dune_lang.Package_version
 
 let of_opam_package_version opam_version =

--- a/src/dune_pkg/package_version.mli
+++ b/src/dune_pkg/package_version.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type t = Dune_lang.Package_version.t
 

--- a/src/dune_pkg/resolve_opam_formula.ml
+++ b/src/dune_pkg/resolve_opam_formula.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 module Relop = Dune_lang.Relop
 
 let apply_filter env ~with_test ~(formula : OpamTypes.filtered_formula)

--- a/src/dune_pkg/resolve_opam_formula.mli
+++ b/src/dune_pkg/resolve_opam_formula.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** Evaluate the filters in a filtered formula returning the resulting formula. *)
 val apply_filter

--- a/src/dune_pkg/single_run_file_cache.ml
+++ b/src/dune_pkg/single_run_file_cache.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type 'error t =
   { temp_dir : Path.t lazy_t

--- a/src/dune_pkg/single_run_file_cache.mli
+++ b/src/dune_pkg/single_run_file_cache.mli
@@ -1,5 +1,4 @@
-open! Import
-open! Stdune
+open Stdune
 
 (** A cache that stores an association between files and string keys that will
     be deleted when dune terminates. For example this could be used to cache

--- a/src/dune_pkg/variable_value.ml
+++ b/src/dune_pkg/variable_value.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (* Currently only string values can be represented. Opam silently converts
    between strings to booleans when appropriate so this doesn't prevent boolean

--- a/src/dune_pkg/variable_value.mli
+++ b/src/dune_pkg/variable_value.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type t
 

--- a/src/dune_rules/coq/coq_lib_name.ml
+++ b/src/dune_rules/coq/coq_lib_name.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (* This file is licensed under The MIT License *)
 (* (c) MINES ParisTech 2018-2019               *)

--- a/src/dune_rules/glob_files_expand.ml
+++ b/src/dune_rules/glob_files_expand.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 open Memo.O
 
 (* Returns a list containing all descendant directories of the directory whose

--- a/src/dune_rules/glob_files_expand.mli
+++ b/src/dune_rules/glob_files_expand.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 module Expanded : sig
   type t

--- a/src/dune_rules/link_mode.mli
+++ b/src/dune_rules/link_mode.mli
@@ -1,5 +1,5 @@
 (** Link mode of OCaml programs *)
-open! Import
+open Import
 
 type t =
   | Byte

--- a/src/dune_rules/link_time_code_gen_type.ml
+++ b/src/dune_rules/link_time_code_gen_type.ml
@@ -1,5 +1,3 @@
-open! Import
-
 type t =
   { to_link : Lib_flags.Lib_and_module.L.t
   ; force_linkall : bool

--- a/src/dune_rules/link_time_code_gen_type.mli
+++ b/src/dune_rules/link_time_code_gen_type.mli
@@ -1,5 +1,3 @@
-open! Import
-
 type t =
   { to_link : Lib_flags.Lib_and_module.L.t
   ; force_linkall : bool

--- a/src/dune_rules/melange/melange.mli
+++ b/src/dune_rules/melange/melange.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 module Module_system : sig
   type t =

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -1,5 +1,4 @@
 open Import
-open! Action_builder.O
 
 (* This module interprets [(menhir ...)] stanzas -- that is, it provides build
    rules for Menhir parsers. *)

--- a/src/dune_rules/merlin/merlin_ident.mli
+++ b/src/dune_rules/merlin/merlin_ident.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** Merlin identifiers allow the unique identification of a merlin file attached
     to a specific [library] or [executable] stanza. *)

--- a/src/dune_rules/module_trie.ml
+++ b/src/dune_rules/module_trie.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 module Map = Module_name.Map
 
 type key = Module_name.Path.t

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -1,6 +1,6 @@
 (** OCaml flags *)
 
-open! Import
+open Import
 
 type t
 

--- a/src/dune_rules/ocaml_stdlib.ml
+++ b/src/dune_rules/ocaml_stdlib.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 type t =
   { modules_before_stdlib : Module_name.Set.t

--- a/src/dune_rules/pkg_build_progress.ml
+++ b/src/dune_rules/pkg_build_progress.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 module Status = struct
   type t =

--- a/src/dune_rules/pkg_build_progress.mli
+++ b/src/dune_rules/pkg_build_progress.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 
 (** Formats a message in the style of a progress message. The text of
     the message will be "<verb> <object_>" with the verb colored to match

--- a/src/dune_rules/pkg_dev_tool.ml
+++ b/src/dune_rules/pkg_dev_tool.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 include Dune_pkg.Dev_tool
 
 let install_path_base_dir_name = ".dev-tool"

--- a/src/dune_rules/pkg_dev_tool.mli
+++ b/src/dune_rules/pkg_dev_tool.mli
@@ -1,4 +1,4 @@
-open! Import
+open Import
 include module type of Dune_pkg.Dev_tool
 
 val install_path_base_dir_name : string

--- a/src/dune_rules/recursive_include.ml
+++ b/src/dune_rules/recursive_include.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 open Memo.O
 
 module Include_term = struct

--- a/src/dune_rules/recursive_include.mli
+++ b/src/dune_rules/recursive_include.mli
@@ -6,7 +6,7 @@
     the result of parsing the file. Supports chains of recursively included
     files, and detects include loops. *)
 
-open! Import
+open Import
 
 (** The type of terms in the configuration language obtained by adding (include
     ...) statements to the base language *)

--- a/src/dune_rules/sites/generate_sites_module_rules.mli
+++ b/src/dune_rules/sites/generate_sites_module_rules.mli
@@ -1,6 +1,6 @@
 (** Generate module stanza *)
 
-open! Stdune
+open Stdune
 
 (** create the rule and return the produced file *)
 val setup_rules

--- a/src/dune_rules/slang_expand.mli
+++ b/src/dune_rules/slang_expand.mli
@@ -1,4 +1,3 @@
-open! Stdune
 open Import
 
 type expander =

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -1,5 +1,5 @@
 open Import
-open! Dune_lang.Decoder
+open Dune_lang.Decoder
 
 type t =
   { name : Loc.t * Lib_name.Local.t

--- a/src/dune_sexp/lexer.mli
+++ b/src/dune_sexp/lexer.mli
@@ -1,5 +1,3 @@
-open! Stdune
-
 module Token : sig
   type t =
     | Atom of Atom.t

--- a/src/dune_sexp/lexer.mll
+++ b/src/dune_sexp/lexer.mll
@@ -1,6 +1,4 @@
 {
-open! Stdune
-
 open Stdune
 
 module Token = struct

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Version = struct
   module T = struct

--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -1,6 +1,6 @@
 (** Management of syntaxes *)
 
-open! Stdune
+open Stdune
 
 module Version : sig
   (** A syntax version.

--- a/src/dune_sexp/t.ml
+++ b/src/dune_sexp/t.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 module Format = Stdlib.Format
 
 type t =

--- a/src/dune_sexp/t.mli
+++ b/src/dune_sexp/t.mli
@@ -1,7 +1,7 @@
 (** Parsing of s-expressions.
 
     This library is internal to dune and guarantees no API stability.*)
-open! Stdune
+open Stdune
 
 (** The S-expression type *)
 type t =

--- a/src/dune_sexp/template.ml
+++ b/src/dune_sexp/template.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Pform = struct
   module Payload = struct

--- a/src/dune_sexp/template.mli
+++ b/src/dune_sexp/template.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Pform : sig
   module Payload : sig

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 module First_line = Versioned_file_first_line
 
 module type S = sig

--- a/src/dune_sexp/versioned_file.mli
+++ b/src/dune_sexp/versioned_file.mli
@@ -1,6 +1,6 @@
 (** Implementation of versioned files *)
 
-open! Stdune
+open Stdune
 module First_line = Versioned_file_first_line
 
 module type S = sig

--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type 'a t = ('a -> eff) -> eff
 

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -4,7 +4,7 @@
     {{:https://en.wikipedia.org/wiki/Structured_concurrency} "structured
     concurrency"}. *)
 
-open! Stdune
+open Stdune
 
 (** {1 Generals} *)
 

--- a/src/fiber/src/lazy.ml
+++ b/src/fiber/src/lazy.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Core
 open Core.O
 

--- a/src/fiber_util/fiber_util.ml
+++ b/src/fiber_util/fiber_util.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Temp = Temp.Monad (struct
     type 'a t = 'a Fiber.t

--- a/src/fiber_util/fiber_util.mli
+++ b/src/fiber_util/fiber_util.mli
@@ -1,6 +1,6 @@
 (** Utilities for working with the Fiber library. *)
 
-open! Stdune
+open Stdune
 
 (** [Temp.Monad] instantiated to the Fiber monad. *)
 module Temp : sig

--- a/src/fswatch_win/bin/dune_fswatch_win.ml
+++ b/src/fswatch_win/bin/dune_fswatch_win.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 let paths =
   let paths = ref [] in

--- a/src/install/context.mli
+++ b/src/install/context.mli
@@ -4,7 +4,7 @@
     installation layout by creating symlinks to artifacts in the build
     directory. *)
 
-open! Import
+open Import
 
 val install_context : Dune_engine.Build_context.t
 

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -1,4 +1,3 @@
-open! Stdune
 open Import
 
 (* The path after the man section mangling done by opam-installer. This roughly

--- a/src/memo/deps.ml
+++ b/src/memo/deps.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Fiber.O
 module Counter = Metrics.Counter
 

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Fiber.O
 
 module type Implicit_output = sig

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Fiber.O
 module Graph = Dune_graph.Graph
 module Console = Dune_console

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 (** A type of memoized computations that can be recomputed incrementally when
     their dependencies change. *)

--- a/src/memo/metrics.ml
+++ b/src/memo/metrics.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 module Counter = struct
   type t = int ref

--- a/src/memo/metrics.mli
+++ b/src/memo/metrics.mli
@@ -1,7 +1,5 @@
 (** Various performance metrics. *)
 
-open! Stdune
-
 module Counter : sig
   type t
 

--- a/src/memo/store.ml
+++ b/src/memo/store.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type ('k, 'v) t = (module Store_intf.Instance with type key = 'k and type value = 'v)
 

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Result.O
 
 module Prog_and_args = struct

--- a/src/ocaml/mode.ml
+++ b/src/ocaml/mode.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type t =
   | Byte

--- a/src/ocaml/mode.mli
+++ b/src/ocaml/mode.mli
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 type t =
   | Byte

--- a/src/ocaml/variant.ml
+++ b/src/ocaml/variant.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 include String
 
 let make s = s

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -1,6 +1,6 @@
 (** DSL to define sets that are defined by a membership : 'a -> bool function. *)
 
-open! Stdune
+open Stdune
 open Dune_sexp
 
 type 'a t

--- a/src/source/cond_expand.ml
+++ b/src/source/cond_expand.ml
@@ -1,4 +1,4 @@
-open! Import
+open Import
 open Memo.O
 
 let eval (cond : Dune_lang.Cond.t) ~dir ~f =

--- a/src/source/cond_expand.mli
+++ b/src/source/cond_expand.mli
@@ -1,5 +1,4 @@
-open! Stdune
-open! Import
+open Import
 
 (** Evaluate a cond statement, choosing the first value whose condition was met
     or [None] if none of the conditions were met. *)

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 include struct
   open Source

--- a/test/blackbox-tests/test-cases/foreign-stubs/github3766.t/test.ml
+++ b/test/blackbox-tests/test-cases/foreign-stubs/github3766.t/test.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 let cwd () = Path.external_ (Path.External.cwd ())
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Csexp_rpc
 open Fiber.O
 module Scheduler = Dune_engine.Scheduler

--- a/test/expect-tests/dune_file_tests.ml
+++ b/test/expect-tests/dune_file_tests.ml
@@ -1,5 +1,5 @@
 open Dune_rules
-open! Stdune
+open Stdune
 open Dune_tests_common
 
 let () = init ()

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 open Dune_lang.Decoder
 open Dune_tests_common
 

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -1,5 +1,5 @@
-open! Stdune
-open! Fiber.O
+open Stdune
+open Fiber.O
 module Dune_rpc = Dune_rpc_private
 open Dune_rpc
 open Dune_rpc_server

--- a/test/expect-tests/ocamlobjinfo_tests.ml
+++ b/test/expect-tests/ocamlobjinfo_tests.ml
@@ -1,4 +1,3 @@
-open! Stdune
 open Dune_tests_common
 module Ocamlobjinfo = Dune_rules.For_tests.Ocamlobjinfo
 

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -1,5 +1,4 @@
 open Stdune
-open! Dune_tests_common
 open Dune_engine
 
 let go =

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -1,5 +1,5 @@
 open Stdune
-open! Dune_tests_common
+open Dune_tests_common
 open Dune_engine
 open Fiber.O
 

--- a/test/expect-tests/vcs/vcs_tests.ml
+++ b/test/expect-tests/vcs/vcs_tests.ml
@@ -1,7 +1,7 @@
 open Stdune
 open Fiber.O
 open Dune_vcs
-open! Dune_tests_common
+open Dune_tests_common
 module Process = Dune_engine.Process
 module Scheduler = Dune_engine.Scheduler
 

--- a/test/unit-tests/ocaml-config/gh637.ml
+++ b/test/unit-tests/ocaml-config/gh637.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 let pwd = Sys.getcwd ()
 

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -1,4 +1,4 @@
-open! Stdune
+open Stdune
 
 let () = Printexc.record_backtrace true
 


### PR DESCRIPTION
The `open!` directive suppresses unused `open`s and allows you to shadow top level names. We shouldn't keep unused opens around as it unnecessarily restricts the dependencies of the build.  We also tend not to use top level names anyway so they add little benefit.

- [ ] <s>updated `hacking.rst` with the reasoning for this style. <s/>
- [ ] add a linter? (prob not worth it)