### PR TITLE
feat(cram): explicitly requested disabled tests now execute

### DIFF
--- a/doc/changes/changed/13081.md
+++ b/doc/changes/changed/13081.md
@@ -1,0 +1,3 @@
+- Disabled cram tests can now be run explicitly with `dune runtest disabled.t`.
+  The `enabled_if` field now only controls whether a test is included in
+  the `@runtest` alias. (#13081, @Alizter)

--- a/doc/reference/dune/cram.rst
+++ b/doc/reference/dune/cram.rst
@@ -52,7 +52,10 @@ Cram
 
    .. describe:: (enabled_if <blang>)
 
-      Control whether the tests are enabled.
+      Control whether the tests are included in the ``runtest`` alias and other
+      aliases specified by the ``alias`` field. When ``enabled_if`` evaluates to
+      ``false``, the test is excluded from these aliases but can still be run
+      explicitly via its own alias (e.g., ``dune build @foo`` for ``foo.t``).
 
       .. seealso:: :doc:`/reference/boolean-language`, :doc:`/concepts/variables`
 

--- a/test/blackbox-tests/test-cases/cram/disabled-test.t
+++ b/test/blackbox-tests/test-cases/cram/disabled-test.t
@@ -1,0 +1,28 @@
+Test behavior of disabled cram tests.
+
+The enabled_if field controls whether a test is included in @runtest.
+Currently, disabled tests silently succeed when run explicitly - the test
+simply doesn't run but no error is reported.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (applies_to disabled)
+  >  (enabled_if false))
+  > EOF
+
+  $ cat > disabled.t <<EOF
+  >   $ echo "hello"
+  >   wrong output
+  > EOF
+
+The disabled test is skipped from @runtest:
+
+  $ dune runtest
+
+Running the disabled test explicitly also silently succeeds (no diff shown):
+
+  $ dune runtest disabled.t

--- a/test/blackbox-tests/test-cases/cram/disabled-test.t
+++ b/test/blackbox-tests/test-cases/cram/disabled-test.t
@@ -1,8 +1,7 @@
-Test behavior of disabled cram tests.
+Test that disabled cram tests can still be run explicitly.
 
-The enabled_if field controls whether a test is included in @runtest.
-Currently, disabled tests silently succeed when run explicitly - the test
-simply doesn't run but no error is reported.
+The enabled_if field controls whether a test is included in @runtest,
+but does not prevent the test from being run explicitly.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.21)
@@ -23,6 +22,14 @@ The disabled test is skipped from @runtest:
 
   $ dune runtest
 
-Running the disabled test explicitly also silently succeeds (no diff shown):
+But can be run explicitly (the diff proves it ran):
 
   $ dune runtest disabled.t
+  File "disabled.t", line 1, characters 0-0:
+  --- disabled.t
+  +++ disabled.t.corrected
+  @@ -1,2 +1,2 @@
+     $ echo "hello"
+  -  wrong output
+  +  hello
+  [1]


### PR DESCRIPTION
Previously when a user tried to run a disabled cram test, set using the `(enabled_if)` field of the `(cram)` stanza, they would see dune succeed silently having skipped the test.

When this is part of `dune runtest foo/` in a directory, this behaviour is fine. But if the user explicitly requested a disabled test then this behaviour can be confusing.

This PR introduces an error message when a user requests a disabled cram test, either via `dune runtest` or the test alias directly.

- [x] another self-review
- [x] changelog
- [x] docs
