### PR TITLE
opam-var-os.t test tweak

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/dune
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/dune
@@ -1,28 +1,3 @@
 (cram
- (deps opam-vars)
+ (deps %{bin:opam})
  (applies_to opam-var-os))
-
-(data_only_dirs fake_opam_root)
-
-; Without this, no copying rules will be setup for the .opam-switch directory
-
-(subdir
- fake_opam_root/default
- (dirs :standard .opam-switch))
-
-; We trick opam into thinking it has a config file with fake_opam_root so that we can
-; access the os variables without having to do opam init
-
-(rule
- (target opam-vars)
- (deps
-  (source_tree fake_opam_root))
- (action
-  (with-stdout-to
-   %{target}
-   (progn
-    (run %{bin:opam} --cli 2.1 var --root fake_opam_root arch)
-    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os)
-    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-distribution)
-    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-family)
-    (run %{bin:opam} --cli 2.1 var --root fake_opam_root os-version)))))

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -1,8 +1,25 @@
+# Technically, this test should depend on something that comes from the OS so
+# that it re-runs after an update. That's a little hard to express however, and
+# one must remember to manually force to re-run it after an upgrade.
+
   $ . ../helpers.sh
 
 Here we test global opam variables that are system specific. Since these values change
 between systems, we can't hardcode them in the test. Instead, we use the opam var command
 to compare their values.
+
+  $ export OPAMROOT=$(mktemp -d)
+  $ mkdir -p $OPAMROOT/default/.opam-switch/
+  $ cat >$OPAMROOT/default/.opam-switch/switch-config <<EOF
+  > opam-version: "2.0"
+  > EOF
+  $ cat >$OPAMROOT/config <<EOF
+  > opam-version: "2.0"
+  > switch: "default"
+  > installed-switches: ["default"]
+  > EOF
+  $ v() { opam --cli 2.1 var $1; }
+  $ { v arch ; v os ; v os-distribution ; v os-family ; v os-version ; } > opam-vars
 
 # arch os os-distribution os-family os-version user group
 


### PR DESCRIPTION
Modify the test to create the opam environment inside the test.

Doing it via dune rules doesn't by us anything and just makes it harder
to re-run the test when the opam variables become out of date.
