### PR TITLE
dir_contents: track 2 module sets, by compilation mode

### DIFF
--- a/src/dune_rules/compilation_mode.ml
+++ b/src/dune_rules/compilation_mode.ml
@@ -27,3 +27,82 @@ let modes (modes : Lib_mode.Map.Set.t) =
   | true, _, true | _, true, true -> { modes = [ Ocaml; Melange ]; merlin = Ocaml }
   | false, false, false -> { modes = []; merlin = Ocaml }
 ;;
+
+module By_mode = struct
+  type mode = t
+
+  type nonrec 'a t =
+    { ocaml : 'a
+    ; melange : 'a
+    }
+
+  let just t ~for_ =
+    match for_ with
+    | Ocaml -> { ocaml = Some t; melange = None }
+    | Melange -> { ocaml = None; melange = Some t }
+  ;;
+
+  let both t = { ocaml = t; melange = t }
+  let from_fun f = { ocaml = f ~for_:Ocaml; melange = f ~for_:Melange }
+
+  let to_list t =
+    match t.ocaml, t.melange with
+    | Some ocaml, Some melange -> [ Ocaml, ocaml; Melange, melange ]
+    | Some ocaml, None -> [ Ocaml, ocaml ]
+    | None, Some melange -> [ Melange, melange ]
+    | None, None -> []
+  ;;
+
+  let of_list xs ~init =
+    List.fold_left xs ~init:{ ocaml = init; melange = init } ~f:(fun acc (k, item) ->
+      match k with
+      | Ocaml -> { acc with ocaml = item }
+      | Melange -> { acc with melange = item })
+  ;;
+
+  let map t ~f = { ocaml = f ~for_:Ocaml t.ocaml; melange = f ~for_:Melange t.melange }
+
+  let get ~for_ t =
+    match for_ with
+    | Ocaml -> t.ocaml
+    | Melange -> t.melange
+  ;;
+
+  let set ~for_ t x =
+    match for_ with
+    | Ocaml -> { t with ocaml = x }
+    | Melange -> { t with melange = x }
+  ;;
+
+  let to_dyn f t =
+    let open Dyn in
+    record [ "ocaml", f t.ocaml; "melange", f t.melange ]
+  ;;
+
+  module Memo = struct
+    open Memo.O
+
+    let from_fun f =
+      let+ ocaml = f ~for_:Ocaml
+      and+ melange = f ~for_:Melange in
+      { ocaml; melange }
+    ;;
+
+    let map
+      :  'a option t
+      -> f:(for_:mode -> 'a option -> 'b option Memo.t)
+      -> 'b option t Memo.t
+      =
+      fun t ~f ->
+      let+ y =
+        let { ocaml; melange } = map t ~f in
+        Memo.parallel_map
+          [ Ocaml, ocaml; Melange, melange ]
+          ~f:(fun (for_, x) ->
+            let+ x = x in
+            for_, x)
+      in
+      of_list y ~init:None
+    ;;
+  end
+end

--- a/src/dune_rules/compilation_mode.mli
+++ b/src/dune_rules/compilation_mode.mli
@@ -13,3 +13,31 @@ type modes =
   }
 
 val modes : Lib_mode.Map.Set.t -> modes
+
+module By_mode : sig
+  type mode := t
+
+  type 'a t =
+    { ocaml : 'a
+    ; melange : 'a
+    }
+
+  val just : 'a -> for_:mode -> 'a option t
+  val both : 'a -> 'a t
+  val from_fun : (for_:mode -> 'a) -> 'a t
+  val to_list : 'a option t -> (mode * 'a) list
+  val of_list : (mode * 'a) list -> init:'a -> 'a t
+  val map : 'a t -> f:(for_:mode -> 'a -> 'b) -> 'b t
+  val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
+  val get : for_:mode -> 'a t -> 'a
+  val set : for_:mode -> 'a t -> 'a -> 'a t
+
+  module Memo : sig
+    val map
+      :  'a option t
+      -> f:(for_:mode -> 'a option -> 'b option Memo.t)
+      -> 'b option t Memo.t
+
+    val from_fun : (for_:mode -> 'a Memo.t) -> 'a t Memo.t
+  end
+end

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -25,7 +25,7 @@ type t =
   ; mlds : (Documentation.t * Doc_sources.mld list) list Memo.Lazy.t
   ; coq : Coq_sources.t Memo.Lazy.t
   ; rocq : Rocq_sources.t Memo.Lazy.t
-  ; ml : Ml_sources.t Memo.Lazy.t
+  ; ml : Ml_sources.t Memo.Lazy.t Compilation_mode.By_mode.t
   ; source_dir : Source_tree.Dir.t option
   }
 
@@ -39,7 +39,7 @@ let empty kind ~dir ~source_dir =
   ; dir
   ; source_dir
   ; text_files = Filename.Set.empty
-  ; ml = Memo.Lazy.of_val Ml_sources.empty
+  ; ml = Compilation_mode.By_mode.both (Memo.Lazy.of_val Ml_sources.empty)
   ; mlds = Memo.Lazy.of_val []
   ; foreign_sources = Memo.Lazy.of_val Foreign_sources.empty
   ; coq = Memo.Lazy.of_val Coq_sources.empty
@@ -91,7 +91,7 @@ let dir t = t.dir
 let source_dir t = t.source_dir
 let coq t = Memo.Lazy.force t.coq
 let rocq t = Memo.Lazy.force t.rocq
-let ocaml t = Memo.Lazy.force t.ml
+let ocaml t = Memo.Lazy.force (Compilation_mode.By_mode.get ~for_:Ocaml t.ml)
 
 let dirs t =
   match t.kind with
@@ -266,7 +266,7 @@ end = struct
               ; source_dir = Some st_dir
               ; dir
               ; text_files = files
-              ; ml
+              ; ml = { Compilation_mode.By_mode.ocaml = ml; melange = ml }
               ; mlds
               ; foreign_sources =
                   Memo.lazy_ (fun () ->
@@ -406,7 +406,7 @@ end = struct
                  ; source_dir
                  ; dir
                  ; text_files = files
-                 ; ml
+                 ; ml = { Compilation_mode.By_mode.ocaml = ml; melange = ml }
                  ; foreign_sources
                  ; mlds
                  ; coq
@@ -418,7 +418,7 @@ end = struct
              ; source_dir = Some source_dir
              ; dir
              ; text_files = files
-             ; ml
+             ; ml = { Compilation_mode.By_mode.ocaml = ml; melange = ml }
              ; foreign_sources
              ; mlds
              ; coq
@@ -508,5 +508,5 @@ let () =
     let* t =
       Context.DB.by_dir dir >>| Context.name >>= Super_context.find_exn >>= Load.get ~dir
     in
-    Memo.Lazy.force t.ml >>= Ml_sources.artifacts)
+    Memo.Lazy.force t.ml.ocaml >>= Ml_sources.artifacts)
 ;;


### PR DESCRIPTION
- In the single context universal design (ref #10630), Melange sources will live under `<module-group-root>/.melange_src`
- These modules are copied from their `Module.File.original_path` to the `.melange_src` directory
- Follow-up PRs will wire up obtaining the right module set via `Dir_contents.ml ~for t` instead of `Dir_contents.ocaml t`