### PR TITLE
test(invalid-module): show bad error message

### DIFF
--- a/test/blackbox-tests/test-cases/invalid-module.t
+++ b/test/blackbox-tests/test-cases/invalid-module.t
@@ -15,3 +15,13 @@ artifacts
   $ touch invalid-module.ml
 
   $ dune build
+
+  $ cat > dune <<EOF
+  > (library (name foo))
+  > EOF
+  $ dune build
+  Error: foo__Invalid-module corresponds to an invalid module name
+  -> required by _build/default/foo__.ml-gen
+  -> required by alias all
+  -> required by alias default
+  [1]


### PR DESCRIPTION
this only seems handled incidentally. the error message isn't great and is leaking dune internals