### PR TITLE
test: variables of undefined packages

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/opam-var/undefined-pkg-var.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/undefined-pkg-var.t
@@ -1,0 +1,26 @@
+Variables referencing packages not in the lock evaluate to empty string,
+matching opam semantics.
+
+  $ mkrepo
+
+  $ mkpkg "in-lock"
+
+  $ mkpkg "test-pkg" <<'EOF'
+  > depends: [ "in-lock" ]
+  > build: [
+  >   [ "sh" "-c" "echo 'in-lock:[%{in-lock:version}%]'" ]
+  >   [ "sh" "-c" "echo 'not-in-lock:[%{not-in-lock:version}%]'" ]
+  > ]
+  > EOF
+
+  $ solve test-pkg
+  Solution for dune.lock:
+  - in-lock.0.0.1
+  - test-pkg.0.0.1
+
+  $ build_pkg test-pkg
+  File "dune.lock/test-pkg.0.0.1.pkg", line 8, characters 16-65:
+  8 |      (run sh -c "echo 'not-in-lock:[%{pkg:not-in-lock:version}]'"))))))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Undefined package variable "version"
+  [1]


### PR DESCRIPTION
At the moment we have two kinds of undefined package variable. 

1. The package is undefined.
2. The package is defined, but the variable is undefined.

We raise the same error on both of these at the moment, but these two cases are actually distinct. The second should really be an error, but according to opam semantics the first should evaluate to the empty string, at least in string interpolation.

An example of where this comes up in the wild is here:
https://github.com/dra27/opam-repository/blob/b4c092154b06471b3ed5886716ff45e4e8f58c17/packages/ocaml/ocaml.5.5.0/opam#L38

The `%{dkml-base-compiler:version}%` variable's package doesn't exist unless the correct opam repository is available. Therefore in most cases opam evaluates this to the empty string.

This test demonstrates that we error on this behaviour and a future fix should make it evaluate to the empty string.

Part of the work on
- #13229 