### PR TITLE
fix(test): make test utilities conditional on library availability

### DIFF
--- a/test/blackbox-tests/utils/dune
+++ b/test/blackbox-tests/utils/dune
@@ -1,11 +1,15 @@
 (executable
  (name dune_cmd)
  (modules dune_cmd)
+ (enabled_if
+  (<> %{profile} dune-bootstrap))
  (libraries stdune re dune-configurator build_path_prefix_map str unix))
 
 (executable
  (name action_trace)
  (modules action_trace)
+ (enabled_if
+  (<> %{profile} dune-bootstrap))
  (libraries stdune unix csexp dune_action_trace))
 
 (ocamllex dunepp)


### PR DESCRIPTION
Add enabled_if conditions to dune_cmd and action_trace executables so they are only built when their required external libraries (dune-configurator and csexp) are available. This prevents build failures during `make release` when test dependencies aren't installed.