### PR TITLE
refactor: distinguish between unexpanded vs expanded install entries

### DIFF
--- a/bin/describe/package_entries.ml
+++ b/bin/describe/package_entries.ml
@@ -15,7 +15,7 @@ let term =
   @@ fun () ->
   let open Memo.O in
   Dune_rules.Install_rules.stanzas_to_entries super_context
-  >>| Package.Name.Map.to_dyn (Dyn.list Install.Entry.Sourced.to_dyn)
+  >>| Package.Name.Map.to_dyn (Dyn.list Install.Entry.Sourced.Unexpanded.to_dyn)
   >>| Describe_format.print_dyn format
 ;;
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -437,7 +437,7 @@ let install_entry
       ~package
       ~dir
       ~create_install_files
-      (entry : Path.t Install.Entry.t)
+      (entry : Path.t Install.Entry.Expanded.t)
       ~dst
       ~verbosity
   =
@@ -478,7 +478,7 @@ let install_entry
       in
       Ops.copy_file ~src:entry.src ~dst ~executable ~kind ~package ~conf
     in
-    Install.Entry.set_src entry dst
+    Install.Entry.Expanded.set_src entry dst
 ;;
 
 let run
@@ -582,8 +582,8 @@ let run
       let entries_per_package =
         List.map install_files ~f:(fun (package, install_file) ->
           let entries =
-            Install.Entry.load_install_file install_file Path.of_local
-            |> List.filter ~f:(fun (entry : Path.t Install.Entry.t) ->
+            Install.Entry.Expanded.load_install_file install_file Path.of_local
+            |> List.filter ~f:(fun (entry : Path.t Install.Entry.Expanded.t) ->
               Sections.should_install sections entry.section)
           in
           match
@@ -680,7 +680,8 @@ let run
                 ~findlib_toolchain:(Context.findlib_toolchain context)
                 package
             in
-            Install.Entry.gen_install_file entries |> Io.write_file (Path.source fn))))
+            Install.Entry.Expanded.gen_install_file entries
+            |> Io.write_file (Path.source fn))))
   in
   Path.Set.to_list !files_deleted_in
   (* This [List.rev] is to ensure we process children directories before

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -1292,9 +1292,13 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Coq_stanza.Theory.t)
         let dst = Path.Local.(to_string (relative dst_dir plugin_file_basename)) in
         let entry =
           (* TODO this [loc] should come from [s.buildable.libraries] *)
-          Install.Entry.make Section.Lib_root ~dst ~kind:`File plugin_file
+          Install.Entry.Unexpanded.make
+            Section.Lib_root
+            ~dst
+            ~kind:Install.Entry.Unexpanded.File
+            plugin_file
         in
-        Install.Entry.Sourced.create ~loc entry))
+        Install.Entry.Sourced.Unexpanded.create ~loc entry))
     else []
   in
   List.concat_map ~f:rules_for_lib ml_libs
@@ -1337,9 +1341,13 @@ let install_rules ~sctx ~dir s =
     let to_dst f = Path.Local.to_string @@ Path.Local.relative dst_dir f in
     let make_entry (orig_file : Path.Build.t) (dst_file : string) =
       let entry =
-        Install.Entry.make Section.Lib_root ~dst:(to_dst dst_file) orig_file ~kind:`File
+        Install.Entry.Unexpanded.make
+          Section.Lib_root
+          ~dst:(to_dst dst_file)
+          orig_file
+          ~kind:Install.Entry.Unexpanded.File
       in
-      Install.Entry.Sourced.create ~loc entry
+      Install.Entry.Sourced.Unexpanded.create ~loc entry
     in
     let+ coq_sources = Dir_contents.coq dir_contents in
     coq_sources

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -63,6 +63,6 @@ val install_rules
   :  sctx:Super_context.t
   -> dir:Path.Build.t
   -> Coq_stanza.Theory.t
-  -> Install.Entry.Sourced.t list Memo.t
+  -> Install.Entry.Sourced.Unexpanded.t list Memo.t
 
 val coq_env : dir:Path.Build.t -> Coq_flags.t Action_builder.t

--- a/src/dune_rules/install_entry_with_site.ml
+++ b/src/dune_rules/install_entry_with_site.ml
@@ -5,15 +5,15 @@ module Dst = Entry.Dst
 
 let make_with_site (section : Section_with_site.t) ?dst get_section ~kind src =
   match section with
-  | Section section -> Memo.return (Entry.make section ?dst ~kind src)
+  | Section section -> Memo.return (Entry.Unexpanded.make section ?dst ~kind src)
   | Site { pkg; site; loc } ->
     let+ section = get_section ~loc ~pkg ~site in
     let dst =
       let dst = Entry.adjust_dst' ~src ~dst ~section in
       Dst.add_prefix (Site.to_string site) dst
     in
-    let dst_with_pkg_prefix = Dst.add_prefix (Package.Name.to_string pkg) dst in
     let (section : Section.t), dst =
+      let dst_with_pkg_prefix = Dst.add_prefix (Package.Name.to_string pkg) dst in
       match section with
       | Lib -> Lib_root, dst_with_pkg_prefix
       | Libexec -> Libexec_root, dst_with_pkg_prefix
@@ -30,7 +30,7 @@ let make_with_site (section : Section_with_site.t) ?dst get_section ~kind src =
       | Man
       | Misc -> section, dst
     in
-    Entry.make_with_dst section dst ~kind ~src
+    Entry.Unexpanded.make_with_dst section dst ~kind ~src
 ;;
 
 module Entry_with_site = struct

--- a/src/dune_rules/install_entry_with_site.mli
+++ b/src/dune_rules/install_entry_with_site.mli
@@ -6,9 +6,9 @@ val make_with_site
   :  Section_with_site.t
   -> ?dst:string
   -> (loc:Loc.t -> pkg:Package.Name.t -> site:Site.t -> Section.t Memo.t)
-  -> kind:Install.Entry.kind
+  -> kind:Install.Entry.Unexpanded.kind
   -> Path.Build.t
-  -> Path.Build.t Install.Entry.t Memo.t
+  -> Install.Entry.Unexpanded.t Memo.t
 
 (** Same as Entry, but the destination can be in the site of a package *)
 module Entry_with_site : sig

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -75,7 +75,7 @@ let check_runtime_deps_relative_path local_path ~loc ~lib_info =
 module Stanzas_to_entries : sig
   val stanzas_to_entries
     :  Super_context.t
-    -> Install.Entry.Sourced.t list Package.Name.Map.t Memo.t
+    -> Install.Entry.Sourced.Unexpanded.t list Package.Name.Map.t Memo.t
 end = struct
   let lib_ppxs ctx ~scope ~(lib : Library.t) =
     match lib.kind with
@@ -151,12 +151,12 @@ end = struct
            | None -> subdir
            | Some lib_subdir -> Filename.concat lib_subdir subdir)
     in
-    fun section ~loc ?sub_dir ?dst fn ->
+    fun section ~loc ?sub_dir ?dst ~kind fn ->
       let entry =
-        Install.Entry.make
+        Install.Entry.Unexpanded.make
           section
           fn
-          ~kind:`File
+          ~kind
           ~dst:
             (let dst =
                match dst with
@@ -167,17 +167,17 @@ end = struct
              | None -> dst
              | Some dir -> sprintf "%s/%s" dir dst)
       in
-      Install.Entry.Sourced.create ~loc entry
+      Install.Entry.Sourced.Unexpanded.create ~loc entry
   ;;
 
   let doc_install_files ~loc mld_contents =
     List.rev_map mld_contents ~f:(fun (mld : Doc_sources.mld) ->
-      Install.Entry.make
-        ~kind:`File
+      Install.Entry.Unexpanded.make
+        ~kind:Install.Entry.Unexpanded.File
         ~dst:(sprintf "odoc-pages/%s" (Path.Local.to_string mld.in_doc))
         Section.Doc
         mld.path
-      |> Install.Entry.Sourced.create ~loc)
+      |> Install.Entry.Sourced.Unexpanded.create ~loc)
   ;;
 
   let lib_install_files
@@ -243,7 +243,7 @@ end = struct
               in
               sub_dir, dst
           in
-          make_entry ?sub_dir Lib source ?dst))
+          make_entry ~kind:File ?sub_dir Lib source ?dst))
     in
     let additional_deps (loc, deps) =
       Lib_file_deps.eval deps ~expander ~loc ~paths:(Disallow_external lib_name)
@@ -255,8 +255,8 @@ end = struct
           ~jsoo_enabled:Jsoo_rules.jsoo_enabled
           path
         >>| function
-        | None -> path, `File
-        | Some dir_target_path -> dir_target_path, `Directory)
+        | None -> path, Install.Entry.Unexpanded.File
+        | Some dir_target_path -> dir_target_path, Directory)
       >>| Path.Build.Map.of_list_reduce ~f:(fun _ kind -> kind)
       >>| Path.Build.Map.to_list_map ~f:(fun path kind ->
         let sub_dir =
@@ -268,9 +268,7 @@ end = struct
             |> Path.Local.descendant ~of_:(Path.Build.local lib_src_dir)
             |> Option.map ~f:Path.Local.to_string
         in
-        let dep = make_entry ?sub_dir Lib path in
-        let entry = Install.Entry.set_kind dep.entry kind in
-        { dep with entry })
+        make_entry ~kind ?sub_dir Lib path)
     in
     let { Lib_config.has_native; ext_obj; _ } = lib_config in
     let { Lib_mode.Map.ocaml = { Mode.Dict.byte; native } as ocaml; melange } =
@@ -352,24 +350,28 @@ end = struct
     and+ dll_files =
       dll_files ~modes:ocaml ~dynlink:lib.dynlink ~ctx info
       >>| List.rev_map ~f:(fun a ->
-        let entry = Install.Entry.make ~kind:`File Stublibs a in
-        Install.Entry.Sourced.create ~loc entry)
+        let entry =
+          Install.Entry.Unexpanded.make ~kind:Install.Entry.Unexpanded.File Stublibs a
+        in
+        Install.Entry.Sourced.Unexpanded.create ~loc entry)
     in
     let install_c_headers =
       List.rev_map lib.install_c_headers ~f:(fun (loc, base) ->
         Path.Build.relative dir (base ^ Foreign_language.header_extension)
-        |> make_entry ~loc Lib)
+        |> make_entry ~kind:File ~loc Lib)
     in
     List.rev_concat
       [ sources
       ; melange_runtime_entries
-      ; List.rev_map module_files ~f:(fun (sub_dir, file) -> make_entry ?sub_dir Lib file)
+      ; List.rev_map module_files ~f:(fun (sub_dir, file) ->
+          make_entry ~kind:File ?sub_dir Lib file)
       ; (match lib.kind with
          | Parameter -> []
          | Virtual | Dune_file _ ->
            List.rev_concat
-             [ List.rev_map lib_files ~f:(fun (section, file) -> make_entry section file)
-             ; List.rev_map execs ~f:(make_entry Libexec)
+             [ List.rev_map lib_files ~f:(fun (section, file) ->
+                 make_entry ~kind:File section file)
+             ; List.rev_map execs ~f:(make_entry ~kind:File Libexec)
              ; dll_files
              ; install_c_headers
              ; public_headers
@@ -462,9 +464,9 @@ end = struct
     let+ files =
       Install_entry.File.to_file_bindings_expanded install_conf.files ~expand ~dir
       >>= Memo.List.map ~f:(fun fb ->
-        let+ entry = make_entry ~kind:`File fb in
+        let+ entry = make_entry ~kind:File fb in
         let loc = File_binding.Expanded.src_loc fb in
-        Install.Entry.Sourced.create ~loc entry)
+        Install.Entry.Sourced.Unexpanded.create ~loc entry)
     and+ files_from_dirs =
       Install_entry.Dir.to_file_bindings_expanded
         install_conf.dirs
@@ -473,8 +475,8 @@ end = struct
         ~relative_dst_path_starts_with_parent_error_when:`Deprecation_warning_from_3_11
       >>= Memo.List.map ~f:(fun fb ->
         let loc = File_binding.Expanded.src_loc fb in
-        let+ entry = make_entry ~kind:`Directory fb in
-        Install.Entry.Sourced.create ~loc entry)
+        let+ entry = make_entry ~kind:Directory fb in
+        Install.Entry.Sourced.Unexpanded.create ~loc entry)
     and+ source_trees =
       (* There's no deprecation warning when a relative destination path
          starts with a parent in this feature. It's safe to raise an error in
@@ -487,7 +489,7 @@ end = struct
         ~relative_dst_path_starts_with_parent_error_when:`Always_error
       >>= Memo.List.map ~f:(fun fb ->
         let loc = File_binding.Expanded.src_loc fb in
-        let* entry = make_entry ~kind:`Source_tree fb in
+        let* entry = make_entry ~kind:Source_tree fb in
         let+ () =
           Source_tree.find_dir (Path.Build.drop_build_context_exn entry.src)
           >>| function
@@ -495,7 +497,7 @@ end = struct
           | None ->
             User_error.raise ~loc [ Pp.text "This source directory does not exist" ]
         in
-        Install.Entry.Sourced.create ~loc entry)
+        Install.Entry.Sourced.Unexpanded.create ~loc entry)
     in
     List.rev_concat [ files; files_from_dirs; source_trees ]
   ;;
@@ -541,8 +543,12 @@ end = struct
         let opam_file = Package_paths.opam_file ctx pkg in
         let init =
           let file section local_file dst =
-            Install.Entry.make section local_file ~kind:`File ~dst
-            |> Install.Entry.Sourced.create
+            Install.Entry.Unexpanded.make
+              section
+              local_file
+              ~kind:Install.Entry.Unexpanded.File
+              ~dst
+            |> Install.Entry.Sourced.Unexpanded.create
           in
           let deprecated_meta_and_dune_files =
             Package.deprecated_package_names pkg
@@ -579,8 +585,13 @@ end = struct
             if is_odig_doc_file fn
             then (
               let odig_file = Path.Build.relative pkg_dir fn in
-              let entry = Install.Entry.make Doc ~kind:`File odig_file in
-              Install.Entry.Sourced.create entry :: acc)
+              let entry =
+                Install.Entry.Unexpanded.make
+                  Doc
+                  ~kind:Install.Entry.Unexpanded.File
+                  odig_file
+              in
+              Install.Entry.Sourced.Unexpanded.create entry :: acc)
             else acc))
     and+ entries =
       let* package_db = Package_db.create ctx.name in
@@ -606,8 +617,11 @@ end = struct
          for all. *)
       List.sort
         entries
-        ~compare:(fun (a : Install.Entry.Sourced.t) (b : Install.Entry.Sourced.t) ->
-          Install.Entry.compare Path.Build.compare a.entry b.entry))
+        ~compare:
+          (fun
+            (a : Install.Entry.Sourced.Unexpanded.t)
+            (b : Install.Entry.Sourced.Unexpanded.t)
+          -> Install.Entry.Unexpanded.compare a.entry b.entry))
   ;;
 
   let stanzas_to_entries =
@@ -732,11 +746,11 @@ end = struct
     let+ files =
       let+ map = Stanzas_to_entries.stanzas_to_entries sctx in
       Package.Name.Map.Multi.find map pkg_name
-      |> List.map ~f:(fun (e : Install.Entry.Sourced.t) ->
+      |> List.map ~f:(fun (e : Install.Entry.Sourced.Unexpanded.t) ->
         let kind =
           match e.entry.kind with
-          | `File -> `File
-          | `Directory | `Source_tree -> `Dir
+          | File -> `File
+          | Directory | Source_tree -> `Dir
         in
         e.entry.section, (kind, e.entry.dst))
       |> Section.Map.of_list_multi
@@ -972,11 +986,11 @@ let symlink_source_dir ~dir ~dst =
 
 let symlink_installed_artifacts_to_build_install
       (ctx : Build_context.t)
-      (entries : Install.Entry.Sourced.t list)
+      (entries : Install.Entry.Sourced.Unexpanded.t list)
       ~install_paths
   =
   let install_dir = Install.Context.dir ~context:ctx.name in
-  Memo.parallel_map entries ~f:(fun (s : Install.Entry.Sourced.t) ->
+  Memo.parallel_map entries ~f:(fun (s : Install.Entry.Sourced.Unexpanded.t) ->
     let entry = s.entry in
     let dst =
       let relative =
@@ -995,7 +1009,7 @@ let symlink_installed_artifacts_to_build_install
       Rule.make ~info:(From_dune_file loc) ~targets build
     in
     match entry.kind with
-    | `Source_tree ->
+    | Install.Entry.Unexpanded.Source_tree ->
       symlink_source_dir ~dir:src ~dst
       >>| List.map ~f:(fun (suffix, dst, build) ->
         let rule = rule build in
@@ -1004,22 +1018,25 @@ let symlink_installed_artifacts_to_build_install
             Install.Entry.map_dst entry ~f:(fun dst ->
               Install.Entry.Dst.add_suffix dst (Path.Local.to_string suffix))
           in
-          let entry = Install.Entry.set_src entry dst in
-          Install.Entry.set_kind entry `File
+          let entry = Install.Entry.Unexpanded.expand entry in
+          Install.Entry.Expanded.set_src entry dst
         in
         { s with entry }, rule)
-    | (`File | `Directory) as kind ->
+    | File ->
       let entry =
-        let entry = Install.Entry.set_src entry dst in
+        let entry = Install.Entry.Unexpanded.expand entry in
+        let entry = Install.Entry.Expanded.set_src entry dst in
         { s with entry }
       in
-      let action =
-        (match kind with
-         | `File -> Action_builder.symlink
-         | `Directory -> Action_builder.symlink_dir)
-          ~src
-          ~dst
+      let action = Action_builder.symlink ~src ~dst in
+      Memo.return [ entry, rule action ]
+    | Directory ->
+      let entry =
+        let entry = Install.Entry.Unexpanded.expand entry in
+        let entry = Install.Entry.Expanded.set_src entry dst in
+        { s with entry }
       in
+      let action = Action_builder.symlink_dir ~src ~dst in
       Memo.return [ entry, rule action ])
 ;;
 
@@ -1045,7 +1062,8 @@ let packages =
       Memo.parallel_map packages ~f:(fun (pkg : Package.t) ->
         Package.name pkg
         |> install_entries sctx
-        >>| List.map ~f:(fun (e : Install.Entry.Sourced.t) -> e.entry.src, Package.id pkg))
+        >>| List.map ~f:(fun (e : Install.Entry.Sourced.Unexpanded.t) ->
+          e.entry.src, Package.id pkg))
     in
     List.rev_concat l
     |> Path.Build.Map.of_list_fold ~init:Package.Id.Set.empty ~f:Package.Id.Set.add
@@ -1139,7 +1157,7 @@ let package_deps (pkg : Package.t) files =
 include (
 struct
   module Spec = struct
-    type ('path, 'target) t = Path.t Install.Entry.t list * 'target
+    type ('path, 'target) t = Path.t Install.Entry.Expanded.t list * 'target
 
     let name = "gen-install-file"
     let version = 2
@@ -1148,7 +1166,7 @@ struct
     let encode (_entries, dst) _path target : Sexp.t = List [ target dst ]
 
     let make_entry entry path comps =
-      Install.Entry.set_src entry path
+      Install.Entry.Expanded.set_src entry path
       |> Install.Entry.map_dst ~f:(fun dst -> Install.Entry.Dst.concat_all dst comps)
     ;;
 
@@ -1159,8 +1177,12 @@ struct
           List.rev_map acc ~f:(fun (path, comps) ->
             let comps = List.rev comps in
             make_entry entry path comps)
-          |> List.sort ~compare:(fun (x : _ Install.Entry.t) (y : _ Install.Entry.t) ->
-            Path.compare x.src y.src)
+          |> List.sort
+               ~compare:
+                 (fun
+                   (x : Path.t Install.Entry.Expanded.t)
+                   (y : Path.t Install.Entry.Expanded.t)
+                 -> Path.compare x.src y.src)
         | (dir, comps) :: dirs ->
           (match Path.Untracked.readdir_unsorted_with_kinds dir with
            | Error (e, x, y) -> raise (Unix.Unix_error (e, x, y))
@@ -1186,14 +1208,10 @@ struct
         let+ entries =
           Fiber.parallel_map entries ~f:(fun (entry : _ Install.Entry.t) ->
             match entry.kind with
-            | `File -> Fiber.return [ entry ]
-            | `Directory -> Fiber.return (read_dir_recursively entry)
-            | `Source_tree ->
-              Code_error.raise
-                "This entry should have been expanded into `File"
-                [ "entry", Install.Entry.to_dyn Path.to_dyn entry ])
+            | Install.Entry.Expanded.File -> Fiber.return [ entry ]
+            | Directory -> Fiber.return (read_dir_recursively entry))
         in
-        List.concat entries |> Install.Entry.gen_install_file
+        List.concat entries |> Install.Entry.Expanded.gen_install_file
       in
       Async.async (fun () -> Io.write_file (Path.build dst) entries)
     ;;
@@ -1204,7 +1222,10 @@ struct
   let gen_install_file entries ~dst = A.action (entries, dst)
 end :
 sig
-  val gen_install_file : Path.t Install.Entry.t list -> dst:Path.Build.t -> Action.t
+  val gen_install_file
+    :  Path.t Install.Entry.Expanded.t list
+    -> dst:Path.Build.t
+    -> Action.t
 end)
 
 let gen_package_install_file_rules sctx (package : Package.t) =
@@ -1220,7 +1241,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
   let files =
     Action_builder.map
       entries
-      ~f:(List.rev_map ~f:(fun (e : Install.Entry.Sourced.t) -> e.entry.src))
+      ~f:(List.rev_map ~f:(fun (e : Install.Entry.Sourced.Expanded.t) -> e.entry.src))
     |> Action_builder.memoize "entries"
   in
   let* dune_project = Dune_load.find_project ~dir:pkg_build_dir in
@@ -1305,16 +1326,19 @@ let gen_package_install_file_rules sctx (package : Package.t) =
             let toolchain = Context_name.to_string toolchain in
             Path.of_string (toolchain ^ "-sysroot")
           in
-          List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.t) ->
+          List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
             { e with
               entry =
-                Install.Entry.add_install_prefix e.entry ~paths:install_paths ~prefix
+                Install.Entry.Expanded.add_install_prefix
+                  e.entry
+                  ~paths:install_paths
+                  ~prefix
             })
       in
       if not (Package.allow_empty package)
       then
         if
-          List.for_all entries ~f:(fun (e : Install.Entry.Sourced.t) ->
+          List.for_all entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
             match e.source with
             | Dune -> true
             | User _ -> false)
@@ -1328,8 +1352,8 @@ let gen_package_install_file_rules sctx (package : Package.t) =
                  the dune-project file"
                 (Package.Name.to_string package_name)
             ]);
-      List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.t) ->
-        Install.Entry.set_src e.entry (Path.build e.entry.src))
+      List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
+        Install.Entry.Expanded.set_src e.entry (Path.build e.entry.src))
     in
     entries
     >>| gen_install_file ~dst:install_file

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -9,7 +9,7 @@ val symlink_rules : Super_context.t -> dir:Path.Build.t -> (Subdir_set.t * Rules
 
 val stanzas_to_entries
   :  Super_context.t
-  -> Install.Entry.Sourced.t list Dune_lang.Package_name.Map.t Memo.t
+  -> Install.Entry.Sourced.Unexpanded.t list Dune_lang.Package_name.Map.t Memo.t
 
 (** Generate rules for [.dune-package], [META.<package-name>] files. and
     [<package-name>.install] files. *)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1887,7 +1887,12 @@ module Install_action = struct
         |> List.map ~f:(fun (name, value) -> Package_variable_name.of_opam name, value)
     ;;
 
-    let install_entry ~src ~install_file ~target_dir (entry : Path.t Install.Entry.t) =
+    let install_entry
+          ~src
+          ~install_file
+          ~target_dir
+          (entry : Path.t Install.Entry.Expanded.t)
+      =
       match Path.Untracked.exists src, entry.optional with
       | false, true -> None
       | false, false ->
@@ -1963,7 +1968,7 @@ module Install_action = struct
             let* map =
               let install_entries =
                 let dir = Path.parent_exn install_file in
-                Install.Entry.load_install_file install_file (fun local ->
+                Install.Entry.Expanded.load_install_file install_file (fun local ->
                   Path.append_local dir local)
               in
               let by_src =

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -1205,9 +1205,13 @@ let install_rules ~sctx ~dir s =
     let to_dst f = Path.Local.to_string @@ Path.Local.relative dst_dir f in
     let make_entry (orig_file : Path.Build.t) (dst_file : string) =
       let entry =
-        Install.Entry.make Section.Lib_root ~dst:(to_dst dst_file) orig_file ~kind:`File
+        Install.Entry.Unexpanded.make
+          Section.Lib_root
+          ~dst:(to_dst dst_file)
+          orig_file
+          ~kind:Install.Entry.Unexpanded.File
       in
-      Install.Entry.Sourced.create ~loc entry
+      Install.Entry.Sourced.Unexpanded.create ~loc entry
     in
     let+ rocq_sources = Dir_contents.rocq dir_contents in
     rocq_sources

--- a/src/dune_rules/rocq/rocq_rules.mli
+++ b/src/dune_rules/rocq/rocq_rules.mli
@@ -70,7 +70,7 @@ val install_rules
   :  sctx:Super_context.t
   -> dir:Path.Build.t
   -> Rocq_stanza.Theory.t
-  -> Install.Entry.Sourced.t list Memo.t
+  -> Install.Entry.Sourced.Unexpanded.t list Memo.t
 
 (** Compute the effective Rocq enviroment *)
 val rocq_env : dir:Path.Build.t -> Rocq_flags.t Action_builder.t

--- a/src/dune_rules/sites/plugin_rules.ml
+++ b/src/dune_rules/sites/plugin_rules.ml
@@ -58,8 +58,8 @@ let install_rules ~sctx ~package_db ~dir ({ name; site = loc, (pkg, site); _ } a
         ~dst:(sprintf "%s/%s" (Package.Name.to_string name) Dune_findlib.Package.meta_fn)
         (Site { pkg; site; loc })
         (Package_db.section_of_site package_db)
-        ~kind:`File
+        ~kind:File
         meta
     in
-    [ Install.Entry.Sourced.create ~loc entry ])
+    [ Install.Entry.Sourced.Unexpanded.create ~loc entry ])
 ;;

--- a/src/dune_rules/sites/plugin_rules.mli
+++ b/src/dune_rules/sites/plugin_rules.mli
@@ -7,4 +7,4 @@ val install_rules
   -> package_db:Package_db.t
   -> dir:Path.Build.t
   -> Plugin.t
-  -> Install.Entry.Sourced.t list Memo.t
+  -> Install.Entry.Sourced.Unexpanded.t list Memo.t

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -72,15 +72,9 @@ end = struct
   let install_path t section p = Path.relative (Paths.get t section) (to_string p)
 end
 
-type kind =
-  [ `File
-  | `Directory
-  | `Source_tree
-  ]
-
-type 'src t =
+type ('src, 'kind) t =
   { src : 'src
-  ; kind : kind
+  ; kind : 'kind
   ; dst : Dst.t
   ; section : Section.t
   ; optional : bool
@@ -89,60 +83,15 @@ type 'src t =
 let map_dst t ~f = { t with dst = f t.dst }
 
 let to_dyn =
-  let dyn_of_kind =
-    let open Dyn in
-    function
-    | `File -> variant "File" []
-    | `Directory -> variant "Directory" []
-    | `Source_tree -> variant "Source_tree" []
-  in
-  fun f { src; kind; dst; section; optional } ->
-    let open Dyn in
-    record
-      [ "src", f src
-      ; "kind", dyn_of_kind kind
-      ; "dst", Dst.to_dyn dst
-      ; "section", Section.to_dyn section
-      ; "optional", Dyn.bool optional
-      ]
-;;
-
-module Sourced = struct
-  type source =
-    | User of Loc.t
-    | Dune
-
-  type nonrec t =
-    { source : source
-    ; entry : Path.Build.t t
-    }
-
-  let create ?loc entry =
-    { source =
-        (match loc with
-         | None -> Dune
-         | Some loc -> User loc)
-    ; entry
-    }
-  ;;
-
-  let to_dyn { source; entry } =
-    let open Dyn in
-    let source_to_dyn = function
-      | Dune -> Variant ("Dune", [])
-      | User loc -> Variant ("User", [ Loc.to_dyn loc ])
-    in
-    Record [ "source", source_to_dyn source; "entry", to_dyn Path.Build.to_dyn entry ]
-  ;;
-end
-
-let compare compare_src { optional; src; dst; section; kind } t =
-  let open Ordering.O in
-  let= () = Section.compare section t.section in
-  let= () = Dst.compare dst t.dst in
-  let= () = compare_src src t.src in
-  let= () = Bool.compare optional t.optional in
-  Poly.compare kind t.kind
+  fun dyn_of_kind f { src; kind; dst; section; optional } ->
+  let open Dyn in
+  record
+    [ "src", f src
+    ; "kind", dyn_of_kind kind
+    ; "dst", Dst.to_dyn dst
+    ; "section", Section.to_dyn section
+    ; "optional", Dyn.bool optional
+    ]
 ;;
 
 let adjust_dst_gen =
@@ -200,101 +149,192 @@ let adjust_dst' ~src ~dst ~section =
   adjust_dst_gen ~src_suffix:(Full (Path.to_string (Path.build src))) ~dst ~section
 ;;
 
-let make section ?dst ~kind src =
-  let dst = adjust_dst' ~src ~dst ~section in
-  { optional = false; src; dst; section; kind }
+let compare compare_src { optional; src; dst; section; kind } t =
+  let open Ordering.O in
+  let= () = Section.compare section t.section in
+  let= () = Dst.compare dst t.dst in
+  let= () = compare_src src t.src in
+  let= () = Bool.compare optional t.optional in
+  Poly.compare kind t.kind
 ;;
 
-let make_with_dst section dst ~kind ~src = { optional = false; src; dst; section; kind }
-let set_src t src = { t with src }
-let set_kind t kind = { t with kind }
 let relative_installed_path t ~paths = Dst.install_path paths t.section t.dst
 
-let add_install_prefix t ~paths ~prefix =
-  let opam_will_install_in_this_dir = Paths.get paths t.section in
-  let i_want_to_install_the_file_as =
-    relative_installed_path t ~paths
-    |> Path.as_in_source_tree_exn
-    |> Path.append_source prefix
-  in
-  let dst =
-    Path.reach i_want_to_install_the_file_as ~from:opam_will_install_in_this_dir
-  in
-  { t with dst = Dst.explicit dst }
-;;
+module Expanded = struct
+  type kind =
+    | File
+    | Directory
 
-let of_install_file ~optional ~src ~dst ~section =
-  { src
-  ; section
-  ; dst = Dst.of_install_file ~section ~src_basename:(Path.basename src) dst
-  ; kind = `File
-  ; optional
-  }
-;;
+  type nonrec 'src t = ('src, kind) t
 
-let group entries =
-  List.map entries ~f:(fun (entry : _ t) -> entry.section, entry)
-  |> Section.Map.of_list_multi
-;;
+  let set_src t src = { t with src }
 
-let gen_install_file entries =
-  let buf = Buffer.create 4096 in
-  let pr fmt = Printf.bprintf buf (fmt ^^ "\n") in
-  Section.Map.iteri (group entries) ~f:(fun section entries ->
-    pr "%s: [" (Section.to_string section);
-    List.sort ~compare:(compare Path.compare) entries
-    |> List.iter ~f:(fun (e : Path.t t) ->
-      let src = Path.to_string e.src in
-      match
-        Dst.to_install_file ~src_basename:(Path.basename e.src) ~section:e.section e.dst
-      with
-      | None -> pr "  %S" src
-      | Some dst -> pr "  %S {%S}" src dst);
-    pr "]");
-  Buffer.contents buf
-;;
-
-let load_install_file path local =
-  let open OpamParserTypes.FullPos in
-  let file = Io.with_lexbuf_from_file path ~f:Dune_pkg.Opam_file.parse in
-  let fail { filename = pos_fname; start; stop } msg =
-    let position_of_loc (pos_lnum, pos_cnum) =
-      { Lexing.pos_fname; pos_lnum; pos_bol = 0; pos_cnum }
+  let add_install_prefix t ~paths ~prefix =
+    let opam_will_install_in_this_dir = Paths.get paths t.section in
+    let i_want_to_install_the_file_as =
+      relative_installed_path t ~paths
+      |> Path.as_in_source_tree_exn
+      |> Path.append_source prefix
     in
-    let start = position_of_loc start in
-    let stop = position_of_loc stop in
-    let loc = Loc.create ~start ~stop in
-    User_error.raise ~loc [ Pp.text msg ]
-  in
-  List.concat_map file.file_contents ~f:(function
-    | { pelem = Variable (section, files); pos } ->
-      (match Section.of_string section.pelem with
-       | None -> fail pos "Unknown install section"
-       | Some section ->
-         (match files with
-          | { pelem = List l; _ } ->
-            let install_file src dst =
-              let optional, src =
-                match String.drop_prefix src ~prefix:"?" with
-                | None -> false, src
-                | Some src -> true, src
+    let dst =
+      Path.reach i_want_to_install_the_file_as ~from:opam_will_install_in_this_dir
+    in
+    { t with dst = Dst.explicit dst }
+  ;;
+
+  let of_install_file ~optional ~src ~dst ~section =
+    { src
+    ; section
+    ; dst = Dst.of_install_file ~section ~src_basename:(Path.basename src) dst
+    ; kind = File
+    ; optional
+    }
+  ;;
+
+  let group entries =
+    List.map entries ~f:(fun (entry : _ t) -> entry.section, entry)
+    |> Section.Map.of_list_multi
+  ;;
+
+  let gen_install_file entries =
+    let buf = Buffer.create 4096 in
+    let pr fmt = Printf.bprintf buf (fmt ^^ "\n") in
+    Section.Map.iteri (group entries) ~f:(fun section entries ->
+      pr "%s: [" (Section.to_string section);
+      List.sort ~compare:(compare Path.compare) entries
+      |> List.iter ~f:(fun (e : Path.t t) ->
+        let src = Path.to_string e.src in
+        match
+          Dst.to_install_file ~src_basename:(Path.basename e.src) ~section:e.section e.dst
+        with
+        | None -> pr "  %S" src
+        | Some dst -> pr "  %S {%S}" src dst);
+      pr "]");
+    Buffer.contents buf
+  ;;
+
+  let load_install_file path local =
+    let open OpamParserTypes.FullPos in
+    let file = Io.with_lexbuf_from_file path ~f:Dune_pkg.Opam_file.parse in
+    let fail { filename = pos_fname; start; stop } msg =
+      let position_of_loc (pos_lnum, pos_cnum) =
+        { Lexing.pos_fname; pos_lnum; pos_bol = 0; pos_cnum }
+      in
+      let start = position_of_loc start in
+      let stop = position_of_loc stop in
+      let loc = Loc.create ~start ~stop in
+      User_error.raise ~loc [ Pp.text msg ]
+    in
+    List.concat_map file.file_contents ~f:(function
+      | { pelem = Variable (section, files); pos } ->
+        (match Section.of_string section.pelem with
+         | None -> fail pos "Unknown install section"
+         | Some section ->
+           (match files with
+            | { pelem = List l; _ } ->
+              let install_file src dst =
+                let optional, src =
+                  match String.drop_prefix src ~prefix:"?" with
+                  | None -> false, src
+                  | Some src -> true, src
+                in
+                let src =
+                  if Filename.is_relative src
+                  then local (Path.Local.of_string src)
+                  else Path.external_ (Path.External.of_string src)
+                in
+                of_install_file ~optional ~src ~dst ~section
               in
-              let src =
-                if Filename.is_relative src
-                then local (Path.Local.of_string src)
-                else Path.external_ (Path.External.of_string src)
-              in
-              of_install_file ~optional ~src ~dst ~section
-            in
-            List.map l.pelem ~f:(function
-              | { pelem = String src; _ } -> install_file src None
-              | { pelem =
-                    Option
-                      ( { pelem = String src; _ }
-                      , { pelem = [ { pelem = String dst; _ } ]; _ } )
-                ; _
-                } -> install_file src (Some dst)
-              | { pelem = _; pos } -> fail pos "Invalid value in .install file")
-          | { pelem = _; pos } -> fail pos "Invalid value for install section"))
-    | { pelem = Section _; pos } -> fail pos "Sections are not allowed in .install file")
-;;
+              List.map l.pelem ~f:(function
+                | { pelem = String src; _ } -> install_file src None
+                | { pelem =
+                      Option
+                        ( { pelem = String src; _ }
+                        , { pelem = [ { pelem = String dst; _ } ]; _ } )
+                  ; _
+                  } -> install_file src (Some dst)
+                | { pelem = _; pos } -> fail pos "Invalid value in .install file")
+            | { pelem = _; pos } -> fail pos "Invalid value for install section"))
+      | { pelem = Section _; pos } -> fail pos "Sections are not allowed in .install file")
+  ;;
+end
+
+module Unexpanded = struct
+  type kind =
+    | File
+    | Directory
+    | Source_tree
+
+  type nonrec t = (Path.Build.t, kind) t
+
+  let to_dyn =
+    let dyn_of_kind =
+      let open Dyn in
+      function
+      | File -> variant "File" []
+      | Directory -> variant "Directory" []
+      | Source_tree -> variant "Source_tree" []
+    in
+    fun f t -> to_dyn dyn_of_kind f t
+  ;;
+
+  let make section ?dst ~kind src =
+    let dst = adjust_dst' ~src ~dst ~section in
+    { optional = false; src; dst; section; kind }
+  ;;
+
+  let make_with_dst section dst ~kind ~src = { optional = false; src; dst; section; kind }
+
+  let expand : t -> Path.Build.t Expanded.t =
+    fun t ->
+    let kind =
+      match t.kind with
+      | File | Source_tree -> Expanded.File
+      | Directory -> Expanded.Directory
+    in
+    { t with kind }
+  ;;
+
+  let compare a b = compare Path.Build.compare a b
+end
+
+module Sourced = struct
+  type source =
+    | User of Loc.t
+    | Dune
+
+  type nonrec 'entry t =
+    { source : source
+    ; entry : 'entry
+    }
+
+  let create ?loc entry =
+    { source =
+        (match loc with
+         | None -> Dune
+         | Some loc -> User loc)
+    ; entry
+    }
+  ;;
+
+  let to_dyn =
+    let source_to_dyn = function
+      | Dune -> Dyn.variant "Dune" []
+      | User loc -> Dyn.variant "User" [ Loc.to_dyn loc ]
+    in
+    fun f { source; entry } ->
+      let open Dyn in
+      Record [ "source", source_to_dyn source; "entry", f Path.Build.to_dyn entry ]
+  ;;
+
+  module Unexpanded = struct
+    type nonrec t = Unexpanded.t t
+
+    let create = create
+    let to_dyn t = to_dyn Unexpanded.to_dyn t
+  end
+
+  module Expanded = struct
+    type nonrec t = Path.Build.t Expanded.t t
+  end
+end


### PR DESCRIPTION
- `install_rules` expand source trees into expanded file entries
- `.install` files only contain expanded entries

This PR makes this distinction explicit.