### PR TITLE
Add (files) stanza

### DIFF
--- a/doc/changes/added/12879.md
+++ b/doc/changes/added/12879.md
@@ -1,0 +1,2 @@
+- Added `(files)` stanza, similar to `(dirs)` to control which files are visible
+  to Dune on a per-directory basis. (#12879, @nojb)

--- a/doc/reference/dune/files.rst
+++ b/doc/reference/dune/files.rst
@@ -1,0 +1,19 @@
+files
+-----
+
+.. versionadded:: 3.21
+
+The ``files`` stanza allows restricting which files Dune should consider in the
+current directory. Its syntax mirrors the :doc:`/reference/predicate-language`
+used by the ``dirs`` stanza and supports ``:standard`` (which expands to all
+files), globs, and set operations.
+
+This is useful in mixed build setups where external tools such as ``make``
+produce artifacts that Dune should ignore.
+
+Examples:
+
+.. code:: dune
+
+   (files :standard \ *.cm*)   ;; ignore bytecode/native artifacts
+   (files *.ml *.mli)          ;; only keep OCaml sources

--- a/doc/reference/dune/index.rst
+++ b/doc/reference/dune/index.rst
@@ -56,6 +56,7 @@ The following pages describe the available stanzas and their meanings.
       dynamic_include
       env
       dirs
+      files
       data_only_dirs
       ignored_subdirs
       include_subdirs

--- a/src/source/dune_file.mli
+++ b/src/source/dune_file.mli
@@ -25,6 +25,15 @@ val path : t -> Path.Source.t option
 
 val sub_dir_status : t -> Source_dir_status.Spec.t
 
+module Files : sig
+  type t
+
+  val default : t
+  val eval : t -> files:Filename.Set.t -> Filename.Set.t
+end
+
+val files : t -> Files.t
+
 (** Directories introduced via [(subdir ..)] *)
 val sub_dirnames : t -> Filename.t list
 

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -194,6 +194,14 @@ and contents
   =
   let files = Dir_contents.files readdir in
   let+ dune_file = Dune_file.load ~dir:path dir_status project ~files ~parent:dune_file in
+  let files =
+    let predicate =
+      match dune_file with
+      | None -> Dune_file.Files.default
+      | Some dune_file -> Dune_file.files dune_file
+    in
+    Dune_file.Files.eval predicate ~files
+  in
   let vcs = Dir0.Vcs.get_vcs ~default:default_vcs ~readdir ~path in
   let sub_dirs =
     let sub_dirs =

--- a/test/blackbox-tests/test-cases/files-stanza.t
+++ b/test/blackbox-tests/test-cases/files-stanza.t
@@ -1,0 +1,47 @@
+The ``files`` stanza lets us ignore source artifacts produced by other build
+tools.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+First, without the stanza, a pre-existing artifact conflicts with an explicit
+rule targeting the same filename.
+
+  $ touch mymod.ml
+  $ cat >dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (wrapped false))
+  > (rule (with-stdout-to foo.xyz (progn)))
+  > EOF
+  $ touch mylib.cma
+  $ dune build
+  Error: Multiple rules generated for _build/default/mylib.cma:
+  - dune:1
+  - file present in source tree
+  Hint: rm -f mylib.cma
+  [1]
+  $ touch foo.xyz
+  $ dune build
+  Error: Multiple rules generated for _build/default/foo.xyz:
+  - dune:4
+  - file present in source tree
+  Hint: rm -f foo.xyz
+  [1]
+
+With ``(files ...)`` the source artifact is ignored and the rule can build the
+target.
+
+  $ cat >>dune <<EOF
+  > (files :standard \ *.cma *.xyz)
+  > EOF
+
+  $ dune build
+  $ ls _build/default
+  foo.xyz
+  mylib.a
+  mylib.cma
+  mylib.cmxa
+  mylib.cmxs
+  mymod.ml

--- a/test/blackbox-tests/test-cases/stanzas/subdir-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/stanzas/subdir-stanza/basic.t
@@ -38,7 +38,7 @@ dir.
   File "bar/dune", line 1, characters 16-19:
   1 | (data_only_dirs foo)
                       ^^^
-  Error: This stanza stanza was already specified at:
+  Error: This stanza was already specified at:
   dune:1
   [1]
 


### PR DESCRIPTION
This PR is an attempt to define a `(files)` stanza following discussion in #11819. The syntax (and semantics) are rather close to the existing `(dirs)` stanza. See the doc and the example for more.

Only the `dune`-file-level stanza is introduced here. Later, we could allow specifying it at the level of `dune-project` and/or `dune-workspace` to provide project- or workspace-wide defaults.

I am not very familiar with this part of the code (the source tree scanning logic), so a review by someone knowledgeable would be appreciated.

@gasche: could you try this branch with your use case and report back if it works as expected? You will need to add something like `(files :standard \ *.cm* *.o *.a)` to the Dune files of the compiler tree. You will also need to bump the `(lang dune ...)` version in `dune-project` to `3.21` (I tried to do it quickly, but it needs some other adaptations and I ran out of time to investigate that!).