### PR TITLE
feat(ocamllex): support dynamic `(modules ..)` evaluation 

### DIFF
--- a/doc/changes/added/13105.md
+++ b/doc/changes/added/13105.md
@@ -1,0 +1,4 @@
+- Allow expansion of special forms like `(:include ..)` and `%{read-lines:..}`
+  in the `modules` specification for the `ocamllex` stanza. (#13105,
+  @anmonteiro)
+

--- a/src/dune_lang/ordered_set_lang.mli
+++ b/src/dune_lang/ordered_set_lang.mli
@@ -49,6 +49,11 @@ module Unexpanded : sig
   include Conv.S with type t := t
 
   val encode : t -> Dune_sexp.t list
+
+  val decode_since_expanded
+    :  since_expanded:Syntax.Version.t
+    -> (t, Decoder.values) Decoder.parser
+
   val standard : t
   val of_strings : pos:string * int * int * int -> string list -> t
   val include_single : context:Univ_map.t -> pos:string * int * int * int -> string -> t

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -161,8 +161,6 @@ end = struct
           | Rocq_stanza.Extraction.T s ->
             Memo.return (Rocq_stanza.Extraction.ml_target_fnames s)
           | Menhir_stanza.T menhir -> Memo.return (Menhir_stanza.targets menhir)
-          | Ocamllex.T ocamllex ->
-            Memo.return (List.map ocamllex.modules ~f:(fun s -> s ^ ".ml"))
           | Ocamlyacc.T ocamlyacc ->
             Memo.return
               (List.concat_map ocamlyacc.modules ~f:(fun s -> [ s ^ ".ml"; s ^ ".mli" ]))

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -221,7 +221,7 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander ~dune_file ~dir:ctx_d
         Expander.eval_blang expander ocamllex.enabled_if
         >>= (function
          | false -> Memo.return ()
-         | true -> Ocamllex_rules.gen_rules ocamllex ~sctx ~dir:ctx_dir)
+         | true -> Ocamllex_rules.gen_rules ocamllex ~sctx ~dir_contents ~dir:ctx_dir)
       | Ocamlyacc.T ocamlyacc ->
         Expander.eval_blang expander ocamlyacc.enabled_if
         >>= (function

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -36,6 +36,12 @@ val modules_and_obj_dir
 (** Modules attached to a library, executable, or melange.emit stanza. *)
 val modules : t -> libs:Lib.DB.t -> for_:for_ -> Modules.t Memo.t
 
+module Parser_generators : sig
+  type for_ = Ocamllex of Loc.t
+
+  val source_modules : t -> for_:for_ -> Module.Source.t Module_trie.t option
+end
+
 (** Find out the origin of the stanza for a given module *)
 val find_origin : t -> libs:Lib.DB.t -> Module_name.Path.t -> Origin.t option Memo.t
 

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -24,6 +24,7 @@ module File = struct
 
   let dialect t = t.dialect
   let path t = t.path
+  let original_path t = t.original_path
 
   let version_installed t ~src_root ~install_dir =
     let path =
@@ -35,7 +36,10 @@ module File = struct
     { t with path }
   ;;
 
-  let make dialect path = { dialect; path; original_path = path }
+  let make ?original_path dialect path =
+    let original_path = Option.value original_path ~default:path in
+    { dialect; path; original_path }
+  ;;
 
   let to_dyn { path; original_path; dialect } =
     let open Dyn in
@@ -188,6 +192,8 @@ module Source = struct
     | None -> base
     | Some i -> i :: base
   ;;
+
+  let files_by_ml_kind t = t.files
 
   let map_files t ~f =
     let files = Ml_kind.Dict.mapi ~f t.files in

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -7,7 +7,8 @@ module File : sig
 
   val dialect : t -> Dialect.t
   val path : t -> Path.t
-  val make : Dialect.t -> Path.t -> t
+  val original_path : t -> Path.t
+  val make : ?original_path:Path.t -> Dialect.t -> Path.t -> t
 end
 
 module Kind : sig
@@ -34,6 +35,7 @@ module Source : sig
   val make : impl:File.t option -> intf:File.t option -> Module_name.Path.t -> t
   val has : t -> ml_kind:Ml_kind.t -> bool
   val files : t -> File.t list
+  val files_by_ml_kind : t -> File.t option Ml_kind.Dict.t
   val path : t -> Module_name.Path.t
   val to_dyn : t -> Dyn.t
   val src_dir : t -> Path.t

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -23,6 +23,7 @@ type kind =
 val eval
   :  expander:Expander.t
   -> modules:Module.Source.t Module_trie.t
+  -> module_path:Module_name.t list option
   -> stanza_loc:Loc.t
   -> private_modules:Ordered_set_lang.Unexpanded.t
   -> kind:kind

--- a/src/dune_rules/ocamllex_rules.ml
+++ b/src/dune_rules/ocamllex_rules.ml
@@ -21,26 +21,42 @@ let ocamllex =
       args
 ;;
 
-let rule sctx ~dir ~loc ~mode : Action.Full.t Action_builder.With_targets.t -> unit Memo.t
-  =
-  Super_context.add_rule sctx ~dir ~mode ~loc
-;;
-
-let gen_rules ~sctx ~dir { Ocamllex.loc; modules; mode; enabled_if = _ } =
-  Memo.sequential_iter modules ~f:(fun name ->
-    let src = Path.Build.relative dir (name ^ ".mll") in
-    let dst = Path.Build.relative dir (name ^ ".ml") in
-    let open Memo.O in
-    let* mode =
-      let* expander = Super_context.expander sctx ~dir in
-      Rule_mode_expand.expand_path ~expander ~dir mode
-    in
-    let action =
-      ocamllex
-        sctx
-        ~loc
-        ~dir
-        [ As [ "-q"; "-o" ]; Target dst; Command.Args.Dep (Path.build src) ]
-    in
-    rule sctx ~dir ~loc ~mode action)
+let gen_rules ~sctx ~dir_contents ~dir t =
+  let open Memo.O in
+  let { Ocamllex.loc; mode; modules = _; enabled_if = _ } = t in
+  let* ml_sources = Dir_contents.ocaml dir_contents in
+  let source_modules =
+    Ml_sources.Parser_generators.source_modules ml_sources ~for_:(Ocamllex loc)
+  in
+  match source_modules with
+  | None -> Memo.return ()
+  | Some source_modules ->
+    Module_trie.to_map source_modules
+    |> Module_name.Map.to_list
+    |> Memo.parallel_iter ~f:(fun (_name, m) ->
+      let source = Module.Source.files m |> List.hd in
+      let src_dir = Module.Source.src_dir m |> Path.as_in_build_dir_exn in
+      match Path.Build.equal dir src_dir with
+      | false ->
+        let ocamllex_dir = Path.Build.drop_build_context_exn dir in
+        let src_dir = Path.Build.drop_build_context_exn src_dir in
+        User_error.raise
+          ~loc
+          [ Pp.text
+              "The `ocamllex' stanza for a module must be specified in the same \
+               directory as the module it generates."
+          ; Pp.textf "- module directory: %s" (Path.Source.to_string src_dir)
+          ; Pp.textf "- ocamllex directory: %s" (Path.Source.to_string ocamllex_dir)
+          ]
+      | true ->
+        let action =
+          let src = Module.File.original_path source in
+          let dst = Module.File.path source |> Path.as_in_build_dir_exn in
+          ocamllex sctx ~loc ~dir [ As [ "-q"; "-o" ]; Target dst; Command.Args.Dep src ]
+        in
+        let* mode =
+          let* expander = Super_context.expander sctx ~dir in
+          Rule_mode_expand.expand_path ~expander ~dir mode
+        in
+        Super_context.add_rule sctx ~dir ~mode ~loc action)
 ;;

--- a/src/dune_rules/ocamllex_rules.mli
+++ b/src/dune_rules/ocamllex_rules.mli
@@ -1,3 +1,8 @@
 open Import
 
-val gen_rules : sctx:Super_context.t -> dir:Path.Build.t -> Ocamllex.t -> unit Memo.t
+val gen_rules
+  :  sctx:Super_context.t
+  -> dir_contents:Dir_contents.t
+  -> dir:Path.Build.t
+  -> Ocamllex.t
+  -> unit Memo.t

--- a/src/dune_rules/stanzas/ocamllex.ml
+++ b/src/dune_rules/stanzas/ocamllex.ml
@@ -2,8 +2,7 @@ open Import
 
 type t =
   { loc : Loc.t
-  ; (* CR anmonteiro we're missing some validation on the modules field here *)
-    modules : string list
+  ; modules : Ordered_set_lang.Unexpanded.t
   ; mode : Rule_mode.t
   ; enabled_if : Blang.t
   }
@@ -14,15 +13,24 @@ include Stanza.Make (struct
     include Poly
   end)
 
+let since_expanded = 3, 22
+
 let decode =
   let open Dune_lang.Decoder in
   (let+ loc = loc
-   and+ modules = repeat string in
+   and+ modules = Ordered_set_lang.Unexpanded.decode_since_expanded ~since_expanded in
    { loc; modules; mode = Standard; enabled_if = Blang.true_ })
   <|> fields
         (let+ loc = loc
-         and+ modules = field "modules" (repeat string)
+         and+ modules = Ordered_set_lang.Unexpanded.field ~since_expanded "modules"
          and+ mode = Rule_mode_decoder.field
          and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) () in
          { loc; modules; mode; enabled_if })
+;;
+
+let modules_settings t =
+  { Modules_settings.root_module = None
+  ; modules_without_implementation = Ordered_set_lang.Unexpanded.standard
+  ; modules = t.modules
+  }
 ;;

--- a/src/dune_rules/stanzas/ocamllex.mli
+++ b/src/dune_rules/stanzas/ocamllex.mli
@@ -2,11 +2,12 @@ open Import
 
 type t =
   { loc : Loc.t
-  ; modules : string list
+  ; modules : Ordered_set_lang.Unexpanded.t
   ; mode : Rule_mode.t
   ; enabled_if : Blang.t
   }
 
 val decode : t Dune_lang.Decoder.t
+val modules_settings : t -> Modules_settings.t
 
 include Stanza.S with type t := t

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-dynamic-modules.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-dynamic-modules.t
@@ -25,17 +25,37 @@ The unit `mod.mll` is present in the working tree, `lib.ml` uses it:
   >   | eof { false }
   > EOF
 
-file `gen/lst`:
+  $ cat >foo.ml <<EOF
+  > let x = Mod.lex
+  > EOF
+  $ cat >dune <<EOF
+  > (ocamllex (:include gen/lst))
+  > (library (name foo))
+  > EOF
 
+Building under dune 3.22 throws an error
+
+  $ dune build foo.cma
+  File "dune", line 1, characters 10-28:
+  1 | (ocamllex (:include gen/lst))
+                ^^^^^^^^^^^^^^^^^^
+  Error: the ability to specify non-constant module lists is only available
+  since version 3.22 of the dune language. Please update your dune-project file
+  to have (lang dune 3.22).
+  [1]
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+  $ dune build foo.cma
+
+`%{read-lines:..}` also works
+
+  $ dune clean
   $ cat >dune <<EOF
   > (ocamllex
   >  (modules (:include gen/lst)))
+  > (library (name foo))
   > EOF
 
-  $ dune b
-  File "dune", line 2, characters 10-28:
-  2 |  (modules (:include gen/lst)))
-                ^^^^^^^^^^^^^^^^^^
-  Error: Atom or quoted string expected
-  [1]
-
+  $ dune build foo.cma

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-gh10301.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-gh10301.t
@@ -23,7 +23,10 @@ Show an edge case of `(include_subdirs ..)` and ocamllex
   File "dune", line 3, characters 0-16:
   3 | (ocamllex lexer)
       ^^^^^^^^^^^^^^^^
-  Error: No rule found for lexer.mll
+  Error: The `ocamllex' stanza for a module must be specified in the same
+  directory as the module it generates.
+  - module directory: src/a
+  - ocamllex directory: .
   [1]
 
 The `(ocamllex ..)` stanza must live next to the source file

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-include-unqualified.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-include-unqualified.t
@@ -21,4 +21,4 @@
   >   | _   { true  }
   >   | eof { false }
   > EOF
-  $ dune build ./lib/foo/lexer.ml
+  $ dune build


### PR DESCRIPTION
depends on #13100 and #13103

### Summary:

- `Ml_sources` now indexes the `ocamllex` stanzas and deduces the targets based on that
- Dune records the modules that are generated by `ocamllex` such that we can query their source information when generating corresponding rules.