### PR TITLE
Add c_library_flags to foreign_library

### DIFF
--- a/doc/changes/added/13484.md
+++ b/doc/changes/added/13484.md
@@ -1,0 +1,1 @@
+- Add support for `c_library_flags` in foreign_stubs (#13484, @madroach)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -271,7 +271,7 @@ let foreign_rules (library : Foreign_library.t) ~sctx ~expander ~dir ~dir_conten
         ~has_cxx:(fun () -> Foreign.Sources.has_cxx_sources foreign_sources)
         sctx
     in
-    Expander.expand_and_eval_set expander Ordered_set_lang.Unexpanded.standard ~standard
+    Expander.expand_and_eval_set expander library.c_library_flags ~standard
   in
   ocamlmklib
     ~archive_name

--- a/src/dune_rules/stanzas/foreign_library.ml
+++ b/src/dune_rules/stanzas/foreign_library.ml
@@ -6,6 +6,7 @@ type t =
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
   ; extra_objects : Ordered_set_lang.Unexpanded.t
+  ; c_library_flags : Ordered_set_lang.Unexpanded.t
   }
 
 let decode =
@@ -20,8 +21,12 @@ let decode =
        Ordered_set_lang.Unexpanded.field
          "extra_objects"
          ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 19))
+     and+ c_library_flags =
+       Ordered_set_lang.Unexpanded.field
+         "c_library_flags"
+         ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 23))
      in
-     { archive_name; archive_name_loc; stubs; enabled_if; extra_objects })
+     { archive_name; archive_name_loc; stubs; enabled_if; extra_objects; c_library_flags })
 ;;
 
 include Stanza.Make (struct

--- a/src/dune_rules/stanzas/foreign_library.mli
+++ b/src/dune_rules/stanzas/foreign_library.mli
@@ -26,6 +26,7 @@ type t =
   ; stubs : Foreign.Stubs.t
   ; enabled_if : Blang.t
   ; extra_objects : Ordered_set_lang.Unexpanded.t
+  ; c_library_flags : Ordered_set_lang.Unexpanded.t
   }
 
 val decode : t Dune_lang.Decoder.t

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-library-flags.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-library-flags.t
@@ -1,0 +1,96 @@
+----------------------------------------------------------------------------------
+Tests for the (c_library_flags ...) field in foreign code stanzas.
+
+  $ echo "(lang dune 3.23)" > dune-project
+
+----------------------------------------------------------------------------------
+* Build a library with (foreign_stubs ...) that uses (c_library_flags ...).
+
+  $ mkdir stubs
+
+  $ cat >stubs/dune <<EOF
+  > (library
+  >  (name stubs_lib)
+  >  (modules stubs_lib)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names trig))
+  >  (c_library_flags :standard -lm))
+  > (executable
+  >  (name main_stubs)
+  >  (modes exe byte)
+  >  (libraries stubs_lib)
+  >  (modules main_stubs))
+  > EOF
+
+  $ cat >stubs/stubs_lib.ml <<EOF
+  > external cos_int : int -> int = "cos_int"
+  > EOF
+
+  $ cat >stubs/stubs_lib.mli <<EOF
+  > val cos_int : int -> int
+  > EOF
+
+  $ cat >stubs/main_stubs.ml <<EOF
+  > let () = Printf.printf "%d\n" (Stubs_lib.cos_int 0)
+  > EOF
+
+  $ cat >stubs/trig.c <<EOF
+  > #include <math.h>
+  > #include <caml/mlvalues.h>
+  > value cos_int(value x) {
+  >   return Val_int((int) (cos((double) Int_val(x)) * 1000.0));
+  > }
+  > EOF
+
+  $ dune exec ./stubs/main_stubs.exe
+  1000
+
+  $ dune build stubs/main_stubs.bc
+  $ (cd _build/default && ocamlrun -I stubs stubs/main_stubs.bc)
+  1000
+
+* Build a foreign archive with (foreign_library ...) that uses (c_library_flags ...).
+
+  $ mkdir foreign-library
+
+  $ cat >foreign-library/dune <<EOF
+  > (foreign_library
+  >  (archive_name trig)
+  >  (language c)
+  >  (names trig)
+  >  (c_library_flags :standard -lm))
+  > (library
+  >  (name foreign_library_lib)
+  >  (modules foreign_library_lib)
+  >  (foreign_archives trig))
+  > (executable
+  >  (name main_foreign_library)
+  >  (modes exe byte)
+  >  (libraries foreign_library_lib)
+  >  (modules main_foreign_library))
+  > EOF
+
+  $ cat >foreign-library/foreign_library_lib.ml <<EOF
+  > external cos_int : int -> int = "cos_int"
+  > EOF
+
+  $ cat >foreign-library/foreign_library_lib.mli <<EOF
+  > val cos_int : int -> int
+  > EOF
+
+  $ cat >foreign-library/main_foreign_library.ml <<EOF
+  > let () = Printf.printf "%d\n" (Foreign_library_lib.cos_int 0)
+  > EOF
+
+  $ cat >foreign-library/trig.c <<EOF
+  > #include <math.h>
+  > #include <caml/mlvalues.h>
+  > value cos_int(value x) {
+  >   return Val_int((int) (cos((double) Int_val(x)) * 1000.0));
+  > }
+  > EOF
+
+  $ dune build foreign-library/main_foreign_library.bc
+  $ (cd _build/default && ocamlrun -I foreign-library foreign-library/main_foreign_library.bc)
+  1000


### PR DESCRIPTION
To me it seems `c_library_flags` actually belongs to the `foreign_stubs`, not the `library` stanza, since `ocamlmklib` is called by `foreign_stubs` or `foreign_library`, not directly from `library`, or `executable`, no?
