### PR TITLE
fix(fswatch_win): avoid use after free()

### DIFF
--- a/src/fswatch_win/fswatch_win_stubs.c
+++ b/src/fswatch_win/fswatch_win_stubs.c
@@ -502,10 +502,13 @@ value fswatch_win_shutdown(value v_fsenv) {
   CloseHandle(fsenv->signal);
   CloseHandle(fsenv->afterAdd);
 
-  for (struct events *e = pop_events(fsenv); e; e = e->next) {
+  struct events *e = pop_events(fsenv);
+  while (e != NULL) {
     free(e->path);
     free(e->buffer);
+    struct events *next = e->next;
     free(e);
+    e = next;
   }
 
   caml_acquire_runtime_system();


### PR DESCRIPTION
I noticed this when disabling warnings in #12750. We were accessing `e` after having freed it. This patch will delay the free until after we access the next event.