### PR TITLE
Add test for duplicate pins

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/duplicate-pins.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/duplicate-pins.t
@@ -1,0 +1,122 @@
+Test cases where pins are duplicated
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a dependency that we can depend on.
+
+  $ mkdir _dep_a
+  $ cat > _dep_a/dune-project <<EOF
+  > (lang dune 3.22)
+  > (generate_opam_files true)
+  > (package
+  >  (name dep_a))
+  > EOF
+  $ cat > _dep_a/dune <<EOF
+  > (library
+  >  (public_name dep_a))
+  > EOF
+  $ cat > _dep_a/dep_a.ml <<EOF
+  > let dep = "A"
+  > EOF
+
+Also generate an .opam file to be able to pin from OPAM.
+
+  $ (cd _dep_a && dune build dep_a.opam)
+
+In our main project we depend on the same pin twice.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (pin
+  >  (url file://$PWD/_dep_a)
+  >  (package (name dep_a)))
+  > (pin
+  >  (url file://$PWD/_dep_a)
+  >  (package (name dep_a)))
+  > EOF
+
+We expect that locking will fail as we're trying to pin the same package
+multiple times:
+
+  $ dune pkg lock
+  File "dune-project", line 4, characters 1-23:
+  4 |  (package (name dep_a)))
+       ^^^^^^^^^^^^^^^^^^^^^^
+  Error: package "dep_a" is already defined
+  [1]
+
+We define another package, `dep_b` which depends on `dep_a`
+
+  $ mkdir _dep_b
+  $ cat > _dep_b/dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+  $ cat > _dep_b/dune <<EOF
+  > (library
+  >  (public_name dep_b)
+  >  (libraries dep_a))
+  > EOF
+  $ cat > _dep_b/dep_b.ml <<EOF
+  > let dep = Printf.sprintf "%sB" Dep_a.dep
+  > EOF
+
+We create a fork of `dep_a` in the `dep_c` folder and modify it to display
+something different:
+
+  $ cp -r _dep_a _dep_c
+  $ cat > _dep_c/dep_a.ml <<EOF
+  > let dep = "C"
+  > EOF
+
+`dep_b` pins `dep_a` via the `pin-depends` but it pins the fork that displays
+"C":
+
+  $ cat > _dep_b/dep_b.opam << EOF
+  > opam-version: "2.0"
+  > pin-depends: [ "dep_a" "file://$PWD/_dep_c" ]
+  > depends: ["dep_a"]
+  > build: ["dune" "build" "-p" name "@install"]
+  > EOF
+
+In our main project we pin `dep_a` to the original version via the pin stanza,
+as well as `dep_b`.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (pin
+  >  (url file://$PWD/_dep_a)
+  >  (package (name dep_a)))
+  > (pin
+  >  (url file://$PWD/_dep_b)
+  >  (package (name dep_b)))
+  > (package
+  >  (name main)
+  >  (depends dep_b))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries dep_b))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > print_endline Dep_b.dep
+  > EOF
+
+This is accepted by the solver, despite `dep_a` being pinned to different
+locations via Dune and OPAM:
+
+  $ dune pkg lock
+  Solution for dune.lock
+  
+  Dependencies common to all supported platforms:
+  - dep_a.dev
+  - dep_b.dev
+
+Executing the binary shows that the pinning from Dune has taken preference over
+the `pin-depends` stanza in `dep_b`:
+
+  $ dune exec ./main.exe
+  AB


### PR DESCRIPTION
I noticed that there is no test that checked the `"package %S is already defined"` message:

```sh
$ rg "package .* is already defined"
src/dune_lang/dune_project.ml
513:          "package %s is already defined in %S"
813:      [ Pp.textf "package %s is already defined" (Package.name p |> Package.Name.to_string)

src/dune_lang/pin_stanza.ml
32:      [ Pp.textf "package %S is already defined" (Package_name.to_string name) ]

test/blackbox-tests/test-cases/pkg/pin-stanza/duplicate-pins.t
46:  Error: package "dep_a" is already defined

test/blackbox-tests/test-cases/exclusive-package-dirs.t
19:  Error: package foo is already defined in "foo"
```

So I wrote a test. It works properly. Thus I was curious what happens if I declare a duplicate pin via a dependency. It gets ignored (which come to think of it, is probably the right thing to do). See the test.