### PR TITLE
test: depend on jq everywhere

### DIFF
--- a/test/blackbox-tests/test-cases/cinaps/dune
+++ b/test/blackbox-tests/test-cases/cinaps/dune
@@ -2,7 +2,3 @@
  (applies_to :whole_subtree)
  (deps
   (package cinaps)))
-
-(cram
- (applies_to link-flags)
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -3,7 +3,7 @@
 
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:jq} %{bin:coqc} %{bin:coqdep} scrub_coq_args.sh)
+ (deps %{bin:coqc} %{bin:coqdep} scrub_coq_args.sh)
  (alias runtest-coq)
  (enabled_if
   (= %{env:DUNE_COQ_TEST=disable} enable)))

--- a/test/blackbox-tests/test-cases/cram/dune
+++ b/test/blackbox-tests/test-cases/cram/dune
@@ -6,10 +6,6 @@
  (applies_to error subprocess)
  (enabled_if false))
 
-(cram
- (applies_to timeout-redigest cram-double-alias)
- (deps %{bin:jq}))
-
 ;; mac has a different sh error message
 
 (cram

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/dune
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/dune
@@ -1,3 +1,0 @@
-(cram
- (applies_to cross-compilation-ocamlfind)
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/directory-targets/dune
+++ b/test/blackbox-tests/test-cases/directory-targets/dune
@@ -5,7 +5,3 @@
 (cram
  (applies_to remove-write-permissions)
  (deps %{bin:bash}))
-
-(cram
- (applies_to loading-inside-directory-target)
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -30,6 +30,7 @@
  (deps
   (env_var OCAML_COLOR)
   (env_var DUNE_JOBS)
+  %{bin:jq}
   %{bin:dune_cmd}
   (package dune))
  ;; We don't allow conflict markers in tests
@@ -131,10 +132,5 @@
 
 (cram
  (applies_to hidden-deps-unsupported)
- (deps %{bin:jq})
  (enabled_if
   (< %{ocaml_version} 5.2.0)))
-
-(cram
- (applies_to trace-file)
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/inline-tests/dune
+++ b/test/blackbox-tests/test-cases/inline-tests/dune
@@ -8,10 +8,6 @@
  (deps %{bin:refmt}))
 
 (cram
- (applies_to simple)
- (deps %{bin:jq}))
-
-(cram
  (applies_to github6607)
  (deps
   (package stdune)))

--- a/test/blackbox-tests/test-cases/promote/dune
+++ b/test/blackbox-tests/test-cases/promote/dune
@@ -1,3 +1,0 @@
-(cram
- (applies_to promote-variables promote-only-when-needed)
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/rocq/dune
+++ b/test/blackbox-tests/test-cases/rocq/dune
@@ -3,7 +3,7 @@
 
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:jq} %{bin:rocq} scrub_coq_args.sh)
+ (deps %{bin:rocq} scrub_coq_args.sh)
  (alias runtest-rocq)
  (enabled_if
   (= %{env:DUNE_ROCQ_TEST=disable} enable)))

--- a/test/blackbox-tests/test-cases/trace/dune
+++ b/test/blackbox-tests/test-cases/trace/dune
@@ -1,2 +1,0 @@
-(cram
- (deps %{bin:jq}))

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/dune
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/dune
@@ -1,3 +1,0 @@
-(cram
- (applies_to artifact-variables)
- (deps %{bin:jq}))


### PR DESCRIPTION
It's a bit impractical to use this dependency precisely.