### PR TITLE
fix(module_trie): allow setting nested path

### DIFF
--- a/src/dune_rules/module_trie.ml
+++ b/src/dune_rules/module_trie.ml
@@ -49,7 +49,7 @@ let rec gen_set_k t ps v ~on_exists =
         | Some c -> on_exists c)
       else (
         match x with
-        | None -> None
+        | None -> Some (Map (gen_set_k Map.empty ps v ~on_exists))
         | Some (Leaf _ as leaf) -> Some leaf
         | Some (Map m) -> Some (Map (gen_set_k m ps v ~on_exists))))
 ;;


### PR DESCRIPTION
previously: `Module_trie.set Module_trie.empty ["a"; "b"] x` would be silently ignored