### PR TITLE
fix(pkg): remove duplication in portable lock directories

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -466,7 +466,13 @@ let opam_package_to_lock_file_pkg
   in
   let get_solver_var variable_name =
     Solver_stats.Updater.expand_variable stats_updater variable_name;
-    Solver_env.get solver_env variable_name
+    if
+      portable_lock_dir
+      && Package_variable_name.Set.mem
+           Package_variable_name.platform_specific
+           variable_name
+    then None
+    else Solver_env.get solver_env variable_name
   in
   let* build_command =
     if Resolved_package.dune_build resolved_package

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -61,35 +61,15 @@ Create a package that writes a different value to some files depending on the os
   (version 0.0.1)
   
   (build
-   (choice
-    ((((arch x86_64) (os linux)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64) (os linux)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Linux > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))
-    ((((arch x86_64) (os macos)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo x86_64 > %{share}/machine")))))
-    ((((arch arm64) (os macos)))
-     ((action
-       (progn
-        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
-        (run touch %{lib}/%{pkg-self:name}/META)
-        (run sh -c "echo Darwin > %{share}/kernel")
-        (run sh -c "echo arm64 > %{share}/machine")))))))
+   (all_platforms
+    ((action
+      (progn
+       (run mkdir -p %{share} %{lib}/%{pkg-self:name})
+       (run touch %{lib}/%{pkg-self:name}/META)
+       (when (= %{os} macos) (run sh -c "echo Darwin > %{share}/kernel"))
+       (when (= %{os} linux) (run sh -c "echo Linux > %{share}/kernel"))
+       (when (= %{arch} x86_64) (run sh -c "echo x86_64 > %{share}/machine"))
+       (when (= %{arch} arm64) (run sh -c "echo arm64 > %{share}/machine")))))))
 
   $ DUNE_CONFIG__ARCH=arm64 dune build
   $ cat $pkg_root/$(dune pkg print-digest foo)/target/share/kernel

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-custom-solver-env.t
@@ -63,7 +63,9 @@ Confirming that the build action creates the conditional file:
       (progn
        (run mkdir -p %{share} %{lib}/%{pkg-self:name})
        (run touch %{lib}/%{pkg-self:name}/META)
-       (run sh -c "echo %{sys_ocaml_version} > %{share}/sys-ocaml-version"))))))
+       (when
+        (= %{sys_ocaml_version} 5.4.0+solver-env-version-override)
+        (run sh -c "echo %{sys_ocaml_version} > %{share}/sys-ocaml-version")))))))
 
 Build and print the file that was conditionally added. Note that the value of
 "sys-ocaml-version" at solve-time may be different from "sys-ocaml-version" at


### PR DESCRIPTION
Rather than duplicating the build logic in portable lock directories for each platform, we keep around the when-conditional so that we have a more compact lock file.