### PR TITLE
blake3: disable useless warning on ARM

### DIFF
--- a/vendor/ocaml-blake3-mini/dune
+++ b/vendor/ocaml-blake3-mini/dune
@@ -198,6 +198,7 @@
    (= %{architecture} "aarch64")))
  (archive_name blake3)
  (language c)
+ (flags :standard -Wno-unused-function)
  (names blake3 blake3_portable blake3_dispatch blake3_neon))
 
 ; 3. Portable C implementation


### PR DESCRIPTION
```
blake3_dispatch.c:115:5: warning: ‘get_cpu_features’ defined but not used [-Wunused-function]
  115 |     get_cpu_features(void) {
      |     ^~~~~~~~~~~~~~~~
```