### PR TITLE
pkg: Enable pkg_build_progress by default

### DIFF
--- a/.github/workflows/multi-repo-build.yml
+++ b/.github/workflows/multi-repo-build.yml
@@ -33,9 +33,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
-    env:
-      # TODO: Remove
-      DUNE_CONFIG__PKG_BUILD_PROGRESS: enabled
     steps:
       - name: Checkout Dune
         uses: actions/checkout@v5

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -19,7 +19,6 @@ let out =
 
 let default_toggles : (string * [ `Disabled | `Enabled ]) list =
   [ "toolchains", `Enabled
-  ; "pkg_build_progress", `Disabled
   ; "lock_dev_tool", `Disabled
   ; "bin_dev_tools", `Disabled
   ; "portable_lock_dir", `Disabled
@@ -97,10 +96,6 @@ let () =
       , toggle "toolchains"
       , " Enable the toolchains behaviour, allowing dune to install the compiler in a \
          user-wide directory." )
-    ; ( "--pkg-build-progress"
-      , toggle "pkg_build_progress"
-      , " Enable the displaying of package build progress.\n\
-        \      This flag is experimental and shouldn't be relied on by packagers." )
     ; ( "--lock-dev-tool"
       , toggle "lock_dev_tool"
       , " Enable ocamlformat dev-tool, allows 'dune fmt' to build ocamlformat and use \

--- a/flake.nix
+++ b/flake.nix
@@ -82,8 +82,6 @@
           pkg:
           pkg.overrideAttrs {
             configureFlags = [
-              "--pkg-build-progress"
-              "enable"
               "--lock-dev-tool"
               "enable"
               "--portable-lock-dir"

--- a/src/dune_rules/compile_time.ml
+++ b/src/dune_rules/compile_time.ml
@@ -1,11 +1,6 @@
 open Import
 
 let toolchains = Config.make_toggle ~name:"toolchains" ~default:Setup.toolchains
-
-let pkg_build_progress =
-  Config.make_toggle ~name:"pkg_build_progress" ~default:Setup.pkg_build_progress
-;;
-
 let lock_dev_tools = Config.make_toggle ~name:"lock_dev_tool" ~default:Setup.lock_dev_tool
 let bin_dev_tools = Config.make_toggle ~name:"bin_dev_tools" ~default:Setup.bin_dev_tools
 

--- a/src/dune_rules/compile_time.mli
+++ b/src/dune_rules/compile_time.mli
@@ -14,10 +14,6 @@ open Import
     For more detail, see src/dune_rules/pkg_toolchains.mli *)
 val toolchains : Config.Toggle.t Config.t
 
-(** Enable or disable the displaying of package build progress.
-    For more detail, see src/dune_rules/pkg_build_progress.mli *)
-val pkg_build_progress : Config.Toggle.t Config.t
-
 (** Enable or disable using package management to install dev tools. *)
 val lock_dev_tools : Config.Toggle.t Config.t
 

--- a/src/dune_rules/pkg_build_progress.ml
+++ b/src/dune_rules/pkg_build_progress.ml
@@ -36,9 +36,9 @@ module Message = struct
   ;;
 
   let display t =
-    match Config.get Compile_time.pkg_build_progress with
-    | `Enabled -> Console.print_user_message (user_message t)
-    | `Disabled -> ()
+    match !Dune_engine.Clflags.display with
+    | Quiet -> ()
+    | Short | Verbose -> Console.print_user_message (user_message t)
   ;;
 
   let encode { package_name; package_version; status } =

--- a/src/dune_rules/pkg_build_progress.mli
+++ b/src/dune_rules/pkg_build_progress.mli
@@ -18,9 +18,8 @@ val format_user_message
     the console so users can be informed about which of their
     project's dependencies are currently being installed.
 
-    The message will only print if the
-    DUNE_CONFIG__PKG_BUILD_PROGRESS config variable is "enabled"
-    (it's "disabled" by default). *)
+    The action respects the display setting and will not print anything
+    when the display setting is quiet. *)
 val progress_action
   :  Package.Name.t
   -> Package_version.t

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -13,7 +13,6 @@ let roots : string option Install.Roots.t =
 
 let prefix : string option = None
 let toolchains = `Enabled
-let pkg_build_progress = `Disabled
 let lock_dev_tool = `Disabled
 let bin_dev_tools = `Disabled
 let portable_lock_dir = `Disabled

--- a/src/dune_rules/setup.mli
+++ b/src/dune_rules/setup.mli
@@ -11,7 +11,6 @@ val library_path : string list
 val roots : string option Install.Roots.t
 
 val toolchains : Dune_config.Config.Toggle.t
-val pkg_build_progress : Dune_config.Config.Toggle.t
 val lock_dev_tool : Dune_config.Config.Toggle.t
 val bin_dev_tools : Dune_config.Config.Toggle.t
 val portable_lock_dir : Dune_config.Config.Toggle.t

--- a/test/blackbox-tests/test-cases/pkg/build-progress.t
+++ b/test/blackbox-tests/test-cases/pkg/build-progress.t
@@ -1,0 +1,23 @@
+This test verifies the @pkg-install alias outputs the build progress when
+--display is short or verbose.
+
+  $ . ./helpers.sh
+
+Add a lock file for a fake library foo:
+  $ make_lockdir
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > EOF
+
+Verify that the build progress is displayed correctly
+  $ dune build @pkg-install --display short
+      Building foo.0.0.1
+
+  $ dune clean
+
+  $ dune build @pkg-install --display verbose 2>&1 | grep Building
+      Building foo.0.0.1
+
+  $ dune clean
+
+  $ dune build @pkg-install --display quiet


### PR DESCRIPTION
The feature has been tested enough by the users of the dune preview build, and it is now ready to be enabled for all users by default.