### PR TITLE
fix(cram): lexing of single space comment after output

### DIFF
--- a/src/dune_rules/cram/cram_lexer.mll
+++ b/src/dune_rules/cram/cram_lexer.mll
@@ -108,7 +108,7 @@ and output loc maybe_comment = parse
   | "  $ " ([^'\n']* as str)
     { eol_then_command_or_finish (loc_of_dollar lexbuf) str lexbuf }
   | ' ' ((nonspace not_nl*) as rest)
-    { check_eol_for_output loc ((" " ^ rest) :: maybe_comment) lexbuf }
+    { after_comment_line_in_output loc ((" " ^ rest) :: maybe_comment) lexbuf }
   | ' ' '\n'
     { Lexing.new_line lexbuf;
       output loc (" " :: maybe_comment) lexbuf }
@@ -125,8 +125,8 @@ and after_output_line_in_output loc maybe_comment = parse
   | '\n' { Lexing.new_line lexbuf; output loc maybe_comment lexbuf }
   | eof  { output loc maybe_comment lexbuf }
 
-and check_eol_for_output loc maybe_comment = parse
-  | '\n' { Lexing.new_line lexbuf; output loc maybe_comment lexbuf }
+and after_comment_line_in_output loc maybe_comment = parse
+  | '\n' { Lexing.new_line lexbuf; comment loc maybe_comment lexbuf }
   | eof  {
     let loc = Loc.set_stop loc (Lexing.lexeme_start_p lexbuf) in
     Some (loc, Comment (List.rev maybe_comment)) }

--- a/test/expect-tests/dune_rules/cram_parsing_tests.ml
+++ b/test/expect-tests/dune_rules/cram_parsing_tests.ml
@@ -453,6 +453,15 @@ let%expect_test "single-space comment after output" =
     ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
     ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 8 }
     }
+    File "test.t", line 2, characters 0-8:
+    2 |   output
+        ^^^^^^^^
+
+    Comment [ " But local theme" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 2; pos_bol = 9; pos_cnum = 9 }
+    ; stop = { pos_lnum = 2; pos_bol = 9; pos_cnum = 17 }
+    }
     File "test.t", line 4, characters 2-8:
     4 |   $ cmd2
           ^^^^^^

--- a/test/expect-tests/dune_rules/cram_parsing_tests.ml
+++ b/test/expect-tests/dune_rules/cram_parsing_tests.ml
@@ -437,3 +437,30 @@ let%expect_test "stray command continuation is a comment" =
     }
     |}]
 ;;
+
+(* Test for https://github.com/ocaml/dune/issues/12899: single-space comment
+   after output *)
+let%expect_test "single-space comment after output" =
+  test "  $ cmd1\n  output\n But local theme\n  $ cmd2";
+  [%expect
+    {|
+    File "test.t", line 1, characters 2-8:
+    1 |   $ cmd1
+          ^^^^^^
+
+    Command [ "cmd1" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 2 }
+    ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 8 }
+    }
+    File "test.t", line 4, characters 2-8:
+    4 |   $ cmd2
+          ^^^^^^
+
+    Command [ "cmd2" ]
+    { pos_fname = "test.t"
+    ; start = { pos_lnum = 4; pos_bol = 35; pos_cnum = 37 }
+    ; stop = { pos_lnum = 4; pos_bol = 35; pos_cnum = 43 }
+    }
+    |}]
+;;


### PR DESCRIPTION
This PR fixes the regression reported in https://github.com/ocaml/dune/issues/12899.

The first commit adds a regression test for a command block followed by a comment starting with a single space. Previously the comment would be dropped.

The second commit fixes this issue and renames the function in the lexer to make it clearer.

- fix https://github.com/ocaml/dune/issues/12899