### PR TITLE
Stdune: validate pids correctly

### DIFF
--- a/otherlibs/stdune/src/pid.ml
+++ b/otherlibs/stdune/src/pid.ml
@@ -6,6 +6,6 @@ let equal = Int.equal
 let to_int t = t
 
 let of_int t =
-  assert (t >= 0);
+  assert (t > 0);
   t
 ;;


### PR DESCRIPTION
0 is not a valid pid