### PR TITLE
Test that shows that rev-store is not checked for validity properly

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/invalid-rev-store.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-rev-store.t
@@ -1,0 +1,52 @@
+Tests behavior when the rev store repo is not a correct git bare repo
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+Create a package to lock
+
+  $ mkdir _repo
+  $ git -C _repo init --initial-branch=main --quiet
+  $ cat > _repo/dune-project <<EOF
+  > (lang dune 3.22)
+  > (package (name testpkg))
+  > EOF
+  $ git -C _repo add -A
+  $ git -C _repo commit -m "Initial commit" --quiet
+
+Locking the package works
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (pin
+  >  (url "git+file://$PWD/_repo")
+  >  (package (name testpkg)))
+  > (package
+  >  (name my)
+  >  (allow_empty)
+  >  (depends testpkg))
+  > EOF
+
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - testpkg.dev
+
+The rev store is set up correctly:
+
+  $ git -C $PWD/.cache/dune/git-repo rev-parse --is-bare-repository
+  true
+
+Let's replace the rev-store with one that's not properly initialized:
+
+  $ rm -rf $PWD/.cache/dune/git-repo
+  $ mkdir $PWD/.cache/dune/git-repo
+  $ git -C $PWD/.cache/dune/git-repo rev-parse --is-bare-repository 2>&1 | grep -o "invalid gitfile format"
+  invalid gitfile format
+  [128]
+
+Dune does not detect the invalid rev-store and fails with an unhelpful error
+message because git is confused:
+
+  $ dune_pkg_lock_normalized 2>&1 | grep -o "invalid gitfile format"
+  invalid gitfile format
+  [1]


### PR DESCRIPTION
In `rev_store.ml` we currently try to create the rev-store folder and if it exists then we assume that it is a bare repo. This is not necessarily the case and if the folder is e.g. empty (because a previous `init --bare` failed) the rev-store is permanently bricked with no way to recover (bar the user removing it but it is unclear from the error what the user can do, as `git` points at somewhere else).

Noticed this behavior when pairing on a strange test failure on #13297 with @Alizter and paired with @Sudha247 to create a repro case.

This PR is a variant of #13392 which reproduces the same behavior using a different approach which does not require the changes from #13297.