### PR TITLE
jq: add a function to get the slowest running commands

### DIFF
--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -8,3 +8,9 @@ def redactCommandTimes:
         .value = "redacted"
       else . end)
     else . end);
+
+def slowestCommands($n):
+  [.[] | select(type == "object" and .args.commands != null)
+       | .args.test as $test | .args.commands[] | {test: $test} + .]
+  | sort_by(-.real)
+  | .[:$n];


### PR DESCRIPTION
Can be executed with:

```
$ dune trace cat | jq -s 'include "test/blackbox-tests/dune"; slowestCommands(30)'
```