### PR TITLE
feat(scope): add scope stanza for library visibility control

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -85,7 +85,7 @@ module Workspace = struct
   let get () =
     let open Memo.O in
     Memo.run
-      (let+ packages = Dune_rules.Dune_load.packages ()
+      (let+ packages = Dune_rules.Scope.DB.packages ()
        and+ contexts = Context.DB.all () in
        { packages; contexts })
   ;;

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -121,7 +121,7 @@ let unset_solver_vars_of_workspace workspace ~lock_dir_path =
 
 let find_local_packages =
   let open Memo.O in
-  Dune_rules.Dune_load.packages ()
+  Dune_rules.Scope.DB.packages ()
   >>| Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
 ;;
 

--- a/doc/reference/dune/index.rst
+++ b/doc/reference/dune/index.rst
@@ -60,6 +60,7 @@ The following pages describe the available stanzas and their meanings.
       data_only_dirs
       ignored_subdirs
       include_subdirs
+      scope
       vendored_dirs
       subdir
 

--- a/doc/reference/dune/scope.rst
+++ b/doc/reference/dune/scope.rst
@@ -1,0 +1,62 @@
+scope
+-----
+
+.. versionadded:: 3.22
+
+The ``scope`` stanza controls which libraries from a subdirectory are visible
+to the current project. This is useful when vendoring external projects that
+define multiple packages, allowing you to expose only the libraries you need.
+
+.. code:: dune
+
+   (scope
+    (dir <directory>)
+    (packages <packages>))
+
+``(dir <directory>)`` specifies the immediate subdirectory containing the
+libraries. Only direct children of the current directory are allowed; to scope
+a nested directory, place the scope stanza in the appropriate parent directory
+or use a :doc:`subdir` stanza.
+
+``(packages <packages>)`` uses :doc:`../ordered-set-language` to specify which
+packages should be visible. All public libraries (those with a ``public_name``)
+from the specified packages become accessible. Libraries without a
+``public_name`` are never visible through scope stanzas, as they are project-
+internal and not intended for external use.
+
+It is an error to specify a package that does not exist in the scoped directory.
+
+Examples
+========
+
+Expose all libraries from a single package:
+
+.. code:: dune
+
+   (scope
+    (dir fmt.0.9.0)
+    (packages fmt))
+
+Expose libraries from multiple packages in one directory:
+
+.. code:: dune
+
+   (scope
+    (dir cohttp.6.0.0)
+    (packages cohttp cohttp-lwt cohttp-async))
+
+Expose all packages using ``:standard``:
+
+.. code:: dune
+
+   (scope
+    (dir vendor.1.0.0)
+    (packages :standard))
+
+Expose all packages except specific ones:
+
+.. code:: dune
+
+   (scope
+    (dir cohttp.6.0.0)
+    (packages :standard \ cohttp-async))

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -72,3 +72,4 @@ module Copy_files = Copy_files
 module Enabled_if = Enabled_if
 module Alias_conf = Alias_conf
 module Include_subdirs = Include_subdirs
+module Scope_stanza = Scope_stanza

--- a/src/dune_lang/package.ml
+++ b/src/dune_lang/package.ml
@@ -21,6 +21,11 @@ module Duplicate_dep_warning = struct
     }
 end
 
+type status =
+  { enabled : bool
+  ; vendored : bool
+  }
+
 type t =
   { id : Id.t
   ; opam_file : Path.Source.t

--- a/src/dune_lang/package.mli
+++ b/src/dune_lang/package.mli
@@ -13,6 +13,11 @@ type opam_file =
   | Exists of bool
   | Generated
 
+type status =
+  { enabled : bool
+  ; vendored : bool
+  }
+
 type t
 
 val loc : t -> Loc.t

--- a/src/dune_lang/scope_stanza.ml
+++ b/src/dune_lang/scope_stanza.ml
@@ -1,0 +1,47 @@
+open Import
+
+type t =
+  { loc : Loc.t
+  ; directory : Filename.t
+  ; packages : Ordered_set_lang.t
+  }
+
+let decode ~dir =
+  let open Decoder in
+  let+ loc, (directory, packages) =
+    fields
+      (let+ _, directory = field "dir" dir
+       and+ packages = Ordered_set_lang.field "packages" in
+       directory, packages)
+    |> located
+  in
+  { loc; directory; packages }
+;;
+
+let directory t = t.directory
+let loc t = t.loc
+
+let eval_packages t ~standard =
+  let standard_set = Package_name.Set.of_list standard in
+  let allowed =
+    Ordered_set_lang.eval
+      t.packages
+      ~parse:(fun ~loc:_ s -> Package_name.of_string s)
+      ~eq:Package_name.equal
+      ~standard
+    |> Package_name.Set.of_list
+  in
+  let invalid = Package_name.Set.diff allowed standard_set in
+  if not (Package_name.Set.is_empty invalid)
+  then
+    User_error.raise
+      ~loc:t.loc
+      [ Pp.textf
+          "The following packages are not available in directory %S: %s"
+          t.directory
+          (Package_name.Set.to_list invalid
+           |> List.map ~f:Package_name.to_string
+           |> String.concat ~sep:", ")
+      ];
+  allowed
+;;

--- a/src/dune_lang/scope_stanza.mli
+++ b/src/dune_lang/scope_stanza.mli
@@ -1,0 +1,8 @@
+open Import
+
+type t
+
+val decode : dir:(Loc.t * Filename.t) Decoder.t -> t Decoder.t
+val directory : t -> Filename.t
+val loc : t -> Loc.t
+val eval_packages : t -> standard:Package_name.t list -> Package_name.Set.t

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -200,7 +200,7 @@ let collect_stanzas =
 let rules ~sctx ~dir tests project =
   let* stanzas = collect_stanzas ~dir
   and* with_package_mask =
-    let+ mask = Dune_load.mask () >>| Only_packages.enumerate in
+    let+ mask = Scope.DB.mask () >>| Only_packages.enumerate in
     match
       Dune_project.exclusive_package project ~dir:(Path.Build.drop_build_context_exn dir)
       |> Option.map ~f:Package.Id.name

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -10,5 +10,6 @@ val projects_by_root : unit -> Dune_project.t Path.Source.Map.t Memo.t
 val find_project : dir:Path.Build.t -> Dune_project.t Memo.t
 val stanzas_in_dir : Path.Build.t -> Dune_file.t option Memo.t
 val mask : unit -> Only_packages.t Memo.t
-val packages : unit -> Package.t Package.Name.Map.t Memo.t
+val packages : unit -> (Package.t * Package.status) list Package.Name.Map.t Memo.t
 val projects : unit -> Dune_project.t list Memo.t
+val scopes : unit -> Dune_lang.Scope_stanza.t Path.Source.Map.t Memo.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -732,7 +732,7 @@ let raise_on_lock_dir_out_of_sync =
       then
         let* path, lock_dir = Lock_dir.get_with_path ctx >>| User_error.ok_exn in
         let+ local_packages =
-          Dune_load.packages ()
+          Scope.DB.packages ()
           >>| Dune_lang.Package.Name.Map.map ~f:Dune_pkg.Local_package.of_package
         in
         match

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -576,7 +576,7 @@ end = struct
   let stanzas_to_entries sctx =
     let ctx = Context.build_context (Super_context.context sctx) in
     let* stanzas = Dune_load.dune_files ctx.name in
-    let* packages = Dune_load.packages () in
+    let* packages = Scope.DB.packages () in
     let+ init =
       Package_map_traversals.parallel_map packages ~f:(fun _name (pkg : Package.t) ->
         let opam_file = Package_paths.opam_file ctx pkg in
@@ -1131,7 +1131,7 @@ let install_entries sctx package =
 
 let packages =
   let f sctx =
-    let* packages = Dune_load.packages () in
+    let* packages = Scope.DB.packages () in
     let packages = Package.Name.Map.values packages in
     let+ l =
       Memo.parallel_map packages ~f:(fun (pkg : Package.t) ->
@@ -1346,7 +1346,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
     files >>| Path.Set.of_list_map ~f:Path.build >>= Action_builder.path_set
   in
   let* () =
-    let* all_packages = Dune_load.packages () in
+    let* all_packages = Scope.DB.packages () in
     let target_alias =
       Dep_conf_eval.package_install ~context:build_context ~pkg:package
     in
@@ -1463,7 +1463,7 @@ let scheme_per_ctx_memo =
     ~input:(module Super_context.As_memo_key)
     "install-rule-scheme"
     (fun sctx ->
-       Dune_load.packages ()
+       Scope.DB.packages ()
        >>| Package.Name.Map.values
        >>= Memo.parallel_map ~f:(fun pkg -> scheme sctx (Package.name pkg))
        >>| Scheme.all

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -308,7 +308,7 @@ let setup_lock_rules ~dir ~lock_dir : Gen_rules.result =
       (let open Action_builder.O in
        let+ packages =
          let open Memo.O in
-         Dune_load.packages ()
+         Scope.DB.packages ()
          >>| Dune_lang.Package.Name.Map.map ~f:Local_package.of_package
          |> Action_builder.of_memo
        and+ repos =

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -532,7 +532,7 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
     match t.package with
     | None -> Memo.return true
     | Some package ->
-      let+ mask = Dune_load.mask () in
+      let+ mask = Scope.DB.mask () in
       Only_packages.mem_all mask || Only_packages.mem mask (Package.name package)
   in
   Memo.when_ do_it register_rules

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -646,7 +646,7 @@ module Toplevel_index = struct
 end
 
 let setup_toplevel_index_rule sctx output =
-  let* packages = Dune_load.packages () in
+  let* packages = Scope.DB.packages () in
   let index = Toplevel_index.of_packages packages output in
   let content = Toplevel_index.content output index in
   let ctx = Super_context.context sctx in
@@ -1184,7 +1184,7 @@ let has_rules ?(directory_targets = Path.Build.Map.empty) m =
 
 let with_package pkg ~f =
   let pkg = Package.Name.of_string pkg in
-  let* packages = Dune_load.packages () in
+  let* packages = Scope.DB.packages () in
   match Package.Name.Map.find packages pkg with
   | Some pkg -> has_rules (f pkg)
   | None -> Memo.return Gen_rules.no_rules
@@ -1208,7 +1208,7 @@ let gen_rules sctx ~dir rest =
        >>> setup_toplevel_index_rule sctx Html
        >>> setup_toplevel_index_rule sctx Json)
   | [ "_markdown" ] ->
-    let* packages = Dune_load.packages () in
+    let* packages = Scope.DB.packages () in
     let ctx = Super_context.context sctx in
     let all_package_dirs =
       Package.Name.Map.to_list packages
@@ -1269,7 +1269,7 @@ let gen_rules sctx ~dir rest =
               setup_lib_odocl_rules sctx lib ~requires
             | Some pkg -> setup_pkg_odocl_rules sctx ~pkg ~for_)
        and+ () =
-         let* packages = Dune_load.packages () in
+         let* packages = Scope.DB.packages () in
          match
            Package.Name.Map.find packages (Package.Name.of_string lib_unique_name_or_pkg)
          with
@@ -1310,7 +1310,7 @@ let gen_rules sctx ~dir rest =
               setup_lib_html_rules sctx ~search_db lib
             | Some pkg -> setup_pkg_html_rules sctx ~pkg ~for_)
        and+ () =
-         let* packages = Dune_load.packages () in
+         let* packages = Scope.DB.packages () in
          match
            Package.Name.Map.find packages (Package.Name.of_string lib_unique_name_or_pkg)
          with

--- a/src/dune_rules/odoc_new.ml
+++ b/src/dune_rules/odoc_new.ml
@@ -394,7 +394,7 @@ module Valid = struct
   let valid_libs_and_packages =
     let run (ctx, all, projects) =
       let* libs_and_pkgs =
-        let* mask = Dune_load.mask () in
+        let* mask = Scope.DB.mask () in
         Scope.DB.with_all ctx ~f:(fun find ->
           Memo.List.fold_left projects ~init:([], []) ~f:(fun (libs_acc, pkg_acc) proj ->
             let* vendored = Source_tree.is_vendored (Dune_project.root proj) in
@@ -1257,7 +1257,7 @@ let ext_package_mlds (ctx : Context.t) (pkg : Package.Name.t) =
 ;;
 
 let pkg_mlds sctx pkg =
-  let* pkgs = Dune_load.packages () in
+  let* pkgs = Scope.DB.packages () in
   if Package.Name.Map.mem pkgs pkg
   then
     let+ res, warnings = Odoc.mlds sctx pkg in

--- a/src/dune_rules/package_db.ml
+++ b/src/dune_rules/package_db.ml
@@ -9,7 +9,7 @@ type any_package =
   | Build of unit Action_builder.t
 
 let find_package ctx pkg =
-  let* packages = Dune_load.packages () in
+  let* packages = Scope.DB.packages () in
   match Package.Name.Map.find packages pkg with
   | Some p -> Memo.return (Some (Local p))
   | None ->

--- a/src/dune_rules/package_scope.ml
+++ b/src/dune_rules/package_scope.ml
@@ -1,0 +1,87 @@
+open Import
+open Memo.O
+
+type t = Package.Name.Set.t Path.Source.Map.t
+
+let packages_under_dir by_dir ~dir =
+  Path.Source.Map.foldi by_dir ~init:Package.Name.Set.empty ~f:(fun pkg_dir names acc ->
+    if Path.Source.is_descendant pkg_dir ~of_:dir
+    then Package.Name.Set.union acc names
+    else acc)
+  |> Package.Name.Set.to_list
+;;
+
+let scope_db =
+  Memo.lazy_ ~name:"package-scope-db" (fun () ->
+    let* all_packages = Dune_load.packages ()
+    and* scope_stanzas = Dune_load.scopes () in
+    let packages_by_dir =
+      Package.Name.Map.fold all_packages ~init:Path.Source.Map.empty ~f:(fun pkgs acc ->
+        List.fold_left pkgs ~init:acc ~f:(fun acc (pkg, _status) ->
+          let dir = Package.dir pkg in
+          Path.Source.Map.update acc dir ~f:(function
+            | None -> Some (Package.Name.Set.singleton (Package.name pkg))
+            | Some set -> Some (Package.Name.Set.add set (Package.name pkg)))))
+    in
+    Memo.return
+      (Path.Source.Map.mapi scope_stanzas ~f:(fun scoped_dir stanza ->
+         let standard = packages_under_dir packages_by_dir ~dir:scoped_dir in
+         Dune_lang.Scope_stanza.eval_packages stanza ~standard)))
+;;
+
+let find_scope_for_dir scopes src_dir =
+  let rec find_in_ancestors dir =
+    match Path.Source.Map.find scopes dir with
+    | Some allowed -> Some (dir, allowed)
+    | None ->
+      (match Path.Source.parent dir with
+       | None -> None
+       | Some parent -> find_in_ancestors parent)
+  in
+  find_in_ancestors src_dir
+;;
+
+let packages_and_mask =
+  Memo.lazy_ ~name:"package-scope-packages" (fun () ->
+    let+ scopes = Memo.Lazy.force scope_db
+    and+ all_packages = Dune_load.packages () in
+    let packages =
+      Package.Name.Map.fold all_packages ~init:Package.Name.Map.empty ~f:(fun pkgs acc ->
+        let visible_pkgs =
+          List.filter pkgs ~f:(fun (pkg, _status) ->
+            let pkg_dir = Package.dir pkg in
+            match find_scope_for_dir scopes pkg_dir with
+            | None -> true
+            | Some (_, allowed) -> Package.Name.Set.mem allowed (Package.name pkg))
+        in
+        match visible_pkgs with
+        | [] -> acc
+        | [ (pkg, status) ] ->
+          Package.Name.Map.add_exn acc (Package.name pkg) (pkg, status)
+        | (pkg1, _) :: (pkg2, _) :: _ ->
+          User_error.raise
+            [ Pp.textf
+                "The package %S is defined more than once:"
+                (Package.Name.to_string (Package.name pkg1))
+            ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc pkg1))
+            ; Pp.textf "- %s" (Loc.to_file_colon_line (Package.loc pkg2))
+            ])
+    in
+    let mask = Only_packages.mask (Package.Name.Map.map packages ~f:(fun x -> [ x ])) in
+    let packages =
+      Only_packages.filter_packages mask (Package.Name.Map.map packages ~f:fst)
+    in
+    packages, mask)
+;;
+
+let packages () =
+  let+ packages, _ = Memo.Lazy.force packages_and_mask in
+  packages
+;;
+
+let mask () =
+  let+ _, mask = Memo.Lazy.force packages_and_mask in
+  mask
+;;
+
+let db () = Memo.Lazy.force scope_db

--- a/src/dune_rules/package_scope.mli
+++ b/src/dune_rules/package_scope.mli
@@ -1,0 +1,8 @@
+open Import
+
+type t = Package.Name.Set.t Path.Source.Map.t
+
+val db : unit -> t Memo.t
+val find_scope_for_dir : t -> Path.Source.t -> (Path.Source.t * Package.Name.Set.t) option
+val packages : unit -> Package.t Package.Name.Map.t Memo.t
+val mask : unit -> Only_packages.t Memo.t

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -380,7 +380,30 @@ module DB = struct
     value, public_libs
   ;;
 
-  let create_from_stanzas ~projects_by_root ~(context : Context_name.t) stanzas =
+  let filter_by_scope scopes stanzas =
+    if Path.Source.Map.is_empty scopes
+    then stanzas
+    else
+      List.filter_map stanzas ~f:(fun (ctx_dir, stanza) ->
+        match stanza with
+        | Library_related_stanza.Library lib ->
+          let visible =
+            match Option.map (Library.package lib) ~f:Package.name with
+            | None -> false
+            | Some pkg_name ->
+              let src_dir = Path.Build.drop_build_context_exn ctx_dir in
+              (match Package_scope.find_scope_for_dir scopes src_dir with
+               | None -> true
+               | Some (_, allowed) -> Package.Name.Set.mem allowed pkg_name)
+          in
+          Option.some_if visible (ctx_dir, stanza)
+        | _ -> Some (ctx_dir, stanza))
+  ;;
+
+  let packages = Package_scope.packages
+  let mask = Package_scope.mask
+
+  let create_from_stanzas ~projects_by_root ~(context : Context_name.t) ~scopes stanzas =
     let stanzas, coq_stanzas, rocq_stanzas =
       let build_dir = Context_name.build_dir context in
       Dune_file.fold_static_stanzas
@@ -405,6 +428,7 @@ module DB = struct
             acc, coq_acc, (ctx_dir, rocq_lib) :: rocq_acc
           | _ -> acc, coq_acc, rocq_acc)
     in
+    let stanzas = filter_by_scope scopes stanzas in
     create ~projects_by_root ~context stanzas coq_stanzas rocq_stanzas
   ;;
 
@@ -412,8 +436,9 @@ module DB = struct
     Per_context.create_by_name ~name:"scope" (fun context ->
       Memo.Lazy.create (fun () ->
         let* projects_by_root = Dune_load.projects_by_root ()
+        and* scopes = Package_scope.db ()
         and* stanzas = Dune_load.dune_files context in
-        create_from_stanzas ~projects_by_root ~context stanzas)
+        create_from_stanzas ~projects_by_root ~context ~scopes stanzas)
       |> Memo.Lazy.force)
     |> Staged.unstage
   ;;

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -17,8 +17,9 @@ val coq_libs : t -> Coq_lib.DB.t Memo.t
 
 val rocq_libs : t -> Rocq_lib.DB.t Memo.t
 
-(** Scope databases *)
 module DB : sig
+  val packages : unit -> Package.t Package.Name.Map.t Memo.t
+  val mask : unit -> Only_packages.t Memo.t
   val find_by_dir : Path.Build.t -> t Memo.t
   val find_by_project : Context_name.t -> Dune_project.t -> t Memo.t
   val public_libs : Context_name.t -> Lib.DB.t Memo.t

--- a/src/dune_rules/sites/generate_sites_module_rules.ml
+++ b/src/dune_rules/sites/generate_sites_module_rules.ml
@@ -134,7 +134,7 @@ let plugins_code packages buf pkg sites =
 
 let setup_rules sctx ~dir (def : Generate_sites_module_stanza.t) =
   let impl =
-    let+ packages = Dune_load.packages () in
+    let+ packages = Scope.DB.packages () in
     let buf = Buffer.create 1024 in
     if def.sourceroot then sourceroot_code buf;
     if def.relocatable then relocatable_code buf;

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -314,7 +314,7 @@ let create ~(context : Context.t) ~(host : t option) ~packages ~stanzas =
 
 let all =
   Memo.lazy_ ~name:"Super_context.all" (fun () ->
-    let* packages = Dune_load.packages ()
+    let* packages = Scope.DB.packages ()
     and* contexts = Context.DB.all () in
     let rec sctxs =
       lazy

--- a/src/source/dune_file.ml
+++ b/src/source/dune_file.ml
@@ -75,9 +75,10 @@ module Dir_map = struct
       { sexps : Dune_lang.Ast.t list
       ; subdir_status : Source_dir_status.Spec.input
       ; files : Files.t
+      ; scope : (Loc.t * Dune_lang.Scope_stanza.t) Filename.Map.t
       }
 
-    let to_dyn { sexps; subdir_status = _; files = _ } =
+    let to_dyn { sexps; subdir_status = _; files = _; scope = _ } =
       let open Dyn in
       record
         [ "sexps", list Dune_lang.to_dyn (List.map ~f:Dune_lang.Ast.remove_locs sexps) ]
@@ -87,6 +88,7 @@ module Dir_map = struct
       { sexps = []
       ; subdir_status = Source_dir_status.Map.init ~f:(fun _ -> None)
       ; files = None
+      ; scope = Filename.Map.empty
       }
     ;;
 
@@ -95,6 +97,9 @@ module Dir_map = struct
       ; subdir_status =
           Source_dir_status.Map.merge d1.subdir_status d2.subdir_status ~f:no_dupes
       ; files = no_dupes d1.files d2.files
+      ; scope =
+          Filename.Map.union d1.scope d2.scope ~f:(fun _dir v1 v2 ->
+            no_dupes (Some v1) (Some v2))
       }
     ;;
   end
@@ -142,6 +147,7 @@ module Ast = struct
     | Vendored_dirs of Loc.t * Predicate_lang.Glob.Element.t Predicate_lang.t
     | Dirs of Loc.t * Predicate_lang.Glob.t
     | Files of Loc.t * Predicate_lang.Glob.t
+    | Scope of Dune_lang.Scope_stanza.t
     | Subdir of Path.Local.t * t list
     | Include of
         { loc : Loc.t
@@ -226,6 +232,14 @@ module Ast = struct
     Vendored_dirs (loc, vendored)
   ;;
 
+  let scope =
+    let+ s =
+      Dune_lang.Syntax.since Stanza.syntax (3, 22)
+      >>> Dune_lang.Scope_stanza.decode ~dir:(strict_subdir "scope")
+    in
+    Scope s
+  ;;
+
   let dirs =
     let+ loc, dirs =
       Dune_lang.Syntax.since Stanza.syntax (1, 6)
@@ -294,6 +308,7 @@ module Ast = struct
       multi_field "ignored_subdirs" (ignored_sub_dirs ~inside_subdir)
     and+ vendored_dirs = field_o "vendored_dirs" vendored_dirs
     and+ data_only_dirs = field_o "data_only_dirs" data_only_dirs
+    and+ scope_stanzas = multi_field "scope" scope
     and+ include_stanza = multi_field "include" decode_include
     and+ rest = leftover_fields in
     let ast =
@@ -303,6 +318,7 @@ module Ast = struct
         ; Option.to_list vendored_dirs
         ; subdirs
         ; ignored_sub_dirs
+        ; scope_stanzas
         ; include_stanza
         ; Option.to_list data_only_dirs
         ]
@@ -315,7 +331,14 @@ module Ast = struct
   let statically_evaluated_stanzas =
     (* This list must be kept in sync with [decode]
        [include] is excluded b/c it's also a normal stanza *)
-    [ "data_only_dirs"; "vendored_dirs"; "ignored_sub_dirs"; "subdir"; "dirs"; "files" ]
+    [ "data_only_dirs"
+    ; "vendored_dirs"
+    ; "scope"
+    ; "ignored_sub_dirs"
+    ; "subdir"
+    ; "dirs"
+    ; "files"
+    ]
   ;;
 
   let decode ~inside_subdir ~inside_include =
@@ -375,6 +398,7 @@ module Group = struct
     ; vendored_dirs : (Loc.t * Predicate_lang.Glob.Element.t Predicate_lang.t) option
     ; dirs : (Loc.t * Predicate_lang.Glob.t) option
     ; files : (Loc.t * Predicate_lang.Glob.t) option
+    ; scope : (Loc.t * Dune_lang.Scope_stanza.t) Filename.Map.t
     ; leftovers : Dune_lang.Ast.t list
     ; subdirs : (Path.Local.t * Ast.t list) list
     }
@@ -385,6 +409,7 @@ module Group = struct
     ; vendored_dirs = None
     ; dirs = None
     ; files = None
+    ; scope = Filename.Map.empty
     ; subdirs = []
     ; leftovers = []
     }
@@ -432,6 +457,11 @@ module Group = struct
       in
       { t with dirs = Some dirs }
     | Files (loc, glob) -> { t with files = Some (no_dupes "files" loc t.files glob) }
+    | Scope s ->
+      let dir = Dune_lang.Scope_stanza.directory s in
+      let loc = Dune_lang.Scope_stanza.loc s in
+      let v = no_dupes "scope" loc (Filename.Map.find t.scope dir) s in
+      { t with scope = Filename.Map.set t.scope dir v }
     | Subdir (path, stanzas) -> { t with subdirs = (path, stanzas) :: t.subdirs }
     | Leftovers stanzas -> { t with leftovers = List.rev_append stanzas t.leftovers }
     | Include _ -> assert false
@@ -460,7 +490,9 @@ let rec to_dir_map ast ~dune_version =
   let node =
     let subdir_status = Group.subdir_status group in
     let files = group.files in
-    Dir_map.singleton { Dir_map.Per_dir.sexps = group.leftovers; subdir_status; files }
+    let scope = group.scope in
+    Dir_map.singleton
+      { Dir_map.Per_dir.sexps = group.leftovers; subdir_status; files; scope }
   in
   let subdirs =
     List.map group.subdirs ~f:(fun (path, stanzas) ->
@@ -518,6 +550,7 @@ let dirs_stanza_loc t =
 ;;
 
 let files t = (Dir_map.root t.plain).files
+let scope t = (Dir_map.root t.plain).scope
 
 let load_plain sexps ~file ~from_parent ~project =
   let+ parsed =

--- a/src/source/dune_file.mli
+++ b/src/source/dune_file.mli
@@ -37,6 +37,9 @@ end
 
 val files : t -> Files.t
 
+(** Scope stanzas, keyed by the subdirectory they apply to *)
+val scope : t -> (Loc.t * Dune_lang.Scope_stanza.t) Filename.Map.t
+
 (** Directories introduced via [(subdir ..)] *)
 val sub_dirnames : t -> Filename.t list
 

--- a/src/source/only_packages.mli
+++ b/src/source/only_packages.mli
@@ -22,11 +22,6 @@ type t
 val enumerate : t -> [ `Set of Package.Name.Set.t | `All ]
 val mem : t -> Package.Name.t -> bool
 val mem_all : t -> bool
-
-val mask
-  :  (Package.t * [ `Enabled | `Disabled ]) Package.Name.Map.t
-  -> vendored:Package.Name.Set.t
-  -> t
-
-val filter_packages : t -> Package.t Package.Name.Map.t -> Package.t Package.Name.Map.t
+val mask : (Package.t * Package.status) list Package.Name.Map.t -> t
+val filter_packages : t -> 'a Package.Name.Map.t -> 'a Package.Name.Map.t
 val filter_packages_in_project : vendored:bool -> Dune_project.t -> Dune_project.t

--- a/test/blackbox-tests/test-cases/scope/nested.t
+++ b/test/blackbox-tests/test-cases/scope/nested.t
@@ -1,0 +1,129 @@
+Test nested scope stanzas (scope stanza in a subdirectory)
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+Create a nested directory structure:
+- duniverse/
+
+  $ mkdir -p duniverse/scopetest_fmt.0.9.0 duniverse/scopetest_cohttp.6.0.0
+
+Create scopetest_fmt library:
+  $ cat > duniverse/scopetest_fmt.0.9.0/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name scopetest_fmt))
+  > EOF
+
+  $ cat > duniverse/scopetest_fmt.0.9.0/dune << EOF
+  > (library
+  >  (name scopetest_fmt)
+  >  (modules scopetest_fmt)
+  >  (public_name scopetest_fmt))
+  > (library
+  >  (name scopetest_fmt_tty)
+  >  (modules scopetest_fmt_tty)
+  >  (public_name scopetest_fmt.tty))
+  > EOF
+
+  $ cat > duniverse/scopetest_fmt.0.9.0/scopetest_fmt.ml << EOF
+  > let msg = "scopetest_fmt"
+  > EOF
+
+  $ cat > duniverse/scopetest_fmt.0.9.0/scopetest_fmt_tty.ml << EOF
+  > let msg = "scopetest_fmt.tty"
+  > EOF
+
+Create scopetest_cohttp library:
+  $ cat > duniverse/scopetest_cohttp.6.0.0/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name scopetest_cohttp))
+  > EOF
+
+  $ cat > duniverse/scopetest_cohttp.6.0.0/dune << EOF
+  > (library
+  >  (name scopetest_cohttp)
+  >  (modules scopetest_cohttp)
+  >  (public_name scopetest_cohttp))
+  > (library
+  >  (name scopetest_cohttp_async)
+  >  (modules scopetest_cohttp_async)
+  >  (public_name scopetest_cohttp.async))
+  > EOF
+
+  $ cat > duniverse/scopetest_cohttp.6.0.0/scopetest_cohttp.ml << EOF
+  > let msg = "scopetest_cohttp"
+  > EOF
+
+  $ cat > duniverse/scopetest_cohttp.6.0.0/scopetest_cohttp_async.ml << EOF
+  > let msg = "scopetest_cohttp.async"
+  > EOF
+
+Create scope stanzas in duniverse/dune to expose packages:
+  $ cat > duniverse/dune << EOF
+  > (scope
+  >  (dir scopetest_fmt.0.9.0)
+  >  (packages scopetest_fmt))
+  > (scope
+  >  (dir scopetest_cohttp.6.0.0)
+  >  (packages scopetest_cohttp))
+  > EOF
+
+Create main app that uses the exposed libraries:
+  $ cat > dune << EOF
+  > (executable
+  >  (name main)
+  >  (libraries scopetest_fmt scopetest_fmt.tty scopetest_cohttp scopetest_cohttp.async))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = print_endline (Scopetest_fmt.msg ^ " " ^ Scopetest_cohttp.msg)
+  > EOF
+
+Build should succeed - all libraries from the exposed packages are visible:
+  $ dune exec ./main.exe
+  scopetest_fmt scopetest_cohttp
+
+Test deeply nested scope: scope stanza in deeper directory
+  $ mkdir -p duniverse/extras
+  $ cat > duniverse/extras/dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+Add another library in extras:
+  $ mkdir -p duniverse/extras/scopetest_lwt.5.0.0
+  $ cat > duniverse/extras/scopetest_lwt.5.0.0/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name scopetest_lwt))
+  > EOF
+
+  $ cat > duniverse/extras/scopetest_lwt.5.0.0/dune << EOF
+  > (library
+  >  (name scopetest_lwt)
+  >  (public_name scopetest_lwt))
+  > EOF
+
+  $ cat > duniverse/extras/scopetest_lwt.5.0.0/scopetest_lwt.ml << EOF
+  > let msg = "scopetest_lwt"
+  > EOF
+
+Create scope stanza in duniverse/extras/dune:
+  $ cat > duniverse/extras/dune << EOF
+  > (scope
+  >  (dir scopetest_lwt.5.0.0)
+  >  (packages scopetest_lwt))
+  > EOF
+
+Main app should be able to use scopetest_lwt through the nested scope:
+  $ cat > dune << EOF
+  > (executable
+  >  (name main)
+  >  (libraries scopetest_lwt))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = print_endline Scopetest_lwt.msg
+  > EOF
+
+  $ dune exec ./main.exe
+  scopetest_lwt

--- a/test/blackbox-tests/test-cases/scope/per-directory.t
+++ b/test/blackbox-tests/test-cases/scope/per-directory.t
@@ -1,0 +1,241 @@
+Test that scope stanzas are applied per-directory, not globally.
+
+This tests that different directories can have different scope rules for the
+same packages, and that the visibility is correctly scoped to each directory.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+Create two separate areas, each with its own vendor directory containing
+the same two packages (pkg_x and pkg_y):
+
+  $ mkdir -p area_a/vendor area_b/vendor
+
+Area A's vendor:
+  $ cat > area_a/vendor/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name pkg_x))
+  > (package (name pkg_y))
+  > EOF
+
+  $ cat > area_a/vendor/dune << EOF
+  > (library
+  >  (name lib_x_a)
+  >  (public_name pkg_x.from_a))
+  > (library
+  >  (name lib_y_a)
+  >  (public_name pkg_y.from_a))
+  > EOF
+
+  $ cat > area_a/vendor/lib_x_a.ml << EOF
+  > let msg = "lib_x from area_a"
+  > EOF
+
+  $ cat > area_a/vendor/lib_y_a.ml << EOF
+  > let msg = "lib_y from area_a"
+  > EOF
+
+Area B's vendor (same package names, different content):
+  $ cat > area_b/vendor/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name pkg_x))
+  > (package (name pkg_y))
+  > EOF
+
+  $ cat > area_b/vendor/dune << EOF
+  > (library
+  >  (name lib_x_b)
+  >  (public_name pkg_x.from_b))
+  > (library
+  >  (name lib_y_b)
+  >  (public_name pkg_y.from_b))
+  > EOF
+
+  $ cat > area_b/vendor/lib_x_b.ml << EOF
+  > let msg = "lib_x from area_b"
+  > EOF
+
+  $ cat > area_b/vendor/lib_y_b.ml << EOF
+  > let msg = "lib_y from area_b"
+  > EOF
+
+=============================================================================
+Set up different scope rules for each area:
+- Area A exposes only pkg_x
+- Area B exposes only pkg_y
+=============================================================================
+
+  $ cat > area_a/dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > area_a/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_x))
+  > EOF
+
+  $ cat > area_b/dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > area_b/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_y))
+  > EOF
+
+=============================================================================
+Test: Executable in area_a should see pkg_x but NOT pkg_y
+=============================================================================
+
+  $ cat > area_a/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_x))
+  > (executable
+  >  (name main_a)
+  >  (libraries pkg_x.from_a))
+  > EOF
+
+  $ cat > area_a/main_a.ml << EOF
+  > let () = print_endline Lib_x_a.msg
+  > EOF
+
+pkg_x should be visible in area_a:
+  $ dune exec ./area_a/main_a.exe
+  lib_x from area_a
+
+pkg_y should NOT be visible in area_a (it was not exposed by area_a's scope):
+  $ cat > area_a/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_x))
+  > (executable
+  >  (name main_a)
+  >  (libraries pkg_y.from_a))
+  > EOF
+
+  $ cat > area_a/main_a.ml << EOF
+  > let () = print_endline Lib_y_a.msg
+  > EOF
+
+  $ dune build ./area_a/main_a.exe 2>&1 | head -8
+  File "area_a/dune", line 6, characters 12-24:
+  6 |  (libraries pkg_y.from_a))
+                  ^^^^^^^^^^^^
+  Error: Library "pkg_y.from_a" not found.
+  -> required by
+     _build/default/area_a/.main_a.eobjs/native/dune__exe__Main_a.cmx
+  -> required by _build/default/area_a/main_a.exe
+  [1]
+
+=============================================================================
+Test: Executable in area_b should see pkg_y but NOT pkg_x
+=============================================================================
+
+  $ cat > area_b/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_y))
+  > (executable
+  >  (name main_b)
+  >  (libraries pkg_y.from_b))
+  > EOF
+
+  $ cat > area_b/main_b.ml << EOF
+  > let () = print_endline Lib_y_b.msg
+  > EOF
+
+pkg_y should be visible in area_b:
+  $ dune exec ./area_b/main_b.exe
+  lib_y from area_b
+
+pkg_x should NOT be visible in area_b (it was not exposed by area_b's scope):
+  $ cat > area_b/dune << EOF
+  > (scope
+  >  (dir vendor)
+  >  (packages pkg_y))
+  > (executable
+  >  (name main_b)
+  >  (libraries pkg_x.from_b))
+  > EOF
+
+  $ cat > area_b/main_b.ml << EOF
+  > let () = print_endline Lib_x_b.msg
+  > EOF
+
+  $ dune build ./area_b/main_b.exe 2>&1 | head -8
+  File "area_b/dune", line 6, characters 12-24:
+  6 |  (libraries pkg_x.from_b))
+                  ^^^^^^^^^^^^
+  Error: Library "pkg_x.from_b" not found.
+  -> required by
+     _build/default/area_b/.main_b.eobjs/native/dune__exe__Main_b.cmx
+  -> required by _build/default/area_b/main_b.exe
+  [1]
+
+=============================================================================
+Test: Duplicate packages without scope stanzas should still error
+=============================================================================
+
+Create a fresh project with duplicate package names but NO scope stanzas:
+
+  $ mkdir -p dup_test/vendor_a dup_test/vendor_b
+
+  $ cat > dup_test/dune-project <<EOF
+  > (lang dune 3.18)
+  > (name dup_test)
+  > (package (name dup_test))
+  > EOF
+
+  $ cat > dup_test/vendor_a/dune-project <<EOF
+  > (lang dune 3.18)
+  > (name dup_pkg)
+  > (package (name dup_pkg))
+  > EOF
+
+  $ cat > dup_test/vendor_a/dune <<EOF
+  > (library
+  >  (name dup_lib)
+  >  (public_name dup_pkg))
+  > EOF
+
+  $ cat > dup_test/vendor_a/dup_lib.ml <<EOF
+  > let x = "from vendor_a"
+  > EOF
+
+  $ cat > dup_test/vendor_b/dune-project <<EOF
+  > (lang dune 3.18)
+  > (name dup_pkg)
+  > (package (name dup_pkg))
+  > EOF
+
+  $ cat > dup_test/vendor_b/dune <<EOF
+  > (library
+  >  (name dup_lib)
+  >  (public_name dup_pkg))
+  > EOF
+
+  $ cat > dup_test/vendor_b/dup_lib.ml <<EOF
+  > let x = "from vendor_b"
+  > EOF
+
+  $ cat > dup_test/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries dup_pkg))
+  > EOF
+
+  $ cat > dup_test/main.ml <<EOF
+  > let () = print_endline Dup_lib.x
+  > EOF
+
+Without scope stanzas, duplicate packages should still cause an error:
+
+  $ dune build ./dup_test/main.exe 2>&1 | head -5
+  Error: The package "dup_pkg" is defined more than once:
+  - dup_test/vendor_b/dune-project:3
+  - dup_test/vendor_a/dune-project:3
+  [1]

--- a/test/blackbox-tests/test-cases/scope/run.t
+++ b/test/blackbox-tests/test-cases/scope/run.t
@@ -1,0 +1,321 @@
+Comprehensive test of scope stanza semantics
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+Create a vendored directory with multiple packages and libraries:
+
+  $ mkdir -p vendor.1.0.0/lib_a1 vendor.1.0.0/lib_a2 vendor.1.0.0/lib_b
+
+  $ cat > vendor.1.0.0/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name pkg_a))
+  > (package (name pkg_b))
+  > EOF
+
+Package A has two libraries (in separate dirs to avoid module conflicts):
+  $ cat > vendor.1.0.0/lib_a1/dune << EOF
+  > (library
+  >  (name lib_a1)
+  >  (public_name pkg_a.lib1))
+  > EOF
+
+  $ cat > vendor.1.0.0/lib_a1/lib_a1.ml << EOF
+  > let name = "lib_a1"
+  > EOF
+
+  $ cat > vendor.1.0.0/lib_a2/dune << EOF
+  > (library
+  >  (name lib_a2)
+  >  (public_name pkg_a.lib2))
+  > EOF
+
+  $ cat > vendor.1.0.0/lib_a2/lib_a2.ml << EOF
+  > let name = "lib_a2"
+  > EOF
+
+Package B has one library:
+  $ cat > vendor.1.0.0/lib_b/dune << EOF
+  > (library
+  >  (name lib_b)
+  >  (public_name pkg_b.lib))
+  > EOF
+
+  $ cat > vendor.1.0.0/lib_b/lib_b.ml << EOF
+  > let name = "lib_b"
+  > EOF
+
+=============================================================================
+Test 1: Expose all packages - all libraries visible
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a pkg_b))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_a.lib1 pkg_a.lib2 pkg_b.lib))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = Printf.printf "%s %s %s\n" Lib_a1.name Lib_a2.name Lib_b.name
+  > EOF
+
+  $ dune exec ./main.exe
+  lib_a1 lib_a2 lib_b
+
+=============================================================================
+Test 2: Only expose pkg_a - all libraries from pkg_a visible
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_a.lib1 pkg_a.lib2))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = Printf.printf "%s %s\n" Lib_a1.name Lib_a2.name
+  > EOF
+
+  $ dune exec ./main.exe
+  lib_a1 lib_a2
+
+Package B should NOT be accessible:
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_b.lib))
+  > EOF
+
+  $ dune build main.exe 2>&1 | head -5
+  File "dune", line 6, characters 12-21:
+  6 |  (libraries pkg_b.lib))
+                  ^^^^^^^^^
+  Error: Library "pkg_b.lib" not found.
+  -> required by _build/default/.main.eobjs/native/dune__exe__Main.cmx
+  [1]
+
+=============================================================================
+Test 3: Private libraries are not visible through scope
+=============================================================================
+
+Add a private library to vendor directory:
+  $ mkdir -p vendor.1.0.0/lib_private
+  $ cat > vendor.1.0.0/lib_private/dune << EOF
+  > (library
+  >  (name lib_private))
+  > EOF
+
+  $ cat > vendor.1.0.0/lib_private/lib_private.ml << EOF
+  > let name = "private"
+  > EOF
+
+Private library should not be accessible even when exposing all packages:
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a pkg_b))
+  > (executable
+  >  (name main)
+  >  (libraries lib_private))
+  > EOF
+
+  $ dune build main.exe 2>&1 | head -5
+  File "dune", line 6, characters 12-23:
+  6 |  (libraries lib_private))
+                  ^^^^^^^^^^^
+  Error: Library "lib_private" not found.
+  -> required by _build/default/.main.eobjs/native/dune__exe__Main.cmx
+  [1]
+
+=============================================================================
+Test 4: Non-existent package - error at scope stanza
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages nonexistent))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_a.lib1))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = ()
+  > EOF
+
+Invalid packages are detected early:
+  $ dune build main.exe 2>&1 | head -5
+  File "dune", lines 2-3, characters 1-43:
+  2 |  (dir vendor.1.0.0)
+  3 |  (packages nonexistent))
+  Error: The following packages are not available in directory "vendor.1.0.0":
+  nonexistent
+  [1]
+
+=============================================================================
+Test 5: Ordered set language - :standard exposes all packages
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages :standard))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_a.lib1 pkg_a.lib2 pkg_b.lib))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = Printf.printf "%s %s %s\n" Lib_a1.name Lib_a2.name Lib_b.name
+  > EOF
+
+  $ dune exec ./main.exe
+  lib_a1 lib_a2 lib_b
+
+=============================================================================
+Test 6: Ordered set language - :standard \ exclusion
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages :standard \ pkg_b))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_a.lib1 pkg_a.lib2))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = Printf.printf "%s %s\n" Lib_a1.name Lib_a2.name
+  > EOF
+
+  $ dune exec ./main.exe
+  lib_a1 lib_a2
+
+pkg_b should be excluded:
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages :standard \ pkg_b))
+  > (executable
+  >  (name main)
+  >  (libraries pkg_b.lib))
+  > EOF
+
+  $ dune build main.exe 2>&1 | head -5
+  File "dune", line 6, characters 12-21:
+  6 |  (libraries pkg_b.lib))
+                  ^^^^^^^^^
+  Error: Library "pkg_b.lib" not found.
+  -> required by _build/default/.main.eobjs/native/dune__exe__Main.cmx
+  [1]
+
+=============================================================================
+Test 7: Error - only immediate subdirectories allowed
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0/lib_a1)
+  >  (packages pkg_a))
+  > EOF
+
+  $ dune build 2>&1 | head -7
+  File "dune", line 2, characters 6-25:
+  2 |  (dir vendor.1.0.0/lib_a1)
+            ^^^^^^^^^^^^^^^^^^^
+  Error: only immediate sub-directories may be specified.
+  Hint: to ignore vendor.1.0.0/lib_a1, write "(scope lib_a1)" in
+  vendor.1.0.0/dune
+  [1]
+
+=============================================================================
+Test 8: Error - invalid directory names
+=============================================================================
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir .)
+  >  (packages pkg_a))
+  > EOF
+
+  $ dune build 2>&1 | head -6
+  File "dune", line 2, characters 6-7:
+  2 |  (dir .)
+            ^
+  Error: invalid sub-directory name "."
+  Hint: did you mean (scope *)?
+  [1]
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir ..)
+  >  (packages pkg_a))
+  > EOF
+
+  $ dune build 2>&1 | head -5
+  File "dune", line 2, characters 6-8:
+  2 |  (dir ..)
+            ^^
+  Error: invalid sub-directory name ".."
+  [1]
+
+=============================================================================
+Test 9: Error - scope requires dune lang 3.22
+=============================================================================
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.21)
+  > EOF
+
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a))
+  > EOF
+
+  $ dune build 2>&1 | head -7
+  File "dune", lines 1-3, characters 0-45:
+  1 | (scope
+  2 |  (dir vendor.1.0.0)
+  3 |  (packages pkg_a))
+  Error: 'scope' is only available since version 3.22 of the dune language.
+  Please update your dune-project file to have (lang dune 3.22).
+  [1]
+
+Restore dune-project:
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > EOF
+
+=============================================================================
+Test 10: Duplicate scope stanzas - error
+=============================================================================
+
+Multiple scope stanzas targeting the same directory in the same file:
+  $ cat > dune << EOF
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_a))
+  > (scope
+  >  (dir vendor.1.0.0)
+  >  (packages pkg_b))
+  > EOF
+
+  $ dune build 2>&1 | head -5
+  File "dune", lines 5-6, characters 1-37:
+  5 |  (dir vendor.1.0.0)
+  6 |  (packages pkg_b))
+  Error: may not set the "scope" stanza more than once
+  [1]

--- a/test/blackbox-tests/test-cases/scope/vendor-dash-p.t
+++ b/test/blackbox-tests/test-cases/scope/vendor-dash-p.t
@@ -1,0 +1,137 @@
+Test interaction between scope stanzas, vendored packages, and -p flag.
+
+The -p flag includes all vendored packages automatically. Scope stanzas
+control which packages are visible. The interaction should be:
+- Dune_load.mask: includes ALL vendored packages (approximation)
+- Scope.DB.mask: includes only scope-visible vendored packages (refined)
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name mypkg))
+  > EOF
+
+Create two vendored directories with the same package name:
+
+  $ mkdir -p vendor_a vendor_b
+
+  $ cat > vendor_a/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name bar))
+  > EOF
+
+  $ cat > vendor_a/dune << EOF
+  > (library
+  >  (name bar_a)
+  >  (public_name bar))
+  > EOF
+
+  $ cat > vendor_a/bar_a.ml << EOF
+  > let msg = "bar from vendor_a"
+  > EOF
+
+  $ cat > vendor_b/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name bar))
+  > EOF
+
+  $ cat > vendor_b/dune << EOF
+  > (library
+  >  (name bar_b)
+  >  (public_name bar))
+  > EOF
+
+  $ cat > vendor_b/bar_b.ml << EOF
+  > let msg = "bar from vendor_b"
+  > EOF
+
+Mark both as vendored, but only expose vendor_a/bar via scope:
+
+  $ cat > dune << EOF
+  > (vendored_dirs vendor_a vendor_b)
+  > (scope
+  >  (dir vendor_a)
+  >  (packages bar))
+  > (scope
+  >  (dir vendor_b)
+  >  (packages))
+  > (executable
+  >  (name main)
+  >  (public_name mypkg)
+  >  (libraries bar))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = print_endline Bar_a.msg
+  > EOF
+
+Build without -p should work (scope makes vendor_a/bar visible):
+
+  $ dune exec ./main.exe
+  bar from vendor_a
+
+Build with -p mypkg should also work (vendored package included):
+
+  $ dune exec -p mypkg ./main.exe
+  bar from vendor_a
+
+Now test with a non-vendored local package that shadows the vendored ones:
+
+  $ mkdir -p local_bar
+
+  $ cat > local_bar/dune-project << EOF
+  > (lang dune 3.22)
+  > (package (name bar))
+  > EOF
+
+  $ cat > local_bar/dune << EOF
+  > (library
+  >  (name bar_local)
+  >  (public_name bar))
+  > EOF
+
+  $ cat > local_bar/bar_local.ml << EOF
+  > let msg = "bar from local"
+  > EOF
+
+Update scope to expose local_bar instead of vendor_a (hide both vendored):
+
+  $ cat > dune << EOF
+  > (vendored_dirs vendor_a vendor_b)
+  > (scope
+  >  (dir vendor_a)
+  >  (packages))
+  > (scope
+  >  (dir vendor_b)
+  >  (packages))
+  > (scope
+  >  (dir local_bar)
+  >  (packages bar))
+  > (executable
+  >  (name main)
+  >  (public_name mypkg)
+  >  (libraries bar))
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = print_endline Bar_local.msg
+  > EOF
+
+Build without -p should work:
+
+  $ dune exec ./main.exe
+  bar from local
+
+Build with -p mypkg - vendored packages are always included automatically.
+Even though scope hides vendor_a/bar and vendor_b/bar, the name "bar" is
+still in the vendored set (approximation), so local_bar/bar is visible:
+
+  $ dune exec -p mypkg ./main.exe
+  bar from local
+
+Explicitly including bar in -p gives an error because the source tree
+traversal (before scope filtering) sees vendored packages named "bar":
+
+  $ dune exec -p mypkg,bar ./main.exe
+  Error: Package bar is vendored and so will never be masked. It is redundant
+  to pass it to --only-packages.
+  [1]


### PR DESCRIPTION
The scope stanza controls which libraries from a subdirectory are visible to the current project. This allows for selectively exposing libraries when vendoring external projects.

Syntax:

```
  (scope
   (dir <directory>)
   (packages <pkg1> <pkg2> ...))
```

The (dir ...) field specifies an immediate subdirectory containing libraries. The (packages ...) field lists packages whose libraries should be visible. All public libraries from the specified packages become accessible.

Fixes https://github.com/ocaml/dune/issues/7058