### PR TITLE
improve repeated executable error message

### DIFF
--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -106,10 +106,12 @@ module Per_stanza = struct
       | Ok map ->
         String.Map.map map ~f:(fun (origin, modules, obj_dir, _loc) ->
           origin, modules, obj_dir)
-      | Error (name, (_, _, _, loc1), (_, _, _, _loc2)) ->
+      | Error (name, (_, _, _, loc1), (_, _, _, loc2)) ->
         User_error.raise
           ~loc:loc1
-          [ Pp.textf "Executable %S appears for the second time in this directory" name ]
+          [ Pp.textf "Executable %S appears for the second time in this directory" name
+          ; Pp.textf "Already defined at %s" (Loc.to_file_colon_line loc2)
+          ]
     in
     let melange_emits =
       match

--- a/test/blackbox-tests/test-cases/exe-name-collision.t
+++ b/test/blackbox-tests/test-cases/exe-name-collision.t
@@ -20,4 +20,5 @@ Executables using the same name, defined in the same folder.
   1 | (executable
   2 |  (name foo))
   Error: Executable "foo" appears for the second time in this directory
+  Already defined at dune:3
   [1]

--- a/test/blackbox-tests/test-cases/exe-name-collision.t
+++ b/test/blackbox-tests/test-cases/exe-name-collision.t
@@ -1,0 +1,23 @@
+Executables using the same name, defined in the same folder.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.13)
+  > EOF
+
+  $ cat > dune << EOF
+  > (executable
+  >  (name foo))
+  > (executable
+  >  (name foo))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let () = ()
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-2, characters 0-24:
+  1 | (executable
+  2 |  (name foo))
+  Error: Executable "foo" appears for the second time in this directory
+  [1]


### PR DESCRIPTION
When two exectuable stanzas produce the same names in a directory we get an error message. Instead of discarding the location of the second occurrence we mention it. 