### PR TITLE
Remove dependency on bc in pkg cram tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,6 @@
           testBuildInputs =
             with pkgs;
             [
-              bc
               file
               jq
               ripgrep
@@ -172,7 +171,6 @@
               mercurial
               unzip
               coreutils
-              bc
               curl
               git
               binaryen

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -23,7 +23,7 @@
   (run %{bin:shellcheck} -s bash %{deps})))
 
 (cram
- (deps %{bin:git} %{bin:bc})
+ (deps %{bin:git})
  (setup_scripts helpers.sh ../git-helpers.sh)
  (applies_to :whole_subtree))
 

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -100,7 +100,7 @@ mk_ocaml() {
   local patch
   patch=$(echo "$version" | cut -d. -f3)
   local next
-  next=$(echo "$patch + 1" | bc)
+  next=$((patch + 1))
   local constraint="{>= \"$major.$minor.$patch~\" & < \"$major.$minor.$next~\"}"
 
   mkpkg ocaml "$version" <<- EOF


### PR DESCRIPTION
This would reduce a dependency for getting the tests to run in Windows. See #13293 