### PR TITLE
Use Bin.add_exe instead of concat-ing Bin.exe always

### DIFF
--- a/src/dune_rules/which.ml
+++ b/src/dune_rules/which.ml
@@ -7,13 +7,11 @@ let programs_for_which_we_prefer_opt_ext =
 
 let with_opt p = p ^ ".opt"
 
-let candidates =
-  let make p = p ^ Bin.exe in
-  fun prog ->
-    let base = [ make prog ] in
-    if List.mem programs_for_which_we_prefer_opt_ext prog ~equal:String.equal
-    then make (with_opt prog) :: base
-    else base
+let candidates prog =
+  let base = [ Bin.add_exe prog ] in
+  if List.mem programs_for_which_we_prefer_opt_ext prog ~equal:String.equal
+  then Bin.add_exe (with_opt prog) :: base
+  else base
 ;;
 
 let best_in_dir ~dir program =

--- a/test/unit-tests/which/which_tests.expected
+++ b/test/unit-tests/which/which_tests.expected
@@ -1,5 +1,5 @@
 candidates "ocamlc" = [ "ocamlc.opt.exe"; "ocamlc.exe" ]
-candidates "ocamlc.exe" = [ "ocamlc.exe.exe" ]
-candidates "OCAMLC.EXE" = [ "OCAMLC.EXE.exe" ]
+candidates "ocamlc.exe" = [ "ocamlc.exe" ]
+candidates "OCAMLC.EXE" = [ "OCAMLC.EXE" ]
 candidates "foo" = [ "foo.exe" ]
-candidates "foo.exe" = [ "foo.exe.exe" ]
+candidates "foo.exe" = [ "foo.exe" ]


### PR DESCRIPTION
This PR fixes a bug with `which` on Windows where `.exe.exe`
candidates are generated and searched for. 