### PR TITLE
fix: add copy rules for opam templates of fs-io and top-closure

### DIFF
--- a/dune-file
+++ b/dune-file
@@ -44,6 +44,12 @@
 (rule
  (copy dune-private-libs.opam.template chrome-trace.opam.template))
 
+(rule
+ (copy dune-private-libs.opam.template fs-io.opam.template))
+
+(rule
+ (copy dune-private-libs.opam.template top-closure.opam.template))
+
 (env
  (_
   (flags :standard %{dune-warnings} -alert -unstable)

--- a/fs-io.opam
+++ b/fs-io.opam
@@ -14,8 +14,12 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"
@@ -24,9 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["none"]

--- a/top-closure.opam
+++ b/top-closure.opam
@@ -13,8 +13,12 @@ depends: [
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"
@@ -23,9 +27,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["none"]


### PR DESCRIPTION
This should allow for the `fs-io` and `top-closure` opam files to generate correctly. We follow the pattern we have for the other packages. Importantly the test step is removed as it should be since we have no tests to run.

fix #12947 