### PR TITLE
refactor: remove unnecessary layer of indirection for computing digests

### DIFF
--- a/src/dune_cache/local.mli
+++ b/src/dune_cache/local.mli
@@ -50,7 +50,6 @@ end
 val store_artifacts
   :  mode:Dune_cache_storage.Mode.t
   -> rule_digest:Digest.t
-  -> compute_digest:(executable:bool -> Path.t -> Digest.t Fiber.t)
   -> Target.t Targets.Produced.t
   -> Store_artifacts_result.t Fiber.t
 

--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -121,10 +121,7 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~produced_targets
   with
   | Error _ -> Fiber.return None
   | Ok targets ->
-    let compute_digest ~executable path =
-      Fiber.return (Digest.file_with_executable_bit ~executable path)
-    in
-    Local.store_artifacts ~mode ~rule_digest ~compute_digest targets
+    Local.store_artifacts ~mode ~rule_digest targets
     >>= (function
      | Stored targets_and_digests ->
        Log.info "cache store success" [ "hex", Dyn.string hex ];


### PR DESCRIPTION
No longer needed since the cached digest is available outside of the engine