### PR TITLE
Stune: Introduce a Time module

### DIFF
--- a/bench/metrics.ml
+++ b/bench/metrics.ml
@@ -30,7 +30,8 @@ let make (times : Proc.Times.t) (gc : Gc.stat) =
       times.resource_usage
       ~default:{ user_cpu_time = 0.; system_cpu_time = 0. }
   in
-  { elapsed_time = times.elapsed_time
+  let elapsed_time = Time.Span.to_secs times.elapsed_time in
+  { elapsed_time
   ; user_cpu_time
   ; system_cpu_time
   ; minor_words = gc.minor_words

--- a/bin/build.ml
+++ b/bin/build.ml
@@ -1,9 +1,9 @@
 open Import
 
 let with_metrics ~common f =
-  let start_time = Unix.gettimeofday () in
+  let start_time = Time.now () in
   Fiber.finalize f ~finally:(fun () ->
-    let duration = Unix.gettimeofday () -. start_time in
+    let duration = Time.diff (Time.now ()) start_time in
     if Common.print_metrics common
     then (
       let gc_stat = Gc.quick_stat () in
@@ -14,7 +14,7 @@ let with_metrics ~common f =
            ([ Pp.textf "%s" memo_counters_report
             ; Pp.textf
                 "(%.2fs total, %.1fM heap words)"
-                duration
+                (Time.Span.to_secs duration)
                 (float_of_int gc_stat.heap_words /. 1_000_000.)
             ; Pp.text "Timers:"
             ]
@@ -23,7 +23,7 @@ let with_metrics ~common f =
                   Pp.textf
                     "%s - time spent = %.2fs, count = %d"
                     timer
-                    cumulative_time
+                    (Time.Span.to_secs cumulative_time)
                     count)
                 (String.Map.to_list (Metrics.Timer.aggregated_timers ())))));
     Memo.Metrics.reset ();

--- a/bin/monitor.ml
+++ b/bin/monitor.ml
@@ -246,7 +246,7 @@ let monitor ~quit_on_disconnect () =
       Console.Status_line.set
         (Console.Status_line.Live
            (fun () -> Pp.verbatim ("Waiting for RPC server" ^ String.make (i mod 4) '.')));
-      let+ () = Dune_engine.Scheduler.sleep ~seconds:0.3 in
+      let+ () = Dune_engine.Scheduler.sleep (Time.Span.of_secs 0.3) in
       Some (i + 1))
 ;;
 

--- a/bin/pkg/lock.ml
+++ b/bin/pkg/lock.ml
@@ -346,7 +346,7 @@ let solve_lock_dir
        | None -> solve_for_platforms)
     | false -> [ solver_env ]
   in
-  let time_start = Unix.gettimeofday () in
+  let time_start = Time.now () in
   let* repos =
     let repo_map = repositories_of_workspace workspace in
     let repo_names =
@@ -360,7 +360,7 @@ let solve_lock_dir
       ~repositories:(repositories_of_lock_dir workspace ~lock_dir_path)
   in
   let* pins = resolve_project_pins project_pins in
-  let time_solve_start = Unix.gettimeofday () in
+  let time_solve_start = Time.now () in
   progress_state := Some Progress_indicator.Per_lockdir.State.Solving;
   let* result =
     solve_multiple_platforms
@@ -418,14 +418,18 @@ let solve_lock_dir
       =
       solver_result
     in
-    let time_end = Unix.gettimeofday () in
+    let time_end = Time.now () in
     let maybe_perf_stats =
       if print_perf_stats
       then
         [ Pp.nop
         ; Pp.textf "Expanded packages: %d" num_expanded_packages
-        ; Pp.textf "Updated repos in: %.2fs" (time_solve_start -. time_start)
-        ; Pp.textf "Solved dependencies in: %.2fs" (time_end -. time_solve_start)
+        ; Pp.textf
+            "Updated repos in: %.2fs"
+            (Time.Span.to_secs (Time.diff time_solve_start time_start))
+        ; Pp.textf
+            "Solved dependencies in: %.2fs"
+            (Time.Span.to_secs (Time.diff time_end time_solve_start))
         ]
       else []
     in

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -76,13 +76,13 @@ let establish_connection_exn () =
 
 let establish_connection_with_retry () =
   let open Fiber.O in
-  let pause_between_retries_s = 0.2 in
+  let pause_between_retries_s = Time.Span.of_secs 0.2 in
   let rec loop () =
     establish_connection ()
     >>= function
     | Ok x -> Fiber.return x
     | Error _ ->
-      let* () = Dune_engine.Scheduler.sleep ~seconds:pause_between_retries_s in
+      let* () = Dune_engine.Scheduler.sleep pause_between_retries_s in
       loop ()
   in
   loop ()

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -32,7 +32,7 @@ end
 
 module Times = struct
   type t =
-    { elapsed_time : float
+    { elapsed_time : Time.Span.t
     ; resource_usage : Resource_usage.t option
     }
 end
@@ -41,7 +41,7 @@ module Process_info = struct
   type t =
     { pid : Pid.t
     ; status : Unix.process_status
-    ; end_time : float
+    ; end_time : Time.t
     ; resource_usage : Resource_usage.t option
     }
 end
@@ -66,6 +66,7 @@ let wait wait flags =
       | Pid pid -> Pid.to_int pid
     in
     let pid, status, end_time, resource_usage = stub_wait4 pid flags in
+    let end_time = Time.of_epoch_secs end_time in
     { Process_info.pid = Pid.of_int pid
     ; status
     ; end_time

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -19,7 +19,8 @@ end
 
 module Times : sig
   type t =
-    { elapsed_time : float (** Same as the "real" time reported by the "time" command *)
+    { elapsed_time : Time.Span.t
+      (** Same as the "real" time reported by the "time" command *)
     ; resource_usage : Resource_usage.t option
     }
 end
@@ -28,7 +29,7 @@ module Process_info : sig
   type t =
     { pid : Pid.t
     ; status : Unix.process_status
-    ; end_time : float (** Time at which the process finished. *)
+    ; end_time : Time.t (** Time at which the process finished. *)
     ; resource_usage : Resource_usage.t option
     }
 end

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -74,6 +74,7 @@ module Pid = Pid
 module Applicative = Applicative
 module Json = Json
 module Log = Log
+module Time = Time
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/otherlibs/stdune/src/time.ml
+++ b/otherlibs/stdune/src/time.ml
@@ -1,0 +1,20 @@
+type t = float
+
+let now () = Unix.gettimeofday ()
+let to_secs t = t
+let of_epoch_secs x = x
+let diff = ( -. )
+
+module Span = struct
+  type t = float
+
+  let zero = 0.
+  let max = Float.max
+  let compare = Float.compare
+  let of_secs x = x
+  let add = ( +. )
+  let diff = ( -. )
+  let to_secs t = t
+end
+
+let add t x = t +. x

--- a/otherlibs/stdune/src/time.mli
+++ b/otherlibs/stdune/src/time.mli
@@ -1,0 +1,20 @@
+type t
+
+val now : unit -> t
+val to_secs : t -> float
+val of_epoch_secs : float -> t
+
+module Span : sig
+  type t
+
+  val zero : t
+  val max : t -> t -> t
+  val compare : t -> t -> Ordering.t
+  val of_secs : float -> t
+  val add : t -> t -> t
+  val diff : t -> t -> t
+  val to_secs : t -> float
+end
+
+val add : t -> Span.t -> t
+val diff : t -> t -> Span.t

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -14,7 +14,7 @@ let maybe_async =
 ;;
 
 module Duration = struct
-  type t = float option
+  type t = Time.Span.t option
 
   let empty = None
 
@@ -23,7 +23,7 @@ module Duration = struct
     | None, None -> None
     | Some _, None -> x
     | None, Some _ -> y
-    | Some x, Some y -> Some (x +. y)
+    | Some x, Some y -> Some (Time.Span.add x y)
   ;;
 end
 
@@ -39,7 +39,7 @@ module Produce = struct
 
   let return : 'a. 'a -> 'a t = fun a state -> Fiber.return (a, state)
 
-  let incr_duration : float -> 'a t =
+  let incr_duration : Time.Span.t -> 'a t =
     fun how_much state ->
     Fiber.return ((), State.combine state { duration = Some how_much })
   ;;
@@ -125,7 +125,7 @@ module Exec_result = struct
 
   type ok =
     { dynamic_deps_stages : (Dep.Set.t * Dep.Facts.t) list
-    ; duration : float option
+    ; duration : Time.Span.t option
     }
 
   type t = (ok, Error.t list) Result.t

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -18,7 +18,7 @@ module Exec_result : sig
         (* The set can be derived from the facts by getting the keys of the
            facts map. We don't do it because conversion isn't free *)
         (Dep.Set.t * Dep.Facts.t) list
-    ; duration : float option
+    ; duration : Time.Span.t option
     }
 
   type t = (ok, Error.t list) Result.t

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -14,11 +14,11 @@ module Failure_mode : sig
         the process exits with one of these codes. *)
     | Return : ('a, 'a * int) t (** Accept any error code and return it. *)
     | Timeout :
-        { timeout_seconds : float option
+        { timeout : Time.Span.t option
         ; failure_mode : ('a, 'b) t
         }
         -> ('a, ('b, [ `Timed_out ]) result) t
-    (** In addition to the [failure_mode], finish early if [timeout_seconds]
+    (** In addition to the [failure_mode], finish early if [timeout]
         was reached. *)
 end
 

--- a/src/dune_engine/running_jobs.ml
+++ b/src/dune_engine/running_jobs.ml
@@ -5,7 +5,7 @@ module Id = Stdune.Id.Make ()
 type job =
   { pid : Pid.t
   ; description : unit Pp.t
-  ; started_at : float
+  ; started_at : Time.t
   ; id : Id.t
   }
 

--- a/src/dune_engine/running_jobs.mli
+++ b/src/dune_engine/running_jobs.mli
@@ -9,7 +9,7 @@ module Id : Id.S
 type job =
   { pid : Pid.t
   ; description : unit Pp.t
-  ; started_at : float
+  ; started_at : Time.t
   ; id : Id.t
   }
 
@@ -21,7 +21,7 @@ type event =
 type t
 
 val current : t -> job Id.Map.t
-val start : Id.t -> Pid.t -> description:unit Pp.t -> started_at:float -> unit Fiber.t
+val start : Id.t -> Pid.t -> description:unit Pp.t -> started_at:Time.t -> unit Fiber.t
 val stop : Id.t -> unit Fiber.t
 val equal : t -> t -> bool
 

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -69,7 +69,7 @@ module Run : sig
 
   val go
     :  Config.t
-    -> ?timeout_seconds:float
+    -> ?timeout:Time.Span.t
     -> ?file_watcher:file_watcher
     -> on_event:(Config.t -> Event.t -> unit)
     -> (unit -> 'a Fiber.t)
@@ -96,7 +96,7 @@ val with_job_slot : (Fiber.Cancel.t -> Config.t -> 'a Fiber.t) -> 'a Fiber.t
     true, kill the entire process group instead of just the process in case of
     timeout. *)
 val wait_for_process
-  :  ?timeout_seconds:float
+  :  ?timeout:Time.Span.t
   -> ?is_process_group_leader:bool
   -> Pid.t
   -> Proc.Process_info.t Fiber.t
@@ -107,7 +107,7 @@ type termination_reason =
   | Timeout
 
 val wait_for_build_process
-  :  ?timeout_seconds:float
+  :  ?timeout:Time.Span.t
   -> ?is_process_group_leader:bool
   -> Pid.t
   -> (Proc.Process_info.t * termination_reason) Fiber.t
@@ -149,7 +149,7 @@ val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
 (** [sleep duration] wait for [duration] seconds to elapse. Sleepers
     are checked for wake up at a rate of once per 0.1 seconds. So
     [duration] should be at least this long. *)
-val sleep : seconds:float -> unit Fiber.t
+val sleep : Time.Span.t -> unit Fiber.t
 
 val stats : unit -> Dune_trace.Out.t option Fiber.t
 

--- a/src/dune_metrics/dune_metrics.ml
+++ b/src/dune_metrics/dune_metrics.ml
@@ -6,13 +6,13 @@ let enable () = enabled := true
 module Timer = struct
   module Measure = struct
     type t =
-      { cumulative_time : float
+      { cumulative_time : Time.Span.t
       ; count : int
       }
   end
 
   type t =
-    { start_time : float
+    { start_time : Time.t
     ; tag : string
     ; mutable stopped : bool
     }
@@ -28,15 +28,15 @@ module Timer = struct
            | Some { Measure.cumulative_time; count } ->
              Some
                { Measure.cumulative_time =
-                   cumulative_time +. (Unix.gettimeofday () -. start_time)
+                   Time.Span.add cumulative_time (Time.diff (Time.now ()) start_time)
                ; count = count + 1
                }
            | None ->
              Some
-               { Measure.cumulative_time = Unix.gettimeofday () -. start_time; count = 1 })
+               { Measure.cumulative_time = Time.diff (Time.now ()) start_time; count = 1 })
   ;;
 
-  let start tag = { start_time = Unix.gettimeofday (); tag; stopped = false }
+  let start tag = { start_time = Time.now (); tag; stopped = false }
 
   let stop t =
     match !enabled with
@@ -51,7 +51,7 @@ module Timer = struct
     match !enabled with
     | false -> f ()
     | true ->
-      let start_time = Unix.gettimeofday () in
+      let start_time = Time.now () in
       Exn.protect ~f ~finally:(fun () ->
         update_aggregate { tag; start_time; stopped = false })
   ;;

--- a/src/dune_metrics/dune_metrics.mli
+++ b/src/dune_metrics/dune_metrics.mli
@@ -11,7 +11,7 @@ val reset : unit -> unit
 module Timer : sig
   module Measure : sig
     type t =
-      { cumulative_time : float
+      { cumulative_time : Time.Span.t
       ; count : int
       }
   end

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -352,14 +352,14 @@ let lock_path { dir; _ } =
 ;;
 
 let rec attempt_to_lock flock lock ~max_retries =
-  let sleep_duration = 0.1 in
+  let sleep_duration = Time.Span.of_secs 0.1 in
   match Flock.lock_non_block flock lock with
   | Error e -> Fiber.return @@ Error e
   | Ok `Success -> Fiber.return (Ok `Success)
   | Ok `Failure ->
     if max_retries > 0
     then
-      let* () = Scheduler.sleep ~seconds:sleep_duration in
+      let* () = Scheduler.sleep sleep_duration in
       attempt_to_lock flock lock ~max_retries:(max_retries - 1)
     else Fiber.return (Ok `Failure)
 ;;

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -272,6 +272,7 @@ let handler (t : _ t Fdecl.t) handle : 'build_arg Dune_rpc_server.Handler.t =
     let start_job { Running_jobs.pid; description; started_at; id } =
       let id = Running_jobs.Id.to_int id |> Job.Id.create in
       let pid = Pid.to_int pid in
+      let started_at = Time.to_secs started_at in
       Job.Event.Start { Job.started_at; id; pid; description }
     in
     let stop_job id = Job.Event.Stop (Job.Id.create (Running_jobs.Id.to_int id)) in

--- a/src/dune_rules/cram/cram_exec.mli
+++ b/src/dune_rules/cram/cram_exec.mli
@@ -13,7 +13,7 @@ val run
   -> dir:Path.t
   -> script:Path.t
   -> output:Path.Build.t
-  -> timeout:(Loc.t * float) option
+  -> timeout:(Loc.t * Time.Span.t) option
   -> setup_scripts:Path.t list
   -> Action.t
 

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -11,7 +11,7 @@ module Spec = struct
     ; enabled_if : (Expander.t * Blang.t) list
     ; locks : Path.Set.t Action_builder.t
     ; packages : Package.Name.Set.t
-    ; timeout : (Loc.t * float) option
+    ; timeout : (Loc.t * Time.Span.t) option
     ; conflict_markers : Cram_stanza.Conflict_markers.t
     ; setup_scripts : Path.t list
     }
@@ -297,7 +297,7 @@ let rules ~sctx ~dir tests =
                 Option.merge
                   acc.timeout
                   stanza.timeout
-                  ~f:(Ordering.min (fun x y -> Float.compare (snd x) (snd y)))
+                  ~f:(Ordering.min (fun x y -> Time.Span.compare (snd x) (snd y)))
               in
               let conflict_markers =
                 Option.value ~default:acc.conflict_markers stanza.conflict_markers

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -44,7 +44,7 @@ type t =
   ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
-  ; timeout : (Loc.t * float) option
+  ; timeout : (Loc.t * Time.Span.t) option
   ; setup_scripts : (Loc.t * string) list
   }
 
@@ -92,7 +92,7 @@ let decode =
           >>> located float
           >>| fun (loc, t) ->
           if t >= 0.
-          then loc, t
+          then loc, Time.Span.of_secs t
           else
             User_error.raise
               ~loc

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -22,7 +22,7 @@ type t =
   ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
   ; runtest_alias : (Loc.t * bool) option
-  ; timeout : (Loc.t * float) option
+  ; timeout : (Loc.t * Time.Span.t) option
   ; setup_scripts : (Loc.t * string) list
   }
 

--- a/src/dune_threaded_console/dune_threaded_console_intf.ml
+++ b/src/dune_threaded_console/dune_threaded_console_intf.ml
@@ -39,7 +39,12 @@ module type S = sig
       underestimation of the actual amount of time spent, we will render faster
       than the desired frame rate. If it is an overestimation, we will render
       slower. *)
-  val handle_user_events : now:float -> time_budget:float -> Mutex.t -> state -> float
+  val handle_user_events
+    :  now:Time.t
+    -> time_budget:Time.Span.t
+    -> Mutex.t
+    -> state
+    -> Time.t
 
   (** [reset] is called by the main thread to reset the user interface. *)
   val reset : unit -> unit

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -44,7 +44,7 @@ module Event : sig
 
   val process
     :  name:string option
-    -> started_at:float
+    -> started_at:Time.t
     -> targets:targets option
     -> categories:string list
     -> pid:Pid.t
@@ -61,11 +61,11 @@ module Event : sig
     :  file:Path.t
     -> module_:string
     -> [ `Save | `Load ]
-    -> start:float
-    -> stop:float
+    -> start:Time.t
+    -> stop:Time.t
     -> t
 
-  val scan_source : name:string -> start:float -> stop:float -> dir:Path.Source.t -> t
+  val scan_source : name:string -> start:Time.t -> stop:Time.t -> dir:Path.Source.t -> t
   val scheduler_idle : unit -> t
   val config : version:string option -> t
   val gc : unit -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -10,7 +10,7 @@ module Async = struct
 
   type nonrec t =
     { event_data : data
-    ; start : float
+    ; start : Time.t
     }
 
   let create ~event_data ~start = { event_data; start }
@@ -38,11 +38,11 @@ type t = Chrome_trace.Event.t
 let scan_source ~name ~start ~stop ~dir =
   let module Event = Chrome_trace.Event in
   let module Timestamp = Event.Timestamp in
-  let dur = Timestamp.of_float_seconds (stop -. start) in
+  let dur = Time.diff stop start |> Time.Span.to_secs |> Timestamp.of_float_seconds in
   let common =
     Event.common_fields
       ~name:(name ^ ": " ^ Path.Source.to_string dir)
-      ~ts:(Timestamp.of_float_seconds start)
+      ~ts:(Timestamp.of_float_seconds (Time.to_secs start))
       ()
   in
   let args = [ "dir", `String (Path.Source.to_string dir) ] in
@@ -52,7 +52,7 @@ let scan_source ~name ~start ~stop ~dir =
 let evalauted_rules ~rule_total =
   let open Chrome_trace in
   let args = [ "value", `Int rule_total ] in
-  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
   let common = Event.common_fields ~name:"evaluated_rules" ~ts () in
   Event.counter common args
 ;;
@@ -71,14 +71,16 @@ let config ~version =
     | Some v -> ("version", Stdune.Json.string v) :: args
   in
   let open Chrome_trace in
-  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
   let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
   Event.instant ~args common
 ;;
 
 let scheduler_idle () =
   let fields =
-    let ts = Chrome_trace.Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts =
+      Chrome_trace.Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs)
+    in
     Chrome_trace.Event.common_fields ~name:"watch mode iteration" ~ts ()
   in
   (* the instant event allows us to separate build commands from
@@ -136,7 +138,7 @@ let process
       | Some n -> n
       | None -> Filename.basename prog
     in
-    let ts = Timestamp.of_float_seconds started_at in
+    let ts = Timestamp.of_float_seconds (Time.to_secs started_at) in
     Event.common_fields ~cat:(Category.to_string Process :: categories) ~name ~ts ()
   in
   let always =
@@ -173,15 +175,20 @@ let process
       ]
   in
   let args = always @ extended in
-  let dur = Event.Timestamp.of_float_seconds times.elapsed_time in
+  let dur = Event.Timestamp.of_float_seconds (Time.Span.to_secs times.elapsed_time) in
   Event.complete ~args ~dur common
 ;;
 
 let persistent ~file ~module_ what ~start ~stop =
   let module Event = Chrome_trace.Event in
   let module Timestamp = Event.Timestamp in
-  let dur = Timestamp.of_float_seconds (stop -. start) in
-  let common = Event.common_fields ~name:"db" ~ts:(Timestamp.of_float_seconds start) () in
+  let dur = Time.diff stop start |> Time.Span.to_secs |> Timestamp.of_float_seconds in
+  let common =
+    Event.common_fields
+      ~name:"db"
+      ~ts:(Timestamp.of_float_seconds (Time.to_secs start))
+      ()
+  in
   let args =
     [ "path", `String (Path.to_string file)
     ; "module", `String module_
@@ -208,7 +215,7 @@ module Rpc = struct
   let session ~id stage =
     let open Chrome_trace in
     let common =
-      let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+      let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
       Event.common_fields ~ts ~name:"rpc_session" ()
     in
     let id = Chrome_trace.Id.create (`Int id) in
@@ -233,7 +240,7 @@ module Rpc = struct
       | `Notification -> args
       | `Request id -> ("request_id", to_json id) :: args
     in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
     let common = Event.common_fields ~cat:[ Category.to_string Rpc ] ~ts ~name () in
     Event.async
       (Chrome_trace.Id.create (`Int id))
@@ -244,7 +251,7 @@ module Rpc = struct
 
   let packet_read ~id ~success ~error =
     let open Chrome_trace in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
     let args =
       let base = [ "id", `Int id; "success", `Bool success ] in
       match error with
@@ -263,7 +270,7 @@ module Rpc = struct
 
   let packet_write ~id ~count =
     let open Chrome_trace in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
     let args = [ "id", `Int id; "count", `Int count ] in
     let common =
       Event.common_fields
@@ -277,7 +284,7 @@ module Rpc = struct
 
   let accept ~success ~error =
     let open Chrome_trace in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
     let args =
       let base = [ "success", `Bool success ] in
       match error with
@@ -292,7 +299,7 @@ module Rpc = struct
 
   let close ~id =
     let open Chrome_trace in
-    let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+    let ts = Time.now () |> Time.to_secs |> Event.Timestamp.of_float_seconds in
     let args = [ "id", `Int id ] in
     let common =
       Event.common_fields ~cat:[ Category.to_string Rpc; "session" ] ~name:"close" ~ts ()
@@ -304,7 +311,7 @@ end
 let gc () =
   let module Event = Chrome_trace.Event in
   let module Json = Chrome_trace.Json in
-  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let ts = Time.now () |> Time.to_secs |> Event.Timestamp.of_float_seconds in
   let common = Event.common_fields ~cat:[ Category.to_string Gc ] ~name:"gc" ~ts () in
   let args =
     let stat = Gc.quick_stat () in
@@ -325,7 +332,7 @@ let gc () =
 let fd_count () =
   let module Event = Chrome_trace.Event in
   let module Json = Chrome_trace.Json in
-  let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
+  let ts = Time.now () |> Time.to_secs |> Event.Timestamp.of_float_seconds in
   match Fd_count.get () with
   | Unknown -> None
   | This fds ->

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -66,7 +66,7 @@ let start t k : Event.Async.t option =
   | None -> None
   | Some _ ->
     let event_data = k () in
-    let start = Unix.gettimeofday () in
+    let start = Time.now () in
     Some (Event.Async.create ~event_data ~start)
 ;;
 
@@ -75,14 +75,14 @@ let finish t event =
   | None -> ()
   | Some { Event.Async.start; event_data = { args; cat; name } } ->
     let dur =
-      let stop = Unix.gettimeofday () in
-      Timestamp.of_float_seconds (stop -. start)
+      let stop = Time.now () in
+      Time.diff stop start |> Time.Span.to_secs |> Timestamp.of_float_seconds
     in
     let common =
       Chrome_trace.Event.common_fields
         ?cat
         ~name
-        ~ts:(Timestamp.of_float_seconds start)
+        ~ts:(Timestamp.of_float_seconds (Time.to_secs start))
         ()
     in
     let event = Chrome_trace.Event.complete ?args common ~dur in

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -54,15 +54,10 @@ module Make (D : Desc) = struct
   let to_string (v : D.t) = Printf.sprintf "%s%s" magic (Marshal.to_string v [])
 
   let with_record what ~file ~f =
-    let start = Unix.gettimeofday () in
+    let start = Time.now () in
     let res = Result.try_with f in
     Dune_trace.emit Persistent (fun () ->
-      Dune_trace.Event.persistent
-        ~file
-        ~module_:D.name
-        what
-        ~start
-        ~stop:(Unix.gettimeofday ()));
+      Dune_trace.Event.persistent ~file ~module_:D.name what ~start ~stop:(Time.now ()));
     Result.ok_exn res
   ;;
 

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1300,13 +1300,13 @@ let dump_cached_graph ?(on_not_cached = `Raise) ?(time_nodes = false) cell =
       let* attributes =
         if time_nodes
         then (
-          let start = Unix.gettimeofday () in
+          let start = Time.now () in
           (* CR-someday cmoseley: We could record errors here and include them
              as part of the graph. *)
           let+ (_ : (_, Collect_errors_monoid.t) result) =
             report_and_collect_errors (fun () -> dep_node.spec.f dep_node.input)
           in
-          let runtime = Unix.gettimeofday () -. start in
+          let runtime = Time.Span.to_secs (Time.diff (Time.now ()) start) in
           String.Map.of_list_exn [ "runtime", Graph.Attribute.Float runtime ])
         else Fiber.return String.Map.empty
       in

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -362,9 +362,9 @@ module Dir = struct
            | None -> map_reduce
            | Some stats ->
              fun t ~traverse ~trace_event_name ~f ->
-               let start = Unix.gettimeofday () in
+               let start = Time.now () in
                let+ res = map_reduce t ~traverse ~trace_event_name ~f in
-               let stop = Unix.gettimeofday () in
+               let stop = Time.now () in
                let event =
                  Dune_trace.Event.scan_source
                    ~name:trace_event_name

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -25,16 +25,14 @@ let init () =
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build")
 ;;
 
-let now () = Unix.gettimeofday ()
-
 let retry_loop (type a) ~period ~timeout ~(f : unit -> a option) : a option =
-  let t0 = now () in
+  let t0 = Time.now () in
   let rec loop () =
     match f () with
     | Some res -> Some res
     | None ->
-      let t1 = now () in
-      if Base.Float.( < ) (t1 -. t0) timeout
+      let t1 = Time.now () in
+      if Base.Float.( < ) (Time.Span.to_secs (Time.diff t1 t0)) timeout
       then (
         Thread.delay period;
         loop ())

--- a/test/expect-tests/dune_patch/dune_patch_tests.ml
+++ b/test/expect-tests/dune_patch/dune_patch_tests.ml
@@ -150,7 +150,7 @@ let test files (patch, patch_contents) =
   in
   Scheduler.Run.go
     config
-    ~timeout_seconds:5.0
+    ~timeout:(Time.Span.of_secs 5.0)
     ~file_watcher:No_watcher
     ~on_event:(fun _ _ -> ())
   @@ fun () ->

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -34,7 +34,7 @@ let init_chan ~root_dir =
     let* res = once () in
     match res with
     | Some res -> Fiber.return res
-    | None -> Scheduler.sleep ~seconds:0.2 >>= loop
+    | None -> Scheduler.sleep (Time.Span.of_secs 0.2) >>= loop
   in
   loop ()
 ;;
@@ -109,7 +109,7 @@ let run ?env ~prog ~argv () =
   Unix.close stdout_w;
   Unix.close stderr_w;
   ( pid
-  , (let+ proc = Scheduler.wait_for_process ~timeout_seconds:3.0 pid in
+  , (let+ proc = Scheduler.wait_for_process ~timeout:(Time.Span.of_secs 3.0) pid in
      if proc.status <> Unix.WEXITED 0
      then (
        let name =
@@ -195,5 +195,6 @@ let run run =
     ~finally:(fun () -> Sys.chdir cwd)
     ~f:(fun () ->
       Sys.chdir (Path.to_string dir);
-      Scheduler.Run.go config run ~timeout_seconds:5.0 ~on_event:(fun _ _ -> ()))
+      Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0) ~on_event:(fun _ _ ->
+        ()))
 ;;

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -14,7 +14,7 @@ let try_ ~times ~delay_seconds ~f =
       (match res with
        | Some s -> Fiber.return (Some s)
        | None ->
-         let* () = Scheduler.sleep ~seconds:delay_seconds in
+         let* () = Scheduler.sleep (Time.Span.of_secs delay_seconds) in
          loop (n - 1))
   in
   loop times
@@ -42,7 +42,8 @@ let run =
       ~finally:(fun () -> Sys.chdir cwd)
       ~f:(fun () ->
         Sys.chdir (Path.to_string dir);
-        Scheduler.Run.go config run ~timeout_seconds:5.0 ~on_event:(fun _ _ -> ()))
+        Scheduler.Run.go config run ~timeout:(Time.Span.of_secs 5.0) ~on_event:(fun _ _ ->
+          ()))
 ;;
 
 let%expect_test "turn on dune watch and wait until the connection is listed" =

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -14,14 +14,9 @@ let default =
   }
 ;;
 
-let go ?(timeout_seconds = 0.3) ?(config = default) f =
+let go ?(timeout = Time.Span.of_secs 0.3) ?(config = default) f =
   try
-    Scheduler.Run.go
-      ~timeout_seconds
-      config
-      ~file_watcher:No_watcher
-      ~on_event:(fun _ _ -> ())
-      f
+    Scheduler.Run.go ~timeout config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ()) f
   with
   | Scheduler.Run.Shutdown.E Requested -> ()
 ;;

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -16,11 +16,11 @@ let%expect_test "create and wait for timer" =
     ~on_event:(fun _ _ -> ())
     config
     (fun () ->
-       let now () = Unix.gettimeofday () in
+       let now () = Time.now () in
        let start = now () in
-       let duration = 0.2 in
-       let+ () = Scheduler.sleep ~seconds:duration in
-       assert (now () -. start >= duration);
+       let duration = Time.Span.of_secs 0.2 in
+       let+ () = Scheduler.sleep duration in
+       assert (Time.Span.to_secs (Time.diff (now ()) start) >= Time.Span.to_secs duration);
        print_endline "timer finished successfully");
   [%expect {| timer finished successfully |}]
 ;;
@@ -32,7 +32,10 @@ let%expect_test "multiple timers" =
     (fun () ->
        [ 0.3; 0.2; 0.1 ]
        |> Fiber.parallel_iter ~f:(fun duration ->
-         let+ () = Scheduler.sleep ~seconds:duration in
+         let+ () =
+           let duration = Time.Span.of_secs duration in
+           Scheduler.sleep duration
+         in
          printfn "finished %0.2f" duration));
   [%expect
     {|
@@ -53,7 +56,9 @@ let%expect_test "run process with timeout" =
          in
          Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int
        in
-       let+ _ = Scheduler.wait_for_process ~timeout_seconds:0.1 pid in
+       let+ (_ : Proc.Process_info.t) =
+         Scheduler.wait_for_process ~timeout:(Time.Span.of_secs 0.1) pid
+       in
        print_endline "sleep timed out");
   [%expect
     {|


### PR DESCRIPTION
Handling floats and keeping track of units using labels is getting tiresome. We now have a `Time` module for timestamps and `Time.Span.t` for durations. The representation still uses floats for now.