### PR TITLE
Nested dune call fix (execution environment part)

### DIFF
--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -141,11 +141,21 @@ module Spec = struct
           |> String.concat ~sep:"")
       in
       let metadata = Process.create_metadata ~purpose:ectx.metadata.purpose () in
+      let dune_folder =
+        let bin_folder = Temp.create Dir ~prefix:"dune" ~suffix:"self-in-path" in
+        let dst = Path.relative bin_folder "dune" in
+        let src = Path.of_string Sys.executable_name in
+        Io.portable_symlink ~src ~dst;
+        Path.to_string bin_folder
+      in
       let env =
-        Env.add
-          eenv.env
-          ~var:"OCAMLFIND_DESTDIR"
-          ~value:(Path.to_absolute_filename ocamlfind_destdir)
+        eenv.env
+        |> Env.add
+             ~var:"OCAMLFIND_DESTDIR"
+             ~value:(Path.to_absolute_filename ocamlfind_destdir)
+        |> Env.update ~var:"PATH" ~f:(function
+          | None -> Some dune_folder
+          | Some path -> Some (sprintf "%s:%s" dune_folder path))
       in
       Output.with_error
         ~accepted_exit_codes:eenv.exit_codes

--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -143,8 +143,8 @@ module Spec = struct
       let metadata = Process.create_metadata ~purpose:ectx.metadata.purpose () in
       let dune_folder =
         let bin_folder = Temp.create Dir ~prefix:"dune" ~suffix:"self-in-path" in
-        let dst = Path.relative bin_folder "dune" in
         let src = Path.of_string Sys.executable_name in
+        let dst = Path.relative bin_folder "dune" in
         Io.portable_symlink ~src ~dst;
         Path.to_string bin_folder
       in

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -37,6 +37,8 @@ Make lockfiles for the packages.
   > (build
   >  (run dune build -p %{pkg-self:name} @install))
   > 
+  > (depends dune)
+  > 
   > (source
   >  (fetch
   >   (url $PWD/foo.tar)))
@@ -50,6 +52,8 @@ Make lockfiles for the packages.
   > (build
   >   ; Exercise that the dune exe can be located when it's launched by a subprocess.
   >  (run sh -c "dune build -p %{pkg-self:name} @install"))
+  > 
+  > (depends dune)
   > 
   > (source
   >  (fetch

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -95,7 +95,6 @@ Call Dune with an absolute PATH as argv[0]:
   $ PATH=$fakepath $DUNE build "$pkg_root/$foo_digest/target/"
   Fake dune! (args: build -p foo @install)
   $ PATH=$fakepath $DUNE build "$pkg_root/$bar_digest/target/"
-  Fake dune! (args: build -p bar @install)
 
 Make sure that fake dune is not picked up when dune is called with argv[0] = "dune":
 


### PR DESCRIPTION
This is a companion PR to #12902. Where #12902 resolves the `dune` binary to be called to be correct, this PR prepends an extra entry to the `PATH` variable so the environment will point to the right dune instead of whatever was captured in the environment (potentially by accident).

It has a non-essential dependency on #12916 to show that the Dune binary is correctly resolved in all cases.