### PR TITLE
test: fix gh7600

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/github7600.t
+++ b/test/blackbox-tests/test-cases/include-qualified/github7600.t
@@ -18,6 +18,7 @@ directories too.
   $ cat > src/foo.ml
 
   $ mkdir src/baz-bar
+  $ touch src/baz-bar/x.ml
 
   $ dune build @install
   File "src/baz-bar", line 1, characters 0-0:


### PR DESCRIPTION
require a module to exist in the crawled directory to validate the module name