### PR TITLE
fix: close fd on empty digest

### DIFF
--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -83,7 +83,9 @@ let file_async file =
   in
   Counter.add Metrics.Digest.File.bytes size;
   if size = 0
-  then Fiber.return (Lazy.force zero)
+  then
+    let+ () = Fiber.return @@ Unix.close fd in
+    Lazy.force zero
   else if size < async_digest_minimum
   then Fiber.return (digest_and_close_fd fd)
   else Dune_scheduler.Scheduler.async_exn (fun () -> digest_and_close_fd fd)


### PR DESCRIPTION
We were opening this file descriptor, but for size 0 files, never closing it.