### PR TITLE
doc: Add pointers to editor configuration

### DIFF
--- a/doc/howto/configure-editors-with-package-management.md
+++ b/doc/howto/configure-editors-with-package-management.md
@@ -1,18 +1,21 @@
 How to Configure Editors with Package Management
 ================================================
 
-This document aims to help people set up their editors for use with
-Dune package management. Different configurations are required than when using opam to manage dependencies.```
+This document aims to help people set up their editors for use with Dune
+package management. Different configurations are required than when using opam
+to manage dependencies.
 
 :::{note}
-This list is not exhaustive. If you have a configuration for your editor that is not included here, we would welcome a [pull request to the Dune
+This list is not exhaustive. If you have a configuration for your editor that
+is not included here, we would welcome a [pull request to the Dune
 repository](https://github.com/ocaml/dune/pulls) documenting the configuration.
 :::
 
 Emacs
 -----
 
-For Emacs, we recommend using `ocaml-eglot` mode with Dune package management. Follow the [instructions in the OCaml-eglot
+For Emacs, we recommend using `ocaml-eglot` mode with Dune package management.
+Follow the [instructions in the OCaml-eglot
 repository](https://github.com/tarides/ocaml-eglot?tab=readme-ov-file#usage-with-dune-pkg).
 
 Neovim
@@ -33,5 +36,6 @@ repository](https://github.com/ocamllabs/vscode-ocaml-platform?tab=readme-ov-fil
 More information
 ----------------
 
-For general information on editor set up for OCaml (not including configuration specific to dune package management) check out [the community
-documentation on OCaml.org](https://ocaml.org/docs/set-up-editor).
+For general information on editor set up for OCaml (not including configuration
+specific to dune package management) check out [the community documentation on
+OCaml.org](https://ocaml.org/docs/set-up-editor).

--- a/doc/howto/configure-editors-with-package-management.md
+++ b/doc/howto/configure-editors-with-package-management.md
@@ -5,6 +5,14 @@ This documents aims to help people on how to set up their editors when using
 Dune package management. The way to do so is somewhat different than using
 previous approaches, thus configuration might need to be adapted.
 
+:::{note}
+This list is not exhaustive, the lack of your editor does not mean that it is
+not possible to use Dune package management with the editor, we just don't have
+an instruction for it yet. Feel free to submit information and updates about
+your favorite editor as a [pull request to the Dune
+repository](https://github.com/ocaml/dune/pulls).
+:::
+
 Emacs
 -----
 
@@ -26,3 +34,9 @@ Visual Studio Code
 The configuration for the VSCode OCaml Platform extension is [described in the
 vscode-ocaml-platform
 repository](https://github.com/ocamllabs/vscode-ocaml-platform?tab=readme-ov-file#dune-package-management-dpm).
+
+More information
+----------------
+
+For more information on editor set up for OCaml check out [the community
+documentation on OCaml.org](https://ocaml.org/docs/set-up-editor).

--- a/doc/howto/configure-editors-with-package-management.md
+++ b/doc/howto/configure-editors-with-package-management.md
@@ -1,23 +1,18 @@
 How to Configure Editors with Package Management
 ================================================
 
-This documents aims to help people on how to set up their editors when using
-Dune package management. The way to do so is somewhat different than using
-previous approaches, thus configuration might need to be adapted.
+This document aims to help people set up their editors for use with
+Dune package management. Different configurations are required than when using opam to manage dependencies.```
 
 :::{note}
-This list is not exhaustive, the lack of your editor does not mean that it is
-not possible to use Dune package management with the editor, we just don't have
-an instruction for it yet. Feel free to submit information and updates about
-your favorite editor as a [pull request to the Dune
-repository](https://github.com/ocaml/dune/pulls).
+This list is not exhaustive. If you have a configuration for your editor that is not included here, we would welcome a [pull request to the Dune
+repository](https://github.com/ocaml/dune/pulls) documenting the configuration.
 :::
 
 Emacs
 -----
 
-To use configure the OCaml-eglot mode with Dune package management support
-follow the [instructions in the OCaml-eglot
+For Emacs, we recommend using `ocaml-eglot` mode with Dune package management. Follow the [instructions in the OCaml-eglot
 repository](https://github.com/tarides/ocaml-eglot?tab=readme-ov-file#usage-with-dune-pkg).
 
 Neovim
@@ -38,5 +33,5 @@ repository](https://github.com/ocamllabs/vscode-ocaml-platform?tab=readme-ov-fil
 More information
 ----------------
 
-For more information on editor set up for OCaml check out [the community
+For general information on editor set up for OCaml (not including configuration specific to dune package management) check out [the community
 documentation on OCaml.org](https://ocaml.org/docs/set-up-editor).

--- a/doc/howto/configure-editors-with-package-management.md
+++ b/doc/howto/configure-editors-with-package-management.md
@@ -1,0 +1,28 @@
+How to Configure Editors with Package Management
+================================================
+
+This documents aims to help people on how to set up their editors when using
+Dune package management. The way to do so is somewhat different than using
+previous approaches, thus configuration might need to be adapted.
+
+Emacs
+-----
+
+To use configure the OCaml-eglot mode with Dune package management support
+follow the [instructions in the OCaml-eglot
+repository](https://github.com/tarides/ocaml-eglot?tab=readme-ov-file#usage-with-dune-pkg).
+
+Neovim
+------
+
+The instructions on how to configure `ocaml.nvim`, the OCaml plugin for Neovim
+can be found [in the `ocaml.nvim`
+repository](https://github.com/tarides/ocaml.nvim?tab=readme-ov-file#using-dune).
+
+
+Visual Studio Code
+------------------
+
+The configuration for the VSCode OCaml Platform extension is [described in the
+vscode-ocaml-platform
+repository](https://github.com/ocamllabs/vscode-ocaml-platform?tab=readme-ov-file#dune-package-management-dpm).

--- a/doc/howto/index.rst
+++ b/doc/howto/index.rst
@@ -25,3 +25,4 @@ These guides will help you use Dune's features in your project.
    override-default-entrypoint
    release-binaries-with-github-action
    use-opam-alongside-dune-package-management
+   configure-editors-with-package-management


### PR DESCRIPTION
This PR adds some pointers to the instructions on how to configure editors. It doesn't preclude us from writing more involved howtos for each editor but it is nice to be able to point people to the relevant plugins that are supported and their instructions.

The links were contributed by @Sudha247.

Closes #12799