### PR TITLE
Move Let_syntax to own module

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -58,12 +58,6 @@ open struct
 end
 
 module Package = Dune_lang.Package
-
-module Let_syntax = struct
-  let ( let+ ) t f = Term.(const f $ t)
-  let ( and+ ) a b = Term.(const (fun x y -> x, y) $ a $ b)
-end
-
 open Let_syntax
 
 let copts_sect = "COMMON OPTIONS"

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -82,11 +82,6 @@ val build_info : unit Cmdliner.Term.t
 
 val default_build_dir : string
 
-module Let_syntax : sig
-  val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
-  val ( and+ ) : 'a Cmdliner.Term.t -> 'b Cmdliner.Term.t -> ('a * 'b) Cmdliner.Term.t
-end
-
 (** [one_of term1 term2] allows options from [term1] or exclusively options from
     [term2]. If the user passes options from both terms, an error is reported. *)
 val one_of : 'a Cmdliner.Term.t -> 'a Cmdliner.Term.t -> 'a Cmdliner.Term.t

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -86,7 +86,7 @@ end
 
 module Dune_rpc = Dune_rpc_private
 module Graph = Dune_graph.Graph
-include Common.Let_syntax
+include Let_syntax
 
 module Main : sig
   include module type of struct

--- a/bin/let_syntax.ml
+++ b/bin/let_syntax.ml
@@ -1,0 +1,2 @@
+let ( let+ ) t f = Cmdliner.Term.(const f $ t)
+let ( and+ ) a b = Cmdliner.Term.(const (fun x y -> x, y) $ a $ b)

--- a/bin/let_syntax.mli
+++ b/bin/let_syntax.mli
@@ -1,0 +1,2 @@
+val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
+val ( and+ ) : 'a Cmdliner.Term.t -> 'b Cmdliner.Term.t -> ('a * 'b) Cmdliner.Term.t


### PR DESCRIPTION
This "Common" module is getting much too big and we need to start using parts of it without pulling in everything.