### PR TITLE
Defunctionalize the dune sexp decoder

### DIFF
--- a/src/dune_lang/targets_spec.ml
+++ b/src/dune_lang/targets_spec.ml
@@ -44,10 +44,11 @@ type 'a t =
   | Infer
 
 let decode_target ~allow_directory_targets =
+  let module K = Kind in
   let open Dune_sexp.Decoder in
   let file =
     let+ file = String_with_vars.decode in
-    file, Kind.File
+    file, K.File
   in
   let dir =
     let+ dir = sum ~force_parens:true [ "dir", String_with_vars.decode ] in
@@ -56,18 +57,19 @@ let decode_target ~allow_directory_targets =
       User_error.raise
         ~loc:(String_with_vars.loc dir)
         [ Pp.text "Directory targets require the 'directory-targets' extension" ];
-    dir, Kind.Directory
+    dir, K.Directory
   in
   file <|> dir
 ;;
 
 let decode_static ~allow_directory_targets =
+  let module K = Kind in
   let open Dune_sexp.Decoder in
   let+ syntax_version = Syntax.get_exn Stanza.syntax
   and+ targets = repeat (decode_target ~allow_directory_targets) in
   if syntax_version < (1, 3)
   then
-    List.iter targets ~f:(fun (target, (_ : Kind.t)) ->
+    List.iter targets ~f:(fun (target, (_ : K.t)) ->
       if String_with_vars.has_pforms target
       then
         Syntax.Error.since

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -379,11 +379,12 @@ let encode ({ source; obj_name; pp = _; visibility; kind; install_as = _ } as t)
 ;;
 
 let decode ~src_dir =
+  let module K = Kind in
   let open Dune_lang.Decoder in
   fields
     (let+ obj_name = field "obj_name" Module_name.Unique.decode
      and+ visibility = field "visibility" Visibility.decode
-     and+ kind = field_o "kind" Kind.decode
+     and+ kind = field_o "kind" K.decode
      and+ source = field "source" (Source.decode ~dir:src_dir) in
      let kind =
        match kind with

--- a/src/dune_sexp/decoder.mli
+++ b/src/dune_sexp/decoder.mli
@@ -122,16 +122,18 @@ val keyword : string -> unit t
     [after] to parse the rest. *)
 val until_keyword : string -> before:'a t -> after:'b t -> ('a list * 'b option) t
 
-(** What is currently being parsed. The second argument is the atom at the
-    beginning of the list when inside a [sum ...] or [field ...]. *)
-type kind =
-  | Values of Loc.t * string option
-  | Fields of Loc.t * string option
+module Kind : sig
+  (** What is currently being parsed. The second argument is the atom at the
+      beginning of the list when inside a [sum ...] or [field ...]. *)
+  type t =
+    | Values of Loc.t * string option
+    | Fields of Loc.t * string option
+end
 
 (** [kind] returns the current kind of the parser, whether it is parsing a list
     of values or a list of fields, together with the atom at the beginning of
     a list when inside [sum ...] or [field ...]. *)
-val kind : (kind, _) parser
+val kind : (Kind.t, _) parser
 
 (** [repeat t] uses [t] to consume all remaining elements of the input until the
     end of sequence is reached. *)


### PR DESCRIPTION
Defunctionalize the CPS based implementation into constructors that can be optimized. This is an almost mechanical transformation to allow:

1. The removal of some useless closures
2. A proper implementation of `either` that doesn't mindlessly backtrack
3. Much later, a removal of the `>>=` to allow to retarget the decoder in the command line.

There's other benefits as well, but this is enough for now.