### PR TITLE
Fix #10635

### DIFF
--- a/doc/changes/fixed/10635.md
+++ b/doc/changes/fixed/10635.md
@@ -1,0 +1,3 @@
+- Fix installation of implementations of virtual libraries. This failed when
+  the implementation had no private modules, but the virtual library did
+  (#10635, @rgrinberg)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -280,7 +280,19 @@ end = struct
       let obj_dir = Lib_info.obj_dir info in
       let cm_dir =
         let external_obj_dir =
-          Obj_dir.convert_to_external obj_dir ~dir:(Path.build dir)
+          let has_private_modules =
+            (* CR-someday rgrinberg: This is a bit of a hack because we are
+               installing private modules of the private library inside an
+               implementation that has no private modules. We should just stop
+               install the virtual library artifacts altogether since they're
+               already installed in their own directory. *)
+            let vlib_has_private_modules =
+              List.exists installable_modules.vlib ~f:(fun m ->
+                Module.visibility m = Private)
+            in
+            vlib_has_private_modules || Obj_dir.need_dedicated_public_dir obj_dir
+          in
+          Obj_dir.convert_to_external obj_dir ~dir:(Path.build dir) ~has_private_modules
         in
         fun m cm_kind ->
           let visibility = Module.visibility m in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2720,7 +2720,9 @@ let to_dune_lib
   let obj_dir =
     match Lib_info.obj_dir lib.info |> Obj_dir.to_local with
     | None -> assert false
-    | Some obj_dir -> Obj_dir.convert_to_external ~dir obj_dir
+    | Some obj_dir ->
+      let has_private_modules = Obj_dir.need_dedicated_public_dir obj_dir in
+      Obj_dir.convert_to_external ~dir ~has_private_modules obj_dir
   in
   let modules =
     let install_dir = Obj_dir.dir obj_dir in

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -413,10 +413,9 @@ let to_dyn (type path) (t : path t) =
   | External e -> variant "External" [ External.to_dyn e ]
 ;;
 
-let convert_to_external (t : Path.Build.t t) ~dir =
+let convert_to_external (t : Path.Build.t t) ~dir ~has_private_modules =
   match t with
   | Local e ->
-    let has_private_modules = Local.need_dedicated_public_dir e in
     External (External.make ~dir ~has_private_modules ~private_lib:e.private_lib)
   | _ -> assert false
 ;;

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -74,7 +74,13 @@ val make_external_no_private : dir:Path.t -> Path.t t
 
 val encode : Path.t t -> Dune_lang.t list
 val decode : dir:Path.t -> Path.t t Dune_lang.Decoder.t
-val convert_to_external : Path.Build.t t -> dir:Path.t -> Path.t t
+
+val convert_to_external
+  :  Path.Build.t t
+  -> dir:Path.t
+  -> has_private_modules:bool
+  -> Path.t t
+
 val cm_dir : 'path t -> Lib_mode.Cm_kind.t -> Visibility.t -> 'path
 val to_dyn : _ t -> Dyn.t
 val make_exe : dir:Path.Build.t -> name:string -> Path.Build.t t

--- a/test/blackbox-tests/test-cases/virtual-libraries/github10635.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github10635.t
@@ -43,7 +43,4 @@ Implementation with public_name (but no private modules of its own):
 
 Should build without "External.cm_dir" errors:
 
-  $ dune build @install 2>&1 | grep -i "code_error\|external.cm_dir" || true
-    ("External.cm_dir",
-  Raised at Stdune__Code_error.raise in file
-    "otherlibs/stdune/src/code_error.ml", line 10, characters 30-62
+  $ dune build @install


### PR DESCRIPTION
Correctly set the private directory when converting object directories from private to external.