### PR TITLE
fix(pkg): catch undefined package variables

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -148,7 +148,11 @@ let opam_string_to_slang ~package ~loc opam_string =
          when String.is_prefix ~prefix:"%{" interp && String.is_suffix ~suffix:"}%" interp
          ->
          let ident = String.sub ~pos:2 ~len:(String.length interp - 4) interp in
-         opam_raw_fident_to_slang ~loc ident
+         (* In opam, undefined variables in string interpolation evaluate to
+            empty string. Wrap the result in catch_undefined_var to match this
+            behavior. *)
+         Result.map (opam_raw_fident_to_slang ~loc ident) ~f:(fun slang ->
+           Slang.catch_undefined_var slang ~fallback:(Slang.text ""))
        | other ->
          Error
            (User_error.make

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -117,8 +117,11 @@ Package which has boolean where string was expected. This should be caught while
    (all_platforms
     ((action
       (progn
-       (run ./configure --prefix=%{prefix} --docdir=%{doc}/ocaml)
-       (run %{make} -j%{jobs}))))))
+       (run
+        ./configure
+        (concat --prefix= (catch_undefined_var %{prefix} ""))
+        (concat --docdir= (catch_undefined_var %{doc} "") /ocaml))
+       (run %{make} (concat -j (catch_undefined_var %{jobs} ""))))))))
 
   $ cat ${default_lock_dir}/with-percent-sign.0.0.1.pkg
   (version 0.0.1)
@@ -304,54 +307,73 @@ preserved between opam and dune.
    (all_platforms
     ((action
       (progn
-       (run echo "a %{pkg-self:installed} b")
+       (run
+        echo
+        (concat "a " (catch_undefined_var %{pkg-self:installed} "") " b"))
        (run
         echo
         (concat
          "c "
-         (if (catch_undefined_var %{pkg-self:installed} false) x y)
+         (catch_undefined_var
+          (if (catch_undefined_var %{pkg-self:installed} false) x y)
+          "")
          " d"))
        (run
         echo
         (concat
          "e "
-         (if (catch_undefined_var %{pkg:foo:installed} false) x y)
+         (catch_undefined_var
+          (if (catch_undefined_var %{pkg:foo:installed} false) x y)
+          "")
          " f"))
        (run
         echo
         (concat
          "g "
-         (if
-          (catch_undefined_var
-           (and %{pkg:foo:installed} %{pkg:bar:installed} %{pkg-self:installed})
-           false)
-          x
-          y)
+         (catch_undefined_var
+          (if
+           (catch_undefined_var
+            (and
+             %{pkg:foo:installed}
+             %{pkg:bar:installed}
+             %{pkg-self:installed})
+            false)
+           x
+           y)
+          "")
          " h"))
-       (run echo --%{pkg-self:enable}-feature)
+       (run
+        echo
+        (concat -- (catch_undefined_var %{pkg-self:enable} "") -feature))
        (run
         echo
         (concat
          --
-         (if (catch_undefined_var %{pkg-self:installed} false) enable disable)
+         (catch_undefined_var
+          (if (catch_undefined_var %{pkg-self:installed} false) enable disable)
+          "")
          -feature))
        (run
         echo
         (concat
          --
-         (if
-          (catch_undefined_var
-           (and %{pkg:foo:installed} %{pkg:bar:installed})
-           false)
-          enable
-          disable)
+         (catch_undefined_var
+          (if
+           (catch_undefined_var
+            (and %{pkg:foo:installed} %{pkg:bar:installed})
+            false)
+           enable
+           disable)
+          "")
          -feature))
        (run
         echo
         (concat
          --
-         (if
-          (catch_undefined_var (and %{pkg:foo:enable} %{pkg:bar:enable}) false)
-          x
-          y)
+         (catch_undefined_var
+          (if
+           (catch_undefined_var (and %{pkg:foo:enable} %{pkg:bar:enable}) false)
+           x
+           y)
+          "")
          -feature)))))))

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -65,31 +65,107 @@ Create a package that writes a different value to some files depending on the os
     ((((arch x86_64) (os linux)))
      ((action
        (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
+        (run
+         mkdir
+         -p
+         %{share}
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")))
+        (run
+         touch
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")
+          /META))
+        (run
+         sh
+         -c
+         (concat "echo Linux > " (catch_undefined_var %{share} "") /kernel))
+        (run
+         sh
+         -c
+         (concat "echo x86_64 > " (catch_undefined_var %{share} "") /machine))))))
     ((((arch arm64) (os linux)))
      ((action
        (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))
+        (run
+         mkdir
+         -p
+         %{share}
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")))
+        (run
+         touch
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")
+          /META))
+        (run
+         sh
+         -c
+         (concat "echo Linux > " (catch_undefined_var %{share} "") /kernel))
+        (run
+         sh
+         -c
+         (concat "echo arm64 > " (catch_undefined_var %{share} "") /machine))))))
     ((((arch x86_64) (os macos)))
      ((action
        (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
+        (run
+         mkdir
+         -p
+         %{share}
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")))
+        (run
+         touch
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")
+          /META))
+        (run
+         sh
+         -c
+         (concat "echo Darwin > " (catch_undefined_var %{share} "") /kernel))
+        (run
+         sh
+         -c
+         (concat "echo x86_64 > " (catch_undefined_var %{share} "") /machine))))))
     ((((arch arm64) (os macos)))
      ((action
        (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))))
+        (run
+         mkdir
+         -p
+         %{share}
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")))
+        (run
+         touch
+         (concat
+          (catch_undefined_var %{lib} "")
+          /
+          (catch_undefined_var %{pkg-self:name} "")
+          /META))
+        (run
+         sh
+         -c
+         (concat "echo Darwin > " (catch_undefined_var %{share} "") /kernel))
+        (run
+         sh
+         -c
+         (concat "echo arm64 > " (catch_undefined_var %{share} "") /machine))))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -61,9 +61,30 @@ Confirming that the build action creates the conditional file:
    (all_platforms
     ((action
       (progn
-       (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-       (run touch %{lib}/%{pkg-self:name}/META)
-       (run sh -c "echo %{sys_ocaml_version} > %{share}/sys-ocaml-version"))))))
+       (run
+        mkdir
+        -p
+        %{share}
+        (concat
+         (catch_undefined_var %{lib} "")
+         /
+         (catch_undefined_var %{pkg-self:name} "")))
+       (run
+        touch
+        (concat
+         (catch_undefined_var %{lib} "")
+         /
+         (catch_undefined_var %{pkg-self:name} "")
+         /META))
+       (run
+        sh
+        -c
+        (concat
+         "echo "
+         (catch_undefined_var %{sys_ocaml_version} "")
+         " > "
+         (catch_undefined_var %{share} "")
+         /sys-ocaml-version)))))))
 
 Build and print the file that was conditionally added. Note that the value of
 "sys-ocaml-version" at solve-time may be different from "sys-ocaml-version" at

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -73,13 +73,13 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/
-  foo.0.0.1-8a5ad1a19f5f8d72369fe49a7f3ca0f3
-  linux-only.0.0.1-a1576fc5a8c775d87e8186b53db62eef
+  foo.0.0.1-dd2053df7e4195c21d4ca02e3382a72c
+  linux-only.0.0.1-1f9f3882dc7fc80b255d673f9388a700
 
   $ dune clean
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/
-  foo.0.0.1-be71f4a233c5170a74ac038f693ea063
-  macos-only.0.0.1-158076f066cd0c29ae731e289007e0a5
+  foo.0.0.1-9239511d918ee88a97a5111113de4120
+  macos-only.0.0.1-916cbf8066ac1320a64e5235170b490e

--- a/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/run-converted-opam-commands.t
@@ -127,9 +127,10 @@ Generate a mock opam repository
   $ build_single_package error4
   Solution for dune.lock:
   - error4.0.0.1
-  File "dune.lock/error4.0.0.1.pkg", line 5, characters 7-37:
-  5 |   (run not-a-program-%{pkg-self:name} echo hello)))
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "dune.lock/error4.0.0.1.pkg", lines 6-8, characters 3-76:
+  6 |    (concat
+  7 |     not-a-program-
+  8 |     (catch_undefined_var %{pkg-self:name} ""))
   Error: Program not-a-program-error4 not found in the tree or in PATH
    (context: default)
   [1]


### PR DESCRIPTION
This is an attempt at giving opam-like semantics to undefined variables like those found here: https://github.com/ocaml/opam-repository/blob/c6bb7c00ad7f23f02d71f9c47548f1e9b1169b4c/packages/ocaml/ocaml.5.5.0/opam#L38