### PR TITLE
Align`is_prefix`/`is_suffix` with OCaml stdlib names

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -61,7 +61,7 @@ module Dep = struct
   let alias_rec ~dir s = Dep_conf.Alias_rec (make_alias_sw ~dir s)
 
   let parse_alias s =
-    if not (String.is_prefix s ~prefix:"@")
+    if not (String.starts_with ~prefix:"@" s)
     then None
     else (
       let pos, recursive =

--- a/otherlibs/stdune/src/bin.ml
+++ b/otherlibs/stdune/src/bin.ml
@@ -27,7 +27,7 @@ let exists fn =
 ;;
 
 let add_exe prog =
-  if String.is_suffix (String.lowercase prog) ~suffix:exe then prog else prog ^ exe
+  if String.ends_with ~suffix:exe (String.lowercase prog) then prog else prog ^ exe
 ;;
 
 let which ~path prog =

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -205,7 +205,7 @@ end = struct
     else (
       let of_len = String.length of_ in
       let t_len = String.length t in
-      if t_len > of_len && t.[of_len] = '/' && String.is_prefix t ~prefix:of_
+      if t_len > of_len && t.[of_len] = '/' && String.starts_with ~prefix:of_ t
       then Some (String.drop t (of_len + 1))
       else None)
   ;;
@@ -216,7 +216,7 @@ end = struct
     ||
     let of_len = String.length of_ in
     let t_len = String.length t in
-    t_len > of_len && t.[of_len] = '/' && String.is_prefix t ~prefix:of_
+    t_len > of_len && t.[of_len] = '/' && String.starts_with ~prefix:of_ t
   ;;
 
   module Reach = struct
@@ -582,7 +582,9 @@ end = struct
   let to_string_maybe_quoted t = String.maybe_quoted (to_string t)
 
   let is_descendant b ~of_:a =
-    if is_root a then true else String.is_prefix ~prefix:(to_string a ^ "/") (to_string b)
+    if is_root a
+    then true
+    else String.starts_with ~prefix:(to_string a ^ "/") (to_string b)
   ;;
 
   module Map = String.Map

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -18,6 +18,25 @@ module StringLabels = struct
     fun ~f s -> loop s 0 (String.length s) f
   ;;
 
+  let[@warning "-32"] starts_with s ~prefix =
+    let prefix_len = String.length prefix in
+    match String.length s < prefix_len with
+    | true -> false
+    | false ->
+      let s_prefix = String.sub s 0 prefix_len in
+      String.equal prefix s_prefix
+  ;;
+
+  let[@warning "-32"] ends_with s ~suffix =
+    let len = String.length s in
+    let suffix_len = String.length suffix in
+    match len < suffix_len with
+    | true -> false
+    | false ->
+      let s_suffix = String.sub s (len - suffix_len) suffix_len in
+      String.equal suffix s_suffix
+  ;;
+
   (* overwrite them with stdlib versions if available *)
   include Stdlib.StringLabels
 end
@@ -64,20 +83,20 @@ struct
         && check_suffix s ~suffix suffix_len offset (i + 1))
   ;;
 
-  let is_prefix s ~prefix =
+  let starts_with ~prefix s =
     let len = length s in
     let prefix_len = length prefix in
     len >= prefix_len && check_prefix s ~prefix prefix_len 0
   ;;
 
-  let is_suffix s ~suffix =
+  let ends_with ~suffix s =
     let len = length s in
     let suffix_len = length suffix in
     len >= suffix_len && check_suffix s ~suffix suffix_len (len - suffix_len) 0
   ;;
 
   let drop_prefix s ~prefix =
-    if is_prefix s ~prefix
+    if starts_with ~prefix s
     then
       if length s = length prefix
       then Some ""
@@ -92,7 +111,7 @@ struct
   ;;
 
   let drop_suffix s ~suffix =
-    if is_suffix s ~suffix
+    if ends_with ~suffix s
     then
       if length s = length suffix
       then Some ""
@@ -311,7 +330,7 @@ let drop_prefix_and_suffix t ~prefix ~suffix =
   let s_len = String.length suffix in
   let t_len = String.length t in
   let p_s_len = p_len + s_len in
-  if p_s_len <= t_len && is_prefix t ~prefix && is_suffix t ~suffix
+  if p_s_len <= t_len && starts_with ~prefix t && ends_with ~suffix t
   then Some (sub t ~pos:p_len ~len:(t_len - p_s_len))
   else None
 ;;

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -12,8 +12,8 @@ val to_dyn : t -> Dyn.t
 val break : t -> pos:int -> t * t
 val is_empty : t -> bool
 val of_list : char list -> t
-val is_prefix : t -> prefix:t -> bool
-val is_suffix : t -> suffix:t -> bool
+val starts_with : prefix:t -> t -> bool
+val ends_with : suffix:t -> t -> bool
 val take : t -> int -> t
 val drop : t -> int -> t
 val split_n : t -> int -> t * t

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -22,7 +22,7 @@ open Simplified
 
 let echo s =
   let lines = String.split_lines s in
-  if String.is_suffix s ~suffix:"\n"
+  if String.ends_with ~suffix:"\n" s
   then List.map lines ~f:(fun s -> Run ("echo", [ s ]))
   else (
     match List.rev lines with

--- a/src/dune_engine/context_name.ml
+++ b/src/dune_engine/context_name.ml
@@ -18,7 +18,7 @@ include (
     let of_string_opt name =
       if
         name = ""
-        || String.is_prefix name ~prefix:"."
+        || String.starts_with ~prefix:"." name
         || name = "log"
         || String.contains name '/'
         || String.contains name '\\'

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -560,7 +560,7 @@ end = struct
           User_message.Style.Ansi_styles styles)
       in
       let without_color = Ansi_color.strip s in
-      let has_embedded_location = String.is_prefix ~prefix:"File " without_color in
+      let has_embedded_location = String.starts_with ~prefix:"File " without_color in
       Has_output { with_color; without_color; has_embedded_location }
   ;;
 

--- a/src/dune_graph/graph.ml
+++ b/src/dune_graph/graph.ml
@@ -226,7 +226,7 @@ let serialize_summary t oc =
      these nodes to a single table since they only have a single entry each *)
   let rename_all_deps label =
     Option.map label ~f:(fun label ->
-      if String.is_suffix label ~suffix:".all-deps" then "*.all-deps" else label)
+      if String.ends_with ~suffix:".all-deps" label then "*.all-deps" else label)
   in
   let by_label =
     Int.Map.fold t.nodes ~init:String_opt_map.empty ~f:(fun node acc ->

--- a/src/dune_lang/lib_dep.ml
+++ b/src/dune_lang/lib_dep.ml
@@ -38,8 +38,8 @@ module Select = struct
                  Path.Local.to_string prefix, ext
                in
                match
-                 ( String.is_prefix ~prefix:result_prefix (Path.Local.to_string file)
-                 , String.is_suffix file_str ~suffix:result_suffix )
+                 ( String.starts_with ~prefix:result_prefix (Path.Local.to_string file)
+                 , String.ends_with ~suffix:result_suffix file_str )
                with
                | true, true -> ()
                | _result_is_prefix, _result_is_suffix ->

--- a/src/dune_lang/package_constraint.ml
+++ b/src/dune_lang/package_constraint.ml
@@ -157,7 +157,7 @@ let decode =
     in
     peek_exn
     >>= function
-    | Atom (_loc, A s) when String.is_prefix s ~prefix:":" ->
+    | Atom (_loc, A s) when String.starts_with ~prefix:":" s ->
       let+ () = junk in
       Bvar (Variable (Package_variable_name.of_string (String.drop s 1)))
     | _ -> sum (ops @ logops))

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -116,6 +116,8 @@ module Project = struct
 
   let decode =
     Decoder.atom_matching ~desc:"variable" (fun s ->
-      if String.is_prefix s ~prefix:":" then Some (of_string (String.drop s 1)) else None)
+      if String.starts_with ~prefix:":" s
+      then Some (of_string (String.drop s 1))
+      else None)
   ;;
 end

--- a/src/dune_lang/string_with_vars.ml
+++ b/src/dune_lang/string_with_vars.ml
@@ -263,22 +263,22 @@ type yes_no_unknown =
 
 let is_suffix t ~suffix:want =
   match known_suffix t with
-  | Full s -> if String.is_suffix ~suffix:want s then Yes else No
+  | Full s -> if String.ends_with ~suffix:want s then Yes else No
   | Partial { suffix = have; source_pform } ->
-    if String.is_suffix ~suffix:want have
+    if String.ends_with ~suffix:want have
     then Yes
-    else if String.is_suffix ~suffix:have want
+    else if String.ends_with ~suffix:have want
     then Unknown { source_pform }
     else No
 ;;
 
 let is_prefix t ~prefix:want =
   match known_prefix t with
-  | Full s -> if String.is_prefix ~prefix:want s then Yes else No
+  | Full s -> if String.starts_with ~prefix:want s then Yes else No
   | Partial { prefix = have; source_pform } ->
-    if String.is_prefix ~prefix:want have
+    if String.starts_with ~prefix:want have
     then Yes
-    else if String.is_prefix ~prefix:have want
+    else if String.starts_with ~prefix:have want
     then Unknown { source_pform }
     else No
 ;;

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -145,8 +145,8 @@ let opam_string_to_slang ~package ~loc opam_string =
       (match Re.Group.get group 0 with
        | "%%" -> Ok (Slang.text "%")
        | interp
-         when String.is_prefix ~prefix:"%{" interp && String.is_suffix ~suffix:"}%" interp
-         ->
+         when String.starts_with ~prefix:"%{" interp
+              && String.ends_with ~suffix:"}%" interp ->
          let ident = String.sub ~pos:2 ~len:(String.length interp - 4) interp in
          opam_raw_fident_to_slang ~loc ident
        | other ->

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -470,7 +470,7 @@ let run_with_exit_code { dir; _ } ~allow_codes ~display args =
   else (
     match exit_code with
     | 129
-      when String.is_prefix ~prefix:"error: unknown option `no-write-fetch-head'" stderr
+      when String.starts_with ~prefix:"error: unknown option `no-write-fetch-head'" stderr
       ->
       User_error.raise
         [ User_message.command

--- a/src/dune_pkg/sys_poll.ml
+++ b/src/dune_pkg/sys_poll.ml
@@ -31,7 +31,7 @@ let normalise_arch raw =
     when a = "armv8b"
          || a = "armv8l"
          || List.exists
-              ~f:(fun prefix -> String.is_prefix ~prefix a)
+              ~f:(fun prefix -> String.starts_with ~prefix a)
               [ "armv5"; "armv6"; "earmv6"; "armv7"; "earmv7" ] -> "arm32"
   | s -> s
 ;;

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -53,14 +53,14 @@ let map_loc_to_source_path loc =
 let cram_stanzas =
   let is_conflict_marker line =
     [ "======="; "%%%%%%%"; "+++++++"; "-------"; "|||||||" ]
-    |> List.exists ~f:(fun prefix -> String.is_prefix line ~prefix)
+    |> List.exists ~f:(fun prefix -> String.starts_with ~prefix line)
   in
   let find_conflict ~loc state line =
     match state with
-    | `No_conflict when String.is_prefix ~prefix:"<<<<<<<" line -> `Started loc
+    | `No_conflict when String.starts_with ~prefix:"<<<<<<<" line -> `Started loc
     | `Started loc when is_conflict_marker line -> `Has_markers loc
     | `Has_markers loc when is_conflict_marker line -> `Has_markers loc
-    | `Has_markers start_loc when String.is_prefix ~prefix:">>>>>>>" line ->
+    | `Has_markers start_loc when String.starts_with ~prefix:">>>>>>>" line ->
       User_error.raise
         ~loc:(Loc.span start_loc loc)
         [ Pp.text

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -191,7 +191,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
           if ext = ext_lib
           then (
             let file = Path.relative t.dir f in
-            if String.is_prefix f ~prefix:Foreign.Archive.Name.lib_file_prefix
+            if String.starts_with ~prefix:Foreign.Archive.Name.lib_file_prefix f
             then Left file
             else Right file)
           else Skip)
@@ -308,7 +308,7 @@ module Loader = struct
             List.filter_partition_map contents ~f:(fun (name, kind) ->
               match resolve_link ~dir:path ~fname:name kind with
               | Some S_DIR -> Left name
-              | Some S_REG when String.is_prefix name ~prefix:file_prefix -> Right name
+              | Some S_REG when String.starts_with ~prefix:file_prefix name -> Right name
               | _ -> Skip)
           in
           Ok

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -12,7 +12,7 @@ let default_context_flags (ctx : Build_context.t) ocaml_config ~project =
   let cflags = Ocaml_config.ocamlc_cflags ocaml_config in
   let c, cxx =
     let cxxflags =
-      List.filter cflags ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
+      List.filter cflags ~f:(fun s -> not (String.starts_with ~prefix:"-std=" s))
     in
     match Dune_project.use_standard_c_and_cxx_flags project with
     | None | Some false -> Action_builder.(return cflags, return cxxflags)
@@ -339,7 +339,7 @@ let build_o_files
       |> List.fold_left ~init:[] ~f:(fun acc dc ->
         Dir_contents.text_files dc
         |> Filename.Set.fold ~init:acc ~f:(fun fn acc ->
-          if String.is_suffix fn ~suffix:Foreign_language.header_extension
+          if String.ends_with ~suffix:Foreign_language.header_extension fn
           then Path.relative (Path.build (Dir_contents.dir dc)) fn :: acc
           else acc))
     in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -455,7 +455,7 @@ end = struct
 
   let is_odig_doc_file fn =
     List.exists [ "README"; "LICENSE"; "CHANGE"; "HISTORY" ] ~f:(fun prefix ->
-      String.is_prefix fn ~prefix)
+      String.starts_with ~prefix fn)
   ;;
 
   let entries_of_install_stanza ~dir ~expander ~package_db (install_conf : Install_conf.t)
@@ -932,7 +932,7 @@ end = struct
           in
           let pp =
             Pp.concat_map template ~sep:Pp.newline ~f:(fun s ->
-              if String.is_prefix s ~prefix:"#"
+              if String.starts_with ~prefix:"#" s
               then (
                 match String.extract_blank_separated_words (String.drop s 1) with
                 | [ ("JBUILDER_GEN" | "DUNE_GEN") ] -> Meta.pp meta.entries

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -185,12 +185,13 @@ end = struct
     let rec loop acc = function
       | [] -> acc
       | "--enable" :: name :: rest -> loop (enable name acc) rest
-      | maybe_enable :: rest when String.is_prefix maybe_enable ~prefix:"--enable=" ->
+      | maybe_enable :: rest when String.starts_with ~prefix:"--enable=" maybe_enable ->
         (match String.drop_prefix maybe_enable ~prefix:"--enable=" with
          | Some name -> loop (enable name acc) rest
          | _ -> assert false)
       | "--disable" :: name :: rest -> loop (disable name acc) rest
-      | maybe_disable :: rest when String.is_prefix maybe_disable ~prefix:"--disable=" ->
+      | maybe_disable :: rest when String.starts_with ~prefix:"--disable=" maybe_disable
+        ->
         (match String.drop_prefix maybe_disable ~prefix:"--disable=" with
          | Some name -> loop (disable name acc) rest
          | _ -> assert false)
@@ -198,7 +199,8 @@ end = struct
       | "--effects" :: "cps" :: rest -> loop { acc with effects = Some Cps } rest
       | "--effects" :: "double-translation" :: rest ->
         loop { acc with effects = Some Double_translation } rest
-      | maybe_effects :: rest when String.is_prefix maybe_effects ~prefix:"--effects=" ->
+      | maybe_effects :: rest when String.starts_with ~prefix:"--effects=" maybe_effects
+        ->
         let backend =
           Option.bind
             (String.drop_prefix maybe_effects ~prefix:"--effects=")
@@ -251,20 +253,21 @@ end = struct
     let rec loop acc = function
       | [] -> acc
       | "--enable" :: ("effects" | "use-js-string") :: rest -> loop acc rest
-      | maybe_enable :: rest when String.is_prefix maybe_enable ~prefix:"--enable=" ->
+      | maybe_enable :: rest when String.starts_with ~prefix:"--enable=" maybe_enable ->
         (match String.drop_prefix maybe_enable ~prefix:"--enable=" with
          | Some ("effects" | "use-js-string") -> loop acc rest
          | Some _ -> loop (maybe_enable :: acc) rest
          | None -> assert false)
       | "--disable" :: ("effects" | "use-js-string") :: rest -> loop acc rest
-      | maybe_disable :: rest when String.is_prefix maybe_disable ~prefix:"--disable=" ->
+      | maybe_disable :: rest when String.starts_with ~prefix:"--disable=" maybe_disable
+        ->
         (match String.drop_prefix maybe_disable ~prefix:"--disable=" with
          | Some ("effects" | "use-js-string") -> loop acc rest
          | Some _ -> loop (maybe_disable :: acc) rest
          | None -> assert false)
       | "--effects" :: _backend :: rest -> loop acc rest
-      | maybe_effects :: rest when String.is_prefix maybe_effects ~prefix:"--effects=" ->
-        loop acc rest
+      | maybe_effects :: rest when String.starts_with ~prefix:"--effects=" maybe_effects
+        -> loop acc rest
       | "--toplevel" :: rest -> loop acc rest
       | other :: rest -> loop (other :: acc) rest
     in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -473,7 +473,7 @@ module Pkg = struct
       | ".hg" | ".git" | "_darcs" | "_opam" | "_build" | "_esy" -> true
       | _ -> false
     in
-    let skip_file = String.is_prefix ~prefix:".#" in
+    let skip_file = String.starts_with ~prefix:".#" in
     let rec loop root acc path =
       let full_path = Path.External.append_local root path in
       Fs_memo.dir_contents (External full_path)

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -750,7 +750,7 @@ let filename =
 
 let extension =
   plain_string (fun ~loc s ->
-    if String.is_prefix ~prefix:"." s
+    if String.starts_with ~prefix:"." s
     then User_error.raise ~loc [ Pp.textf "extension must not start with '.'" ];
     "." ^ s)
 ;;

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -126,11 +126,11 @@ let adjust_dst_gen =
       let is_executable =
         let has_ext ext =
           match src_suffix with
-          | Full s -> String.is_suffix s ~suffix:ext
+          | Full s -> String.ends_with ~suffix:ext s
           | Partial { source_pform; suffix } ->
-            if String.is_suffix suffix ~suffix:ext
+            if String.ends_with ~suffix:ext suffix
             then true
-            else if String.is_suffix ext ~suffix
+            else if String.ends_with ~suffix ext
             then error source_pform
             else false
         in

--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -33,6 +33,6 @@ let supports_cmi_file version = version >= (5, 0, 0)
 let supports_oxcaml version =
   let jst = "+jst" in
   let ox = "+ox" in
-  Stdune.String.is_suffix ~suffix:jst version
-  || Stdune.String.is_suffix ~suffix:ox version
+  Stdune.String.ends_with ~suffix:jst version
+  || Stdune.String.ends_with ~suffix:ox version
 ;;

--- a/src/source/cram_test.ml
+++ b/src/source/cram_test.ml
@@ -9,7 +9,7 @@ type t =
 
 let fname_in_dir_test = "run.t"
 let suffix = ".t"
-let is_cram_suffix = String.is_suffix ~suffix
+let is_cram_suffix = String.ends_with ~suffix
 
 let to_dyn =
   let open Dyn in

--- a/src/source/dir_contents.ml
+++ b/src/source/dir_contents.ml
@@ -60,9 +60,9 @@ let is_special (st_kind : Unix.file_kind) =
 ;;
 
 let is_temp_file fn =
-  String.is_prefix fn ~prefix:".#"
-  || String.is_suffix fn ~suffix:".swp"
-  || String.is_suffix fn ~suffix:"~"
+  String.starts_with ~prefix:".#" fn
+  || String.ends_with ~suffix:".swp" fn
+  || String.ends_with ~suffix:"~" fn
 ;;
 
 let of_source_path_impl path =

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -557,7 +557,7 @@ module Context = struct
     ;;
 
     let name_hint_opt name =
-      if String.is_prefix ~prefix:"/" name
+      if String.starts_with ~prefix:"/" name
       then (
         let context_name = Filename.basename name in
         Some [ Pp.textf "(name %s) would be a valid context name" context_name ])


### PR DESCRIPTION
I've ran into a case where I used `String.starts_with` which worked fine on my machine but broke on CI because we were testing on an older OCaml version. Turns out the Dune way is currently `String.is_prefix`.

So I thought it would be better to use the same name as the OCaml 4.13+ stdlib does, thus we can also use the stdlibs implementation if available and it is easier for people to pick up as there's no mistake which function should be used. Furthermore it prevents a mix of `String.starts_with` and `String.is_prefix` code making it to `main` if we stop testing on <4.13.