### PR TITLE
Remove `--ignore-lock-dir` as it has been obsoleted by `--pkg=disabled`

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -132,7 +132,6 @@ module Options_implied_by_dash_p = struct
     ; always_show_command_line : bool
     ; promote_install_files : bool
     ; require_dune_project_file : bool
-    ; ignore_lock_dir : bool
     }
 
   let docs = copts_sect
@@ -251,9 +250,6 @@ module Options_implied_by_dash_p = struct
         last
         & opt_all ~vopt:true bool [ false ]
         & info [ "require-dune-project-file" ] ~docs ~doc:(Some doc))
-    and+ ignore_lock_dir =
-      let doc = "Ignore dune.lock/ directory." in
-      Arg.(value & flag & info [ "ignore-lock-dir" ] ~docs ~doc:(Some doc))
     in
     { root
     ; only_packages = No_restriction
@@ -264,7 +260,6 @@ module Options_implied_by_dash_p = struct
     ; always_show_command_line
     ; promote_install_files
     ; require_dune_project_file
-    ; ignore_lock_dir
     }
   ;;
 
@@ -574,7 +569,6 @@ module Builder = struct
     ; ignore_promoted_rules : bool
     ; force : bool
     ; no_print_directory : bool
-    ; ignore_lock_dir : bool
     ; store_orig_src_dir : bool
     ; default_target : Arg.Dep.t (* For build & runtest only *)
     ; watch : Dune_rpc_impl.Watch_mode_config.t
@@ -750,7 +744,6 @@ module Builder = struct
          ; always_show_command_line
          ; promote_install_files
          ; require_dune_project_file
-         ; ignore_lock_dir
          }
       =
       Options_implied_by_dash_p.term
@@ -934,7 +927,6 @@ module Builder = struct
     ; ignore_promoted_rules
     ; force
     ; no_print_directory
-    ; ignore_lock_dir
     ; store_orig_src_dir
     ; default_target
     ; watch
@@ -990,7 +982,6 @@ module Builder = struct
         ; ignore_promoted_rules
         ; force
         ; no_print_directory
-        ; ignore_lock_dir
         ; store_orig_src_dir
         ; default_target
         ; watch
@@ -1023,7 +1014,6 @@ module Builder = struct
     && Bool.equal t.ignore_promoted_rules ignore_promoted_rules
     && Bool.equal t.force force
     && Bool.equal t.no_print_directory no_print_directory
-    && Bool.equal t.ignore_lock_dir ignore_lock_dir
     && Bool.equal t.store_orig_src_dir store_orig_src_dir
     && Arg.Dep.equal t.default_target default_target
     && Dune_rpc_impl.Watch_mode_config.equal t.watch watch
@@ -1265,7 +1255,6 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   Dune_rules.Clflags.promote_install_files := c.builder.promote_install_files;
   Dune_engine.Clflags.always_show_command_line := c.builder.always_show_command_line;
   Dune_rules.Clflags.ignore_promoted_rules := c.builder.ignore_promoted_rules;
-  Dune_rules.Clflags.ignore_lock_dir := c.builder.ignore_lock_dir;
   Source.Clflags.on_missing_dune_project_file
   := if c.builder.require_dune_project_file then Error else Warn;
   (Dune_engine.Clflags.can_go_in_shared_cache_default

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -5,7 +5,7 @@ let term =
   let common, config = Common.init builder in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
     Memo.run
-    (* CR-ElectreAAS: we should be using lock_dir_active (and not ignore --ignore-lock-dir) *)
+    (* CR-ElectreAAS: we should be using lock_dir_active *)
     @@
     let open Memo.O in
     let+ workspace = Workspace.workspace () in

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -4,5 +4,4 @@ let promote_install_files = ref false
 let display = Dune_engine.Clflags.display
 let capture_outputs = Dune_engine.Clflags.capture_outputs
 let debug_package_logs = ref false
-let ignore_lock_dir = ref false
 let concurrency = ref 1

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -16,7 +16,4 @@ val capture_outputs : bool ref
 (** Print package output when building with package management *)
 val debug_package_logs : bool ref
 
-(** Whether we are ignoring "dune.lock/". *)
-val ignore_lock_dir : bool ref
-
 val concurrency : int ref

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -289,18 +289,15 @@ let lock_dirs_of_workspace (workspace : Workspace.t) =
 
 let lock_dir_active ctx =
   let open Memo.O in
-  if !Clflags.ignore_lock_dir
-  then Memo.return false
-  else
-    let* workspace = Workspace.workspace () in
-    match workspace.config.pkg_enabled with
-    | Set (_, `Enabled) -> Memo.return true
-    | Set (_, `Disabled) -> Memo.return false
-    | Unset ->
-      get_source_path_for_context ctx
-      >>= (function
-       | None -> Memo.return false
-       | Some source -> Source_tree.find_dir source >>| Option.is_some)
+  let* workspace = Workspace.workspace () in
+  match workspace.config.pkg_enabled with
+  | Set (_, `Enabled) -> Memo.return true
+  | Set (_, `Disabled) -> Memo.return false
+  | Unset ->
+    get_source_path_for_context ctx
+    >>= (function
+     | None -> Memo.return false
+     | Some source -> Source_tree.find_dir source >>| Option.is_some)
 ;;
 
 let source_kind (source : Dune_pkg.Source.t) =

--- a/test/blackbox-tests/test-cases/pkg/pkg-enabled-cli.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-enabled-cli.t
@@ -55,32 +55,6 @@ With the CLI option disabled
   $ dune pkg enabled --pkg disabled --workspace=./dune-workspace.disabled
   [1]
 
-## With a lock directory, but we ignore it
-
-  $ test -d dune.lock
-
-  $ dune pkg enabled --ignore-lock-dir
-^^^ This is a bug. It should be disabled.
-We have a lock directory, but it is ignored.
-It should behave the same as if there was no lockdir
-
-This translates to explicitly asking for autolocking
-  $ dune pkg enabled --ignore-lock-dir --workspace=./dune-workspace.enabled
-  $ dune pkg enabled --ignore-lock-dir --workspace=./dune-workspace.disabled
-  [1]
-
-These 3 translate to explicitly asking for autolocking
-  $ dune pkg enabled --pkg enabled --ignore-lock-dir
-  $ dune pkg enabled --pkg enabled --ignore-lock-dir --workspace=./dune-workspace.enabled
-  $ dune pkg enabled --pkg enabled --ignore-lock-dir --workspace=./dune-workspace.disabled
-
-  $ dune pkg enabled --pkg disabled --ignore-lock-dir
-  [1]
-  $ dune pkg enabled --pkg disabled --ignore-lock-dir --workspace=./dune-workspace.enabled
-  [1]
-  $ dune pkg enabled --pkg disabled --ignore-lock-dir --workspace=./dune-workspace.disabled
-  [1]
-
 ## With a project file
 
   $ cat > dune-project << EOF


### PR DESCRIPTION
The purpose of `--ignore-lock-dir` was to disable package management in case a package was installed via OPAM as the presence of a lock dir was the only thing required to trigger package management. Thus it was an option that was implied in `-p`. But with #13458 merged, `-p` reasonably switched to `--pkg=disabled`.

This leaves `--ignore-lock-dir` as a more or less worse version of `--pkg=disabled`, with unclear semantics if these two options are combined. This PR removes the option altogether.

As to why it was called `--ignore-lock-dir` and not `--disable-package-management`: For the longest time an explicitly created lock dir was the only way to use package management, thus these two terms are equivalent. Notably, ``-ignore-lock-dir` should never imply autolocking, because that directly contradicts the "disable in the OPAM context" usecase.

Closes #13468
Closes #13469
Closes #13470
Closes #13472