### PR TITLE
chore: bump minimal OCaml version to 4.14

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,8 +95,8 @@ jobs:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
-  nix-build-4-08:
-    name: Nix Build 4.08
+  nix-build-4-14:
+    name: Nix Build 4.14
     strategy:
       fail-fast: false
       matrix:
@@ -114,7 +114,7 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
-      - run: nix develop -i .#bootstrap-check_4_08 -c make release
+      - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
     # This builds OxCaml with the flake version which is typically ahead of the

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
 version=0.28.1
 profile=janestreet
-ocaml-version=4.08.0
+ocaml-version=4.14.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In particular, this makes it easy to handle
 
 ## Requirements
 
-Dune requires OCaml version 4.08.0 to build itself and can build OCaml projects
+Dune requires OCaml version 4.14.0 to build itself and can build OCaml projects
 using OCaml 4.02.3 or greater.
 
 ## Installation

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -4,7 +4,7 @@ open Printf
 (* This program performs version checking of the compiler and switches to the
    secondary compiler if necessary. The script should execute in OCaml 4.02! *)
 
-let min_supported_natively = 4, 08, 0
+let min_supported_natively = 4, 14, 0
 
 let keep_generated_files =
   let anon s = raise (Arg.Bad (sprintf "don't know what to do with %s\n" s)) in
@@ -103,7 +103,7 @@ let () =
        compiler
        (* Make sure to produce a self-contained binary as dlls tend to cause
           issues *)
-       (if v < (4, 10, 1) then "-custom" else "-output-complete-exe")
+       "-output-complete-exe"
        prog
        (if v >= (5, 0, 0) then "-I +unix " else "")
        (List.map modules ~f:(fun m -> m ^ ".ml") |> String.concat ~sep:" "));

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1158,10 +1158,7 @@ end = struct
     | false, Some path -> path, Mode.Native, ".cmxa"
   ;;
 
-  let output_complete_obj_arg =
-    if ocaml_version < (4, 10) then "-custom" else "-output-complete-exe"
-  ;;
-
+  let output_complete_obj_arg = "-output-complete-exe"
   let unix_library_flags = if ocaml_version >= (5, 0) then [ "-I"; "+unix" ] else []
 
   type t = string String.Map.t

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -94,8 +94,8 @@ jobs:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
-  nix-build-4-08:
-    name: Nix Build 4.08
+  nix-build-4-14:
+    name: Nix Build 4.14
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
             nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
-      - run: nix develop -i .#bootstrap-check_4_08 -c make release
+      - run: nix develop -i .#bootstrap-check_4_14 -c make release
 
   nix-build-ox:
     # This builds OxCaml with the flake version which is typically ahead of the

--- a/doc/changes/changed/13533.md
+++ b/doc/changes/changed/13533.md
@@ -1,0 +1,2 @@
+- Bump the minimal OCaml version required to build Dune from 4.08 to 4.14.
+  (#13533, @Alizter)

--- a/dune-project
+++ b/dune-project
@@ -230,7 +230,7 @@ understood by dune language."))
  (dir otherlibs/ocamlc-loc)
  (synopsis "Parse ocaml compiler output into structured form")
  (conflicts
-  (ocaml-lsp-server (< 1.15.0)))
+  (ocaml-lsp-server (< 1.17.0)))
  (depends
   (ocaml (>= 4.08.0))
   (dyn (= :version)))

--- a/dune-project
+++ b/dune-project
@@ -81,7 +81,7 @@ executable was built.
   (pp (>= 1.1.0))
   (dyn (= :version))
   (stdune (= :version))
-  (ocaml (>= 4.08)))
+  (ocaml (>= 4.14)))
  (maintenance_intent none)
  (description "\
 !!!!!!!!!!!!!!!!!!!!!!
@@ -177,7 +177,7 @@ understood by dune language."))
  (dir otherlibs/dyn)
  (synopsis "Dynamic type")
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.14))
   (ordering (= :version))
   (pp (>= 1.1.0)))
  (maintenance_intent none)
@@ -188,7 +188,7 @@ understood by dune language."))
  (dir otherlibs/ordering)
  (synopsis "Element ordering")
  (depends
-  (ocaml (>= 4.08.0)))
+  (ocaml (>= 4.14)))
  (maintenance_intent none)
  (description "Element ordering"))
 
@@ -197,7 +197,7 @@ understood by dune language."))
  (dir otherlibs/xdg)
  (synopsis "XDG Base Directory Specification")
  (depends
-  (ocaml (>= 4.08)))
+  (ocaml (>= 4.14)))
  (description "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"))
 
 (package
@@ -205,7 +205,7 @@ understood by dune language."))
  (dir otherlibs/top-closure)
  (synopsis "Topological Closure")
  (depends
-  (ocaml (>= 4.08)))
+  (ocaml (>= 4.14)))
  (maintenance_intent none)
  (description "Generic Topological Closure"))
 
@@ -214,7 +214,7 @@ understood by dune language."))
  (dir otherlibs/stdune)
  (synopsis "Dune's unstable standard library")
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.14))
   base-unix
   (csexp (>= 1.5.0))
   (dyn (= :version))
@@ -232,7 +232,7 @@ understood by dune language."))
  (conflicts
   (ocaml-lsp-server (< 1.17.0)))
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.14))
   (dyn (= :version)))
  (maintenance_intent none)
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
@@ -242,7 +242,7 @@ understood by dune language."))
  (dir otherlibs/chrome-trace)
  (synopsis "Chrome trace event generation library")
  (depends
-  (ocaml (>= 4.08.0)))
+  (ocaml (>= 4.14)))
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 
 (package
@@ -251,7 +251,7 @@ understood by dune language."))
  (synopsis "File System Operations")
  (depends
   base-unix
-  (ocaml (>= 4.08)))
+  (ocaml (>= 4.14)))
  (maintenance_intent none)
  (description "Misc. Collection of File System Operations"))
 

--- a/flake.nix
+++ b/flake.nix
@@ -495,14 +495,14 @@
             '';
           };
 
-          bootstrap-check_4_08 = pkgs.mkShell {
+          bootstrap-check_4_14 = pkgs.mkShell {
             inherit INSIDE_NIX;
             buildInputs = [
               pkgs.gnumake
-              pkgs-old.ocaml-ng.ocamlPackages_4_08.ocaml
+              pkgs.ocaml-ng.ocamlPackages_4_14.ocaml
             ];
             meta.description = ''
-              Provides a minimal shell environment with OCaml 4.08 in order
+              Provides a minimal shell environment with OCaml 4.14 in order
               to test the bootstrapping script.
             '';
           };

--- a/opam/chrome-trace.opam
+++ b/opam/chrome-trace.opam
@@ -11,7 +11,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/opam/dune-private-libs.opam
+++ b/opam/dune-private-libs.opam
@@ -22,7 +22,7 @@ depends: [
   "pp" {>= "1.1.0"}
   "dyn" {= version}
   "stdune" {= version}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -5,7 +5,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/opam/dyn.opam
+++ b/opam/dyn.opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}
   "odoc" {with-doc}

--- a/opam/fs-io.opam
+++ b/opam/fs-io.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
   "base-unix"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/opam/ocamlc-loc.opam
+++ b/opam/ocamlc-loc.opam
@@ -11,7 +11,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "dyn" {= version}
   "odoc" {with-doc}
 ]

--- a/opam/ocamlc-loc.opam
+++ b/opam/ocamlc-loc.opam
@@ -16,7 +16,7 @@ depends: [
   "odoc" {with-doc}
 ]
 conflicts: [
-  "ocaml-lsp-server" {< "1.15.0"}
+  "ocaml-lsp-server" {< "1.17.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]

--- a/opam/ordering.opam
+++ b/opam/ordering.opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/opam/stdune.opam
+++ b/opam/stdune.opam
@@ -11,7 +11,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "base-unix"
   "csexp" {>= "1.5.0"}
   "dyn" {= version}

--- a/opam/top-closure.opam
+++ b/opam/top-closure.opam
@@ -10,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/opam/xdg.opam
+++ b/opam/xdg.opam
@@ -11,7 +11,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -876,7 +876,7 @@ let report_process_finished
       ~dir
       ~stdout
       ~stderr
-      ~times:(times : Proc.Times.t))
+      ~(times : Proc.Times.t))
 ;;
 
 let await ~timeout { response_file; pid; is_process_group_leader; _ } =


### PR DESCRIPTION
We bump the minimal OCaml version required to build dune to 4.14.

- [x] changelog
- [ ] check `dune-secondary` package and how we can support older OCaml users. (prob best to wait for complaints first)