### PR TITLE
chore: Solve shellcheck problems

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -17,8 +17,7 @@
 
 (rule
  (alias runtest)
- (enabled_if
-  (and false %{bin-available:shellcheck}))
+ (enabled_if %{bin-available:shellcheck})
  (deps helpers.sh)
  (action
   (run %{bin:shellcheck} -s bash %{deps})))

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -281,8 +281,8 @@ EOF
 }
 
 print_source() {
-  cat "${default_lock_dir}"/"$1".pkg \
-  | dune_cmd print-from 'source' \
+  dune_cmd print-from 'source' \
+	  < "${default_lock_dir}"/"$1".pkg \
   | dune_cmd print-until '^$' \
   | dune_cmd subst "$PWD" "PWD" \
   | tr '\n' ' ' \

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
@@ -16,13 +16,9 @@
  (action
   (run %{bin:bash} -n %{deps})))
 
-;; this file has too many problems. enable once you're brave enough to solve
-;; them
-
 (rule
  (alias runtest)
- (enabled_if
-  (and false %{bin-available:shellcheck}))
+ (enabled_if %{bin-available:shellcheck})
  (deps helpers.sh)
  (action
   (run %{bin:shellcheck} -s bash %{deps})))

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -28,7 +28,7 @@ EOF
 (executable
  (public_name ocamlformat))
 EOF
-  tar cf ocamlformat-$version.tar ocamlformat
+  tar cf "ocamlformat-${version}.tar" ocamlformat
   rm -rf ocamlformat
 }
 
@@ -42,7 +42,7 @@ make_ocamlformat_opam_pkg() {
   fi
   if [ ! "$port" = "" ]
   then
-    mkpkg ocamlformat $version <<EOF
+    mkpkg ocamlformat "$version" <<EOF
 build: [
   [
      "dune"
@@ -55,12 +55,12 @@ build: [
 url {
   src: "http://127.0.0.1:$port"
   checksum: [
-    "md5=$(md5sum ocamlformat-$version.tar | cut -f1 -d' ')"
+    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
   ]
 }
 EOF
   else
-    mkpkg ocamlformat $version <<EOF
+    mkpkg ocamlformat "$version" <<EOF
 build: [
   [
      "dune"
@@ -73,7 +73,7 @@ build: [
 url {
   src: "file://$PWD/ocamlformat-$version.tar"
   checksum: [
-    "md5=$(md5sum ocamlformat-$version.tar | cut -f1 -d' ')"
+    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
   ]
 }
 EOF
@@ -117,7 +117,7 @@ make_printer_lib() {
 (lang dune 3.13)
 (package (name printer))
 EOF
-  if [ $version = "1.0" ]
+  if [ "${version}" = "1.0" ]
   then
   cat > printer/printer.ml <<EOF
 let print () = print_endline "formatted"
@@ -131,13 +131,13 @@ EOF
 (library
  (public_name printer))
 EOF
-  tar cf printer.$version.tar printer
+  tar cf "printer.${version}.tar" printer
   rm -r printer
 }
 
 make_opam_printer() {
   version=$1
-  mkpkg printer $version <<EOF
+  mkpkg printer "$version" <<EOF
 build: [
    [
     "dune"
@@ -150,7 +150,7 @@ build: [
  url {
  src: "file://$PWD/printer.$version.tar"
  checksum: [
-  "md5=$(md5sum printer.$version.tar | cut -f1 -d' ')"
+  "md5=$(md5sum "printer.${version}.tar" | cut -f1 -d' ')"
  ]
 }
 EOF

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -1,7 +1,8 @@
 dev_tool_lock_dir="_build/.dev-tools.locks/ocamlformat"
 
 make_fake_ocamlformat() {
-  version=$1
+  local version=$1
+  local ml_file
   if [ "$#" -eq "1" ]
   then
     ml_file=""
@@ -33,7 +34,8 @@ EOF
 }
 
 make_ocamlformat_opam_pkg() {
-  version=$1
+  local version=$1
+  local port
   if [ "$#" -eq "2" ]
   then
     port="$2"
@@ -109,9 +111,8 @@ EOF
 EOF
 }
 
-
 make_printer_lib() {
-  version=$1
+  local version=$1
   mkdir printer
   cat > printer/dune-project <<EOF
 (lang dune 3.13)
@@ -136,7 +137,7 @@ EOF
 }
 
 make_opam_printer() {
-  version=$1
+  local version=$1
   mkpkg printer "$version" <<EOF
 build: [
    [


### PR DESCRIPTION
This PR follows up #13233 and solves remaining issues shellcheck was complaining about.

I've opted to disable [SC2016](https://www.shellcheck.net/wiki/SC2016) as it states:

> This suggestion is primarily meant to help newbies who assume single and double quotes are basically the same, like in Python and JavaScript. It's not at all meant to discourage experienced users from using single quotes in general. If you are well aware of the difference, please do not hesitate to permanently disable this suggestion

Writing the code `"\$SANDBOX"` to satisfy SC is less readable and IMHO worse, thus I would actually suggest we globally disable it.