### PR TITLE
Move trace events to dune_trace

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1423,14 +1423,9 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   Dune_console.separate_messages c.builder.separate_error_messages;
   Option.iter c.stats ~f:(fun stats ->
     if Dune_trace.extended_build_job_info stats
-    then
-      (* Communicate config settings as an instant event here. *)
-      let open Chrome_trace in
-      let args = [ "build_dir", `String (Path.Build.to_string Path.Build.root) ] in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
-      let event = Event.instant ~args common in
-      Dune_trace.emit stats event);
+    then (
+      let event = Dune_trace.Event.config () in
+      Dune_trace.emit stats event));
   (* Setup hook for printing GC stats to a file *)
   at_exit (fun () ->
     match c.builder.dump_gc_stats with

--- a/doc/changes/changed/12867.md
+++ b/doc/changes/changed/12867.md
@@ -1,0 +1,3 @@
+- Persistent DB and process events have been slightly modified. Persistent
+  DB events have more concise names and job events always include full
+  information. (#12867, @rgrinberg)

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,7 @@
             file
             mercurial
             unzip
+            perl
           ]
           ++ lib.optionals stdenv.isLinux [ strace ];
         testNativeBuildInputs =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -307,17 +307,13 @@ end = struct
 
   let report_evaluated_rule_exn (t : Build_config.t) =
     Option.iter t.stats ~f:(fun stats ->
-      let module Event = Chrome_trace.Event in
       let event =
         let rule_total =
           match Fiber.Svar.read State.t with
           | Building progress -> progress.number_of_rules_discovered
           | _ -> assert false
         in
-        let args = [ "value", `Int rule_total ] in
-        let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-        let common = Event.common_fields ~name:"evaluated_rules" ~ts () in
-        Event.counter common args
+        Dune_trace.Event.evalauted_rules ~rule_total
       in
       Dune_trace.emit stats event)
   ;;

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -185,7 +185,7 @@ let create ~mode ~dune_stats ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
     Dune_trace.start dune_stats (fun () ->
       let cat = Some [ "create-sandbox" ] in
       let name = Loc.to_file_colon_line rule_loc in
-      Dune_trace.Event.data ~cat ~name ~args:None)
+      Dune_trace.Event.Async.data ~cat ~name ~args:None)
   in
   init ();
   let sandbox_dir =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1182,15 +1182,7 @@ module Run = struct
        But we don't care because the user enabled this manually with
        [--trace-file] *)
     Option.iter stats ~f:(fun stats ->
-      let event =
-        let fields =
-          let ts = Chrome_trace.Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-          Chrome_trace.Event.common_fields ~name:"watch mode iteration" ~ts ()
-        in
-        (* the instant event allows us to separate build commands from
-           different iterations of the watch mode in the event viewer *)
-        Chrome_trace.Event.instant ~scope:Global fields
-      in
+      let event = Dune_trace.Event.scheduler_idle () in
       Dune_trace.emit stats event;
       Dune_trace.flush stats)
   ;;

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -253,7 +253,7 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
   let event =
     Dune_trace.(
       start (global ()) (fun () ->
-        Dune_trace.Event.data
+        Dune_trace.Event.Async.data
           ~cat:None
           ~name:label
           ~args:

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -84,22 +84,24 @@ let printf t format_string =
 let emit t event = printf t "%s" (Json.to_string (Chrome_trace.Event.to_json event))
 
 module Event = struct
-  type data =
-    { args : Chrome_trace.Event.args option
-    ; cat : string list option
-    ; name : string
-    }
+  module Async = struct
+    type data =
+      { args : Chrome_trace.Event.args option
+      ; cat : string list option
+      ; name : string
+      }
 
-  type nonrec t =
-    { t : t
-    ; event_data : data
-    ; start : float
-    }
+    type nonrec t =
+      { t : t
+      ; event_data : data
+      ; start : float
+      }
 
-  let data ~args ~cat ~name = { args; cat; name }
+    let data ~args ~cat ~name = { args; cat; name }
+  end
 end
 
-let start t k : Event.t option =
+let start t k : Event.Async.t option =
   match t with
   | None -> None
   | Some t ->
@@ -111,7 +113,7 @@ let start t k : Event.t option =
 let finish event =
   match event with
   | None -> ()
-  | Some { Event.t; start; event_data = { args; cat; name } } ->
+  | Some { Event.Async.t; start; event_data = { args; cat; name } } ->
     let dur =
       let stop = Unix.gettimeofday () in
       Timestamp.of_float_seconds (stop -. start)

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -81,8 +81,6 @@ let printf t format_string =
   Printf.ksprintf t.print ("%c" ^^ format_string ^^ "\n") c
 ;;
 
-let emit t event = printf t "%s" (Json.to_string (Chrome_trace.Event.to_json event))
-
 module Event = struct
   module Async = struct
     type data =
@@ -99,7 +97,187 @@ module Event = struct
 
     let data ~args ~cat ~name = { args; cat; name }
   end
+
+  type t = Chrome_trace.Event.t
+
+  let scan_source ~name ~start ~stop ~dir =
+    let module Event = Chrome_trace.Event in
+    let module Timestamp = Event.Timestamp in
+    let dur = Timestamp.of_float_seconds (stop -. start) in
+    let common =
+      Event.common_fields
+        ~name:(name ^ ": " ^ Path.Source.to_string dir)
+        ~ts:(Timestamp.of_float_seconds start)
+        ()
+    in
+    let args = [ "dir", `String (Path.Source.to_string dir) ] in
+    Event.complete common ~args ~dur
+  ;;
+
+  let evalauted_rules ~rule_total =
+    let open Chrome_trace in
+    let args = [ "value", `Int rule_total ] in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let common = Event.common_fields ~name:"evaluated_rules" ~ts () in
+    Event.counter common args
+  ;;
+
+  let config () =
+    let open Chrome_trace in
+    let args = [ "build_dir", `String (Path.Build.to_string Path.Build.root) ] in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
+    Event.instant ~args common
+  ;;
+
+  let scheduler_idle () =
+    let fields =
+      let ts = Chrome_trace.Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      Chrome_trace.Event.common_fields ~name:"watch mode iteration" ~ts ()
+    in
+    (* the instant event allows us to separate build commands from
+       different iterations of the watch mode in the event viewer *)
+    Chrome_trace.Event.instant ~scope:Global fields
+  ;;
+
+  module Exit_status = struct
+    type error =
+      | Failed of int
+      | Signaled of Signal.t
+
+    type t = (int, error) result
+  end
+
+  let process
+        ~name
+        ~started_at
+        ~targets
+        ~categories
+        ~pid
+        ~exit
+        ~prog
+        ~process_args
+        ~dir
+        ~stdout
+        ~stderr
+        ~(times : Proc.Times.t)
+    =
+    let open Chrome_trace in
+    let common =
+      let name =
+        match name with
+        | Some n -> n
+        | None -> Filename.basename prog
+      in
+      let ts = Timestamp.of_float_seconds started_at in
+      Event.common_fields ~cat:("process" :: categories) ~name ~ts ()
+    in
+    let always =
+      [ "process_args", `List (List.map process_args ~f:(fun arg -> `String arg))
+      ; "pid", `Int (Pid.to_int pid)
+      ]
+    in
+    let extended =
+      let exit =
+        match exit with
+        | Ok n -> [ "exit", `Int n ]
+        | Error (Exit_status.Failed n) ->
+          [ "exit", `Int n; "error", `String (sprintf "exited with code %d" n) ]
+        | Error (Signaled s) ->
+          [ "exit", `Int (Signal.to_int s)
+          ; "error", `String (sprintf "got signal %s" (Signal.name s))
+          ]
+      in
+      let output name s =
+        match s with
+        | "" -> []
+        | s -> [ name, `String s ]
+      in
+      List.concat
+        [ [ "prog", `String prog
+          ; "dir", `String (Option.map ~f:Path.to_string dir |> Option.value ~default:".")
+          ]
+        ; targets
+        ; exit
+        ; output "stdout" stdout
+        ; output "stderr" stderr
+        ]
+    in
+    let args = always @ extended in
+    let dur = Event.Timestamp.of_float_seconds times.elapsed_time in
+    Event.complete ~args ~dur common
+  ;;
+
+  let persistent ~file ~module_ what ~start ~stop =
+    let module Event = Chrome_trace.Event in
+    let module Timestamp = Event.Timestamp in
+    let dur = Timestamp.of_float_seconds (stop -. start) in
+    let common =
+      Event.common_fields ~name:"db" ~ts:(Timestamp.of_float_seconds start) ()
+    in
+    let args =
+      [ "path", `String (Path.to_string file)
+      ; "module", `String module_
+      ; ( "operation"
+        , `String
+            (match what with
+             | `Save -> "save"
+             | `Load -> "load") )
+      ]
+    in
+    Event.complete common ~args ~dur
+  ;;
+
+  module Rpc = struct
+    type stage =
+      | Start
+      | Stop
+
+    let async_kind_of_stage = function
+      | Start -> Chrome_trace.Event.Start
+      | Stop -> End
+    ;;
+
+    let session ~id stage =
+      let open Chrome_trace in
+      let common =
+        let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+        Event.common_fields ~ts ~name:"rpc_session" ()
+      in
+      let id = Chrome_trace.Id.create (`Int id) in
+      Event.async id (async_kind_of_stage stage) common
+    ;;
+
+    let rec to_json : Sexp.t -> Chrome_trace.Json.t = function
+      | Atom s -> `String s
+      | List s -> `List (List.map s ~f:to_json)
+    ;;
+
+    let message what ~meth_ ~id stage =
+      let open Chrome_trace in
+      let name =
+        match what with
+        | `Notification -> "notification"
+        | `Request _ -> "request"
+      in
+      let args = [ "meth", `String meth_ ] in
+      let args =
+        match what with
+        | `Notification -> args
+        | `Request id -> ("request_id", to_json id) :: args
+      in
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let common = Event.common_fields ~cat:[ "rpc" ] ~ts ~name () in
+      Event.async
+        (Chrome_trace.Id.create (`Int id))
+        ~args
+        (async_kind_of_stage stage)
+        common
+    ;;
+  end
 end
+
+let emit t event = printf t "%s" (Json.to_string (Chrome_trace.Event.to_json event))
 
 let start t k : Event.Async.t option =
   match t with

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -23,18 +23,20 @@ val close : t -> unit
 val extended_build_job_info : t -> bool
 
 module Event : sig
-  type t
-  type data
+  module Async : sig
+    type t
+    type data
 
-  val data
-    :  args:(string * Json.t) list option
-    -> cat:string list option
-    -> name:string
-    -> data
+    val data
+      :  args:(string * Json.t) list option
+      -> cat:string list option
+      -> name:string
+      -> data
+  end
 end
 
-val start : t option -> (unit -> Event.data) -> Event.t option
-val finish : Event.t option -> unit
+val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
+val finish : Event.Async.t option -> unit
 val flush : t -> unit
 
 module Private : sig

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -364,19 +364,13 @@ module Dir = struct
              fun t ~traverse ~trace_event_name ~f ->
                let start = Unix.gettimeofday () in
                let+ res = map_reduce t ~traverse ~trace_event_name ~f in
+               let stop = Unix.gettimeofday () in
                let event =
-                 let stop = Unix.gettimeofday () in
-                 let module Event = Chrome_trace.Event in
-                 let module Timestamp = Event.Timestamp in
-                 let dur = Timestamp.of_float_seconds (stop -. start) in
-                 let common =
-                   Event.common_fields
-                     ~name:(trace_event_name ^ ": " ^ Path.Source.to_string t.path)
-                     ~ts:(Timestamp.of_float_seconds start)
-                     ()
-                 in
-                 let args = [ "dir", `String (Path.Source.to_string t.path) ] in
-                 Event.complete common ~args ~dur
+                 Dune_trace.Event.scan_source
+                   ~name:trace_event_name
+                   ~start
+                   ~stop
+                   ~dir:t.path
                in
                Dune_trace.emit stats event;
                res)

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -126,3 +126,7 @@
  (applies_to hidden-deps-unsupported)
  (enabled_if
   (< %{ocaml_version} 5.2.0)))
+
+(cram
+ (applies_to trace-file)
+ (deps %{bin:perl}))

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -2,15 +2,15 @@
 
 This captures the commands that are being run:
 
-  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
+  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g' | perl -pe 's/"prog":".*?"/"prog":"PROG"/g'
   {"args":{"dir":"."},"ph":"X","dur":...,"name":"Dune load: .","cat":"","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-config"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-bin-annot-occurrences","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-cmi-file",".prog.eobjs/byte/prog.cmi","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"],"pid":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"path":"_build/.db","module":"INCREMENTAL-DB"},"ph":"X","dur":...,"name":"Writing Persistent Dune State","cat":"","ts":...,"pid":...,"tid":...}
-  {"args":{"path":"_build/.digest-db","module":"DIGEST-DB"},"ph":"X","dur":...,"name":"Writing Persistent Dune State","cat":"","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-config"],"pid":...,"prog":"PROG","dir":".","exit":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...,"prog":"PROG","dir":"_build/default","target_files":["_build/default/.prog.eobjs/prog.impl.d"],"exit":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-bin-annot-occurrences","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...,"prog":"PROG","dir":"_build/default","target_files":["_build/default/.prog.eobjs/byte/prog.cmi","_build/default/.prog.eobjs/byte/prog.cmo","_build/default/.prog.eobjs/byte/prog.cmt"],"exit":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-cmi-file",".prog.eobjs/byte/prog.cmi","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"],"pid":...,"prog":"PROG","dir":"_build/default","target_files":["_build/default/.prog.eobjs/native/prog.cmx","_build/default/.prog.eobjs/native/prog.o"],"exit":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"],"pid":...,"prog":"PROG","dir":"_build/default","target_files":["_build/default/prog.exe"],"exit":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"path":"_build/.db","module":"INCREMENTAL-DB","operation":"save"},"ph":"X","dur":...,"name":"db","cat":"","ts":...,"pid":...,"tid":...}
+  {"args":{"path":"_build/.digest-db","module":"DIGEST-DB","operation":"save"},"ph":"X","dur":...,"name":"db","cat":"","ts":...,"pid":...,"tid":...}
 
 As well as data about the garbage collector:
 


### PR DESCRIPTION
Chrome trace itself should remain an implementation detail as much as possible.

There are some minor differences in the events emitted. See the 2nd commit for a description