### PR TITLE
Fix: dune pkg enabled doesn't know about the flag --ignore-lock-dir

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled-ignore-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled-ignore-lock-dir.t
@@ -8,7 +8,6 @@ With one that is properly detected, pkg is enabled
   $ test -d dune.lock
   $ dune pkg enabled
 
-However the --ignore-lock-dir option raises a bug in the detection mechanism
+The --ignore-lock-dir flag reverts to the initial behaviour as expected
   $ dune pkg enabled --ignore-lock-dir
-^^^^^^^^
-This should be [1]
+  [1]


### PR DESCRIPTION
Fixes #13469

Commit 1 adds the test reproducing the issue, commit 2 fixes it