### PR TITLE
Deduplicate opam parse errors

### DIFF
--- a/otherlibs/stdune/src/result.ml
+++ b/otherlibs/stdune/src/result.ml
@@ -79,6 +79,7 @@ module O = struct
   let ( >>| ) t f = map t ~f
   let ( let* ) = ( >>= )
   let ( let+ ) = ( >>| )
+  let ( and* ) = both
   let ( and+ ) = both
 end
 

--- a/otherlibs/stdune/src/result.mli
+++ b/otherlibs/stdune/src/result.mli
@@ -24,6 +24,7 @@ module O : sig
   val ( let* ) : ('a, 'error) t -> ('a -> ('b, 'error) t) -> ('b, 'error) t
   val ( and+ ) : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t
   val ( let+ ) : ('a, 'error) t -> ('a -> 'b) -> ('b, 'error) t
+  val ( and* ) : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t
 end
 
 val map : ('a, 'error) t -> f:('a -> 'b) -> ('b, 'error) t
@@ -35,6 +36,8 @@ val to_dyn : 'a Dyn.builder -> 'error Dyn.builder -> ('a, 'error) t Dyn.builder
 
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
+
+val both : ('a, 'e) t -> ('b, 'e) t -> ('a * 'b, 'e) t
 
 (** For compatibility with some other code *)
 type ('a, 'error) result = ('a, 'error) t

--- a/src/dune_pkg/lock_pkg.mli
+++ b/src/dune_pkg/lock_pkg.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 (** Add values for expanding [%{name}] for a package *)
 val add_self_to_filter_env
   :  OpamPackage.t
@@ -15,4 +17,4 @@ val opam_package_to_lock_file_pkg
   -> pinned:bool
   -> Resolved_package.t
   -> portable_lock_dir:bool
-  -> Lock_dir.Pkg.t
+  -> (Lock_dir.Pkg.t, User_message.t) result

--- a/src/dune_pkg/opam_solver.mli
+++ b/src/dune_pkg/opam_solver.mli
@@ -28,5 +28,8 @@ val solve_lock_dir
            handling both portable and non-portable lockdirs with the same code.
            Once portable lockdirs are enabled unconditionally, remove this
            argument. *)
-  -> (Solver_result.t, [ `Diagnostic_message of User_message.Style.t Pp.t ]) result
+  -> ( Solver_result.t
+       , [ `Solve_error of User_message.Style.t Pp.t | `Manifest_error of User_message.t ]
+       )
+       result
        Fiber.t

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -32,4 +32,6 @@ val local_package
   -> OpamPackage.t
   -> t
 
-val get_opam_package_files : t list -> File_entry.t list list Fiber.t
+val get_opam_package_files
+  :  t list
+  -> (File_entry.t list list, User_message.t) result Fiber.t

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
@@ -1,0 +1,77 @@
+Test that errors with opam package manifests are only printed a single time
+even when they are encountered by multiple concurrent runs of the opam solver.
+
+  $ . ../helpers.sh
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Project depending on a package "foo":
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > (package
+  >  (name x)
+  >  (depends foo))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name x)
+  >  (libraries foo))
+  > EOF
+
+Create the package "foo" with an invalid opam file:
+  $ mkpkg foo <<EOF
+  > invalid opam file
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  File "$TESTCASE_ROOT/mock-opam-repository/packages/foo/foo.0.0.1/opam", line 2, characters 8-12:
+  2 | invalid opam file
+              ^^^^
+  Error: unable to parse opam file
+  Parse error
+  [1]
+
+Create the package "foo" with an opam file that creates a circular dep with the project:
+  $ mkpkg foo <<EOF
+  > depends: [ "x" ]
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Error: Dune does not support packages outside the workspace depending on
+  packages in the workspace. The package "foo" is not in the workspace but it
+  depends on the package "x" which is in the workspace.
+  [1]
+
+Create the package "foo" with an invalid variable interpolation:
+  $ mkpkg foo <<EOF
+  > build: [ "./configure" "--prefix=%{prefix" ]
+  > EOF
+
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  File "$TESTCASE_ROOT/mock-opam-repository/packages/foo/foo.0.0.1/opam", line 1, characters 0-0:
+  Error: Encountered malformed variable interpolation while processing commands
+  for package foo.0.0.1.
+  The variable interpolation:
+  %{prefix
+  [1]
+
+Add a file to the package but change its permission to not be readable:
+  $ mkpkg foo
+  $ pkg_dir=$mock_packages/foo/foo.0.0.1
+  $ mkdir -p $pkg_dir/files
+  $ touch $pkg_dir/files/foo.txt
+Make sure to undo the permission change on exit.
+  $ trap "chmod +r $pkg_dir/files" EXIT
+  $ chmod -r $pkg_dir/files
+  $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
+  Warning: Unable to read directory
+  mock-opam-repository/packages/foo/foo.0.0.1/files. Ignoring.
+  Remove this message by ignoring by adding:
+  (dirs \ files)
+  to the dune file: mock-opam-repository/packages/foo/foo.0.0.1/dune
+  Reason: opendir(mock-opam-repository/packages/foo/foo.0.0.1/files): Permission denied
+  File "$TESTCASE_ROOT/mock-opam-repository/packages/foo/foo.0.0.1/files", line 1, characters 0-0:
+  Error: Unable to read file in opam repository:
+  opendir($TESTCASE_ROOT/mock-opam-repository/packages/foo/foo.0.0.1/files/): Permission denied
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -45,8 +45,8 @@ to solve for macos, linux, and windows by default.
   No package solution was found for some requsted platforms.
   
   Platforms with no solution:
-  - arch = x86_64; os = linux
   - arch = arm64; os = linux
+  - arch = x86_64; os = linux
   
   See the log or run with --verbose for more details. Configure platforms to
   solve for in the dune-workspace file.


### PR DESCRIPTION
Generating portable lockdirs requires running the solver several times, possibly in parallel. Errors parsing opam files would be printed multiple times. This change threads result types through some of the solver logic so errors can be collected and deduplicated before printing.