### PR TITLE
RPC: move logging to trace

### DIFF
--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -6,6 +6,7 @@
   dyn
   dune_util
   dune_console
+  dune_trace
   csexp
   fiber
   dune_async_io

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -319,6 +319,52 @@ module Event = struct
         (async_kind_of_stage stage)
         common
     ;;
+
+    let packet_read ~id ~success ~error =
+      let open Chrome_trace in
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let args =
+        let base = [ "id", `Int id; "success", `Bool success ] in
+        match error with
+        | None -> base
+        | Some err -> ("error", `String err) :: base
+      in
+      let common =
+        Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_read" ~ts ()
+      in
+      Event.instant ~args common
+    ;;
+
+    let packet_write ~id ~count =
+      let open Chrome_trace in
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let args = [ "id", `Int id; "count", `Int count ] in
+      let common =
+        Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_write" ~ts ()
+      in
+      Event.instant ~args common
+    ;;
+
+    let accept ~success ~error =
+      let open Chrome_trace in
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let args =
+        let base = [ "success", `Bool success ] in
+        match error with
+        | None -> base
+        | Some err -> ("error", `String err) :: base
+      in
+      let common = Event.common_fields ~cat:[ "rpc"; "accept" ] ~name:"accept" ~ts () in
+      Event.instant ~args common
+    ;;
+
+    let close ~id =
+      let open Chrome_trace in
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let args = [ "id", `Int id ] in
+      let common = Event.common_fields ~cat:[ "rpc"; "session" ] ~name:"close" ~ts () in
+      Event.instant ~args common
+    ;;
   end
 end
 

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -83,6 +83,11 @@ module Event : sig
       -> id:int
       -> stage
       -> t
+
+    val packet_read : id:int -> success:bool -> error:string option -> t
+    val packet_write : id:int -> count:int -> t
+    val accept : success:bool -> error:string option -> t
+    val close : id:int -> t
   end
 end
 


### PR DESCRIPTION
The log was a bad place for this stuff since the output is naturally structured.