### PR TITLE
melange single-context: track compilation context type

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -169,7 +169,7 @@ let gen_rules sctx t ~dir ~scope =
       let requires_link = Lib.Compile.requires_link compile_info in
       let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
       Compilation_context.create
-        ()
+        Ocaml
         ~super_context:sctx
         ~scope
         ~obj_dir

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -102,6 +102,7 @@ type t =
   ; bin_annot : bool
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
+  ; for_ : Compilation_mode.t
   }
 
 let loc t = t.loc
@@ -164,7 +165,7 @@ let create
       ?bin_annot
       ?loc
       ?instances
-      ()
+      for_
   =
   let project = Scope.project scope in
   let context = Super_context.context super_context in
@@ -235,8 +236,11 @@ let create
   ; loc
   ; ocaml
   ; instances
+  ; for_
   }
 ;;
+
+let for_ t = t.for_
 
 let alias_and_root_module_flags =
   let extra = [ "-w"; "-49"; "-nopervasives"; "-nostdlib" ] in

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -39,7 +39,7 @@ val create
   -> ?bin_annot:bool
   -> ?loc:Loc.t
   -> ?instances:Parameterised_rules.instances list Resolve.Memo.t
-  -> unit
+  -> Compilation_mode.t
   -> t Memo.t
 
 (** Return a compilation context suitable for compiling the alias module. *)
@@ -74,6 +74,7 @@ val modes : t -> Lib_mode.Map.Set.t
 val for_wrapped_compat : t -> t
 val for_root_module : t -> Module.t -> t
 val ocaml : t -> Ocaml_toolchain.t
+val for_ : t -> Compilation_mode.t
 
 val for_module_generated_at_link_time
   :  t

--- a/src/dune_rules/compilation_mode.ml
+++ b/src/dune_rules/compilation_mode.ml
@@ -1,0 +1,29 @@
+open Import
+
+type t =
+  | Ocaml
+  | Melange
+
+type modes =
+  { modes : t list
+  ; merlin : t
+  }
+
+let equal a b =
+  match a, b with
+  | Ocaml, Ocaml | Melange, Melange -> true
+  | Ocaml, Melange | Melange, Ocaml -> false
+;;
+
+let to_dyn = function
+  | Ocaml -> Dyn.variant "Ocaml" []
+  | Melange -> Dyn.variant "Melange" []
+;;
+
+let modes (modes : Lib_mode.Map.Set.t) =
+  match modes.ocaml.byte, modes.ocaml.native, modes.melange with
+  | false, false, true -> { modes = [ Melange ]; merlin = Melange }
+  | true, _, false | _, true, false -> { modes = [ Ocaml ]; merlin = Ocaml }
+  | true, _, true | _, true, true -> { modes = [ Ocaml; Melange ]; merlin = Ocaml }
+  | false, false, false -> { modes = []; merlin = Ocaml }
+;;

--- a/src/dune_rules/compilation_mode.mli
+++ b/src/dune_rules/compilation_mode.mli
@@ -1,0 +1,15 @@
+open Import
+
+type t =
+  | Ocaml
+  | Melange
+
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t
+
+type modes =
+  { modes : t list
+  ; merlin : t
+  }
+
+val modes : Lib_mode.Map.Set.t -> modes

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -201,7 +201,7 @@ let executables_rules
           x)
     in
     Compilation_context.create
-      ()
+      Ocaml
       ~loc:exes.buildable.loc
       ~super_context:sctx
       ~scope

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -287,7 +287,7 @@ include Sub_system.Register_end_point (struct
           Lib.closure ~linking:true ((lib :: libs) @ more_libs)
         in
         Compilation_context.create
-          ()
+          Ocaml
           ~super_context:sctx
           ~scope
           ~obj_dir

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -497,6 +497,7 @@ let cctx
       ~parameters
       ~compile_info
       ~modes
+      ~for_
   =
   let* flags = Buildable_rules.ocaml_flags sctx ~dir lib.buildable.flags
   and* implements = Virtual_rules.impl sctx ~lib ~scope in
@@ -530,7 +531,7 @@ let cctx
     | Private None -> None
   in
   Compilation_context.create
-    ()
+    for_
     ~super_context:sctx
     ~scope
     ~obj_dir
@@ -674,7 +675,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
     let { Lib_config.has_native; _ } = ocaml.lib_config in
     Mode_conf.Lib.Set.eval lib.modes ~has_native
   in
-  let f () =
+  let f for_ =
     let* source_modules =
       Dir_contents.ocaml dir_contents >>= Ml_sources.modules ~libs ~for_:(Library lib_id)
     in
@@ -690,6 +691,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
         ~parameters
         ~compile_info
         ~modes
+        ~for_
     in
     let* () =
       match buildable.ctypes with
@@ -711,5 +713,9 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir in
   let merlin_ident = Merlin_ident.for_lib (Library.best_name lib) in
-  Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f
+  Buildable_rules.with_lib_deps
+    (Super_context.context sctx)
+    merlin_ident
+    ~dir
+    ~f:(fun () -> f Ocaml)
 ;;

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -481,7 +481,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None
       ~package:None
-      ()
+      Ocaml
   in
   let ext = ".bc.exe" in
   let+ (_ : Exe.dep_graphs) =

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -408,7 +408,7 @@ let setup_emit_cmj_rules
     let* cctx =
       let direct_requires = Lib.Compile.direct_requires compile_info in
       Compilation_context.create
-        ()
+        Melange
         ~loc:mel.loc
         ~super_context:sctx
         ~scope

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -319,7 +319,7 @@ let build_ppx_driver =
         ~melange_package_name:None
         ~package:None
         ~bin_annot:false
-        ()
+        Ocaml
     in
     let+ (_ : Exe.dep_graphs) =
       let program : Exe.Program.t =

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -237,7 +237,7 @@ module Stanza = struct
         let requires_link = Lib.Compile.requires_link compile_info in
         let obj_dir = Source.obj_dir source in
         Compilation_context.create
-          ()
+          Ocaml
           ~super_context:sctx
           ~scope
           ~obj_dir

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -233,7 +233,7 @@ let setup sctx ~dir =
   let* cctx =
     let requires_link = Memo.lazy_ (fun () -> requires) in
     Compilation_context.create
-      ()
+      Ocaml
       ~super_context:sctx
       ~scope
       ~obj_dir


### PR DESCRIPTION
this is the first patch towards the single-context universal RFC in https://github.com/ocaml/dune/issues/10630.

- The implementation plan is to produce separate compilation contexts according to whether we're compiling OCaml or Melange modules
- Each compilation context tracks the requirements to compile a module set
- The next patch will produce a different module set per OCaml / Melange mode in library or `melange.emit`.