### PR TITLE
refactor: rewrite parser generator ml sources as a function of the stanzas

### DIFF
--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -41,7 +41,7 @@ module Parser_generators : sig
     | Ocamllex of Loc.t
     | Ocamlyacc of Loc.t
 
-  val source_modules : t -> for_:for_ -> Module.Source.t Module_trie.t option
+  val modules : t -> for_:for_ -> Module.Source.t Module_trie.t option
 end
 
 (** Find out the origin of the stanza for a given module *)

--- a/src/dune_rules/module_trie.mli
+++ b/src/dune_rules/module_trie.mli
@@ -19,7 +19,7 @@ val mapi : 'a t -> f:(key -> 'a -> 'b) -> 'b t
 val of_map : 'a Module_name.Map.t -> 'a t
 val find : 'a t -> key -> 'a option
 val set : 'a t -> key -> 'a -> 'a t
-val set_map : 'a t -> key -> 'a Module_name.Map.t -> ('a t, 'a node) result
+val set_map : 'a t -> Module_name.t list -> 'a Module_name.Map.t -> ('a t, 'a node) result
 val remove : 'a t -> key -> 'a t
 val mem : 'a t -> key -> bool
 val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -20,14 +20,6 @@ type kind =
   | Exe_or_normal_lib
   | Parameter
 
-val expand_only_available
-  :  expander:Expander.t
-  -> modules:Module.Source.t Module_trie.t
-  -> module_path:Module_name.t list option
-  -> stanza_loc:Loc.t
-  -> Modules_settings.t
-  -> (Loc.t * Module.Source.t) Module_trie.t Memo.t
-
 val eval
   :  expander:Expander.t
   -> modules:Module.Source.t Module_trie.t

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -20,10 +20,14 @@ type kind =
   | Exe_or_normal_lib
   | Parameter
 
+val expand_all_unchecked
+  :  expander:Expander.t
+  -> Ordered_set_lang.Unexpanded.t
+  -> (Loc.t * (Module_name.t * string)) Module_trie.t Memo.t
+
 val eval
   :  expander:Expander.t
   -> modules:Module.Source.t Module_trie.t
-  -> module_path:Module_name.t list option
   -> stanza_loc:Loc.t
   -> private_modules:Ordered_set_lang.Unexpanded.t
   -> kind:kind

--- a/src/dune_rules/stanzas/parser_generators.ml
+++ b/src/dune_rules/stanzas/parser_generators.ml
@@ -42,10 +42,3 @@ let decode =
          and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) () in
          { loc; modules; mode; enabled_if })
 ;;
-
-let modules_settings modules =
-  { Modules_settings.root_module = None
-  ; modules_without_implementation = Ordered_set_lang.Unexpanded.standard
-  ; modules
-  }
-;;

--- a/src/dune_rules/stanzas/parser_generators.mli
+++ b/src/dune_rules/stanzas/parser_generators.mli
@@ -13,7 +13,6 @@ type for_ =
 
 val tool : for_ -> string
 val decode : t Dune_lang.Decoder.t
-val modules_settings : Ordered_set_lang.Unexpanded.t -> Modules_settings.t
 
 module Ocamllex : Stanza.S with type t := t
 module Ocamlyacc : Stanza.S with type t := t

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-and-dash-p.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-and-dash-p.t
@@ -32,8 +32,8 @@ Adding an `ocamllex` stanza for `a` still let's the build through for `-p foo`
 Building `bar` still fails
 
   $ dune build -p bar
-  File "dune", line 5, characters 28-29:
-  5 |  (public_name bar) (modules a))
-                                  ^
-  Error: Module A doesn't exist.
+  File "dune", line 1, characters 0-22:
+  1 | (ocamllex (modules a))
+      ^^^^^^^^^^^^^^^^^^^^^^
+  Error: No rule found for a.mll
   [1]

--- a/test/blackbox-tests/test-cases/ocamllex/ocamllex-gh10301.t
+++ b/test/blackbox-tests/test-cases/ocamllex/ocamllex-gh10301.t
@@ -23,10 +23,7 @@ Show an edge case of `(include_subdirs ..)` and ocamllex
   File "dune", line 3, characters 0-16:
   3 | (ocamllex lexer)
       ^^^^^^^^^^^^^^^^
-  Error: The `ocamllex' stanza for a module must be specified in the same
-  directory as the module it generates.
-  - module directory: src/a
-  - ocamllex directory: .
+  Error: No rule found for lexer.mll
   [1]
 
 The `(ocamllex ..)` stanza must live next to the source file


### PR DESCRIPTION
I made a mistake when implementing this by indexing the source tree for `.ml{l,y}` files, when to Dune they're only a function of the respective stanza.

This caused more problems as I was porting the Menhir rules. This reverts a lot of the code in favor of a simpler implementation.