### PR TITLE
pkg: add chrome tracing stat events

### DIFF
--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -183,9 +183,9 @@ let snapshot t =
 let create ~mode ~dune_stats ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
   let event =
     Dune_stats.start dune_stats (fun () ->
-      let cat = Some [ "create-sandbox" ] in
+      let cat = [ "create-sandbox" ] in
       let name = Loc.to_file_colon_line rule_loc in
-      let args = None in
+      let args = [] in
       { cat; name; args })
   in
   init ();

--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -72,6 +72,16 @@ let choose_for_filename_default_to_tar filename =
 ;;
 
 let extract t ~archive ~target =
+  let open Dune_stats.Fiber.O in
+  let& () =
+    { Dune_stats.name = "extract"
+    ; cat = [ "fetch" ]
+    ; args =
+        [ "archive", `String (Path.to_string archive)
+        ; "target", `String (Path.to_string target)
+        ]
+    }
+  in
   let* () = Fiber.return () in
   let command = Lazy.force t.command in
   let prefix = Path.basename target in

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -253,19 +253,17 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
   let event =
     Dune_stats.(
       start (global ()) (fun () ->
-        { cat = None
+        { cat = [ "fetch" ]
         ; name = label
         ; args =
-            (let args =
-               [ "url", `String (OpamUrl.to_string url)
-               ; "target", `String (Path.to_string target)
-               ]
-             in
-             Some
-               (match checksum with
-                | None -> args
-                | Some checksum ->
-                  ("checksum", `String (Checksum.to_string checksum)) :: args))
+            List.concat
+              [ Option.map checksum ~f:(fun checksum ->
+                  "checksum", `String (Checksum.to_string checksum))
+                |> Option.to_list
+              ; [ "url", `String (OpamUrl.to_string url)
+                ; "target", `String (Path.to_string target)
+                ]
+              ]
         }))
   in
   let unsupported_backend s =

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -243,6 +243,13 @@ let all_packages_versions_map ts opam_package_name =
 ;;
 
 let load_all_versions_by_keys ts =
+  let open Dune_stats.Fiber.O in
+  let& () =
+    { Dune_stats.name = "load_all_versions_by_keys"
+    ; cat = [ "opam_repo" ]
+    ; args = [ "version_count", `Int (OpamPackage.Version.Map.cardinal ts) ]
+    }
+  in
   let from_git, from_dirs =
     OpamPackage.Version.Map.values ts
     |> List.partition_map ~f:(fun (repo, (pkg : Key.t)) ->

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -717,6 +717,13 @@ module Entry = struct
 end
 
 let fetch_allow_failure repo ~url obj =
+  let open Dune_stats.Fiber.O in
+  let& () =
+    { Dune_stats.name = "fetch"
+    ; cat = [ "rev_store" ]
+    ; args = [ "url", `String url; "object", `String (Object.to_hex obj) ]
+    }
+  in
   with_mutex repo obj ~f:(fun () ->
     object_exists repo obj
     >>= function
@@ -922,6 +929,13 @@ module At_rev = struct
   ;;
 
   let rec of_rev repo ~revision =
+    let open Dune_stats.Fiber.O in
+    let& () =
+      { Dune_stats.name = "of_rev"
+      ; cat = [ "rev_store" ]
+      ; args = [ "revision", `String (Object.to_hex revision) ]
+      }
+    in
     let* files, submodules = files_and_submodules repo revision in
     let commit_paths = path_commit_map submodules in
     let+ files =
@@ -1021,6 +1035,16 @@ module At_rev = struct
         }
         ~target
     =
+    let open Dune_stats.Fiber.O in
+    let& () =
+      { Dune_stats.name = "check_out"
+      ; cat = [ "rev_store" ]
+      ; args =
+          [ "revision", `String (Object.to_hex revision)
+          ; "target", `String (Path.to_string target)
+          ]
+      }
+    in
     let git = Lazy.force Vcs.git in
     let temp_dir =
       Temp_dir.dir_for_target ~target ~prefix:"rev-store" ~suffix:(Object.to_hex revision)

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -226,6 +226,8 @@ let sys_ocaml_version ~path =
 let make_lazy f = Fiber.Lazy.create f |> Fiber.Lazy.force
 
 let make ~path =
+  let open Dune_stats.Not_a_fiber.O in
+  let& () = { Dune_stats.name = "make"; cat = [ "sys_poll" ]; args = [] } in
   let arch = make_lazy (fun () -> arch ~path) in
   let os = make_lazy (fun () -> os ~path) in
   let os_release_fields = lazy (os_release_fields ()) in

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -208,8 +208,17 @@ let get_with_path ctx =
         [ "context", Context_name.to_dyn ctx ]
   in
   let* () = Build_system.build_dir path in
-  Load.load path
-  >>= function
+  let* lock_dir =
+    let open Dune_stats.Memo.O in
+    let& () =
+      { Dune_stats.name = "load_lock_dir"
+      ; cat = [ "lock_dir" ]
+      ; args = [ "lock_dir", `String (Path.to_string path) ]
+      }
+    in
+    Load.load path
+  in
+  match lock_dir with
   | Error e -> Memo.return (Error e)
   | Ok lock_dir ->
     let+ workspace_lock_dir = get_workspace_lock_dir ctx in

--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -3,4 +3,4 @@
  (foreign_stubs
   (language c)
   (names dune_stats_stubs))
- (libraries stdune chrome_trace spawn unix))
+ (libraries stdune chrome_trace spawn unix fiber memo))

--- a/src/dune_stats/dune_stats.mli
+++ b/src/dune_stats/dune_stats.mli
@@ -23,14 +23,34 @@ val extended_build_job_info : t -> bool
 type event
 
 type event_data =
-  { args : Chrome_trace.Event.args option
-  ; cat : string list option
+  { args : Chrome_trace.Event.args
+  ; cat : string list
   ; name : string
   }
 
 val start : t option -> (unit -> event_data) -> event option
 val finish : event option -> unit
 val flush : t -> unit
+
+module Not_a_fiber : sig
+  (** Please make sure what you are wrapping is not a fiber. *)
+
+  module O : sig
+    val ( let& ) : event_data -> (unit -> 'a) -> 'a
+  end
+end
+
+module Fiber : sig
+  module O : sig
+    val ( let& ) : event_data -> (unit -> 'a Fiber.t) -> 'a Fiber.t
+  end
+end
+
+module Memo : sig
+  module O : sig
+    val ( let& ) : event_data -> (unit -> 'a Memo.t) -> 'a Memo.t
+  end
+end
 
 module Private : sig
   module Fd_count : sig

--- a/test/blackbox-tests/test-cases/pkg/trace-file.t
+++ b/test/blackbox-tests/test-cases/pkg/trace-file.t
@@ -1,0 +1,165 @@
+Test that dune pkg lock and build generate trace events.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a library to package:
+
+  $ mkdir foo
+  $ cd foo
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+  $ cat > dune <<EOF
+  > (library (public_name foo))
+  > EOF
+  $ cd ..
+  $ tar cf foo.tar foo
+  $ rm -rf foo
+
+Configure fake curl to serve the tarball:
+
+  $ echo foo.tar >> fake-curls
+  $ PORT=1
+
+Create package with URL:
+
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["dune" "build" "-p" name "-j" jobs]
+  > ]
+  > url {
+  >  src: "http://0.0.0.0:$PORT"
+  >  checksum: [
+  >   "md5=$(md5sum foo.tar | cut -f1 -d' ')"
+  >  ]
+  > }
+  > EOF
+
+Make a simple package without URL:
+
+  $ mkpkg bar
+
+Make a simple library for bar package:
+
+  $ mkdir bar_src
+  $ cd bar_src
+  $ cat > dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name bar))
+  > EOF
+  $ cat > bar.ml <<EOF
+  > let y = "bar"
+  > EOF
+  $ cat > dune <<EOF
+  > (library (public_name bar))
+  > EOF
+  $ cd ..
+  $ tar cf bar.tar bar_src
+  $ rm -rf bar_src
+
+Configure fake curl to serve bar tarball:
+
+  $ echo bar.tar >> fake-curls
+
+Update bar package to have URL:
+
+  $ mkpkg bar <<EOF
+  > build: [
+  >   ["dune" "build" "-p" name "-j" jobs]
+  > ]
+  > url {
+  >  src: "http://0.0.0.0:2"
+  >  checksum: [
+  >   "md5=$(md5sum bar.tar | cut -f1 -d' ')"
+  >  ]
+  > }
+  > EOF
+
+Create a project that depends on both packages:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package
+  >  (name myproject)
+  >  (depends foo bar))
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > let () = print_endline (Foo.x ^ " " ^ Bar.y)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries foo bar))
+  > EOF
+
+  $ add_mock_repo_if_needed
+
+Lock the project with tracing enabled:
+  $ export TRACE_FILE=lock-trace.json
+
+  $ dune pkg lock --trace-file $TRACE_FILE
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - bar.0.0.1
+  - foo.0.0.1
+
+Checks how many times string occurs in trace.
+  $ test() {
+  >   grep -c "$1" "$TRACE_FILE"
+  > }
+
+The system should only be polled once.
+  $ test '"cat":"sys_poll"'
+  > test '"name":"make"'
+  1
+  1
+
+Loading opam repo + overlays.
+  $ test '"cat":"opam_repo"'
+  > test '"name":"load_all_versions_by_keys"'
+  8
+  8
+
+  $ test '"cat":"solver"'
+  > test '"name":"repo_candidate"'
+  > test '"name":"build_problem"'
+  > test '"name":"solve_package_list"'
+  20
+  8
+  4
+  4
+
+Writing the lock dir.
+  $ test '"cat":"lock_dir"'
+  > test '"name":"write_lock_dir"'
+  1
+  1
+
+  $ rm $TRACE_FILE
+
+Now build with tracing to check fetch and archive events:
+
+  $ dune build --trace-file $TRACE_FILE main.exe
+
+  $ test '"cat":"lock_dir"'
+  > test '"name":"load_lock_dir"'
+  7
+  7
+
+  $ test '"cat":"fetch"'
+  > test '"name":"dune-fetch"'
+  > test '"name":"extract"'
+  4
+  2
+  2
+
+  $ dune exec ./main.exe
+  foo bar


### PR DESCRIPTION
We add some more chrome tracing events to various pkg related areas. In order to do this ergonomically, we introduce some convenience wrappers for `Dune_stat` which appear to be quite pleasant to use.

* `cat:sys_poll`
  * [x] `name:make`
* `cat:opam_repo`
  * [ ] `name:load_all_versions_by_keys` (this needs a better name)
* `cat:solver`
  * [x] `name:repo_candidate`
  * [x] `name:build_problem`
  * [x] `name:solve_package_list`
* `cat:lock_dir`
  * [ ] `name:write_lock_dir` (these don't match the code names)
  * [x] `name:load_lock_dir`
* `cat:fetch`
  * [ ] `name:dune-fetch` (needs rename)
  * [x] `name:extract`
* `cat:pkg_rules`
  * [ ] `name:setup`