### PR TITLE
Update nested dune test to emulate calling `dune build` more closely

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -83,9 +83,9 @@ Test that the project can be built normally.
 Make a fake dune exe:
 
   $ mkdir .bin
-  $ cat > .bin/dune <<EOF
+  $ cat > .bin/dune << 'EOF'
   > #!/bin/sh
-  > echo "Fake dune! (args: \$@)"
+  > echo "Fake dune! (args: $@)"
   > EOF
   $ chmod a+x .bin/dune
 

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -75,9 +75,11 @@ Make a fake dune exe:
 
 Try building in an environment where `dune` refers to the fake dune.
 
-Remember the path to the dune under test:
+Remember the path to the dune under test, otherwise we would launch the wrong
+Dune and add our fake `dune` to the PATH.
 
-  $ DUNE=$(which dune)  # otherwise we would start by running the wrong dune
+  $ DUNE=$(which dune)
+  $ fakepath=$PWD/.bin:$PATH
 
 Remember the digests, to not to have to call nested Dunes:
 
@@ -86,19 +88,19 @@ Remember the digests, to not to have to call nested Dunes:
 
 Call Dune with an absolute PATH as argv[0]:
 
-  $ PATH=$PWD/.bin:$PATH $DUNE build "$pkg_root/$foo_digest/target/"
+  $ PATH=$fakepath $DUNE build "$pkg_root/$foo_digest/target/"
   Fake dune! (args: build -p foo @install)
-  $ PATH=$PWD/.bin:$PATH $DUNE build "$pkg_root/$bar_digest/target/"
+  $ PATH=$fakepath $DUNE build "$pkg_root/$bar_digest/target/"
   Fake dune! (args: build -p bar @install)
 
 Call Dune with argv[0] set to a relative PATH. Make sure "dune" in PATH refers
 to the fake dune:
 
-  $ PATH=$PWD/.bin:$PATH dune_cmd exec-a "dune" sh -c "which dune"
+  $ PATH=$fakepath dune_cmd exec-a "dune" sh -c "which dune"
   $TESTCASE_ROOT/.bin/dune
 
 Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
 
   $ dune clean
-  $ PATH=$PWD/.bin:$PATH dune_cmd exec-a "dune" $DUNE build "$pkg_root/$foo_digest/target/"
+  $ PATH=$fakepath dune_cmd exec-a "dune" $DUNE build "$pkg_root/$foo_digest/target/"
   Fake dune! (args: build -p foo @install)

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -93,12 +93,6 @@ Call Dune with an absolute PATH as argv[0]:
   $ PATH=$fakepath $DUNE build "$pkg_root/$bar_digest/target/"
   Fake dune! (args: build -p bar @install)
 
-Call Dune with argv[0] set to a relative PATH. Make sure "dune" in PATH refers
-to the fake dune:
-
-  $ PATH=$fakepath dune_cmd exec-a "dune" sh -c "which dune"
-  $TESTCASE_ROOT/.bin/dune
-
 Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
 
   $ dune clean

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -25,12 +25,26 @@ Make a project that depends on the test packages:
   > (lang dune 3.13)
   > (package
   >  (name x)
-  >  (allow_empty)
   >  (depends foo bar))
   > EOF
 
   $ cat > dune <<EOF
-  > (data_only_dirs bin)
+  > (executable
+  >  (name exec_a)
+  >  (public_name exec-a)
+  >  (libraries unix))
+  > EOF
+
+Small helper binary to implement `exec -a` in a portable way
+
+  $ cat > exec_a.ml <<EOF
+  > let () =
+  >   let desired_argv0 = Sys.argv.(1) in
+  >   let prog = Sys.argv.(2) in
+  >   let args = Array.length Sys.argv in
+  >   let new_args = Array.init (args - 2) (fun i -> Sys.argv.(i+2)) in
+  >   new_args.(0) <- desired_argv0;
+  >   Unix.execvp prog new_args
   > EOF
 
 Make lockfiles for the packages.
@@ -65,18 +79,54 @@ Make lockfiles for the packages.
 Test that the project can be built normally.
   $ build_pkg foo
 
+
 Make a fake dune exe:
-  $ mkdir bin
-  $ cat > bin/dune <<EOF
+
+  $ mkdir .bin
+  $ cat > .bin/dune <<EOF
   > #!/bin/sh
   > echo "Fake dune! (args: \$@)"
   > EOF
-  $ chmod a+x bin/dune
+  $ chmod a+x .bin/dune
+
+  $ dune build @install
+  $ mkdir .temp
+  $ dune install --prefix $PWD/.temp
+  $ cp .temp/bin/exec-a $PWD/.bin/
+
+Show that the binary works like `exec -a` would work
+
+  $ .bin/exec-a "desired-argv0" sh -c 'echo $0'
+  desired-argv0
 
   $ dune clean
+
 Try building in an environment where `dune` refers to the fake dune.
+
+Remember the path to the dune under test:
+
   $ DUNE=$(which dune)  # otherwise we would start by running the wrong dune
-  $ PATH=$PWD/bin:$PATH $DUNE build $pkg_root/$($dune pkg print-digest foo)/target/
+
+Remember the digests, to not to have to call nested Dunes:
+
+  $ foo_digest="$(dune pkg print-digest foo)"
+  $ bar_digest="$(dune pkg print-digest bar)"
+
+Call Dune with an absolute PATH as argv[0]:
+
+  $ PATH=$PWD/.bin:$PATH $DUNE build "$pkg_root/$foo_digest/target/"
   Fake dune! (args: build -p foo @install)
-  $ PATH=$PWD/bin:$PATH $DUNE build $pkg_root/$($dune pkg print-digest bar)/target/
+  $ PATH=$PWD/.bin:$PATH $DUNE build "$pkg_root/$bar_digest/target/"
   Fake dune! (args: build -p bar @install)
+
+Call Dune with argv[0] set to a relative PATH. Make sure "dune" in PATH refers
+to the fake dune:
+
+  $ (PATH=$PWD/.bin:$PATH exec-a "dune" sh -c "which dune")
+  $TESTCASE_ROOT/.bin/dune
+
+Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
+
+  $ dune clean
+  $ (PATH=$PWD/.bin:$PATH exec-a "dune" $DUNE build "$pkg_root/$foo_digest/target/")
+  Fake dune! (args: build -p foo @install)

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -334,6 +334,29 @@ module Wait_for_file_to_appear = struct
   let () = register name of_args run
 end
 
+(* implements `exec -a` in a portable way *)
+module Exec_a = struct
+  type t =
+    { argv0 : string
+    ; prog : string
+    ; args : string list
+    }
+
+  let name = "exec-a"
+
+  let of_args = function
+    | argv0 :: prog :: args -> { argv0; prog; args }
+    | _ -> raise (Arg.Bad "Required arguments are <argv0> <program> [argument]...")
+  ;;
+
+  let run { argv0; prog; args } =
+    let args = Array.of_list @@ (argv0 :: args) in
+    Unix.execvp prog args
+  ;;
+
+  let () = register name of_args run
+end
+
 let () =
   let name, args =
     match Array.to_list Sys.argv with


### PR DESCRIPTION
The way the test is implemented, the code testing dune is always calling the (outside, Dune unter test) via its absolute path.

This change, extracted from #12902 calls Dune via absolute path but wraps it in an utility where argv[0] is set to "dune" instead of the absolute path, more closely resembling a call to `dune build` instead of (a hypothetical) `/usr/bin/dune build`.