### PR TITLE
fix: allow exit hooks to produce trace events

### DIFF
--- a/src/dune_digest/cached_digest.ml
+++ b/src/dune_digest/cached_digest.ml
@@ -145,7 +145,7 @@ let dump () =
         P.dump db_file (Lazy.force cache)))
 ;;
 
-let () = at_exit dump
+let () = Dune_trace.at_exit dump
 
 let invalidate_cached_timestamps () =
   if Lazy.is_val cache

--- a/src/dune_engine/hooks.ml
+++ b/src/dune_engine/hooks.ml
@@ -38,4 +38,4 @@ end
 
 module End_of_build = Make ()
 
-let () = at_exit End_of_build.run
+let () = Dune_trace.at_exit End_of_build.run

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -73,7 +73,7 @@ module Workspace_local = struct
        that text by the "Saving..." message. If this hypothetical scenario turns
        out to be a real problem, we will need to add some synchronisation
        mechanism to prevent clearing the status line too early. *)
-    let () = at_exit dump
+    let () = Dune_trace.at_exit dump
 
     let get path =
       let t = Lazy.force t in

--- a/src/dune_rules/copy_line_directive.ml
+++ b/src/dune_rules/copy_line_directive.ml
@@ -33,7 +33,7 @@ module DB = struct
       Persistent.dump file (Lazy.force t))
   ;;
 
-  let () = at_exit dump
+  let () = Dune_trace.at_exit dump
 
   let rec follow_while path ~f =
     let t = Lazy.force t in

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -239,6 +239,7 @@ val enabled : Category.t -> bool
 val emit : ?buffered:bool -> Category.t -> (unit -> Event.t) -> unit
 val emit_all : ?buffered:bool -> Category.t -> (unit -> Event.t list) -> unit
 val flush : unit -> unit
+val at_exit : (unit -> unit) -> unit
 
 module Private : sig
   module Fd_count : sig


### PR DESCRIPTION
Exit hooks which produce events must run after the exit hook of Dune_trace itself