### PR TITLE
chore: add index taret to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ dev-switch:
 	$(MAKE) install-ocamlformat
 	opam install -y $(DEV_DEPS)
 
+.PHONY: index
+index: $(BIN)
+	$(BIN) build @ocaml-index
+
 .PHONY: test
 test: $(BIN)
 	$(BIN) runtest


### PR DESCRIPTION
This allows us to write `make index` to quickly run ocaml-index