### PR TITLE
test(pkg): Use dune's scheduler to spawn threads

### DIFF
--- a/test/expect-tests/dune_pkg/fetch_tests.ml
+++ b/test/expect-tests/dune_pkg/fetch_tests.ml
@@ -32,13 +32,11 @@ let serve_once ~filename =
   Http.Server.start server;
   let port = Http.Server.port server in
   let thread =
-    Thread.create
-      (fun server ->
-         Http.Server.accept server ~f:(fun session ->
-           let () = Http.Server.accept_request session in
-           Http.Server.respond_file session ~file:filename);
-         Http.Server.stop server)
-      server
+    Scheduler.spawn_thread (fun () ->
+      Http.Server.accept server ~f:(fun session ->
+        let () = Http.Server.accept_request session in
+        Http.Server.respond_file session ~file:filename);
+      Http.Server.stop server)
   in
   port, thread
 ;;


### PR DESCRIPTION
This is the only way to make sure that the thread spawned will not get signals it's not supposed to