### PR TITLE
fix(pkg): ensure dev tool lock dir is built before loading

### DIFF
--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -250,6 +250,8 @@ let get_exn ctx = get ctx >>| User_error.ok_exn
 
 let of_dev_tool dev_tool =
   let path = dev_tool |> dev_tool_external_lock_dir |> Path.external_ in
+  (* Ensure the internal lock dir is built so copy rules run *)
+  let* () = Build_system.build_dir (dev_tool_lock_dir dev_tool) in
   Load.load_exn path
 ;;
 


### PR DESCRIPTION
This forces the build system to build the internal lock directory of a dev tool before loading it. Previously this would race causing issues.