### PR TITLE
Move dev-tool lock dirs into hidden folder

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -80,7 +80,7 @@ let solve ~dev_tool ~local_packages =
     | `Disabled -> workspace
   in
   (* as we want to write to the source, we're using the source lock dir here *)
-  let lock_dir = Dune_rules.Lock_dir.dev_tool_source_lock_dir dev_tool |> Path.source in
+  let lock_dir = Dune_rules.Lock_dir.dev_tool_untracked_lock_dir dev_tool in
   Memo.of_reproducible_fiber
   @@ Pkg.Lock.solve
        workspace
@@ -174,14 +174,11 @@ let extra_dependencies dev_tool =
 
 let lockdir_status dev_tool =
   let open Memo.O in
-  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_source_lock_dir dev_tool in
-  let* lock_dir_exists =
-    Dune_engine.Fs_memo.dir_exists (In_source_dir dev_tool_lock_dir)
-  in
+  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_untracked_lock_dir dev_tool in
+  let lock_dir_exists = Path.exists dev_tool_lock_dir in
   match lock_dir_exists with
   | false -> Memo.return `No_lockdir
   | true ->
-    let dev_tool_lock_dir = Path.source dev_tool_lock_dir in
     (match Lock_dir.read_disk dev_tool_lock_dir with
      | Error _ -> Memo.return `No_lockdir
      | Ok { packages; _ } ->

--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -80,7 +80,9 @@ let solve ~dev_tool ~local_packages =
     | `Disabled -> workspace
   in
   (* as we want to write to the source, we're using the source lock dir here *)
-  let lock_dir = Dune_rules.Lock_dir.dev_tool_untracked_lock_dir dev_tool in
+  let lock_dir =
+    Dune_rules.Lock_dir.dev_tool_external_lock_dir dev_tool |> Path.external_
+  in
   Memo.of_reproducible_fiber
   @@ Pkg.Lock.solve
        workspace
@@ -174,11 +176,14 @@ let extra_dependencies dev_tool =
 
 let lockdir_status dev_tool =
   let open Memo.O in
-  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_untracked_lock_dir dev_tool in
-  let lock_dir_exists = Path.exists dev_tool_lock_dir in
+  let dev_tool_lock_dir = Dune_rules.Lock_dir.dev_tool_external_lock_dir dev_tool in
+  let* lock_dir_exists =
+    Dune_engine.Fs_memo.dir_exists (Path.Outside_build_dir.External dev_tool_lock_dir)
+  in
   match lock_dir_exists with
   | false -> Memo.return `No_lockdir
   | true ->
+    let dev_tool_lock_dir = Path.external_ dev_tool_lock_dir in
     (match Lock_dir.read_disk dev_tool_lock_dir with
      | Error _ -> Memo.return `No_lockdir
      | Ok { packages; _ } ->

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -61,8 +61,8 @@ let term =
             [ Pp.textf "no library is defined in %s" (String.maybe_quoted dir) ]
         | true ->
           let* () = Build_system.build_file utop_exe in
-          let* utop_dev_tool_lock_dir_exists =
-            Memo.Lazy.force Utop.utop_dev_tool_lock_dir_exists
+          let utop_dev_tool_lock_dir_exists =
+            Lazy.force Utop.utop_dev_tool_lock_dir_exists
           in
           let* () =
             if utop_dev_tool_lock_dir_exists

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -61,8 +61,8 @@ let term =
             [ Pp.textf "no library is defined in %s" (String.maybe_quoted dir) ]
         | true ->
           let* () = Build_system.build_file utop_exe in
-          let utop_dev_tool_lock_dir_exists =
-            Lazy.force Utop.utop_dev_tool_lock_dir_exists
+          let* utop_dev_tool_lock_dir_exists =
+            Memo.Lazy.force Utop.utop_dev_tool_lock_dir_exists
           in
           let* () =
             if utop_dev_tool_lock_dir_exists

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -197,6 +197,13 @@ let solve_multiple_platforms
           |> Platforms_by_message.all_solver_errors_raising_if_any_manifest_errors )
 ;;
 
+let user_lock_dir_path path =
+  match (path : Path.t) with
+  | In_source_tree _ -> path
+  | In_build_dir _ -> path
+  | External e -> Dune_pkg.Pkg_workspace.dev_tool_path_to_source_dir e |> Path.source
+;;
+
 let summary_message
       ~portable_lock_dir
       ~lock_dir_path
@@ -259,7 +266,9 @@ let summary_message
     in
     (Pp.tag
        User_message.Style.Success
-       (Pp.textf "Solution for %s" (Path.to_string_maybe_quoted lock_dir_path))
+       (Pp.textf
+          "Solution for %s"
+          (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
      :: Pp.nop
      :: Pp.text "Dependencies common to all supported platforms:"
      :: pp_package_set common_packages
@@ -268,7 +277,9 @@ let summary_message
   else
     (Pp.tag
        User_message.Style.Success
-       (Pp.textf "Solution for %s:" (Path.to_string_maybe_quoted lock_dir_path))
+       (Pp.textf
+          "Solution for %s:"
+          (Path.to_string_maybe_quoted (user_lock_dir_path lock_dir_path)))
      :: (match Lock_dir.Packages.to_pkg_list lock_dir.packages with
          | [] -> Pp.tag User_message.Style.Warning @@ Pp.text "(no dependencies to lock)"
          | packages -> pp_packages packages)
@@ -493,7 +504,9 @@ let solve
         ([ Pp.text "Unable to solve dependencies for the following lock directories:" ]
          @ List.concat_map errors ~f:(fun (path, errors) ->
            let messages = List.map errors ~f:fst in
-           [ Pp.textf "Lock directory %s:" (Path.to_string_maybe_quoted path)
+           [ Pp.textf
+               "Lock directory %s:"
+               (Path.to_string_maybe_quoted (user_lock_dir_path path))
            ; Pp.vbox (Pp.concat ~sep:Pp.cut messages)
            ]))
   | Ok write_disks_with_summaries ->

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -526,10 +526,11 @@ let in_source_tree path =
        Path.Source.L.relative Path.Source.root components
      | source_components ->
        (match Path.Build.explode b with
-        | ".dev-tools.locks" :: dev_tool :: components ->
-          Path.Source.L.relative
-            Path.Source.root
-            ([ "_build"; ".dev-tools.locks"; dev_tool ] @ components)
+        | (".dev-tools.locks" as prefix) :: dev_tool :: components ->
+          let build_as_source =
+            Path.build_dir |> Path.to_string |> Path.Source.of_string
+          in
+          Path.Source.L.relative build_as_source (prefix :: dev_tool :: components)
         | build_components ->
           Code_error.raise
             "Unexpected location of lock directory in build directory"

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -869,7 +869,7 @@ module Pkg = struct
   ;;
 
   (* More general version of [files_dir] which works on generic paths *)
-  let files_dir_generic package_name maybe_package_version ~lock_dir =
+  let files_dir package_name maybe_package_version ~lock_dir =
     (* TODO(steve): Once portable lockdirs are enabled by default, make the
        package version non-optional *)
     let extension = ".files" in
@@ -882,11 +882,6 @@ module Pkg = struct
          ^ "."
          ^ Package_version.to_string package_version
          ^ extension)
-  ;;
-
-  (* TODO remove *)
-  let files_dir package_name maybe_package_version ~lock_dir =
-    files_dir_generic package_name maybe_package_version ~lock_dir
   ;;
 
   let source_files_dir package_name maybe_package_version ~lock_dir =
@@ -1494,10 +1489,7 @@ module Write_disk = struct
               let maybe_package_version =
                 if portable_lock_dir then Some package_version else None
               in
-              Pkg.files_dir_generic
-                package_name
-                maybe_package_version
-                ~lock_dir:lock_dir_path
+              Pkg.files_dir package_name maybe_package_version ~lock_dir:lock_dir_path
             in
             Path.mkdir_p files_dir;
             List.iter files ~f:(fun { File_entry.original; local_file } ->

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1391,9 +1391,14 @@ module Write_disk = struct
     | Ok `Non_existant -> Fun.const ()
     | Ok `Is_existing_lock_dir ->
       fun () ->
-        (* dev-tool lock dirs are external paths despite living in _build, they're
-           safe to remove *)
-        Path.rm_rf ~allow_external:true path
+        let path =
+          match path with
+          | In_source_tree _ | In_build_dir _ -> path
+          | External e ->
+            (* it might be a dev-tool path, try to convert *)
+            Workspace.dev_tool_path_to_source_dir e |> Path.source
+        in
+        Path.rm_rf path
     | Error e -> raise_user_error_on_check_existance path e
   ;;
 

--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1787,18 +1787,9 @@ let loc_in_source_tree loc =
   loc
   |> Loc.map_pos ~f:(fun ({ pos_fname; _ } as pos) ->
     let path = Path.of_string pos_fname in
-    match path with
-    | External _ | In_source_tree _ -> pos
-    | In_build_dir b ->
-      (match Path.Build.explode b with
-       | ".dev-tools.locks" :: _ ->
-         (* we're excluding the hidden dev-tools.locks folders in the build folder
-          from rewriting  *)
-         pos
-       | _otherwise ->
-         let new_path = in_source_tree path in
-         let pos_fname = Path.Source.to_string new_path in
-         { pos with pos_fname }))
+    let new_path = in_source_tree path in
+    let pos_fname = Path.Source.to_string new_path in
+    { pos with pos_fname })
 ;;
 
 let check_if_solved_for_platform { solved_for_platforms; _ } ~platform =

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -79,10 +79,9 @@ let dev_tool_path_to_source_dir path =
       [ "external", Path.External.to_dyn path ]
   | In_build_dir b ->
     (match Path.Build.explode b with
-     | ".dev-tools.locks" :: dev_tool_name :: components ->
-       Path.Source.L.relative
-         Path.Source.root
-         ([ "_build"; ".dev-tools.locks"; dev_tool_name ] @ components)
+     | (".dev-tools.locks" as prefix) :: dev_tool_name :: components ->
+       let build_as_source = Path.build_dir |> Path.to_string |> Path.Source.of_string in
+       Path.Source.L.relative build_as_source (prefix :: dev_tool_name :: components)
      | components ->
        Code_error.raise
          "Unexpected external path"

--- a/src/dune_pkg/workspace.ml
+++ b/src/dune_pkg/workspace.ml
@@ -70,3 +70,37 @@ module Repository = struct
 
   let opam_url { name = _; url } = url
 end
+
+let dev_tool_path_to_source_dir path =
+  let of_ =
+    Path.Build.relative Path.Build.root ".dev-tools.locks"
+    |> Path.build
+    |> Path.to_absolute_filename
+    |> Path.External.of_string
+  in
+  let in_dev_tool_dir = Path.External.is_descendant ~of_ path in
+  match in_dev_tool_dir with
+  | false ->
+    Code_error.raise
+      "External lock dir path is unsupported"
+      [ "dir", Path.External.to_dyn path ]
+  | true ->
+    let prefix = Path.External.to_string of_ in
+    let as_string = Path.External.to_string path in
+    let relative =
+      String.sub
+        as_string
+        ~pos:(String.length prefix)
+        ~len:(String.length as_string - String.length prefix)
+    in
+    let exploded = String.split ~on:'/' relative in
+    (match exploded with
+     | "" :: dev_tool_name :: components ->
+       Path.Source.L.relative
+         Path.Source.root
+         ([ "_build"; ".dev-tools.locks"; dev_tool_name ] @ components)
+     | components ->
+       Code_error.raise
+         "Unexpected external path"
+         [ "dir", Path.External.to_dyn path; "components", Dyn.(list string) components ])
+;;

--- a/src/dune_pkg/workspace.mli
+++ b/src/dune_pkg/workspace.mli
@@ -25,3 +25,5 @@ module Repository : sig
 
   val name : t -> Name.t
 end
+
+val dev_tool_path_to_source_dir : Path.External.t -> Path.Source.t

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -189,11 +189,11 @@ let find_checksum, find_url =
           Dune_pkg.Dev_tool.all
           ~init:(Checksum.Map.empty, Digest.Map.empty)
           ~f:(fun acc dev_tool ->
-            let dir = Lock_dir.dev_tool_untracked_lock_dir dev_tool in
+            let dir = Lock_dir.dev_tool_external_lock_dir dev_tool in
             let exists =
               (* Note we use [Path.Untracked] here rather than [Fs_memo] because a tool's
                  lockdir may be generated part way through a build. *)
-              Path.Untracked.exists dir
+              Path.Untracked.exists (Path.external_ dir)
             in
             match exists with
             | false -> Memo.return acc

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -189,11 +189,11 @@ let find_checksum, find_url =
           Dune_pkg.Dev_tool.all
           ~init:(Checksum.Map.empty, Digest.Map.empty)
           ~f:(fun acc dev_tool ->
-            let dir = Lock_dir.dev_tool_source_lock_dir dev_tool in
+            let dir = Lock_dir.dev_tool_untracked_lock_dir dev_tool in
             let exists =
               (* Note we use [Path.Untracked] here rather than [Fs_memo] because a tool's
                  lockdir may be generated part way through a build. *)
-              Path.Untracked.exists (Path.source dir)
+              Path.Untracked.exists dir
             in
             match exists with
             | false -> Memo.return acc

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -33,7 +33,9 @@ end
 
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
-    Lock_dir.dev_tool_untracked_lock_dir Ocamlformat |> Path.Untracked.exists
+    Lock_dir.dev_tool_external_lock_dir Ocamlformat
+    |> Path.external_
+    |> Path.Untracked.exists
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -33,9 +33,12 @@ end
 
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
-    Lock_dir.dev_tool_external_lock_dir Ocamlformat
-    |> Path.external_
-    |> Path.Untracked.exists
+    (* we assume that if lock_dev_tools is set, then the lock dir was created
+       via locking and can expect it to exist. If it doesn't, it's a bug
+    *)
+    match Config.get Compile_time.lock_dev_tools with
+    | `Enabled -> true
+    | `Disabled -> false
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -33,8 +33,7 @@ end
 
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
-    let path = Lock_dir.dev_tool_source_lock_dir Ocamlformat in
-    Source_tree.find_dir path >>| Option.is_some
+    Lock_dir.dev_tool_source_lock_dir Ocamlformat |> Path.source |> Path.Untracked.exists
   ;;
 
   (* Config files for ocamlformat. When these are changed, running
@@ -129,7 +128,7 @@ let gen_rules_output
   let loc = Format_config.loc config in
   let dir = Path.Build.parent_exn output_dir in
   let alias_formatted = Alias.fmt ~dir:output_dir in
-  let* ocamlformat_is_locked = Ocamlformat.dev_tool_lock_dir_exists () in
+  let ocamlformat_is_locked = Ocamlformat.dev_tool_lock_dir_exists () in
   let setup_formatting file =
     (let input_basename = Path.Source.basename file in
      let input = Path.Build.relative dir input_basename in

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -33,7 +33,7 @@ end
 
 module Ocamlformat = struct
   let dev_tool_lock_dir_exists () =
-    Lock_dir.dev_tool_source_lock_dir Ocamlformat |> Path.source |> Path.Untracked.exists
+    Lock_dir.dev_tool_untracked_lock_dir Ocamlformat |> Path.Untracked.exists
   ;;
 
   (* Config files for ocamlformat. When these are changed, running

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -148,7 +148,9 @@ let dev_tool_to_path_segment dev_tool =
 ;;
 
 let dev_tool_source_lock_dir dev_tool =
-  let dev_tools_path = Path.Source.(relative root "dev-tools.locks") in
+  let dev_tools_path =
+    Path.Source.L.relative Path.Source.root [ "_build"; ".dev-tools.locks" ]
+  in
   let dev_tool_segment = dev_tool_to_path_segment dev_tool in
   Path.Source.append_local dev_tools_path dev_tool_segment
 ;;

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -148,10 +148,13 @@ let dev_tool_to_path_segment dev_tool =
 ;;
 
 (* This function returns the lock dir that is created outside the build system. *)
-let dev_tool_untracked_lock_dir dev_tool =
-  let dev_tools_path = Path.Build.relative Path.Build.root ".dev-tools.locks" in
+let dev_tool_external_lock_dir dev_tool =
+  let external_root =
+    Path.Build.root |> Path.build |> Path.to_absolute_filename |> Path.External.of_string
+  in
+  let dev_tools_path = Path.External.relative external_root ".dev-tools.locks" in
   let dev_tool_segment = dev_tool_to_path_segment dev_tool in
-  Path.Build.append_local dev_tools_path dev_tool_segment |> Path.build
+  Path.External.append_local dev_tools_path dev_tool_segment
 ;;
 
 (* This function returns the lock dir location where the build system can create
@@ -243,12 +246,12 @@ let get ctx = get_with_path ctx >>| Result.map ~f:snd
 let get_exn ctx = get ctx >>| User_error.ok_exn
 
 let of_dev_tool dev_tool =
-  let path = dev_tool_untracked_lock_dir dev_tool in
+  let path = dev_tool |> dev_tool_external_lock_dir |> Path.external_ in
   Load.load_exn path
 ;;
 
 let of_dev_tool_if_lock_dir_exists dev_tool =
-  let path = dev_tool_untracked_lock_dir dev_tool in
+  let path = dev_tool |> dev_tool_external_lock_dir |> Path.external_ in
   let exists =
     (* Note we use [Path.Untracked] here rather than [Fs_memo] because a tool's
        lockdir may be generated part way through a build. *)

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -21,7 +21,7 @@ val default_path : Path.t
 val default_source_path : Path.Source.t
 
 (** The location in the source tree where a dev tool lock dir is expected *)
-val dev_tool_source_lock_dir : Dune_pkg.Dev_tool.t -> Path.Source.t
+val dev_tool_untracked_lock_dir : Dune_pkg.Dev_tool.t -> Path.t
 
 (** Returns the path to the lock_dir that will be used to lock the
     given dev tool *)

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -21,7 +21,7 @@ val default_path : Path.t
 val default_source_path : Path.Source.t
 
 (** The location in the source tree where a dev tool lock dir is expected *)
-val dev_tool_untracked_lock_dir : Dune_pkg.Dev_tool.t -> Path.t
+val dev_tool_external_lock_dir : Dune_pkg.Dev_tool.t -> Path.External.t
 
 (** Returns the path to the lock_dir that will be used to lock the
     given dev tool *)

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -410,10 +410,10 @@ let copy_lock_dir ~target ~lock_dir ~deps ~files =
   let open Action_builder.O in
   Action_builder.deps deps
   >>> (Path.Set.to_list_map files ~f:(fun src ->
-         let suffix = Path.drop_prefix_exn src ~prefix:lock_dir in
-         let dst = Path.Build.append_local target suffix in
-         let parent = Path.Build.parent_exn dst in
-         Action.progn [ Action.mkdir parent; Action.copy src dst ])
+         let dst =
+           Path.drop_prefix_exn src ~prefix:lock_dir |> Path.Build.append_local target
+         in
+         Action.progn [ Action.mkdir (Path.Build.parent_exn dst); Action.copy src dst ])
        |> Action.concurrent
        |> Action.Full.make
        |> Action_builder.return)

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -507,7 +507,7 @@ let setup_dev_tool_lock_rules ~dir dev_tool =
   let package_name = Dev_tool.package_name dev_tool in
   let dev_tool_name = Dune_lang.Package_name.to_string package_name in
   let dir = Path.Build.relative dir dev_tool_name in
-  let lock_dir = Lock_dir.dev_tool_untracked_lock_dir dev_tool in
+  let lock_dir = dev_tool |> Lock_dir.dev_tool_external_lock_dir |> Path.external_ in
   (* dev tool lock files are created in _build outside of the build system
      so we have to tell the build system not to try to create them *)
   setup_copy_rules ~dir ~assume_src_exists:true ~lock_dir

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -424,60 +424,44 @@ let copy_lock_dir ~target ~lock_dir ~deps ~files =
             ~dirs:(Path.Build.Set.singleton target))
 ;;
 
-let files dir =
-  let rec recurse dir =
-    match Path.Untracked.readdir_unsorted_with_kinds dir with
-    | Ok entries ->
-      entries
-      |> List.fold_left
-           ~init:(Path.Set.empty, Path.Set.empty)
-           ~f:(fun (files, empty_directories) (entry, kind) ->
-             let path = Path.relative dir entry in
-             match (kind : Unix.file_kind) with
-             | S_REG ->
-               let files = Path.Set.add files path in
-               files, empty_directories
-             | S_DIR ->
-               let files', empty_directories' = recurse path in
-               (match Path.Set.is_empty files', Path.Set.is_empty empty_directories' with
-                | true, true ->
-                  let empty_directories = Path.Set.add empty_directories path in
-                  files, empty_directories
-                | _, _ ->
-                  let files = Path.Set.union files files' in
-                  let empty_directories =
-                    Path.Set.union empty_directories empty_directories'
-                  in
-                  files, empty_directories)
-             | otherwise ->
-               Code_error.raise
-                 "unsupported kind of file in folder"
-                 [ "path", Path.to_dyn path; "kind", File_kind.to_dyn otherwise ])
-    | Error (ENOENT, _, _) -> Path.Set.empty, Path.Set.empty
+let scan_lock_directory =
+  let rec scan dir =
+    let open Memo.O in
+    Fs_memo.dir_contents (Path.as_outside_build_dir_exn dir)
+    >>= function
+    | Error (ENOENT, _, _) -> Memo.return Path.Set.empty
     | Error unix_error ->
       User_error.raise
-        [ Pp.textf
-            "Failed to read lock dir files of %s:"
-            (Path.to_string_maybe_quoted dir)
-        ; Pp.text (Unix_error.Detailed.to_string_hum unix_error)
+        [ Pp.textf "Failed to read directory %s:" (Path.to_string_maybe_quoted dir)
+        ; Unix_error.Detailed.pp unix_error
         ]
+    | Ok entries ->
+      Fs_cache.Dir_contents.to_list entries
+      |> Memo.parallel_map ~f:(fun (entry, kind) ->
+        let path = Path.relative dir entry in
+        match (kind : File_kind.t) with
+        | S_REG -> Memo.return (Path.Set.singleton path)
+        | S_DIR -> scan path
+        | kind ->
+          User_error.raise
+            [ Pp.textf
+                "Lock directory contains file %S with unsupported kind %S"
+                (Path.to_string_maybe_quoted path)
+                (File_kind.to_string kind)
+            ])
+      >>| Path.Set.union_all
   in
-  let files, empty_directories = recurse dir in
-  Dep.Set.of_source_files ~files ~empty_directories, files
+  fun lock_dir_path ->
+    let+ files = scan lock_dir_path in
+    Dep.Set.of_source_files ~files ~empty_directories:Path.Set.empty, files
 ;;
 
-let setup_copy_rules ~dir:target ~assume_src_exists ~lock_dir =
-  let+ () = Memo.return () in
-  let deps, files = files lock_dir in
+let setup_copy_rules ~dir:target ~lock_dir =
+  let+ deps, files = scan_lock_directory lock_dir in
   let directory_targets, rules =
     match Path.Set.is_empty files with
     | true -> Path.Build.Map.empty, Rules.empty
     | false ->
-      let deps =
-        match assume_src_exists with
-        | false -> deps
-        | true -> Dep.Set.empty
-      in
       let directory_targets = Path.Build.Map.singleton target Loc.none in
       let { Action_builder.With_targets.build; targets } =
         copy_lock_dir ~target ~lock_dir ~deps ~files
@@ -499,7 +483,7 @@ let setup_lock_rules_with_source (workspace : Workspace.t) ~dir ~lock_dir =
   match source with
   | `Source_tree lock_dir ->
     let dir = Path.Build.append_source dir lock_dir in
-    setup_copy_rules ~assume_src_exists:false ~dir ~lock_dir:(Path.source lock_dir)
+    setup_copy_rules ~dir ~lock_dir:(Path.source lock_dir)
   | `Generated -> Memo.return (setup_lock_rules ~dir ~lock_dir)
 ;;
 
@@ -508,9 +492,7 @@ let setup_dev_tool_lock_rules ~dir dev_tool =
   let dev_tool_name = Dune_lang.Package_name.to_string package_name in
   let dir = Path.Build.relative dir dev_tool_name in
   let lock_dir = dev_tool |> Lock_dir.dev_tool_external_lock_dir |> Path.external_ in
-  (* dev tool lock files are created in _build outside of the build system
-     so we have to tell the build system not to try to create them *)
-  setup_copy_rules ~dir ~assume_src_exists:true ~lock_dir
+  setup_copy_rules ~dir ~lock_dir
 ;;
 
 let setup_rules ~components ~dir =

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -9,7 +9,9 @@ let ocaml_index_dev_tool_exe_path_building_if_necessary () =
 ;;
 
 let ocaml_index_dev_tool_exists () =
-  Lock_dir.dev_tool_untracked_lock_dir Ocaml_index |> Path.Untracked.exists
+  Lock_dir.dev_tool_external_lock_dir Ocaml_index
+  |> Path.external_
+  |> Path.Untracked.exists
 ;;
 
 let ocaml_index sctx ~dir =

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -9,7 +9,7 @@ let ocaml_index_dev_tool_exe_path_building_if_necessary () =
 ;;
 
 let ocaml_index_dev_tool_exists () =
-  Lock_dir.dev_tool_source_lock_dir Ocaml_index |> Path.source |> Path.Untracked.exists
+  Lock_dir.dev_tool_untracked_lock_dir Ocaml_index |> Path.Untracked.exists
 ;;
 
 let ocaml_index sctx ~dir =

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -86,11 +86,7 @@ module Package_universe = struct
     | Dependencies ctx -> Lock_dir.get_path ctx
     | Dev_tool dev_tool ->
       (* CR-Leonidas-from-XIV: It probably isn't always [Some] *)
-      dev_tool
-      |> Lock_dir.dev_tool_source_lock_dir
-      |> Path.source
-      |> Option.some
-      |> Memo.return
+      dev_tool |> Lock_dir.dev_tool_untracked_lock_dir |> Option.some |> Memo.return
   ;;
 end
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1495,10 +1495,10 @@ end = struct
             in
             resolve db dep_loc dep_pkg_digest package_universe)
       and+ files_dir =
-        let+ lock_dir =
+        let* lock_dir =
           Package_universe.lock_dir_path package_universe >>| Option.value_exn
         in
-        let files_dir =
+        let+ files_dir =
           let module Pkg = Dune_pkg.Lock_dir.Pkg in
           (* TODO(steve): simplify this once portable lockdirs become the
              default. This logic currently handles both the cases where
@@ -1510,15 +1510,17 @@ end = struct
           let path_with_version =
             Pkg.source_files_dir info.name (Some info.version) ~lock_dir
           in
-          let path_with_version_exists =
-            Path.Untracked.exists (Path.source path_with_version)
+          let* path_with_version_exists =
+            Fs_memo.dir_exists (Path.Outside_build_dir.In_source_dir path_with_version)
           in
           match path_with_version_exists with
-          | true -> Some (Pkg.files_dir info.name (Some info.version) ~lock_dir)
+          | true ->
+            Memo.return @@ Some (Pkg.files_dir info.name (Some info.version) ~lock_dir)
           | false ->
             let path_without_version = Pkg.source_files_dir info.name None ~lock_dir in
-            let path_without_version_exists =
-              Path.Untracked.exists (Path.source path_without_version)
+            let+ path_without_version_exists =
+              Fs_memo.dir_exists
+                (Path.Outside_build_dir.In_source_dir path_without_version)
             in
             (match path_without_version_exists with
              | true -> Some (Pkg.files_dir info.name None ~lock_dir)

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -147,9 +147,9 @@ let requires ~loc ~db ~libs =
 ;;
 
 let utop_dev_tool_lock_dir_exists =
-  Memo.Lazy.create (fun () ->
-    let path = Lock_dir.dev_tool_source_lock_dir Utop in
-    Fs_memo.dir_exists (In_source_dir path))
+  lazy
+    (let path = Lock_dir.dev_tool_untracked_lock_dir Utop in
+     Path.Untracked.exists path)
 ;;
 
 let utop_findlib_conf = Filename.concat utop_dir_basename "findlib.conf"
@@ -168,8 +168,8 @@ let utop_ocamlpath = Memo.Lazy.create (fun () -> Pkg_rules.dev_tool_ocamlpath Ut
    we need to tell findlib where to look for libraries by means of a custom
    findlib.conf file. *)
 let findlib_conf sctx ~dir =
-  Memo.Lazy.force utop_dev_tool_lock_dir_exists
-  >>= function
+  Lazy.force utop_dev_tool_lock_dir_exists
+  |> function
   | false ->
     (* If there isn't lockdir don't create the findlib.conf rule. *)
     Memo.return ()
@@ -187,7 +187,7 @@ let findlib_conf sctx ~dir =
 
 let lib_db sctx ~dir =
   let* scope = Scope.DB.find_by_dir dir in
-  let* lock_dir_exists = Memo.Lazy.force utop_dev_tool_lock_dir_exists in
+  let lock_dir_exists = Lazy.force utop_dev_tool_lock_dir_exists in
   match lock_dir_exists with
   | false -> Memo.return (Scope.libs scope)
   | true ->

--- a/src/dune_rules/utop.mli
+++ b/src/dune_rules/utop.mli
@@ -8,7 +8,7 @@ val utop_exe : Filename.t
 
 val utop_dir_basename : Filename.t
 val utop_findlib_conf : Filename.t
-val utop_dev_tool_lock_dir_exists : bool Lazy.t
+val utop_dev_tool_lock_dir_exists : bool Memo.Lazy.t
 val libs_under_dir : Super_context.t -> db:Lib.DB.t -> dir:Path.t -> Lib.t list Memo.t
 val setup : Super_context.t -> dir:Path.Build.t -> unit Memo.t
 

--- a/src/dune_rules/utop.mli
+++ b/src/dune_rules/utop.mli
@@ -8,7 +8,7 @@ val utop_exe : Filename.t
 
 val utop_dir_basename : Filename.t
 val utop_findlib_conf : Filename.t
-val utop_dev_tool_lock_dir_exists : bool Memo.Lazy.t
+val utop_dev_tool_lock_dir_exists : bool Lazy.t
 val libs_under_dir : Super_context.t -> db:Lib.DB.t -> dir:Path.t -> Lib.t list Memo.t
 val setup : Super_context.t -> dir:Path.Build.t -> unit Memo.t
 

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -742,18 +742,11 @@ let source_path_of_lock_dir_path path =
   | In_build_dir b ->
     (match Path.Build.explode b with
      | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
-     | [ ".dev-tools.locks"; dev_tool_name ] ->
-       Path.Source.L.relative
-         Path.Source.root
-         [ "_build"; ".dev-tools.locks"; dev_tool_name ]
      | components ->
        Code_error.raise
          "Unsupported build path"
          [ "dir", Path.Build.to_dyn b; "components", Dyn.(list string) components ])
-  | External e ->
-    Code_error.raise
-      "External lock dir path is unsupported"
-      [ "dir", Path.External.to_dyn e ]
+  | External e -> Dune_pkg.Pkg_workspace.dev_tool_path_to_source_dir e
 ;;
 
 let find_lock_dir t path =

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -742,6 +742,8 @@ let source_path_of_lock_dir_path path =
   | In_build_dir b ->
     (match Path.Build.explode b with
      | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
+     | [ ".dev-tools.locks"; dev_tool ] ->
+       Path.Source.L.relative Path.Source.root [ "_build"; ".dev-tools.locks"; dev_tool ]
      | components ->
        Code_error.raise
          "Unsupported build path"

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -742,7 +742,14 @@ let source_path_of_lock_dir_path path =
   | In_build_dir b ->
     (match Path.Build.explode b with
      | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
-     | _ -> Code_error.raise "Unsupported build path" [ "dir", Path.Build.to_dyn b ])
+     | [ ".dev-tools.locks"; dev_tool_name ] ->
+       Path.Source.L.relative
+         Path.Source.root
+         [ "_build"; ".dev-tools.locks"; dev_tool_name ]
+     | components ->
+       Code_error.raise
+         "Unsupported build path"
+         [ "dir", Path.Build.to_dyn b; "components", Dyn.(list string) components ])
   | External e ->
     Code_error.raise
       "External lock dir path is unsupported"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
@@ -19,7 +19,7 @@ Initial file:
   let () = print_endline "Hello, world"
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
@@ -40,7 +40,7 @@ attempt to build the package "foo".
   $ cat foo.ml
   let () = print_endline "Hello, world"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.0.1
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -1,6 +1,6 @@
 . ../helpers.sh
 
-dev_tool_lock_dir="dev-tools.locks/ocamlformat"
+dev_tool_lock_dir="_build/.dev-tools.locks/ocamlformat"
 
 make_fake_ocamlformat() {
   version=$1

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -29,7 +29,7 @@ Add a fake executable in the PATH
 
 Build the OCamlFormat binary dev-tool
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   File "dune", line 1, characters 0-0:
   Error: Files _build/default/dune and _build/default/.formatted/dune differ.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -45,7 +45,7 @@ Format using the dev-tools feature, it does not invoke the OCamlFormat binary fr
 the project dependencies (0.26.2) but instead builds and runs the OCamlFormat binary as a
 dev-tool (0.26.3).
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
@@ -1,0 +1,48 @@
+Checks whether dev-tool locking takes custom build directories correctly into account.
+
+  $ . ./helpers.sh
+
+Set up some ocamlformat that we want to install.
+
+  $ ocamlformat_version="0.26.2"
+  $ make_fake_ocamlformat "${ocamlformat_version}"
+  $ make_ocamlformat_opam_pkg "${ocamlformat_version}"
+
+  $ cat > .ocamlformat <<EOF
+  > version = ${ocamlformat_version}
+  > EOF
+
+Override the build directory that we want to build in. We do this by replacing
+the build directory in `$dev_tool_lock_dir` with our custom build directory.
+
+  $ default_build_dir="_build"
+  $ custom_build_dir="_other_build"
+  $ default_dev_tool_lock_dir="${dev_tool_lock_dir}"
+  $ dev_tool_lock_dir=$(echo "${dev_tool_lock_dir}" | sed "s/^$default_build_dir/$custom_build_dir/")
+
+Create a configuration with this custom build directory
+
+  $ make_project_with_dev_tool_lockdir
+  $ enable_pkg
+
+Make sure we don't have a lock dir
+
+  $ [ -e "${dev_tool_lock_dir}"/lock.dune ] || echo "Lock dir does not exist in custom location"
+  Lock dir does not exist in custom location
+  $ [ -e "${default_dev_tool_lock_dir}"/lock.dune ] || echo "Lock dir does not exist in default location"
+  Lock dir does not exist in default location
+
+Install our fake ocamlformat, making sure to override the build directory.
+
+  $ dune tools install ocamlformat --build-dir="${custom_build_dir}"
+  Solution for _other_build/.dev-tools.locks/ocamlformat:
+  - ocamlformat.0.26.2
+
+This should've worked and picked up our ocamlformat using the lock dir
+configuration from the dune-workspace. But also, we should now have a lock dir
+at the right location, in our custom build dir.
+
+  $ [ -e "${dev_tool_lock_dir}"/lock.dune ] && echo "Lock dir created in the correct, custom location"
+  Lock dir created in the correct, custom location
+  $ [ -e "${default_dev_tool_lock_dir}"/lock.dune ] || echo "Lock dir does not exist in default location"
+  Lock dir does not exist in default location

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -94,7 +94,7 @@ It shows that the project uses printer.2.0
 Format foo.ml, "dune fmt" uses printer.1.0 instead. There is no conflict with different
 versions of the same dependency.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   - printer.1.0
   File "foo.ml", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -15,7 +15,7 @@ It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.4
-  File "$TESTCASE_ROOT/_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
+  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
   4 |  (run dune build -p %{pkg-self:name} @install))
             ^^^^
   Error: Logs for package ocamlformat
@@ -24,9 +24,4 @@ It fails during the build because of missing OCamlFormat module.
                     ^^^^^^^^^^^
   Error: Module "Ocamlformat" doesn't exist.
   
-  -> required by
-     _build/_private/default/.dev-tool/ocamlformat/target/bin/ocamlformat
-  -> required by _build/default/.formatted/foo.ml
-  -> required by alias .formatted/fmt
-  -> required by alias fmt
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -15,7 +15,7 @@ It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.4
-  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
+  File "$TESTCASE_ROOT/_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
   4 |  (run dune build -p %{pkg-self:name} @install))
             ^^^^
   Error: Logs for package ocamlformat
@@ -24,4 +24,9 @@ It fails during the build because of missing OCamlFormat module.
                     ^^^^^^^^^^^
   Error: Module "Ocamlformat" doesn't exist.
   
+  -> required by
+     _build/_private/default/.dev-tool/ocamlformat/target/bin/ocamlformat
+  -> required by _build/default/.formatted/foo.ml
+  -> required by alias .formatted/fmt
+  -> required by alias fmt
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -13,9 +13,9 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 
 It fails during the build because of missing OCamlFormat module.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.4
-  File "dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
+  File "_build/.dev-tools.locks/ocamlformat/ocamlformat.pkg", line 4, characters 6-10:
   4 |  (run dune build -p %{pkg-self:name} @install))
             ^^^^
   Error: Logs for package ocamlformat

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -25,7 +25,7 @@ Make dune-project that uses the mocked dev-tool opam-reposiotry.
 Without a ".ocamlformat" file, "dune fmt" takes the latest version of
 OCamlFormat.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.3
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -46,7 +46,7 @@ An important cleaning here, "dune fmt" will relock and build the new version(0.2
 With a ".ocamlformat" file, "dune fmt" takes the version mentioned inside ".ocamlformat"
 file.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -68,7 +68,7 @@ When the lock dir is removed, the solving/lock is renewed:
 
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -28,7 +28,7 @@ Create ".ocamlformat-ignore"
 
 Check with the feature when ".ocamlformat-ignore" file exists.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt --preview
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -8,7 +8,7 @@ Test `dune tools which ocamlformat`:
 
 Install ocamlformat as a dev tool:
   $ dune tools install ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
 
 Verify that ocamlformat is installed:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -1,7 +1,7 @@
-'dune fmt' produce lock files inside "dev-tools.locks/ocamlformat" before it starts building
+'dune fmt' produces lock files inside the dev tool lock directory before it starts building
 ocamlformat and its dependencies during the same run of the "dune fmt" command. The source tree is
 loaded before the lock files are produced, this is why any 'patch' file inside
-'dev-tools.locks/ocmalformat' is not copied inside the 'build' directory when a rule depends on it.
+the dev tool lock dir is not copied inside the 'build' directory when a rule depends on it.
 
 The issue was that there is a rule that depends on an 'patch' file in order to copy the file
 inside '_private/default/..' directory, since the file could not be copied, the rule is not activated.
@@ -61,7 +61,7 @@ Make a project that uses the fake ocamlformat:
 
 First run of 'dune fmt' is supposed to format the fail.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -28,7 +28,7 @@ Initial file:
 This should choose the 0.24+foo version:
   $ echo "version=0.24" > .ocamlformat
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.24+foo
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -43,7 +43,7 @@ This should choose the 0.24+bar version:
   $ echo "version=0.25" > .ocamlformat
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.25+bar
   File "foo.ml", line 1, characters 0-0:
   Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
@@ -60,7 +60,7 @@ This should fail as there is no version matching 0.24.1:
   $ rm -r "${dev_tool_lock_dir}"
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dev-tools.locks/ocamlformat:
+  Lock directory _build/.dev-tools.locks/ocamlformat:
   Couldn't solve the package dependency formula.
   Selected candidates: ocamlformat_dev_tool_wrapper.dev
   - ocamlformat -> (problem)

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
@@ -12,7 +12,7 @@ Make a fake ocamlformat package
 
 Install ocamlformat once to generate the lockdir.
   $ dune tools install ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.0
 
 Delete ocamlformat's lockfile.
@@ -24,5 +24,5 @@ Reinstall ocamlformat.
   contain a lockfile for the package "ocamlformat". This may indicate that the
   lock directory has been tampered with. Please avoid making manual changes to
   tool lock directories. The tool will now be relocked.
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -15,7 +15,7 @@ Update ".ocamlformat" file with unknown version of OCamlFormat.
 Format, it shows the solving error.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune fmt
   Error: Unable to solve dependencies for the following lock directories:
-  Lock directory dev-tools.locks/ocamlformat:
+  Lock directory _build/.dev-tools.locks/ocamlformat:
   Couldn't solve the package dependency formula.
   The following packages couldn't be found: ocamlformat
   [1]

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
@@ -22,7 +22,7 @@ Create .ocamlformat file
 
 Install ocamlformat. 0.26.0 should be installed because that's the version in .ocamlformat.
   $ dune tools install ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.0
 
 Change the version in .ocamlformat.
@@ -35,5 +35,5 @@ Install ocamlformat again. Dune should detect that the version has changed and r
   The lock directory for the tool "ocamlformat" exists but contains a solution
   for 0.26.0 of the tool, whereas version 0.27.0 now needs to be installed. The
   tool will now be re-locked.
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.27.0

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -21,7 +21,7 @@ The command will fail because the dev tool is not installed:
 
 Install the dev tool:
   $ dune tools exec ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -8,7 +8,7 @@ Exercise running the ocamlformat wrapper command.
   $ make_project_with_dev_tool_lockdir
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune tools exec ocamlformat
-  Solution for dev-tools.locks/ocamlformat:
+  Solution for _build/.dev-tools.locks/ocamlformat:
   - ocamlformat.0.26.2
        Running 'ocamlformat'
   formatted with version 0.26.2

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -25,7 +25,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -24,7 +24,7 @@ Make a fake ocamllsp package that prints out the PATH variable:
 
 Confirm that each dev tool's bin directory is now in PATH:
   $ dune tools exec ocamllsp | tr : '\n' | grep '_build/_private/default/.dev-tool'
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -29,7 +29,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially ocamllsp will be depend on ocaml.5.2.0 to match the project.
   $ dune tools exec ocamllsp
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
@@ -54,7 +54,7 @@ before running. Ocamllsp now depends on ocaml.5.1.0.
   changed to 5.1.0 (formerly the compiler version was 5.2.0). The dev-tool
   "ocaml-lsp-server" will be re-locked and rebuilt with this version of the
   compiler.
-  Solution for dev-tools.locks/ocaml-lsp-server:
+  Solution for _build/.dev-tools.locks/ocaml-lsp-server:
   - ocaml.5.1.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -1,4 +1,4 @@
-dev_tool_lock_dir="dev-tools.locks/ocaml-lsp-server"
+dev_tool_lock_dir="_build/.dev-tools.locks/ocaml-lsp-server"
 
 # Create a dune-workspace file with mock repos set up for the main
 # project and the ocamllsp lockdir.

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -25,7 +25,7 @@ a lockdir containing an "ocaml" lockfile.
   > EOF
 
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc:
   - ocaml.5.2.0
   - odoc.0.0.1
   hello from fake odoc

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -29,7 +29,7 @@ same version of the ocaml compiler as the code that it's analyzing.
 
 Initially odoc will be depend on ocaml.5.2.0 to match the project.
   $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune ocaml doc
-  Solution for dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc:
   - ocaml.5.2.0
   - odoc.0.0.1
   hello from fake odoc
@@ -65,7 +65,7 @@ before running. Odoc now depends on ocaml.5.1.0.
   The version of the compiler package ("ocaml") in this project's lockdir has
   changed to 5.1.0 (formerly the compiler version was 5.2.0). The dev-tool
   "odoc" will be re-locked and rebuilt with this version of the compiler.
-  Solution for dev-tools.locks/odoc:
+  Solution for _build/.dev-tools.locks/odoc:
   - ocaml.5.1.0
   - odoc.0.0.1
   hello from fake odoc

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -1,4 +1,4 @@
-dev_tool_lock_dir="dev-tools.locks/odoc"
+dev_tool_lock_dir="_build/.dev-tools.locks/odoc"
 
 # Create a dune-workspace file with mock repos set up for the main
 # project and the odoc lockdir.


### PR DESCRIPTION
This follows the discussion from the 29th of October where we decided that the dev-tools can (for now) live in a directory that is unlikely to be committed to git.

closes https://github.com/ocaml/dune/issues/12097