### PR TITLE
Remove dune-*-experimental

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,17 +78,6 @@
           dune-static-overlay
         ];
 
-        add-experimental-configure-flags =
-          pkg:
-          pkg.overrideAttrs {
-            configureFlags = [
-              "--lock-dev-tool"
-              "enable"
-              "--portable-lock-dir"
-              "enable"
-            ];
-          };
-
         ocamlformat =
           let
             ocamlformat_version =
@@ -174,8 +163,6 @@
             };
           dune = self.packages.${system}.default;
           dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
-          dune-experimental = add-experimental-configure-flags self.packages.${system}.dune;
-          dune-static-experimental = add-experimental-configure-flags self.packages.${system}.dune-static;
         };
 
         devShells =


### PR DESCRIPTION
I'll preface with the fact that I don't know much about Nix or Flakes, so I'm asking reviewers to be extra vigilant when reviewing this:

As we don't want to enable configure flags by default in the nightly anymore, the nightly can just use dune/dune-static going forward. Thus I've removed the `dune-experimental` variants.

Currently a draft, until https://github.com/ocaml-dune/binary-distribution/pull/171 is merged to avoid merging too early, thus breaking the current preview builds.