### PR TITLE
feat: preserve package data during  by default

### DIFF
--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -1,25 +1,84 @@
 open Import
 
+(* Preserve package management data by default. See #12976 *)
+let preserved_context_dirs = [ ".pkg"; ".dev-tool" ]
+let preserved_build_dirs = [ ".dev-tools.locks" ]
+
+let clear_context_dir path =
+  match Path.readdir_unsorted_with_kinds path with
+  | Error _ -> ()
+  | Ok entries ->
+    List.iter entries ~f:(fun (name, kind) ->
+      if not (List.mem preserved_context_dirs name ~equal:String.equal)
+      then (
+        let p = Path.relative path name in
+        match kind with
+        | Unix.S_DIR -> Path.rm_rf p
+        | _ -> Fpath.unlink_no_err (Path.to_string p)))
+;;
+
+let clear_private_dir path =
+  match Path.readdir_unsorted_with_kinds path with
+  | Error _ -> ()
+  | Ok entries ->
+    List.iter entries ~f:(fun (name, kind) ->
+      let p = Path.relative path name in
+      match kind with
+      | Unix.S_DIR -> clear_context_dir p
+      | _ -> Fpath.unlink_no_err (Path.to_string p))
+;;
+
+let clean_preserving_packages () =
+  if Path.exists Path.build_dir
+  then (
+    match Path.readdir_unsorted_with_kinds Path.build_dir with
+    | Error _ -> Path.rm_rf Path.build_dir
+    | Ok entries ->
+      List.iter entries ~f:(fun (name, kind) ->
+        let p = Path.relative Path.build_dir name in
+        match kind with
+        | Unix.S_DIR ->
+          if List.mem preserved_build_dirs name ~equal:String.equal
+          then ()
+          else if String.equal name "_private"
+          then clear_private_dir p
+          else clear_context_dir p
+        | _ -> Fpath.unlink_no_err (Path.to_string p)))
+;;
+
 let command =
   let doc = "Clean the project." in
   let man =
     [ `S "DESCRIPTION"
-    ; `P {|Removes files added by dune such as _build, <package>.install, and .merlin|}
+    ; `P
+        {|Removes files added by dune such as _build, <package>.install, and .merlin.
+
+By default, package management data (.pkg and .dev-tool directories) is preserved
+to avoid expensive rebuilds. Use --full to remove everything including packages.|}
     ; `Blocks Common.help_secs
     ]
   in
   let term =
-    let+ builder = Common.Builder.term in
-    (* Disable log file creation. Indeed, we are going to delete the whole build directory
-       right after and that includes deleting the log file. Not only would creating the
-       log file be useless but with some FS this also causes [dune clean] to fail (cf
-       https://github.com/ocaml/dune/issues/2964). *)
+    let+ builder = Common.Builder.term
+    and+ full =
+      Arg.(
+        value
+        & flag
+        & info
+            [ "full" ]
+            ~doc:
+              (Some
+                 "Remove everything including package management data. By default, the \
+                  .pkg and .dev-tool directories are preserved."))
+    in
+    (* Disable log file creation since we're about to delete the build directory.
+       See https://github.com/ocaml/dune/issues/2964 *)
     let builder = Common.Builder.disable_log_file builder in
     let _common, _config = Common.init builder in
     Dune_util.Global_lock.lock_exn ~timeout:None;
     Dune_engine.Target_promotion.files_in_source_tree_to_delete ()
     |> Path.Source.Set.iter ~f:(fun p -> Fpath.unlink_no_err (Path.Source.to_string p));
-    Path.rm_rf Path.build_dir
+    if full then Path.rm_rf Path.build_dir else clean_preserving_packages ()
   in
   Cmd.v (Cmd.info "clean" ~doc ~man) term
 ;;

--- a/test/blackbox-tests/test-cases/pkg/clean-preserves-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/clean-preserves-packages.t
@@ -1,0 +1,55 @@
+Test that `dune clean` preserves package management data by default,
+and `dune clean --full` removes everything.
+
+  $ . ./helpers.sh
+
+Create a simple package dependency:
+
+  $ make_lockdir
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.17)
+  > (package (name bar) (depends foo) (allow_empty))
+  > EOF
+
+Build the package:
+
+  $ build_pkg foo
+
+Verify the package directory exists:
+
+  $ test -d _build/_private/default/.pkg && echo "Package dir exists"
+  Package dir exists
+
+Now run `dune clean` (without --full):
+
+  $ dune clean
+
+The .pkg directory should still exist:
+
+  $ test -d _build/_private/default/.pkg && echo "Package dir preserved"
+  Package dir preserved
+
+The package target (with cookie) should still exist:
+
+  $ test -f "$(get_build_pkg_dir foo)/target/cookie" && echo "Package cookie preserved"
+  Package cookie preserved
+
+Now test that `dune clean --full` removes everything:
+
+  $ dune clean --full
+
+The _build directory should be gone:
+
+  $ test -d _build && echo "_build exists" || echo "_build removed"
+  _build removed
+
+Rebuild and verify everything works:
+
+  $ build_pkg foo
+
+  $ test -d _build/_private/default/.pkg && echo "Package rebuilt"
+  Package rebuilt

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -77,7 +77,8 @@ Build the project as if we were on linux and confirm that only the linux-specifi
   foo.0.0.1-5e48eb7073ada94c09fb13ac3853f1e9
   linux-only.0.0.1-f754e8cf64f80c214f1a86ee403f0dc3
 
-  $ dune clean
+Use --full to remove all packages including those from the previous platform:
+  $ dune clean --full
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build


### PR DESCRIPTION
This PR addresses issue #12976 where dune clean deletes package management data, causing users to lose their installed packages and dev tools unexpectedly.

Approach taken:
By default, dune clean now preserves package management data while still cleaning build artifacts. A new --full flag is added for users who want the old behavior of removing everything.