### PR TITLE
Add a test for multiple contexts with Dune package management

### DIFF
--- a/doc/reference/dune-workspace/context.rst
+++ b/doc/reference/dune-workspace/context.rst
@@ -1,28 +1,19 @@
 context
 -------
 
-The ``(context ...)`` stanza declares a build context. The kind of context can
-be either ``(default ...)`` for the default build context, or ``(opam ...)`` to
-use an opam switch.
+The ``(context ...)`` stanza declares a build context. The argument can be
+either ``default`` or ``(default)`` for the default build context, or it can be
+the description of an opam switch, as follows:
 
 .. code:: dune
 
-    (context
-      (default
-        <optional-fields>))
-
-.. code:: dune
-
-    (context
-      (opam
-        (switch <opam-switch-name>)
-          <optional-fields>))
+    (context (opam (switch <opam-switch-name>)
+                   <optional-fields>))
 
 ``<optional-fields>`` are:
 
 -  ``(name <name>)`` is the subdirectory's name for ``_build``, where this
-   build's context artifacts will be stored. If omitted, the context name
-   defaults to ``default``.
+   build's context artifacts will be stored.
 
 -  ``(lock_dir <path>)`` specifies the lock directory that will be used for
    building this context (if any). If no lock directory is specified
@@ -80,8 +71,8 @@ use an opam switch.
   archives statically linked into the runtime system.
 
 
-Both ``(default ...)`` and ``(opam ...)`` accept a ``targets`` field to setup
-cross compilation. See :ref:`cross-compilation` for more information.
+Both ``(default ...)`` and ``(opam ...)`` accept a ``targets`` field in order to
+setup cross compilation. See :ref:`cross-compilation` for more information.
 
 Merlin reads compilation artifacts, and it can only read the compilation
 artifacts of a single context. Usually, you should use the artifacts from the


### PR DESCRIPTION
This adds a test to show usage of multiple contexts, in the context of Dune package management.

The documentation was not super clear on how to do this. I've made some tweaks which hopefully makes it clearer, but I also intend to write a how-to guide for this with ThreadSanitizer and Dune package management as an example.