### PR TITLE
ox: keep compat with oxcaml/oxcaml#main

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -146,6 +146,29 @@ jobs:
           gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_08 -c make release 
 
+  nix-build-ox:
+    # This builds OxCaml with the flake version which is typically ahead of the
+    # OxCaml opam repository
+    name: Build with OxCaml
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+          gc-max-store-size-linux: 2G
+      - run: nix develop -i .#bootstrap-ox -c make release 
+
 #
 # Stage 2
 #

--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764950604,
-        "narHash": "sha256-ihghtDwL4ioBLg9yphaK2RXoZjJYPvoKgLWGR6GGwPk=",
+        "lastModified": 1765456638,
+        "narHash": "sha256-Q/BaBegWD0FlxIndp4roXfPSWxHEQF/+PeLHmg3AbHs=",
         "owner": "oxcaml",
         "repo": "oxcaml",
-        "rev": "847bf56d6bd9fa8744546a96db820466c4a6ead2",
+        "rev": "8e7b3655a43711d05419647a3bcda4a6b0374f93",
         "type": "github"
       },
       "original": {

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -128,7 +128,7 @@ let win32_unlink fn =
        retry_loop 30)
 ;;
 
-let unlink_exn = if Stdlib.Sys.win32 then win32_unlink else Unix.unlink
+let unlink_exn = if Stdlib.Sys.win32 then win32_unlink else fun t -> Unix.unlink t
 
 type unlink_status =
   | Success

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -238,7 +238,7 @@ module Session = struct
   let write t b =
     match Platform.OS.value with
     | Linux -> send t b
-    | _ -> Unix.single_write t b
+    | _ -> fun pos len -> Unix.single_write t b pos len
   ;;
 
   let rec csexp_write_loop fd out_buf token =

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -47,7 +47,7 @@ let global () = !global
 let create dst =
   let print =
     match dst with
-    | Out out -> Stdlib.output_string out
+    | Out out -> fun str -> Stdlib.output_string out str
     | Custom c -> c.write
   in
   let close =


### PR DESCRIPTION
Can be tested with
```
nix develop .#bootstrap-ox -c make test-bootstrap
```

We also add a CI job to test the oxcaml bootstrap so that we don't break compatability with the version in the flake. In the future this can be bumped as needed.