### PR TITLE
Fix ocamlobjinfo output parsing

### DIFF
--- a/src/dune_rules/ocamlobjinfo.mll
+++ b/src/dune_rules/ocamlobjinfo.mll
@@ -31,10 +31,12 @@ and intfs acc_units acc = parse
   | ws hash ws (name as name) newline { intfs acc_units (add_intf acc name) lexbuf }
   | "Implementations imported:" newline { impls acc_units acc lexbuf }
   | "File " [^ '\n']+ newline { ocamlobjinfo (acc :: acc_units) empty lexbuf }
+  | [^ '\n' ]* newline { intfs acc_units acc lexbuf }
   | _ | eof { acc :: acc_units }
 and impls acc_units acc = parse
   | ws hash ws (name as name) newline { impls acc_units (add_impl acc name) lexbuf }
   | "File " [^ '\n']+ newline { ocamlobjinfo (acc :: acc_units) empty lexbuf }
+  | [^ '\n' ]* newline {  impls acc_units acc lexbuf }
   | _ | eof { acc :: acc_units }
 
 and archive acc = parse

--- a/test/expect-tests/ocamlobjinfo_tests.ml
+++ b/test/expect-tests/ocamlobjinfo_tests.ml
@@ -248,5 +248,10 @@ Required globals:
 Uses unsafe features: no
 Force link: no
 |fixture};
-  [%expect {| [ { impl = set {}; intf = set { "m1"; "m2" } } ] |}]
+  [%expect
+    {|
+    [ { impl = set {}; intf = set { "m1"; "m2" } }
+    ; { impl = set {}; intf = set { "m3"; "m4" } }
+    ]
+    |}]
 ;;

--- a/test/expect-tests/ocamlobjinfo_tests.ml
+++ b/test/expect-tests/ocamlobjinfo_tests.ml
@@ -225,3 +225,28 @@ let%expect_test "parse_archive extracts unit names" =
     set { "bar"; "foo"; "helper" }
     |}]
 ;;
+
+let%expect_test "regression test" =
+  parse
+    {fixture|
+File foo/bar.cmo
+Unit name: Bar
+Interfaces imported:
+	03e897aee435213573adf13c80fcb505	M1
+	863a7f5288599b181f046f0f55277b0f	M2
+Required globals:
+	X
+Uses unsafe features: no
+Force link: no
+File foo/baz.cmo
+Unit name: Baz
+Interfaces imported:
+	1b835c1e0367d04fd16979463a84a7cd	M3
+	6b06eead182e9e338552e756d414f9e8	M4
+Required globals:
+	Y
+Uses unsafe features: no
+Force link: no
+|fixture};
+  [%expect {| [ { impl = set {}; intf = set { "m1"; "m2" } } ] |}]
+;;


### PR DESCRIPTION
Do not stop parsing when encountering an unrecognized line