### PR TITLE
cram: fix evaluation under bash

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -558,7 +558,7 @@ let run_cram_test
     sh
     ((match shell with
       | Sh -> []
-      | Bash -> [ "-euo"; "pipefail" ])
+      | Bash -> [ "-uo"; "pipefail" ])
      @ [ Path.to_string sh_script.script ])
   >>| function
   | Ok () ->

--- a/test/blackbox-tests/test-cases/cram/bash-shell.t
+++ b/test/blackbox-tests/test-cases/cram/bash-shell.t
@@ -33,7 +33,7 @@ Demonstrate the shell field in the cram stanza
 
   $ cat >options.t <<'EOF'
   >   $ set -o | grep -e pipefail -e nounset -e errexit
-  >   errexit        	on
+  >   errexit        	off
   >   nounset        	on
   >   pipefail       	on
   > EOF
@@ -47,10 +47,6 @@ Demonstrate the shell field in the cram stanza
   > EOF
 
   $ dune runtest code.t
-  File "code.t", line 1, characters 0-0:
-  Error: Files _build/default/code.t and _build/default/code.t.corrected
-  differ.
-  [1]
 
   $ cat >exit1.t <<EOF
   >   $ false
@@ -58,7 +54,3 @@ Demonstrate the shell field in the cram stanza
   > EOF
 
   $ dune runtest exit1.t
-  File "exit1.t", line 1, characters 0-0:
-  Error: Files _build/default/exit1.t and _build/default/exit1.t.corrected
-  differ.
-  [1]


### PR DESCRIPTION
We can't have `-e` because we rely on the exit codes being recorded in the script itself