### PR TITLE
Fix test suite outside of macos

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -21,11 +21,6 @@
  (deps %{bin:dunepp}))
 
 (cram
- (deps %{bin:codesign})
- (enabled_if
-  (= %{system} macosx)))
-
-(cram
  (applies_to :whole_subtree)
  (deps
   (env_var OCAML_COLOR)


### PR DESCRIPTION
`enabled_if` on cram tests applies the `enabled_if` on the tests that it
matches rather than on the `cram` statement itself.

It's a shame that we don't have a good way to accomplish what you've tried here. The best I can think of is some sort `:include` hackery in the list of deps that generates the dependency conditionally.

cc @anmonteiro 