### PR TITLE
fix: stop starting rpc with dune promote (#13428)

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -78,7 +78,7 @@ module Apply = struct
     let files_to_promote = files_to_promote ~common files in
     match Dune_util.Global_lock.lock ~timeout:None with
     | Ok () ->
-      Scheduler.go_with_rpc_server ~common ~config (fun () ->
+      Scheduler.go_without_rpc_server ~common ~config (fun () ->
         let open Fiber.O in
         let+ () = Fiber.return () in
         Diff_promotion.promote_files_registered_in_last_run files_to_promote)

--- a/doc/changes/changed/13428.md
+++ b/doc/changes/changed/13428.md
@@ -1,0 +1,1 @@
+- Stop starting RPC server with `$ dune promote` (#13428, @rgrinberg)


### PR DESCRIPTION
backport: use Scheduler.go_without_rpc_server