### PR TITLE
Update submodule test now that things work

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/git-submodule.t
+++ b/test/blackbox-tests/test-cases/pkg/git-submodule.t
@@ -35,14 +35,13 @@ someotherrepo as a submodule.
   > (build (progn (run cat foo) (run cat mysubmodule/bar)))
   > EOF
 
-Building this package should pull in both repositories. At the moment this is
-not the case and only somerepo is pulled.
+Building this package should pull in both repositories:
 
-  $ build_pkg test 2>&1 | sed -E 's|.*/cat|cat|'
+  $ build_pkg test
   hello
   world
 
-When the above works it should act like:
+It should act exactly like:
 
   $ make_lockpkg test <<EOF
   > (version 0.0.1)


### PR DESCRIPTION
While going through the tests looking at the usages of `sed` I noticed that this test works now (fixed in #12046) so I've updated the wording and removed `sed`.