### PR TITLE
Use Env_path helper to update PATH with the dune folder

### DIFF
--- a/src/dune_rules/run_with_path.ml
+++ b/src/dune_rules/run_with_path.ml
@@ -146,16 +146,14 @@ module Spec = struct
         let src = Path.of_string Sys.executable_name in
         let dst = Path.relative bin_folder "dune" in
         Io.portable_symlink ~src ~dst;
-        Path.to_string bin_folder
+        bin_folder
       in
       let env =
         eenv.env
         |> Env.add
              ~var:"OCAMLFIND_DESTDIR"
              ~value:(Path.to_absolute_filename ocamlfind_destdir)
-        |> Env.update ~var:"PATH" ~f:(function
-          | None -> Some dune_folder
-          | Some path -> Some (sprintf "%s:%s" dune_folder path))
+        |> Env_path.cons ~dir:dune_folder
       in
       Output.with_error
         ~accepted_exit_codes:eenv.exit_codes

--- a/test/blackbox-tests/test-cases/pkg/build-action-path.t
+++ b/test/blackbox-tests/test-cases/pkg/build-action-path.t
@@ -24,4 +24,4 @@ Verify that the run with path action correctly adds Dune to PATH on all platform
   > EOF
 
   $ dune build @pkg-install 2>&1
-  $PATH incorrect!
+  $PATH correct!

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -95,9 +95,6 @@
 
 (cram
  (applies_to build-action-path)
- ; TODO: Enable on all platforms once Windows bug is fixed
- (enabled_if
-  (= %{os_type} Win32))
  (alias runtest-windows))
 
 ;; disabled for flakiness


### PR DESCRIPTION
The code previously used : as the path separator, but Windows uses ;. ~This could potentially fix the issue reported in #12433~ (I hadn't looked at what dune_folder actually was, and misunderstood that this could potentially fix the issue in #12433)