### PR TITLE
Remove pointless temp files uses for dependency analysis

### DIFF
--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -616,9 +616,7 @@ module Module = struct
   ;;
 
   module Dep = struct
-    type t =
-      | Immediate of Module.t * Ml_kind.t
-      | Transitive of Module.t * Ml_kind.t
+    type t = Immediate of Module.t * Ml_kind.t
 
     let make_name m kind ext =
       let ext =
@@ -631,13 +629,12 @@ module Module = struct
 
     let basename = function
       | Immediate (m, kind) -> make_name m kind Filename.Extension.d
-      | Transitive (m, kind) -> make_name m kind Filename.Extension.all_deps
     ;;
   end
 
   let dep t dep ~for_ =
     match (dep : Dep.t) with
-    | Immediate (m, _) | Transitive (m, _) ->
+    | Immediate (m, _) ->
       (match Module.kind m with
        | Module.Kind.Alias _ | Root -> None
        | _ ->

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -151,9 +151,7 @@ module Module : sig
   end
 
   module Dep : sig
-    type t =
-      | Immediate of Module.t * Ml_kind.t
-      | Transitive of Module.t * Ml_kind.t
+    type t = Immediate of Module.t * Ml_kind.t
   end
 
   val dep : Path.Build.t t -> Dep.t -> for_:Compilation_mode.t -> Path.Build.t option

--- a/test/blackbox-tests/test-cases/cyclic-dep-executable.t
+++ b/test/blackbox-tests/test-cases/cyclic-dep-executable.t
@@ -20,11 +20,10 @@
   > EOF
 
   $ dune build
-  Error: Dependency cycle between:
-     _build/default/.foo.eobjs/dune__exe__Baz.impl.all-deps
-  -> _build/default/.foo.eobjs/dune__exe__Bar.impl.all-deps
-  -> _build/default/.foo.eobjs/dune__exe__Baz.impl.all-deps
-  -> required by _build/default/.foo.eobjs/dune__exe__Foo.impl.all-deps
+  Error: dependency cycle involving module Foo:
+     Bar
+  -> Baz
+  -> Bar
   -> required by _build/default/foo.exe
   -> required by alias all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
@@ -23,7 +23,6 @@ We shouldn't allow foo/y/$x.ml to depend on foo/foo.ml
   X is the main module of the library and is the only module exposed outside of
   the library. Consequently, it should be the one depending on all the other
   modules in the library.
-  -> required by _build/default/.foo.objs/foo__X__Y__Z.impl.all-deps
   -> required by _build/default/.foo.objs/byte/foo__X__Y__Z.cmo
   -> required by _build/default/foo.cma
   -> required by alias all

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
@@ -23,7 +23,6 @@ We shouldn't allow foo/$x.ml to depend on foo/foo.ml
   Baz is the main module of the library and is the only module exposed outside
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
-  -> required by _build/default/.foo.objs/foo__Baz__Bar.impl.all-deps
   -> required by _build/default/.foo.objs/byte/foo__Baz__Bar.cmo
   -> required by _build/default/foo.cma
   -> required by alias all

--- a/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
@@ -39,7 +39,6 @@ We also forbid submodules from depending on their interface modules:
   Baz is the main module of the library and is the only module exposed outside
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
-  -> required by _build/default/.foo.objs/foo__Baz__Bar.impl.all-deps
   -> required by _build/default/.foo.objs/byte/foo__Baz__Bar.cmo
   -> required by _build/default/foo.cma
   -> required by alias all
@@ -60,7 +59,6 @@ Or their parent interface modules:
   Baz is the main module of the library and is the only module exposed outside
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
-  -> required by _build/default/.foo.objs/foo__Baz__Foo__Z.impl.all-deps
   -> required by _build/default/.foo.objs/byte/foo__Baz__Foo__Z.cmo
   -> required by _build/default/foo.cma
   -> required by alias all

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -33,14 +33,13 @@ This kind of cycle has a difficult to understand error message.
   8 |  (name foo_simple)
   9 |  (inline_tests (backend backend_simple)))
   Error: Dependency cycle between:
-     _build/default/.foo_simple.objs/foo_simple__Bar.impl.all-deps
+     _build/default/.foo_simple.objs/foo_simple__Bar.impl.d
   -> _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmi
   -> _build/default/.foo_simple.inline-tests/.t.eobjs/native/dune__exe__Main.cmx
   -> _build/default/.foo_simple.inline-tests/inline-test-runner.exe
   -> alias runtest-foo_simple in dune:9
   -> _build/default/bar.ml
   -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.d
-  -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.all-deps
   -> required by _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmo
   -> required by _build/default/foo_simple.cma
   -> required by alias all

--- a/test/blackbox-tests/test-cases/melange/module-cycle.t
+++ b/test/blackbox-tests/test-cases/melange/module-cycle.t
@@ -19,10 +19,16 @@
   > EOF
 
   $ dune build @check
-  Error: Dependency cycle between:
-     _build/default/.output.mobjs/melange__Main.impl.all-deps
-  -> _build/default/.output.mobjs/melange__Hello.impl.all-deps
-  -> _build/default/.output.mobjs/melange__Main.impl.all-deps
+  Error: dependency cycle involving module Hello:
+     Main
+  -> Hello
+  -> Main
+  -> required by _build/default/.output.mobjs/melange/melange__Hello.cmi
+  -> required by alias check
+  Error: dependency cycle involving module Main:
+     Hello
+  -> Main
+  -> Hello
   -> required by _build/default/.output.mobjs/melange/melange__Main.cmi
   -> required by alias check
   [1]

--- a/test/blackbox-tests/test-cases/ocaml-dep-single-exe.t
+++ b/test/blackbox-tests/test-cases/ocaml-dep-single-exe.t
@@ -12,4 +12,4 @@ necessary.
   hello world
 
 We check to see if ocamldep artifacts have been created:
-  $ find _build/default -name "*.all-deps" -or -name "*.d"
+  $ find _build/default -name "*.d"

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-alias-module.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-alias-module.t
@@ -11,6 +11,5 @@ We don't need to run ocamldep on ther alias module
 
   $ dune build foo.cma
 
-  $ find _build -iname "*.d" -o -iname "*.all-deps" | sort
-  _build/default/.foo.objs/foo__Bar.impl.all-deps
+  $ find _build -iname "*.d" | sort
   _build/default/.foo.objs/foo__Bar.impl.d

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
@@ -20,7 +20,6 @@ Dune uses ocamldep to prevent a module from depending on itself.
   Foo is the main module of the library and is the only module exposed outside
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
-  -> required by _build/default/lib/.foo.objs/foo__Bar.impl.all-deps
   -> required by _build/default/lib/.foo.objs/byte/foo__Bar.cmo
   -> required by _build/default/lib/foo.cma
   -> required by alias lib/all

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -59,11 +59,11 @@ cryptic and can involve unrelated files:
 
   $ echo 'val xx : B.t' >> indirect/c.mli
   $ dune build @indirect-deps
-  Error: Dependency cycle between:
-     _build/default/indirect/.a.eobjs/a.impl.all-deps
-  -> _build/default/indirect/.a.eobjs/b.impl.all-deps
-  -> _build/default/indirect/.a.eobjs/c.intf.all-deps
-  -> _build/default/indirect/.a.eobjs/a.impl.all-deps
+  Error: dependency cycle involving module A:
+     C
+  -> B
+  -> A
+  -> C
   -> required by _build/default/indirect/a.exe
   -> required by alias indirect/indirect-deps in indirect/dune:6
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/virtual-modules-excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/virtual-modules-excluded-by-modules-field.t
@@ -44,7 +44,7 @@ X is warned about:
   1 | (library
   2 |  (name impl)
   3 |  (implements foo))
-  Error: No rule found for src/.foo.objs/y.impl.all-deps
+  Error: No rule found for src/.foo.objs/y.impl.d
   [1]
 
 In 3.11 onwards this warning becomes an error

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -930,7 +930,9 @@ let%expect_test "cyclic dependency error" =
       ; [ [ "id"; "0" ]
         ; [ "message"
           ; [ "Verbatim"
-            ; "Cycle_error.E\n\
+            ; "Error: dependency cycle involving module Foo:\n\
+               -> Baz\n\
+               -> Bar\n\
                "
             ]
           ]


### PR DESCRIPTION
There's no point to save the computation of transitive closures. These are very quick to compute on the fly since everything is in memory.

If we ever consider caching them again, creating 2 files per module isn't the way to go anyway.