### PR TITLE
Cram: Add command level timing information

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1316,6 +1316,7 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
             ; Log
             ; File_watcher
             ; Diagnostics
+            ; Cram
             ]
         | Some s ->
           String.split ~on:',' s

--- a/doc/changes/added/13092.md
+++ b/doc/changes/added/13092.md
@@ -1,0 +1,2 @@
+- Add timing information for every command executed by cram (#13092,
+  @rgrinberg)

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -17,6 +17,7 @@ type t =
   | File_watcher
   | Diagnostics
   | Log
+  | Cram
 
 let all =
   [ Rpc
@@ -35,6 +36,7 @@ let all =
   ; File_watcher
   ; Diagnostics
   ; Log
+  ; Cram
   ]
 ;;
 
@@ -55,6 +57,7 @@ let to_string = function
   | File_watcher -> "file_watcher"
   | Diagnostics -> "diagnostics"
   | Log -> "log"
+  | Cram -> "cram"
 ;;
 
 let of_string =
@@ -87,5 +90,6 @@ module Set = Bit_set.Make (struct
       | File_watcher -> 13
       | Diagnostics -> 14
       | Log -> 15
+      | Cram -> 16
     ;;
   end)

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -15,6 +15,7 @@ type t =
   | File_watcher
   | Diagnostics
   | Log
+  | Cram
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -18,6 +18,7 @@ module Category : sig
     | File_watcher
     | Diagnostics
     | Log
+    | Cram
 
   val of_string : string -> t option
 end
@@ -125,6 +126,21 @@ module Event : sig
     val packet_write : id:int -> count:int -> t
     val accept : success:bool -> error:string option -> t
     val close : id:int -> t
+  end
+
+  module Cram : sig
+    type times =
+      { real : Time.Span.t
+      ; system : Time.Span.t
+      ; user : Time.Span.t
+      }
+
+    type command =
+      { command : string list
+      ; times : times
+      }
+
+    val test : command list -> t
   end
 end
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -432,3 +432,34 @@ let log { Log.Message.level; message; args } =
   in
   Event.instant ~args ~name now Log
 ;;
+
+module Cram = struct
+  type times =
+    { real : Time.Span.t
+    ; system : Time.Span.t
+    ; user : Time.Span.t
+    }
+
+  type command =
+    { command : string list
+    ; times : times
+    }
+
+  let test commands =
+    let now = Time.now () in
+    let args =
+      [ ( "commands"
+        , List.map commands ~f:(fun { command; times = { real; user; system } } ->
+            Arg.record
+              [ "command", Arg.list (List.map command ~f:Arg.string)
+              ; "real", Event.make_dur real
+              ; "user", Event.make_dur user
+              ; "system", Event.make_dur system
+              ]
+            |> Arg.list)
+          |> Arg.list )
+      ]
+    in
+    Event.instant ~args ~name:"cram" now Cram
+  ;;
+end

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -1,2 +1,10 @@
 def logs($m):
   select(.cat == "log" and (.args.message | contains($m))) | .args;
+
+def redactCommandTimes:
+  walk(if type == "object" then
+    with_entries(
+      if .key | IN("dur", "real", "user", "system") then
+        .value = "redacted"
+      else . end)
+    else . end);

--- a/test/blackbox-tests/test-cases/cram/trace-commands.t
+++ b/test/blackbox-tests/test-cases/cram/trace-commands.t
@@ -1,0 +1,88 @@
+Demonstrate command level trace events
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (shell bash))
+  > EOF
+
+  $ cat >foo.t <<'EOF'
+  >   $ echo a
+  >   > echo b
+  > Break
+  >   $ echo c
+  > EOF
+
+  $ dune runtest foo.t
+  File "foo.t", line 1, characters 0-0:
+  Error: Files _build/default/foo.t and _build/default/foo.t.corrected differ.
+  [1]
+
+  $ dune trace cat | jq 'include "dune"; select(.cat == "cram") | .args | redactCommandTimes'
+  {
+    "commands": [
+      {
+        "command": [
+          "echo a",
+          "echo b"
+        ],
+        "real": "redacted",
+        "user": "redacted",
+        "system": "redacted"
+      },
+      {
+        "command": [
+          "echo c"
+        ],
+        "real": "redacted",
+        "user": "redacted",
+        "system": "redacted"
+      }
+    ]
+  }
+
+We have to override TIMEFORMAT to get this timing information:
+
+  $ cat >timeformat.t <<'EOF'
+  >   $ echo $TIMEFORMAT
+  > EOF
+
+  $ dune runtest timeformat.t
+  File "timeformat.t", line 1, characters 0-0:
+  Error: Files _build/default/timeformat.t and
+  _build/default/timeformat.t.corrected differ.
+  [1]
+  $ dune promotion show timeformat.t
+    $ echo $TIMEFORMAT
+    %3R|%3S|%3U
+  
+
+Timeout:
+
+  $ cat > dune <<EOF
+  > (cram
+  >  (timeout 0.1)
+  >  (shell bash))
+  > EOF
+
+  $ cat >timeout.t <<EOF
+  >    $ echo foo
+  >    $ sleep 10
+  > EOF
+
+  $ dune runtest timeout.t
+  File "timeout.t", line 1, characters 0-0:
+  Error: Files _build/default/timeout.t and _build/default/timeout.t.corrected
+  differ.
+  [1]
+
+  $ dune trace cat | jq 'include "dune"; select(.cat == "cram") | .args | redactCommandTimes'
+  {
+    "commands": []
+  }
+
+  $ dune promotion show
+  


### PR DESCRIPTION
Cram tests executed with bash will now emit trace events with timing information for every command in a test script. This is useful for understanding why some cram tests are slow.