### PR TITLE
trace: cram test names in events

### DIFF
--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -586,7 +586,7 @@ let run_cram_test
           (match duration with
            | None -> None
            | Some times -> Some { Dune_trace.Event.Cram.command; times }))
-      |> Dune_trace.Event.Cram.test);
+      |> Dune_trace.Event.Cram.test ~test:src);
     sanitize ~parent_script:script detailed_output
   | Error `Timed_out ->
     let timeout_loc, timeout = Option.value_exn timeout in

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -149,7 +149,7 @@ module Event : sig
       ; times : times
       }
 
-    val test : command list -> t
+    val test : test:Path.t -> command list -> t
   end
 end
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -476,10 +476,11 @@ module Cram = struct
     ; times : times
     }
 
-  let test commands =
+  let test ~test commands =
     let now = Time.now () in
     let args =
-      [ ( "commands"
+      [ "test", Arg.path test
+      ; ( "commands"
         , List.map commands ~f:(fun { command; times = { real; user; system } } ->
             Arg.record
               [ "command", Arg.list (List.map command ~f:Arg.string)

--- a/test/blackbox-tests/test-cases/cram/trace-commands.t
+++ b/test/blackbox-tests/test-cases/cram/trace-commands.t
@@ -23,6 +23,7 @@ Demonstrate command level trace events
 
   $ dune trace cat | jq 'include "dune"; select(.cat == "cram") | .args | redactCommandTimes'
   {
+    "test": "_build/default/foo.t",
     "commands": [
       {
         "command": [
@@ -81,6 +82,7 @@ Timeout:
 
   $ dune trace cat | jq 'include "dune"; select(.cat == "cram") | .args | redactCommandTimes'
   {
+    "test": "_build/default/timeout.t",
     "commands": []
   }
 


### PR DESCRIPTION
Add the source of the test that has the per commands summary