### PR TITLE
Fix forge casing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -325,7 +325,7 @@ implementations of virtual libraries. (@anmonteiro, #11248)
   the correct semantics for `(implicit_transitive_deps false)`.
   (#10644, fixes #9333, ocsigen/tyxml#274, #2733, #4963, @MA0100)
 
-- Add support for specifying Gitlab organization repositories in `source`
+- Add support for specifying GitLab organization repositories in `source`
   stanzas (#10766, fixes #6723, @H-ANSEN)
 
 - New option to control jsoo sourcemap generation in env and executable stanza

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1244,7 +1244,7 @@ implementations of virtual libraries. (@anmonteiro, #11248)
   (#7576 , fixes #5852, @emillon)
 
 - Change directory of odoc assets to `odoc.support` (was `_odoc_support`) so
-  that it works with Github Pages out of the box. (#7588, fixes #7364,
+  that it works with GitHub Pages out of the box. (#7588, fixes #7364,
   @emillon)
 
 3.7.0 (2023-02-17)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ Our development process is as follows:
 - Substantial changes should be preceded by upfront design and planning,
   proportional to the scope and impact of the intended change.
   - This design should be reviewed by at least one other party.
-  - Github issues are an appropriate venue for most design discussions, but more
+  - GitHub issues are an appropriate venue for most design discussions, but more
     involved design work may warrant an RFC or ADR.
-- Github is the preferred venue for discussing architectural and design decisions.
+- GitHub is the preferred venue for discussing architectural and design decisions.
   Exchanges in meetings and chat are valuable, but we insist on deliberating and
   recording the what and why of our work in the persistent record of GitHub.
 - Changes are submitted via GitHub pull requests against the `main` branch.

--- a/doc/dev/rev-store.md
+++ b/doc/dev/rev-store.md
@@ -16,7 +16,7 @@ Git is implemented as a way to store revisions and being able to address them.
 However, these revisions do not have to have a common ancestor and given Git
 uses SHA1 hashes for addressing it is possible to join multiple repositories in
 one single Git repository without clashing. A fairly common usecase outside of
-Dune are `gh-pages` branches to serve documentation on Github, which do not
+Dune are `gh-pages` branches to serve documentation on GitHub, which do not
 share a common parent with the main branch of the repository.
 
 The revision store exploits this feature by putting all revisions of all

--- a/doc/howto/homebrew-package.rst
+++ b/doc/howto/homebrew-package.rst
@@ -8,7 +8,7 @@ installed by Dune while building the Homebrew package.
 
 To use Dune package management to build a project as a Homebrew package, the
 project must have a source archive hosted online somewhere (e.g. a gzipped
-tarball on the project's Github release page).
+tarball on the project's GitHub release page).
 
 Before making a Homebrew package, it's a good idea to familiarize yourself with
 Homebrew's terminology and packaging conventions `here
@@ -16,19 +16,19 @@ Homebrew's terminology and packaging conventions `here
 
 Homebrew packages are recommended to be source-based, and for the source code
 to be explicitly versioned, so for this example assume ``my_app`` has a
-versioned archive hosted on Github with version ``0.1.0``.
+versioned archive hosted on GitHub with version ``0.1.0``.
 
 Homebrew can generate a starting point for a formula if you point it at a
-source archive hosted on Github:
+source archive hosted on GitHub:
 
 .. code:: console
 
   $ brew create https://github.com/me/my_app/archive/refs/tags/0.1.0.tar.gz
 
 A source archive like the one in the above command is generated when you
-release a project on Github. The above command will generate a file named
+release a project on GitHub. The above command will generate a file named
 ``my_app.rb`` in your current tap. All the project metadata will be filled in
-automatically based on the project on Github. All we need to do now is to
+automatically based on the project on GitHub. All we need to do now is to
 specify dependencies and the commands ``brew`` should run when installing the
 package.
 

--- a/doc/howto/release-binaries-with-github-action.rst
+++ b/doc/howto/release-binaries-with-github-action.rst
@@ -1,19 +1,19 @@
-How to Release a Binary Distribution of an Application on Github with Dune
+How to Release a Binary Distribution of an Application on GitHub with Dune
 ==========================================================================
 
-This guide will show you how to write a Github Action which builds a binary
+This guide will show you how to write a GitHub Action which builds a binary
 distribution of an application for various platforms using Dune package
-management, and uploads the compiled artifacts to a Github release.
+management, and uploads the compiled artifacts to a GitHub release.
 
 We'll make a workflow called "Release" which will run every time a tag is pushed
-to the repo on Github. The workflow will build the project for the targets
+to the repo on GitHub. The workflow will build the project for the targets
 ``x86_64-linux``, ``x86_64-macos``, and ``aarch64-macos``, and then upload a
-gzipped tarball of the built artifacts to a Github release named after the tag.
+gzipped tarball of the built artifacts to a GitHub release named after the tag.
 
 Dune will be installed by the `setup-dune
 <https://github.com/ocaml-dune/setup-dune>`_ action.
 
-The following is the manifest for a Github Action workflow which releases a
+The following is the manifest for a GitHub Action workflow which releases a
 binary distribution of a package named ``my_app``.
 
 .. code:: yaml

--- a/doc/reference/dune-project/source.rst
+++ b/doc/reference/dune-project/source.rst
@@ -21,7 +21,7 @@ source
        - ``(github user/repo)``
      * - `Bitbucket <https://bitbucket.org>`_
        - ``(bitbucket user/repo)``
-     * - `Gitlab <https://gitlab.com>`_
+     * - `GitLab <https://gitlab.com>`_
        - | ``(gitlab user/repo)``
          | ``(gitlab organization/project/repo)`` *(New in 3.17)*
      * - `Sourcehut <https://sr.ht>`_

--- a/doc/reference/dune-project/source.rst
+++ b/doc/reference/dune-project/source.rst
@@ -17,7 +17,7 @@ source
 
      * - Service
        - Syntax
-     * - `Github <https://github.com>`_
+     * - `GitHub <https://github.com>`_
        - ``(github user/repo)``
      * - `Bitbucket <https://bitbucket.org>`_
        - ``(bitbucket user/repo)``

--- a/doc/reference/dune-project/source.rst
+++ b/doc/reference/dune-project/source.rst
@@ -24,7 +24,7 @@ source
      * - `GitLab <https://gitlab.com>`_
        - | ``(gitlab user/repo)``
          | ``(gitlab organization/project/repo)`` *(New in 3.17)*
-     * - `Sourcehut <https://sr.ht>`_
+     * - `SourceHut <https://sr.ht>`_
        - ``(sourcehut user/repo)``
      * - `Codeberg <https://codeberg.org>`_
        - ``(codeberg user/repo)`` *(New in 3.17)*

--- a/src/dune_lang/source_kind.ml
+++ b/src/dune_lang/source_kind.ml
@@ -112,7 +112,7 @@ module Host = struct
         | Gitlab _, [ user; repo ] ->
           Gitlab (User_repo { user; repo }), Some ((2, 8), name)
         | Gitlab _, [ org; proj; repo ] ->
-          Gitlab (Org_repo { org; proj; repo }), Some ((3, 17), "Gitlab organization repo")
+          Gitlab (Org_repo { org; proj; repo }), Some ((3, 17), "GitLab organization repo")
         | Gitlab _, _ ->
           User_error.raise
             ~loc
@@ -121,7 +121,7 @@ module Host = struct
           User_error.raise
             ~loc
             ~hints:
-              [ Pp.textf "The provided form '%s' is specific to Gitlab projects" str ]
+              [ Pp.textf "The provided form '%s' is specific to GitLab projects" str ]
             [ Pp.textf "%s repository must be of form user/repo" name ]
         | _, _ ->
           User_error.raise

--- a/test/blackbox-tests/test-cases/project-source/source-stanza.t
+++ b/test/blackbox-tests/test-cases/project-source/source-stanza.t
@@ -84,7 +84,7 @@ Test github forge.
   File "dune-project", line 4, characters 16-29:
   4 | (source (github org/proj/repo))
                       ^^^^^^^^^^^^^
-  Error: Github repository must be of form user/repo
+  Error: GitHub repository must be of form user/repo
   Hint: The provided form 'org/proj/repo' is specific to GitLab projects
   [1]
 
@@ -96,7 +96,7 @@ Test bitbucket forge.
   4 | (source (bitbucket org/proj/repo))
                          ^^^^^^^^^^^^^
   Error: Bitbucket repository must be of form user/repo
-  Hint: The provided form 'org/proj/repo' is specific to Gitlab projects
+  Hint: The provided form 'org/proj/repo' is specific to GitLab projects
   [1]
 
 Test sourcehut forge.
@@ -106,8 +106,8 @@ Test sourcehut forge.
   File "dune-project", line 4, characters 19-32:
   4 | (source (sourcehut org/proj/repo))
                          ^^^^^^^^^^^^^
-  Error: Sourcehut repository must be of form user/repo
-  Hint: The provided form 'org/proj/repo' is specific to Gitlab projects
+  Error: SourceHut repository must be of form user/repo
+  Hint: The provided form 'org/proj/repo' is specific to GitLab projects
   [1]
 
 Test codeberg forge.
@@ -118,7 +118,7 @@ Test codeberg forge.
   4 | (source (codeberg org/proj/repo))
                         ^^^^^^^^^^^^^
   Error: Codeberg repository must be of form user/repo
-  Hint: The provided form 'org/proj/repo' is specific to Gitlab projects
+  Hint: The provided form 'org/proj/repo' is specific to GitLab projects
   [1]
 
 So far we have been using '(lang dune 3.17)' which supports gitlab organization
@@ -132,7 +132,7 @@ syntax.
   File "dune-project", line 4, characters 8-30:
   4 | (source (gitlab org/proj/repo))
               ^^^^^^^^^^^^^^^^^^^^^^
-  Error: Gitlab organization repo is only available since version 3.17 of the
+  Error: GitLab organization repo is only available since version 3.17 of the
   dune language. Please update your dune-project file to have (lang dune 3.17).
   [1]
 

--- a/test/blackbox-tests/test-cases/project-source/source-stanza.t
+++ b/test/blackbox-tests/test-cases/project-source/source-stanza.t
@@ -85,7 +85,7 @@ Test github forge.
   4 | (source (github org/proj/repo))
                       ^^^^^^^^^^^^^
   Error: Github repository must be of form user/repo
-  Hint: The provided form 'org/proj/repo' is specific to Gitlab projects
+  Hint: The provided form 'org/proj/repo' is specific to GitLab projects
   [1]
 
 Test bitbucket forge.


### PR DESCRIPTION
These casings were not only inconsistent, but incorrect with respect to the naming of the actual entities. Data constructors in separate commits (& can be cherry-picked out/dropped) since some folks prefer different rules for data constructors (tho I much prefer respecting the original casing where possible).

I am _hoping_ I don’t have to modify any more of the test strings. I tried running the tests, but seems not all dependencies were picked up some I am not 100% sure they all succeeded. `./dune.exe build` did compile for what it’s worth.

Original trigger was this doc page: https://dune.readthedocs.io/en/stable/reference/dune-project/source.html

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.