### PR TITLE
chore: force cmdliner doc argument to be explicit

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -1,6 +1,10 @@
 open Stdune
 include Cmdliner.Arg
 
+let info ?deprecated ?absent ?docs ?docv ~doc ?env names =
+  Cmdliner.Arg.info ?deprecated ?absent ?docs ?docv ?doc ?env names
+;;
+
 include struct
   open Dune_lang
   module Stanza = Stanza

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -1,8 +1,19 @@
 open Stdune
 
 include module type of struct
-  include Cmdliner.Arg
-end
+    include Cmdliner.Arg
+  end
+  with type info := Cmdliner.Arg.info
+
+val info
+  :  ?deprecated:string
+  -> ?absent:string
+  -> ?docs:string
+  -> ?docv:string
+  -> doc:string option
+  -> ?env:Cmdliner.Cmd.Env.info
+  -> string list
+  -> Cmdliner.Arg.info
 
 module Path : sig
   module External : sig

--- a/bin/build.ml
+++ b/bin/build.ml
@@ -162,7 +162,8 @@ let build =
         ]
     ]
   in
-  let name_ = Arg.info [] ~docv:"TARGET" in
+  (* CR-someday Alizter: document this option *)
+  let name_ = Arg.info [] ~docv:"TARGET" ~doc:None in
   let term =
     let+ builder = Common.Builder.term
     and+ targets = Arg.(value & pos_all dep [] name_)
@@ -174,10 +175,11 @@ let build =
             [ "alias-rec" ]
             ~docv:"ALIAS"
             ~doc:
-              "Build the alias $(docv) in its parent directory and all subdirectories. \
-               Equivalent to the build target $(b,@)$(docv). Example: $(b,--alias-rec \
-               dir/foo) builds the $(b,foo) alias in $(b,dir/) and all its \
-               subdirectories. Repeatable.")
+              (Some
+                 "Build the alias $(docv) in its parent directory and all \
+                  subdirectories. Equivalent to the build target $(b,@)$(docv). Example: \
+                  $(b,--alias-rec dir/foo) builds the $(b,foo) alias in $(b,dir/) and \
+                  all its subdirectories. Repeatable."))
     and+ aliases =
       Arg.(
         value
@@ -186,9 +188,10 @@ let build =
             [ "alias" ]
             ~docv:"ALIAS"
             ~doc:
-              "Build $(docv) in its parent directory only. Equivalent to the build \
-               target $(b,@@)$(docv). Example: $(b,--alias dir/foo) builds the $(b,foo) \
-               alias in $(b,dir/) only. Repeatable.")
+              (Some
+                 "Build $(docv) in its parent directory only. Equivalent to the build \
+                  target $(b,@@)$(docv). Example: $(b,--alias dir/foo) builds the \
+                  $(b,foo) alias in $(b,dir/) only. Repeatable."))
     in
     let targets = List.concat [ targets; aliases; aliases_rec ] in
     let targets =

--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -28,7 +28,7 @@ let trim =
          & info
              ~docv:"BYTES"
              [ "trimmed-size" ]
-             ~doc:"Size to trim from the cache. $(docv) is the same as for --size.")
+             ~doc:(Some "Size to trim from the cache. $(docv) is the same as for --size."))
      and+ size =
        Arg.(
          value
@@ -37,13 +37,14 @@ let trim =
              ~docv:"BYTES"
              [ "size" ]
              ~doc:
-               (sprintf
-                  "Size to trim the cache to. $(docv) is the number of bytes followed by \
-                   a unit. Byte units can be one of %s."
-                  (String.enumerate_or
-                     (List.map
-                        ~f:(fun (units, _) -> List.hd units)
-                        Bytes_unit.conversion_table))))
+               (Some
+                  (sprintf
+                     "Size to trim the cache to. $(docv) is the number of bytes followed \
+                      by a unit. Byte units can be one of %s."
+                     (String.enumerate_or
+                        (List.map
+                           ~f:(fun (units, _) -> List.hd units)
+                           Bytes_unit.conversion_table)))))
      in
      Log.init_disabled ();
      let open Result.O in
@@ -84,7 +85,9 @@ let size =
        Arg.(
          value
          & flag
-         & info [ "machine-readable" ] ~doc:"Outputs size as a plain number of bytes.")
+         & info
+             [ "machine-readable" ]
+             ~doc:(Some "Outputs size as a plain number of bytes."))
      in
      let size = Dune_cache.Trimmer.overhead_size () in
      if machine_readable

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -75,7 +75,7 @@ let debug_backtraces =
     & info
         [ "debug-backtraces" ]
         ~docs:copts_sect
-        ~doc:"Always print exception backtraces.")
+        ~doc:(Some "Always print exception backtraces."))
 ;;
 
 let default_build_dir = "_build"
@@ -94,7 +94,9 @@ let one_of term1 term2 =
 let build_info =
   let+ build_info =
     Arg.(
-      value & flag & info [ "build-info" ] ~docs:"OPTIONS" ~doc:"Show build information.")
+      value
+      & flag
+      & info [ "build-info" ] ~docs:"OPTIONS" ~doc:(Some "Show build information."))
   in
   if build_info
   then (
@@ -154,14 +156,14 @@ module Options_implied_by_dash_p = struct
                  [ "config-file" ]
                  ~docs
                  ~docv:"FILE"
-                 ~doc:"Load this configuration file instead of the default one.")
+                 ~doc:(Some "Load this configuration file instead of the default one."))
          in
          Option.map fn ~f:(fun fn -> This (Arg.Path.path fn)))
         (let+ x =
            Arg.(
              value
              & flag
-             & info [ "no-config" ] ~docs ~doc:"Do not load the configuration file")
+             & info [ "no-config" ] ~docs ~doc:(Some "Do not load the configuration file"))
          in
          Option.some_if x No_config)
     in
@@ -206,7 +208,12 @@ module Options_implied_by_dash_p = struct
       Arg.(
         value
         & opt (some dir) None
-        & info [ "root" ] ~docs ~docv:"DIR" ~doc ~env:(Cmd.Env.info ~doc "DUNE_ROOT"))
+        & info
+            [ "root" ]
+            ~docs
+            ~docv:"DIR"
+            ~doc:(Some doc)
+            ~env:(Cmd.Env.info ~doc "DUNE_ROOT"))
     and+ ignore_promoted_rules =
       Arg.(
         value
@@ -215,9 +222,10 @@ module Options_implied_by_dash_p = struct
             [ "ignore-promoted-rules" ]
             ~docs
             ~doc:
-              "Ignore rules with (mode promote), except ones with (only ...). The \
-               variable %{ignoring_promoted_rules} in dune files reflects whether this \
-               option was passed or not.")
+              (Some
+                 "Ignore rules with (mode promote), except ones with (only ...). The \
+                  variable %{ignoring_promoted_rules} in dune files reflects whether \
+                  this option was passed or not."))
     and+ config_from_config_file = config_term
     and+ default_target =
       Arg.(
@@ -228,26 +236,27 @@ module Options_implied_by_dash_p = struct
             ~docs
             ~docv:"TARGET"
             ~doc:
-              "Set the default target that is used when none is specified to $(b,dune \
-               build).")
+              (Some
+                 "Set the default target that is used when none is specified to $(b,dune \
+                  build)."))
     and+ always_show_command_line =
       let doc = "Always show the full command lines of programs executed by dune." in
-      Arg.(value & flag & info [ "always-show-command-line" ] ~docs ~doc)
+      Arg.(value & flag & info [ "always-show-command-line" ] ~docs ~doc:(Some doc))
     and+ promote_install_files =
       let doc = "Promote any generated <package>.install files to the source tree." in
       Arg.(
         last
         & opt_all ~vopt:true bool [ false ]
-        & info [ "promote-install-files" ] ~docs ~doc)
+        & info [ "promote-install-files" ] ~docs ~doc:(Some doc))
     and+ require_dune_project_file =
       let doc = "Fail if a dune-project file is missing." in
       Arg.(
         last
         & opt_all ~vopt:true bool [ false ]
-        & info [ "require-dune-project-file" ] ~docs ~doc)
+        & info [ "require-dune-project-file" ] ~docs ~doc:(Some doc))
     and+ ignore_lock_dir =
       let doc = "Ignore dune.lock/ directory." in
-      Arg.(value & flag & info [ "ignore-lock-dir" ] ~docs ~doc)
+      Arg.(value & flag & info [ "ignore-lock-dir" ] ~docs ~doc:(Some doc))
     in
     { root
     ; only_packages = No_restriction
@@ -285,12 +294,13 @@ module Options_implied_by_dash_p = struct
           ~docs
           ~docv:"PACKAGES"
           ~doc:
-            (sprintf
-               "Put $(b,dune) into a reproducible $(i,release) mode. Shorthand for \
-                $(b,%s). You should use this option for release builds. For instance, \
-                you must use this option in your $(i,<package>.opam) files. Except if \
-                you already use $(b,-p), as $(b,-p) implies this option."
-               (String.concat ~sep:" " shorthand_for)))
+            (Some
+               (sprintf
+                  "Put $(b,dune) into a reproducible $(i,release) mode. Shorthand for \
+                   $(b,%s). You should use this option for release builds. For instance, \
+                   you must use this option in your $(i,<package>.opam) files. Except if \
+                   you already use $(b,-p), as $(b,-p) implies this option."
+                  (String.concat ~sep:" " shorthand_for))))
   ;;
 
   let options =
@@ -306,12 +316,13 @@ module Options_implied_by_dash_p = struct
               ~docs
               ~docv:"PACKAGES"
               ~doc:
-                "Ignore stanzas referring to a package that is not in $(b,PACKAGES). \
-                 $(b,PACKAGES) is a comma-separated list of package names. Note that \
-                 this has the same effect as deleting the relevant stanzas from dune \
-                 files. It is mostly meant for releases. During development, it is \
-                 likely that what you want instead is to build a particular \
-                 $(b,<package>.install) target.")
+                (Some
+                   "Ignore stanzas referring to a package that is not in $(b,PACKAGES). \
+                    $(b,PACKAGES) is a comma-separated list of package names. Note that \
+                    this has the same effect as deleting the relevant stanzas from dune \
+                    files. It is mostly meant for releases. During development, it is \
+                    likely that what you want instead is to build a particular \
+                    $(b,<package>.install) target."))
       in
       match names with
       | None -> Only_packages.Clflags.No_restriction
@@ -330,10 +341,11 @@ module Options_implied_by_dash_p = struct
             ~docs
             ~docv:"PACKAGES"
             ~doc:
-              "Shorthand for $(b,--release --only-packages PACKAGE). You must use this \
-               option in your $(i,<package>.opam) files, in order to build only what's \
-               necessary when your project contains multiple packages as well as getting \
-               reproducible builds.")
+              (Some
+                 "Shorthand for $(b,--release --only-packages PACKAGE). You must use \
+                  this option in your $(i,<package>.opam) files, in order to build only \
+                  what's necessary when your project contains multiple packages as well \
+                  as getting reproducible builds."))
   ;;
 
   let term =
@@ -349,10 +361,11 @@ module Options_implied_by_dash_p = struct
             ~docs
             ~env:(Cmd.Env.info ~doc "DUNE_PROFILE")
             ~doc:
-              (Printf.sprintf
-                 "Select the build profile, for instance $(b,dev) or $(b,release). The \
-                  default is $(b,%s)."
-                 (Profile.to_string Profile.default)))
+              (Some
+                 (Printf.sprintf
+                    "Select the build profile, for instance $(b,dev) or $(b,release). \
+                     The default is $(b,%s)."
+                    (Profile.to_string Profile.default))))
     in
     match profile with
     | None -> t
@@ -367,7 +380,10 @@ let display_term =
        Arg.(
          value
          & flag
-         & info [ "verbose" ] ~docs:copts_sect ~doc:"Same as $(b,--display verbose)")
+         & info
+             [ "verbose" ]
+             ~docs:copts_sect
+             ~doc:(Some "Same as $(b,--display verbose)"))
      in
      Option.some_if verbose Dune_config.Display.verbose)
     Arg.(
@@ -380,7 +396,7 @@ let display_term =
       in
       value
       & opt (some (enum Display.all)) None
-      & info [ "display" ] ~docs:copts_sect ~docv:"MODE" ~doc)
+      & info [ "display" ] ~docs:copts_sect ~docv:"MODE" ~doc:(Some doc))
 ;;
 
 let shared_with_config_file =
@@ -399,7 +415,7 @@ let shared_with_config_file =
           [ "j" ]
           ~docs
           ~docv:"JOBS"
-          ~doc:"Run no more than $(i,JOBS) commands simultaneously.")
+          ~doc:(Some "Run no more than $(i,JOBS) commands simultaneously."))
   and+ sandboxing_preference =
     let all =
       List.map Dune_engine.Sandbox_mode.all_except_patch_back_source_tree ~f:(fun s ->
@@ -415,14 +431,15 @@ let shared_with_config_file =
                ~doc:"Sandboxing mode to use by default. (see --sandbox)"
                "DUNE_SANDBOX")
           ~doc:
-            (Printf.sprintf
-               "Set sandboxing mode. Some actions require a certain sandboxing mode, so \
-                they will ignore this setting. The allowed values are: %s."
-               (String.concat
-                  ~sep:", "
-                  (List.map
-                     Dune_engine.Sandbox_mode.all_except_patch_back_source_tree
-                     ~f:Dune_engine.Sandbox_mode.to_string))))
+            (Some
+               (Printf.sprintf
+                  "Set sandboxing mode. Some actions require a certain sandboxing mode, \
+                   so they will ignore this setting. The allowed values are: %s."
+                  (String.concat
+                     ~sep:", "
+                     (List.map
+                        Dune_engine.Sandbox_mode.all_except_patch_back_source_tree
+                        ~f:Dune_engine.Sandbox_mode.to_string)))))
   and+ terminal_persistence =
     let modes = Dune_config.Terminal_persistence.all in
     let doc =
@@ -435,7 +452,7 @@ let shared_with_config_file =
     Arg.(
       value
       & opt (some (enum modes)) None
-      & info [ "terminal-persistence" ] ~docs ~docv:"MODE" ~doc)
+      & info [ "terminal-persistence" ] ~docs ~docv:"MODE" ~doc:(Some doc))
   and+ display = display_term
   and+ cache_enabled =
     let doc =
@@ -447,7 +464,7 @@ let shared_with_config_file =
     Arg.(
       value
       & opt (some (enum Dune_config.Cache.Toggle.all)) None
-      & info [ "cache" ] ~docs ~env:(Cmd.Env.info ~doc "DUNE_CACHE") ~doc)
+      & info [ "cache" ] ~docs ~env:(Cmd.Env.info ~doc "DUNE_CACHE") ~doc:(Some doc))
   and+ cache_storage_mode =
     let doc =
       Printf.sprintf
@@ -462,7 +479,7 @@ let shared_with_config_file =
           [ "cache-storage-mode" ]
           ~docs
           ~env:(Cmd.Env.info ~doc "DUNE_CACHE_STORAGE_MODE")
-          ~doc)
+          ~doc:(Some doc))
   and+ cache_check_probability =
     let doc =
       Printf.sprintf
@@ -478,7 +495,7 @@ let shared_with_config_file =
           [ "cache-check-probability" ]
           ~docs
           ~env:(Cmd.Env.info ~doc "DUNE_CACHE_CHECK_PROBABILITY")
-          ~doc)
+          ~doc:(Some doc))
   and+ action_stdout_on_success =
     Arg.(
       value
@@ -486,12 +503,13 @@ let shared_with_config_file =
       & info
           [ "action-stdout-on-success" ]
           ~doc:
-            "Specify how to deal with the standard output of actions when they succeed. \
-             Possible values are: $(b,print) to just print it to Dune's output, \
-             $(b,swallow) to completely ignore it and $(b,must-be-empty) to enforce that \
-             the action printed nothing. With $(b,must-be-empty), Dune will consider \
-             that the action failed if it printed something to its standard output. The \
-             default is $(b,print).")
+            (Some
+               "Specify how to deal with the standard output of actions when they \
+                succeed. Possible values are: $(b,print) to just print it to Dune's \
+                output, $(b,swallow) to completely ignore it and $(b,must-be-empty) to \
+                enforce that the action printed nothing. With $(b,must-be-empty), Dune \
+                will consider that the action failed if it printed something to its \
+                standard output. The default is $(b,print)."))
   and+ action_stderr_on_success =
     Arg.(
       value
@@ -499,11 +517,12 @@ let shared_with_config_file =
       & info
           [ "action-stderr-on-success" ]
           ~doc:
-            "Same as $(b,--action-stdout-on-success) but for standard error instead of \
-             standard output. A good default for large mono-repositories is \
-             $(b,--action-stdout-on-success=swallow \
-             --action-stderr-on-success=must-be-empty). This ensures that a successful \
-             build has a \"clean\" empty output.")
+            (Some
+               "Same as $(b,--action-stdout-on-success) but for standard error instead \
+                of standard output. A good default for large mono-repositories is \
+                $(b,--action-stdout-on-success=swallow \
+                --action-stderr-on-success=must-be-empty). This ensures that a \
+                successful build has a \"clean\" empty output."))
   in
   { Dune_config.Partial.display
   ; concurrency
@@ -575,11 +594,12 @@ let cache_debug_flags_term : Cache_debug_flags.t Term.t =
           [ "debug-cache" ]
           ~docs:copts_sect
           ~doc:
-            (sprintf
-               "Show debug messages on cache misses for the given cache layers. Value is \
-                a comma-separated list of cache layer names. All available cache layers: \
-                %s."
-               all_layer_names))
+            (Some
+               (sprintf
+                  "Show debug messages on cache misses for the given cache layers. Value \
+                   is a comma-separated list of cache layer names. All available cache \
+                   layers: %s."
+                  all_layer_names)))
   in
   value initial
 ;;
@@ -664,8 +684,9 @@ module Builder = struct
             [ "debug-dependency-path" ]
             ~docs
             ~doc:
-              "In case of error, print the dependency path from the targets on the \
-               command line to the rule that failed.")
+              (Some
+                 "In case of error, print the dependency path from the targets on the \
+                  command line to the rule that failed."))
     and+ debug_backtraces = debug_backtraces
     and+ debug_artifact_substitution =
       Arg.(
@@ -674,7 +695,7 @@ module Builder = struct
         & info
             [ "debug-artifact-substitution" ]
             ~docs
-            ~doc:"Print debugging info about artifact substitution")
+            ~doc:(Some "Print debugging info about artifact substitution"))
     and+ debug_load_dir =
       Arg.(
         value
@@ -682,7 +703,7 @@ module Builder = struct
         & info
             [ "debug-load-dir" ]
             ~docs
-            ~doc:"Print debugging info about directory loading")
+            ~doc:(Some "Print debugging info about directory loading"))
     and+ debug_digests =
       Arg.(
         value
@@ -690,7 +711,7 @@ module Builder = struct
         & info
             [ "debug-digests" ]
             ~docs
-            ~doc:"Explain why Dune decides to re-digest some files")
+            ~doc:(Some "Explain why Dune decides to re-digest some files"))
     and+ debug_package_logs =
       let doc = "Always print the standard logs when building packages" in
       Arg.(
@@ -699,7 +720,7 @@ module Builder = struct
         & info
             [ "debug-package-logs" ]
             ~docs
-            ~doc
+            ~doc:(Some doc)
             ~env:(Cmd.Env.info ~doc "DUNE_DEBUG_PACKAGE_LOGS"))
     and+ no_buffer =
       let doc =
@@ -712,7 +733,7 @@ module Builder = struct
          interleaving. Additionally you should use $(b,--verbose) as well, to make sure \
          that commands are printed before they are being executed."
       in
-      Arg.(value & flag & info [ "no-buffer" ] ~docs ~docv:"DIR" ~doc)
+      Arg.(value & flag & info [ "no-buffer" ] ~docs ~docv:"DIR" ~doc:(Some doc))
     and+ workspace_file =
       let doc = "Use this specific workspace file instead of looking it up." in
       Arg.(
@@ -722,7 +743,7 @@ module Builder = struct
             [ "workspace" ]
             ~docs
             ~docv:"FILE"
-            ~doc
+            ~doc:(Some doc)
             ~env:(Cmd.Env.info ~doc "DUNE_WORKSPACE"))
     and+ promote =
       one_of
@@ -734,14 +755,15 @@ module Builder = struct
                  [ "auto-promote" ]
                  ~docs
                  ~doc:
-                   "Automatically promote files. This is similar to running $(b,dune \
-                    promote) after the build.")
+                   (Some
+                      "Automatically promote files. This is similar to running $(b,dune \
+                       promote) after the build."))
          in
          Option.some_if auto Dune_engine.Clflags.Promote.Automatically)
         (let+ disable =
            let doc = "Disable all promotion rules" in
            let env = Cmd.Env.info ~doc "DUNE_DISABLE_PROMOTION" in
-           Arg.(value & flag & info [ "disable-promotion" ] ~docs ~env ~doc)
+           Arg.(value & flag & info [ "disable-promotion" ] ~docs ~env ~doc:(Some doc))
          in
          Option.some_if disable Dune_engine.Clflags.Promote.Never)
     and+ force =
@@ -751,8 +773,9 @@ module Builder = struct
         & info
             [ "force"; "f" ]
             ~doc:
-              "Force actions associated to aliases to be re-executed even if their \
-               dependencies haven't changed.")
+              (Some
+                 "Force actions associated to aliases to be re-executed even if their \
+                  dependencies haven't changed."))
     and+ watch =
       let+ res =
         one_of
@@ -763,8 +786,9 @@ module Builder = struct
                & info
                    [ "watch"; "w" ]
                    ~doc:
-                     "Instead of terminating build after completion, wait continuously \
-                      for file changes.")
+                     (Some
+                        "Instead of terminating build after completion, wait \
+                         continuously for file changes."))
            in
            if watch then Some Dune_rpc_impl.Watch_mode_config.Eager else None)
           (let+ watch =
@@ -774,8 +798,9 @@ module Builder = struct
                & info
                    [ "passive-watch-mode" ]
                    ~doc:
-                     "Similar to [--watch], but only start a build when instructed \
-                      externally by an RPC.")
+                     (Some
+                        "Similar to [--watch], but only start a build when instructed \
+                         externally by an RPC."))
            in
            if watch then Some Dune_rpc_impl.Watch_mode_config.Passive else None)
       in
@@ -789,7 +814,7 @@ module Builder = struct
         & info
             [ "print-metrics" ]
             ~docs
-            ~doc:"Print out various performance metrics after every build.")
+            ~doc:(Some "Print out various performance metrics after every build."))
     and+ dump_memo_graph_file =
       Arg.(
         value
@@ -798,7 +823,7 @@ module Builder = struct
             [ "dump-memo-graph" ]
             ~docs
             ~docv:"FILE"
-            ~doc:"Dump the dependency graph to a file after the build is complete.")
+            ~doc:(Some "Dump the dependency graph to a file after the build is complete."))
     and+ dump_memo_graph_format =
       Arg.(
         value
@@ -807,7 +832,7 @@ module Builder = struct
             [ "dump-memo-graph-format" ]
             ~docs
             ~docv:"FORMAT"
-            ~doc:"Set the file format used by $(b,--dump-memo-graph)")
+            ~doc:(Some "Set the file format used by $(b,--dump-memo-graph)"))
     and+ dump_memo_graph_with_timing =
       Arg.(
         value
@@ -816,10 +841,11 @@ module Builder = struct
             [ "dump-memo-graph-with-timing" ]
             ~docs
             ~doc:
-              "Re-run each cached node in the Memo graph after building and include the \
-               run duration in the output of $(b,--dump-memo-graph). Since all nodes \
-               contain a cached value, each measurement will only account for a single \
-               node.")
+              (Some
+                 "Re-run each cached node in the Memo graph after building and include \
+                  the run duration in the output of $(b,--dump-memo-graph). Since all \
+                  nodes contain a cached value, each measurement will only account for a \
+                  single node."))
     and+ dump_gc_stats =
       Arg.(
         value
@@ -828,7 +854,9 @@ module Builder = struct
             [ "dump-gc-stats" ]
             ~docs
             ~docv:"FILE"
-            ~doc:"Dump the garbage collector stats to a file after the build is complete.")
+            ~doc:
+              (Some
+                 "Dump the garbage collector stats to a file after the build is complete."))
     and+ { Options_implied_by_dash_p.root
          ; only_packages
          ; ignore_promoted_rules
@@ -846,7 +874,7 @@ module Builder = struct
       Arg.(
         value
         & opt (some Arg.context_name) None
-        & info [ "x" ] ~docs ~doc:"Cross-compile using this toolchain.")
+        & info [ "x" ] ~docs ~doc:(Some "Cross-compile using this toolchain."))
     and+ build_dir =
       let doc = "Specified build directory. _build if unspecified" in
       Arg.(
@@ -857,7 +885,7 @@ module Builder = struct
             ~docs
             ~docv:"FILE"
             ~env:(Cmd.Env.info ~doc "DUNE_BUILD_DIR")
-            ~doc)
+            ~doc:(Some doc))
     and+ diff_command =
       let doc =
         "Shell command to use to diff files. Use - to disable printing the diff."
@@ -865,7 +893,11 @@ module Builder = struct
       Arg.(
         value
         & opt (some string) None
-        & info [ "diff-command" ] ~docs ~env:(Cmd.Env.info ~doc "DUNE_DIFF_COMMAND") ~doc)
+        & info
+            [ "diff-command" ]
+            ~docs
+            ~env:(Cmd.Env.info ~doc "DUNE_DIFF_COMMAND")
+            ~doc:(Some doc))
     and+ stats_trace_file =
       Arg.(
         value
@@ -875,7 +907,9 @@ module Builder = struct
             ~docs
             ~docv:"FILE"
             ~doc:
-              "Output trace data in catapult format (compatible with chrome://tracing).")
+              (Some
+                 "Output trace data in catapult format (compatible with \
+                  chrome://tracing)."))
     and+ stats_trace_extended =
       Arg.(
         value
@@ -883,7 +917,7 @@ module Builder = struct
         & info
             [ "trace-extended" ]
             ~docs
-            ~doc:"Output extended trace data (requires trace-file).")
+            ~doc:(Some "Output extended trace data (requires trace-file)."))
     and+ no_print_directory =
       Arg.(
         value
@@ -891,7 +925,7 @@ module Builder = struct
         & info
             [ "no-print-directory" ]
             ~docs
-            ~doc:"Suppress \"Entering directory\" messages.")
+            ~doc:(Some "Suppress \"Entering directory\" messages."))
     and+ store_orig_src_dir =
       let doc = "Store original source location in dune-package metadata." in
       Arg.(
@@ -901,7 +935,7 @@ module Builder = struct
             [ "store-orig-source-dir" ]
             ~docs
             ~env:(Cmd.Env.info ~doc "DUNE_STORE_ORIG_SOURCE_DIR")
-            ~doc)
+            ~doc:(Some doc))
     and+ () = build_info
     and+ instrument_with =
       let doc =
@@ -917,7 +951,7 @@ module Builder = struct
             ~docs
             ~env:(Cmd.Env.info ~doc "DUNE_INSTRUMENT_WITH")
             ~docv:"BACKENDS"
-            ~doc)
+            ~doc:(Some doc))
     and+ file_watcher =
       let doc =
         "Mechanism to detect changes in the source. Automatic to make dune run an \
@@ -930,7 +964,7 @@ module Builder = struct
             (enum
                [ "automatic", Dune_engine.Scheduler.Run.Automatic; "manual", No_watcher ])
             Automatic
-        & info [ "file-watcher" ] ~doc)
+        & info [ "file-watcher" ] ~doc:(Some doc))
     and+ watch_exclusions =
       let std_exclusions = Dune_config.standard_watch_exclusions in
       let doc =
@@ -947,7 +981,7 @@ module Builder = struct
         Arg.(
           value
           & opt_all (list ~sep:';' string) [ std_exclusions ]
-          & info [ "watch-exclusions" ] ~docs ~docv:"REGEX" ~doc)
+          & info [ "watch-exclusions" ] ~docs ~docv:"REGEX" ~doc:(Some doc))
       in
       Term.(const List.flatten $ arg)
     and+ wait_for_filesystem_clock =
@@ -957,13 +991,14 @@ module Builder = struct
         & info
             [ "wait-for-filesystem-clock" ]
             ~doc:
-              "Dune digest file contents for better incrementally. These digests are \
-               themselves cached. In some cases, Dune needs to drop some digest cache \
-               entries in order for things to be reliable. This option makes Dune wait \
-               for the file system clock to advance so that it doesn't need to drop \
-               anything. You should probably not care about this option; it is mostly \
-               useful for Dune developers to make Dune tests of the digest cache more \
-               reproducible.")
+              (Some
+                 "Dune digest file contents for better incrementally. These digests are \
+                  themselves cached. In some cases, Dune needs to drop some digest cache \
+                  entries in order for things to be reliable. This option makes Dune \
+                  wait for the file system clock to advance so that it doesn't need to \
+                  drop anything. You should probably not care about this option; it is \
+                  mostly useful for Dune developers to make Dune tests of the digest \
+                  cache more reproducible."))
     and+ cache_debug_flags = cache_debug_flags_term
     and+ report_errors_config =
       Arg.(
@@ -978,25 +1013,26 @@ module Builder = struct
         & info
             [ "error-reporting" ]
             ~doc:
-              "Controls when the build errors are reported. $(b,early) reports errors as \
-               soon as they are discovered. $(b,deterministic) reports errors at the end \
-               of the build in a deterministic order. $(b,twice) reports each error \
-               twice: once as soon as the error is discovered and then again at the end \
-               of the build, in a deterministic order.")
+              (Some
+                 "Controls when the build errors are reported. $(b,early) reports errors \
+                  as soon as they are discovered. $(b,deterministic) reports errors at \
+                  the end of the build in a deterministic order. $(b,twice) reports each \
+                  error twice: once as soon as the error is discovered and then again at \
+                  the end of the build, in a deterministic order."))
     and+ separate_error_messages =
       Arg.(
         value
         & flag
         & info
             [ "display-separate-messages" ]
-            ~doc:"Separate error messages with a blank line.")
+            ~doc:(Some "Separate error messages with a blank line."))
     and+ stop_on_first_error =
       Arg.(
         value
         & flag
         & info
             [ "stop-on-first-error" ]
-            ~doc:"Stop the build as soon as an error is encountered.")
+            ~doc:(Some "Stop the build as soon as an error is encountered."))
     in
     if Option.is_none stats_trace_file && stats_trace_extended
     then User_error.raise [ Pp.text "--trace-extended can only be used with --trace" ];

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -75,7 +75,7 @@ val envs : Cmdliner.Cmd.Env.info list
 val debug_backtraces : bool Cmdliner.Term.t
 val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 val display_term : Dune_config.Display.t option Cmdliner.Term.t
-val context_arg : doc:string -> Dune_engine.Context_name.t Cmdliner.Term.t
+val context_arg : doc:string option -> Dune_engine.Context_name.t Cmdliner.Term.t
 
 (** A [--build-info] command line argument that print build information
     (included in [term]) *)

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -21,18 +21,21 @@ let term =
   let+ default_builder = Common.Builder.term
   and+ context =
     let doc = "Run the Coq toplevel in this build context." in
-    Common.context_arg ~doc
+    Common.context_arg ~doc:(Some doc)
   and+ coqtop =
     let doc = "Run the given toplevel command instead of the default." in
-    Arg.(value & opt string "coqtop" & info [ "toplevel" ] ~docv:"CMD" ~doc)
+    Arg.(value & opt string "coqtop" & info [ "toplevel" ] ~docv:"CMD" ~doc:(Some doc))
   and+ coq_file_arg =
-    Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"COQFILE"))
-  and+ extra_args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS"))
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"COQFILE" ~doc:None))
+  and+ extra_args =
+    (* CR-someday Alizter: document this option *)
+    Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS" ~doc:None))
   and+ no_rebuild =
     Arg.(
       value
       & flag
-      & info [ "no-build" ] ~doc:"Don't rebuild dependencies before executing.")
+      & info [ "no-build" ] ~doc:(Some "Don't rebuild dependencies before executing."))
   in
   let common, config =
     let builder =

--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -2,9 +2,11 @@ open Import
 
 let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
   let+ builder = Common.Builder.term
-  and+ paths = Arg.(value & pos_all string [ "." ] & info [] ~docv:"DIR")
+  (* CR-someday Alizter: document this option *)
+  and+ paths = Arg.(value & pos_all string [ "." ] & info [] ~docv:"DIR" ~doc:None)
   and+ context =
-    Common.context_arg ~doc:"The context to look in. Defaults to the default context."
+    Common.context_arg
+      ~doc:(Some "The context to look in. Defaults to the default context.")
   in
   let common, config = Common.init builder in
   let request (_ : Dune_rules.Main.build_system) =

--- a/bin/describe/describe_depexts.ml
+++ b/bin/describe/describe_depexts.ml
@@ -10,7 +10,7 @@ let print_depexts context_name =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ context_name = Common.context_arg ~doc:"Build context to use." in
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.") in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () -> print_depexts context_name)

--- a/bin/describe/describe_external_lib_deps.ml
+++ b/bin/describe/describe_external_lib_deps.ml
@@ -201,7 +201,7 @@ let to_dyn context_name external_resolved_libs =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ context_name = Common.context_arg ~doc:"Build context to use."
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ _ = Describe_lang_compat.arg
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in

--- a/bin/describe/describe_format.ml
+++ b/bin/describe/describe_format.ml
@@ -8,7 +8,7 @@ let all = [ "sexp", Sexp; "csexp", Csexp ]
 
 let arg =
   let doc = Printf.sprintf "$(docv) must be %s" (Arg.doc_alts_enum all) in
-  Arg.(value & opt (enum all) Sexp & info [ "format" ] ~docv:"FORMAT" ~doc)
+  Arg.(value & opt (enum all) Sexp & info [ "format" ] ~docv:"FORMAT" ~doc:(Some doc))
 ;;
 
 let print_as_sexp dyn =

--- a/bin/describe/describe_lang_compat.ml
+++ b/bin/describe/describe_lang_compat.ml
@@ -6,6 +6,7 @@ let arg =
         [ "lang" ]
         ~docv:"VERSION"
         ~doc:
-          "This argument has no effect and is deprecated. It exists solely for backwards \
-           compatibility.")
+          (Some
+             "This argument has no effect and is deprecated. It exists solely for \
+              backwards compatibility."))
 ;;

--- a/bin/describe/describe_location.ml
+++ b/bin/describe/describe_location.ml
@@ -22,9 +22,11 @@ let info = Cmd.info "location" ~doc ~man
 
 let term : unit Term.t =
   let+ builder = Common.Builder.term
-  and+ context = Common.context_arg ~doc:{|Run the command in this build context.|}
+  and+ context = Common.context_arg ~doc:(Some {|Run the command in this build context.|})
   and+ prog =
-    Arg.(required & pos 0 (some Exec.Cmd_arg.conv) None (Arg.info [] ~docv:"PROG"))
+    (* CR-someday Alizter: document this option *)
+    Arg.(
+      required & pos 0 (some Exec.Cmd_arg.conv) None (Arg.info [] ~docv:"PROG" ~doc:None))
   in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config

--- a/bin/describe/describe_opam_files.ml
+++ b/bin/describe/describe_opam_files.ml
@@ -8,7 +8,7 @@ let term =
     let doc =
       "Print opam filenames, each on their own line. This ignores the --format argument."
     in
-    Arg.(value & flag & info [ "files" ] ~doc)
+    Arg.(value & flag & info [ "files" ] ~doc:(Some doc))
   in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config

--- a/bin/describe/describe_pkg.ml
+++ b/bin/describe/describe_pkg.ml
@@ -186,8 +186,9 @@ module List_locked_dependencies = struct
         & info
             [ "transitive" ]
             ~doc:
-              "Display transitive dependencies (by default only immediate dependencies \
-               are displayed)")
+              (Some
+                 "Display transitive dependencies (by default only immediate \
+                  dependencies are displayed)"))
     and+ lock_dirs = Pkg.Pkg_common.Lock_dirs_arg.term in
     let builder = Common.Builder.forbid_builds builder in
     let common, config = Common.init builder in

--- a/bin/describe/describe_pp.ml
+++ b/bin/describe/describe_pp.ml
@@ -157,9 +157,12 @@ let get_pped_file super_context file =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ context_name = Common.context_arg ~doc:"Build context to use."
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ _ = Describe_lang_compat.arg
-  and+ file = Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"FILE")) in
+  and+ file =
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some string) None (Arg.info [] ~docv:"FILE" ~doc:None))
+  in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config
   @@ fun () ->

--- a/bin/describe/describe_tests.ml
+++ b/bin/describe/describe_tests.ml
@@ -128,7 +128,7 @@ end
 
 let term : unit Term.t =
   let+ builder = Common.Builder.term
-  and+ context_name = Common.context_arg ~doc:"Build context to use."
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config

--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -19,7 +19,7 @@ module Options = struct
     & flag
     & info
         [ "with-deps" ]
-        ~doc:"Whether the dependencies between modules should be printed."
+        ~doc:(Some "Whether the dependencies between modules should be printed.")
   ;;
 
   let arg_with_pps =
@@ -29,8 +29,9 @@ module Options = struct
     & info
         [ "with-pps" ]
         ~doc:
-          "Whether the dependencies towards ppx-rewriters (that are called at compile \
-           time) should be taken into account."
+          (Some
+             "Whether the dependencies towards ppx-rewriters (that are called at compile \
+              time) should be taken into account.")
   ;;
 
   let arg_sanitize_for_tests =
@@ -40,8 +41,9 @@ module Options = struct
     & info
         [ "sanitize-for-tests" ]
         ~doc:
-          "Sanitize the absolute paths in workspace items, and the associated UIDs, so \
-           that the output is reproducible."
+          (Some
+             "Sanitize the absolute paths in workspace items, and the associated UIDs, \
+              so that the output is reproducible.")
   ;;
 
   let arg : t Term.t =
@@ -245,7 +247,7 @@ module Lang = struct
            & info
                [ "lang" ]
                ~docv:"VERSION"
-               ~doc:"Behave the same as this version of Dune.")
+               ~doc:(Some "Behave the same as this version of Dune."))
        in
        if v = (0, 1)
        then `Ok v
@@ -625,9 +627,11 @@ let term : unit Term.t =
           []
           ~docv:"DIRS"
           ~doc:
-            "prints a description of the workspace's structure. If some directories DIRS \
-             are provided, then only those directories of the workspace are considered.")
-  and+ context_name = Common.context_arg ~doc:"Build context to use."
+            (Some
+               "prints a description of the workspace's structure. If some directories \
+                DIRS are provided, then only those directories of the workspace are \
+                considered."))
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ format = Describe_format.arg
   and+ lang = Lang.arg
   and+ options = Options.arg in

--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -2,7 +2,7 @@ open Import
 
 let term =
   let+ builder = Common.Builder.term
-  and+ context_name = Common.context_arg ~doc:"Build context to use."
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
   and+ format = Describe_format.arg in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -300,11 +300,19 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
 
 let term : unit Term.t =
   let+ builder = Common.Builder.term
-  and+ context = Common.context_arg ~doc:{|Run the command in this build context.|}
-  and+ prog = Arg.(required & pos 0 (some Cmd_arg.conv) None (Arg.info [] ~docv:"PROG"))
+  and+ context = Common.context_arg ~doc:(Some {|Run the command in this build context.|})
+  and+ prog =
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some Cmd_arg.conv) None (Arg.info [] ~docv:"PROG" ~doc:None))
   and+ no_rebuild =
-    Arg.(value & flag & info [ "no-build" ] ~doc:"don't rebuild target before executing")
-  and+ args = Arg.(value & pos_right 0 Cmd_arg.conv [] (Arg.info [] ~docv:"ARGS")) in
+    Arg.(
+      value
+      & flag
+      & info [ "no-build" ] ~doc:(Some "don't rebuild target before executing"))
+  and+ args =
+    (* CR-someday Alizter: document this option *)
+    Arg.(value & pos_right 0 Cmd_arg.conv [] (Arg.info [] ~docv:"ARGS" ~doc:None))
+  in
   (* TODO we should make sure to finalize the current backend before exiting dune.
      For watch mode, we should finalize the backend and then restart it in between
      runs. *)

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -18,10 +18,11 @@ let info = Cmd.info "external-lib-deps" ~doc ~man
 let term =
   Term.ret
   @@ let+ _ = Common.Builder.term
-     and+ _ = Arg.(value & flag & info [ "missing" ] ~doc:{|unused|})
-     and+ _ = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET")
-     and+ _ = Arg.(value & flag & info [ "unstable-by-dir" ] ~doc:{|unused|})
-     and+ _ = Arg.(value & flag & info [ "sexp" ] ~doc:{|unused|}) in
+     and+ _ = Arg.(value & flag & info [ "missing" ] ~doc:(Some {|unused|}))
+     (* CR-someday Alizter: document this option *)
+     and+ _ = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET" ~doc:None)
+     and+ _ = Arg.(value & flag & info [ "unstable-by-dir" ] ~doc:(Some {|unused|}))
+     and+ _ = Arg.(value & flag & info [ "sexp" ] ~doc:(Some {|unused|})) in
      `Error (false, "This subcommand has been moved to dune describe external-lib-deps.")
 ;;
 

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -66,9 +66,10 @@ let command =
         & info
             [ "preview" ]
             ~doc:
-              "Just print the changes that would be made without actually applying them. \
-               This takes precedence over auto-promote as that flag is assumed for this \
-               command.")
+              (Some
+                 "Just print the changes that would be made without actually applying \
+                  them. This takes precedence over auto-promote as that flag is assumed \
+                  for this command."))
     in
     let builder =
       Common.Builder.set_promote builder (if preview then Never else Automatically)

--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -41,11 +41,11 @@ let term =
   let+ path_opt =
     let docv = "FILE" in
     let doc = "Path to the dune file to parse." in
-    Arg.(value & pos 0 (some file) None & info [] ~docv ~doc)
+    Arg.(value & pos 0 (some file) None & info [] ~docv ~doc:(Some doc))
   and+ version =
     let docv = "VERSION" in
     let doc = "Which version of Dune language to use." in
-    Arg.(value & opt (some version) None & info [ "dune-version" ] ~docv ~doc)
+    Arg.(value & opt (some version) None & info [ "dune-version" ] ~docv ~doc:(Some doc))
   and+ builder = Common.Builder.term in
   let version =
     match version with

--- a/bin/help.ml
+++ b/bin/help.ml
@@ -107,7 +107,9 @@ let info = Cmd.info "help" ~doc ~man ~envs:Common.envs
 let term =
   Term.ret
   @@ let+ man_format = Arg.man_format
-     and+ what = Arg.(value & pos 0 (some (enum commands)) None & info [] ~docv:"TOPIC")
+     and+ what =
+       (* CR-someday Alizter: document this option *)
+       Arg.(value & pos 0 (some (enum commands)) None & info [] ~docv:"TOPIC" ~doc:None)
      and+ () = Common.build_info in
      match what with
      | None -> `Help (man_format, Some "help")

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -70,7 +70,8 @@ let print_completion kind name =
 
 let path =
   let docv = "PATH" in
-  Arg.(value & pos 1 (some string) None & info [] ~docv)
+  (* CR-someday Alizter: document this option *)
+  Arg.(value & pos 1 (some string) None & info [] ~docv ~doc:None)
 ;;
 
 let context_cwd : Init_context.t Term.t =
@@ -118,13 +119,13 @@ end
 let libraries =
   let docv = "LIBRARIES" in
   let doc = "A comma separated list of libraries on which the component depends" in
-  Arg.(value & opt (list atom_conv) [] & info [ "libs" ] ~docv ~doc)
+  Arg.(value & opt (list atom_conv) [] & info [ "libs" ] ~docv ~doc:(Some doc))
 ;;
 
 let pps =
   let docv = "PREPROCESSORS" in
   let doc = "A comma separated list of ppx preprocessors used by the component" in
-  Arg.(value & opt (list atom_conv) [] & info [ "ppx" ] ~docv ~doc)
+  Arg.(value & opt (list atom_conv) [] & info [ "ppx" ] ~docv ~doc:(Some doc))
 ;;
 
 let public : Public_name.t option Term.t =
@@ -136,13 +137,14 @@ let public : Public_name.t option Term.t =
   Arg.(
     value
     & opt ~vopt:(Some Public_name.Use_name) (some Public_name.conv) None
-    & info [ "public" ] ~docv ~doc)
+    & info [ "public" ] ~docv ~doc:(Some doc))
 ;;
 
 let common : Component.Options.Common.t Term.t =
   let+ name =
     let docv = "NAME" in
-    Arg.(required & pos 0 (some component_name_conv) None & info [] ~docv)
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some component_name_conv) None & info [] ~docv ~doc:None)
   and+ public = public
   and+ libraries = libraries
   and+ pps = pps in
@@ -153,7 +155,8 @@ let common : Component.Options.Common.t Term.t =
 let project_common : Component.Options.Common.t Term.t =
   let+ project_name =
     let docv = "NAME" in
-    Arg.(required & pos 0 (some project_name_conv) None & info [] ~docv)
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some project_name_conv) None & info [] ~docv ~doc:None)
   and+ libraries = libraries
   and+ pps = pps in
   let public = Dune_project_name.to_string_hum project_name in
@@ -177,7 +180,7 @@ let inline_tests : bool Term.t =
     "Whether to use inline tests. Only applicable for $(b,library) and $(b,project) \
      components."
   in
-  Arg.(value & flag & info [ "inline-tests" ] ~docv ~doc)
+  Arg.(value & flag & info [ "inline-tests" ] ~docv ~doc:(Some doc))
 ;;
 
 let opt_default ~default term = Term.(const (Option.value ~default) $ term)
@@ -245,7 +248,7 @@ let project =
          Arg.(
            value
            & opt (some (enum Component.Options.Project.Template.commands)) None
-           & info [ "kind" ] ~docv ~doc)
+           & info [ "kind" ] ~docv ~doc:(Some doc))
      and+ pkg =
        let docv = "PACKAGE_MANAGER" in
        let doc =
@@ -257,7 +260,7 @@ let project =
          Arg.(
            value
            & opt (some (enum Component.Options.Project.Pkg.commands)) None
-           & info [ "pkg" ] ~docv ~doc)
+           & info [ "pkg" ] ~docv ~doc:(Some doc))
      in
      let name =
        match common.public with

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -691,7 +691,8 @@ let run
 
 let make ~what =
   let doc = Format.asprintf "%a packages defined in the workspace." pp_what what in
-  let name_ = Arg.info [] ~docv:"PACKAGE" in
+  (* CR-someday Alizter: document this option *)
+  let name_ = Arg.info [] ~docv:"PACKAGE" ~doc:None in
   let absolute_path =
     Arg.conv'
       ( (fun path ->
@@ -711,8 +712,9 @@ let make ~what =
             ~env:(Cmd.Env.info "DUNE_INSTALL_PREFIX")
             ~docv:"PREFIX"
             ~doc:
-              "Directory where files are copied. For instance binaries are copied into \
-               $(i,\\$prefix/bin), library files into $(i,\\$prefix/lib), etc...")
+              (Some
+                 "Directory where files are copied. For instance binaries are copied \
+                  into $(i,\\$prefix/bin), library files into $(i,\\$prefix/lib), etc..."))
     and+ destdir =
       Arg.(
         value
@@ -721,7 +723,7 @@ let make ~what =
             [ "destdir" ]
             ~env:(Cmd.Env.info "DESTDIR")
             ~docv:"PATH"
-            ~doc:"This directory is prepended to all installed paths.")
+            ~doc:(Some "This directory is prepended to all installed paths."))
     and+ libdir_from_command_line =
       Arg.(
         value
@@ -730,59 +732,80 @@ let make ~what =
             [ "libdir" ]
             ~docv:"PATH"
             ~doc:
-              "Directory where library files are copied, relative to $(b,prefix) or \
-               absolute. If $(b,--prefix) is specified the default is \
-               $(i,\\$prefix/lib). Only absolute path accepted.")
+              (Some
+                 "Directory where library files are copied, relative to $(b,prefix) or \
+                  absolute. If $(b,--prefix) is specified the default is \
+                  $(i,\\$prefix/lib). Only absolute path accepted."))
     and+ mandir_from_command_line =
       let doc =
         "Manually override the directory to install man pages. Only absolute path \
          accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "mandir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "mandir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ docdir_from_command_line =
       let doc =
         "Manually override the directory to install documentation files. Only absolute \
          path accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "docdir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "docdir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ etcdir_from_command_line =
       let doc =
         "Manually override the directory to install configuration files. Only absolute \
          path accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "etcdir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "etcdir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ bindir_from_command_line =
       let doc =
         "Manually override the directory to install public binaries. Only absolute path \
          accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "bindir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "bindir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ sbindir_from_command_line =
       let doc =
         "Manually override the directory to install files from sbin section. Only \
          absolute path accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "sbindir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "sbindir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ datadir_from_command_line =
       let doc =
         "Manually override the directory to install files from share section. Only \
          absolute path accepted."
       in
-      Arg.(value & opt (some absolute_path) None & info [ "datadir" ] ~docv:"PATH" ~doc)
+      Arg.(
+        value
+        & opt (some absolute_path) None
+        & info [ "datadir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ libexecdir_from_command_line =
       let doc =
         "Manually override the directory to install executable library files. Only \
          absolute path accepted."
       in
       Arg.(
-        value & opt (some absolute_path) None & info [ "libexecdir" ] ~docv:"PATH" ~doc)
+        value
+        & opt (some absolute_path) None
+        & info [ "libexecdir" ] ~docv:"PATH" ~doc:(Some doc))
     and+ dry_run =
       Arg.(
         value
         & flag
         & info
             [ "dry-run" ]
-            ~doc:"Only display the file operations that would be performed.")
+            ~doc:(Some "Only display the file operations that would be performed."))
     and+ relocatable =
       Arg.(
         value
@@ -790,8 +813,9 @@ let make ~what =
         & info
             [ "relocatable" ]
             ~doc:
-              "Make the binaries relocatable (the installation directory can be moved). \
-               The installation directory must be specified with --prefix")
+              (Some
+                 "Make the binaries relocatable (the installation directory can be \
+                  moved). The installation directory must be specified with --prefix"))
     and+ create_install_files =
       Arg.(
         value
@@ -799,8 +823,10 @@ let make ~what =
         & info
             [ "create-install-files" ]
             ~doc:
-              "Do not directly install, but create install files in the root directory \
-               and create substituted files if needed in destdir (_destdir by default).")
+              (Some
+                 "Do not directly install, but create install files in the root \
+                  directory and create substituted files if needed in destdir (_destdir \
+                  by default)."))
     and+ pkgs = Arg.(value & pos_all package_name [] name_)
     and+ context =
       Arg.(
@@ -810,8 +836,9 @@ let make ~what =
             [ "context" ]
             ~docv:"CONTEXT"
             ~doc:
-              "Select context to install from. By default, install files from all \
-               defined contexts.")
+              (Some
+                 "Select context to install from. By default, install files from all \
+                  defined contexts."))
     and+ sections = Sections.term in
     let builder = Common.Builder.forbid_builds builder in
     let builder = Common.Builder.disable_log_file builder in

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -11,7 +11,7 @@ let term =
       & flag
       & info
           [ "na"; "not-available" ]
-          ~doc:"List libraries that are not available and explain why")
+          ~doc:(Some "List libraries that are not available and explain why"))
   in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server

--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -15,7 +15,10 @@ let info = Cmd.info "dump" ~doc ~man
 
 let term =
   let+ builder = Common.Builder.term
-  and+ file = Arg.(required & pos 0 (some Arg.path) None & Arg.info [] ~docv:"FILE") in
+  and+ file =
+    (* CR-someday Alizter: document this option *)
+    Arg.(required & pos 0 (some Arg.path) None & Arg.info [] ~docv:"FILE" ~doc:None)
+  in
   let _common, _config = Common.init builder in
   let (Persistent.T ((module D), data)) = Persistent.load_exn (Arg.Path.path file) in
   Console.print [ Dyn.pp (D.to_dyn data) ]

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -272,7 +272,7 @@ let command =
         & flag
         & info
             [ "quit-on-disconnect" ]
-            ~doc:"Quit if the connection to the server is lost.")
+            ~doc:(Some "Quit if the connection to the server is lost."))
     in
     let builder = Common.Builder.forbid_builds builder in
     let builder = Common.Builder.disable_log_file builder in

--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -17,7 +17,8 @@ module Selected_context = struct
       & info
           [ "context" ]
           ~docv:"CONTEXT"
-          ~doc:"Select the Dune build context that will be used to return information")
+          ~doc:
+            (Some "Select the Dune build context that will be used to return information"))
   ;;
 end
 
@@ -218,7 +219,8 @@ module Dump_config = struct
 
   let term =
     let+ builder = Common.Builder.term
-    and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH")
+    (* CR-someday Alizter: document this option *)
+    and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH" ~doc:None)
     and+ selected_context = Selected_context.arg in
     let common, config =
       let builder =
@@ -291,8 +293,9 @@ module Dump_dot_merlin = struct
             []
             ~docv:"PATH"
             ~doc:
-              "The path to the folder of which the configuration should be printed. \
-               Defaults to the current directory.")
+              (Some
+                 "The path to the folder of which the configuration should be printed. \
+                  Defaults to the current directory."))
     and+ selected_context = Selected_context.arg in
     let common, config =
       let builder =

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -42,8 +42,11 @@ let files_to_load_of_requires sctx requires =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
-  and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run top.|} in
+  (* CR-someday Alizter: document this option *)
+  and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR" ~doc:None)
+  and+ ctx_name =
+    Common.context_arg ~doc:(Some {|Select context where to build/run top.|})
+  in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->
     let open Fiber.O in
@@ -217,8 +220,10 @@ module Module = struct
       Arg.(
         required
         & pos 0 (some string) None
-        & Arg.info [] ~docv:"MODULE" ~doc:"Path to an OCaml module.")
-    and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run top.|} in
+        & Arg.info [] ~docv:"MODULE" ~doc:(Some "Path to an OCaml module."))
+    and+ ctx_name =
+      Common.context_arg ~doc:(Some {|Select context where to build/run top.|})
+    in
     let common, config = Common.init builder in
     Scheduler.go_with_rpc_server ~common ~config (fun () ->
       let open Fiber.O in

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -21,9 +21,12 @@ let lock_utop_if_dev_tool_enabled () =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR")
-  and+ ctx_name = Common.context_arg ~doc:{|Select context where to build/run utop.|}
-  and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
+  (* CR-someday Alizter: document this option *)
+  and+ dir = Arg.(value & pos 0 string "" & Arg.info [] ~docv:"DIR" ~doc:None)
+  and+ ctx_name =
+    Common.context_arg ~doc:(Some {|Select context where to build/run utop.|})
+  (* CR-someday Alizter: document this option *)
+  and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS" ~doc:None)) in
   let common, config = Common.init builder in
   let dir = Common.prefix_target common dir in
   if not (Path.is_directory (Path.of_string dir))

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -541,7 +541,8 @@ let term =
   let+ builder = Common.Builder.term
   and+ version_preference = Version_preference.term
   and+ lock_dirs_arg = Pkg_common.Lock_dirs_arg.term
-  and+ print_perf_stats = Arg.(value & flag & info [ "print-perf-stats" ]) in
+  (* CR-someday Alizter: document this option *)
+  and+ print_perf_stats = Arg.(value & flag & info [ "print-perf-stats" ] ~doc:None) in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->

--- a/bin/pkg/outdated.ml
+++ b/bin/pkg/outdated.ml
@@ -72,7 +72,7 @@ let term =
       & flag
       & info
           [ "transitive" ]
-          ~doc:"Check for outdated packages in transitive dependencies")
+          ~doc:(Some "Check for outdated packages in transitive dependencies"))
   and+ lock_dirs_arg = Pkg_common.Lock_dirs_arg.term in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -74,7 +74,7 @@ module Version_preference = struct
     Arg.(
       value
       & opt (some (enum all_by_string)) None
-      & info [ "version-preference" ] ~doc ~docv)
+      & info [ "version-preference" ] ~doc:(Some doc) ~docv)
   ;;
 
   let choose ~from_arg ~from_context =
@@ -181,7 +181,9 @@ module Lock_dirs_arg = struct
                []
                ~docv:"LOCKDIRS"
                ~doc:
-                 "Lock directories to check for outdated packages. Defaults to dune.lock.")
+                 (Some
+                    "Lock directories to check for outdated packages. Defaults to \
+                     dune.lock."))
        in
        Selected (List.map arg ~f:Path.Source.of_string))
       (let+ _all =
@@ -190,7 +192,9 @@ module Lock_dirs_arg = struct
            & flag
            & info
                [ "all" ]
-               ~doc:"Check all lock directories in the workspace for outdated packages.")
+               ~doc:
+                 (Some
+                    "Check all lock directories in the workspace for outdated packages."))
        in
        All)
   ;;

--- a/bin/pkg/print_digest.ml
+++ b/bin/pkg/print_digest.ml
@@ -6,8 +6,10 @@ let term =
     Arg.(
       required
       & pos 0 (some string) None
-      & info [] ~doc:"The name of the package" ~docv:"PACKAGE")
-  and+ context_name = Common.context_arg ~doc:"Context used to determine lockdir" in
+      & info [] ~doc:(Some "The name of the package") ~docv:"PACKAGE")
+  and+ context_name =
+    Common.context_arg ~doc:(Some "Context used to determine lockdir")
+  in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   let package_name =

--- a/bin/pkg/search.ml
+++ b/bin/pkg/search.ml
@@ -107,7 +107,8 @@ let search_packages ~query () =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ query = Arg.(value & pos 0 (some string) None & info [] ~docv:"QUERY") in
+  (* CR-someday Alizter: document this option *)
+  and+ query = Arg.(value & pos 0 (some string) None & info [] ~docv:"QUERY" ~doc:None) in
   let builder = Common.Builder.forbid_builds builder in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -185,7 +185,7 @@ module Syntax = struct
 
   let term =
     let doc = "Output the rules in Makefile syntax." in
-    let+ makefile = Arg.(value & flag & info [ "m"; "makefile" ] ~doc) in
+    let+ makefile = Arg.(value & flag & info [ "m"; "makefile" ] ~doc:(Some doc)) in
     if makefile then Makefile else Sexp
   ;;
 
@@ -263,7 +263,7 @@ let term =
     Arg.(
       value
       & opt (some string) None
-      & info [ "o" ] ~docv:"FILE" ~doc:"Output to a file instead of stdout.")
+      & info [ "o" ] ~docv:"FILE" ~doc:(Some "Output to a file instead of stdout."))
   and+ recursive =
     Arg.(
       value
@@ -271,10 +271,12 @@ let term =
       & info
           [ "r"; "recursive" ]
           ~doc:
-            "Print all rules needed to build the transitive dependencies of the given \
-             targets.")
+            (Some
+               "Print all rules needed to build the transitive dependencies of the given \
+                targets."))
   and+ syntax = Syntax.term
-  and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
+  (* CR-someday Alizter: document this option *)
+  and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET" ~doc:None) in
   let common, config = Common.init builder in
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -74,7 +74,8 @@ let pp ppf ~fields sexps =
 
 let term =
   let+ builder = Common.Builder.term
-  and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH")
+  (* CR-someday Alizter: document this option *)
+  and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH" ~doc:None)
   and+ fields =
     Arg.(
       value
@@ -83,8 +84,9 @@ let term =
           [ "field" ]
           ~docv:"FIELD"
           ~doc:
-            "Only print this field. This option can be repeated multiple times to print \
-             multiple fields.")
+            (Some
+               "Only print this field. This option can be repeated multiple times to \
+                print multiple fields."))
   in
   let common, config = Common.init builder in
   Scheduler.go_with_rpc_server ~common ~config (fun () ->

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -52,7 +52,10 @@ module Apply = struct
 
   let term =
     let+ builder = Common.Builder.term
-    and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
+    and+ files =
+      (* CR-someday Alizter: document this option *)
+      Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE" ~doc:None)
+    in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
     match Dune_util.Global_lock.lock ~timeout:None with
@@ -82,7 +85,10 @@ module Diff = struct
 
   let term =
     let+ builder = Common.Builder.term
-    and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
+    and+ files =
+      (* CR-someday Alizter: document this option *)
+      Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE" ~doc:None)
+    in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
     Scheduler.go_with_rpc_server ~common ~config (fun () ->
@@ -97,7 +103,10 @@ module Files = struct
 
   let term =
     let+ builder = Common.Builder.term
-    and+ files = Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE") in
+    and+ files =
+      (* CR-someday Alizter: document this option *)
+      Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE" ~doc:None)
+    in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
     Scheduler.go_with_rpc_server ~common ~config (fun () ->

--- a/bin/rpc/rpc_build.ml
+++ b/bin/rpc/rpc_build.ml
@@ -1,7 +1,8 @@
 open Import
 
 let term =
-  let name_ = Arg.info [] ~docv:"TARGET" in
+  (* CR-someday Alizter: document this option *)
+  let name_ = Arg.info [] ~docv:"TARGET" ~doc:None in
   let+ (builder : Common.Builder.t) = Common.Builder.term
   and+ wait = Rpc_common.wait_term
   and+ targets = Arg.(value & pos_all string [] name_) in

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -60,7 +60,7 @@ let client_term builder f =
 
 let wait_term =
   let doc = "Poll until server starts listening and then establish connection." in
-  Arg.(value & flag & info [ "wait" ] ~doc)
+  Arg.(value & flag & info [ "wait" ] ~doc:(Some doc))
 ;;
 
 let establish_connection () =

--- a/bin/rpc/rpc_status.ml
+++ b/bin/rpc/rpc_status.ml
@@ -100,8 +100,9 @@ let term =
       & info
           [ "all" ]
           ~doc:
-            "Show all running Dune instances together with their root, pids and number \
-             of clients.")
+            (Some
+               "Show all running Dune instances together with their root, pids and \
+                number of clients."))
   in
   Rpc_common.client_term builder
   @@ fun () ->

--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -34,7 +34,8 @@ let runtest_info =
 ;;
 
 let runtest_term =
-  let name = Arg.info [] ~docv:"TEST" in
+  (* CR-someday Alizter: document this option *)
+  let name = Arg.info [] ~docv:"TEST" ~doc:None in
   let+ builder = Common.Builder.term
   and+ test_paths = Arg.(value & pos_all string [ "." ] name) in
   let common, config = Common.init builder in

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -88,10 +88,11 @@ let which_command dev_tool =
         & info
             [ "allow-not-installed" ]
             ~doc:
-              (sprintf
-                 "If %s is not installed as a dev tool, still print where it would be \
-                  installed."
-                 exe_name))
+              (Some
+                 (sprintf
+                    "If %s is not installed as a dev tool, still print where it would be \
+                     installed."
+                    exe_name)))
     in
     let _ : Common.t * Dune_config_file.Dune_config.t = Common.init builder in
     if allow_not_installed || Path.exists exe_path
@@ -128,7 +129,8 @@ let exec_command dev_tool =
   let exe_name = Pkg_dev_tool.exe_name dev_tool in
   let term =
     let+ builder = Common.Builder.term
-    and+ args = Arg.(value & pos_all string [] (info [] ~docv:"ARGS")) in
+    (* CR-someday Alizter: document this option *)
+    and+ args = Arg.(value & pos_all string [] (info [] ~docv:"ARGS" ~doc:None)) in
     let common, config = Common.init builder in
     lock_build_and_run_dev_tool ~common ~config builder dev_tool ~args
   in
@@ -156,7 +158,9 @@ let env_command =
       Arg.(
         value
         & flag
-        & info [ "fish" ] ~doc:"Print command for the fish shell rather than POSIX shells")
+        & info
+            [ "fish" ]
+            ~doc:(Some "Print command for the fish shell rather than POSIX shells"))
     in
     let _ : Common.t * Dune_config.t = Common.init builder in
     if fish


### PR DESCRIPTION
A common issue we have is undocumented arguments. It doesn't help that cmdliner hides the doc argument making it easy to miss. This is a common point of confusion for users https://github.com/ocaml/dune/issues/12722. In order to aid this we make the argument explicit. This makes it more apparent what is documented and what isn't.