### PR TITLE
Instantiate takes a resolved library

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -617,8 +617,7 @@ module Parameterised = struct
 
   let instantiate ~loc lib args ~parent_parameters =
     let open Resolve.O in
-    let* lib = lib
-    and* args = make_arguments args in
+    let* args = make_arguments args in
     let* lib = apply_arguments lib args in
     let+ () =
       let* all_args = parameterised_arguments lib in
@@ -1755,10 +1754,10 @@ end = struct
     let open Memo.O in
     let resolve_parameterised_dep (loc, lib) ~arguments =
       resolve_dep db (loc, lib) ~private_deps
-      >>| function
-      | None -> None
-      | Some dep ->
-        Some (Parameterised.instantiate ~loc dep arguments ~parent_parameters:parameters)
+      >>| Option.map ~f:(fun dep ->
+        let open Resolve.O in
+        let* dep = dep in
+        Parameterised.instantiate ~loc dep arguments ~parent_parameters:parameters)
     in
     Memo.List.fold_left ~init:Resolved.Builder.empty deps ~f:(fun acc (dep : Lib_dep.t) ->
       match dep with

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -30,7 +30,7 @@ module Parameterised : sig
 
   val instantiate
     :  loc:Loc.t
-    -> t Resolve.t
+    -> t
     -> (Loc.t * t Resolve.t) list
     -> parent_parameters:t list
     -> t Resolve.t

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -349,10 +349,7 @@ let resolve_instantiation scope instance_name =
     | Some lib ->
       Memo.List.map ~f:go args
       >>| List.map ~f:(fun arg -> Loc.none, arg)
-      >>| Lib.Parameterised.instantiate
-            ~loc:Loc.none
-            (Resolve.return lib)
-            ~parent_parameters:[]
+      >>| Lib.Parameterised.instantiate ~loc:Loc.none lib ~parent_parameters:[]
   in
   go (Parameterised_name.of_string instance_name) |> Resolve.Memo.read_memo
 ;;


### PR DESCRIPTION
Since we're always resolving it in instantiate anyway, let's make the caller do it.