### PR TITLE
Nested dune call fix (executable resolution part)

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -90,11 +90,9 @@ Remember the digests, to not to have to call nested Dunes:
 Call Dune with an absolute PATH as argv[0]:
 
   $ PATH=$fakepath $DUNE build "$pkg_root/$foo_digest/target/"
-  Fake dune! (args: build -p foo @install)
   $ PATH=$fakepath $DUNE build "$pkg_root/$bar_digest/target/"
 
 Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
 
   $ dune clean
   $ PATH=$fakepath dune_cmd exec-a "dune" $DUNE build "$pkg_root/$foo_digest/target/"
-  Fake dune! (args: build -p foo @install)

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -92,7 +92,15 @@ Call Dune with an absolute PATH as argv[0]:
   $ PATH=$fakepath $DUNE build "$pkg_root/$foo_digest/target/"
   $ PATH=$fakepath $DUNE build "$pkg_root/$bar_digest/target/"
 
-Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
+argv[0] is set by the calling program (like a shell or cram test runner) and
+could be wrong, hence it cannot always be trusted. In the examples above we
+launch dune with an absolute path, thus one could just use argv[0] to get the
+exact path to the `dune` binary.
+
+To make sure that we pick up the right dune even when argv[0] is being set to
+unhelpful values we launch the binary but set the value to a relative value,
+namely argv[0] = "dune". This is exactly what happens if `dune` is in the PATH
+and the user launches `dune` in a shell.
 
   $ dune clean
   $ PATH=$fakepath dune_cmd exec-a "dune" $DUNE build "$pkg_root/$foo_digest/target/"


### PR DESCRIPTION
#10019 mentions that Dune should run itself when encountering package rules, which is quite sensible to do. This PR fixes part of the problem - the `run` command resolution. When encountering a command dune attempts to look up the programs path. But if the command is `dune`, we can immediately resolve this to the current executable (was we are Dune, even if the command is not called `dune` but `dune.exe` or `main.exe` or something else). This prevents capture of an accidental dune executable (as exhibited by the repro fix).

This PR thus solves the first case of #10020, where `dune` is called directly. It does not fix the second part (dune not part of the path), which requires a different fix that I intend to submit as a separate PR (as the fix is somewhat independent from this one).