### PR TITLE
Introduce an event for debugging directory loading

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -614,7 +614,6 @@ module Builder = struct
     { debug_dep_path : bool
     ; debug_backtraces : bool
     ; debug_artifact_substitution : bool
-    ; debug_load_dir : bool
     ; debug_digests : bool
     ; debug_package_logs : bool
     ; wait_for_filesystem_clock : bool
@@ -700,14 +699,6 @@ module Builder = struct
             [ "debug-artifact-substitution" ]
             ~docs
             ~doc:(Some "Print debugging info about artifact substitution"))
-    and+ debug_load_dir =
-      Arg.(
-        value
-        & flag
-        & info
-            [ "debug-load-dir" ]
-            ~docs
-            ~doc:(Some "Print debugging info about directory loading"))
     and+ debug_digests =
       Arg.(
         value
@@ -1033,7 +1024,6 @@ module Builder = struct
     { debug_dep_path
     ; debug_backtraces
     ; debug_artifact_substitution
-    ; debug_load_dir
     ; debug_digests
     ; debug_package_logs
     ; wait_for_filesystem_clock
@@ -1092,7 +1082,6 @@ module Builder = struct
         { debug_dep_path
         ; debug_backtraces
         ; debug_artifact_substitution
-        ; debug_load_dir
         ; debug_digests
         ; debug_package_logs
         ; wait_for_filesystem_clock
@@ -1133,7 +1122,6 @@ module Builder = struct
     Bool.equal t.debug_dep_path debug_dep_path
     && Bool.equal t.debug_backtraces debug_backtraces
     && Bool.equal t.debug_artifact_substitution debug_artifact_substitution
-    && Bool.equal t.debug_load_dir debug_load_dir
     && Bool.equal t.debug_digests debug_digests
     && Bool.equal t.debug_package_logs debug_package_logs
     && Bool.equal t.wait_for_filesystem_clock wait_for_filesystem_clock
@@ -1391,7 +1379,6 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   Dune_engine.Clflags.report_errors_config := c.builder.report_errors_config;
   Dune_engine.Clflags.debug_backtraces c.builder.debug_backtraces;
   Dune_rules.Clflags.debug_artifact_substitution := c.builder.debug_artifact_substitution;
-  Dune_engine.Clflags.debug_load_dir := c.builder.debug_load_dir;
   Dune_engine.Clflags.debug_fs_cache := c.builder.cache_debug_flags.fs_cache;
   Dune_digest.Clflags.debug_digests := c.builder.debug_digests;
   Dune_rules.Clflags.debug_package_logs := c.builder.debug_package_logs;

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -25,7 +25,6 @@ let debug_backtraces b =
   Memo.Debug.track_locations_of_lazy_values := b
 ;;
 
-let debug_load_dir = ref false
 let promote = ref None
 let force = ref false
 let always_show_command_line = ref false

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -14,9 +14,6 @@ val debug_backtraces : bool -> unit
 (** Print debug info for cached file-system operations *)
 val debug_fs_cache : bool ref
 
-(** Print debug info when loading rules in directories *)
-val debug_load_dir : bool ref
-
 module Promote : sig
   type t =
     | Automatically

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -874,10 +874,7 @@ end = struct
   ;;
 
   let load_dir_impl ~dir : Loaded.t Memo.t =
-    if !Clflags.debug_load_dir
-    then
-      Console.print_user_message
-        (User_message.make [ Pp.textf "Loading build directory %s" (Path.to_string dir) ]);
+    Dune_trace.emit Debug (fun () -> Dune_trace.Event.load_dir dir);
     get_dir_triage ~dir
     >>= function
     | Known l -> Memo.return l

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -12,9 +12,22 @@ type t =
   | Scheduler
   | Promote
   | Build
+  | Debug
 
 let all =
-  [ Rpc; Gc; Fd; Sandbox; Persistent; Process; Rules; Pkg; Scheduler; Promote; Build ]
+  [ Rpc
+  ; Gc
+  ; Fd
+  ; Sandbox
+  ; Persistent
+  ; Process
+  ; Rules
+  ; Pkg
+  ; Scheduler
+  ; Promote
+  ; Build
+  ; Debug
+  ]
 ;;
 
 let to_string = function
@@ -29,6 +42,7 @@ let to_string = function
   | Scheduler -> "scheduler"
   | Promote -> "promote"
   | Build -> "build"
+  | Debug -> "debug"
 ;;
 
 let of_string =
@@ -56,5 +70,6 @@ module Set = Bit_set.Make (struct
       | Scheduler -> 8
       | Promote -> 9
       | Build -> 10
+      | Debug -> 11
     ;;
   end)

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -10,6 +10,7 @@ type t =
   | Scheduler
   | Promote
   | Build
+  | Debug
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -13,6 +13,7 @@ module Category : sig
     | Scheduler
     | Promote
     | Build
+    | Debug
 
   val of_string : string -> t option
 end
@@ -82,6 +83,7 @@ module Event : sig
     }
 
   val resolve_targets : Path.t list -> alias list -> t
+  val load_dir : Path.t -> t
 
   module Rpc : sig
     type stage =

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -388,3 +388,13 @@ let resolve_targets targets aliases =
   in
   Event.instant ~args common
 ;;
+
+let load_dir dir =
+  let module Event = Chrome_trace.Event in
+  let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
+  let args = [ "dir", `String (Path.to_string dir) ] in
+  let common =
+    Event.common_fields ~cat:[ Category.to_string Debug ] ~name:"load-dir" ~ts ()
+  in
+  Event.instant ~args common
+;;

--- a/test/blackbox-tests/test-cases/directory-targets/dune
+++ b/test/blackbox-tests/test-cases/directory-targets/dune
@@ -5,3 +5,7 @@
 (cram
  (applies_to remove-write-permissions)
  (deps %{bin:bash}))
+
+(cram
+ (applies_to loading-inside-directory-target)
+ (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
@@ -13,11 +13,22 @@ rule.
   >  (action (bash "echo creating output dir && mkdir -p output/a && touch output/a/b")))
   > EOF
 
-  $ dune build --debug-load-dir output/
-  Loading build directory _build/default
-  Loading build directory _build/default/.dune
-  Loading build directory _build
+  $ loadedDirs() {
+  > jq -c '.[] | select(.name == "load-dir") | .args' $1
+  > }
+
+  $ build() {
+  > dune build --trace-file trace.json $@
+  > loadedDirs trace.json
+  > }
+
+  $ export DUNE_TRACE=debug
+
+  $ build output/
   creating output dir
+  {"dir":"_build/default"}
+  {"dir":"_build/default/.dune"}
+  {"dir":"_build"}
   $ find _build/default/output
   _build/default/output
   _build/default/output/a
@@ -27,11 +38,11 @@ We are loading the rules in output/a and while making sure that we don't delete
 and re-create output/b. The following should not re-run the rule that recreates
 output/
 
-  $ dune build --debug-load-dir output/a/b
-  Loading build directory _build/default/output/a
-  Loading build directory _build/default
-  Loading build directory _build/default/.dune
-  Loading build directory _build
+  $ build output/a/b
+  {"dir":"_build/default/output/a"}
+  {"dir":"_build/default"}
+  {"dir":"_build/default/.dune"}
+  {"dir":"_build"}
   $ find _build/default/output
   _build/default/output
   _build/default/output/a
@@ -39,11 +50,7 @@ output/
 
 Now we try loading the rules in output/a and make sure that nothing is deleted:
 
-  $ dune rules --debug-load-dir output/a/
-  Loading build directory _build/default/output
-  Loading build directory _build/default
-  Loading build directory _build/default/.dune
-  Loading build directory _build
+  $ dune rules --trace-file trace.json output/a/
   ((deps ())
    (targets ((files ()) (directories (_build/default/output))))
    (context default)
@@ -51,6 +58,13 @@ Now we try loading the rules in output/a and make sure that nothing is deleted:
     (chdir
      _build/default
      (bash "echo creating output dir && mkdir -p output/a && touch output/a/b"))))
+
+  $ loadedDirs trace.json
+  {"dir":"_build/default/output"}
+  {"dir":"_build/default"}
+  {"dir":"_build/default/.dune"}
+  {"dir":"_build"}
+
   $ find _build/default/output
   _build/default/output
   _build/default/output/a


### PR DESCRIPTION
Replaces the `--debug-load-dir` flag.