### PR TITLE
 fix(include-qualified): delay invalid module errors 

### DIFF
--- a/src/dune_rules/module_trie.ml
+++ b/src/dune_rules/module_trie.ml
@@ -1,175 +1,190 @@
 open Import
-module Map = Module_name.Map
 
-type key = Module_name.Path.t
+module type S = sig
+  type t
 
-type 'a t = 'a node Map.t
+  include Comparable_intf.S with type key := t
+end
 
-and 'a node =
-  | Leaf of 'a
-  | Map of 'a t
+module Make (S : S) :
+  Module_trie_intf.S with type 'a map := 'a S.Map.t and type el := S.t = struct
+  module Map = S.Map
 
-let empty = Map.empty
+  type 'a map = 'a Map.t
+  type el = S.t
+  type key = el Nonempty_list.t
 
-let mapi =
-  let rec loop t f acc =
-    Map.mapi t ~f:(fun name node ->
-      let path = Nonempty_list.(name :: acc) in
-      match node with
-      | Leaf a -> Leaf (f (Nonempty_list.rev path) a)
-      | Map m -> Map (loop m f (Nonempty_list.to_list path)))
-  in
-  fun t ~f -> loop t f []
-;;
+  type 'a t = 'a node map
 
-let map t ~f = mapi t ~f:(fun _key m -> f m)
-let of_map t : _ t = Map.map t ~f:(fun v -> Leaf v)
+  and 'a node =
+    | Leaf of 'a
+    | Map of 'a t
 
-let rec find t (p :: ps : key) =
-  match Map.find t p with
-  | None -> None
-  | Some (Leaf a) -> Option.some_if (List.is_empty ps) a
-  | Some (Map t) ->
-    (match ps with
-     | [] -> None
-     | p :: ps -> find t (p :: ps))
-;;
+  let empty = Map.empty
 
-let rec gen_set_k t (p :: ps : key) v ~on_exists =
-  Map.update t p ~f:(fun x ->
-    match ps with
-    | [] ->
-      (match x with
-       | None -> Some v
-       | Some c -> on_exists c)
-    | p :: ps ->
-      (match x with
-       | None -> Some (Map (gen_set_k Map.empty (p :: ps) v ~on_exists))
-       | Some (Leaf _ as leaf) -> Some leaf
-       | Some (Map m) -> Some (Map (gen_set_k m (p :: ps) v ~on_exists))))
-;;
+  let mapi =
+    let rec loop t f acc =
+      Map.mapi t ~f:(fun name node ->
+        let path = Nonempty_list.(name :: acc) in
+        match node with
+        | Leaf a -> Leaf (f (Nonempty_list.rev path) a)
+        | Map m -> Map (loop m f (Nonempty_list.to_list path)))
+    in
+    fun t ~f -> loop t f []
+  ;;
 
-let gen_set (type a) (t : a t) ps v =
-  let exception Duplicate of a node in
-  match gen_set_k t ps v ~on_exists:(fun v -> raise_notrace (Duplicate v)) with
-  | s -> Ok s
-  | exception Duplicate d -> Error d
-;;
+  let map t ~f = mapi t ~f:(fun _key m -> f m)
+  let of_map t : _ t = Map.map t ~f:(fun v -> Leaf v)
 
-let set t path v = gen_set_k t path (Leaf v) ~on_exists:(fun _ -> Some (Leaf v))
-let set_map t k v = gen_set t k (Map (of_map v))
-let non_empty_map m = if Map.is_empty m then None else Some (Map m)
+  let rec find t (p :: ps : key) =
+    match Map.find t p with
+    | None -> None
+    | Some (Leaf a) -> Option.some_if (List.is_empty ps) a
+    | Some (Map t) ->
+      (match ps with
+       | [] -> None
+       | p :: ps -> find t (p :: ps))
+  ;;
 
-let rec filter_map t ~f =
-  Map.filter_map t ~f:(function
-    | Map m -> non_empty_map (filter_map m ~f)
-    | Leaf a ->
-      (match f a with
-       | None -> None
-       | Some a -> Some (Leaf a)))
-;;
+  let rec gen_set_k t (p :: ps : key) v ~on_exists =
+    Map.update t p ~f:(fun x ->
+      match ps with
+      | [] ->
+        (match x with
+         | None -> Some v
+         | Some c -> on_exists c)
+      | p :: ps ->
+        (match x with
+         | None -> Some (Map (gen_set_k Map.empty (p :: ps) v ~on_exists))
+         | Some (Leaf _ as leaf) -> Some leaf
+         | Some (Map m) -> Some (Map (gen_set_k m (p :: ps) v ~on_exists))))
+  ;;
 
-let rec remove t (p :: ps : key) =
-  Map.update t p ~f:(fun x ->
-    match ps with
-    | [] -> None
-    | p :: ps ->
-      (match x with
-       | None -> None
-       | Some (Leaf _ as leaf) -> Some leaf
-       | Some (Map m) -> non_empty_map (remove m (p :: ps))))
-;;
+  let gen_set (type a) (t : a t) ps v =
+    let exception Duplicate of a node in
+    match gen_set_k t ps v ~on_exists:(fun v -> raise_notrace (Duplicate v)) with
+    | s -> Ok s
+    | exception Duplicate d -> Error d
+  ;;
 
-let mem t p = Option.is_some (find t p)
+  let set t path v = gen_set_k t path (Leaf v) ~on_exists:(fun _ -> Some (Leaf v))
+  let set_map t k v = gen_set t k (Map (of_map v))
+  let non_empty_map m = if Map.is_empty m then None else Some (Map m)
 
-let foldi t ~init ~f =
-  let rec loop acc path t =
-    Map.foldi ~init:acc t ~f:(fun k v acc ->
-      match v with
-      | Leaf s -> f (Nonempty_list.rev (k :: path)) s acc
-      | Map t -> loop acc (k :: path) t)
-  in
-  loop init [] t
-;;
+  let rec filter_map t ~f =
+    Map.filter_map t ~f:(function
+      | Map m -> non_empty_map (filter_map m ~f)
+      | Leaf a ->
+        (match f a with
+         | None -> None
+         | Some a -> Some (Leaf a)))
+  ;;
 
-let fold t ~init ~f = foldi t ~init ~f:(fun _key -> f)
+  let rec remove t (p :: ps : key) =
+    Map.update t p ~f:(fun x ->
+      match ps with
+      | [] -> None
+      | p :: ps ->
+        (match x with
+         | None -> None
+         | Some (Leaf _ as leaf) -> Some leaf
+         | Some (Map m) -> non_empty_map (remove m (p :: ps))))
+  ;;
 
-let rec to_dyn f t =
-  Map.to_dyn
-    (function
-      | Leaf a -> f a
-      | Map a -> to_dyn f a)
-    t
-;;
+  let mem t p = Option.is_some (find t p)
 
-let merge x y ~f =
-  let rec base ~path ~f t =
-    Map.foldi t ~init:empty ~f:(fun k v acc ->
-      let path = Nonempty_list.(k :: path) in
-      match v with
-      | Leaf leaf ->
-        (match f (Nonempty_list.rev path) leaf with
-         | None -> acc
-         | Some leaf -> Map.add_exn acc k (Leaf leaf))
-      | Map m ->
-        let path = Nonempty_list.to_list path in
-        Map.add_exn acc k (Map (base ~path ~f m)))
-  in
-  let rec loop path x y =
-    match x, y with
-    | None, None -> assert false
-    | Some x, None -> base x ~path ~f:(fun path x -> f path (Some x) None)
-    | None, Some y -> base y ~path ~f:(fun path x -> f path None (Some x))
-    | Some x, Some y ->
-      Map.merge x y ~f:(fun (name : Module_name.t) x y ->
-        let path = Nonempty_list.(name :: path) in
-        let rev_path = Nonempty_list.rev path in
-        let leaf l r =
-          match f rev_path l r with
-          | None -> None
-          | Some x -> Some (Leaf x)
-        in
-        let path = Nonempty_list.to_list path in
-        match x, y with
-        | None, None -> assert false
-        (* leaves *)
-        | None, Some (Leaf y) -> leaf None (Some y)
-        | Some (Leaf x), None -> leaf (Some x) None
-        | Some (Leaf x), Some (Leaf y) -> leaf (Some x) (Some y)
-        (* maps *)
-        | None, Some (Map v) ->
-          non_empty_map (base v ~path ~f:(fun path x -> f path None (Some x)))
-        | Some (Map v), None ->
-          non_empty_map (base v ~path ~f:(fun path x -> f path (Some x) None))
-        | Some (Map x), Some (Map y) -> non_empty_map (loop path (Some x) (Some y))
-        (* mixed *)
-        | Some (Leaf _), Some (Map y) -> non_empty_map (loop path None (Some y))
-        | Some (Map x), Some (Leaf _) -> non_empty_map (loop path (Some x) None))
-  in
-  loop [] (Some x) (Some y)
-;;
+  let foldi t ~init ~f =
+    let rec loop acc path t =
+      Map.foldi ~init:acc t ~f:(fun k v acc ->
+        match v with
+        | Leaf s -> f (Nonempty_list.rev (k :: path)) s acc
+        | Map t -> loop acc (k :: path) t)
+    in
+    loop init [] t
+  ;;
 
-let singleton path v = set empty path v
+  let fold t ~init ~f = foldi t ~init ~f:(fun _key -> f)
 
-let as_singleton t =
-  match
-    fold t ~init:None ~f:(fun v acc ->
-      match acc with
-      | None -> Some v
-      | Some _ -> raise_notrace Exit)
-  with
-  | None | (exception Exit) -> None
-  | Some v -> Some v
-;;
+  let rec to_dyn f t =
+    Map.to_dyn
+      (function
+        | Leaf a -> f a
+        | Map a -> to_dyn f a)
+      t
+  ;;
 
-let to_map t =
-  Module_name.Map.map t ~f:(function
-    | Leaf v -> v
-    | Map _ -> assert false)
-;;
+  let merge x y ~f =
+    let rec base ~path ~f t =
+      Map.foldi t ~init:empty ~f:(fun k v acc ->
+        let path = Nonempty_list.(k :: path) in
+        match v with
+        | Leaf leaf ->
+          (match f (Nonempty_list.rev path) leaf with
+           | None -> acc
+           | Some leaf -> Map.add_exn acc k (Leaf leaf))
+        | Map m ->
+          let path = Nonempty_list.to_list path in
+          Map.add_exn acc k (Map (base ~path ~f m)))
+    in
+    let rec loop path x y =
+      match x, y with
+      | None, None -> assert false
+      | Some x, None -> base x ~path ~f:(fun path x -> f path (Some x) None)
+      | None, Some y -> base y ~path ~f:(fun path x -> f path None (Some x))
+      | Some x, Some y ->
+        Map.merge x y ~f:(fun (name : el) x y ->
+          let path = Nonempty_list.(name :: path) in
+          let rev_path = Nonempty_list.rev path in
+          let leaf l r =
+            match f rev_path l r with
+            | None -> None
+            | Some x -> Some (Leaf x)
+          in
+          let path = Nonempty_list.to_list path in
+          match x, y with
+          | None, None -> assert false
+          (* leaves *)
+          | None, Some (Leaf y) -> leaf None (Some y)
+          | Some (Leaf x), None -> leaf (Some x) None
+          | Some (Leaf x), Some (Leaf y) -> leaf (Some x) (Some y)
+          (* maps *)
+          | None, Some (Map v) ->
+            non_empty_map (base v ~path ~f:(fun path x -> f path None (Some x)))
+          | Some (Map v), None ->
+            non_empty_map (base v ~path ~f:(fun path x -> f path (Some x) None))
+          | Some (Map x), Some (Map y) -> non_empty_map (loop path (Some x) (Some y))
+          (* mixed *)
+          | Some (Leaf _), Some (Map y) -> non_empty_map (loop path None (Some y))
+          | Some (Map x), Some (Leaf _) -> non_empty_map (loop path (Some x) None))
+    in
+    loop [] (Some x) (Some y)
+  ;;
 
-let toplevel_only (t : _ t) =
-  Module_name.Map.filter_map t ~f:(function
-    | Leaf v -> Some v
-    | Map _ -> None)
-;;
+  let singleton path v = set empty path v
+
+  let as_singleton t =
+    match
+      fold t ~init:None ~f:(fun v acc ->
+        match acc with
+        | None -> Some v
+        | Some _ -> raise_notrace Exit)
+    with
+    | None | (exception Exit) -> None
+    | Some v -> Some v
+  ;;
+
+  let to_map t =
+    Map.map t ~f:(function
+      | Leaf v -> v
+      | Map _ -> assert false)
+  ;;
+
+  let toplevel_only (t : _ t) =
+    Map.filter_map t ~f:(function
+      | Leaf v -> Some v
+      | Map _ -> None)
+  ;;
+end
+
+include Make (Module_name)
+module By_dir = Make (Filename)

--- a/src/dune_rules/module_trie.mli
+++ b/src/dune_rules/module_trie.mli
@@ -5,29 +5,8 @@
 
 open Import
 
-type 'a t = 'a node Module_name.Map.t
+include
+  Module_trie_intf.S with type 'a map := 'a Module_name.Map.t and type el := Module_name.t
 
-and 'a node =
-  | Leaf of 'a
-  | Map of 'a t
-
-type key = Module_name.Path.t
-
-val empty : 'a t
-val map : 'a t -> f:('a -> 'b) -> 'b t
-val mapi : 'a t -> f:(key -> 'a -> 'b) -> 'b t
-val of_map : 'a Module_name.Map.t -> 'a t
-val find : 'a t -> key -> 'a option
-val set : 'a t -> key -> 'a -> 'a t
-val set_map : 'a t -> key -> 'a Module_name.Map.t -> ('a t, 'a node) result
-val remove : 'a t -> key -> 'a t
-val mem : 'a t -> key -> bool
-val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
-val foldi : 'a t -> init:'acc -> f:(key -> 'a -> 'acc -> 'acc) -> 'acc
-val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
-val to_map : 'a t -> 'a Module_name.Map.t
-val singleton : key -> 'a -> 'a t
-val merge : 'a t -> 'b t -> f:(key -> 'a option -> 'b option -> 'c option) -> 'c t
-val as_singleton : 'a t -> 'a option
-val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
-val toplevel_only : 'a t -> 'a Module_name.Map.t
+module By_dir :
+  Module_trie_intf.S with type 'a map := 'a Filename.Map.t and type el := Filename.t

--- a/src/dune_rules/module_trie_intf.ml
+++ b/src/dune_rules/module_trie_intf.ml
@@ -1,0 +1,32 @@
+open Import
+
+module type S = sig
+  type 'a map
+  type el
+  type key = el Nonempty_list.t
+
+  type 'a t = 'a node map
+
+  and 'a node =
+    | Leaf of 'a
+    | Map of 'a t
+
+  val empty : 'a t
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+  val mapi : 'a t -> f:(key -> 'a -> 'b) -> 'b t
+  val of_map : 'a map -> 'a t
+  val find : 'a t -> key -> 'a option
+  val set : 'a t -> key -> 'a -> 'a t
+  val set_map : 'a t -> key -> 'a map -> ('a t, 'a node) result
+  val remove : 'a t -> key -> 'a t
+  val mem : 'a t -> key -> bool
+  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
+  val foldi : 'a t -> init:'acc -> f:(key -> 'a -> 'acc -> 'acc) -> 'acc
+  val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
+  val to_map : 'a t -> 'a map
+  val singleton : key -> 'a -> 'a t
+  val merge : 'a t -> 'b t -> f:(key -> 'a option -> 'b option -> 'c option) -> 'c t
+  val as_singleton : 'a t -> 'a option
+  val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
+  val toplevel_only : 'a t -> 'a map
+end

--- a/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/include-qualified/include-qualified-empty-dir.t
@@ -17,11 +17,4 @@ directories that don't contain source files
 The directory `bar-baz`, even though not a valid module name, doesn't have any
 source files. The library should still compile.
 
-  $ dune build foo.cma --display=short
-  File "bar-baz", line 1, characters 0-0:
-  Error: "bar-baz" is an invalid module name.
-  Module names must be non-empty, start with a letter, and composed only of the
-  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: bar_baz would be a correct module name
-  [1]
-
+  $ dune build foo.cma

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-include-qualified-empty-dir.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-include-qualified-empty-dir.t
@@ -27,9 +27,3 @@ The directory `bar-baz`, even though not a valid module name, doesn't have any
 source files. The library should still compile.
 
   $ dune build foo.cma
-  File "bar-baz", line 1, characters 0-0:
-  Error: "bar-baz" is an invalid module name.
-  Module names must be non-empty, start with a letter, and composed only of the
-  following characters: 'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: bar_baz would be a correct module name
-  [1]


### PR DESCRIPTION
depends on #13144

- for each module group:
    1. build a module trie by path component (without parsing into a module name)
    2. delay parsing the path component to a module name until the module becomes part of a group

closes https://github.com/ocaml/dune/issues/7628
refs https://github.com/ocaml/dune/issues/7605, which should be trivial to implement on top of this