### PR TITLE
Move Dune_util.Log to Stdune.Log

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -220,7 +220,7 @@ let format_results bench_results =
 ;;
 
 let () =
-  Dune_util.Log.init ~file:No_log_file ();
+  Log.init ~file:No_log_file ();
   let dir = Temp.create Dir ~prefix:"dune" ~suffix:"bench" in
   Sys.chdir (Path.to_string dir);
   Path.as_external dir |> Option.value_exn |> Path.set_root;

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -644,7 +644,7 @@ module Builder = struct
     ; stats_trace_file : string option
     ; allow_builds : bool
     ; default_root_is_cwd : bool
-    ; log_file : Dune_util.Log.File.t
+    ; log_file : Log.File.t
     }
 
   let root t = t.root

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -36,7 +36,7 @@ module Builder : sig
   val forbid_builds : t -> t
   val default_root_is_cwd : t -> bool
   val set_default_root_is_cwd : t -> bool -> t
-  val set_log_file : t -> Dune_util.Log.File.t -> t
+  val set_log_file : t -> Log.File.t -> t
   val disable_log_file : t -> t
   val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
   val default_target : t -> Arg.Dep.t

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -84,7 +84,6 @@ include struct
   module Resolved_package = Resolved_package
 end
 
-module Log = Dune_util.Log
 module Dune_rpc = Dune_rpc_private
 module Graph = Dune_graph.Graph
 include Common.Let_syntax

--- a/otherlibs/chrome-trace/test/dune
+++ b/otherlibs/chrome-trace/test/dune
@@ -4,7 +4,6 @@
  (libraries
   dune_tests_common
   stdune
-  dune_trace
   chrome_trace
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/otherlibs/stdune/src/log.ml
+++ b/otherlibs/stdune/src/log.ml
@@ -1,6 +1,3 @@
-open Stdune
-module Console = Dune_console
-
 module File = struct
   type t =
     | Default
@@ -57,12 +54,15 @@ let log msg =
     Option.iter oc ~f:(fun oc -> User_message.make (msg ()) |> log_oc oc)
 ;;
 
+let forward_verbose = Fdecl.create Dyn.opaque
+let set_forward_verbose = Fdecl.set forward_verbose
+
 let info_user_message msg =
   match t () with
   | None -> ()
   | Some { oc; _ } ->
     Option.iter oc ~f:(fun oc -> log_oc oc msg);
-    if !verbose then Console.print_user_message msg
+    if !verbose then (Fdecl.get forward_verbose) msg
 ;;
 
 let info paragraphs = info_user_message (User_message.make paragraphs)

--- a/otherlibs/stdune/src/log.mli
+++ b/otherlibs/stdune/src/log.mli
@@ -1,5 +1,4 @@
 (** Log file *)
-open Stdune
 
 module File : sig
   type t =
@@ -19,6 +18,8 @@ val init_disabled : unit -> unit
 
 (** Print the message only the log file (despite verbose mode) if it's set *)
 val log : (unit -> User_message.Style.t Pp.t list) -> unit
+
+val set_forward_verbose : (User_message.t -> unit) -> unit
 
 (** Print an informative message in the log *)
 val info_user_message : User_message.t -> unit

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -73,6 +73,7 @@ module Sys = Sys
 module Pid = Pid
 module Applicative = Applicative
 module Json = Json
+module Log = Log
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -1,7 +1,6 @@
 open Stdune
 open Fiber.O
 open Dune_async_io
-module Log = Dune_util.Log
 module Session_id = Id.Make ()
 
 module Socket = struct

--- a/src/dune_cache/import.ml
+++ b/src/dune_cache/import.ml
@@ -4,5 +4,4 @@ module Store_result = Dune_cache_storage.Store_result
 module Targets = Dune_targets
 module Cached_digest = Dune_digest.Cached_digest
 module Console = Dune_console
-module Log = Dune_util.Log
 include Stdune

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -8,7 +8,6 @@ module Dune_config = struct
   module Stanza = Dune_lang.Stanza
   module String_with_vars = Dune_lang.String_with_vars
   module Pform = Dune_lang.Pform
-  module Log = Dune_util.Log
   module Config = Dune_config.Config
 
   (* the configuration file use the same version numbers as dune-project files for

--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -170,3 +170,4 @@ module Status_line = struct
 end
 
 let () = User_warning.set_reporter print_user_message
+let () = Log.set_forward_verbose print_user_message

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -3,7 +3,6 @@ module Digest = Dune_digest.Digest
 module Cached_digest = Dune_digest.Cached_digest
 module Console = Dune_console
 module Metrics = Dune_metrics
-module Log = Dune_util.Log
 module Compound_user_error = Dune_rpc_private.Compound_user_error
 module Stringlike = Dune_util.Stringlike
 

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -9,7 +9,6 @@
   lmdb
   fiber
   fiber_util
-  chrome_trace
   dune_engine
   dune_util
   dune_trace

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -1,6 +1,5 @@
 include Stdune
 module Stringlike = Dune_util.Stringlike
-module Log = Dune_util.Log
 
 module type Stringlike = Dune_util.Stringlike
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -156,15 +156,14 @@ module Cache = struct
            [ "dune"; "rev_store" ]
        in
        let rev_store_cache = Dune_config.Config.get rev_store_cache in
-       Dune_util.Log.info
+       Log.info
          [ Pp.textf
              "Revision store cache: %s"
              (Dune_config.Config.Toggle.to_string rev_store_cache)
          ];
        match rev_store_cache, Path.mkdir_p path with
        | `Enabled, () ->
-         Dune_util.Log.info
-           [ Pp.textf "Revision store cache location: %s" (Path.to_string path) ];
+         Log.info [ Pp.textf "Revision store cache location: %s" (Path.to_string path) ];
          Some path
        | `Disabled, () -> None)
   ;;

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -668,7 +668,7 @@ struct
             (match exn.exn with
              | Dune_util.Report_error.Already_reported -> ()
              | _ ->
-               Dune_util.Log.info
+               Log.info
                  [ Pp.textf
                      "encountered error serving rpc client (id %d)"
                      (Session.Id.to_int id)

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -5,7 +5,6 @@
  (libraries
   action_ext
   build_path_prefix_map
-  chrome_trace
   csexp
   action_plugin
   dune_action_plugin

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -73,13 +73,13 @@ let make ~frames_per_second (module Base : S) : (module Dune_console.Backend) =
       let cleanup exn =
         state.finished <- true;
         Option.iter exn ~f:(fun exn ->
-          Dune_util.Log.info [ Pp.text "Console failed"; Exn_with_backtrace.pp exn ]);
+          Log.info [ Pp.text "Console failed"; Exn_with_backtrace.pp exn ]);
         (match Exn_with_backtrace.try_with Base.finish with
          | Ok () -> ()
          | Error exn ->
            (* we can't log to console because we are cleaning it up and we
               borked it *)
-           Dune_util.Log.log (fun () ->
+           Log.log (fun () ->
              [ Pp.text "Error cleaning up console"; Exn_with_backtrace.pp exn ]));
         Condition.broadcast finish_cv;
         Mutex.unlock mutex

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -2,13 +2,12 @@
  (name dune_util)
  (libraries
   stdune
+  dune_console
   dune_trace
-  chrome_trace
   xdg
   dyn
   ordering
   pp
-  dune_console
   build_path_prefix_map
   dune_sexp
   dune_config

--- a/src/dune_util/dune_util.ml
+++ b/src/dune_util/dune_util.ml
@@ -1,4 +1,3 @@
-module Log = Log
 module Persistent = Persistent
 module Report_error = Report_error
 module Stringlike = Stringlike

--- a/src/dune_util/import.ml
+++ b/src/dune_util/import.ml
@@ -1,3 +1,2 @@
-module Console = Dune_console
 include Stdune
 include Dune_config

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -208,7 +208,7 @@ let gen_report exn backtrace =
       | User -> msg
       | Developer -> append msg (i_must_not_crash ())
     in
-    Console.print_user_message msg
+    Dune_console.print_user_message msg
 ;;
 
 let report { Exn_with_backtrace.exn; backtrace } = gen_report exn (Some backtrace)

--- a/src/source/dune
+++ b/src/source/dune
@@ -1,7 +1,6 @@
 (library
  (name source)
  (libraries
-  chrome_trace
   dune_config
   dune_config_file
   dune_console

--- a/test/expect-tests/common/dune
+++ b/test/expect-tests/common/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_tests_common)
  (modules dune_tests_common)
- (libraries stdune dune_console dune_util))
+ (libraries stdune dune_console))

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -11,7 +11,7 @@ let init =
        Path.set_root (Path.External.cwd ());
        Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build");
        Console.Backend.(set dumb);
-       Dune_util.Log.init ())
+       Log.init ())
   in
   fun () -> Lazy.force init
 ;;

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -6,7 +6,7 @@ open Dune_rpc_server
 module Scheduler = Test_scheduler
 
 let () = Printexc.record_backtrace false
-let () = Dune_util.Log.init_disabled ()
+let () = Log.init_disabled ()
 let print pp = Format.printf "%a@." Pp.to_fmt pp
 let print_dyn dyn = print (Dyn.pp dyn)
 

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -9,7 +9,7 @@ module Session = Csexp_rpc.Session
 
 (* enable to debug process stdout/stderr *)
 let debug = false
-let () = if debug then Dune_util.Log.init ~file:Stderr ()
+let () = if debug then Log.init ~file:Stderr ()
 
 let dune_prog =
   lazy


### PR DESCRIPTION
Allows us to log things from just about anywhere in the dune code base