### PR TITLE
refactor(ocamllex): port ocamllex rules from `Rule_conf`

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -161,6 +161,8 @@ end = struct
           | Rocq_stanza.Extraction.T s ->
             Memo.return (Rocq_stanza.Extraction.ml_target_fnames s)
           | Menhir_stanza.T menhir -> Memo.return (Menhir_stanza.targets menhir)
+          | Ocamllex.T ocamllex ->
+            Memo.return (List.map ocamllex.modules ~f:(fun s -> s ^ ".ml"))
           | Rule_conf.T rule ->
             Simple_rules.user_rule sctx rule ~dir ~expander
             >>| (function

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -217,6 +217,11 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander ~dune_file ~dir:ctx_d
   and+ () =
     Memo.parallel_iter stanzas ~f:(fun stanza ->
       match Stanza.repr stanza with
+      | Ocamllex.T ocamllex ->
+        Expander.eval_blang expander ocamllex.enabled_if
+        >>= (function
+         | false -> Memo.return ()
+         | true -> Ocamllex_rules.gen_rules ocamllex ~sctx ~dir:ctx_dir)
       | Menhir_stanza.T m ->
         Expander.eval_blang expander m.enabled_if
         >>= (function

--- a/src/dune_rules/ocamllex_rules.ml
+++ b/src/dune_rules/ocamllex_rules.ml
@@ -1,0 +1,39 @@
+open Import
+
+type 'a args = 'a Command.Args.t list
+
+let ocamllex_bin sctx ~loc ~dir =
+  Super_context.resolve_program sctx ~loc:(Some loc) ~dir ~where:Original_path "ocamllex"
+;;
+
+let ocamllex sctx ~loc ~dir (args : 'a args) : Action.Full.t Action_builder.With_targets.t
+  =
+  let ocamllex_bin = ocamllex_bin sctx ~loc ~dir in
+  let build_dir = Super_context.context sctx |> Context.build_dir in
+  Command.run_dyn_prog (* ~sandbox *) ~dir:(Path.build build_dir) ocamllex_bin args
+;;
+
+let rule sctx ~dir ~loc ~mode : Action.Full.t Action_builder.With_targets.t -> unit Memo.t
+  =
+  Super_context.add_rule sctx ~dir ~mode ~loc
+;;
+
+let gen_rules ~sctx ~dir { Ocamllex.loc; modules; mode; enabled_if = _ } =
+  let module S = String_with_vars in
+  Memo.sequential_iter modules ~f:(fun name ->
+    let src = Path.Build.relative dir (name ^ ".mll") in
+    let dst = Path.Build.relative dir (name ^ ".ml") in
+    let open Memo.O in
+    let* mode =
+      let* expander = Super_context.expander sctx ~dir in
+      Rule_mode_expand.expand_path ~expander ~dir mode
+    in
+    let action =
+      ocamllex
+        sctx
+        ~loc
+        ~dir
+        [ As [ "-q"; "-o" ]; Target dst; Command.Args.Dep (Path.build src) ]
+    in
+    rule sctx ~dir ~loc ~mode action)
+;;

--- a/src/dune_rules/ocamllex_rules.mli
+++ b/src/dune_rules/ocamllex_rules.mli
@@ -1,0 +1,3 @@
+open Import
+
+val gen_rules : sctx:Super_context.t -> dir:Path.Build.t -> Ocamllex.t -> unit Memo.t

--- a/src/dune_rules/stanzas/ocamllex.ml
+++ b/src/dune_rules/stanzas/ocamllex.ml
@@ -1,0 +1,28 @@
+open Import
+
+type t =
+  { loc : Loc.t
+  ; (* CR anmonteiro we're missing some validation on the modules field here *)
+    modules : string list
+  ; mode : Rule_mode.t
+  ; enabled_if : Blang.t
+  }
+
+include Stanza.Make (struct
+    type nonrec t = t
+
+    include Poly
+  end)
+
+let decode =
+  let open Dune_lang.Decoder in
+  (let+ loc = loc
+   and+ modules = repeat string in
+   { loc; modules; mode = Standard; enabled_if = Blang.true_ })
+  <|> fields
+        (let+ loc = loc
+         and+ modules = field "modules" (repeat string)
+         and+ mode = Rule_mode_decoder.field
+         and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) () in
+         { loc; modules; mode; enabled_if })
+;;

--- a/src/dune_rules/stanzas/ocamllex.mli
+++ b/src/dune_rules/stanzas/ocamllex.mli
@@ -1,0 +1,12 @@
+open Import
+
+type t =
+  { loc : Loc.t
+  ; modules : string list
+  ; mode : Rule_mode.t
+  ; enabled_if : Blang.t
+  }
+
+val decode : t Dune_lang.Decoder.t
+
+include Stanza.S with type t := t

--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -182,37 +182,6 @@ type lex_or_yacc =
   ; enabled_if : Blang.t
   }
 
-let ocamllex_to_rule { loc; modules; mode; enabled_if } =
-  let module S = String_with_vars in
-  List.map modules ~f:(fun name ->
-    let src = name ^ ".mll" in
-    let dst = name ^ ".ml" in
-    { targets =
-        (* CR-someday aalekseyev: want to use [multiplicity = One] here, but
-           can't because this is might get parsed with old dune syntax where
-           [multiplicity = One] is not supported. *)
-        Static { targets = [ S.make_text loc dst, File ]; multiplicity = Multiple }
-    ; deps = Bindings.singleton (Dep_conf.File (S.virt_text __POS__ src))
-    ; action =
-        ( loc
-        , Chdir
-            ( S.virt_pform __POS__ (Var Workspace_root)
-            , Dune_lang.Action.run
-                (S.virt_text __POS__ "ocamllex")
-                [ S.virt_text __POS__ "-q"
-                ; S.virt_text __POS__ "-o"
-                ; S.virt_pform __POS__ (Var Targets)
-                ; S.virt_pform __POS__ (Var Deps)
-                ] ) )
-    ; mode
-    ; locks = []
-    ; loc
-    ; enabled_if
-    ; aliases = []
-    ; package = None
-    })
-;;
-
 let ocamlyacc_to_rule { loc; modules; mode; enabled_if } =
   let module S = String_with_vars in
   List.map modules ~f:(fun name ->
@@ -254,5 +223,4 @@ let lex_or_yacc =
          { loc; modules; mode; enabled_if })
 ;;
 
-let ocamllex = lex_or_yacc >>| ocamllex_to_rule
 let ocamlyacc = lex_or_yacc >>| ocamlyacc_to_rule

--- a/src/dune_rules/stanzas/rule_conf.mli
+++ b/src/dune_rules/stanzas/rule_conf.mli
@@ -19,4 +19,3 @@ val decode : t Dune_sexp.Decoder.t
 type lex_or_yacc
 
 val ocamlyacc : t list Dune_lang.Decoder.t
-val ocamllex : t list Dune_lang.Decoder.t

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -72,7 +72,7 @@ let stanzas : Stanza.Parser.t list =
     ; ("executable", Executables.(decode_stanza single))
     ; ("executables", Executables.(decode_stanza multi))
     ; ("rule", Rule_conf.(decode_stanza Rule_conf.decode))
-    ; ("ocamllex", Rule_conf.(decode_stanzas ocamllex))
+    ; "ocamllex", Ocamllex.decode_stanza Ocamllex.decode
     ; ("ocamlyacc", Rule_conf.(decode_stanzas ocamlyacc))
     ; ("install", Install_conf.(decode_stanza decode))
     ; ("alias", Alias_conf.(decode_stanza decode))


### PR DESCRIPTION
this is a pre-requisite to fix issues such as #13060, #10301, etc.