### PR TITLE
Revert "fix(ctypes): add proper user message for missing modules"

### DIFF
--- a/src/dune_rules/ctypes/ctypes_field.ml
+++ b/src/dune_rules/ctypes/ctypes_field.ml
@@ -91,16 +91,15 @@ end
 module Type_description = struct
   type t =
     { functor_ : Module_name.t
-    ; functor_loc : Loc.t
     ; instance : Module_name.t
     }
 
   let decode =
     let open Dune_lang.Decoder in
     fields
-      (let+ functor_loc, functor_ = located @@ field "functor" Module_name.decode
+      (let+ functor_ = field "functor" Module_name.decode
        and+ instance = field "instance" Module_name.decode in
-       { functor_; functor_loc; instance })
+       { functor_; instance })
   ;;
 end
 
@@ -109,7 +108,6 @@ module Function_description = struct
     { concurrency : Concurrency_policy.t
     ; errno_policy : Errno_policy.t
     ; functor_ : Module_name.t
-    ; functor_loc : Loc.t
     ; instance : Module_name.t
     }
 
@@ -118,12 +116,11 @@ module Function_description = struct
     fields
       (let+ concurrency = field_o "concurrency" Concurrency_policy.decode
        and+ errno_policy = field_o "errno_policy" Errno_policy.decode
-       and+ functor_loc, functor_ = located @@ field "functor" Module_name.decode
+       and+ functor_ = field "functor" Module_name.decode
        and+ instance = field "instance" Module_name.decode in
        { concurrency = Option.value concurrency ~default:Concurrency_policy.default
        ; errno_policy = Option.value errno_policy ~default:Errno_policy.default
        ; functor_
-       ; functor_loc
        ; instance
        })
   ;;

--- a/src/dune_rules/ctypes/ctypes_field.mli
+++ b/src/dune_rules/ctypes/ctypes_field.mli
@@ -36,7 +36,6 @@ end
 module Type_description : sig
   type t =
     { functor_ : Module_name.t
-    ; functor_loc : Loc.t
     ; instance : Module_name.t
     }
 end
@@ -46,7 +45,6 @@ module Function_description : sig
     { concurrency : Concurrency_policy.t
     ; errno_policy : Errno_policy.t
     ; functor_ : Module_name.t
-    ; functor_loc : Loc.t
     ; instance : Module_name.t
     }
 end

--- a/test/blackbox-tests/test-cases/ctypes/gh12018.t
+++ b/test/blackbox-tests/test-cases/ctypes/gh12018.t
@@ -42,16 +42,7 @@ Reproduction case for https://github.com/ocaml/dune/issues/12018
   > EOF
 
   $ LIBEX=$(realpath "$PWD/libexample")
-  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./foo.exe
-  File "dune", line 3, characters 10-13:
-  3 |  (modules foo)
-                ^^^
-  Error: Module Function_description is required by ctypes at dune:13 but is
-  missing in the modules field of the stanza.
-  File "dune", line 3, characters 10-13:
-  3 |  (modules foo)
-                ^^^
-  Error: Module Type_description is required by ctypes at dune:10 but is
-  missing in the modules field of the stanza.
-  [1]
-
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./foo.exe 2>&1 | head -3
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("link_many: unable to find module",

--- a/test/blackbox-tests/test-cases/ctypes/github-5561-name-mangle.t
+++ b/test/blackbox-tests/test-cases/ctypes/github-5561-name-mangle.t
@@ -16,16 +16,8 @@
   > EOF
 
   $ bash -c 'set -o pipefail; dune build 2>&1 | head -n 20'
-  File "dune", lines 1-9, characters 0-211:
-  1 | (library
-  2 |  (name foo)
-  3 |  (ctypes
-  4 |   (external_library_name fooBar)
-  5 |   (build_flags_resolver vendored)
-  6 |   (generated_entry_point Types_generated2)
-  7 |   (type_description
-  8 |    (instance Type)
-  9 |    (functor Type_description))))
-  Error: Module Type_description is required by ctypes at dune:9 but is missing
-  in the modules field of the stanza.
+  File "fooBar__type_gen.ml", line 3, characters 12-28:
+  3 |     (module Type_description.Types)
+                  ^^^^^^^^^^^^^^^^
+  Error: Unbound module Type_description
   [1]


### PR DESCRIPTION
This reverts commit 87faddcc1b00d8802b5ec71ddf7e8dd798cdae37 from #12124.

The validation introduced in https://github.com/ocaml/dune/pull/12124 is incorrect as explained in https://github.com/ocaml/dune/issues/13001. Reproduction case is here https://github.com/ocaml/dune/pull/13000. I will merge these separately so it is easier to backport.

This PR reverts the PR that introduced the incorrect validation.

- https://github.com/ocaml/dune/pull/12124
- https://github.com/ocaml/dune/issues/13001
- https://github.com/ocaml/dune/pull/13000