### PR TITLE
Fix #12809

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -658,8 +658,7 @@ module Substitute = struct
         , String.Map.to_list artifacts
         , Package.Name.Map.to_list_map depends ~f:(fun _ (m, p) -> m, paths p)
         , expander.version
-        , expander.context
-        , Env.Map.to_list expander.env |> Digest.generic |> Digest.to_string_raw )
+        , expander.context )
         |> Digest.generic
         |> Digest.to_string_raw
       in

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -150,4 +150,3 @@ Modifying this variable should not trigger a rebuild:
 
   $ export FOOBAR=1
   $ build_pkg test 2>&1
-  running

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -129,3 +129,25 @@ It is also possible to use variables of your dependencies:
   $ build_pkg test 2>&1 | sanitize_pkg_digest dependency.0.0.1
   There is also some paths set:
   '%{dependency:lib}%' is '../../dependency.0.0.1-DIGEST_HASH/target/lib/dependency'
+
+The substitute action should not observe the environment:
+
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (source (copy $PWD/test-source))
+  > (depends dependency)
+  > (build
+  >  (progn
+  >   (system "echo running")
+  >   (substitute foo.in foo)))
+  > EOF
+  $ touch test-source/foo.in
+  $ build_pkg test 2>&1
+  running
+  $ build_pkg test 2>&1
+
+Modifying this variable should not trigger a rebuild:
+
+  $ export FOOBAR=1
+  $ build_pkg test 2>&1
+  running


### PR DESCRIPTION
Fixes #12809

Stop observing the environment in substitute actions. There are no opam variables for viewing the env environment.