### PR TITLE
fix(fsevents): handle coalesced FSEvents flags for consistent event semantics

### DIFF
--- a/doc/changes/fixed/13381.md
+++ b/doc/changes/fixed/13381.md
@@ -1,0 +1,3 @@
+- Fix FSEvents to handle coalesced event flags correctly on macOS. Rename
+  events are now properly detected when ItemRenamed and ItemCreated flags are
+  both set. (#13381, @samoht)

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -577,7 +577,8 @@ let fsevents_standard_event ~should_exclude event path =
   else (
     let kind =
       match Fsevents.Event.action event with
-      | Rename | Unknown -> Fs_memo_event.Unknown
+      | Unknown -> Fs_memo_event.Unknown
+      | Rename -> if Path.exists path then Created else Deleted
       | Create -> Created
       | Remove -> Deleted
       | Modify -> if Fsevents.Event.kind event = File then File_changed else Unknown

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -8,9 +8,7 @@
  (modules dune_file_watcher_tests_macos)
  (inline_tests
   (enabled_if
-   (and
-    (<> %{env:CI=false} true) ;; in github action, CI=true
-    (= %{system} macosx)))
+   (= %{system} macosx))
   (deps
    (sandbox always)))
  (libraries

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -8,7 +8,6 @@ let%expect_test _ =
   let events_buffer = ref [] in
   let watcher =
     Dune_file_watcher.create_default
-      ~fsevents_debounce:(Time.Span.of_secs 0.)
       ~scheduler:
         { spawn_thread = (fun f -> Thread.create f ())
         ; thread_safe_send_emit_events_job =

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -36,18 +36,19 @@ let%expect_test _ =
   let print_events n = print_events ~try_to_get_events ~expected:n in
   Dune_file_watcher.wait_for_initial_watches_established_blocking watcher;
   Stdio.Out_channel.write_all "x" ~data:"x";
-  print_events 3;
+  print_events 2;
   [%expect
     {|
     { path = In_source_tree "."; kind = "Created" }
-    { path = In_build_dir "."; kind = "Created" }
-    { path = In_source_tree "x"; kind = "Unknown" } |}];
+    { path = In_source_tree "x"; kind = "Created" }
+    |}];
   Unix.rename "x" "y";
   print_events 2;
   [%expect
     {|
-    { path = In_source_tree "x"; kind = "Unknown" }
-    { path = In_source_tree "y"; kind = "Unknown" } |}];
+    { path = In_source_tree "x"; kind = "Deleted" }
+    { path = In_source_tree "y"; kind = "Created" }
+    |}];
   let (_ : _) = Fpath.mkdir_p "d/w" in
   Stdio.Out_channel.write_all "d/w/x" ~data:"x";
   print_events 3;
@@ -55,8 +56,9 @@ let%expect_test _ =
     {|
     { path = In_source_tree "d"; kind = "Created" }
     { path = In_source_tree "d/w"; kind = "Created" }
-    { path = In_source_tree "d/w/x"; kind = "Unknown" } |}];
+    { path = In_source_tree "d/w/x"; kind = "Created" }
+    |}];
   Stdio.Out_channel.write_all "d/w/y" ~data:"y";
   print_events 1;
-  [%expect {| { path = In_source_tree "d/w/y"; kind = "Unknown" } |}]
+  [%expect {| { path = In_source_tree "d/w/y"; kind = "Created" } |}]
 ;;

--- a/test/expect-tests/fsevents/dune
+++ b/test/expect-tests/fsevents/dune
@@ -2,9 +2,7 @@
  (name fsevents_tests)
  (inline_tests
   (enabled_if
-   (and
-    (<> %{env:CI=false} true)
-    (= %{system} macosx)))
+   (= %{system} macosx))
   (deps
    (sandbox always)))
  (libraries

--- a/test/expect-tests/fsevents/fsevents_tests.ml
+++ b/test/expect-tests/fsevents/fsevents_tests.ml
@@ -248,8 +248,9 @@ let%expect_test "move file" =
     Unix.rename "old" "new");
   [%expect
     {|
-    > { action = "Create"; kind = "File"; path = "$TESTCASE_ROOT/old" }
-    > { action = "Rename"; kind = "File"; path = "$TESTCASE_ROOT/new" } |}]
+    > { action = "Rename"; kind = "File"; path = "$TESTCASE_ROOT/old" }
+    > { action = "Rename"; kind = "File"; path = "$TESTCASE_ROOT/new" }
+    |}]
 ;;
 
 let%expect_test "raise inside callback" =


### PR DESCRIPTION
FSEvents may set multiple flags on a single event when operations are coalesced. In particular, ItemRenamed and ItemCreated can both be set on rename operations.

Check ItemRenamed before ItemCreated to avoid misclassifying renames. Use ItemInodeMetaMod to disambiguate coalesced ItemCreated|ItemModified: the flag is set when modifying an existing inode, not when creating a new file with content.

This PR extracts the FSEvents fixes from #13324.