### PR TITLE
fix(stdlib): depend on `modules_before_stdlib`

### DIFF
--- a/doc/changes/fixed/13624.md
+++ b/doc/changes/fixed/13624.md
@@ -1,0 +1,3 @@
+- Fix sandboxed builds of `library` stanzas that set
+  `(stdlib (modules_before_stdlib ..))` (#13624, @anmonteiro)
+

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -80,6 +80,10 @@ module With_vlib : sig
     -> Module_name.t
     -> (Module.t list, [ `Parent_cycle ]) result
 
+  (** Additional dependencies that aren't always reported by [ocamldep], such
+      as `(modules_before_stdlib ..)` in `(stdlib ..)` libraries. *)
+  val implicit_deps : t -> of_:Module.t -> Module.t list
+
   val find : t -> Module_name.t -> Module.t option
   val impl_only : t -> Module.t list
 

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -158,6 +158,7 @@ let deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind ~for_ unit =
             |> Action_builder.lines_of
             >>| parse_deps_exn ~file:(Module.File.path source)
             >>| parse_module_names ~dir ~unit ~modules
+            >>| Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit)
           in
           let transitive_deps = transitive_deps obj_dir immediate_deps ~for_ in
           let immediate_deps = List.map immediate_deps ~f:Module.obj_name in

--- a/test/blackbox-tests/test-cases/stdlib/stdlib-sandbox.t
+++ b/test/blackbox-tests/test-cases/stdlib/stdlib-sandbox.t
@@ -53,6 +53,3 @@ Show interaction between `(library (stdlib ..))` and sandboxed builds
 Fails to pick up the hidden stdlib deps in the sandbox
 
   $ DUNE_SANDBOX=symlink dune build
-  File "_none_", line 1:
-  Error: Unbound module CamlinternalFormatBasics
-  [1]


### PR DESCRIPTION
in the sandbox, modules in a `(stdlib ..)` library implicitly depend on `(modules_before_stdlib ..)`