### PR TITLE
feat(init): use a src directory to store the source

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -313,6 +313,7 @@ module Component = struct
         { template : Template.t
         ; inline_tests : bool
         ; pkg : Pkg.t
+        ; use_src_dir : bool
         }
     end
 
@@ -537,6 +538,7 @@ module Component = struct
     ;;
 
     let proj_exec dir ({ context; common; options } : Options.Project.t Options.t) =
+      let dir = if options.use_src_dir then Path.Source.relative dir "src" else dir in
       let lib_target =
         src
           { context = { context with dir = Path.Source.relative dir "lib" }
@@ -570,6 +572,7 @@ module Component = struct
     ;;
 
     let proj_lib dir ({ context; common; options } : Options.Project.t Options.t) =
+      let dir = if options.use_src_dir then Path.Source.relative dir "src" else dir in
       let lib_target =
         src
           { context = { context with dir = Path.Source.relative dir "lib" }

--- a/bin/dune_init.mli
+++ b/bin/dune_init.mli
@@ -80,6 +80,7 @@ module Component : sig
         { template : Template.t
         ; inline_tests : bool
         ; pkg : Pkg.t
+        ; use_src_dir : bool
         }
     end
 

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -186,6 +186,15 @@ let inline_tests : bool Term.t =
 
 let opt_default ~default term = Term.(const (Option.value ~default) $ term)
 
+let use_src_dir : bool Term.t =
+  let docv = "USE_SRC_DIR" in
+  let doc =
+    "Whether to store the sources in a src/ directory or not. Only applicable for $(b, \
+     project)"
+  in
+  Arg.(value & flag & info [ "with-src-dir" ] ~docv ~doc:(Some doc))
+;;
+
 let executable =
   let doc = "A binary executable." in
   let man = [] in
@@ -237,6 +246,7 @@ let project =
      and+ path = path
      and+ common = project_common
      and+ inline_tests = inline_tests
+     and+ use_src_dir = use_src_dir
      and+ template =
        let docv = "PROJECT_KIND" in
        let doc =
@@ -288,7 +298,8 @@ let project =
          Memo.run @@ init_context project_defaults)
      in
      Component.init
-       (Project { context; common; options = { template; inline_tests; pkg } });
+       (Project
+          { context; common; options = { template; inline_tests; pkg; use_src_dir } });
      print_completion "project" (Dune_lang.Atom.of_string name)
 ;;
 


### PR DESCRIPTION
Hi,

This is a recurring topic coming on the Discuss forum about Dune not "acting like other build system" (aka `cargo`). If, IMHO, the power of Dune is that you can create the structure you want, I can understand that some people could be lost without a "more usual structure".


Even if I personally use the structure with `bin/` and `lib/` and `test/` at the root of the project, this PR introduces a flag `--with-src-dir` so `dune` could init the project structure with a `src/` directory. I hope this fix could at least make it easier for the beginners to get started before they dig more in the documentation 👍🏻 

I'm not sure about the naming: I would be happy with any better suggestion.
