### PR TITLE
Remove json library

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -4,7 +4,6 @@
  (libraries
   dune_trace
   dune_console
-  json
   stdune
   fiber
   dune_lang

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -117,12 +117,6 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
-  ; { path = "src/json"
-    ; main_module_name = Some "Json"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
   ; { path = "src/dune_trace"
     ; main_module_name = Some "Dune_trace"
     ; include_subdirs = No

--- a/otherlibs/chrome-trace/test/dune
+++ b/otherlibs/chrome-trace/test/dune
@@ -5,7 +5,6 @@
   dune_tests_common
   stdune
   dune_trace
-  json
   chrome_trace
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/otherlibs/stdune/src/json.ml
+++ b/otherlibs/stdune/src/json.ml
@@ -1,5 +1,12 @@
-open Stdune
-include Chrome_trace.Json
+type t =
+  [ `Int of int
+  | `Float of float
+  | `String of string
+  | `List of t list
+  | `Bool of bool
+  | `Assoc of (string * t) list
+  | `Null
+  ]
 
 let copy_substring s buf start pos =
   if pos > start then Buffer.add_substring buf s start (pos - start)
@@ -18,7 +25,8 @@ let rec quote_characters_to_buf s buf n start pos =
     | '\r' -> escape s buf n start pos "\\r"
     | '\\' -> escape s buf n start pos "\\\\"
     | '"' -> escape s buf n start pos "\\\""
-    | '\000' .. '\031' as c -> escape s buf n start pos (sprintf "\\u%04x" (Char.code c))
+    | '\000' .. '\031' as c ->
+      escape s buf n start pos (Printf.sprintf "\\u%04x" (Char.code c))
     | '\032' .. '\127' -> quote_characters_to_buf s buf n start (pos + 1)
     (* Check for valid UTF-8 *)
     | '\xc0' .. '\xdf' when is_cb (pos + 1) ->

--- a/otherlibs/stdune/src/json.mli
+++ b/otherlibs/stdune/src/json.mli
@@ -1,4 +1,12 @@
-type t = Chrome_trace.Json.t
+type t =
+  [ `Int of int
+  | `Float of float
+  | `String of string
+  | `List of t list
+  | `Bool of bool
+  | `Assoc of (string * t) list
+  | `Null
+  ]
 
 val to_string : t -> string
 val string : string -> t

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -72,6 +72,7 @@ module Scanf = Scanf
 module Sys = Sys
 module Pid = Pid
 module Applicative = Applicative
+module Json = Json
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -6,7 +6,6 @@
   action_ext
   build_path_prefix_map
   chrome_trace
-  json
   csexp
   action_plugin
   dune_action_plugin

--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -3,4 +3,4 @@
  (foreign_stubs
   (language c)
   (names dune_trace_stubs))
- (libraries stdune json chrome_trace spawn unix))
+ (libraries stdune chrome_trace spawn unix))

--- a/src/json/dune
+++ b/src/json/dune
@@ -1,3 +1,0 @@
-(library
- (name json)
- (libraries chrome_trace stdune))


### PR DESCRIPTION
The separate library slows down compilation for no particular reason. This json module dosen't add any dependencies so it can just live in stdune.