### PR TITLE
ci: multi-repo-build set --display short

### DIFF
--- a/.github/workflows/multi-repo-build.yml
+++ b/.github/workflows/multi-repo-build.yml
@@ -111,4 +111,4 @@ jobs:
           fi
 
       - name: Build
-        run: cd workspace && nix run .. -- build
+        run: cd workspace && nix run .. -- build --display short


### PR DESCRIPTION
This allows us to track progress in the job a little easier.