### PR TITLE
Hoist up [Dune_sexp.Decoder.sum] uses

### DIFF
--- a/src/dune_lang/ordered_set_lang.ml
+++ b/src/dune_lang/ordered_set_lang.ml
@@ -98,15 +98,15 @@ module Parse = struct
     many []
   ;;
 
-  let with_include ~elt =
-    generic
-      ~elt
-      ~inc:
-        (sum
-           [ ( ":include"
-             , let+ s = String_with_vars.decode in
-               Include s )
-           ])
+  let with_include =
+    let inc =
+      sum
+        [ ( ":include"
+          , let+ s = String_with_vars.decode in
+            Include s )
+        ]
+    in
+    fun ~elt -> generic ~elt ~inc
   ;;
 
   let without_include ~elt =

--- a/src/dune_lang/targets_spec.ml
+++ b/src/dune_lang/targets_spec.ml
@@ -43,23 +43,25 @@ type 'a t =
   | Static of 'a Static.t
   | Infer
 
-let decode_target ~allow_directory_targets =
+let decode_target =
   let module K = Kind in
   let open Dune_sexp.Decoder in
-  let file =
-    let+ file = String_with_vars.decode in
-    file, K.File
-  in
-  let dir =
-    let+ dir = sum ~force_parens:true [ "dir", String_with_vars.decode ] in
-    if not allow_directory_targets
-    then
-      User_error.raise
-        ~loc:(String_with_vars.loc dir)
-        [ Pp.text "Directory targets require the 'directory-targets' extension" ];
-    dir, K.Directory
-  in
-  file <|> dir
+  let dir = sum ~force_parens:true [ "dir", String_with_vars.decode ] in
+  fun ~allow_directory_targets ->
+    let file =
+      let+ file = String_with_vars.decode in
+      file, K.File
+    in
+    let dir =
+      let+ dir = dir in
+      if not allow_directory_targets
+      then
+        User_error.raise
+          ~loc:(String_with_vars.loc dir)
+          [ Pp.text "Directory targets require the 'directory-targets' extension" ];
+      dir, K.Directory
+    in
+    file <|> dir
 ;;
 
 let decode_static ~allow_directory_targets =

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -53,8 +53,8 @@ let rec decode_one =
   let not_or a = not (Or a) in
   fun f ->
     let open Decoder in
-    let bool_ops () =
-      sum [ "or", many f or_ []; "and", many f and_ []; "not", many f not_or [] ]
+    let bool_ops =
+      lazy (sum [ "or", many f or_ []; "and", many f and_ []; "not", many f not_or [] ])
     in
     let elt =
       let+ e = f in
@@ -79,7 +79,7 @@ let rec decode_one =
          User_error.raise
            ~loc
            [ Pp.text ":include isn't supported in the predicate language" ]
-       | "or" | "and" | "not" -> bool_ops ()
+       | "or" | "and" | "not" -> Lazy.force bool_ops
        | s when s <> "" && s.[0] <> '-' && s.[0] <> ':' ->
          User_error.raise
            ~loc


### PR DESCRIPTION
We seem to create these values from scratch all the time instead of reusing them. Let's not do that where it's easy to reuse these values