### PR TITLE
Disable flaky cram test

### DIFF
--- a/test/blackbox-tests/test-cases/cram/dune
+++ b/test/blackbox-tests/test-cases/cram/dune
@@ -3,7 +3,7 @@
  (deps %{bin:ps}))
 
 (cram
- (applies_to error)
+ (applies_to error subprocess)
  (enabled_if false))
 
 ;; mac has a different sh error message


### PR DESCRIPTION
https://github.com/ocaml/dune/actions/runs/20197506171/job/57983619302?pr=12943

```
File "test/blackbox-tests/test-cases/cram/subprocess.t", line 30, characters 0-1:
 |
 |  $ cat > mycram.t <<EOF
 |  >   $ sleep 5 &
 |  >   $ echo \$! > $pidFile
 |  > EOF
 |
 |We can now run this test, which will record its PID in the file.
 |
 |  $ dune runtest mycram.t
 |
 |The test finished successfully, now we make sure that the PID was correctly
 |terminated.
 |
 |  $ [ -s $pidFile ] && echo pid file created
 |  pid file created
 |  $ ps -p $(cat $pidFile) > /dev/null || echo "Process terminated"
-|  Process terminated
```