### PR TITLE
refactor: remove unnecessary all_errors parameter

### DIFF
--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -116,7 +116,6 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~produced_targets
         match Local.Target.create target with
         | Some _ -> Ok ()
         | None -> Error ())
-      ~all_errors:false
       produced_targets
   with
   | Error _ -> Fiber.return None
@@ -169,9 +168,7 @@ let compute_target_digests_or_raise_error
       ~allow_dirs:true
       ~remove_write_permissions:should_remove_write_permissions_on_generated_files
   in
-  match
-    Targets.Produced.map_with_errors ~f:compute_digest ~all_errors:true produced_targets
-  with
+  match Targets.Produced.map_with_errors ~f:compute_digest produced_targets with
   | Ok result -> result
   | Error errors ->
     let missing, errors =

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -130,7 +130,6 @@ module Workspace_local = struct
     | Ok targets ->
       (match
          Targets.Produced.map_with_errors
-           ~all_errors:false
            ~f:(Cached_digest.build_file ~allow_dirs:true)
            targets
        with

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -162,7 +162,6 @@ module Produced : sig
   val map_with_errors
     :  ?d:(Path.Build.t -> (unit, 'e) result)
     -> f:(Path.Build.t -> ('b, 'e) result)
-    -> all_errors:bool
     -> 'a t
     -> ('b t, (Path.Build.t * 'e) Nonempty_list.t) result
 


### PR DESCRIPTION
It will not work when we use it with fibers anyway