### PR TITLE
fix: switching to custom lock dir

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/lockdir-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-switch.t
@@ -43,12 +43,7 @@ Now change the workspace to use a custom lock directory:
   > EOF
 
   $ dune exec -- bar
-  Error: No rule found for default/.lock/dune.lock (context _private)
-  -> required by lock directory environment for context "default"
-  -> required by base environment for context "default"
-  -> required by loading findlib for context "default"
-  -> required by creating installed environment for "default"
-  [1]
+  hello from bar
 
 Now try with a context stanza that references the custom lock directory with a
 context stanza:


### PR DESCRIPTION
Reproduction and fix for #12717.

This test demonstrates two issues.

1. We are making some assumptions about which custom lock directories we have in the workspace. This means that a rule wasn't being loaded or was being expected to exist.
2. <s>When combining the `context` stanza we get some internal errors.</s> Seems to be fixed by #12653.