### PR TITLE
ci: reenable rocq

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -290,26 +290,6 @@ jobs:
             ~/work/dune/dune/_opam
           key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
-  coq:
-    name: Coq 8.16.1
-    needs: nix-build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v34
-        with:
-          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: |
-            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
-          gc-max-store-size-linux: 5G
-      - run: nix develop .#coq -c make test-coq
-        env:
-          # We disable the Dune cache when running the tests
-          DUNE_CACHE: disabled
-
   rocq:
     name: Rocq 9.1
     needs: nix-build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -310,56 +310,39 @@ jobs:
           # We disable the Dune cache when running the tests
           DUNE_CACHE: disabled
 
-  # Disabled until these in nix
-  # rocq:
-  #   name: Rocq Language (Rocq 9.1.0)
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         # Keep packages and OCaml version in sync with the version
-  #         # in the makefile; rocq-stdlib should be easy to remove
-  #         - ocaml-compiler: 5.3
-  #           opam-packages: rocq-core.9.1.0 rocq-stdlib.9.0.0 csexp re spawn pp uutf
-  #           test-target: test-rocq
-  #         - ocaml-compiler: 4.14
-  #           opam-packages: rocq-core.9.1.0 rocq-stdlib.9.0.0 csexp re spawn pp uutf rocq-native
-  #           test-target: test-rocq-native
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v6
-  #
-  #     - name: Setup OCaml
-  #       uses: ocaml/setup-ocaml@v3
-  #       with:
-  #         ocaml-compiler: ${{ matrix.ocaml-compiler }}
-  #         dune-cache: true
-  #     - name: Load opam cache when not Windows
-  #       if: runner.os != 'Windows'
-  #       id: opam-cache
-  #       uses: actions/cache/restore@v5
-  #       with:
-  #         path: |
-  #           ~/.opam
-  #           ~/work/dune/dune/_opam
-  #         key: opam-rocq-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
-  #
-  #     - name: install Rocq Prover
-  #       run: opam install -y ${{ matrix.opam-packages }}
-  #     - name: test Rocq Prover Build Language
-  #       run: opam exec -- make ${{ matrix.test-target }}
-  #       env:
-  #         # We disable the Dune cache when running the tests
-  #         DUNE_CACHE: disabled
-  #
-  #     - name: Save cache when not Windows
-  #       uses: actions/cache/save@v5
-  #       if: steps.opam-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
-  #       with:
-  #         path: |
-  #           ~/.opam
-  #           ~/work/dune/dune/_opam
-  #         key: opam-rocq-${{ matrix.ocaml-compiler }}-${{ hashFiles('**.opam') }}
+  rocq:
+    name: Rocq 9.1
+    needs: nix-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 5G
+      - run: nix develop .#rocq -c make test-rocq
+
+  rocq-native:
+    name: Rocq 9.1 (native)
+    needs: nix-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 5G
+      - run: nix develop .#rocq-native -c make test-rocq-native
 
   wasm:
     name: Wasm_of_ocaml

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test-rocq: $(BIN)
 
 .PHONY: test-rocq-native
 test-rocq-native: $(BIN)
-	DUNE_ROCQ_NATIVE_TEST=enable $(BIN) build @runtest-rocq-native
+	DUNE_ROCQ_TEST=enable DUNE_ROCQ_NATIVE_TEST=enable $(BIN) build @runtest-rocq-native
 
 test-melange: $(BIN)
 	$(BIN) build @runtest-melange

--- a/flake.nix
+++ b/flake.nix
@@ -92,14 +92,6 @@
                 );
               })
               melange.overlays.default
-              (self: super: {
-                coq_8_16_native = super.coq_8_16.overrideAttrs (a: {
-                  configureFlags = [
-                    "-native-compiler"
-                    "yes"
-                  ];
-                });
-              })
             ];
           in
           f pkgs
@@ -410,7 +402,7 @@
           slim = makeDuneDevShell {
             meta.description = ''
               Provides a minimal shell environment built purely from nixpkgs
-              that can run the testsuite (except the coq / melange tests).
+              that can run the testsuite (except the melange tests).
             '';
           };
           slim-melange = makeDuneDevShell {
@@ -419,7 +411,7 @@
             ];
             meta.description = ''
               Provides a minimal shell environment built purely from nixpkgs
-              that can run the testsuite (except the coq tests).
+              that can run the test suite
             '';
           };
           slim-opam =
@@ -432,28 +424,6 @@
                 dependencies to run the testsuite.";
               '';
             };
-
-          coq = pkgs.mkShell {
-            inherit INSIDE_NIX;
-            nativeBuildInputs = (testNativeBuildInputs pkgs);
-            # Coq requires OCaml 4.x
-            inputsFrom = [
-              pkgs.ocaml-ng.ocamlPackages_4_14.dune_3
-            ];
-            buildInputs = with pkgs; [
-              ocaml-ng.ocamlPackages_4_14.csexp
-              ocaml-ng.ocamlPackages_4_14.pp
-              ocaml-ng.ocamlPackages_4_14.re
-              ocaml-ng.ocamlPackages_4_14.spawn
-              ocaml-ng.ocamlPackages_4_14.uutf
-              coq_8_16_native
-              coq_8_16_native.ocamlPackages.findlib
-            ];
-            meta.description = ''
-              Provides a minimal shell environment built purely from nixpkgs
-              that can build Dune and the Coq testsuite.
-            '';
-          };
 
           rocq = makeDuneDevShell {
             extraBuildInputs = pkgs: [

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -46,8 +46,8 @@ def coqcCoqdepFlags:
 
 def coqdocFlags:
     processes
-  | select((.args.prog | basename) == "coqdoc")
-  | .args.process_args
+  | select((.args.prog | basename | (contains("rocq") or contains("coq"))) and .args.process_args[0] == "doc")
+  | .args.process_args[1:]
   | .[]
   | rocqArg;
 

--- a/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
@@ -50,21 +50,15 @@ Now we check the flags that were passed to coqdep and coqc:
 
   $ dune trace cat | jq 'include "dune"; coqcCoqdepFlags'
   {
-    "name": "finish",
-    "args": [
-      "--config"
-    ]
-  }
-  {
-    "name": "finish",
+    "name": "rocq",
     "args": [
       "dep",
       "-boot",
       "-R",
-      "$TESTCASE_ROOT/lib/coq/theories",
+      "coq/theories",
       "Corelib",
       "-Q",
-      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "coq/user-contrib/B",
       "B",
       "-R",
       ".",
@@ -76,7 +70,7 @@ Now we check the flags that were passed to coqdep and coqc:
     ]
   }
   {
-    "name": "finish",
+    "name": "rocq",
     "args": [
       "compile",
       "-q",
@@ -88,10 +82,10 @@ Now we check the flags that were passed to coqdep and coqc:
       "ondemand",
       "-boot",
       "-R",
-      "$TESTCASE_ROOT/lib/coq/theories",
+      "coq/theories",
       "Corelib",
       "-Q",
-      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "coq/user-contrib/B",
       "B",
       "-R",
       ".",

--- a/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
@@ -133,15 +133,6 @@ Coq package should fail:
   -> required by _build/install/default/lib/coq/user-contrib/Common/Foo.glob
   -> required by _build/default/example-coq.install
   -> required by alias install
-  File "coq/extracted/dune", line 6, characters 11-17:
-  6 |  (theories Stdlib Common))
-                 ^^^^^^
-  Theory "Stdlib" has not been found.
-  -> required by _build/default/coq/extracted/CRelationClasses.ml
-  -> required by _build/default/coq/CRelationClasses.ml
-  -> required by _build/install/default/lib/example-coq/coq/CRelationClasses.ml
-  -> required by _build/default/example-coq.install
-  -> required by alias install
   [1]
   $ cat example-coq.install
   cat: example-coq.install: No such file or directory

--- a/test/blackbox-tests/test-cases/rocq/coq-config.t/dune
+++ b/test/blackbox-tests/test-cases/rocq/coq-config.t/dune
@@ -17,7 +17,7 @@
    (progn
     (pipe-outputs
      ; We need to scrub ignored config values
-     (run %{bin:rocq} --config)
+     (run %{bin:rocq} compile --config)
      (run sed "/^COQCORELIB=/d")
      (run sed "/^DOCDIR=/d")
      (run sed "/^OCAMLFIND=/d")
@@ -25,5 +25,5 @@
      (run sed "/^WARN=/d")
      (run sed "/^HASNATDYNLINK=/d")
      (run sed "/^COQ_SRC_SUBDIRS=/d"))
-    (run %{bin:rocq} -print-version)
-    (run %{bin:rocq} -print-version)))))
+    (run %{bin:rocq} --print-version)
+    (run %{bin:rocq} --print-version)))))

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-flags-header-footer.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-flags-header-footer.t
@@ -27,7 +27,6 @@ Testing the rocqdoc_header and rocqdoc_footer field of the env stanza.
   $ dune build @doc
 
   $ dune trace cat | jq -c 'include "dune"; coqdocFlags'
-  "doc"
   "-R"
   "coq/theories"
   "Corelib"
@@ -47,7 +46,6 @@ Testing the rocqdoc_header and rocqdoc_footer field of the env stanza.
   $ dune build @doc-latex
 
   $ dune trace cat | jq -c 'include "dune"; coqdocFlags'
-  "doc"
   "-R"
   "coq/theories"
   "Corelib"

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-flags.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-flags.t
@@ -20,7 +20,6 @@ Testing the coqdoc flags field of the env stanza.
   $ dune build @doc
 
   $ dune trace cat | jq 'include "dune"; coqdocFlags'
-  "doc"
   "-R"
   "coq/theories"
   "Corelib"

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
@@ -14,3 +14,4 @@ Dune should be passing '--coqlib' to coqdoc, but it doesn't. This is a bug.
 
   $ dune trace cat | jq -c 'include "dune"; select(.args.process_args.[0] == "doc") | .args.process_args'
   ["doc","-R","../Coq","Corelib","-R",".","A","--toc","--html","-d","A.html","a.v"]
+  ["doc","-R","../Coq","Corelib","-R",".","A","--toc","--html","-d","A.html","a.v"]

--- a/test/blackbox-tests/test-cases/rocq/coqpp.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqpp.t/run.t
@@ -67,7 +67,7 @@ Same again but with one .mlg file removed
   > EOF
 
   $ dune build
-  File "marg.mlg", line 3, characters 12-20:
+  File "marg.mlg", line 3, characters 12-16:
   Error: Unbound module Gram
   [1]
 

--- a/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-flags.t/run.t
@@ -3,23 +3,51 @@ Testing that the correct flags are being passed to dune rocq top
 The flags passed to coqc:
   $ dune build
   $ dune trace cat | jq 'include "dune"; rocqFlags'
-  "compile"
-  "-w"
-  "-notation-overridden"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "minimal"
-  "Test.v"
+  {
+    "name": "rocq",
+    "args": [
+      "--config"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "dep",
+      "-boot",
+      "-R",
+      "coq/theories",
+      "Corelib",
+      "-R",
+      ".",
+      "minimal",
+      "-dyndep",
+      "opt",
+      "-vos",
+      "Test.v"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "compile",
+      "-w",
+      "-notation-overridden",
+      "-w",
+      "-deprecated-native-compiler-option",
+      "-w",
+      "-native-compiler-disabled",
+      "-native-compiler",
+      "ondemand",
+      "-boot",
+      "-R",
+      "coq/theories",
+      "Corelib",
+      "-R",
+      ".",
+      "minimal",
+      "Test.v"
+    ]
+  }
 
 The flags passed to coqtop:
   $ dune rocq top --toplevel=echo Test.v | ../../scrub_coq_args.sh

--- a/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-root.t/run.t
@@ -21,6 +21,6 @@ This test is currently broken due to the workspace resolution being faulty #5899
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project file. You must enable it using (using rocq 0.11) in your
-  dune-project file.
+  dune-project or workspace file. You must enable it using (using rocq 0.11) in
+  the file.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/failed-config.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/failed-config.t/run.t
@@ -6,10 +6,10 @@ First we create a wrapper around coqc so we can make it fail. It should only fai
   $ mkdir bin
   $ cat > bin/rocq <<'EOF'
   > #!/bin/sh
-  > if    [ $1 = --config ]        && [ -n "$FAIL_CONFIG" ]; then
+  > if    [ "$1" = --config ] && [ -n "$FAIL_CONFIG" ]; then
   >   echo "rocq --config has failed for some reason" >&2
   >   exit 1
-  > elif  [ $1 = --print-version ] && [ -n "$FAIL_VERSION" ]; then
+  > elif  [ "$1" = --print-version ] && [ -n "$FAIL_VERSION" ]; then
   >   echo "rocq --print-version has failed for some reason" >&2
   >   exit 1
   > fi
@@ -127,7 +127,7 @@ however a failing --print-version will not.
   > EOF
 
 Should fail.
-  $ export coqlib="$(rocq -config | grep COQLIB | sed 's/COQLIB=//')"
+  $ export coqlib="$(rocq --config | grep COQLIB | sed 's/COQLIB=//')"
   $ FAIL_CONFIG=1 \
   > dune build @config 
   File "dune", line 4, characters 8-23:

--- a/test/blackbox-tests/test-cases/rocq/flags.t
+++ b/test/blackbox-tests/test-cases/rocq/flags.t
@@ -23,35 +23,9 @@ Test case: default flags
   > }
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: :standard
 
@@ -62,35 +36,9 @@ TC: :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: override :standard
 
@@ -101,34 +49,9 @@ TC: override :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: add to :standard
 
@@ -139,36 +62,9 @@ TC: add to :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in workspace + override standard
 
@@ -184,35 +80,9 @@ TC: extend in workspace + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in workspace + override standard
 
@@ -222,36 +92,9 @@ TC: extend in workspace + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + override standard
 
@@ -262,35 +105,9 @@ TC: extend in dune (env) + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + standard
 
@@ -301,37 +118,9 @@ TC: extend in dune (env) + standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-type-in-type","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + workspace + standard
 
@@ -347,34 +136,6 @@ TC: extend in dune (env) + workspace + standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-bt"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-w"
-  "-native-compiler-disabled"
-  "-native-compiler"
-  "ondemand"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-bt","-w","-deprecated-native-compiler-option","-w","-native-compiler-disabled","-native-compiler","ondemand","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}

--- a/test/blackbox-tests/test-cases/rocq/github3624.t
+++ b/test/blackbox-tests/test-cases/rocq/github3624.t
@@ -17,6 +17,6 @@ good when the coq extension is not enabled.
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project file. You must enable it using (using rocq 0.11) in your
-  dune-project file.
+  dune-project or workspace file. You must enable it using (using rocq 0.11) in
+  the file.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/compose-installed-compat.t/run.t
@@ -52,15 +52,15 @@ Now we check the flags that were passed to coqdep and coqc:
 
   $ dune trace cat | jq 'include "dune"; coqcCoqdepFlags'
   {
-    "name": "finish",
+    "name": "rocq",
     "args": [
       "dep",
       "-boot",
       "-R",
-      "$TESTCASE_ROOT/lib/coq/theories",
+      "coq/theories",
       "Corelib",
       "-Q",
-      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "coq/user-contrib/B",
       "B",
       "-R",
       ".",
@@ -72,7 +72,7 @@ Now we check the flags that were passed to coqdep and coqc:
     ]
   }
   {
-    "name": "finish",
+    "name": "rocq",
     "args": [
       "compile",
       "-q",
@@ -83,15 +83,15 @@ Now we check the flags that were passed to coqdep and coqc:
       "-native-compiler",
       "on",
       "-nI",
-      "/home/runner/work/dune/dune/_opam/lib/rocq-runtime/kernel",
+      "rocq-runtime/kernel",
       "-nI",
       ".",
       "-boot",
       "-R",
-      "$TESTCASE_ROOT/lib/coq/theories",
+      "coq/theories",
       "Corelib",
       "-Q",
-      "$TESTCASE_ROOT/lib/coq/user-contrib/B",
+      "coq/user-contrib/B",
       "B",
       "-R",
       ".",

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-flags.t/run.t
@@ -3,27 +3,55 @@ Testing that the correct flags are being passed to dune rocq top
 The flags passed to coqc:
   $ dune build
   $ dune trace cat | jq 'include "dune"; rocqFlags'
-  "compile"
-  "-w"
-  "-notation-overridden"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "minimal"
-  "Test.v"
+  {
+    "name": "rocq",
+    "args": [
+      "--config"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "dep",
+      "-boot",
+      "-R",
+      "coq/theories",
+      "Corelib",
+      "-R",
+      ".",
+      "minimal",
+      "-dyndep",
+      "opt",
+      "-vos",
+      "Test.v"
+    ]
+  }
+  {
+    "name": "rocq",
+    "args": [
+      "compile",
+      "-w",
+      "-notation-overridden",
+      "-w",
+      "-deprecated-native-compiler-option",
+      "-native-output-dir",
+      ".",
+      "-native-compiler",
+      "on",
+      "-nI",
+      "rocq-runtime/kernel",
+      "-nI",
+      ".",
+      "-boot",
+      "-R",
+      "coq/theories",
+      "Corelib",
+      "-R",
+      ".",
+      "minimal",
+      "Test.v"
+    ]
+  }
 
 The flags passed to coqtop:
   $ dune rocq top --toplevel=echo Test.v | ../../scrub_coq_args.sh

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-root.t/run.t
@@ -22,6 +22,6 @@ This test is currently broken due to the workspace resolution being faulty #5899
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project file. You must enable it using (using rocq 0.11) in your
-  dune-project file.
+  dune-project or workspace file. You must enable it using (using rocq 0.11) in
+  the file.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/flags.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/flags.t
@@ -23,39 +23,9 @@ Test case: default flags
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: :standard
 
@@ -66,39 +36,9 @@ TC: :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: override :standard
 
@@ -109,38 +49,9 @@ TC: override :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: add to :standard
 
@@ -151,40 +62,9 @@ TC: add to :standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in workspace + override standard
 
@@ -200,39 +80,9 @@ TC: extend in workspace + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in workspace + override standard
 
@@ -242,40 +92,9 @@ TC: extend in workspace + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + override standard
 
@@ -286,39 +105,9 @@ TC: extend in dune (env) + override standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + standard
 
@@ -329,41 +118,9 @@ TC: extend in dune (env) + standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-type-in-type"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-type-in-type","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}
 
 TC: extend in dune (env) + workspace + standard
 
@@ -379,38 +136,6 @@ TC: extend in dune (env) + workspace + standard
   > EOF
 
   $ runFlags
-  "--config"
-  "dep"
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "-dyndep"
-  "opt"
-  "-vos"
-  "foo.v"
-  "compile"
-  "-q"
-  "-type-in-type"
-  "-bt"
-  "-w"
-  "-deprecated-native-compiler-option"
-  "-native-output-dir"
-  "."
-  "-native-compiler"
-  "on"
-  "-nI"
-  "rocq-runtime/kernel"
-  "-nI"
-  "."
-  "-boot"
-  "-R"
-  "coq/theories"
-  "Corelib"
-  "-R"
-  "."
-  "foo"
-  "foo.v"
+  {"name":"rocq","args":["--config"]}
+  {"name":"rocq","args":["dep","-boot","-R","coq/theories","Corelib","-R",".","foo","-dyndep","opt","-vos","foo.v"]}
+  {"name":"rocq","args":["compile","-q","-type-in-type","-bt","-w","-deprecated-native-compiler-option","-native-output-dir",".","-native-compiler","on","-nI","rocq-runtime/kernel","-nI",".","-boot","-R","coq/theories","Corelib","-R",".","foo","foo.v"]}


### PR DESCRIPTION
In this PR we:
- add rocq to the nix flake
- fixup the output of all the rocq tests
- fixup the output of all the rocq-native tests
- re-enable the Rocq CI for both normal and native
- remove coq from the nix flake and the ci
