### PR TITLE
disable warnings on windows and macos

### DIFF
--- a/vendor/ocaml-blake3-mini/dune
+++ b/vendor/ocaml-blake3-mini/dune
@@ -4,8 +4,7 @@
  (foreign_archives blake3)
  (foreign_stubs
   (language c)
-  (names blake3_stubs)
-  (flags :standard -O3)))
+  (names blake3_stubs)))
 
 ; There are 3 configrations for the blake3 rules:
 ; 1. Handwritten assembly for x86_64

--- a/vendor/ocaml-inotify/src/dune
+++ b/vendor/ocaml-inotify/src/dune
@@ -1,5 +1,24 @@
+(rule
+ (enabled_if
+  (= %{ocaml-config:ccomp_type} "msvc"))
+ (target c_flags.sexp)
+ (action
+  (write-file %{target} "()")))
+
+(rule
+ (enabled_if
+  (<> %{ocaml-config:ccomp_type} "msvc"))
+ (target c_flags.sexp)
+ (action
+  (write-file %{target} "(-Wno-unused-variable)")))
+
 (library
  (name ocaml_inotify)
- (wrapped   true)
- (foreign_stubs (language c) (names inotify_stubs))
- (flags     (-w -3-6-27-32-33-35-50)))
+ (foreign_stubs
+  (language c)
+  (flags
+   :standard
+   (:include c_flags.sexp))
+  (names inotify_stubs))
+ (flags
+  (-w -3-6-27-32-33-35-50)))

--- a/vendor/ocaml-lmdb/dune
+++ b/vendor/ocaml-lmdb/dune
@@ -4,5 +4,9 @@
  (libraries unix bigstringaf)
  (foreign_stubs
   (language c)
-  (flags :standard -I .)
+  (flags
+   :standard
+   -I
+   .
+   (:include flags/c_flags.sexp))
   (names lmdb_stubs mdb midl)))

--- a/vendor/ocaml-lmdb/flags/dune
+++ b/vendor/ocaml-lmdb/flags/dune
@@ -1,0 +1,4 @@
+(rule
+ (with-stdout-to
+  c_flags.sexp
+  (run %{ocaml} %{dep:gen_c_flags.ml} %{ocaml-config:ccomp_type})))

--- a/vendor/ocaml-lmdb/flags/gen_c_flags.ml
+++ b/vendor/ocaml-lmdb/flags/gen_c_flags.ml
@@ -1,0 +1,19 @@
+let flags =
+  if (not Sys.win32) || Array.length Sys.argv < 2
+  then "()"
+  else
+    (if Sys.argv.(1) = "msvc"
+     then
+       [ "/wd5287"; "/wd4333"; "/wd4172"; "/wd4146"; "/wd4244" ]
+       |> List.map (Printf.sprintf "%S")
+     else
+       [ "-Wno-return-local-addr"
+       ; "-Wno-unused-label"
+       ; "-Wno-unused-but-set-variable"
+       ; "-Wno-format"
+       ])
+    |> String.concat " "
+    |> Printf.sprintf "(%s)"
+;;
+
+let () = print_endline flags

--- a/vendor/update-ocaml-inotify.sh
+++ b/vendor/update-ocaml-inotify.sh
@@ -27,4 +27,5 @@ cp -v "$SRC"/lib/*.{ml,mli,c} "$lib_name"/src
 cp -v "$SRC"/lib/dune "$lib_name"/src
 cp -v "$SRC"/LICENSE.txt "$lib_name"/
 
+git checkout "$lib_name"/src/dune
 git add -A .

--- a/vendor/update-ocaml-lmdb.sh
+++ b/vendor/update-ocaml-lmdb.sh
@@ -49,5 +49,6 @@ sed -i.bak '/^#ifndef MDB_USE_ROBUST/i\
 ' ocaml-lmdb/mdb.c && rm ocaml-lmdb/mdb.c.bak
 
 git checkout ocaml-lmdb/dune
+git checkout ocaml-lmdb/flags
 git add -A .
 


### PR DESCRIPTION
This PR disables the specific warnings we get when compiling lmdb and it's OCaml stubs on Windows (msvc and mingw only). We don't intend to fix them so they are just noise for our CI.