### PR TITLE
refactor: Make [Fpath.mkdir_p] return polymorphic variant

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -361,8 +361,8 @@ module File_ops_real (W : sig
        it turns out that [dir] exists and is not a directory. Even better, make
        [Path.mkdir_p] return an explicit variant to deal with. *)
     match Fpath.mkdir_p (Path.to_string p) with
-    | Created -> ()
-    | Already_exists ->
+    | `Created -> ()
+    | `Already_exists ->
       (match Path.is_directory p with
        | true -> ()
        | false ->

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -1,16 +1,18 @@
 (** Functions on paths that are represented as strings *)
 
+(** No parent directory, use [mkdir_p] if you want to create it too. *)
 type mkdir_result =
-  | Already_exists (** The directory already exists. No action was taken. *)
-  | Created (** The directory was created. *)
-  | Missing_parent_directory
-  (** No parent directory, use [mkdir_p] if you want to create it too. *)
+  [ `Already_exists (** The directory already exists. No action was taken. *)
+  | `Created (** The directory was created. *)
+  | `Missing_parent_directory
+  ]
 
 val mkdir : ?perms:int -> string -> mkdir_result
 
 type mkdir_p_result =
-  | Already_exists (** The directory already exists. No action was taken. *)
-  | Created (** The directory was created. *)
+  [ `Already_exists (** The directory already exists. No action was taken. *)
+  | `Created (** The directory was created. *)
+  ]
 
 val dyn_of_mkdir_p_result : mkdir_p_result -> Dyn.t
 val mkdir_p : ?perms:int -> string -> mkdir_p_result

--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -634,8 +634,8 @@ let ensure_build_dir_exists () =
   | External p ->
     let p = External.to_string p in
     (match Fpath.mkdir ~perms p with
-     | Created | Already_exists -> ()
-     | Missing_parent_directory ->
+     | `Created | `Already_exists -> ()
+     | `Missing_parent_directory ->
        User_error.raise
          [ Pp.textf
              "Cannot create external build directory %s. Make sure that the parent dir \

--- a/otherlibs/stdune/src/temp.ml
+++ b/otherlibs/stdune/src/temp.ml
@@ -44,9 +44,9 @@ let destroy = function
 let create_temp_dir ?perms path =
   let dir = Path.to_string path in
   match Fpath.mkdir ?perms dir with
-  | Created -> Ok ()
-  | Already_exists -> Error `Retry
-  | Missing_parent_directory ->
+  | `Created -> Ok ()
+  | `Already_exists -> Error `Retry
+  | `Missing_parent_directory ->
     Code_error.raise
       "[Temp.create_temp_dir] called in a nonexistent directory"
       [ "dir", Path.to_dyn path ]

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -91,6 +91,6 @@ let create_cache_directories () =
   ]
   |> Result.List.iter ~f:(fun path ->
     match Fpath.mkdir_p (Path.to_string path) with
-    | Already_exists | Created -> Ok ()
+    | `Already_exists | `Created -> Ok ()
     | exception Unix.Unix_error (e, _, _) -> Error (path, e))
 ;;

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -635,7 +635,7 @@ let load_or_create ~dir =
   let+ () =
     with_flock lock ~f:(fun () ->
       match Fpath.mkdir_p (Path.to_string dir) with
-      | Already_exists ->
+      | `Already_exists ->
         (* CR-Leonidas-from-XIV: this doesn't actually care about whethe the
            result is [true] or [false] (and it doesn't matter too much), it's
            mostly about whether rev-parse recognizes the repo as valid. *)
@@ -657,7 +657,7 @@ let load_or_create ~dir =
                  "The folder at the revision store location is not a valid bare git \
                   repository."
              ])
-      | Created ->
+      | `Created ->
         run t ~display:Quiet [ "init"; "--bare" ]
         >>| (function
          | Ok () -> ()

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -413,7 +413,7 @@ let prepare_sync () =
   | Cleared -> ()
   | Directory_does_not_exist ->
     (match Fpath.mkdir_p dir with
-     | Already_exists | Created -> ())
+     | `Already_exists | `Created -> ())
 ;;
 
 let spawn_external_watcher ~root ~backend ~watch_exclusions =


### PR DESCRIPTION
Allows the constructors to be shared. Will be useful in a subsequent PR
