### PR TITLE
refactor: simplify tracing of persistent stores

### DIFF
--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -70,13 +70,8 @@ module Make (D : Desc) = struct
         | exception Invalid_argument s ->
           raise (Invalid_argument (sprintf "%s (%s)" s D.name)))
     in
-    let dump =
-      lazy
-        (match Dune_trace.global () with
-         | None -> dump
-         | Some _ -> fun file v -> with_record `Save ~file ~f:(fun () -> dump file v))
-    in
-    fun file (v : D.t) -> (Lazy.force dump) file v
+    let dump file v = with_record `Save ~file ~f:(fun () -> dump file v) in
+    fun file (v : D.t) -> dump file v
   ;;
 
   let load =


### PR DESCRIPTION
Adding code to handle when the trace is disabled is a pointless optimization