### PR TITLE
refactor: remove [spawn_thread] in [Async_io]

### DIFF
--- a/src/dune_scheduler/async_io.ml
+++ b/src/dune_scheduler/async_io.ml
@@ -13,7 +13,6 @@ module type Scheduler = sig
   val fill_jobs : Fiber.fill list -> unit
   val register_job_started : unit -> unit
   val cancel_job_started : unit -> unit
-  val spawn_thread : (unit -> unit) -> Thread.t
 end
 
 let byte = Bytes.make 1 '0'
@@ -232,7 +231,7 @@ let rec select_loop t =
 
 let start t =
   let module Scheduler = (val t.scheduler : Scheduler) in
-  Scheduler.spawn_thread (fun () ->
+  Thread0.spawn (fun () ->
     Mutex.lock t.mutex;
     match select_loop t with
     | () -> Mutex.unlock t.mutex

--- a/src/dune_scheduler/async_io.mli
+++ b/src/dune_scheduler/async_io.mli
@@ -19,7 +19,6 @@ module type Scheduler = sig
   val fill_jobs : Fiber.fill list -> unit
   val register_job_started : unit -> unit
   val cancel_job_started : unit -> unit
-  val spawn_thread : (unit -> unit) -> Thread.t
 end
 
 (** [with_io scheduler f] runs [f] with [scheduler]. All operations in this

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -284,7 +284,6 @@ end = struct
     let fiber =
       set t (fun () ->
         let module Scheduler = struct
-          let spawn_thread = spawn_thread
           let register_job_started () = Event.Queue.register_worker_task_started t.events
           let fill_jobs jobs = Event.Queue.send_worker_tasks_completed t.events jobs
           let cancel_job_started () = Event.Queue.cancel_work_task_started t.events


### PR DESCRIPTION
No need to pass this when it's available in the same library