### PR TITLE
feat(pkg): interpret %{pkg-self:build-id} variable

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -43,8 +43,7 @@ let is_valid_global_variable_name = function
 
 (* CR-rgrinberg: we need this validation in substitution actions as well *)
 let is_valid_package_variable_name = function
-  | "hash" | "build-id" | "misc" | "opam-version" | "depends" | "build" | "opamfile" ->
-    false
+  | "hash" | "misc" | "opam-version" | "depends" | "build" | "opamfile" -> false
   | _ -> true
 ;;
 

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -817,6 +817,11 @@ module Action_expander = struct
          | "enable" ->
            Memo.return @@ Ok [ Value.String (if present then "enable" else "disable") ]
          | "installed" -> Memo.return @@ Ok [ Value.String (Bool.to_string present) ]
+         | "build-id" ->
+           (* build-id is used by some packages (e.g., relocatable-compiler) for
+              caching across opam switches. Since dune doesn't do this, we use a
+              fixed dummy value that won't collide with real opam build-ids. *)
+           Memo.return @@ Ok [ Value.String "d00ed00ed00ed00ed00ed00ed00ed00e" ]
          | _ ->
            (match paths with
             | None -> Memo.return (Error (`Undefined_pkg_var variable_name))

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-pkg.t
@@ -1,5 +1,7 @@
 Here we test the translation and implementation of opam package variables.
 
+CR-soon Alizter: The numbers here are pointless since we have line numbers.
+
 We echo each package variable. 
 
   $ mkrepo
@@ -42,6 +44,8 @@ We echo each package variable.
   >   [ "echo" "40" foo:with-doc ]
   >   [ "echo" "41"   _:with-dev-setup ]
   >   [ "echo" "42" foo:with-dev-setup ]
+  >   [ "echo"  _:build-id ]
+  >   [ "echo" foo:build-id ]
   > ]
   > EOF
   > mkpkg "foo" <<EOF
@@ -101,7 +105,9 @@ corresponding Dune version.
        (run echo 39 %{pkg-self:with-doc})
        (run echo 40 %{pkg:foo:with-doc})
        (run echo 41 %{pkg-self:with-dev-setup})
-       (run echo 42 %{pkg:foo:with-dev-setup}))))))
+       (run echo 42 %{pkg:foo:with-dev-setup})
+       (run echo %{pkg-self:build-id})
+       (run echo %{pkg:foo:build-id}))))))
   
   (depends
    (all_platforms (foo)))
@@ -138,7 +144,7 @@ The values here are not important, but Dune should be able to interpret the vari
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-dev-setup"
   File "dune.lock/testpkg.0.0.1.pkg", line 48, characters 18-43:
-  48 |      (run echo 42 %{pkg:foo:with-dev-setup}))))))
+  48 |      (run echo 42 %{pkg:foo:with-dev-setup})
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Undefined package variable "with-dev-setup"
   [1]

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
@@ -27,10 +27,6 @@ These should all have nice error messages explaining that they are not supported
   $ fail_solve _:hash
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
   Error: Variable "hash" is not supported.
-# _:build-id
-  $ fail_solve _:build-id
-  File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "build-id" is not supported.
 # misc
   $ fail_solve misc
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:


### PR DESCRIPTION
According to [1] and [2], `build-id` is a SHA256 hash identifying the precise package version with all its dependencies.

Consumers of this variable, such as the process.sh script in [3], use this to identify specific packages in existing opam switches. In [3] this is used to find an already-built relocatable OCaml compiler.

In dune we wish to re-use [3] for choosing the relocatable compiler, therefore we need to substitute the value with something that will not be picked up as a hash from an existing opam valuation of build-id.

For now we choose a magic number that is easily recognizable in case anything needs to be debugged.

[1] https://github.com/ocaml/opam/blob/master/src/state/opamPackageVar.ml 
[2] https://github.com/ocaml/opam/wiki/Spec-for-Extended-package-specific-variables
[3] https://github.com/dra27/opam-repository/tree/relocatable

Addressing relevant concern in:
- #13229