### PR TITLE
don't control concurrency from INSIDE_DUNE 

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -408,6 +408,10 @@ let shared_with_config_file =
         ( (fun s -> Result.map_error (Concurrency.of_string s) ~f:(fun s -> `Msg s))
         , fun pp x -> Format.pp_print_string pp (Concurrency.to_string x) )
     in
+    let doc =
+      "Run no more than $(i,JOBS) commands simultaneously. $(i,JOBS) must be a positive \
+       integer or $(b,auto) to auto-detect the number of cores (the default)."
+    in
     Arg.(
       value
       & opt (some arg) None
@@ -415,7 +419,8 @@ let shared_with_config_file =
           [ "j" ]
           ~docs
           ~docv:"JOBS"
-          ~doc:(Some "Run no more than $(i,JOBS) commands simultaneously."))
+          ~env:(Cmd.Env.info ~doc "DUNE_JOBS")
+          ~doc:(Some doc))
   and+ sandboxing_preference =
     let all =
       List.map Dune_engine.Sandbox_mode.all_except_patch_back_source_tree ~f:(fun s ->

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -110,7 +110,9 @@ let warn_ignore_arguments lock_held_by =
 ;;
 
 let should_warn ~warn_forwarding builder =
-  warn_forwarding && not (Common.Builder.equal builder Common.Builder.default)
+  (not Execution_env.inside_dune)
+  && warn_forwarding
+  && not (Common.Builder.equal builder Common.Builder.default)
 ;;
 
 let send_request ~f connection name =

--- a/doc/changes/added/12800.md
+++ b/doc/changes/added/12800.md
@@ -1,0 +1,2 @@
+- Add `DUNE_JOBS` environment variable for controlling concurrency of Dune from
+  environment. (#12800, @Alizter)

--- a/doc/changes/added/12800.md
+++ b/doc/changes/added/12800.md
@@ -1,2 +1,3 @@
 - Add `DUNE_JOBS` environment variable for controlling concurrency of Dune from
-  environment. (#12800, @Alizter)
+  environment. The `INSIDE_DUNE` variable also now no longer controls
+  concurrency (#12800, @Alizter)

--- a/doc/reference/config/jobs.rst
+++ b/doc/reference/config/jobs.rst
@@ -13,3 +13,8 @@ where ``<setting>`` is one of:
 
 - ``<number>``, a positive integer specifying the maximum number of jobs Dune
   may use simultaneously.
+
+This setting can also be controlled via the ``-j`` command-line option or the
+``DUNE_JOBS`` environment variable. The command-line option takes precedence
+over the environment variable, which takes precedence over the configuration
+file.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -418,6 +418,25 @@ to the user's workspace. However, one can customize this directory by using the
    # Absolute paths are also allowed
    $ dune build --build-dir /tmp/build foo.exe
 
+Controlling Concurrency
+=======================
+
+By default Dune automatically detects the number of CPU cores and runs that
+many jobs in parallel. You can override this using the ``-j`` flag or the
+``DUNE_JOBS`` environment variable with either a positive integer or ``auto``
+to use the default auto-detection.
+
+.. code:: console
+
+   $ dune build -j 4
+
+   # this is equivalent to:
+   $ DUNE_JOBS=4 dune build
+
+The command-line option takes precedence over the environment variable, which
+takes precedence over the :doc:`jobs </reference/config/jobs>` setting in the
+configuration file.
+
 Installing a Package
 ====================
 

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -484,7 +484,7 @@ module Dune_config = struct
 
   let default =
     { display = Simple { verbosity = Quiet; status_line = not Execution_env.inside_dune }
-    ; concurrency = (if Execution_env.inside_dune then Fixed 1 else Auto)
+    ; concurrency = Auto
     ; terminal_persistence = Clear_on_rebuild
     ; sandboxing_preference = []
     ; cache_enabled = Enabled_except_user_rules

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -3,6 +3,7 @@
   (env-vars
    (DUNE_CONFIG__BACKGROUND_SANDBOXES disabled)
    (DUNE_CONFIG__BACKGROUND_DIGESTS disabled)
+   (DUNE_JOBS 1)
    ;; We set ocaml to always be colored since it changes the output of
    ;; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144
    (OCAML_COLOR always))
@@ -23,6 +24,7 @@
  (applies_to :whole_subtree)
  (deps
   (env_var OCAML_COLOR)
+  (env_var DUNE_JOBS)
   %{bin:dune_cmd}
   (package dune))
  ;; We don't allow conflict markers in tests

--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-build-command.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-build-command.t
@@ -7,7 +7,6 @@ Demonstrate running "dune build" concurrently with an eager rpc server.
   $ dune build --watch &
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
-  Success, waiting for filesystem changes...
   File "foo.ml", line 1, characters 9-21:
   1 | let () = print_endlin "Hello, World!"
                ^^^^^^^^^^^^
@@ -28,11 +27,6 @@ Make sure the RPC server is properly started:
 Demonstrate that we can run "dune build" while the watch server is running.
   $ dune build
   Success
-
-Demonstrate that a warning is displayed when extra arguments are passed to
-"dune build", since those arguments will be ignored.
-  $ dune build --auto-promote 2>&1 | tr '\n' ' ' | sed 's/(pid: [0-9]*)/(pid: PID)/'
-  Warning: Your build request is being forwarded to a running Dune instance (pid: PID). Note that certain command line arguments may be ignored. Success 
 
 Demonstrate that error messages are still printed by "dune build" when it's
 acting as an RPC client while running concurrently with an RPC server.

--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-exec-command.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-exec-command.t
@@ -10,7 +10,6 @@ testing the --no-build option:
   $ dune build README.md --watch &
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
-  Success, waiting for filesystem changes...
 
 Make sure the RPC server is properly started:
   $ dune rpc ping --wait
@@ -32,11 +31,6 @@ Demonstrate running an executable from PATH:
   executable "echo" within this project. Dune will attempt to resolve the
   executable's name within your PATH only.
   bar
-
-Demonstrate printing a warning if arguments are passed that would be ignored
-due to how Dune builds via RPC:
-  $ dune exec --force ./foo.exe 2>&1 | tr '\n' ' ' | sed 's/(pid: [0-9]*)/(pid: PID)/'
-  Warning: Your build request is being forwarded to a running Dune instance (pid: PID). Note that certain command line arguments may be ignored. foo 
 
 Demonstrate trying to run exec in watch mode while another watch server is running:
   $ dune exec ./foo.exe --watch 2>&1 | tr '\n' ' ' | sed 's/(pid: [0-9]*)/(pid: PID)/'

--- a/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-runtest-command.t
+++ b/test/blackbox-tests/test-cases/watching/watching-eager-concurrent-runtest-command.t
@@ -12,7 +12,6 @@ Define a test that just prints "Hello, World!"
   $ dune build --watch &
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
-  Success, waiting for filesystem changes...
   Hello, World!
 
 Make sure the RPC server is properly started:
@@ -23,11 +22,6 @@ Test that we can run a test while another instance of dune is running in watch
 mode:
   $ dune runtest 2>&1
   Success
-
-Test that passing extra arguments to `dune runtest` prints a warning when
-running concurrently with another instance of dune in watch mode:
-  $ dune runtest --auto-promote 2>&1 | tr '\n' ' ' | sed 's/(pid: [0-9]*)/(pid: PID)/'
-  Warning: Your build request is being forwarded to a running Dune instance (pid: PID). Note that certain command line arguments may be ignored. Success 
 
   $ dune shutdown
   $ wait

--- a/test/expect-tests/dune_config_file/dune_config_test.ml
+++ b/test/expect-tests/dune_config_file/dune_config_test.ml
@@ -19,7 +19,7 @@ let%expect_test "cache-check-probability 0.1" =
   [%expect
     {|
     { display = Simple { verbosity = Quiet; status_line = false }
-    ; concurrency = Fixed 1
+    ; concurrency = Auto
     ; terminal_persistence = Clear_on_rebuild
     ; sandboxing_preference = []
     ; cache_enabled = Enabled_except_user_rules
@@ -44,7 +44,7 @@ let%expect_test "cache-storage-mode copy" =
   [%expect
     {|
     { display = Simple { verbosity = Quiet; status_line = false }
-    ; concurrency = Fixed 1
+    ; concurrency = Auto
     ; terminal_persistence = Clear_on_rebuild
     ; sandboxing_preference = []
     ; cache_enabled = Enabled_except_user_rules
@@ -69,7 +69,7 @@ let%expect_test "cache-storage-mode hardlink" =
   [%expect
     {|
     { display = Simple { verbosity = Quiet; status_line = false }
-    ; concurrency = Fixed 1
+    ; concurrency = Auto
     ; terminal_persistence = Clear_on_rebuild
     ; sandboxing_preference = []
     ; cache_enabled = Enabled_except_user_rules


### PR DESCRIPTION
`INSIDE_DUNE` sets the concurrency of `dune` to `1`. We use this behaviour when running our tests. However, running `dune` inside of `dune`, as is common in package management, means that the child process also observes `INSIDE_DUNE` and therefore affects the concurrency when we haven't explicitly passed `-j`, as is the case for OxCaml:

- https://github.com/ocaml/dune/issues/12737

This PR introduces a new environment variable `DUNE_JOBS` whose sole job is to configure the concurrency from the environment.

Our second change is to decouple the concurrency control from `INSIDE_DUNE`. This means that `INSIDE_DUNE` no longer sets the concurrency to `1`. This means that we have to explicitly set `DUNE_JOBS` in our cram tests. We don't however set the value for the expect tests.

Setting `DUNE_JOBS` for our cram tests has an unfortunate side-effect, and <s>is</s> was the cause of most of the noise in this PR. It triggers a warning message given by an RPC client when a `dune`'s config differs from the default values. I've therefore disabled this warning when `INSIDE_DUNE` since it doesn't have any utility for us. Also, depending on the `pid` contents of the build lock in a racy way is not sound.

- [x] update docs
  - [x] mention new env var in cli docs and man pages
  - [x] document concurrency properly
- [x] changelog
- [x] Find a way to silence or perhaps get rid of the warning. (It's not a very good warning to begin with)

