### PR TITLE
Add `dune-find-dominating` command to `dune.el`

### DIFF
--- a/doc/changes/added/12696.md
+++ b/doc/changes/added/12696.md
@@ -1,0 +1,2 @@
+- Add `dune-find-dominating` to `dune.el`, a command to find the
+  dominating dune file. (#12696, @arvidj)

--- a/editor-integration/emacs/dune.el
+++ b/editor-integration/emacs/dune.el
@@ -426,6 +426,17 @@ For customization purposes, use `dune-mode-hook'."
   (compile (format "%s build @@runtest" dune-command))
   (dune-promote))
 
+;;;###autoload
+(defun dune-find-dominating ()
+  "Find dominating dune file."
+  (interactive)
+  (if-let* ((dune-file-dir (locate-dominating-file "." "dune"))
+            (dune-file (concat dune-file-dir "dune")))
+      (progn
+        (xref-push-marker-stack)
+        (find-file dune-file))
+    (error "Found no dune file dominating %s" default-directory)))
+
 (defun dune-project-p (directory)
   "Return t if DIRECTORY is a dune project."
   (file-exists-p (expand-file-name "dune-project" directory)))


### PR DESCRIPTION
Add a command `dune-find-dominating` to `dune.el`. It finds the dominating `dune` file, and allows you to jump back using `xref-go-back`.