### PR TITLE
chore: update nix flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765644376,
-        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
+        "lastModified": 1766870016,
+        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
+        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765771730,
-        "narHash": "sha256-pHqMybp6jYxV4a/wOAo+NM9l3hWwpIH0S4kwqxv567Q=",
+        "lastModified": 1766954034,
+        "narHash": "sha256-uTqJvUxEsqUdKh5qDF7EBOFgDwV+SIiH2BU1fWI6yGU=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "0ed5e45e848fbfceac095dd30e24bc6370a02d43",
+        "rev": "50a9e2bf8de3ea924754d7e242dc055d22b34d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
the nix overlays cache has a 2 week retention, which will cause us to build more stuff than necessary once that's passed.