### PR TITLE
test(cram): show cram_lexer crash on `>>` characters

### DIFF
--- a/test/blackbox-tests/test-cases/cram/conflict-marker-lexer-error.t
+++ b/test/blackbox-tests/test-cases/cram/conflict-marker-lexer-error.t
@@ -1,0 +1,13 @@
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > t1.t <<'EOF'
+  >   $ echo '>> Hello'
+  >   >> Hello
+  > EOF
+  $ dune runtest 2>&1 | grep -i "\(I must not crash\|exn =\)"
+     { exn = "Failure(\"lexing: empty token\")" })
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+


### PR DESCRIPTION
this looks like a regression from Dune 3.20.