### PR TITLE
Fix dependencies of utop dev tool

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -388,3 +388,30 @@ jobs:
       - run: |
           nix develop .#ox-minimal -c ocaml --version
           nix develop .#ox-minimal -c make test-ox
+
+  utop-dev-tool-test:
+    name: Test that the utop dev tool can be built and run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
+      - name: Set up a project, install utop as a dev tool, and run it
+        shell: nix shell -c bash -e {0}
+        run: |
+          cd $(mktemp -d)
+          dune init project foo
+          cd foo
+          echo 'let message = "Hello, World!"' > lib/foo.ml
+          echo 'print_endline Foo.message' > script.ml
+          dune pkg lock
+          dune tools install utop
+          dune utop . script.ml
+

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2418,9 +2418,12 @@ let ocaml_toolchain context =
 
 let all_deps universe =
   let* db =
-    (* Disallow sharing so that the only packages in the DB are the ones from
-       the universe's respective lock directory. *)
-    DB.of_ctx (Package_universe.context_name universe) ~allow_sharing:false
+    match (universe : Package_universe.t) with
+    | Dependencies ctx ->
+      (* Disallow sharing so that the only packages in the DB are the ones from
+         the universe's respective lock directory. *)
+      DB.of_ctx ctx ~allow_sharing:false
+    | Dev_tool tool -> DB.of_dev_tool tool >>| fst
   in
   Pkg_digest.Map.values db.pkg_digest_table
   |> Memo.parallel_map ~f:(fun { DB.Pkg_table.pkg_digest; _ } ->


### PR DESCRIPTION
This fixes a bug in computing dependencies of a dev tool package when using dune package management. It only affected the utop dev tool. This change also adds an integration test for the utop dev tool. The test is a github action workflow rather than a cram test so that the real utop package can be tested, since the utop rules have some logic which is specific to the utop package and thus is non-trivial to accurately test with a mock utop package as we do with other dev tool tests.