### PR TITLE
refactor: add Tests variant to Ml_sources.Origin.t

### DIFF
--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -8,6 +8,7 @@ module Origin : sig
   type t =
     | Library of Library.t
     | Executables of Executables.t
+    | Tests of Tests.t
     | Melange of Melange_stanzas.Emit.t
 
   val preprocess : t -> Preprocess.With_instrumentation.t Preprocess.Per_module.t

--- a/src/dune_rules/top_module.ml
+++ b/src/dune_rules/top_module.ml
@@ -42,6 +42,7 @@ let find_module sctx src =
          @@ fun () ->
          match origin with
          | Executables exes -> Exe_rules.rules ~sctx ~dir_contents ~scope ~expander exes
+         | Tests tests -> Exe_rules.rules ~sctx ~dir_contents ~scope ~expander tests.exes
          | Library lib -> Lib_rules.rules lib ~sctx ~dir_contents ~expander ~scope
          | Melange mel ->
            Melange_rules.setup_emit_cmj_rules ~sctx ~dir_contents ~expander ~scope mel


### PR DESCRIPTION
We add a way to find if an ml source comes from a `(tests)` stanza. We also take the opportunity to improve the error message when there are overlapping tests / executables.