### PR TITLE
dune_trace: simplify event format

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,6 @@
               file
               jq
               mercurial
-              perl
               unzip
               coreutils
               bc

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -101,7 +101,7 @@ module Session = struct
   let create fd =
     Unix.set_nonblock fd;
     let id = Id.gen () in
-    Dune_trace.emit Rpc (fun () -> Dune_trace.Event.Rpc.session ~id:(Id.to_int id) Start);
+    Dune_trace.emit Rpc (fun () -> Dune_trace.Event.Rpc.session ~id:(Id.to_int id) `Start);
     let state =
       let size = 8192 in
       Open

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -88,8 +88,9 @@ module Event : sig
 
   module Rpc : sig
     type stage =
-      | Start
-      | Stop
+      [ `Start
+      | `Stop
+      ]
 
     val session : id:int -> stage -> t
 

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -132,4 +132,4 @@
 
 (cram
  (applies_to trace-file)
- (deps %{bin:perl}))
+ (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -1,18 +1,128 @@
+  $ export DUNE_TRACE="process,gc"
   $ dune build prog.exe --trace-file trace.json
 
 This captures the commands that are being run:
 
-  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g' | perl -pe 's/"prog":".*?"/"prog":"PROG"/g'
-  {"args":{"dir":"."},"ph":"X","dur":...,"name":"Dune load: .","cat":"","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-config"],"pid":...,"categories":[],"prog":"PROG","dir":".","exit":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...,"categories":[],"prog":"PROG","dir":"_build/default","exit":...,"target_files":["_build/default/.prog.eobjs/prog.impl.d"]},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-bin-annot-occurrences","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...,"categories":[],"prog":"PROG","dir":"_build/default","exit":...,"target_files":["_build/default/.prog.eobjs/byte/prog.cmi","_build/default/.prog.eobjs/byte/prog.cmo","_build/default/.prog.eobjs/byte/prog.cmt"]},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-cmi-file",".prog.eobjs/byte/prog.cmi","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"],"pid":...,"categories":[],"prog":"PROG","dir":"_build/default","exit":...,"target_files":["_build/default/.prog.eobjs/native/prog.cmx","_build/default/.prog.eobjs/native/prog.o"]},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"],"pid":...,"categories":[],"prog":"PROG","dir":"_build/default","exit":...,"target_files":["_build/default/prog.exe"]},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"path":"_build/.db","module":"INCREMENTAL-DB","operation":"save"},"ph":"X","dur":...,"name":"db","cat":"","ts":...,"pid":...,"tid":...}
-  {"args":{"path":"_build/.digest-db","module":"DIGEST-DB","operation":"save"},"ph":"X","dur":...,"name":"db","cat":"","ts":...,"pid":...,"tid":...}
+  $ jq '.[] | select(.cat == "process") | .args | del(.pid) | .prog |= sub(".*/"; "")' trace.json
+  {
+    "process_args": [
+      "-config"
+    ],
+    "categories": [],
+    "prog": "ocamlc.opt",
+    "dir": ".",
+    "exit": 0
+  }
+  {
+    "process_args": [
+      "-modules",
+      "-impl",
+      "prog.ml"
+    ],
+    "categories": [],
+    "prog": "ocamldep.opt",
+    "dir": "_build/default",
+    "exit": 0,
+    "target_files": [
+      "_build/default/.prog.eobjs/prog.impl.d"
+    ]
+  }
+  {
+    "process_args": [
+      "-w",
+      "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+      "-strict-sequence",
+      "-strict-formats",
+      "-short-paths",
+      "-keep-locs",
+      "-g",
+      "-bin-annot",
+      "-bin-annot-occurrences",
+      "-I",
+      ".prog.eobjs/byte",
+      "-no-alias-deps",
+      "-opaque",
+      "-o",
+      ".prog.eobjs/byte/prog.cmo",
+      "-c",
+      "-impl",
+      "prog.ml"
+    ],
+    "categories": [],
+    "prog": "ocamlc.opt",
+    "dir": "_build/default",
+    "exit": 0,
+    "target_files": [
+      "_build/default/.prog.eobjs/byte/prog.cmi",
+      "_build/default/.prog.eobjs/byte/prog.cmo",
+      "_build/default/.prog.eobjs/byte/prog.cmt"
+    ]
+  }
+  {
+    "process_args": [
+      "-w",
+      "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+      "-strict-sequence",
+      "-strict-formats",
+      "-short-paths",
+      "-keep-locs",
+      "-g",
+      "-I",
+      ".prog.eobjs/byte",
+      "-I",
+      ".prog.eobjs/native",
+      "-cmi-file",
+      ".prog.eobjs/byte/prog.cmi",
+      "-no-alias-deps",
+      "-opaque",
+      "-o",
+      ".prog.eobjs/native/prog.cmx",
+      "-c",
+      "-impl",
+      "prog.ml"
+    ],
+    "categories": [],
+    "prog": "ocamlopt.opt",
+    "dir": "_build/default",
+    "exit": 0,
+    "target_files": [
+      "_build/default/.prog.eobjs/native/prog.cmx",
+      "_build/default/.prog.eobjs/native/prog.o"
+    ]
+  }
+  {
+    "process_args": [
+      "-w",
+      "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+      "-strict-sequence",
+      "-strict-formats",
+      "-short-paths",
+      "-keep-locs",
+      "-g",
+      "-o",
+      "prog.exe",
+      ".prog.eobjs/native/prog.cmx"
+    ],
+    "categories": [],
+    "prog": "ocamlopt.opt",
+    "dir": "_build/default",
+    "exit": 0,
+    "target_files": [
+      "_build/default/prog.exe"
+    ]
+  }
 
 As well as data about the garbage collector:
 
-  $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/([^0-9])[0-9]+/\1.../g' | sort -u
-  {"ph":"C","args":{"value":...},"name":"evaluated_rules","cat":"","ts":...,"pid":...,"tid":...}
+  $ jq '[ .[] | select(.cat == "gc") ] | .[0] | .args | keys' trace.json
+  [
+    "compactions",
+    "heap_words",
+    "major_collections",
+    "major_words",
+    "minor_collections",
+    "minor_words",
+    "promoted_words",
+    "stack_size",
+    "top_heap_words"
+  ]


### PR DESCRIPTION
First, we remove counter events. Those aren't any better than instant events with arguments.

Second, we wrap most of the chrome_trace API in a single module. We plan to move away from this format for various reasons.

Thirdly, we add some missing categories. Looks like some events were emitted without categories. The new API forbids emitting such events.

Lastly, we get rid of perl for jq.