### PR TITLE
refactor: make `Dir_contents` `(include_qualified ..)` dirs `Nonempty_list.t`s

### DIFF
--- a/src/dune_rules/coq/coq_sources.ml
+++ b/src/dune_rules/coq/coq_sources.ml
@@ -33,7 +33,7 @@ let coq_modules_of_files ~dirs =
     =
     { sd with files = String.Set.filter files ~f:(fun f -> Filename.check_suffix f ".v") }
   in
-  let dirs = List.map dirs ~f:filter_v_files in
+  let dirs = Nonempty_list.map dirs ~f:filter_v_files |> Nonempty_list.to_list in
   let build_mod_dir { Source_file_dir.dir; path_to_root = prefix; files; source_dir = _ } =
     String.Set.to_list_map files ~f:(fun file ->
       let name, _ = Filename.split_extension file in
@@ -70,7 +70,8 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
         Coq_lib_name.Map.add_exn
           acc.directories
           (snd coq.name)
-          (List.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir))
+          (Nonempty_list.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir)
+           |> Nonempty_list.to_list)
       in
       let libraries = Coq_lib_name.Map.add_exn acc.libraries (snd coq.name) modules in
       let rev_map =

--- a/src/dune_rules/coq/coq_sources.mli
+++ b/src/dune_rules/coq/coq_sources.mli
@@ -17,7 +17,7 @@ val of_dir
   :  Stanza.t list
   -> dir:Path.Build.t
   -> include_subdirs:Loc.t * Include_subdirs.t
-  -> dirs:Source_file_dir.t list
+  -> dirs:Source_file_dir.t Nonempty_list.t
   -> t
 
 (** [find_module ~source t] finds a Coq library name and module corresponding to

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -253,8 +253,13 @@ end = struct
               stanzas >>= load_text_files sctx st_dir ~src_dir ~dir)
           in
           let dirs =
-            [ { Source_file_dir.dir; path_to_root = []; files; source_dir = Some st_dir }
-            ]
+            Nonempty_list.
+              [ { Source_file_dir.dir
+                ; path_to_root = []
+                ; files
+                ; source_dir = Some st_dir
+                }
+              ]
           in
           let ml =
             Memo.lazy_ (fun () ->
@@ -346,12 +351,13 @@ end = struct
                         })))
            in
            let dirs =
-             { Source_file_dir.dir
-             ; path_to_root = []
-             ; files
-             ; source_dir = Some source_dir
-             }
-             :: subdirs
+             Nonempty_list.(
+               { Source_file_dir.dir
+               ; path_to_root = []
+               ; files
+               ; source_dir = Some source_dir
+               }
+               :: subdirs)
            in
            let lib_config =
              let+ ocaml = Context.ocaml ctx in

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -96,7 +96,7 @@ module Unresolved = struct
 
   let load_dirs ~dune_version dirs =
     List.fold_left
-      dirs
+      (Nonempty_list.to_list dirs)
       ~init:String.Map.empty
       ~f:(fun acc { Source_file_dir.dir; path_to_root = _; files; source_dir = _ } ->
         let sources = load ~dir ~dune_version ~files in

--- a/src/dune_rules/foreign_sources.mli
+++ b/src/dune_rules/foreign_sources.mli
@@ -13,5 +13,5 @@ val make
   :  Stanza.t list
   -> dir:Path.Build.t
   -> dune_version:Syntax.Version.t
-  -> dirs:Source_file_dir.t list
+  -> dirs:Source_file_dir.t Nonempty_list.t
   -> t Memo.t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -607,6 +607,7 @@ let make
       ~dirs
   =
   let+ modules_of_stanzas =
+    let dirs = Nonempty_list.to_list dirs in
     let modules =
       let dialects = Dune_project.dialects project in
       match include_subdirs with

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -60,5 +60,5 @@ val make
   -> loc:Loc.t
   -> lookup_vlib:(loc:Loc.t -> dir:Path.Build.t -> t Memo.t)
   -> include_subdirs:Loc.t * Include_subdirs.t
-  -> dirs:Source_file_dir.t list
+  -> dirs:Source_file_dir.t Nonempty_list.t
   -> t Memo.t

--- a/src/dune_rules/rocq/rocq_sources.ml
+++ b/src/dune_rules/rocq/rocq_sources.ml
@@ -46,7 +46,7 @@ let rocq_modules_of_files ~dirs =
     =
     { sd with files = String.Set.filter files ~f:(fun f -> Filename.check_suffix f ".v") }
   in
-  let dirs = List.map dirs ~f:filter_v_files in
+  let dirs = Nonempty_list.map dirs ~f:filter_v_files |> Nonempty_list.to_list in
   let build_mod_dir { Source_file_dir.dir; path_to_root = prefix; files; source_dir = _ } =
     String.Set.to_list_map files ~f:(fun file ->
       let name, _ = Filename.split_extension file in
@@ -83,7 +83,8 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
         Rocq_lib_name.Map.add_exn
           acc.directories
           (snd rocq.name)
-          (List.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir))
+          (Nonempty_list.map dirs ~f:(fun (d : Source_file_dir.t) -> d.dir)
+           |> Nonempty_list.to_list)
       in
       let libraries = Rocq_lib_name.Map.add_exn acc.libraries (snd rocq.name) modules in
       let rev_map =

--- a/src/dune_rules/rocq/rocq_sources.mli
+++ b/src/dune_rules/rocq/rocq_sources.mli
@@ -30,7 +30,7 @@ val of_dir
   :  Stanza.t list
   -> dir:Path.Build.t
   -> include_subdirs:Loc.t * Include_subdirs.t
-  -> dirs:Source_file_dir.t list
+  -> dirs:Source_file_dir.t Nonempty_list.t
   -> t
 
 (** [find_module ~source t] finds a Rocq library name and module corresponding to


### PR DESCRIPTION
part of a series of patches to add dynamic module support to `(ocamllex ..)` / `(ocamlyacc ..)` stanzas.