### PR TITLE
Improve incrementality of jsoo build

### DIFF
--- a/src/dune_rules/cm_files.ml
+++ b/src/dune_rules/cm_files.ml
@@ -40,6 +40,11 @@ let top_sorted_cms t ~mode =
     Obj_dir.Module.L.cm_files t.obj_dir ~kind:(Ocaml kind) modules)
 ;;
 
+let top_sorted_modules t =
+  Action_builder.map t.top_sorted_modules ~f:(fun modules ->
+    filter_excluded_modules t modules)
+;;
+
 let top_sorted_objects_and_cms t ~mode =
   Action_builder.map t.top_sorted_modules ~f:(fun modules ->
     let modules = filter_excluded_modules t modules in

--- a/src/dune_rules/cm_files.mli
+++ b/src/dune_rules/cm_files.mli
@@ -17,4 +17,5 @@ val make
 
 val unsorted_objects_and_cms : t -> mode:Mode.t -> Path.t list
 val top_sorted_cms : t -> mode:Mode.t -> Path.t list Action_builder.t
+val top_sorted_modules : t -> Module.t list Action_builder.t
 val top_sorted_objects_and_cms : t -> mode:Mode.t -> Path.t list Action_builder.t

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -884,6 +884,58 @@ let build_cm
     ~sourcemap:Js_of_ocaml.Sourcemap.Inline
 ;;
 
+let build_cma_js sctx ~dir ~in_context ~obj_dir ~config ~linkall ~mode cm_files basename =
+  let name = with_js_ext ~mode basename in
+  let target = in_obj_dir ~obj_dir ~config [ name ] in
+  let flags = in_context.Js_of_ocaml.In_context.flags in
+  let linkall =
+    let open Action_builder.O in
+    let+ linkall = linkall
+    and+ jsoo_version =
+      let* jsoo = jsoo ~dir sctx in
+      Action_builder.of_memo @@ Version.jsoo_version jsoo
+    in
+    Command.Args.As
+      (match jsoo_version, linkall with
+       | Some version, true ->
+         (match Version.compare version (5, 1) with
+          | Lt -> []
+          | Gt | Eq -> [ "--linkall" ])
+       | None, _ | _, false -> [])
+  in
+  let modules =
+    let open Action_builder.O in
+    let+ l = Cm_files.top_sorted_modules cm_files in
+    let l =
+      List.map l ~f:(fun m ->
+        in_obj_dir
+          ~obj_dir
+          ~config
+          [ Module_name.Unique.to_string (Module.obj_name m)
+            ^ Filename.Extension.to_string (Js_of_ocaml.Ext.cmo ~mode)
+          ]
+        |> Path.build)
+    in
+    l
+  in
+  js_of_ocaml_rule
+    sctx
+    ~dir
+    ~sub_command:Link
+    ~config:None
+    ~flags
+    ~mode
+    ~spec:
+      (S
+         [ A "-a"
+         ; Dyn (Action_builder.map modules ~f:(fun x -> Command.Args.Deps x))
+         ; Dyn linkall
+         ])
+    ~target
+    ~sourcemap:Js_of_ocaml.Sourcemap.Inline
+    ~directory_targets:[]
+;;
+
 let for_ = Compilation_mode.Ocaml
 
 let setup_shared_runtime_rule sctx s_config s_digest =

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -63,6 +63,18 @@ val build_exe
   -> standalone_runtime:standalone_runtime option
   -> unit Memo.t
 
+val build_cma_js
+  :  Super_context.t
+  -> dir:Path.Build.t
+  -> in_context:Js_of_ocaml.In_context.t
+  -> obj_dir:Path.Build.t Obj_dir.t
+  -> config:Config.t option
+  -> linkall:bool Action_builder.t
+  -> mode:Js_of_ocaml.Mode.t
+  -> Cm_files.t
+  -> string
+  -> Action.Full.t Action_builder.With_targets.t
+
 val setup_separate_compilation_rules : Super_context.t -> string list -> unit Memo.t
 val runner : string
 

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -403,7 +403,27 @@ let iter_modes_concurrently (t : _ Ocaml.Mode.Dict.t) ~(f : Ocaml.Mode.t -> unit
   ()
 ;;
 
-let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~lib_info =
+let cm_files_for_lib (lib : Library.t) ~cctx =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let modules = Compilation_context.modules cctx in
+  let ext_obj = (Compilation_context.ocaml cctx).lib_config.ext_obj in
+  let top_sorted_modules =
+    let impl_only = Modules.With_vlib.impl_only modules in
+    Dep_graph.top_closed_implementations
+      (Compilation_context.dep_graphs cctx).impl
+      impl_only
+  in
+  let excluded_modules =
+    (* ctypes type_gen and function_gen scripts should not be included in the
+       library. Otherwise they will spew stuff to stdout on library load. *)
+    match lib.buildable.ctypes with
+    | Some ctypes -> Ctypes_field.non_installable_modules ctypes
+    | None -> []
+  in
+  Cm_files.make ~excluded_modules ~obj_dir ~ext_obj ~modules ~top_sorted_modules ()
+;;
+
+let setup_build_archives (lib : Library.t) ~cm_files ~cctx ~expander ~lib_info =
   let obj_dir = Compilation_context.obj_dir cctx in
   let flags = Compilation_context.flags cctx in
   let modules = Compilation_context.modules cctx in
@@ -447,16 +467,6 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
     match lib.kind with
     | Parameter -> Memo.return ()
     | Virtual | Dune_file _ ->
-      let cm_files =
-        let excluded_modules =
-          (* ctypes type_gen and function_gen scripts should not be included in the
-           library. Otherwise they will spew stuff to stdout on library load. *)
-          match lib.buildable.ctypes with
-          | Some ctypes -> Ctypes_field.non_installable_modules ctypes
-          | None -> []
-        in
-        Cm_files.make ~excluded_modules ~obj_dir ~ext_obj ~modules ~top_sorted_modules ()
-      in
       iter_modes_concurrently modes.ocaml ~f:(fun mode ->
         build_lib lib ~native_archives ~dir ~sctx ~expander ~flags ~mode ~cm_files)
   in
@@ -502,7 +512,6 @@ let cctx
     Parameterised_instances.instances ~sctx ~db:(Scope.libs scope) lib.buildable.libraries
   in
   let package = Library.package lib in
-  let js_of_ocaml = Js_of_ocaml.In_context.make ~dir lib.buildable.js_of_ocaml in
   (* XXX(anmonteiro): `melange_package_name` is used to derive Melange's
      `--mel-package-name` argument. We only use the library name for public
      libraries / private libraries with `(package ..)` because we need Melange
@@ -527,7 +536,7 @@ let cctx
     ~parameters
     ~preprocessing:pp
     ~opaque:Inherit_from_settings
-    ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
+    ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
     ~package
     ~melange_package_name
     ~modes
@@ -551,12 +560,7 @@ let library_rules
   let scope = Compilation_context.scope cctx in
   let* requires_compile = Compilation_context.requires_compile cctx in
   let lib_config = (Compilation_context.ocaml cctx).lib_config in
-  let top_sorted_modules =
-    let impl_only = Modules.With_vlib.impl_only modules in
-    Dep_graph.top_closed_implementations
-      (Compilation_context.dep_graphs cctx).impl
-      impl_only
-  in
+  let cm_files = cm_files_for_lib lib ~cctx in
   let* expander = Super_context.expander sctx ~dir in
   let lib_info =
     Library.to_lib_info
@@ -569,7 +573,9 @@ let library_rules
     Compilation_mode.of_mode_set (Lib_info.modes lib_info)
   in
   let* () = Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir implements in
-  let* () = Check_rules.add_cycle_check sctx ~dir top_sorted_modules in
+  let* () =
+    Check_rules.add_cycle_check sctx ~dir (Cm_files.top_sorted_modules cm_files)
+  in
   let* () = gen_wrapped_compat_modules lib cctx
   and* () = Module_compilation.build_all cctx
   and* () = Check_rules.add_obj_dir sctx ~obj_dir for_merlin in
@@ -580,7 +586,7 @@ let library_rules
   and+ () =
     Memo.when_
       (not (Library.is_virtual lib))
-      (fun () -> setup_build_archives lib ~lib_info ~top_sorted_modules ~cctx ~expander)
+      (fun () -> setup_build_archives lib ~lib_info ~cm_files ~cctx ~expander)
   and+ () =
     let vlib_stubs_o_files = Virtual_rules.stubs_o_files implements in
     Memo.when_

--- a/src/dune_rules/lib_rules.mli
+++ b/src/dune_rules/lib_rules.mli
@@ -8,6 +8,8 @@ val foreign_rules
   -> dir_contents:Dir_contents.t
   -> unit Memo.t
 
+val cm_files_for_lib : Library.t -> cctx:Compilation_context.t -> Cm_files.t
+
 val compile_context
   :  Library.t
   -> sctx:Super_context.t

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -72,6 +72,7 @@ val foreign_lib_files
     declared in. *)
 val archive : t -> dir:Path.Build.t -> ext:Filename.Extension.t -> Path.Build.t
 
+val archive_basename : t -> ext:Filename.Extension.t -> string
 val best_name : t -> Lib_name.t
 val is_virtual : t -> bool
 val is_impl : t -> bool

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -30,6 +30,8 @@ specify js mode (#1940).
   .b.eobjs/jsoo/b.cmo.js
   .e.eobjs/jsoo/e.cmo.js
   .foo.objs/jsoo/default/foo.cma.js
+  .foo.objs/jsoo/default/foo.cmo.js
+  .foo.objs/jsoo/default/foo__C.cmo.js
   .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
   .js/default/stdlib/std_exit.cmo.js
   .js/default/stdlib/stdlib.cma.js

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -21,8 +21,11 @@ tests js_of_ocaml conigs
   bin/bin2.bc.js
   bin/bin3.bc.js
   lib/.library1.objs/jsoo/!use-js-string/library1.cma.js
+  lib/.library1.objs/jsoo/!use-js-string/library1.cmo.js
   lib/.library1.objs/jsoo/default/library1.cma.js
+  lib/.library1.objs/jsoo/default/library1.cmo.js
   lib/.library1.objs/jsoo/use-js-string/library1.cma.js
+  lib/.library1.objs/jsoo/use-js-string/library1.cmo.js
   $ node _build/default/bin/bin1.bc.js
   Hello bin1
   Hi library1

--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -14,6 +14,9 @@ Compilation using jsoo
   bin/.technologic.eobjs/jsoo/z.cmo.js
   bin/technologic.bc.js
   lib/.x.objs/jsoo/default/x.cma.js
+  lib/.x.objs/jsoo/default/x.cmo.js
+  lib/.x.objs/jsoo/default/x__.cmo.js
+  lib/.x.objs/jsoo/default/x__Y.cmo.js
   $ node ./_build/default/bin/technologic.bc.js
   buy it
   use it

--- a/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
@@ -16,6 +16,9 @@ Compilation using WasmOO
   bin/technologic.bc.wasm.assets
   bin/technologic.bc.wasm.js
   lib/.x.objs/jsoo/default/x.wasma
+  lib/.x.objs/jsoo/default/x.wasmo
+  lib/.x.objs/jsoo/default/x__.wasmo
+  lib/.x.objs/jsoo/default/x__Y.wasmo
   $ node ./_build/default/bin/technologic.bc.wasm.js
   buy it
   use it


### PR DESCRIPTION
Move #7389 on top of #13611.

Instead of compiling *.cma files to JavaScript. We can compile individual *.cmos to javascript and link all *.cmo.js together.
This results in a much better incremental build as jsoo no longer recompile compilation units that were not modified.

Linking *.cmo.js into a cma.js should be much faster than any compilation with jsoo.

This can only be done for local libraries as "installed" ones are not required to provide individual cmo. This is fine.