### PR TITLE
Stanza parse remove useless helper

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -60,7 +60,10 @@ module File = struct
     ;;
 
     let csts_conflict project ~dir (a : Cst.t) (b : Cst.t) =
-      let of_ast = Dune_rules.Stanzas.of_ast project ~dir in
+      let of_ast sexp =
+        let parser = Dune_project.stanza_parser project ~dir in
+        Dune_lang.Decoder.parse parser Univ_map.empty sexp
+      in
       (let open Option.O in
        let* a_ast = Cst.abstract a in
        let+ b_ast = Cst.abstract b in

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -117,12 +117,6 @@ let stanzas : Stanza.Parser.t list =
 ;;
 
 let () = Dune_project.Lang.register Stanza.syntax stanzas
-let parse parser = Dune_lang.Decoder.parse parser Univ_map.empty
-
-let of_ast (project : Dune_project.t) ~dir sexp =
-  let parser = Dune_project.stanza_parser project ~dir in
-  parse parser sexp
-;;
 
 let stanza_package stanza =
   match

--- a/src/dune_rules/stanzas/stanzas.mli
+++ b/src/dune_rules/stanzas/stanzas.mli
@@ -13,8 +13,3 @@ module Dynamic_include : sig
 end
 
 val stanza_package : Stanza.t -> Package.Id.t option
-
-(** [of_ast project ~dir ast] is the list of [Stanza.t]s derived from decoding
-    the [ast] according to the syntax given by [kind] in the context of the
-    [project] *)
-val of_ast : Dune_project.t -> dir:Path.Source.t -> Dune_lang.Ast.t -> Stanza.t list


### PR DESCRIPTION
Just a wrapper around `Dune_project.stanza_parser` that doesn't add much.