### PR TITLE
slang: test and improve the simplification of slang

### DIFF
--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -316,7 +316,15 @@ let rec simplify = function
         | Const true -> simplify then_
         | Const false -> simplify else_
         | condition ->
-          Form (loc, If { condition; then_ = simplify then_; else_ = simplify else_ }))
+          let then_ = simplify then_ in
+          let else_ = simplify else_ in
+          (match then_, else_ with
+           | Form (_, Blang (Const true)), Form (_, Blang (Const false)) ->
+             Form (loc, Blang condition)
+           | Form (_, Blang (Const false)), Form (_, Blang (Const true)) ->
+             Form (loc, Blang (Not condition))
+           | _ when equal then_ else_ -> then_
+           | _ -> Form (loc, If { condition; then_; else_ })))
      | Has_undefined_var t ->
        (match simplify t with
         | Form (_, Blang (Const _)) -> Form (loc, Blang (Const false))

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -312,13 +312,11 @@ let rec simplify = function
         | Const false -> Nil
         | _ -> Form (loc, When (simplified_condition, simplify t)))
      | If { condition; then_; else_ } ->
-       Form
-         ( loc
-         , If
-             { condition = simplify_blang condition
-             ; then_ = simplify then_
-             ; else_ = simplify else_
-             } )
+       (match simplify_blang condition with
+        | Const true -> simplify then_
+        | Const false -> simplify else_
+        | condition ->
+          Form (loc, If { condition; then_ = simplify then_; else_ = simplify else_ }))
      | Has_undefined_var t -> Form (loc, Has_undefined_var (simplify t))
      | Catch_undefined_var { value; fallback } ->
        Form

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -352,7 +352,10 @@ and simplify_blang = function
   | Expr (Form (_, Blang blang)) -> simplify_blang blang
   | Expr s -> Expr (simplify s)
   | Compare (op, lhs, rhs) -> Compare (op, simplify lhs, simplify rhs)
-  | Not blang -> Not (simplify_blang blang)
+  | Not blang ->
+    (match simplify_blang blang with
+     | Const b -> Const (not b)
+     | blang -> Not blang)
   | And [ b ] -> simplify_blang b
   | And blangs ->
     let blangs =

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -355,6 +355,7 @@ and simplify_blang = function
   | Not blang ->
     (match simplify_blang blang with
      | Const b -> Const (not b)
+     | Not blang -> blang
      | blang -> Not blang)
   | And [ b ] -> simplify_blang b
   | And blangs ->

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -349,7 +349,16 @@ and simplify_blang = function
      | _ -> expr)
   | Expr (Form (_, Blang blang)) -> simplify_blang blang
   | Expr s -> Expr (simplify s)
-  | Compare (op, lhs, rhs) -> Compare (op, simplify lhs, simplify rhs)
+  | Compare (op, lhs, rhs) ->
+    let lhs = simplify lhs in
+    let rhs = simplify rhs in
+    (match lhs, rhs with
+     | Literal l, Literal r ->
+       (match op, String_with_vars.text_only l, String_with_vars.text_only r with
+        | Relop.Eq, Some l, Some r -> Const (String.equal l r)
+        | Relop.Neq, Some l, Some r -> Const (not (String.equal l r))
+        | _ -> Compare (op, lhs, rhs))
+     | _ -> Compare (op, lhs, rhs))
   | Not blang ->
     (match simplify_blang blang with
      | Const b -> Const (not b)

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -176,10 +176,9 @@ let%expect_test "not false" =
   [%expect {| Const true |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Expr ... *)
 let%expect_test "not not" =
   print_blang (not_ (not_ (expr (pform "x"))));
-  [%expect {| Not (Not (Expr (Literal (template "%{pkg-self:x}")))) |}]
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
 (* Blang: Compare *)

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -303,16 +303,14 @@ let%expect_test "when unknown" =
 
 (* Slang: If *)
 
-(* CR-soon Alizter: should reduce to Literal "yes" *)
 let%expect_test "if true" =
   print_slang (Slang.if_ (const true) ~then_:(Slang.text "yes") ~else_:(Slang.text "no"));
-  [%expect {| If (Const true, Literal "yes", Literal "no") |}]
+  [%expect {| Literal "yes" |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Literal "no" *)
 let%expect_test "if false" =
   print_slang (Slang.if_ (const false) ~then_:(Slang.text "yes") ~else_:(Slang.text "no"));
-  [%expect {| If (Const false, Literal "yes", Literal "no") |}]
+  [%expect {| Literal "no" |}]
 ;;
 
 let%expect_test "if unknown" =

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -68,11 +68,10 @@ let%expect_test "expr pform" =
   [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "expr (blang const)" =
   let inner = Slang.catch_undefined_var (Slang.bool false) ~fallback:(Slang.bool true) in
   print_blang (expr inner);
-  [%expect {| Expr (Catch_undefined_var (Blang (Const false), Blang (Const true))) |}]
+  [%expect {| Const false |}]
 ;;
 
 (* Blang: And *)
@@ -355,10 +354,9 @@ let%expect_test "if eta: same branches" =
 
 (* Slang: Catch_undefined_var *)
 
-(* CR-soon Alizter: should reduce to Blang (Const false) *)
 let%expect_test "catch const" =
   print_slang (Slang.catch_undefined_var (Slang.bool false) ~fallback:(Slang.bool true));
-  [%expect {| Catch_undefined_var (Blang (Const false), Blang (Const true)) |}]
+  [%expect {| Blang (Const false) |}]
 ;;
 
 let%expect_test "catch unknown" =
@@ -374,10 +372,9 @@ let%expect_test "has_undefined_var pform" =
   [%expect {| Has_undefined_var (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Blang (Const false) *)
 let%expect_test "has_undefined_var const" =
   print_slang (Slang.has_undefined_var (Slang.bool true));
-  [%expect {| Has_undefined_var (Blang (Const true)) |}]
+  [%expect {| Blang (Const false) |}]
 ;;
 
 (* Slang: And_absorb_undefined_var *)

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -1,0 +1,442 @@
+open Dune_lang
+
+let () = Dune_tests_common.init ()
+let const b : Slang.blang = Blang.Const b
+let not_ b : Slang.blang = Blang.Not b
+let and_ bs : Slang.blang = Blang.And bs
+let or_ bs : Slang.blang = Blang.Or bs
+let expr t : Slang.blang = Blang.Expr t
+let compare op a b : Slang.blang = Blang.Compare (op, a, b)
+
+let pform name =
+  Slang.pform
+    (Pform.Macro { macro = Pform.Macro.Pkg_self; payload = Pform.Payload.of_string name })
+;;
+
+let print_slang (s : Slang.t) =
+  Slang.simplify s
+  |> Slang.remove_locs
+  |> Slang.to_dyn
+  |> Dyn.pp
+  |> Stdlib.Format.printf "%a@." Pp.to_fmt
+;;
+
+let print_blang (b : Slang.blang) =
+  Slang.simplify_blang b
+  |> Slang.Blang.remove_locs
+  |> Slang.Blang.to_dyn
+  |> Dyn.pp
+  |> Stdlib.Format.printf "%a@." Pp.to_fmt
+;;
+
+(* Blang: Const *)
+
+let%expect_test "const true" =
+  print_blang (const true);
+  [%expect {| Const true |}]
+;;
+
+let%expect_test "const false" =
+  print_blang (const false);
+  [%expect {| Const false |}]
+;;
+
+(* Blang: Expr *)
+
+let%expect_test "expr true literal" =
+  print_blang (expr (Slang.text "true"));
+  [%expect {| Const true |}]
+;;
+
+let%expect_test "expr false literal" =
+  print_blang (expr (Slang.text "false"));
+  [%expect {| Const false |}]
+;;
+
+let%expect_test "expr blang true" =
+  print_blang (expr (Slang.bool true));
+  [%expect {| Const true |}]
+;;
+
+let%expect_test "expr blang false" =
+  print_blang (expr (Slang.bool false));
+  [%expect {| Const false |}]
+;;
+
+let%expect_test "expr pform" =
+  print_blang (expr (pform "x"));
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "expr (blang const)" =
+  let inner = Slang.catch_undefined_var (Slang.bool false) ~fallback:(Slang.bool true) in
+  print_blang (expr inner);
+  [%expect {| Expr (Catch_undefined_var (Blang (Const false), Blang (Const true))) |}]
+;;
+
+(* Blang: And *)
+
+let%expect_test "and singleton" =
+  print_blang (and_ [ expr (pform "x") ]);
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "and false short-circuits" =
+  print_blang (and_ [ expr (pform "x"); const false; expr (pform "y") ]);
+  [%expect
+    {|
+    And
+      (Expr (Literal (template "%{pkg-self:x}")),
+       Const false,
+       Expr (Literal (template "%{pkg-self:y}")))
+    |}]
+;;
+
+(* CR-soon Alizter: should reduce to Expr ... *)
+let%expect_test "and filters true" =
+  print_blang (and_ [ const true; expr (pform "x") ]);
+  [%expect {| And (Const true, Expr (Literal (template "%{pkg-self:x}"))) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const true *)
+let%expect_test "and all true" =
+  print_blang (and_ [ const true; const true ]);
+  [%expect {| And (Const true, Const true) |}]
+;;
+
+let%expect_test "and flattens" =
+  print_blang (and_ [ and_ [ expr (pform "a"); expr (pform "b") ]; expr (pform "c") ]);
+  [%expect
+    {|
+    And
+      (Expr (Literal (template "%{pkg-self:a}")),
+       Expr (Literal (template "%{pkg-self:b}")),
+       Expr (Literal (template "%{pkg-self:c}")))
+    |}]
+;;
+
+(* Blang: Or *)
+
+let%expect_test "or singleton" =
+  print_blang (or_ [ expr (pform "x") ]);
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const true *)
+let%expect_test "or true short-circuits" =
+  print_blang (or_ [ expr (pform "x"); const true; expr (pform "y") ]);
+  [%expect
+    {|
+    Or
+      (Expr (Literal (template "%{pkg-self:x}")),
+       Const true,
+       Expr (Literal (template "%{pkg-self:y}")))
+    |}]
+;;
+
+(* CR-soon Alizter: should reduce to Expr ... *)
+let%expect_test "or filters false" =
+  print_blang (or_ [ const false; expr (pform "x") ]);
+  [%expect {| Or (Const false, Expr (Literal (template "%{pkg-self:x}"))) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "or all false" =
+  print_blang (or_ [ const false; const false ]);
+  [%expect {| Or (Const false, Const false) |}]
+;;
+
+let%expect_test "or flattens" =
+  print_blang (or_ [ or_ [ expr (pform "a"); expr (pform "b") ]; expr (pform "c") ]);
+  [%expect
+    {|
+    Or
+      (Expr (Literal (template "%{pkg-self:a}")),
+       Expr (Literal (template "%{pkg-self:b}")),
+       Expr (Literal (template "%{pkg-self:c}")))
+    |}]
+;;
+
+(* Blang: Not *)
+
+let%expect_test "not unknown" =
+  print_blang (not_ (expr (pform "x")));
+  [%expect {| Not (Expr (Literal (template "%{pkg-self:x}"))) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "not true" =
+  print_blang (not_ (const true));
+  [%expect {| Not (Const true) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const true *)
+let%expect_test "not false" =
+  print_blang (not_ (const false));
+  [%expect {| Not (Const false) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Expr ... *)
+let%expect_test "not not" =
+  print_blang (not_ (not_ (expr (pform "x"))));
+  [%expect {| Not (Not (Expr (Literal (template "%{pkg-self:x}")))) |}]
+;;
+
+(* Blang: Compare *)
+
+let%expect_test "compare unknown" =
+  print_blang (compare Relop.Eq (pform "x") (pform "y"));
+  [%expect
+    {|
+    Compare
+      (=, Literal (template "%{pkg-self:x}"), Literal (template "%{pkg-self:y}"))
+    |}]
+;;
+
+let%expect_test "compare mixed" =
+  print_blang (compare Relop.Eq (Slang.text "a") (pform "x"));
+  [%expect {| Compare (=, Literal "a", Literal (template "%{pkg-self:x}")) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const true *)
+let%expect_test "compare eq same" =
+  print_blang (compare Relop.Eq (Slang.text "a") (Slang.text "a"));
+  [%expect {| Compare (=, Literal "a", Literal "a") |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "compare eq different" =
+  print_blang (compare Relop.Eq (Slang.text "a") (Slang.text "b"));
+  [%expect {| Compare (=, Literal "a", Literal "b") |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const false *)
+let%expect_test "compare neq same" =
+  print_blang (compare Relop.Neq (Slang.text "a") (Slang.text "a"));
+  [%expect {| Compare (<>, Literal "a", Literal "a") |}]
+;;
+
+(* CR-soon Alizter: should reduce to Const true *)
+let%expect_test "compare neq different" =
+  print_blang (compare Relop.Neq (Slang.text "a") (Slang.text "b"));
+  [%expect {| Compare (<>, Literal "a", Literal "b") |}]
+;;
+
+(* Ordering comparisons are not reduced because comparison semantics depend on
+   context (e.g. version comparison vs string comparison). *)
+
+let%expect_test "compare lt" =
+  print_blang (compare Relop.Lt (Slang.text "a") (Slang.text "b"));
+  [%expect {| Compare (<, Literal "a", Literal "b") |}]
+;;
+
+let%expect_test "compare le" =
+  print_blang (compare Relop.Lte (Slang.text "a") (Slang.text "a"));
+  [%expect {| Compare (<=, Literal "a", Literal "a") |}]
+;;
+
+let%expect_test "compare gt" =
+  print_blang (compare Relop.Gt (Slang.text "b") (Slang.text "a"));
+  [%expect {| Compare (>, Literal "b", Literal "a") |}]
+;;
+
+let%expect_test "compare ge" =
+  print_blang (compare Relop.Gte (Slang.text "a") (Slang.text "a"));
+  [%expect {| Compare (>=, Literal "a", Literal "a") |}]
+;;
+
+(* Slang: Nil/Literal *)
+
+let%expect_test "nil" =
+  print_slang Slang.Nil;
+  [%expect {| Nil |}]
+;;
+
+let%expect_test "literal" =
+  print_slang (Slang.text "hello");
+  [%expect {| Literal "hello" |}]
+;;
+
+(* Slang: Concat
+
+   Concat simplification combines all Literal elements (text and pforms) into a
+   single String_with_vars template. Non-Literal elements (When, If, etc.)
+   prevent full simplification. *)
+
+let%expect_test "concat empty" =
+  print_slang (Slang.concat []);
+  [%expect {| Literal "" |}]
+;;
+
+let%expect_test "concat singleton" =
+  print_slang (Slang.concat [ Slang.text "hello" ]);
+  [%expect {| Literal "hello" |}]
+;;
+
+let%expect_test "concat filters nil" =
+  print_slang (Slang.concat [ Slang.text "a"; Slang.Nil; Slang.text "b" ]);
+  [%expect {| Literal (template "ab") |}]
+;;
+
+let%expect_test "concat combines literals" =
+  print_slang (Slang.concat [ Slang.text "a"; Slang.text "b"; Slang.text "c" ]);
+  [%expect {| Literal (template "abc") |}]
+;;
+
+let%expect_test "concat combines pforms" =
+  print_slang (Slang.concat [ pform "x"; pform "y" ]);
+  [%expect {| Literal (template "%{pkg-self:x}%{pkg-self:y}") |}]
+;;
+
+let%expect_test "concat combines mixed" =
+  print_slang (Slang.concat [ Slang.text "a"; pform "x"; Slang.text "b" ]);
+  [%expect {| Literal (template "a%{pkg-self:x}b") |}]
+;;
+
+let%expect_test "concat non-literal" =
+  print_slang
+    (Slang.concat [ Slang.text "a"; Slang.when_ (expr (pform "c")) (Slang.text "b") ]);
+  [%expect
+    {|
+    Concat
+      (Literal "a", When (Expr (Literal (template "%{pkg-self:c}")), Literal "b"))
+    |}]
+;;
+
+(* Slang: When *)
+
+let%expect_test "when true" =
+  print_slang (Slang.when_ (const true) (Slang.text "hello"));
+  [%expect {| Literal "hello" |}]
+;;
+
+let%expect_test "when false" =
+  print_slang (Slang.when_ (const false) (Slang.text "hello"));
+  [%expect {| Nil |}]
+;;
+
+let%expect_test "when unknown" =
+  print_slang (Slang.when_ (expr (pform "x")) (Slang.text "hello"));
+  [%expect {| When (Expr (Literal (template "%{pkg-self:x}")), Literal "hello") |}]
+;;
+
+(* Slang: If *)
+
+(* CR-soon Alizter: should reduce to Literal "yes" *)
+let%expect_test "if true" =
+  print_slang (Slang.if_ (const true) ~then_:(Slang.text "yes") ~else_:(Slang.text "no"));
+  [%expect {| If (Const true, Literal "yes", Literal "no") |}]
+;;
+
+(* CR-soon Alizter: should reduce to Literal "no" *)
+let%expect_test "if false" =
+  print_slang (Slang.if_ (const false) ~then_:(Slang.text "yes") ~else_:(Slang.text "no"));
+  [%expect {| If (Const false, Literal "yes", Literal "no") |}]
+;;
+
+let%expect_test "if unknown" =
+  print_slang
+    (Slang.if_ (expr (pform "x")) ~then_:(Slang.text "yes") ~else_:(Slang.text "no"));
+  [%expect
+    {| If (Expr (Literal (template "%{pkg-self:x}")), Literal "yes", Literal "no") |}]
+;;
+
+(* CR-soon Alizter: should reduce to Blang (Expr ...) *)
+let%expect_test "if eta: true/false" =
+  print_slang
+    (Slang.if_ (expr (pform "c")) ~then_:(Slang.bool true) ~else_:(Slang.bool false));
+  [%expect
+    {|
+    If
+      (Expr (Literal (template "%{pkg-self:c}")),
+       Blang (Const true),
+       Blang (Const false))
+    |}]
+;;
+
+(* CR-soon Alizter: should reduce to Blang (Not ...) *)
+let%expect_test "if eta: false/true" =
+  print_slang
+    (Slang.if_ (expr (pform "c")) ~then_:(Slang.bool false) ~else_:(Slang.bool true));
+  [%expect
+    {|
+    If
+      (Expr (Literal (template "%{pkg-self:c}")),
+       Blang (Const false),
+       Blang (Const true))
+    |}]
+;;
+
+(* CR-soon Alizter: should reduce to Literal "same" *)
+let%expect_test "if eta: same branches" =
+  print_slang
+    (Slang.if_ (expr (pform "c")) ~then_:(Slang.text "same") ~else_:(Slang.text "same"));
+  [%expect
+    {|
+    If
+      (Expr (Literal (template "%{pkg-self:c}")), Literal "same", Literal "same")
+    |}]
+;;
+
+(* Slang: Catch_undefined_var *)
+
+(* CR-soon Alizter: should reduce to Blang (Const false) *)
+let%expect_test "catch const" =
+  print_slang (Slang.catch_undefined_var (Slang.bool false) ~fallback:(Slang.bool true));
+  [%expect {| Catch_undefined_var (Blang (Const false), Blang (Const true)) |}]
+;;
+
+let%expect_test "catch unknown" =
+  print_slang (Slang.catch_undefined_var (pform "x") ~fallback:(Slang.bool false));
+  [%expect
+    {| Catch_undefined_var (Literal (template "%{pkg-self:x}"), Blang (Const false)) |}]
+;;
+
+(* Slang: Has_undefined_var *)
+
+let%expect_test "has_undefined_var pform" =
+  print_slang (Slang.has_undefined_var (pform "x"));
+  [%expect {| Has_undefined_var (Literal (template "%{pkg-self:x}")) |}]
+;;
+
+(* CR-soon Alizter: should reduce to Blang (Const false) *)
+let%expect_test "has_undefined_var const" =
+  print_slang (Slang.has_undefined_var (Slang.bool true));
+  [%expect {| Has_undefined_var (Blang (Const true)) |}]
+;;
+
+(* Slang: And_absorb_undefined_var *)
+
+let%expect_test "and_absorb flattens" =
+  print_slang
+    (Slang.and_absorb_undefined_var
+       [ expr (Slang.and_absorb_undefined_var [ expr (pform "a"); expr (pform "b") ])
+       ; expr (pform "c")
+       ]);
+  [%expect
+    {|
+    And_absorb_undefined_var
+      (Expr (Literal (template "%{pkg-self:a}")),
+       Expr (Literal (template "%{pkg-self:b}")),
+       Expr (Literal (template "%{pkg-self:c}")))
+    |}]
+;;
+
+(* Slang: Or_absorb_undefined_var *)
+
+let%expect_test "or_absorb flattens" =
+  print_slang
+    (Slang.or_absorb_undefined_var
+       [ expr (Slang.or_absorb_undefined_var [ expr (pform "a"); expr (pform "b") ])
+       ; expr (pform "c")
+       ]);
+  [%expect
+    {|
+    Or_absorb_undefined_var
+      (Expr (Literal (template "%{pkg-self:a}")),
+       Expr (Literal (template "%{pkg-self:b}")),
+       Expr (Literal (template "%{pkg-self:c}")))
+    |}]
+;;

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -315,41 +315,22 @@ let%expect_test "if unknown" =
     {| If (Expr (Literal (template "%{pkg-self:x}")), Literal "yes", Literal "no") |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Blang (Expr ...) *)
 let%expect_test "if eta: true/false" =
   print_slang
     (Slang.if_ (expr (pform "c")) ~then_:(Slang.bool true) ~else_:(Slang.bool false));
-  [%expect
-    {|
-    If
-      (Expr (Literal (template "%{pkg-self:c}")),
-       Blang (Const true),
-       Blang (Const false))
-    |}]
+  [%expect {| Blang (Expr (Literal (template "%{pkg-self:c}"))) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Blang (Not ...) *)
 let%expect_test "if eta: false/true" =
   print_slang
     (Slang.if_ (expr (pform "c")) ~then_:(Slang.bool false) ~else_:(Slang.bool true));
-  [%expect
-    {|
-    If
-      (Expr (Literal (template "%{pkg-self:c}")),
-       Blang (Const false),
-       Blang (Const true))
-    |}]
+  [%expect {| Blang (Not (Expr (Literal (template "%{pkg-self:c}")))) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Literal "same" *)
 let%expect_test "if eta: same branches" =
   print_slang
     (Slang.if_ (expr (pform "c")) ~then_:(Slang.text "same") ~else_:(Slang.text "same"));
-  [%expect
-    {|
-    If
-      (Expr (Literal (template "%{pkg-self:c}")), Literal "same", Literal "same")
-    |}]
+  [%expect {| Literal "same" |}]
 ;;
 
 (* Slang: Catch_undefined_var *)

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -179,28 +179,24 @@ let%expect_test "compare mixed" =
   [%expect {| Compare (=, Literal "a", Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const true *)
 let%expect_test "compare eq same" =
   print_blang (compare Relop.Eq (Slang.text "a") (Slang.text "a"));
-  [%expect {| Compare (=, Literal "a", Literal "a") |}]
+  [%expect {| Const true |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "compare eq different" =
   print_blang (compare Relop.Eq (Slang.text "a") (Slang.text "b"));
-  [%expect {| Compare (=, Literal "a", Literal "b") |}]
+  [%expect {| Const false |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "compare neq same" =
   print_blang (compare Relop.Neq (Slang.text "a") (Slang.text "a"));
-  [%expect {| Compare (<>, Literal "a", Literal "a") |}]
+  [%expect {| Const false |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const true *)
 let%expect_test "compare neq different" =
   print_blang (compare Relop.Neq (Slang.text "a") (Slang.text "b"));
-  [%expect {| Compare (<>, Literal "a", Literal "b") |}]
+  [%expect {| Const true |}]
 ;;
 
 (* Ordering comparisons are not reduced because comparison semantics depend on

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -166,16 +166,14 @@ let%expect_test "not unknown" =
   [%expect {| Not (Expr (Literal (template "%{pkg-self:x}"))) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "not true" =
   print_blang (not_ (const true));
-  [%expect {| Not (Const true) |}]
+  [%expect {| Const false |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const true *)
 let%expect_test "not false" =
   print_blang (not_ (const false));
-  [%expect {| Not (Const false) |}]
+  [%expect {| Const true |}]
 ;;
 
 (* CR-soon Alizter: should reduce to Expr ... *)

--- a/test/expect-tests/dune_lang/slang_tests.ml
+++ b/test/expect-tests/dune_lang/slang_tests.ml
@@ -82,28 +82,19 @@ let%expect_test "and singleton" =
   [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "and false short-circuits" =
   print_blang (and_ [ expr (pform "x"); const false; expr (pform "y") ]);
-  [%expect
-    {|
-    And
-      (Expr (Literal (template "%{pkg-self:x}")),
-       Const false,
-       Expr (Literal (template "%{pkg-self:y}")))
-    |}]
+  [%expect {| Const false |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Expr ... *)
 let%expect_test "and filters true" =
   print_blang (and_ [ const true; expr (pform "x") ]);
-  [%expect {| And (Const true, Expr (Literal (template "%{pkg-self:x}"))) |}]
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const true *)
 let%expect_test "and all true" =
   print_blang (and_ [ const true; const true ]);
-  [%expect {| And (Const true, Const true) |}]
+  [%expect {| Const true |}]
 ;;
 
 let%expect_test "and flattens" =
@@ -124,28 +115,19 @@ let%expect_test "or singleton" =
   [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const true *)
 let%expect_test "or true short-circuits" =
   print_blang (or_ [ expr (pform "x"); const true; expr (pform "y") ]);
-  [%expect
-    {|
-    Or
-      (Expr (Literal (template "%{pkg-self:x}")),
-       Const true,
-       Expr (Literal (template "%{pkg-self:y}")))
-    |}]
+  [%expect {| Const true |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Expr ... *)
 let%expect_test "or filters false" =
   print_blang (or_ [ const false; expr (pform "x") ]);
-  [%expect {| Or (Const false, Expr (Literal (template "%{pkg-self:x}"))) |}]
+  [%expect {| Expr (Literal (template "%{pkg-self:x}")) |}]
 ;;
 
-(* CR-soon Alizter: should reduce to Const false *)
 let%expect_test "or all false" =
   print_blang (or_ [ const false; const false ]);
-  [%expect {| Or (Const false, Const false) |}]
+  [%expect {| Const false |}]
 ;;
 
 let%expect_test "or flattens" =


### PR DESCRIPTION
The goal of this PR is two-fold, firstly to document the current simplification behaviour and secondly to improve it.

The first commit in this PR adds tests for various cases we would expect slang to simplify. The subsequent cases all target a particular case and allow it to happen.

This will be used in 
- #13466 

in order to simplify eagerly evaluated expressions and will be more useful generally to reduce the duplication and complexity of portable lock directories.