### PR TITLE
test: replace aliases with functions

### DIFF
--- a/test/blackbox-tests/test-cases/env/env-cflags.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-cflags.t/run.t
@@ -1,20 +1,22 @@
-  $ alias dune_printenv="dune printenv --profile default --field c_flags --field cxx_flags"
+  $ printenv() {
+  > dune printenv --profile default --field c_flags --field cxx_flags $@
+  > }
 
-  $ dune_printenv .
+  $ printenv .
   (c_flags (":standard + in ."))
   (cxx_flags (":standard + in ."))
 
-  $ dune_printenv src
+  $ printenv src
   (c_flags
    (":standard + in ." ":standard + in src"))
   (cxx_flags
    (":standard + in ." ":standard + in src"))
 
-  $ dune_printenv bin
+  $ printenv bin
   (c_flags ("in bin"))
   (cxx_flags ("in bin"))
 
-  $ dune_printenv run
+  $ printenv run
   (c_flags (-DTEST_C))
   (cxx_flags (-DTEST_CPP))
 

--- a/test/blackbox-tests/test-cases/env/env-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-simple.t/run.t
@@ -1,34 +1,36 @@
-  $ alias dune_printenv='dune printenv --profile default --field flags'
+  $ printenv() {
+  > dune printenv --profile default --field flags $@
+  > }
 
-  $ dune_printenv .
+  $ printenv .
   (flags
    (-w -40 ":standard + in ."))
 
-  $ dune_printenv src
+  $ printenv src
   (flags
    (-w -40 ":standard + in ." ":standard + in src"))
 
-  $ dune_printenv bin
+  $ printenv bin
   (flags ("in bin"))
 
-  $ dune_printenv vendor
+  $ printenv vendor
   (flags
    (-w -40 ":standard + in ."))
 
 Vendored project without env customization, the global default should
 apply:
 
-  $ dune_printenv vendor/without-env-customization
+  $ printenv vendor/without-env-customization
   (flags
    (-w -40))
 
 Vendored project with env customization, the global default +
 customization of vendored project should apply:
 
-  $ dune_printenv vendor/with-env-customization
+  $ printenv vendor/with-env-customization
   (flags
    (-w -40 ":standard + in vendor/with-env-customization"))
 
-  $ dune_printenv vendor/with-env-customization/src
+  $ printenv vendor/with-env-customization/src
   (flags ("in vendor/with-env-customization/src"))
 


### PR DESCRIPTION
aliases do not work in all non-interactive shells