### PR TITLE
fix: Truncate rev store lock

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -380,6 +380,7 @@ let with_flock lock_path ~f =
        | Ok `Success ->
          Fiber.finalize
            (fun () ->
+              Unix.ftruncate fd 0;
               Dune_util.Global_lock.write_pid fd;
               f ())
            ~finally:(fun () ->


### PR DESCRIPTION
Truncate the rev store before writing the pid. Otherwise, we can get
some leftover.

This is the exact same issue that we've had with dune's own lock file.
In a subsequent PR, we'll tweak the API so that this issue becomes
impossible.
