### PR TITLE
Add pin to benchmark as well

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install deps on Unix
         run: |
+          opam pin -n . --with-version=3.22.0
           opam install . --deps-only --with-test
           opam exec -- make dev-deps
           # Install hyperfine


### PR DESCRIPTION
#13303 passed CI but the build-time bench but somehow https://github.com/ocaml/dune/actions/runs/20989820448/job/60332284880 failed.

This PR applies the same fix as in #13303. It makes sense to have pinning since we generally pin nowadays to avoid having to wait for releases to use new features so this is essentially just adding it in places where it was accidentally missing.