### PR TITLE
dune trace: move evaluated rules counter under debug

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -308,7 +308,7 @@ end = struct
   ;;
 
   let report_evaluated_rule_exn () =
-    Dune_trace.emit Rules (fun () ->
+    Dune_trace.emit Debug (fun () ->
       let rule_total =
         match Fiber.Svar.read State.t with
         | Building progress -> progress.number_of_rules_discovered


### PR DESCRIPTION
It's hardly useful, and quite noisy.