### PR TITLE
Scheduler.no_rpc_no_build

### DIFF
--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -45,7 +45,7 @@ let run_fmt_command ~common ~config ~preview builder =
   | Error lock_held_by ->
     (* The --preview flag is being ignored by the RPC server, warn the user. *)
     if preview then Rpc.Rpc_common.warn_ignore_arguments lock_held_by;
-    Scheduler.go_without_rpc_server ~common ~config (fun () ->
+    Scheduler.no_build_no_rpc ~config (fun () ->
       Rpc.Rpc_common.fire_request
         ~name:"format"
         ~wait:true

--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -65,8 +65,8 @@ let term =
        with
        | None -> Dune_lang.Syntax.greatest_supported_version_exn Dune_lang.Stanza.syntax
        | Some root ->
-         let common, config = Common.init_with_root ~root builder in
-         Scheduler.go_with_rpc_server ~common ~config
+         let _common, config = Common.init_with_root ~root builder in
+         Scheduler.no_build_no_rpc ~config
          @@ fun () ->
          Memo.run
          @@

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -78,9 +78,10 @@ let context_cwd : Init_context.t Term.t =
   let+ builder = Common.Builder.term
   and+ path = path in
   let builder = Common.Builder.set_default_root_is_cwd builder true in
-  let common, config = Common.init builder in
+  let _common, config = Common.init builder in
   let project_defaults = config.project_defaults in
-  Scheduler.go_with_rpc_server ~common ~config (fun () ->
+  (* CR-soon rgrinberg: remove pointless args *)
+  Scheduler.no_build_no_rpc ~config (fun () ->
     Memo.run (Init_context.make path project_defaults))
 ;;
 
@@ -280,9 +281,10 @@ let project =
        in
        let builder = Builder.set_root common_builder root in
        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p root in
-       let common, config = Common.init builder in
+       let _common, config = Common.init builder in
        let project_defaults = config.project_defaults in
-       Scheduler.go_with_rpc_server ~common ~config (fun () ->
+       (* CR-soon rgrinberg: remove pointless args *)
+       Scheduler.no_build_no_rpc ~config (fun () ->
          Memo.run @@ init_context project_defaults)
      in
      Component.init

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -842,8 +842,9 @@ let make ~what =
     and+ sections = Sections.term in
     let builder = Common.Builder.forbid_builds builder in
     let builder = Common.Builder.disable_log_file builder in
+    (* CR-soon rgrinberg: stop taking pointless args *)
     let common, config = Common.init builder in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    Scheduler.no_build_no_rpc ~config (fun () ->
       let from_command_line =
         { Install.Roots.lib_root = libdir_from_command_line
         ; etc_root = etcdir_from_command_line

--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -222,15 +222,15 @@ module Dump_config = struct
     (* CR-someday Alizter: document this option *)
     and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH" ~doc:None)
     and+ selected_context = Selected_context.arg in
-    let common, config =
+    let _common, config =
       let builder =
         let builder = Common.Builder.forbid_builds builder in
         Common.Builder.disable_log_file builder
       in
       Common.init builder
     in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      Server.dump ~selected_context dir)
+    (* CR-soon rgrinberg: remove pointless args *)
+    Scheduler.no_build_no_rpc ~config (fun () -> Server.dump ~selected_context dir)
   ;;
 
   let command = Cmd.v info term
@@ -254,14 +254,15 @@ let start_session_info name = Cmd.info name ~doc ~man
 let start_session_term =
   let+ builder = Common.Builder.term
   and+ selected_context = Selected_context.arg in
-  let common, config =
+  let _common, config =
     let builder =
       let builder = Common.Builder.forbid_builds builder in
       Common.Builder.disable_log_file builder
     in
     Common.init builder
   in
-  Scheduler.go_with_rpc_server ~common ~config (Server.start ~selected_context)
+  (* CR-soon rgrinberg: remove pointless args *)
+  Scheduler.no_build_no_rpc ~config (Server.start ~selected_context)
 ;;
 
 let command = Cmd.v (start_session_info "ocaml-merlin") start_session_term
@@ -297,14 +298,15 @@ module Dump_dot_merlin = struct
                  "The path to the folder of which the configuration should be printed. \
                   Defaults to the current directory."))
     and+ selected_context = Selected_context.arg in
-    let common, config =
+    let _common, config =
       let builder =
         let builder = Common.Builder.forbid_builds builder in
         Common.Builder.disable_log_file builder
       in
       Common.init builder
     in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
+    (* CR-soon rgrinberg: stop taking pointless args *)
+    Scheduler.no_build_no_rpc ~config (fun () ->
       match path with
       | Some s -> Server.dump_dot_merlin ~selected_context s
       | None -> Server.dump_dot_merlin ~selected_context ".")

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -78,12 +78,13 @@ module Apply = struct
     let files_to_promote = files_to_promote ~common files in
     match Dune_util.Global_lock.lock ~timeout:None with
     | Ok () ->
+      (* Why are we starting an RPC server??? *)
       Scheduler.go_with_rpc_server ~common ~config (fun () ->
         let open Fiber.O in
         let+ () = Fiber.return () in
         Diff_promotion.promote_files_registered_in_last_run files_to_promote)
     | Error lock_held_by ->
-      Scheduler.go_without_rpc_server ~common ~config (fun () ->
+      Scheduler.no_build_no_rpc ~config (fun () ->
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"promote_many"
@@ -109,8 +110,8 @@ module Diff = struct
     in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      Diff_promotion.display files_to_promote)
+    (* CR-soon rgrinberg: remove pointless args *)
+    Scheduler.no_build_no_rpc ~config (fun () -> Diff_promotion.display files_to_promote)
   ;;
 
   let command = Cmd.v info term
@@ -127,8 +128,8 @@ module Files = struct
     in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      display_files files_to_promote)
+    (* CR-soon rgrinberg: remove pointless args *)
+    Scheduler.no_build_no_rpc ~config (fun () -> display_files files_to_promote)
   ;;
 
   let command = Cmd.v info term
@@ -144,8 +145,8 @@ module Show = struct
     in
     let common, config = Common.init builder in
     let files_to_promote = files_to_promote ~common files in
-    Scheduler.go_with_rpc_server ~common ~config (fun () ->
-      show_corrected_contents files_to_promote)
+    (* CR-soon rgrinberg: remove pointless args *)
+    Scheduler.no_build_no_rpc ~config (fun () -> show_corrected_contents files_to_promote)
   ;;
 
   let command = Cmd.v info term

--- a/bin/runtest.ml
+++ b/bin/runtest.ml
@@ -47,7 +47,7 @@ let runtest_term =
         ~to_cwd:(Common.root common).to_cwd
         ~test_paths)
   | Error lock_held_by ->
-    Scheduler.go_without_rpc_server ~common ~config (fun () ->
+    Scheduler.no_build_no_rpc ~config (fun () ->
       let open Fiber.O in
       Rpc.Rpc_common.fire_request
         ~name:"runtest"

--- a/bin/scheduler.ml
+++ b/bin/scheduler.ml
@@ -67,6 +67,18 @@ let rpc server =
   }
 ;;
 
+let no_build_no_rpc ~config:dune_config f =
+  let config =
+    Dune_config.for_scheduler
+      dune_config
+      None
+      ~print_ctrl_c_warning:true
+      ~watch_exclusions:[]
+  in
+  Dune_rules.Clflags.concurrency := config.concurrency;
+  Run.go config ~on_event:(fun _ _ -> ()) f
+;;
+
 let go_without_rpc_server ~(common : Common.t) ~config:dune_config f =
   let stats = Common.stats common in
   let config =

--- a/bin/scheduler.mli
+++ b/bin/scheduler.mli
@@ -1,6 +1,7 @@
 open Import
 
 val maybe_clear_screen : details_hum:string list -> Dune_config.t -> unit
+val no_build_no_rpc : config:Dune_config.t -> (unit -> 'a Fiber.t) -> 'a
 
 val go_without_rpc_server
   :  common:Common.t

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -525,14 +525,7 @@ let term =
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string Common.default_build_dir);
   Dune_config.init config ~watch:false;
   Log.init_disabled ();
-  Dune_engine.Scheduler.Run.go
-    ~on_event:(fun _ _ -> ())
-    (Dune_config.for_scheduler
-       config
-       ~watch_exclusions:[]
-       None
-       ~print_ctrl_c_warning:false)
-    subst
+  Scheduler.no_build_no_rpc ~config subst
 ;;
 
 let command = Cmd.v info term

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -51,7 +51,7 @@ let lock_and_build_dev_tool ~common ~config builder dev_tool =
   let open Fiber.O in
   match Dune_util.Global_lock.lock ~timeout:None with
   | Error lock_held_by ->
-    Scheduler.go_without_rpc_server ~common ~config (fun () ->
+    Scheduler.no_build_no_rpc ~config (fun () ->
       let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in
       build_dev_tool_via_rpc builder lock_held_by dev_tool)
   | Ok () ->

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -15,8 +15,9 @@ let info = Cmd.info "upgrade" ~doc ~man
 
 let term =
   let+ builder = Common.Builder.term in
-  let common, config = Common.init builder in
-  Scheduler.go_with_rpc_server ~common ~config (fun () -> Dune_upgrader.upgrade ())
+  (* CR-soon rgrinberg: stop taking pointless args *)
+  let _common, config = Common.init builder in
+  Scheduler.no_build_no_rpc ~config Dune_upgrader.upgrade
 ;;
 
 let command = Cmd.v info term


### PR DESCRIPTION
Some commands do not need to spawn RPC nor build anything. Let's
introduce a simplified way to launch a scheduler for such commands and
use it in a few places.