### PR TITLE
Tests: remove reliance on _build/log

### DIFF
--- a/test/blackbox-tests/test-cases/cram/cram-double-alias.t
+++ b/test/blackbox-tests/test-cases/cram/cram-double-alias.t
@@ -15,11 +15,11 @@ aliases that are being built together.
   >   $ echo foo
   > EOF
 
-  $ dune build @this @runtest
+  $ dune build --trace-file trace.json @this @runtest
   File "foo.t", line 1, characters 0-0:
   Error: Files _build/default/foo.t and _build/default/foo.t.corrected differ.
   [1]
 
 Here we make sure that the cram test is only run once
-  $ cat _build/log | grep dune_cram | sed 's/.*dune_cram_[0-9a-f]*_/dune_cram_HASH_/g'
-  dune_cram_HASH_.cram.sh/main.sh)
+  $ jq '[ .[] | select(.cat == "process,cram") ] | length' trace.json
+  1

--- a/test/blackbox-tests/test-cases/cram/dune
+++ b/test/blackbox-tests/test-cases/cram/dune
@@ -7,7 +7,7 @@
  (enabled_if false))
 
 (cram
- (applies_to timeout-redigest)
+ (applies_to timeout-redigest cram-double-alias)
  (deps %{bin:jq}))
 
 ;; mac has a different sh error message

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -107,7 +107,7 @@ But when lang dune is 3.3 or higher the warning becomes an error:
     -keep-locs))
   Leaving directory 'outer'
 
-  $ dune build --root=outer
+  $ dune build --trace=trace.json --root=outer
   Entering directory 'outer'
   Leaving directory 'outer'
   $ pat="\-o [./a-zA-Z_]\{1,\}.cmx"
@@ -116,6 +116,11 @@ But when lang dune is 3.3 or higher the warning becomes an error:
   -o .outer.eobjs/native/dune__exe__Outer.cmx
   $ grep "$pat" $log | sort | grep -n -E -o "\-w [^ ]+"
   1:-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+
+  $ jq '.[] | select(.cat == "process") | .args |
+  >   select(.target_files and (.target_files | any(contains(".cmx")))) |
+  >   .process_args | .[index("-w") + 1]' trace.json
+  "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40"
 
 This is unexpected as vendored projects should be built according to their
 declared dune-project rather than the dune-project of the outer project.

--- a/test/blackbox-tests/test-cases/inline_tests/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/dune
@@ -8,6 +8,10 @@
  (deps %{bin:refmt}))
 
 (cram
+ (applies_to simple)
+ (deps %{bin:jq}))
+
+(cram
  (applies_to github6607)
  (deps
   (package stdune)))

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t
@@ -39,7 +39,7 @@ Inline tests also generate an alias
   [1]
 
 Make sure building both aliases doesn't build both
-  $ dune build @runtest @lib-foo_simple
+  $ dune build --trace-file trace.json @runtest @lib-foo_simple
   Error: Alias "lib-foo_simple" specified on the command line is empty.
   It is not defined in . or any of its descendants.
   File "dune", line 9, characters 1-40:
@@ -48,8 +48,8 @@ Make sure building both aliases doesn't build both
   Fatal error: exception File ".foo_simple.inline-tests/main.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 This test demonstrates that the action is being run once
-  $ cat _build/log | sed 's/\$ //g' | grep inline-test-runner 
-  (cd _build/default && .foo_simple.inline-tests/inline-test-runner.exe)
+  $ jq '.[] | select(.cat == "process") | .args.prog | select(contains("inline-test-runner.exe"))' trace.json
+  ".foo_simple.inline-tests/inline-test-runner.exe"
 
 The expected behavior for the following three tests is to output nothing: the tests are disabled or ignored.
   $ env -u OCAMLRUNPARAM dune runtest --profile release


### PR DESCRIPTION
Using _build/trace.json is more reliable and the log is going away