### PR TITLE
Fix: merge multiple identical opam pins on a local package 

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends-multiple.t
@@ -1,5 +1,5 @@
 Having multiple opam packages that all depend on one pinned pkg in
-the workspace causes confusion
+the workspace caused confusion
 
   $ mkrepo
   $ add_mock_repo_if_needed
@@ -28,13 +28,12 @@ Main left & right both depend on the trouble maker package in their opam file
   > pin-depends: [ "trouble.1.0.0" "file://$PWD/trouble" ]
   > EOF
 
-This should work
+This now works!
   $ dune_pkg_lock_normalized
-  File "main_left.opam", line 1, characters 0-0:
-  Error: local package trouble cannot be pinned
-  [1]
+  Solution for dune.lock:
+  - trouble.1.0.0
 
-If the versions disagree, we don't give a clear error
+If the versions disagree, we give a clear error
   $ cat > main_left.opam << EOF
   > opam-version: "2.0"
   > build: [ "echo" "main_left" ]
@@ -44,10 +43,11 @@ If the versions disagree, we don't give a clear error
 
   $ dune_pkg_lock_normalized
   File "main_left.opam", line 1, characters 0-0:
-  Error: local package trouble cannot be pinned
+  Error: local package trouble is pinned here with version 9.9.9, but also
+  version 1.0.0 in main_right.opam:1
   [1]
 
-If the urls disagree, we also don't give a clear error
+If the urls disagree, we also give a clear error
   $ cat > main_left.opam << EOF
   > opam-version: "2.0"
   > build: [ "echo" "main_left" ]
@@ -57,7 +57,8 @@ If the urls disagree, we also don't give a clear error
 
   $ dune_pkg_lock_normalized
   File "main_left.opam", line 1, characters 0-0:
-  Error: local package trouble cannot be pinned
+  Error: local package trouble is pinned twice with different URLs
+  it is also defined in main_right.opam:1
   [1]
 
 If instead of two opam pins we have one opam pin and one dune pin

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends-multiple.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/pin-depends-multiple.t
@@ -28,7 +28,90 @@ Main left & right both depend on the trouble maker package in their opam file
   > pin-depends: [ "trouble.1.0.0" "file://$PWD/trouble" ]
   > EOF
 
+This should work
   $ dune_pkg_lock_normalized
   File "main_left.opam", line 1, characters 0-0:
   Error: local package trouble cannot be pinned
   [1]
+
+If the versions disagree, we don't give a clear error
+  $ cat > main_left.opam << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "main_left" ]
+  > depends: [ "trouble" ]
+  > pin-depends: [ "trouble.9.9.9" "file://$PWD/trouble" ]
+  > EOF
+
+  $ dune_pkg_lock_normalized
+  File "main_left.opam", line 1, characters 0-0:
+  Error: local package trouble cannot be pinned
+  [1]
+
+If the urls disagree, we also don't give a clear error
+  $ cat > main_left.opam << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "main_left" ]
+  > depends: [ "trouble" ]
+  > pin-depends: [ "trouble.1.0.0" "file://$PWD/other" ]
+  > EOF
+
+  $ dune_pkg_lock_normalized
+  File "main_left.opam", line 1, characters 0-0:
+  Error: local package trouble cannot be pinned
+  [1]
+
+If instead of two opam pins we have one opam pin and one dune pin
+  $ cat > main_left.opam << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "main_left" ]
+  > depends: [ "trouble" ]
+  > pin-depends: [ "trouble.1.0.0" "file://$PWD/trouble" ]
+  > EOF
+
+  $ rm main_right.opam
+  $ mkdir right
+  $ cat > right/dune-project << EOF
+  > (lang dune 3.14)
+  > (pin
+  >  (url "file://$PWD/trouble")
+  >  (package
+  >   (name trouble)
+  >   (version "1.0.0")))
+  > (package
+  >  (name main_right)
+  >  (depends trouble))
+  > EOF
+
+This works!
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - trouble.1.0.0
+
+If the versions disagree, we favor the opam info?
+  $ cat > main_left.opam << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "main_left" ]
+  > depends: [ "trouble" ]
+  > pin-depends: [ "trouble.0.0.1" "file://$PWD/trouble" ]
+  > EOF
+
+We pick the opam version here. 
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - trouble.0.0.1
+
+If the urls disagree, we give a somewhat clear error
+  $ cat > main_left.opam << EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "main_left" ]
+  > depends: [ "trouble" ]
+  > pin-depends: [ "trouble.1.0.0" "file://$PWD/other" ]
+  > EOF
+
+  $ dune_pkg_lock_normalized
+  File "main_left.opam", line 1, characters 0-0:
+  Error: unable to discover an opam file for package trouble
+  [1]
+
+For a test covering the case where we have two pins in dune-projects,
+check override-single-workspace.t


### PR DESCRIPTION
Fixes #12990 

Commit 1 expands the test
Commit 2 fixes one bug, but there is remaining weirdness going on
~~Commit 3 is just what felt to me like a readibility improvement, completely optional~~ deleted as not wanted