### PR TITLE
ci: auto-install depexts in multi-repo-build

### DIFF
--- a/.github/workflows/multi-repo-build.yml
+++ b/.github/workflows/multi-repo-build.yml
@@ -8,12 +8,12 @@ on:
         required: true
         type: string
       depext_linux:
-        description: 'Space-separated apt packages for Linux (optional)'
+        description: 'Space-separated apt packages for Linux (optional, falls back to dune show depexts)'
         required: false
         type: string
         default: ''
       depext_macos:
-        description: 'Space-separated brew packages for macOS (optional)'
+        description: 'Space-separated brew packages for macOS (optional, falls back to dune show depexts)'
         required: false
         type: string
         default: ''
@@ -34,6 +34,14 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Print workflow inputs
+        run: |
+          echo "=== Multi-Repo Build Inputs ==="
+          echo "Repos: ${{ inputs.repos }}"
+          echo "Depext Linux: ${{ inputs.depext_linux || '(auto-detect)' }}"
+          echo "Depext macOS: ${{ inputs.depext_macos || '(auto-detect)' }}"
+          echo "==============================="
+
       - name: Checkout Dune
         uses: actions/checkout@v6
 
@@ -76,18 +84,31 @@ jobs:
           cat dune-workspace
 
       - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux' && inputs.depext_linux != ''
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ inputs.depext_linux }}
+          if [ -n "${{ inputs.depext_linux }}" ]; then
+            depexts="${{ inputs.depext_linux }}"
+          else
+            depexts=$(cd workspace && nix shell .. -c dune show depexts)
+          fi
+          if [ -n "$depexts" ]; then
+            echo "Installing depexts: $depexts"
+            sudo apt-get update
+            sudo apt-get install -y $depexts
+          fi
 
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS' && inputs.depext_macos != ''
+        if: runner.os == 'macOS'
         run: |
-          brew install ${{ inputs.depext_macos }}
-
-      - name: Lock dependencies
-        run: cd workspace && nix run .. -- pkg lock
+          if [ -n "${{ inputs.depext_macos }}" ]; then
+            depexts="${{ inputs.depext_macos }}"
+          else
+            depexts=$(cd workspace && nix shell .. -c dune show depexts)
+          fi
+          if [ -n "$depexts" ]; then
+            echo "Installing depexts: $depexts"
+            brew install $depexts
+          fi
 
       - name: Build
         run: cd workspace && nix run .. -- build


### PR DESCRIPTION
We add a way to automatically install depexts in the multi-repo-build action.