### PR TITLE
fix(copyfile): inline linux/version.h

### DIFF
--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -64,10 +64,10 @@ CAMLprim value stdune_sendfile(value v_in, value v_out, value v_size) {
 
 #include <sys/sendfile.h>
 #include <sys/utsname.h>
-#include <linux/version.h>
 #include <dlfcn.h>
 #include <stdio.h>
 
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
 #define FD_val(value) Int_val(value)
 
 CAMLprim value stdune_copyfile(value v_from, value v_to) {


### PR DESCRIPTION
The kernel headers cannot be expected to be available on every linux distribution. The version header can therefore be inlined easily.

In the kernel, the generated file looks like:

```
define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) +  \
	((c) > 255 ? 255 : (c)))';
```

but we don't really need the extra check on `c`.

fix #12896.