### PR TITLE
fix: account for workspace binaries when generating rules for `./.bin`

### DIFF
--- a/doc/changes/fixed/12952.md
+++ b/doc/changes/fixed/12952.md
@@ -1,0 +1,3 @@
+- Resolve context and workspace binaries introduced by the respective `(env
+  (binaries ..))` stanzas. (#12952, fixes #6220, @anmonteiro)
+

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -24,6 +24,9 @@ val bin_dir_basename : Filename.t
     rules defined in [dir] *)
 val local_bin : Path.Build.t -> Path.Build.t
 
+(** Binaries that are symlinked in the associated .bin directory *)
+val local_binaries : t -> File_binding.Expanded.t list Memo.t
+
 (** A named artifact that is looked up in the PATH if not found in the tree If
     the name is an absolute path, it is used as it. *)
 val binary

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -16,8 +16,7 @@ val make
 
 val external_env : t -> Env.t Memo.t
 
-(** Binaries that are symlinked in the associated .bin directory of [dir]. This
-    associated directory is *)
+(** Binaries that are symlinked in the associated .bin directory of [dir]. *)
 val local_binaries : t -> File_binding.Expanded.t list Memo.t
 
 val artifacts : t -> Artifacts.t Memo.t

--- a/test/blackbox-tests/test-cases/dune-workspace-binaries-overlap.t
+++ b/test/blackbox-tests/test-cases/dune-workspace-binaries-overlap.t
@@ -76,24 +76,11 @@ Workspace binary should print "Workspace."
 
   $ dune clean
   $ dune build ./message.txt
-  File "dune", lines 1-3, characters 0-78:
-  1 | (rule
-  2 |  (target message.txt)
-  3 |  (action (with-stdout-to %{target} (run foobar))))
-  Error: No rule found for .bin/foobar
-  File "dune", lines 1-3, characters 0-78:
-  1 | (rule
-  2 |  (target message.txt)
-  3 |  (action (with-stdout-to %{target} (run foobar))))
-  Error: No rule found for .bin/foobar (context other_context)
-  [1]
   $ cat _build/default/message.txt
-  cat: _build/default/message.txt: No such file or directory
-  [1]
+  Workspace.
 
 Context binaries override the workspace binaries. Expecting "Context."
 
   $ cat _build/other_context/message.txt
-  cat: _build/other_context/message.txt: No such file or directory
-  [1]
+  Context.
 

--- a/test/blackbox-tests/test-cases/dune-workspace-binaries.t
+++ b/test/blackbox-tests/test-cases/dune-workspace-binaries.t
@@ -27,9 +27,3 @@ a dune-workspace file:
 
   $ chmod +x test.sh
   $ dune build ./message.txt
-  File "dune", lines 1-3, characters 0-78:
-  1 | (rule
-  2 |  (target message.txt)
-  3 |  (action (with-stdout-to %{target} (run foobar))))
-  Error: No rule found for .bin/foobar
-  [1]

--- a/test/blackbox-tests/test-cases/github5555.t
+++ b/test/blackbox-tests/test-cases/github5555.t
@@ -11,7 +11,7 @@ This test is about `binaries` in `env` stanzas in `dune-workspace` files.
   > EOF
 
   $ cat >x <<EOF
-  > #/bin/sh
+  > #!/bin/sh
   > echo foo
   > EOF
 
@@ -72,18 +72,11 @@ With 3.2, this fixes the error.
 In the default context:
 
   $ t 3.2 _ x
-  Error: No rule found for .bin/x
-  -> required by %{bin:x} at dune:3
-  -> required by alias foo in dune:1
-  [1]
+  foo
 
 And for explicit profiles:
 
   $ t 3.2 dev x
-  Error: No rule found for .bin/x
-  -> required by %{bin:x} at dune:3
-  -> required by alias foo in dune:1
-  [1]
 
 And for another profile:
 


### PR DESCRIPTION
fixes #6220

- [x] changes entry