### PR TITLE
Make `Resolved_package` API consistently take an `OpamFile.OPAM.t`

### DIFF
--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -164,10 +164,8 @@ let of_package (t : Dune_lang.Package.t) =
     ; pins = Package_name.Map.empty
     ; command_source = Assume_defaults
     }
-  | Some { file; contents = opam_file_string } ->
-    let _opam_file_loc, opam_file =
-      Opam_file.opam_file_of_string_exn ~contents:opam_file_string (Path.source file)
-    in
+  | Some { file; contents } ->
+    let opam_file = Opam_file.opam_file_of_string_exn ~contents (Path.source file) in
     let command_source =
       Opam_file
         { build = opam_file |> OpamFile.OPAM.build

--- a/src/dune_pkg/local_package.ml
+++ b/src/dune_pkg/local_package.ml
@@ -165,8 +165,8 @@ let of_package (t : Dune_lang.Package.t) =
     ; command_source = Assume_defaults
     }
   | Some { file; contents = opam_file_string } ->
-    let opam_file =
-      Opam_file.read_from_string_exn ~contents:opam_file_string (Path.source file)
+    let _opam_file_loc, opam_file =
+      Opam_file.opam_file_of_string_exn ~contents:opam_file_string (Path.source file)
     in
     let command_source =
       Opam_file

--- a/src/dune_pkg/opam_file.ml
+++ b/src/dune_pkg/opam_file.ml
@@ -27,17 +27,18 @@ let loc_of_opam_pos
 let opam_file_of_string_exn ~contents path =
   let filename = Path.to_absolute_filename path |> OpamFilename.raw in
   let pos = OpamTypesBase.pos_file filename in
-  let loc = Loc.in_file path in
   try
     let syntax = OpamFile.Syntax.of_string (OpamFile.make filename) contents in
-    loc, OpamPp.parse OpamFile.OPAM.pp_raw_fields ~pos syntax.file_contents
+    OpamPp.parse OpamFile.OPAM.pp_raw_fields ~pos syntax.file_contents
   with
   | OpamPp.Bad_version (_, message) ->
-    User_error.raise ~loc [ Pp.text "unexpected version"; Pp.text message ]
+    User_error.raise
+      ~loc:(Loc.in_file path)
+      [ Pp.text "unexpected version"; Pp.text message ]
   | OpamPp.Bad_format (pos, message) ->
     let loc =
       match pos with
-      | None -> loc
+      | None -> Loc.in_file path
       | Some pos -> loc_of_opam_pos pos
     in
     User_error.raise ~loc [ Pp.text "unable to parse opam file"; Pp.text message ]

--- a/src/dune_pkg/opam_file.mli
+++ b/src/dune_pkg/opam_file.mli
@@ -4,11 +4,11 @@ open Stdune
 
 (** [opam_file_of_string_exn ~contents p] creates an [OpamFile.OPAM.t] from
     [content] and stores [p] as the location of the OPAM file. *)
-val opam_file_of_string_exn : contents:string -> Path.t -> Loc.t * OpamFile.OPAM.t
+val opam_file_of_string_exn : contents:string -> Path.t -> OpamFile.OPAM.t
 
 (** [opam_file_of_path p] reads the file at path [p] and creates an
     [OpamFile.OPAM.t] from the contents *)
-val opam_file_of_path : Path.t -> Loc.t * OpamFile.OPAM.t
+val opam_file_of_path : Path.t -> OpamFile.OPAM.t
 
 val opam_file_with
   :  package:OpamPackage.t

--- a/src/dune_pkg/opam_file.mli
+++ b/src/dune_pkg/opam_file.mli
@@ -2,7 +2,19 @@
 
 open Stdune
 
-val read_from_string_exn : contents:string -> Path.t -> OpamFile.OPAM.t
+(** [opam_file_of_string_exn ~contents p] creates an [OpamFile.OPAM.t] from
+    [content] and stores [p] as the location of the OPAM file. *)
+val opam_file_of_string_exn : contents:string -> Path.t -> Loc.t * OpamFile.OPAM.t
+
+(** [opam_file_of_path p] reads the file at path [p] and creates an
+    [OpamFile.OPAM.t] from the contents *)
+val opam_file_of_path : Path.t -> Loc.t * OpamFile.OPAM.t
+
+val opam_file_with
+  :  package:OpamPackage.t
+  -> url:OpamUrl.t option
+  -> OpamFile.OPAM.t
+  -> OpamFile.OPAM.t
 
 type value := OpamParserTypes.FullPos.value
 

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -168,7 +168,8 @@ let load_opam_package_from_dir ~(dir : Path.t) package =
     let files_dir = Some (Paths.files_dir package) in
     let opam_file =
       let path = Path.append_local dir opam_file_path in
-      Opam_file.opam_file_of_path path
+      let loc = Loc.in_file path in
+      loc, Opam_file.opam_file_of_path path
     in
     Some (Resolved_package.local_fs package opam_file ~dir ~files_dir ~url:None)
 ;;
@@ -184,7 +185,8 @@ let load_packages_from_git rev_store opam_packages =
     ~f:(fun (opam_file, package, rev, files_dir) contents ->
       let opam_file =
         let path = opam_file |> Rev_store.File.path |> Path.of_local in
-        Opam_file.opam_file_of_string_exn ~contents path
+        let loc = Loc.in_file path in
+        loc, Opam_file.opam_file_of_string_exn ~contents path
       in
       Resolved_package.git_repo
         package

--- a/src/dune_pkg/pin.ml
+++ b/src/dune_pkg/pin.ml
@@ -312,8 +312,7 @@ let resolve (t : DB.t) ~(scan_project : Scan_project.t)
         in
         Resolved_package.local_package
           ~command_source:local_package.command_source
-          package.loc
-          opam_file
+          (package.loc, opam_file)
           opam_package
       in
       resolve package.name resolved_package

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -72,7 +72,8 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
   | Path dir ->
     let opam_file =
       let path = Path.append_local dir opam_file_path in
-      Opam_file.opam_file_of_path path
+      let loc = Loc.in_file path in
+      loc, Opam_file.opam_file_of_path path
     in
     Resolved_package.local_fs package opam_file ~dir ~files_dir ~url:(Some url)
     |> Fiber.return
@@ -99,7 +100,8 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
     in
     let opam_file =
       let path = Path.of_local opam_file_path in
-      Opam_file.opam_file_of_string_exn ~contents path
+      let loc = Loc.in_file path in
+      loc, Opam_file.opam_file_of_string_exn ~contents path
     in
     Resolved_package.git_repo package opam_file rev ~files_dir ~url:(Some url)
 ;;

--- a/src/dune_pkg/pinned_package.ml
+++ b/src/dune_pkg/pinned_package.ml
@@ -70,10 +70,14 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
   let* opam_file_path, files_dir = discover_layout loc name mount in
   match Mount.backend mount with
   | Path dir ->
-    Resolved_package.local_fs package ~dir ~opam_file_path ~files_dir ~url:(Some url)
+    let opam_file =
+      let path = Path.append_local dir opam_file_path in
+      Opam_file.opam_file_of_path path
+    in
+    Resolved_package.local_fs package opam_file ~dir ~files_dir ~url:(Some url)
     |> Fiber.return
   | Git rev ->
-    let+ opam_file_contents =
+    let+ contents =
       (* CR-rgrinberg: not efficient to make such individual calls *)
       Mount.read mount opam_file_path
       >>| function
@@ -93,11 +97,9 @@ let resolve_package { Local_package.loc; url = loc_url, url; name; version; orig
           ; "files", Dyn.list Path.Local.to_dyn files
           ]
     in
-    Resolved_package.git_repo
-      package
-      ~opam_file:opam_file_path
-      ~opam_file_contents
-      rev
-      ~files_dir
-      ~url:(Some url)
+    let opam_file =
+      let path = Path.of_local opam_file_path in
+      Opam_file.opam_file_of_string_exn ~contents path
+    in
+    Resolved_package.git_repo package opam_file rev ~files_dir ~url:(Some url)
 ;;

--- a/src/dune_pkg/resolved_package.mli
+++ b/src/dune_pkg/resolved_package.mli
@@ -5,30 +5,38 @@ type t
 val package : t -> OpamPackage.t
 val opam_file : t -> OpamFile.OPAM.t
 val loc : t -> Loc.t
+
+(** Determines whether the package is to be built using Dune or not *)
 val dune_build : t -> bool
+
+(** A resolved package representing Dune itself. Dune is always handled in a special
+    manner as we never want to build it so this value is a placeholder for cases
+    where the code needs a resolved package for Dune.
+ *)
 val dune : t
 
+(** Creates a resolved package from a source stored in Git, remote or local. *)
 val git_repo
   :  OpamPackage.t
-  -> opam_file:Path.Local.t
-  -> opam_file_contents:string
+  -> Loc.t * OpamFile.OPAM.t
   -> Rev_store.At_rev.t
   -> files_dir:Path.Local.t option
   -> url:OpamUrl.t option
   -> t
 
+(** Creates a resolved package from a source stored in the local file system. *)
 val local_fs
   :  OpamPackage.t
+  -> Loc.t * OpamFile.OPAM.t
   -> dir:Path.t
-  -> opam_file_path:Path.Local.t
   -> files_dir:Path.Local.t option
   -> url:OpamUrl.t option
   -> t
 
+(** Creates a resolved package from a source stored in the workspace. *)
 val local_package
   :  command_source:Local_package.command_source
-  -> Loc.t
-  -> OpamFile.OPAM.t
+  -> Loc.t * OpamFile.OPAM.t
   -> OpamPackage.t
   -> t
 


### PR DESCRIPTION
As a follow-up to https://github.com/ocaml/dune/pull/13176#discussion_r2657889072 this refactors the `Resolved_package` API so the functions that construct a `Resolved_package.t` take somewhat similar arguments, i.e. an `OpamFile.OPAM.t`.

This should make it easier to call the right function at the right place.