### PR TITLE
add warning that dune-site forces linkall

### DIFF
--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -98,6 +98,11 @@ site using the :doc:`generate_sites_module stanza
 The generated module ``mysites`` depends on the library ``dune-site`` provided
 by Dune. As such, the dependency on ``dune-site`` must be specified explicitly.
 
+.. warning::
+
+   An executable that depends (even transitively) on `dune-site` will be compiled with
+   `linkall`, regardless of other options.
+
 .. note::
 
    The dependency on ``dune-site`` also needs to be added to the ``depends``

--- a/otherlibs/dune-site/src/dune
+++ b/otherlibs/dune-site/src/dune
@@ -9,3 +9,6 @@
  (libraries
   (re_export dune-private-libs.dune-section)
   dune-site.private))
+
+(documentation
+ (package dune-site))

--- a/otherlibs/dune-site/src/index.mld
+++ b/otherlibs/dune-site/src/index.mld
@@ -1,0 +1,3 @@
+{1 [dune-site] - loading additional files at runtime. }
+
+{:https://dune.readthedocs.io/en/stable/sites.html#how-to-load-additional-files-at-runtime}


### PR DESCRIPTION
addresses https://github.com/ocaml/dune/issues/12749

I don't know what to do about the index.mld, I haven't used `dune-site` and I only have a superficial understanding of it from reading the manual… so I can't really write a full index.mld file

just having a link feels a bit wrong (what when the url for the doc changes??)

should the mld file just be the same content as the rst but translated??