### PR TITLE
Add ocaml-index as a dev tool

### DIFF
--- a/bin/tools/group.ml
+++ b/bin/tools/group.ml
@@ -8,7 +8,14 @@ module Exec = struct
     Cmd.group
       info
       (List.map
-         [ Ocamlformat; Ocamllsp; Ocamlearlybird; Odig; Opam_publish; Dune_release ]
+         [ Ocamlformat
+         ; Ocamllsp
+         ; Ocamlearlybird
+         ; Odig
+         ; Opam_publish
+         ; Dune_release
+         ; Ocaml_index
+         ]
          ~f:Tools_common.exec_command)
   ;;
 end

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -9,6 +9,7 @@ type t =
   | Odig
   | Opam_publish
   | Dune_release
+  | Ocaml_index
 
 let to_dyn = function
   | Ocamlformat -> Dyn.variant "Ocamlformat" []
@@ -19,10 +20,20 @@ let to_dyn = function
   | Odig -> Dyn.variant "Odig" []
   | Opam_publish -> Dyn.variant "Opam_publish" []
   | Dune_release -> Dyn.variant "Dune_release" []
+  | Ocaml_index -> Dyn.variant "Ocaml_index" []
 ;;
 
 let all =
-  [ Ocamlformat; Odoc; Ocamllsp; Utop; Ocamlearlybird; Odig; Opam_publish; Dune_release ]
+  [ Ocamlformat
+  ; Odoc
+  ; Ocamllsp
+  ; Utop
+  ; Ocamlearlybird
+  ; Odig
+  ; Opam_publish
+  ; Dune_release
+  ; Ocaml_index
+  ]
 ;;
 
 let equal a b =
@@ -43,6 +54,9 @@ let equal a b =
   | Opam_publish, _ -> false
   | _, Opam_publish -> false
   | Dune_release, Dune_release -> true
+  | Dune_release, _ -> false
+  | _, Dune_release -> false
+  | Ocaml_index, Ocaml_index -> true
 ;;
 
 let hash = Poly.hash
@@ -56,6 +70,7 @@ let package_name = function
   | Odig -> Package_name.of_string "odig"
   | Opam_publish -> Package_name.of_string "opam-publish"
   | Dune_release -> Package_name.of_string "dune-release"
+  | Ocaml_index -> Package_name.of_string "ocaml-index"
 ;;
 
 let of_package_name package_name =
@@ -68,6 +83,7 @@ let of_package_name package_name =
   | "odig" -> Odig
   | "opam-publish" -> Opam_publish
   | "dune-release" -> Dune_release
+  | "ocaml-index" -> Ocaml_index
   | other -> User_error.raise [ Pp.textf "No such dev tool: %s" other ]
 ;;
 
@@ -80,6 +96,7 @@ let exe_name = function
   | Odig -> "odig"
   | Opam_publish -> "opam-publish"
   | Dune_release -> "dune-release"
+  | Ocaml_index -> "ocaml-index"
 ;;
 
 let exe_path_components_within_package t = [ "bin"; exe_name t ]
@@ -93,5 +110,5 @@ let needs_to_build_with_same_compiler_as_project = function
     false
   | Opam_publish -> false
   | Dune_release -> false
-  | Utop | Odoc | Ocamllsp | Odig -> true
+  | Utop | Odoc | Ocamllsp | Ocaml_index | Odig -> true
 ;;

--- a/src/dune_pkg/dev_tool.mli
+++ b/src/dune_pkg/dev_tool.mli
@@ -7,6 +7,7 @@ type t =
   | Odig
   | Opam_publish
   | Dune_release
+  | Ocaml_index
 
 val to_dyn : t -> Dyn.t
 val all : t list

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -1,8 +1,27 @@
 open Import
 open Memo.O
 
+let ocaml_index_dev_tool_exe_path_building_if_necessary () =
+  let open Action_builder.O in
+  let path = Path.build (Pkg_dev_tool.exe_path Ocaml_index) in
+  let+ () = Action_builder.path path in
+  Ok path
+;;
+
+let ocaml_index_dev_tool_exists () =
+  Lock_dir.dev_tool_source_lock_dir Ocaml_index |> Path.source |> Path.Untracked.exists
+;;
+
 let ocaml_index sctx ~dir =
-  Super_context.resolve_program ~loc:None ~dir sctx "ocaml-index"
+  match ocaml_index_dev_tool_exists () with
+  | true -> ocaml_index_dev_tool_exe_path_building_if_necessary ()
+  | false ->
+    Super_context.resolve_program
+      sctx
+      ~dir
+      "ocaml-index"
+      ~loc:None
+      ~hint:"opam install ocaml-index"
 ;;
 
 let index_file_name = "cctx.ocaml-index"

--- a/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
+++ b/test/blackbox-tests/test-cases/pkg/dev-tools-help-message.t
@@ -23,6 +23,12 @@ Output the help text:
              dune-release executable (pass flags to dune-release after the '--'
              argument, such as 'dune tools exec dune-release -- --help').
   
+         ocaml-index [OPTION]… [ARGS]…
+             Wrapper for running ocaml-index intended to be run automatically
+             by a text editor. All positional arguments will be passed to the
+             ocaml-index executable (pass flags to ocaml-index after the '--'
+             argument, such as 'dune tools exec ocaml-index -- --help').
+  
          ocamlearlybird [OPTION]… [ARGS]…
              Wrapper for running ocamlearlybird intended to be run
              automatically by a text editor. All positional arguments will be

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -28,6 +28,7 @@ Confirm that each dev tool's bin directory is now in PATH:
   - ocaml.5.2.0
   - ocaml-lsp-server.0.0.1
        Running 'ocamllsp'
+  $TESTCASE_ROOT/_build/_private/default/.dev-tool/ocaml-index/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/dune-release/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/opam-publish/target/bin
   $TESTCASE_ROOT/_build/_private/default/.dev-tool/odig/target/bin


### PR DESCRIPTION
Adding `ocaml-index` as a dev tool. This is mainly to ensure there's a way to obtain `ocaml-index` for the build alias `dune build @ocaml-index`. Fixes #12055.