### PR TITLE
feature: switch timestamps to nanoseconds

### DIFF
--- a/otherlibs/dune-action-trace/dune_action_trace.ml
+++ b/otherlibs/dune-action-trace/dune_action_trace.ml
@@ -9,23 +9,26 @@ module Event = struct
 
   module Arg = struct
     let string s = Csexp.Atom s
-    let float x = string (string_of_float x)
+    let int x = string (string_of_int x)
     let list xs = Csexp.List xs
     let record xs = List.map xs ~f:(fun (k, v) -> list [ string k; v ])
-    let time ts = float ts
-    let span span = float span
+    let time_ns ts = int ts
+    let span_ns span = int span
   end
 
   let base ~name cat : Csexp.t list = [ Atom cat; Atom name ]
 
-  let instant ?(args = []) ~category ~name ~time_in_seconds () =
-    Csexp.List (base ~name category @ [ Arg.time time_in_seconds ] @ Arg.record args)
+  let instant ?(args = []) ~category ~name ~time_in_nanoseconds () =
+    Csexp.List
+      (base ~name category @ [ Arg.time_ns time_in_nanoseconds ] @ Arg.record args)
   ;;
 
-  let span ?(args = []) ~category ~name ~start_in_seconds ~duration_in_seconds () =
+  let span ?(args = []) ~category ~name ~start_in_nanoseconds ~duration_in_nanoseconds () =
     Csexp.List
       (base ~name category
-       @ [ Csexp.List [ Arg.time start_in_seconds; Arg.span duration_in_seconds ] ]
+       @ [ Csexp.List
+             [ Arg.time_ns start_in_nanoseconds; Arg.span_ns duration_in_nanoseconds ]
+         ]
        @ Arg.record args)
   ;;
 end

--- a/otherlibs/dune-action-trace/dune_action_trace.mli
+++ b/otherlibs/dune-action-trace/dune_action_trace.mli
@@ -9,7 +9,7 @@ module Event : sig
     :  ?args:args
     -> category:string
     -> name:string
-    -> time_in_seconds:float
+    -> time_in_nanoseconds:int
     -> unit
     -> t
 
@@ -17,8 +17,8 @@ module Event : sig
     :  ?args:args
     -> category:string
     -> name:string
-    -> start_in_seconds:float
-    -> duration_in_seconds:float
+    -> start_in_nanoseconds:int
+    -> duration_in_nanoseconds:int
     -> unit
     -> t
 end

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -22,4 +22,5 @@
    wait4_stubs
    platform_stubs
    copyfile_stubs
-   signal_stubs)))
+   signal_stubs
+   time_stubs)))

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -69,7 +69,7 @@ end
 external stub_wait4
   :  int
   -> Unix.wait_flag list
-  -> (int * Unix.process_status * float * Resource_usage.t) option
+  -> (int * Unix.process_status * int * Resource_usage.t) option
   = "dune_wait4"
 
 type wait =
@@ -87,10 +87,9 @@ let wait wait flags =
     in
     stub_wait4 pid flags
     |> Option.map ~f:(fun (pid, status, end_time, resource_usage) ->
-      let end_time = Time.of_epoch_secs end_time in
       { Process_info.pid = Pid.of_int pid
       ; status
-      ; end_time
+      ; end_time = Time.of_ns end_time
       ; resource_usage = Some resource_usage
       }))
 ;;

--- a/otherlibs/stdune/src/time.ml
+++ b/otherlibs/stdune/src/time.ml
@@ -1,20 +1,29 @@
-type t = float
+type t = int
 
-let now () = Unix.gettimeofday ()
-let to_secs t = t
-let of_epoch_secs x = x
-let diff = ( -. )
+external now : unit -> t = "dune_clock_gettime_realtime"
+
+let ns_per_sec = 1_000_000_000
+let ns_per_sec_float = float_of_int ns_per_sec
+let to_secs t = float_of_int t /. ns_per_sec_float
+let to_ns t = t
+let of_epoch_secs x = int_of_float (x *. ns_per_sec_float)
+let of_ns x = x
 
 module Span = struct
-  type t = float
+  type t = int
 
-  let zero = 0.
-  let max = Float.max
-  let compare = Float.compare
-  let of_secs x = x
-  let add = ( +. )
-  let diff = ( -. )
-  let to_secs t = t
+  let zero = 0
+  let max = max
+  let compare a b = Int.compare a b
+  let of_secs x = int_of_float (x *. ns_per_sec_float)
+  let to_secs t = float_of_int t /. ns_per_sec_float
+  let of_ns x = x
+  let to_ns x = x
+  let add = ( + )
+  let diff = ( - )
 end
 
-let add t x = t +. x
+let add t span = t + span
+let diff t1 t2 = t1 - t2
+let ( > ) a b = a > b
+let ( >= ) a b = a >= b

--- a/otherlibs/stdune/src/time.mli
+++ b/otherlibs/stdune/src/time.mli
@@ -2,7 +2,9 @@ type t
 
 val now : unit -> t
 val to_secs : t -> float
+val to_ns : t -> int
 val of_epoch_secs : float -> t
+val of_ns : int -> t
 
 module Span : sig
   type t
@@ -11,10 +13,14 @@ module Span : sig
   val max : t -> t -> t
   val compare : t -> t -> Ordering.t
   val of_secs : float -> t
+  val to_secs : t -> float
+  val of_ns : int -> t
+  val to_ns : t -> int
   val add : t -> t -> t
   val diff : t -> t -> t
-  val to_secs : t -> float
 end
 
 val add : t -> Span.t -> t
 val diff : t -> t -> Span.t
+val ( > ) : t -> t -> bool
+val ( >= ) : t -> t -> bool

--- a/otherlibs/stdune/src/time_stubs.c
+++ b/otherlibs/stdune/src/time_stubs.c
@@ -1,0 +1,38 @@
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+// Windows epoch starts 1601-01-01, Unix epoch starts 1970-01-01
+// Difference is 11644473600 seconds
+#define SEC_TO_UNIX_EPOCH 11644473600LL
+
+CAMLprim value dune_clock_gettime_realtime(value v_unit) {
+  (void)v_unit;
+  FILETIME ft;
+  GetSystemTimePreciseAsFileTime(&ft);
+
+  ULARGE_INTEGER li;
+  li.LowPart = ft.dwLowDateTime;
+  li.HighPart = ft.dwHighDateTime;
+
+  // Convert from 100ns intervals since Windows epoch to ns since Unix epoch
+  int64_t ns = (li.QuadPart - SEC_TO_UNIX_EPOCH * 10000000LL) * 100;
+  return Val_long(ns);
+}
+
+#else  // Unix-like systems
+
+#include <time.h>
+
+CAMLprim value dune_clock_gettime_realtime(value v_unit) {
+  (void)v_unit;
+  struct timespec tp;
+  clock_gettime(CLOCK_REALTIME, &tp);
+  int64_t ns = ((int64_t)tp.tv_sec * 1000000000LL) + (int64_t)tp.tv_nsec;
+  return Val_long(ns);
+}
+
+#endif

--- a/src/dune_scheduler/alarm_clock.ml
+++ b/src/dune_scheduler/alarm_clock.ml
@@ -34,7 +34,7 @@ let polling_loop t () =
       let now = Time.now () in
       let expired, active =
         List.partition_map t.alarms ~f:(fun (expiration, ivar) ->
-          if now > expiration
+          if Time.( > ) now expiration
           then Left (Fiber.Fill (ivar, `Finished))
           else Right (expiration, ivar))
       in

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -14,8 +14,8 @@ module Arg = struct
   let int x = Sexp.Atom (string_of_int x)
   let bool x = Sexp.Atom (string_of_bool x)
   let record xs = List.map xs ~f:(fun (k, v) -> list [ string k; v ])
-  let time ts = float (Time.to_secs ts)
-  let span span = float (Time.Span.to_secs span)
+  let time ts = int (Time.to_ns ts)
+  let span span = int (Time.Span.to_ns span)
 end
 
 let gc_args () =

--- a/src/dune_util/global_lock.ml
+++ b/src/dune_util/global_lock.ml
@@ -7,7 +7,7 @@ let with_timeout ~timeout f =
   let now () = Time.now () in
   let deadline = Time.add (now ()) timeout in
   let rec loop () =
-    if now () >= deadline
+    if Time.(now () >= deadline)
     then `Timed_out
     else (
       match f () with


### PR DESCRIPTION
Floats are boxed and imprecise. Use nanoseconds since epoch since they fit in a single word