### PR TITLE
ci: use `actions/cache/{restore,save}` for opam steps

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,13 +40,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
-          gc-max-store-size-macos: 2G
       - run: nix build
 
   nix-test:
@@ -62,12 +55,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 10G
       - run: nix develop -i -c make test
 
   fmt:
@@ -78,12 +65,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop .#fmt -c make fmt
 
   doc:
@@ -94,12 +75,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop .#doc -c make doc
         env:
           LC_ALL: C
@@ -117,12 +92,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
   nix-build-4-08:
@@ -138,12 +107,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_08 -c make release
 
   nix-build-ox:
@@ -167,7 +130,7 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
-      - run: nix develop -i .#bootstrap-ox -c make release 
+      - run: nix develop -i .#bootstrap-ox -c make release
 
 #
 # Stage 2
@@ -233,6 +196,22 @@ jobs:
         if: ${{ matrix.apt_update == true }}
         run: sudo apt update
 
+      - name: Load opam cache when not Windows
+        if: runner.os != 'Windows'
+        id: opam-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Load opam cache when Windows
+        if: runner.os == 'Windows'
+        id: opam-cache-windows
+        uses: actions/cache/restore@v5
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
         with:
@@ -273,6 +252,20 @@ jobs:
         run: opam install ./dune-configurator.opam
         if: ${{ matrix.configurator == true }}
 
+      - name: Save cache when not Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Save cache when Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
   coq:
     name: Coq 8.16.1
     needs: nix-build
@@ -282,12 +275,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#coq -c make test-coq
         env:
           # We disable the Dune cache when running the tests
@@ -310,6 +297,23 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+
+      - name: Load opam cache when not Windows
+        if: runner.os != 'Windows'
+        id: opam-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Load opam cache when Windows
+        if: runner.os == 'Windows'
+        id: opam-cache-windows
+        uses: actions/cache/restore@v5
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -322,6 +326,20 @@ jobs:
         env:
           # We disable the Dune cache when running the tests
           DUNE_CACHE: disabled
+
+      - name: Save cache when not Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Save cache when Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   wasm:
     name: Wasm_of_ocaml
@@ -340,6 +358,22 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@v6
+
+      - name: Load opam cache when not Windows
+        if: runner.os != 'Windows'
+        id: opam-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.opam
+          key: opam-wasm-${{ hashFiles('**.opam') }}
+
+      - name: Load opam cache when Windows
+        if: runner.os == 'Windows'
+        id: opam-cache-windows
+        uses: actions/cache/restore@v5
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml 5.2.x
         uses: ocaml/setup-ocaml@v3
@@ -361,6 +395,20 @@ jobs:
       - name: Run Tests
         run: opam exec -- make test-wasm
 
+      - name: Save cache when not Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Save cache when Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
   cygwin:
     name: Cygwin Build
     runs-on: windows-latest
@@ -375,7 +423,7 @@ jobs:
       ## In order to build dune locally we need to have the re library
       ## available. Even if we do, it is likely that our vendored blake3 rules
       ## will miss cygwin support. So for now, we don't enable the rest.
-      
+
       # - name: Build Dune
       # run: _boot/dune build dune.install
 
@@ -385,6 +433,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Load opam cache when not Windows
+        if: runner.os != 'Windows'
+        id: opam-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Load opam cache when Windows
+        if: runner.os == 'Windows'
+        id: opam-cache-windows
+        uses: actions/cache/restore@v5
+        with:
+          path: _opam
+          key: opam-ox-${{ hashFiles('**.opam') }}
 
       - name: Install OCaml
         uses: ocaml/setup-ocaml@v3
@@ -407,6 +471,20 @@ jobs:
       - name: Run OxCaml tests
         run: opam exec -- ./dune.exe test ./test/blackbox-tests/test-cases/oxcaml
 
+      - name: Save cache when not Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        with:
+          path: ~/.opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
+      - name: Save cache when Windows
+        uses: actions/cache/save@v5
+        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        with:
+          path: _opam
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+
   create-local-opam-switch:
     name: Create local opam switch
     needs: nix-build
@@ -420,6 +498,7 @@ jobs:
           - 5
     runs-on: ${{ matrix.os }}
     steps:
+      # TODO: opam cache here?
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
         with:
@@ -443,12 +522,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
       - run: nix develop .#microbench -c make dune build bench/micro
 
   utop-dev-tool-test:
@@ -459,12 +532,6 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 2G
       - name: Set up a project, install utop as a dev tool, and run it
         shell: nix shell -c bash -e {0}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -219,7 +219,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
@@ -277,7 +277,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
 
   coq:
     name: Coq 8.16.1
@@ -329,7 +329,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
@@ -360,7 +360,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
 
   wasm:
     name: Wasm_of_ocaml
@@ -398,7 +398,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-wasm-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml 5.2.x
         uses: ocaml/setup-ocaml@v3
@@ -427,7 +427,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-wasm-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
@@ -436,7 +436,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-wasm-${{ hashFiles('**.opam') }}
 
   cygwin:
     name: Cygwin Build
@@ -471,7 +471,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-ox-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
         if: runner.os == 'Windows'
@@ -511,7 +511,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-ox-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
@@ -520,7 +520,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-ox-${{ hashFiles('**.opam') }}
 
   create-local-opam-switch:
     name: Create local opam switch

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -203,6 +203,11 @@ jobs:
         if: ${{ matrix.apt_update == true }}
         run: sudo apt update
 
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
       - name: Load opam cache when not Windows
         if: runner.os != 'Windows'
         id: opam-cache
@@ -222,11 +227,6 @@ jobs:
             ~/.opam
             ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.windows-system }}-${{ hashFiles('**.opam') }}
-
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       # Install ocamlfind-secondary and ocaml-secondary-compiler, if needed
       - run: |
@@ -319,6 +319,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
       - name: Load opam cache when not Windows
         if: runner.os != 'Windows'
         id: opam-cache
@@ -329,11 +334,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
       - name: install Rocq Prover
         run: opam install -y ${{ matrix.opam-packages }}
       - name: test Rocq Prover Build Language
@@ -369,6 +369,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      - name: Use OCaml 5.2.x
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.2.x
       - name: Load opam cache when not Windows
         if: runner.os != 'Windows'
         id: opam-cache
@@ -378,11 +382,6 @@ jobs:
             ~/.opam
             ~/work/dune/dune/_opam
           key: opam-wasm-${{ hashFiles('**.opam') }}
-
-      - name: Use OCaml 5.2.x
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 5.2.x
 
       - name: Install faked binaryen-bin package
         # The binaries have already been downloaded
@@ -433,6 +432,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ocaml-variants.5.2.0+ox
+          opam-repositories: |
+            oxcaml: "git+https://github.com/oxcaml/opam-repository.git"
+            default: "git+https://github.com/ocaml/opam-repository.git"
+          opam-pin: false
+
       - name: Load opam cache when not Windows
         if: runner.os != 'Windows'
         id: opam-cache
@@ -443,14 +451,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-ox-${{ hashFiles('**.opam') }}
 
-      - name: Install OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ocaml-variants.5.2.0+ox
-          opam-repositories: |
-            oxcaml: "git+https://github.com/oxcaml/opam-repository.git"
-            default: "git+https://github.com/ocaml/opam-repository.git"
-          opam-pin: false
 
       - name: Pin deps
         run: opam pin add -n . --with-version=3.21.0

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -340,7 +340,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
+          key: opam-rocq-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: install Rocq Prover
         run: opam install -y ${{ matrix.opam-packages }}
@@ -357,7 +357,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
+          key: opam-rocq-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   wasm:
     name: Wasm_of_ocaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -172,10 +172,12 @@ jobs:
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
             os: windows-latest
+            windows-system: msvc
             run_tests: true
           ## mingw
           - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
             os: windows-latest
+            windows-system: mingw
             run_tests: true
           # OCaml 4:
           ## ubuntu (x86)
@@ -219,7 +221,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.windows-system }}-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
@@ -277,7 +279,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.windows-system }}-${{ hashFiles('**.opam') }}
 
   coq:
     name: Coq 8.16.1
@@ -327,16 +329,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
-      - name: Load opam cache when Windows
-        if: runner.os == 'Windows'
-        id: opam-cache-windows
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
-
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -359,15 +351,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
-      - name: Save cache when Windows
-        uses: actions/cache/save@v5
-        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ replace(matrix.ocaml-compiler, ',', '-') }}-${{ hashFiles('**.opam') }}
-
   wasm:
     name: Wasm_of_ocaml
     needs: nix-build
@@ -389,16 +372,6 @@ jobs:
       - name: Load opam cache when not Windows
         if: runner.os != 'Windows'
         id: opam-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-wasm-${{ hashFiles('**.opam') }}
-
-      - name: Load opam cache when Windows
-        if: runner.os == 'Windows'
-        id: opam-cache-windows
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -429,15 +402,6 @@ jobs:
       - name: Save cache when not Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-wasm-${{ hashFiles('**.opam') }}
-
-      - name: Save cache when Windows
-        uses: actions/cache/save@v5
-        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
           path: |
             ~/.opam
@@ -479,16 +443,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-ox-${{ hashFiles('**.opam') }}
 
-      - name: Load opam cache when Windows
-        if: runner.os == 'Windows'
-        id: opam-cache-windows
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-ox-${{ hashFiles('**.opam') }}
-
       - name: Install OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -513,15 +467,6 @@ jobs:
       - name: Save cache when not Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
-        with:
-          path: |
-            ~/.opam
-            ~/work/dune/dune/_opam
-          key: opam-ox-${{ hashFiles('**.opam') }}
-
-      - name: Save cache when Windows
-        uses: actions/cache/save@v5
-        if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
           path: |
             ~/.opam

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -288,6 +288,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 5G
       - run: nix develop .#coq -c make test-coq
         env:
           # We disable the Dune cache when running the tests
@@ -569,6 +575,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 2G
       - name: Set up a project, install utop as a dev tool, and run it
         shell: nix shell -c bash -e {0}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -107,6 +107,12 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 2G
       - run: nix develop -i .#bootstrap-check_4_08 -c make release
 
   nix-build-ox:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -206,7 +206,9 @@ jobs:
         id: opam-cache
         uses: actions/cache/restore@v5
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
@@ -214,7 +216,9 @@ jobs:
         id: opam-cache-windows
         uses: actions/cache/restore@v5
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
@@ -261,14 +265,18 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   coq:
@@ -308,7 +316,9 @@ jobs:
         id: opam-cache
         uses: actions/cache/restore@v5
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
@@ -316,7 +326,9 @@ jobs:
         id: opam-cache-windows
         uses: actions/cache/restore@v5
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Setup OCaml
@@ -336,14 +348,18 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   wasm:
@@ -369,7 +385,9 @@ jobs:
         id: opam-cache
         uses: actions/cache/restore@v5
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-wasm-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
@@ -377,7 +395,9 @@ jobs:
         id: opam-cache-windows
         uses: actions/cache/restore@v5
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Use OCaml 5.2.x
@@ -404,14 +424,18 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   cygwin:
@@ -444,7 +468,9 @@ jobs:
         id: opam-cache
         uses: actions/cache/restore@v5
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
@@ -452,7 +478,9 @@ jobs:
         id: opam-cache-windows
         uses: actions/cache/restore@v5
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-ox-${{ hashFiles('**.opam') }}
 
       - name: Install OCaml
@@ -480,14 +508,18 @@ jobs:
         uses: actions/cache/save@v5
         if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
         with:
-          path: ~/.opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
         if: steps.opam-cache-windows.outputs.cache-hit != 'true' && runner.os == 'Windows'
         with:
-          path: _opam
+          path: |
+            ~/.opam
+            ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
   create-local-opam-switch:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -156,39 +156,46 @@ jobs:
         include:
           # OCaml trunk:
           - ocaml-compiler: ocaml-variants.5.5.0+trunk
+            cache-prefix: ocaml-variants.5.5.0+trunk
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)
           - ocaml-compiler: 5.4.x
+            cache-prefix: 5.4.x
             os: ubuntu-latest
             run_tests: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 5.4.x
+            cache-prefix: 5.4.x
             os: macos-latest
             run_tests: true
           ## macos (x86)
           - ocaml-compiler: 5.4.x
+            cache-prefix: 5.4.x
             os: macos-15-intel
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
             os: windows-latest
-            windows-system: msvc
+            cache-prefix: ocaml-compiler.5.4.0-system-msvc
             run_tests: true
           ## mingw
           - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
             os: windows-latest
-            windows-system: mingw
+            cache-prefix: ocaml-compiler.5.4.0-system-mingw
             run_tests: true
           # OCaml 4:
           ## ubuntu (x86)
           - ocaml-compiler: 4.14.x
+            cache-prefix: 4.14.x
             os: ubuntu-latest
           ## ubuntu (x86-32)
           - ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
+            cache-prefix: "ocaml-variants.4.14.2-ocaml-option-32bit"
             os: ubuntu-latest
             apt_update: true
           ## macos (Apple Silicon)
           - ocaml-compiler: 4.14.x
+            cache-prefix: 4.14.x
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
@@ -216,7 +223,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
       - name: Load opam cache when Windows
         if: runner.os == 'Windows'
@@ -226,7 +233,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.windows-system }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
       # Install ocamlfind-secondary and ocaml-secondary-compiler, if needed
       - run: |
@@ -270,7 +277,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
       - name: Save cache when Windows
         uses: actions/cache/save@v5
@@ -279,7 +286,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.windows-system }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
   coq:
     name: Coq 8.16.1
@@ -332,7 +339,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
       - name: install Rocq Prover
         run: opam install -y ${{ matrix.opam-packages }}
@@ -349,7 +356,7 @@ jobs:
           path: |
             ~/.opam
             ~/work/dune/dune/_opam
-          key: opam-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+          key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
   wasm:
     name: Wasm_of_ocaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -145,6 +145,7 @@ jobs:
   build:
     name: Build
     # we only start building our other jobs, once our main tests have passed
+    needs: nix-test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -145,7 +145,6 @@ jobs:
   build:
     name: Build
     # we only start building our other jobs, once our main tests have passed
-    needs: nix-test
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
saves ~4 minutes when installing the opam dependencies after the `setup-ocaml` action.

Could save even more if `setup-ocaml` allowed sharing the cache.