### PR TITLE
chore: improve micro bench runner script

### DIFF
--- a/bench/micro/runner.sh
+++ b/bench/micro/runner.sh
@@ -1,12 +1,21 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 export BENCHMARKS_RUNNER=TRUE
-case "$1" in
-  "dune" ) test="dune_bench"; main="main";;
-  "memo" ) test="memo_bench"; main="memo_bench_main";;
-  "thread_pool" ) test="thread_pool_bench"; main="thread_pool_bench_main";;
-  "digest" ) test="digest_bench"; main="digest_bench_main";;
-  "path" ) test="path_bench"; main="path_bench_main";;
-esac
+
+declare -A benchmarks=(
+  [dune]="dune_bench:main"
+  [memo]="memo_bench:memo_bench_main"
+  [thread_pool]="thread_pool_bench:thread_pool_bench_main"
+  [digest]="digest_bench:digest_bench_main"
+  [path]="path_bench:path_bench_main"
+)
+
+if [[ -z "${benchmarks[$1]}" ]]; then
+  echo "Unknown benchmark: $1" >&2
+  echo "Available: ${!benchmarks[*]}" >&2
+  exit 1
+fi
+
+IFS=: read -r test main <<< "${benchmarks[$1]}"
 shift;
 export BENCH_LIB="$test"
 exec ./dune.exe exec --release -- "./bench/micro/$main.exe" -fork -run-without-cross-library-inlining "$@"


### PR DESCRIPTION
Using an associative array makes it possible to enumerate over the options when giving an unknown argument. Previously it would say something like
```
Error: Program './bench/micro/.exe' not found!
```
now it says:
```
Unknown benchmark: invalid
Available: thread_pool memo path digest dune
```