### PR TITLE
fix: stop starting rpc with dune promote

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -48,8 +48,7 @@ module Apply = struct
     let files_to_promote = files_to_promote ~common files in
     match Dune_util.Global_lock.lock ~timeout:None with
     | Ok () ->
-      (* Why are we starting an RPC server??? *)
-      Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
+      Scheduler_setup.go_without_rpc_server ~common ~config (fun () ->
         let open Fiber.O in
         let+ () = Fiber.return () in
         let missing =

--- a/doc/changes/changed/13428.md
+++ b/doc/changes/changed/13428.md
@@ -1,0 +1,1 @@
+- Stop starting RPC server with `$ dune promote` (#13428, @rgrinberg)


### PR DESCRIPTION
Don't think anyone ran into this since the RPC is very short lived, but there's really no reason to start an RPC server for a command that will terminate this quickly