### PR TITLE
Reword portable lockdir solve message and remove platforms

### DIFF
--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -261,10 +261,7 @@ let summary_message
        User_message.Style.Success
        (Pp.textf "Solution for %s" (Path.to_string_maybe_quoted lock_dir_path))
      :: Pp.nop
-     :: Pp.text "This solution supports the following platforms:"
-     :: Pp.enumerate (snd lock_dir.solved_for_platforms) ~f:Solver_env.pp_oneline
-     :: Pp.nop
-     :: Pp.text "Dependencies on all supported platforms:"
+     :: Pp.text "Dependencies common to all supported platforms:"
      :: pp_package_set common_packages
      :: (maybe_uncommon_packages @ maybe_perf_stats))
     @ maybe_unsolved_platforms_message)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -36,13 +36,7 @@ Create a package that writes a different value to some files depending on the os
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/lock.dune

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -48,10 +48,7 @@ Create a custom dune-workspace to solve for openbsd.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = openbsd
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/lock.dune

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -51,17 +51,7 @@ Solve the project:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux; sys-ocaml-version =
-    5.4.0+solver-env-version-override
-  - arch = arm64; os = linux; sys-ocaml-version =
-    5.4.0+solver-env-version-override
-  - arch = x86_64; os = macos; sys-ocaml-version =
-    5.4.0+solver-env-version-override
-  - arch = arm64; os = macos; sys-ocaml-version =
-    5.4.0+solver-env-version-override
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
 
 Confirming that the build action creates the conditional file:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -24,13 +24,7 @@ Demonstrate various cases representing depexts in lockfiles.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
 
   $ cat ${default_lock_dir}/foo.0.0.1.pkg

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
@@ -54,12 +54,7 @@ correct depext names can be chosen for the current distro at build time.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = macos; os-distribution = homebrew; os-family = homebrew
-  - arch = x86_64; os = linux
-  - arch = x86_64; os = win32; os-distribution = cygwin; os-family = windows
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - conf-pkg-config.0.0.1
 
 Print the name of the depext on a variety of os/distro/versions:

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
@@ -40,8 +40,5 @@ Create a workspace with some typos in package variable names
   "os-family"?
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   (none)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -35,11 +35,7 @@ to solve for macos, linux, and windows by default.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
   
   No package solution was found for some requsted platforms.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -54,13 +54,7 @@ A package that conditionally depends on packages depending on the OS:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
   
   Additionally, some packages will only be built on specific platforms.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -71,13 +71,7 @@ Solve the project. The solution will contain extra files for both versions of fo
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - bar.0.0.1
   
   Additionally, some packages will only be built on specific platforms.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -55,13 +55,7 @@ Define a package bar which conditionally depends on different versions of foo:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - bar.0.0.1
   
   Additionally, some packages will only be built on specific platforms.

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
@@ -20,11 +20,5 @@ avoid-version, include a message to that extent in the output.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1 (this version should be avoided)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
@@ -31,13 +31,7 @@ Solve dependencies:
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - a.0.0.1
   - b.0.0.2
   - c.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
@@ -30,13 +30,7 @@ dune-workspace.
   $ DUNE_CONFIG__PORTABLE_LOCK_DIR=enabled dune pkg lock
   Solution for dune.lock
   
-  This solution supports the following platforms:
-  - arch = x86_64; os = linux
-  - arch = arm64; os = linux
-  - arch = x86_64; os = macos
-  - arch = arm64; os = macos
-  
-  Dependencies on all supported platforms:
+  Dependencies common to all supported platforms:
   - foo.0.0.1
 
 The list-locked-dependencies command does some validation that there are no


### PR DESCRIPTION
Removing the list of platforms printed when solving portable lockdirs is intended to reduce noise in our tests and to make tests robust to changing the default set of platforms which dune will solve for in the future. Also rewords the message for clarity.