### PR TITLE
Move `Path.link` to `Fpath.link`

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -52,6 +52,14 @@ let rec mkdir_p ?perms t_s =
            Code_error.raise "failed to create parent directory" [ "t_s", Dyn.string t_s ]))
 ;;
 
+let link src dst =
+  match Unix.link src dst with
+  | exception Unix.Unix_error (Unix.EUNKNOWNERR -1142, syscall, arg)
+  (* Needed for OCaml < 5.1 on windows *) ->
+    Exn.reraise (Unix.Unix_error (Unix.EMLINK, syscall, arg))
+  | s -> s
+;;
+
 let resolve_link path =
   match Unix.readlink path with
   | exception Unix.Unix_error (EINVAL, _, _) -> Ok None

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -14,6 +14,9 @@ type mkdir_p_result =
 
 val mkdir_p : ?perms:int -> string -> mkdir_p_result
 
+(** [link src dst] creates a hardlink from [src] to [dst]. *)
+val link : string -> string -> unit
+
 type follow_symlink_error =
   | Not_a_symlink
   | Max_depth_exceeded

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -438,14 +438,14 @@ let portable_hardlink ~src ~dst =
         user_error "Too many indirections; is this a cyclic symbolic link?"
       | Error (Unix_error error) -> user_error (Unix_error.Detailed.to_string_hum error)
     in
-    (try Path.link src dst with
+    (try Fpath.link (Path.to_string src) (Path.to_string dst) with
      | Unix.Unix_error (Unix.EEXIST, _, _) ->
        (* CR-someday amokhov: Investigate why we need to occasionally clear the
           destination (we also do this in the symlink case above). Perhaps, the
           list of dependencies may have duplicates? If yes, it may be better to
           filter out the duplicates first. *)
        Path.unlink_exn dst;
-       Path.link src dst
+       Fpath.link (Path.to_string src) (Path.to_string dst)
      | Unix.Unix_error (Unix.EMLINK, _, _) ->
        (* If we can't make a new hard link because we reached the limit on the
           number of hard links per file, we fall back to copying. We expect

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1215,15 +1215,6 @@ let is_directory t =
 
 let rmdir t = Unix.rmdir (to_string t)
 let unlink_exn t = Fpath.unlink_exn (to_string t)
-
-let link src dst =
-  match Unix.link (to_string src) (to_string dst) with
-  | exception Unix.Unix_error (Unix.EUNKNOWNERR -1142, syscall, arg)
-  (* Needed for OCaml < 5.1 on windows *) ->
-    Exn.reraise (Unix.Unix_error (Unix.EMLINK, syscall, arg))
-  | s -> s
-;;
-
 let unlink_no_err t = Fpath.unlink_no_err (to_string t)
 let build_dir_exists () = is_directory build_dir
 

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -352,9 +352,6 @@ val rmdir : t -> unit
 val unlink_exn : t -> unit
 val unlink_no_err : t -> unit
 
-(** [link src dst] creates a hardlink from [src] to [dst]. *)
-val link : t -> t -> unit
-
 (** If the path does not exist, this function is a no-op. *)
 val rm_rf : ?allow_external:bool -> t -> unit
 

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -61,7 +61,7 @@ end
    [$file] is the shared cache entry for the empty file. After that, no more
    hard links on [$file] will be allowed, triggering the [EMLINK] code path. *)
 let link_even_if_there_are_too_many_links_already ~src ~dst =
-  try Path.link src dst with
+  try Fpath.link (Path.to_string src) (Path.to_string dst) with
   | Unix.Unix_error (Unix.EMLINK, _, _) ->
     Temp.with_temp_file
       ~dir:(Lazy.force temp_dir)
@@ -75,7 +75,7 @@ let link_even_if_there_are_too_many_links_already ~src ~dst =
            copy we've just created in the [temp_file]. *)
         Path.rename temp_file src;
         (* This should now succeed. *)
-        Path.link src dst)
+        Fpath.link (Path.to_string src) (Path.to_string dst))
 ;;
 
 module Artifacts = struct

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -9,10 +9,12 @@ module Optimistically = struct
   ;;
 
   let link ~src ~dst =
-    try Path.link src dst with
+    let src' = Path.to_string src in
+    let dst' = Path.to_string dst in
+    try Fpath.link src' dst' with
     | Unix.Unix_error (Unix.ENOENT, _, _) ->
       Path.mkdir_p (Path.parent_exn dst);
-      Path.link src dst
+      Fpath.link src' dst'
   ;;
 end
 


### PR DESCRIPTION
As discussed in #12931.

I can remove the other `to_string` wrappers as well, but it is a bit of churn as they're used in a number of places.