### PR TITLE
Update Dune language version to 3.21 in "How to Use Opam Alongside Dune Package Management"

### DIFF
--- a/doc/howto/use-opam-alongside-dune-package-management.rst
+++ b/doc/howto/use-opam-alongside-dune-package-management.rst
@@ -31,7 +31,7 @@ file:
 
 .. code:: dune
 
-   (lang dune 3.20)
+   (lang dune 3.21)
 
    (pkg enabled)
 

--- a/doc/howto/use-opam-alongside-dune-package-management.rst
+++ b/doc/howto/use-opam-alongside-dune-package-management.rst
@@ -16,7 +16,7 @@ following contents:
 
 .. code:: dune
 
-   (lang dune 3.20)
+   (lang dune 3.21)
 
    (pkg disabled)
 


### PR DESCRIPTION
Apparently the `(pkg disabled)` does not work correctly on version `3.20`.