### PR TITLE
Remove --trace-extended

### DIFF
--- a/doc/changes/changed/12908.md
+++ b/doc/changes/changed/12908.md
@@ -1,0 +1,2 @@
+- Removed the `--trace-extended` flag. Its functionality is always enabled when
+  tracing is active (#12908, @rgrinberg)

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -19,7 +19,6 @@ type t =
   { print : string -> unit
   ; close : unit -> unit
   ; flush : unit -> unit
-  ; extended_build_job_info : bool
   ; mutable after_first_event : bool
   }
 
@@ -46,7 +45,7 @@ let set_global t =
 
 let global () = !global
 
-let create ~extended_build_job_info dst =
+let create dst =
   let print =
     match dst with
     | Out out -> Stdlib.output_string out
@@ -62,11 +61,10 @@ let create ~extended_build_job_info dst =
     | Out out -> fun () -> flush out
     | Custom c -> c.flush
   in
-  { print; close; after_first_event = false; flush; extended_build_job_info }
+  { print; close; after_first_event = false; flush }
 ;;
 
 let flush t = t.flush ()
-let extended_build_job_info t = t.extended_build_job_info
 
 let next_leading_char t =
   match t.after_first_event with

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -12,10 +12,9 @@ type dst =
 
 val global : unit -> t option
 val set_global : t -> unit
-val create : extended_build_job_info:bool -> dst -> t
+val create : dst -> t
 val record_gc_and_fd : t -> unit
 val close : t -> unit
-val extended_build_job_info : t -> bool
 
 module Event : sig
   module Async : sig


### PR DESCRIPTION
This flag is now useless as it only controls whether a single event is emitted. We can just always emit this event instead.