### PR TITLE
Test: hidden deps flags using trace

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -126,6 +126,7 @@
 
 (cram
  (applies_to hidden-deps-unsupported)
+ (deps %{bin:jq})
  (enabled_if
   (< %{ocaml_version} 5.2.0)))
 


### PR DESCRIPTION
Use the trace file to extract -I and -H files from the trace