### PR TITLE
chore: fix dune_targets dependency

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -2,6 +2,7 @@ include Stdune
 include Dune_config_file
 include Dune_vcs
 include Dune_scheduler
+module Targets = Dune_targets
 
 include struct
   open Dune_engine
@@ -17,7 +18,6 @@ include struct
   module Dpath = Dpath
   module Findlib = Dune_rules.Findlib
   module Diff_promotion = Diff_promotion
-  module Targets = Targets
   module Context_name = Context_name
 end
 

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -14,7 +14,6 @@ module Alias = Alias
 module Dpath = Dpath
 module Rules = Rules
 module Rule = Rule
-module Targets = Dune_targets
 module Target_promotion = Target_promotion
 module Build_context = Build_context
 module Build_config = Build_config

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -21,6 +21,7 @@
   dune_rpc_private
   dune_section
   dune_site_private
+  dune_targets
   dune_trace
   dune_util
   dune_vcs

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -33,6 +33,8 @@ include struct
   module type Stringlike = Stringlike
 end
 
+module Targets = Dune_targets
+
 include struct
   open Dune_engine
   module Dir_set = Dir_set
@@ -53,7 +55,6 @@ include struct
   module Process = Process
   module Execution_parameters = Execution_parameters
   module Build_context = Build_context
-  module Targets = Targets
   module Utils = Utils
   module Load_rules = Load_rules
   module Response_file = Response_file


### PR DESCRIPTION
This was being re-exported by dune_engine rather than being depended on directly as a library. This meant that module aliases would fail to resolve on older OCaml versions and generally it is a bit misleading.