### PR TITLE
Repro case for #12311

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/error-message.t
@@ -75,3 +75,52 @@ when the program is not found.
   Hint: You may want to verify the following depexts are installed:
   - unknown-package
   [1]
+
+Update the foo lockfile to have a single depext name:
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (run dune build))
+  > (depexts foo)
+  > (source
+  >  (fetch
+  >   (url file://$PWD/foo.tar)
+  >   (checksum md5=$(md5sum foo.tar | cut -f1 -d' '))))
+  > EOF
+Build the project, when it fails building 'foo' package, it shows the depexts
+error message.
+  $ dune build
+  File "dune.lock/foo.pkg", line 3, characters 6-10:
+  3 |  (run dune build))
+            ^^^^
+  Error: Logs for package foo
+  File "dune-project", line 1, characters 0-0:
+  Error: Invalid first line, expected: (lang <lang> <version>)
+  
+  Hint: You may want to verify the following depexts are installed:- foo
+  [1]
+
+Update the foo lockfile to have short depext names:
+  $ make_lockpkg foo <<EOF
+  > (version 0.0.1)
+  > (build
+  >  (run dune build))
+  > (depexts a b)
+  > (source
+  >  (fetch
+  >   (url file://$PWD/foo.tar)
+  >   (checksum md5=$(md5sum foo.tar | cut -f1 -d' '))))
+  > EOF
+Build the project, when it fails building 'foo' package, it shows the depexts
+error message.
+  $ dune build
+  File "dune.lock/foo.pkg", line 3, characters 6-10:
+  3 |  (run dune build))
+            ^^^^
+  Error: Logs for package foo
+  File "dune-project", line 1, characters 0-0:
+  Error: Invalid first line, expected: (lang <lang> <version>)
+  
+  Hint: You may want to verify the following depexts are installed:- a
+                                                                   - b
+  [1]


### PR DESCRIPTION
This is a reproduction of the bug reported in #12311. I played around with the pretty printer a bit, but unfortunately, I haven't figured out a reliable way to print a new line after "Hint:", so I don't have a better suggestion than #12312. It seems the pretty printer breaks after Hint only if the full line is over a certain length, which is not the case in the example in this patch.

If we're ok with just reliably breaking after the `You may want to verify the following depexts are installed:` line, I'll add it to this PR.