### PR TITLE
refactor: remove some unnecessary wrappers in [Path.External]

### DIFF
--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -77,7 +77,6 @@ module External : sig
   val initial_cwd : t
   val cwd : unit -> t
   val relative : t -> string -> t
-  val mkdir_p : ?perms:int -> t -> unit
   val of_filename_relative_to_initial_cwd : string -> t
   val append_local : t -> Local.t -> t
 


### PR DESCRIPTION
They're just wrapping the corresponding [Fpath] functions