### PR TITLE
Remove context from the substitute action's digest

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -657,8 +657,7 @@ module Substitute = struct
         ( paths expander.paths
         , String.Map.to_list artifacts
         , Package.Name.Map.to_list_map depends ~f:(fun _ (m, p) -> m, paths p)
-        , expander.version
-        , expander.context )
+        , expander.version )
         |> Digest.generic
         |> Digest.to_string_raw
       in


### PR DESCRIPTION
The action can't observe the context, so there's no need to include it. Note that the context leaks via paths that the action can observe, so removing this from the digest doesn't affect recompilation at all. Thus, this change is just a refactoring.