### PR TITLE
minor: Remove program_not_found_message utility function

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -73,7 +73,7 @@ module Prog = struct
     let create ?hint ~context ~program ~loc () = { hint; context; program; loc }
 
     let raise { context; program; hint; loc } =
-      raise (User_error.E (Utils.program_not_found_message ?hint ~loc ~context program))
+      Utils.program_not_found ?hint ~loc ~context program
     ;;
 
     let to_dyn { context; program; hint; loc = _ } =

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -10,12 +10,5 @@ val program_not_found
   -> string
   -> _
 
-val program_not_found_message
-  :  ?context:Context_name.t
-  -> ?hint:string
-  -> loc:Loc.t option
-  -> string
-  -> User_message.t
-
 (** Pretty-printer for suggesting a given shell command to the user *)
 val pp_command_hint : string -> _ Pp.t


### PR DESCRIPTION
The `Dune_engine.Utils` module already exposes a `program_not_found` utility that does what would be needed in most cases