### PR TITLE
Document that `Path.link` creates a hardlink

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -351,6 +351,8 @@ val is_directory : t -> bool
 val rmdir : t -> unit
 val unlink_exn : t -> unit
 val unlink_no_err : t -> unit
+
+(** [link src dst] creates a hardlink from [src] to [dst]. *)
 val link : t -> t -> unit
 
 (** If the path does not exist, this function is a no-op. *)


### PR DESCRIPTION
It uses `Unix.link` internally which is documented in the OCaml manual but adding a bit of documentation won't hurt.