### PR TITLE
Fix #8042, multiple `rocq.extraction` in directory.

### DIFF
--- a/bin/rocq/rocqtop.ml
+++ b/bin/rocq/rocqtop.ml
@@ -122,7 +122,7 @@ let term =
         | Some (`Extraction extr) ->
           ( Dune_rules.Rocq.Rocq_rules.rocqtop_args_extraction ~sctx ~dir extr rocq_module
           , extr.buildable.use_stdlib
-          , "DuneExtraction"
+          , Dune_rules.Rocq.Rocq_rules.extraction_wrapper_name extr
           , extr.buildable.mode )
       in
       (* Run rocqdep *)

--- a/doc/changes/fixed/13531.md
+++ b/doc/changes/fixed/13531.md
@@ -1,0 +1,3 @@
+- Fix failure when multiple `rocq.extraction` stanzas existing in a directory
+  (#13531, fixes #8042, @rlepigre-skylabs-ai)
+

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -1245,8 +1245,12 @@ let setup_rocqpp_rules ~sctx ~dir ({ loc; modules } : Rocq_stanza.Rocqpp.t) =
   List.rev_map ~f:mlg_rule mlg_files |> Super_context.add_rules ~loc ~dir sctx
 ;;
 
+let extraction_wrapper_name (s : Rocq_stanza.Extraction.t) : string =
+  "Dune_Extraction_" ^ Rocq_module.Name.to_string (snd s.prelude)
+;;
+
 let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.t) =
-  let wrapper_name = "DuneExtraction" ^ Rocq_module.Name.to_string (snd s.prelude) in
+  let wrapper_name = extraction_wrapper_name s in
   let* rocq_module =
     let+ rocq = Dir_contents.rocq dir_contents in
     Rocq_sources.extract rocq s
@@ -1315,7 +1319,7 @@ let rocqtop_args_extraction ~sctx ~dir (s : Rocq_stanza.Extraction.t) rocq_modul
     let context = Super_context.context sctx |> Context.name in
     extraction_context ~context ~scope s.buildable
   in
-  let wrapper_name = "DuneExtraction" ^ Rocq_module.Name.to_string (snd s.prelude) in
+  let wrapper_name = extraction_wrapper_name s in
   let boot_type = Bootstrap.make ~scope ~use_stdlib ~wrapper_name rocq_module in
   let boot_flags = Resolve.Memo.read boot_type |> Action_builder.map ~f:Bootstrap.flags in
   let per_file_flags = None in

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -1246,7 +1246,7 @@ let setup_rocqpp_rules ~sctx ~dir ({ loc; modules } : Rocq_stanza.Rocqpp.t) =
 ;;
 
 let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.t) =
-  let wrapper_name = "DuneExtraction" in
+  let wrapper_name = "DuneExtraction" ^ Rocq_module.Name.to_string (snd s.prelude) in
   let* rocq_module =
     let+ rocq = Dir_contents.rocq dir_contents in
     Rocq_sources.extract rocq s
@@ -1315,7 +1315,7 @@ let rocqtop_args_extraction ~sctx ~dir (s : Rocq_stanza.Extraction.t) rocq_modul
     let context = Super_context.context sctx |> Context.name in
     extraction_context ~context ~scope s.buildable
   in
-  let wrapper_name = "DuneExtraction" in
+  let wrapper_name = "DuneExtraction" ^ Rocq_module.Name.to_string (snd s.prelude) in
   let boot_type = Bootstrap.make ~scope ~use_stdlib ~wrapper_name rocq_module in
   let boot_flags = Resolve.Memo.read boot_type |> Action_builder.map ~f:Bootstrap.flags in
   let per_file_flags = None in

--- a/src/dune_rules/rocq/rocq_rules.mli
+++ b/src/dune_rules/rocq/rocq_rules.mli
@@ -23,6 +23,10 @@ val deps_of
   -> Rocq_module.t
   -> unit Dune_engine.Action_builder.t
 
+(** Wrapper name used for the extraction stanza, used for calling [deps_of] on
+    in `dune rocq top`. *)
+val extraction_wrapper_name : Rocq_stanza.Extraction.t -> string
+
 (** ** Rules for Rocq stanzas *)
 
 (** [rocq.theory] stanza rules *)

--- a/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
@@ -42,5 +42,5 @@
   Mod2.ml
   Mod2.mli
   $ ls _build/default/.*.d | sort
-  _build/default/.DuneExtractionExtr1.theory.d
-  _build/default/.DuneExtractionExtr2.theory.d
+  _build/default/.Dune_Extraction_Extr1.theory.d
+  _build/default/.Dune_Extraction_Extr2.theory.d

--- a/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
@@ -1,0 +1,46 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat >Extr1.v <<EOF
+  > Require Import Corelib.extraction.Extraction.
+  > Extraction "Mod1.ml" app.
+  > EOF
+
+  $ cat >Extr2.v <<EOF
+  > Require Import Corelib.extraction.Extraction.
+  > Extraction "Mod2.ml" length.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude Extr1)
+  >  (extracted_modules Mod1)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > 
+  > (rocq.extraction
+  >  (prelude Extr2)
+  >  (extracted_modules Mod2)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  $ ls _build/default | sort
+  Extr1.glob
+  Extr1.v
+  Extr1.vo
+  Extr1.vok
+  Extr1.vos
+  Extr2.glob
+  Extr2.v
+  Extr2.vo
+  Extr2.vok
+  Extr2.vos
+  Mod1.ml
+  Mod1.mli
+  Mod2.ml
+  Mod2.mli
+  $ ls _build/default/.*.d | sort
+  _build/default/.DuneExtractionExtr1.theory.d
+  _build/default/.DuneExtractionExtr2.theory.d

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/extract.t
@@ -44,10 +44,10 @@
   $ ls _build/default
   Datatypes.ml
   Datatypes.mli
-  NDuneExtraction_extract.cmi
-  NDuneExtraction_extract.cmx
-  NDuneExtraction_extract.cmxs
-  NDuneExtraction_extract.o
+  NDune_Extraction_extract_extract.cmi
+  NDune_Extraction_extract_extract.cmx
+  NDune_Extraction_extract_extract.cmxs
+  NDune_Extraction_extract_extract.o
   extract.glob
   extract.ml
   extract.mli


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/8042.