### PR TITLE
test: add some missing O_CLOEXEC in the tests

### DIFF
--- a/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-signal.t
@@ -19,7 +19,7 @@ since it shouldn't affect dune's other functions.
 
   $ cat > touch.ml <<EOF
   > let touch path =
-  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  let fd = Unix.openfile path [ Unix.O_CREA; O_CLOEXEC ] 0o777 in
   >  Unix.close fd
   > ;;
   > EOF

--- a/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-stdin.t
@@ -15,7 +15,7 @@ We use the done flag as a signal that the program has finished.
 
   $ cat > touch.ml <<EOF
   > let touch path =
-  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  let fd = Unix.openfile path [ Unix.O_CREAT; O_CLOEXEC ] 0o777 in
   >  Unix.close fd
   > ;;
   > EOF

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/touch.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/touch.ml
@@ -1,3 +1,3 @@
 let touch path =
-  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  let fd = Unix.openfile path [ Unix.O_CREAT ; O_CLOEXEC ] 777 in
   Unix.close fd

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-fail.t
@@ -15,7 +15,7 @@ non-zero exit code.
 
   $ cat > foo.ml <<EOF
   > let touch path =
-  >  let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+  >  let fd = Unix.openfile path [ Unix.O_CREAT; O_CLOEXEC ] 0o777 in
   >  Unix.close fd
   > ;;
   > 

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/foo.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/foo.ml
@@ -1,5 +1,5 @@
 let touch path =
-  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  let fd = Unix.openfile path [ Unix.O_CREAT; O_CLOEXEC ] 777 in
   Unix.close fd
 
 let () =

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/bin/main.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-multi-levels.t/bin/main.ml
@@ -1,6 +1,6 @@
 let () =
   let touch path =
-    let fd = Unix.openfile path [ Unix.O_CREAT ] 0o777 in
+    let fd = Unix.openfile path [ Unix.O_CREAT; O_CLOEXEC ] 0o777 in
     Unix.close fd
   in
   print_endline "foo";

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/touch.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/touch.ml
@@ -1,3 +1,3 @@
 let touch path =
-  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  let fd = Unix.openfile path [ Unix.O_CREAT; O_CLOEXEC ] 777 in
   Unix.close fd

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -69,7 +69,7 @@ module Wait_for_fs_clock_to_advance = struct
   let run () =
     let fn = "." ^ name ^ ".tmp" in
     let fstime () =
-      Unix.close (Unix.openfile fn [ O_WRONLY; O_CREAT; O_TRUNC ] 0o644);
+      Unix.close (Unix.openfile fn [ O_WRONLY; O_CREAT; O_TRUNC; O_CLOEXEC ] 0o644);
       let t = (Unix.stat fn).st_ctime in
       Unix.unlink fn;
       t

--- a/test/expect-tests/dune_util/flock_tests.ml
+++ b/test/expect-tests/dune_util/flock_tests.ml
@@ -1,7 +1,7 @@
 open Stdune
 
 let%expect_test "blocking lock" =
-  let fd = Unix.openfile "tlc1" [ Unix.O_CREAT ] 0o777 in
+  let fd = Unix.openfile "tlc1" [ Unix.O_CREAT; O_CLOEXEC ] 0o777 in
   let lock = Flock.create fd in
   print_endline "acquiring lock";
   (match Flock.lock_block lock Exclusive with
@@ -19,7 +19,7 @@ let%expect_test "blocking lock" =
 ;;
 
 let%expect_test "nonblocking lock" =
-  let fd flag = Unix.openfile "tlc2" [ flag ] 0o777 in
+  let fd flag = Unix.openfile "tlc2" [ O_CLOEXEC; flag ] 0o777 in
   let fd1 = fd Unix.O_CREAT in
   let lock1 = Flock.create fd1 in
   print_endline "acquiring lock";
@@ -52,7 +52,7 @@ let%expect_test "nonblocking lock" =
 ;;
 
 let%expect_test "double lock" =
-  let fd = Unix.openfile "tlc3" [ Unix.O_CREAT ] 0o600 in
+  let fd = Unix.openfile "tlc3" [ Unix.O_CREAT; O_CLOEXEC ] 0o600 in
   let lock = Flock.create fd in
   (match Flock.lock_non_block lock Exclusive with
    | Ok `Success -> print_endline "lock 1 worked"


### PR DESCRIPTION
I think we have too many touch implementations