### PR TITLE
fix(rpc): don't wait for build lock to be released

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -227,7 +227,7 @@ let build =
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"build"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_impl.Decl.build

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -229,7 +229,7 @@ let build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog =
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"build"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_impl.Decl.build

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -48,7 +48,7 @@ let run_fmt_command ~common ~config ~preview builder =
     Scheduler.no_build_no_rpc ~config (fun () ->
       Rpc.Rpc_common.fire_request
         ~name:"format"
-        ~wait:true
+        ~wait:false
         ~warn_forwarding:false
         ~lock_held_by
         builder

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -61,7 +61,7 @@ module Apply = struct
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"promote_many"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_private.Procedures.Public.promote_many

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -39,7 +39,7 @@ let build_dev_tool_via_rpc builder lock_held_by dev_tool =
   let open Fiber.O in
   Rpc.Rpc_common.fire_request
     ~name:"build"
-    ~wait:true
+    ~wait:false
     ~lock_held_by
     builder
     Dune_rpc_impl.Decl.build

--- a/test/blackbox-tests/test-cases/build-lock-no-rpc.t
+++ b/test/blackbox-tests/test-cases/build-lock-no-rpc.t
@@ -1,0 +1,100 @@
+Test that dune fails fast when the build lock is held but no RPC server is
+available. This is a regression test for
+https://github.com/ocaml/dune/issues/12900
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.18)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name foo))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+Helper to run a command while holding the build lock without an RPC server:
+
+  $ with_build_lock_held() {
+  >   mkdir -p _build
+  >   (
+  >     flock -x 9
+  >     printf '1' > _build/.lock
+  >     "$@"
+  >   ) 9>_build/.lock
+  > }
+
+Hold the lock without running an RPC server, then try various commands.
+They should all fail immediately instead of hanging.
+
+  $ with_build_lock_held dune build
+  Error: Another dune instance (pid: 1) has the build directory locked but is
+  not running an RPC server.
+  [1]
+
+  $ with_build_lock_held dune exec ./foo.exe
+  Error: Another dune instance (pid: 1) has the build directory locked but is
+  not running an RPC server.
+  [1]
+
+  $ with_build_lock_held dune fmt
+  Error: Another dune instance (pid: 1) has the build directory locked but is
+  not running an RPC server.
+  [1]
+
+  $ with_build_lock_held dune promote
+  Error: Another dune instance (pid: 1) has the build directory locked but is
+  not running an RPC server.
+  [1]
+
+  $ with_build_lock_held dune runtest
+  Error: Another dune instance (pid: 1) has the build directory locked but is
+  not running an RPC server.
+  [1]
+
+We are not starting an RPC server for clean, but we do care if the lock is
+held.
+
+  $ with_build_lock_held dune clean
+  Error: A running dune (pid: 1) instance has locked the build directory. If
+  this is not the case, please delete "_build/.lock".
+  [1]
+
+Explicit RPC commands do not check the lock first, so they get a simpler error:
+
+  $ dune rpc ping
+  Error: RPC server not running.
+  [1]
+
+  $ dune rpc build
+  Error: RPC server not running.
+  [1]
+
+  $ dune shutdown
+  Error: RPC server not running.
+  [1]
+
+  $ dune diagnostics
+  Error: RPC server not running.
+  [1]
+
+Commands that start their own RPC server will fail when trying to acquire the
+lock:
+
+  $ with_build_lock_held dune utop . 2>&1 | head -3
+  Error: A running dune (pid: 1) instance has locked the build directory. If
+  this is not the case, please delete "_build/.lock".
+
+  $ with_build_lock_held dune ocaml top 2>&1 | head -3
+  Error: A running dune (pid: 1) instance has locked the build directory. If
+  this is not the case, please delete "_build/.lock".
+
+  $ with_build_lock_held dune printenv 2>&1 | head -3
+  Error: A running dune (pid: 1) instance has locked the build directory. If
+  this is not the case, please delete "_build/.lock".
+
+  $ with_build_lock_held dune describe workspace 2>&1 | head -3
+  Error: A running dune (pid: 1) instance has locked the build directory. If
+  this is not the case, please delete "_build/.lock".
+

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -131,3 +131,8 @@
  (applies_to hidden-deps-unsupported)
  (enabled_if
   (< %{ocaml_version} 5.2.0)))
+
+(cram
+ (applies_to build-lock-no-rpc)
+ (deps %{bin:flock})
+ (timeout 5))


### PR DESCRIPTION
In many cases it doesn't make sense to way for the RPC server when connecting. The existence of a build lock does not guarantee there will be a server.

- fix https://github.com/ocaml/dune/issues/12900