### PR TITLE
Js_of_ocaml: share standalone runtimes

### DIFF
--- a/doc/changes/added/13621.md
+++ b/doc/changes/added/13621.md
@@ -1,0 +1,1 @@
+- Js_of_ocaml: share standalone runtimes (#13621, @vouillon)

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -309,7 +309,7 @@ let link_many
   let modules = Compilation_context.modules cctx in
   let* link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in
   (* Build shared jsoo standalone runtimes (one per mode) *)
-  let* shared_runtimes =
+  let* (shared_runtimes : Jsoo_rules.standalone_runtime option Js_of_ocaml.Mode.Pair.t) =
     let in_context_for jsoo_mode =
       Compilation_context.js_of_ocaml cctx
       |> Js_of_ocaml.Mode.Pair.select ~mode:jsoo_mode

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -628,7 +628,8 @@ let gen_rules ctx sctx ~dir components : Gen_rules.result Memo.t =
     has_rules
       ~dir
       (match rest with
-       | [] -> Subdir_set.all
+       | [] | [ _ ] -> Subdir_set.all
+       | [ _; ".runtime" ] -> Subdir_set.all
        | _ -> Subdir_set.empty)
       (fun () ->
          (* XXX the use of the super context is dubious here. We're using it to

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -934,6 +934,43 @@ let jsoo_is_whole_program t ~dir ~in_context =
   { Js_of_ocaml.Mode.Pair.js = is_whole_program js; wasm = is_whole_program wasm }
 ;;
 
+let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
+  let sctx = Compilation_context.super_context cc in
+  let dir = Compilation_context.dir cc in
+  let { Js_of_ocaml.In_context.javascript_files
+      ; wasm_files
+      ; flags
+      ; compilation_mode
+      ; sourcemap = _
+      ; enabled_if = _
+      }
+    =
+    in_context
+  in
+  let* cmode =
+    match compilation_mode with
+    | None -> js_of_ocaml_compilation_mode sctx ~dir ~mode
+    | Some x -> Memo.return x
+  in
+  match (cmode : Js_of_ocaml.Compilation_mode.t) with
+  | Whole_program -> Memo.return None
+  | Separate_compilation ->
+    assert (Js_of_ocaml.Mode.select ~mode ~js:(wasm_files = []) ~wasm:true);
+    let runtime_files = javascript_files @ wasm_files in
+    let obj_dir = Compilation_context.obj_dir cc in
+    let target =
+      in_obj_dir
+        ~obj_dir
+        ~config:None
+        [ "runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode) ]
+    in
+    let+ () =
+      standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap:Inline
+      |> Super_context.add_rule ~loc sctx ~dir
+    in
+    Some target
+;;
+
 let build_exe
       cc
       ~loc
@@ -945,6 +982,7 @@ let build_exe
       ~linkall
       ~link_time_code_gen
       ~jsoo_mode:mode
+      ~standalone_runtime
   =
   let sctx = Compilation_context.super_context cc in
   let dir = Compilation_context.dir cc in
@@ -954,14 +992,6 @@ let build_exe
     in_context
   in
   let target = Path.Build.set_extension src ~ext:(Js_of_ocaml.Ext.exe ~mode) in
-  let standalone_runtime =
-    in_obj_dir
-      ~obj_dir
-      ~config:None
-      [ Path.Build.basename
-          (Path.Build.set_extension src ~ext:(Js_of_ocaml.Ext.runtime ~mode))
-      ]
-  in
   let* rule_mode : Rule.Mode.t =
     let* expander = Super_context.expander sctx ~dir in
     let rule_mode =
@@ -989,20 +1019,35 @@ let build_exe
   in
   match (cmode : Js_of_ocaml.Compilation_mode.t) with
   | Separate_compilation ->
+    let standalone_runtime_target, needs_runtime_rule =
+      match standalone_runtime with
+      | Some path -> path, false
+      | None ->
+        ( in_obj_dir
+            ~obj_dir
+            ~config:None
+            [ Path.Build.basename
+                (Path.Build.set_extension src ~ext:(Js_of_ocaml.Ext.runtime ~mode))
+            ]
+        , true )
+    in
     let+ () =
-      standalone_runtime_rule
-        ~mode
-        cc
-        ~runtime_files
-        ~target:standalone_runtime
-        ~flags
-        ~sourcemap:Inline
-      |> Super_context.add_rule ~loc sctx ~dir
+      if needs_runtime_rule
+      then
+        standalone_runtime_rule
+          ~mode
+          cc
+          ~runtime_files
+          ~target:standalone_runtime_target
+          ~flags
+          ~sourcemap:Inline
+        |> Super_context.add_rule ~loc sctx ~dir
+      else Memo.return ()
     and+ () =
       link_rule
         ~mode
         cc
-        ~runtime:standalone_runtime
+        ~runtime:standalone_runtime_target
         ~target
         ~directory_targets
         ~obj_dir

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -481,6 +481,100 @@ let jsoo_runtime_files ~(mode : Js_of_ocaml.Mode.t) libs =
       (Lib.info t))
 ;;
 
+module Runtime_key : sig
+  type encoded = Digest.t
+
+  module Decoded : sig
+    type t = private
+      { mode : Js_of_ocaml.Mode.t
+      ; lib_names : Lib_name.t list
+      ; project_root : Path.Source.t option
+      }
+
+    val of_libs : mode:Js_of_ocaml.Mode.t -> Lib.t list -> t
+  end
+
+  val encode : Decoded.t -> encoded
+  val decode : encoded -> Decoded.t
+end = struct
+  type encoded = Digest.t
+
+  module Decoded = struct
+    type t =
+      { mode : Js_of_ocaml.Mode.t
+      ; lib_names : Lib_name.t list
+      ; project_root : Path.Source.t option
+      }
+
+    let equal x y =
+      Js_of_ocaml.Mode.equal x.mode y.mode
+      && List.equal Lib_name.equal x.lib_names y.lib_names
+      && Option.equal Path.Source.equal x.project_root y.project_root
+    ;;
+
+    let to_string { mode; lib_names; project_root } =
+      let s =
+        sprintf
+          "%s runtime for %s"
+          (Js_of_ocaml.Mode.select ~mode ~js:"js" ~wasm:"wasm")
+          (String.enumerate_and (List.map lib_names ~f:Lib_name.to_string))
+      in
+      match project_root with
+      | None -> s
+      | Some dir ->
+        sprintf "%s (in project: %s)" s (Path.Source.to_string_maybe_quoted dir)
+    ;;
+
+    let of_libs ~mode libs =
+      let libs_with_runtime =
+        List.filter libs ~f:(fun lib ->
+          not (List.is_empty (jsoo_runtime_files ~mode [ lib ])))
+      in
+      let lib_names =
+        List.sort libs_with_runtime ~compare:(fun a b ->
+          Lib_name.compare (Lib.name a) (Lib.name b))
+        |> List.map ~f:Lib.name
+      in
+      let project_root = Lib.L.project_root libs_with_runtime in
+      { mode; lib_names; project_root }
+    ;;
+  end
+
+  let reverse_table : (Digest.t, Decoded.t) Table.t = Table.create (module Digest) 128
+
+  let encode ({ Decoded.mode; lib_names; project_root } as x) =
+    let y = Digest.generic (mode, lib_names, project_root) in
+    match Table.find reverse_table y with
+    | None ->
+      Table.set reverse_table y x;
+      y
+    | Some x' ->
+      if Decoded.equal x x'
+      then y
+      else
+        User_error.raise
+          [ Pp.textf "Hash collision between jsoo standalone runtimes:"
+          ; Pp.textf "- cache : %s" (Decoded.to_string x')
+          ; Pp.textf "- fetch : %s" (Decoded.to_string x)
+          ]
+  ;;
+
+  let decode y =
+    match Table.find reverse_table y with
+    | Some x -> x
+    | None ->
+      User_error.raise
+        [ Pp.textf
+            "I don't know what jsoo runtime set %s correspond to."
+            (Digest.to_string y)
+        ]
+  ;;
+end
+
+type standalone_runtime =
+  | Shared of Digest.t
+  | Per_stanza of Path.Build.t
+
 let standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap =
   let dir = Compilation_context.dir cc in
   let sctx = Compilation_context.super_context cc in
@@ -603,7 +697,7 @@ let cmo_js_of_module ~mode m =
 let link_rule
       ~mode
       cc
-      ~runtime
+      ~runtime_dep
       ~target
       ~directory_targets
       ~obj_dir
@@ -677,7 +771,7 @@ let link_rule
            | None, _ | _, false -> [])
       ]
   in
-  let spec = Command.Args.S [ Dep (Path.build runtime); Dyn get_all ] in
+  let spec = Command.Args.S [ Dyn runtime_dep; Dyn get_all ] in
   js_of_ocaml_rule
     sctx
     ~mode
@@ -792,9 +886,58 @@ let build_cm
 
 let for_ = Compilation_mode.Ocaml
 
+let setup_shared_runtime_rule sctx s_config s_digest =
+  let config = Config.of_string s_config in
+  let ctx = Super_context.context sctx in
+  let build_context = Context.build_context ctx in
+  match Digest.from_hex s_digest with
+  | None -> User_error.raise [ Pp.textf "invalid jsoo runtime key: %s" s_digest ]
+  | Some digest ->
+    let { Runtime_key.Decoded.mode; lib_names; project_root } =
+      Runtime_key.decode digest
+    in
+    let* scope =
+      let dir =
+        match project_root with
+        | None -> Context.build_dir ctx
+        | Some dir -> Path.Build.append_source build_context.build_dir dir
+      in
+      Scope.DB.find_by_dir dir
+    in
+    let* libs =
+      let lib_db = Scope.libs scope in
+      Memo.parallel_map lib_names ~f:(fun name ->
+        Lib.DB.resolve lib_db (Loc.none, name) |> Resolve.Memo.read_memo)
+    in
+    let runtime_files = jsoo_runtime_files ~mode libs in
+    let dir = in_build_dir build_context ~config [ ".runtime"; s_digest ] in
+    let target =
+      in_build_dir
+        build_context
+        ~config
+        [ ".runtime"
+        ; s_digest
+        ; "runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode)
+        ]
+    in
+    js_of_ocaml_rule
+      sctx
+      ~mode
+      ~sub_command:Build_runtime
+      ~dir
+      ~flags:Js_of_ocaml.In_context.default.flags
+      ~target
+      ~spec:(Command.Args.Deps runtime_files)
+      ~config:(Some (Action_builder.return config))
+      ~sourcemap:Inline
+      ~directory_targets:[]
+    |> Super_context.add_rule sctx ~dir
+;;
+
 let setup_separate_compilation_rules sctx components =
   match components with
-  | _ :: _ :: _ :: _ | [] | [ _ ] -> Memo.return ()
+  | [ s_config; ".runtime"; s_digest ] -> setup_shared_runtime_rule sctx s_config s_digest
+  | [] | [ _ ] | [ _; ".runtime" ] -> Memo.return ()
   | [ s_config; s_pkg ] ->
     let config = Config.of_string s_config in
     let pkg = Lib_name.parse_string_exn (Loc.none, s_pkg) in
@@ -868,6 +1011,7 @@ let setup_separate_compilation_rules sctx components =
              ~sourcemap:Js_of_ocaml.Sourcemap.Inline
              ~shapes
            |> Super_context.add_rule sctx ~dir)))
+  | _ -> Memo.return ()
 ;;
 
 let js_of_ocaml_compilation_mode t ~dir ~mode =
@@ -957,18 +1101,30 @@ let build_standalone_runtime cc ~loc ~in_context ~jsoo_mode:mode =
   | Separate_compilation ->
     assert (Js_of_ocaml.Mode.select ~mode ~js:(wasm_files = []) ~wasm:true);
     let runtime_files = javascript_files @ wasm_files in
-    let obj_dir = Compilation_context.obj_dir cc in
-    let target =
-      in_obj_dir
-        ~obj_dir
-        ~config:None
-        [ "runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode) ]
+    let* eligible =
+      if List.is_empty runtime_files
+      then
+        Resolve.Memo.peek (Compilation_context.requires_link cc)
+        >>| function
+        | Ok libs -> Some (Runtime_key.encode (Runtime_key.Decoded.of_libs ~mode libs))
+        | Error () -> None
+      else Memo.return None
     in
-    let+ () =
-      standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap:Inline
-      |> Super_context.add_rule ~loc sctx ~dir
-    in
-    Some target
+    (match eligible with
+     | Some digest -> Memo.return (Some (Shared digest))
+     | None ->
+       let obj_dir = Compilation_context.obj_dir cc in
+       let target =
+         in_obj_dir
+           ~obj_dir
+           ~config:None
+           [ "runtime" ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode) ]
+       in
+       let+ () =
+         standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap:Inline
+         |> Super_context.add_rule ~loc sctx ~dir
+       in
+       Some (Per_stanza target))
 ;;
 
 let build_exe
@@ -1019,35 +1175,47 @@ let build_exe
   in
   match (cmode : Js_of_ocaml.Compilation_mode.t) with
   | Separate_compilation ->
-    let standalone_runtime_target, needs_runtime_rule =
+    let runtime_dep, per_exe_runtime_target =
       match standalone_runtime with
-      | Some path -> path, false
+      | Some (Shared digest) ->
+        let ctx = Super_context.context sctx |> Context.build_context in
+        ( (let open Action_builder.O in
+           let+ config = resolve_config sctx ~dir ~mode flags in
+           Command.Args.Dep
+             (Path.build
+                (in_build_dir
+                   ctx
+                   ~config
+                   [ ".runtime"
+                   ; Digest.to_string digest
+                   ; "runtime"
+                     ^ Filename.Extension.to_string (Js_of_ocaml.Ext.runtime ~mode)
+                   ])))
+        , None )
+      | Some (Per_stanza path) ->
+        Action_builder.return (Command.Args.Dep (Path.build path)), None
       | None ->
-        ( in_obj_dir
+        let path =
+          in_obj_dir
             ~obj_dir
             ~config:None
             [ Path.Build.basename
                 (Path.Build.set_extension src ~ext:(Js_of_ocaml.Ext.runtime ~mode))
             ]
-        , true )
+        in
+        Action_builder.return (Command.Args.Dep (Path.build path)), Some path
     in
     let+ () =
-      if needs_runtime_rule
-      then
-        standalone_runtime_rule
-          ~mode
-          cc
-          ~runtime_files
-          ~target:standalone_runtime_target
-          ~flags
-          ~sourcemap:Inline
+      match per_exe_runtime_target with
+      | Some target ->
+        standalone_runtime_rule ~mode cc ~runtime_files ~target ~flags ~sourcemap:Inline
         |> Super_context.add_rule ~loc sctx ~dir
-      else Memo.return ()
+      | None -> Memo.return ()
     and+ () =
       link_rule
         ~mode
         cc
-        ~runtime:standalone_runtime_target
+        ~runtime_dep
         ~target
         ~directory_targets
         ~obj_dir

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -38,12 +38,16 @@ val build_cm
   -> config:Config.t option
   -> Action.Full.t Action_builder.With_targets.t
 
+type standalone_runtime =
+  | Shared of Digest.t
+  | Per_stanza of Path.Build.t
+
 val build_standalone_runtime
   :  Compilation_context.t
   -> loc:Loc.t
   -> in_context:Js_of_ocaml.In_context.t
   -> jsoo_mode:Js_of_ocaml.Mode.t
-  -> Path.Build.t option Memo.t
+  -> standalone_runtime option Memo.t
 
 val build_exe
   :  Compilation_context.t
@@ -56,7 +60,7 @@ val build_exe
   -> linkall:bool Action_builder.t
   -> link_time_code_gen:Link_time_code_gen_type.t Resolve.t
   -> jsoo_mode:Js_of_ocaml.Mode.t
-  -> standalone_runtime:Path.Build.t option
+  -> standalone_runtime:standalone_runtime option
   -> unit Memo.t
 
 val setup_separate_compilation_rules : Super_context.t -> string list -> unit Memo.t

--- a/src/dune_rules/jsoo/jsoo_rules.mli
+++ b/src/dune_rules/jsoo/jsoo_rules.mli
@@ -38,6 +38,13 @@ val build_cm
   -> config:Config.t option
   -> Action.Full.t Action_builder.With_targets.t
 
+val build_standalone_runtime
+  :  Compilation_context.t
+  -> loc:Loc.t
+  -> in_context:Js_of_ocaml.In_context.t
+  -> jsoo_mode:Js_of_ocaml.Mode.t
+  -> Path.Build.t option Memo.t
+
 val build_exe
   :  Compilation_context.t
   -> loc:Loc.t
@@ -49,6 +56,7 @@ val build_exe
   -> linkall:bool Action_builder.t
   -> link_time_code_gen:Link_time_code_gen_type.t Resolve.t
   -> jsoo_mode:Js_of_ocaml.Mode.t
+  -> standalone_runtime:Path.Build.t option
   -> unit Memo.t
 
 val setup_separate_compilation_rules : Super_context.t -> string list -> unit Memo.t

--- a/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
@@ -6,12 +6,13 @@ Jsoo and build-info
   Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.js
   unknown
-  $ dune install --prefix _install --display short
-  Installing _install/lib/main/META
-  Installing _install/lib/main/dune-package
-  Installing _install/lib/main/opam
-  Installing _install/bin/main
-  Installing _install/bin/main.bc.js
+  $ dune install --prefix _install
+  $ find _install -type f | sort
+  _install/bin/main
+  _install/bin/main.bc.js
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _install/bin/main.bc.js
   unknown
   $ git init -q
@@ -26,18 +27,14 @@ Jsoo and build-info
   Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.js
   unknown
-  $ dune install --prefix _install --display short
-  Deleting _install/lib/main/META
-  Installing _install/lib/main/META
-  Deleting _install/lib/main/dune-package
-  Installing _install/lib/main/dune-package
-  Deleting _install/lib/main/opam
-  Installing _install/lib/main/opam
-  Deleting _install/bin/main
-  Installing _install/bin/main
-  Deleting _install/bin/main.bc.js
-  Installing _install/bin/main.bc.js
-  Installing _install/doc/main/README
+  $ dune install --prefix _install
+  $ find _install -type f | sort
+  _install/bin/main
+  _install/bin/main.bc.js
+  _install/doc/main/README
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _install/bin/main.bc.js
   v1-1-xxxxx-dirty
   $ echo "(name main)" >> dune-project
@@ -47,18 +44,13 @@ Jsoo and build-info
   Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.js
   0.2.0
-  $ dune install --prefix _install --display short
-  Deleting _install/lib/main/META
-  Installing _install/lib/main/META
-  Deleting _install/lib/main/dune-package
-  Installing _install/lib/main/dune-package
-  Deleting _install/lib/main/opam
-  Installing _install/lib/main/opam
-  Deleting _install/bin/main
-  Installing _install/bin/main
-  Deleting _install/bin/main.bc.js
-  Installing _install/bin/main.bc.js
-  Deleting _install/doc/main/README
-  Installing _install/doc/main/README
+  $ dune install --prefix _install
+  $ find _install -type f | sort
+  _install/bin/main
+  _install/bin/main.bc.js
+  _install/doc/main/README
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _build/default/src/main.bc.js
   0.2.0

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -23,8 +23,7 @@ specify js mode (#1940).
 
   $ dune clean
   $ dune build --display short @@all 2>&1 | grep js_of_ocaml
-   js_of_ocaml .b.eobjs/jsoo/runtime.bc.runtime.js
-   js_of_ocaml .e.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
    js_of_ocaml .js/default/stdlib/stdlib.cma.js
    js_of_ocaml .js/default/stdlib/std_exit.cmo.js
    js_of_ocaml .b.eobjs/jsoo/b.cmo.js

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -22,15 +22,19 @@ Check that js targets are attached to @all, but not for tests that do not
 specify js mode (#1940).
 
   $ dune clean
-  $ dune build --display short @@all 2>&1 | grep js_of_ocaml
-   js_of_ocaml .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
-   js_of_ocaml .js/default/stdlib/stdlib.cma.js
-   js_of_ocaml .js/default/stdlib/std_exit.cmo.js
-   js_of_ocaml .b.eobjs/jsoo/b.cmo.js
-   js_of_ocaml b.bc.js
-   js_of_ocaml .foo.objs/jsoo/default/foo.cma.js
-   js_of_ocaml .e.eobjs/jsoo/e.cmo.js
-   js_of_ocaml e.bc.js
+  $ dune build @@all
+  $ dune trace cat | jq -r 'include "dune";
+  >   processes
+  > | select(.args.prog | test("js_of_ocaml$"))
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
+  .b.eobjs/jsoo/b.cmo.js
+  .e.eobjs/jsoo/e.cmo.js
+  .foo.objs/jsoo/default/foo.cma.js
+  .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/default/stdlib/std_exit.cmo.js
+  .js/default/stdlib/stdlib.cma.js
+  b.bc.js
+  e.bc.js
 
 Check that building a JS-enabled executable that depends on a library works.
 

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -23,8 +23,8 @@ specify js mode (#1940).
 
   $ dune clean
   $ dune build --display short @@all 2>&1 | grep js_of_ocaml
-   js_of_ocaml .b.eobjs/jsoo/b.bc.runtime.js
-   js_of_ocaml .e.eobjs/jsoo/e.bc.runtime.js
+   js_of_ocaml .b.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .e.eobjs/jsoo/runtime.bc.runtime.js
    js_of_ocaml .js/default/stdlib/stdlib.cma.js
    js_of_ocaml .js/default/stdlib/std_exit.cmo.js
    js_of_ocaml .b.eobjs/jsoo/b.cmo.js

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -1,6 +1,32 @@
 tests js_of_ocaml conigs
 
-  $ dune build bin/bin1.bc.js bin/bin2.bc.js bin/bin3.bc.js
+  $ dune build bin/bin1.bc.js bin/bin2.bc.js bin/bin3.bc.js --display short
+   js_of_ocaml bin/.bin1.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/use-js-string/stdlib/std_exit.cmo.js
+   js_of_ocaml .js/use-js-string/stdlib/stdlib.cma.js
+        ocamlc lib/.library1.objs/byte/library1.{cmi,cmo,cmt}
+   js_of_ocaml bin/.bin2.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/!use-js-string/stdlib/std_exit.cmo.js
+   js_of_ocaml .js/!use-js-string/stdlib/stdlib.cma.js
+   js_of_ocaml bin/.bin3.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/default/stdlib/std_exit.cmo.js
+   js_of_ocaml .js/default/stdlib/stdlib.cma.js
+        ocamlc bin/.bin1.eobjs/byte/dune__exe__Bin1.{cmi,cmti}
+        ocamlc lib/library1.cma
+        ocamlc bin/.bin2.eobjs/byte/dune__exe__Bin2.{cmi,cmti}
+        ocamlc bin/.bin3.eobjs/byte/dune__exe__Bin3.{cmi,cmti}
+        ocamlc bin/.bin1.eobjs/byte/dune__exe__Bin1.{cmo,cmt}
+   js_of_ocaml lib/.library1.objs/jsoo/use-js-string/library1.cma.js
+   js_of_ocaml lib/.library1.objs/jsoo/!use-js-string/library1.cma.js
+   js_of_ocaml lib/.library1.objs/jsoo/default/library1.cma.js
+        ocamlc bin/.bin2.eobjs/byte/dune__exe__Bin2.{cmo,cmt}
+        ocamlc bin/.bin3.eobjs/byte/dune__exe__Bin3.{cmo,cmt}
+   js_of_ocaml bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js
+   js_of_ocaml bin/.bin2.eobjs/jsoo/dune__exe__Bin2.cmo.js
+   js_of_ocaml bin/.bin3.eobjs/jsoo/dune__exe__Bin3.cmo.js
+   js_of_ocaml bin/bin1.bc.js
+   js_of_ocaml bin/bin2.bc.js
+   js_of_ocaml bin/bin3.bc.js
   $ node _build/default/bin/bin1.bc.js
   Hello bin1
   Hi library1

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -1,14 +1,14 @@
 tests js_of_ocaml conigs
 
   $ dune build bin/bin1.bc.js bin/bin2.bc.js bin/bin3.bc.js --display short
-   js_of_ocaml bin/.bin1.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
    js_of_ocaml .js/use-js-string/stdlib/std_exit.cmo.js
    js_of_ocaml .js/use-js-string/stdlib/stdlib.cma.js
         ocamlc lib/.library1.objs/byte/library1.{cmi,cmo,cmt}
-   js_of_ocaml bin/.bin2.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/!use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
    js_of_ocaml .js/!use-js-string/stdlib/std_exit.cmo.js
    js_of_ocaml .js/!use-js-string/stdlib/stdlib.cma.js
-   js_of_ocaml bin/.bin3.eobjs/jsoo/runtime.bc.runtime.js
+   js_of_ocaml .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
    js_of_ocaml .js/default/stdlib/std_exit.cmo.js
    js_of_ocaml .js/default/stdlib/stdlib.cma.js
         ocamlc bin/.bin1.eobjs/byte/dune__exe__Bin1.{cmi,cmti}

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -1,32 +1,28 @@
 tests js_of_ocaml conigs
 
-  $ dune build bin/bin1.bc.js bin/bin2.bc.js bin/bin3.bc.js --display short
-   js_of_ocaml .js/use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
-   js_of_ocaml .js/use-js-string/stdlib/std_exit.cmo.js
-   js_of_ocaml .js/use-js-string/stdlib/stdlib.cma.js
-        ocamlc lib/.library1.objs/byte/library1.{cmi,cmo,cmt}
-   js_of_ocaml .js/!use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
-   js_of_ocaml .js/!use-js-string/stdlib/std_exit.cmo.js
-   js_of_ocaml .js/!use-js-string/stdlib/stdlib.cma.js
-   js_of_ocaml .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
-   js_of_ocaml .js/default/stdlib/std_exit.cmo.js
-   js_of_ocaml .js/default/stdlib/stdlib.cma.js
-        ocamlc bin/.bin1.eobjs/byte/dune__exe__Bin1.{cmi,cmti}
-        ocamlc lib/library1.cma
-        ocamlc bin/.bin2.eobjs/byte/dune__exe__Bin2.{cmi,cmti}
-        ocamlc bin/.bin3.eobjs/byte/dune__exe__Bin3.{cmi,cmti}
-        ocamlc bin/.bin1.eobjs/byte/dune__exe__Bin1.{cmo,cmt}
-   js_of_ocaml lib/.library1.objs/jsoo/use-js-string/library1.cma.js
-   js_of_ocaml lib/.library1.objs/jsoo/!use-js-string/library1.cma.js
-   js_of_ocaml lib/.library1.objs/jsoo/default/library1.cma.js
-        ocamlc bin/.bin2.eobjs/byte/dune__exe__Bin2.{cmo,cmt}
-        ocamlc bin/.bin3.eobjs/byte/dune__exe__Bin3.{cmo,cmt}
-   js_of_ocaml bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js
-   js_of_ocaml bin/.bin2.eobjs/jsoo/dune__exe__Bin2.cmo.js
-   js_of_ocaml bin/.bin3.eobjs/jsoo/dune__exe__Bin3.cmo.js
-   js_of_ocaml bin/bin1.bc.js
-   js_of_ocaml bin/bin2.bc.js
-   js_of_ocaml bin/bin3.bc.js
+  $ dune build bin/bin1.bc.js bin/bin2.bc.js bin/bin3.bc.js
+  $ dune trace cat | jq -r 'include "dune";
+  >   processes
+  > | select(.args.prog | test("js_of_ocaml$"))
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
+  .js/!use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/!use-js-string/stdlib/std_exit.cmo.js
+  .js/!use-js-string/stdlib/stdlib.cma.js
+  .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/default/stdlib/std_exit.cmo.js
+  .js/default/stdlib/stdlib.cma.js
+  .js/use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/use-js-string/stdlib/std_exit.cmo.js
+  .js/use-js-string/stdlib/stdlib.cma.js
+  bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js
+  bin/.bin2.eobjs/jsoo/dune__exe__Bin2.cmo.js
+  bin/.bin3.eobjs/jsoo/dune__exe__Bin3.cmo.js
+  bin/bin1.bc.js
+  bin/bin2.bc.js
+  bin/bin3.bc.js
+  lib/.library1.objs/jsoo/!use-js-string/library1.cma.js
+  lib/.library1.objs/jsoo/default/library1.cma.js
+  lib/.library1.objs/jsoo/use-js-string/library1.cma.js
   $ node _build/default/bin/bin1.bc.js
   Hello bin1
   Hi library1

--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -1,7 +1,19 @@
 Compilation using jsoo
 
   $ dune build bin/technologic.bc.js @install
-
+  $ dune trace cat | jq -r 'include "dune";
+  >   processes
+  > | select(.args.prog | test("js_of_ocaml$"))
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
+  .js/default/js_of_ocaml-compiler.runtime/jsoo_runtime.cma.js
+  .js/default/js_of_ocaml/js_of_ocaml.cma.js
+  .js/default/stdlib/std_exit.cmo.js
+  .js/default/stdlib/stdlib.cma.js
+  bin/.technologic.eobjs/jsoo/runtime.bc.runtime.js
+  bin/.technologic.eobjs/jsoo/technologic.cmo.js
+  bin/.technologic.eobjs/jsoo/z.cmo.js
+  bin/technologic.bc.js
+  lib/.x.objs/jsoo/default/x.cma.js
   $ node ./_build/default/bin/technologic.bc.js
   buy it
   use it

--- a/test/blackbox-tests/test-cases/wasmoo/build-info.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/build-info.t/run.t
@@ -6,25 +6,26 @@ Jsoo and build-info
   Warning: Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.wasm.js
   unknown
-  $ dune install --prefix _install --display short 2>&1 | sed 's/-[a-f0-9]*[.]wasm/.wasm/'
-  Installing _install/lib/main/META
-  Installing _install/lib/main/dune-package
-  Installing _install/lib/main/opam
-  Installing _install/bin/main
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/prelude.wasm
-  Installing _install/bin/main.bc.wasm.assets/runtime.wasm
-  Installing _install/bin/main.bc.wasm.assets/start.wasm
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm.map
-  Installing _install/bin/main.bc.wasm.js
+  $ dune install --prefix _install
+  $ find _install -type f | sed 's/-[a-f0-9]*[.]wasm/.wasm/' | sort -u
+  _install/bin/main
+  _install/bin/main.bc.wasm.assets/build_info.wasm
+  _install/bin/main.bc.wasm.assets/build_info.wasm.map
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
+  _install/bin/main.bc.wasm.assets/prelude.wasm
+  _install/bin/main.bc.wasm.assets/runtime.wasm
+  _install/bin/main.bc.wasm.assets/start.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm.map
+  _install/bin/main.bc.wasm.assets/stdlib.wasm
+  _install/bin/main.bc.wasm.assets/stdlib.wasm.map
+  _install/bin/main.bc.wasm.js
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _install/bin/main.bc.wasm.js
   unknown
   $ git init -q
@@ -39,42 +40,27 @@ Jsoo and build-info
   Warning: Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.wasm.js
   unknown
-  $ dune install --prefix _install --display short 2>&1 | sed 's/-[a-f0-9]*[.]wasm/.wasm/'
-  Deleting _install/lib/main/META
-  Installing _install/lib/main/META
-  Deleting _install/lib/main/dune-package
-  Installing _install/lib/main/dune-package
-  Deleting _install/lib/main/opam
-  Installing _install/lib/main/opam
-  Deleting _install/bin/main
-  Installing _install/bin/main
-  Deleting _install/bin/main.bc.wasm.assets/build_info.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm
-  Deleting _install/bin/main.bc.wasm.assets/build_info.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
-  Deleting _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/prelude.wasm
-  Installing _install/bin/main.bc.wasm.assets/prelude.wasm
-  Deleting _install/bin/main.bc.wasm.assets/runtime.wasm
-  Installing _install/bin/main.bc.wasm.assets/runtime.wasm
-  Deleting _install/bin/main.bc.wasm.assets/start.wasm
-  Installing _install/bin/main.bc.wasm.assets/start.wasm
-  Deleting _install/bin/main.bc.wasm.assets/std_exit.wasm
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm
-  Deleting _install/bin/main.bc.wasm.assets/std_exit.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/stdlib.wasm
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm
-  Deleting _install/bin/main.bc.wasm.assets/stdlib.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm.map
-  Deleting _install/bin/main.bc.wasm.js
-  Installing _install/bin/main.bc.wasm.js
-  Installing _install/doc/main/README
+  $ dune install --prefix _install
+  $ find _install -type f | sed 's/-[a-f0-9]*[.]wasm/.wasm/' | sort -u
+  _install/bin/main
+  _install/bin/main.bc.wasm.assets/build_info.wasm
+  _install/bin/main.bc.wasm.assets/build_info.wasm.map
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
+  _install/bin/main.bc.wasm.assets/prelude.wasm
+  _install/bin/main.bc.wasm.assets/runtime.wasm
+  _install/bin/main.bc.wasm.assets/start.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm.map
+  _install/bin/main.bc.wasm.assets/stdlib.wasm
+  _install/bin/main.bc.wasm.assets/stdlib.wasm.map
+  _install/bin/main.bc.wasm.js
+  _install/doc/main/README
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _install/bin/main.bc.wasm.js
   v1-1-xxxxx-dirty
   $ echo "(name main)" >> dune-project
@@ -84,42 +70,26 @@ Jsoo and build-info
   Warning: Consider passing '-g' option to ocamlc.
   $ node _build/default/src/main.bc.wasm.js
   0.2.0
-  $ dune install --prefix _install --display short 2>&1 | sed 's/-[a-f0-9]*[.]wasm/.wasm/'
-  Deleting _install/lib/main/META
-  Installing _install/lib/main/META
-  Deleting _install/lib/main/dune-package
-  Installing _install/lib/main/dune-package
-  Deleting _install/lib/main/opam
-  Installing _install/lib/main/opam
-  Deleting _install/bin/main
-  Installing _install/bin/main
-  Deleting _install/bin/main.bc.wasm.assets/build_info.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm
-  Deleting _install/bin/main.bc.wasm.assets/build_info.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/build_info.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
-  Installing _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
-  Deleting _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/prelude.wasm
-  Installing _install/bin/main.bc.wasm.assets/prelude.wasm
-  Deleting _install/bin/main.bc.wasm.assets/runtime.wasm
-  Installing _install/bin/main.bc.wasm.assets/runtime.wasm
-  Deleting _install/bin/main.bc.wasm.assets/start.wasm
-  Installing _install/bin/main.bc.wasm.assets/start.wasm
-  Deleting _install/bin/main.bc.wasm.assets/std_exit.wasm
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm
-  Deleting _install/bin/main.bc.wasm.assets/std_exit.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/std_exit.wasm.map
-  Deleting _install/bin/main.bc.wasm.assets/stdlib.wasm
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm
-  Deleting _install/bin/main.bc.wasm.assets/stdlib.wasm.map
-  Installing _install/bin/main.bc.wasm.assets/stdlib.wasm.map
-  Deleting _install/bin/main.bc.wasm.js
-  Installing _install/bin/main.bc.wasm.js
-  Deleting _install/doc/main/README
-  Installing _install/doc/main/README
+  $ dune install --prefix _install
+  $ find _install -type f | sed 's/-[a-f0-9]*[.]wasm/.wasm/' | sort -u
+  _install/bin/main
+  _install/bin/main.bc.wasm.assets/build_info.wasm
+  _install/bin/main.bc.wasm.assets/build_info.wasm.map
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm
+  _install/bin/main.bc.wasm.assets/build_info__Build_info_data.wasm.map
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm
+  _install/bin/main.bc.wasm.assets/dune__exe__Main.wasm.map
+  _install/bin/main.bc.wasm.assets/prelude.wasm
+  _install/bin/main.bc.wasm.assets/runtime.wasm
+  _install/bin/main.bc.wasm.assets/start.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm
+  _install/bin/main.bc.wasm.assets/std_exit.wasm.map
+  _install/bin/main.bc.wasm.assets/stdlib.wasm
+  _install/bin/main.bc.wasm.assets/stdlib.wasm.map
+  _install/bin/main.bc.wasm.js
+  _install/doc/main/README
+  _install/lib/main/META
+  _install/lib/main/dune-package
+  _install/lib/main/opam
   $ node _build/default/src/main.bc.wasm.js
   0.2.0

--- a/test/blackbox-tests/test-cases/wasmoo/inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/inline-tests.t/run.t
@@ -16,7 +16,7 @@ Run inline tests using Node.js
   inline tests (Wasm)
   inline tests (Wasm)
 
-  $ dune build wasm/.inline_tests_wasm.inline-tests/inline_test_runner_inline_tests_wasm.bc --display short
+  $ dune build wasm/.inline_tests_wasm.inline-tests/inline_test_runner_inline_tests_wasm.bc
   Error: Don't know how to build
   wasm/.inline_tests_wasm.inline-tests/inline_test_runner_inline_tests_wasm.bc
   [1]

--- a/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
@@ -6,7 +6,7 @@ Compilation using WasmOO
       ocamldep lib/.x.objs/x.impl.d
         ocamlc lib/.x.objs/byte/x__.{cmi,cmo,cmt}
       ocamldep lib/.x.objs/x__Y.impl.d
-  wasm_of_ocaml bin/.technologic.eobjs/jsoo/technologic.bc.runtime.wasma
+  wasm_of_ocaml bin/.technologic.eobjs/jsoo/runtime.bc.runtime.wasma
       ocamldep bin/.technologic.eobjs/dune__exe__Z.impl.d
       ocamlopt lib/.x.objs/native/x__.{cmx,o}
         ocamlc lib/.x.objs/byte/x__Y.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/wasmoo/no-check-prim.t/run.t
@@ -1,35 +1,21 @@
 Compilation using WasmOO
 
-  $ dune build --display short bin/technologic.bc.wasm.js @install  2>&1 | \
-  > sed s,^\ *$(ocamlc -config-var c_compiler),\ \ C_COMPILER,g
-      ocamldep bin/.technologic.eobjs/dune__exe__Technologic.impl.d
-      ocamldep lib/.x.objs/x.impl.d
-        ocamlc lib/.x.objs/byte/x__.{cmi,cmo,cmt}
-      ocamldep lib/.x.objs/x__Y.impl.d
-  wasm_of_ocaml bin/.technologic.eobjs/jsoo/runtime.bc.runtime.wasma
-      ocamldep bin/.technologic.eobjs/dune__exe__Z.impl.d
-      ocamlopt lib/.x.objs/native/x__.{cmx,o}
-        ocamlc lib/.x.objs/byte/x__Y.{cmi,cmo,cmt}
-  wasm_of_ocaml .js/default/stdlib/stdlib.wasma
-  wasm_of_ocaml .js/default/stdlib/std_exit.wasmo
-        ocamlc bin/.technologic.eobjs/byte/dune__exe.{cmi,cmo,cmt}
-      ocamldep bin/.technologic.eobjs/dune__exe__Technologic.intf.d
-      ocamlopt lib/.x.objs/native/x__Y.{cmx,o}
-        ocamlc lib/.x.objs/byte/x.{cmi,cmo,cmt}
-  wasm_of_ocaml .js/default/js_of_ocaml-compiler.runtime/jsoo_runtime.wasma
-      ocamlopt lib/.x.objs/native/x.{cmx,o}
-        ocamlc bin/.technologic.eobjs/byte/dune__exe__Z.{cmi,cmo,cmt}
-        ocamlc lib/x.cma
-        ocamlc bin/.technologic.eobjs/byte/dune__exe__Technologic.{cmi,cmti}
-  wasm_of_ocaml .js/default/js_of_ocaml/js_of_ocaml.wasma
-      ocamlopt lib/x.{a,cmxa}
-        ocamlc bin/.technologic.eobjs/byte/dune__exe__Technologic.{cmo,cmt}
-  wasm_of_ocaml lib/.x.objs/jsoo/default/x.wasma
-      ocamlopt lib/x.cmxs
-  wasm_of_ocaml bin/.technologic.eobjs/jsoo/dune__exe.wasmo
-  wasm_of_ocaml bin/.technologic.eobjs/jsoo/dune__exe__Z.wasmo
-  wasm_of_ocaml bin/.technologic.eobjs/jsoo/dune__exe__Technologic.wasmo
-  wasm_of_ocaml bin/technologic.bc.wasm.{js,assets}
+  $ dune build bin/technologic.bc.wasm.js @install
+  $ dune trace cat | jq -r 'include "dune";
+  >   processes
+  > | select(.args.prog | test("wasm_of_ocaml$"))
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
+  .js/default/js_of_ocaml-compiler.runtime/jsoo_runtime.wasma
+  .js/default/js_of_ocaml/js_of_ocaml.wasma
+  .js/default/stdlib/std_exit.wasmo
+  .js/default/stdlib/stdlib.wasma
+  bin/.technologic.eobjs/jsoo/dune__exe.wasmo
+  bin/.technologic.eobjs/jsoo/dune__exe__Technologic.wasmo
+  bin/.technologic.eobjs/jsoo/dune__exe__Z.wasmo
+  bin/.technologic.eobjs/jsoo/runtime.bc.runtime.wasma
+  bin/technologic.bc.wasm.assets
+  bin/technologic.bc.wasm.js
+  lib/.x.objs/jsoo/default/x.wasma
   $ node ./_build/default/bin/technologic.bc.wasm.js
   buy it
   use it


### PR DESCRIPTION
At the moment, in separate compilation mode, we are building one custom runtime per executable, even though the same runtime could be used by the different executable. 

The first commit implement the sharing at the level of a stanza, while the second commit extends it to workspace-wide sharing.

I'm not completely sure the added complexity is worth it. A clean run of the Js_of_ocaml test suite go from 3 minutes down to 2m40 with this change, but it's kind of extreme.

@hhugo What do you think?