### PR TITLE
test(melange): speed up remaining Melange tests with `melange.node`

### DIFF
--- a/test/blackbox-tests/test-cases/melange/copy-files-simple.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-simple.t
@@ -9,7 +9,6 @@ Test simple interactions between melange.emit and copy_files
   > (melange.emit
   >  (target output)
   >  (emit_stdlib false)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (alias mel))
   > 
@@ -24,9 +23,11 @@ Test simple interactions between melange.emit and copy_files
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "../assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > EOF
 
@@ -42,7 +43,6 @@ Copy the file into the output folder, so we can use same path as in-source
   > (melange.emit
   >  (target output)
   >  (emit_stdlib false)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (alias mel))
   > 
@@ -52,9 +52,11 @@ Copy the file into the output folder, so we can use same path as in-source
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -18,15 +18,16 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./some_dir ./index.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
   > let file_path = "./some_dir/inside-dir-target.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ dune build --root lib
@@ -65,14 +66,16 @@ Test `melange.runtime_deps` in a library that has been installed
   >  (target output)
   >  (alias mel)
   >  (emit_stdlib false)
-  >  (libraries foo melange.node)
+  >  (libraries foo)
   >  (preprocess (pps melange.ppx)))
   > EOF
 
   $ cat > app/main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
@@ -15,15 +15,16 @@ Test simple interactions between melange.emit and copy_files
   >  (alias mel)
   >  (target output)
   >  (emit_stdlib false)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (runtime_deps ./some_dir))
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./some_dir/inside-dir-target.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > EOF
 
@@ -41,7 +42,6 @@ Depend on a path inside the directory target
   >  (alias mel)
   >  (target output)
   >  (emit_stdlib false)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (runtime_deps ./some_dir/other/nested/inside-dir-target.txt))
   > EOF
@@ -51,7 +51,6 @@ Dune symlinks the entire directory target
 
   $ ls _build/default/output
   main.js
-  node_modules
   some_dir
 
   $ realpath _build/default/output/some_dir

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -10,7 +10,6 @@ Test simple interactions between melange.emit and copy_files
   >  (alias mel)
   >  (emit_stdlib false)
   >  (target output)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (runtime_deps assets/file.txt (glob_files_rec ./globbed/*.txt)))
   > EOF
@@ -24,9 +23,11 @@ Test simple interactions between melange.emit and copy_files
   $ echo b.txt > globbed/b.txt
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > EOF
 
@@ -60,14 +61,12 @@ The runtime_dep index.txt was copied to the build folder
   assets
   globbed
   main.js
-  node_modules
 
   $ dune build output/assets/file.txt --display=short
   $ ls _build/default/output
   assets
   globbed
   main.js
-  node_modules
   $ ls _build/default/output/globbed
   a.txt
   b.txt

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-dir-target-runtime-deps.t
@@ -17,15 +17,16 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./some_dir ./file.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
   > let file_path = "./index.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ dune build
@@ -49,7 +50,6 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./some_dir/inside-dir-target.txt ./some_dir ./file.txt))
   > EOF

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-include-qualified.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-include-qualified.t
@@ -16,14 +16,15 @@ nested more than the dune-project file
   >  (public_name foo)
   >  (name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./runtime/runtime.js))
   > EOF
   $ cat > lib/packages/foo/src/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/runtime/runtime.js") \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/runtime/runtime.js") ~encoding:"utf8"
   > EOF
 
   $ dune build --root lib
@@ -50,7 +51,6 @@ nested more than the dune-project file
   >  (public_name foo)
   >  (name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./runtime/runtime.js))
   > EOF

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
@@ -15,14 +15,15 @@ nested more than the dune-project file
   >  (public_name foo)
   >  (name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./runtime.js))
   > EOF
   $ cat > lib/packages/foo/src/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/runtime.js") \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/runtime.js") ~encoding:"utf8"
   > EOF
 
   $ dune build --root lib

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -14,15 +14,16 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt nested/hello.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
   > let file_path = "./index.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ dune build --root lib
@@ -61,14 +62,16 @@ Test `melange.runtime_deps` in a library that has been installed
   >  (target output)
   >  (alias mel)
   >  (emit_stdlib false)
-  >  (libraries foo melange.node)
+  >  (libraries foo)
   >  (preprocess (pps melange.ppx)))
   > EOF
 
   $ cat > app/main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF

--- a/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-dir-target-runtime-deps.t
@@ -25,14 +25,15 @@ Test `melange.runtime_deps` in a private library
   > (library
   >  (name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./some_dir))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./some_dir/inside-dir-target.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ mkdir assets
@@ -41,9 +42,11 @@ Test `melange.runtime_deps` in a private library
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF
@@ -63,7 +66,6 @@ The runtime_dep index.txt was copied to the build folder
   assets
   lib
   main.js
-  node_modules
 
   $ ls _build/default/output/lib
   foo.js

--- a/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
@@ -21,14 +21,15 @@ Test `melange.runtime_deps` in a private library
   > (library
   >  (name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./index.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ mkdir assets
@@ -37,9 +38,11 @@ Test `melange.runtime_deps` in a private library
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF

--- a/test/blackbox-tests/test-cases/melange/promote-in-source-installed-lib-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/promote-in-source-installed-lib-with-runtime-deps.t
@@ -14,15 +14,16 @@ Show target promotion in-source for `melange.emit`
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt nested/hello.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
   > let file_path = "./index.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ dune build --root lib
@@ -62,14 +63,16 @@ Show target promotion in-source for `melange.emit`
   >  (alias mel)
   >  (emit_stdlib false)
   >  (promote (until-clean))
-  >  (libraries foo melange.node)
+  >  (libraries foo)
   >  (preprocess (pps melange.ppx)))
   > EOF
 
   $ cat > app/main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF

--- a/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
@@ -14,15 +14,16 @@ Test `melange.runtime_deps` in a public library in the workspace
   > (library
   >  (public_name foo)
   >  (modes melange)
-  >  (libraries melange.node)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt nested/hello.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let () = Js.log2 "dirname:" dirname
   > let file_path = "./index.txt"
-  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let read_asset () = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > EOF
 
   $ dune build
@@ -47,16 +48,18 @@ Test `melange.runtime_deps` in a public library in the workspace
   > (melange.emit
   >  (alias mel)
   >  (target output)
-  >  (libraries foo melange.node)
+  >  (libraries foo)
   >  (preprocess (pps melange.ppx))
   >  (emit_stdlib false)
   >  (runtime_deps assets/file.txt))
   > EOF
 
   $ cat > main.ml <<EOF
+  > external readFileSync : string -> encoding:string -> string = "readFileSync"
+  > [@@mel.module "fs"]
   > let dirname = [%mel.raw "__dirname"]
   > let file_path = "./assets/file.txt"
-  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let file_content = readFileSync (dirname ^ "/" ^ file_path) ~encoding:"utf8"
   > let () = Js.log file_content
   > let () = Js.log (Foo.read_asset ())
   > EOF


### PR DESCRIPTION
`melange.node` brings in `melange.js`, which requires emitting a few dozen JS files per test run.