### PR TITLE
fix FreeBSD build

### DIFF
--- a/vendor/ocaml-lmdb/lmdb_stubs.c
+++ b/vendor/ocaml-lmdb/lmdb_stubs.c
@@ -17,6 +17,8 @@
 
 #ifdef _WIN32
 #include <malloc.h>
+#elif defined(__FreeBSD__)
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif

--- a/vendor/ocaml-lmdb/mdb.c
+++ b/vendor/ocaml-lmdb/mdb.c
@@ -5851,7 +5851,7 @@ mdb_env_close0(MDB_env *env, int excl)
 		/* Clearing readers is done in this function because
 		 * me_txkey with its destructor must be disabled first.
 		 *
-		 * We skip the reader mutex, so we touch only
+		 * We skip the the reader mutex, so we touch only
 		 * data owned by this process (me_close_readers and
 		 * our readers), and clear each reader atomically.
 		 */

--- a/vendor/update-ocaml-lmdb.sh
+++ b/vendor/update-ocaml-lmdb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version=6bcf6fe35167efc44b15bf14a909fb2fd53de923
+version=2a73ea2016d6af88931d01f7b2e60800adfc2003
 lmdb_version=14d6629bc8a9fe40d8a6bee1bf71c45afe7576b6
 
 set -e -o pipefail


### PR DESCRIPTION
The lmdb stubs needed some tweaking. This should allow the builds on FreeBSD in the opam ci to progress.

@shonfeder this shouldn't block the release but probably nice to have in a patch release for 3.21.