### PR TITLE
chore: bump OCaml version 5.3 -> 5.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -168,22 +168,22 @@ jobs:
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)
-          - ocaml-compiler: 5.3.x
+          - ocaml-compiler: 5.4.x
             os: ubuntu-latest
             run_tests: true
           ## macos (Apple Silicon)
-          - ocaml-compiler: 5.3.x
+          - ocaml-compiler: 5.4.x
             os: macos-latest
             run_tests: true
           ## macos (x86)
           - ocaml-compiler: 5.4.x
             os: macos-15-intel
           ## MSVC
-          - ocaml-compiler: ocaml-compiler.5.3.0,system-msvc
+          - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
             os: windows-latest
             run_tests: true
           ## mingw
-          - ocaml-compiler: ocaml-base-compiler.5.3.0,system-mingw
+          - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
             os: windows-latest
             run_tests: true
           # OCaml 4:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DEV_DEPS := \
 core_bench \
 patdiff
 
-TEST_OCAMLVERSION := 5.3.0
+TEST_OCAMLVERSION := 5.4.0
 # When updating this version, don't forget to also bump the number in the docs.
 
 -include Makefile.dev
@@ -108,9 +108,6 @@ test-melange: $(BIN)
 
 test-all: $(BIN)
 	$(BIN) build @runtest @runtest-js @runtest-coq @runtest-melange
-
-test-all-sans-melange: $(BIN)
-	$(BIN) build @runtest @runtest-js @runtest-coq
 
 test-ox: $(BIN)
 	$(BIN) runtest test/blackbox-tests/test-cases/oxcaml

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -54,10 +54,10 @@ Here are the most common commands you'll be running:
    $ ./dune.exe build @foo
 
 
-Note that tests are currently written for version 5.3.0 of the OCaml compiler.
+Note that tests are currently written for version 5.4.0 of the OCaml compiler.
 Some tests depend on the specific wording of compilation errors which can change
 between compiler versions, so to reliably run the tests make sure that
-``ocaml.5.3.0`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
+``ocaml.5.4.0`` is installed. The ``TEST_OCAMLVERSION`` in the ``Makefile`` at
 the root of the Dune repo contains the current compiler version for which tests
 are written.
 

--- a/doc/tutorials/developing-with-dune/introduction.md
+++ b/doc/tutorials/developing-with-dune/introduction.md
@@ -44,7 +44,7 @@ Let's create a local switch: `cd` to this directory and run the following comman
 This can take a few minutes.
 
 ```sh
-opam switch create ./ 5.3.0
+opam switch create ./ 5.4.0
 ```
 
 This command has created a directory named `_opam` in the current directory.

--- a/dune.opam
+++ b/dune.opam
@@ -59,7 +59,7 @@ depends: [
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
-  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -20,7 +20,7 @@ depends: [
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
-  "ppxlib" { with-dev-setup & >= "0.35.0" & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
   "ctypes" { with-dev-setup & os != "win32" }
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }

--- a/flake.lock
+++ b/flake.lock
@@ -44,16 +44,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1742771785,
-        "narHash": "sha256-Ihd2b1B/GnRTd0yk63kQ3ryLhgT3hp+Md0BYwOKP+YA=",
+        "lastModified": 1762666707,
+        "narHash": "sha256-USvFyipdEedaBan3H8X1NxfuQi0IDYal5PdsCwmN2Q4=",
         "owner": "melange-re",
         "repo": "melange",
-        "rev": "2432b02d9c1990ae62fd44fad8bb53ea35b1e6b0",
+        "rev": "7b51f143b537076f1ad694464ca2a1102cd23287",
         "type": "github"
       },
       "original": {
         "owner": "melange-re",
-        "ref": "refs/tags/5.1.0-53",
+        "ref": "refs/tags/6.0.0-54",
         "repo": "melange",
         "type": "github"
       }
@@ -66,15 +66,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1742165088,
-        "narHash": "sha256-N5IZA13/RAd6uYJEn12UlfPpPxyBOuVw4am0qadtUms=",
+        "lastModified": 1760240634,
+        "narHash": "sha256-cmPZs92Vva6X06E8MreMVn6Yu5gqZtAYLJRweTEWwRY=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "e914cab0ec7d53130d5f1e283283628c98a3583c",
+        "rev": "b8d6659bfe3045938afa83f37b7c357c052d10c7",
         "type": "github"
       },
       "original": {
         "owner": "melange-re",
+        "ref": "5.4",
         "repo": "melange-compiler-libs",
         "type": "github"
       }
@@ -102,17 +103,33 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752012998,
-        "narHash": "sha256-Q82Ms+FQmgOBkdoSVm+FBpuFoeUAffNerR5yVV7SgT8=",
+        "lastModified": 1762156382,
+        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a2130494ad647f953593c4e84ea4df839fbd68c",
+        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1746662029,
+        "narHash": "sha256-2lFR2IQHaaUA5X2JMzQ3SGkj5IXFU/ztqpKD4I6vWCw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7f50d4b33363d3948543f6a02b90a2c66852a453",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7f50d4b33363d3948543f6a02b90a2c66852a453",
         "type": "github"
       }
     },
@@ -123,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752292614,
-        "narHash": "sha256-PwW/5J+SslGqkaCEad/1fvbTgPw2eI2UJkjStmGSChI=",
+        "lastModified": 1762273825,
+        "narHash": "sha256-jn3EGl4vV/fvBkEmeqsrArZX6PA/uyOhJSKw+Y9rj7I=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "fbbcd2e563cf33e4a4fdbac4395e7276a506ef09",
+        "rev": "e0ec05d668a5d5463b0ca981aa481545af494eb1",
         "type": "github"
       },
       "original": {
@@ -145,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760541218,
-        "narHash": "sha256-eZ2Nx8eXmiTurtJVBlC+MU45N6qFF76LDAa/aum4ZTk=",
+        "lastModified": 1762278632,
+        "narHash": "sha256-bnGCcvEF9ZEsgDSCEgXeHGl/TDL4oxxb+G8/bWp7FNI=",
         "owner": "oxcaml",
         "repo": "oxcaml",
-        "rev": "eea9697287f10719188cfd82d667caaeba346e87",
+        "rev": "10dd7883b15da7a0b3ea9729e95af3fbc360fa0d",
         "type": "github"
       },
       "original": {
@@ -161,11 +178,11 @@
     "oxcaml-opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1760195033,
-        "narHash": "sha256-qWWJ4WiV3hnOw4dFUq363BVejLwkxTk6OaZHUSkHylg=",
+        "lastModified": 1761753924,
+        "narHash": "sha256-g7wbVoC4f2B6khTQn3S6AORitobXt9OnDAI+vIQioLU=",
         "owner": "oxcaml",
         "repo": "opam-repository",
-        "rev": "eeedfd918e54a8741d26af1a4ff2991b21c1045f",
+        "rev": "a1ea0d33dd5662b89183f751c3fec566d7860b75",
         "type": "github"
       },
       "original": {
@@ -179,6 +196,7 @@
         "flake-utils": "flake-utils",
         "melange": "melange",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old",
         "ocaml-overlays": "ocaml-overlays",
         "oxcaml": "oxcaml",
         "oxcaml-opam-repository": "oxcaml-opam-repository"

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,10 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-old.url = "github:nixos/nixpkgs/7f50d4b33363d3948543f6a02b90a2c66852a453";
     flake-utils.url = "github:numtide/flake-utils";
     melange = {
-      url = "github:melange-re/melange/refs/tags/5.1.0-53";
+      url = "github:melange-re/melange/refs/tags/6.0.0-54";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ocaml-overlays = {
@@ -24,6 +25,7 @@
       self,
       flake-utils,
       nixpkgs,
+      nixpkgs-old,
       melange,
       ocaml-overlays,
       oxcaml,
@@ -35,7 +37,7 @@
         pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
           ocaml-overlays.overlays.default
           (self: super: {
-            ocamlPackages = super.ocaml-ng.ocamlPackages_5_3.overrideScope (
+            ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
               oself: osuper: {
                 mdx = osuper.mdx.override {
                   logs = oself.logs;
@@ -63,8 +65,13 @@
           oxcamlOpamRepo = oxcaml-opam-repository;
         };
 
+        # Older nixpkgs for OCaml 4.02 support
+        pkgs-old = nixpkgs-old.legacyPackages.${system}.appendOverlays [
+          ocaml-overlays.overlays.default
+        ];
+
         dune-static-overlay = self: super: {
-          ocamlPackages = super.ocaml-ng.ocamlPackages_5_3.overrideScope (
+          ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
             oself: osuper: {
               dune_3 = osuper.dune_3.overrideAttrs (a: {
                 src = ./.;
@@ -91,19 +98,16 @@
 
         ocamlformat =
           let
-            ocamlformat_version =
-              let
-                lists = pkgs.lib.lists;
-                strings = pkgs.lib.strings;
-                ocamlformat_config = strings.splitString "\n" (builtins.readFile ./.ocamlformat);
-                prefix = "version=";
-                ocamlformat_version_pred = line: strings.hasPrefix prefix line;
-                version_line = lists.findFirst ocamlformat_version_pred "not_found" ocamlformat_config;
-                version = strings.removePrefix prefix version_line;
-              in
-              builtins.replaceStrings [ "." ] [ "_" ] version;
+            lists = pkgs.lib.lists;
+            strings = pkgs.lib.strings;
+            ocamlformat_config = strings.splitString "\n" (builtins.readFile ./.ocamlformat);
+            prefix = "version=";
+            ocamlformat_version_pred = line: strings.hasPrefix prefix line;
+            version_line = lists.findFirst ocamlformat_version_pred "not_found" ocamlformat_config;
+            version_string = strings.removePrefix prefix version_line;
+            ocamlformat_attr = builtins.replaceStrings [ "." ] [ "_" ] version_string;
           in
-          builtins.getAttr ("ocamlformat_" + ocamlformat_version) pkgs;
+          builtins.getAttr ("ocamlformat_" + ocamlformat_attr) nixpkgs.legacyPackages.${system};
 
         testBuildInputs =
           with pkgs;
@@ -287,11 +291,11 @@
             fmt = pkgs.mkShell {
               inherit INSIDE_NIX;
               nativeBuildInputs = [ ocamlformat ];
-              # re shouldn't be needed. this is an issue with the fmt rules
               inputsFrom = [
                 pkgs.dune_3
               ];
               buildInputs = with pkgs.ocamlPackages; [
+                # These shouldn't be needed. this is an issue with the fmt rules
                 csexp
                 pp
                 re
@@ -355,9 +359,9 @@
 
             bootstrap-check = pkgs.mkShell {
               inherit INSIDE_NIX;
-              buildInputs = with pkgs; [
-                gnumake
-                ocaml-ng.ocamlPackages_4_02.ocaml
+              buildInputs = [
+                pkgs.gnumake
+                pkgs-old.ocaml-ng.ocamlPackages_4_02.ocaml
               ];
               meta.description = ''
                 Provides a minimal shell environment with OCaml 4.02 in order
@@ -367,9 +371,9 @@
 
             bootstrap-check_4_08 = pkgs.mkShell {
               inherit INSIDE_NIX;
-              buildInputs = with pkgs; [
-                gnumake
-                ocaml-ng.ocamlPackages_4_08.ocaml
+              buildInputs = [
+                pkgs.gnumake
+                pkgs-old.ocaml-ng.ocamlPackages_4_08.ocaml
               ];
               meta.description = ''
                 Provides a minimal shell environment with OCaml 4.08 in order

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -336,6 +336,15 @@ let sources_without_pp t =
     ~f:(Option.map ~f:(fun (x : File.t) -> x.original_path))
 ;;
 
+let source_without_pp ~ml_kind t =
+  let source =
+    match (ml_kind : Ml_kind.t) with
+    | Impl -> t.source.files.impl
+    | Intf -> t.source.files.intf
+  in
+  Option.map source ~f:(fun (x : File.t) -> x.original_path)
+;;
+
 module Obj_map = struct
   include Map.Make (struct
       type nonrec t = t

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -88,6 +88,7 @@ end
 
 val sources : t -> Path.t list
 val sources_without_pp : t -> Path.t list
+val source_without_pp : ml_kind:Ml_kind.t -> t -> Path.t option
 val visibility : t -> Visibility.t
 val encode : t -> src_dir:Path.t -> Dune_lang.t list
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -158,6 +158,7 @@ let build_cm
    let* compiler = compiler in
    let ml_kind = Lib_mode.Cm_kind.source cm_kind in
    let+ src = Module.file m ~ml_kind in
+   let original = Module.source_without_pp m ~ml_kind in
    let dst = Obj_dir.Module.cm_file_exn obj_dir m ~kind:cm_kind in
    let obj =
      Obj_dir.Module.obj_file obj_dir m ~kind:(Ocaml Cmx) ~ext:ocaml.lib_config.ext_obj
@@ -324,6 +325,7 @@ let build_cm
             ; A "-c"
             ; Command.Ml_kind.flag ml_kind
             ; Dep src
+            ; Hidden_deps (Dep.Set.of_files (Option.to_list original))
             ; other_targets
             ]
       >>| Action.Full.add_sandbox sandbox))

--- a/test/blackbox-tests/test-cases/hidden-deps-supported.t/run.t
+++ b/test/blackbox-tests/test-cases/hidden-deps-supported.t/run.t
@@ -49,7 +49,7 @@ Test transitive deps can not be directly accessed, both for compiler versions su
   > EOF
 
   $ dune build ./runf.exe 2>&1 | grep -v ocamlc
-  File "runf.ml", line 1, characters 16-21:
+  File "runf.ml", line 1, characters 16-19:
   1 | let _ = Bar.y + Foo.v
-                      ^^^^^
+                      ^^^
   Error: Unbound module Foo

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/toplevel-lib-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/toplevel-lib-interface.t
@@ -17,8 +17,8 @@ We should forbid lib interfaces modules from depending on themselves:
   $ touch bar.ml
 
   $ dune build @check
-  File "foo.ml", line 1, characters 9-14:
+  File "foo.ml", line 1, characters 9-12:
   1 | let () = Foo.f ()
-               ^^^^^
+               ^^^
   Error: Unbound module Foo
   [1]

--- a/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
@@ -17,9 +17,9 @@ We should forbid lib interfaces modules from depending on themselves:
   $ touch bar.ml
 
   $ dune build @check
-  File "foo.ml", line 1, characters 9-14:
+  File "foo.ml", line 1, characters 9-12:
   1 | let () = Foo.f ()
-               ^^^^^
+               ^^^
   Error: Unbound module Foo
   [1]
 

--- a/test/blackbox-tests/test-cases/include-subdirs/stop-at-project-root.t
+++ b/test/blackbox-tests/test-cases/include-subdirs/stop-at-project-root.t
@@ -32,8 +32,8 @@ Doesn't work with when we make [subproj] a separate project with a dune-project
 file, since include_subdirs is stopped.
 
   $ dune exec ./foo.exe
-  File "foo.ml", line 1, characters 14-19:
+  File "foo.ml", line 1, characters 14-17:
   1 | print_endline Bar.v;;
-                    ^^^^^
+                    ^^^
   Error: Unbound module Bar
   [1]

--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -44,9 +44,9 @@ Trying to build triggers both warnings
   1 | let t = "\e\n" in
                ^^
   Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
-  Hint: Single backslashes \ are reserved for escape sequences
-  (\n, \r, ...). Did you check the list of OCaml escape sequences?
-  To get a backslash character, escape it with a second backslash: \\.
+    Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+    Did you check the list of OCaml escape sequences?
+    To get a backslash character, escape it with a second backslash: \\.
   File "main.ml", line 1, characters 4-5:
   1 | let t = "\e\n" in
           ^
@@ -83,9 +83,9 @@ Can also pass flags from the env stanza. Let's go back to failing state:
   1 | let t = "\e\n" in
                ^^
   Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
-  Hint: Single backslashes \ are reserved for escape sequences
-  (\n, \r, ...). Did you check the list of OCaml escape sequences?
-  To get a backslash character, escape it with a second backslash: \\.
+    Hint: Single backslashes \ are reserved for escape sequences (\n, \r, ...).
+    Did you check the list of OCaml escape sequences?
+    To get a backslash character, escape it with a second backslash: \\.
   File "main.ml", line 1, characters 4-5:
   1 | let t = "\e\n" in
           ^

--- a/test/blackbox-tests/test-cases/melange/ppx-preview.t
+++ b/test/blackbox-tests/test-cases/melange/ppx-preview.t
@@ -25,6 +25,8 @@ Show PPX snippet preview is shown in Dune
   $ export DUNE_SANDBOX=symlink
   $ dune build @melange
   File "lib/the_lib.ml", line 1, characters 7-11:
+  1 | let x: nope = "hello"
+             ^^^^
   Error: Unbound type constructor nope
   [1]
 

--- a/test/blackbox-tests/test-cases/melange/private-module.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/private-module.t/run.t
@@ -1,7 +1,7 @@
 X is not accessible as it is private
   $ dune build private-module/foo.js
-  File "foo.ml", line 1, characters 0-9:
+  File "foo.ml", line 1, characters 0-5:
   1 | Lib.X.run ();;
-      ^^^^^^^^^
+      ^^^^^
   Error: The module Lib.X is an alias for module Lib__X, which is missing
   [1]

--- a/test/blackbox-tests/test-cases/menhir/menhir-include-subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/menhir/menhir-include-subdirs.t/run.t
@@ -10,10 +10,10 @@ Menhir in other places than the root of the file hierarchy.
   > }
 
   $ test unqualified
-  File "foo.ml", line 2, characters 2-14:
+  File "foo.ml", line 2, characters 2-5:
   2 |   Bar.Baz.unit (fun _ -> Bar.Baz.EOF) (Lexing.from_string "")
-        ^^^^^^^^^^^^
+        ^^^
   Error: Unbound module Bar
-  Hint: Did you mean Baz?
+  Hint:    Did you mean Baz?
   [1]
   $ test qualified

--- a/test/blackbox-tests/test-cases/meta-exports.t
+++ b/test/blackbox-tests/test-cases/meta-exports.t
@@ -48,9 +48,9 @@ However, the compilation without `(implicit_transitive_deps)` fails:
   > EOF
 
   $ OCAMLPATH=$(pwd)/_install dune exec ./main.exe
-  File "main.ml", line 1, characters 19-24:
+  File "main.ml", line 1, characters 19-22:
   1 | let () = print_int Bar.x; print_newline ()
-                         ^^^^^
+                         ^^^
   Error: Unbound module Bar
   [1]
 

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
@@ -34,9 +34,9 @@ This check doesn't apply to single module libraries:
   > let x = Foo.x
   > EOF
   $ dune build @all
-  File "lib/foo.ml", line 1, characters 8-13:
+  File "lib/foo.ml", line 1, characters 8-11:
   1 | let x = Foo.x
-              ^^^^^
+              ^^^
   Error: Unbound module Foo
   [1]
   $ rm lib/foo.ml
@@ -64,9 +64,9 @@ Although we get slightly different behavior if wrapping is on or off:
   > (wrapped_executables false)
   > EOF
   $ dune exec ./exe/foo.exe
-  File "exe/foo.ml", line 1, characters 0-11:
+  File "exe/foo.ml", line 1, characters 0-3:
   1 | Foo.Bar.run ();;
-      ^^^^^^^^^^^
+      ^^^
   Error: Unbound module Foo
   [1]
 

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -141,9 +141,9 @@ dev-tools don't leak into the project.
 
 There is no leak here. It is not taking Printer module from the printer of dev-tools dependency.
   $ dune exec -- foo
-  File "foo.ml", line 1, characters 9-22:
+  File "foo.ml", line 1, characters 9-16:
   1 | let () = Printer.print ()
-               ^^^^^^^^^^^^^
+               ^^^^^^^
   Error: Unbound module Printer
-  Hint: Did you mean Printexc or Printf?
+  Hint:    Did you mean Printexc or Printf?
   [1]

--- a/test/blackbox-tests/test-cases/private-modules/inaccessible-in-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules/inaccessible-in-deps.t/run.t
@@ -1,6 +1,6 @@
   $ dune build
-  File "foo.ml", line 1, characters 0-5:
+  File "foo.ml", line 1, characters 0-1:
   1 | X.run ();;
-      ^^^^^
+      ^
   Error: Unbound module X
   [1]

--- a/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
@@ -31,9 +31,9 @@ X is warned about:
   Warning: These modules appear in the private_modules field:
   - X
   They must also appear in the modules field.
-  File "src/y.ml", line 1, characters 9-14:
+  File "src/y.ml", line 1, characters 9-10:
   1 | let () = X.foo ()
-               ^^^^^
+               ^
   Error: Unbound module X
   [1]
 
@@ -63,8 +63,8 @@ This warning should be ignored if we are in vendored_dirs
   $ cat > bar.ml
 
   $ dune build ./bar.exe
-  File "src/y.ml", line 1, characters 9-14:
+  File "src/y.ml", line 1, characters 9-10:
   1 | let () = X.foo ()
-               ^^^^^
+               ^
   Error: Unbound module X
   [1]

--- a/test/blackbox-tests/test-cases/private-package-lib/main.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/main.t
@@ -137,9 +137,9 @@ But we shouldn't be able to access it directly:
   > print_endline Secret.secret
   > EOF
   $ dune exec ./subproj/subproj.exe
-  File "subproj/subproj.ml", line 1, characters 14-27:
+  File "subproj/subproj.ml", line 1, characters 14-20:
   1 | print_endline Secret.secret
-                    ^^^^^^^^^^^^^
+                    ^^^^^^
   Error: Unbound module Secret
   [1]
 
@@ -168,9 +168,9 @@ But we cannot use such libraries directly:
   > EOF
   $ dune exec --root use -- ./run.exe
   Entering directory 'use'
-  File "run.ml", line 1, characters 43-56:
+  File "run.ml", line 1, characters 43-49:
   1 | print_endline ("direct access attempt: " ^ Secret.secret)
-                                                 ^^^^^^^^^^^^^
+                                                 ^^^^^^
   Error: Unbound module Secret
   Leaving directory 'use'
   [1]

--- a/test/blackbox-tests/test-cases/transitive-deps-mode.t/run.t
+++ b/test/blackbox-tests/test-cases/transitive-deps-mode.t/run.t
@@ -1,6 +1,6 @@
 run should not access foo
   $ dune build ./run.exe 2>&1 | grep -v ocamlc
-  File "run.ml", line 1, characters 34-39:
+  File "run.ml", line 1, characters 34-37:
   1 | Printf.printf "Can't access %d\n" Foo.v
-                                        ^^^^^
+                                        ^^^
   Error: Unbound module Foo

--- a/test/blackbox-tests/test-cases/utop/utop-default/lib-in-root.t/run.t
+++ b/test/blackbox-tests/test-cases/utop/utop-default/lib-in-root.t/run.t
@@ -1,7 +1,7 @@
 By default, dune utop tries to make a toplevel for the current directory:
 
   $ echo 'Stdlib.exit 0;;' | dune utop . -- -init "" | grep -v 'version'
-  Enter "#help;;" for help.
+  Enter #help;; for help.
   
   Init file not found: "".
   # 

--- a/test/blackbox-tests/test-cases/utop/utop-default/nothing-in-root.t/run.t
+++ b/test/blackbox-tests/test-cases/utop/utop-default/nothing-in-root.t/run.t
@@ -1,7 +1,7 @@
 Utop will load libs recursively:
 
   $ echo 'Stdlib.exit 0;;' | dune utop . -- -init "" | grep -v 'version'
-  Enter "#help;;" for help.
+  Enter #help;; for help.
   
   Init file not found: "".
   # 

--- a/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
@@ -1,18 +1,18 @@
   $ dune build 2>&1 | grep -v ocamlc
-  File "fooexe.ml", line 3, characters 0-7:
+  File "fooexe.ml", line 3, characters 0-3:
   3 | Bar.run ();;
-      ^^^^^^^
+      ^^^
   Error (alert deprecated): module Bar
   Will be removed past 2020-20-20. Use Mylib.Bar instead.
   
-  File "fooexe.ml", line 4, characters 0-7:
+  File "fooexe.ml", line 4, characters 0-3:
   4 | Foo.run ();;
-      ^^^^^^^
+      ^^^
   Error (alert deprecated): module Foo
   Will be removed past 2020-20-20. Use Mylib.Foo instead.
   
-  File "fooexe.ml", line 7, characters 11-22:
+  File "fooexe.ml", line 7, characters 11-20:
   7 | module X : Intf_only.S = struct end
-                 ^^^^^^^^^^^
+                 ^^^^^^^^^
   Error (alert deprecated): module Intf_only
   Will be removed past 2020-20-20. Use Mylib.Intf_only instead.


### PR DESCRIPTION
We update the CI, tests and development version of dune to OCaml 5.4.

<s> This is currently waiting for a 5.4 compatible melange release. The recent versions on main appear to break in strange ways.</s>

- [x] Fix melange tests. Melange currently has a regression where it is failing to follow symlinks. This is breaking ~20 of the tests. We can fix them by setting the sandbox mode to `none`. We might have a fix in a few days so waiting for now.
- [ ] Wait for melange 6.0 in opam repo