### PR TITLE
fix(select-field): `Skip` select form files without a dialect extension

### DIFF
--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -776,10 +776,7 @@ module Generated_modules = struct
                   (match ml_kind with
                    | Ml_kind.Impl -> Left (module_path, (loc, file))
                    | Intf -> Right (module_path, (loc, file)))
-                | None ->
-                  User_error.raise
-                    ~loc
-                    [ Pp.text "No solution found for this select form." ])))
+                | None -> Skip)))
       in
       let impls = parse_one_set ~dir impl_files in
       let intfs = parse_one_set ~dir intf_files in

--- a/test/blackbox-tests/test-cases/select-field/select-validation.t
+++ b/test/blackbox-tests/test-cases/select-field/select-validation.t
@@ -111,9 +111,5 @@ name
   >  (action (progn (echo "pull\n") (with-stdout-to %{targets} (echo "")))))
   > EOF
   $ dune build
-  File "dune", lines 4-6, characters 2-110:
-  4 |   (select link-opam-manifest from
-  5 |    (unix -> link-opam-manifest.pull)
-  6 |    (!unix -> link-opam-manifest.dummy))))
-  Error: No solution found for this select form.
-  [1]
+  pull
+  dummy


### PR DESCRIPTION
fixes the test added in #13271 