### PR TITLE
refactor: remove some dead

### DIFF
--- a/src/dune_cache/shared.mli
+++ b/src/dune_cache/shared.mli
@@ -1,11 +1,8 @@
 (** Implementation of Dune shared cache. *)
-open Import
 
 module type S = Shared_intf.S
 
 module Make (_ : sig
     val debug_shared_cache : bool
     val config : Config.t
-    val upload : rule_digest:Digest.t -> unit Fiber.t
-    val download : rule_digest:Digest.t -> unit Fiber.t
   end) : Shared_intf.S

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -79,8 +79,6 @@ let init
     Dune_cache.Shared.Make (struct
       let debug_shared_cache = cache_debug_flags.shared_cache
       let config = cache_config
-      let upload ~rule_digest:_ = Fiber.return ()
-      let download ~rule_digest:_ = Fiber.return ()
     end)
   in
   Build_config.set


### PR DESCRIPTION
These stubs were left for the cache daemon. A component that we don't
really have at the moment, and have no short or medium term plans to
integrate.
