### PR TITLE
Add a test to show difference between vendored directory and data only directory

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/vendored-vs-data-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/vendored-vs-data-dir.t
@@ -5,14 +5,13 @@ doesn't use the vendored packages as a dependency.
 We create the necessary packages first
 
   $ mkrepo
+  $ add_mock_repo_if_needed
 
-  $ mkdir vendor
-  $ mkdir vendor/a
-  $ mkdir vendor/b
+  $ mkdir -p vendor/a vendor/b
 
   $ mkpkg lwt
   $ mkpkg eio
-  $ mk_ocaml 5.2.0
+  $ mkpkg ocaml 5.2.0
 
 The vendored packages have some dependencies respectively
   $ cat >vendor/a/dune-project << EOF
@@ -35,17 +34,7 @@ The vendored packages have some dependencies respectively
   >  eio))
   > EOF
 
-We create a common dune-workspace file to reference the mock repo
 
-  $ cat >dune-workspace << EOF
-  > (lang dune 3.21)
-  > (pkg enabled)
-  > (lock_dir
-  >  (repositories mock))
-  > (repository
-  >  (name mock)
-  >  (url "file://$PWD/mock-opam-repository"))
-  > EOF
 
 Now we're adding these as vendored directories.
 
@@ -74,14 +63,10 @@ dependencies.
   - eio.0.0.1
   - lwt.0.0.1
   - ocaml.5.2.0
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0
 
 
 Now, let's treat the vendor packages as `data_only_dirs`. This means dune won't
 scan the vendored directories for its dependencies.
-
-  $ rm dune
 
   $ cat >dune <<EOF
   > (data_only_dirs vendor)
@@ -92,5 +77,3 @@ scan the vendored directories for its dependencies.
   
   Dependencies common to all supported platforms:
   - ocaml.5.2.0
-  - ocaml-base-compiler.5.2.0
-  - ocaml-compiler.5.2.0


### PR DESCRIPTION
This adds a cram test to showcase the behavioral differences between `vendored_dirs` and `data_only_dirs` when scanning for dependencies. I started looking into this after a report by @samoht that vendoring behaves differently from the `opam` workflow.

The behavior is indeed different from opam. When you try to build `vendored_dirs` with Dune, it only builds them if the vendored package is present as a dependency. However, after discussing this with @Leonidas-from-XIV, it seems that the expected behavior in `dune pkg` is to scan and list all dependencies in the lock file.

With `opam`, dependency installation is accounted solely by the top-level `.opam` file. In contrast, `dune pkg` is more proactive: it attempts to scan all potentially required dependencies because it doesn't, and cannot know in advance whether packages in `vendored_dirs` are actually used as dependencies or not.

However, once the dependencies are locked and built, Dune only builds the top-level directory and not the subdirectories if they're not added as dependencies.