### PR TITLE
Fix unused libs check

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -214,7 +214,7 @@ let executables_rules
   let* requires_compile = Compilation_context.requires_compile cctx in
   let* () =
     let toolchain = Compilation_context.ocaml cctx in
-    let direct_requires = Lib.Compile.direct_requires compile_info in
+    let user_written_requires = Lib.Compile.user_written_requires compile_info in
     let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
     Unused_libs_rules.gen_rules
       sctx
@@ -223,7 +223,7 @@ let executables_rules
       ~obj_dir
       ~modules
       ~dir
-      ~direct_requires
+      ~user_written_requires
       ~allow_unused_libraries
   in
   let* () =

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -85,6 +85,8 @@ module Compile : sig
   (** Return the list of dependencies needed for linking this library/exe *)
   val requires_link : t -> lib list Resolve.t Memo.Lazy.t
 
+  val user_written_requires : t -> (Loc.t * lib) list Resolve.Memo.t
+
   (** Dependencies listed by the user + runtime dependencies from ppx *)
   val direct_requires : t -> lib list Resolve.Memo.t
 

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -627,7 +627,7 @@ let library_rules
       { super_context = sctx; dir; stanza = lib; scope; source_modules; compile_info }
   and+ () =
     let toolchain = Compilation_context.ocaml cctx in
-    let direct_requires = Lib.Compile.direct_requires compile_info in
+    let user_written_requires = Lib.Compile.user_written_requires compile_info in
     let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
     Unused_libs_rules.gen_rules
       sctx
@@ -636,7 +636,7 @@ let library_rules
       ~obj_dir
       ~modules
       ~dir
-      ~direct_requires
+      ~user_written_requires
       ~allow_unused_libraries
   and+ merlin =
     let+ requires_hidden = Compilation_context.requires_hidden cctx

--- a/src/dune_rules/unused_libs_rules.ml
+++ b/src/dune_rules/unused_libs_rules.ml
@@ -2,10 +2,10 @@ open Import
 open Memo.O
 
 let classify_libs sctx libs =
-  Memo.parallel_map libs ~f:(fun lib ->
+  Memo.parallel_map libs ~f:(fun (loc, lib) ->
     let+ modules = Dir_contents.modules_of_lib sctx lib in
-    lib, modules)
-  >>| List.partition_map ~f:(fun (lib, modules) ->
+    loc, lib, modules)
+  >>| List.partition_map ~f:(fun (loc, lib, modules) ->
     match modules with
     | Some modules ->
       let module_set =
@@ -13,14 +13,14 @@ let classify_libs sctx libs =
         |> Module_name.Unique.Map.keys
         |> Module_name.Unique.Set.of_list
       in
-      Left (lib, module_set)
+      Left (lib, (loc, module_set))
     | None ->
       (match
          let archives = Lib.info lib |> Lib_info.archives in
          Mode.Dict.get archives Byte
        with
-       | [] -> Left (lib, Module_name.Unique.Set.empty)
-       | archive :: _ -> Right (lib, archive)))
+       | [] -> Left (lib, (loc, Module_name.Unique.Set.empty))
+       | archive :: _ -> Right (lib, (loc, archive))))
 ;;
 
 let gen_rules
@@ -30,7 +30,7 @@ let gen_rules
       ~obj_dir
       ~modules
       ~dir
-      ~direct_requires
+      ~user_written_requires
       ~allow_unused_libraries
   =
   match
@@ -48,8 +48,8 @@ let gen_rules
       let open Action_builder.O in
       let build_dir = Obj_dir.dir obj_dir in
       let* local_modules, external_lib_archives =
-        let* direct_requires = Resolve.Memo.read direct_requires in
-        classify_libs sctx direct_requires |> Action_builder.of_memo
+        let* user_written_requires = Resolve.Memo.read user_written_requires in
+        classify_libs sctx user_written_requires |> Action_builder.of_memo
       in
       let* results =
         Ocamlobjinfo.rules
@@ -58,7 +58,7 @@ let gen_rules
           ~sandbox:(Some Sandbox_config.needs_sandboxing)
           ~units
       and* external_modules =
-        List.map external_lib_archives ~f:(fun (lib, archive) ->
+        List.map external_lib_archives ~f:(fun (lib, (loc, archive)) ->
           let+ modules =
             Ocamlobjinfo.archive_rules
               toolchain
@@ -66,7 +66,7 @@ let gen_rules
               ~sandbox:(Some Sandbox_config.needs_sandboxing)
               ~archive
           in
-          lib, modules)
+          lib, (loc, modules))
         |> Action_builder.all
       in
       let* allowed_libs = Resolve.Memo.read allow_unused_libraries in
@@ -82,7 +82,7 @@ let gen_rules
         in
         external_modules @ local_modules
         |> Lib.Map.of_list_exn
-        |> Lib.Map.foldi ~init:[] ~f:(fun lib lib_modules acc ->
+        |> Lib.Map.foldi ~init:[] ~f:(fun lib (dep_loc, lib_modules) acc ->
           (* Skip libraries with no modules *)
           if Module_name.Unique.Set.is_empty lib_modules
           then acc
@@ -94,21 +94,19 @@ let gen_rules
             in
             (* Check if library is in the allow list *)
             let is_allowed = Lib.Set.mem allowed_set lib in
-            if is_used then acc else if is_allowed then acc else lib :: acc))
+            if is_used then acc else if is_allowed then acc else (dep_loc, lib) :: acc))
       in
       match unused_libs with
       | [] -> Action_builder.return (Action.progn [])
-      | libs ->
+      | (loc, _) :: _ ->
         Action_builder.fail
           { fail =
               (fun () ->
-                (* CR-someday rgrinberg: ideally, we'd use the locations of the
-                   unused libraries, but they've already been discarded. *)
                 User_error.raise
                   ~loc
                   [ Pp.text "Unused libraries:"
-                  ; Pp.enumerate libs ~f:(fun lib ->
-                      Lib.name lib |> Lib_name.to_string |> Pp.verbatim)
+                  ; Pp.enumerate unused_libs ~f:(fun (_, lib) ->
+                      Pp.textf "%s" (Lib.name lib |> Lib_name.to_string))
                   ])
           }
     in

--- a/src/dune_rules/unused_libs_rules.mli
+++ b/src/dune_rules/unused_libs_rules.mli
@@ -7,6 +7,6 @@ val gen_rules
   -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
   -> dir:Path.Build.t
-  -> direct_requires:Lib.t list Resolve.Memo.t
+  -> user_written_requires:(Loc.t * Lib.t) list Resolve.Memo.t
   -> allow_unused_libraries:Lib.t list Resolve.Memo.t
   -> unit Memo.t

--- a/test/blackbox-tests/test-cases/unused-libs/allow-unused-libraries.t
+++ b/test/blackbox-tests/test-cases/unused-libs/allow-unused-libraries.t
@@ -53,12 +53,9 @@ Create three libraries - one will be used, two won't be used:
 Build the unused-libs alias - should only error on unused_not_allowed:
 
   $ dune build @unused-libs
-  File "dune", lines 13-17, characters 0-138:
-  13 | (executable
-  14 |  (name main)
-  15 |  (modules main)
+  File "dune", line 16, characters 36-54:
   16 |  (libraries used_lib unused_allowed unused_not_allowed)
-  17 |  (allow_unused_libraries unused_allowed))
+                                           ^^^^^^^^^^^^^^^^^^
   Error: Unused libraries:
   - unused_not_allowed
   [1]
@@ -134,11 +131,9 @@ Build - dep_lib should not error on base_lib, but top_lib should error on
 unused_dep:
 
   $ dune build @unused-libs
-  File "dune", lines 15-18, characters 0-76:
-  15 | (library
-  16 |  (name top_lib)
-  17 |  (modules top_lib)
+  File "dune", line 18, characters 20-30:
   18 |  (libraries dep_lib unused_dep))
+                           ^^^^^^^^^^
   Error: Unused libraries:
   - unused_dep
   [1]

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-alias.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-alias.t
@@ -14,9 +14,13 @@ Test that the unused-libs alias exists and can be built
   >  (modules unused_lib))
   > 
   > (library
+  >  (name unused_lib2)
+  >  (modules unused_lib2))
+  > 
+  > (library
   >  (name mylib)
   >  (modules mylib)
-  >  (libraries used_lib unused_lib))
+  >  (libraries used_lib unused_lib unused_lib2))
   > EOF
 
   $ cat > used_lib.ml <<EOF
@@ -27,16 +31,19 @@ Test that the unused-libs alias exists and can be built
   > let unused_helper x = x * 2
   > EOF
 
+  $ cat > unused_lib2.ml <<EOF
+  > let unused_helper x = x * 3
+  > EOF
+
   $ cat > mylib.ml <<EOF
   > let compute x = Used_lib.helper x
   > EOF
 
   $ dune build @unused-libs
-  File "dune", lines 9-12, characters 0-73:
-   9 | (library
-  10 |  (name mylib)
-  11 |  (modules mylib)
-  12 |  (libraries used_lib unused_lib))
+  File "dune", line 16, characters 32-43:
+  16 |  (libraries used_lib unused_lib unused_lib2))
+                                       ^^^^^^^^^^^
   Error: Unused libraries:
+  - unused_lib2
   - unused_lib
   [1]

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-exe.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-exe.t
@@ -40,11 +40,9 @@ Create two libraries - one that will be used and one that won't:
 Build the unused-libs alias:
 
   $ dune build @unused-libs
-  File "dune", lines 9-12, characters 0-74:
-   9 | (executable
-  10 |  (name main)
-  11 |  (modules main)
+  File "dune", line 12, characters 21-31:
   12 |  (libraries used_lib unused_lib))
+                            ^^^^^^^^^^
   Error: Unused libraries:
   - unused_lib
   [1]

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-external.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-external.t
@@ -58,10 +58,9 @@ Create a dune project that uses these external libraries:
 Build the unused-libs alias:
 
   $ OCAMLPATH=$PWD/findlib dune build @unused-libs
-  File "dune", lines 1-3, characters 0-56:
-  1 | (library
-  2 |  (name mylib)
+  File "dune", line 3, characters 21-31:
   3 |  (libraries ext_used ext_unused))
+                           ^^^^^^^^^^
   Error: Unused libraries:
   - ext_unused
   [1]

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-ppx-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-ppx-runtime-deps.t
@@ -30,10 +30,3 @@ Demonstrate ppx_runtime_deps issues
   > EOF
 
   $ dune build @use/unused-libs
-  File "use/dune", lines 1-3, characters 0-48:
-  1 | (executable
-  2 |  (name use)
-  3 |  (preprocess (pps foo)))
-  Error: Unused libraries:
-  - runtime
-  [1]

--- a/test/blackbox-tests/test-cases/unused-libs/unused-libs-re-exports.t
+++ b/test/blackbox-tests/test-cases/unused-libs/unused-libs-re-exports.t
@@ -31,10 +31,3 @@ Demonstrate that re_exports is incorrectly triggering the unused library check:
   > EOF
 
   $ dune build @use/unused-libs
-  File "use/dune", lines 1-3, characters 0-41:
-  1 | (executable
-  2 |  (libraries bar)
-  3 |  (name use))
-  Error: Unused libraries:
-  - foo
-  [1]


### PR DESCRIPTION
Add locations for dependencies written by users and use them in error
messages.

Also, only take into account dependencies explicitly written by the user
for the unused library check.
