### PR TITLE
$ dune trace commands

### DIFF
--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -44,6 +44,88 @@ let base_of_sexp (sexp : Sexp.t) =
   | _ -> invalid_sexp sexp
 ;;
 
+type process_info =
+  { prog : string
+  ; args : string list
+  ; dir : string option
+  ; exit_code : int
+  ; error : string option
+  ; stderr : string
+  }
+
+let parse_process_event (sexp : Sexp.t) : process_info option =
+  match base_of_sexp sexp with
+  | "process", "finish", _ts, rest ->
+    let rec extract_fields prog args dir exit error stderr = function
+      | [] -> prog, args, dir, exit, error, stderr
+      | Sexp.List [ Atom "process_args"; List arg_sexps ] :: rest ->
+        let args =
+          List.filter_map arg_sexps ~f:(function
+            | Sexp.Atom s -> Some s
+            | _ -> None)
+        in
+        extract_fields prog (Some args) dir exit error stderr rest
+      | List [ Atom "prog"; Atom p ] :: rest ->
+        extract_fields (Some p) args dir exit error stderr rest
+      | List [ Atom "dir"; Atom d ] :: rest ->
+        extract_fields prog args (Some d) exit error stderr rest
+      | List [ Atom "exit"; Atom e ] :: rest ->
+        let exit_code =
+          try int_of_string e with
+          | Failure _ -> 0
+        in
+        extract_fields prog args dir (Some exit_code) error stderr rest
+      | List [ Atom "error"; Atom err ] :: rest ->
+        extract_fields prog args dir exit (Some err) stderr rest
+      | List [ Atom "stderr"; Atom s ] :: rest ->
+        extract_fields prog args dir exit error (Some s) rest
+      | _ :: rest -> extract_fields prog args dir exit error stderr rest
+    in
+    let prog, args, dir, exit, error, stderr =
+      extract_fields None None None None None None rest
+    in
+    Option.map prog ~f:(fun prog ->
+      { prog
+      ; args = Option.value args ~default:[]
+      ; dir
+      ; exit_code = Option.value exit ~default:0
+      ; error
+      ; stderr = Option.value stderr ~default:""
+      })
+  | _ -> None
+;;
+
+let format_shell_command (info : process_info) : string =
+  let module Escape = Escape0 in
+  let cmd =
+    let quoted_prog = Escape.quote_if_needed info.prog in
+    let quoted_args = List.map info.args ~f:Escape.quote_if_needed in
+    String.concat ~sep:" " (quoted_prog :: quoted_args)
+  in
+  match info.dir with
+  | None -> sprintf "(%s)" cmd
+  | Some dir ->
+    let dir = Escape.quote_if_needed dir in
+    Printf.sprintf "(cd %s && %s)" dir cmd
+;;
+
+let format_output (info : process_info) : string =
+  let cmd_line = format_shell_command info in
+  if info.exit_code = 0
+  then cmd_line
+  else (
+    let error_line =
+      match info.error with
+      | Some err -> Printf.sprintf "# %s" err
+      | None -> Printf.sprintf "# Exit code: %d" info.exit_code
+    in
+    let lines = [ cmd_line; error_line ] in
+    let lines =
+      if info.stderr <> "" then lines @ [ "# Stderr:"; info.stderr ] else lines
+    in
+    String.concat ~sep:"\n" lines)
+;;
+
 let iter_sexps_follow file ~f =
   Io.String_path.with_file_in ~binary:true file ~f:(fun chan ->
     let rec loop () =
@@ -183,10 +265,40 @@ let cat =
   Cmd.v info term
 ;;
 
+let commands =
+  let info =
+    let doc = "Display executed processes in shell format" in
+    Cmd.info "commands" ~doc
+  in
+  let term =
+    let+ trace_file =
+      Arg.(
+        value
+        & opt (some string) None
+        & info
+            [ "trace-file" ]
+            ~docv:"FILE"
+            ~doc:(Some "Read this trace file (default: _build/trace.json)"))
+    in
+    let trace_file =
+      match trace_file with
+      | Some s -> s
+      | None -> Path.Local.to_string Common.default_trace_file
+    in
+    iter_sexps trace_file ~f:(fun sexp ->
+      match parse_process_event sexp with
+      | Some info ->
+        let output = format_output info in
+        print_endline output
+      | None -> ())
+  in
+  Cmd.v info term
+;;
+
 let group =
   let info =
     let doc = "Commands to view dune's event trace" in
     Cmd.info "trace" ~doc
   in
-  Cmd.group info [ cat ]
+  Cmd.group info [ cat; commands ]
 ;;

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -75,6 +75,7 @@ module Applicative = Applicative
 module Json = Json
 module Log = Log
 module Time = Time
+module Escape0 = Escape
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/test/blackbox-tests/test-cases/trace/commands-advanced.t
+++ b/test/blackbox-tests/test-cases/trace/commands-advanced.t
@@ -1,0 +1,87 @@
+Test dune trace commands with special characters and multiple directories
+
+Set up a project with subdirectories:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ mkdir -p subdir
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target quotes.txt)
+  >  (action (bash "echo 'Hello \"World\"' > quotes.txt")))
+  > EOF
+
+  $ cat >subdir/dune <<EOF
+  > (rule
+  >  (target output.txt)
+  >  (action (bash "echo 'test' > output.txt")))
+  > EOF
+
+Build targets to generate trace with commands from different directories:
+
+  $ dune build quotes.txt subdir/output.txt 2>&1 | grep -v "Entering directory"
+  [1]
+
+Verify commands show correct working directories:
+
+  $ dune trace commands | grep "cd.*subdir" | dune_cmd subst '[^ ]*/bin/' '' | head -1
+  (cd _build/default/subdir && bash -e -u -o pipefail -c "echo 'test' > output.txt")
+
+Verify root directory commands:
+
+  $ dune trace commands | grep "cd \$TESTCASE_ROOT &&" | head -1
+  [1]
+
+Test that all process events are captured:
+
+  $ dune trace commands | grep "^(cd" | wc -l | awk '{if($1 > 0) print "Found process events"}'
+  Found process events
+
+Test log output format is consistent (each command on one line unless it fails):
+
+  $ dune trace commands | grep "^(cd" | head -1 | grep -c "cd.*&&.*bash"
+  0
+  [1]
+
+Create a rule with a command that has special shell characters:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target special.txt)
+  >  (action (bash "echo 'test' | cat > special.txt")))
+  > EOF
+
+  $ dune build special.txt 2>&1 | grep -v "Entering directory"
+  [1]
+
+Verify special characters are properly quoted in output:
+
+  $ dune trace commands | grep special | tail -1 | dune_cmd subst '[^ ]*/bin/' ''
+  (cd _build/default && bash -e -u -o pipefail -c "echo 'test' | cat > special.txt")
+
+Test that successful commands (exit code 0) don't show exit code:
+
+  $ dune trace commands | grep -A 1 "special.txt" | grep -c "Exit code" || echo "No exit code for success"
+  0
+  No exit code for success
+
+Test with a command in a deeply nested directory:
+
+  $ mkdir -p a/b/c
+
+  $ cat >a/b/c/dune <<EOF
+  > (rule
+  >  (target nested.txt)
+  >  (action (bash "pwd > nested.txt")))
+  > EOF
+
+  $ dune build a/b/c/nested.txt 2>&1 | grep -v "Entering directory"
+  [1]
+
+Verify deeply nested paths are shown correctly:
+
+  $ dune trace commands | grep "cd.*a/b/c" | head -1 | dune_cmd subst '[^ ]*/bin/' ''
+  (cd _build/default/a/b/c && bash -e -u -o pipefail -c "pwd > nested.txt")

--- a/test/blackbox-tests/test-cases/trace/commands.t
+++ b/test/blackbox-tests/test-cases/trace/commands.t
@@ -1,0 +1,56 @@
+Test dune trace commands command
+
+Set up a simple project with rules that execute various commands:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target success.txt)
+  >  (action (system "echo 'Hello World' > success.txt")))
+  > 
+  > (rule
+  >  (target failure.txt)
+  >  (deps success.txt)
+  >  (action (system "echo 'Error message' >&2 && exit 1")))
+  > 
+  > (rule
+  >  (target spaces.txt)
+  >  (action (system "echo test > spaces.txt")))
+  > EOF
+
+Build the successful target to generate trace events:
+
+  $ dune build success.txt
+
+Now test the basic trace commands output - it should show commands in shell format:
+
+  $ dune trace commands | grep -E "^\(cd .* && " | head -3 | dune_cmd subst '[^ ]*/bin/' ''
+  (cd . && ocamlc.opt -config)
+  (cd _build/default && sh -c "echo 'Hello World' > success.txt")
+
+Verify the format is executable by checking it contains cd && pattern:
+
+  $ dune trace commands | grep "cd.*&&.*sh" | dune_cmd subst '[^ ]*/bin/' '' | head -1
+  (cd _build/default && sh -c "echo 'Hello World' > success.txt")
+
+Test with a failing command to verify stderr output:
+
+  $ dune build failure.txt
+  File "dune", lines 5-8, characters 0-104:
+  5 | (rule
+  6 |  (target failure.txt)
+  7 |  (deps success.txt)
+  8 |  (action (system "echo 'Error message' >&2 && exit 1")))
+  Error message
+  [1]
+
+Check that failed processes show exit code and stderr:
+
+  $ dune trace commands | grep -A 3 "exit 1" | dune_cmd subst '[^ ]*/bin/' ''
+  (cd _build/default && sh -c "echo 'Error message' >&2 && exit 1")
+  # exited with code 1
+  # Stderr:
+  Error message


### PR DESCRIPTION
Introduce a`$ dune trace commands` to replace the _build/log file and --verbose mode.

This sub-command reads the commands dune has executed from the trace file and outputs them in a readable, shell like way.