### PR TITLE
Split flags and pp flags in module compilation

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -70,6 +70,8 @@ let () =
   Dune_project.Extension.register_simple syntax (return [ name, decode_stanza decode ])
 ;;
 
+let flags = Ocaml_flags.of_list [ "-w"; "-24" ]
+
 let gen_rules sctx t ~dir ~scope =
   let loc = t.loc in
   (* Files checked by cinaps *)
@@ -175,7 +177,7 @@ let gen_rules sctx t ~dir ~scope =
         ~opaque:(Explicit false)
         ~requires_compile
         ~requires_link
-        ~flags:(Ocaml_flags.of_list [ "-w"; "-24" ])
+        ~flags
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None
         ~package:None

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -254,14 +254,11 @@ let build_cm
         Resolve.Memo.read (Compilation_context.parameters cctx)
         >>| List.concat_map ~f:(fun m -> [ "-parameter"; Module_name.to_string m ]))
    in
-   let flags, sandbox =
-     let flags =
-       Command.Args.dyn (Ocaml_flags.get (Compilation_context.flags cctx) mode)
-     in
+   let flags = Command.Args.dyn (Ocaml_flags.get (Compilation_context.flags cctx) mode) in
+   let pp_flags, sandbox =
      match Module.pp_flags m with
-     | None -> flags, sandbox
-     | Some (pp, sandbox') ->
-       S [ flags; Command.Args.dyn pp ], Sandbox_config.inter sandbox sandbox'
+     | None -> Command.Args.empty, sandbox
+     | Some (pp, sandbox') -> Command.Args.dyn pp, Sandbox_config.inter sandbox sandbox'
    in
    let output =
      match phase with
@@ -301,6 +298,7 @@ let build_cm
             ~dir:(Path.build (Context.build_dir ctx))
             compiler
             [ flags
+            ; pp_flags
             ; cmt_args
             ; Command.Args.S obj_dirs
             ; Command.Args.as_any


### PR DESCRIPTION
No there's no append these together and flags are going to be shared.

To increase sharing further, split hoist up some constant definitions of `Ocaml_flags.t`