### PR TITLE
Revert "Make promoted files read-only"

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -680,7 +680,7 @@ let run
                 ~findlib_toolchain:(Context.findlib_toolchain context)
                 package
             in
-            Install.Entry.gen_install_file entries |> Io.overwrite_file (Path.source fn))))
+            Install.Entry.gen_install_file entries |> Io.write_file (Path.source fn))))
   in
   Path.Set.to_list !files_deleted_in
   (* This [List.rev] is to ensure we process children directories before

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -153,15 +153,7 @@ let subst_file path ~map opam_package_files =
       | None, Some x -> Some x
       | Some x, Some y -> Some (x ^ "\n" ^ y)
     in
-    (match contents with
-     | None -> ()
-     | Some contents ->
-       (try Io.write_file path contents with
-        | Unix.Unix_error (Unix.EACCES, _, _) ->
-          let Unix.{ st_perm; _ } = Path.stat_exn path in
-          Path.chmod path ~mode:(Path.Permissions.add Path.Permissions.write st_perm);
-          Io.write_file path contents;
-          Path.chmod path ~mode:st_perm))
+    Option.iter contents ~f:(Io.write_file path)
 ;;
 
 (* Extending the Dune_project APIs, but adding capability to modify *)

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -153,7 +153,15 @@ let subst_file path ~map opam_package_files =
       | None, Some x -> Some x
       | Some x, Some y -> Some (x ^ "\n" ^ y)
     in
-    Option.iter ~f:(Io.overwrite_file path) contents
+    (match contents with
+     | None -> ()
+     | Some contents ->
+       (try Io.write_file path contents with
+        | Unix.Unix_error (Unix.EACCES, _, _) ->
+          let Unix.{ st_perm; _ } = Path.stat_exn path in
+          Path.chmod path ~mode:(Path.Permissions.add Path.Permissions.write st_perm);
+          Io.write_file path contents;
+          Path.chmod path ~mode:st_perm))
 ;;
 
 (* Extending the Dune_project APIs, but adding capability to modify *)

--- a/doc/changes/changed/12519.md
+++ b/doc/changes/changed/12519.md
@@ -1,1 +1,0 @@
-- Make promoted files read-only. (#12519, #12465, @MisterDA)

--- a/doc/changes/changed/12519.md
+++ b/doc/changes/changed/12519.md
@@ -1,1 +1,1 @@
-- Make promoted files read-only. (#12542, #12540, #12519, #12465, @MisterDA)
+- Make promoted files read-only. (#12519, #12465, @MisterDA)

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -282,18 +282,6 @@ struct
     else with_file_out ~binary ?perm fn ~f:(fun oc -> output_string oc data)
   ;;
 
-  let overwrite_file ?binary fn data =
-    let path = Path.to_string fn in
-    try write_file ?binary fn data with
-    | Unix.Unix_error (Unix.EACCES, _, _) ->
-      let Unix.{ st_perm; _ } = Unix.stat path in
-      let user_write = 0o200 in
-      Unix.chmod path (st_perm lor user_write);
-      Fun.protect
-        ~finally:(fun () -> Unix.chmod path st_perm)
-        (fun () -> write_file ?binary fn data)
-  ;;
-
   let write_lines ?binary ?perm fn lines =
     with_file_out ?binary ?perm fn ~f:(fun oc ->
       List.iter

--- a/otherlibs/stdune/src/io_intf.ml
+++ b/otherlibs/stdune/src/io_intf.ml
@@ -25,10 +25,6 @@ module type S = sig
   val write_lines : ?binary:bool -> ?perm:int -> path -> string list -> unit
   val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
 
-  (** Try to write the file. On failure, temporarily set the write
-      permission, and retry writing once. *)
-  val overwrite_file : ?binary:bool -> path -> string -> unit
-
   val setup_copy
     :  ?chmod:(int -> int)
     -> src:path

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -82,10 +82,9 @@ let promote_target_if_not_up_to_date
         ];
       if promote_until_clean then To_delete.add dst;
       (* The file in the build directory might be read-only if it comes from the
-         shared cache. We don't want the file in the source tree to be writable
-         by the user, since a new promotion will overwrite it, so we explicitly
-         remove the write permission. *)
-      let chmod = Path.Permissions.remove Path.Permissions.write in
+         shared cache. However, we want the file in the source tree to be
+         writable by the user, so we explicitly set the user writable bit. *)
+      let chmod = Path.Permissions.add Path.Permissions.write in
       let+ () = promote_source ~chmod ~delete_dst_if_it_is_a_directory:true ~src ~dst in
       true
   in

--- a/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promotion-in-source-tree.t
@@ -20,9 +20,9 @@ Reproduction case for #3026
 Run Dune a first time to fill the cache, then delete the promoted file and run
 Dune again. At the end of the first run, the file [_build/default/file] should
 get deduplicated and so become read-only. As a result, on the second run the
-promoted file will be copied from a read-only file. We don't want the user to be
-able to edit this file even if it is in the source tree, as Dune will always
-overwrite it, so Dune should ensure the file isn't writable.
+promoted file will be copied from a read-only file. However, we still want the
+user to be able to edit this file given that it is in the source tree, so Dune
+should change the permission of this file.
 
 We check that Dune does change the permission by echoing something into the file
 after the second run.
@@ -40,5 +40,4 @@ after the second run.
   $ cat file
   Hello, world!
 
-  $ dune_cmd stat permissions file
-  444
+  $ echo plop > file

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -72,7 +72,6 @@ when calling dune subst:
       "@doc" {with-doc}
     ]
   ]
-  $ dune build -p foo @install
 
 When the version of the language >= 2.7, odoc is automatically added to
 the doc dependencies:
@@ -192,16 +191,13 @@ the doc dependencies:
     ]
     ["dune" "install" "-p" name "--create-install-files" name]
   ]
-  $ dune subst
-  $ dune build -p foo --promote-install-files=false @install
-  $ dune install -p foo --create-install-files foo --prefix=$PWD/local
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (name foo)
   > (generate_opam_files true)
   > (subst disabled)
-  > (package (name foo) (depends (odoc :with-test) something) (allow_empty))
+  > (package (name foo) (depends (odoc :with-test) something))
   > EOF
 
   $ dune build foo.opam
@@ -219,14 +215,13 @@ the doc dependencies:
       "@doc" {with-doc}
     ]
   ]
-  $ dune build -p foo @install
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (name foo)
   > (generate_opam_files true)
   > (subst enabled)
-  > (package (name foo) (depends (odoc :with-test) something) (allow_empty))
+  > (package (name foo) (depends (odoc :with-test) something))
   > EOF
 
   $ dune build foo.opam
@@ -245,5 +240,3 @@ the doc dependencies:
       "@doc" {with-doc}
     ]
   ]
-  $ dune subst
-  $ dune build -p foo @install

--- a/test/blackbox-tests/test-cases/ignore-promoted-rules-internal-rules.t
+++ b/test/blackbox-tests/test-cases/ignore-promoted-rules-internal-rules.t
@@ -11,9 +11,6 @@ Reported in #8417
   > EOF
 
   $ dune build foo.opam
-  $ dune_cmd stat permissions foo.opam
-  444
-  $ chmod +w foo.opam
   $ echo foobar_extra >> foo.opam
   $ grep foobar_extra foo.opam
   foobar_extra

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -125,9 +125,6 @@ Dune restores only1 if it's modified in the source tree
 
   $ cat only1
   0
-  $ dune_cmd stat permissions only1
-  444
-  $ chmod +w only1
   $ echo 1 > only1
   $ dune build only2
   $ cat only1

--- a/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
+++ b/test/blackbox-tests/test-cases/promote/promote-only-when-needed.t
@@ -22,9 +22,6 @@ Dune doesn't promote the file again if it's unchanged.
 
 Dune does promotes the file again if it's changed.
 
-  $ dune_cmd stat permissions promoted
-  444
-  $ chmod +w promoted
   $ echo hi > promoted
   $ dune build promoted --verbose 2>&1 | grep "Promoting"
   Promoting "_build/default/promoted" to "promoted"

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -50,9 +50,6 @@ Remove a directory and rebuild.
 
 Modify a file and rebuild.
 
-  $ dune_cmd stat permissions d1/b
-  444
-  $ chmod +w d1/b
   $ echo -n "*" > d1/b
   $ cat d1/a d1/b d1/d2/c
   +*+

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -50,9 +50,6 @@ Now try deleting the promoted file.
 
 Now try replacing its content.
 
-  $ dune_cmd stat permissions promoted
-  444
-  $ chmod +w promoted
   $ echo hi > promoted
   $ build result
   Success


### PR DESCRIPTION
Reverts https://github.com/ocaml/dune/pull/12519 and https://github.com/ocaml/dune/pull/12542, as a workaround go unblock the release https://github.com/ocaml/dune/issues/12619

Ultimately, we plan to bring this, or a related configuration parameter, back (as per https://github.com/ocaml/dune/issues/12746).