### PR TITLE
fix: Fix crash on non-ASCII version in dune-project

### DIFF
--- a/doc/changes/fixed/12794.md
+++ b/doc/changes/fixed/12794.md
@@ -1,0 +1,3 @@
+- Improve error message when invalid version strings are used in `dune-project`
+  files. Non-ASCII characters and malformed versions now show a helpful hint
+  with an example of the correct format. (#12794, fixes #12751, @benodiwal)

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -66,7 +66,7 @@ struct
             | None -> []
             | Some lang ->
               let latest = Syntax.greatest_supported_version_exn lang.syntax in
-              [ Pp.textf "try %s" (Syntax.Version.to_string latest) ]
+              [ Pp.textf "lang dune %s" (Syntax.Version.to_string latest) ]
           in
           User_error.raise
             ~loc:ver_loc

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -61,7 +61,7 @@ struct
         match Atom.parse ver with
         | Some atom -> atom
         | None ->
-          let hint =
+          let hints =
             match Table.find langs name with
             | None -> []
             | Some lang ->
@@ -70,7 +70,7 @@ struct
           in
           User_error.raise
             ~loc:ver_loc
-            ~hints:hint
+            ~hints
             [ Pp.text "Invalid version. Version must be two numbers separated by a dot." ]
       in
       let dune_lang_ver =

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -57,11 +57,13 @@ struct
 
     let parse first_line : Instance.t =
       let { First_line.lang = name_loc, name; version = ver_loc, ver } = first_line in
+      let ver_atom =
+        match Atom.parse ver with
+        | Some atom -> atom
+        | None -> User_error.raise ~loc:ver_loc [ Pp.text "Invalid version string" ]
+      in
       let dune_lang_ver =
-        Decoder.parse
-          Syntax.Version.decode
-          Univ_map.empty
-          (Atom (ver_loc, Atom.of_string ver))
+        Decoder.parse Syntax.Version.decode Univ_map.empty (Atom (ver_loc, ver_atom))
       in
       match Table.find langs name with
       | None ->

--- a/src/dune_sexp/versioned_file.ml
+++ b/src/dune_sexp/versioned_file.ml
@@ -60,7 +60,18 @@ struct
       let ver_atom =
         match Atom.parse ver with
         | Some atom -> atom
-        | None -> User_error.raise ~loc:ver_loc [ Pp.text "Invalid version string" ]
+        | None ->
+          let hint =
+            match Table.find langs name with
+            | None -> []
+            | Some lang ->
+              let latest = Syntax.greatest_supported_version_exn lang.syntax in
+              [ Pp.textf "try %s" (Syntax.Version.to_string latest) ]
+          in
+          User_error.raise
+            ~loc:ver_loc
+            ~hints:hint
+            [ Pp.text "Invalid version. Version must be two numbers separated by a dot." ]
       in
       let dune_lang_ver =
         Decoder.parse Syntax.Version.decode Univ_map.empty (Atom (ver_loc, ver_atom))

--- a/test/blackbox-tests/test-cases/lang-invalid-version.t
+++ b/test/blackbox-tests/test-cases/lang-invalid-version.t
@@ -5,7 +5,7 @@ such situations provide a clear error.
   >   cat > dune-project <<EOF
   > (lang dune $1)
   > EOF
-  >   dune build 2>&1 | grep "Internal error"
+  >   dune build 2>&1 | grep "Invalid version string"
   > }
 
 Invalid version number:
@@ -16,16 +16,16 @@ Invalid version number:
 Test with various non-ASCII characters:
 
   $ test_invalid_version "è"
-  Internal error, please report upstream including the contents of _build/log.
+  Error: Invalid version string
 
   $ test_invalid_version "π3.14"
-  Internal error, please report upstream including the contents of _build/log.
+  Error: Invalid version string
 
   $ test_invalid_version "α"
-  Internal error, please report upstream including the contents of _build/log.
+  Error: Invalid version string
 
   $ test_invalid_version "😀"
-  Internal error, please report upstream including the contents of _build/log.
+  Error: Invalid version string
 
   $ test_invalid_version "中3.16文"
-  Internal error, please report upstream including the contents of _build/log.
+  Error: Invalid version string

--- a/test/blackbox-tests/test-cases/lang-invalid-version.t
+++ b/test/blackbox-tests/test-cases/lang-invalid-version.t
@@ -5,27 +5,56 @@ such situations provide a clear error.
   >   cat > dune-project <<EOF
   > (lang dune $1)
   > EOF
-  >   dune build 2>&1 | grep "Invalid version string"
+  >   dune build
   > }
 
 Invalid version number:
 
   $ test_invalid_version "Ali"
+  File "dune-project", line 1, characters 11-14:
+  1 | (lang dune Ali)
+                 ^^^
+  Error: Atom of the form NNN.NNN expected
   [1]
 
 Test with various non-ASCII characters:
 
   $ test_invalid_version "è"
-  Error: Invalid version string
+  File "dune-project", line 1, characters 11-13:
+  1 | (lang dune è)
+                 ^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  Hint: try 3.21
+  [1]
 
   $ test_invalid_version "π3.14"
-  Error: Invalid version string
+  File "dune-project", line 1, characters 11-17:
+  1 | (lang dune π3.14)
+                 ^^^^^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  Hint: try 3.21
+  [1]
 
   $ test_invalid_version "α"
-  Error: Invalid version string
+  File "dune-project", line 1, characters 11-13:
+  1 | (lang dune α)
+                 ^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  Hint: try 3.21
+  [1]
 
   $ test_invalid_version "😀"
-  Error: Invalid version string
+  File "dune-project", line 1, characters 11-15:
+  1 | (lang dune 😀)
+                 ^^^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  Hint: try 3.21
+  [1]
 
   $ test_invalid_version "中3.16文"
-  Error: Invalid version string
+  File "dune-project", line 1, characters 11-21:
+  1 | (lang dune 中3.16文)
+                 ^^^^^^^^^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  Hint: try 3.21
+  [1]

--- a/test/blackbox-tests/test-cases/lang-invalid-version.t
+++ b/test/blackbox-tests/test-cases/lang-invalid-version.t
@@ -19,6 +19,9 @@ Invalid version number:
 
 Test with various non-ASCII characters:
 
+CR-someday benodiwal: The version_loc is greedy and captures the closing
+parenthesis.
+
   $ test_invalid_version "è"
   File "dune-project", line 1, characters 11-13:
   1 | (lang dune è)
@@ -50,6 +53,9 @@ Test with various non-ASCII characters:
   Error: Invalid version. Version must be two numbers separated by a dot.
   Hint: lang dune 3.21
   [1]
+
+CR-someday benodiwal: Unicode string lengths are miscomputed in location
+excerpts for East Asian characters.
 
   $ test_invalid_version "中3.16文"
   File "dune-project", line 1, characters 11-21:

--- a/test/blackbox-tests/test-cases/lang-invalid-version.t
+++ b/test/blackbox-tests/test-cases/lang-invalid-version.t
@@ -24,7 +24,7 @@ Test with various non-ASCII characters:
   1 | (lang dune è)
                  ^^
   Error: Invalid version. Version must be two numbers separated by a dot.
-  Hint: try 3.21
+  Hint: lang dune 3.21
   [1]
 
   $ test_invalid_version "π3.14"
@@ -32,7 +32,7 @@ Test with various non-ASCII characters:
   1 | (lang dune π3.14)
                  ^^^^^^
   Error: Invalid version. Version must be two numbers separated by a dot.
-  Hint: try 3.21
+  Hint: lang dune 3.21
   [1]
 
   $ test_invalid_version "α"
@@ -40,7 +40,7 @@ Test with various non-ASCII characters:
   1 | (lang dune α)
                  ^^
   Error: Invalid version. Version must be two numbers separated by a dot.
-  Hint: try 3.21
+  Hint: lang dune 3.21
   [1]
 
   $ test_invalid_version "😀"
@@ -48,7 +48,7 @@ Test with various non-ASCII characters:
   1 | (lang dune 😀)
                  ^^^^
   Error: Invalid version. Version must be two numbers separated by a dot.
-  Hint: try 3.21
+  Hint: lang dune 3.21
   [1]
 
   $ test_invalid_version "中3.16文"
@@ -56,5 +56,5 @@ Test with various non-ASCII characters:
   1 | (lang dune 中3.16文)
                  ^^^^^^^^^^
   Error: Invalid version. Version must be two numbers separated by a dot.
-  Hint: try 3.21
+  Hint: lang dune 3.21
   [1]


### PR DESCRIPTION
Closes #12751

Earlier:
```bash
Internal error, please report upstream including the contents of _build/log.
Description:
  ("Dune_lang.Atom.of_string got invalid atom", { atom = "\195\168" })
Raised at Stdune__Code_error.raise in file "stdune__Code_error.ml", line 11,
  characters 30-62
Called from Dune_sexp__Versioned_file.Make.Lang.parse in file
  "dune_sexp__Versioned_file.ml", line 65, characters 26-44
Called from Dune_sexp__Versioned_file.Make.parse_lang_exn in file
  "dune_sexp__Versioned_file.ml", line 92, characters 15-36
Called from Dune_sexp__Versioned_file.Make.parse_contents in file
  "dune_sexp__Versioned_file.ml" (inlined), line 104, characters 14-31
Called from Dune_lang__Dune_project.load_dune_project in file
  "dune_lang__Dune_project.ml", line 1031, characters 2-77
Called from Fiber__Scheduler.exec in file "fiber__Scheduler.ml", line 77,
  characters 8-11
-> required by ("<unnamed>", ())
-> required by ("dune_load", ())
-> required by ("Super_context.all", ())
-> required by ("toplevel", ())

I must not crash.  Uncertainty is the mind-killer. Exceptions are the
little-death that brings total obliteration.  I will fully express my cases. 
Execution will pass over me and through me.  And when it has gone past, I
will unwind the stack along its path.  Where the cases are handled there will
be nothing.  Only I will remain.
```

Now:
```bash
File "dune-project", line 1, characters 11-13:
1 | (lang dune è)
               ^^
Error: Invalid version string
```