### PR TITLE
test: show that #10301 doesn't reproduce an issue

### DIFF
--- a/test/blackbox-tests/test-cases/menhir/gh10301.t
+++ b/test/blackbox-tests/test-cases/menhir/gh10301.t
@@ -1,8 +1,11 @@
+Show an edge case of `(include_subdirs ..)` and ocamllex / menhir
 
   $ cat > dune-project << EOF
   > (lang dune 3.13)
   > (using menhir 3.0)
   > EOF
+
+We add a `(menhir ..)` stanza in the group root dune file
 
   $ mkdir -p src/a
   $ cat > dune << EOF
@@ -21,7 +24,17 @@
   >   | _   { true  }
   >   | eof { false }
   > EOF
-  $ touch src/a/parser.mly
+  $ cat >src/a/parser.mly <<'EOF'
+  > %token EOF
+  > %start main
+  > %type <unit> main
+  > %%
+  > main:
+  >   | EOF { () }
+  > EOF
+
+Dune doesn't find the parser from the root dune file
+
   $ dune build
   File "dune", lines 3-5, characters 0-42:
   3 | (menhir
@@ -30,3 +43,17 @@
   Error: No rule found for parser.mly
   [1]
 
+Show that the menhir stanza must live next to the source
+
+  $ cat > dune << EOF
+  > (include_subdirs unqualified)
+  > (library (name foo))
+  > (ocamllex lexer)
+  > EOF
+  $ cat > src/a/dune << EOF
+  > (menhir
+  >  (modules parser)
+  >  (flags --dump))
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
- we define that for ocamllex, ocamlyacc, menhir, etc. the rule must live next to the source 
- show that this invalidates the reproduction in #10301