### PR TITLE
Dune_trace: add pid and initial_cwd to initial event

### DIFF
--- a/doc/changes/added/13026.md
+++ b/doc/changes/added/13026.md
@@ -1,0 +1,1 @@
+- Add the initial cwd to the first config event (#13026, @rgrinberg)

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -85,6 +85,8 @@ let config ~version =
       ; "argv", `List (Array.to_list Sys.argv |> List.map ~f:Json.string)
       ; "env", `List (Unix.environment () |> Array.to_list |> List.map ~f:Json.string)
       ; "root", `String Path.(to_absolute_filename root)
+      ; "pid", `Int (Unix.getpid ())
+      ; "initial_cwd", Json.string Fpath.initial_cwd
       ]
     in
     match version with


### PR DESCRIPTION
The pid is already there, but we add it here anyway as we are planning to remove the redundant pid elsewhere.