### PR TITLE
Simplify stdune log

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -220,7 +220,7 @@ let format_results bench_results =
 ;;
 
 let () =
-  Log.init ~file:No_log_file ();
+  Log.init No_log_file;
   let dir = Temp.create Dir ~prefix:"dune" ~suffix:"bench" in
   Sys.chdir (Path.to_string dir);
   Path.as_external dir |> Option.value_exn |> Path.set_root;

--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -46,7 +46,7 @@ let trim =
                            ~f:(fun (units, _) -> List.hd units)
                            Bytes_unit.conversion_table)))))
      in
-     Log.init_disabled ();
+     Log.init No_log_file;
      let open Result.O in
      match
        let+ goal =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1325,7 +1325,7 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string c.builder.build_dir);
   (* Once we have the build directory set, initialise the logging. We can't do
      this earlier, because the build log typically goes into [_build/log]. *)
-  Log.init () ~file:builder.log_file;
+  Log.init builder.log_file;
   (* We need to print this before reading the workspace file, so that the editor
      can interpret errors in the workspace file. *)
   print_entering_message c;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -524,7 +524,7 @@ let term =
   Path.set_root (Path.External.cwd ());
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string Common.default_build_dir);
   Dune_config.init config ~watch:false;
-  Log.init_disabled ();
+  Log.init No_log_file;
   Scheduler.no_build_no_rpc ~config subst
 ;;
 

--- a/otherlibs/stdune/src/log.ml
+++ b/otherlibs/stdune/src/log.ml
@@ -16,7 +16,7 @@ type real = { oc : out_channel option }
 let t = Fdecl.create Dyn.opaque
 let verbose = ref false
 
-let init ?(file = File.Default) () =
+let init (file : File.t) =
   let oc =
     match file with
     | No_log_file -> None
@@ -36,7 +36,6 @@ let init ?(file = File.Default) () =
   Fdecl.set t (Some { oc })
 ;;
 
-let init_disabled () = Fdecl.set t None
 let t () = Fdecl.get t
 
 let log_oc oc msg =

--- a/otherlibs/stdune/src/log.mli
+++ b/otherlibs/stdune/src/log.mli
@@ -10,11 +10,7 @@ module File : sig
 end
 
 (** Initialise the log file *)
-val init : ?file:File.t -> unit -> unit
-
-(** Initialise this module with a disabled logger, i.e. swallowing error
-    messages. *)
-val init_disabled : unit -> unit
+val init : File.t -> unit
 
 (** Print the message only the log file (despite verbose mode) if it's set *)
 val log : (unit -> User_message.Style.t Pp.t list) -> unit

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -11,7 +11,7 @@ let init =
        Path.set_root (Path.External.cwd ());
        Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build");
        Console.Backend.(set dumb);
-       Log.init ())
+       Log.init No_log_file)
   in
   fun () -> Lazy.force init
 ;;

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -6,7 +6,7 @@ open Dune_rpc_server
 module Scheduler = Test_scheduler
 
 let () = Printexc.record_backtrace false
-let () = Log.init_disabled ()
+let () = Log.init No_log_file
 let print pp = Format.printf "%a@." Pp.to_fmt pp
 let print_dyn dyn = print (Dyn.pp dyn)
 

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -9,7 +9,7 @@ module Session = Csexp_rpc.Session
 
 (* enable to debug process stdout/stderr *)
 let debug = false
-let () = if debug then Log.init ~file:Stderr ()
+let () = if debug then Log.init Stderr
 
 let dune_prog =
   lazy


### PR DESCRIPTION
* remove [Log.init_disabled]. It's redundant.
* improve [Log.init] to just take the only argument it wants
