### PR TITLE
Add expected output tests for Rocq.

### DIFF
--- a/doc/changes/added/13632.md
+++ b/doc/changes/added/13632.md
@@ -1,0 +1,1 @@
+- Support for Rocq expected output tests (#13632, @rlepigre-skylabs-ai)

--- a/doc/rocq.rst
+++ b/doc/rocq.rst
@@ -81,6 +81,11 @@ The stanza builds all the ``.v`` files in the given directory and its
 subdirectories if the :ref:`include-subdirs <include-subdirs-rocq>` stanza is
 present.
 
+When a ``.v`` file has a corresponding ``.expected`` file, Rocq's standard
+output is captured instead of being output to the terminal, and the output is
+diffed with the ``.expected`` file as part of the ``runtest`` alias. When the
+output differs, it can be promoted as with, e.g., cram tests.
+
 For usage of this stanza, see the :ref:`rocq-examples`.
 
 The semantics of the fields are:

--- a/src/dune_rules/rocq/rocq_module.ml
+++ b/src/dune_rules/rocq/rocq_module.ml
@@ -34,23 +34,20 @@ module Module = struct
      Bar.` may benefit from it. *)
   type t =
     { source : Path.t
-    ; expected : Path.t option
     ; prefix : string list
     ; name : Name.t
     }
 
-  let compare { source; expected; prefix; name } t =
+  let compare { source; prefix; name } t =
     let open Ordering.O in
     let= () = Path.compare source t.source in
-    let= () = Option.compare Path.compare expected t.expected in
     let= () = List.compare prefix t.prefix ~compare:String.compare in
     Name.compare name t.name
   ;;
 
-  let to_dyn { source; expected; prefix; name } =
+  let to_dyn { source; prefix; name } =
     Dyn.record
       [ "source", Path.to_dyn source
-      ; "expected", Dyn.option Path.to_dyn expected
       ; "prefix", Dyn.list Dyn.string prefix
       ; "name", Name.to_dyn name
       ]
@@ -60,7 +57,7 @@ end
 include Module
 module Map = Map.Make (Module)
 
-let make ~source ~expected ~prefix ~name = { source; expected; prefix; name }
+let make ~source ~prefix ~name = { source; prefix; name }
 let source x = x.source
 let prefix x = x.prefix
 let name x = x.name
@@ -90,10 +87,9 @@ let glob_file x ~obj_dir =
   Path.Build.relative vo_dir (x.name ^ ".glob")
 ;;
 
-let expected_and_output_file x ~obj_dir =
-  Option.map x.expected ~f:(fun expected ->
-    let vo_dir = build_vo_dir ~obj_dir x in
-    expected, Path.Build.relative vo_dir (x.name ^ ".output"))
+let output_file x ~obj_dir =
+  let vo_dir = build_vo_dir ~obj_dir x in
+  Path.Build.relative vo_dir (x.name ^ ".output")
 ;;
 
 (* As of today we do the same for build and install, it used not to be
@@ -137,7 +133,7 @@ let parse ~dir ~loc s =
     let prefix = List.rev prefix in
     let source = List.fold_left prefix ~init:dir ~f:Path.Build.relative in
     let source = Path.build @@ Path.Build.relative source (name ^ ".v") in
-    make ~name ~expected:None ~source ~prefix
+    make ~name ~source ~prefix
 ;;
 
 let eval =

--- a/src/dune_rules/rocq/rocq_module.mli
+++ b/src/dune_rules/rocq/rocq_module.mli
@@ -33,7 +33,6 @@ module Map : Map.S with type key = t
 (** A Rocq module [a.b.foo] defined in file [a/b/foo.v] *)
 val make
   :  source:Path.t (** file = .v source file; module name has to be the same so far *)
-  -> expected:Path.t option (** Expected output file (.expected suffix) if it exists *)
   -> prefix:string list (** Library-local qualified prefix *)
   -> name:Name.t (** Name of the module *)
   -> t
@@ -45,7 +44,7 @@ val prefix : t -> string list
 val name : t -> Name.t
 val dep_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 val glob_file : t -> obj_dir:Path.Build.t -> Path.Build.t
-val expected_and_output_file : t -> obj_dir:Path.Build.t -> (Path.t * Path.Build.t) option
+val output_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 
 (** Some of the object files should not be installed, we control this with the
     following parameter *)

--- a/src/dune_rules/rocq/rocq_module.mli
+++ b/src/dune_rules/rocq/rocq_module.mli
@@ -33,6 +33,7 @@ module Map : Map.S with type key = t
 (** A Rocq module [a.b.foo] defined in file [a/b/foo.v] *)
 val make
   :  source:Path.t (** file = .v source file; module name has to be the same so far *)
+  -> expected:Path.t option (** Expected output file (.expected suffix) if it exists *)
   -> prefix:string list (** Library-local qualified prefix *)
   -> name:Name.t (** Name of the module *)
   -> t
@@ -44,6 +45,7 @@ val prefix : t -> string list
 val name : t -> Name.t
 val dep_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 val glob_file : t -> obj_dir:Path.Build.t -> Path.Build.t
+val expected_and_output_file : t -> obj_dir:Path.Build.t -> (Path.t * Path.Build.t) option
 
 (** Some of the object files should not be installed, we control this with the
     following parameter *)

--- a/src/dune_rules/rocq/rocq_sources.mli
+++ b/src/dune_rules/rocq/rocq_sources.mli
@@ -42,6 +42,9 @@ val lookup_module
   -> Rocq_module.t
   -> [ `Theory of Theory.t | `Extraction of Extraction.t ] option
 
+(** Returns the path to the .expected file for a module, if one exists *)
+val expected_file : t -> Rocq_module.t -> Path.Build.t option
+
 val mlg_files
   :  sctx:Super_context.t
   -> dir:Path.Build.t

--- a/test/blackbox-tests/test-cases/rocq/expected-modules.t
+++ b/test/blackbox-tests/test-cases/rocq/expected-modules.t
@@ -1,5 +1,4 @@
-Test that expected files work with explicit (modules ...).
-Currently expected files are ignored when using explicit (modules ...):
+Test that expected files work with explicit (modules ...):
 
   $ cat > dune-project <<EOF
   > (lang dune 3.21)
@@ -17,4 +16,13 @@ Currently expected files are ignored when using explicit (modules ...):
   > EOF
 
   $ touch foo.expected
+  $ dune runtest
+  File "foo.expected", line 1, characters 0-0:
+  --- foo.expected
+  +++ foo.output
+  @@ -0,0 +1 @@
+  +Inductive Corelib.Init.Datatypes.nat
+  [1]
+  $ dune promote
+  Promoting _build/default/foo.output to foo.expected.
   $ dune runtest

--- a/test/blackbox-tests/test-cases/rocq/expected-modules.t
+++ b/test/blackbox-tests/test-cases/rocq/expected-modules.t
@@ -1,0 +1,20 @@
+Test that expected files work with explicit (modules ...).
+Currently expected files are ignored when using explicit (modules ...):
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rocq.theory
+  >  (name a)
+  >  (modules foo))
+  > EOF
+
+  $ cat > foo.v <<EOF
+  > Locate nat.
+  > EOF
+
+  $ touch foo.expected
+  $ dune runtest

--- a/test/blackbox-tests/test-cases/rocq/extraction/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extract.t
@@ -54,3 +54,23 @@
   foo.exe
   foo.ml
   foo.mli
+
+  $ cat >extract.expected <<EOF
+  > Hello!
+  > EOF
+  $ dune runtest
+  File "./extract.v", line 8, characters 0-23:
+  Warning: Setting extraction output directory by default to
+  "$TESTCASE_ROOT/_build/default".
+  Use "Set Extraction Output Directory" or command line option
+  "-output-directory" to set a different directory for extracted files to
+  appear in. [extraction-default-directory,extraction,default]
+  File "extract.expected", line 1, characters 0-0:
+  --- extract.expected
+  +++ extract.output
+  @@ -1 +0,0 @@
+  -Hello!
+  [1]
+  $ dune promote
+  Promoting _build/default/extract.output to extract.expected.
+  $ dune runtest

--- a/test/blackbox-tests/test-cases/rocq/rocq-expected-test.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-expected-test.t
@@ -1,0 +1,59 @@
+Testing the expected test support.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (include_subdirs qualified)
+  > (rocq.theory
+  >  (name a))
+  > EOF
+
+  $ cat > foo.v <<EOF
+  > Locate nat.
+  > EOF
+
+  $ mkdir sub
+  $ cat > sub/bar.v <<EOF
+  > Locate bool.
+  > EOF
+
+  $ dune build 2>&1 | sort
+  Inductive Corelib.Init.Datatypes.bool
+  Inductive Corelib.Init.Datatypes.nat
+
+  $ dune clean
+  $ touch foo.expected
+  $ dune build
+  Inductive Corelib.Init.Datatypes.bool
+  $ dune runtest
+  File "foo.expected", line 1, characters 0-0:
+  --- foo.expected
+  +++ foo.output
+  @@ -0,0 +1 @@
+  +Inductive Corelib.Init.Datatypes.nat
+  [1]
+
+  $ dune promote
+  Promoting _build/default/foo.output to foo.expected.
+  $ cat foo.expected
+  Inductive Corelib.Init.Datatypes.nat
+  $ dune runtest
+
+  $ touch sub/bar.expected
+  $ dune build
+  $ dune runtest
+  File "sub/bar.expected", line 1, characters 0-0:
+  --- sub/bar.expected
+  +++ sub/bar.output
+  @@ -0,0 +1 @@
+  +Inductive Corelib.Init.Datatypes.bool
+  [1]
+
+  $ dune promote
+  Promoting _build/default/sub/bar.output to sub/bar.expected.
+  $ cat sub/bar.expected
+  Inductive Corelib.Init.Datatypes.bool
+  $ dune runtest

--- a/test/blackbox-tests/test-cases/rocq/rocq-test-mode.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-test-mode.t
@@ -1,0 +1,31 @@
+Testing the expected test support.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (include_subdirs qualified)
+  > (rocq.theory
+  >  (flags (:standard -test-mode))
+  >  (name a))
+  > EOF
+
+  $ cat > foo.v <<EOF
+  > Fail Check true = 13.
+  > EOF
+
+  $ touch foo.expected
+  $ dune runtest
+  File "foo.expected", line 1, characters 0-0:
+  --- foo.expected
+  +++ foo.output
+  @@ -0,0 +1,3 @@
+  +File "./foo.v", line 1, characters 18-20:
+  +The command has indeed failed with message:
+  +The term "13" has type "nat" while it is expected to have type "bool".
+  [1]
+  $ dune promote
+  Promoting _build/default/foo.output to foo.expected.
+  $ dune runtest


### PR DESCRIPTION
When a `.v` file has a corresponding `.expected` file in a `rocq.theory`, Rocq's standard output is captured instead of being output to the terminal, and the output is `diff`-ed with the `.expected` file as part of the `runtest` alias.