### PR TITLE
coq: move away from parsing _build/log in tests

### DIFF
--- a/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
@@ -46,7 +46,7 @@ so this also tests that it won't be a problem.
 
 
 Next we go into our Dune project and build it.
-  $ dune build --root A
+  $ dune build --trace-file trace.json --root A
   Entering directory 'A'
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
@@ -58,20 +58,56 @@ Next we go into our Dune project and build it.
 
 Now we check the flags that were passed to coqdep and coqc:
 
-  $ tail -4 A/_build/log | head -2 | ../scrub_coq_args.sh
-  coqdep
-  -boot
-  -R coq/theories Coq
-  -Q $TESTCASE_ROOT/lib/coq/user-contrib/B B
-  -R . A -dyndep opt -vos a.v >
-  _build/default/.A.theory.d
-  coqc -q
-  -w -deprecated-native-compiler-option -native-output-dir .
-  -native-compiler on
-  -nI lib/coq-core/kernel
-  -nI .
-  -boot
-  -R coq/theories Coq
-  -Q $TESTCASE_ROOT/lib/coq/user-contrib/B B
-  -R . A
-  a.v
+  $ jq '.[] | select(.name == "coqc" or .name == "coqdep") | {name, args: (.args.process_args | map(sub(".*/coq-core"; "coq-core")))}' trace.json
+  {
+    "name": "coqc",
+    "args": [
+      "--config"
+    ]
+  }
+  {
+    "name": "coqdep",
+    "args": [
+      "-boot",
+      "-R",
+      "$TESTCASE_ROOT/lib/coq/theories",
+      "Coq",
+      "-Q",
+      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "B",
+      "-R",
+      ".",
+      "A",
+      "-dyndep",
+      "opt",
+      "-vos",
+      "a.v"
+    ]
+  }
+  {
+    "name": "coqc",
+    "args": [
+      "-q",
+      "-w",
+      "-deprecated-native-compiler-option",
+      "-native-output-dir",
+      ".",
+      "-native-compiler",
+      "on",
+      "-nI",
+      "coq-core/kernel",
+      "-nI",
+      ".",
+      "-boot",
+      "-R",
+      "$TESTCASE_ROOT/lib/coq/theories",
+      "Coq",
+      "-Q",
+      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "B",
+      "-R",
+      ".",
+      "A",
+      "a.v"
+    ]
+  }

--- a/test/blackbox-tests/test-cases/coq/coqdoc-flags-header-footer.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-flags-header-footer.t
@@ -24,26 +24,44 @@ Testing the coqdoc_header and coqdoc_footer field of the env stanza.
   > footer
   > EOF
 
-  $ dune build @doc
+  $ dune build --trace-file trace.json @doc
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*coq/coq/'
-  coqdoc
-  coq/theories Coq
-  -R . a --toc --with-header header.html --with-footer footer.html --html -d a.html
-  foo.v
+  $ jq '.[] | select(.name == "coqdoc") | .args.process_args | .[] | sub(".*/coq"; "/coq")' trace.json
+  "-R"
+  "/coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "--with-header"
+  "header.html"
+  "--with-footer"
+  "footer.html"
+  "--html"
+  "-d"
+  "a.html"
+  "foo.v"
 
-  $ dune build @doc-latex
+  $ dune build --trace-file trace.json @doc-latex
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*coq/coq/'
-  coqdoc
-  coq/theories Coq
-  -R . a --toc --latex -d a.tex
-  foo.v
+  $ jq '.[] | select(.name == "coqdoc") | .args.process_args | .[] | sub(".*/coq"; "/coq")' trace.json
+  "-R"
+  "/coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "--latex"
+  "-d"
+  "a.tex"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/coq/coqdoc-flags.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-flags.t
@@ -17,14 +17,23 @@ Testing the coqdoc flags field of the env stanza.
   > Definition a := 42.
   > EOF
 
-  $ dune build @doc
+  $ dune build --trace-file trace.json @doc
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*coq/coq/' 
-  coqdoc
-  coq/theories Coq
-  -R . a --toc -toc-depth 2 --html -d a.html
-  foo.v
+  $ jq '.[] | select(.name == "coqdoc") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "-toc-depth"
+  "2"
+  "--html"
+  "-d"
+  "a.html"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
@@ -1,6 +1,6 @@
 Testing coqdoc when composed with a boot library
 
-  $ dune build A/A.html
+  $ dune build --trace-file trace.json A/A.html
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
@@ -16,8 +16,9 @@ Testing coqdoc when composed with a boot library
 
 Dune should be passing '--coqlib' to coqdoc, but it doesn't. This is a bug.
 
-  $ cat _build/log | sed 's/$ (cd .*coqc/coqc/' | sed 's/$ (cd .*coqdoc/coqdoc/' | sed '/# /d' | sed '/> /d' | sort
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -boot -R Coq Coq Coq/mytheory.v)
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Coq -R A A A/a.v)
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Coq Coq/Init/Prelude.v)
-  coqdoc -R ../Coq Coq -R . A --toc --html -d A.html a.v)
+  $ jq -c '.[] | select(.name == "coqc" or .name == "coqdoc") | .args.process_args' trace.json
+  ["--config"]
+  ["-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-noinit","-boot","-R","Coq","Coq","Coq/Init/Prelude.v"]
+  ["-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","Coq","Coq","Coq/mytheory.v"]
+  ["-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-noinit","-boot","-R","Coq","Coq","-R","A","A","A/a.v"]
+  ["-R","../Coq","Coq","-R",".","A","--toc","--html","-d","A.html","a.v"]

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
@@ -1,41 +1,74 @@
 Testing that the correct flags are being passed to dune coq top
 
 The flags passed to coqc:
-  $ dune build && tail -1 _build/log | ../../scrub_coq_args.sh
+  $ dune build --trace-file trace.json
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc
-  -w -notation-overridden
-  -w -deprecated-native-compiler-option -native-output-dir .
-  -native-compiler on
-  -nI lib/coq-core/kernel
-  -nI .
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . minimal
-  Test.v
+
+  $ jq '[ .[] | select(.name == "coqc") | .args.process_args ] | .[1] | .[] | sub(".*/coq/"; "coq/") | sub(".*/coq-core/"; "coq-core/")' trace.json
+  "-w"
+  "-notation-overridden"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-native-output-dir"
+  "."
+  "-native-compiler"
+  "on"
+  "-nI"
+  "coq-core/kernel"
+  "-nI"
+  "."
+  "-I"
+  "coq-core/plugins/btauto"
+  "-I"
+  "coq-core/plugins/cc"
+  "-I"
+  "coq-core/plugins/derive"
+  "-I"
+  "coq-core/plugins/extraction"
+  "-I"
+  "coq-core/plugins/firstorder"
+  "-I"
+  "coq-core/plugins/funind"
+  "-I"
+  "coq-core/plugins/ltac"
+  "-I"
+  "coq-core/plugins/ltac2"
+  "-I"
+  "coq-core/plugins/micromega"
+  "-I"
+  "coq-core/plugins/nsatz"
+  "-I"
+  "coq-core/plugins/number_string_notation"
+  "-I"
+  "coq-core/plugins/ring"
+  "-I"
+  "coq-core/plugins/rtauto"
+  "-I"
+  "coq-core/plugins/ssreflect"
+  "-I"
+  "coq-core/plugins/ssrmatching"
+  "-I"
+  "coq-core/plugins/tauto"
+  "-I"
+  "coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "minimal"
+  "Test.v"
 
 The flags passed to coqtop:
   $ dune coq top --toplevel=echo Test.v | ../../scrub_coq_args.sh

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -3,7 +3,7 @@
 
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:coqc} %{bin:coqdep} scrub_coq_args.sh)
+ (deps %{bin:jq} %{bin:coqc} %{bin:coqdep} scrub_coq_args.sh)
  (alias runtest-coq)
  (enabled_if
   (= %{env:DUNE_COQ_TEST=disable} enable)))

--- a/test/blackbox-tests/test-cases/coq/flags.t
+++ b/test/blackbox-tests/test-cases/coq/flags.t
@@ -16,39 +16,73 @@ Test case: default flags
   >  (name foo))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ runFlags() {
+  > jq '.[] | select(.name == "coqc") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  > }
+
+  $ dune build foo.vo --trace-file trace.json
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: :standard
 
@@ -59,39 +93,69 @@ TC: :standard
   > EOF
 
   $ rm _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: override :standard
 
@@ -101,39 +165,68 @@ TC: override :standard
   >  (flags ))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: add to :standard
 
@@ -143,39 +236,71 @@ TC: add to :standard
   >  (flags :standard -type-in-type))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
+
 
 TC: extend in workspace + override standard
 
@@ -190,39 +315,69 @@ TC: extend in workspace + override standard
   > (env (dev (coq (flags -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in workspace + override standard
 
@@ -231,39 +386,70 @@ TC: extend in workspace + override standard
   > (env (dev (coq (flags :standard -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + override standard
 
@@ -274,39 +460,69 @@ TC: extend in dune (env) + override standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + standard
 
@@ -317,39 +533,71 @@ TC: extend in dune (env) + standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q -type-in-type -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-type-in-type"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + workspace + standard
 
@@ -365,36 +613,68 @@ TC: extend in dune (env) + workspace + standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  $ dune build --trace-file trace.json foo.vo
   Warning: Dune's Coq Build Language is deprecated, and will be removed in Dune
   3.24. Please upgrade to the new Rocq Build Language.
   Hint: To disable this warning, add the following to your dune-project file:
   (warnings (deprecated_coq_lang disabled))
-  coqc -q -type-in-type -bt
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -I lib/coq/../coq-core/plugins/btauto
-  -I lib/coq/../coq-core/plugins/cc
-  -I lib/coq/../coq-core/plugins/derive
-  -I lib/coq/../coq-core/plugins/extraction
-  -I lib/coq/../coq-core/plugins/firstorder
-  -I lib/coq/../coq-core/plugins/funind
-  -I lib/coq/../coq-core/plugins/ltac
-  -I lib/coq/../coq-core/plugins/ltac2
-  -I lib/coq/../coq-core/plugins/micromega
-  -I lib/coq/../coq-core/plugins/nsatz
-  -I lib/coq/../coq-core/plugins/number_string_notation
-  -I lib/coq/../coq-core/plugins/ring
-  -I lib/coq/../coq-core/plugins/rtauto
-  -I lib/coq/../coq-core/plugins/ssreflect
-  -I lib/coq/../coq-core/plugins/ssrmatching
-  -I lib/coq/../coq-core/plugins/tauto
-  -I lib/coq/../coq-core/plugins/tutorial/p0
-  -I lib/coq/../coq-core/plugins/tutorial/p1
-  -I lib/coq/../coq-core/plugins/tutorial/p2
-  -I lib/coq/../coq-core/plugins/tutorial/p3
-  -I lib/coq/../coq-core/plugins/zify
-  -R coq/theories Coq
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "-q"
+  "-type-in-type"
+  "-bt"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-I"
+  "coq/../coq-core/plugins/btauto"
+  "-I"
+  "coq/../coq-core/plugins/cc"
+  "-I"
+  "coq/../coq-core/plugins/derive"
+  "-I"
+  "coq/../coq-core/plugins/extraction"
+  "-I"
+  "coq/../coq-core/plugins/firstorder"
+  "-I"
+  "coq/../coq-core/plugins/funind"
+  "-I"
+  "coq/../coq-core/plugins/ltac"
+  "-I"
+  "coq/../coq-core/plugins/ltac2"
+  "-I"
+  "coq/../coq-core/plugins/micromega"
+  "-I"
+  "coq/../coq-core/plugins/nsatz"
+  "-I"
+  "coq/../coq-core/plugins/number_string_notation"
+  "-I"
+  "coq/../coq-core/plugins/ring"
+  "-I"
+  "coq/../coq-core/plugins/rtauto"
+  "-I"
+  "coq/../coq-core/plugins/ssreflect"
+  "-I"
+  "coq/../coq-core/plugins/ssrmatching"
+  "-I"
+  "coq/../coq-core/plugins/tauto"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p0"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p1"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p2"
+  "-I"
+  "coq/../coq-core/plugins/tutorial/p3"
+  "-I"
+  "coq/../coq-core/plugins/zify"
+  "-R"
+  "coq/theories"
+  "Coq"
+  "-R"
+  "."
+  "foo"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
@@ -40,7 +40,7 @@ so this also tests that it won't be a problem.
 
 
 Next we go into our Dune project and build it.
-  $ dune build --root A
+  $ dune build --trace-file trace.json --root A
   Entering directory 'A'
   Inductive hello : Set :=
       I : hello | am : hello | an : hello | install : hello | loc : hello.
@@ -48,19 +48,54 @@ Next we go into our Dune project and build it.
 
 Now we check the flags that were passed to coqdep and coqc:
 
-  $ tail -4 A/_build/log | head -2 | ../scrub_coq_args.sh
-  rocq dep
-  -boot
-  -R coq/theories Corelib
-  -Q $TESTCASE_ROOT/lib/coq/user-contrib/B B
-  -R . A -dyndep opt -vos a.v >
-  _build/default/.A.theory.d
-  rocq compile -q
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -Q $TESTCASE_ROOT/lib/coq/user-contrib/B B
-  -R . A
-  a.v
+  $ jq '.[] | select(.name == "rocq" or .name == "coqdep") | {name, args: (.args.process_args | map(sub(".*/coq-core"; "coq-core")))}' trace.json
+  {
+    "name": "rocq",
+    "args": [
+      "--config"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "dep",
+      "-boot",
+      "-R",
+      "$TESTCASE_ROOT/lib/coq/theories",
+      "Corelib",
+      "-Q",
+      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "B",
+      "-R",
+      ".",
+      "A",
+      "-dyndep",
+      "opt",
+      "-vos",
+      "a.v"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "compile",
+      "-q",
+      "-w",
+      "-deprecated-native-compiler-option",
+      "-w",
+      "-native-compiler-disabled",
+      "-native-compiler",
+      "ondemand",
+      "-boot",
+      "-R",
+      "$TESTCASE_ROOT/lib/coq/theories",
+      "Corelib",
+      "-Q",
+      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "B",
+      "-R",
+      ".",
+      "A",
+      "a.v"
+    ]
+  }

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-flags-header-footer.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-flags-header-footer.t
@@ -24,18 +24,38 @@ Testing the rocqdoc_header and rocqdoc_footer field of the env stanza.
   > footer
   > EOF
 
-  $ dune build @doc
+  $ dune build --trace-file trace.json @doc
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*rocq/rocq/'
-  rocq doc
-  -R coq/theories Corelib
-  -R . a --toc --with-header header.html --with-footer footer.html --html -d a.html
-  foo.v
+  $ jq -c '.[] | select(.cat == "process" and .args.process_args.[0] == "doc") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  "doc"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "--with-header"
+  "header.html"
+  "--with-footer"
+  "footer.html"
+  "--html"
+  "-d"
+  "a.html"
+  "foo.v"
 
-  $ dune build @doc-latex
+  $ dune build --trace-file trace.json @doc-latex
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*rocq/rocq/'
-  rocq doc
-  -R coq/theories Corelib
-  -R . a --toc --latex -d a.tex
-  foo.v
+  $ jq -c '.[] | select(.cat == "process" and .args.process_args.[0] == "doc") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  "doc"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "--latex"
+  "-d"
+  "a.tex"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-flags.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-flags.t
@@ -17,10 +17,20 @@ Testing the coqdoc flags field of the env stanza.
   > Definition a := 42.
   > EOF
 
-  $ dune build @doc
+  $ dune build --trace-file trace.json @doc
 
-  $ tail _build/log -n 1 | ./scrub_coq_args.sh | sed 's/.*rocq/rocq/'
-  rocq doc
-  -R coq/theories Corelib
-  -R . a --toc -toc-depth 2 --html -d a.html
-  foo.v
+  $ jq '.[] | select(.cat == "process" and .args.process_args.[0] == "doc") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  "doc"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "a"
+  "--toc"
+  "-toc-depth"
+  "2"
+  "--html"
+  "-d"
+  "a.html"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
@@ -1,6 +1,6 @@
 Testing coqdoc when composed with a boot library
 
-  $ dune build A/A.html
+  $ dune build --trace-file trace.json A/A.html
 
   $ ls _build/default/A
   A.html
@@ -12,8 +12,5 @@ Testing coqdoc when composed with a boot library
 
 Dune should be passing '--coqlib' to coqdoc, but it doesn't. This is a bug.
 
-  $ cat _build/log | sed 's/$ (cd .*rocq/rocq/' | sed '/# /d' | sed '/> /d' | sort
-  rocq compile -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -boot -R Coq Corelib Coq/mytheory.v)
-  rocq compile -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Corelib -R A A A/a.v)
-  rocq compile -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -noinit -boot -R Coq Corelib Coq/Init/Prelude.v)
-  rocq doc -R ../Coq Corelib -R . A --toc --html -d A.html a.v)
+  $ jq -c '.[] | select(.cat == "process" and .args.process_args.[0] == "doc") | .args.process_args' trace.json
+  ["doc","-R","../Coq","Corelib","-R",".","A","--toc","--html","-d","A.html","a.v"]

--- a/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-flags.t/run.t
@@ -1,16 +1,25 @@
 Testing that the correct flags are being passed to dune rocq top
 
 The flags passed to coqc:
-  $ dune build && tail -1 _build/log | ../../scrub_coq_args.sh
-  rocq compile
-  -w -notation-overridden
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . minimal
-  Test.v
+  $ dune build --trace-file trace.json
+  $ jq '.[] | select(.cat == "process" and (.args.process_args.[0] == "compile")) | .args.process_args | .[] | sub(".*/coq/theories"; "coq/theories")' trace.json
+  "compile"
+  "-w"
+  "-notation-overridden"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "minimal"
+  "Test.v"
 
 The flags passed to coqtop:
   $ dune rocq top --toplevel=echo Test.v | ../../scrub_coq_args.sh

--- a/test/blackbox-tests/test-cases/rocq/dune
+++ b/test/blackbox-tests/test-cases/rocq/dune
@@ -3,7 +3,7 @@
 
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:rocq} scrub_coq_args.sh)
+ (deps %{bin:jq} %{bin:rocq} scrub_coq_args.sh)
  (alias runtest-rocq)
  (enabled_if
   (= %{env:DUNE_ROCQ_TEST=disable} enable)))

--- a/test/blackbox-tests/test-cases/rocq/flags.t
+++ b/test/blackbox-tests/test-cases/rocq/flags.t
@@ -16,15 +16,42 @@ Test case: default flags
   >  (name foo))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags() {
+  > dune clean
+  > dune build --trace-file trace.json foo.vo
+  > jq -c '.[] | select(.name == "rocq") | .args.process_args | .[] | sub(".*/coq/"; "coq/")' trace.json
+  > }
+
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: :standard
 
@@ -34,16 +61,37 @@ TC: :standard
   >  (flags :standard))
   > EOF
 
-  $ rm _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ dune build --trace-file trace.json foo.vo
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: override :standard
 
@@ -53,15 +101,35 @@ TC: override :standard
   >  (flags ))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: add to :standard
 
@@ -71,15 +139,37 @@ TC: add to :standard
   >  (flags :standard -type-in-type))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in workspace + override standard
 
@@ -94,15 +184,36 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in workspace + override standard
 
@@ -111,15 +222,37 @@ TC: extend in workspace + override standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + override standard
 
@@ -129,16 +262,36 @@ TC: extend in dune (env) + override standard
   > (env (dev (rocq (flags -type-in-type))))
   > EOF
 
-  $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + standard
 
@@ -148,16 +301,38 @@ TC: extend in dune (env) + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q -type-in-type -type-in-type
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-type-in-type"
+  "-type-in-type"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"
 
 TC: extend in dune (env) + workspace + standard
 
@@ -172,13 +347,35 @@ TC: extend in dune (env) + workspace + standard
   > (env (dev (rocq (flags :standard -type-in-type))))
   > EOF
 
-  $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
-  rocq compile -q -type-in-type -bt
-  -w -deprecated-native-compiler-option
-  -w -native-compiler-disabled
-  -native-compiler ondemand
-  -boot
-  -R coq/theories Corelib
-  -R . foo
-  foo.v
+  $ runFlags
+  "--config"
+  "dep"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "-dyndep"
+  "opt"
+  "-vos"
+  "foo.v"
+  "compile"
+  "-q"
+  "-type-in-type"
+  "-bt"
+  "-w"
+  "-deprecated-native-compiler-option"
+  "-w"
+  "-native-compiler-disabled"
+  "-native-compiler"
+  "ondemand"
+  "-boot"
+  "-R"
+  "coq/theories"
+  "Corelib"
+  "-R"
+  "."
+  "foo"
+  "foo.v"

--- a/test/blackbox-tests/test-cases/rocq/modules_flags.t
+++ b/test/blackbox-tests/test-cases/rocq/modules_flags.t
@@ -7,6 +7,21 @@ Reproducing test case for https://github.com/ocaml/dune/issues/12638.
 
   $ touch foo.v bar.v
 
+  $ jqScript=$(mktemp)
+
+  $ cat >$jqScript <<'EOF'
+  > .[] |
+  > select(.cat == "process") |
+  > .args.process_args as $arr |
+  > [range(0; $arr | length - 1) as $i |
+  >   if ($arr[$i] == "-w" and ($arr[$i + 1] | contains("deprecated"))) then [$arr[$i], $arr[$i + 1]] else empty end]
+  > | .[]
+  > EOF
+
+  $ printFlags() {
+  > jq -f $jqScript trace.json
+  > }
+
   $ cat > dune <<EOF
   > (rocq.theory
   >  (name a)
@@ -15,10 +30,27 @@ Reproducing test case for https://github.com/ocaml/dune/issues/12638.
   >   (bar (-w -deprecated-since-8.16))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh | grep deprecated-since
-  -w -deprecated-since-8.15
-  $ dune build bar.vo && tail -n 1 _build/log | ./scrub_coq_args.sh | grep deprecated-since
-  -w -deprecated-since-8.16
+  $ dune build --trace-file trace.json foo.vo
+  $ printFlags
+  [
+    "-w",
+    "-deprecated-since-8.15"
+  ]
+  [
+    "-w",
+    "-deprecated-native-compiler-option"
+  ]
+
+  $ dune build --trace-file trace.json bar.vo
+  $ printFlags
+  [
+    "-w",
+    "-deprecated-since-8.16"
+  ]
+  [
+    "-w",
+    "-deprecated-native-compiler-option"
+  ]
   $ dune clean
 
   $ cat > dune <<EOF
@@ -28,7 +60,19 @@ Reproducing test case for https://github.com/ocaml/dune/issues/12638.
   >   (bar (-w -deprecated-since-8.16))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh | grep deprecated-since
-  [1]
-  $ dune build bar.vo && tail -n 1 _build/log | ./scrub_coq_args.sh | grep deprecated-since
-  -w -deprecated-since-8.16
+  $ dune build --trace-file trace.json foo.vo
+  $ printFlags
+  [
+    "-w",
+    "-deprecated-native-compiler-option"
+  ]
+  $ dune build --trace-file trace.json bar.vo
+  $ printFlags
+  [
+    "-w",
+    "-deprecated-since-8.16"
+  ]
+  [
+    "-w",
+    "-deprecated-native-compiler-option"
+  ]


### PR DESCRIPTION
Use trace + jq as elsewhere in dune's test suite.