### PR TITLE
refactor(dune_rules): use module original path in more places

### DIFF
--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -89,7 +89,10 @@ let melange_args (cctx : Compilation_context.t) (cm_kind : Lib_mode.Cm_kind.t) m
     in
     let mel_package_name, mel_package_output =
       let package_output =
-        Module.file ~ml_kind:Impl module_ |> Option.value_exn |> Path.parent_exn
+        Module.source ~ml_kind:Impl module_
+        |> Option.value_exn
+        |> Module.File.original_path
+        |> Path.parent_exn
       in
       match Compilation_context.melange_package_name cctx with
       | None -> [], package_output


### PR DESCRIPTION
- when promoting back to source (e.g. via `(lint ..)`)
- when computing the Melange package output hierarchy