### PR TITLE
Remove reliance on the log file in some cram test

### DIFF
--- a/test/blackbox-tests/test-cases/cram/dune
+++ b/test/blackbox-tests/test-cases/cram/dune
@@ -6,6 +6,10 @@
  (applies_to error subprocess)
  (enabled_if false))
 
+(cram
+ (applies_to timeout-redigest)
+ (deps %{bin:jq}))
+
 ;; mac has a different sh error message
 
 (cram

--- a/test/blackbox-tests/test-cases/cram/timeout-redigest.t
+++ b/test/blackbox-tests/test-cases/cram/timeout-redigest.t
@@ -8,21 +8,19 @@ Testing how timeout affects the digest:
 
 This test counts the occurances of the cram script in the log.
   $ check() {
-  >   cat _build/log | grep -c main.sh
+  > dune test --trace-file trace.json mytest.t
+  > jq '[ .[] | select(.cat == "process,cram") ] | length' trace.json
   > }
 
 We can observe the test is run the first time:
 
-  $ dune test mytest.t
   $ check
   1
 
 And is not run the second time:
 
-  $ dune test mytest.t
   $ check
   0
-  [1]
 
 If we add a timeout, we would not expect for the digest of the cram test to
 change.
@@ -34,14 +32,11 @@ change.
 
 However this is currently not the case and we rerun the cram test:
 
-  $ dune test mytest.t
   $ check
   1
 
-  $ dune test mytest.t
   $ check
   0
-  [1]
 
 This is again the case on another time change:
 
@@ -50,12 +45,9 @@ This is again the case on another time change:
   >  (timeout 2))
   > EOF
  
-  $ dune test mytest.t
   $ check
   1
 
-  $ dune test mytest.t
   $ check
   0
-  [1]
 


### PR DESCRIPTION
Use jq and the trace file instead.

cc @Alizter let's keep this style in mind going forward. It makes for better tests and the log file is going away.