### PR TITLE
test(pkg): errors on non-existant branches

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/non-existent-branch.t
@@ -1,0 +1,31 @@
+Test that we get a clear error when referencing a non-existent branch in a
+repository URL.
+
+Create a git repository with a single branch:
+
+  $ mkrepo
+  $ mkpkg foo 1.0
+  $ cd mock-opam-repository
+  $ git init --quiet
+  $ git add -A
+  $ git commit --quiet -m "Initial commit"
+  $ cd ..
+
+Reference a branch that does not exist:
+
+  $ add_mock_repo_if_needed "git+file://$PWD/mock-opam-repository#nonexistent-branch"
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.10)
+  > 
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ dune pkg lock 2>&1 | dune_cmd subst '/[^ ]*/bin/git' 'git'
+  Error: Command returned nothing: cd
+  $TESTCASE_ROOT/.cache/dune/git-repo
+  && git rev-parse
+  --verify --quiet nonexistent-branch^{commit}
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
@@ -1,0 +1,36 @@
+Test that we get a clear error when a pin references a non-existent branch.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a git repo to pin:
+
+  $ mkdir _repo
+  $ cd _repo
+  $ git init --initial-branch=main --quiet
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ git add -A
+  $ git commit -qm "initial commit"
+  $ cd ..
+
+Reference a branch that does not exist in the pin:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "git+file://$PWD/_repo#nonexistent-branch")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ dune pkg lock 2>&1 | dune_cmd subst '/[^ ]*/bin/git' 'git'
+  Error: Command returned nothing: cd
+  $TESTCASE_ROOT/.cache/dune/git-repo
+  && git rev-parse
+  --verify --quiet nonexistent-branch^{commit}
+  [1]


### PR DESCRIPTION
This error is not handled well by the revision store and leaks implementation details to the user with no clear idea of what went wrong.

Reproduction case for
- #13295 