### PR TITLE
Document what `dev` is used for

### DIFF
--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -3,6 +3,9 @@
 open Import
 
 module Pkg_info : sig
+  (** Representation of the parsed package in a lock dir.
+
+     The [dev] field configures the "dev" filter from OPAM formulae. *)
   type t =
     { name : Package_name.t
     ; version : Package_version.t


### PR DESCRIPTION
I was wondering why `(dev)` is recorded in lockdirs and @Alizter checked what it is used for. This adds the result to the type so next time someone is wondering the answer is easy to find.