### PR TITLE
refactor: remove the hooks copy-pasta

### DIFF
--- a/otherlibs/stdune/src/at_exit.ml
+++ b/otherlibs/stdune/src/at_exit.ml
@@ -1,0 +1,35 @@
+module List = ListLabels
+
+type t =
+  { run : unit -> unit
+  ; mutable pre : t list
+  }
+
+let main = { run = (fun () -> ()); pre = [] }
+
+let run_hook f =
+  match Exn_with_backtrace.try_with f with
+  | Ok () -> ()
+  | Error exn -> Format.eprintf "%a@." Exn_with_backtrace.pp_uncaught exn
+;;
+
+let () =
+  at_exit (fun () ->
+    let rec loop ({ run; pre } as t) =
+      List.iter (List.rev pre) ~f:loop;
+      t.pre <- [];
+      run_hook run
+    in
+    loop main)
+;;
+
+let at_exit t run =
+  let hook = { run; pre = [] } in
+  t.pre <- hook :: t.pre;
+  hook
+;;
+
+let at_exit_ignore t run =
+  let (_ : t) = at_exit t run in
+  ()
+;;

--- a/otherlibs/stdune/src/at_exit.mli
+++ b/otherlibs/stdune/src/at_exit.mli
@@ -1,0 +1,5 @@
+type t
+
+val main : t
+val at_exit : t -> (unit -> unit) -> t
+val at_exit_ignore : t -> (unit -> unit) -> unit

--- a/otherlibs/stdune/src/global_lock.ml
+++ b/otherlibs/stdune/src/global_lock.ml
@@ -144,20 +144,4 @@ let unlock () =
     locked := false)
 ;;
 
-let hooks = ref []
-
-let () =
-  at_exit (fun () ->
-    let hooks =
-      let res = !hooks in
-      hooks := [];
-      List.rev res
-    in
-    List.iter hooks ~f:(fun f ->
-      match Exn_with_backtrace.try_with f with
-      | Ok () -> ()
-      | Error exn -> Format.eprintf "%a@." Exn_with_backtrace.pp_uncaught exn);
-    unlock ())
-;;
-
-let at_exit f = hooks := f :: !hooks
+let at_exit = At_exit.at_exit At_exit.main unlock

--- a/otherlibs/stdune/src/global_lock.mli
+++ b/otherlibs/stdune/src/global_lock.mli
@@ -19,4 +19,4 @@ val lock_exn : timeout:Time.Span.t option -> unit
 val unlock : unit -> unit
 
 val write_pid : Unix.file_descr -> unit
-val at_exit : (unit -> unit) -> unit
+val at_exit : At_exit.t

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -81,6 +81,7 @@ module Config = Config
 module Metrics = Metrics
 module Counter = Counter
 module Global_lock = Global_lock
+module At_exit = At_exit
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/src/dune_digest/cached_digest.ml
+++ b/src/dune_digest/cached_digest.ml
@@ -145,7 +145,7 @@ let dump () =
         P.dump db_file (Lazy.force cache)))
 ;;
 
-let () = Dune_trace.at_exit dump
+let () = At_exit.at_exit_ignore Dune_trace.at_exit dump
 
 let invalidate_cached_timestamps () =
   if Lazy.is_val cache

--- a/src/dune_engine/hooks.ml
+++ b/src/dune_engine/hooks.ml
@@ -38,4 +38,4 @@ end
 
 module End_of_build = Make ()
 
-let () = Dune_trace.at_exit End_of_build.run
+let () = At_exit.at_exit_ignore Dune_trace.at_exit End_of_build.run

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -73,7 +73,7 @@ module Workspace_local = struct
        that text by the "Saving..." message. If this hypothetical scenario turns
        out to be a real problem, we will need to add some synchronisation
        mechanism to prevent clearing the status line too early. *)
-    let () = Dune_trace.at_exit dump
+    let () = At_exit.at_exit_ignore Dune_trace.at_exit dump
 
     let get path =
       let t = Lazy.force t in

--- a/src/dune_rules/copy_line_directive.ml
+++ b/src/dune_rules/copy_line_directive.ml
@@ -33,7 +33,7 @@ module DB = struct
       Persistent.dump file (Lazy.force t))
   ;;
 
-  let () = Dune_trace.at_exit dump
+  let () = At_exit.at_exit_ignore Dune_trace.at_exit dump
 
   let rec follow_while path ~f =
     let t = Lazy.force t in

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -21,19 +21,9 @@ module Out = struct
 end
 
 let global = ref None
-let hooks = ref []
 
-let () =
-  Global_lock.at_exit (fun () ->
-    let hooks =
-      let res = !hooks in
-      hooks := [];
-      List.rev res
-    in
-    List.iter hooks ~f:(fun f ->
-      match Exn_with_backtrace.try_with f with
-      | Ok () -> ()
-      | Error exn -> Format.eprintf "%a@." Exn_with_backtrace.pp_uncaught exn);
+let at_exit =
+  At_exit.at_exit Global_lock.at_exit (fun () ->
     match !global with
     | None -> ()
     | Some t ->
@@ -51,8 +41,6 @@ let () =
          in
          Io.copy_file ~src:t.path ~dst ()))
 ;;
-
-let at_exit f = hooks := f :: !hooks
 
 let set_global t =
   if Option.is_some !global then Code_error.raise "global stats have been set" [];

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -239,7 +239,7 @@ val enabled : Category.t -> bool
 val emit : ?buffered:bool -> Category.t -> (unit -> Event.t) -> unit
 val emit_all : ?buffered:bool -> Category.t -> (unit -> Event.t list) -> unit
 val flush : unit -> unit
-val at_exit : (unit -> unit) -> unit
+val at_exit : At_exit.t
 
 module Private : sig
   module Fd_count : sig


### PR DESCRIPTION
Introduce [Stdune.At_exit] to simplify this pattern of ordering hooks