### PR TITLE
Respect potentially existing lock dir when running format rules

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
@@ -60,10 +60,9 @@ Formatting should use the locked ocamlformat with the feature flag enabled:
 It should also use the locked dev tool when the feature flag is not passed:
 
   $ dune fmt --preview
-  ocamlformat from PATH, not pkg
-  -> required by _build/default/.formatted/foo.ml
-  -> required by alias .formatted/fmt
-  -> required by alias fmt
+  File "foo.ml", line 1, characters 0-0:
+  Error: Files _build/default/foo.ml and _build/default/.formatted/foo.ml
+  differ.
   [1]
 
 It should use the ocamlformat from PATH when the lock dir is deleted:


### PR DESCRIPTION
The reason that we check the flag first is because unless running with `LOCK_DEV_TOOL` we are not implicitly creating a lock dir for the dev tool. But there might still be an eligible dev tool lock dir (created by `dune tools install ocamlformat` previously) so we should still check it.

Closes #12839.