### PR TITLE
fix(pkg): unknown packages should have variables evaluate to empty

### DIFF
--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -51,7 +51,13 @@ let one_of t xs = List.mem xs ~equal t
 (** Returns the slang value of a variable for an absent package. Returns None
     for variables without known values or contexts where substitution shouldn't
     occur. *)
-let absent_package_value t = if equal t installed then Some (Slang.bool false) else None
+let absent_package_value ~for_string_interp t =
+  if equal t installed
+  then Some (Slang.bool false)
+  else if for_string_interp && equal t version
+  then Some (Slang.text "")
+  else None
+;;
 
 let platform_specific =
   Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -38,7 +38,7 @@ val one_of : t -> t list -> bool
 (** Returns the slang value of a variable for an absent package. Returns None
     for variables without known values or contexts where substitution shouldn't
     occur. *)
-val absent_package_value : t -> Slang.t option
+val absent_package_value : for_string_interp:bool -> t -> Slang.t option
 
 (** The set of variable names whose values are expected to differ depending on
     the current platform. *)

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -63,7 +63,7 @@ let opam_variable_to_slang =
     Package_variable.to_pform { Package_variable.name = variable_name; scope }
     |> Slang.pform
   in
-  fun ~loc ~packages_in_solution packages variable ->
+  fun ~loc ~packages_in_solution ~for_string_interp packages variable ->
     let variable_string = OpamVariable.to_string variable in
     let variable_name = Package_variable_name.of_string variable_string in
     let convert_with_package_name package_name =
@@ -77,7 +77,7 @@ let opam_variable_to_slang =
            if Package_name.Map.mem packages_in_solution pkg_name
            then pform
            else
-             Package_variable_name.absent_package_value variable_name
+             Package_variable_name.absent_package_value ~for_string_interp variable_name
              |> Option.value ~default:pform
          | None -> opam_var_to_pform variable_name Self)
     in
@@ -123,11 +123,18 @@ let desugar_special_string_interpolation_syntax
   | _ -> fident
 ;;
 
-let opam_fident_to_slang ~loc ~packages_in_solution fident =
+let opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp fident =
   let packages, variable, string_converter =
     OpamFilter.desugar_fident fident |> desugar_special_string_interpolation_syntax
   in
-  let slang = opam_variable_to_slang ~loc ~packages_in_solution packages variable in
+  let for_string_interp =
+    match string_converter with
+    | Some _ -> false
+    | None -> for_string_interp
+  in
+  let slang =
+    opam_variable_to_slang ~loc ~packages_in_solution ~for_string_interp packages variable
+  in
   match string_converter with
   | None -> slang
   | Some (then_, else_) ->
@@ -144,9 +151,9 @@ let opam_fident_to_slang ~loc ~packages_in_solution fident =
        Slang.if_ condition ~then_:(Slang.text then_) ~else_:(Slang.text else_))
 ;;
 
-let opam_raw_fident_to_slang ~loc ~packages_in_solution raw_ident =
+let opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp raw_ident =
   OpamTypesBase.filter_ident_of_string raw_ident
-  |> opam_fident_to_slang ~loc ~packages_in_solution
+  |> opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp
 ;;
 
 let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
@@ -160,7 +167,7 @@ let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
          when String.starts_with ~prefix:"%{" interp
               && String.ends_with ~suffix:"}%" interp ->
          let ident = String.sub ~pos:2 ~len:(String.length interp - 4) interp in
-         opam_raw_fident_to_slang ~loc ~packages_in_solution ident
+         opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:true ident
        | other ->
          User_error.raise
            ~loc
@@ -234,7 +241,9 @@ let filter_to_blang ~packages_in_solution ~package ~loc filter =
   let filter_to_slang (filter : OpamTypes.filter) =
     match filter with
     | FString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
-    | FIdent fident -> opam_fident_to_slang ~loc ~packages_in_solution fident
+    | FIdent fident ->
+      (* FIdent in filter context is truthy, not string interpolation *)
+      opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:false fident
     | other ->
       Code_error.raise
         "The opam file parser should only allow identifiers and strings in places where \
@@ -304,7 +313,11 @@ let opam_commands_to_actions
                 match simple_arg with
                 | CString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
                 | CIdent ident ->
-                  opam_raw_fident_to_slang ~loc ~packages_in_solution ident
+                  opam_raw_fident_to_slang
+                    ~loc
+                    ~packages_in_solution
+                    ~for_string_interp:true
+                    ident
               in
               Slang.simplify slang
             in

--- a/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
@@ -21,8 +21,9 @@ context:
   Solution for dune.lock:
   - test-version-var.0.0.1
 
-Currently the variable is left as a pform. It should resolve to empty string
-at solve time:
+String interpolation contexts resolve to empty string at solve time. Truthy and
+filter contexts are left for build time evaluation where they will be undefined
+and thus falsey:
 
   $ cat dune.lock/test-version-var.0.0.1.pkg
   (version 0.0.1)
@@ -31,8 +32,9 @@ at solve time:
    (all_platforms
     ((action
       (progn
-       (run echo %{pkg:absent:version})
-       (run echo %{pkg:absent:version})
+       (run echo "")
+       (run echo "")
        (run echo (if (catch_undefined_var %{pkg:absent:version} false) yes no))
        (when %{pkg:not-in-lock:version} (run echo "has version"))
        (when (not %{pkg:not-in-lock:version}) (run echo "no version")))))))
+


### PR DESCRIPTION
As described in
- #13465 

We fix the expansion of variables of unknown packages to become the empty string. We also evaluate to default values the variables of known packages in other parts of the lock directory.

- Fixes https://github.com/ocaml/dune/issues/13660

Part of the work on
- #13229 