### PR TITLE
fix: same error message for both ascii and non ascii invalid version cases

### DIFF
--- a/doc/changes/fixed/12833.md
+++ b/doc/changes/fixed/12833.md
@@ -1,0 +1,3 @@
+- Improve error message for invalid version formats in both `(lang dune ...)` and
+  `(using extension ...)` declarations. Changes "Atom of the form NNN.NNN expected"
+  to "Invalid version. Version must be two numbers separated by a dot." (#12833, @benodiwal)

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -41,7 +41,10 @@ module Version = struct
            ; Pp.textf "This version is parsed as just %d.%d." a b
            ];
          v
-       | Error () -> User_error.raise ~loc [ Pp.text "Atom of the form NNN.NNN expected" ])
+       | Error () ->
+         User_error.raise
+           ~loc
+           [ Pp.text "Invalid version. Version must be two numbers separated by a dot." ])
     | sexp -> User_error.raise ~loc:(Ast.loc sexp) [ Pp.text "Atom expected" ]
   ;;
 

--- a/test/blackbox-tests/test-cases/extensions-invalid-version.t
+++ b/test/blackbox-tests/test-cases/extensions-invalid-version.t
@@ -20,6 +20,11 @@ Invalid version number:
 
 Test with various non-ASCII characters:
 
+CR-someday benodiwal: Non-ASCII characters in extension versions fail at the
+s-expression parsing level, showing a generic "Invalid dune-project file" error
+instead of the specific version validation error with hints. This would require
+changes to the s-expression parser to handle properly.
+
   $ test_invalid_version "è"
   File "dune-project", line 2, characters 14-14:
   2 | (using menhir è)

--- a/test/blackbox-tests/test-cases/extensions-invalid-version.t
+++ b/test/blackbox-tests/test-cases/extensions-invalid-version.t
@@ -1,0 +1,61 @@
+Test invalid version numbers in extension declarations. We want to make sure that
+such situations provide a clear error.
+
+  $ test_invalid_version() {
+  >   cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using menhir $1)
+  > EOF
+  >   dune build
+  > }
+
+Invalid version number:
+
+  $ test_invalid_version "Ali"
+  File "dune-project", line 2, characters 14-17:
+  2 | (using menhir Ali)
+                    ^^^
+  Error: Invalid version. Version must be two numbers separated by a dot.
+  [1]
+
+Test with various non-ASCII characters:
+
+  $ test_invalid_version "è"
+  File "dune-project", line 2, characters 14-14:
+  2 | (using menhir è)
+                    
+  Error: Invalid dune-project file
+  [1]
+
+
+  $ test_invalid_version "π3.14"
+  File "dune-project", line 2, characters 14-14:
+  2 | (using menhir π3.14)
+                    
+  Error: Invalid dune-project file
+  [1]
+
+
+  $ test_invalid_version "α"
+  File "dune-project", line 2, characters 14-14:
+  2 | (using menhir α)
+                    
+  Error: Invalid dune-project file
+  [1]
+
+
+  $ test_invalid_version "😀"
+  File "dune-project", line 2, characters 14-14:
+  2 | (using menhir 😀)
+                    
+  Error: Invalid dune-project file
+  [1]
+
+
+  $ test_invalid_version "中3.16文"
+  File "dune-project", line 2, characters 14-14:
+  2 | (using menhir 中3.16文)
+                    
+  Error: Invalid dune-project file
+  [1]
+

--- a/test/blackbox-tests/test-cases/lang-invalid-version.t
+++ b/test/blackbox-tests/test-cases/lang-invalid-version.t
@@ -14,7 +14,7 @@ Invalid version number:
   File "dune-project", line 1, characters 11-14:
   1 | (lang dune Ali)
                  ^^^
-  Error: Atom of the form NNN.NNN expected
+  Error: Invalid version. Version must be two numbers separated by a dot.
   [1]
 
 Test with various non-ASCII characters:


### PR DESCRIPTION
Improves error message for invalid version formats in dune-project files. Changes "Atom of the form NNN.NNN expected" to
  "Invalid version. Version must be two numbers separated by a dot."

  This affects both (lang dune ...) and (using extension ...) declarations with invalid ASCII versions like "Ali". Both now
  show the clearer error message.

  Note: Non-ASCII characters in extension versions (e.g., (using menhir è)) still show a generic "Invalid dune-project file"
  error because they fail at the s-expression parsing level. This would require changes to the parser and could be addressed
  in a follow-up issue.

  Added test coverage for extension version errors in test/blackbox-tests/test-cases/extensions-invalid-version.t

  Discussed in #12794