### PR TITLE
backport: test(melange): show `(melange.emit ..)` doesn't respect `-p <PKG>`

### DIFF
--- a/doc/changes/fixed/13522.md
+++ b/doc/changes/fixed/13522.md
@@ -1,0 +1,2 @@
+- Fix `melange.emit` not respecting the package mask via `-p <PKG>` (#13522,
+  @anmonteiro)

--- a/src/dune_rules/stanzas/stanzas.ml
+++ b/src/dune_rules/stanzas/stanzas.ml
@@ -135,6 +135,7 @@ let stanza_package stanza =
      | Tests.T { package = Some package; _ } -> Some package
      | Coq_stanza.Theory.T { package = Some package; _ } -> Some package
      | Rocq_stanza.Theory.T { package = Some package; _ } -> Some package
+     | Melange_stanzas.Emit.T { package = Some package; _ } -> Some package
      | _ -> None)
     |> Option.map ~f:Package.id
   with

--- a/test/blackbox-tests/test-cases/melange/melange-emit-package.t
+++ b/test/blackbox-tests/test-cases/melange/melange-emit-package.t
@@ -80,14 +80,11 @@ we can still build my-ppx independently
 
   $ dune build -p my-ppx
 
-and fails if it can't resolve libraries to build the alias
+and fails to build any `@melange`-related stuff, because none is defined for
+the package `my-ppx`
 
   $ dune build @melange -p my-ppx
-  File "test/dune", line 6, characters 12-19:
-  6 |  (libraries mel-foo))
-                  ^^^^^^^
-  Error: Library "mel-foo" not found.
-  -> required by _build/default/test/js-out/test/test_entry.js
-  -> required by alias test/melange
+  Error: Alias "melange" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
   [1]
 

--- a/test/blackbox-tests/test-cases/melange/melange-runtest-multiple-packages.t
+++ b/test/blackbox-tests/test-cases/melange/melange-runtest-multiple-packages.t
@@ -33,9 +33,8 @@ Show interaction of `dune runtest -p ..` and `(melange.emit ..)`
 Selecting only the package a should not build b
 
   $ dune runtest -p a
-  $ ls _build/default/b/out/b
-  x.js
+  $ test -e _build/default/b/out/b/x.js
+  [1]
 
   $ dune runtest -p b
-  $ ls _build/default/b/out/b
-  x.js
+  $ test -e _build/default/b/out/b/x.js

--- a/test/blackbox-tests/test-cases/melange/melange-runtest-multiple-packages.t
+++ b/test/blackbox-tests/test-cases/melange/melange-runtest-multiple-packages.t
@@ -1,0 +1,41 @@
+Show interaction of `dune runtest -p ..` and `(melange.emit ..)`
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using melange 1.0)
+  > (package (name a))
+  > (package (name b))
+  > EOF
+
+  $ mkdir a b
+  $ cat > a/dune <<EOF
+  > (melange.emit
+  >  (alias runtest)
+  >  (package a)
+  >  (emit_stdlib false)
+  >  (target out))
+  > EOF
+  $ cat > a/x.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+  $ cat > b/dune <<EOF
+  > (melange.emit
+  >  (alias runtest)
+  >  (package b)
+  >  (emit_stdlib false)
+  >  (target out))
+  > EOF
+  $ cat > b/x.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+Selecting only the package a should not build b
+
+  $ dune runtest -p a
+  $ ls _build/default/b/out/b
+  x.js
+
+  $ dune runtest -p b
+  $ ls _build/default/b/out/b
+  x.js


### PR DESCRIPTION
Backport of both 

- https://github.com/ocaml/dune/pull/13521
- https://github.com/ocaml/dune/pull/13522