### PR TITLE
Report that the opam version is 2.2.0 while solving

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/just-print-solver-env.t
@@ -44,14 +44,14 @@ Add some build contexts with different environments
   - with-dev-setup = false
   - with-doc = false
   Solver environment for lock directory dune.linux.lock:
-  - opam-version = 2.2.0~alpha-vendored
+  - opam-version = 2.2.0
   - os = linux
   - post = true
   - with-dev-setup = false
   - with-doc = false
   Solver environment for lock directory dune.linux.no-doc.lock:
   - arch = x86_64
-  - opam-version = 2.2.0~alpha-vendored
+  - opam-version = 2.2.0
   - os = linux
   - os-distribution = ubuntu
   - os-family = ubuntu
@@ -61,7 +61,7 @@ Add some build contexts with different environments
   - with-dev-setup = false
   - with-doc = false
   Solver environment for lock directory dune.lock:
-  - opam-version = 2.2.0~alpha-vendored
+  - opam-version = 2.2.0
   - post = true
   - with-dev-setup = false
   - with-doc = false

--- a/vendor/opam/src/core/opamVersionInfo.ml
+++ b/vendor/opam/src/core/opamVersionInfo.ml
@@ -1,1 +1,1 @@
-let version = "2.2.0~alpha-vendored"
+let version = "2.2.0"


### PR DESCRIPTION
Certain packages require that the opam version be 2.2.0 or above, and the solver will refuse to include those packages with the current opam version baked into dune, which is 2.2.0~alpha-vendored.