### PR TITLE
Optimize Lib.compare

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -354,9 +354,9 @@ end = struct
       }
 
     let compare { path; name } t =
-      let open Ordering.O in
-      let= () = Lib_name.compare name t.name in
-      Path.compare path t.path
+      match Lib_name.compare name t.name with
+      | Eq -> Path.compare path t.path
+      | x -> x
     ;;
 
     let to_dyn { path; name } =


### PR DESCRIPTION
We don't need this extra closure and this function turns out to be called a lot