### PR TITLE
fix: register promotions from sandboxed actions

### DIFF
--- a/doc/changes/fixed/13520.md
+++ b/doc/changes/fixed/13520.md
@@ -1,0 +1,3 @@
+- Fix `diff` promotions originating from sandboxed rules. Previously, they
+  would be completely ignored as the sandbox with the promoted file would be
+  destroyed if the promotion fired (#13520, @rgrinberg)

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -27,7 +27,9 @@ let exec loc ({ Diff.optional; file1; file2; mode } as diff) =
     let is_copied_from_source_tree file =
       match Path.extract_build_context_dir_maybe_sandboxed file with
       | None -> false
-      | Some (_, file) -> Stdune.Path.exists (Path.source file)
+      | Some (_, file) ->
+        (* CR-someday rgrinberg: isn't this racy? *)
+        Stdune.Path.exists (Path.source file)
     in
     let in_source_or_target =
       is_copied_from_source_tree file1 || not (Stdune.Path.exists file1)
@@ -41,10 +43,7 @@ let exec loc ({ Diff.optional; file1; file2; mode } as diff) =
            User_message.Annots.singleton
              Diff_promotion.Annot.annot
              { Diff_promotion.Annot.in_source = source_file
-             ; in_build =
-                 (if optional && in_source_or_target
-                  then Diff_promotion.File.in_staging_area source_file
-                  else file2)
+             ; in_build = Diff_promotion.File.in_staging_area source_file
              }
          in
          if mode = Binary
@@ -64,15 +63,16 @@ let exec loc ({ Diff.optional; file1; file2; mode } as diff) =
              (Path.build file2)
              ~skip_trailing_cr:(mode = Text && Sys.win32))
       ~finally:(fun () ->
+        let register how =
+          Diff_promotion.register_intermediate how ~source_file ~correction_file:file2
+        in
         (match optional with
          | false ->
            (* Promote if in the source tree or not a target. The second case
-                means that the diffing have been done with the empty file *)
+              means that the diffing have been done with the empty file *)
            if in_source_or_target && not (is_copied_from_source_tree (Path.build file2))
-           then Diff_promotion.register_dep ~source_file ~correction_file:file2
+           then register `Copy
          | true ->
-           if in_source_or_target
-           then Diff_promotion.register_intermediate ~source_file ~correction_file:file2
-           else remove_intermediate_file ());
+           if in_source_or_target then register `Move else remove_intermediate_file ());
         Fiber.return ()))
 ;;

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -42,12 +42,7 @@ val promote_files_registered_in_last_run : Files_to_promote.t -> Path.Source.t l
 (** Register an intermediate file to promote. The build path may point to the
     sandbox and the file will be moved to the staging area. *)
 val register_intermediate
-  :  source_file:Path.Source.t
+  :  [ `Copy | `Move ]
+  -> source_file:Path.Source.t
   -> correction_file:Path.Build.t
   -> unit
-
-(** Register file to promote where the correction file is a dependency of the
-    current action (rather than an intermediate file). [correction_file]
-    refers to a path in the build dir, not in the sandbox (it can point to the
-    sandbox, but the sandbox root will be stripped). *)
-val register_dep : source_file:Path.Source.t -> correction_file:Path.Build.t -> unit

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -136,7 +136,7 @@ Reproduction case for #1772
   [1]
   $ rm -f _build/default/x.gen
   $ dune promote
-  Skipping promotion of _build/default/x.gen to x as the file is missing.
+  Promoting _build/default/x.gen to x.
   Promoting _build/default/y.gen to y.
 
 Tests for promote-into

--- a/test/blackbox-tests/test-cases/promote/promote-sandboxing.t
+++ b/test/blackbox-tests/test-cases/promote/promote-sandboxing.t
@@ -33,7 +33,7 @@ Demonstrate a promotion going missing because of sandboxing
   {
     "src": "_build/default/foo",
     "dst": "bar",
-    "how": "direct"
+    "how": "staged"
   }
   promotions:
   bar
@@ -51,9 +51,9 @@ Demonstrate a promotion going missing because of sandboxing
   {
     "src": "_build/default/foo",
     "dst": "bar",
-    "how": "direct"
+    "how": "staged"
   }
   promotions:
   bar
   promoting ...
-  Skipping promotion of _build/default/foo to bar as the file is missing.
+  Promoting _build/default/foo to bar.

--- a/test/blackbox-tests/test-cases/promote/promotion-diff.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-diff.t
@@ -43,7 +43,7 @@
   $ dune promotion diff --diff-command 'diff -u' 2>&1 | sed -e 's/\t.*$//'
   File "a.expected", line 1, characters 0-0:
   --- a.expected
-  +++ _build/default/a.actual
+  +++ _build/.promotion-staging/a.expected
   @@ -1 +1 @@
   -A expected
   +A actual
@@ -66,7 +66,7 @@
   Warning: Nothing to promote for nothing-to-promote.txt.
   File "a.expected", line 1, characters 0-0:
   --- a.expected
-  +++ _build/default/a.actual
+  +++ _build/.promotion-staging/a.expected
   @@ -1 +1 @@
   -A expected
   +A actual

--- a/test/blackbox-tests/test-cases/read-only-symlink-target.t/run.t
+++ b/test/blackbox-tests/test-cases/read-only-symlink-target.t/run.t
@@ -24,7 +24,7 @@ This command should succeed:
   +(* formatted *)
   Promoting _build/default/.formatted/ocamlformat.ml to ocamlformat.ml.
   Promoting _build/default/result/.formatted/foo.ml to result/foo.ml.
-  Error: Error promoting _build/default/result/.formatted/foo.ml to
+  Error: Error promoting _build/.promotion-staging/result/foo.ml to
   result/foo.ml
   Unix.Unix_error(Unix.EACCES, "unlink", "result/foo.ml")
   [1]

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -324,7 +324,7 @@ let%expect_test "promotion" =
           ]
         ]
       ; [ "promotion"
-        ; [ [ [ "in_build"; "$CWD/_build/default/x.gen" ]
+        ; [ [ [ "in_build"; "$CWD/_build/.promotion-staging/x" ]
             ; [ "in_source"; "$CWD/x" ]
             ]
           ]
@@ -356,7 +356,7 @@ let%expect_test "optional promotion" =
     {|
     Building (alias foo)
     Build (alias foo) failed
-    FAILURE: promotion file $CWD/_build/default/output.actual does not exist
+    FAILURE: promotion file $CWD/_build/.promotion-staging/output.expected does not exist
     [ "Add"
     ; [ [ "directory"; "$CWD" ]
       ; [ "id"; "0" ]
@@ -390,7 +390,7 @@ let%expect_test "optional promotion" =
           ]
         ]
       ; [ "promotion"
-        ; [ [ [ "in_build"; "$CWD/_build/default/output.actual" ]
+        ; [ [ [ "in_build"; "$CWD/_build/.promotion-staging/output.expected" ]
             ; [ "in_source"; "$CWD/output.expected" ]
             ]
           ]


### PR DESCRIPTION
When a diff action failed inside a sandbox, it would invariably the rule
and the sandbox would be cleaned up. Consequently, the intented
promotion would dissapear.

We now copy the promotion to the staging area to make sure it's
available.
