### PR TITLE
per-context cram test builds multiple contexts

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -3,7 +3,7 @@ Set lock file per context.
 TODO: versioning will be added once this feature is stable
 
   $ cat >dune-workspace <<EOF
-  > (lang dune 3.8)
+  > (lang dune 3.21)
   > (context
   >  (default
   >   (lock_dir foo.lock)))
@@ -23,7 +23,20 @@ TODO: versioning will be added once this feature is stable
   > (build
   >  (system "echo building from %{context_name}"))
   > EOF
-  $ ln -s foo.lock bar.lock
 
-  $ build_pkg test
+  $ mkdir bar.lock
+  $ cat >bar.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > (repositories (complete true))
+  > EOF
+  $ cat >bar.lock/test.pkg <<EOF
+  > (version 0.0.2)
+  > (build
+  >  (system "echo building from %{context_name}"))
+  > EOF
+
+  $ dune build @@_build/default/pkg-install
   building from default
+
+  $ dune build @@_build/foo/pkg-install
+  building from foo

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -16,7 +16,6 @@ TODO: versioning will be added once this feature is stable
   $ mkdir foo.lock
   $ cat >foo.lock/lock.dune <<EOF
   > (lang package 0.1)
-  > (repositories (complete true))
   > EOF
   $ cat >foo.lock/test.pkg <<EOF
   > (version 0.0.1)
@@ -27,13 +26,14 @@ TODO: versioning will be added once this feature is stable
   $ mkdir bar.lock
   $ cat >bar.lock/lock.dune <<EOF
   > (lang package 0.1)
-  > (repositories (complete true))
   > EOF
   $ cat >bar.lock/test.pkg <<EOF
   > (version 0.0.2)
   > (build
   >  (system "echo 'building from %{context_name}\nversion: %{pkg:test:version}'"))
   > EOF
+
+Build both contexts
 
   $ dune build @@_build/default/pkg-install
   building from default

--- a/test/blackbox-tests/test-cases/pkg/per-context.t
+++ b/test/blackbox-tests/test-cases/pkg/per-context.t
@@ -21,7 +21,7 @@ TODO: versioning will be added once this feature is stable
   $ cat >foo.lock/test.pkg <<EOF
   > (version 0.0.1)
   > (build
-  >  (system "echo building from %{context_name}"))
+  >  (system "echo 'building from %{context_name}\nversion: %{pkg:test:version}'"))
   > EOF
 
   $ mkdir bar.lock
@@ -32,11 +32,13 @@ TODO: versioning will be added once this feature is stable
   $ cat >bar.lock/test.pkg <<EOF
   > (version 0.0.2)
   > (build
-  >  (system "echo building from %{context_name}"))
+  >  (system "echo 'building from %{context_name}\nversion: %{pkg:test:version}'"))
   > EOF
 
   $ dune build @@_build/default/pkg-install
   building from default
+  version: 0.0.1
 
   $ dune build @@_build/foo/pkg-install
   building from foo
+  version: 0.0.2


### PR DESCRIPTION
Making the test build from multiple contexts as discussed in #13217. This is a minimal change compared to #13127.