### PR TITLE
feat(oxcaml): parameterised inline_tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -373,10 +373,10 @@ jobs:
           opam-pin: false
 
       - name: Pin deps
-        run: opam pin add -n . --with-version=3.20.2+ox
+        run: opam pin add -n . --with-version=3.21.0
 
       - name: Install deps
-        run: opam install csexp pp re spawn uutf ./dune.opam
+        run: opam install csexp pp re spawn uutf ppx_inline_test ./dune.opam
 
       - name: Build dune
         run: opam exec -- make bootstrap

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -288,6 +288,24 @@ a ``deps`` field the ``inline_tests`` field. The argument of this
     (inline_tests (deps data.txt))
     (preprocess (pps ppx_expect)))
 
+Specifying Inline Test arguments for Parameterised Libraries
+------------------------------------------------------------
+
+If your library is parameterised (see
+:doc:`/reference/dune/library_parameter`), you must specify which
+implementation of the parameters to use with the ``arguments`` field.  For
+example, suppose `foo` is a parameterised library that takes parameters
+`a_param` and `b_param`, you can specify the implementations of these
+parameters for inline tests as follows:
+
+.. code:: ocaml
+
+   (library
+    (name foo)
+    (parameters a_param b_param)
+    (inline_tests
+     (arguments a_impl b_impl)))
+
 
 Passing Special Arguments to the Test Runner
 --------------------------------------------

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -134,6 +134,7 @@ module Tests = struct
     ; executable_link_flags : Ordered_set_lang.Unexpanded.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
+    ; arguments : (Loc.t * Lib_name.t) list
     ; enabled_if : Blang.t
     }
 
@@ -165,6 +166,12 @@ module Tests = struct
                    ocaml_flags, link_flags))
        and+ backend = field_o "backend" (located Lib_name.decode)
        and+ libraries = field "libraries" (repeat (located Lib_name.decode)) ~default:[]
+       and+ arguments =
+         field
+           "arguments"
+           (Dune_lang.Syntax.since Dune_lang.Oxcaml.syntax (0, 1)
+            >>> repeat (located Lib_name.decode))
+           ~default:[]
        and+ modes =
          field
            "modes"
@@ -180,6 +187,7 @@ module Tests = struct
        ; executable_link_flags
        ; backend
        ; libraries
+       ; arguments
        ; modes
        ; enabled_if
        })

--- a/src/dune_rules/inline_tests_info.mli
+++ b/src/dune_rules/inline_tests_info.mli
@@ -46,6 +46,7 @@ module Tests : sig
     ; executable_link_flags : Ordered_set_lang.Unexpanded.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
+    ; arguments : (Loc.t * Lib_name.t) list
     ; enabled_if : Blang.t
     }
 

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -30,9 +30,10 @@ module Parameterised : sig
 
   val instantiate
     :  loc:Loc.t
+    -> from:[ `depends | `inline_tests ]
     -> t
     -> (Loc.t * t Resolve.t) list
-    -> parent_parameters:t list
+    -> parent_parameters:(Loc.t * t) list
     -> t Resolve.t
 end
 

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -349,7 +349,11 @@ let resolve_instantiation scope instance_name =
     | Some lib ->
       Memo.List.map ~f:go args
       >>| List.map ~f:(fun arg -> Loc.none, arg)
-      >>| Lib.Parameterised.instantiate ~loc:Loc.none lib ~parent_parameters:[]
+      >>| Lib.Parameterised.instantiate
+            ~loc:Loc.none
+            ~from:`depends
+            lib
+            ~parent_parameters:[]
   in
   go (Parameterised_name.of_string instance_name) |> Resolve.Memo.read_memo
 ;;

--- a/test/blackbox-tests/test-cases/oxcaml/instantiate-parameterised.t
+++ b/test/blackbox-tests/test-cases/oxcaml/instantiate-parameterised.t
@@ -70,11 +70,10 @@ It's an error for the binary to partially instantiate `lib_ab`:
   File "bin/dune", line 3, characters 26-32:
   3 |   (libraries (instantiate lib_ab b_impl))) ; missing a_impl
                                 ^^^^^^
-  Error: Parameter "project.a" is missing.
+  Error: Missing argument for parameter "project.a".
   -> required by _build/default/bin/bin.exe
   -> required by _build/install/default/bin/project.bin
-  Hint: Pass an argument implementing project.a to the dependency, or add
-  (parameters project.a)
+  Hint: Pass an argument implementing "project.a" to the dependency.
   [1]
 
 It's an error to instantiate twice without renamming: (dune might be able to
@@ -141,12 +140,11 @@ dependencies, because its parameter `b` is missing:
   File "bin/dune", line 6, characters 31-37:
   6 |     (instantiate lib_ab a_impl a_of_b)))
                                      ^^^^^^
-  Error: Parameter "project.b" is missing.
+  Error: Missing argument for parameter "project.b".
   -> required by _build/default/bin/.bin.eobjs/native/dune__exe__Bin.cmx
   -> required by _build/default/bin/bin.exe
   -> required by _build/install/default/bin/project.bin
-  Hint: Pass an argument implementing project.b to the dependency, or add
-  (parameters project.b)
+  Hint: Pass an argument implementing "project.b" to the dependency.
   [1]
 
 However `lib_ab` can depend on `a_of_b`, such that the parameter `b` will be

--- a/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
+++ b/test/blackbox-tests/test-cases/oxcaml/library-field-parameters.t
@@ -335,13 +335,12 @@ required parameters.
   File "bin/dune", line 1, characters 34-37:
   1 | (executable (name bin) (libraries lib))
                                         ^^^
-  Error: Parameter "project.a" is missing.
+  Error: Missing argument for parameter "project.a".
   -> required by _build/default/bin/.bin.eobjs/native/dune__exe__Bin.cmx
   -> required by _build/default/bin/bin.exe
   -> required by alias bin/all
   -> required by alias default
-  Hint: Pass an argument implementing project.a to the dependency, or add
-  (parameters project.a)
+  Hint: Pass an argument implementing "project.a" to the dependency.
   [1]
 
   $ rm -r bin
@@ -357,14 +356,13 @@ Same for libraries:
   File "lib2/dune", line 1, characters 32-35:
   1 | (library (name lib2) (libraries lib))
                                       ^^^
-  Error: Parameter "project.a" is missing.
+  Error: Missing argument for parameter "project.a".
   -> required by library "lib2" in _build/default/lib2
   -> required by _build/default/lib2/.lib2.objs/native/lib2.cmx
   -> required by _build/default/lib2/lib2.a
   -> required by alias lib2/all
   -> required by alias default
-  Hint: Pass an argument implementing project.a to the dependency, or add
-  (parameters project.a)
+  Hint: Pass an argument implementing "project.a" to the dependency.
   [1]
 
 It works if `lib2` is itself parameterised with the same parameters as `lib`:

--- a/test/blackbox-tests/test-cases/oxcaml/parameterised-inline-test.t
+++ b/test/blackbox-tests/test-cases/oxcaml/parameterised-inline-test.t
@@ -1,0 +1,150 @@
+Testing the instantiation of parameterised inline tests.
+
+  $ cat >> dune-project <<EOF
+  > (lang dune 3.20)
+  > (using oxcaml 0.1)
+  > EOF
+
+We first define a parameter signature:
+
+  $ mkdir param
+  $ echo 'val param : string' > param/param.mli
+  $ cat > param/dune <<EOF
+  > (library_parameter (name param))
+  > EOF
+
+Then a parameterised library, which uses inline tests:
+
+  $ mkdir lib
+  $ cat > lib/lib.ml <<EOF
+  > let param = Param.param
+  > let%test _ = Param.param = "impl"
+  > EOF
+  $ cat > lib/dune <<EOF
+  > (library
+  >   (name lib)
+  >   (parameters param)
+  >   (inline_tests)
+  >   (preprocess (pps ppx_inline_test)))
+  > EOF
+
+Running the test fails, because we did not specify an implementation for the
+parameter:
+
+  $ dune runtest
+  File "lib/dune", line 3, characters 14-19:
+  3 |   (parameters param)
+                    ^^^^^
+  Error: To run the inline tests, please provide the missing parameter "param".
+  -> required by
+     _build/default/lib/.lib.inline-tests/.t.eobjs/native/dune__exe__Main.cmx
+  -> required by _build/default/lib/.lib.inline-tests/inline-test-runner.exe
+  -> required by _build/default/lib/.lib.inline-tests/partitions-best
+  -> required by alias lib/runtest-lib in lib/dune:4
+  -> required by alias lib/runtest in lib/dune:1
+  Hint: Add (arguments ...) to the inline_tests to specify which implementation
+  of the parameter "param" to use.
+  [1]
+
+We add an implementation:
+
+  $ mkdir impl
+  $ echo 'let param = "impl"' > impl/impl.ml
+  $ cat > impl/dune <<EOF
+  > (library
+  >   (name impl)
+  >   (implements param))
+  > EOF
+
+And specify that `(inline_tests)` should use it with `(arguments impl)`:
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >   (name lib)
+  >   (parameters param)
+  >   (inline_tests (arguments impl))
+  >   (preprocess (pps ppx_inline_test)))
+  > EOF
+
+It should work:
+
+  $ dune runtest
+
+We break the test to confirm that the inline test is running:
+
+  $ cat > lib/lib.ml <<EOF
+  > let param = "lib(" ^ Param.param ^ ")"
+  > let%test _ = Param.param = "not impl"
+  > EOF
+
+  $ dune runtest
+  File "lib/lib.ml", line 2, characters 0-37: <<Param.param = "not impl">> is false.
+  
+  FAILED 1 / 1 tests
+  [1]
+
+Using another implementation:
+
+  $ mkdir not_impl
+  $ echo 'let param = "not impl"' > not_impl/not_impl.ml
+  $ cat > not_impl/dune <<EOF
+  > (library
+  >   (name not_impl)
+  >   (implements param))
+  > EOF
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >   (name lib)
+  >   (parameters param)
+  >   (inline_tests (arguments not_impl))
+  >   (preprocess (pps ppx_inline_test)))
+  > EOF
+
+This now works:
+
+  $ dune runtest
+
+Adding another library which has a dependency on the parameterised `lib`:
+
+  $ mkdir lib2
+  $ cat > lib2/lib2_util.ml <<EOF
+  > let lib_param = Lib.param
+  > EOF
+  $ cat > lib2/lib2.ml <<EOF
+  > let%test _ = Lib2_util.lib_param = "lib(impl)"
+  > EOF
+  $ cat > lib2/dune <<EOF
+  > (library
+  >   (name lib2)
+  >   (parameters param)
+  >   (libraries lib)
+  >   (inline_tests (arguments impl))
+  >   (preprocess (pps ppx_inline_test)))
+  > EOF
+
+(Note that the library has two files, which triggers the inline_test
+preprocessor to generate `.pp.ml` files, which influences how the parameterised
+libraries can read the ocamldep outputs since the filenames are not the
+unpreprocessed ones.)
+
+This should also work:
+
+  $ dune runtest
+
+Using the wrong implementation should break the test again:
+
+  $ cat > lib2/dune <<EOF
+  > (library
+  >   (name lib2)
+  >   (parameters param)
+  >   (libraries lib)
+  >   (inline_tests (arguments not_impl))
+  >   (preprocess (pps ppx_inline_test)))
+  > EOF
+
+  $ dune runtest
+  File "lib2/lib2.ml", line 1, characters 0-46: <<Lib2_util.lib_param = "lib(impl)">> is false.
+  
+  FAILED 1 / 1 tests
+  [1]


### PR DESCRIPTION
Follow-up on the instantiation of parameterised libraries #12561 to support `inline_tests` (marking this PR as a draft since only the last commit is new).

To run the inline tests of a parameterised library, the user should specify with `(arguments ...)` which implementation of the parameters to use, as otherwise the test can't be ran.

Fix https://github.com/ocaml/dune/issues/12110