### PR TITLE
Add cli option to turn on/off package management

### DIFF
--- a/bin/common.mli
+++ b/bin/common.mli
@@ -37,7 +37,7 @@ module Builder : sig
   val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
   val default_target : t -> Arg.Dep.t
   val term : t Cmdliner.Term.t
-  val term_without_trace : t Cmdliner.Term.t
+  val term_no_trace_no_pkg : t Cmdliner.Term.t
   val default : t
 end
 

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -75,7 +75,7 @@ let path =
 ;;
 
 let context_cwd : Init_context.t Term.t =
-  let+ builder = Common.Builder.term_without_trace
+  let+ builder = Common.Builder.term_no_trace_no_pkg
   and+ path = path in
   let builder = Common.Builder.set_default_root_is_cwd builder true in
   let _common, config = Common.init builder in
@@ -233,7 +233,7 @@ let project =
   in
   let man = [] in
   Cmd.v (Cmd.info "project" ~doc ~man)
-  @@ let+ common_builder = Builder.term_without_trace
+  @@ let+ common_builder = Builder.term_no_trace_no_pkg
      and+ path = path
      and+ common = project_common
      and+ inline_tests = inline_tests

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -214,7 +214,15 @@ let check_pkg_management_enabled () =
   let+ workspace = Workspace.workspace () in
   match workspace.config.pkg_enabled with
   | Set (_, `Enabled) | Unset -> ()
-  | Set (loc, `Disabled) ->
+  | Set (Cli, `Disabled) ->
+    User_error.raise
+      [ Pp.text "Package management is disabled in a command line argument." ]
+      ~hints:
+        [ Pp.text
+            "To enable package management, remove the explicit --pkg=disabled flag from \
+             your command line arguments."
+        ]
+  | Set (Loc loc, `Disabled) ->
     User_error.raise
       ~loc
       [ Pp.text "Package management is disabled in workspace configuration." ]

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -5,6 +5,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     Memo.run
+    (* CR-ElectreAAS: we should be using lock_dir_active (and not ignore --ignore-lock-dir) *)
     @@
     let open Memo.O in
     let+ workspace = Workspace.workspace () in

--- a/doc/reference/dune-workspace/index.rst
+++ b/doc/reference/dune-workspace/index.rst
@@ -50,5 +50,6 @@ project.
   env
   lock_dir
   pin
+  pkg
   profile
   repository

--- a/doc/reference/dune-workspace/pkg.rst
+++ b/doc/reference/dune-workspace/pkg.rst
@@ -1,0 +1,17 @@
+pkg
+====
+
+.. warning::
+
+   :doc:`Dune Package Management </explanation/package-management>` is not
+   final yet and the configuration options are subject to change.
+
+This stanza allows enabling/disabling the package management features of Dune.
+
+.. describe:: (pkg <setting>)
+
+    .. versionadded:: 3.20
+    
+    Where ``<setting>`` can be ``enabled`` or ``disabled``.
+
+Note that the command line option ``--pkg`` has precedence over this stanza.

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -66,10 +66,21 @@ module Dune_config : sig
         - [Set (loc, `Disabled)]: Package management is explicitly disabled. Forces package 
           management to be inactive even if lock directories are present.
 
-        - [Unset]: Package management enablement is not explicitly configured.  *)
+        - [Unset]: Package management enablement is not explicitly configured.
+        
+        [loc] is only relevant for error reporting. *)
+
+    type where =
+      | Cli
+      | Loc of Loc.t
+
     type t =
-      | Set of Loc.t * Config.Toggle.t
+      | Set of where * Config.Toggle.t
       | Unset
+
+    val all : where -> (string * t) list
+    val to_dyn : t -> Dyn.t
+    val equal : t -> t -> bool
   end
 
   module Terminal_persistence : sig

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled-cli.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled-cli.t
@@ -1,0 +1,95 @@
+# Test the behaviour of the --pkg enabled/disabled command line option.
+
+  $ cat > dune-workspace.enabled << EOF
+  > (lang dune 3.20)
+  > (pkg enabled)
+  > EOF
+
+  $ cat > dune-workspace.disabled << EOF
+  > (lang dune 3.20)
+  > (pkg disabled)
+  > EOF
+
+## No lock directory
+
+Default behaviour is disabled, as there is no lock directory
+  $ dune pkg enabled
+  [1]
+  $ dune pkg enabled --workspace=./dune-workspace.enabled
+  $ dune pkg enabled --workspace=./dune-workspace.disabled
+  [1]
+
+With the CLI option enabled
+  $ dune pkg enabled --pkg enabled
+  $ dune pkg enabled --pkg enabled --workspace=./dune-workspace.enabled 
+  $ dune pkg enabled --pkg enabled --workspace=./dune-workspace.disabled 
+
+With the CLI option disabled
+  $ dune pkg enabled --pkg disabled
+  [1]
+The CLI option has priority over the workspace file
+  $ dune pkg enabled --pkg disabled --workspace=./dune-workspace.enabled
+  [1]
+  $ dune pkg enabled --pkg disabled --workspace=./dune-workspace.disabled
+  [1]
+
+## With a lock directory present
+  $ make_lockdir
+
+Default behaviour is enabled, as a lockdir is detected
+  $ dune pkg enabled
+  $ dune pkg enabled --workspace=./dune-workspace.enabled
+  $ dune pkg enabled --workspace=./dune-workspace.disabled
+  [1]
+
+With the CLI option enabled
+  $ dune pkg enabled --pkg enabled
+  $ dune pkg enabled --pkg enabled --workspace=./dune-workspace.enabled
+  $ dune pkg enabled --pkg enabled --workspace=./dune-workspace.disabled
+
+With the CLI option disabled
+  $ dune pkg enabled --pkg disabled
+  [1]
+  $ dune pkg enabled --pkg disabled --workspace=./dune-workspace.enabled
+  [1]
+  $ dune pkg enabled --pkg disabled --workspace=./dune-workspace.disabled
+  [1]
+
+## With a lock directory, but we ignore it
+
+  $ test -d dune.lock
+
+  $ dune pkg enabled --ignore-lock-dir
+^^^ This is a bug. It should be disabled.
+We have a lock directory, but it is ignored.
+It should behave the same as if there was no lockdir
+
+This translates to explicitly asking for autolocking
+  $ dune pkg enabled --ignore-lock-dir --workspace=./dune-workspace.enabled
+  $ dune pkg enabled --ignore-lock-dir --workspace=./dune-workspace.disabled
+  [1]
+
+These 3 translate to explicitly asking for autolocking
+  $ dune pkg enabled --pkg enabled --ignore-lock-dir
+  $ dune pkg enabled --pkg enabled --ignore-lock-dir --workspace=./dune-workspace.enabled
+  $ dune pkg enabled --pkg enabled --ignore-lock-dir --workspace=./dune-workspace.disabled
+
+  $ dune pkg enabled --pkg disabled --ignore-lock-dir
+  [1]
+  $ dune pkg enabled --pkg disabled --ignore-lock-dir --workspace=./dune-workspace.enabled
+  [1]
+  $ dune pkg enabled --pkg disabled --ignore-lock-dir --workspace=./dune-workspace.disabled
+  [1]
+
+## With a project file
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.20)
+  > (package (name foo) (allow_empty))
+  > EOF
+
+The '-p' option implies --pkg=disabled, and it has priority over the workspace
+  $ dune pkg enabled -p foo --workspace=./dune-workspace.enabled
+  [1]
+  $ dune pkg enabled -p foo --workspace=./dune-workspace.disabled
+  [1]


### PR DESCRIPTION
Fixes #12819, see the motivation section of the issue.

## Added

I added a `--pkg` option in the common section, taking either `enabled` or `disabled` as arguments. It does what it says, the behaviour is shared with the `pkg` field in workspace files (note that [the docs](https://dune.readthedocs.io/en/stable/reference/dune-workspace/index.html) don't mention that field yet).

The CLI option has priority over the workspace configuration. See added test for details.

### Implementation notes

#### Interaction with `--ignore-lock-dir`

It is rather simple:
- `pkg = enabled` means autolocking is activated.
- `pkg = disabled` means no lock directory is ever considered anyway.

I still think these two options are too related to be separated, and should be merged eventually, but that isn't included in this PR.

#### Overlap with the existing `pkg` option

The `dune init` command option has a `pkg` option which relates to either opam or esy, nothing related to what I'm doing here. However the name can't be used for two different options (thanks Cmdliner), so I added a boolean `allow_pkg_flag` to sort that out. Not the cleanest option, advice appreciated.

#### Priority calculation

I found [this comment in workspace.mli](https://github.com/ocaml/dune/blob/main/src/source/workspace.mli#L114-L123) which clearly states priority order, worth a quick look

#### Documentation changes

I added an entry for the `pkg` field in workspace files which was missing, alluding to the CLI option. [Rendered output visible here.](https://dune--13458.org.readthedocs.build/en/13458/reference/dune-workspace/pkg.html)

- [ ] ~~changes entry~~ no changes entry for pkg related stuff

cc @Alizter @art-w as they helped me with this <3

