### PR TITLE
Dune trace subcommand

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -40,6 +40,7 @@ let all : _ Cmdliner.Cmd.t list =
     ; Pkg.Group.group
     ; Pkg.Group.Alias.group
     ; Tools.Group.group
+    ; Trace.group
     ]
   in
   terms @ groups

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -1,0 +1,27 @@
+open Import
+
+let cat =
+  let info = Cmd.info "cat" in
+  let term =
+    let+ () = Term.const () in
+    let bytes = Bytes.create (1 lsl 16) in
+    Io.String_path.with_file_in ~binary:true "_build/trace.json" ~f:(fun i ->
+      let rec loop () =
+        match input i bytes 0 (Bytes.length bytes) with
+        | 0 | (exception End_of_file) -> ()
+        | n ->
+          output stdout bytes 0 n;
+          loop ()
+      in
+      loop ())
+  in
+  Cmd.v info term
+;;
+
+let group =
+  let info =
+    let doc = "Commands to view dune's event trace" in
+    Cmd.info "trace" ~doc
+  in
+  Cmd.group info [ cat ]
+;;

--- a/bin/trace.mli
+++ b/bin/trace.mli
@@ -1,0 +1,3 @@
+open Import
+
+val group : unit Cmd.t

--- a/doc/changes/added/13055.md
+++ b/doc/changes/added/13055.md
@@ -1,0 +1,2 @@
+- Introduce the `$ dune trace cat` subcommand to view the trace file. (#13055,
+  @rgrinberg)

--- a/doc/changes/changed/13015.md
+++ b/doc/changes/changed/13015.md
@@ -1,0 +1,2 @@
+- Move all logging statements to the trace file. All log statements now contain
+  structured payloads (#13015, fixes #12904, @rgrinberg)

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -1,0 +1,18 @@
+dune trace cat can be used to view the trace:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+  $ dune build
+  $ dune trace cat | jq -c '.[] | keys'
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","dur","name","ph","pid","tid","ts"]
+  ["args","cat","name","ph","pid","tid","ts"]
+  ["args","cat","dur","name","ph","pid","tid","ts"]
+  ["args","cat","dur","name","ph","pid","tid","ts"]
+  ["cat","name","ph","pid","tid","ts"]

--- a/test/blackbox-tests/test-cases/trace/dune
+++ b/test/blackbox-tests/test-cases/trace/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:jq}))


### PR DESCRIPTION
For now, this command is fairly useless as it's essentially just `cat` with a fixed file location.

More features will be added once we change the default format.