### PR TITLE
pkg: allow lockdirs to go in shared cache

### DIFF
--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -377,9 +377,7 @@ let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
          ~selected_depopts
          ~pins
          ~version_preference
-       |> Action.Full.make
-            ~can_go_in_shared_cache:false (* TODO: probably ok this allow this? *)
-            ~sandbox:Sandbox_config.needs_sandboxing)
+       |> Action.Full.make ~sandbox:Sandbox_config.needs_sandboxing)
       |> Action_builder.with_no_targets
       |> Action_builder.With_targets.add_directories ~directory_targets:[ target ]
     in


### PR DESCRIPTION
Before we merge this we need to re-review how we digest the locking action to make sure we won't poison any caches.