### PR TITLE
Fix incomprehensible error message when git revision doesn't exist

### DIFF
--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -516,8 +516,8 @@ let cat_file { dir; _ } command =
 
 let rev_parse { dir; _ } rev =
   let git = Lazy.force Vcs.git in
-  let+ line, code =
-    Process.run_capture_line
+  let+ lines, code =
+    Process.run_capture_lines
       ~dir
       ~display:Quiet
       ~env
@@ -525,7 +525,9 @@ let rev_parse { dir; _ } rev =
       git
       [ "rev-parse"; "--verify"; "--quiet"; sprintf "%s^{commit}" rev ]
   in
-  if code = 0 then Some (Option.value_exn (Object.of_sha1 line)) else None
+  match lines, code with
+  | [ line ], 0 -> Some (Option.value_exn (Object.of_sha1 line))
+  | _, _ -> None
 ;;
 
 let object_exists_no_lock { dir; _ } obj =

--- a/test/blackbox-tests/test-cases/pkg/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/non-existent-branch.t
@@ -1,0 +1,33 @@
+Test that we get a clear error when referencing a non-existent branch in a
+repository URL.
+
+Create a git repository with a single branch:
+
+  $ mkrepo
+  $ mkpkg foo 1.0
+  $ cd mock-opam-repository
+  $ git init --quiet
+  $ git add -A
+  $ git commit --quiet -m "Initial commit"
+  $ cd ..
+
+Reference a branch that does not exist:
+
+  $ add_mock_repo_if_needed "git+file://$PWD/mock-opam-repository#nonexistent-branch"
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.10)
+  > 
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ export BUILD_PATH_PREFIX_MAP="PWD=//$PWD:$BUILD_PATH_PREFIX_MAP"
+  $ dune pkg lock 2>&1 | dune_cmd subst '-\d+' '-eol' | dune_cmd delete '\^+'
+  File "dune-workspace", line 6, characters 6-eol:
+  6 |  (url "git+file:PWD/mock-opam-repository#nonexistent-branch"))
+  revision "nonexistent-branch" not found in
+  file:PWD/mock-opam-repository
+  [1]
+

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
@@ -1,0 +1,37 @@
+Test that we get a clear error when a pin references a non-existent branch.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a git repo to pin:
+
+  $ mkdir _repo
+  $ cd _repo
+  $ git init --initial-branch=main --quiet
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (package (name foo))
+  > EOF
+  $ git add -A
+  $ git commit -qm "initial commit"
+  $ cd ..
+
+Reference a branch that does not exist in the pin:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.13)
+  > (pin
+  >  (url "git+file://$PWD/_repo#nonexistent-branch")
+  >  (package (name foo)))
+  > (package
+  >  (name main)
+  >  (depends foo))
+  > EOF
+
+  $ export BUILD_PATH_PREFIX_MAP="PWD=//$PWD:$BUILD_PATH_PREFIX_MAP"
+  $ dune pkg lock 2>&1 | dune_cmd subst '-\d+' '-eol' | dune_cmd delete '\^+'
+  File "dune-project", line 3, characters 6-eol:
+  3 |  (url "git+file:PWD/_repo#nonexistent-branch")
+  revision "nonexistent-branch" not found in
+  file:PWD/_repo
+  [1]


### PR DESCRIPTION
Fixes #13295, incorporates the tests from #13294

`Process.run_capture_lines` (with an 's') gives a much better error message than the without-s counterpart