### PR TITLE
Scheduler: fix pid races

### DIFF
--- a/doc/changes/fixed/13245.md
+++ b/doc/changes/fixed/13245.md
@@ -1,0 +1,2 @@
+- Fix dune trying to kill processes that were already reaped due to race
+  conditions (#13245, @rgrinberg)

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -69,7 +69,7 @@ end
 external stub_wait4
   :  int
   -> Unix.wait_flag list
-  -> int * Unix.process_status * float * Resource_usage.t
+  -> (int * Unix.process_status * float * Resource_usage.t) option
   = "dune_wait4"
 
 type wait =
@@ -85,11 +85,12 @@ let wait wait flags =
       | Any -> -1
       | Pid pid -> Pid.to_int pid
     in
-    let pid, status, end_time, resource_usage = stub_wait4 pid flags in
-    let end_time = Time.of_epoch_secs end_time in
-    { Process_info.pid = Pid.of_int pid
-    ; status
-    ; end_time
-    ; resource_usage = Some resource_usage
-    })
+    stub_wait4 pid flags
+    |> Option.map ~f:(fun (pid, status, end_time, resource_usage) ->
+      let end_time = Time.of_epoch_secs end_time in
+      { Process_info.pid = Pid.of_int pid
+      ; status
+      ; end_time
+      ; resource_usage = Some resource_usage
+      }))
 ;;

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -50,5 +50,10 @@ type wait =
   | Any
   | Pid of Pid.t
 
-(** This function is not implemented on Windows *)
-val wait : wait -> Unix.wait_flag list -> Process_info.t
+(** This function is not implemented on Windows.
+
+   Returns [None] if there are no children. If [WNOHANG] is passed, also
+   returns [None] if none of the proceseses are finished yet.
+   When successful, returns information about the reaped process.
+ *)
+val wait : wait -> Unix.wait_flag list -> Process_info.t option

--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -99,6 +99,7 @@ let name = function
 ;;
 
 let compare (x : t) (y : t) = Poly.compare x y
+let equal (x : t) (y : t) = Poly.equal x y
 
 let to_dyn =
   let open Dyn in

--- a/otherlibs/stdune/src/signal.mli
+++ b/otherlibs/stdune/src/signal.mli
@@ -38,4 +38,5 @@ val name : t -> string
 val to_int : t -> int
 val to_dyn : t -> Dyn.t
 val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
 val of_int : int -> t

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -10,11 +10,16 @@ void dune_wait4(value v_pid, value flags) {
 
 #else
 
+#ifndef Val_none
+#define Val_none Val_int(0)
+#endif
+
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
+#include <errno.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -23,6 +28,14 @@ void dune_wait4(value v_pid, value flags) {
 #define TAG_WEXITED 0
 #define TAG_WSIGNALED 1
 #define TAG_WSTOPPED 2
+
+static inline value caml_alloc_some_compat(value v) {
+  CAMLparam1(v);
+  CAMLlocal1(some);
+  some = caml_alloc_small(1, 0);
+  Field(some, 0) = v;
+  CAMLreturn(some);
+}
 
 CAMLextern int caml_convert_signal_number(int);
 CAMLextern int caml_rev_convert_signal_number(int);
@@ -62,10 +75,19 @@ value dune_wait4(value v_pid, value flags) {
   caml_enter_blocking_section();
   // returns the pid of the terminated process, or -1 on error
   pid = wait4(pid, &status, cv_flags, &ru);
+  int wait_errno = errno;
   gettimeofday(&tp, NULL);
   caml_leave_blocking_section();
-  if (pid == -1)
-    uerror("wait4", Nothing);
+  if (pid == 0) {
+    CAMLreturn(Val_none);
+  } else if (pid == -1) {
+    if (wait_errno == ECHILD) {
+      CAMLreturn(Val_none);
+    } else {
+      errno = wait_errno;
+      uerror("wait4", Nothing);
+    }
+  }
 
   times = caml_alloc_tuple(9);
   Store_field(times, 0, caml_copy_double(ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6));
@@ -84,7 +106,7 @@ value dune_wait4(value v_pid, value flags) {
   Store_field(res, 2,
               caml_copy_double(((double)tp.tv_sec + (double)tp.tv_usec / 1e6)));
   Store_field(res, 3, times);
-  CAMLreturn(res);
+  CAMLreturn(caml_alloc_some_compat(res));
 }
 
 #endif

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -16,6 +16,7 @@ type t =
   | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
+  | Job_complete_ready
 
 module Queue : sig
   type event := t
@@ -33,6 +34,9 @@ module Queue : sig
   (** Register the fact that a job was started. *)
   val register_job_started : t -> unit
 
+  (** Register the fact that a job was finished. *)
+  val finish_job : t -> unit
+
   (** Number of jobs for which the status hasn't been reported yet .*)
   val pending_jobs : t -> int
 
@@ -49,6 +53,7 @@ module Queue : sig
 
   val send_invalidation_event : t -> Memo.Invalidation.t -> unit
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit
+  val send_job_completed_ready : t -> unit
   val send_shutdown : t -> Shutdown.Reason.t -> unit
   val send_timers_completed : t -> Fiber.fill Nonempty_list.t -> unit
   val yield_if_there_are_pending_events : t -> unit Fiber.t

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -14,3 +14,5 @@ val is_running : t -> Pid.t -> bool
 
 (** Send the following signal to all running processes. *)
 val killall : t -> int -> unit
+
+val wait_unix : t -> Fiber.fill list

--- a/src/dune_scheduler/signal_watcher.mli
+++ b/src/dune_scheduler/signal_watcher.mli
@@ -1,1 +1,1 @@
-val init : print_ctrl_c_warning:bool -> Event.Queue.t -> unit
+val init : print_ctrl_c_warning:bool -> Event.Queue.t -> Thread.t

--- a/src/dune_scheduler/thread0.mli
+++ b/src/dune_scheduler/thread0.mli
@@ -2,6 +2,10 @@ open Stdune
 
 type t = Thread.t
 
+(** Magic signal to interrupt to the signal watching thread *)
+val signal_watcher_interrupt : Signal.t
+
+val join : t -> unit
 val interrupt_signals : Signal.t list
 val spawn : (unit -> unit) -> Thread.t
 val delay : float -> unit

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -65,6 +65,8 @@ module Event : sig
     -> times:Proc.Times.t
     -> t
 
+  val unknown_process : Proc.Process_info.t -> t
+
   type timeout =
     { pid : Pid.t
     ; group_leader : bool

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -14,6 +14,7 @@ dune trace cat can be used to view the trace:
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
+  ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
 


### PR DESCRIPTION
Spawning/killing processes in on thread and reaping them in another is
inherently racy on Unix. Let's not do that.

The old code is kept on Windows as it doesn't have such races.