### PR TITLE
Revive a well behaved patch_back_source_tree

### DIFF
--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -101,7 +101,28 @@ module File = struct
   ;;
 end
 
-type db = File.t list
+type what =
+  [ `File
+  | `Directory
+  ]
+
+let dyn_of_what =
+  let open Dyn in
+  function
+  | `File -> variant "File" []
+  | `Directory -> variant "Directory" []
+;;
+
+type op =
+  | File of File.t
+  | Delete of what * Path.Source.t
+
+let dyn_of_op = function
+  | File f -> Dyn.variant "File" [ File.to_dyn f ]
+  | Delete (what, d) -> Dyn.variant "Delete" [ dyn_of_what what; Path.Source.to_dyn d ]
+;;
+
+type db = op list
 
 let db : db ref = ref []
 let clear_cache () = db := []
@@ -133,28 +154,31 @@ let register_intermediate how ~source_file ~correction_file =
        ~src:(Path.build correction_file)
        ~dst:(Path.build staging)
        ());
-  db := { src; staging = Some staging; dst = source_file } :: !db
+  db := File { src; staging = Some staging; dst = source_file } :: !db
 ;;
 
 module P = Persistent.Make (struct
-    type t = File.t list
+    type t = db
 
     let name = "TO-PROMOTE"
-    let version = 3
-    let to_dyn = Dyn.list File.to_dyn
+    let version = 4
+    let to_dyn = Dyn.list dyn_of_op
 
     let test_example () =
-      [ { File.src = Path.Build.(relative root "foo")
-        ; dst = Path.Source.of_string "bar"
-        ; staging = Some Path.Build.(relative root "baz")
-        }
+      [ File
+          { File.src = Path.Build.(relative root "foo")
+          ; dst = Path.Source.of_string "bar"
+          ; staging = Some Path.Build.(relative root "baz")
+          }
+      ; Delete (`File, Path.Source.of_string "foo")
+      ; Delete (`Directory, Path.Source.of_string "foo")
       ]
     ;;
   end)
 
 let db_file = Path.relative Path.build_dir ".to-promote"
 
-let dump_db db =
+let dump_db (db : db) =
   if Path.build_dir_exists ()
   then (
     match db with
@@ -166,17 +190,19 @@ let dump_db db =
 let load_db () = Option.value ~default:[] (P.load db_file)
 
 let group_by_targets db =
-  List.map db ~f:(fun { File.src; staging; dst } -> dst, (src, staging))
+  List.map db ~f:(fun op ->
+    match op with
+    | Delete (what, f) -> f, `Delete what
+    | File { File.src; staging; dst } -> dst, `Promote (src, staging))
   |> Path.Source.Map.of_list_multi
   (* Sort the list of possible sources for deterministic behavior *)
-  |> Path.Source.Map.map
-       ~f:(List.sort ~compare:(fun (x, _) (y, _) -> Path.Build.compare x y))
+  |> Path.Source.Map.map ~f:(List.sort ~compare:Poly.compare)
 ;;
 
 let promote_one dst srcs =
   match srcs with
   | [] -> assert false
-  | (src, staging) :: others ->
+  | op :: others ->
     (* We used to remove promoted files from the digest cache, to force Dune
        to redigest them on the next run. We did this because on OSX [mtime] is
        not precise enough and if a file is modified and promoted quickly, it
@@ -190,19 +216,29 @@ let promote_one dst srcs =
        not promote into the build directory anyway), and source digests should
        be correctly invalidated via [fs_memo]. If that doesn't happen, we
        should fix [fs_memo] instead of manually resetting the caches here. *)
-    File.promote { src; staging; dst };
-    List.iter others ~f:(fun (path, _staging) ->
+    (match op with
+     | `Promote (src, staging) -> File.promote { src; staging; dst }
+     | `Delete `File -> Fpath.unlink_exn (Path.Source.to_string dst)
+     | `Delete `Directory -> Fpath.rm_rf (Path.Source.to_string dst));
+    List.iter others ~f:(fun op ->
+      let path =
+        match op with
+        | `Promote (src, _) -> Path.build src
+        | `Delete _ -> Path.source dst
+      in
       Console.print
-        [ Pp.textf " -> ignored %s." (Path.to_string_maybe_quoted (Path.build path))
-        ; Pp.space
-        ])
+        [ Pp.textf " -> ignored %s." (Path.to_string_maybe_quoted path); Pp.space ])
 ;;
 
 let do_promote_all db = group_by_targets db |> Path.Source.Map.iteri ~f:promote_one
 
 let do_promote_these db files =
   let by_targets = group_by_targets db in
-  let by_targets, missing =
+  let ( (by_targets :
+          [> `Delete of what | `Promote of Path.Build.t * Path.Build.t option ] list
+            Path.Source.Map.t)
+      , missing )
+    =
     let files = Path.Source.Set.of_list files in
     Path.Source.Set.fold files ~init:(by_targets, []) ~f:(fun fn (map, missing) ->
       match Path.Source.Map.find map fn with
@@ -213,8 +249,10 @@ let do_promote_these db files =
   in
   let remaining =
     Path.Source.Map.to_list by_targets
-    |> List.concat_map ~f:(fun (dst, srcs) ->
-      List.map srcs ~f:(fun (src, staging) -> { File.src; staging; dst }))
+    |> List.concat_map ~f:(fun (dst, ops) ->
+      List.map ops ~f:(function
+        | `Delete what -> Delete (what, dst)
+        | `Promote (src, staging) -> File { File.src; staging; dst }))
   in
   (* [group_by_targets] will sort all files, but the [fold] above reverses
      the list of missing files. Here we re-reverse it so it is sorted.
@@ -259,7 +297,13 @@ type all =
 (** [partition_db db files_to_promote] splits [files_to_promote] into two lists
     - The files present in [db] as actual [File.t]s.
     - The files absent from [db] as [Path]s. *)
-let partition_db db files_to_promote =
+let partition_db (db : db) files_to_promote =
+  let db =
+    (* CR-soon rgrinberg: communicate deletions to the user *)
+    List.filter_map db ~f:(function
+      | File f -> Some f
+      | Delete _ -> None)
+  in
   let present, missing =
     match files_to_promote with
     | Files_to_promote.All -> db, []
@@ -271,3 +315,5 @@ let partition_db db files_to_promote =
   in
   { present; missing }
 ;;
+
+let register_delete what src = db := Delete (what, src) :: !db

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -46,3 +46,5 @@ val register_intermediate
   -> source_file:Path.Source.t
   -> correction_file:Path.Build.t
   -> unit
+
+val register_delete : [ `File | `Directory ] -> Path.Source.t -> unit

--- a/src/dune_engine/sandbox_config.ml
+++ b/src/dune_engine/sandbox_config.ml
@@ -63,6 +63,12 @@ module Partial = struct
       | _ -> None)
   ;;
 
+  let patch_back_source_tree =
+    Sandbox_mode.Dict.of_func (function
+      | Some Patch_back_source_tree -> Some true
+      | _ -> Some false)
+  ;;
+
   let disallow (mode : Sandbox_mode.t) =
     Sandbox_mode.Dict.of_func (fun mode' ->
       if Sandbox_mode.equal mode mode' then Some false else None)

--- a/src/dune_engine/sandbox_config.mli
+++ b/src/dune_engine/sandbox_config.mli
@@ -47,5 +47,6 @@ module Partial : sig
   val no_special_requirements : t
   val no_sandboxing : t
   val needs_sandboxing : t
+  val patch_back_source_tree : t
   val disallow : Sandbox_mode.t -> t
 end

--- a/src/dune_lang/dep_conf.mli
+++ b/src/dune_lang/dep_conf.mli
@@ -21,7 +21,10 @@ module Sandbox_config : sig
 
   val fold
     :  t
-    -> f:([ `None | `Always | `Preserve_file_kind ] -> 'acc -> 'acc)
+    -> f:
+         ([ `None | `Always | `Preserve_file_kind | `Patch_back_source_tree ]
+          -> 'acc
+          -> 'acc)
     -> init:'acc
     -> 'acc
 end

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -9,6 +9,7 @@ let make_sandboxing_config config =
       | `None -> Sandbox_config.Partial.no_sandboxing
       | `Always -> Sandbox_config.Partial.needs_sandboxing
       | `Preserve_file_kind -> Sandbox_config.Partial.disallow Sandbox_mode.symlink
+      | `Patch_back_source_tree -> Sandbox_config.Partial.patch_back_source_tree
     in
     partial :: acc)
   |> Dune_engine.Sandbox_config.Partial.merge ~loc

--- a/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
@@ -1,0 +1,243 @@
+Test for (sandbox patch_back_source_tree)
+
+This sandbox allows to safely "modify" source files by turning modifications
+into promotions.
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.22)
+  > EOF
+
+Targest are not promoted
+------------------------
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree))
+  >  (targets x)
+  >  (action (system "echo 'Hello, world!' > x")))
+  > EOF
+
+  $ dune build x
+  $ dune promote
+  $ if [[ -f x ]]; then echo promoted; else echo not promoted; fi
+  not promoted
+
+All modified dependencies are promoted
+--------------------------------------
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps x (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!' > x")))
+  > EOF
+
+  $ echo blah > x
+  $ dune build
+  $ dune promote x
+  Promoting _build/default/x to x.
+  $ cat x
+  Hello, world!
+
+Non-modified dependencies are not promoted
+------------------------------------------
+
+  $ rm -f x
+  $ cat >dune<<EOF
+  > (rule
+  >  (alias default)
+  >  (deps x (sandbox patch_back_source_tree))
+  >  (action (system "echo 'Hello, world!'")))
+  > (rule (with-stdout-to x (progn)))
+  > EOF
+
+  $ dune build
+  Hello, world!
+  $ dune promotion list
+
+All other new files are copied
+------------------------------
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!' > y")))
+  > EOF
+
+  $ dune build
+  $ dune promote
+  Promoting _build/default/y to y.
+  $ cat y
+  Hello, world!
+
+Directories are created if needed
+---------------------------------
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "mkdir z; echo 'Hello, world!' > z/z")))
+  > EOF
+
+  $ dune build
+  $ dune promote
+  Promoting _build/default/z/z to z/z.
+  $ cat z/z
+  Hello, world!
+
+Actions are allowed to delete files
+-----------------------------------
+
+  $ touch foo
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps foo (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "rm foo")))
+  > EOF
+
+  $ dune build
+  $ dune promote
+  $ [[ ! -f foo ]] && echo foo has been deleted
+  foo has been deleted
+
+Actions are allowed to delete directories
+-----------------------------------------
+
+  $ mkdir -p todelete/y/
+  $ touch todelete/y/foo
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps todelete/y/foo (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "rm -rf todelete")))
+  > EOF
+
+  $ dune build
+
+  $ dune promote
+  $ [[ ! -d todelete ]] && echo todelete has been deleted
+  todelete has been deleted
+
+Actions are allowed to change directories into files
+----------------------------------------------------
+
+  $ mkdir -p dir/y/
+  $ touch dir/y/foo
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps dir/y/foo (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "rm -rf dir && echo foo > dir")))
+  > EOF
+
+  $ dune promote
+  $ [[ -f dir ]] && cat dir
+  [1]
+  $ [[ -d dir ]] && echo still a directory
+  still a directory
+
+Interaction with explicit sandboxing
+------------------------------------
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree) (sandbox none))
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!'")))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-4, characters 0-121:
+  1 | (rule
+  2 |  (deps (sandbox patch_back_source_tree) (sandbox none))
+  3 |  (alias default)
+  4 |  (action (system "echo 'Hello, world!'")))
+  Error: This rule forbids all sandboxing modes (but it also requires
+  sandboxing)
+  [1]
+
+Selecting an explicit sandbox mode via the command line doesn't affect
+the rule:
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!' > x")))
+  > EOF
+
+  $ test_with ()
+  > {
+  >   rm -f x
+  >   dune clean
+  >   dune build --sandbox $1
+  >   dune promote
+  >   cat x
+  > }
+
+  $ test_with copy
+  Promoting _build/default/x to x.
+  Hello, world!
+  $ test_with hardlink
+  Promoting _build/default/x to x.
+  Hello, world!
+  $ test_with symlink
+  Promoting _build/default/x to x.
+  Hello, world!
+
+Interaction with files writable status
+--------------------------------------
+
+If a source file is read-only, the action sees it as writable:
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps x (sandbox patch_back_source_tree))
+  >  (alias default)
+  >  (action (system "if test -w x; then echo writable; else echo non-writable; fi; echo blah > x")))
+  > EOF
+
+  $ echo xx > x
+  $ chmod -w x
+
+  $ if test -w x; then echo writable; else echo non-writable; fi
+  non-writable
+
+  $ dune build
+  writable
+
+And as the action modified `x`, its permissions have now changed
+inside the source tree:
+
+  $ dune promote
+  Promoting _build/default/x to x.
+
+  $ if test -w x; then echo writable; else echo non-writable; fi
+  writable
+
+Reproduction case for copying the action stamp file
+---------------------------------------------------
+
+There used to be a bug causing the internal action stamp file to be
+produced in the sandbox and copied back:
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (deps (sandbox patch_back_source_tree))
+  >  (alias blah)
+  >  (action (system "echo 'Hello, world!'")))
+  > EOF
+
+  $ dune build @blah
+  Hello, world!
+
+This is the internal stamp file:
+
+  $ ls _build/.actions/default/blah* | dune_cmd subst '/blah-.+' '/blah-REDACTED'
+  _build/.actions/default/blah-REDACTED

--- a/test/expect-tests/persistent/persistent_tests.ml
+++ b/test/expect-tests/persistent/persistent_tests.ml
@@ -35,8 +35,8 @@ let%expect_test "persistent digests" =
     da4ce847dd41df462849adecfe43f4eb
     ---
 
-    TO-PROMOTE version 3
-    f2d6070d92c27497a6c2d89782d81c99
+    TO-PROMOTE version 4
+    7c6836b84261a895294bfe85d29f5280
     ---
 
     COPY-LINE-DIRECTIVE-MAP version 2


### PR DESCRIPTION
This mode can be used to run actions that would like to modify dependencies. Such actions are fairly common with existing linters and other tools that assume the source tree is mutable.

The previous iteration of this feature made the changes to the source tree automatically. That is problematic because it had the potential to make watch mode loop or just bork the workspace completely. In this version, patch back no longer automatically modifies the workspace. Instead, it must register the changes it wants to apply. The user then chooses to apply these changes with `$ dune promote`.

cc @raphael-proust I think you were interested in this feature