### PR TITLE
fix(pkg): add leading/trailing separator for colon env update operators

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -402,7 +402,11 @@ module Env_update = struct
     else (
       match kind with
       | `Colon ->
-        let old_v = Option.value ~default:[] old_v in
+        let old_v =
+          match old_v with
+          | None | Some [] -> [ Value.String "" ]
+          | Some v -> v
+        in
         Some (f ~old_v ~new_v)
       | `Plus ->
         (match old_v with

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -76,9 +76,9 @@ Appended without leading sep
   > build_pkg deps-on-with-setenv 
   Hello from the other package!
   Prepended without trailing sep
-  Prepended with trailing sep
+  Prepended with trailing sep:
   Appended without leading sep
-  Appended with leading sep
+  :Appended with leading sep
 
 We now make a third package that updates the env in a similar way, in order to see the
 difference between a propagated export_env versus the initial env.
@@ -131,7 +131,7 @@ Appended 2nd time without leading sep:Appended without leading sep
   > build_pkg deps-on-with-setenv-2
   Hello from the second package!
   Prepended 2nd time without trailing sep:Prepended without trailing sep
-  Prepended 2nd time with sep:Prepended with trailing sep
+  Prepended 2nd time with sep:Prepended with trailing sep:
   Appended without leading sep:Appended 2nd time without leading sep
-  Appended with leading sep:Appended 2nd time with leading sep
+  :Appended with leading sep:Appended 2nd time with leading sep
 

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -20,8 +20,5 @@ Setting environment variables in actions
   XYZ=111:000
   FOO=myfoo
   BAR=yyy:xxx
-  BAZ=baz
-  QUX=qux
-
-Note that the value so of BAZ and QUX above should be "baz:" and ":qux" respectively.
-See https://github.com/ocaml/dune/issues/10440
+  BAZ=baz:
+  QUX=:qux


### PR DESCRIPTION
The := and =: operators should add trailing/leading separators when the variable is unset or empty, per opam's documented semantics. Previously, these operators behaved identically to += and =+ for unset variables.

Fixes #10440