### PR TITLE
chore: update test to have better syntax error

### DIFF
--- a/test/blackbox-tests/test-cases/cram/gh4230.t
+++ b/test/blackbox-tests/test-cases/cram/gh4230.t
@@ -5,13 +5,14 @@ Syntax error inside a cram command
   > EOF
 
   $ cat >t1.t <<EOF
-  >   $ foo-bar() { true; }
+  >   $ if then fi
   > EOF
 
-  $ dune runtest --auto-promote 2>&1 | sed -E -e 's/.+\.sh:/$SUBTEST.sh:/' -e 's/cd.*\&\&.*.sh/cd $DIR \&\& $SUBTEST.sh/'
+  $ dune runtest --auto-promote
   File "t1.t", line 1, characters 0-0:
   Error: Files _build/default/t1.t and _build/default/t1.t.corrected differ.
   Promoting _build/default/t1.t.corrected to t1.t.
+  [1]
 
   $ cat >t1.t <<EOF
   >   $ exit 1


### PR DESCRIPTION
In the latest version of bash, it's now allowed to write such a function, so this test relying on this being a syntax error is incorrect. We update it with a new bash syntax error and remove useless comamnds.