### PR TITLE
pkg: recognize default dune build commands

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/lockfiles-dune-keyword.t
+++ b/test/blackbox-tests/test-cases/pkg/lockfiles-dune-keyword.t
@@ -1,0 +1,52 @@
+When Dune generates a lockfile for a package, if the package had the default
+Dune build command, use the "dune" keyword in the lockfile rather than copying
+its build command.
+
+  $ mkrepo
+  $ add_mock_repo_if_needed
+
+  $ mkpkg foo <<EOF
+  > build: [
+  >   ["dune" "subst"] {dev}
+  >   [
+  >     "dune"
+  >     "build"
+  >     "-p"
+  >     name
+  >     "-j"
+  >     jobs
+  >     "@install"
+  >     "@runtest" {with-test}
+  >     "@doc" {with-doc}
+  >   ]
+  > ]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (package
+  >  (name bar)
+  >  (depends foo))
+  > EOF
+
+  $ cat > bar.ml <<EOF
+  > let () = print_endline Foo.foo
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (public_name bar)
+  >  (libraries foo))
+  > EOF
+
+Lock, build, and run the executable in the project:
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  - foo.0.0.1
+
+The lockfile contains the "dune" keyword rather than the build command:
+  $ cat dune.lock/foo.0.0.1.pkg
+  (version 0.0.1)
+  
+  (build
+   (all_platforms ((dune))))


### PR DESCRIPTION
When generating lockfiles, if a package appears to have a build command that was generated by Dune, use the "dune" build command in the package's lockfile rather than including its literal build command.

This is a step towards building some dependencies in the same dune process as the one orchestrating the build rather than creating a separate dune process for each dependency. There will always be cases where dune needs to build dependencies in separate processes, such as packages that build with `make`, but packages that use the default dune build commands are good candidates for building in the same process. Dune already has the machinery to recognize "dune" build commands, however it still creates a new dune process to build such packages.