### PR TITLE
dyn: format more values as valid literals

### DIFF
--- a/doc/changes/changed/13394.md
+++ b/doc/changes/changed/13394.md
@@ -1,0 +1,2 @@
+- Dyn.char now gets quoted in Dyn.pp allowing for parsing as an OCaml char.
+  (#13394, grants #13378, @Alizter)

--- a/doc/changes/changed/13394.md
+++ b/doc/changes/changed/13394.md
@@ -1,2 +1,5 @@
-- Dyn.char now gets quoted in Dyn.pp allowing for parsing as an OCaml char.
+- `Dyn.pp` now prints valid OCaml literals for more constructors:
+  - `Char` is quoted (e.g., `'a'`)
+  - `Int32`/`Int64`/`Nativeint` include literal suffixes (`l`/`L`/`n`)
+  - `Float` handles `infinity`, `neg_infinity`, and `nan`
   (#13394, grants #13378, @Alizter)

--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -83,8 +83,12 @@ let float_to_string =
     loop 0
   in
   fun x ->
-    let s = format_float "%.15g" x in
-    valid_float_lexeme @@ if float_of_string s = x then s else format_float "%.17g" x
+    match Float.classify_float x with
+    | FP_nan -> "nan"
+    | FP_infinite -> if x > 0. then "infinity" else "neg_infinity"
+    | FP_normal | FP_subnormal | FP_zero ->
+      let s = format_float "%.15g" x in
+      valid_float_lexeme @@ if float_of_string s = x then s else format_float "%.17g" x
 ;;
 
 let pp_sequence start stop x ~f =

--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -108,9 +108,9 @@ let rec pp ?(in_arg = false) =
   | Opaque -> Pp.verbatim "<opaque>"
   | Unit -> Pp.verbatim "()"
   | Int i -> Pp.verbatim (string_of_int i)
-  | Int32 i -> Pp.verbatim (Int32.to_string i)
-  | Int64 i -> Pp.verbatim (Int64.to_string i)
-  | Nativeint i -> Pp.verbatim (Nativeint.to_string i)
+  | Int32 i -> Pp.verbatim (Int32.to_string i ^ "l")
+  | Int64 i -> Pp.verbatim (Int64.to_string i ^ "L")
+  | Nativeint i -> Pp.verbatim (Nativeint.to_string i ^ "n")
   | Bool b -> Pp.verbatim (string_of_bool b)
   | String s -> string_in_ocaml_syntax s
   | Bytes b -> string_in_ocaml_syntax (Bytes.to_string b)

--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -114,7 +114,7 @@ let rec pp ?(in_arg = false) =
   | Bool b -> Pp.verbatim (string_of_bool b)
   | String s -> string_in_ocaml_syntax s
   | Bytes b -> string_in_ocaml_syntax (Bytes.to_string b)
-  | Char c -> Pp.char c
+  | Char c -> Pp.verbatim (Printf.sprintf "%C" c)
   | Float f -> Pp.verbatim (float_to_string f)
   | Option None -> pp ~in_arg (Variant ("None", []))
   | Option (Some x) -> pp ~in_arg (Variant ("Some", [ x ]))

--- a/otherlibs/dyn/dyn.mli
+++ b/otherlibs/dyn/dyn.mli
@@ -26,6 +26,10 @@ type t =
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val hash : t -> int
+
+(** Prints valid OCaml literals for all constructors except:
+    [Bytes], [Float] (infinity/nan), [Opaque], [Map], [Set]. *)
+
 val pp : t -> _ Pp.t
 val to_string : t -> string
 

--- a/otherlibs/dyn/dyn.mli
+++ b/otherlibs/dyn/dyn.mli
@@ -28,7 +28,7 @@ val compare : t -> t -> Ordering.t
 val hash : t -> int
 
 (** Prints valid OCaml literals for all constructors except:
-    [Bytes], [Float] (infinity/nan), [Opaque], [Map], [Set]. *)
+    [Bytes], [Opaque], [Map], [Set]. *)
 
 val pp : t -> _ Pp.t
 val to_string : t -> string

--- a/otherlibs/dyn/test/dyn_float_tests.ml
+++ b/otherlibs/dyn/test/dyn_float_tests.ml
@@ -17,9 +17,9 @@ let%expect_test "special values" =
   print_float nan;
   [%expect {| nan |}];
   print_float infinity;
-  [%expect {| inf |}];
+  [%expect {| infinity |}];
   print_float neg_infinity;
-  [%expect {| -inf |}]
+  [%expect {| neg_infinity |}]
 ;;
 
 let%expect_test "scientific notation" =
@@ -82,7 +82,8 @@ let%expect_test "round-trip verification" =
   (* Verify that parsing the output gives back the original value *)
   let check x =
     let s = Dyn.to_string (Dyn.float x) in
-    let y = float_of_string s in
+    (* float_of_string doesn't accept "neg_infinity", handle specially *)
+    let y = if s = "neg_infinity" then neg_infinity else float_of_string s in
     if x = y || (x <> x && y <> y) (* nan <> nan *)
     then print_endline "ok"
     else Printf.printf "FAIL: %s -> %f\n" s y

--- a/otherlibs/dyn/test/dyn_pp_tests.ml
+++ b/otherlibs/dyn/test/dyn_pp_tests.ml
@@ -1,27 +1,23 @@
 let print dyn = print_endline (Dyn.to_string dyn)
 
-(* CR-soon Alizter: Char is currently printed as a raw character, not as an
-   OCaml char literal. This means there are no quotes and special characters
-   are not escaped. *)
-
 let%expect_test "char - printable" =
   print (Dyn.char 'a');
-  [%expect {| a |}];
+  [%expect {| 'a' |}];
   print (Dyn.char 'Z');
-  [%expect {| Z |}];
+  [%expect {| 'Z' |}];
   print (Dyn.char '0');
-  [%expect {| 0 |}];
+  [%expect {| '0' |}];
   print (Dyn.char ':');
-  [%expect {| : |}]
+  [%expect {| ':' |}]
 ;;
 
 let%expect_test "char - special" =
   print (Dyn.char '\'');
-  [%expect {| ' |}];
+  [%expect {| '\'' |}];
   print (Dyn.char '"');
-  [%expect {| " |}];
+  [%expect {| '"' |}];
   print (Dyn.char '\\');
-  [%expect {| \ |}]
+  [%expect {| '\\' |}]
 ;;
 
 (* CR-soon Alizter: Int32/Int64/Nativeint are printed without their literal

--- a/otherlibs/dyn/test/dyn_pp_tests.ml
+++ b/otherlibs/dyn/test/dyn_pp_tests.ml
@@ -20,40 +20,37 @@ let%expect_test "char - special" =
   [%expect {| '\\' |}]
 ;;
 
-(* CR-soon Alizter: Int32/Int64/Nativeint are printed without their literal
-   suffix, making them indistinguishable from regular ints. *)
-
 let%expect_test "int32" =
   print (Dyn.int32 42l);
-  [%expect {| 42 |}];
+  [%expect {| 42l |}];
   print (Dyn.int32 (-1l));
-  [%expect {| -1 |}];
+  [%expect {| -1l |}];
   print (Dyn.int32 0l);
-  [%expect {| 0 |}];
+  [%expect {| 0l |}];
   print (Dyn.int32 Int32.max_int);
-  [%expect {| 2147483647 |}];
+  [%expect {| 2147483647l |}];
   print (Dyn.int32 Int32.min_int);
-  [%expect {| -2147483648 |}]
+  [%expect {| -2147483648l |}]
 ;;
 
 let%expect_test "int64" =
   print (Dyn.int64 42L);
-  [%expect {| 42 |}];
+  [%expect {| 42L |}];
   print (Dyn.int64 (-1L));
-  [%expect {| -1 |}];
+  [%expect {| -1L |}];
   print (Dyn.int64 0L);
-  [%expect {| 0 |}];
+  [%expect {| 0L |}];
   print (Dyn.int64 Int64.max_int);
-  [%expect {| 9223372036854775807 |}];
+  [%expect {| 9223372036854775807L |}];
   print (Dyn.int64 Int64.min_int);
-  [%expect {| -9223372036854775808 |}]
+  [%expect {| -9223372036854775808L |}]
 ;;
 
 let%expect_test "nativeint" =
   print (Dyn.nativeint 42n);
-  [%expect {| 42 |}];
+  [%expect {| 42n |}];
   print (Dyn.nativeint (-1n));
-  [%expect {| -1 |}];
+  [%expect {| -1n |}];
   print (Dyn.nativeint 0n);
-  [%expect {| 0 |}]
+  [%expect {| 0n |}]
 ;;

--- a/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
+++ b/test/expect-tests/dune_rpc_impl/dune_rpc_impl_tests.ml
@@ -54,7 +54,7 @@ let%expect_test "serialize and deserialize error message" =
             (0,
              Concat
                (Break (("", 1, ""), ("", 0, "")),
-                [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                 ; Verbatim "Oh no!"
                 ])),
           Break (("", 0, ""), ("", 0, ""))))
@@ -70,10 +70,11 @@ let%expect_test "serialize and deserialize error message" =
                   (0,
                    Concat
                      (Break (("", 1, ""), ("", 0, "")),
-                      [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                      [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                       ; Verbatim "Oh no!"
                       ])))),
-          Break (("", 0, ""), ("", 0, "")))) |}]
+          Break (("", 0, ""), ("", 0, ""))))
+    |}]
 ;;
 
 let%expect_test "serialize and deserialize error message with location" =
@@ -103,7 +104,7 @@ let%expect_test "serialize and deserialize error message with location" =
                  (0,
                   Concat
                     (Break (("", 1, ""), ("", 0, "")),
-                     [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                     [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                      ; Verbatim "An error with location!"
                      ])),
                Break (("", 0, ""), ("", 0, "")))
@@ -126,11 +127,12 @@ let%expect_test "serialize and deserialize error message with location" =
                        (0,
                         Concat
                           (Break (("", 1, ""), ("", 0, "")),
-                           [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                           [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                            ; Verbatim "An error with location!"
                            ])))),
                Break (("", 0, ""), ("", 0, "")))
-          ])) |}]
+          ]))
+    |}]
 ;;
 
 let%expect_test "serialize and deserialize error with location excerpt and hint" =
@@ -172,7 +174,7 @@ let%expect_test "serialize and deserialize error with location excerpt and hint"
                  (0,
                   Concat
                     (Break (("", 1, ""), ("", 0, "")),
-                     [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                     [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                      ; Verbatim "An error with location!"
                      ])),
                Break (("", 0, ""), ("", 0, "")))
@@ -219,7 +221,7 @@ let%expect_test "serialize and deserialize error with location excerpt and hint"
                             (0,
                              Concat
                                (Break (("", 1, ""), ("", 0, "")),
-                                [ Seq (Tag (Error, Verbatim "Error"), Char :)
+                                [ Seq (Tag (Error, Verbatim "Error"), Char ':')
                                 ; Verbatim "An error with location!"
                                 ]))
                         ; Box
@@ -238,5 +240,6 @@ let%expect_test "serialize and deserialize error with location excerpt and hint"
                                 Verbatim "Hint 2"))
                         ]))),
                Break (("", 0, ""), ("", 0, "")))
-          ])) |}]
+          ]))
+    |}]
 ;;


### PR DESCRIPTION
`Dyn.pp` now prints valid OCaml literals for more constructors:
- `Char` is quoted (e.g., `'a'`)
- `Int32`/`Int64`/`Nativeint` include literal suffixes (`l`/`L`/`n`)
- `Float` handles `infinity`, `neg_infinity`, and `nan`

To enforce these invariants we add some new generated roundtrip tests. They take a dynamic value, synthesise an OCaml type for it and then print it into a module. This module is promoted and built normally. Any mismatches with the promoted output will cause the diff to fail. If the new diff is invalid OCaml syntax, the compiler will tell us.

The tests show the cases we don't currently handle and these have been documented accordingly.

- Fixes #13378
- [x] changelog
- [x] roundtrip tests