### PR TITLE
fix(cram): improve and deduplicate test suggestions

### DIFF
--- a/bin/runtest_common.ml
+++ b/bin/runtest_common.ml
@@ -20,37 +20,33 @@ let find_cram_test cram_tests path =
     | Error (Dune_rules.Cram_rules.Missing_run_t _) | Ok _ -> None)
 ;;
 
+let all_tests_of_dir parent_dir =
+  let open Memo.O in
+  let+ cram_candidates =
+    cram_tests_of_dir parent_dir
+    >>| List.filter_map ~f:(fun res ->
+      Result.to_option res
+      |> Option.map ~f:(fun test -> Source.Cram_test.path test |> Path.Source.to_string))
+  and+ dir_candidates =
+    let* parent_source_dir = Source_tree.find_dir parent_dir in
+    match parent_source_dir with
+    | None -> Memo.return []
+    | Some parent_source_dir ->
+      let dirs = Source_tree.Dir.sub_dirs parent_source_dir in
+      String.Map.to_list dirs
+      |> Memo.List.map ~f:(fun (_candidate, candidate_path) ->
+        Source_tree.Dir.sub_dir_as_t candidate_path
+        >>| Source_tree.Dir.path
+        >>| Path.Source.to_string)
+  in
+  List.concat [ cram_candidates; dir_candidates ]
+;;
+
 let explain_unsuccessful_search path ~parent_dir =
   let open Memo.O in
-  (* If the user misspelled the test name, we give them a hint. *)
-  let+ hints =
-    (* We search for all files and directories in the parent directory and
-       suggest them as possible candidates. *)
-    let+ candidates =
-      let+ cram_candidates =
-        let+ cram_tests = cram_tests_of_dir parent_dir in
-        List.filter_map cram_tests ~f:(fun res ->
-          Result.to_option res
-          |> Option.map ~f:(fun test ->
-            Source.Cram_test.path test |> Path.Source.to_string))
-      and+ dir_candidates =
-        let* parent_source_dir = Source_tree.find_dir parent_dir in
-        match parent_source_dir with
-        | None -> Memo.return []
-        | Some parent_source_dir ->
-          let dirs = Source_tree.Dir.sub_dirs parent_source_dir in
-          String.Map.to_list dirs
-          |> Memo.List.map ~f:(fun (_candidate, candidate_path) ->
-            Source_tree.Dir.sub_dir_as_t candidate_path
-            >>| Source_tree.Dir.path
-            >>| Path.Source.to_string)
-      in
-      List.concat [ cram_candidates; dir_candidates ]
-    in
-    User_message.did_you_mean (Path.Source.to_string path) ~candidates
-  in
+  let+ candidates = all_tests_of_dir parent_dir in
   User_error.raise
-    ~hints
+    ~hints:(User_message.did_you_mean (Path.Source.to_string path) ~candidates)
     [ Pp.textf "%S does not match any known test." (Path.Source.to_string path) ]
 ;;
 

--- a/bin/runtest_common.ml
+++ b/bin/runtest_common.ml
@@ -40,6 +40,8 @@ let all_tests_of_dir parent_dir =
         >>| Path.Source.to_string)
   in
   List.concat [ cram_candidates; dir_candidates ]
+  |> String.Set.of_list
+  |> String.Set.to_list
 ;;
 
 let explain_unsuccessful_search path ~parent_dir =

--- a/test/blackbox-tests/test-cases/runtest-cmd-hints.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-hints.t
@@ -13,7 +13,7 @@ Test the "did you mean" hints for dune runtest command.
 
   $ dune test dip.t
   Error: "dip.t" does not match any known test.
-  Hint: did you mean dir.t or dir.t?
+  Hint: did you mean dir.t?
   [1]
 
   $ dune test other_dip

--- a/test/blackbox-tests/test-cases/runtest-cmd-hints.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-hints.t
@@ -1,0 +1,22 @@
+Test the "did you mean" hints for dune runtest command.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ mkdir dir.t other_dir
+  $ cat > dir.t/run.t <<EOF
+  >   $ echo "Directory-based cram test"
+  >   Directory-based cram test
+  > EOF
+  $ cat > dir_t
+
+  $ dune test dip.t
+  Error: "dip.t" does not match any known test.
+  Hint: did you mean dir_t or dir.t?
+  [1]
+
+  $ dune test other_dip
+  Error: "other_dip" does not match any known test.
+  Hint: did you mean other_dir?
+  [1]

--- a/test/blackbox-tests/test-cases/runtest-cmd-hints.t
+++ b/test/blackbox-tests/test-cases/runtest-cmd-hints.t
@@ -13,7 +13,7 @@ Test the "did you mean" hints for dune runtest command.
 
   $ dune test dip.t
   Error: "dip.t" does not match any known test.
-  Hint: did you mean dir_t or dir.t?
+  Hint: did you mean dir.t or dir.t?
   [1]
 
   $ dune test other_dip


### PR DESCRIPTION
- In the first commit we split up listing and finding cram tests.
- In the second commit we only suggest cram tests when giving hints.
- In the third commit we deduplicate suggestions that we give.