### PR TITLE
Cleanup cram tests

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -8,7 +8,7 @@
    (DUNE_DEBUG_PACKAGE_LOGS 1))))
 
 (cram
- (deps %{bin:git} ../git-helpers.sh)
+ (deps %{bin:git} %{bin:bc})
  (setup_scripts helpers.sh ../git-helpers.sh)
  (applies_to :whole_subtree))
 


### PR DESCRIPTION
We should depend on bc explicitly.

On the other hand, there's no need to depend on git-helpers.sh since
it's a setup-script already.
