### PR TITLE
Indent heredoc content in helpers

### DIFF
--- a/test/blackbox-tests/test-cases/boot/helpers.sh
+++ b/test/blackbox-tests/test-cases/boot/helpers.sh
@@ -26,12 +26,12 @@ export BUILD_PATH_PREFIX_MAP="/OCAMLC=$ocamlc:$BUILD_PATH_PREFIX_MAP"
 # which is then used to bootstrap the fake dune.
 create_dune() {
   cat > bin/main.ml
-  cat > bin/dune <<EOF
-(executable
- (name main)
- (libraries $1)
- (bootstrap_info bootstrap-info))
-EOF
+  cat > bin/dune <<- EOF
+	(executable
+	 (name main)
+	 (libraries $1)
+	 (bootstrap_info bootstrap-info))
+	EOF
   dune build bin/bootstrap-info
   cp _build/default/bin/bootstrap-info boot/libs.ml
   bootstrap.exe && _boot/dune.exe

--- a/test/blackbox-tests/test-cases/oxcaml/helpers.sh
+++ b/test/blackbox-tests/test-cases/oxcaml/helpers.sh
@@ -1,10 +1,10 @@
 export XDG_CACHE_HOME="$PWD/.cache"
 
 init_project() {
-  cat > "dune-project" <<EOF
-(lang dune 3.20)
-(using oxcaml 0.1)
-EOF
+  cat > "dune-project" <<- EOF
+	(lang dune 3.20)
+	(using oxcaml 0.1)
+	EOF
 }
 
 make_dir_with_dune() {
@@ -16,29 +16,29 @@ make_dir_with_dune() {
 make_dummy_intf() {
   dir="$1"
   name="$2"
-  cat >> "$dir/$name.mli" <<EOF
-type t
-val f : t -> unit
-EOF
+  cat >> "$dir/$name.mli" <<- EOF
+	type t
+	val f : t -> unit
+	EOF
 }
 
 make_dummy_impl() {
   dir="$1"
   name="$2"
-  cat >> "$dir/$name.ml" <<EOF
-type t = int
-let f _ = ()
-EOF
+  cat >> "$dir/$name.ml" <<- EOF
+	type t = int
+	let f _ = ()
+	EOF
 }
 
 make_lib_impl() {
   name="$1"
   implements="$2"
-  make_dir_with_dune $name <<EOF
-(library
-  (name $name)
-  (implements $implements))
-EOF
+  make_dir_with_dune $name <<- EOF
+	(library
+	  (name $name)
+	  (implements $implements))
+	EOF
 }
 
 target_cmi() {

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -103,34 +103,34 @@ mk_ocaml() {
   next=$(echo "$patch + 1" | bc)
   local constraint="{>= \"$major.$minor.$patch~\" & < \"$major.$minor.$next~\"}"
 
-  mkpkg ocaml "$version" << EOF
-  depends: [
-   "ocaml-base-compiler" $constraint |
-   "ocaml-variants" $constraint
-  ]
-EOF
+  mkpkg ocaml "$version" <<- EOF
+	depends: [
+	  "ocaml-base-compiler" $constraint |
+	  "ocaml-variants" $constraint
+	]
+	EOF
 
-  mkpkg ocaml-base-compiler "$version" << EOF
-  depends: [
-   "ocaml-compiler" $constraint
-  ]
-  flags: compiler
-  conflict-class: "ocaml-core-compiler"
-EOF
+  mkpkg ocaml-base-compiler "$version" <<- EOF
+	depends: [
+	  "ocaml-compiler" $constraint
+	]
+	flags: compiler
+	conflict-class: "ocaml-core-compiler"
+	EOF
 
-  mkpkg ocaml-variants "$version" << EOF
-  depends: [
-   "ocaml-compiler" {= "$version"}
-  ]
-  flags: compiler
-  conflict-class: "ocaml-core-compiler"
-EOF
+  mkpkg ocaml-variants "$version" <<- EOF
+	depends: [
+	  "ocaml-compiler" {= "$version"}
+	]
+	flags: compiler
+	conflict-class: "ocaml-core-compiler"
+	EOF
 
-  mkpkg ocaml-compiler "$version" << EOF
-  depends: [
-   "ocaml" {= "$version" & post}
-  ]
-EOF
+  mkpkg ocaml-compiler "$version" <<- EOF
+	depends: [
+	  "ocaml" {= "$version" & post}
+	]
+	EOF
 }
 
 set_pkg_to () {
@@ -165,31 +165,31 @@ add_mock_repo_if_needed() {
 
   if [ ! -e dune-workspace ]
   then
-      cat >dune-workspace <<EOF
-(lang dune 3.20)
-(lock_dir
- (repositories mock))
-(repository
- (name mock)
- (url "${repo}"))
-EOF
+      cat >dune-workspace <<- EOF
+	(lang dune 3.20)
+	(lock_dir
+	 (repositories mock))
+	(repository
+	 (name mock)
+	 (url "${repo}"))
+	EOF
   else
     if ! grep '(name mock)' dune-workspace > /dev/null
     then
       # add the repo definition
-      cat >>dune-workspace <<EOF
-(repository
- (name mock)
- (url "${repo}"))
-EOF
+      cat >>dune-workspace <<- EOF
+	(repository
+	 (name mock)
+	 (url "${repo}"))
+	EOF
  
       # reference the repo - only add lock_dir if no existing lock_dir references mock
       if ! grep '(repositories' dune-workspace | grep 'mock' > /dev/null
       then
-        cat >>dune-workspace <<EOF
-(lock_dir
- (repositories mock))
-EOF
+        cat >>dune-workspace <<- EOF
+	(lock_dir
+	 (repositories mock))
+	EOF
       fi
   
     fi
@@ -199,14 +199,14 @@ EOF
 create_mock_repo() {
   # Always create a fresh workspace with mock repository configuration
   local repo="${1:-file://$(pwd)/mock-opam-repository}"
-  cat >dune-workspace <<EOF
-(lang dune 3.20)
-(lock_dir
- (repositories mock))
-(repository
- (name mock)
- (url "${repo}"))
-EOF
+  cat >dune-workspace <<- EOF
+	(lang dune 3.20)
+	(lock_dir
+	 (repositories mock))
+	(repository
+	 (name mock)
+	 (url "${repo}"))
+	EOF
 }
 
 make_lockpkg() {
@@ -264,20 +264,20 @@ solve_project() {
 
 make_lockdir() {
   mkdir -p "${source_lock_dir}"
-  cat > "${source_lock_dir}"/lock.dune <<EOF
-(lang package 0.1)
-(repositories (complete true))
-EOF
+  cat > "${source_lock_dir}"/lock.dune <<- EOF
+	(lang package 0.1)
+	(repositories (complete true))
+	EOF
 }
 
 make_project() {
-  cat <<EOF
-(lang dune 3.20)
- (package
-  (name x)
-  (allow_empty)
-  (depends $@))
-EOF
+  cat <<- EOF
+	(lang dune 3.20)
+	 (package
+	  (name x)
+	  (allow_empty)
+	  (depends $@))
+	EOF
 }
 
 print_source() {

--- a/test/blackbox-tests/test-cases/pkg/merlin/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/merlin/helpers.sh
@@ -3,28 +3,28 @@ dev_tool_lock_dir="_build/.dev-tools.locks/merlin"
 # Create a dune-workspace file with mock repos configured for the main
 # project lockdir and the merlin dev-tool lockdir.
 setup_merlin_workspace() {
-  cat > dune-workspace <<EOF
-(lang dune 3.20)
-(lock_dir
- (path "${dev_tool_lock_dir}")
- (repositories mock))
- (lock_dir
-  (repositories mock))
-(repository
- (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
-(pkg enabled)
-EOF
+  cat > dune-workspace <<- EOF
+	(lang dune 3.20)
+	(lock_dir
+	 (path "${dev_tool_lock_dir}")
+	 (repositories mock))
+	 (lock_dir
+	  (repositories mock))
+	(repository
+	 (name mock)
+	 (url "file://$(pwd)/mock-opam-repository"))
+	(pkg enabled)
+	EOF
 }
 
 # Create a fake merlin package containing an executable that
 # just prints a message.
 make_mock_merlin_package() {
-  mkpkg merlin <<EOF
-install: [
-  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamlmerlin" ]
-  [ "sh" "-c" "echo 'echo hello from fake ocamlmerlin' >> %{bin}%/ocamlmerlin" ]
-  [ "sh" "-c" "chmod a+x %{bin}%/ocamlmerlin" ]
-]
-EOF
+  mkpkg merlin <<- EOF
+	install: [
+	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamlmerlin" ]
+	  [ "sh" "-c" "echo 'echo hello from fake ocamlmerlin' >> %{bin}%/ocamlmerlin" ]
+	  [ "sh" "-c" "chmod a+x %{bin}%/ocamlmerlin" ]
+	]
+	EOF
 }

--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/helpers.sh
@@ -10,25 +10,25 @@ make_fake_ocamlformat() {
     ml_file="$2"
   fi
   mkdir ocamlformat
-  cat > ocamlformat/dune-project <<EOF
-(lang dune 3.13)
-(package (name ocamlformat))
-EOF
+  cat > ocamlformat/dune-project <<- EOF
+	(lang dune 3.13)
+	(package (name ocamlformat))
+	EOF
   if [ ! "$ml_file" = "no-ml-file" ]
   then
-    cat > ocamlformat/ocamlformat.ml <<EOF
-let version = "$version"
-let () =
-  if Sys.file_exists ".ocamlformat-ignore" then
-  print_endline "ignoring some files"
-;;
-let () = print_endline ("formatted with version "^version)
-EOF
+    cat > ocamlformat/ocamlformat.ml <<- EOF
+	let version = "$version"
+	let () =
+	  if Sys.file_exists ".ocamlformat-ignore" then
+	  print_endline "ignoring some files"
+	;;
+	let () = print_endline ("formatted with version "^version)
+	EOF
   fi
-  cat > ocamlformat/dune <<EOF
-(executable
- (public_name ocamlformat))
-EOF
+  cat > ocamlformat/dune <<- EOF
+	(executable
+	 (public_name ocamlformat))
+	EOF
   tar cf "ocamlformat-${version}.tar" ocamlformat
   rm -rf ocamlformat
 }
@@ -44,129 +44,129 @@ make_ocamlformat_opam_pkg() {
   fi
   if [ ! "$port" = "" ]
   then
-    mkpkg ocamlformat "$version" <<EOF
-build: [
-  [
-     "dune"
-     "build"
-     "-p"
-     name
-     "@install"
-  ]
-]
-url {
-  src: "http://127.0.0.1:$port"
-  checksum: [
-    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
-  ]
-}
-EOF
+    mkpkg ocamlformat "$version" <<- EOF
+	build: [
+	  [
+	     "dune"
+	     "build"
+	     "-p"
+	     name
+	     "@install"
+	  ]
+	]
+	url {
+	  src: "http://127.0.0.1:$port"
+	  checksum: [
+	    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
+	  ]
+	}
+	EOF
   else
-    mkpkg ocamlformat "$version" <<EOF
-build: [
-  [
-     "dune"
-     "build"
-     "-p"
-     name
-     "@install"
-  ]
-]
-url {
-  src: "file://$PWD/ocamlformat-$version.tar"
-  checksum: [
-    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
-  ]
-}
-EOF
+    mkpkg ocamlformat "$version" <<- EOF
+	build: [
+	  [
+	     "dune"
+	     "build"
+	     "-p"
+	     name
+	     "@install"
+	  ]
+	]
+	url {
+	  src: "file://$PWD/ocamlformat-$version.tar"
+	  checksum: [
+	    "md5=$(md5sum "ocamlformat-${version}.tar" | cut -f1 -d' ')"
+	  ]
+	}
+	EOF
   fi
 }
 
 make_project_with_dev_tool_lockdir() {
-  cat > dune-project <<EOF
-(lang dune 3.13)
-(package
- (name foo))
-EOF
-  cat > foo.ml <<EOF
-let () = print_endline "Hello, world"
-EOF
-  cat > dune <<EOF
-(executable
- (public_name foo))
-EOF
-  cat > dune-workspace <<EOF
-(lang dune 3.20)
-
-(lock_dir
- (path "${dev_tool_lock_dir}")
- (repositories mock))
-
-(lock_dir
-  (repositories mock))
-
-(repository
- (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
-EOF
+  cat > dune-project <<- EOF
+	(lang dune 3.13)
+	(package
+	 (name foo))
+	EOF
+  cat > foo.ml <<- EOF
+	let () = print_endline "Hello, world"
+	EOF
+  cat > dune <<- EOF
+	(executable
+	 (public_name foo))
+	EOF
+  cat > dune-workspace <<- EOF
+	(lang dune 3.20)
+	
+	(lock_dir
+	 (path "${dev_tool_lock_dir}")
+	 (repositories mock))
+	
+	(lock_dir
+	  (repositories mock))
+	
+	(repository
+	 (name mock)
+	 (url "file://$(pwd)/mock-opam-repository"))
+	EOF
 }
 
 make_printer_lib() {
   local version=$1
   mkdir printer
-  cat > printer/dune-project <<EOF
-(lang dune 3.13)
-(package (name printer))
-EOF
+  cat > printer/dune-project <<- EOF
+	(lang dune 3.13)
+	(package (name printer))
+	EOF
   if [ "${version}" = "1.0" ]
   then
-  cat > printer/printer.ml <<EOF
-let print () = print_endline "formatted"
-EOF
+  cat > printer/printer.ml <<- EOF
+	let print () = print_endline "formatted"
+	EOF
   else
-  cat > printer/printer.ml <<EOF
-let print () = print_endline "Hello World!"
-EOF
+  cat > printer/printer.ml <<- EOF
+	let print () = print_endline "Hello World!"
+	EOF
   fi
-  cat > printer/dune <<EOF
-(library
- (public_name printer))
-EOF
+  cat > printer/dune <<- EOF
+	(library
+	 (public_name printer))
+	EOF
   tar cf "printer.${version}.tar" printer
   rm -r printer
 }
 
 make_opam_printer() {
   local version=$1
-  mkpkg printer "$version" <<EOF
-build: [
-   [
-    "dune"
-    "build"
-    "-p"
-    name
-    "@install"
-   ]
- ]
- url {
- src: "file://$PWD/printer.$version.tar"
- checksum: [
-  "md5=$(md5sum "printer.${version}.tar" | cut -f1 -d' ')"
- ]
-}
-EOF
+  mkpkg printer "$version" <<- EOF
+	build: [
+	   [
+	    "dune"
+	    "build"
+	    "-p"
+	    name
+	    "@install"
+	   ]
+	 ]
+	 url {
+	 src: "file://$PWD/printer.$version.tar"
+	 checksum: [
+	  "md5=$(md5sum "printer.${version}.tar" | cut -f1 -d' ')"
+	 ]
+	}
+	EOF
 }
 
 make_fake_ocamlformat_from_path() {
   mkdir .bin
-  cat > .bin/ocamlformat <<EOF
-#!/bin/sh
-if [ -f ".ocamlformat-ignore" ]
-then
-  echo "ignoring some files"
-fi
-echo "fake ocamlformat from PATH"
-EOF
+  cat > .bin/ocamlformat <<-EOF
+	#!/bin/sh
+	if [ -f ".ocamlformat-ignore" ]
+	then
+	  echo "ignoring some files"
+	fi
+	echo "fake ocamlformat from PATH"
+	EOF
   chmod +x .bin/ocamlformat
   PATH=$PWD/.bin:$PATH
 }

--- a/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/ocamllsp/helpers.sh
@@ -3,28 +3,28 @@ dev_tool_lock_dir="_build/.dev-tools.locks/ocaml-lsp-server"
 # Create a dune-workspace file with mock repos set up for the main
 # project and the ocamllsp lockdir.
 setup_ocamllsp_workspace() {
-  cat > dune-workspace <<EOF
-(lang dune 3.20)
-(lock_dir
- (path "${dev_tool_lock_dir}")
- (repositories mock))
- (lock_dir
-  (repositories mock))
-(repository
- (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
-(pkg enabled)
-EOF
+  cat > dune-workspace <<- EOF
+	(lang dune 3.20)
+	(lock_dir
+	 (path "${dev_tool_lock_dir}")
+	 (repositories mock))
+	 (lock_dir
+	  (repositories mock))
+	(repository
+	 (name mock)
+	 (url "file://$(pwd)/mock-opam-repository"))
+	(pkg enabled)
+	EOF
 }
 
 # Create a fake ocaml-lsp-server package containing an executable that
 # just prints a message.
 make_mock_ocamllsp_package() {
-  mkpkg ocaml-lsp-server <<EOF
-install: [
-  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamllsp" ]
-  [ "sh" "-c" "echo 'echo hello from fake ocamllsp' >> %{bin}%/ocamllsp" ]
-  [ "sh" "-c" "chmod a+x %{bin}%/ocamllsp" ]
-]
-EOF
+  mkpkg ocaml-lsp-server <<- EOF
+	install: [
+	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/ocamllsp" ]
+	  [ "sh" "-c" "echo 'echo hello from fake ocamllsp' >> %{bin}%/ocamllsp" ]
+	  [ "sh" "-c" "chmod a+x %{bin}%/ocamllsp" ]
+	]
+	EOF
 }

--- a/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/odoc/helpers.sh
@@ -3,28 +3,28 @@ dev_tool_lock_dir="_build/.dev-tools.locks/odoc"
 # Create a dune-workspace file with mock repos set up for the main
 # project and the odoc lockdir.
 setup_odoc_workspace() {
-  cat > dune-workspace <<EOF
-(lang dune 3.20)
-(pkg enabled)
-(lock_dir
- (path "${dev_tool_lock_dir}")
- (repositories mock))
- (lock_dir
-  (repositories mock))
-(repository
- (name mock)
- (url "file://$(pwd)/mock-opam-repository"))
-EOF
+  cat > dune-workspace <<- EOF
+	(lang dune 3.20)
+	(pkg enabled)
+	(lock_dir
+	 (path "${dev_tool_lock_dir}")
+	 (repositories mock))
+	 (lock_dir
+	  (repositories mock))
+	(repository
+	 (name mock)
+	 (url "file://$(pwd)/mock-opam-repository"))
+	EOF
 }
 
 # Create a fake odoc package containing an executable that
 # just prints a message.
 make_mock_odoc_package() {
-  mkpkg odoc <<EOF
-install: [
-  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/odoc" ]
-  [ "sh" "-c" "echo 'echo hello from fake odoc' >> %{bin}%/odoc" ]
-  [ "sh" "-c" "chmod a+x %{bin}%/odoc" ]
-]
-EOF
+  mkpkg odoc <<- EOF
+	install: [
+	  [ "sh" "-c" "echo '#!/bin/sh' > %{bin}%/odoc" ]
+	  [ "sh" "-c" "echo 'echo hello from fake odoc' >> %{bin}%/odoc" ]
+	  [ "sh" "-c" "chmod a+x %{bin}%/odoc" ]
+	]
+	EOF
 }

--- a/test/blackbox-tests/test-cases/pkg/search/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/search/helpers.sh
@@ -14,18 +14,18 @@ create_dune_workspace_with_mock_repos() {
   # Always create a fresh workspace with mock repository configuration
   repo1="file://$(pwd)/mock-opam-repository"
   repo2="file://$(pwd)/other-opam-repository"
-  cat >dune-workspace <<EOF
-(lang dune 3.20)
-(pkg enabled)
-(lock_dir
- (repositories other mock))
-(repository
- (name mock)
- (url "${repo1}"))
-(repository
- (name other)
- (url "${repo2}"))
-EOF
+  cat >dune-workspace <<- EOF
+	(lang dune 3.20)
+	(pkg enabled)
+	(lock_dir
+	 (repositories other mock))
+	(repository
+	 (name mock)
+	 (url "${repo1}"))
+	(repository
+	 (name other)
+	 (url "${repo2}"))
+	EOF
 }
 
 mk_multiple_packages() {
@@ -40,10 +40,10 @@ mk_multiple_packages() {
       else
         prefix="Short synopsis for"
       fi
-      mkpkg "$pkg" "$version" <<EOF
-depends: [ "ocaml" {>= "4.12.0"} ]
-synopsis: "$prefix package: '$pkg' version: '$version'"
-EOF
+      mkpkg "$pkg" "$version" <<- EOF
+	depends: [ "ocaml" {>= "4.12.0"} ]
+	synopsis: "$prefix package: '$pkg' version: '$version'"
+	EOF
     done
   done
 }


### PR DESCRIPTION
Using `<<-` instead of `<<` allows us to indent the contents that we want to write and bash will filter out the leading tabs, thus the content written won't have the leading tabs.

This makes the scripts easier to read as the data is now indented and thus functions don't have have random parts starting at the beginning of the line.

Since we have switched to using `bash`, we don't have to worry whether `<<-` is in POSIX `sh`; it works in bash.