### PR TITLE
Use setup_scripts in the pkg tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -1,7 +1,5 @@
 Test that section pforms are substituted with absolute paths.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints-ocaml-system.t
@@ -1,8 +1,6 @@
 Test that we support the use case of using additional constraints to force the
 system compiler to be used instead of installing the compiler.
 
-  $ . ./helpers.sh
-
 Create packages resembling the ocaml compiler packages
   $ mkrepo
 

--- a/test/blackbox-tests/test-cases/pkg/additional-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/additional-constraints.t
@@ -1,7 +1,5 @@
 It's possible to include additional packages or constraints in workspace files:
 
-  $ . ./helpers.sh
-
   $ cat >dune-workspace <<EOF
   > (lang dune 3.11)
   > (lock_dir

--- a/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
+++ b/test/blackbox-tests/test-cases/pkg/alias-pkg-install.t
@@ -1,8 +1,6 @@
 This test verifies the @pkg-install alias fetch and build the project dependencies
 without building the project itself.
 
-  $ . ./helpers.sh
-
 Create a project using the fake library as a dependency:
   $ cat > dune-project << EOF
   > (lang dune 3.16)

--- a/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
@@ -1,6 +1,5 @@
 Test that auto-locking correctly detects when to rebuild based on repository changes.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
   $ enable_pkg

--- a/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/broken-symlink-in-dependency.t
@@ -1,8 +1,6 @@
 Test that dune can handle the case where a dependency's source contains a
 symlink with a missing destination.
 
-  $ . ./helpers.sh
-
 Define a package foo containing a broken symlink.
   $ mkdir foo
   $ touch foo/a.txt

--- a/test/blackbox-tests/test-cases/pkg/build-package-logs.t
+++ b/test/blackbox-tests/test-cases/pkg/build-package-logs.t
@@ -1,6 +1,5 @@
 Test the error message when installing package that fails.
 
-  $ . ./helpers.sh
   $ make_lockdir
   $ export DUNE_DEBUG_PACKAGE_LOGS=0
 

--- a/test/blackbox-tests/test-cases/pkg/build-progress.t
+++ b/test/blackbox-tests/test-cases/pkg/build-progress.t
@@ -1,8 +1,6 @@
 This test verifies the @pkg-install alias outputs the build progress when
 --display is short or verbose.
 
-  $ . ./helpers.sh
-
 Add a lock file for a fake library foo:
   $ make_lockdir
   $ make_lockpkg foo <<EOF

--- a/test/blackbox-tests/test-cases/pkg/build-single-package.t
+++ b/test/blackbox-tests/test-cases/pkg/build-single-package.t
@@ -1,7 +1,5 @@
 Requesting to build a single package should not build unrelated things:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
+++ b/test/blackbox-tests/test-cases/pkg/check-dependency-hash.t
@@ -2,7 +2,7 @@ Tests that changing the dependencies of a project cause lockdir validation to
 fail due to the dependency hash not matching the hash stored in the lockdir.
 
 Dummy opam repo so we can generate lockdirs
-  $ . ./helpers.sh
+
   $ mkrepo
   $ mkpkg a <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
+++ b/test/blackbox-tests/test-cases/pkg/checksum-local-archive.t
@@ -1,7 +1,5 @@
 Make sure that we verify archives of local archives
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ touch foo.tar.gz

--- a/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
+++ b/test/blackbox-tests/test-cases/pkg/command-from-user-path.t
@@ -1,7 +1,5 @@
 Make sure we can run exes from the user's PATH variable.
 
-  $ . ./helpers.sh
-
 Create a directory containing a shell script and add the directory to PATH.
   $ mkdir bin
   $ cat > bin/hello <<EOF

--- a/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
+++ b/test/blackbox-tests/test-cases/pkg/commit-hash-references.t
@@ -1,7 +1,5 @@
 What happens if a branch has the same format as a ref?
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.0
   $ cd mock-opam-repository

--- a/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/common-filters-deps.t
@@ -1,7 +1,6 @@
 Demonstrate that local dependencies that are marked as {with-test} can be
 included.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg post <<EOF

--- a/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/compiler-post-dependencies.t
@@ -1,6 +1,5 @@
 Exercise dune resolving the post dependencies found in compiler packages.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ cat >dune-workspace << EOF

--- a/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
+++ b/test/blackbox-tests/test-cases/pkg/compute-checksums-when-missing.t
@@ -2,7 +2,7 @@ Test that dune will add checksums to lockfiles when the package has a source
 archive but no checksum. This test uses an http server to serve packages to
 test checksum generation, since we only generate checksums for packages
 downloaded from non-local sources.
-  $ . ./helpers.sh
+
   $ mkrepo
 
 A file that will comprise the package source:
@@ -84,7 +84,6 @@ Check that no checksum is computed for a local source directory:
   $ solve foo 2>&1
   Solution for dune.lock:
   - foo.0.0.1
-
 
 Create 3 packages that all share the same source url with no checksum. Dune
 will need to download each package's source archive to compute their hashes.

--- a/test/blackbox-tests/test-cases/pkg/conflict-class.t
+++ b/test/blackbox-tests/test-cases/pkg/conflict-class.t
@@ -1,8 +1,6 @@
 This test demonstrates a local package that's in the same conflict-class of a
 dependency.
 
-  $ . ./helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/conflicts.t
+++ b/test/blackbox-tests/test-cases/pkg/conflicts.t
@@ -1,6 +1,5 @@
 The solver should repsect the (conflicts) field of the (package) stanza.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 0.0.1
   $ mkpkg bar << EOF

--- a/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
+++ b/test/blackbox-tests/test-cases/pkg/constraint-conjunction.t
@@ -1,7 +1,6 @@
 Exercise the solver on a package with a conjunction in its dependency
 constraints.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -1,4 +1,4 @@
-  $ . ./helpers.sh
+
   $ mkrepo
 
   $ mkpkg standard-dune <<EOF

--- a/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
+++ b/test/blackbox-tests/test-cases/pkg/curl-not-installed.t
@@ -1,6 +1,5 @@
 Test the error message when curl is needed but not installed.
 
-  $ . ./helpers.sh
   $ make_lockdir
 
   $ makepkg() {

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -1,7 +1,5 @@
 Some environment variables are automatically exported by packages:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/default-git-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/default-git-branch.t
@@ -4,9 +4,6 @@ Once the branch is modified, dune should rebuild the package.
 
 This bug is reported in #10063
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
-
   $ src="_git_source"
 
   $ mkdir $src && cd $src

--- a/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
+++ b/test/blackbox-tests/test-cases/pkg/dependency-install-file.t
@@ -1,7 +1,5 @@
 A package that installs itself into the ocaml stdlib should work.
 
-  $ . ./helpers.sh
-
   $ mkdir nondune
   $ cd nondune
   $ cat > nondune.ml <<EOF

--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -1,6 +1,5 @@
  When a package fails to build, dune will print opam depexts warning.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/print-depexts.t
@@ -1,6 +1,5 @@
 Show that the depexts that a project has can be printed.
 
-  $ . ../helpers.sh
   $ mkrepo
 
 Make a project:

--- a/test/blackbox-tests/test-cases/pkg/depexts/solve.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/solve.t
@@ -1,6 +1,5 @@
 Solving would add opam 'depext' field to lock directory packages
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
@@ -1,6 +1,5 @@
 Solving with an unknown variable on depexts:
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-added-to-deps-when-available.t
@@ -1,7 +1,6 @@
 Test that available optional dependencies of a package are added to the
 "depends" field of that package's lockfile.
 
-  $ . ../helpers.sh
   $ mkrepo
 
   $ mkpkg a

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-optional.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-optional.t
@@ -1,6 +1,5 @@
 This tests that depopts are considered optional by the solver.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ mkpkg foo
   $ mkpkg bar

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-conflicting-constraints.t
@@ -1,7 +1,6 @@
 We test depopts with conflicting constraints to see which one the solver will
 prefer if any:
 
-  $ . ../helpers.sh
   $ mkpkg foo 1
   $ mkpkg foo 2
 

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts-with-constraints.t
@@ -1,6 +1,5 @@
 We test how the solver chooses a solution for depopts with constraints.
 
-  $ . ../helpers.sh
   $ mkrepo
 
 We create a package "foo" that is the dependency of two packages "optional" and

--- a/test/blackbox-tests/test-cases/pkg/depopts/depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/depopts.t
@@ -1,6 +1,5 @@
 Selecting depopts
 
-  $ . ../helpers.sh
   $ mkrepo
   $ mkpkg foo
   $ mkpkg bar

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11058.t
@@ -2,8 +2,6 @@ Reproduce github issue #11058
 
 Handling of more than one depopt:
 
-  $ . ../helpers.sh
-
   $ mkpkg a
   $ mkpkg b
   $ mkpkg c

--- a/test/blackbox-tests/test-cases/pkg/depopts/gh11698.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/gh11698.t
@@ -1,7 +1,5 @@
 Reproduce the bug in #11698
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/opam-package-with-depopts.t
@@ -1,6 +1,5 @@
 We test how opam files with depopts fields are translated into dune.lock files:
 
-  $ . ../helpers.sh
   $ mkrepo
 
 Make a package with a depopts field

--- a/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
+++ b/test/blackbox-tests/test-cases/pkg/depopts/workspace-select.t
@@ -1,7 +1,5 @@
 Demonstrate how depopts can be forced in the workspace
 
-  $ . ../helpers.sh
-
   $ mkrepo
 
   $ mkpkg foo

--- a/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/describe-pkg-lock.t
@@ -1,4 +1,4 @@
-  $ . ./helpers.sh
+
   $ mkrepo
 
 Testing the output of the dune describe pkg lock command.

--- a/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
+++ b/test/blackbox-tests/test-cases/pkg/different-dune-in-path.t
@@ -1,7 +1,5 @@
 Clarify the behavior when the `dune` in PATH is not the one used to start the build.
 
-  $ . ./helpers.sh
-
   $ make_test_package() {
   >   mkdir tmp
   >   cd tmp
@@ -60,7 +58,6 @@ Make lockfiles for the packages.
 
 Test that the project can be built normally.
   $ build_pkg foo
-
 
 Make a fake dune exe:
 

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -8,7 +8,8 @@
    (DUNE_DEBUG_PACKAGE_LOGS 1))))
 
 (cram
- (deps helpers.sh %{bin:git} ../git-helpers.sh)
+ (deps %{bin:git} ../git-helpers.sh)
+ (setup_scripts helpers.sh ../git-helpers.sh)
  (applies_to :whole_subtree))
 
 (cram

--- a/test/blackbox-tests/test-cases/pkg/duplicate-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/duplicate-packages.t
@@ -1,8 +1,6 @@
 A workspace with a package that exists in the lock file and in the workspace
 shouldn't be allowed (for now)
 
-  $ . ./helpers.sh
-
   $ cat >dune-project <<EOF
   > (lang dune 3.11)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e-autolock.t
@@ -1,7 +1,6 @@
 Same setup as e2e.t but this time using building without an explicit
 `dune pkg lock`.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
   $ enable_pkg

--- a/test/blackbox-tests/test-cases/pkg/e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/e2e.t
@@ -1,6 +1,5 @@
 Exercises end to end locking and building a simple project.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/env-conditional-dependencies.t
@@ -1,4 +1,4 @@
-  $ . ./helpers.sh
+
   $ mkrepo
  
 A package with different linux and macos dependencies including a test-only

--- a/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/exclusively-extra-sources.t
@@ -1,6 +1,5 @@
 Test for packages with no source field but with extra_sources.
 
-  $ . ./helpers.sh
   $ make_lockdir
   $ make_lockpkg foo <<EOF
   > (version 1)

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -1,7 +1,5 @@
 Packages can export environment variables
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
@@ -1,7 +1,5 @@
 A lock directory which does not exist in the source tree:
 
-  $ . ./helpers.sh
-
   $ mkdir project
 
   $ make_lockdir

--- a/test/blackbox-tests/test-cases/pkg/external-source.t
+++ b/test/blackbox-tests/test-cases/pkg/external-source.t
@@ -1,7 +1,5 @@
 Test that can fetch the sources from an external dir
 
-  $ . ./helpers.sh
-
   $ mkdir foo
   $ echo "y" > foo/x
 

--- a/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-source-overlap-with-source.t
@@ -1,7 +1,6 @@
 Test for packages with an extra-source file with the same name as a
 file in the package's source.
 
-  $ . ./helpers.sh
   $ make_lockdir
   $ make_lockpkg foo <<EOF
   > (version 1)

--- a/test/blackbox-tests/test-cases/pkg/extra-sources.t
+++ b/test/blackbox-tests/test-cases/pkg/extra-sources.t
@@ -1,8 +1,5 @@
 Fetch from more than one source
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ mkdir foo
   $ cat >foo/bar <<EOF

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache.t
@@ -1,7 +1,5 @@
 Testing that files are only fetched once.
 
-  $ . ./helpers.sh
-
 No need to set DUNE_CACHE (enabled by default) as the
 fetch rules are always considered safe to cache, but we'll set a custom
 directory for the shared cache.

--- a/test/blackbox-tests/test-cases/pkg/fetch-local-source.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-local-source.t
@@ -1,6 +1,5 @@
 Test that dune can fetch local sources.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a local source archive:

--- a/test/blackbox-tests/test-cases/pkg/file-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/file-depends.t
@@ -4,7 +4,6 @@ field which is a list of external files, together with their checksums, that
 the package depends on. We make sure that such a package really does depend on
 the files found in files-depend. 
 
-  $ . ./helpers.sh
   $ make_lockdir
   $ foo=$PWD/foo make_lockpkg file-depends <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
+++ b/test/blackbox-tests/test-cases/pkg/findlib-meta-optional-directory.t
@@ -2,8 +2,6 @@ Demonstrate the handling of findlib directories that don't exist
 
 Reproduces #11405
 
-  $ . ./helpers.sh
-
   $ mkdir external_sources
 
   $ cat >external_sources/META <<EOF

--- a/test/blackbox-tests/test-cases/pkg/gh10959.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10959.t
@@ -1,7 +1,5 @@
 Repro `dune exec --watch` crash with pkg management
 
-  $ . ./helpers.sh
-
   $ mkdir external_sources
   $ cat >external_sources/dune-project <<EOF
   > (lang dune 3.11)

--- a/test/blackbox-tests/test-cases/pkg/gh10985.t
+++ b/test/blackbox-tests/test-cases/pkg/gh10985.t
@@ -28,8 +28,6 @@ Now we set up a lock file with this package and then attempt to use it:
   > (lang dune 3.11)
   > EOF
 
-  $ . ../helpers.sh
-
   $ make_lockdir
   $ make_lockpkg mypkg <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/gh11265.t
+++ b/test/blackbox-tests/test-cases/pkg/gh11265.t
@@ -1,6 +1,5 @@
 Package conflicts are ignored when dune-projects contains multiple conflicts
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg bar
 

--- a/test/blackbox-tests/test-cases/pkg/gh8325.t
+++ b/test/blackbox-tests/test-cases/pkg/gh8325.t
@@ -1,7 +1,5 @@
 Things should be the same whether dependencies are specified or not.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
 If we have a package we depend on

--- a/test/blackbox-tests/test-cases/pkg/git-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/git-repo.t
@@ -1,7 +1,5 @@
 We want to make sure our OPAM-repository in git support works well.
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.0 <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/git-source.t
@@ -1,8 +1,5 @@
 Test fetching from git
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
-
   $ mkdir somerepo
   $ cd somerepo
   $ git init --quiet

--- a/test/blackbox-tests/test-cases/pkg/git-submodule.t
+++ b/test/blackbox-tests/test-cases/pkg/git-submodule.t
@@ -1,5 +1,3 @@
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
 
 When we fetch a package source we should also fetch any submodules. Since we
 will use the file protocol for git submodules we will need to explicitly enable

--- a/test/blackbox-tests/test-cases/pkg/hash-algos.t
+++ b/test/blackbox-tests/test-cases/pkg/hash-algos.t
@@ -1,6 +1,5 @@
 Test that dune supports lockfiles with md5, sha256 and sha512 hashes.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ignore-lock-package-build.t
@@ -2,8 +2,6 @@ When building a project with -p we should ignore the lock directory. This is so
 that packages with lockdirs in their source archive can be built by opam
 without using locked dependencies.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (build

--- a/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/ignored-dune-lock.t
@@ -1,7 +1,5 @@
 Test that shows what happens when dune.lock is ignored.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -3,7 +3,6 @@ the dune version to match the version of dune being used to generate the
 constraint. On another hand, we ensure `dune` can be used as a declared
 dependency.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ test() {

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -1,7 +1,5 @@
 Install actions should have the switch directory prepared:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -1,7 +1,5 @@
 Testing install actions
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/install-entry-build-dir.t
@@ -1,7 +1,5 @@
 Use build paths in the install entries of a package
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -1,7 +1,5 @@
 Test missing entries in the .install file
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ lockfile() {
   > make_lockpkg test <<EOF

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -1,7 +1,5 @@
 Test that installed binaries are visible in dependent packages
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-opam-repo-errors.t/run.t
@@ -1,7 +1,5 @@
 Test the error cases for invalid opam repositories
 
-  $ . ../helpers.sh
-
   $ cat >dune-project <<EOF
   > (lang dune 3.8)
   > (package

--- a/test/blackbox-tests/test-cases/pkg/invalid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-version.t
@@ -3,7 +3,6 @@ gives a good user message rather. It is very likely that users will type
 foo.1.2.3 for a package version due to the convention in opam.
 In this case we could also hint at the correct syntax for dune-project files.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.2.3
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/libraries.t
+++ b/test/blackbox-tests/test-cases/pkg/libraries.t
@@ -1,8 +1,6 @@
 This test attempts to build a library installed through a lock file and then
 use it inside dune.
 
-  $ . ./helpers.sh
-
 We set up a library that will be installed as part of the package:
 
   $ mkdir external_sources

--- a/test/blackbox-tests/test-cases/pkg/local-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/local-dune.t
@@ -1,7 +1,5 @@
 Dune is defined in the workspace where we're solving
 
-  $ . ./helpers.sh
-
   $ mkrepo
 
   $ mkpkg bar <<EOF

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-regeneration-safety.t/run.t
@@ -1,7 +1,5 @@
 Create a lock directory that didn't originally exist
 
-  $ . ../helpers.sh
-
   $ cat > dune-workspace <<EOF
   > (lang dune 3.20)
   > (pkg enabled)

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -6,8 +6,6 @@ for generating platform-specific lockdirs should be removed in favour of making
 all lockdirs portable.
   $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
 
-  $ . ./helpers.sh
-
   $ mkrepo
 
   $ mkpkg arm64-only <<EOF

--- a/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-out-of-sync.t
@@ -2,8 +2,6 @@ Trying to build a package after updating the dependencies in dune-project but
 without running `dune_pkg_lock_normalized` must raise an error in the context of Dune
 Package Managemenet. 
 
-  $ . ./helpers.sh
-
 Create a fake project and lock it:
 
   $ mkrepo

--- a/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-tampering.t
@@ -2,7 +2,6 @@ Tests that dune can detect when the lockdir has diverged from the local package
 dependencies due to tampering with the lockdir. These are cases that won't be
 caught by checking the dependency hash.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg a <<EOF
   > depends: [ "c" "d" ]

--- a/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-validation.t
@@ -1,9 +1,6 @@
 Check that if the user tampers with the lockdir in a way that invalidates the
 package graph then it's caught when loading the lockdir.
 
-  $ . ./helpers.sh
-
-
   $ make_lockdir
   $ make_lockpkg a <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-deps-respect-constraints.t
@@ -2,7 +2,6 @@ When populating the "deps" field of a lockfile, only packages which have locked
 versions compatible with the lockfile's package's dependency version
 constraints should be included.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a 0.0.1

--- a/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfile-generation.t/run.t
@@ -1,7 +1,5 @@
 Simple example of generating a lock file with Dune
 
-  $ . ../helpers.sh
-
 Helper shell function that generates an opam file for a package:
 
   $ emptypkg() {

--- a/test/blackbox-tests/test-cases/pkg/log-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/log-solution.t
@@ -1,7 +1,6 @@
 Make sure the solution of the lock directory solver is written into the build
 log.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
   $ enable_pkg

--- a/test/blackbox-tests/test-cases/pkg/make.t
+++ b/test/blackbox-tests/test-cases/pkg/make.t
@@ -1,5 +1,4 @@
 Build a package with make
-  $ . ./helpers.sh
 
   $ mkdir foo
   $ cat >foo/Makefile <<EOF

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-basic.t
@@ -2,9 +2,6 @@ Test that the "dune tools exec ocamlmerlin" command causes merlin to be
 locked, built and run when the command is run from a dune project with
 a lockdir containing an "ocaml" lockfile.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_merlin_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-env.t
@@ -1,9 +1,6 @@
 Test that after evaling the output of 'dune tools env', the first ocamlmerlin
 executable in PATH is the one installed by dune as a dev tool.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_merlin_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dev-tool-merlin-relock-on-ocaml-version-change.t
@@ -4,9 +4,6 @@ with the version of the ocaml compiler now in the project's
 lockdir. This is necessary because merlin must be compiled with the
 same version of the ocaml compiler as the code that it's analyzing.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_merlin_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/merlin/dune
+++ b/test/blackbox-tests/test-cases/pkg/merlin/dune
@@ -1,3 +1,3 @@
 (cram
- (deps helpers.sh)
+ (setup_scripts helpers.sh)
  (applies_to :whole_subtree))

--- a/test/blackbox-tests/test-cases/pkg/multi-project-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/multi-project-cycle.t
@@ -1,7 +1,5 @@
 Demonstrate how dune handles project dependency cycles in the same project
 
-  $ . ./helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/multi-project.t
+++ b/test/blackbox-tests/test-cases/pkg/multi-project.t
@@ -1,7 +1,5 @@
 Multiple projects support
 
-  $ . ./helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repo-override.t
@@ -1,8 +1,5 @@
 Multiple opam repositories that define the same package:
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
-
   $ pkg="packages/foo"
   $ mkdir -p repo1/$pkg repo2/$pkg
 
@@ -60,7 +57,6 @@ Define 1.0.0 in repo1 and 2.0.0 in repo2 for the same package:
   
   (build
    (all_platforms ((action (run echo repo2)))))
-
 
 We define 2.0.0 in both repo1 and repo2, but repo1 is listed first, so it
 should take priority

--- a/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/multiple-opam-repos.t
@@ -1,7 +1,5 @@
 We want to test that support for multiple opam repositories works.
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.0 <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
+++ b/test/blackbox-tests/test-cases/pkg/non-existent-dep.t
@@ -2,7 +2,7 @@ A package depending on a package that doesn't exist.
 The solver now gives a more sane error message.
 
 A few packages here so the errors could get large.
-  $ . ./helpers.sh
+
   $ mkrepo
   $ add_mock_repo_if_needed
   $ mkpkg a 0.0.1

--- a/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
+++ b/test/blackbox-tests/test-cases/pkg/non-local-package-depends-on-local-package-error.t
@@ -1,7 +1,6 @@
 Test that we produce an error message when a non-local package depends on a
 local package.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-compiler.t
@@ -3,7 +3,7 @@ Setting the compiler in the lock directory
 We need some data for ocamlc -config
 
   $ mkdir stdlib && touch stdlib/Makefile.config
-  $ . ./helpers.sh
+
   $ cat >ocaml.config <<EOF
   > version: 4.14.1
   > standard_library_default: $PWD/stdlib

--- a/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
+++ b/test/blackbox-tests/test-cases/pkg/ocaml-syntax-gh10839.t
@@ -2,8 +2,6 @@ Reproduce #10839.
 
 Dune file in OCaml syntax and a files directory should work
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ make_lockpkg base-bytes <<EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
@@ -1,5 +1,5 @@
 (cram
- (deps helpers.sh)
+ (setup_scripts helpers.sh)
  (applies_to :whole_subtree))
 
 (cram

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh10991.t
@@ -1,6 +1,5 @@
 Test that ocamlformat is re-run when a source file changes.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ make_project_with_dev_tool_lockdir
 

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/gh11037.t
@@ -1,7 +1,6 @@
 Exercise differences between the behavior of `dune fmt` when a lockdir is
 present and a lockdir is absent.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ make_project_with_dev_tool_lockdir
 

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -1,5 +1,3 @@
-. ../helpers.sh
-
 dev_tool_lock_dir="_build/.dev-tools.locks/ocamlformat"
 
 make_fake_ocamlformat() {

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-conflict-with-project.t
@@ -1,7 +1,6 @@
 If the dev-tool feature is enabled then "dune fmt" should invoke the "ocamlformat"
 executable from the dev-tool and not the one from PATH.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-avoid-taking-from-project-deps.t
@@ -5,7 +5,6 @@ dependencies.
 If the dev-tool feature is not enabled then "dune fmt" should invoke the
 "ocamlformat" executable from the project's regular package dependencies.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"
@@ -13,7 +12,6 @@ If the dev-tool feature is not enabled then "dune fmt" should invoke the
 
   $ make_ocamlformat_opam_pkg "0.26.2"
   $ make_ocamlformat_opam_pkg "0.26.3"
-
 
 Make a project that depends on the fake ocamlformat.0.26.2:
   $ make_project_with_dev_tool_lockdir

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-custom-build-dir.t
@@ -1,7 +1,5 @@
 Checks whether dev-tool locking takes custom build directories correctly into account.
 
-  $ . ./helpers.sh
-
 Set up some ocamlformat that we want to install.
 
   $ ocamlformat_version="0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-deps-conflict-project-deps.t
@@ -6,7 +6,6 @@ printer.1.0, and the project depends on a different version, printer.2.0.
 It shows those two do not conflict, and the dev-tools dependencies do not leak
 into the user build environment.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a fake OCamlFormat which depends on printer lib:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dev-tool-fails-to-build.t
@@ -1,7 +1,6 @@
 With a faulty version of OCamlFormat, "dune fmt" is supposed to stop with the
 build error of "ocamlformat".
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a fake ocamlformat with a missing ocamlformat.ml file:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-dune-tools-install.t
@@ -1,7 +1,6 @@
 Test that checks the interaction of `dune fmt` with `dune tools install
 ocamlformat`.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Set up a ocamlformat via OPAM package:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-e2e.t
@@ -1,6 +1,5 @@
 Exercises end to end, locking and building ocamlformat dev tool.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-ignore.t
@@ -1,6 +1,5 @@
 Make sure the format rules depends on ".ocamlformat-ignore" file when it exists.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-install.t
@@ -1,5 +1,5 @@
 Test `dune tools which ocamlformat`:
-  $ . ./helpers.sh
+
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-patch-extra-files.t
@@ -10,8 +10,6 @@ because the 'patch' file is already present.
 
 The issue is now fixed.
 
-
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a fake ocamlformat:

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relaxed-version-constraints.t
@@ -1,7 +1,7 @@
 Check that dune can choose a version of ocamlformat with a suffix (e.g.
 0.24+foo) to satisfy a .ocamlformat config that specifies a matching version
 without the suffix.
-  $ . ./helpers.sh
+
   $ mkrepo
   $ make_project_with_dev_tool_lockdir
 

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-relock-on-corrupt-lockdir.t
@@ -1,7 +1,6 @@
 When installing a dev tool which already has a lockdir, detect the case where
 the tool's lockfile is absent from the lockdir and relock.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a fake ocamlformat package

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-solving-fails.t
@@ -1,7 +1,6 @@
 When an OCamlFormat version does not exist, "dune fmt" would fail with a
 solving error.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a project with no dependency on OCamlFormat.

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-version-change.t
@@ -1,7 +1,6 @@
 When the version in .ocamlformat changes, automatically relock ocamlformat with
 the new version.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.0"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-which.t
@@ -1,5 +1,5 @@
 Test `dune tools which ocamlformat`:
-  $ . ./helpers.sh
+
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/ocamlformat-wrapper.t
@@ -1,6 +1,5 @@
 Exercise running the ocamlformat wrapper command.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ make_fake_ocamlformat "0.26.2"

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-basic.t
@@ -2,9 +2,6 @@ Test that the "dune tools exec ocamllsp" command causes ocamllsp to be
 locked, built and run when the command is run from a dune project with
 a lockdir containing an "ocaml" lockfile.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_ocamllsp_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-env-path-var.t
@@ -1,9 +1,6 @@
 Test that the ocamllsp dev tool executes in an environment where other dev
 tools are in PATH.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ mk_ocaml 5.2.0
   $ setup_ocamllsp_workspace

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-install-concurrent-with-watch-server.t
@@ -1,8 +1,5 @@
 Test that ocamllsp can be installed while dune is running in watch mode.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_ocamllsp_package
   $ mkpkg ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-no-ocaml-lockfile.t
@@ -1,8 +1,6 @@
 Exercise the behaviour of "dune tools exec ocamllsp" when the lockdir
 doesn't contain a lockfile for the "ocaml" package.
 
-  $ . ../helpers.sh
-
   $ cat > dune-project <<EOF
   > (lang dune 3.16)
   > 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-ocamlformat.t
@@ -1,8 +1,5 @@
 Test that the ocamllsp dev tool can see the ocamlformat dev tool.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ mkpkg ocaml 5.2.0
 

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-outside-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-outside-dune-project.t
@@ -1,7 +1,6 @@
 Exercise the behaviour of "dune tools exec ocamllsp" when run outside
 of a dune project.
 
-
 This is necessary for dune to act as it normally would outside of a
 dune workspace.
   $ unset INSIDE_DUNE

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-relock-on-ocaml-version-change.t
@@ -4,9 +4,6 @@ with the version of the ocaml compiler now in the project's
 lockdir. This is necessary because ocamllsp must be compiled with the
 same version of the ocaml compiler as the code that it's analyzing.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_ocamllsp_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dev-tool-ocamllsp-special-compiler-version.t
@@ -1,8 +1,5 @@
 Test the special compiler version is picked up by ocamllsp.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_ocamllsp_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/dune
@@ -1,5 +1,5 @@
 (cram
- (deps helpers.sh)
+ (setup_scripts helpers.sh)
  (applies_to :whole_subtree))
 
 ;; flaky https://github.com/ocaml/dune/actions/runs/15262698269/job/42923225446

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-basic.t
@@ -2,9 +2,6 @@ Test that the "dune ocaml doc" command causes odoc to be
 locked, built and run when the command is run from a dune project with
 a lockdir containing an "ocaml" lockfile.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_odoc_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-no-ocaml-lockfile.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-no-ocaml-lockfile.t
@@ -1,8 +1,6 @@
 Exercise the behaviour of "dune ocaml doc" when the lockdir
 doesn't contain a lockfile for the "ocaml" package.
 
-  $ . ../helpers.sh
-
   $ cat > dune-project <<EOF
   > (lang dune 3.16)
   > 

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-relock-on-ocaml-version-change.t
@@ -4,9 +4,6 @@ with the version of the ocaml compiler now in the project's
 lockdir. This is necessary because odoc must be compiled with the
 same version of the ocaml compiler as the code that it's analyzing.
 
-  $ . ../helpers.sh
-  $ . ./helpers.sh
-
   $ mkrepo
   $ make_mock_odoc_package
   $ mk_ocaml 5.2.0

--- a/test/blackbox-tests/test-cases/pkg/odoc/dune
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dune
@@ -1,5 +1,5 @@
 (cram
- (deps helpers.sh)
+ (setup_scripts helpers.sh)
  (applies_to :whole_subtree))
 
 ;; issues with dev tool lock dirs in source

--- a/test/blackbox-tests/test-cases/pkg/opam-file-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-file-errors.t
@@ -1,5 +1,5 @@
 Tests for error messages while reading package metadata from opam files
-  $ . ./helpers.sh
+
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/opam-file.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-file.t
@@ -1,6 +1,5 @@
 Tests for reading dependencies out of opam files
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-generate-ocaml-package.t
@@ -1,6 +1,5 @@
 The ocaml compiler needs to be marked inside the lock dir:
 
-  $ . ./helpers.sh
   $ mkrepo
 
 To mark it, we use `conflict-class: "ocaml-core-compiler"`

--- a/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-only-metadata.t
@@ -1,5 +1,5 @@
 Test that we can read package metadata from opam files.
-  $ . ./helpers.sh
+
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-copy-files.t
@@ -1,7 +1,6 @@
 This test checks that the files in the files/ directory inside a package in an opam
 repository are copied correctly to the dune.lock file.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a patch

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle-with-or.t
@@ -6,7 +6,6 @@ cycle. We have the following packages:
 Now c depends either on a or on a fourth package d. Therefore there is a valid solution
 available that avoids a cycle.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-cycle.t
@@ -1,6 +1,5 @@
 Testing how the solver handles cycles in an opam repository.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a <<'EOF'

--- a/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-files-unix-error.t
@@ -1,7 +1,6 @@
 This test demonstrates the behaviour when a Unix error is encountered when copying the
 files/ directory from a package directory inside an opam repository.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a patch

--- a/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-install-no-build.t
@@ -1,6 +1,5 @@
 In this test we test the translation of an opam package with only an install step.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with only an install step 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-subst-patch.t
@@ -1,8 +1,7 @@
 We test how opam files with substs fields together with patches fields are translated into
 the dune.lock file. Opam allows substitution to happen before the patches phase, so we
 must do the same.
- 
-  $ . ./helpers.sh
+
   $ mkrepo
 
 Make a package with a substs and patches field field 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
@@ -1,7 +1,6 @@
 In this test we test the translation of a package with a build-env field and no build or
 install step into a dune lock file.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a build-env field and no build or install step

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
@@ -1,7 +1,6 @@
 In this test we test the translation of a package with a build-env field into a dune lock
 file.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a build-env field

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
@@ -3,7 +3,6 @@ since been deprecated to the `build` field with a filter.
 
 In this test we demonstrate that we don't currently do anything special with those fields.
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg with-build-test-doc <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-extra-source.t
@@ -1,4 +1,4 @@
-  $ . ./helpers.sh
+
   $ mkrepo
 
 Make a package with an extra-source field
@@ -51,7 +51,6 @@ The lockfile should contain the fetching of extra sources.
      (checksum
       sha256=8beda92f97cde6d4a55a836ca6dc9f860bb5f1a6b765b80be4594943288571cf))))
   (source (copy $TESTCASE_ROOT/source))
-
 
 The lockfile should contain the fetching of extra sources with md5 checksums.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-files-install.t
@@ -1,8 +1,6 @@
 This test demonstrates a package where the .install file being created by the
 file copying step rather than the build step.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ mkdir -p ${default_lock_dir}/foo.files
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-filtered-deps.t
@@ -1,6 +1,5 @@
 Demonstrate the translation of filtered dependencies
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg pkg-post <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-filter.t
@@ -1,7 +1,6 @@
 We test the translation of an opam package with a patches field with a filter into a dune
 lock file.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a patch behind a filter

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch-multiple.t
@@ -1,7 +1,6 @@
 We test the conversion and build of the opam file patch field with multiple entries with
 patch files that patch multiple files.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with two patches, one inside a directory. The first patch patches a single

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-patch.t
@@ -1,7 +1,6 @@
 This test checks that the patches field of an opam file is correctly translated into the
 appropriate build step.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a patch
@@ -9,7 +8,6 @@ Make a package with a patch
   > patches: ["foo.patch"]
   > build: ["cat" "foo.ml"]
   > EOF
-
 
   $ mkdir -p $mock_packages/with-patch/with-patch.0.0.1/files
   $ cat >$mock_packages/with-patch/with-patch.0.0.1/files/foo.patch <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -1,6 +1,5 @@
 Testing the translation of the setenv field of an opam file into the dune lock dir.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a package with a setenv. We also test all the kinds of env updates here expcept for
@@ -134,5 +133,4 @@ Appended 2nd time without leading sep:Appended without leading sep
   Prepended 2nd time with sep:Prepended with trailing sep
   Appended without leading sep:Appended 2nd time without leading sep
   Appended with leading sep:Appended 2nd time with leading sep
-
 

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-subst.t
@@ -1,6 +1,5 @@
 We test how opam files with substs fields are translated into the dune.lock file.
- 
-  $ . ./helpers.sh
+
   $ mkrepo
 
 Make a package with a substs field 

--- a/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-repository-download.t
@@ -1,7 +1,5 @@
 Helper shell function that generates an opam file for a package:
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
 
 Make a mock repo tarball that will get used by dune to download the package

--- a/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-solver-or.t
@@ -1,6 +1,5 @@
 Demonstrate the generation of the lock directory in the presence of "|"
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a1 0.0.1 <<EOF
@@ -38,7 +37,6 @@ packages, so comparing their version numbers is meaningless.
   Solution for dune.lock:
   - a1.0.0.1
   - b.0.0.1
-
 
 Release a new version of b specifying version numers of deps. Note
 that only a2 exists with the specified version. If the solver chooses

--- a/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-source-conversion.t
@@ -1,7 +1,5 @@
 Test conversion of opam sources into lock dir package specifications
 
-  $ . ./helpers.sh
-
   $ mkrepo
 
   $ mkpkg testpkg <<EOF

--- a/test/blackbox-tests/test-cases/pkg/opam-var/make-over-gmake.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/make-over-gmake.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh 
-
 If both make and gmake are available, we should prefer make.
 
 opam doesn't resolve make but rather runs make literally so it is up to whatever is in

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-dep-filtering.t
@@ -1,7 +1,5 @@
 Demonstrate how dependencies are filtered in opam files:
 
-  $ . ../helpers.sh 
-
   $ build_single_package() {
   > solve_project <<EOF
   > (lang dune 3.11)

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
 Here we test the translation and implementation of global opam variables. OS specific
 variables can be found in `opam-var-os.t`.
 

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-os.t
@@ -2,8 +2,6 @@
 # that it re-runs after an update. That's a little hard to express however, and
 # one must remember to manually force to re-run it after an upgrade.
 
-  $ . ../helpers.sh
-
 Here we test global opam variables that are system specific. Since these values change
 between systems, we can't hardcode them in the test. Instead, we use the opam var command
 to compare their values.

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
 Here we test the translation and implementation of opam package variables.
 
 We echo each package variable. 

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
 These opam variables are known as "switch variables" in opam, but since in Dune we don't
 have switches, we consider them glboal variables. To keep inline with opam we consider
 there to be a single switch named "dune" and all the installation locations should be in

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
   $ mkrepo
   > fail_solve() {
   >   mkpkg testpkg <<EOF

--- a/test/blackbox-tests/test-cases/pkg/outdated-with-dev-setup.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated-with-dev-setup.t
@@ -1,6 +1,5 @@
 Reproduce internal error with dune pkg outdated in #11188.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg a
   $ mkpkg b

--- a/test/blackbox-tests/test-cases/pkg/outdated.t
+++ b/test/blackbox-tests/test-cases/pkg/outdated.t
@@ -1,4 +1,3 @@
-  $ . ./helpers.sh
 
   $ outdated () {
   >  dune pkg outdated $@

--- a/test/blackbox-tests/test-cases/pkg/package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/package-cycle.t
@@ -1,7 +1,5 @@
 Package resolution creating a cycle
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg a <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/package-files.t
+++ b/test/blackbox-tests/test-cases/pkg/package-files.t
@@ -1,8 +1,6 @@
 Additional files overlaid on top of the source can be found in the
 %pkg.files/ directory:
 
-  $ . ./helpers.sh
-
   $ mkdir test-source
   $ touch test-source/foo
 

--- a/test/blackbox-tests/test-cases/pkg/package-name-with-plus-character.t
+++ b/test/blackbox-tests/test-cases/pkg/package-name-with-plus-character.t
@@ -2,7 +2,6 @@ Ensure dune can handle the special string interpolation syntax used by opam for
 packages whose names contain a '+' character. This syntax is described in
 https://opam.ocaml.org/doc/Manual.html#Variables
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
+++ b/test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
@@ -1,7 +1,6 @@
 Test that solver vars in filters are replaced by their values in filter
 expressions in lockfiles.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 Declare a package which refers to some variables:

--- a/test/blackbox-tests/test-cases/pkg/patch.t
+++ b/test/blackbox-tests/test-cases/pkg/patch.t
@@ -1,7 +1,5 @@
 Applying patches
 
-  $ . ./helpers.sh
-
   $ mkdir test-source
   $ make_lockdir
   $ make_lockpkg test <<EOF

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -2,8 +2,6 @@ Set lock file per context.
 
 TODO: versioning will be added once this feature is stable
 
-  $ . ./helpers.sh
-
   $ cat >dune-workspace <<EOF
   > (lang dune 3.8)
   > (context

--- a/test/blackbox-tests/test-cases/pkg/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-depends.t
@@ -1,8 +1,5 @@
 Demonstrate our support for pin-depends.
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
-
   $ add_mock_repo_if_needed
   $ cat >dune-project <<EOF
   > (lang dune 3.13)

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/basic.t
@@ -1,8 +1,6 @@
 The pin stanza allows us to define packages that are not available
 in any repository
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/build-command-dune-project.t
@@ -1,7 +1,5 @@
 Demonstrate the build command we construct for different types of projects:
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/cycle.t
@@ -5,8 +5,6 @@ it's even worth checking for. What matters is that there are no cycles at the
 package level, the sources can contain a cycle, we just need to make sure we
 detect it and not descend into an infinite loop.
 
-  $ . ../helpers.sh
-
   $ mkdir a b
 
   $ cat >a/dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source-nested.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source-nested.t
@@ -1,8 +1,5 @@
 Package sources can be set to git and be nested:
 
-  $ . ../../git-helpers.sh
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/git-source.t
@@ -1,8 +1,5 @@
 Package sources can be set to git:
 
-  $ . ../../git-helpers.sh
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/ignored-dirs.t
@@ -1,7 +1,5 @@
 Pulling projects should respect ignored directories.
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/mixed-opam-dune.t
@@ -1,8 +1,6 @@
 We try to use a project that has both opam files and a dune-project file. We
 should favor the dune metadata in such a case.
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/multiple-packages.t
@@ -1,7 +1,5 @@
 We can pull multiple packages from a single source
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/no-package.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/no-package.t
@@ -1,7 +1,5 @@
 Here we try to pin a package to a source that doesn't define said package:
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-only.t
@@ -1,7 +1,5 @@
 We try to pull an opam package that isn't a dune project
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/opam-template.t
@@ -1,8 +1,6 @@
 A user may set the build command using the opam template feature. This build
 command is currently not respected when the package is pinned.
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/override-single-workspace.t
@@ -1,7 +1,5 @@
 Override a source when multiple projects in a workspace set it.
 
-  $ . ../helpers.sh
-
 Here we demonstrate that projects override their sub projects:
 
   $ mkdir a && cd a

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/overriding.t
@@ -1,7 +1,5 @@
 We can override the sources set by packages we're fetching:
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends.t
@@ -1,8 +1,6 @@
 Setting the source of a package to a non dune package with pin-depends should
 respect the pin-depends
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depopts.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depopts.t
@@ -1,7 +1,6 @@
 Test that it's possible to lock a project that depends on a pinned
 package with depopts.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-dune.t
@@ -1,7 +1,5 @@
 Pinning dune itself
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/recursive.t
@@ -1,7 +1,5 @@
 Sources are traversed recursively (unlike pins)
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
@@ -1,8 +1,6 @@
 Demonstrate that you can't use a relative path referring outside the workspace
 in the pin stanza:
 
-  $ . ../helpers.sh
-
 Make a package containing a library:
   $ mkdir foo
   $ cat > foo/dune-workspace <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/unknown-dune-version.t
@@ -1,6 +1,5 @@
 We are unable to pin projects that the version of dune doesn't understand.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/update-non-dune-local-pin.t
@@ -2,8 +2,6 @@ This demonstrates pinning a non-opam package and then modifying its sources.
 Whenever the sources are modified, dune should rebuild the package in the
 workspace where it's locked.
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/workspace.t
@@ -1,7 +1,5 @@
 It should be possible to include custom repos from the workspace:
 
-  $ . ../helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-action-when.t
@@ -1,7 +1,5 @@
 Testing the when action in lockfiles
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
 Case with a mix of uncoditional and conditional actions in a progn action

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps.t
@@ -1,7 +1,5 @@
 We should be able to specify (package ..) deps on locally built packages.
 
-  $ . ./helpers.sh
-
   $ cat >dune-project <<EOF
   > (lang dune 3.11)
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-disabled-workflow.t
@@ -10,7 +10,6 @@ This means that:
 3. This should work even when lock directories are present.
 4. Explicit settings should override auto-detection.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 First, create a dummy library package in a subdirectory that we can depend on:

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled.t
@@ -1,8 +1,6 @@
 Exercise the "dune pkg enabled" command which checks whether package management
 should be used.
 
-  $ . ./helpers.sh
-
   $ mkrepo
 
   $ cat >dune-workspace <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -4,7 +4,6 @@ exit codes and error messages, see #11560 for example output
 Create a mock package whose url is a corrupted/invalid tar file attempt to
 build this package and check for sufficient error handling
 
-  $ . ./helpers.sh
   $ echo "corrupted tar" > corrupted.tar
 
   $ mkpkg foo <<EOF

--- a/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-lock-then-autolock.t
@@ -1,7 +1,6 @@
 Test that explicit locking followed by auto-locking produces equivalent results
 and does not trigger unnecessary rebuilds.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-validate-on-build.t
@@ -7,8 +7,6 @@ the current platform isn't one of the platforms for which a solution exists in
 the lockdir, and this is tested in "portable-lockdirs-custom-platforms".
   $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
 
-  $ . ./helpers.sh
-
   $ mkrepo
 
   $ mkpkg a <<EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -1,6 +1,5 @@
 Basic usage of portable lockdirs.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-platforms.t
@@ -1,6 +1,5 @@
 Specifying custom platforms to solve for.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -1,7 +1,6 @@
 Exercise solving with portable lockdirs when there is a custom solver
 environment that affects the solution.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-dedup-manifest-errors.t
@@ -1,7 +1,6 @@
 Test that errors with opam package manifests are only printed a single time
 even when they are encountered by multiple concurrent runs of the opam solver.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-basic.t
@@ -1,6 +1,5 @@
 Demonstrate various cases representing depexts in lockfiles.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-depexts-pkg-config.t
@@ -2,7 +2,6 @@ Exercise generating depexts in portable lockdirs by solving a project that
 depends on a simplified copy of conf-pkg-config - a package whose depexts vary
 greatly depending on the platform.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -1,6 +1,5 @@
 Demonstrate the case where a project can't be solved at all.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-package-variable-typo-detection.t
@@ -1,6 +1,5 @@
 Detect common typos with package variables when describing platforms to solve for.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-partial-solve.t
@@ -1,6 +1,5 @@
 Demonstrate the case where a project can only be solved for a subset of platforms.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -1,6 +1,5 @@
 Test for a project whose dependencies are different depending on the platform.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version-extra-files.t
@@ -1,7 +1,6 @@
 Test that extra files associated with a package are handled correctly when
 multiple different versions of the package are present in the lockdir.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -1,6 +1,5 @@
 Test for a project which depends on different versions of the same package depending on the platform.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-print-avoid-version.t
@@ -1,7 +1,6 @@
 When solving portable lockdirs, if any packages in the solution are marked
 avoid-version, include a message to that extent in the output.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-validation.t
@@ -1,6 +1,5 @@
 Exercise the `dune pkg validate-lockdir` command on portable lockdirs.
 
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-with-doc.t
@@ -1,8 +1,6 @@
 Test that the with-doc variable is stored in the lockdir when it's set in
 dune-workspace.
 
-
-  $ . ../helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
+++ b/test/blackbox-tests/test-cases/pkg/post-deps-solving.t
@@ -1,6 +1,5 @@
 Solving for post dependencies:
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg bar

--- a/test/blackbox-tests/test-cases/pkg/project-package-cycle.t
+++ b/test/blackbox-tests/test-cases/pkg/project-package-cycle.t
@@ -1,7 +1,5 @@
 Demonstrate how dune handles project dependency cycles in the same project
 
-  $ . ./helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
+++ b/test/blackbox-tests/test-cases/pkg/project-version-dependence.t
@@ -1,8 +1,6 @@
 Demonstrate that there should be no dependence on the dune lang version for
 building packages:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -2,8 +2,6 @@ We want to test that a failing flock(2) shows an error.
 
 Thus we first create a repo:
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.0 <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock.t
@@ -2,8 +2,6 @@ Testing whether the revision store locks properly.
 
 To start with we create a repository in with a `foo` package.
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo 1.0 <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -1,4 +1,3 @@
-  $ . ./helpers.sh
 
 Generate a mock opam repository
   $ mkdir -p mock-opam-repository
@@ -32,7 +31,6 @@ Generate a mock opam repository
   > ]
   > EOF
 
-
   $ mkpkg baz <<EOF
   > install: [
   >   ["echo" "installed" { installed } "not installed" { ! installed }]
@@ -41,7 +39,6 @@ Generate a mock opam repository
   >   ["echo" "madeup-defined" { ? madeup } "installed-defined" { ? installed } ]
   > ]
   > EOF
-
 
   $ mkpkg error1 <<EOF
   > install: [

--- a/test/blackbox-tests/test-cases/pkg/run-local.t
+++ b/test/blackbox-tests/test-cases/pkg/run-local.t
@@ -2,8 +2,6 @@ Test that local commands, such as `./configure`, are called from the sandbox, as
 they could have been created or modified by previous build commands (such as
 `patch`)
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/search/basic.t
+++ b/test/blackbox-tests/test-cases/pkg/search/basic.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
 We setup a simple mock repository directory with a couple of packages.
 
   $ mkrepo

--- a/test/blackbox-tests/test-cases/pkg/search/dune
+++ b/test/blackbox-tests/test-cases/pkg/search/dune
@@ -1,2 +1,2 @@
 (cram
- (deps helpers.sh))
+ (setup_scripts helpers.sh))

--- a/test/blackbox-tests/test-cases/pkg/search/empty-repo.t
+++ b/test/blackbox-tests/test-cases/pkg/search/empty-repo.t
@@ -1,5 +1,3 @@
-  $ . ../helpers.sh
-
 We use an empty repository with no packages for this test.
 
   $ mkrepo

--- a/test/blackbox-tests/test-cases/pkg/search/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/search/helpers.sh
@@ -1,5 +1,3 @@
-. ../helpers.sh
-
 mkrepo_other() {
   local mock_packages
   mock_packages="other-opam-repository/packages"

--- a/test/blackbox-tests/test-cases/pkg/search/many-results.t
+++ b/test/blackbox-tests/test-cases/pkg/search/many-results.t
@@ -1,7 +1,4 @@
-  $ . ../helpers.sh
-
 Load search/helpers.sh for helper to create many packages
-  $ . ./helpers.sh
 
 We setup a simple mock repository directory with a couple of packages.
 

--- a/test/blackbox-tests/test-cases/pkg/search/multiple-repos-conflicting-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/search/multiple-repos-conflicting-packages.t
@@ -1,7 +1,4 @@
-  $ . ../helpers.sh
-
 Source helpers for creating another repo, etc.
-  $ . ./helpers.sh
 
 We setup a couple of different mock repositories. First, create
 mock-opam-repository with a couple of packages

--- a/test/blackbox-tests/test-cases/pkg/search/multiple-repos.t
+++ b/test/blackbox-tests/test-cases/pkg/search/multiple-repos.t
@@ -1,7 +1,4 @@
-  $ . ../helpers.sh
-
 Source helpers for creating another repo, etc.
-  $ . ./helpers.sh
 
 We setup a couple of different mock repositories. First, create
 mock-opam-repository with a couple of packages

--- a/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/self-version-constraint.t
@@ -1,7 +1,5 @@
 Demonstrates constraints that self reference the version
 
-  $ . ./helpers.sh
-
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -1,6 +1,5 @@
 Test that the OCAMLFIND_DESTDIR environment variable is set when running
 install and build commands.
-  $ . ./helpers.sh
 
   $ make_lockdir
   $ make_lockpkg test <<'EOF'

--- a/test/blackbox-tests/test-cases/pkg/setenv-bin-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/setenv-bin-dir.t
@@ -1,8 +1,6 @@
 We set the PATH with (exported_env ..) and this should be reflected when
 looking up binaries in the workspace.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ bin=foobarbin

--- a/test/blackbox-tests/test-cases/pkg/simple-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/simple-lock.t
@@ -1,7 +1,5 @@
 Test that we run the build command
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/pkg/sites-plugin.t
@@ -1,6 +1,5 @@
 Test sites plugins from another package
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/slang.t
+++ b/test/blackbox-tests/test-cases/pkg/slang.t
@@ -1,4 +1,3 @@
-  $ . ./helpers.sh
 
   $ make_lockdir
 

--- a/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-compiler-dependency.t
@@ -1,7 +1,6 @@
 Creates some packages that simulate some of the ocaml compiler
 packages and test solving a project that depends on "ocaml".
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ CURRENT=5.2.0

--- a/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
+++ b/test/blackbox-tests/test-cases/pkg/solve-lockdir-without-context.t
@@ -1,7 +1,6 @@
 This test checks whether a custom lock dir can be created, without having to
 specify it in the context.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg a <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
+++ b/test/blackbox-tests/test-cases/pkg/solver-vars-in-lockdir-metadata.t
@@ -9,7 +9,6 @@ lockdirs. The analogous cases for portable lockdirs is tested in
 and "portable-lockdirs-custom-platforms" (setting platform variables in dune-workspace).
   $ export DUNE_CONFIG__PORTABLE_LOCK_DIR=disabled
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg no-deps-a 1.0 <<EOF

--- a/test/blackbox-tests/test-cases/pkg/source-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/source-caching.t
@@ -1,7 +1,5 @@
 This test demonstrates that fetching package sources should be cached
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ tarball=source.tar

--- a/test/blackbox-tests/test-cases/pkg/source-copy-mask.t
+++ b/test/blackbox-tests/test-cases/pkg/source-copy-mask.t
@@ -1,6 +1,5 @@
 We shouldn't copy files that aren't sources
 
-  $ . ./helpers.sh
   $ make_lockdir
 
   $ src=_foo

--- a/test/blackbox-tests/test-cases/pkg/source-empty-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/source-empty-dir.t
@@ -1,6 +1,5 @@
 Demonstrate that we copy empty directories
 
-  $ . ./helpers.sh
   $ make_lockdir
 
   $ src=_foo

--- a/test/blackbox-tests/test-cases/pkg/submodules.t
+++ b/test/blackbox-tests/test-cases/pkg/submodules.t
@@ -1,8 +1,6 @@
 We want to make sure locking works even with submodules. Submodules can
 contains submodules on their own which should also work.
 
-  $ . ../git-helpers.sh
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg foo <<EOF
   > EOF

--- a/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/subst-installed-variable.t
@@ -1,7 +1,5 @@
 Test the %{pkg:installed}% form inside file substitution:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/substitute.t
+++ b/test/blackbox-tests/test-cases/pkg/substitute.t
@@ -1,7 +1,5 @@
 The test-source folder has a file to use substitution on.
 
-  $ . ./helpers.sh
-
   $ mkdir test-source
   $ cat >test-source/foo.ml.in <<EOF
   > This file will be fed to the substitution mechanism

--- a/test/blackbox-tests/test-cases/pkg/tarball.t
+++ b/test/blackbox-tests/test-cases/pkg/tarball.t
@@ -1,7 +1,5 @@
 Demonstrate that we should support tarballs with and without a root directory
 
-  $ . ./helpers.sh
-
   $ mkdir _source/
   $ touch _source/foo
 

--- a/test/blackbox-tests/test-cases/pkg/test-only-deps.t
+++ b/test/blackbox-tests/test-cases/pkg/test-only-deps.t
@@ -1,6 +1,5 @@
 Test that we can identify the test-only locked dependencies of a package
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg a 0.0.1 <<EOF

--- a/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-installation.t
@@ -1,7 +1,6 @@
 Test the installation of toolchains package by building and installing
 a mock compiler package using dune's toolchain mechanism.
 
-  $ . ./helpers.sh
   $ make_lockdir
 
   $ mkdir fake-compiler

--- a/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/toolchain-variables.t
@@ -1,7 +1,6 @@
 Test the installation of toolchains package by building and installing
 a mock compiler package using dune's toolchain mechanism.
 
-  $ . ./helpers.sh
   $ make_lockdir
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-package-source.t
@@ -1,7 +1,5 @@
 Demonstrate what happens when we try to fetch from a source that doesn't exist:
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
   $ runtest() {

--- a/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
+++ b/test/blackbox-tests/test-cases/pkg/unavailable-packages.t
@@ -1,7 +1,6 @@
 Test that the solver environment associate with lockdirs is respected by the
 solver.
 
-  $ . ./helpers.sh
   $ mkrepo
 
 This test is specialized to non-portable lockdirs. For an analogous test of

--- a/test/blackbox-tests/test-cases/pkg/unknown-package.t
+++ b/test/blackbox-tests/test-cases/pkg/unknown-package.t
@@ -1,7 +1,5 @@
 Try to build a package that doesn't exist
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ build_pkg fakepkg
   Error: The project does not depend on the package "fakepkg".

--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -1,7 +1,6 @@
 Exercise dune solving projects with version constraints on dune that aren't
 satisfied by the currently-running dune.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ add_mock_repo_if_needed
 

--- a/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/validate-lockdir-depends-on-dune.t
@@ -1,6 +1,5 @@
 Reproduce internal error with dune pkg validate-lockdir in #11188.
 
-  $ . ./helpers.sh
   $ mkrepo
   $ mkpkg a <<EOF
   > depends: [ "dune" ]

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -1,7 +1,5 @@
 Test that we can set variables
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<EOF
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/with-test-dependencies.t
@@ -1,6 +1,5 @@
 Test variable filters on dependencies
 
-  $ . ./helpers.sh
   $ mkrepo
 
   $ mkpkg foo-dependency <<EOF

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -1,8 +1,6 @@
 Demonstrate what happens if a user attempts to add to modify the PATH variable
 using the withenv action.
 
-  $ . ./helpers.sh
-
 This path is system-specific so we need to be able to remove it from the output.
   $ DUNE_PATH=$(dirname $(which dune))
 

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -1,7 +1,5 @@
 Setting environment variables in actions
 
-  $ . ./helpers.sh
-
   $ make_lockdir
   $ make_lockpkg test <<'EOF'
   > (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -1,7 +1,5 @@
 Test the error message when unzip is needed but not installed.
 
-  $ . ./helpers.sh
-
   $ make_lockdir
 
 Set up our fake decompressor binaries, they all just copy the file to the


### PR DESCRIPTION
`setup_scripts` allow us to automatically insert the boilerplate for sourcing some helper script. This is a pattern that we've used a bunch in the package management tests, so this turns out to remove a bunch of repetitive setup code.

cc @Alizter @Leonidas-from-XIV @ElectreAAS as a reminder not to write `. ../helpers.sh` anymore