### PR TITLE
ci: enforce unique prefix when restoring cache

### DIFF
--- a/.github/workflows/multi-repo-build.yml
+++ b/.github/workflows/multi-repo-build.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}-nix-build-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-nix-build-
+          primary-key: nix-${{ runner.os }}-nix-build--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-nix-build--
           save: false
 
       - name: Build Dune

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,8 +43,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
           gc-max-store-size-macos: 2G
       - run: nix build
@@ -65,8 +65,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 10G
       - run: nix develop -i -c make test
 
@@ -81,8 +81,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
       - run: nix develop .#fmt -c make fmt
 
@@ -97,8 +97,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
       - run: nix develop .#doc -c make doc
         env:
@@ -120,8 +120,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
@@ -141,10 +141,10 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
-      - run: nix develop -i .#bootstrap-check_4_08 -c make release 
+      - run: nix develop -i .#bootstrap-check_4_08 -c make release
 
   nix-build-ox:
     # This builds OxCaml with the flake version which is typically ahead of the
@@ -164,8 +164,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-ox -c make release 
 
@@ -285,8 +285,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
       - run: nix develop .#coq -c make test-coq
         env:
@@ -446,8 +446,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 5G
       - run: nix develop .#microbench -c make dune build bench/micro
 
@@ -462,8 +462,8 @@ jobs:
       - uses: nix-community/cache-nix-action@v6
         with:
           primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
       - name: Set up a project, install utop as a dev tool, and run it
         shell: nix shell -c bash -e {0}


### PR DESCRIPTION
By using a double dash `--` we can explicitly mark the prefix part of the cache key, avoiding wrong restores.

This had caused unrelated jobs to use eachother's cache which meant they had to fallback to the secondary cache from nix overlays. That's fine, but we should only do that when we don't have our main cache available.

tldr; stop `nix-build-` prefix matching on `nix-build-ox-` by ending prefix with `--`.