### PR TITLE
feat: add the `%{jobs}` variable

### DIFF
--- a/doc/changes/added/13555.md
+++ b/doc/changes/added/13555.md
@@ -1,0 +1,2 @@
+- Add the `%{jobs}` variable that reports the maximum number of
+  concurrent jobs Dune has been allowed to have. (#13555, @MisterDA)

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -78,6 +78,9 @@ Dune supports the following variables:
   stricter warning set. The old behaviour of Dune can be recovered by using the
   following stanza in a top-level ``dune`` file: ``(env (dev (flags :standard
   %{dune-warnings})))``.
+- ``jobs`` is the maximum number of concurrent jobs Dune has been allowed to
+  have (see :doc:`/reference/config/jobs.rst`). An initial value of ``auto``
+  expands to the auto-detected number of cores.
 - ``<ext>:<path>`` where ``<ext>`` is one of ``cmo``, ``cmi``, ``cma``,
   ``cmx``, or ``cmxa``. See :ref:`variables-for-artifacts`.
 - ``env:<var>=<default`` expands to the value of the environment

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -138,6 +138,7 @@ module Var = struct
     | Pkg of Pkg.t
     | Oxcaml_supported
     | Dune_warnings
+    | Jobs
 
   let compare : t -> t -> Ordering.t = Poly.compare
 
@@ -193,7 +194,8 @@ module Var = struct
        | Os os -> Os.to_dyn os
        | Pkg pkg -> Pkg.to_dyn pkg
        | Oxcaml_supported -> variant "Oxcaml_supported" []
-       | Dune_warnings -> variant "Dune_warnings" [])
+       | Dune_warnings -> variant "Dune_warnings" []
+       | Jobs -> variant "Jobs" [])
   ;;
 
   let of_opam_global_variable_name name =
@@ -547,6 +549,7 @@ let encode_to_latest_dune_lang_version t =
        | Pkg pkg -> Some (Var.Pkg.encode_to_latest_dune_lang_version pkg)
        | Oxcaml_supported -> Some "oxcaml_supported"
        | Dune_warnings -> Some "dune-warnings"
+       | Jobs -> Some "jobs"
      with
      | None -> Pform_was_deleted
      | Some name -> Success { name; payload = None })
@@ -768,6 +771,7 @@ module Env = struct
         ; ( "oxcaml_supported"
           , since ~what:Oxcaml.syntax ~version:(0, 1) Var.Oxcaml_supported )
         ; "dune-warnings", since ~version:(3, 21) Var.Dune_warnings
+        ; "jobs", since ~version:(3, 22) Var.Jobs
         ]
       in
       String.Map.of_list_exn

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -92,6 +92,7 @@ module Var : sig
     | Pkg of Pkg.t
     | Oxcaml_supported
     | Dune_warnings
+    | Jobs
 
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -578,6 +578,7 @@ let expand_pform_var (context : Context.t) ~dir ~source (var : Pform.Var.t) =
            let+ scope = scope in
            let dune_version = Dune_project.dune_version (Scope.project scope) in
            Value.L.strings (Ocaml_flags.dune_warnings ~dune_version ~profile:Dev)))
+  | Jobs -> string_of_int !Clflags.concurrency |> string |> Memo.return |> static
 ;;
 
 let ocaml_config_macro source macro_invocation context =

--- a/test/blackbox-tests/test-cases/variables/jobs.t
+++ b/test/blackbox-tests/test-cases/variables/jobs.t
@@ -7,17 +7,9 @@ Test that the %{jobs} variable matches the configured concurrency.
   > (rule (alias runtest) (action (echo "make -j%{jobs}")))
   > EOF
   $ dune runtest -j3615
-  File "dune", line 1, characters 44-51:
-  1 | (rule (alias runtest) (action (echo "make -j%{jobs}")))
-                                                  ^^^^^^^
-  Error: Unknown variable %{jobs}
-  [1]
+  make -j3615
   $ cat >dune <<EOF
   > (rule (alias runtest) (action (echo "make -j%{jobs}")))
   > EOF
   $ dune runtest -jauto
-  File "dune", line 1, characters 44-51:
-  1 | (rule (alias runtest) (action (echo "make -j%{jobs}")))
-                                                  ^^^^^^^
-  Error: Unknown variable %{jobs}
-  [1]
+  make -j16


### PR DESCRIPTION
`%{jobs}` is the maximum number of concurrent jobs Dune has been allowed to have (see https://dune.readthedocs.io/en/latest/reference/config/jobs.html). An initial value of `auto` for the config variable expands to the auto-detected number of cores.
See [_Dune, cmake and `-j`_ on Discuss](https://discuss.ocaml.org/t/dune-cmake-and-j/17768) (cc @tbrk).

A grep for `%{jobs}` returned a few matches, that are direct translations of opam `jobs` variable. I don't understand whether it was actually supported somehow or not, it seems not, but maybe I've missed something.

```
test/blackbox-tests/test-cases/pkg/opam-var/opam-var-global.t
23:       (run echo %{jobs})

test/blackbox-tests/test-cases/pkg/partial-filter-evaluation.t
43:        %{jobs}
77:      (run dune build -p %{pkg-self:name} -j %{jobs} --foobar @install @doc)))))

test/blackbox-tests/test-cases/pkg/extra-sources.t
122:       (run dune build -p %{pkg-self:name} -j %{jobs}))))))

test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
29:  >   [make "-j%{jobs}%"]
107:       (run dune build -p %{pkg-self:name} -j %{jobs} @install))))))
121:       (run %{make} -j%{jobs}))))))
```

I wrote on Discuss:

> Actually, when I use Dune’s foreign build sandboxing, it happens often that Dune waits for the build of the foreign library to finish, with just one job in flight. In that case, the foreign build system could freely use all of the possible cores, since Dune doesn’t execute any job in parallel with the foreign build system.

It's just important not to run an unbounded number of jobs.