### PR TITLE
fix: acquire dune lock before overwriting trace

### DIFF
--- a/bin/common.mli
+++ b/bin/common.mli
@@ -40,6 +40,7 @@ module Builder : sig
   val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
   val default_target : t -> Arg.Dep.t
   val term : t Cmdliner.Term.t
+  val term_without_trace : t Cmdliner.Term.t
   val default : t
 end
 

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -75,7 +75,7 @@ let path =
 ;;
 
 let context_cwd : Init_context.t Term.t =
-  let+ builder = Common.Builder.term
+  let+ builder = Common.Builder.term_without_trace
   and+ path = path in
   let builder = Common.Builder.set_default_root_is_cwd builder true in
   let _common, config = Common.init builder in
@@ -233,7 +233,7 @@ let project =
   in
   let man = [] in
   Cmd.v (Cmd.info "project" ~doc ~man)
-  @@ let+ common_builder = Builder.term
+  @@ let+ common_builder = Builder.term_without_trace
      and+ path = path
      and+ common = project_common
      and+ inline_tests = inline_tests

--- a/otherlibs/stdune/src/config.ml
+++ b/otherlibs/stdune/src/config.ml
@@ -8,6 +8,7 @@ type 'a t =
   }
 
 let env_name t = sprintf "DUNE_CONFIG__%s" (String.uppercase_ascii t.name)
+let is_initialized () = !initialized
 
 let get t =
   if not !initialized

--- a/otherlibs/stdune/src/config.mli
+++ b/otherlibs/stdune/src/config.mli
@@ -27,6 +27,9 @@ val make : name:string -> of_string:(string -> ('a, string) result) -> default:'
 
 val make_toggle : name:string -> default:Toggle.t -> Toggle.t t
 
+(** [is_initialized ()] returns whether [init] has been called *)
+val is_initialized : unit -> bool
+
 (** [get t] return the value of the configuration for [t] *)
 val get : 'a t -> 'a
 

--- a/src/dune_util/global_lock.ml
+++ b/src/dune_util/global_lock.ml
@@ -90,7 +90,12 @@ module Lock_held_by = struct
 end
 
 let lock ~timeout =
-  match Config.(get global_lock) with
+  match
+    (* If Config hasn't been initialized yet, default to `Enabled behavior.
+       This allows the lock to be acquired early (e.g., before creating trace
+       files) to prevent corruption. *)
+    if Config.is_initialized () then Config.(get global_lock) else `Enabled
+  with
   | `Disabled -> Ok ()
   | `Enabled ->
     if !locked

--- a/test/blackbox-tests/test-cases/dune-init/dune-init-proj-no-spurious-build-dir.t
+++ b/test/blackbox-tests/test-cases/dune-init/dune-init-proj-no-spurious-build-dir.t
@@ -11,7 +11,6 @@ directory in the current directory.
   > }
 
   $ ls
-  _build
   foo
   $ ls foo
   bin
@@ -25,7 +24,6 @@ directory in the current directory.
   Success: initialized project component named foo
   Leaving directory 'bar'
   $ ls
-  _build
   bar
   foo
   $ ls bar
@@ -42,7 +40,6 @@ directory in the current directory.
   Success: initialized project component named foo
   Leaving directory 'baz'
   $ ls
-  _build
   bar
   baz
   foo

--- a/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
+++ b/test/blackbox-tests/test-cases/pkg/rev-store-lock-linux.t
@@ -27,7 +27,7 @@ We set the project up to depend on `foo`
 There should be some kind of error message if getting the revision store lock
 fails (simulated here with a failing flock(2) call):
 
-  $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache strace -e inject=flock:error=EBADFD -o /dev/null dune pkg lock
+  $ XDG_CACHE_HOME=$(pwd)/dune-workspace-cache strace -e inject=flock:error=EBADFD:when=2 -o /dev/null dune pkg lock
   Error: Failed to get a lock for the revision store at
   $TESTCASE_ROOT/dune-workspace-cache/dune/rev-store.lock:
   File descriptor in bad state


### PR DESCRIPTION
Before writing to the trace, we need to make sure to acquire the lock.