### PR TITLE
feat(pkg): relocatable compiler support

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -534,7 +534,7 @@ module Pkg = struct
 
   let install_roots t =
     let default_install_roots = Paths.install_roots t.paths in
-    match Pkg_toolchain.is_compiler_and_toolchains_enabled t.info.name with
+    match Pkg_toolchain.is_compiler_package_with_toolchains_enabled t.info.name with
     | false -> default_install_roots
     | true ->
       (* Compiler packages store their libraries in a subdirectory named "ocaml". *)
@@ -1370,12 +1370,29 @@ module DB = struct
     { id : Id.t
     ; pkg_digest_table : Pkg_table.t
     ; system_provided : Package.Name.Set.t
+    ; is_relocatable_compiler_context : bool
     }
 
   let equal x y = Id.equal x.id y.id
 
-  let create ~pkg_digest_table ~system_provided =
-    { id = Id.gen (); pkg_digest_table; system_provided }
+  let create =
+    (* A compiler is relocatable if the solution contains the
+       "relocatable-compiler" meta-package (from dra27's overlay repo) or
+       the "relocatable" virtual package (from upstream opam-repository). *)
+    let is_relocatable_meta_package name =
+      Package.Name.equal name (Package.Name.of_string "relocatable-compiler")
+      || Package.Name.equal name (Package.Name.of_string "relocatable")
+    in
+    fun ~pkg_digest_table ~system_provided ->
+      { id = Id.gen ()
+      ; pkg_digest_table
+      ; system_provided
+      ; is_relocatable_compiler_context =
+          Pkg_digest.Map.existsi
+            pkg_digest_table
+            ~f:(fun _ { Pkg_table.pkg = { info = { name; _ }; _ }; _ } ->
+              is_relocatable_meta_package name)
+      }
   ;;
 
   let pkg_digest_of_name lock_dir platform pkg_name ~system_provided =
@@ -1560,9 +1577,11 @@ end = struct
       let build_command = Option.map build_command ~f:relocate_build in
       let paths =
         let paths = Paths.map_path write_paths ~f:Path.build in
-        match Pkg_toolchain.is_compiler_and_toolchains_enabled info.name with
-        | false -> paths
-        | true ->
+        if
+          db.is_relocatable_compiler_context
+          || not (Pkg_toolchain.is_compiler_package_with_toolchains_enabled info.name)
+        then paths
+        else (
           (* Modify the environment as well as build and install commands for
              the compiler package. The specific changes are:
              - setting the prefix in the build environment to inside the user's
@@ -1573,7 +1592,8 @@ end = struct
                toolchain directory
              - if a matching version of the compiler is
                already installed in the user's toolchain directory then the
-               build and install commands are replaced with no-ops *)
+               build and install commands are replaced with no-ops
+             *)
           let prefix = Pkg_toolchain.installation_prefix pkg in
           let install_roots =
             Pkg_toolchain.install_roots ~prefix
@@ -1582,7 +1602,7 @@ end = struct
           { paths with
             prefix = Path.outside_build_dir prefix
           ; install_roots = Lazy.from_val install_roots
-          }
+          })
       in
       let t =
         { Pkg.id

--- a/src/dune_rules/pkg_toolchain.ml
+++ b/src/dune_rules/pkg_toolchain.ml
@@ -47,7 +47,7 @@ let installation_prefix pkg =
   Path.Outside_build_dir.relative pkg_dir "target"
 ;;
 
-let is_compiler_and_toolchains_enabled name =
+let is_compiler_package_with_toolchains_enabled name =
   match Config.get Compile_time.toolchains with
   | `Enabled -> Dune_pkg.Dev_tool.is_compiler_package name
   | `Disabled -> false

--- a/src/dune_rules/pkg_toolchain.mli
+++ b/src/dune_rules/pkg_toolchain.mli
@@ -18,7 +18,7 @@ val base_dir : unit -> Path.Outside_build_dir.t
     manage their compiler installation with opam or a system package
     manager, as compilers packages that would be installed by dune will
     not work correctly. *)
-val is_compiler_and_toolchains_enabled : Package.Name.t -> bool
+val is_compiler_package_with_toolchains_enabled : Package.Name.t -> bool
 
 (** Returns the path to the directory containing the given package within the
     toolchain directory. This will be something like

--- a/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
+++ b/test/blackbox-tests/test-cases/pkg/relocatable-compiler.t
@@ -1,0 +1,184 @@
+Test that relocatable compilers bypass toolchain cache. A compiler is
+considered relocatable if the solution contains either:
+- The "relocatable-compiler" meta-package (from dra27's overlay repo)
+- The "relocatable" virtual package (from upstream opam-repository)
+
+  $ mkrepo
+  $ mkdir -p relocatable-repo/packages
+
+Create the relocatable compiler packages in separate repo:
+
+  $ mkdir -p relocatable-repo/packages/compiler-cloning/compiler-cloning.0.0.1
+  $ cat > relocatable-repo/packages/compiler-cloning/compiler-cloning.0.0.1/opam << 'EOF'
+  > opam-version: "2.0"
+  > EOF
+
+  $ mkdir -p relocatable-repo/packages/relocatable-compiler/relocatable-compiler.5.4.0
+  $ cat > relocatable-repo/packages/relocatable-compiler/relocatable-compiler.5.4.0/opam << 'EOF'
+  > opam-version: "2.0"
+  > depends: [ "compiler-cloning" ]
+  > build: [ "sh" "-c" "echo %{_:build-id}% > build-id.txt" ]
+  > install: [ "cp" "build-id.txt" "%{lib}%/relocatable-compiler/" ]
+  > EOF
+
+  $ mkdir -p relocatable-repo/packages/ocaml-base-compiler/ocaml-base-compiler.5.4.0
+  $ cat > relocatable-repo/packages/ocaml-base-compiler/ocaml-base-compiler.5.4.0/opam << 'EOF'
+  > opam-version: "2.0"
+  > depends: [ "relocatable-compiler" {= "5.4.0"} ]
+  > build: [
+  >   [ "sh" "-c" "echo 'ocamlc binary' > ocamlc.opt" ]
+  >   [ "ln" "-s" "ocamlc.opt" "ocamlc" ]
+  > ]
+  > install: [
+  >   [ "mkdir" "-p" "%{bin}%" ]
+  >   [ "cp" "ocamlc.opt" "%{bin}%/" ]
+  >   [ "cp" "-P" "ocamlc" "%{bin}%/" ]
+  > ]
+  > EOF
+
+  $ mkdir -p relocatable-repo/packages/ocaml/ocaml.5.4.0
+  $ cat > relocatable-repo/packages/ocaml/ocaml.5.4.0/opam << 'EOF'
+  > opam-version: "2.0"
+  > depends: [ "ocaml-base-compiler" {= "5.4.0"} ]
+  > EOF
+
+Also create a standard ocaml-base-compiler 5.4 in mock repo. This tests that
+the relocatable repo takes priority:
+
+  $ mkpkg ocaml-base-compiler 5.4.0 
+
+  $ mkpkg ocaml 5.4.0 << 'EOF'
+  > depends: [ "ocaml-base-compiler" {= "5.4.0"} ]
+  > EOF
+
+  $ cat > dune-project << 'EOF'
+  > (lang dune 3.22)
+  > (package
+  >  (name test)
+  >  (allow_empty)
+  >  (depends ocaml))
+  > EOF
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.20)
+  > (lock_dir
+  >  (repositories relocatable-repo mock)) ; Order here is important here
+  > (repository
+  >  (name relocatable-repo)
+  >  (url "file://$PWD/relocatable-repo"))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+We enable caching to verify that packages are built normally and get hardlinked
+into the cache. A hardlink count > 1 proves the file was cached.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$PWD/dune-cache
+
+Solving for OCaml 5.4 should pick up the relocatable compiler.
+
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - compiler-cloning.0.0.1
+  - ocaml.5.4.0
+  - ocaml-base-compiler.5.4.0
+  - relocatable-compiler.5.4.0
+
+  $ build_pkg ocaml-base-compiler
+
+Toolchain cache should be empty:
+
+  $ test -d dune-cache/toolchains
+  [1]
+
+Check the installed files from the compiler are hardlinked (cached as regular
+package):
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir ocaml-base-compiler)/target/bin/ocamlc.opt
+  3
+
+Test the upstream opam-repository approach: the "relocatable" virtual package.
+Non-relocatable compilers conflict with it, so if it's in the solution the
+compiler must be relocatable. See https://github.com/ocaml/opam-repository/pull/29451
+
+We clean up the previous build state first:
+
+  $ rm -rf _build dune.lock dune-cache mock-opam-repository
+  $ mkrepo
+
+  $ mkpkg relocatable packages << 'EOF'
+  > EOF
+
+The non-relocatable compiler in the mock repo conflicts with relocatable:
+
+  $ mkpkg ocaml-base-compiler 5.3.0 << 'EOF'
+  > conflicts: [ "relocatable" ]
+  > build: [
+  >   [ "sh" "-c" "echo 'ocamlc binary' > ocamlc.opt" ]
+  >   [ "ln" "-s" "ocamlc.opt" "ocamlc" ]
+  > ]
+  > install: [
+  >   [ "mkdir" "-p" "%{bin}%" ]
+  >   [ "cp" "ocamlc.opt" "%{bin}%/" ]
+  >   [ "cp" "-P" "ocamlc" "%{bin}%/" ]
+  > ]
+  > EOF
+
+A relocatable compiler does not conflict with relocatable:
+
+  $ mkpkg ocaml-base-compiler 5.3.0+relocatable << 'EOF'
+  > build: [
+  >   [ "sh" "-c" "echo 'relocatable ocamlc' > ocamlc.opt" ]
+  >   [ "ln" "-s" "ocamlc.opt" "ocamlc" ]
+  > ]
+  > install: [
+  >   [ "mkdir" "-p" "%{bin}%" ]
+  >   [ "cp" "ocamlc.opt" "%{bin}%/" ]
+  >   [ "cp" "-P" "ocamlc" "%{bin}%/" ]
+  > ]
+  > EOF
+
+  $ mkpkg ocaml 5.3.0 << 'EOF'
+  > depends: [ "ocaml-base-compiler" {>= "5.3.0"} ]
+  > EOF
+
+  $ cat > dune-project << 'EOF'
+  > (lang dune 3.22)
+  > (package
+  >  (name test)
+  >  (allow_empty)
+  >  (depends ocaml relocatable))
+  > EOF
+
+  $ cat > dune-workspace << EOF
+  > (lang dune 3.20)
+  > (lock_dir
+  >  (repositories mock))
+  > (repository
+  >  (name mock)
+  >  (url "file://$PWD/mock-opam-repository"))
+  > EOF
+
+Requiring relocatable should exclude the non-relocatable compiler:
+
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - ocaml.5.3.0
+  - ocaml-base-compiler.5.3.0+relocatable
+  - relocatable.packages
+
+  $ build_pkg ocaml-base-compiler
+
+Toolchain cache should be empty:
+
+  $ test -d dune-cache/toolchains
+  [1]
+
+Check the installed files from the compiler are hardlinked (cached as regular
+package):
+
+  $ dune_cmd stat hardlinks $(get_build_pkg_dir ocaml-base-compiler)/target/bin/ocamlc.opt
+  3
+


### PR DESCRIPTION
This PR adds a way for us to detect if a compiler in our "package universe" is relocatable. Knowing this means we can avoid the use of our toolchains functionality and instead build the compiler like a regular package.

The current chosen heuristic for knowing so is by inspecting if we have the `reloctable-compiler` meta-package available (for interoperability with David's relocatable opam repository) or by checking for the `relocatable` meta-package in opam-repository.

We add a test checking the checking behaviour and making sure that compiler-like packages are able to be cached in these cases.

To try it out for yourself, put the following in `dune-workspace`:
```
(repository
 (name dra27-relocatable)
 (url "git+https://github.com/dra27/opam-repository.git#relocatable"))

(lock_dir
 (repositories dra27-relocatable :standard))
```

Or use `(ocaml (= 5.5.0)) relocatable` in your `package` `(depends)`.

Part of the work on:
- #13229 