### PR TITLE
chore: add lib dependency on dune_config_file

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -363,24 +363,6 @@ let local_libraries =
     ; special_builtin_support = None
     ; root_module = None
     }
-  ; { path = "src/dune_patch"
-    ; main_module_name = Some "Dune_patch"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
-  ; { path = "otherlibs/dune-site/src/private"
-    ; main_module_name = Some "Dune_site_private"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
-  ; { path = "src/scheme"
-    ; main_module_name = Some "Scheme"
-    ; include_subdirs = No
-    ; special_builtin_support = None
-    ; root_module = None
-    }
   ; { path = "src/dune_threaded_console"
     ; main_module_name = Some "Dune_threaded_console"
     ; include_subdirs = No
@@ -419,6 +401,24 @@ let local_libraries =
     }
   ; { path = "src/dune_config_file"
     ; main_module_name = Some "Dune_config_file"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
+  ; { path = "src/dune_patch"
+    ; main_module_name = Some "Dune_patch"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
+  ; { path = "otherlibs/dune-site/src/private"
+    ; main_module_name = Some "Dune_site_private"
+    ; include_subdirs = No
+    ; special_builtin_support = None
+    ; root_module = None
+    }
+  ; { path = "src/scheme"
+    ; main_module_name = Some "Scheme"
     ; include_subdirs = No
     ; special_builtin_support = None
     ; root_module = None

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -8,6 +8,7 @@
   csexp
   action_plugin
   dune_action_plugin
+  dune_config_file
   dune_console
   dune_digest
   dune_engine

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -289,8 +289,10 @@ let lock_dirs_of_workspace (workspace : Workspace.t) =
 
 let lock_dir_active ctx =
   let open Memo.O in
-  let* workspace = Workspace.workspace () in
-  match workspace.config.pkg_enabled with
+  let* { config = { Dune_config_file.Dune_config.pkg_enabled; _ }; _ } =
+    Workspace.workspace ()
+  in
+  match pkg_enabled with
   | Set (_, `Enabled) -> Memo.return true
   | Set (_, `Disabled) -> Memo.return false
   | Unset ->


### PR DESCRIPTION
I only noticed that this was under-specified on 4.14. Not sure what OCaml 5.4 is doing that we don't need to explicitly depend on this. My guess is that the module alias resolution is a little stronger.

The `@unused-lib` alias doesn't seem to complain.

This doesn't affect the bootstrap because we don't do libraries here.