### PR TITLE
melange single context: allow resolving libraries per compilation mode

### DIFF
--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -385,6 +385,8 @@ module Crawl = struct
       module_ ~obj_dir ~deps_for_intf ~deps_for_impl m :: acc)
   ;;
 
+  let for_ = Compilation_mode.Ocaml
+
   (* Builds a workspace item for the provided executables object *)
   let executables sctx ~options ~project ~dir (exes : Executables.t)
     : (Descr.Item.t * Lib.Set.t) option Memo.t
@@ -428,10 +430,10 @@ module Crawl = struct
       let+ requires =
         let* compile_info = Exe_rules.compile_info ~scope exes in
         let open Resolve.Memo.O in
-        let* requires = Lib.Compile.direct_requires compile_info in
+        let* requires = Lib.Compile.direct_requires compile_info ~for_ in
         if options.with_pps
         then
-          let+ pps = Lib.Compile.pps compile_info in
+          let+ pps = Lib.Compile.pps compile_info ~for_ in
           pps @ requires
         else Resolve.Memo.return requires
       in
@@ -451,7 +453,7 @@ module Crawl = struct
 
   (* Builds a workspace item for the provided library object *)
   let library sctx ~options (lib : Lib.t) : Descr.Item.t option Memo.t =
-    let* requires = Lib.requires lib in
+    let* requires = Lib.requires lib ~for_ in
     match Resolve.peek requires with
     | Error () -> Memo.return None
     | Ok requires ->
@@ -595,7 +597,7 @@ module Crawl = struct
       (* the executables' libraries, and the project's libraries *)
       Lib.Set.union exe_libs project_libs
       |> Lib.Set.to_list
-      |> Lib.descriptive_closure ~with_pps:options.with_pps
+      |> Lib.descriptive_closure ~with_pps:options.with_pps ~for_
       >>= Memo.parallel_map ~f:(library ~options sctx)
       >>| List.filter_opt
     in

--- a/bin/ocaml/top.ml
+++ b/bin/ocaml/top.ml
@@ -71,7 +71,8 @@ let term =
         Dune_rules.Utop.libs_under_dir sctx ~db ~dir:(Path.build dir)
       in
       let* requires =
-        Dune_rules.Resolve.Memo.read_memo (Dune_rules.Lib.closure ~linking:true libs)
+        Dune_rules.Resolve.Memo.read_memo
+          (Dune_rules.Lib.closure ~linking:true libs ~for_:Ocaml)
       in
       let* lib_config =
         let+ ocaml = Context.ocaml context in

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -30,7 +30,7 @@ let available_exes ~dir (exes : Executables.t) =
       ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
   in
   (* CR-someday rgrinberg: what if a preprocessor is unavailable? *)
-  let+ available = Lib.Compile.direct_requires compile_info in
+  let+ available = Lib.Compile.direct_requires compile_info ~for_:Ocaml in
   Resolve.is_ok available
 ;;
 

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -59,11 +59,13 @@ let include_subdirs dir_contents =
   | Include Unqualified -> Unqualified
 ;;
 
+let for_ = Compilation_mode.Ocaml
+
 let make_root_module sctx ~name compile_info =
   let open Action_builder.O in
   let+ entries =
-    let requires_compile = Lib.Compile.direct_requires compile_info in
-    Root_module.entries sctx ~requires_compile ~for_:Ocaml
+    let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
+    Root_module.entries sctx ~requires_compile ~for_
   in
   { Root_module_data.name; entries }
 ;;
@@ -160,7 +162,7 @@ let make_main sctx ~root_module compile_info dir_contents =
 
 let gen_rules sctx (exes : Executables.t) ~dir compile_info dir_contents =
   Memo.Option.iter exes.bootstrap_info ~f:(fun fname ->
-    let requires_link = Lib.Compile.requires_link compile_info in
+    let requires_link = Lib.Compile.requires_link compile_info ~for_ in
     Action_builder.write_file_dyn
       (Path.Build.relative dir fname)
       (let open Action_builder.O in

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -21,8 +21,8 @@ let ocaml_flags t ~dir (spec : Dune_lang.Ocaml_flags.Spec.t) =
     Ocaml_flags.with_vendored_flags ~ocaml_version flags
 ;;
 
-let gen_select_rules sctx ~dir compile_info =
-  Lib.Compile.resolved_selects compile_info
+let gen_select_rules sctx ~dir compile_info ~for_ =
+  Lib.Compile.resolved_selects compile_info ~for_
   |> Resolve.Memo.read_memo
   >>= Memo.parallel_iter ~f:(fun { Lib.Compile.Resolved_select.dst_fn; src_fn; loc } ->
     let dst = Path.Build.append_local dir dst_fn in

--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -10,7 +10,12 @@ open Import
     function has returned. Consider adding a type annotation to make sure this
     doesn't happen by mistake. *)
 
-val gen_select_rules : Super_context.t -> dir:Path.Build.t -> Lib.Compile.t -> unit Memo.t
+val gen_select_rules
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> Lib.Compile.t
+  -> for_:Compilation_mode.t
+  -> unit Memo.t
 
 (** Generate the rules for the [(select ...)] forms in library dependencies *)
 val with_lib_deps

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -71,6 +71,7 @@ let () =
 ;;
 
 let flags = Ocaml_flags.of_list [ "-w"; "-24" ]
+let for_ = Compilation_mode.Ocaml
 
 let gen_rules sctx t ~dir ~scope =
   let loc = t.loc in
@@ -165,11 +166,11 @@ let gen_rules sctx t ~dir ~scope =
         in
         Pp_spec.pp_module preprocess module_ >>| Modules.With_vlib.singleton_exe
       in
-      let requires_compile = Lib.Compile.direct_requires compile_info in
-      let requires_link = Lib.Compile.requires_link compile_info in
+      let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
+      let requires_link = Lib.Compile.requires_link compile_info ~for_ in
       let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
       Compilation_context.create
-        Ocaml
+        for_
         ~super_context:sctx
         ~scope
         ~obj_dir

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -471,7 +471,7 @@ let libs_of_theory ~lib_db ~theories_deps plugins : (Lib.t list * _) Resolve.Mem
     Resolve.List.concat_map ~f:Coq_lib.Dune.libraries dune_theories |> Resolve.Memo.lift
   in
   let libs = libs @ dlibs in
-  let+ findlib_libs = Lib.closure ~linking:false (List.map ~f:snd libs) in
+  let+ findlib_libs = Lib.closure ~linking:false (List.map ~f:snd libs) ~for_:Ocaml in
   findlib_libs, legacy_theories
 ;;
 

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -135,6 +135,8 @@ let o_files
     Mode.Map.Multi.add_all o_files All extra_o_files)
 ;;
 
+let for_ = Compilation_mode.Ocaml
+
 let executables_rules
       ~sctx
       ~dir
@@ -189,8 +191,8 @@ let executables_rules
   in
   let programs = programs ~modules ~exes in
   let* cctx =
-    let requires_compile = Lib.Compile.direct_requires compile_info in
-    let requires_link = Lib.Compile.requires_link compile_info in
+    let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
+    let requires_link = Lib.Compile.requires_link compile_info ~for_ in
     let instances =
       Parameterised_rules.instances ~sctx ~db:(Scope.libs scope) exes.buildable.libraries
     in
@@ -221,7 +223,7 @@ let executables_rules
   let* requires_compile = Compilation_context.requires_compile cctx in
   let* () =
     let toolchain = Compilation_context.ocaml cctx in
-    let user_written_requires = Lib.Compile.user_written_requires compile_info in
+    let user_written_requires = Lib.Compile.user_written_requires compile_info ~for_ in
     let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
     Unused_libs_rules.gen_rules
       sctx
@@ -374,7 +376,7 @@ let rules ~sctx ~dir_contents ~scope ~expander (exes : Executables.t) =
       ~compile_info
       ~embed_in_plugin_libraries:exes.embed_in_plugin_libraries
   in
-  let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir
+  let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir ~for_
   and* () = Bootstrap_info.gen_rules sctx exes ~dir compile_info dir_contents in
   let merlin_ident = Merlin_ident.for_exes ~names:(Nonempty_list.map ~f:snd exes.names) in
   Buildable_rules.with_lib_deps (Super_context.context sctx) merlin_ident ~dir ~f

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -186,6 +186,7 @@ include Sub_system.Register_end_point (struct
           ; scope
           ; source_modules
           ; compile_info = _
+          ; for_
           }
           ~expander
           ~(info : Info.t)
@@ -284,10 +285,10 @@ include Sub_system.Register_end_point (struct
           let* more_libs =
             Resolve.Memo.List.map info.libraries ~f:(Lib.DB.resolve lib_db)
           in
-          Lib.closure ~linking:true ((lib :: libs) @ more_libs)
+          Lib.closure ~linking:true ((lib :: libs) @ more_libs) ~for_
         in
         Compilation_context.create
-          Ocaml
+          for_
           ~super_context:sctx
           ~scope
           ~obj_dir

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -432,7 +432,7 @@ end = struct
                  ~dune_version
                  ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
              in
-             let+ requires = Lib.Compile.direct_requires compile_info in
+             let+ requires = Lib.Compile.direct_requires compile_info ~for_:Ocaml in
              Resolve.is_ok requires)
       | Coq_stanza.Theory.T d -> Memo.return (Option.is_some d.package)
       | Rocq_stanza.Theory.T d -> Memo.return (Option.is_some d.package)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -706,6 +706,8 @@ let build_cm
     ~sourcemap:Js_of_ocaml.Sourcemap.Inline
 ;;
 
+let for_ = Compilation_mode.Ocaml
+
 let setup_separate_compilation_rules sctx components =
   match components with
   | _ :: _ :: _ :: _ | [] | [ _ ] -> Memo.return ()
@@ -721,8 +723,8 @@ let setup_separate_compilation_rules sctx components =
        let info = Lib.info pkg in
        let requires =
          let open Resolve.Memo.O in
-         let* reqs = Lib.requires pkg in
-         Lib.closure ~linking:false reqs
+         let* reqs = Lib.requires pkg ~for_ in
+         Lib.closure ~linking:false reqs ~for_
        in
        let lib_name = Lib_name.to_string (Lib.name pkg) in
        let* archives =

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -384,14 +384,14 @@ module T = struct
     { info : Lib_info.external_
     ; name : Lib_name.t
     ; unique_id : Id.t
-    ; re_exports : t list Resolve.t
+    ; re_exports : t list Resolve.t Compilation_mode.By_mode.t
     ; (* [requires] is contains all required libraries, including the ones
          mentioned in [re_exports]. *)
-      requires : t list Resolve.t
-    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t
-    ; ppx_runtime_deps : t list Resolve.t
-    ; pps : t list Resolve.t
-    ; resolved_selects : Resolved_select.t list Resolve.t
+      requires : t list Resolve.t Compilation_mode.By_mode.t
+    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.By_mode.t
+    ; ppx_runtime_deps : t list Resolve.t Compilation_mode.By_mode.t
+    ; pps : t list Resolve.t Compilation_mode.By_mode.t
+    ; resolved_selects : Resolved_select.t list Resolve.t Compilation_mode.By_mode.t
     ; allow_unused_libraries : t list Resolve.t
     ; parameters : (Loc.t * t) list Resolve.t
     ; arguments : t option list
@@ -496,10 +496,14 @@ let info t = t.info
 let project t = t.project
 let implements t = Option.map ~f:Memo.return t.implements
 let parameters t = Resolve.Memo.lift (Resolve.map ~f:(List.map ~f:snd) t.parameters)
-let requires t = Memo.return t.requires
-let re_exports t = Memo.return t.re_exports
-let ppx_runtime_deps t = Memo.return t.ppx_runtime_deps
-let pps t = Memo.return t.pps
+let requires t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.requires)
+let re_exports t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.re_exports)
+
+let ppx_runtime_deps t ~for_ =
+  Memo.return (Compilation_mode.By_mode.get ~for_ t.ppx_runtime_deps)
+;;
+
+let pps t ~for_ = Memo.return (Compilation_mode.By_mode.get ~for_ t.pps)
 
 let is_local t =
   match Lib_info.obj_dir t.info |> Obj_dir.byte_dir with
@@ -673,9 +677,12 @@ module Parameterised = struct
 
   let remove_arguments lib = { lib with parameters = Resolve.return []; arguments = [] }
 
-  let requires (lib : lib) =
+  let requires (lib : lib) ~for_ =
     let open Resolve.O in
-    let+ deps = lib.requires >>= Resolve.List.map ~f:(complement_arguments ~parent:lib) in
+    let+ deps =
+      Compilation_mode.By_mode.get lib.requires ~for_
+      >>= Resolve.List.map ~f:(complement_arguments ~parent:lib)
+    in
     let deps = List.filter_opt lib.arguments @ deps in
     match lib.arguments with
     | [] -> deps
@@ -954,6 +961,7 @@ module Vlib : sig
   val associate
     :  (t * Dep_stack.t) list
     -> [ `Compile | `Link | `Partial_link ]
+    -> for_:Compilation_mode.t
     -> t list Resolve.Memo.t
 
   module Unimplemented : sig
@@ -974,8 +982,7 @@ end = struct
     let empty = { implemented = Set.empty; unimplemented = Set.empty }
 
     let add t lib =
-      let virtual_ = Lib_info.virtual_ lib.info in
-      match lib.implements, virtual_ with
+      match lib.implements, Lib_info.virtual_ lib.info with
       | None, false -> Resolve.Memo.return t
       | Some _, true -> assert false (* can't be virtual and implement *)
       | None, true ->
@@ -1072,7 +1079,7 @@ end = struct
     end
     in
     let open R.O in
-    fun ts impls ->
+    fun ts impls ~for_ ->
       let rec loop t =
         let t = Option.value ~default:t (Map.find impls t) in
         let* res, visited = R.get in
@@ -1080,7 +1087,7 @@ end = struct
         then R.return ()
         else
           let* () = R.set (res, Set.add visited t) in
-          let* deps = R.lift (Resolve.Memo.lift (Parameterised.requires t)) in
+          let* deps = R.lift (Resolve.Memo.lift (Parameterised.requires t ~for_)) in
           let* () = many deps in
           R.modify (fun (res, visited) -> t :: res, visited)
       and many deps = R.List.iter deps ~f:loop in
@@ -1089,7 +1096,7 @@ end = struct
       List.rev res
   ;;
 
-  let associate closure kind =
+  let associate closure kind ~for_ =
     let linking, allow_partial =
       match kind with
       | `Compile -> false, true
@@ -1101,7 +1108,7 @@ end = struct
     if linking && not (Table.Partial.is_empty impls)
     then
       let* impls = Table.make impls ~allow_partial in
-      second_step_closure closure impls
+      second_step_closure closure impls ~for_
     else Resolve.Memo.return closure
   ;;
 end
@@ -1173,21 +1180,28 @@ module rec Resolve_names : sig
     -> parameters:(Loc.t * t) list
     -> pps:(Loc.t * Lib_name.t) list
     -> dune_version:Dune_lang.Syntax.Version.t option
+    -> for_:Compilation_mode.t
     -> Resolved.t Memo.t
 
   val compile_closure_with_overlap_checks
     :  db option
     -> lib list
     -> forbidden_libraries:Loc.t Map.t
+    -> for_:Compilation_mode.t
     -> lib list Resolve.Memo.t
 
   val linking_closure_with_overlap_checks
     :  db option
     -> lib list
     -> forbidden_libraries:Loc.t Map.t
+    -> for_:Compilation_mode.t
     -> lib list Resolve.Memo.t
 
-  val check_forbidden : lib list -> forbidden_libraries:Loc.t Map.t -> unit Resolve.Memo.t
+  val check_forbidden
+    :  lib list
+    -> forbidden_libraries:Loc.t Map.t
+    -> for_:Compilation_mode.t
+    -> unit Resolve.Memo.t
 
   val make_instantiate
     :  db Lazy.t
@@ -1268,15 +1282,35 @@ end = struct
         let instrumentation_backend =
           instrumentation_backend db.instrument_with resolve_forbid_ignore
         in
-        Lib_info.preprocess info
-        |> Instrumentation.with_instrumentation ~instrumentation_backend
-        >>| Preprocess.Per_module.pps
+        let modes = (Compilation_mode.of_mode_set (Lib_info.modes info)).modes in
+        Memo.parallel_map modes ~f:(fun for_ ->
+          Lib_info.preprocess info
+          |> Instrumentation.with_instrumentation ~instrumentation_backend
+          >>| fun pps -> for_, Preprocess.Per_module.pps pps)
+        |> Memo.map ~f:Resolve.all
+        >>| Compilation_mode.By_mode.of_list ~init:[]
       in
       let* parameters = Resolve.Memo.lift parameters in
       let dune_version = Lib_info.dune_version info in
-      Lib_info.requires info
-      |> resolve_deps_and_add_runtime_deps db ~private_deps ~parameters ~dune_version ~pps
-      |> Memo.map ~f:Resolve.return
+      let resolved =
+        Compilation_mode.By_mode.map pps ~f:(fun ~for_ pps ->
+          let open Memo.O in
+          let+ resolved =
+            Lib_info.requires info
+            |> resolve_deps_and_add_runtime_deps
+                 db
+                 ~private_deps
+                 ~parameters
+                 ~dune_version
+                 ~pps
+                 ~for_
+          in
+          resolved)
+      in
+      let open Memo.O in
+      let+ ocaml = resolved.ocaml
+      and+ melange = resolved.melange in
+      Resolve.return { Compilation_mode.By_mode.ocaml; melange }
     in
     let* implements =
       match Lib_info.implements info with
@@ -1291,41 +1325,6 @@ end = struct
           | Parameter | Virtual -> Resolve.Memo.return implements
         in
         Memo.map res ~f:Option.some
-    in
-    let* requires =
-      let open Resolve.Memo.O in
-      let* resolved = Memo.return resolved in
-      let* requires = Memo.return resolved.requires in
-      let+ requires_params = Memo.return parameters
-      and+ requires_implements =
-        match implements with
-        | None -> Resolve.Memo.return []
-        | Some impl ->
-          let* impl = Memo.return impl in
-          (match Lib_info.kind impl.info with
-           | Parameter -> Resolve.Memo.return [ impl ]
-           | Virtual ->
-             let requires_for_closure_check =
-               List.filter requires ~f:(fun lib -> not (equal lib impl))
-             in
-             let+ () =
-               check_forbidden
-                 requires_for_closure_check
-                 ~forbidden_libraries:(Map.singleton impl Loc.none)
-             in
-             [ impl ]
-           | Dune_file _ ->
-             Code_error.raise
-               "expected Virtual or Parameter"
-               [ "implements", to_dyn impl ])
-      in
-      let requires_params = List.map ~f:snd requires_params in
-      let requires = List.concat [ requires_implements; requires_params; requires ] in
-      let (_ : Set.t), requires =
-        List.fold_left requires ~init:(Set.empty, []) ~f:(fun (seen, lst) lib ->
-          if Set.mem seen lib then seen, lst else Set.add seen lib, lib :: lst)
-      in
-      List.rev requires
     in
     let resolve_impl impl_name =
       let open Resolve.Memo.O in
@@ -1372,22 +1371,67 @@ end = struct
                        (Package.Name.to_string p')
                    ])))
     in
+    let* requires =
+      Compilation_mode.By_mode.Memo.from_fun (fun ~for_ ->
+        let open Resolve.Memo.O in
+        let* resolved = Memo.return resolved in
+        let* requires =
+          Memo.return (Compilation_mode.By_mode.get ~for_ resolved).requires
+        in
+        let+ requires_params = Memo.return parameters
+        and+ requires_implements =
+          match implements with
+          | None -> Resolve.Memo.return []
+          | Some impl ->
+            let* impl = Memo.return impl in
+            (match Lib_info.kind impl.info with
+             | Parameter -> Resolve.Memo.return [ impl ]
+             | Virtual ->
+               let requires_for_closure_check =
+                 List.filter requires ~f:(fun lib -> not (equal lib impl))
+               in
+               let+ () =
+                 check_forbidden
+                   requires_for_closure_check
+                   ~forbidden_libraries:(Map.singleton impl Loc.none)
+                   ~for_
+               in
+               [ impl ]
+             | Dune_file _ ->
+               Code_error.raise
+                 "expected Virtual or Parameter"
+                 [ "implements", to_dyn impl ])
+        in
+        let requires_params = List.map ~f:snd requires_params in
+        let requires = List.concat [ requires_implements; requires_params; requires ] in
+        let (_ : Set.t), requires =
+          List.fold_left requires ~init:(Set.empty, []) ~f:(fun (seen, lst) lib ->
+            if Set.mem seen lib then seen, lst else Set.add seen lib, lib :: lst)
+        in
+        List.rev requires)
+    in
     let* ppx_runtime_deps =
-      Lib_info.ppx_runtime_deps info |> resolve_simple_deps db ~private_deps
+      let ppx_runtime_deps = Lib_info.ppx_runtime_deps info in
+      Compilation_mode.By_mode.Memo.from_fun (fun ~for_:_ ->
+        let deps = ppx_runtime_deps in
+        resolve_simple_deps db ~private_deps deps)
     in
     let user_written_requires =
-      let+ complex =
-        Lib_info.requires info |> resolve_complex_deps db ~private_deps ~parameters:[]
-      in
-      Resolve_names.Resolved.user_written complex
+      Compilation_mode.By_mode.from_fun (fun ~for_:_ ->
+        let open Memo.O in
+        let+ complex =
+          Lib_info.requires info |> resolve_complex_deps db ~private_deps ~parameters:[]
+        in
+        Resolve_names.Resolved.user_written complex)
     in
     let* allow_unused_libraries =
       Lib_info.allow_unused_libraries info |> resolve_simple_deps db ~private_deps
     in
     let src_dir = Lib_info.src_dir info in
-    let map_error x =
-      Resolve.push_stack_frame x ~human_readable_description:(fun () ->
-        Dep_path.Entry.Lib.pp { name; path = src_dir })
+    let map_error =
+      Compilation_mode.By_mode.map ~f:(fun ~for_:_ x ->
+        Resolve.push_stack_frame x ~human_readable_description:(fun () ->
+          Dep_path.Entry.Lib.pp { name; path = src_dir }))
     in
     let requires = map_error requires in
     let ppx_runtime_deps = map_error ppx_runtime_deps in
@@ -1402,10 +1446,21 @@ end = struct
     in
     let rec t =
       lazy
-        (let open Resolve.O in
-         let resolved_selects = resolved >>| fun r -> r.selects in
-         let pps = resolved >>= fun r -> r.pps in
-         let re_exports = resolved >>= fun r -> r.re_exports in
+        (let resolved_selects =
+           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+             let open Resolve.O in
+             resolved >>| Compilation_mode.By_mode.get ~for_ >>| fun r -> r.selects)
+         in
+         let pps =
+           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+             let open Resolve.O in
+             resolved >>| Compilation_mode.By_mode.get ~for_ >>= fun r -> r.pps)
+         in
+         let re_exports =
+           Compilation_mode.By_mode.from_fun (fun ~for_ ->
+             let open Resolve.O in
+             resolved >>| Compilation_mode.By_mode.get ~for_ >>= fun r -> r.re_exports)
+         in
          { info
          ; name
          ; unique_id
@@ -1443,8 +1498,14 @@ end = struct
            | Disabled_because_of_enabled_if -> Some "unsatisfied 'enabled_if'"
            | Optional ->
              (* TODO this could be made lazier *)
-             let requires = Resolve.is_ok requires in
-             let ppx_runtime_deps = Resolve.is_ok t.ppx_runtime_deps in
+             let requires =
+               List.for_all [ requires.ocaml; requires.melange ] ~f:Resolve.is_ok
+             in
+             let ppx_runtime_deps =
+               List.for_all
+                 [ t.ppx_runtime_deps.ocaml; t.ppx_runtime_deps.melange ]
+                 ~f:Resolve.is_ok
+             in
              if requires && ppx_runtime_deps
              then None
              else Some "optional with unavailable dependencies")
@@ -1633,14 +1694,14 @@ end = struct
     end
     in
     let open R.O in
-    fun ts ->
+    fun ts ~for_ ->
       let rec one (t : lib) =
         let* res, visited = R.get in
         if Set.mem visited t
         then R.return ()
         else
           let* () = R.set (res, Set.add visited t) in
-          let* re_exports = R.lift (Memo.return t.re_exports) in
+          let* re_exports = R.lift (re_exports t ~for_) in
           let* () = many re_exports in
           R.modify (fun (res, visited) -> t :: res, visited)
       and many l = R.List.iter l ~f:one in
@@ -1815,7 +1876,7 @@ end = struct
     ; runtime_deps : t list Resolve.Memo.t
     }
 
-  let pp_deps db pps ~dune_version ~private_deps =
+  let pp_deps db pps ~dune_version ~private_deps ~for_ =
     let allow_only_ppx_deps =
       match dune_version with
       | Some version -> Dune_lang.Syntax.Version.Infix.(version >= (2, 2))
@@ -1849,13 +1910,13 @@ end = struct
             (match allow_only_ppx_deps, Lib_info.kind lib.info with
              | true, Dune_file Normal -> Error.only_ppx_deps_allowed ~loc lib.info
              | _ -> Resolve.return (Some lib)))
-        >>= linking_closure_with_overlap_checks None ~forbidden_libraries:Map.empty
+        >>= linking_closure_with_overlap_checks None ~forbidden_libraries:Map.empty ~for_
       in
       let runtime_deps =
         let* pps = pps in
         Resolve.List.concat_map pps ~f:(fun pp ->
           let open Resolve.O in
-          pp.ppx_runtime_deps
+          Compilation_mode.By_mode.get pp.ppx_runtime_deps ~for_
           >>= Resolve.List.map ~f:(fun dep ->
             check_private_deps ~loc ~private_deps dep |> Resolve.of_result))
         |> Memo.return
@@ -1870,9 +1931,10 @@ end = struct
         ~parameters
         ~pps
         ~dune_version
+        ~for_
     : Resolved.t Memo.t
     =
-    let { runtime_deps; pps } = pp_deps db pps ~dune_version ~private_deps in
+    let { runtime_deps; pps } = pp_deps db pps ~dune_version ~private_deps ~for_ in
     let open Memo.O in
     let resolved = Resolve.map ~f:(List.map ~f:snd) resolved in
     let re_exports = Resolve.map ~f:(List.map ~f:snd) re_exports in
@@ -1881,7 +1943,7 @@ end = struct
       let* resolved = Memo.return resolved in
       let* runtime_deps = runtime_deps in
       let parameters = List.map ~f:snd parameters in
-      re_exports_closure (List.concat [ resolved; runtime_deps; parameters ])
+      re_exports_closure (List.concat [ resolved; runtime_deps; parameters ]) ~for_
     and+ pps = pps in
     { Resolved.requires; pps; selects; re_exports }
   ;;
@@ -1893,10 +1955,11 @@ end = struct
         ~parameters
         ~pps
         ~dune_version
+        ~for_
     =
     let open Memo.O in
     resolve_complex_deps db ~private_deps ~parameters deps
-    >>= add_pp_runtime_deps db ~private_deps ~parameters ~dune_version ~pps
+    >>= add_pp_runtime_deps db ~private_deps ~parameters ~dune_version ~pps ~for_
   ;;
 
   (* Compute transitive closure of libraries to figure which ones will trigger
@@ -1978,11 +2041,11 @@ end = struct
     in
     (* Gather vlibs that are transitively implemented by another vlib's default
        implementation. *)
-    let rec visit ~stack ancestor_vlib lib =
+    let rec visit ~stack ancestor_vlib lib ~for_ =
       R.visit lib ~stack ~f:(fun lib ->
         let open R.O in
         (* Visit direct dependencies *)
-        let* deps = R.lift (Memo.return lib.requires) in
+        let* deps = R.lift (requires lib ~for_) in
         let* () =
           R.lift
             (Resolve.Memo.List.filter deps ~f:(fun x ->
@@ -1992,7 +2055,7 @@ end = struct
                  (match peek with
                   | Ok x -> x
                   | Error () -> false)))
-          >>= R.List.iter ~f:(visit ~stack:(lib.info :: stack) ancestor_vlib)
+          >>= R.List.iter ~f:(visit ~stack:(lib.info :: stack) ancestor_vlib ~for_)
         in
         (* If the library is an implementation of some virtual library that
            overrides default, add a link in the graph. *)
@@ -2003,7 +2066,7 @@ end = struct
             match res, ancestor_vlib with
             | true, None ->
               (* Recursion: no ancestor, vlib is explored *)
-              visit ~stack:(lib.info :: stack) None vlib
+              visit ~stack:(lib.info :: stack) None vlib ~for_
             | true, Some ancestor ->
               let* () =
                 R.modify (fun s ->
@@ -2012,7 +2075,7 @@ end = struct
                       Map.Multi.cons s.vlib_default_parent lib ancestor
                   })
               in
-              visit ~stack:(lib.info :: stack) None vlib
+              visit ~stack:(lib.info :: stack) None vlib ~for_
             | false, _ ->
               (* If lib is the default implementation, we'll manage it when
                  handling virtual lib. *)
@@ -2026,14 +2089,14 @@ end = struct
           let* impl = R.lift (impl_for lib) in
           (match impl with
            | None -> R.return ()
-           | Some impl -> visit ~stack:(lib.info :: stack) (Some lib) impl))
+           | Some impl -> visit ~stack:(lib.info :: stack) (Some lib) impl ~for_))
     in
     (* For each virtual library we know which vlibs will be implemented when
        enabling its default implementation. *)
-    fun libraries ->
+    fun libraries ~for_ ->
       let* status, () =
         R.run
-          (R.List.iter ~f:(visit ~stack:[] None) libraries)
+          (R.List.iter ~f:(visit ~stack:[] None ~for_) libraries)
           { visited = Map.empty; vlib_default_parent = Map.empty }
       in
       Resolve.Memo.List.filter_map
@@ -2071,12 +2134,12 @@ end = struct
       include M
     end
 
-    let result computation kind =
+    let result computation kind ~for_ =
       let* state, () = R.run computation R.empty_state in
-      Vlib.associate (List.rev state.result) kind
+      Vlib.associate (List.rev state.result) kind ~for_
     ;;
 
-    let rec visit (t : t) ~stack (implements_via, (lib : lib)) =
+    let rec visit (t : t) ~stack ~for_ (implements_via, (lib : lib)) =
       let open R.O in
       let* state = R.get in
       if Set.mem state.visited lib
@@ -2118,14 +2181,14 @@ end = struct
                         ]))
           in
           let* new_stack = R.lift (Dep_stack.push stack ~implements_via lib) in
-          let* (deps : lib list) =
-            R.lift (Resolve.Memo.lift (Parameterised.requires lib))
-          in
+          let* deps = R.lift (Resolve.Memo.lift (Parameterised.requires lib ~for_)) in
           let* unimplemented' = R.lift (Vlib.Unimplemented.add state.unimplemented lib) in
           let* () =
             R.modify (fun state -> { state with unimplemented = unimplemented' })
           in
-          let* () = R.List.iter deps ~f:(fun l -> visit t (None, l) ~stack:new_stack) in
+          let* () =
+            R.List.iter deps ~f:(fun l -> visit t (None, l) ~stack:new_stack ~for_)
+          in
           (match Parameterised.status lib with
            | Partial -> R.return ()
            | Not_parameterised | Complete ->
@@ -2133,27 +2196,27 @@ end = struct
     ;;
   end
 
-  let step1_closure db ts ~forbidden_libraries =
+  let step1_closure db ts ~forbidden_libraries ~for_ =
     let closure = Closure.make ~db ~forbidden_libraries in
     ( closure
     , Closure.R.List.iter ts ~f:(fun lib ->
-        Closure.visit closure ~stack:Dep_stack.empty (None, lib)) )
+        Closure.visit closure ~stack:Dep_stack.empty (None, lib) ~for_) )
   ;;
 
-  let compile_closure_with_overlap_checks db ts ~forbidden_libraries =
-    let (_ : Closure.t), state = step1_closure db ts ~forbidden_libraries in
-    Closure.result state `Compile
+  let compile_closure_with_overlap_checks db ts ~forbidden_libraries ~for_ =
+    let (_ : Closure.t), state = step1_closure db ts ~forbidden_libraries ~for_ in
+    Closure.result state `Compile ~for_
   ;;
 
-  let linking_closure_with_overlap_checks db ts ~forbidden_libraries =
-    let closure, state = step1_closure db ts ~forbidden_libraries in
+  let linking_closure_with_overlap_checks db ts ~forbidden_libraries ~for_ =
+    let closure, state = step1_closure db ts ~forbidden_libraries ~for_ in
     let res =
       let open Closure.R.O in
       let rec impls_via_defaults () =
         let* defaults =
           let* state = Closure.R.get in
           Vlib.Unimplemented.with_default_implementations state.unimplemented
-          |> resolve_default_libraries
+          |> resolve_default_libraries ~for_
           |> Closure.R.lift
         in
         match defaults with
@@ -2162,18 +2225,18 @@ end = struct
       and fill_impls libs =
         let* () =
           Closure.R.List.iter libs ~f:(fun (via, lib) ->
-            Closure.visit closure (Some via, lib) ~stack:Dep_stack.empty)
+            Closure.visit closure (Some via, lib) ~stack:Dep_stack.empty ~for_)
         in
         impls_via_defaults ()
       in
       state >>> impls_via_defaults ()
     in
-    Closure.result res `Link
+    Closure.result res `Link ~for_
   ;;
 
-  let check_forbidden ts ~forbidden_libraries =
-    let (_ : Closure.t), state = step1_closure None ts ~forbidden_libraries in
-    let+ (_ : lib list) = Closure.result state `Partial_link in
+  let check_forbidden ts ~forbidden_libraries ~for_ =
+    let (_ : Closure.t), state = step1_closure None ts ~forbidden_libraries ~for_ in
+    let+ (_ : lib list) = Closure.result state `Partial_link ~for_ in
     ()
   ;;
 end
@@ -2185,7 +2248,7 @@ let closure l ~linking =
   else Resolve_names.compile_closure_with_overlap_checks None l ~forbidden_libraries
 ;;
 
-let descriptive_closure (l : lib list) ~with_pps : lib list Memo.t =
+let descriptive_closure (l : lib list) ~with_pps ~for_ : lib list Memo.t =
   (* [add_work todo l] adds the libraries in [l] to the list [todo],
      that contains the libraries to handle next *)
   let open Memo.O in
@@ -2200,23 +2263,32 @@ let descriptive_closure (l : lib list) ~with_pps : lib list Memo.t =
      libraries that are contained in the todo list [todo] and are not
      in the set of libraries [acc] to the initial set of libraries
      [acc] *)
-  let rec work (todo : lib list list) (acc : Set.t) =
+  let rec work (todo : lib list list) (acc : Set.t) ~for_ =
     match todo with
     | [] -> Memo.return acc
-    | [] :: todo -> work todo acc
+    | [] :: todo -> work todo acc ~for_
     | (lib :: libs) :: todo ->
       if Set.mem acc lib
-      then work (add_work todo libs) acc
+      then work (add_work todo libs) acc ~for_
       else (
         let todo = add_work todo libs
         and acc = Set.add acc lib in
-        let* todo = if with_pps then register_work todo lib.pps else Memo.return todo in
-        let* todo = register_work todo lib.ppx_runtime_deps in
-        let* todo = register_work todo lib.requires in
-        work todo acc)
+        let* todo =
+          if with_pps
+          then register_work todo (Compilation_mode.By_mode.get ~for_:Ocaml lib.pps)
+          else Memo.return todo
+        in
+        let* todo =
+          register_work todo (Compilation_mode.By_mode.get lib.ppx_runtime_deps ~for_)
+        in
+        let* todo =
+          let requires = Compilation_mode.By_mode.get lib.requires ~for_ in
+          register_work todo requires
+        in
+        work todo acc ~for_)
   in
   (* we compute the transitive closure *)
-  let+ trans_closure = work [ l ] Set.empty in
+  let+ trans_closure = work [ l ] Set.empty ~for_ in
   (* and then convert it to a list *)
   Set.to_list trans_closure
 ;;
@@ -2225,51 +2297,60 @@ module Compile = struct
   module Resolved_select = Resolved_select
 
   type nonrec t =
-    { direct_requires : t list Resolve.Memo.t
-    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t
-    ; requires_link : t list Resolve.t Memo.Lazy.t
-    ; pps : t list Resolve.Memo.t
-    ; resolved_selects : Resolved_select.t list Resolve.Memo.t
+    { direct_requires : t list Resolve.Memo.t Compilation_mode.By_mode.t
+    ; user_written_requires : (Loc.t * t) list Resolve.Memo.t Compilation_mode.By_mode.t
+    ; requires_link : t list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t
+    ; pps : t list Resolve.Memo.t Compilation_mode.By_mode.t
+    ; resolved_selects : Resolved_select.t list Resolve.Memo.t Compilation_mode.By_mode.t
     ; allow_unused_libraries : t list Resolve.Memo.t
     ; sub_systems : Sub_system0.Instance.t Memo.Lazy.t Sub_system_name.Map.t
     }
 
   let for_lib ~allow_overlaps db (t : lib) =
     let requires =
-      (* This makes sure that the default implementation belongs to the same
+      Compilation_mode.By_mode.map t.requires ~f:(fun ~for_:_ requires ->
+        (* This makes sure that the default implementation belongs to the same
          package before we build the virtual library *)
-      let* () =
-        match t.default_implementation with
-        | None -> Resolve.Memo.return ()
-        | Some i ->
-          let+ (_ : lib) = Memo.Lazy.force i in
-          ()
-      in
-      Memo.return t.requires
+        let* () =
+          match t.default_implementation with
+          | None -> Resolve.Memo.return ()
+          | Some i ->
+            let+ (_ : lib) = Memo.Lazy.force i in
+            ()
+        in
+        Memo.return requires)
     in
-    let requires_link =
+    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t =
       let db = Option.some_if (not allow_overlaps) db in
-      Memo.lazy_ (fun () ->
-        requires
-        >>= Resolve_names.compile_closure_with_overlap_checks
-              db
-              ~forbidden_libraries:Map.empty)
+      Compilation_mode.By_mode.map requires ~f:(fun ~for_ requires ->
+        Memo.lazy_ (fun () ->
+          let open Resolve.Memo.O in
+          requires
+          >>= Resolve_names.compile_closure_with_overlap_checks
+                db
+                ~forbidden_libraries:Map.empty
+                ~for_))
     in
     { direct_requires = requires
     ; user_written_requires = t.user_written_requires
     ; requires_link
-    ; resolved_selects = Memo.return t.resolved_selects
-    ; pps = Memo.return t.pps
+    ; resolved_selects =
+        Compilation_mode.By_mode.map t.resolved_selects ~f:(fun ~for_:_ -> Memo.return)
+    ; pps = Compilation_mode.By_mode.map t.pps ~f:(fun ~for_:_ -> Memo.return)
     ; allow_unused_libraries = Memo.return t.allow_unused_libraries
     ; sub_systems = t.sub_systems
     }
   ;;
 
-  let direct_requires t = t.direct_requires
-  let user_written_requires t = t.user_written_requires
-  let requires_link t = t.requires_link
-  let resolved_selects t = t.resolved_selects
-  let pps t = t.pps
+  let direct_requires t ~for_ = Compilation_mode.By_mode.get t.direct_requires ~for_
+
+  let user_written_requires t ~for_ =
+    Compilation_mode.By_mode.get t.user_written_requires ~for_
+  ;;
+
+  let requires_link t ~for_ = Compilation_mode.By_mode.get t.requires_link ~for_
+  let resolved_selects t ~for_ = Compilation_mode.By_mode.get t.resolved_selects ~for_
+  let pps t ~for_ = Compilation_mode.By_mode.get t.pps ~for_
   let allow_unused_libraries t = t.allow_unused_libraries
 
   let sub_systems t =
@@ -2467,6 +2548,11 @@ module DB = struct
         ~pps
         ~dune_version
     =
+    let for_ =
+      match targets with
+      | `Melange_emit _name -> Compilation_mode.Melange
+      | `Exe _ -> Ocaml
+    in
     let resolved =
       Memo.lazy_ (fun () ->
         Resolve_names.resolve_deps_and_add_runtime_deps
@@ -2475,75 +2561,104 @@ module DB = struct
           ~pps
           ~parameters:[]
           ~private_deps:Allow_all
-          ~dune_version:(Some dune_version))
+          ~dune_version:(Some dune_version)
+          ~for_)
     in
-    let requires_link =
-      Memo.Lazy.create (fun () ->
-        let* forbidden_libraries =
-          Resolve.Memo.List.map forbidden_libraries ~f:(fun (loc, name) ->
-            let+ lib = resolve t (loc, name) in
-            lib, loc)
-          >>| Map.of_list
-          >>= function
-          | Ok res -> Resolve.Memo.return res
-          | Error (lib, _, loc) ->
-            Error.make
-              ~loc
-              [ Pp.textf
-                  "Library %S appears for the second time"
-                  (Lib_name.to_string lib.name)
-              ]
-        and+ res =
-          let open Memo.O in
-          let+ resolved = Memo.Lazy.force resolved in
-          resolved.requires
-        in
-        Resolve.Memo.push_stack_frame
-          (fun () ->
-             Resolve_names.linking_closure_with_overlap_checks
-               (Option.some_if (not allow_overlaps) t)
-               ~forbidden_libraries
-               res)
-          ~human_readable_description:(fun () ->
-            match targets with
-            | `Melange_emit name -> Pp.textf "melange target %s" name
-            | `Exe Nonempty_list.[ (loc, name) ] ->
-              Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
-            | `Exe (Nonempty_list.((loc, _) :: _) as names) ->
-              Pp.textf
-                "executables %s in %s"
-                (String.enumerate_and (Nonempty_list.to_list_map ~f:snd names))
-                (Loc.to_file_colon_line loc)))
+    let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.By_mode.t =
+      let requires_link =
+        Memo.Lazy.create (fun () ->
+          let* forbidden_libraries =
+            Resolve.Memo.List.map forbidden_libraries ~f:(fun (loc, name) ->
+              let+ lib = resolve t (loc, name) in
+              lib, loc)
+            >>| Map.of_list
+            >>= function
+            | Ok res -> Resolve.Memo.return res
+            | Error (lib, _, loc) ->
+              Error.make
+                ~loc
+                [ Pp.textf
+                    "Library %S appears for the second time"
+                    (Lib_name.to_string lib.name)
+                ]
+          and+ res =
+            let open Memo.O in
+            let+ resolved = Memo.Lazy.force resolved in
+            resolved.requires
+          in
+          Resolve.Memo.push_stack_frame
+            (fun () ->
+               Resolve_names.linking_closure_with_overlap_checks
+                 (Option.some_if (not allow_overlaps) t)
+                 ~forbidden_libraries
+                 ~for_
+                 res)
+            ~human_readable_description:(fun () ->
+              match targets with
+              | `Melange_emit name -> Pp.textf "melange target %s" name
+              | `Exe Nonempty_list.[ (loc, name) ] ->
+                Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
+              | `Exe (Nonempty_list.((loc, _) :: _) as names) ->
+                Pp.textf
+                  "executables %s in %s"
+                  (String.enumerate_and
+                     (Nonempty_list.map ~f:snd names |> Nonempty_list.to_list))
+                  (Loc.to_file_colon_line loc)))
+      in
+      let init =
+        Compilation_mode.By_mode.both (Memo.lazy_ (fun () -> Resolve.Memo.return []))
+      in
+      Compilation_mode.By_mode.set init ~for_ requires_link
     in
-    let pps =
-      let open Memo.O in
-      let+ resolved = Memo.Lazy.force resolved in
-      resolved.pps
+    let pps : lib list Resolve.Memo.t Compilation_mode.By_mode.t =
+      let pps =
+        let open Memo.O in
+        let+ resolved = Memo.Lazy.force resolved in
+        resolved.pps
+      in
+      let init = Compilation_mode.By_mode.both (Resolve.Memo.return []) in
+      Compilation_mode.By_mode.set init ~for_ pps
     in
-    let direct_requires =
-      let open Memo.O in
-      let+ resolved = Memo.Lazy.force resolved in
-      resolved.requires
+    let direct_requires : lib list Resolve.Memo.t Compilation_mode.By_mode.t =
+      let direct_requires =
+        let open Memo.O in
+        let+ resolved = Memo.Lazy.force resolved in
+        resolved.requires
+      in
+      let init = Compilation_mode.By_mode.both (Resolve.Memo.return []) in
+      Compilation_mode.By_mode.set init ~for_ direct_requires
     in
-    let resolved_selects =
-      let open Memo.O in
-      let+ resolved = Memo.Lazy.force resolved in
-      resolved.selects
+    let resolved_selects
+      : Resolved_select.t list Resolve.Memo.t Compilation_mode.By_mode.t
+      =
+      let resolved_selects =
+        let open Memo.O in
+        let+ resolved = Memo.Lazy.force resolved in
+        Resolve.return resolved.selects
+      in
+      let init = Compilation_mode.By_mode.both (Resolve.Memo.return []) in
+      Compilation_mode.By_mode.set init ~for_ resolved_selects
     in
     let allow_unused_libraries =
       Resolve_names.resolve_simple_deps t ~private_deps:Allow_all allow_unused_libraries
     in
-    let user_written_requires =
-      Memo.lazy_ (fun () ->
-        Resolve_names.resolve_complex_deps t ~private_deps:Allow_all deps ~parameters:[]
-        |> Memo.map ~f:Resolve_names.Resolved.user_written)
-      |> Memo.Lazy.force
+    let user_written_requires
+      : (Loc.t * lib) list Resolve.Memo.t Compilation_mode.By_mode.t
+      =
+      let resolved_user_written_requires =
+        Memo.lazy_ (fun () ->
+          Resolve_names.resolve_complex_deps t ~private_deps:Allow_all deps ~parameters:[]
+          |> Memo.map ~f:Resolve_names.Resolved.user_written)
+        |> Memo.Lazy.force
+      in
+      let init = Compilation_mode.By_mode.both (Resolve.Memo.return []) in
+      Compilation_mode.By_mode.set init ~for_ resolved_user_written_requires
     in
     { Compile.direct_requires
     ; user_written_requires
     ; requires_link
     ; pps
-    ; resolved_selects = resolved_selects |> Memo.map ~f:Resolve.return
+    ; resolved_selects
     ; allow_unused_libraries
     ; sub_systems = Sub_system_name.Map.empty
     }
@@ -2573,6 +2688,17 @@ module DB = struct
     instrumentation_backend t.instrument_with (resolve t) libname
   ;;
 end
+
+let to_resolve_memo
+  :  lib list Resolve.t Compilation_mode.By_mode.t
+  -> lib list Compilation_mode.By_mode.t Resolve.Memo.t
+  =
+  fun t ->
+  let open Resolve.Memo.O in
+  let+ ocaml = Resolve.Memo.lift t.ocaml
+  and+ melange = Resolve.Memo.lift t.melange in
+  { Compilation_mode.By_mode.ocaml; melange }
+;;
 
 let to_dune_lib
       ({ info; _ } as lib)
@@ -2626,28 +2752,32 @@ let to_dune_lib
     use_public_name
       ~info_field:(Lib_info.default_implementation info)
       ~lib_field:(Option.map ~f:Memo.Lazy.force lib.default_implementation)
-  and+ ppx_runtime_deps = Memo.return lib.ppx_runtime_deps
-  and+ requires = Memo.return lib.requires
-  and+ re_exports = Memo.return lib.re_exports in
-  let ppx_runtime_deps = add_loc ppx_runtime_deps in
+  and+ ppx_runtime_deps = to_resolve_memo lib.ppx_runtime_deps
+  and+ requires = to_resolve_memo lib.requires
+  and+ re_exports = to_resolve_memo lib.re_exports in
+  let ppx_runtime_deps = add_loc ppx_runtime_deps.ocaml in
   let requires =
-    List.map requires ~f:(fun lib ->
-      if List.exists re_exports ~f:(fun r -> r = lib)
-      then Lib_dep.Re_export (loc, mangled_name lib)
-      else (
-        match lib.arguments with
-        | [] -> Direct (loc, mangled_name lib)
-        | args ->
-          Instantiate
-            { loc
-            ; lib = mangled_name lib
-            ; arguments =
-                List.filter_map args ~f:(function
-                  | None -> None
-                  | Some arg -> Some (Loc.none, mangled_name arg))
-            ; new_name = None
-            }))
+    Compilation_mode.By_mode.map requires ~f:(fun ~for_ requires ->
+      List.map requires ~f:(fun lib ->
+        if
+          List.exists (Compilation_mode.By_mode.get re_exports ~for_) ~f:(fun r ->
+            r = lib)
+        then Lib_dep.Re_export (loc, mangled_name lib)
+        else (
+          match lib.arguments with
+          | [] -> Direct (loc, mangled_name lib)
+          | args ->
+            Instantiate
+              { loc
+              ; lib = mangled_name lib
+              ; arguments =
+                  List.filter_map args ~f:(function
+                    | None -> None
+                    | Some arg -> Some (Loc.none, mangled_name arg))
+              ; new_name = None
+              })))
   in
+  let requires = requires.ocaml in
   let name = mangled_name lib in
   let remove_public_dep_prefix paths =
     let prefix = Lib_info.src_dir lib.info in

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -24,7 +24,7 @@ module Parameterised : sig
   val arguments : t -> t list
   val applied_modules : t -> Module_name.t Parameterised_name.t list Resolve.t
   val applied_name : t -> Module_name.t Parameterised_name.t Resolve.t
-  val requires : t -> t list Resolve.t
+  val requires : t -> for_:Compilation_mode.t -> t list Resolve.t
   val for_instance : build_dir:Path.Build.t -> ext_lib:string -> t -> t
   val dir : build_dir:Path.Build.t -> t -> Path.Build.t
 
@@ -45,11 +45,11 @@ val main_module_name : t -> Module_name.t option Resolve.Memo.t
 val wrapped : t -> Wrapped.t option Resolve.Memo.t
 
 (** Direct library dependencies of this library *)
-val requires : t -> t list Resolve.Memo.t
+val requires : t -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
-val re_exports : t -> t list Resolve.Memo.t
-val ppx_runtime_deps : t -> t list Resolve.Memo.t
-val pps : t -> t list Resolve.Memo.t
+val re_exports : t -> for_:Compilation_mode.t -> t list Resolve.Memo.t
+val ppx_runtime_deps : t -> for_:Compilation_mode.t -> t list Resolve.Memo.t
+val pps : t -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
 include Comparable_intf.S with type key := t
 
@@ -84,12 +84,15 @@ module Compile : sig
   val for_lib : allow_overlaps:bool -> db -> lib -> t
 
   (** Return the list of dependencies needed for linking this library/exe *)
-  val requires_link : t -> lib list Resolve.t Memo.Lazy.t
+  val requires_link : t -> for_:Compilation_mode.t -> lib list Resolve.t Memo.Lazy.t
 
-  val user_written_requires : t -> (Loc.t * lib) list Resolve.Memo.t
+  val user_written_requires
+    :  t
+    -> for_:Compilation_mode.t
+    -> (Loc.t * lib) list Resolve.Memo.t
 
   (** Dependencies listed by the user + runtime dependencies from ppx *)
-  val direct_requires : t -> lib list Resolve.Memo.t
+  val direct_requires : t -> for_:Compilation_mode.t -> lib list Resolve.Memo.t
 
   module Resolved_select : sig
     type t =
@@ -100,10 +103,13 @@ module Compile : sig
   end
 
   (** Resolved select forms *)
-  val resolved_selects : t -> Resolved_select.t list Resolve.Memo.t
+  val resolved_selects
+    :  t
+    -> for_:Compilation_mode.t
+    -> Resolved_select.t list Resolve.Memo.t
 
   (** Transitive closure of all used ppx rewriters *)
-  val pps : t -> lib list Resolve.Memo.t
+  val pps : t -> for_:Compilation_mode.t -> lib list Resolve.Memo.t
 
   (** Libraries allowed to be unused *)
   val allow_unused_libraries : t -> lib list Resolve.Memo.t
@@ -205,7 +211,7 @@ end
 
 (** {1 Transitive closure} *)
 
-val closure : t list -> linking:bool -> t list Resolve.Memo.t
+val closure : t list -> linking:bool -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
 (** [descriptive_closure ~with_pps libs] computes the smallest set of libraries
     that contains the libraries in the list [libs], and that is transitively
@@ -216,7 +222,11 @@ val closure : t list -> linking:bool -> t list Resolve.Memo.t
     sorted. The difference with [closure libs] is that the latter may raise an
     error when overlapping implementations of virtual libraries are detected.
     [descriptive_closure libs] makes no such check. *)
-val descriptive_closure : t list -> with_pps:bool -> t list Memo.t
+val descriptive_closure
+  :  t list
+  -> with_pps:bool
+  -> for_:Compilation_mode.t
+  -> t list Memo.t
 
 (** {1 Sub-systems} *)
 

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -401,6 +401,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog ~mdx_prog_ge
 ;;
 
 let name = "mdx_gen"
+let for_ = Compilation_mode.Ocaml
 
 let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
   let loc = t.loc in
@@ -461,8 +462,8 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
         ~pps:[]
         ~dune_version
     in
-    let requires_compile = Lib.Compile.direct_requires compile_info
-    and requires_link = Lib.Compile.requires_link compile_info in
+    let requires_compile = Lib.Compile.direct_requires compile_info ~for_
+    and requires_link = Lib.Compile.requires_link compile_info ~for_ in
     let obj_dir = Obj_dir.make_exe ~dir ~name in
     let modules =
       Module.generated ~kind:Impl ~src_dir:dir [ main_module_name ]
@@ -481,7 +482,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None
       ~package:None
-      Ocaml
+      for_
   in
   let ext = ".bc.exe" in
   let+ (_ : Exe.dep_graphs) =

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -732,7 +732,7 @@ module Unprocessed = struct
                      ocaml.version
                    |> Dune_project.Implicit_transitive_deps.to_bool
                  in
-                 Lib.closure [ lib ] ~linking
+                 Lib.closure [ lib ] ~linking ~for_:Melange
                  |> Resolve.Memo.peek
                  >>| function
                  | Ok libs -> libs

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -763,11 +763,16 @@ let setup_pkg_rules_def memo_name f =
   let module Input = struct
     module Super_context = Super_context.As_memo_key
 
-    type t = Super_context.t * Package.Name.t
+    type t = Super_context.t * Package.Name.t * Compilation_mode.t
 
-    let equal (s1, p1) (s2, p2) = Package.Name.equal p1 p2 && Super_context.equal s1 s2
-    let hash = Tuple.T2.hash Super_context.hash Package.Name.hash
-    let to_dyn (_, package) = Package.Name.to_dyn package
+    let equal (s1, p1, c1) (s2, p2, c2) =
+      Package.Name.equal p1 p2
+      && Super_context.equal s1 s2
+      && Compilation_mode.equal c1 c2
+    ;;
+
+    let hash = Tuple.T3.hash Super_context.hash Package.Name.hash Poly.hash
+    let to_dyn (_, package, _) = Package.Name.to_dyn package
   end
   in
   Memo.With_implicit_output.create
@@ -778,11 +783,11 @@ let setup_pkg_rules_def memo_name f =
 ;;
 
 let setup_pkg_odocl_rules_def =
-  let f (sctx, pkg) =
+  let f (sctx, pkg, for_) =
     let* libs = Super_context.context sctx |> Context.name |> libs_of_pkg ~pkg in
     let* requires =
       let libs = (libs :> Lib.t list) in
-      Lib.closure libs ~linking:false
+      Lib.closure libs ~linking:false ~for_
     in
     let* () = Memo.parallel_iter libs ~f:(setup_lib_odocl_rules sctx ~requires)
     and* _ =
@@ -799,8 +804,8 @@ let setup_pkg_odocl_rules_def =
   setup_pkg_rules_def "setup-package-odocls-rules" f
 ;;
 
-let setup_pkg_odocl_rules sctx ~pkg : unit Memo.t =
-  Memo.With_implicit_output.exec setup_pkg_odocl_rules_def (sctx, pkg)
+let setup_pkg_odocl_rules sctx ~pkg ~for_ : unit Memo.t =
+  Memo.With_implicit_output.exec setup_pkg_odocl_rules_def (sctx, pkg, for_)
 ;;
 
 let out_file (output : Output_format.t) odoc =
@@ -868,7 +873,7 @@ let setup_lib_html_rules sctx ~search_db lib =
 ;;
 
 let setup_pkg_html_rules_def =
-  let f (sctx, pkg) =
+  let f (sctx, pkg, _for_) =
     let ctx = Super_context.context sctx in
     let* libs = Context.name ctx |> libs_of_pkg ~pkg in
     let dir = Paths.html ctx (Pkg pkg) in
@@ -892,8 +897,8 @@ let setup_pkg_html_rules_def =
   setup_pkg_rules_def "setup-package-html-rules" f
 ;;
 
-let setup_pkg_html_rules sctx ~pkg : unit Memo.t =
-  Memo.With_implicit_output.exec setup_pkg_html_rules_def (sctx, pkg)
+let setup_pkg_html_rules sctx ~pkg ~for_ : unit Memo.t =
+  Memo.With_implicit_output.exec setup_pkg_html_rules_def (sctx, pkg, for_)
 ;;
 
 let setup_package_aliases_format sctx (pkg : Package.t) (output : Output_format.t) =
@@ -1066,15 +1071,24 @@ let gen_rules sctx ~dir rest =
          let+ lib = Lib.DB.find lib_db lib in
          Option.bind ~f:Lib.Local.of_lib lib
        in
+       let for_ =
+         match lib with
+         | Some lib ->
+           let modes =
+             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.of_mode_set
+           in
+           modes.for_merlin
+         | None -> Ocaml
+       in
        let+ () =
          match lib with
          | None -> Memo.return ()
          | Some lib ->
            (match Lib_info.package (Lib.Local.info lib) with
             | None ->
-              let* requires = Lib.closure [ Lib.Local.to_lib lib ] ~linking:false in
+              let* requires = Lib.closure [ Lib.Local.to_lib lib ] ~linking:false ~for_ in
               setup_lib_odocl_rules sctx lib ~requires
-            | Some pkg -> setup_pkg_odocl_rules sctx ~pkg)
+            | Some pkg -> setup_pkg_odocl_rules sctx ~pkg ~for_)
        and+ () =
          let* packages = Dune_load.packages () in
          match
@@ -1083,7 +1097,7 @@ let gen_rules sctx ~dir rest =
          | None -> Memo.return ()
          | Some pkg ->
            let name = Package.name pkg in
-           setup_pkg_odocl_rules sctx ~pkg:name
+           setup_pkg_odocl_rules sctx ~pkg:name ~for_
        in
        ())
   | [ "_html"; lib_unique_name_or_pkg ] ->
@@ -1097,6 +1111,15 @@ let gen_rules sctx ~dir rest =
          let+ lib = Lib.DB.find lib_db lib in
          Option.bind ~f:Lib.Local.of_lib lib
        in
+       let for_ =
+         match lib with
+         | Some lib ->
+           let modes =
+             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.of_mode_set
+           in
+           modes.for_merlin
+         | None -> Ocaml
+       in
        let+ () =
          match lib with
          | None -> Memo.return ()
@@ -1106,7 +1129,7 @@ let gen_rules sctx ~dir rest =
               (* lib with no package above it *)
               let* search_db = search_db_for_lib sctx lib in
               setup_lib_html_rules sctx ~search_db lib
-            | Some pkg -> setup_pkg_html_rules sctx ~pkg)
+            | Some pkg -> setup_pkg_html_rules sctx ~pkg ~for_)
        and+ () =
          let* packages = Dune_load.packages () in
          match
@@ -1115,7 +1138,7 @@ let gen_rules sctx ~dir rest =
          | None -> Memo.return ()
          | Some pkg ->
            let name = Package.name pkg in
-           setup_pkg_html_rules sctx ~pkg:name
+           setup_pkg_html_rules sctx ~pkg:name ~for_
        in
        ())
   | _ -> Memo.return (Gen_rules.redirect_to_parent Gen_rules.Rules.empty)

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -321,7 +321,7 @@ let instantiate ~sctx lib =
       impl_only
   in
   let* requires =
-    Lib.closure ~linking:true [ lib ]
+    Lib.closure ~linking:true [ lib ] ~for_
     |> Resolve.Memo.map
          ~f:(List.map ~f:(Lib.Parameterised.for_instance ~build_dir ~ext_lib))
   in

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -411,7 +411,7 @@ let libs_of_theory ~lib_db ~theories_deps plugins : (Lib.t list * _) Resolve.Mem
     Resolve.List.concat_map ~f:Rocq_lib.Dune.libraries dune_theories |> Resolve.Memo.lift
   in
   let libs = libs @ dlibs in
-  let+ findlib_libs = Lib.closure ~linking:false (List.map ~f:snd libs) in
+  let+ findlib_libs = Lib.closure ~linking:false (List.map ~f:snd libs) ~for_:Ocaml in
   findlib_libs, legacy_theories
 ;;
 

--- a/src/dune_rules/sub_system.ml
+++ b/src/dune_rules/sub_system.ml
@@ -135,8 +135,8 @@ module Register_end_point (M : End_point) = struct
   let gen info (c : Library_compilation_context.t) =
     let* backends =
       let ( let& ) t f = Resolve.Memo.bind t ~f in
-      let& deps = Lib.Compile.direct_requires c.compile_info in
-      let& pps = Lib.Compile.pps c.compile_info in
+      let& deps = Lib.Compile.direct_requires c.compile_info ~for_:c.for_ in
+      let& pps = Lib.Compile.pps c.compile_info ~for_:c.for_ in
       let& written_by_user =
         match M.Info.backends info with
         | None -> Memo.return (Resolve.return None)

--- a/src/dune_rules/sub_system_intf.ml
+++ b/src/dune_rules/sub_system_intf.ml
@@ -85,6 +85,7 @@ module Library_compilation_context = struct
     ; stanza : Library.t
     ; scope : Scope.t
     ; source_modules : Module.t list
+    ; for_ : Compilation_mode.t
     ; compile_info : Lib.Compile.t
     }
 end

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -113,6 +113,8 @@ let pp_flags t =
   | No_preprocessing -> Action_builder.return Pp.nop
 ;;
 
+let for_ = Compilation_mode.Ocaml
+
 let setup_module_rules t =
   let main_ml =
     (let open Action_builder.O in
@@ -233,11 +235,11 @@ module Stanza = struct
             (Ocaml_flags.default ~dune_version ~profile)
             [ "-w"; "-24" ]
         in
-        let requires_compile = Lib.Compile.direct_requires compile_info in
-        let requires_link = Lib.Compile.requires_link compile_info in
+        let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
+        let requires_link = Lib.Compile.requires_link compile_info ~for_ in
         let obj_dir = Source.obj_dir source in
         Compilation_context.create
-          Ocaml
+          for_
           ~super_context:sctx
           ~scope
           ~obj_dir

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -31,6 +31,8 @@ module Libs_and_ppxs =
 
 module Source_tree_map_reduce = Source_tree.Dir.Make_map_reduce (Memo) (Libs_and_ppxs)
 
+let for_ = Compilation_mode.Ocaml
+
 let add_stanza db ~dir (acc, pps) stanza =
   match Stanza.repr stanza with
   | Library.T l ->
@@ -89,7 +91,7 @@ let add_stanza db ~dir (acc, pps) stanza =
           ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
           ~forbidden_libraries:exes.forbidden_libraries
       in
-      let+ available = Lib.Compile.direct_requires compile_info in
+      let+ available = Lib.Compile.direct_requires compile_info ~for_ in
       Resolve.peek available
     in
     (match libs with
@@ -143,7 +145,7 @@ let requires ~loc ~db ~libs =
   (loc, Lib_name.of_string "utop")
   |> Lib.DB.resolve db
   >>| (fun utop -> utop :: libs)
-  >>= Lib.closure ~linking:true
+  >>= Lib.closure ~linking:true ~for_
 ;;
 
 let utop_dev_tool_lock_dir_exists =
@@ -233,7 +235,7 @@ let setup sctx ~dir =
   let* cctx =
     let requires_link = Memo.lazy_ (fun () -> requires) in
     Compilation_context.create
-      Ocaml
+      for_
       ~super_context:sctx
       ~scope
       ~obj_dir

--- a/test/blackbox-tests/test-cases/melange/transitive-ppx.t
+++ b/test/blackbox-tests/test-cases/melange/transitive-ppx.t
@@ -34,7 +34,7 @@ Test interaction of melange.emit library ppx dependencies
                         ^^^^^^^^^^^
   Error: Library "not-present" not found.
   -> required by library "mel-subdir" in _build/default/lib/impl
-  -> required by _build/default/META.mel-subdir
+  -> required by _build/default/mel-subdir.dune-package
   -> required by alias all
   -> required by alias default
   [1]


### PR DESCRIPTION
- `lib.ml` resolves requires / links per compilation mode
- this is needed to allow the same library to have 2 sets of library dependencies, per compilation mode (ocaml / melange)