### PR TITLE
ocaml index: memoize per context indices

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -687,6 +687,7 @@ module Unprocessed = struct
         ~expander
     =
     let open Action_builder.O in
+    let context = Super_context.context sctx in
     let+ config =
       let* stdlib_dir =
         Action_builder.of_memo
@@ -717,7 +718,7 @@ module Unprocessed = struct
              | Some lib ->
                let+ libs =
                  let* linking =
-                   let+ ocaml = Context.ocaml (Super_context.context sctx) in
+                   let+ ocaml = Context.ocaml context in
                    Dune_project.implicit_transitive_deps
                      (Scope.project scope)
                      ocaml.version
@@ -732,7 +733,7 @@ module Unprocessed = struct
                List.concat [ requires_compile; libs ])
       in
       let+ flags = flags
-      and+ indexes = Ocaml_index.context_indexes sctx
+      and+ indexes = Ocaml_index.context_indexes context
       and+ deps_src_dirs, deps_obj_dirs = add_lib_dirs sctx mode requires_compile
       and+ hidden_src_dirs, hidden_obj_dirs =
         let requires_hidden = Resolve.peek requires_hidden |> Result.value ~default:[] in
@@ -755,7 +756,7 @@ module Unprocessed = struct
       ; indexes
       ; parameters
       }
-    and+ pp_config = pp_config t (Super_context.context sctx) ~expander in
+    and+ pp_config = pp_config t context ~expander in
     let per_file_config =
       (* And copy for each module the resulting pp flags *)
       modules

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -125,10 +125,7 @@ let cctx_rules cctx =
   Super_context.add_rule sctx ~dir aggregate
 ;;
 
-let context_indexes sctx =
-  Action_builder.of_memo
-  @@
-  let ctx = Super_context.context sctx in
+let context_indexes ctx =
   Context.name ctx
   |> Dune_load.dune_files
   >>| Dune_file.fold_static_stanzas ~init:[] ~f:(fun dune_file stanza acc ->
@@ -147,6 +144,7 @@ let context_indexes sctx =
     match obj with
     | None -> acc
     | Some obj_dir -> Path.build (index_path_in_obj_dir obj_dir) :: acc)
+  |> Action_builder.of_memo
 ;;
 
 let project_rule sctx project =
@@ -163,5 +161,5 @@ let project_rule sctx project =
   Rules.Produce.Alias.add_deps
     ocaml_index_alias
     (let open Action_builder.O in
-     context_indexes sctx >>= Action_builder.paths_existing)
+     Super_context.context sctx |> context_indexes >>= Action_builder.paths_existing)
 ;;

--- a/src/dune_rules/merlin/ocaml_index.mli
+++ b/src/dune_rules/merlin/ocaml_index.mli
@@ -17,7 +17,7 @@ val cctx_rules : Compilation_context.t -> unit Memo.t
 
 (** [context_indexes] lists all the available cctx.ocaml-index files in the
     given context *)
-val context_indexes : Super_context.t -> Path.t list Action_builder.t
+val context_indexes : Context.t -> Path.t list Action_builder.t
 
 (** [project_rule] adds a rule that will aggregate all the generated indexes
     into one global, project-wide, index *)


### PR DESCRIPTION
There's no reason to generate these once per .merlin file.