### PR TITLE
feat: add counters and elapsed time to progress display

### DIFF
--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -34,13 +34,20 @@ let on_event dune_config _config = function
              | Build_failed__now_waiting_for_changes -> Build_system.Progress.init
              | Building progress -> progress
            in
+           let elapsed = Unix.gettimeofday () -. progression.start_time in
+           let elapsed_str =
+             if elapsed < 60.0
+             then sprintf "%.0fs" elapsed
+             else sprintf "%.0fm%.0fs" (floor (elapsed /. 60.0)) (mod_float elapsed 60.0)
+           in
            Pp.seq
              (Pp.tag User_message.Style.Error (Pp.verbatim "Source files changed"))
              (Pp.verbatim
                 (sprintf
-                   ", restarting current build... (%u/%u)"
+                   ", restarting current build... (%u/%u, %s)"
                    progression.number_of_rules_executed
-                   progression.number_of_rules_discovered))))
+                   progression.number_of_rules_discovered
+                   elapsed_str))))
   | Build_finish build_result ->
     let message =
       match build_result with

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -7,6 +7,7 @@ module Progress = struct
     { number_of_rules_discovered : int
     ; number_of_rules_executed : int
     ; number_of_rules_failed : int
+    ; start_time : float
     }
 
   let to_dyn t =
@@ -14,22 +15,29 @@ module Progress = struct
       [ "number_of_rules_discovered", Dyn.int t.number_of_rules_discovered
       ; "number_of_rules_executed", Dyn.int t.number_of_rules_executed
       ; "number_of_rules_failed", Dyn.int t.number_of_rules_failed
+      ; "start_time", Dyn.float t.start_time
       ]
   ;;
 
   let equal
-        { number_of_rules_discovered; number_of_rules_executed; number_of_rules_failed }
+        { number_of_rules_discovered
+        ; number_of_rules_executed
+        ; number_of_rules_failed
+        ; start_time
+        }
         t
     =
     Int.equal number_of_rules_discovered t.number_of_rules_discovered
     && Int.equal number_of_rules_executed t.number_of_rules_executed
     && Int.equal number_of_rules_failed t.number_of_rules_failed
+    && start_time = t.start_time
   ;;
 
   let init =
     { number_of_rules_discovered = 0
     ; number_of_rules_executed = 0
     ; number_of_rules_failed = 0
+    ; start_time = Unix.gettimeofday ()
     }
   ;;
 end

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -68,9 +68,10 @@ module Progress : sig
     { number_of_rules_discovered : int
     ; number_of_rules_executed : int
     ; number_of_rules_failed : int
+    ; start_time : float
     }
 
-  (** Initialize with zeros on all measures. *)
+  (** Initialize with zeros on all measures and current time as start_time. *)
   val init : t
 end
 


### PR DESCRIPTION
Update the build progress status line to show:
- done/total rule counters
- running jobs count
- queued count (remaining minus running)
- elapsed time since build start

New format: "150/330 done, 8 running, 172 queued (12s)"
Old format: "Done: 45% (150/330, 180 left) (jobs: 8)"

Part of the work for issue #12992.