### PR TITLE
Add user warning when waiting for build directory lock

### DIFF
--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -95,7 +95,7 @@ let establish_connection_with_retry () =
         in
         User_warning.emit
           [ Pp.textf
-              "Another dune instance%s is currently running. Waiting for it to finish..."
+              "Another dune instance%s is currently running. Waiting connect to it..."
               pid_suffix
           ; Pp.textf
               "If you're certain no other dune process is running, you can resolve this by \


### PR DESCRIPTION
Resolves https://github.com/ocaml/dune/issues/12685

* Emit a warning when dune needs to wait for the build directory lock held by
another process
* Include the PID of the lock-holding process when available
* Provide actionable guidance on removing stale lock files

Example output:

```
Warning: Build directory is locked by another dune process (pid: 12345). Waiting
for the lock to be released...
If this process is no longer running, delete the lock file: _build/.lock
```