### PR TITLE
Dune trace: emit final event

### DIFF
--- a/doc/changes/added/13018.md
+++ b/doc/changes/added/13018.md
@@ -1,0 +1,1 @@
+- Emit final trace event before exiting. (#13018, @rgrinberg)

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -10,7 +10,9 @@ let () =
   at_exit (fun () ->
     match !global with
     | None -> ()
-    | Some t -> Out.close t)
+    | Some t ->
+      Out.emit t (Event.exit ());
+      Out.close t)
 ;;
 
 let set_global t =

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -76,6 +76,13 @@ let config ~version =
   Event.instant ~args common
 ;;
 
+let exit () =
+  let open Chrome_trace in
+  let ts = Event.Timestamp.of_float_seconds (Time.now () |> Time.to_secs) in
+  let common = Event.common_fields ~cat:[ "config" ] ~name:"exit" ~ts () in
+  Event.instant common
+;;
+
 let scheduler_idle () =
   let fields =
     let ts =


### PR DESCRIPTION
Emit final event before exiting. This is mostly useful for automation