### PR TITLE
fix(ocaml-index): modules of overlapping exes

### DIFF
--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -396,10 +396,6 @@ let build_and_link_many
       cctx
   =
   let* () = Module_compilation.build_all cctx in
-  let* () =
-    Memo.when_ (Compilation_context.bin_annot cctx) (fun () ->
-      Ocaml_index.cctx_rules cctx)
-  in
   link_many
     ?link_args
     ?o_files

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -576,7 +576,13 @@ let library_rules
   let for_ = Compilation_context.for_ cctx in
   let+ () =
     Memo.when_ (Compilation_context.bin_annot cctx) (fun () ->
-      Ocaml_index.cctx_rules cctx)
+      let modules_to_index =
+        Compilation_context.modules cctx
+        |> Modules.With_vlib.drop_vlib
+        |> Modules.fold_user_written ~init:[] ~f:List.cons
+        |> Action_builder.return
+      in
+      Ocaml_index.index_modules_rule ~modules_to_index cctx)
   and+ () =
     Memo.when_
       (not (Library.is_virtual lib))

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -448,7 +448,13 @@ let setup_emit_cmj_rules
     let* () = Module_compilation.build_all cctx in
     let* () =
       Memo.when_ (Compilation_context.bin_annot cctx) (fun () ->
-        Ocaml_index.cctx_rules cctx)
+        let modules_to_index =
+          Compilation_context.modules cctx
+          |> Modules.With_vlib.drop_vlib
+          |> Modules.fold_user_written ~init:[] ~f:List.cons
+          |> Action_builder.return
+        in
+        Ocaml_index.index_modules_rule ~modules_to_index cctx)
     in
     let* requires_compile = Compilation_context.requires_compile cctx in
     let* requires_hidden = Compilation_context.requires_hidden cctx in

--- a/src/dune_rules/merlin/ocaml_index.mli
+++ b/src/dune_rules/merlin/ocaml_index.mli
@@ -1,24 +1,32 @@
 open Import
 
-(** This module provides support for the [ocaml-uideps] indexing tool. Its role
+(** This module provides support for the [ocaml-index] indexing tool. Its role
     is to index every value in the project by their definition in order for
-    language server to be able to fetch project-wide occurrences.
+    language servers to be able to fetch project-wide occurrences.
 
-    Indexing all definitions usages is a two step process:
+    Indexing all definition usages is a two step process:
 
-    - first, for all compilation contexts we generate the uideps for all the
-      modules in that cctx in the corresponding obj_dir.
-    - then we aggregate all these separate indexes into a unique one. *)
+    1. For all compilation contexts we generate the indexes for the modules in
+       that cctx in the corresponding obj_dir.
 
-(** [cctx_rules cctx] sets the rules needed to generate the indexes for every
-    module in the compilation context [cctx] and aggregate them in a
-    [cctx.uideps] index covering the whole compilation context. *)
-val cctx_rules : Compilation_context.t -> unit Memo.t
+    2. We aggregate all these separate indexes into a unique one. *)
+
+(** [index_modules_rule ~modules_to_index cctx] sets up the rules needed to
+    generate the indexes for the given modules and aggregates them in a
+    cctx.ocaml-index file covering the whole compilation context.
+
+    The callers decide which modules to index:
+    - For libraries/melange: all user-written modules.
+    - For executables: modules reachable from each top level module. *)
+val index_modules_rule
+  :  modules_to_index:Module.t list Action_builder.t
+  -> Compilation_context.t
+  -> unit Memo.t
 
 (** [context_indexes] lists all the available cctx.ocaml-index files in the
-    given context *)
+    given context. *)
 val context_indexes : Context.t -> Path.t list Action_builder.t
 
 (** [project_rule] adds a rule that will aggregate all the generated indexes
-    into one global, project-wide, index *)
+    into one global, project-wide, index. *)
 val project_rule : Super_context.t -> Dune_project.t -> unit Memo.t

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -41,6 +41,7 @@ val make_wrapped
 val fold_user_written : t -> f:(Module.t -> 'acc -> 'acc) -> init:'acc -> 'acc
 val map_user_written : t -> f:(Module.t -> Module.t Memo.t) -> t Memo.t
 val fold_user_available : t -> f:(Module.t -> 'acc -> 'acc) -> init:'acc -> 'acc
+val is_user_written : Module.t -> bool
 
 module Sourced_module : sig
   type t =

--- a/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes-different-deps.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes-different-deps.t
@@ -55,19 +55,6 @@ shared.ml uses Lib_a, which foo has but bar doesn't:
 Normal build succeeds because each executable only links what it needs:
   $ dune build ./foo.exe ./bar.exe
 
-But ocaml-index fails because bar's compilation context includes shared.ml
-which depends on Lib_a, but bar doesn't have lib_a as a dependency:
+ocaml-index succeeds because each executable only indexes modules reachable
+from its entry point (shared.ml is not reachable from bar.ml):
   $ dune build @ocaml-index
-  File "bar.ml", line 1, characters 23-28:
-  1 | let () = print_endline Lib_b.value_b
-                             ^^^^^
-  Error: Unbound module Lib_b
-  File "foo.ml", line 1, characters 23-28:
-  1 | let () = print_endline Lib_a.value_a
-                             ^^^^^
-  Error: Unbound module Lib_a
-  File "shared.ml", line 1, characters 8-13:
-  1 | let x = Lib_a.value_a
-              ^^^^^
-  Error: Unbound module Lib_a
-  [1]

--- a/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/overlapping-exes.t
@@ -29,6 +29,3 @@ Normal build should succeed:
 
 Building @ocaml-index:
   $ dune build @ocaml-index
-  File "bar.ml", line 1:
-  Error: Could not find the .cmi file for interface bar.mli.
-  [1]


### PR DESCRIPTION
Rather than make a rule that handles both libraries and executables, we make a rule that handles a collection of modules so that libraries, executables and melange can setup the ocaml index rules accordingly.

In the executable case we are more careful with the modules we choose and instead opt for reachable modules.

- fixes https://github.com/ocaml/dune/issues/13566
- [ ] changelog