### PR TITLE
Test for self-in-path dir correctly added to $PATH

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/build-action-path.t
+++ b/test/blackbox-tests/test-cases/pkg/build-action-path.t
@@ -1,0 +1,27 @@
+Verify that the run with path action correctly adds Dune to PATH on all platforms.
+
+  $ make_lockdir
+
+  $ pkg() {
+  > make_lockpkg $1<<EOF
+  > (build (run ocaml $2))
+  > (version dev)
+  > EOF
+  > local files="${source_lock_dir}/$1.files"
+  > local exec_path="${source_lock_dir}/$1.files/$2"
+  > mkdir -p "${files}"
+  > touch "${exec_path}"
+  > cat > "${exec_path}"
+  > }
+
+  $ pkg foo foo.ml<<'EOF'
+  > let () =
+  >  let pathsep = if Sys.win32 then ';' else ':' in
+  >  let path = Sys.getenv "PATH" |> String.split_on_char pathsep |> List.hd in
+  >  if (Filename.basename path |> String.ends_with ~suffix:"self-in-path")
+  >  then print_endline "$PATH correct!"
+  >  else print_endline "$PATH incorrect!"
+  > EOF
+
+  $ dune build @pkg-install 2>&1
+  $PATH incorrect!

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -93,6 +93,13 @@
  (deps %{bin:unzip})
  (applies_to pkg-extract-fail))
 
+(cram
+ (applies_to build-action-path)
+ ; TODO: Enable on all platforms once Windows bug is fixed
+ (enabled_if
+  (= %{os_type} Win32))
+ (alias runtest-windows))
+
 ;; disabled for flakiness
 
 (cram


### PR DESCRIPTION
Companion PR to #13405 to show that the test fails on Windows without the fix added in #13405