### PR TITLE
refactor(module_trie): encode module paths as nonempty lists

### DIFF
--- a/otherlibs/stdune/src/nonempty_list.ml
+++ b/otherlibs/stdune/src/nonempty_list.ml
@@ -2,10 +2,38 @@ type 'a t = ( :: ) of 'a * 'a list
 
 let hd (x :: _) = x
 
+let rev =
+  let rec rev_append l1 (l2 :: l2s : _ t) =
+    match l1 with
+    | [] -> l2 :: l2s
+    | a :: l -> rev_append l (a :: l2 :: l2s : _ t)
+  in
+  fun (x :: xs) -> rev_append xs [ x ]
+;;
+
 let of_list = function
   | [] -> None
   | x :: xs -> Some (x :: xs)
 ;;
 
+let of_list_exn = function
+  | [] -> Code_error.raise "Stdune.Nonempty_list.of_list_exn: empty list" []
+  | x :: xs -> x :: xs
+;;
+
 let to_list (x :: xs) = List.cons x xs
 let map (x :: xs) ~f = f x :: List.map xs ~f
+
+let compare xs ys ~compare =
+  let (x :: xs) = xs
+  and (y :: ys) = ys in
+  List.compare ~compare (x :: xs) (y :: ys)
+;;
+
+let concat xs (t :: ts : _ t) =
+  match xs with
+  | [] -> t :: ts
+  | x :: xs -> x :: (xs @ (t :: ts))
+;;
+
+let ( @ ) = concat

--- a/otherlibs/stdune/src/nonempty_list.mli
+++ b/otherlibs/stdune/src/nonempty_list.mli
@@ -3,6 +3,13 @@
 type 'a t = ( :: ) of 'a * 'a list
 
 val hd : 'a t -> 'a
+val rev : 'a t -> 'a t
 val of_list : 'a list -> 'a t option
+val of_list_exn : 'a list -> 'a t
 val to_list : 'a t -> 'a list
 val map : 'a t -> f:('a -> 'b) -> 'b t
+val compare : 'a t -> 'a t -> compare:('a -> 'a -> Ordering.t) -> Ordering.t
+val concat : 'a list -> 'a t -> 'a t
+
+(** same as [concat]. *)
+val ( @ ) : 'a list -> 'a t -> 'a t

--- a/src/dune_lang/module_name.mli
+++ b/src/dune_lang/module_name.mli
@@ -57,7 +57,8 @@ module Unique : sig
 end
 
 module Path : sig
-  type nonrec t = t list
+  type module_name := t
+  type nonrec t = t Nonempty_list.t
 
   val compare : t -> t -> Ordering.t
   val equal : t -> t -> bool
@@ -71,7 +72,7 @@ module Path : sig
   val wrap : t -> Unique.t
   val encode : t -> Dune_sexp.t list
   val decode : t Decoder.t
-  val append_double_underscore : t -> t
+  val append_double_underscore : module_name list -> t
 end
 
 val wrap : t -> with_:Path.t -> Unique.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -246,7 +246,7 @@ let gen_rules_for_stanzas sctx dir_contents cctxs expander ~dune_file ~dir:ctx_d
            in
            Menhir_rules.module_names m
            |> Memo.List.find_map ~f:(fun name ->
-             let path = base_path @ [ name ] in
+             let path = Nonempty_list.(base_path @ [ name ]) in
              Ml_sources.find_origin ml_sources ~libs:(Scope.libs scope) path
              >>| function
              | None -> None

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -258,7 +258,10 @@ module Run (P : PARAMS) = struct
     let mock_module : Module.t =
       let source =
         let impl = Module.File.make Dialect.ocaml (Path.build (mock_ml base)) in
-        Module.Source.make ~impl:(Some impl) ~intf:None (module_path @ [ name ])
+        Module.Source.make
+          ~impl:(Some impl)
+          ~intf:None
+          Nonempty_list.(module_path @ [ name ])
       in
       Module.of_source ~visibility:Public ~kind:Impl source
     in

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -199,7 +199,7 @@ let modules_of_files_gen ~path ~dir (impl_files, intf_files) =
   let impls = parse_one_set impl_files in
   let intfs = parse_one_set intf_files in
   Module_name.Map.merge impls intfs ~f:(fun name impl intf ->
-    Some (Module.Source.make (path @ [ name ]) ~impl ~intf))
+    Some (Module.Source.make Nonempty_list.(path @ [ name ]) ~impl ~intf))
 ;;
 
 let modules_of_files ~path ~dialects ~dir ~files =
@@ -772,6 +772,11 @@ let make
       let dialects = Dune_project.dialects project in
       match include_subdirs with
       | Include Qualified ->
+        let set_modules acc path modules =
+          match path with
+          | [] -> Ok (Module_trie.of_map modules)
+          | p :: path -> Module_trie.set_map acc (p :: path) modules
+        in
         List.fold_left
           dirs
           ~init:(Module_trie.empty, Module_trie.empty)
@@ -791,8 +796,8 @@ let make
               let parser_gen_modules =
                 Parser_generators.modules_of_files ~dir ~files ~path
               in
-              ( Module_trie.set_map acc path modules
-              , Module_trie.set_map acc_parsing path parser_gen_modules )
+              ( set_modules acc path modules
+              , set_modules acc_parsing path parser_gen_modules )
             with
             | Ok s, Ok s' -> s, s'
             | Error module_, _ | _, Error module_ ->

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -16,7 +16,7 @@ module Kind : sig
     | Intf_only
     | Virtual
     | Impl
-    | Alias of Module_name.Path.t
+    | Alias of Module_name.t list
     | Impl_vmodule
     | Wrapped_compat
     | Root

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -20,7 +20,7 @@ type kind =
 
 let eval0 =
   let key = function
-    | Error s -> [ s ]
+    | Error s -> Nonempty_list.[ s ]
     | Ok m -> [ Module.Source.name m ]
   in
   let module Key = struct
@@ -47,10 +47,10 @@ let eval0 =
   let parse ~all_modules ~loc ~fake_modules ~module_path s =
     let name = Module_name.of_string_allow_invalid (loc, s) in
     let path =
-      let base = [ name ] in
+      let base = Nonempty_list.[ name ] in
       match module_path with
       | None -> base
-      | Some module_path -> module_path @ [ name ]
+      | Some module_path -> Nonempty_list.(module_path @ base)
     in
     match Module_trie.find all_modules path with
     | Some m -> Ok m
@@ -388,7 +388,7 @@ let eval
     ~version;
   let all_modules =
     Module_trie.mapi modules ~f:(fun _path (_, m) ->
-      let name = [ Module.Source.name m ] in
+      let name = Nonempty_list.[ Module.Source.name m ] in
       let visibility =
         if Module_trie.mem private_modules name then Visibility.Private else Public
       in
@@ -410,7 +410,7 @@ let eval
   match root_module with
   | None -> all_modules
   | Some (_, name) ->
-    let path = [ name ] in
+    let path = Nonempty_list.[ name ] in
     let module_ = Module.generated ~kind:Root ~src_dir path in
     Module_trie.set all_modules path module_
 ;;


### PR DESCRIPTION
- encodes in the type system that module paths may never be empty (at least they include the module name itslelf).