### PR TITLE
Dune trace: write events atomically

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1326,7 +1326,7 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
             | None -> User_error.raise [ Pp.textf "unrecognized trace category %S" x ])
       in
       Path.parent trace |> Option.iter ~f:Path.mkdir_p;
-      let stats = Dune_trace.Out.create cats (open_out (Path.to_string trace)) in
+      let stats = Dune_trace.Out.create cats trace in
       Dune_trace.set_global stats;
       Log.init
         (Redirect (fun w -> Dune_trace.emit Log (fun () -> Dune_trace.Event.log w)))

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -111,6 +111,12 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
+  ; { path = "vendor/bigstringaf"
+    ; main_module_name = Some "Bigstringaf"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
   ; { path = "src/dune_trace"
     ; main_module_name = Some "Dune_trace"
     ; include_subdirs = No
@@ -341,12 +347,6 @@ let local_libraries =
     }
   ; { path = "src/dune_findlib"
     ; main_module_name = Some "Dune_findlib"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
-  ; { path = "vendor/bigstringaf"
-    ; main_module_name = Some "Bigstringaf"
     ; include_subdirs = No
     ; special_builtin_support = None
     ; root_module = None

--- a/src/dune_trace/buffer.ml
+++ b/src/dune_trace/buffer.ml
@@ -1,0 +1,44 @@
+open Stdune
+
+type t =
+  { mutable buf : Bigstringaf.t
+  ; mutable pos : int
+  }
+
+let create size =
+  let buf = Bigstringaf.create size in
+  { buf; pos = 0 }
+;;
+
+let max_size t = Bigstringaf.length t.buf
+let available t = Bigstringaf.length t.buf - t.pos
+let clear t = t.pos <- 0
+let to_string t = Bigstringaf.substring t.buf ~off:0 ~len:t.pos
+let buf t = t.buf
+let pos t = t.pos
+
+let add_char t c =
+  Bigstringaf.set t.buf t.pos c;
+  t.pos <- t.pos + 1
+;;
+
+let add_string t str =
+  let len = String.length str in
+  Bigstringaf.blit_from_string str t.buf ~dst_off:t.pos ~src_off:0 ~len;
+  t.pos <- t.pos + len
+;;
+
+let drop t n =
+  assert (t.pos >= n);
+  let buf = Bigstringaf.create (Bigstringaf.length t.buf) in
+  Bigstringaf.blit t.buf ~src_off:n buf ~dst_off:0 ~len:(t.pos - n);
+  t.buf <- buf;
+  t.pos <- t.pos - n
+;;
+
+let resize t new_size =
+  assert (t.pos <= new_size);
+  let buf = Bigstringaf.create new_size in
+  Bigstringaf.blit t.buf buf ~src_off:0 ~dst_off:0 ~len:t.pos;
+  t.buf <- buf
+;;

--- a/src/dune_trace/buffer.mli
+++ b/src/dune_trace/buffer.mli
@@ -1,0 +1,20 @@
+(** A speciallized buffer module used to emit traces in a single [write].
+
+  This is not a general purpose module.
+
+  Callers are responsible to make sure the buffer is big enough before writing
+  anything to it. *)
+
+type t
+
+val create : int -> t
+val add_char : t -> char -> unit
+val add_string : t -> string -> unit
+val buf : t -> Bigstringaf.t
+val pos : t -> int
+val clear : t -> unit
+val to_string : t -> string
+val drop : t -> int -> unit
+val available : t -> int
+val max_size : t -> int
+val resize : t -> int -> unit

--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -3,4 +3,4 @@
  (foreign_stubs
   (language c)
   (names dune_trace_stubs))
- (libraries stdune csexp spawn unix))
+ (libraries stdune csexp bigstringaf spawn unix))

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -47,4 +47,5 @@ let flush () =
 
 module Private = struct
   module Fd_count = Fd_count
+  module Buffer = Buffer
 end

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -147,7 +147,7 @@ end
 module Out : sig
   type t
 
-  val create : Category.t list -> out_channel -> t
+  val create : Category.t list -> Path.t -> t
   val emit : t -> Event.t -> unit
   val start : t option -> (unit -> Event.Async.data) -> Event.Async.t option
   val finish : t -> Event.Async.t option -> unit
@@ -169,4 +169,6 @@ module Private : sig
 
     val get : unit -> t
   end
+
+  module Buffer : module type of Buffer
 end

--- a/src/dune_trace/dune_trace_stubs.c
+++ b/src/dune_trace/dune_trace_stubs.c
@@ -1,6 +1,45 @@
+#include <caml/alloc.h>
+#include <caml/threads.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/bigarray.h>
+#include <caml/unixsupport.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+typedef SSIZE_T	ssize_t;
+#else
+#include <unistd.h>
+#endif
+
+#if OCAML_VERSION_MAJOR < 5
+#define caml_uerror uerror
+#endif
+
+CAMLprim value dune_trace_write(value v_fd, value v_buf, value v_offset,
+                                value v_length) {
+  CAMLparam4(v_fd, v_buf, v_offset, v_length);
+#ifdef _WIN32
+  int fd = win_CRT_fd_of_filedescr(v_fd);
+#else
+  int fd = Int_val(v_fd);
+#endif
+  intnat offset = Long_val(v_offset);
+  intnat length = Long_val(v_length);
+  void *buf = Caml_ba_data_val(v_buf);
+  ssize_t written;
+
+  caml_release_runtime_system();
+  written = write(fd, (char *)buf + offset, length);
+  caml_acquire_runtime_system();
+
+  if (written == -1) {
+    caml_uerror("dune_trace_write", Nothing);
+  }
+
+  CAMLreturn(Val_long(written));
+}
 
 #if defined(__APPLE__)
 #include <libproc.h>

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -1,16 +1,86 @@
 open Stdune
 
 type t =
-  { out : out_channel
+  { fd : Unix.file_descr
+  ; buf : Buffer.t
   ; cats : Category.Set.t
   }
 
-(* all fields of record used *)
+(* CR-someday rgrinberg: remove this once we drop support for < 5.2 *)
+external write_bigstring
+  :  Unix.file_descr
+  -> Bigstringaf.t
+  -> int
+  -> int
+  -> int
+  = "dune_trace_write"
 
-let close t = close_out t.out
-let create cats out = { out; cats = Category.Set.of_list cats }
-let flush t = flush t.out
-let emit t event = Csexp.to_channel t.out event
+let flush =
+  (* This loop will almost always result in a single write, but we make sure to
+     write everything (albeit inefficiently) if the user is running out of disk
+     space, is on NFS, or some exotic operation system that doesn't give us
+     atomic writes with [O_APPEND] *)
+  let rec loop t pos len =
+    if len = 0
+    then Buffer.clear t.buf
+    else (
+      match write_bigstring t.fd (Buffer.buf t.buf) pos (Buffer.pos t.buf - pos) with
+      | n -> loop t (pos + n) (len - n)
+      | exception e ->
+        let () =
+          (* inefficient, but we just want to make sure we're preserving the
+             invariants of [t] even if we fail for some odd reason. *)
+          Buffer.drop t.buf pos
+        in
+        raise e)
+  in
+  fun t -> loop t 0 (Buffer.pos t.buf)
+;;
+
+let close t =
+  flush t;
+  Unix.close t.fd
+;;
+
+let create cats path =
+  let fd =
+    Unix.openfile
+      (Path.to_string path)
+      [ O_TRUNC; O_APPEND; O_CLOEXEC; O_WRONLY; O_CREAT ]
+      0o644
+  in
+  let cats = Category.Set.of_list cats in
+  let buf = Buffer.create (1 lsl 16) in
+  { fd; cats; buf }
+;;
+
+let to_buffer t sexp =
+  let rec loop = function
+    | Csexp.Atom str ->
+      Buffer.add_string t.buf (string_of_int (String.length str));
+      Buffer.add_char t.buf ':';
+      Buffer.add_string t.buf str
+    | List e ->
+      Buffer.add_char t.buf '(';
+      List.iter ~f:loop e;
+      Buffer.add_char t.buf ')'
+  in
+  loop sexp
+;;
+
+let emit_buffered t event =
+  let needed = Csexp.serialised_length event in
+  if Buffer.available t.buf < needed
+  then (
+    let new_size = max (Buffer.pos t.buf + needed) (2 * Buffer.max_size t.buf) in
+    Buffer.resize t.buf new_size);
+  to_buffer t event
+;;
+
+let emit t event =
+  emit_buffered t event;
+  flush t
+;;
 
 let start t k : Event.Async.t option =
   match t with

--- a/test/expect-tests/dune_stats/buffer_tests.ml
+++ b/test/expect-tests/dune_stats/buffer_tests.ml
@@ -1,0 +1,66 @@
+module Buffer = Dune_trace.Private.Buffer
+
+let b () = Buffer.create 100
+
+let test buf f =
+  let pre = Buffer.to_string buf in
+  f buf;
+  let post = Buffer.to_string buf in
+  Printf.printf
+    "%S -> %S available = %d pos = %d max_size = %d\n"
+    pre
+    post
+    (Buffer.available buf)
+    (Buffer.pos buf)
+    (Buffer.max_size buf)
+;;
+
+let%expect_test "empty" =
+  test (b ()) (fun (_ : Buffer.t) -> ());
+  [%expect {| "" -> "" available = 100 pos = 0 max_size = 100 |}]
+;;
+
+let%expect_test "add_char" =
+  let b = b () in
+  test b (fun b -> Buffer.add_char b 'a');
+  [%expect {| "" -> "a" available = 99 pos = 1 max_size = 100 |}];
+  test b (fun b -> Buffer.add_char b 'b');
+  [%expect {| "a" -> "ab" available = 98 pos = 2 max_size = 100 |}];
+  test b (fun b -> Buffer.add_char b 'c');
+  [%expect {| "ab" -> "abc" available = 97 pos = 3 max_size = 100 |}]
+;;
+
+let%expect_test "add_string" =
+  let b = b () in
+  test b (fun b -> Buffer.add_string b "aaa");
+  [%expect {| "" -> "aaa" available = 97 pos = 3 max_size = 100 |}];
+  test b (fun b -> Buffer.add_string b "");
+  [%expect {| "aaa" -> "aaa" available = 97 pos = 3 max_size = 100 |}];
+  test b (fun b -> Buffer.add_string b "bbb");
+  [%expect {| "aaa" -> "aaabbb" available = 94 pos = 6 max_size = 100 |}]
+;;
+
+let%expect_test "clear" =
+  let b = b () in
+  Buffer.add_string b "abcde";
+  test b Buffer.clear;
+  [%expect {| "abcde" -> "" available = 100 pos = 0 max_size = 100 |}]
+;;
+
+let%expect_test "drop" =
+  let b = b () in
+  Buffer.add_string b "abcde";
+  test b (fun b -> Buffer.drop b 1);
+  [%expect {| "abcde" -> "bcde" available = 96 pos = 4 max_size = 100 |}];
+  test b (fun b -> Buffer.drop b 3);
+  [%expect {| "bcde" -> "e" available = 99 pos = 1 max_size = 100 |}]
+;;
+
+let%expect_test "resize" =
+  let b = b () in
+  Buffer.add_string b "abcde";
+  test b (fun b -> Buffer.resize b 50);
+  [%expect {| "abcde" -> "abcde" available = 45 pos = 5 max_size = 50 |}];
+  test b (fun b -> Buffer.resize b 10);
+  [%expect {| "abcde" -> "abcde" available = 5 pos = 5 max_size = 10 |}]
+;;


### PR DESCRIPTION
Rely on disk writes with O_APPEND always being atomic on Linux to make sure that users do not observe partial traces under normal circumstances.