### PR TITLE
Remove Stale CR regarding digesting globs

### DIFF
--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -235,11 +235,7 @@ module Fact = struct
   let file fn digest = File (fn, digest)
 
   let file_selector fs facts =
-    (* CR-someday amokhov: We used to call [File_selector.to_dyn] here that raises under
-       the same conditions that [File_selector.digest_exn] is raising, namely, when
-       the underlying glob is not serialisable. We should make all globs serialisable
-       or use stronger types to statically rule out the possibility of raising here. *)
-    File_selector { file_selector_digest = File_selector.digest_exn fs; facts }
+    File_selector { file_selector_digest = File_selector.digest fs; facts }
   ;;
 
   let alias _alias files = Alias files
@@ -272,12 +268,7 @@ module Set = struct
       | Env var -> Env var :: acc
       | Universe -> Universe :: acc
       | File p -> File (Path.to_string p |> Digest.string) :: acc
-      | File_selector fs ->
-        (* CR-someday amokhov: We used to call [File_selector.to_dyn] here that raises under
-           the same conditions that [File_selector.digest_exn] is raising, namely, when
-           the underlying glob is not serialisable. We should make all globs serialisable
-           or use stronger types to statically rule out the possibility of raising here. *)
-        File_selector (File_selector.digest_exn fs) :: acc
+      | File_selector fs -> File_selector (File_selector.digest fs) :: acc
       | Alias a ->
         Alias
           { dir = Path.Build.to_string (Alias.dir a)

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -13,8 +13,8 @@ let dir t = t.dir
 let only_generated_files t = t.only_generated_files
 let predicate t = t.predicate
 
-let digest_exn { dir; predicate; only_generated_files } =
-  Digest.generic (dir, Predicate_lang.Glob.digest_exn predicate, only_generated_files)
+let digest { dir; predicate; only_generated_files } =
+  Digest.generic (dir, Predicate_lang.Glob.digest predicate, only_generated_files)
 ;;
 
 let compare { dir; predicate; only_generated_files } t =

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -26,6 +26,4 @@ val to_dyn : t -> Dyn.t
 
 val test : t -> Path.t -> bool
 val test_basename : t -> basename:string -> bool
-
-(** Raises on non-serialisable globs, just like most other functions above. *)
-val digest_exn : t -> Digest.t
+val digest : t -> Digest.t

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -196,9 +196,7 @@ module Glob = struct
       | Glob g -> Dyn.variant "Glob" [ Glob.to_dyn (unproxy g) ]
     ;;
 
-    (* CR-someday amokhov: The [_exn] suffix is here because [Glob.to_string] can actually
-       raise. We should clean this all up, at least use the [_exn] suffix consistently. *)
-    let digest_exn = function
+    let digest = function
       | Literal s -> Dune_digest.generic (0, s)
       | Glob g -> Dune_digest.generic (1, Glob.to_string (unproxy g))
     ;;
@@ -266,5 +264,5 @@ module Glob = struct
   let hash t = Poly.hash t
   let decode = decode Element.decode
   let encode t = encode Element.encode t
-  let digest_exn t = map t ~f:Element.digest_exn |> Dune_digest.generic
+  let digest t = map t ~f:Element.digest |> Dune_digest.generic
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -45,7 +45,5 @@ module Glob : sig
   val hash : t -> int
   val decode : t Dune_sexp.Decoder.t
   val encode : t -> Dune_sexp.t
-
-  (** Raises on non-serialisable globs, just like most other functions above. *)
-  val digest_exn : t -> Dune_digest.t
+  val digest : t -> Dune_digest.t
 end


### PR DESCRIPTION
All globs are trivially digestible since they're all constructed from strings. We no longer globs to be constructed from regular expressions.