### PR TITLE
Chore: bump ocamlformat version to 0.28.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.27.0
+version=0.28.1
 profile=janestreet
 ocaml-version=4.08.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ This output will appear in cram test diffs, making it easy to observe values.
 
 ### Development Guidelines
 - Always verify changes build with `dune build @check`
-- Run `dune fmt` to ensure code formatting (requires ocamlformat 0.27.0)
+- Run `dune fmt` to ensure code formatting (requires ocamlformat)
 - Keep lines under 80 characters
 - Only add comments for complex algorithms or when explicitly requested
 - Don't disable warnings or tests unless prompted

--- a/otherlibs/stdune/src/compact_position.ml
+++ b/otherlibs/stdune/src/compact_position.ml
@@ -11,7 +11,7 @@ module Position = struct
   let small_enough =
     let max_size = 1 lsl field_size in
     let test int = int <= max_size in
-    fun [@inline] { Lexing.pos_bol; pos_cnum; pos_lnum; pos_fname = _ } ->
+    fun[@inline] { Lexing.pos_bol; pos_cnum; pos_lnum; pos_fname = _ } ->
       test pos_bol && test pos_cnum && test pos_lnum
   ;;
 
@@ -75,7 +75,7 @@ module Same_line_loc = struct
 
   let small_enough =
     let max_size = 1 lsl field_size in
-    fun [@inline] int -> int <= max_size
+    fun[@inline] int -> int <= max_size
   ;;
 
   let[@inline] to_loc t ~fname:pos_fname =

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1075,8 +1075,8 @@ let as_outside_build_dir_exn : t -> Outside_build_dir.t = function
     Code_error.raise "as_outside_build_dir_exn" [ "path", Build.to_dyn path ]
 ;;
 
-let destruct_build_dir : t -> [ `Inside of Build.t | `Outside of Outside_build_dir.t ]
-  = function
+let destruct_build_dir : t -> [ `Inside of Build.t | `Outside of Outside_build_dir.t ] =
+  function
   | In_source_tree p -> `Outside (In_source_dir p)
   | External s -> `Outside (External s)
   | In_build_dir s -> `Inside s
@@ -1368,18 +1368,18 @@ module Table = struct
   ;;
 
   let filteri_inplace { source; build; external_ } ~f =
-    Source0.Table.filteri_inplace source ~f:(fun [@inline] ~key ~data ->
+    Source0.Table.filteri_inplace source ~f:(fun[@inline] ~key ~data ->
       f ~key:(In_source_tree key) ~data);
-    Build.Table.filteri_inplace build ~f:(fun [@inline] ~key ~data ->
+    Build.Table.filteri_inplace build ~f:(fun[@inline] ~key ~data ->
       f ~key:(In_build_dir key) ~data);
-    External.Table.filteri_inplace external_ ~f:(fun [@inline] ~key ~data ->
+    External.Table.filteri_inplace external_ ~f:(fun[@inline] ~key ~data ->
       f ~key:(External key) ~data)
   ;;
 
   let filter_inplace { source; build; external_ } ~f =
-    Source0.Table.filteri_inplace source ~f:(fun [@inline] ~key:_ ~data -> f data);
-    Build.Table.filteri_inplace build ~f:(fun [@inline] ~key:_ ~data -> f data);
-    External.Table.filteri_inplace external_ ~f:(fun [@inline] ~key:_ ~data -> f data)
+    Source0.Table.filteri_inplace source ~f:(fun[@inline] ~key:_ ~data -> f data);
+    Build.Table.filteri_inplace build ~f:(fun[@inline] ~key:_ ~data -> f data);
+    External.Table.filteri_inplace external_ ~f:(fun[@inline] ~key:_ ~data -> f data)
   ;;
 
   let to_dyn f { source; build; external_ } =

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -677,8 +677,8 @@ module Solver = struct
 
   module Solver = struct
     (* Copyright (C) 2013, Thomas Leonard
-     *See the README file for details, or visit http://0install.net.
-    *)
+     * See the README file for details, or visit http://0install.net.
+     *)
     module Sat = Sat.Make (Input.Impl)
 
     type decision_state =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1093,7 +1093,7 @@ end = struct
       let+ deps_changed =
         (* Make sure [f] gets inlined to avoid unnecessary closure allocations
            and improve stack traces in profiling. *)
-        Deps.changed_or_not cached_value.deps ~f:(fun [@inline] (Dep_node.T dep) ->
+        Deps.changed_or_not cached_value.deps ~f:(fun[@inline] (Dep_node.T dep) ->
           consider_and_restore_from_cache_without_adding_dep dep
           >>= function
           | Ok cached_value_of_dep ->

--- a/test/expect-tests/inotify_tests/inotify_tests.ml
+++ b/test/expect-tests/inotify_tests/inotify_tests.ml
@@ -26,8 +26,8 @@ let remove_dot_slash s = String.drop_prefix s ~prefix:"./" |> Option.value ~defa
 
 (* Events generated from watching directory "." are prefixed with ".". Remove
    the prefix as it's not super interesting. *)
-let remove_dot_slash_from_event : Async_inotify.Event.t -> Async_inotify.Event.t
-  = function
+let remove_dot_slash_from_event : Async_inotify.Event.t -> Async_inotify.Event.t =
+  function
   | Created s -> Created (remove_dot_slash s)
   | Unlinked s -> Unlinked (remove_dot_slash s)
   | Modified s -> Modified (remove_dot_slash s)


### PR DESCRIPTION
Following from #12885 where the OCaml version was bumped, we now have to bump ocamlformat because 0.27.0 is incompatible with OCaml 5.4
Thankfully the diff is small