### PR TITLE
dune_trace: add config category

### DIFF
--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -13,6 +13,7 @@ type t =
   | Promote
   | Build
   | Debug
+  | Config
 
 let all =
   [ Rpc
@@ -27,6 +28,7 @@ let all =
   ; Promote
   ; Build
   ; Debug
+  ; Config
   ]
 ;;
 
@@ -43,6 +45,7 @@ let to_string = function
   | Promote -> "promote"
   | Build -> "build"
   | Debug -> "debug"
+  | Config -> "config"
 ;;
 
 let of_string =
@@ -71,5 +74,6 @@ module Set = Bit_set.Make (struct
       | Promote -> 9
       | Build -> 10
       | Debug -> 11
+      | Config -> 12
     ;;
   end)

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -11,6 +11,7 @@ type t =
   | Promote
   | Build
   | Debug
+  | Config
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -14,6 +14,7 @@ module Category : sig
     | Promote
     | Build
     | Debug
+    | Config
 
   val of_string : string -> t option
 end

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -75,14 +75,18 @@ let config ~version =
   in
   let open Chrome_trace in
   let ts = make_ts (Time.now ()) in
-  let common = Event.common_fields ~cat:[ "config" ] ~name:"config" ~ts () in
+  let common =
+    Event.common_fields ~cat:[ Category.to_string Config ] ~name:"config" ~ts ()
+  in
   Event.instant ~args common
 ;;
 
 let exit () =
   let open Chrome_trace in
   let ts = make_ts (Time.now ()) in
-  let common = Event.common_fields ~cat:[ "config" ] ~name:"exit" ~ts () in
+  let common =
+    Event.common_fields ~cat:[ Category.to_string Config ] ~name:"exit" ~ts ()
+  in
   Event.instant common
 ;;
 


### PR DESCRIPTION
Instead of keeping it stringly typed, we add a proper constructor