### PR TITLE
doc(pkg): fix typos and grammar

### DIFF
--- a/doc/explanation/package-management.md
+++ b/doc/explanation/package-management.md
@@ -142,7 +142,7 @@ Dune uses two repositories by default:
 * `upstream` refers to the default branch of `opam-repository`, which contains
   all the publicly released packages.
 * `overlay` refers to
-  [opam-overlay](https://github.com/ocaml-dune/opam-overlays), which defines
+  [opam-overlays](https://github.com/ocaml-dune/opam-overlays), which defines
   packages patched to work with package management. The long-term goal is to
   have as few packages as possible in this repository as more and more packages
   work within Dune Package Management upstream. Check the

--- a/doc/explanation/package-management.md
+++ b/doc/explanation/package-management.md
@@ -150,7 +150,7 @@ Dune uses two repositories by default:
 
 #### Solving
 
-After Dune has read the constraints and loaded set of candidate packages, it is
+After Dune has read the constraints and loaded the set of candidate packages, it is
 necessary to determine which packages and versions should be selected for the
 package lock.
 

--- a/doc/howto/customize-dev-tools-lock-directories.md
+++ b/doc/howto/customize-dev-tools-lock-directories.md
@@ -91,7 +91,7 @@ configuration:
 It specifies that the lock tool should use a pinned version of `ocamlbuild` as
 well as custom repositories in a specific order (adding the `oxcaml` repository
 in between the repositories that are defined out of the box). Constraints are
-added on the versions of other packages to be selected for for building
+added on the versions of other packages to be selected for building
 ocamlformat.
 
 :::{seealso}

--- a/doc/howto/customize-dev-tools-lock-directories.md
+++ b/doc/howto/customize-dev-tools-lock-directories.md
@@ -8,7 +8,7 @@ server](https://github.com/ocaml/ocaml-lsp) or
 [ocamlformat](https://github.com/ocaml-ppx/ocamlformat).
 
 In general these tools do not require any specific configuration: Dune will
-create a lock dir implicitely and install a compatible version of the tool
+create a lock dir implicitly and install a compatible version of the tool
 depending on its availability in
 [opam-repository](https://github.com/ocaml/opam-repository).
 

--- a/doc/howto/customize-dev-tools-lock-directories.md
+++ b/doc/howto/customize-dev-tools-lock-directories.md
@@ -88,7 +88,7 @@ configuration:
  (repositories overlay oxcaml upstream))
 ```
 
-It specifies that that lock tool should use a pinned version of `ocamlbuild` as
+It specifies that the lock tool should use a pinned version of `ocamlbuild` as
 well as custom repositories in a specific order (adding the `oxcaml` repository
 in between the repositories that are defined out of the box). Constraints are
 added on the versions of other packages to be selected for for building

--- a/doc/howto/customize-dev-tools-lock-directories.md
+++ b/doc/howto/customize-dev-tools-lock-directories.md
@@ -30,7 +30,7 @@ constraints are required.
 Configuring the lock directory for a developer tool works in the same way as
 configuring any other lock directory, via the {doc}`lock_dir stanza
 </reference/dune-workspace/lock_dir>`. The difference however is, that the lock
-dir path for a lock dir cannot be chosen freely and must match the interal path
+dir path for a lock dir cannot be chosen freely and must match the internal path
 that Dune will pick for the lock directory of said developer tool.
 
 The format of the lock dir path is

--- a/doc/howto/set-up-ci-with-package-management.md
+++ b/doc/howto/set-up-ci-with-package-management.md
@@ -2,7 +2,7 @@
 
 For many projects published it can be useful to set up a [continuous
 integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) system.
-This allows to check whether the code builds on other computers, the tests pass
+This allows checking whether the code builds on other computers, the tests pass
 and helps to assess contributions from other people.
 
 There are numerous CI systems available. In this document we will be using

--- a/doc/reference/aliases/pkg-install.rst
+++ b/doc/reference/aliases/pkg-install.rst
@@ -8,7 +8,7 @@ of your ``dune-project`` (see :doc:`/reference/dune-project/package`) and build
 them. It will not build your project.
 
 Indeed, if you need to build the project, you need to use the regular ``dune
-build`` command. Note that if the dependencies have not been already fetch and
+build`` command. Note that if the dependencies have not already been fetched and
 downloaded, ``dune build`` will **also** take care of getting and building them.
 
 .. note::

--- a/doc/reference/dune-workspace/lock_dir.rst
+++ b/doc/reference/dune-workspace/lock_dir.rst
@@ -76,5 +76,5 @@ changed if desired.
 
       .. versionadded:: 3.19
 
-      Defines which optional packages names (``depopts``) the solver should
+      Defines which optional package names (``depopts``) the solver should
       include when attempting to find a solution for the project.

--- a/doc/tutorials/dune-package-management/dependencies.md
+++ b/doc/tutorials/dune-package-management/dependencies.md
@@ -130,7 +130,7 @@ used for opam dependencies in the `dune-project` file.
 
 This change ensures the `fmt` package to install will be compatible with our
 request. These constraints will be taken into account the next time the build
-system is ran.
+system is run.
 
 ```sh
 dune build

--- a/doc/tutorials/dune-package-management/locking.md
+++ b/doc/tutorials/dune-package-management/locking.md
@@ -1,7 +1,7 @@
 # Locking Your Dependencies
 
 In the default use-case Dune will automatically determine which packages to
-install, by reading the package constrains, determining compatible versions and
+install, by reading the package constraints, determining compatible versions and
 installing the dependencies automatically.
 
 For many projects this is a good and acceptable behavior as users often want to

--- a/doc/tutorials/dune-package-management/oxcaml.md
+++ b/doc/tutorials/dune-package-management/oxcaml.md
@@ -9,7 +9,7 @@ that compiles with OxCaml when using Dune package management.
 ## Setting up the `dune-workspace`
 
 OxCaml has a custom `opam-repository` that provides compatible dependencies.
-Dune can use packages from this repositories by configuring it in the
+Dune can use packages from these repositories by configuring it in the
 dune-workspace file using the {doc}`repositories stanza
 </reference/dune-workspace/repository>` and {doc}`lock_dir stanza
 </reference/dune-workspace/lock_dir>`.

--- a/doc/tutorials/dune-package-management/oxcaml.md
+++ b/doc/tutorials/dune-package-management/oxcaml.md
@@ -48,7 +48,7 @@ Let's add a test program that uses OxCaml syntax.
 :icon: file-code
 
 :::{literalinclude} oxcaml/main.ml
-:language: dune
+:language: ocaml
 :::
 
 ::::

--- a/doc/tutorials/dune-package-management/setup.md
+++ b/doc/tutorials/dune-package-management/setup.md
@@ -126,5 +126,5 @@ See {doc}`/reference/aliases/pkg-install` for more information.
 In this section we learned how to set up a Dune project that picks a compiler
 and installs it without the need for any additional tooling.
 
-In the next section {doc}`dependencies` we will look on how to add third party
+In the next section {doc}`dependencies` we will look at how to add third party
 dependencies.


### PR DESCRIPTION
Here are some typos and grammar mistakes that I caught when re-reading the package documents. It's by no means exhaustive, but should provide improvement on the days prior.