### PR TITLE
Network caps to track network access

### DIFF
--- a/bin/lock_dev_tool.ml
+++ b/bin/lock_dev_tool.ml
@@ -66,7 +66,7 @@ let make_local_package_wrapping_dev_tool ~dev_tool ~dev_tool_version ~extra_depe
   }
 ;;
 
-let solve ~dev_tool ~local_packages =
+let solve ~dev_tool ~local_packages network_cap =
   let open Memo.O in
   let* solver_env_from_current_system =
     Pkg.Pkg_common.poll_solver_env_from_current_system ()
@@ -91,6 +91,7 @@ let solve ~dev_tool ~local_packages =
        ~lock_dirs:[ lock_dir ]
        ~print_perf_stats:false
        ~portable_lock_dir:false
+       network_cap
 ;;
 
 let compiler_package_name = Package_name.of_string "ocaml"
@@ -236,7 +237,7 @@ let lockdir_status dev_tool =
    dev tool [dev_tool]. If [version] is [Some v] then version [v] of the tool
    will be chosen by the solver. Otherwise the solver is free to choose the
    appropriate version of the tool to install. *)
-let lock_dev_tool_at_version dev_tool version =
+let lock_dev_tool_at_version dev_tool version network_cap =
   let open Memo.O in
   let* need_to_solve =
     lockdir_status dev_tool
@@ -289,7 +290,7 @@ let lock_dev_tool_at_version dev_tool version =
         ~extra_dependencies
     in
     let local_packages = Package_name.Map.singleton local_pkg.name local_pkg in
-    solve ~dev_tool ~local_packages
+    solve ~dev_tool ~local_packages network_cap
   else Memo.return ()
 ;;
 

--- a/bin/lock_dev_tool.mli
+++ b/bin/lock_dev_tool.mli
@@ -1,4 +1,4 @@
 open Import
 
 val is_enabled : bool Lazy.t
-val lock_dev_tool : Dune_pkg.Dev_tool.t -> unit Memo.t
+val lock_dev_tool : Dune_pkg.Dev_tool.t -> Dune_pkg.Network_cap.t -> unit Memo.t

--- a/bin/pkg/lock.mli
+++ b/bin/pkg/lock.mli
@@ -9,6 +9,7 @@ val solve
   -> lock_dirs:Path.t list
   -> print_perf_stats:bool
   -> portable_lock_dir:bool
+  -> Dune_pkg.Network_cap.t
   -> unit Fiber.t
 
 (** Command to create lock directory *)

--- a/bin/tools/tools_common.mli
+++ b/bin/tools/tools_common.mli
@@ -9,6 +9,7 @@ val lock_build_and_run_dev_tool
   -> Common.Builder.t
   -> Dune_pkg.Dev_tool.t
   -> args:string list
+  -> Dune_pkg.Network_cap.t
   -> 'a
 
 val which_command : Dune_pkg.Dev_tool.t -> unit Cmd.t

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -27,3 +27,4 @@ module Ocamlformat = Ocamlformat
 module Dev_tool = Dev_tool
 module Outdated = Outdated
 module Dune_dep = Dune_dep
+module Network_cap = Network_cap

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -17,16 +17,19 @@ val fetch
   -> checksum:Checksum.t option
   -> target:Path.t
   -> url:Loc.t * OpamUrl.t
+  -> Network_cap.t
   -> (unit, failure) result Fiber.t
 
 val fetch_without_checksum
   :  unpack:bool
   -> target:Path.t
   -> url:Loc.t * OpamUrl.t
+  -> Network_cap.t
   -> (unit, User_message.t option) result Fiber.t
 
 val fetch_git
   :  Rev_store.t
   -> target:Path.t
   -> url:Loc.t * OpamUrl.t
+  -> Network_cap.t
   -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -177,7 +177,11 @@ val transitive_dependency_closure
 
 (** Attempt to download and compute checksums for packages that have source
     archive urls but no checksum. *)
-val compute_missing_checksums : t -> pinned_packages:Package_name.Set.t -> t Fiber.t
+val compute_missing_checksums
+  :  t
+  -> pinned_packages:Package_name.Set.t
+  -> Network_cap.t
+  -> t Fiber.t
 
 (** Combine the platform-specific parts of a pair of lockdirs, throwing a code
     error if the lockdirs differ in a non-platform-specific way. *)

--- a/src/dune_pkg/mount.mli
+++ b/src/dune_pkg/mount.mli
@@ -9,7 +9,7 @@ type backend =
   | Git of Rev_store.At_rev.t
 
 val backend : t -> backend
-val of_opam_url : Loc.t -> OpamUrl.t -> t Fiber.t
+val of_opam_url : Loc.t -> OpamUrl.t -> Network_cap.t -> t Fiber.t
 val stat : t -> Path.Local.t -> [ `Absent_or_unrecognized | `Dir | `File ] Fiber.t
 val read : t -> Path.Local.t -> string option Fiber.t
 val readdir : t -> Path.Local.t -> [ `File | `Dir ] Filename.Map.t Fiber.t

--- a/src/dune_pkg/network_cap.ml
+++ b/src/dune_pkg/network_cap.ml
@@ -1,0 +1,12 @@
+type t = { reason_for_network_access : string }
+
+let create ~reason_for_network_access = { reason_for_network_access }
+
+let log { reason_for_network_access } =
+  match !Dune_engine.Clflags.display with
+  | Quiet | Short -> ()
+  | Verbose ->
+    Dune_console.printf "Performing network access because: %s" reason_for_network_access
+;;
+
+let for_unit_test = create ~reason_for_network_access:"unit test"

--- a/src/dune_pkg/network_cap.mli
+++ b/src/dune_pkg/network_cap.mli
@@ -1,0 +1,10 @@
+(** Represents the right to access the network. Used to track which functions
+    may require internet in order to make it harder to accidentally break
+    offline mode. *)
+type t
+
+val create : reason_for_network_access:string -> t
+val for_unit_test : t
+
+(** Prints the reason for network access in the verbose display mode. *)
+val log : t -> unit

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -65,7 +65,7 @@ let not_found ~loc ~git_output t =
        ])
 ;;
 
-let resolve t ~loc rev_store =
+let resolve t ~loc rev_store network_cap =
   let open Fiber.O in
   let remote = remote t ~loc rev_store in
   match
@@ -89,19 +89,19 @@ let resolve t ~loc rev_store =
             ]))
   | `Object obj -> Fiber.return (Ok (Unresolved obj))
   | `Ref revision ->
-    Rev_store.resolve_revision rev_store remote ~revision
+    Rev_store.resolve_revision rev_store remote ~revision network_cap
     >>| (function
      | None -> not_found ~loc ~git_output:[] t
      | Some o -> Ok (Resolved o))
 ;;
 
-let fetch_revision t ~loc resolve rev_store =
+let fetch_revision t ~loc resolve rev_store network_cap =
   let remote = remote t ~loc rev_store in
   let open Fiber.O in
   match resolve with
-  | Resolved o -> Rev_store.fetch_resolved rev_store remote o >>| Result.ok
+  | Resolved o -> Rev_store.fetch_resolved rev_store remote o network_cap >>| Result.ok
   | Unresolved o ->
-    Rev_store.fetch_object rev_store remote o
+    Rev_store.fetch_object rev_store remote o network_cap
     >>| (function
      | Error git_output -> not_found ~loc ~git_output t
      | Ok rev -> Ok rev)

--- a/src/dune_pkg/opamUrl0.mli
+++ b/src/dune_pkg/opamUrl0.mli
@@ -29,13 +29,19 @@ type resolve =
   | Resolved of Rev_store.Object.resolved
   | Unresolved of Rev_store.Object.t
 
-val resolve : t -> loc:Loc.t -> Rev_store.t -> (resolve, User_message.t) result Fiber.t
+val resolve
+  :  t
+  -> loc:Loc.t
+  -> Rev_store.t
+  -> Network_cap.t
+  -> (resolve, User_message.t) result Fiber.t
 
 val fetch_revision
   :  t
   -> loc:Loc.t
   -> resolve
   -> Rev_store.t
+  -> Network_cap.t
   -> (Rev_store.At_rev.t, User_message.t) result Fiber.t
 
 val set_rev : t -> Rev_store.Object.t -> t

--- a/src/dune_pkg/opam_repo.mli
+++ b/src/dune_pkg/opam_repo.mli
@@ -21,7 +21,7 @@ val of_opam_repo_dir_path : Loc.t -> Path.t -> t
 (** [of_git_repo git source] loads the opam repository located
     at [source] from git. [source] can be any URL that [git remote add]
     supports. *)
-val of_git_repo : Loc.t -> OpamUrl.t -> t Fiber.t
+val of_git_repo : Loc.t -> OpamUrl.t -> Network_cap.t -> t Fiber.t
 
 (** [resolve_repositories ~available_repos ~repositories] resolves a list of
     repository references by looking them up in [available_repos] and creating
@@ -31,6 +31,7 @@ val of_git_repo : Loc.t -> OpamUrl.t -> t Fiber.t
 val resolve_repositories
   :  available_repos:Workspace.Repository.t Workspace.Repository.Name.Map.t
   -> repositories:(Loc.t * Workspace.Repository.Name.t) list
+  -> Network_cap.t
   -> t list Fiber.t
 
 val revision : t -> Rev_store.At_rev.t

--- a/src/dune_pkg/pin.mli
+++ b/src/dune_pkg/pin.mli
@@ -36,4 +36,5 @@ end
 val resolve
   :  DB.t
   -> scan_project:Scan_project.t
+  -> Network_cap.t
   -> Resolved_package.t Package_name.Map.t Fiber.t

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -60,13 +60,16 @@ let discover_layout loc name mount =
            | `Absent_or_unrecognized -> abort ())))
 ;;
 
-let resolve_package { Local_package.loc; url = loc_url, url; name; version; origin = _ } =
+let resolve_package
+      { Local_package.loc; url = loc_url, url; name; version; origin = _ }
+      network_cap
+  =
   let package =
     OpamPackage.create
       (Package_name.to_opam_package_name name)
       (Package_version.to_opam_package_version version)
   in
-  let* mount = Mount.of_opam_url loc_url url in
+  let* mount = Mount.of_opam_url loc_url url network_cap in
   let* opam_file_path, files_dir = discover_layout loc name mount in
   match Mount.backend mount with
   | Path dir ->

--- a/src/dune_pkg/pinned_package.mli
+++ b/src/dune_pkg/pinned_package.mli
@@ -8,4 +8,4 @@
     opam files they correspond to *)
 
 val collect : Local_package.t Package_name.Map.t -> Local_package.pin Package_name.Map.t
-val resolve_package : Local_package.pin -> Resolved_package.t Fiber.t
+val resolve_package : Local_package.pin -> Network_cap.t -> Resolved_package.t Fiber.t

--- a/src/dune_pkg/rev_store.mli
+++ b/src/dune_pkg/rev_store.mli
@@ -101,17 +101,27 @@ end
     the revision is already present, no network I/O is performed. Returns
     [None] if the remote reports "not found". Raises a user error if the
     reference is ambigious. *)
-val resolve_revision : t -> Remote.t -> revision:string -> Object.resolved option Fiber.t
+val resolve_revision
+  :  t
+  -> Remote.t
+  -> revision:string
+  -> Network_cap.t
+  -> Object.resolved option Fiber.t
 
 (** [fetch_object t remote object] ensures that an [object] from the [remote]
     is present in the revision store [t]. If the revision is already present,
     no network I/O is performed. Returns [Error git_error_lines] if the remote
     reports "not found". *)
-val fetch_object : t -> Remote.t -> Object.t -> (At_rev.t, string list) result Fiber.t
+val fetch_object
+  :  t
+  -> Remote.t
+  -> Object.t
+  -> Network_cap.t
+  -> (At_rev.t, string list) result Fiber.t
 
 (** Fetch the file contents of the repository at the given revision into the
     store and return the repository view. *)
-val fetch_resolved : t -> Remote.t -> Object.resolved -> At_rev.t Fiber.t
+val fetch_resolved : t -> Remote.t -> Object.resolved -> Network_cap.t -> At_rev.t Fiber.t
 
 module Debug : sig
   val files_and_submodules_cache : bool ref

--- a/src/dune_pkg/source.mli
+++ b/src/dune_pkg/source.mli
@@ -12,7 +12,14 @@ val to_dyn : t -> Dyn.t
 val hash : t -> int
 val digest_feed : t Dune_digest.Feed.t
 val remove_locs : t -> t
-val compute_missing_checksum : t -> Package_name.t -> pinned:bool -> t Fiber.t
+
+val compute_missing_checksum
+  :  t
+  -> Package_name.t
+  -> pinned:bool
+  -> Network_cap.t
+  -> t Fiber.t
+
 val external_copy : Loc.t * Path.External.t -> t
 val kind : t -> [ `Directory_or_archive of Path.External.t | `Fetch ]
 
@@ -20,4 +27,5 @@ val kind : t -> [ `Directory_or_archive of Path.External.t | `Fetch ]
     caching to reduce network calls. *)
 val fetch_archive_cached
   :  Loc.t * OpamUrl.t
+  -> Network_cap.t
   -> (Import.Path.t, Import.User_message.t option) result Fiber.t

--- a/src/dune_rules/fetch_rules.mli
+++ b/src/dune_rules/fetch_rules.mli
@@ -9,6 +9,7 @@ val fetch
   :  target:Path.Build.t
   -> [ `File | `Directory ]
   -> Dune_pkg.Source.t
+  -> Dune_pkg.Network_cap.t
   -> Action.Full.t With_targets.t
 
 val gen_rules

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2010,6 +2010,12 @@ let rule ?loc { Action_builder.With_targets.build; targets } =
 ;;
 
 let source_rules (pkg : Pkg.t) =
+  let network_cap =
+    Dune_pkg.Network_cap.create
+      ~reason_for_network_access:
+        "If the source of a package isn't already present locally, network access is \
+         needed to download it."
+  in
   let+ source_deps, copy_rules =
     match pkg.info.source with
     | None -> Memo.return (Dep.Set.empty, [])
@@ -2019,7 +2025,11 @@ let source_rules (pkg : Pkg.t) =
       >>= (function
        | `Local (`File, _) | `Fetch ->
          let fetch =
-           Fetch_rules.fetch ~target:pkg.write_paths.source_dir `Directory source
+           Fetch_rules.fetch
+             ~target:pkg.write_paths.source_dir
+             `Directory
+             source
+             network_cap
            |> With_targets.map
                 ~f:
                   (Action.Full.map ~f:(fun action ->
@@ -2066,7 +2076,7 @@ let source_rules (pkg : Pkg.t) =
         | `Directory_or_archive src ->
           loc, Action_builder.copy ~src:(Path.external_ src) ~dst:extra_source
         | `Fetch ->
-          let rule = Fetch_rules.fetch ~target:extra_source `File fetch in
+          let rule = Fetch_rules.fetch ~target:extra_source `File fetch network_cap in
           loc, rule
       in
       Path.build extra_source, rule)

--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -45,8 +45,9 @@ let serve_once ~filename =
 
 let download ?(reproducible = true) ~unpack ~port ~filename ~target ?checksum () =
   let open Fiber.O in
+  let network_cap = Dune_pkg.Network_cap.for_unit_test in
   let url = url ~port ~filename in
-  let* res = Fetch.fetch ~unpack ~checksum ~target ~url:(Loc.none, url) in
+  let* res = Fetch.fetch ~unpack ~checksum ~target ~url:(Loc.none, url) network_cap in
   match res with
   | Error (Unavailable None) ->
     let errs = [ Pp.text "Failure while downloading" ] in
@@ -209,8 +210,9 @@ let%expect_test "downloading, tarball with no checksum match" =
 
 let download_git rev_store url ~target =
   let open Fiber.O in
+  let network_cap = Dune_pkg.Network_cap.for_unit_test in
   Rev_store_tests.git_init_and_config_user (Path.of_string ".")
-  >>> Fetch.fetch_git rev_store ~target ~url:(Loc.none, url)
+  >>> Fetch.fetch_git rev_store ~target ~url:(Loc.none, url) network_cap
   >>| function
   | Error _ ->
     let errs = [ Pp.text "Failure while downloading" ] in


### PR DESCRIPTION
Contributes to https://github.com/ocaml/dune/issues/10508

Adds a [Network_cap.t] type which must be passed to the low-level functions which require network access, and should only be created at the "edge", either in a command or a rule. This will make it harder to accidentally add a requirement on network access to a code path that previously did not require network access, which will become important for maintaining an offline mode for Dune where it avoids updating package repositories and downloading files where possible.