### PR TITLE
Dune_trace: emit based on category

### DIFF
--- a/otherlibs/stdune/src/bit_set.ml
+++ b/otherlibs/stdune/src/bit_set.ml
@@ -52,4 +52,6 @@ struct
       done;
       !acc
   ;;
+
+  let of_list = List.fold_left ~init:empty ~f:add
 end

--- a/otherlibs/stdune/src/bit_set.mli
+++ b/otherlibs/stdune/src/bit_set.mli
@@ -24,4 +24,5 @@ module Make (Element : sig
   val compare : t -> t -> Ordering.t
   val equal : t -> t -> bool
   val of_func : (Element.t -> bool) -> t
+  val of_list : Element.t list -> t
 end

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -306,7 +306,7 @@ end = struct
   ;;
 
   let report_evaluated_rule_exn () =
-    Dune_trace.emit (fun () ->
+    Dune_trace.emit Rules (fun () ->
       let rule_total =
         match Fiber.Svar.read State.t with
         | Building progress -> progress.number_of_rules_discovered

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -824,7 +824,7 @@ let report_process_finished
   in
   let stdout = Result.Out.get stdout in
   let stderr = Result.Out.get stderr in
-  Dune_trace.emit (fun () ->
+  Dune_trace.emit Process (fun () ->
     Dune_trace.Event.process
       ~name:metadata.name
       ~started_at

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -41,7 +41,6 @@ module Run = struct
     ; root : string
     ; where : Dune_rpc.Where.t
     ; server : Csexp_rpc.Server.t Lazy.t
-    ; stats : Dune_trace.Out.t option
     ; server_ivar : Csexp_rpc.Server.t Fiber.Ivar.t
     ; registry : [ `Add | `Skip ]
     }
@@ -97,7 +96,7 @@ module Run = struct
              cleanup_registry := Some path;
              at_exit run_cleanup_registry
            in
-           let* () = Server.serve sessions t.stats t.handler in
+           let* () = Server.serve sessions t.handler in
            Fiber.Pool.close t.pool)
         (fun () -> Fiber.Pool.run t.pool)
     in
@@ -445,7 +444,7 @@ let handler (t : _ t Fdecl.t) handle : 'build_arg Dune_rpc_server.Handler.t =
   rpc
 ;;
 
-let create ~lock_timeout ~registry ~root ~handle stats ~parse_build_arg =
+let create ~lock_timeout ~registry ~root ~handle ~parse_build_arg =
   let t = Fdecl.create Dyn.opaque in
   let pending_jobs = Job_queue.create () in
   let handler = Dune_rpc_server.make (handler t handle) in
@@ -477,7 +476,6 @@ let create ~lock_timeout ~registry ~root ~handle stats ~parse_build_arg =
     ; pool
     ; root
     ; where
-    ; stats
     ; server
     ; registry
     ; server_ivar = Fiber.Ivar.create ()

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -9,7 +9,6 @@ val create
   -> root:string
   -> handle:(unit Dune_rpc_server.Handler.t -> unit)
        (** register additional requests or notifications *)
-  -> Dune_trace.Out.t option
   -> parse_build_arg:(string -> Dune_lang.Dep_conf.t)
   -> Dune_lang.Dep_conf.t t
 

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -281,21 +281,18 @@ module Event = struct
         ; stage : Dune_trace.Event.Rpc.stage
         }
 
-  let emit t stats id =
-    Option.iter stats ~f:(fun stats ->
-      let event =
-        let id = Session_id.to_int id in
-        match t with
-        | Session stage -> Dune_trace.Event.Rpc.session ~id stage
-        | Message { kind; meth_; stage } ->
-          let kind =
-            match kind with
-            | Request id -> `Request (Dune_rpc_private.Id.to_sexp id)
-            | Notification -> `Notification
-          in
-          Dune_trace.Event.Rpc.message kind ~meth_ ~id stage
-      in
-      Dune_trace.Out.emit stats event)
+  let emit t id =
+    Dune_trace.emit Rpc (fun () ->
+      let id = Session_id.to_int id in
+      match t with
+      | Session stage -> Dune_trace.Event.Rpc.session ~id stage
+      | Message { kind; meth_; stage } ->
+        let kind =
+          match kind with
+          | Request id -> `Request (Dune_rpc_private.Id.to_sexp id)
+          | Notification -> `Notification
+        in
+        Dune_trace.Event.Rpc.message kind ~meth_ ~id stage)
   ;;
 end
 
@@ -327,11 +324,10 @@ module H = struct
 
   (* TODO catch and convert dispatch users *)
 
-  let dispatch_notification (type a) (t : a t) stats (session : a Session.t) meth_ n =
+  let dispatch_notification (type a) (t : a t) (session : a Session.t) meth_ n =
     let kind = Notification in
     Event.emit
       (Message { kind; meth_; stage = Dune_trace.Event.Rpc.Start })
-      stats
       (Session.id session);
     let+ result = V.Handler.handle_notification t.handler session n in
     let () =
@@ -346,12 +342,12 @@ module H = struct
           ]
       | Ok r -> r
     in
-    Event.emit (Message { kind; meth_; stage = Stop }) stats (Session.id session)
+    Event.emit (Message { kind; meth_; stage = Stop }) (Session.id session)
   ;;
 
-  let dispatch_request (type a) (t : a t) stats (session : a Session.t) meth_ r id =
+  let dispatch_request (type a) (t : a t) (session : a Session.t) meth_ r id =
     let kind = Request id in
-    Event.emit (Message { kind; meth_; stage = Start }) stats (Session.id session);
+    Event.emit (Message { kind; meth_; stage = Start }) (Session.id session);
     let* response =
       let+ result =
         (* TODO instead of waiting for all errors, wait for the first one.
@@ -369,25 +365,25 @@ module H = struct
         in
         Error (Response.Error.create ~kind:Code_error ~message:"server error" ~payload ())
     in
-    Event.emit (Message { kind; meth_; stage = Stop }) stats (Session.id session);
+    Event.emit (Message { kind; meth_; stage = Stop }) (Session.id session);
     match session.base.close.state with
     | `Closed -> Fiber.return ()
     | `Open -> session.base.send (Some [ Response (id, response) ])
   ;;
 
-  let run_session (type a) (t : a t) stats (session : a Session.t) =
+  let run_session (type a) (t : a t) (session : a Session.t) =
     let open Fiber.O in
     let* () =
       Fiber.Stream.In.parallel_iter session.base.queries ~f:(fun (message : Packet.t) ->
         match message with
         | Response resp -> Session.Stage1.response session.base resp
-        | Notification n -> dispatch_notification t stats session n.method_ n
-        | Request (id, r) -> dispatch_request t stats session r.method_ r id)
+        | Notification n -> dispatch_notification t session n.method_ n
+        | Request (id, r) -> dispatch_request t session r.method_ r id)
     in
     Session.Stage1.close session.base
   ;;
 
-  let negotiate_version (type a) (t : a stage1) stats (session : a Session.Stage1.t) =
+  let negotiate_version (type a) (t : a stage1) (session : a Session.Stage1.t) =
     let open Fiber.O in
     let* query = Fiber.Stream.In.read session.queries in
     match query with
@@ -424,10 +420,10 @@ module H = struct
                session.menu <- Some menu;
                let session = Session.of_stage1 session handler in
                let* () = t.base.on_upgrade session menu in
-               run_session { handler } stats session)))
+               run_session { handler } session)))
   ;;
 
-  let handle (type a) (t : a stage1) stats (session : a Session.Stage1.t) =
+  let handle (type a) (t : a stage1) (session : a Session.Stage1.t) =
     let open Fiber.O in
     let* () = Fiber.return () in
     let* query = Fiber.Stream.In.read session.queries in
@@ -456,7 +452,7 @@ module H = struct
                 in
                 session.send (Some [ Response (id, response) ])
               in
-              negotiate_version t stats session))
+              negotiate_version t session))
   ;;
 
   module Builder = struct
@@ -593,7 +589,7 @@ type t = Server : 'a H.stage1 -> t
 let make (type a) (h : a H.Builder.t) : t = Server (H.Builder.to_handler h)
 let version (Server h) = h.base.version
 
-let new_session (Server handler) stats ~name ~queries ~send =
+let new_session (Server handler) ~name ~queries ~send =
   let session = Fdecl.create Dyn.opaque in
   Fdecl.set
     session
@@ -611,7 +607,7 @@ let new_session (Server handler) stats ~name ~queries ~send =
       Fiber.fork_and_join_unit
         (fun () -> Fiber.Pool.run session.pool)
         (fun () ->
-           let* () = H.handle handler stats session in
+           let* () = H.handle handler session in
            Session.Stage1.close session)
   end
 ;;
@@ -639,7 +635,7 @@ module Make (S : sig
 struct
   open Fiber.O
 
-  let serve sessions stats server =
+  let serve sessions server =
     Fiber.Stream.In.parallel_iter sessions ~f:(fun session ->
       let session =
         let send = function
@@ -655,10 +651,10 @@ struct
           create_sequence (fun () -> S.read session) ~version:(version server) Packet.sexp
         in
         let name = S.name session in
-        new_session server stats ~name ~queries ~send
+        new_session server ~name ~queries ~send
       in
       let id = session#id in
-      Event.emit (Session Start) stats id;
+      Event.emit (Session Start) id;
       let+ res =
         Fiber.map_reduce_errors
           (module Monoid.Unit)
@@ -677,7 +673,7 @@ struct
             Dune_util.Report_error.report exn;
             session#close)
       in
-      Event.emit (Session Stop) stats id;
+      Event.emit (Session Stop) id;
       match res with
       | Ok () -> ()
       | Error () ->

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -159,5 +159,5 @@ module Make (S : sig
     val name : t -> string
   end) : sig
   (** [serve sessions handler] serve all [sessions] using [handler] *)
-  val serve : S.t Fiber.Stream.In.t -> Dune_trace.Out.t option -> t -> unit Fiber.t
+  val serve : S.t Fiber.Stream.In.t -> t -> unit Fiber.t
 end

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -1,0 +1,52 @@
+open Stdune
+
+type t =
+  | Rpc
+  | Gc
+  | Fd
+  | Sandbox
+  | Persistent
+  | Process
+  | Rules
+  | Pkg
+  | Scheduler
+
+let all = [ Rpc; Gc; Fd; Sandbox; Persistent; Process; Rules; Pkg; Scheduler ]
+
+let to_string = function
+  | Rpc -> "rpc"
+  | Gc -> "gc"
+  | Fd -> "fd"
+  | Sandbox -> "sandbox"
+  | Persistent -> "persistent"
+  | Process -> "process"
+  | Rules -> "rules"
+  | Pkg -> "pkg"
+  | Scheduler -> "scheduler"
+;;
+
+let of_string =
+  let all = List.map all ~f:(fun a -> to_string a, a) in
+  fun x -> List.assoc_opt x all
+;;
+
+let to_dyn t = Dyn.variant (String.uppercase_ascii (to_string t)) []
+
+module Set = Bit_set.Make (struct
+    type nonrec t = t
+
+    let to_dyn = to_dyn
+    let all = all
+
+    let to_int = function
+      | Rpc -> 0
+      | Gc -> 1
+      | Fd -> 2
+      | Sandbox -> 3
+      | Persistent -> 4
+      | Process -> 5
+      | Rules -> 6
+      | Pkg -> 7
+      | Scheduler -> 8
+    ;;
+  end)

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -1,0 +1,23 @@
+type t =
+  | Rpc
+  | Gc
+  | Fd
+  | Sandbox
+  | Persistent
+  | Process
+  | Rules
+  | Pkg
+  | Scheduler
+
+val to_string : t -> string
+val of_string : string -> t option
+val to_dyn : t -> Dyn.t
+
+module Set : sig
+  type cat := t
+  type t
+
+  val mem : t -> cat -> bool
+  val empty : t
+  val of_list : cat list -> t
+end

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -1,5 +1,20 @@
 open Stdune
 
+module Category : sig
+  type t =
+    | Rpc
+    | Gc
+    | Fd
+    | Sandbox
+    | Persistent
+    | Process
+    | Rules
+    | Pkg
+    | Scheduler
+
+  val of_string : string -> t option
+end
+
 module Event : sig
   module Async : sig
     type t
@@ -88,7 +103,7 @@ module Out : sig
         ; flush : unit -> unit
         }
 
-  val create : dst -> t
+  val create : Category.t list -> dst -> t
   val emit : t -> Event.t -> unit
   val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
   val finish : t -> Event.Async.t option -> unit
@@ -97,8 +112,10 @@ end
 
 val global : unit -> Out.t option
 val set_global : Out.t -> unit
-val emit : (unit -> Event.t) -> unit
-val emit_all : (unit -> Event.t list) -> unit
+val always_emit : Event.t -> unit
+val emit : Category.t -> (unit -> Event.t) -> unit
+val emit_all : Category.t -> (unit -> Event.t list) -> unit
+val flush : unit -> unit
 
 module Private : sig
   module Fd_count : sig

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -56,7 +56,7 @@ module Make (D : Desc) = struct
   let with_record what ~file ~f =
     let start = Unix.gettimeofday () in
     let res = Result.try_with f in
-    Dune_trace.emit (fun () ->
+    Dune_trace.emit Persistent (fun () ->
       Dune_trace.Event.persistent
         ~file
         ~module_:D.name

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -15,6 +15,4 @@ This captures the commands that are being run:
 As well as data about the garbage collector:
 
   $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/([^0-9])[0-9]+/\1.../g' | sort -u
-  {"ph":"C","args":{"stack_size":...,"heap_words":...,"top_heap_words":...,"minor_words":...,"major_words":...,"promoted_words":...,"compactions":...,"major_collections":...,"minor_collections":...},"name":"gc","cat":"","ts":...,"pid":...,"tid":...}
   {"ph":"C","args":{"value":...},"name":"evaluated_rules","cat":"","ts":...,"pid":...,"tid":...}
-  {"ph":"C","args":{"value":...},"name":"fds","cat":"","ts":...,"pid":...,"tid":...}

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -82,7 +82,7 @@ let test ?(private_menu = []) ?(real_methods = true) ~client ~handler ~init () =
         Chan.close client_chan)
     in
     let server () =
-      let+ () = Drpc.Server.serve sessions None (Dune_rpc_server.make handler) in
+      let+ () = Drpc.Server.serve sessions (Dune_rpc_server.make handler) in
       printfn "server: finished."
     in
     Fiber.parallel_iter [ connect; client; server ] ~f:(fun f -> f ())


### PR DESCRIPTION
Introduce a type for all the categories we emit.

We check if a category is enabled before trying to generate & emit a particular event.

For now, the only way to control categories is via an environment variable. This isn't meant to be user facing, so this isn't documented yet. All events that users will care about will be enabled by default.