### PR TITLE
refactor: remove some unnecessary optional arguments

### DIFF
--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -227,10 +227,9 @@ let promote_files_registered_in_last_run files_to_promote =
 ;;
 
 let diff_for_file (file : File.t) =
-  let msg = User_message.Annots.empty in
   let original = Path.source file.dst in
   let correction = File.correction_file file in
-  Print_diff.get msg original correction
+  Print_diff.get original correction
 ;;
 
 (** [partition_db db files_to_promote] splits [files_to_promote] into two lists

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -215,12 +215,12 @@ let prepare ~skip_trailing_cr annots path1 path2 =
       | Some command -> With_fallback.run command ~fallback:normal_diff)
 ;;
 
-let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
+let print ~skip_trailing_cr annots path1 path2 =
   let p = prepare ~skip_trailing_cr annots path1 path2 in
   With_fallback.exec p
 ;;
 
-let get ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
-  let p = prepare ~skip_trailing_cr annots path1 path2 in
+let get path1 path2 =
+  let p = prepare ~skip_trailing_cr:Sys.win32 User_message.Annots.empty path1 path2 in
   With_fallback.capture p
 ;;

--- a/src/dune_engine/print_diff.mli
+++ b/src/dune_engine/print_diff.mli
@@ -2,7 +2,7 @@ open Import
 
 (** Diff two files that are expected not to match. *)
 val print
-  :  ?skip_trailing_cr:bool
+  :  skip_trailing_cr:bool
   -> User_message.Annots.t
   -> Path.t
   -> Path.t
@@ -14,9 +14,4 @@ module Diff : sig
   val print : t -> unit
 end
 
-val get
-  :  ?skip_trailing_cr:bool
-  -> User_message.Annots.t
-  -> Path.t
-  -> Path.t
-  -> (Diff.t, User_message.t) result Fiber.t
+val get : Path.t -> Path.t -> (Diff.t, User_message.t) result Fiber.t


### PR DESCRIPTION
Either they are always passed, or never passed. In either case, the optionality is unnecessary.