### PR TITLE
refactor(rpc): move dropped to trace

### DIFF
--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -5,7 +5,6 @@
   stdune
   dyn
   dune_util
-  dune_console
   dune_trace
   csexp
   fiber

--- a/src/csexp_rpc/session.ml
+++ b/src/csexp_rpc/session.ml
@@ -208,7 +208,8 @@ let write t sexps =
        (match error with
         | `Cancelled -> ()
         | `Exn exn ->
-          Dune_console.print [ Pp.textf "Rpc Client disconnected"; Exn.pp exn ]);
+          Dune_trace.emit Rpc (fun () ->
+            Dune_trace.Event.Rpc.dropped_write_client_disconnect exn));
        let+ () = close t in
        Error `Closed)
 ;;

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -167,6 +167,7 @@ module Event : sig
     val packet_write : id:int -> count:int -> t
     val accept : success:bool -> error:string option -> t
     val close : id:int -> t
+    val dropped_write_client_disconnect : Exn.t -> t
   end
 
   module Cram : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -467,6 +467,12 @@ module Rpc = struct
     let args = [ "id", Arg.int id ] in
     Event.instant ~args ~name:"close" now Rpc
   ;;
+
+  let dropped_write_client_disconnect exn =
+    let now = Time.now () in
+    let args = [ "exn", Arg.dyn (Exn.to_dyn exn) ] in
+    Event.instant ~args ~name:"drop-write-client-disconnect" now Rpc
+  ;;
 end
 
 let gc () =


### PR DESCRIPTION
This is spam in the console as clients can drop the connection whenever
they want anyway
