### PR TITLE
Implement --target-exec

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -877,7 +877,12 @@ module Builder = struct
       Arg.(
         value
         & opt (some string) None
-        & info [ "target-exec" ] ~docs ~docv:"TOOLCHAIN=CMD" ~doc:(Some doc))
+        & info
+            [ "target-exec" ]
+            ~docs
+            ~docv:"TOOLCHAIN=CMD"
+            ~doc:(Some doc)
+            ~env:(Cmd.Env.info ~doc "DUNE_TARGET_EXEC"))
     and+ build_dir =
       let doc = "Specified build directory. _build if unspecified" in
       Arg.(

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -865,10 +865,11 @@ module Builder = struct
       =
       Options_implied_by_dash_p.term
     and+ x =
+      let doc = "Cross-compile using this toolchain." in
       Arg.(
         value
         & opt (some Arg.context_name) None
-        & info [ "x" ] ~docs ~doc:(Some "Cross-compile using this toolchain."))
+        & info [ "x" ] ~docs ~doc:(Some doc) ~env:(Cmd.Env.info ~doc "DUNE_CROSS_TARGET"))
     and+ target_exec =
       let doc =
         "Wrapper command for running target binaries when cross-compiling. Format: \

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -15,6 +15,7 @@ module Promote = struct
   ;;
 end
 
+let target_exec = ref None
 let report_errors_config = ref Report_errors_config.default
 let stop_on_first_error = ref false
 let debug_fs_cache = ref false

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -1,5 +1,8 @@
 (** Command line flags *)
 
+(** Wrapper for target executables in cross-compilation: (toolchain, prog, args) *)
+val target_exec : (string * string * string list) option ref
+
 val report_errors_config : Report_errors_config.t ref
 
 (** Stop the build upon encountering an error. *)

--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -89,6 +89,7 @@ end
 
 type t =
   | Run of Slang.t list
+  | Runexec of Slang.t list
   | With_accepted_exit_codes of int Predicate_lang.t * t
   | Dynamic_run of String_with_vars.t * String_with_vars.t list
   | Chdir of String_with_vars.t * t

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -78,7 +78,11 @@ module Action_expander : sig
     (* Evaluate a path that "consumes" a target, such as in [(diff? ...
        <file>)] *)
     val consume_file : String_with_vars.t -> Path.Build.t t
-    val prog_and_args : String_with_vars.t -> (Action.Prog.t * string list) t
+
+    val prog_and_args
+      :  force_host:bool
+      -> String_with_vars.t
+      -> (Action.Prog.t * string list) t
 
     module At_rule_eval_stage : sig
       (* Expansion that happens at the time the rule is constructed rather than
@@ -376,7 +380,7 @@ end = struct
 
     let target = add_or_remove_target ~what:"Target" ~f:Path.Build.Map.set
 
-    let prog_args_and_deps sw env acc =
+    let prog_args_and_deps ~force_host sw env acc =
       let b =
         let dir = Path.build env.dir in
         let loc = loc sw in
@@ -416,21 +420,21 @@ end = struct
         let args = Value.L.to_strings ~dir args in
         match prog with
         | Ok prog ->
-          let dep, prog, args = Expander.map_exe env.expander prog args in
+          let dep, prog, args = Expander.map_exe ~force_host env.expander prog args in
           (Ok prog, args), [ dep ]
         | Error _ as v -> (v, []), []
       in
       register_deps b env acc ~f:(function _, deps -> deps)
     ;;
 
-    let prog_and_args sw env acc =
+    let prog_and_args ~force_host sw env acc =
       Memo.map
         ~f:(fun (x, v) ->
           ( Action_builder.bind
               ~f:(fun (prog_and_args, _) -> Action_builder.return prog_and_args)
               x
           , v ))
-        (prog_args_and_deps sw env acc)
+        (prog_args_and_deps ~force_host sw env acc)
     ;;
   end
 end
@@ -440,31 +444,38 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
   let module E = Action_expander.E in
   let open Action_expander.O in
   let module O (* [O] for "outcome" *) = Action in
-  let expand_run prog args =
+  let expand_run ~force_host prog args =
     let+ args = A.all (List.map args ~f:E.strings)
-    and+ prog, more_args = E.prog_and_args prog in
+    and+ prog, more_args = E.prog_and_args ~force_host prog in
     let args = List.concat args in
     prog, more_args @ args
   in
-  match t with
-  | Run args ->
+  let expand_run_action ~force_host ~action_name args =
     let string_args =
       List.filter_map args ~f:(function
         | Slang.Literal sw -> Some sw
         | _ -> None)
     in
     if List.length string_args < List.length args
-    then User_error.raise [ Pp.text "All arguments to \"run\" action must be strings" ];
-    (match string_args with
-     | prog :: args ->
-       let+ prog, args = expand_run prog args in
-       O.Run (prog, Array.Immutable.of_list args)
-     | [] -> User_error.raise [ Pp.text "\"run\" action must have at least one argument" ])
+    then
+      User_error.raise
+        [ Pp.textf "All arguments to \"%s\" action must be strings" action_name ];
+    match string_args with
+    | prog :: args ->
+      let+ prog, args = expand_run ~force_host prog args in
+      O.Run (prog, Array.Immutable.of_list args)
+    | [] ->
+      User_error.raise
+        [ Pp.textf "\"%s\" action must have at least one argument" action_name ]
+  in
+  match t with
+  | Run args -> expand_run_action ~force_host:false ~action_name:"run" args
+  | Runexec args -> expand_run_action ~force_host:true ~action_name:"runexec" args
   | With_accepted_exit_codes (pred, t) ->
     let+ t = expand t in
     O.With_accepted_exit_codes (pred, t)
   | Dynamic_run (prog, args) ->
-    let+ prog, args = expand_run prog args in
+    let+ prog, args = expand_run ~force_host:false prog args in
     Action_plugin.action ~prog ~args
   | Chdir (fn, t) ->
     E.At_rule_eval_stage.path fn ~f:(fun dir ->

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -421,17 +421,17 @@ end = struct
         match prog with
         | Ok prog ->
           let dep, prog, args = Expander.map_exe ~force_host env.expander prog args in
-          (Ok prog, args), [ dep ]
-        | Error _ as v -> (v, []), []
+          Ok prog, args, [ dep ]
+        | Error _ as v -> v, args, []
       in
-      register_deps b env acc ~f:(function _, deps -> deps)
+      register_deps b env acc ~f:(function _, _, deps -> deps)
     ;;
 
     let prog_and_args ~force_host sw env acc =
       Memo.map
         ~f:(fun (x, v) ->
           ( Action_builder.bind
-              ~f:(fun (prog_and_args, _) -> Action_builder.return prog_and_args)
+              ~f:(fun (prog, args, _) -> Action_builder.return (prog, args))
               x
           , v ))
         (prog_args_and_deps ~force_host sw env acc)

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -91,10 +91,9 @@ val implicit : t -> bool
 val compare : t -> t -> Ordering.t
 
 (** [map_exe t exe] returns a version of [exe] that is suitable for being
-    executed on the current machine. For instance, if [t] is a cross-compilation
-    build context, [map_exe t exe] returns the version of [exe] that lives in
-    the host build context. Otherwise, it just returns [exe]. *)
-val map_exe : t -> Path.t -> Path.t
+    executed on the current machine. Returns:
+    [dependency, actual_program, actual_arguments] *)
+val map_exe : t -> Path.t -> string list -> Path.t * Path.t * string list
 
 (** Query where build artifacts should be installed if the user doesn't specify
     an explicit installation directory. *)

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -90,10 +90,16 @@ val implicit : t -> bool
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t
 
-(** [map_exe t exe] returns a version of [exe] that is suitable for being
-    executed on the current machine. Returns:
+(** [map_exe ~force_host t exe] returns a version of [exe] that is suitable for
+    being executed on the current machine. When [force_host] is true, always
+    runs as a native host binary, bypassing any target_exec wrapper. Returns:
     [dependency, actual_program, actual_arguments] *)
-val map_exe : t -> Path.t -> string list -> Path.t * Path.t * string list
+val map_exe
+  :  force_host:bool
+  -> t
+  -> Path.t
+  -> string list
+  -> Path.t * Path.t * string list
 
 (** Query where build artifacts should be installed if the user doesn't specify
     an explicit installation directory. *)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -77,11 +77,11 @@ let set_scope t ~dir ~project ~scope ~scope_host =
 let set_artifacts t ~artifacts_host = { t with artifacts_host }
 let set_expanding_what t x = { t with expanding_what = x }
 
-let map_exe t prog args =
+let map_exe ~force_host t prog args =
   match t.expanding_what with
   | Deps_like_field -> prog, prog, args
   | Nothing_special | User_action _ | User_action_without_targets _ ->
-    Context.map_exe t.context prog args
+    Context.map_exe ~force_host t.context prog args
 ;;
 
 let extend_env t ~env =
@@ -646,7 +646,7 @@ let expand_pform_macro
       (fun t ->
         With
           (dep
-             (match map_exe t (relative ~source t.dir s) [] with
+             (match map_exe ~force_host:false t (relative ~source t.dir s) [] with
               | dep, _, _ -> dep)))
   | Dep -> Need_full_expander (fun t -> With (dep (relative ~source t.dir s)))
   | Bin ->

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -77,11 +77,11 @@ let set_scope t ~dir ~project ~scope ~scope_host =
 let set_artifacts t ~artifacts_host = { t with artifacts_host }
 let set_expanding_what t x = { t with expanding_what = x }
 
-let map_exe t p =
+let map_exe t prog args =
   match t.expanding_what with
-  | Deps_like_field -> p
+  | Deps_like_field -> prog, prog, args
   | Nothing_special | User_action _ | User_action_without_targets _ ->
-    Context.map_exe t.context p
+    Context.map_exe t.context prog args
 ;;
 
 let extend_env t ~env =
@@ -641,7 +641,13 @@ let expand_pform_macro
     (* This case is for %{path-no-dep:...} which was only allowed inside
            jbuild files *)
     assert false
-  | Exe -> Need_full_expander (fun t -> With (dep (map_exe t (relative ~source t.dir s))))
+  | Exe ->
+    Need_full_expander
+      (fun t ->
+        With
+          (dep
+             (match map_exe t (relative ~source t.dir s) [] with
+              | dep, _, _ -> dep)))
   | Dep -> Need_full_expander (fun t -> With (dep (relative ~source t.dir s)))
   | Bin ->
     Need_full_expander

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -115,7 +115,14 @@ val expand_and_eval_set
   -> string list Action_builder.t
 
 val eval_blang : t -> Blang.t -> bool Memo.t
-val map_exe : t -> Path.t -> string list -> Path.t * Path.t * string list
+
+val map_exe
+  :  force_host:bool
+  -> t
+  -> Path.t
+  -> string list
+  -> Path.t * Path.t * string list
+
 val artifacts : t -> Artifacts.t Memo.t
 val expand_locks : t -> Locks.t -> Path.t list Action_builder.t
 

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -115,7 +115,7 @@ val expand_and_eval_set
   -> string list Action_builder.t
 
 val eval_blang : t -> Blang.t -> bool Memo.t
-val map_exe : t -> Path.t -> Path.t
+val map_exe : t -> Path.t -> string list -> Path.t * Path.t * string list
 val artifacts : t -> Artifacts.t Memo.t
 val expand_locks : t -> Locks.t -> Path.t list Action_builder.t
 

--- a/src/dune_rules/per_context.ml
+++ b/src/dune_rules/per_context.ml
@@ -17,7 +17,7 @@ let all =
       let targets =
         List.filter_map targets ~f:(function
           | Native -> None
-          | Named toolchain ->
+          | Named { name = toolchain; _ } ->
             let name = Context_name.target native ~toolchain in
             Some (name, `Target (context, toolchain)))
       in

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -93,7 +93,11 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           let test_exe = s ^ ext in
           let extra_bindings =
             let test_exe_path, _, _ =
-              Expander.map_exe expander (Path.relative (Path.build dir) test_exe) []
+              Expander.map_exe
+                ~force_host:false
+                expander
+                (Path.relative (Path.build dir) test_exe)
+                []
             in
             Pform.Map.singleton test_pform [ Value.Path test_exe_path ]
           in

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -92,8 +92,8 @@ let rules (t : Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           in
           let test_exe = s ^ ext in
           let extra_bindings =
-            let test_exe_path =
-              Expander.map_exe expander (Path.relative (Path.build dir) test_exe)
+            let test_exe_path, _, _ =
+              Expander.map_exe expander (Path.relative (Path.build dir) test_exe) []
             in
             Pform.Map.singleton test_pform [ Value.Path test_exe_path ]
           in

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -319,7 +319,7 @@ module Context = struct
               and+ target_exec =
                 field_o
                   "target_exec"
-                  (Dune_lang.Syntax.since Stanza.syntax (3, 21)
+                  (Dune_lang.Syntax.since Stanza.syntax (3, 22)
                    >>>
                    let+ prog = string
                    and+ args = repeat string in

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -292,29 +292,65 @@ end
 
 module Context = struct
   module Target = struct
+    type named =
+      { name : Context_name.t
+      ; target_exec : (string * string list) option
+      }
+
     type t =
       | Native
-      | Named of Context_name.t
+      | Named of named
 
     let equal x y =
       match x, y with
       | Native, Native -> true
       | Native, _ | _, Native -> false
-      | Named x, Named y -> Context_name.equal x y
+      | Named x, Named y -> Context_name.equal x.name y.name
     ;;
 
     let t =
-      let+ context_name = Context_name.decode in
-      match Context_name.to_string context_name with
-      | "native" -> Native
-      | _ -> Named context_name
+      let open Dune_lang.Decoder in
+      peek
+      >>= function
+      | Some (List _) ->
+        enter
+          (fields
+             (let+ name = field "name" Context_name.decode
+              and+ target_exec =
+                field_o
+                  "target_exec"
+                  (Dune_lang.Syntax.since Stanza.syntax (3, 21)
+                   >>>
+                   let+ prog = string
+                   and+ args = repeat string in
+                   prog, args)
+              in
+              match Context_name.to_string name, target_exec with
+              | "native", Some _ ->
+                User_error.raise
+                  [ Pp.text "Native target cannot have target_exec specified" ]
+              | "native", None -> Native
+              | _ -> Named { name; target_exec }))
+      | _ ->
+        let+ context_name = Context_name.decode in
+        (match Context_name.to_string context_name with
+         | "native" -> Native
+         | _ -> Named { name = context_name; target_exec = None })
     ;;
 
     let to_dyn =
       let open Dyn in
       function
       | Native -> variant "Native" []
-      | Named name -> variant "Named" [ Context_name.to_dyn name ]
+      | Named ({ name; target_exec } : named) ->
+        variant
+          "Named"
+          [ record
+              [ "name", Context_name.to_dyn name
+              ; ( "target_exec"
+                , option (fun (prog, args) -> list string (prog :: args)) target_exec )
+              ]
+          ]
     ;;
 
     let add ts x =
@@ -653,7 +689,7 @@ module Context = struct
     n
     :: List.filter_map (targets t) ~f:(function
       | Native -> None
-      | Named s -> Some (Context_name.target n ~toolchain:s))
+      | Named { name; _ } -> Some (Context_name.target n ~toolchain:name))
   ;;
 
   let default ~x ~profile ~instrument_with =
@@ -682,7 +718,7 @@ module Context = struct
     native
     :: List.filter_map (targets t) ~f:(function
       | Native -> None
-      | Named toolchain ->
+      | Named { name = toolchain; _ } ->
         let name = Context_name.target name ~toolchain in
         Some (Build_context.create ~name))
   ;;
@@ -966,7 +1002,9 @@ let step1 clflags =
          Path.Source.root
        | Some (In_source_dir s) -> s)
   in
-  let x = Option.map x ~f:(fun s -> Context.Target.Named s) in
+  let x =
+    Option.map x ~f:(fun s -> Context.Target.Named { name = s; target_exec = None })
+  in
   let superpose_with_command_line cl field =
     let+ x = field in
     lazy (Option.value cl ~default:(Lazy.force x))
@@ -1086,7 +1124,9 @@ let default clflags =
     =
     clflags
   in
-  let x = Option.map x ~f:(fun s -> Context.Target.Named s) in
+  let x =
+    Option.map x ~f:(fun s -> Context.Target.Named { name = s; target_exec = None })
+  in
   let config =
     create_final_config
       ~config_from_config_file

--- a/src/source/workspace.mli
+++ b/src/source/workspace.mli
@@ -38,9 +38,14 @@ end
 
 module Context : sig
   module Target : sig
+    type named =
+      { name : Context_name.t
+      ; target_exec : (string * string list) option
+      }
+
     type t =
       | Native
-      | Named of Context_name.t
+      | Named of named
 
     val equal : t -> t -> bool
   end

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -1,0 +1,175 @@
+Test target_exec with cross-compilation contexts.
+
+Setup environment:
+
+  $ unset OCAMLFIND_TOOLCHAIN
+  $ unset OCAMLFIND_CONF
+
+Create a simple executable that prints a message:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > hello.ml <<EOF
+  > let () =
+  >   Printf.printf "---- HELLO START ----\n";
+  >   Printf.printf "Hello from OCaml!\n";
+  >   Printf.printf "PWD: %s\n" (Sys.getcwd ());
+  >   Printf.printf "Args: %s\n" (String.concat " " (Array.to_list Sys.argv));
+  >   Printf.printf "---- HELLO END ----\n";
+  >   Printf.eprintf "\n";
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name hello))
+  > 
+  > (rule
+  >  (alias runhello)
+  >  (action (run ./hello.exe --hello-arg1 --hello-arg2)))
+  > 
+  > (rule
+  >  (alias runecho)
+  >  (action (run sh -c "echo \"Hello from context %{context_name}\"")))
+  > EOF
+
+Setup the test_toolchain:
+
+  $ actualocamlc="$(command -v ocamlc)"
+
+  $ mkdir -p etc/findlib.conf.d
+  $ cat >etc/findlib.conf <<EOF
+  > path=""
+  > ocamlc="$PWD/notocamlc"
+  > EOF
+  $ cat >etc/findlib.conf.d/test.conf <<EOF
+  > path(test_toolchain)=""
+  > ocamlc(test_toolchain)="$PWD/notocamlc-test_toolchain"
+  > EOF
+
+  $ cat >notocamlc <<EOF
+  > #!/usr/bin/env sh
+  > $actualocamlc \$@
+  > EOF
+  $ cat >notocamlc-test_toolchain <<EOF
+  > #!/usr/bin/env sh
+  > $actualocamlc \$@
+  > EOF
+  $ chmod +x notocamlc notocamlc-test_toolchain
+
+  $ export OCAMLFIND_CONF=$PWD/etc/findlib.conf
+
+Create wrappers for testing
+
+  $ mkdir -p bin
+  $ cat > bin/test_toolchain_wrapper.sh <<'EOF'
+  > #!/bin/sh
+  > echo "=== TEST_TOOLCHAIN WRAPPER START ==="
+  > echo "WRAPPER PWD: $PWD"
+  > echo "WRAPPER executing: $@"
+  > echo "=== WRAPPER EXEC ==="
+  > exec "$@"
+  > EOF
+
+  $ chmod +x bin/test_toolchain_wrapper.sh
+
+Build @runhello with -x test_toolchain without target_exec
+(should use host binary from ../default/hello.exe)
+
+  $ dune build @runhello -x test_toolchain
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: ../default/hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+
+
+Build with -x test_toolchain and --target-exec test_toolchain=test_toolchain_wrapper.sh
+(should use target binary ./hello.exe wrapped with the wrapper)
+
+  $ PATH="$PWD/bin:$PATH" dune build @runhello -x test_toolchain --target-exec test_toolchain=test_toolchain_wrapper.sh --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  === TEST_TOOLCHAIN WRAPPER START ===
+  WRAPPER PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  WRAPPER executing: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  === WRAPPER EXEC ===
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+
+Build with -x test_toolchain and --target-exec with arguments
+(should use target binary ./hello.exe wrapped with the wrapper)
+
+  $ cat > bin/wrapper_with_args.sh <<'EOF'
+  > #!/bin/sh
+  > echo "=== WRAPPER WITH ARGS START ==="
+  > echo "WRAPPER: all args: $@"
+  > echo "=== WRAPPER EXEC ==="
+  > # Skip the wrapper's own argument and exec the rest
+  > shift
+  > shift
+  > exec "$@"
+  > EOF
+
+  $ chmod +x bin/wrapper_with_args.sh
+
+  $ PATH="$PWD/bin:$PATH" dune build @runhello -x test_toolchain --target-exec "test_toolchain=wrapper_with_args.sh --arg1 --arg2" --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  === WRAPPER WITH ARGS START ===
+  WRAPPER: all args: --arg1 --arg2 $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  === WRAPPER EXEC ===
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+
+Build with -x test_toolchain and --target-exec wih a binary outside of the sources
+(should not use the wrapper)
+
+  $ dune build @runecho -x test_toolchain --target-exec test_toolchain=test_toolchain_wrapper.sh --force
+  Hello from context default
+  Hello from context default.test_toolchain
+
+
+Build with -x test_toolchain and a wrapper that is not in the path
+
+  $ dune build @runhello -x test_toolchain --target-exec test_toolchain=test_toolchain_wrapper.sh --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  Error: Target exec wrapper test_toolchain_wrapper.sh could not be found in
+  the path!
+  -> required by alias runhello (context default.test_toolchain) in dune:4
+  [1]
+
+Build with an invalid --target_exec option
+
+  $ dune build @runhello --target-exec native_wrapper.sh --force
+  Error: --target-exec: invalid format
+  [1]

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -116,6 +116,27 @@ Build with -x test_toolchain and --target-exec test_toolchain=test_toolchain_wra
   Args: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
   ---- HELLO END ----
   
+Build with -x test_toolchain and environment variable DUNE_TARGET_EXEC=test_toolchain=test_toolchain_wrapper.sh
+(should use target binary ./hello.exe wrapped with the wrapper)
+
+  $ PATH="$PWD/bin:$PATH" DUNE_TARGET_EXEC=test_toolchain=test_toolchain_wrapper.sh dune build @runhello -x test_toolchain --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  === TEST_TOOLCHAIN WRAPPER START ===
+  WRAPPER PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  WRAPPER executing: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  === WRAPPER EXEC ===
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+
 
 Build with -x test_toolchain and --target-exec with arguments
 (should use target binary ./hello.exe wrapped with the wrapper)

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -8,7 +8,7 @@ Setup environment:
 Create a simple executable that prints a message:
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.21)
+  > (lang dune 3.22)
   > EOF
 
   $ cat > hello.ml <<EOF
@@ -241,7 +241,7 @@ Test runexec action (should always run host binary, bypassing wrapper)
 Build with dune-workspace
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.21)
+  > (lang dune 3.22)
   > (context
   >  (default
   >    (targets
@@ -270,7 +270,7 @@ Build with dune-workspace
 Build with dune-workspace and arguments
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.21)
+  > (lang dune 3.22)
   > (context
   >  (default
   >    (targets
@@ -326,7 +326,7 @@ Build with dune-workspace and --target-exec should give priority to --target-exe
 Build with invalid dune-workspace
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.21)
+  > (lang dune 3.22)
   > (context
   >  (default
   >    (targets

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -137,6 +137,29 @@ Build with -x test_toolchain and environment variable DUNE_TARGET_EXEC=test_tool
   ---- HELLO END ----
   
 
+Build with environment variables DUNE_CROSS_TARGET=test_toolchain and DUNE_TARGET_EXEC=test_toolchain=test_toolchain_wrapper.sh
+(should cross compile and use target binary ./hello.exe wrapped with the wrapper)
+
+  $ PATH="$PWD/bin:$PATH" DUNE_CROSS_TARGET=test_toolchain DUNE_TARGET_EXEC=test_toolchain=test_toolchain_wrapper.sh dune build @runhello --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+  === TEST_TOOLCHAIN WRAPPER START ===
+  WRAPPER PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  WRAPPER executing: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  === WRAPPER EXEC ===
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: $TESTCASE_ROOT/_build/default.test_toolchain/hello.exe --hello-arg1 --hello-arg2
+  ---- HELLO END ----
+  
+
+
+
 
 Build with -x test_toolchain and --target-exec with arguments
 (should use target binary ./hello.exe wrapped with the wrapper)

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/target-exec.t
@@ -30,6 +30,10 @@ Create a simple executable that prints a message:
   >  (action (run ./hello.exe --hello-arg1 --hello-arg2)))
   > 
   > (rule
+  >  (alias runexec_hello)
+  >  (action (runexec ./hello.exe --runexec-arg1 --runexec-arg2)))
+  > 
+  > (rule
   >  (alias runecho)
   >  (action (run sh -c "echo \"Hello from context %{context_name}\"")))
   > EOF
@@ -173,3 +177,21 @@ Build with an invalid --target_exec option
   $ dune build @runhello --target-exec native_wrapper.sh --force
   Error: --target-exec: invalid format
   [1]
+
+Test runexec action (should always run host binary, bypassing wrapper)
+
+  $ PATH="$PWD/bin:$PATH" dune build @runexec_hello -x test_toolchain --target-exec test_toolchain=test_toolchain_wrapper.sh --force
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default
+  Args: ./hello.exe --runexec-arg1 --runexec-arg2
+  ---- HELLO END ----
+  
+  ---- HELLO START ----
+  Hello from OCaml!
+  PWD: $TESTCASE_ROOT/_build/default.test_toolchain
+  Args: ../default/hello.exe --runexec-arg1 --runexec-arg2
+  ---- HELLO END ----
+  
+
+

--- a/test/blackbox-tests/test-cases/describe/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe/describe_location.t
@@ -48,7 +48,7 @@ Test that executables from dependencies are located correctly:
   > EOF
 
   $ dune describe location bar
-  _build/_private/default/.pkg/bar.0.1-71f2fd5a20f2956e48a2965b20666f1e/target/bin/bar
+  _build/_private/default/.pkg/bar.0.1-18f5ba96e25cb1efb35a00b61cda2990/target/bin/bar
 
 Test that executables from PATH are located correctly:
   $ mkdir bin

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -19,5 +19,5 @@ Test that section pforms are substituted with absolute paths.
 Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
   $ build_pkg test 2>&1 | strip_sandbox
-  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-35943fe1ea902a1ac62aea8f115d162d/target
-  $SANDBOX/_private/default/.pkg/test.0.0.1-35943fe1ea902a1ac62aea8f115d162d/target
+  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-67550fa516eef3314a4ff6e87e99fe5d/target
+  $SANDBOX/_private/default/.pkg/test.0.0.1-67550fa516eef3314a4ff6e87e99fe5d/target

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -33,7 +33,7 @@ Testing install actions
   { files =
       [ (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-f6ed2ec1b5272dd0b899919ab4533208/target/lib/xxx"
+             "_private/default/.pkg/test.0.0.1-1bcbc23258c96a9171e50ea858773794/target/lib/xxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -14,12 +14,12 @@ This should give us a proper error that myfile wasn't generated
   $ lockfile "myfile"
   $ build_pkg test 2>&1 | dune_cmd subst '_build.*_private' '$ROOT/_private'
   Error: entry
-  $ROOT/_private/default/.pkg/test.0.0.1-962f24dc2cb394442fe86368a850a9d0/source/myfile
+  $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/source/myfile
   in
-  $ROOT/_private/default/.pkg/test.0.0.1-962f24dc2cb394442fe86368a850a9d0/source/test.install
+  $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/source/test.install
   does not exist
   -> required by
-     $ROOT/_private/default/.pkg/test.0.0.1-962f24dc2cb394442fe86368a850a9d0/target
+     $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/target
   [1]
 
 This on the other hand shouldn't error because myfile is optional

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -43,19 +43,19 @@ Test that installed binaries are visible in dependent packages
   { files =
       [ (LIB,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-8240dbfd7c93ea3e976f855df6946a09/target/lib/test/libxxx"
+             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/lib/test/libxxx"
          ])
       ; (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-8240dbfd7c93ea3e976f855df6946a09/target/lib/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/lib/lib_rootxxx"
          ])
       ; (BIN,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-8240dbfd7c93ea3e976f855df6946a09/target/bin/foo"
+             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/bin/foo"
          ])
       ; (SHARE_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-8240dbfd7c93ea3e976f855df6946a09/target/share/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/share/lib_rootxxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -49,15 +49,15 @@ opam-var-unsupported.t
 
   $ build_pkg testpkg 2>&1 | dune_cmd subst '.*.sandbox/[^/]+' '.sandbox/$SANDBOX'
   dune
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/source
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/bin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/sbin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/share
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/doc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/etc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/man
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/lib/toplevel
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d349dc24837a78e7f391d386e4fcec8d/target/lib/stublibs
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/source
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/bin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/sbin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/share
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/doc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/etc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/man
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib/toplevel
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -73,13 +73,13 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/
-  foo.0.0.1-5e48eb7073ada94c09fb13ac3853f1e9
-  linux-only.0.0.1-f754e8cf64f80c214f1a86ee403f0dc3
+  foo.0.0.1-8a5ad1a19f5f8d72369fe49a7f3ca0f3
+  linux-only.0.0.1-a1576fc5a8c775d87e8186b53db62eef
 
   $ dune clean
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/
-  foo.0.0.1-c8f5e41510b06a6875f85e9639e1a288
-  macos-only.0.0.1-6fa10e046474f147e8ea1a1932a87966
+  foo.0.0.1-be71f4a233c5170a74ac038f693ea063
+  macos-only.0.0.1-158076f066cd0c29ae731e289007e0a5

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -34,7 +34,7 @@ Test that we can set variables
   abool: true
   astring: foobar
   somestrings: foo bar
-  share path: ../../test.0.0.1-4720c73ae6ba1444af0517c28d2b366e/target/share/test
+  share path: ../../test.0.0.1-9c401dcba674aef73cb59a8542e10768/target/share/test
   version: 1.2.3
 
   $ show_pkg_cookie test
@@ -66,5 +66,5 @@ Now we demonstrate we get a proper error from invalid .config files:
   Error parsing test.config
   Reason: Parse error
   -> required by
-     _build/_private/default/.pkg/test.0.0.1-69ac79828345d1ca458538ce94b5c970/target
+     _build/_private/default/.pkg/test.0.0.1-8af7aa610e92a4df76396bed0f179745/target
   [1]


### PR DESCRIPTION
This PR implements runing a target binary from the host following the proposal at: https://github.com/ocaml/dune/issues/13052

* Add `--target-exec <toolchain>=<wrapper>`
* Add per-target support in `dune-workspace`:
```dune
(context
 (default
   (targets
     native
     ((name test_toolchain) (target_exec wrapper_with_args.sh --arg1 --arg2)))))
```
* Wire it exactly where the binary is currently replaced with a native binary when cross-compiling.
* At the moment the wrapper is expected to be an external binary not produced by the project. This seems quite reasonable.
* Add `DUNE_TARGET_EXEC` and `DUNE_CROSS_TARGET` to specify `--target-exec` (resp. `-x`) through environment variables
* Add a new `runexec` action that bypasses the target exec wrapper when needed.

This is intended for cross-compilation only at the moment so the wrapper is only added in those cases.

### Implementation details

Most of the implementation complexity is at the wrapper substitution level and mostly because it changes the relationship between program and dependency but also because it ties up the program and arguments together.

To help with that, the signature of `map_exe` is changed to include arguments and return dependency, program and arguments. The rest of the downstream code is adapted accordingly while trying to keep the APIs as similar as possible.

### Example

Here's a PR with a complex build system that was lifted to do fully transparent cross-build: https://github.com/savonet/ocaml-posix/pull/24

All you have to do it run:
```shell
dune build -x windows --target-exec windows=wine posix-socket
```

and it cross-builds for windows using the exact same build setup as for native compilation.

### Future work

The long-term goal is to lift this to `opam` and allow transparent cross-building using the same dune-based native package. 

Something like:
```opam
x-dune-cross-enabled: true
x-dune-cross-needs-target-exec: true
```
And use the above environment variables to do a cross-build.

This should allow cross-building opam repository such as https://github.com/ocaml-cross/opam-cross-windows/ to drop all crossbuild enabled packages and directly use the native opam packages.