### PR TITLE
Improve `dune_pkg_lock_normalized`

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -20,14 +20,14 @@ project:
   $ mkpkg dune 2.0.0
 
 Solve the dependencies:
-  $ dune_pkg_lock_normalized | sed -E 's/"3.[0-9]+"/"3.XX"/'
+  $ dune_pkg_lock_normalized | dune_cmd subst '3.[0-9]+' '3.XX'
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
   Couldn't solve the package dependency formula.
   Selected candidates: foo.dev
   - dune -> (problem)
-      User requested = 3.21
-      foo dev requires < 3.0
+      User requested = 3.XX
+      foo dev requires < 3.XX
       Rejected candidates:
-        dune.3.21: Incompatible with restriction: < 3.0
+        dune.3.XX: Incompatible with restriction: < 3.XX


### PR DESCRIPTION
1. The `sed` command didn't do the right thing, so it was replaced by `dune_cmd subst`
2. `dune_cmd subst` added training newlines everywhere, but this is only correct for stdout. It shouldn't append them to files. That made files have trailing newlines. This change fixes inplace editing.
3. `dune_pkg_lock_normalized` created a file `solve-stderr.txt` in the folder. Use a temporary file instead.