### PR TITLE
pkg: delay url resolution

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -21,7 +21,10 @@ Local file system
   does not exist
 
 Git
-  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 | sed "s#$(pwd)#PWD#" | sanitize_pkg_digest foo.dev
+  $ runtest "(fetch (url \"git+file://$PWD/dummy\"))" 2>&1 \
+  > | sed "s#$(pwd)#PWD#" \
+  > | sanitize_pkg_digest foo.dev \
+  > | sed -E 's#/url/[a-f0-9]+#/url/DIGEST#'
   fatal: 'PWD/dummy' does not appear to be a git repository
   fatal: Could not read from remote repository.
   
@@ -29,6 +32,7 @@ Git
   and the repository exists.
   Error: Failed to run external command:
   'git ls-remote "file://PWD/dummy"'
+  -> required by _build/_fetch/url/DIGEST/dir
   -> required by
      _build/_private/default/.pkg/foo.dev-DIGEST_HASH/source
   -> required by


### PR DESCRIPTION
The URL is only needed to construct the action. Therefore, we need to construct inside the action builder.