### PR TITLE
fix: respect the dir stanza for assigning cram tests to packages

### DIFF
--- a/doc/changes/fixed/13581.md
+++ b/doc/changes/fixed/13581.md
@@ -1,0 +1,2 @@
+- Respect the `(dir ..)` field on packages when setting up cram tests (#13581,
+  @rgrinberg)

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -122,6 +122,12 @@ let stanza_parser t ~dir =
   Decoder.set Package_mask.key mask parser
 ;;
 
+let exclusive_package t ~dir =
+  match Package_mask.package_env ~dir ~packages:t.exclusive_dir_packages with
+  | Inside_package p -> Some p
+  | Forbidden_packages _ -> None
+;;
+
 let file t = t.project_file
 
 let implicit_transitive_deps t ocaml_version =

--- a/src/dune_lang/dune_project.mli
+++ b/src/dune_lang/dune_project.mli
@@ -15,6 +15,7 @@ type t
 
 val to_dyn : t -> Dyn.t
 val packages : t -> Package.t Package.Name.Map.t
+val exclusive_package : t -> dir:Path.Source.t -> Package_id.t option
 val name : t -> Dune_project_name.t
 val version : t -> Package_version.t option
 val root : t -> Path.Source.t

--- a/test/blackbox-tests/test-cases/cram/exclusive-package-test.t
+++ b/test/blackbox-tests/test-cases/cram/exclusive-package-test.t
@@ -22,18 +22,6 @@ This command should only run the packages for foo:
 # CR-someday rgrinberg: what happened to formatting here?!
 
   $ dune runtest --only-packages foo
-  File "bar/dir.t/run.t", line 1, characters 0-0:
-  --- bar/dir.t/run.t
-  +++ bar/dir.t/run.t.corrected
-  @@ -1 +1,2 @@
-     $ echo foo
-  +  foo
-  File "bar/file.t", line 1, characters 0-0:
-  --- bar/file.t
-  +++ bar/file.t.corrected
-  @@ -1 +1,2 @@
-     $ echo foo
-  +  foo
   File "foo/dir.t/run.t", line 1, characters 0-0:
   --- foo/dir.t/run.t
   +++ foo/dir.t/run.t.corrected


### PR DESCRIPTION
Doing `dune build @install -p pkg` was broken by the presence of cram tests. Those need to be treated specially because they're discovered in the source tree.