### PR TITLE
test: inline tests whose only mode is `byte`

### DIFF
--- a/test/blackbox-tests/test-cases/test-modes-byte.t
+++ b/test/blackbox-tests/test-cases/test-modes-byte.t
@@ -1,0 +1,24 @@
+Dune should execute inline tests whose only mode is `byte`.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name test_bytecode_repro)
+  >  (inline_tests)
+  >  (preprocess (pps ppx_inline_test))
+  >  (modes byte))
+  > EOF
+
+  $ cat > test_bytecode_repro.ml <<EOF
+  >  let rec fact n = if n = 1 then 1 else n * fact (n - 1)
+  >  let%test _ = fact 5 = 121
+  > EOF
+
+The test should fail:
+
+  $ dune runtest test_bytecode_repro.ml
+
+Currently does not because it is not being run.


### PR DESCRIPTION
Replaces https://github.com/ocaml/dune/pull/9756