### PR TITLE
Revert copyfile change from 804fa3f1ae043310ec574ce0f44d36c79a13c545

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -211,13 +211,23 @@ module Copyfile = struct
       copy_channels ic oc)
   ;;
 
-  let copy_file =
+  let copy_file_best =
     match available with
     | `Sendfile -> sendfile_with_fallback
     | `Copyfile -> copyfile
     | `Nothing -> copy_file_portable
   ;;
+
+  let copy_file_impl = ref `Best
+
+  let copy_file ?chmod ~src ~dst () =
+    match !copy_file_impl with
+    | `Portable -> copy_file_portable ?chmod ~src ~dst ()
+    | `Best -> copy_file_best ?chmod ~src ~dst ()
+  ;;
 end
+
+let set_copy_impl m = Copyfile.copy_file_impl := m
 
 module Make (Path : sig
     type t

--- a/otherlibs/stdune/src/io.mli
+++ b/otherlibs/stdune/src/io.mli
@@ -14,3 +14,5 @@ val portable_symlink : src:Path.t -> dst:Path.t -> unit
 
 (** Hardlink with fallback to copy on systems that don't support it. *)
 val portable_hardlink : src:Path.t -> dst:Path.t -> unit
+
+val set_copy_impl : [ `Portable | `Best ] -> unit

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -102,6 +102,16 @@ let cutoffs_that_reduce_concurrency_in_watch_mode =
     ~default:`Disabled
 ;;
 
+let copy_file =
+  make
+    ~name:"copy_file"
+    ~of_string:(function
+      | "portable" -> Ok `Portable
+      | "fast" -> Ok `Best
+      | _ -> Error (sprintf "only %S and %S are allowed" "fast" "portable"))
+    ~default:`Best
+;;
+
 let background_default =
   match Platform.OS.value with
   | Linux | Windows | Darwin -> `Enabled

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -39,6 +39,9 @@ val global_lock : Toggle.t t
     reduces concurrency *)
 val cutoffs_that_reduce_concurrency_in_watch_mode : Toggle.t t
 
+(** whether dune should optimize file copying on Linux/MacOS *)
+val copy_file : [ `Portable | `Best ] t
+
 (** Execute some actions in background threads. See [Action_exec] for the
     concrete list of actions *)
 val background_actions : Toggle.t t

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -652,6 +652,7 @@ module Dune_config = struct
       | Preserve -> ()
       | Clear_on_rebuild -> Console.reset ()
       | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ());
+    Stdune.Io.set_copy_impl Config.(get copy_file);
     Log.verbose
     := match t.display with
        | Simple { verbosity = Verbose; _ } -> true


### PR DESCRIPTION
At least on older macOS versions we need portable copyfile. Fixes https://github.com/ocaml/dune/issues/12576

@rgrinberg Sorry for a delay with this. If it is possible to get this merged before 3.21.0 release, it will be great.