### PR TITLE
Dune trace cleanups

### DIFF
--- a/bin/common.mli
+++ b/bin/common.mli
@@ -17,7 +17,7 @@ val rpc
      ]
 
 val watch_exclusions : t -> string list
-val stats : t -> Dune_trace.t option
+val stats : t -> Dune_trace.Out.t option
 val print_metrics : t -> bool
 val dump_memo_graph_file : t -> Path.External.t option
 val dump_memo_graph_format : t -> Dune_graph.Graph.File_format.t

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -152,7 +152,7 @@ module Dune_config : sig
   val for_scheduler
     :  t
     -> watch_exclusions:string list
-    -> Dune_trace.t option
+    -> Dune_trace.Out.t option
     -> print_ctrl_c_warning:bool
     -> Dune_engine.Scheduler.Config.t
 end

--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -71,7 +71,7 @@ type t =
       -> src:Path.Build.t
       -> dst:Path.Source.t
       -> unit Fiber.t
-  ; stats : Dune_trace.t option
+  ; stats : Dune_trace.Out.t option
   ; cache_config : Dune_cache.Config.t
   ; cache_debug_flags : Cache_debug_flags.t
   ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t

--- a/src/dune_engine/build_config_intf.ml
+++ b/src/dune_engine/build_config_intf.ml
@@ -119,7 +119,7 @@ module type Build_config = sig
   (** Initialise the build system. This must be called before running the build
       system and only once. *)
   val set
-    :  stats:Dune_trace.t option
+    :  stats:Dune_trace.Out.t option
     -> contexts:(Build_context.t * Context_type.t) list Memo.Lazy.t
     -> promote_source:
          (chmod:(int -> int)
@@ -149,7 +149,7 @@ module type Build_config = sig
         -> src:Path.Build.t
         -> dst:Path.Source.t
         -> unit Fiber.t
-    ; stats : Dune_trace.t option
+    ; stats : Dune_trace.Out.t option
     ; cache_config : Dune_cache.Config.t
     ; cache_debug_flags : Cache_debug_flags.t
     ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -305,17 +305,14 @@ end = struct
     Digest.generic trace
   ;;
 
-  let report_evaluated_rule_exn (t : Build_config.t) =
-    Option.iter t.stats ~f:(fun stats ->
-      let event =
-        let rule_total =
-          match Fiber.Svar.read State.t with
-          | Building progress -> progress.number_of_rules_discovered
-          | _ -> assert false
-        in
-        Dune_trace.Event.evalauted_rules ~rule_total
+  let report_evaluated_rule_exn () =
+    Dune_trace.emit (fun () ->
+      let rule_total =
+        match Fiber.Svar.read State.t with
+        | Building progress -> progress.number_of_rules_discovered
+        | _ -> assert false
       in
-      Dune_trace.emit stats event)
+      Dune_trace.Event.evalauted_rules ~rule_total)
   ;;
 
   module Exec_result = struct
@@ -510,7 +507,7 @@ end = struct
     let config = Build_config.get () in
     wrap_fiber (fun () ->
       let open Fiber.O in
-      report_evaluated_rule_exn config;
+      report_evaluated_rule_exn ();
       let* () =
         maybe_async_rule_file_op (fun () -> Path.mkdir_p (Path.build targets.root))
       in

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -182,7 +182,7 @@ let snapshot t =
 
 let create ~mode ~dune_stats ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
   let event =
-    Dune_trace.start dune_stats (fun () ->
+    Dune_trace.Out.start dune_stats (fun () ->
       Dune_trace.Event.Async.create_sandbox ~loc:rule_loc)
   in
   init ();
@@ -200,7 +200,7 @@ let create ~mode ~dune_stats ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
          targets produced dynamically will be unavailable. *)
       link_deps t ~mode ~deps)
   in
-  Dune_trace.finish event;
+  Option.iter dune_stats ~f:(fun trace -> Dune_trace.Out.finish trace event);
   match mode with
   | Patch_back_source_tree ->
     (* Only supported on Linux because we rely on the mtime changing to detect

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -12,7 +12,7 @@ val map_path : t -> Path.Build.t -> Path.Build.t
 (** Create a new sandbox containing [dirs] and copy or link dependencies [deps] inside it. *)
 val create
   :  mode:Sandbox_mode.some
-  -> dune_stats:Dune_trace.t option
+  -> dune_stats:Dune_trace.Out.t option
   -> rule_loc:Loc.t
   -> dirs:Path.Build.Set.t
   -> deps:Path.Set.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -5,7 +5,7 @@ open Import
 module Config : sig
   type t =
     { concurrency : int
-    ; stats : Dune_trace.t option
+    ; stats : Dune_trace.Out.t option
     ; print_ctrl_c_warning : bool
     ; watch_exclusions : string list
     }
@@ -151,7 +151,7 @@ val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
     [duration] should be at least this long. *)
 val sleep : seconds:float -> unit Fiber.t
 
-val stats : unit -> Dune_trace.t option Fiber.t
+val stats : unit -> Dune_trace.Out.t option Fiber.t
 
 (** Wait for a build input to change. If a build input change was seen but
     hasn't been handled yet, return immediately.

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -250,7 +250,7 @@ let fetch_local ~checksum ~target (url, url_loc) =
 let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
   let event =
     Dune_trace.(
-      start (global ()) (fun () ->
+      Out.start (global ()) (fun () ->
         Dune_trace.Event.Async.fetch
           ~url:(OpamUrl.to_string url)
           ~target
@@ -261,7 +261,8 @@ let fetch ~unpack ~checksum ~target ~url:(url_loc, url) =
   in
   Fiber.finalize
     ~finally:(fun () ->
-      Dune_trace.finish event;
+      Option.iter (Dune_trace.global ()) ~f:(fun trace ->
+        Dune_trace.Out.finish trace event);
       Fiber.return ())
     (fun () ->
        match url.backend with

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -41,7 +41,7 @@ module Run = struct
     ; root : string
     ; where : Dune_rpc.Where.t
     ; server : Csexp_rpc.Server.t Lazy.t
-    ; stats : Dune_trace.t option
+    ; stats : Dune_trace.Out.t option
     ; server_ivar : Csexp_rpc.Server.t Fiber.Ivar.t
     ; registry : [ `Add | `Skip ]
     }

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -9,7 +9,7 @@ val create
   -> root:string
   -> handle:(unit Dune_rpc_server.Handler.t -> unit)
        (** register additional requests or notifications *)
-  -> Dune_trace.t option
+  -> Dune_trace.Out.t option
   -> parse_build_arg:(string -> Dune_lang.Dep_conf.t)
   -> Dune_lang.Dep_conf.t t
 

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -295,7 +295,7 @@ module Event = struct
           in
           Dune_trace.Event.Rpc.message kind ~meth_ ~id stage
       in
-      Dune_trace.emit stats event)
+      Dune_trace.Out.emit stats event)
   ;;
 end
 

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -159,5 +159,5 @@ module Make (S : sig
     val name : t -> string
   end) : sig
   (** [serve sessions handler] serve all [sessions] using [handler] *)
-  val serve : S.t Fiber.Stream.In.t -> Dune_trace.t option -> t -> unit Fiber.t
+  val serve : S.t Fiber.Stream.In.t -> Dune_trace.Out.t option -> t -> unit Fiber.t
 end

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -2,7 +2,7 @@ open Import
 
 (** Tie the knot between [Dune_engine] and [Dune_rules]. *)
 val init
-  :  stats:Dune_trace.t option
+  :  stats:Dune_trace.Out.t option
   -> sandboxing_preference:Sandbox_mode.t list
   -> cache_config:Dune_cache.Config.t
   -> cache_debug_flags:Dune_engine.Cache_debug_flags.t

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -1,27 +1,94 @@
 open Stdune
 module Timestamp = Chrome_trace.Event.Timestamp
+module Event = Event
 
-type dst =
-  | Out of out_channel
-  | Custom of
-      { write : string -> unit
-      ; close : unit -> unit
-      ; flush : unit -> unit
-      }
+module Out = struct
+  type dst =
+    | Out of out_channel
+    | Custom of
+        { write : string -> unit
+        ; close : unit -> unit
+        ; flush : unit -> unit
+        }
 
-type t =
-  { print : string -> unit
-  ; close : unit -> unit
-  ; flush : unit -> unit
-  ; mutable after_first_event : bool
-  }
+  type t =
+    { print : string -> unit
+    ; close : unit -> unit
+    ; flush : unit -> unit
+    ; mutable after_first_event : bool
+    }
 
-(* all fields of record used *)
+  (* all fields of record used *)
 
-let close { print; close; _ } =
-  print "]\n";
-  close ()
-;;
+  let close { print; close; _ } =
+    print "]\n";
+    close ()
+  ;;
+
+  let create dst =
+    let print =
+      match dst with
+      | Out out -> fun str -> Stdlib.output_string out str
+      | Custom c -> c.write
+    in
+    let close =
+      match dst with
+      | Out out -> fun () -> Stdlib.close_out out
+      | Custom c -> c.close
+    in
+    let flush =
+      match dst with
+      | Out out -> fun () -> flush out
+      | Custom c -> c.flush
+    in
+    { print; close; after_first_event = false; flush }
+  ;;
+
+  let flush t = t.flush ()
+
+  let next_leading_char t =
+    match t.after_first_event with
+    | true -> ','
+    | false ->
+      t.after_first_event <- true;
+      '['
+  ;;
+
+  let printf t format_string =
+    let c = next_leading_char t in
+    Printf.ksprintf t.print ("%c" ^^ format_string ^^ "\n") c
+  ;;
+
+  let emit t event = printf t "%s" (Json.to_string (Chrome_trace.Event.to_json event))
+
+  let start t k : Event.Async.t option =
+    match t with
+    | None -> None
+    | Some _ ->
+      let event_data = k () in
+      let start = Unix.gettimeofday () in
+      Some (Event.Async.create ~event_data ~start)
+  ;;
+
+  let finish t event =
+    match event with
+    | None -> ()
+    | Some { Event.Async.start; event_data = { args; cat; name } } ->
+      let dur =
+        let stop = Unix.gettimeofday () in
+        Timestamp.of_float_seconds (stop -. start)
+      in
+      let common =
+        Chrome_trace.Event.common_fields
+          ?cat
+          ~name
+          ~ts:(Timestamp.of_float_seconds start)
+          ()
+      in
+      let event = Chrome_trace.Event.complete ?args common ~dur in
+      emit t event
+  ;;
+end
 
 let global = ref None
 
@@ -29,7 +96,7 @@ let () =
   at_exit (fun () ->
     match !global with
     | None -> ()
-    | Some t -> close t)
+    | Some t -> Out.close t)
 ;;
 
 let set_global t =
@@ -39,392 +106,16 @@ let set_global t =
 
 let global () = !global
 
-let create dst =
-  let print =
-    match dst with
-    | Out out -> fun str -> Stdlib.output_string out str
-    | Custom c -> c.write
-  in
-  let close =
-    match dst with
-    | Out out -> fun () -> Stdlib.close_out out
-    | Custom c -> c.close
-  in
-  let flush =
-    match dst with
-    | Out out -> fun () -> flush out
-    | Custom c -> c.flush
-  in
-  { print; close; after_first_event = false; flush }
-;;
-
-let flush t = t.flush ()
-
-let next_leading_char t =
-  match t.after_first_event with
-  | true -> ','
-  | false ->
-    t.after_first_event <- true;
-    '['
-;;
-
-let printf t format_string =
-  let c = next_leading_char t in
-  Printf.ksprintf t.print ("%c" ^^ format_string ^^ "\n") c
-;;
-
-module Event = struct
-  module Async = struct
-    type data =
-      { args : Chrome_trace.Event.args option
-      ; cat : string list option
-      ; name : string
-      }
-
-    type nonrec t =
-      { t : t
-      ; event_data : data
-      ; start : float
-      }
-
-    let create_sandbox ~loc =
-      { args = Some [ "loc", `String (Loc.to_file_colon_line loc) ]
-      ; name = "create-sandbox"
-      ; cat = Some [ "sandbox" ]
-      }
-    ;;
-
-    let fetch ~url ~target ~checksum =
-      let args = [ "url", `String url; "target", `String (Path.to_string target) ] in
-      let args =
-        match checksum with
-        | None -> args
-        | Some c -> ("checksum", `String c) :: args
-      in
-      { args = Some args; cat = Some [ "pkg" ]; name = "fetch" }
-    ;;
-  end
-
-  type t = Chrome_trace.Event.t
-
-  let scan_source ~name ~start ~stop ~dir =
-    let module Event = Chrome_trace.Event in
-    let module Timestamp = Event.Timestamp in
-    let dur = Timestamp.of_float_seconds (stop -. start) in
-    let common =
-      Event.common_fields
-        ~name:(name ^ ": " ^ Path.Source.to_string dir)
-        ~ts:(Timestamp.of_float_seconds start)
-        ()
-    in
-    let args = [ "dir", `String (Path.Source.to_string dir) ] in
-    Event.complete common ~args ~dur
-  ;;
-
-  let evalauted_rules ~rule_total =
-    let open Chrome_trace in
-    let args = [ "value", `Int rule_total ] in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-    let common = Event.common_fields ~name:"evaluated_rules" ~ts () in
-    Event.counter common args
-  ;;
-
-  let config ~version =
-    let args =
-      let args =
-        [ "build_dir", `String (Path.Build.to_string Path.Build.root)
-        ; "argv", `List (Array.to_list Sys.argv |> List.map ~f:Json.string)
-        ; "env", `List (Unix.environment () |> Array.to_list |> List.map ~f:Json.string)
-        ; "root", `String Path.(to_absolute_filename root)
-        ]
-      in
-      match version with
-      | None -> args
-      | Some v -> ("version", Stdune.Json.string v) :: args
-    in
-    let open Chrome_trace in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-    let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
-    Event.instant ~args common
-  ;;
-
-  let scheduler_idle () =
-    let fields =
-      let ts = Chrome_trace.Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      Chrome_trace.Event.common_fields ~name:"watch mode iteration" ~ts ()
-    in
-    (* the instant event allows us to separate build commands from
-       different iterations of the watch mode in the event viewer *)
-    Chrome_trace.Event.instant ~scope:Global fields
-  ;;
-
-  module Exit_status = struct
-    type error =
-      | Failed of int
-      | Signaled of Signal.t
-
-    type t = (int, error) result
-  end
-
-  type targets =
-    { root : Path.Build.t
-    ; files : Filename.Set.t
-    ; dirs : Filename.Set.t
-    }
-
-  let args_of_targets =
-    let paths root name set =
-      if Filename.Set.is_empty set
-      then []
-      else
-        [ ( name
-          , `List
-              (Filename.Set.to_list_map set ~f:(fun x ->
-                 `String (Path.Build.relative root x |> Path.Build.to_string))) )
-        ]
-    in
-    fun { root; files; dirs } ->
-      paths root "target_files" files @ paths root "target_dirs" dirs
-  ;;
-
-  let process
-        ~name
-        ~started_at
-        ~targets
-        ~categories
-        ~pid
-        ~exit
-        ~prog
-        ~process_args
-        ~dir
-        ~stdout
-        ~stderr
-        ~(times : Proc.Times.t)
-    =
-    let open Chrome_trace in
-    let common =
-      let name =
-        match name with
-        | Some n -> n
-        | None -> Filename.basename prog
-      in
-      let ts = Timestamp.of_float_seconds started_at in
-      Event.common_fields ~cat:("process" :: categories) ~name ~ts ()
-    in
-    let always =
-      [ "process_args", `List (List.map process_args ~f:(fun arg -> `String arg))
-      ; "pid", `Int (Pid.to_int pid)
-      ]
-    in
-    let extended =
-      let exit =
-        match exit with
-        | Ok n -> [ "exit", `Int n ]
-        | Error (Exit_status.Failed n) ->
-          [ "exit", `Int n; "error", `String (sprintf "exited with code %d" n) ]
-        | Error (Signaled s) ->
-          [ "exit", `Int (Signal.to_int s)
-          ; "error", `String (sprintf "got signal %s" (Signal.name s))
-          ]
-      in
-      let output name s =
-        match s with
-        | "" -> []
-        | s -> [ name, `String s ]
-      in
-      List.concat
-        [ [ "prog", `String prog
-          ; "dir", `String (Option.map ~f:Path.to_string dir |> Option.value ~default:".")
-          ]
-        ; exit
-        ; (match targets with
-           | None -> []
-           | Some targets -> args_of_targets targets)
-        ; output "stdout" stdout
-        ; output "stderr" stderr
-        ]
-    in
-    let args = always @ extended in
-    let dur = Event.Timestamp.of_float_seconds times.elapsed_time in
-    Event.complete ~args ~dur common
-  ;;
-
-  let persistent ~file ~module_ what ~start ~stop =
-    let module Event = Chrome_trace.Event in
-    let module Timestamp = Event.Timestamp in
-    let dur = Timestamp.of_float_seconds (stop -. start) in
-    let common =
-      Event.common_fields ~name:"db" ~ts:(Timestamp.of_float_seconds start) ()
-    in
-    let args =
-      [ "path", `String (Path.to_string file)
-      ; "module", `String module_
-      ; ( "operation"
-        , `String
-            (match what with
-             | `Save -> "save"
-             | `Load -> "load") )
-      ]
-    in
-    Event.complete common ~args ~dur
-  ;;
-
-  module Rpc = struct
-    type stage =
-      | Start
-      | Stop
-
-    let async_kind_of_stage = function
-      | Start -> Chrome_trace.Event.Start
-      | Stop -> End
-    ;;
-
-    let session ~id stage =
-      let open Chrome_trace in
-      let common =
-        let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-        Event.common_fields ~ts ~name:"rpc_session" ()
-      in
-      let id = Chrome_trace.Id.create (`Int id) in
-      Event.async id (async_kind_of_stage stage) common
-    ;;
-
-    let rec to_json : Sexp.t -> Chrome_trace.Json.t = function
-      | Atom s -> `String s
-      | List s -> `List (List.map s ~f:to_json)
-    ;;
-
-    let message what ~meth_ ~id stage =
-      let open Chrome_trace in
-      let name =
-        match what with
-        | `Notification -> "notification"
-        | `Request _ -> "request"
-      in
-      let args = [ "meth", `String meth_ ] in
-      let args =
-        match what with
-        | `Notification -> args
-        | `Request id -> ("request_id", to_json id) :: args
-      in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let common = Event.common_fields ~cat:[ "rpc" ] ~ts ~name () in
-      Event.async
-        (Chrome_trace.Id.create (`Int id))
-        ~args
-        (async_kind_of_stage stage)
-        common
-    ;;
-
-    let packet_read ~id ~success ~error =
-      let open Chrome_trace in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let args =
-        let base = [ "id", `Int id; "success", `Bool success ] in
-        match error with
-        | None -> base
-        | Some err -> ("error", `String err) :: base
-      in
-      let common =
-        Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_read" ~ts ()
-      in
-      Event.instant ~args common
-    ;;
-
-    let packet_write ~id ~count =
-      let open Chrome_trace in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let args = [ "id", `Int id; "count", `Int count ] in
-      let common =
-        Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_write" ~ts ()
-      in
-      Event.instant ~args common
-    ;;
-
-    let accept ~success ~error =
-      let open Chrome_trace in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let args =
-        let base = [ "success", `Bool success ] in
-        match error with
-        | None -> base
-        | Some err -> ("error", `String err) :: base
-      in
-      let common = Event.common_fields ~cat:[ "rpc"; "accept" ] ~name:"accept" ~ts () in
-      Event.instant ~args common
-    ;;
-
-    let close ~id =
-      let open Chrome_trace in
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-      let args = [ "id", `Int id ] in
-      let common = Event.common_fields ~cat:[ "rpc"; "session" ] ~name:"close" ~ts () in
-      Event.instant ~args common
-    ;;
-  end
-
-  let gc () =
-    let module Event = Chrome_trace.Event in
-    let module Json = Chrome_trace.Json in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-    let common = Event.common_fields ~name:"gc" ~ts () in
-    let args =
-      let stat = Gc.quick_stat () in
-      [ "stack_size", `Int stat.stack_size
-      ; "heap_words", `Int stat.heap_words
-      ; "top_heap_words", `Int stat.top_heap_words
-      ; "minor_words", `Float stat.minor_words
-      ; "major_words", `Float stat.major_words
-      ; "promoted_words", `Float stat.promoted_words
-      ; "compactions", `Int stat.compactions
-      ; "major_collections", `Int stat.major_collections
-      ; "minor_collections", `Int stat.minor_collections
-      ]
-    in
-    Event.counter common args
-  ;;
-
-  let fd_count () =
-    let module Event = Chrome_trace.Event in
-    let module Json = Chrome_trace.Json in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
-    match Fd_count.get () with
-    | Unknown -> None
-    | This fds ->
-      let args = [ "value", `Int fds ] in
-      let common = Event.common_fields ~name:"fds" ~ts () in
-      Some (Event.counter common args)
-  ;;
-end
-
-let emit t event = printf t "%s" (Json.to_string (Chrome_trace.Event.to_json event))
-
-let start t k : Event.Async.t option =
-  match t with
-  | None -> None
-  | Some t ->
-    let event_data = k () in
-    let start = Unix.gettimeofday () in
-    Some { t; event_data; start }
-;;
-
-let finish event =
-  match event with
+let emit f =
+  match global () with
   | None -> ()
-  | Some { Event.Async.t; start; event_data = { args; cat; name } } ->
-    let dur =
-      let stop = Unix.gettimeofday () in
-      Timestamp.of_float_seconds (stop -. start)
-    in
-    let common =
-      Chrome_trace.Event.common_fields
-        ?cat
-        ~name
-        ~ts:(Timestamp.of_float_seconds start)
-        ()
-    in
-    let event = Chrome_trace.Event.complete ?args common ~dur in
-    emit t event
+  | Some out -> Out.emit out (f ())
+;;
+
+let emit_all f =
+  match global () with
+  | None -> ()
+  | Some out -> List.iter (f ()) ~f:(Out.emit out)
 ;;
 
 module Private = struct

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -1,19 +1,5 @@
 open Stdune
 
-type t
-
-type dst =
-  | Out of out_channel
-  | Custom of
-      { write : string -> unit
-      ; close : unit -> unit
-      ; flush : unit -> unit
-      }
-
-val global : unit -> t option
-val set_global : t -> unit
-val create : dst -> t
-
 module Event : sig
   module Async : sig
     type t
@@ -91,10 +77,28 @@ module Event : sig
   end
 end
 
-val emit : t -> Event.t -> unit
-val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
-val finish : Event.Async.t option -> unit
-val flush : t -> unit
+module Out : sig
+  type t
+
+  type dst =
+    | Out of out_channel
+    | Custom of
+        { write : string -> unit
+        ; close : unit -> unit
+        ; flush : unit -> unit
+        }
+
+  val create : dst -> t
+  val emit : t -> Event.t -> unit
+  val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
+  val finish : t -> Event.Async.t option -> unit
+  val flush : t -> unit
+end
+
+val global : unit -> Out.t option
+val set_global : Out.t -> unit
+val emit : (unit -> Event.t) -> unit
+val emit_all : (unit -> Event.t list) -> unit
 
 module Private : sig
   module Fd_count : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -1,0 +1,323 @@
+open Stdune
+module Timestamp = Chrome_trace.Event.Timestamp
+
+module Async = struct
+  type data =
+    { args : Chrome_trace.Event.args option
+    ; cat : string list option
+    ; name : string
+    }
+
+  type nonrec t =
+    { event_data : data
+    ; start : float
+    }
+
+  let create ~event_data ~start = { event_data; start }
+
+  let create_sandbox ~loc =
+    { args = Some [ "loc", `String (Loc.to_file_colon_line loc) ]
+    ; name = "create-sandbox"
+    ; cat = Some [ "sandbox" ]
+    }
+  ;;
+
+  let fetch ~url ~target ~checksum =
+    let args = [ "url", `String url; "target", `String (Path.to_string target) ] in
+    let args =
+      match checksum with
+      | None -> args
+      | Some c -> ("checksum", `String c) :: args
+    in
+    { args = Some args; cat = Some [ "pkg" ]; name = "fetch" }
+  ;;
+end
+
+type t = Chrome_trace.Event.t
+
+let scan_source ~name ~start ~stop ~dir =
+  let module Event = Chrome_trace.Event in
+  let module Timestamp = Event.Timestamp in
+  let dur = Timestamp.of_float_seconds (stop -. start) in
+  let common =
+    Event.common_fields
+      ~name:(name ^ ": " ^ Path.Source.to_string dir)
+      ~ts:(Timestamp.of_float_seconds start)
+      ()
+  in
+  let args = [ "dir", `String (Path.Source.to_string dir) ] in
+  Event.complete common ~args ~dur
+;;
+
+let evalauted_rules ~rule_total =
+  let open Chrome_trace in
+  let args = [ "value", `Int rule_total ] in
+  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let common = Event.common_fields ~name:"evaluated_rules" ~ts () in
+  Event.counter common args
+;;
+
+let config ~version =
+  let args =
+    let args =
+      [ "build_dir", `String (Path.Build.to_string Path.Build.root)
+      ; "argv", `List (Array.to_list Sys.argv |> List.map ~f:Json.string)
+      ; "env", `List (Unix.environment () |> Array.to_list |> List.map ~f:Json.string)
+      ; "root", `String Path.(to_absolute_filename root)
+      ]
+    in
+    match version with
+    | None -> args
+    | Some v -> ("version", Stdune.Json.string v) :: args
+  in
+  let open Chrome_trace in
+  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
+  Event.instant ~args common
+;;
+
+let scheduler_idle () =
+  let fields =
+    let ts = Chrome_trace.Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    Chrome_trace.Event.common_fields ~name:"watch mode iteration" ~ts ()
+  in
+  (* the instant event allows us to separate build commands from
+       different iterations of the watch mode in the event viewer *)
+  Chrome_trace.Event.instant ~scope:Global fields
+;;
+
+module Exit_status = struct
+  type error =
+    | Failed of int
+    | Signaled of Signal.t
+
+  type t = (int, error) result
+end
+
+type targets =
+  { root : Path.Build.t
+  ; files : Filename.Set.t
+  ; dirs : Filename.Set.t
+  }
+
+let args_of_targets =
+  let paths root name set =
+    if Filename.Set.is_empty set
+    then []
+    else
+      [ ( name
+        , `List
+            (Filename.Set.to_list_map set ~f:(fun x ->
+               `String (Path.Build.relative root x |> Path.Build.to_string))) )
+      ]
+  in
+  fun { root; files; dirs } ->
+    paths root "target_files" files @ paths root "target_dirs" dirs
+;;
+
+let process
+      ~name
+      ~started_at
+      ~targets
+      ~categories
+      ~pid
+      ~exit
+      ~prog
+      ~process_args
+      ~dir
+      ~stdout
+      ~stderr
+      ~(times : Proc.Times.t)
+  =
+  let open Chrome_trace in
+  let common =
+    let name =
+      match name with
+      | Some n -> n
+      | None -> Filename.basename prog
+    in
+    let ts = Timestamp.of_float_seconds started_at in
+    Event.common_fields ~cat:("process" :: categories) ~name ~ts ()
+  in
+  let always =
+    [ "process_args", `List (List.map process_args ~f:(fun arg -> `String arg))
+    ; "pid", `Int (Pid.to_int pid)
+    ]
+  in
+  let extended =
+    let exit =
+      match exit with
+      | Ok n -> [ "exit", `Int n ]
+      | Error (Exit_status.Failed n) ->
+        [ "exit", `Int n; "error", `String (sprintf "exited with code %d" n) ]
+      | Error (Signaled s) ->
+        [ "exit", `Int (Signal.to_int s)
+        ; "error", `String (sprintf "got signal %s" (Signal.name s))
+        ]
+    in
+    let output name s =
+      match s with
+      | "" -> []
+      | s -> [ name, `String s ]
+    in
+    List.concat
+      [ [ "prog", `String prog
+        ; "dir", `String (Option.map ~f:Path.to_string dir |> Option.value ~default:".")
+        ]
+      ; exit
+      ; (match targets with
+         | None -> []
+         | Some targets -> args_of_targets targets)
+      ; output "stdout" stdout
+      ; output "stderr" stderr
+      ]
+  in
+  let args = always @ extended in
+  let dur = Event.Timestamp.of_float_seconds times.elapsed_time in
+  Event.complete ~args ~dur common
+;;
+
+let persistent ~file ~module_ what ~start ~stop =
+  let module Event = Chrome_trace.Event in
+  let module Timestamp = Event.Timestamp in
+  let dur = Timestamp.of_float_seconds (stop -. start) in
+  let common = Event.common_fields ~name:"db" ~ts:(Timestamp.of_float_seconds start) () in
+  let args =
+    [ "path", `String (Path.to_string file)
+    ; "module", `String module_
+    ; ( "operation"
+      , `String
+          (match what with
+           | `Save -> "save"
+           | `Load -> "load") )
+    ]
+  in
+  Event.complete common ~args ~dur
+;;
+
+module Rpc = struct
+  type stage =
+    | Start
+    | Stop
+
+  let async_kind_of_stage = function
+    | Start -> Chrome_trace.Event.Start
+    | Stop -> End
+  ;;
+
+  let session ~id stage =
+    let open Chrome_trace in
+    let common =
+      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      Event.common_fields ~ts ~name:"rpc_session" ()
+    in
+    let id = Chrome_trace.Id.create (`Int id) in
+    Event.async id (async_kind_of_stage stage) common
+  ;;
+
+  let rec to_json : Sexp.t -> Chrome_trace.Json.t = function
+    | Atom s -> `String s
+    | List s -> `List (List.map s ~f:to_json)
+  ;;
+
+  let message what ~meth_ ~id stage =
+    let open Chrome_trace in
+    let name =
+      match what with
+      | `Notification -> "notification"
+      | `Request _ -> "request"
+    in
+    let args = [ "meth", `String meth_ ] in
+    let args =
+      match what with
+      | `Notification -> args
+      | `Request id -> ("request_id", to_json id) :: args
+    in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let common = Event.common_fields ~cat:[ "rpc" ] ~ts ~name () in
+    Event.async
+      (Chrome_trace.Id.create (`Int id))
+      ~args
+      (async_kind_of_stage stage)
+      common
+  ;;
+
+  let packet_read ~id ~success ~error =
+    let open Chrome_trace in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let args =
+      let base = [ "id", `Int id; "success", `Bool success ] in
+      match error with
+      | None -> base
+      | Some err -> ("error", `String err) :: base
+    in
+    let common =
+      Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_read" ~ts ()
+    in
+    Event.instant ~args common
+  ;;
+
+  let packet_write ~id ~count =
+    let open Chrome_trace in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let args = [ "id", `Int id; "count", `Int count ] in
+    let common =
+      Event.common_fields ~cat:[ "rpc"; "packet" ] ~name:"packet_write" ~ts ()
+    in
+    Event.instant ~args common
+  ;;
+
+  let accept ~success ~error =
+    let open Chrome_trace in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let args =
+      let base = [ "success", `Bool success ] in
+      match error with
+      | None -> base
+      | Some err -> ("error", `String err) :: base
+    in
+    let common = Event.common_fields ~cat:[ "rpc"; "accept" ] ~name:"accept" ~ts () in
+    Event.instant ~args common
+  ;;
+
+  let close ~id =
+    let open Chrome_trace in
+    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let args = [ "id", `Int id ] in
+    let common = Event.common_fields ~cat:[ "rpc"; "session" ] ~name:"close" ~ts () in
+    Event.instant ~args common
+  ;;
+end
+
+let gc () =
+  let module Event = Chrome_trace.Event in
+  let module Json = Chrome_trace.Json in
+  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let common = Event.common_fields ~name:"gc" ~ts () in
+  let args =
+    let stat = Gc.quick_stat () in
+    [ "stack_size", `Int stat.stack_size
+    ; "heap_words", `Int stat.heap_words
+    ; "top_heap_words", `Int stat.top_heap_words
+    ; "minor_words", `Float stat.minor_words
+    ; "major_words", `Float stat.major_words
+    ; "promoted_words", `Float stat.promoted_words
+    ; "compactions", `Int stat.compactions
+    ; "major_collections", `Int stat.major_collections
+    ; "minor_collections", `Int stat.minor_collections
+    ]
+  in
+  Event.counter common args
+;;
+
+let fd_count () =
+  let module Event = Chrome_trace.Event in
+  let module Json = Chrome_trace.Json in
+  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  match Fd_count.get () with
+  | Unknown -> None
+  | This fds ->
+    let args = [ "value", `Int fds ] in
+    let common = Event.common_fields ~name:"fds" ~ts () in
+    Some (Event.counter common args)
+;;

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -372,7 +372,7 @@ module Dir = struct
                    ~stop
                    ~dir:t.path
                in
-               Dune_trace.emit stats event;
+               Dune_trace.Out.emit stats event;
                res)
       in
       fun t ~traverse ~trace_event_name ~f ->


### PR DESCRIPTION
* Move event definitions to own module
* Move [Dune_trace.t] and related functions to [Dune_trace.Out]
* Add [Dune_trace.emit] and [Dune_trace.emit_all] and use them