### PR TITLE
 Move the management of Jsoo config details out of dune

### DIFF
--- a/doc/changes/added/13613.md
+++ b/doc/changes/added/13613.md
@@ -1,0 +1,1 @@
+- Move the management of Jsoo config details out of dune (#13613, @vouillon)


### PR DESCRIPTION
Dune had to know about all possible Jsoo config to create rules upfront. This is no longer necessary with https://github.com/ocaml/dune/pull/13611.

The corresponding Js_of_ocaml changes are in https://github.com/ocsigen/js_of_ocaml/pull/2177.