### PR TITLE
test(include-qualified): show error indexing directory without sources

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
@@ -1,0 +1,27 @@
+Test `(include_subdirs qualified)` in the presence of invalid module name
+directories that don't contain source files
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (include_subdirs qualified)
+  > (library (name foo))
+  > EOF
+  $ mkdir bar
+  $ echo hello > bar/some-data.txt
+
+  $ mkdir bar-baz
+
+The directory `bar-baz`, even though not a valid module name, doesn't have any
+source files. The library should still compile.
+
+  $ dune build foo.cma --display=short
+  File "bar-baz", line 1, characters 0-0:
+  Error: "bar-baz" is an invalid module name.
+  Module names must be non-empty, start with a letter, and composed only of the
+  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Hint: bar_baz would be a correct module name
+  [1]
+


### PR DESCRIPTION
this reproduces the error described in https://github.com/ocaml/dune/issues/7628