### PR TITLE
Detect the case where the `git-repo` folder exists but it is not a valid repo

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/invalid-rev-store.t
+++ b/test/blackbox-tests/test-cases/pkg/invalid-rev-store.t
@@ -47,6 +47,10 @@ Let's replace the rev-store with one that's not properly initialized:
 Dune does not detect the invalid rev-store and fails with an unhelpful error
 message because git is confused:
 
-  $ dune_pkg_lock_normalized 2>&1 | grep -o "invalid gitfile format"
-  invalid gitfile format
+  $ dune_pkg_lock_normalized
+  Error: The folder at the revision store location is not a valid bare git
+  repository.
+  Hint: Try deleting the folder with
+  Hint:
+  'rm -rf $TESTCASE_ROOT/.cache/dune/git-repo'
   [1]


### PR DESCRIPTION
If the user has messed up data there, we can only:

  * Delete it and recreate
  * Display an error message and ask the user to deal with this

In this PR I am choosing the latter, just to make sure we don't accidentally delete potentially important user data automatically. I don't think there's a 100% right way, this is just somewhat the safer way. One can of course also argue that the location in `.cache/dune` is dune-managed and if the user puts important data there it is ok for Dune to delete it.