### PR TITLE
test(trace): dune trace cat exits early

### DIFF
--- a/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
+++ b/test/blackbox-tests/test-cases/trace/trace-cat-follow-nested.t
@@ -1,0 +1,59 @@
+Test that dune trace cat --follow doesn't stop on exit events from nested dune
+runs (which have a digest hash), only on the main dune exit event (which has
+no digest hash).
+
+  $ make_dune_project 3.22
+
+  $ fifo="$(mktemp -d)/fifo"
+  $ mkfifo $fifo
+
+Set up a nested dune project:
+
+  $ mkdir inner
+  $ cat >inner/dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (deps (source_tree inner))
+  >  (target x)
+  >  (action
+  >   (progn
+  >    (chdir inner (run dune build))
+  >    (bash "read line < $fifo; touch x"))))
+  > EOF
+
+  $ checkStart() {
+  >   dune trace cat \
+  >     | jq 'select(.name == "init" and .cat == "config")' \
+  >     | head -n 1 \
+  >     || true
+  > } 1> /dev/null 2>&1
+
+  $ dune build ./x &
+
+  $ while ! checkStart; do sleep 0.1; done
+
+Follow mode should see both init/exit pairs. Inner dune has a digest hash in its
+events, outer dune does not:
+
+  $ ( dune trace cat --follow \
+  > | jq 'select(.cat == "config" and (.name == "init" or .name == "exit"))
+  >       | { name, has_digest_hash: (if .args.digest then (.args.digest | type == "string") else false end) }' ) &
+  {
+    "name": "init",
+    "has_digest_hash": false
+  }
+  {
+    "name": "init",
+    "has_digest_hash": true
+  }
+  {
+    "name": "exit",
+    "has_digest_hash": true
+  }
+
+  $ echo resume > $fifo
+
+  $ wait


### PR DESCRIPTION
`dune trace cat --follow` looks for the `config exit` event to finish reading. Since we now include the action traces we exit early.