### PR TITLE
fix(menhir): compile inferred interface in its corresponding module group

### DIFF
--- a/doc/changes/fixed/13118.md
+++ b/doc/changes/fixed/13118.md
@@ -1,0 +1,4 @@
+- Fix compiling Menhir parsers that refer to sibling modules within a
+  subdirectory of `(include_subdirs qualified)`. (#13118, fixes #11119,
+  @anmonteiro)
+

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -254,7 +254,8 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander ~dune_file ~dir:ctx_d
                List.find_map cctxs ~f:(fun (loc, cctx) ->
                  Option.some_if (Loc.equal loc (Ml_sources.Origin.loc origin)) cctx))
            >>= (function
-            | Some cctx -> Menhir_rules.gen_rules cctx m ~dir:ctx_dir
+            | Some cctx ->
+              Menhir_rules.gen_rules cctx m ~module_path:base_path ~dir:ctx_dir
             | None ->
               (* This happens often when passing a [-p ...] option that hides a
                  library *)

--- a/src/dune_rules/menhir/menhir_rules.mli
+++ b/src/dune_rules/menhir/menhir_rules.mli
@@ -8,6 +8,7 @@ val module_names : Menhir_stanza.t -> Module_name.t list
 (** Generate the rules for a [(menhir ...)] stanza. *)
 val gen_rules
   :  dir:Path.Build.t
+  -> module_path:Module_name.t list
   -> Compilation_context.t
   -> Menhir_stanza.t
   -> unit Memo.t

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-group-interface.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-group-interface.t
@@ -32,6 +32,11 @@ We should be able to use menhir as a group interface:
   $ touch group/m.ml
 
   $ dune build
-  File "group/group.mly", line 2, characters 11-12:
-  Error: Unbound module M
-  [1]
+  File "group/group__mock.ml.mock", line 1:
+  Warning 63 [erroneous-printed-signature]: The printed interface differs from
+    the inferred interface. The inferred interface contained items which could
+    not be printed properly due to name collisions between identifiers.
+    File "_none_", line 1:
+    Definition of module Dune__exe__Group__/2 Beware
+    that this warning is purely informational and will not catch all instances
+    of erroneous printed interface.

--- a/test/blackbox-tests/test-cases/menhir/include-subdirs-siblings.t
+++ b/test/blackbox-tests/test-cases/menhir/include-subdirs-siblings.t
@@ -42,6 +42,3 @@
 Menhir parsers in qualified subdirectories should be able to refer to sibling modules:
 
   $ dune build
-  File "lang/parser.mly", line 2, characters 8-11:
-  Error: Unbound module Ast
-  [1]


### PR DESCRIPTION
fixes #11119
