### PR TITLE
Use Action_builder in Gen_meta

### DIFF
--- a/src/dune_rules/gen_meta.mli
+++ b/src/dune_rules/gen_meta.mli
@@ -9,4 +9,4 @@ val gen
   :  package:Package.t
   -> add_directory_entry:bool
   -> Scope.DB.Lib_entry.t list
-  -> Meta.t Memo.t
+  -> Meta.t Action_builder.t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -893,10 +893,8 @@ end = struct
         (let open Action_builder.O in
          (let+ template = template
           and+ (meta : Meta.t) =
-            let open Memo.O in
-            meta_entries
+            Action_builder.of_memo meta_entries
             >>= Gen_meta.gen ~package:pkg ~add_directory_entry:true
-            |> Action_builder.of_memo
           in
           let pp =
             Pp.concat_map template ~sep:Pp.newline ~f:(fun s ->
@@ -945,7 +943,6 @@ end = struct
                 |> List.map ~f:(fun deprecated ->
                   Scope.DB.Lib_entry.Deprecated_library_name deprecated)
                 |> Gen_meta.gen ~package:pkg ~add_directory_entry:false
-                |> Action_builder.of_memo
               in
               let open Pp.O in
               Pp.vbox (Meta.pp meta.entries ++ Pp.cut)


### PR DESCRIPTION
Since we're generating the contents of a file produced by action, this is the right monad to use. All the callers were expecting this type and the removal of `Resolve.Memo.read_memo` preserves lazy loading (although this isn't very relevant here).