### PR TITLE
fix: Better error for unzip failure

### DIFF
--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -68,12 +68,8 @@ let zip =
          | None ->
            Fiber.return
            @@ User_error.raise
-                [Pp.text "No program found to extract zip file. Tried:"; Pp.enumerate
-                    [ "unzip"
-                    ; "bsdtar"
-                    ; "tar"
-                    ]
-                    ~f:Pp.verbatim
+                [ Pp.text "No program found to extract zip file. Tried:"
+                ; Pp.enumerate [ "unzip"; "bsdtar"; "tar" ] ~f:Pp.verbatim
                 ]))
   in
   { command; suffixes = [ ".zip" ] }

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -68,13 +68,12 @@ let zip =
          | None ->
            Fiber.return
            @@ User_error.raise
-                [ Pp.enumerate
-                    [ "No program found to extract zip file. Tried:"
-                    ; "unzip"
+                [Pp.text "No program found to extract zip file. Tried:"; Pp.enumerate
+                    [ "unzip"
                     ; "bsdtar"
                     ; "tar"
                     ]
-                    ~f:(fun a -> Pp.text a)
+                    ~f:Pp.verbatim
                 ]))
   in
   { command; suffixes = [ ".zip" ] }

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -68,10 +68,13 @@ let zip =
          | None ->
            Fiber.return
            @@ User_error.raise
-                [ Pp.textf "No program found to extract zip file. Tried"
-                ; Pp.text "unzip"
-                ; Pp.text "bsdtar"
-                ; Pp.text "tar"
+                [ Pp.enumerate
+                    [ "No program found to extract zip file. Tried"
+                    ; "unzip"
+                    ; "bsdtar"
+                    ; "tar"
+                    ]
+                    ~f:(fun a -> Pp.text a)
                 ]))
   in
   { command; suffixes = [ ".zip" ] }

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -69,7 +69,7 @@ let zip =
            Fiber.return
            @@ User_error.raise
                 [ Pp.enumerate
-                    [ "No program found to extract zip file. Tried"
+                    [ "No program found to extract zip file. Tried:"
                     ; "unzip"
                     ; "bsdtar"
                     ; "tar"

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -10,7 +10,7 @@ module Command = struct
 end
 
 type t =
-  { command : Command.t Lazy.t
+  { command : Command.t Fiber.t Lazy.t
   ; suffixes : string list
   }
 
@@ -32,32 +32,56 @@ let tar =
             and both work equally well for tarballs. *)
          List.find_map [ "tar"; "bsdtar" ] ~f:which
        with
-       | Some bin -> { Command.bin; make_args = make_tar_args }
+       | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
        | None -> Dune_engine.Utils.program_not_found "tar" ~loc:None)
   in
   { command; suffixes = [ ".tar"; ".tar.gz"; ".tgz"; ".tar.bz2"; ".tbz" ] }
+;;
+
+let which_bsdtar (bin_name : string) =
+  let contains s sub =
+    let len_s = String.length s in
+    let len_sub = String.length sub in
+    let rec aux i =
+      if i + len_sub > len_s
+      then false
+      else if String.sub s ~pos:i ~len:len_sub = sub
+      then true
+      else aux (i + 1)
+    in
+    aux 0
+  in
+  let bin_path =
+    match which bin_name with
+    | Some bin -> bin
+    | None -> Dune_engine.Utils.program_not_found "unzip" ~loc:None
+  in
+  let+ output, _error =
+    Process.run_capture_lines ~display:Quiet Return bin_path [ "--version" ]
+  in
+  let output_str = String.concat ~sep:"\n" output in
+  if contains output_str "bsdtar" then Some bin_path else None
 ;;
 
 let zip =
   let command =
     lazy
       (match which "unzip" with
-       | Some bin -> { Command.bin; make_args = make_zip_args }
+       | Some bin -> Fiber.return { Command.bin; make_args = make_zip_args }
        | None ->
-         (* Fall back to using tar to extract zip archives, which is possible in some cases. *)
-         (match
-            (* Test for bsdtar before tar, as if bsdtar is installed then it's
-               likely that the tar binary is GNU tar which can't extract zip
-               archives, whereas bsdtar can. If bsdtar is absent, try using the
-               tar command anyway, as on MacOS, Windows, and some BSD systems,
-               the tar command can extract zip archives. *)
-            List.find_map [ "bsdtar"; "tar" ] ~f:which
-          with
-          | Some bin -> { Command.bin; make_args = make_tar_args }
-          | None ->
-            (* Still reference unzip in the error message, as installing it
-               is the simplest way to fix the problem. *)
-            Dune_engine.Utils.program_not_found "unzip" ~loc:None))
+         let rec find_tar programs =
+           match programs with
+           | [] -> Fiber.return None
+           | x :: xs ->
+             let* res = which_bsdtar x in
+             (match res with
+              | Some _ -> Fiber.return res
+              | None -> find_tar xs)
+         in
+         let* program = find_tar [ "bsdtar"; "tar" ] in
+         (match program with
+          | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
+          | None -> Fiber.return @@ Dune_engine.Utils.program_not_found "unzip" ~loc:None))
   in
   { command; suffixes = [ ".zip" ] }
 ;;
@@ -73,7 +97,7 @@ let choose_for_filename_default_to_tar filename =
 
 let extract t ~archive ~target =
   let* () = Fiber.return () in
-  let command = Lazy.force t.command in
+  let* command = Lazy.force t.command in
   let prefix = Path.basename target in
   let target_in_temp =
     let suffix = Path.basename archive in

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -26,14 +26,14 @@ let make_zip_args ~archive ~target_in_temp =
 
 let tar =
   let command =
-    Fiber.Lazy.create
-      (fun () -> match
-         (* Test for tar before bsdtar as tar is more likely to be installed
+    Fiber.Lazy.create (fun () ->
+      match
+        (* Test for tar before bsdtar as tar is more likely to be installed
             and both work equally well for tarballs. *)
-         List.find_map [ "tar"; "bsdtar" ] ~f:which
-       with
-       | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
-       | None -> Dune_engine.Utils.program_not_found "tar" ~loc:None)
+        List.find_map [ "tar"; "bsdtar" ] ~f:which
+      with
+      | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
+      | None -> Dune_engine.Utils.program_not_found "tar" ~loc:None)
   in
   { command; suffixes = [ ".tar"; ".tar.gz"; ".tgz"; ".tar.bz2"; ".tbz" ] }
 ;;
@@ -53,23 +53,23 @@ let which_bsdtar (bin_name : string) =
 
 let zip =
   let command =
-    Fiber.Lazy.create
-      (fun () -> match which "unzip" with
-       | Some bin -> Fiber.return { Command.bin; make_args = make_zip_args }
-       | None ->
-         let rec find_tar programs =
-           match programs with
-           | [] -> Fiber.return None
-           | x :: xs ->
-             let* res = which_bsdtar x in
-             (match res with
-              | Some _ -> Fiber.return res
-              | None -> find_tar xs)
-         in
-         let* program = find_tar [ "bsdtar"; "tar" ] in
-         (match program with
-          | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
-          | None -> Fiber.return @@ Dune_engine.Utils.program_not_found "unzip" ~loc:None))
+    Fiber.Lazy.create (fun () ->
+      match which "unzip" with
+      | Some bin -> Fiber.return { Command.bin; make_args = make_zip_args }
+      | None ->
+        let rec find_tar programs =
+          match programs with
+          | [] -> Fiber.return None
+          | x :: xs ->
+            let* res = which_bsdtar x in
+            (match res with
+             | Some _ -> Fiber.return res
+             | None -> find_tar xs)
+        in
+        let* program = find_tar [ "bsdtar"; "tar" ] in
+        (match program with
+         | Some bin -> Fiber.return { Command.bin; make_args = make_tar_args }
+         | None -> Fiber.return @@ Dune_engine.Utils.program_not_found "unzip" ~loc:None))
   in
   { command; suffixes = [ ".zip" ] }
 ;;

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -3,9 +3,12 @@ Test the error message when unzip is needed but not installed.
   $ . ./helpers.sh
 
   $ make_lockdir
+  $ alias zip='cp'
+  $ alias unzip='cp'
+  $ alias bsdtar='cp'
 
   $ echo "random" >> test.txt
-  $ zip bar.zip test.txt >> /dev/null
+  $ zip test.txt bar.zip >> /dev/null
 
   $ makepkg() {
   > make_lockpkg $1 <<EOF
@@ -20,24 +23,27 @@ Test the error message when unzip is needed but not installed.
 
 Build the package in an environment without unzip, or tar, or bsdtar.
   $ PATH=$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: No program found to extract zip file. Tried
-  unzip
-  bsdtar
-  tar
-
+  Error: - No program found to extract zip file. Tried
+         - unzip
+         - bsdtar
+         - tar
 
 Build with only tar, not bsdtar or unzip, it should still fail to build
 
   $ PATH=$(dirname $(which dune)):$(dirname $(which tar)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: No program found to extract zip file. Tried
-  unzip
-  bsdtar
-  tar
+  Error: - No program found to extract zip file. Tried
+         - unzip
+         - bsdtar
+         - tar
 
-Build the package with bsdtar and tar, tar doesn't help but bsdtar should
+Build the package with bsdtar and tar, tar doesn't help but bsdtar should. Note
+that however since we're aliasing unzip to cp, it won't do the extraction. But
+that's ok because we just want to check if it's using the correct binary.
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)):$(dirname $(which bsdtar)) build_pkg foo
+  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)):$(dirname $(which bsdtar)) build_pkg foo 2>&1 | grep '^Error:'
+  Error: failed to extract 'bar.zip'
 
-Build with unzip
+Build with unzip. Same failure expected as above.
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which unzip)) build_pkg foo
+  $ PATH=$(dirname $(which dune)):$(dirname $(which unzip)) build_pkg foo 2>&1 | grep '^Error:'
+  Error: failed to extract 'bar.zip'

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -73,7 +73,6 @@ and built.
   >    echo "bsdtar"
   >  ;;
   >  *)
-  >    echo "I am faketar"
   >    cp "$2" "$4/$(basename "${2%.zip}")"
   > esac
   > EOF
@@ -86,10 +85,9 @@ Build with unzip
   > #!/usr/bin/env sh
   > case $1 in
   >  --version)
-  >    echo "bsdtar"
+  >    echo "unzip"
   >  ;;
   >  *)
-  >    echo "I am faketar"
   >    cp "$2" "$4/$(basename "${2%.zip}")"
   > esac
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -1,0 +1,23 @@
+Test the error message when curl is needed but not installed.
+
+  $ . ./helpers.sh
+  $ make_lockdir
+  $ echo "random" >> test.txt
+  $ zip bar.zip test.txt >> /dev/null
+
+  $ makepkg() {
+  > make_lockpkg $1 <<EOF
+  > (source
+  >  (fetch
+  >   (url "file://$(pwd)/bar.zip")))
+  > (version dev)
+  > EOF
+  > }
+
+  $ makepkg foo
+
+Build the package in an environment without curl.
+  $ PATH=$(dirname $(which dune)) build_pkg foo &> error.txt
+  $ cat error.txt | grep "^Error: Program unzip not found in the tree or in PATH"
+  [1]
+

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -4,21 +4,18 @@ Test the error message when unzip is needed but not installed.
 
   $ make_lockdir
 
-  $ mkdir -p fakebin
-  $ cat > fakebin/zip << 'EOF'
-  > #!/usr/bin/env sh
-  > cp "$@"
-  > EOF
-  $ chmod +x fakebin/zip
+  $ mkdir -p .fakebin
+  $ ln -s $(which dune) .fakebin/dune
+  $ ln -s $(which sh) .fakebin/sh
+  $ ln -s $(which cp) .fakebin/cp
 
-  $ echo "random" >> test.txt
-  $ PATH=fakebin:$PATH zip test.txt bar.zip >> /dev/null
+  $ echo "random" >> test.txt.zip
 
   $ makepkg() {
   > make_lockpkg $1 <<EOF
   > (source
   >  (fetch
-  >   (url "file://$(pwd)/bar.zip")))
+  >   (url "file://$(pwd)/test.txt.zip")))
   > (version dev)
   > EOF
   > }
@@ -26,49 +23,75 @@ Test the error message when unzip is needed but not installed.
   $ makepkg foo
 
 Build the package in an environment without unzip, or tar, or bsdtar.
-
-  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  $ PATH=.fakebin build_pkg foo 2>&1 | grep '^Error:' -A 3
   Error: No program found to extract zip file. Tried:
   - unzip
   - bsdtar
   - tar
 
-Build with only tar, not bsdtar or unzip, it should still fail to build
+Build with only tar that doesn't work, not bsdtar or unzip, it should still fail to build
 
-  $ cat > fakebin/tar << 'EOF'
+  $ cat > .fakebin/tar << 'EOF'
   > #!/usr/bin/env sh
-  > cp "$@"
+  > case $1 in
+  >  --version)
+  >    echo "tar"
+  >  ;;
+  >  *)
+  >    cp "$2" "$4/$(basename "${2%.zip}")"
+  > esac
   > EOF
-  $ chmod +x fakebin/tar
-  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  $ chmod +x .fakebin/tar
+  $ PATH=.fakebin build_pkg foo 2>&1 | grep '^Error:' -A 3
   Error: No program found to extract zip file. Tried:
   - unzip
   - bsdtar
   - tar
 
-Build the package with bsdtar and tar, tar doesn't help but bsdtar should. Note
-that however since we're aliasing bsdtar to cp, it will fail. This is because it
-checks if `bsdtar --version` returns the string bsdtar and in this case it
-doesn't. But that's ok because we just want to check if it's using the correct
-binary.
+Build with only tar that works, not bsdtar or unzip, it should work
 
-  $ cat > fakebin/bsdtar << 'EOF'
+  $ cat > .fakebin/tar << 'EOF'
   > #!/usr/bin/env sh
-  > cp "$@"
+  > case $1 in
+  >  --version)
+  >    echo "bsdtar"
+  >  ;;
+  >  *)
+  >    cp "$2" "$4/$(basename "${2%.zip}")"
+  > esac
   > EOF
-  $ chmod +x fakebin/bsdtar
-  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: No program found to extract zip file. Tried:
-  - unzip
-  - bsdtar
-  - tar
+  $ chmod +x .fakebin/tar
+  $ PATH=.fakebin build_pkg foo
 
-Build with unzip. Same failure expected as above.
+Build the package with bsdtar and tar. Now our fake bsdtar will get picked up
+and built.
 
-  $ cat > fakebin/unzip << 'EOF'
+  $ cat > .fakebin/bsdtar << 'EOF'
   > #!/usr/bin/env sh
-  > cp "$@"
+  > case $1 in
+  >  --version)
+  >    echo "bsdtar"
+  >  ;;
+  >  *)
+  >    echo "I am faketar"
+  >    cp "$2" "$4/$(basename "${2%.zip}")"
+  > esac
   > EOF
-  $ chmod +x fakebin/unzip
-  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:'
-  Error: failed to extract 'bar.zip'
+  > chmod +x .fakebin/bsdtar
+  $ PATH=.fakebin build_pkg foo
+
+Build with unzip
+
+  $ cat > .fakebin/unzip << 'EOF'
+  > #!/usr/bin/env sh
+  > case $1 in
+  >  --version)
+  >    echo "bsdtar"
+  >  ;;
+  >  *)
+  >    echo "I am faketar"
+  >    cp "$2" "$4/$(basename "${2%.zip}")"
+  > esac
+  > EOF
+  $ chmod +x .fakebin/unzip
+  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -3,12 +3,16 @@ Test the error message when unzip is needed but not installed.
   $ . ./helpers.sh
 
   $ make_lockdir
-  $ alias zip='cp'
-  $ alias unzip='cp'
-  $ alias bsdtar='cp'
+
+  $ mkdir -p fakebin
+  $ cat > fakebin/zip << 'EOF'
+  > #!/usr/bin/env sh
+  > cp "$@"
+  > EOF
+  $ chmod +x fakebin/zip
 
   $ echo "random" >> test.txt
-  $ zip test.txt bar.zip >> /dev/null
+  $ PATH=fakebin:$PATH zip test.txt bar.zip >> /dev/null
 
   $ makepkg() {
   > make_lockpkg $1 <<EOF
@@ -22,28 +26,49 @@ Test the error message when unzip is needed but not installed.
   $ makepkg foo
 
 Build the package in an environment without unzip, or tar, or bsdtar.
-  $ PATH=$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: - No program found to extract zip file. Tried
+
+  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  Error: - No program found to extract zip file. Tried:
          - unzip
          - bsdtar
          - tar
 
 Build with only tar, not bsdtar or unzip, it should still fail to build
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: - No program found to extract zip file. Tried
+  $ cat > fakebin/tar << 'EOF'
+  > #!/usr/bin/env sh
+  > cp "$@"
+  > EOF
+  $ chmod +x fakebin/tar
+  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  Error: - No program found to extract zip file. Tried:
          - unzip
          - bsdtar
          - tar
 
 Build the package with bsdtar and tar, tar doesn't help but bsdtar should. Note
-that however since we're aliasing unzip to cp, it won't do the extraction. But
-that's ok because we just want to check if it's using the correct binary.
+that however since we're aliasing bsdtar to cp, it will fail. This is because it
+checks if `bsdtar --version` returns the string bsdtar and in this case it
+doesn't. But that's ok because we just want to check if it's using the correct
+binary.
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)):$(dirname $(which bsdtar)) build_pkg foo 2>&1 | grep '^Error:'
-  Error: failed to extract 'bar.zip'
+  $ cat > fakebin/bsdtar << 'EOF'
+  > #!/usr/bin/env sh
+  > cp "$@"
+  > EOF
+  $ chmod +x fakebin/bsdtar
+  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  Error: - No program found to extract zip file. Tried:
+         - unzip
+         - bsdtar
+         - tar
 
 Build with unzip. Same failure expected as above.
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which unzip)) build_pkg foo 2>&1 | grep '^Error:'
+  $ cat > fakebin/unzip << 'EOF'
+  > #!/usr/bin/env sh
+  > cp "$@"
+  > EOF
+  $ chmod +x fakebin/unzip
+  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:'
   Error: failed to extract 'bar.zip'

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -1,6 +1,7 @@
-Test the error message when curl is needed but not installed.
+Test the error message when unzip is needed but not installed.
 
   $ . ./helpers.sh
+
   $ make_lockdir
   $ echo "random" >> test.txt
   $ zip bar.zip test.txt >> /dev/null
@@ -16,8 +17,19 @@ Test the error message when curl is needed but not installed.
 
   $ makepkg foo
 
-Build the package in an environment without curl.
-  $ PATH=$(dirname $(which dune)) build_pkg foo &> error.txt
-  $ cat error.txt | grep "^Error: Program unzip not found in the tree or in PATH"
-  [1]
+Build the package in an environment without unzip, or tar, or bsdtar.
+  $ PATH=$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:'
+  Error: Program unzip not found in the tree or in PATH
 
+Build with only tar, not bsdtar or unzip, it should still fail to build
+
+  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)) build_pkg foo 2>&1 | grep '^Error:'
+  Error: Program unzip not found in the tree or in PATH
+
+Build the package with bsdtar and tar, tar doesn't help but bsdtar should
+
+  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)):$(dirname $(which bsdtar)) build_pkg foo
+
+Build with unzip
+
+  $ PATH=$(dirname $(which dune)):$(dirname $(which unzip)) build_pkg foo

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -3,6 +3,7 @@ Test the error message when unzip is needed but not installed.
   $ . ./helpers.sh
 
   $ make_lockdir
+
   $ echo "random" >> test.txt
   $ zip bar.zip test.txt >> /dev/null
 
@@ -18,13 +19,20 @@ Test the error message when unzip is needed but not installed.
   $ makepkg foo
 
 Build the package in an environment without unzip, or tar, or bsdtar.
-  $ PATH=$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:'
-  Error: Program unzip not found in the tree or in PATH
+  $ PATH=$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  Error: No program found to extract zip file. Tried
+  unzip
+  bsdtar
+  tar
+
 
 Build with only tar, not bsdtar or unzip, it should still fail to build
 
-  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)) build_pkg foo 2>&1 | grep '^Error:'
-  Error: Program unzip not found in the tree or in PATH
+  $ PATH=$(dirname $(which dune)):$(dirname $(which tar)) build_pkg foo 2>&1 | grep '^Error:' -A 3
+  Error: No program found to extract zip file. Tried
+  unzip
+  bsdtar
+  tar
 
 Build the package with bsdtar and tar, tar doesn't help but bsdtar should
 

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -50,6 +50,9 @@ Build with only tar that doesn't work, not bsdtar or unzip, it should still fail
 
 Build with only tar that works, not bsdtar or unzip, it should work
 
+(NOTE: We wrap `(PATH=.fakebin foo)` in parens, otherwise the value of the PATH
+variable can escape to subseqent shell invocations on MacOS.)
+
   $ cat > .fakebin/tar << 'EOF'
   > #!/usr/bin/env sh
   > case $1 in
@@ -61,7 +64,7 @@ Build with only tar that works, not bsdtar or unzip, it should work
   > esac
   > EOF
   $ chmod +x .fakebin/tar
-  $ PATH=.fakebin build_pkg foo
+  $ (PATH=.fakebin build_pkg foo)
 
 Build the package with bsdtar and tar. Now our fake bsdtar will get picked up
 and built.
@@ -76,8 +79,8 @@ and built.
   >    cp "$2" "$4/$(basename "${2%.zip}")"
   > esac
   > EOF
-  > chmod +x .fakebin/bsdtar
-  $ PATH=.fakebin build_pkg foo
+  $ chmod +x .fakebin/bsdtar
+  $ (PATH=.fakebin build_pkg foo)
 
 Build with unzip
 
@@ -92,4 +95,4 @@ Build with unzip
   > esac
   > EOF
   $ chmod +x .fakebin/unzip
-  $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo
+  $ (PATH=.fakebin build_pkg foo)

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -28,10 +28,10 @@ Test the error message when unzip is needed but not installed.
 Build the package in an environment without unzip, or tar, or bsdtar.
 
   $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: - No program found to extract zip file. Tried:
-         - unzip
-         - bsdtar
-         - tar
+  Error: No program found to extract zip file. Tried:
+  - unzip
+  - bsdtar
+  - tar
 
 Build with only tar, not bsdtar or unzip, it should still fail to build
 
@@ -41,10 +41,10 @@ Build with only tar, not bsdtar or unzip, it should still fail to build
   > EOF
   $ chmod +x fakebin/tar
   $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: - No program found to extract zip file. Tried:
-         - unzip
-         - bsdtar
-         - tar
+  Error: No program found to extract zip file. Tried:
+  - unzip
+  - bsdtar
+  - tar
 
 Build the package with bsdtar and tar, tar doesn't help but bsdtar should. Note
 that however since we're aliasing bsdtar to cp, it will fail. This is because it
@@ -58,10 +58,10 @@ binary.
   > EOF
   $ chmod +x fakebin/bsdtar
   $ PATH=fakebin:$(dirname $(which dune)) build_pkg foo 2>&1 | grep '^Error:' -A 3
-  Error: - No program found to extract zip file. Tried:
-         - unzip
-         - bsdtar
-         - tar
+  Error: No program found to extract zip file. Tried:
+  - unzip
+  - bsdtar
+  - tar
 
 Build with unzip. Same failure expected as above.
 


### PR DESCRIPTION
Fixes #11548

Currently the archive driver tries to use `bsdtar` and `tar` to unzip a zip file if `unzip` is not present in the system. This may or may not work depending on the specific implementation. Concretely, if the `tar` is a variant of `bsdtar` it can unpack zip files whearas `tar` cannot. We check that and return an error message that `unzip` is expected and not present.