### PR TITLE
fix(pkg): resolve symlinks from (install) action 

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/absolute-symlink-inside.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/absolute-symlink-inside.t
@@ -1,0 +1,53 @@
+Test symlinks using absolute paths that point inside the target directory.
+Since we use realpath, these resolve correctly and work with caching.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    true BUILDING_FOO_PACKAGE \
+  >    && mkdir -p %{lib}/%{pkg-self:name} \
+  >    && printf 'real content\n' > %{lib}/%{pkg-self:name}/real.txt \
+  >    && ln -s \$(realpath %{lib}/%{pkg-self:name}/real.txt) %{lib}/%{pkg-self:name}/link.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+  $ build_pkg foo
+
+Verify the build ran:
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+
+The symlink is resolved to a regular file:
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  regular file
+
+Both files are hardlinked:
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  3
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  3
+
+Clean and rebuild to verify cache restore:
+
+  $ rm -rf _build
+  $ build_pkg foo
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  0

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/basic-caching.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/basic-caching.t
@@ -1,0 +1,71 @@
+Test that packages with symlinks in their install output are properly cached.
+Dune resolves symlinks to hardlinks so that the cache can store them.
+
+The compiler is one such package that has this kind of layout.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+
+Create a package that installs both a regular file and a symlink to it.
+This is similar to how compilers install binaries (e.g., ocamlc -> ocamlc.opt).
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (progn
+  >   (run true BUILDING_FOO_PACKAGE) ; for grepping later
+  >   (run mkdir -p %{lib}/%{pkg-self:name})
+  >   (run sh -c "echo 'real content' > %{lib}/%{pkg-self:name}/real.txt")
+  >   (run ln -s real.txt %{lib}/%{pkg-self:name}/link.txt)
+  >   (run touch %{lib}/%{pkg-self:name}/META)))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+Build the package:
+
+  $ build_pkg foo
+
+Verify the build ran by checking the trace for our marker command:
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+
+Check that the files exist:
+
+  $ ls $(get_build_pkg_dir foo)/target/lib/foo | sort
+  META
+  link.txt
+  real.txt
+
+The symlink has been resolved to a regular file (hardlink to the target):
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  symbolic link
+
+Check hardlink count. Files should have hardlinks > 1 indicating they are cached.
+real.txt has 3 hardlinks: original, link.txt (resolved), and cache entry.
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  1
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/META
+  1
+
+Clean and rebuild to verify cache restore:
+
+  $ rm -rf _build
+  $ build_pkg foo
+
+The build command should not be rerun since it will be restored from cache.
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/broken-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/broken-symlink.t
@@ -1,0 +1,30 @@
+Test that broken symlinks are detected during symlink resolution.
+
+  $ make_lockdir
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p %{lib}/%{pkg-self:name} \
+  >    && ln -s nonexistent.txt %{lib}/%{pkg-self:name}/broken.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+The broken symlink is detected:
+
+  $ build_pkg foo 2>&1 | sanitize_pkg_digest foo.0.0.1 \
+  > | dune_cmd subst '\.sandbox/[a-f0-9]+' '.sandbox/$SANDBOX'
+  Error:
+  readlink(_build/.sandbox/$SANDBOX/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target/lib/foo/nonexistent.txt): No such file or directory
+  -> required by
+     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/chain-through-outside.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/chain-through-outside.t
@@ -1,0 +1,64 @@
+Test behavior when a symlink chain goes through a file outside the target directory.
+e.g., link.txt -> $PWD/intermediate.txt -> real.txt (where intermediate is outside)
+
+The chain goes through an outside path, but the final target is inside target_dir.
+This case is pathological, but we want to exercise our symlink resolution code.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+
+Create a directory outside the build for the intermediate symlink:
+
+  $ mkdir outside_dir
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p %{lib}/%{pkg-self:name} \
+  >    && printf 'real content\n' > %{lib}/%{pkg-self:name}/real.txt \
+  >    && ln -sf \$(realpath %{lib}/%{pkg-self:name}/real.txt) $PWD/outside_dir/intermediate.txt \
+  >    && ln -s $PWD/outside_dir/intermediate.txt %{lib}/%{pkg-self:name}/link.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+Build the package:
+
+  $ build_pkg foo
+
+The symlink should be resolved to a regular file:
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  regular file
+
+link.txt and real.txt should be hardlinks to the same file (hardlink count > 1):
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  3
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  3
+
+The outside intermediate has only 1 hardlink (it's still just a symlink):
+
+  $ dune_cmd stat hardlinks outside_dir/intermediate.txt
+  1
+
+  $ cat $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  real content
+
+Caching works - the symlink was resolved so it can be cached:
+
+  $ rm -rf _build
+  $ build_pkg foo
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  3

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/dir-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/dir-symlink.t
@@ -1,0 +1,83 @@
+Test behavior with directory symlinks.
+
+  $ make_lockdir
+
+--------------------------------------------------------------------------------
+
+Case 1: No .install file, directory symlink in %{lib}, engine rejects it.
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p %{lib}/%{pkg-self:name} \
+  >    && printf 'content\n' > %{lib}/%{pkg-self:name}/file.txt \
+  >    && mkdir -p %{lib}/%{pkg-self:name}/real_subdir \
+  >    && ln -s real_subdir %{lib}/%{pkg-self:name}/subdir_link \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+CR-someday Alizter: Maybe in this case it actually makes sense to resolve the directory symlink somehow.
+
+  $ build_pkg foo 2>&1 | sanitize_pkg_digest foo.0.0.1
+  Error: Error trying to read targets after a rule was run:
+  - default/.pkg/foo.0.0.1-DIGEST_HASH/target/lib/foo/subdir_link: Unexpected file kind "S_DIR" (directory)
+  -> required by
+     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  [1]
+
+--------------------------------------------------------------------------------
+
+Case 2: .install file explicitly includes directory symlink.
+
+CR-someday Alizter: What should happen in this case? Seems we didn't catch the
+error correctly. Engine bug? Let's try to repro later.
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p real_subdir \
+  >    && printf 'content\n' > real_subdir/file.txt \
+  >    && ln -s real_subdir subdir_link \
+  >    && printf 'lib: [\"real_subdir/file.txt\" \"subdir_link\"]\n' > foo.install"))
+  > EOF
+
+  $ build_pkg foo 2>&1 | sanitize_pkg_digest foo.0.0.1 | sed -E 's#\.sandbox/[^/]+#.sandbox/SANDBOX#g'
+  Error:
+  link(_build/.sandbox/SANDBOX/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target/lib/foo/subdir_link): Operation not permitted
+  -> required by
+     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  [1]
+
+--------------------------------------------------------------------------------
+
+Case 3: .install file excludes the directory symlink.
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p real_subdir \
+  >    && printf 'content\n' > real_subdir/file.txt \
+  >    && ln -s file.txt real_subdir/link.txt \
+  >    && ln -s real_subdir subdir_link \
+  >    && printf 'lib: [\"real_subdir/file.txt\" \"real_subdir/link.txt\"]\n' > foo.install"))
+  > EOF
+
+  $ build_pkg foo
+
+The directory symlink is not in the installed targets, so the engine does not
+reject it. Only the real directory contents are installed:
+
+  $ ls $(get_build_pkg_dir foo)/target/lib/foo
+  file.txt
+  link.txt
+
+The file symlink is converted to a hardlink:
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  regular file
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  2

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/dune
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/dune
@@ -1,0 +1,2 @@
+(cram
+ (setup_scripts helpers.sh))

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/helpers.sh
@@ -1,0 +1,6 @@
+# Count how many times a command with the given argument appears in the trace.
+# Useful for verifying whether a build action ran (count > 0) or was cached (count = 0).
+count_trace() {
+  dune trace cat \
+    | jq -s --arg needle "$1" '[ .[] | select(.cat == "process" and .args.process_args == [$needle]) ] | length'
+}

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/helpers.sh
@@ -2,5 +2,5 @@
 # Useful for verifying whether a build action ran (count > 0) or was cached (count = 0).
 count_trace() {
   dune trace cat \
-    | jq -s --arg needle "$1" '[ .[] | select(.cat == "process" and .args.process_args == [$needle]) ] | length'
+    | jq -s --arg needle "$1" '[ .[] | select(.cat == "process" and .name == "start" and (.args.process_args | any(contains($needle)))) ] | length'
 }

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/link-permission-error.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/link-permission-error.t
@@ -1,0 +1,44 @@
+Test that link errors cause the build to fail.
+
+If the directory containing the symlink is made non-writable, unlinking the
+symlink before hardlinking will fail with EACCES.
+
+  $ make_lockdir
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    mkdir -p %{lib}/%{pkg-self:name} \
+  >    && printf 'real content\n' > %{lib}/%{pkg-self:name}/real.txt \
+  >    && ln -s real.txt %{lib}/%{pkg-self:name}/link.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META \
+  >    && chmod -w %{lib}/%{pkg-self:name}"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+Build fails with a symlink resolution error:
+
+  $ build_pkg foo 2>&1 | sanitize_pkg_digest foo.0.0.1 | dune_cmd subst '\.sandbox/[^/]+' '.sandbox/SANDBOX'
+  Error: failed to delete sandbox in
+  _build/.sandbox/SANDBOX
+  Reason:
+  rmdir(_build/.sandbox/SANDBOX/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target/lib/foo): Directory not empty
+  -> required by
+     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  Error:
+  unlink(_build/.sandbox/SANDBOX/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target/lib/foo/link.txt): Permission denied
+  -> required by
+     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  [1]
+
+Restore permissions for cleanup:
+
+  $ chmod -R +w _build 2>/dev/null; rm -rf _build

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/nested-symlinks.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/nested-symlinks.t
@@ -1,0 +1,76 @@
+Test behavior when a package creates nested symlinks (symlink pointing to symlink).
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+
+Create a package with nested symlinks: link2 -> link1 -> real.txt
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    true BUILDING_FOO_PACKAGE \
+  >    && mkdir -p %{lib}/%{pkg-self:name} \
+  >    && printf 'real content\n' > %{lib}/%{pkg-self:name}/real.txt \
+  >    && ln -s real.txt %{lib}/%{pkg-self:name}/link1.txt \
+  >    && ln -s link1.txt %{lib}/%{pkg-self:name}/link2.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+Build the package:
+
+  $ build_pkg foo
+
+Verify the build ran:
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+
+Check that the files exist:
+
+  $ ls $(get_build_pkg_dir foo)/target/lib/foo | sort
+  META
+  link1.txt
+  link2.txt
+  real.txt
+
+All symlinks should be resolved to regular files (hardlinks):
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  regular file
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link1.txt
+  regular file
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link2.txt
+  regular file
+
+All should have the same content:
+
+  $ cat $(get_build_pkg_dir foo)/target/lib/foo/link1.txt
+  real content
+  $ cat $(get_build_pkg_dir foo)/target/lib/foo/link2.txt
+  real content
+
+Check hardlink counts - all three should be hardlinked to the same inode:
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  4
+
+Clean and rebuild to verify cache restore:
+
+  $ rm -rf _build
+  $ build_pkg foo
+
+The build command should not be rerun since it will be restored from cache:
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  0

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-outside-target.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-outside-target.t
@@ -1,0 +1,55 @@
+Test symlinks pointing to files outside the target directory.
+
+CR-someday Alizter: This behavior is questionable. We convert the symlink to a
+hardlink pointing to an external file, which ties the build output to external
+content. If the external file changes, the target would be stale. Consider
+whether we should leave such symlinks as-is, copy the file, or error instead.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+  $ mkdir outside_dir
+  $ echo 'outside content' > outside_dir/external_file.txt
+
+Create a package with a symlink pointing outside target:
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    true BUILDING_FOO_PACKAGE \
+  >    && mkdir -p %{lib}/%{pkg-self:name} \
+  >    && ln -s $PWD/outside_dir/external_file.txt %{lib}/%{pkg-self:name}/external.txt \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+  $ build_pkg foo
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+
+The symlink is resolved to a hardlink to the external file:
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/external.txt
+  regular file
+
+The content is accessible:
+
+  $ cat $(get_build_pkg_dir foo)/target/lib/foo/external.txt
+  outside content
+
+Since the symlink was resolved to a hardlink, caching works:
+
+  $ rm -rf _build
+  $ build_pkg foo
+  $ count_trace BUILDING_FOO_PACKAGE
+  0

--- a/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-to-directory-with-contents.t
+++ b/test/blackbox-tests/test-cases/pkg/install-symlinks/symlink-to-directory-with-contents.t
@@ -1,0 +1,55 @@
+Test installing files from inside a symlinked directory.
+The source has a symlink to a directory, we install files from inside it (via the symlink),
+but don't install the directory symlink itself.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/_cache
+
+  $ make_lockdir
+
+Create a source with a directory symlink. We install files through the symlink
+but not the symlink itself. Use cp -P to preserve symlinks so our resolution
+code is exercised:
+
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (system "\
+  >    true BUILDING_FOO_PACKAGE \
+  >    && mkdir -p real_dir \
+  >    && printf 'real content\n' > real_dir/real.txt \
+  >    && ln -s real.txt real_dir/link.txt \
+  >    && ln -s real_dir link_to_dir \
+  >    && mkdir -p %{lib}/%{pkg-self:name} \
+  >    && cp link_to_dir/real.txt %{lib}/%{pkg-self:name}/ \
+  >    && cp -P link_to_dir/link.txt %{lib}/%{pkg-self:name}/ \
+  >    && touch %{lib}/%{pkg-self:name}/META"))
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends foo))
+  > EOF
+
+  $ build_pkg foo
+
+  $ count_trace BUILDING_FOO_PACKAGE
+  1
+
+The symlink is resolved by dune's symlink resolution code:
+
+  $ dune_cmd stat kind $(get_build_pkg_dir foo)/target/lib/foo/link.txt
+  regular file
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir foo)/target/lib/foo/real.txt
+  3
+
+Caching works:
+
+  $ rm -rf _build
+  $ build_pkg foo
+  $ count_trace BUILDING_FOO_PACKAGE
+  0


### PR DESCRIPTION
The reloctable compiler, like the other OCaml compilers, has symlinks in it's installation layout. These need to be resolved before we declare them inside the directory target or else the reloctable compiler cannot be cached. This work is tracked in #13229.

In the second commit we introduce a general mechanism to comb through the targets of the install layout for a package and resolve these symlinks by replacing them with a hardlink, falling back to a copy if that is not possible.

We add quite a few tests to exercise the numerous edge cases that come up.

- TODO describe tests a bit more