### PR TITLE
fix(action_trace): ignore json payloads for now

### DIFF
--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -40,6 +40,7 @@ module Extension = struct
   let js = ".js"
   let h = ".h"
   let mlg = ".mlg"
+  let json = ".json"
 
   let is_valid s =
     (not (String.is_empty s)) && Char.equal s.[0] '.' && not (String.contains s '/')

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -47,6 +47,7 @@ module Extension : sig
   val all_deps : t
   val js : t
   val mlg : t
+  val json : t
   val of_string : string -> t option
   val of_string_exn : string -> t
   val to_string : t -> string


### PR DESCRIPTION
A dune that produces json events would bork us. It would be better to just handle these events, but we don't have a json parser handy.