### PR TITLE
feature: add a debug event to dune

### DIFF
--- a/otherlibs/stdune/src/debug.ml
+++ b/otherlibs/stdune/src/debug.ml
@@ -1,0 +1,9 @@
+let all = ref []
+let register ~name f = all := (name, f) :: !all
+
+let dump () =
+  ListLabels.map !all ~f:(fun (name, f) ->
+    ( name
+    , try f () with
+      | exn -> Exn.to_dyn exn ))
+;;

--- a/otherlibs/stdune/src/debug.mli
+++ b/otherlibs/stdune/src/debug.mli
@@ -1,0 +1,4 @@
+(** Register debug information dumpers that can be triggered with [Sigusr1] *)
+val register : name:string -> (unit -> Dyn.t) -> unit
+
+val dump : unit -> (string * Dyn.t) list

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -76,6 +76,7 @@ module Json = Json
 module Log = Log
 module Time = Time
 module Escape0 = Escape
+module Debug = Debug
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -5,6 +5,8 @@ type job =
   ; ivar : Proc.Process_info.t Fiber.Ivar.t
   }
 
+let dyn_of_job { pid; ivar = _ } = Dyn.record [ "pid", Dyn.int (Pid.to_int pid) ]
+
 type build_input_change =
   | Fs_event of Dune_file_watcher.Fs_memo_event.t
   | Invalidation of Memo.Invalidation.t
@@ -42,6 +44,13 @@ module Queue = struct
     ; mutable got_event : bool
     ; mutable yield : unit Fiber.Ivar.t option
     }
+
+  let to_dyn { pending_jobs; pending_worker_tasks; _ } =
+    Dyn.record
+      [ "pending_jobs", Dyn.int pending_jobs
+      ; "pending_worker_tasks", Dyn.int pending_worker_tasks
+      ]
+  ;;
 
   let create () =
     let jobs_completed = Queue.create () in

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -5,6 +5,8 @@ type job =
   ; ivar : Proc.Process_info.t Fiber.Ivar.t
   }
 
+val dyn_of_job : job -> Dyn.t
+
 type build_input_change =
   | Fs_event of Dune_file_watcher.Fs_memo_event.t
   | Invalidation of Memo.Invalidation.t
@@ -22,6 +24,7 @@ module Queue : sig
   type event := t
   type t
 
+  val to_dyn : t -> Dyn.t
   val create : unit -> t
 
   (** Return the next event. File changes event are always flattened and

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -5,6 +5,7 @@ val kill_process_group : Pid.t -> int -> unit
 (** Initialize the process watcher thread. *)
 type t
 
+val to_dyn : t -> Dyn.t
 val init : Event.Queue.t -> t
 
 (** Register a new running job. *)

--- a/src/dune_scheduler/signal_watcher.ml
+++ b/src/dune_scheduler/signal_watcher.ml
@@ -35,6 +35,10 @@ let run ~print_ctrl_c_warning q : unit =
     Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_received signal);
     match signal with
     | _ when Signal.equal signal Thread0.signal_watcher_interrupt -> raise_notrace Exit
+    | _ when Signal.equal signal Thread0.signal_watcher_debug ->
+      Dune_trace.emit Diagnostics (fun () ->
+        let dump = Debug.dump () in
+        Dune_trace.Event.debug dump)
     | Chld -> Event.Queue.send_job_completed_ready q
     | Int | Quit | Term ->
       Event.Queue.send_shutdown q (Signal signal);

--- a/src/dune_scheduler/thread0.ml
+++ b/src/dune_scheduler/thread0.ml
@@ -6,11 +6,12 @@ let join = Thread.join
 let delay = Thread.delay
 let wait_signal = Thread.wait_signal
 let signal_watcher_interrupt : Signal.t = Usr1
+let signal_watcher_debug : Signal.t = Usr2
 
 (* These are the signals that will make the scheduler attempt to terminate dune
    or signal to dune to reap a process *)
 let interrupt_signals : Signal.t list =
-  [ signal_watcher_interrupt; Chld; Int; Quit; Term ]
+  [ signal_watcher_interrupt; signal_watcher_debug; Chld; Int; Quit; Term ]
 ;;
 
 (* In addition, the scheduler also blocks some other signals so that only
@@ -20,8 +21,10 @@ let blocked_signals : Signal.t list = Terminal_signals.signals @ interrupt_signa
 let block_signals =
   lazy
     (let () =
-       List.iter [ signal_watcher_interrupt; Chld ] ~f:(fun signal ->
-         Sys.set_signal (Signal.to_int signal) (Signal_handle (fun _ -> ())))
+       List.iter
+         [ signal_watcher_interrupt; signal_watcher_debug; Chld ]
+         ~f:(fun signal ->
+           Sys.set_signal (Signal.to_int signal) (Signal_handle (fun _ -> ())))
      in
      let signos = List.map blocked_signals ~f:Signal.to_int in
      ignore (Unix.sigprocmask SIG_BLOCK signos : int list))

--- a/src/dune_scheduler/thread0.mli
+++ b/src/dune_scheduler/thread0.mli
@@ -5,6 +5,9 @@ type t = Thread.t
 (** Magic signal to interrupt to the signal watching thread *)
 val signal_watcher_interrupt : Signal.t
 
+(** Magic signal to make dune debugging info *)
+val signal_watcher_debug : Signal.t
+
 val join : t -> unit
 val interrupt_signals : Signal.t list
 val spawn : (unit -> unit) -> Thread.t

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -202,6 +202,8 @@ module Event : sig
 
     val dropped_stale_mtimes : Path.t list -> fs_now:float -> t
   end
+
+  val debug : (string * Dyn.t) list -> t
 end
 
 module Out : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -663,3 +663,9 @@ module Digest = struct
     Event.instant ~args ~name:"dropped_stale_mtimes" now Digest
   ;;
 end
+
+let debug dump =
+  let now = Time.now () in
+  let args = List.map dump ~f:(fun (name, dyn) -> name, Arg.dyn dyn) in
+  Event.instant ~args ~name:"debug" now Diagnostics
+;;

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -1,0 +1,36 @@
+The debug event can be triggered with Sigusr1
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ ready=$(mktemp -d)/ready
+  $ mkfifo $ready
+
+  $ cat >dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action (bash "echo done > $ready; sleep 5")))
+  > EOF
+
+  $ dune build @foo &
+
+  $ read line < $ready
+
+  $ pid=$(dune trace cat | jq '.args.pid' -r | head -1)
+
+  $ kill -s sigusr2 -- $pid
+
+  $ dune trace cat | jq 'select(.name == "debug") | .args | .scheduler.process_watcher |= keys'
+  {
+    "scheduler": {
+      "events": {
+        "pending_jobs": 1,
+        "pending_worker_tasks": 0
+      },
+      "process_watcher": [
+        "running_count",
+        "table"
+      ]
+    }
+  }


### PR DESCRIPTION
Sending sigusr2 to dune will make it emit a special debug event that can
be enriched with runtime information from dune
