### PR TITLE
chore: fix build_changelog.sh headers

### DIFF
--- a/doc/changes/scripts/build_changelog.sh
+++ b/doc/changes/scripts/build_changelog.sh
@@ -6,7 +6,7 @@
 # Author(s): The Dune team
 # Date: 2025-09-29
 #
-# Usage: $ ./build_changelog.sh <X.Y.Z> 
+# Usage: $ ./build_changelog.sh <X.Y.Z>
 # where X.Y.Z is the version of Dune
 
 set -euo pipefail
@@ -21,6 +21,15 @@ add_newline() {
   echo "" >> "$output"
 }
 
+# Version headers have a format like
+#
+# ```
+# l.n.m. (yyyy-mm-dd)
+# -------------------
+# ```
+#
+# Using setext level 2 headings.
+# See https://spec.commonmark.org/0.31.2/#setext-headings
 generate_version_header() {
   today=$(date "+%Y-%m-%d")
 
@@ -52,7 +61,9 @@ append_files_in_dir_if_not_empty() {
     return 0
   fi
 
-  echo "## $subheader" >> "$output"
+  # Subheaders use ATX headings, and must be at level 3 to ensure that they are
+  # subordinate to the version headers.
+  echo "### $subheader" >> "$output"
   add_newline
   for file in $list_of_files; do
       cat "$file" >> "$output"


### PR DESCRIPTION
Before this change, it was producing the category subheadings at the
wrong level (level 2), instead of level 3.

An example of the corrected changelog produced:

```
3.21.0 (2025-12-08)
--------------------

### Fixed

- Fix `include_subdirs qualified` incorrectly picking the furthest module
  instead of the closest when resolving module name ambiguities. (#12587,
  @ElectreAAS and @Alizter)

- Fix: include the module alias in the transitive dependency closure with
  `(include_subdirs qualified)`. (#12299, @anmonteiro)

- Pass private modules with -H when this is available (#12666, @rgrinberg)

- Allow multiple modules in `(modules_flags ...)`, in `coq.theory` (#12733, @rlepigre)

- Improve error message for invalid version formats in both `(lang dune ...)` and
  `(using extension ...)` declarations. Changes "Atom of the form NNN.NNN expected"
  to "Invalid version. Version must be two numbers separated by a dot." (#12833, @benodiwal)

- Fix crash when running `dune build @check` on a library with virtual modules.
  (#12644, fixes #12636, @Alizter)

- Provide a more informative error message when `(pkg enabled)` is put in
  `dune-project` instead of `dune-workspace`. (#12802, fixes #12801,
  @benodiwal)

- Improve error message when invalid version strings are used in `dune-project`
  files. Non-ASCII characters and malformed versions now show a helpful hint
  with an example of the correct format. (#12794, fixes #12751, @benodiwal)

- Stop hiding the `root_module` from the include path (#12239, @rgrinberg)

- Allow `$ dune init` to work on absolute paths (#12601, fixes #7806,
  @rgrinberg)

- `(include_subdirs qualified)`: Add missing alias dependency to module group.
  (#12530, @anmonteiro)

- Add Melange compilation to the `@all` alias in libraries (#12628,
  @anmonteiro)

- melange support: don't emit empty JavaScript modules for generated module
  aliases. (#12464, @anmonteiro)

### Added

- (Experimental): Introduce the `library_parameter` stanza. It allows users to
  declare a parameter when using the OxCaml compiler.
  (#11963, implements #12084, @maiste) 


- Added the ability to scroll horizontally in TUI. (#12386, @Alizter)

- Feature: Include shell command that was executed when a cram test has
  occurred in the error message (#12307, @rgrinberg)

- Add support for `%{cmt:...}` and `%{cmti:...}` variables to reference
  compiled annotation files (.cmt and .cmti) containing typed abstract syntax
  trees with location and type information. (#12634, grants #12633, @Alizter)

- Add `$ dune describe tests` to describe the tests in the workspace
  (@Gromototo, #12545, fixes #12030)

- Allow `dune runtest` to properly run while a watch mode server is running.
  (#12473, grants #8114, @gridbugs and @ElectreAAS)

- Use copy-on-write (COW) when copying files on filesystems that support it
  (Btrfs, ZFS, XFS, etc), under Linux. (#12074, fixes #12071, @nojb)

- Add support for Tangled ATproto-based code repositories (#12197, @avsm)

- Add support for instantiating OxCaml parameterised libraries.
  (#12561, @art-w)
```

Note that the `Fixed` and `Added` headers are at level 3.

Compare with the previous, incorrect logic, produced initially in the current release branch: https://github.com/shonfeder/dune/blob/c5af78ff322225de3e839982600a1180caa951bf/CHANGES.md?plain=1

This incorrect formatting caused the documented release process to produce release with no changelog (e.g., https://github.com/ocaml/dune/releases/tag/3.21.0_alpha0)