### PR TITLE
Revert "fix(test): make macOS file watcher tests less flaky (#13316)"

### DIFF
--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -8,7 +8,9 @@
  (modules dune_file_watcher_tests_macos)
  (inline_tests
   (enabled_if
-   (= %{system} macosx))
+   (and
+    (<> %{env:CI=false} true) ;; in github action, CI=true
+    (= %{system} macosx)))
   (deps
    (sandbox always)))
  (libraries

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.mli
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.mli
@@ -5,8 +5,3 @@ val print_events
   :  try_to_get_events:(unit -> Dune_file_watcher.Fs_memo_event.t list option)
   -> expected:int
   -> unit
-
-val wait_for_paths
-  :  try_to_get_events:(unit -> Dune_file_watcher.Fs_memo_event.t list option)
-  -> paths:string list
-  -> unit


### PR DESCRIPTION
This reverts commit d52ff76c81824574a2a135b56f512b7b84d5fbf6.

The root cause is actually a bug in the FSEvent bindings (see #13324), so it's best to fix the bug rather than the tests!