### PR TITLE
Use `git_repo` to pin git packages

### DIFF
--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -192,6 +192,7 @@ let load_packages_from_git rev_store opam_packages =
         package
         opam_file
         rev
+        ~dune_build:false
         ~files_dir:(Some files_dir)
         ~url:None)
 ;;

--- a/src/dune_pkg/pin.ml
+++ b/src/dune_pkg/pin.ml
@@ -325,6 +325,7 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
             opam_package
             (loc, opam_file)
             at_rev
+            ~dune_build:true
             ~files_dir:None
             ~url:(Some url)
       in

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -125,5 +125,11 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
       let loc = Loc.in_file path in
       loc, Opam_file.opam_file_of_string_exn ~contents path
     in
-    Resolved_package.git_repo package opam_file rev ~files_dir ~url:(Some url)
+    Resolved_package.git_repo
+      package
+      opam_file
+      rev
+      ~dune_build:false
+      ~files_dir
+      ~url:(Some url)
 ;;

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -43,15 +43,9 @@ let extra_files = function
   | Rest t -> Some t.extra_files
 ;;
 
-let git_repo package (loc, opam_file) rev ~files_dir ~url =
+let git_repo package (loc, opam_file) rev ~dune_build ~files_dir ~url =
   let opam_file = Opam_file.opam_file_with ~package ~url opam_file in
-  Rest
-    { dune_build = false
-    ; loc
-    ; package
-    ; opam_file
-    ; extra_files = Git_files (files_dir, rev)
-    }
+  Rest { dune_build; loc; package; opam_file; extra_files = Git_files (files_dir, rev) }
 ;;
 
 let local_fs package (loc, opam_file) ~dir ~files_dir ~url =

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -20,6 +20,7 @@ val git_repo
   :  OpamPackage.t
   -> Loc.t * OpamFile.OPAM.t
   -> Rev_store.At_rev.t
+  -> dune_build:bool
   -> files_dir:Path.Local.t option
   -> url:OpamUrl.t option
   -> t


### PR DESCRIPTION
While trying to figure out which revision a package that is pinned via git is, I realized that for some reason packages pinned via Git are pinned as `Resolved_package.local_package`. I would have expected it to be `git_repo` which also gets an `At_rev.t` (thus keeping a reference to it that I can read later), so I updated the code to do so.

Tests seem to all work fine after fixing `git_repo` so that it can build packages with Dune. Detecting whether a package builds with Dune is a bit fiddly but before `git_repo` always assumed `false` so I've retained that for the other invocations of `git_repo` and in the pinning case I know that the repo to be pinned uses Dune so I can set it to `true`, thus I can avoid guessing.