### PR TITLE
feature: Action Tracing

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -255,6 +255,12 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
+  ; { path = "otherlibs/dune-action-trace"
+    ; main_module_name = Some "Dune_action_trace"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
   ; { path = "src/dune_engine"
     ; main_module_name = Some "Dune_engine"
     ; include_subdirs = No

--- a/otherlibs/dune-action-trace/dune
+++ b/otherlibs/dune-action-trace/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_action_trace)
+ (libraries csexp))

--- a/otherlibs/dune-action-trace/dune_action_trace.ml
+++ b/otherlibs/dune-action-trace/dune_action_trace.ml
@@ -1,0 +1,90 @@
+module List = ListLabels
+
+module Private = struct
+  let trace_dir_env_var = "DUNE_ACTION_TRACE_DIR"
+end
+
+module Event = struct
+  type t = Csexp.t
+
+  module Arg = struct
+    let string s = Csexp.Atom s
+    let float x = string (string_of_float x)
+    let list xs = Csexp.List xs
+    let record xs = List.map xs ~f:(fun (k, v) -> list [ string k; v ])
+    let time ts = float ts
+    let span span = float span
+  end
+
+  let base ~name cat : Csexp.t list = [ Atom cat; Atom name ]
+
+  let instant ?(args = []) ~category ~name ~time_in_seconds () =
+    Csexp.List (base ~name category @ [ Arg.time time_in_seconds ] @ Arg.record args)
+  ;;
+
+  let span ?(args = []) ~category ~name ~start_in_seconds ~duration_in_seconds () =
+    Csexp.List
+      (base ~name category
+       @ [ Csexp.List [ Arg.time start_in_seconds; Arg.span duration_in_seconds ] ]
+       @ Arg.record args)
+  ;;
+end
+
+module Sys = struct
+  let[@warning "-32"] mkdir _ = failwith "unsupported"
+
+  include Sys
+end
+
+module Context = struct
+  type state =
+    | Open of out_channel
+    | Closed
+
+  type t =
+    | Disabled
+    | Enabled of state ref
+
+  let create ~name =
+    match Sys.getenv_opt Private.trace_dir_env_var with
+    | None -> Disabled
+    | Some dir ->
+      (match
+         match Sys.mkdir dir 0o777 with
+         | () -> `Ok
+         | exception Sys_error _ when Sys.is_directory dir -> `Ok
+         | exception _ -> `Failure
+       with
+       | `Failure -> Disabled
+       | `Ok ->
+         Enabled (ref (Open (Filename.open_temp_file ~temp_dir:dir name ".csexp" |> snd))))
+  ;;
+
+  let is_enabled = function
+    | Disabled -> false
+    | Enabled x ->
+      (match !x with
+       | Open _ -> true
+       | Closed -> false)
+  ;;
+
+  let emit t event =
+    match t with
+    | Disabled -> ()
+    | Enabled state ->
+      (match !state with
+       | Closed -> failwith "unable to log event because context is closed"
+       | Open chan -> Csexp.to_channel chan event)
+  ;;
+
+  let close t =
+    match t with
+    | Disabled -> ()
+    | Enabled state ->
+      (match !state with
+       | Closed -> ()
+       | Open chan ->
+         state := Closed;
+         close_out chan)
+  ;;
+end

--- a/otherlibs/dune-action-trace/dune_action_trace.mli
+++ b/otherlibs/dune-action-trace/dune_action_trace.mli
@@ -1,0 +1,37 @@
+(** Actions are allowed to produce events when executed by dune. Such events
+    are aggregated into dune's trace file. *)
+
+module Event : sig
+  type t
+  type args := (string * Csexp.t) list
+
+  val instant
+    :  ?args:args
+    -> category:string
+    -> name:string
+    -> time_in_seconds:float
+    -> unit
+    -> t
+
+  val span
+    :  ?args:args
+    -> category:string
+    -> name:string
+    -> start_in_seconds:float
+    -> duration_in_seconds:float
+    -> unit
+    -> t
+end
+
+module Context : sig
+  type t
+
+  val is_enabled : t -> bool
+  val create : name:string -> t
+  val emit : t -> Event.t -> unit
+  val close : t -> unit
+end
+
+module Private : sig
+  val trace_dir_env_var : string
+end

--- a/src/dune_engine/action_trace.ml
+++ b/src/dune_engine/action_trace.ml
@@ -1,0 +1,123 @@
+open Import
+open Fiber.O
+
+let action_trace_root =
+  lazy
+    (let root = Path.Build.(relative root ".action-trace") in
+     Path.mkdir_p (Path.build root);
+     root)
+;;
+
+type t =
+  { dir : Path.Build.t
+  ; digest : string
+  }
+
+let add_to_env t env =
+  Env.add
+    env
+    ~var:Dune_action_trace.Private.trace_dir_env_var
+    ~value:(Path.to_absolute_filename (Path.build t.dir))
+;;
+
+let create digest =
+  let root = Lazy.force action_trace_root in
+  let digest = Dune_digest.to_string digest in
+  { dir = Path.Build.relative root digest; digest }
+;;
+
+let collect_file file ~digest =
+  Io.with_file_in ~binary:true (Path.build file) ~f:(fun chan ->
+    let rec loop () =
+      (* CR-soon rgrinberg: handle json payloads as well *)
+      match Csexp.input_opt chan with
+      | Ok None -> ()
+      | Error _ ->
+        User_error.raise
+          [ Pp.textf "invalid action trace in %s" (Path.Build.to_string_maybe_quoted file)
+          ]
+      | Ok (Some s) ->
+        Dune_trace.emit ~buffered:true Action (fun () ->
+          Dune_trace.Event.Action.trace ~digest s);
+        loop ()
+    in
+    loop ())
+;;
+
+let collect { dir; digest } =
+  let* () = Fiber.return () in
+  let unrecognized = Queue.create () in
+  let errors = Queue.create () in
+  let needs_cleanup = ref false in
+  let rec loop dir =
+    match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
+    | Error (ENOENT, _, _) -> ()
+    | Error e ->
+      needs_cleanup := true;
+      let error =
+        User_error.make
+          [ Pp.textf "unreadable dir %s" (Path.Build.to_string_maybe_quoted dir)
+          ; Unix_error.Detailed.pp e
+          ]
+      in
+      Queue.push errors (User_error.E error)
+    | Ok names ->
+      needs_cleanup := true;
+      let dirs, files =
+        List.filter_partition_map names ~f:(fun (name, (kind : Unix.file_kind)) ->
+          let kind =
+            match kind with
+            | S_LNK ->
+              (match Path.Untracked.stat (Path.build (Path.Build.relative dir name)) with
+               | Ok s -> Ok s.st_kind
+               | Error e -> Error e)
+            | _ -> Ok kind
+          in
+          match kind with
+          | Ok S_REG -> Right name
+          | Ok S_DIR -> Left name
+          | Ok _ ->
+            Queue.push unrecognized (Path.Build.relative dir name);
+            Skip
+          | Error error ->
+            let error =
+              User_message.make
+                [ Pp.textf
+                    "broken symlink %s"
+                    (Path.Build.to_string_maybe_quoted (Path.Build.relative dir name))
+                ; Unix_error.Detailed.pp error
+                ]
+            in
+            Queue.push errors (User_error.E error);
+            Skip)
+        (* CR-someday rgrinberg: handle symlinks? *)
+      in
+      List.iter files ~f:(fun file ->
+        try collect_file (Path.Build.relative dir file) ~digest with
+        | exn -> Queue.push errors exn);
+      List.iter dirs ~f:(fun name -> loop (Path.Build.relative dir name))
+  in
+  loop dir;
+  Dune_trace.flush ();
+  if !needs_cleanup then Fpath.rm_rf (Path.to_string (Path.build dir));
+  (match Queue.to_list unrecognized with
+   | [] -> ()
+   | unrecognized ->
+     let error =
+       User_message.make
+         [ Pp.text "unrecognized files"
+         ; Pp.enumerate unrecognized ~f:(fun f ->
+             Pp.verbatim (Path.Build.to_string_maybe_quoted f))
+         ]
+     in
+     Queue.push errors (User_error.E error));
+  match Queue.to_list errors with
+  | [] -> Fiber.return ()
+  | errors ->
+    let errors =
+      (* A bit of a useless callstack, but good enough for our purposes here. *)
+      let backtrace = Printexc.get_callstack 10 in
+      List.map errors ~f:(fun exn -> { Exn_with_backtrace.exn; backtrace })
+    in
+    Fiber.reraise_all errors
+;;

--- a/src/dune_engine/action_trace.mli
+++ b/src/dune_engine/action_trace.mli
@@ -1,0 +1,10 @@
+(** Actions executed by dune may produce trace events in a designated
+    directory. These are collected by dune and inserted into its trace file. *)
+
+open Import
+
+type t
+
+val add_to_env : t -> Env.t -> Env.t
+val create : Dune_digest.t -> t
+val collect : t -> unit Fiber.t

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -27,5 +27,6 @@
   spawn
   dune_file_watcher
   dune_digest
+  dune_action_trace
   dune_metrics)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -170,6 +170,7 @@ module Event : sig
   module Action : sig
     val start : name:string -> start:Time.t -> t
     val finish : name:string -> start:Time.t -> t
+    val trace : digest:string -> Csexp.t -> t
   end
 end
 

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -579,4 +579,15 @@ module Action = struct
     let dur = Time.diff (Time.now ()) start in
     Event.complete ~args:[ "name", Arg.string name ] ~name:"finish" ~start ~dur Action
   ;;
+
+  let trace ~digest (csexp : Sexp.t) =
+    match csexp with
+    | List xs -> Sexp.List (xs @ [ Sexp.List [ Atom "digest"; Atom digest ] ])
+    | Atom x ->
+      log
+        { Log.Message.level = `Warn
+        ; message = "invalid event"
+        ; args = [ "payload", Dyn.string x; "digest", Dyn.string digest ]
+        }
+  ;;
 end

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -50,3 +50,6 @@ def coqdocFlags:
   | .args.process_args
   | .[]
   | rocqArg;
+
+def redactedActionTraces:
+  [ .[] | select(.args.digest != null) | .ts |= 0 | .args.digest |= "REDACTED" ] | sort_by(.name) | .[];

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -9,6 +9,7 @@
    (OCAML_COLOR always))
   (binaries
    ../utils/dune_cmd.exe
+   ../utils/action_trace.exe
    ../utils/dunepp.exe
    ../utils/melc_stdlib_prefix.exe
    ../utils/refmt.exe
@@ -35,6 +36,7 @@
   ../dune.jq
   %{bin:jq}
   %{bin:dune_cmd}
+  %{bin:action_trace}
   (package dune))
  ;; We don't allow conflict markers in tests
  (conflict_markers error)

--- a/test/blackbox-tests/test-cases/trace/action-traces/basic.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/basic.t
@@ -1,0 +1,24 @@
+Dune's actions may produce trace events
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action (run action_trace -name foo -cat bar -arg baz)))
+  > EOF
+
+  $ dune build @foo
+
+  $ dune trace cat | jq -s 'include "dune"; redactedActionTraces'
+  {
+    "cat": "bar",
+    "name": "foo",
+    "ts": 0,
+    "args": {
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }

--- a/test/blackbox-tests/test-cases/trace/action-traces/compound.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/compound.t
@@ -1,0 +1,37 @@
+Dune actions may produce multiple trace events
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (progn
+  >    (run action_trace -name foo1 -cat bar -arg baz -dur 20)
+  >    (run action_trace -name foo2 -cat bar -arg baz))))
+  > EOF
+
+  $ dune build @foo
+
+  $ dune trace cat | jq -s 'include "dune"; redactedActionTraces'
+  {
+    "cat": "bar",
+    "name": "foo1",
+    "ts": 0,
+    "args": {
+      "dur": 20,
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }
+  {
+    "cat": "bar",
+    "name": "foo2",
+    "ts": 0,
+    "args": {
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }

--- a/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/invalid-trace.t
@@ -1,0 +1,20 @@
+Invalid traces should be an error
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (alias foo)
+  >  (action (bash "mkdir $DUNE_ACTION_TRACE_DIR && echo foo > $DUNE_ACTION_TRACE_DIR/trace.csexp")))
+  > EOF
+
+  $ dune build @foo 2>&1 | dune_cmd subst '_build/.*' '_build/REDACTED'
+  File "dune", lines 1-3, characters 0-116:
+  1 | (rule
+  2 |  (alias foo)
+  3 |  (action (bash "mkdir $DUNE_ACTION_TRACE_DIR && echo foo > $DUNE_ACTION_TRACE_DIR/trace.csexp")))
+  Error: invalid action trace in
+  _build/REDACTED
+  [1]

--- a/test/blackbox-tests/test-cases/trace/action-traces/multiple-actions.t
+++ b/test/blackbox-tests/test-cases/trace/action-traces/multiple-actions.t
@@ -1,0 +1,37 @@
+Dune should collect traces from all actions
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action (run action_trace -name foo2 -cat bar -arg baz)))
+  > (rule
+  >  (alias foo)
+  >  (action (run action_trace -name foo1 -cat bar -arg baz -dur 20)))
+  > EOF
+
+  $ dune build @foo
+
+  $ dune trace cat | jq -s 'include "dune"; redactedActionTraces'
+  {
+    "cat": "bar",
+    "name": "foo1",
+    "ts": 0,
+    "args": {
+      "dur": 20,
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }
+  {
+    "cat": "bar",
+    "name": "foo2",
+    "ts": 0,
+    "args": {
+      "arg": "baz",
+      "digest": "REDACTED"
+    }
+  }

--- a/test/blackbox-tests/utils/action_trace.ml
+++ b/test/blackbox-tests/utils/action_trace.ml
@@ -1,0 +1,38 @@
+open Dune_action_trace
+module List = ListLabels
+
+let () =
+  let now = Unix.gettimeofday () in
+  let args = ref [] in
+  let () =
+    let current_key = ref None in
+    Array.to_list Sys.argv
+    |> List.tl
+    |> List.iter ~f:(fun v ->
+      if String.starts_with ~prefix:"-" v
+      then current_key := Some (String.sub v 1 (String.length v - 1))
+      else (
+        match !current_key with
+        | None -> failwith "missing field name"
+        | Some k -> args := (k, v) :: !args))
+  in
+  let args = !args in
+  let ctx = Context.create ~name:"dune-tests" in
+  let duration =
+    match List.assoc_opt "duration" args with
+    | None -> None
+    | Some s -> Some (float_of_string s)
+  in
+  let category = List.assoc "cat" args in
+  let name = List.assoc "name" args in
+  let args =
+    List.filter_map args ~f:(fun (k, v) ->
+      if k = "cat" || k = "name" || k = "duration" then None else Some (k, Csexp.Atom v))
+  in
+  match duration with
+  | None -> Context.emit ctx (Event.instant ~args ~category ~name ~time_in_seconds:now ())
+  | Some duration_in_seconds ->
+    Context.emit
+      ctx
+      (Event.span ~args ~category ~name ~start_in_seconds:now ~duration_in_seconds ())
+;;

--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -3,6 +3,11 @@
  (modules dune_cmd)
  (libraries stdune re dune-configurator build_path_prefix_map str unix))
 
+(executable
+ (name action_trace)
+ (modules action_trace)
+ (libraries stdune unix csexp dune_action_trace))
+
 (ocamllex dunepp)
 
 (executable


### PR DESCRIPTION
This PR introduces trace event collection for actions executed by dune. Actions which are executed by dune may emit events into the `DUNE_ACTION_TRACE_DIR`. Such events are collected by dune and added into the trace file.

To produce traces, users must use the `dune_action_trace` library. This library is kept with minimal dependencies to make it as easy as possible for users to collect such traces.