### PR TITLE
chore: remove unnecessary rm -rf vendor/... step

### DIFF
--- a/opam/chrome-trace.opam
+++ b/opam/chrome-trace.opam
@@ -18,8 +18,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-action-plugin.opam
+++ b/opam/dune-action-plugin.opam
@@ -31,8 +31,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-build-info.opam
+++ b/opam/dune-build-info.opam
@@ -24,8 +24,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-configurator.opam
+++ b/opam/dune-configurator.opam
@@ -28,8 +28,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-glob.opam
+++ b/opam/dune-glob.opam
@@ -21,8 +21,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-private-libs.opam
+++ b/opam/dune-private-libs.opam
@@ -29,8 +29,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-private-libs.opam.template
+++ b/opam/dune-private-libs.opam.template
@@ -1,7 +1,5 @@
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-rpc-lwt.opam
+++ b/opam/dune-rpc-lwt.opam
@@ -20,8 +20,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-rpc.opam
+++ b/opam/dune-rpc.opam
@@ -23,8 +23,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dune-site.opam
+++ b/opam/dune-site.opam
@@ -17,8 +17,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/dyn.opam
+++ b/opam/dyn.opam
@@ -19,8 +19,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/fs-io.opam
+++ b/opam/fs-io.opam
@@ -18,8 +18,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/ocamlc-loc.opam
+++ b/opam/ocamlc-loc.opam
@@ -22,8 +22,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/ordering.opam
+++ b/opam/ordering.opam
@@ -17,8 +17,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/stdune.opam
+++ b/opam/stdune.opam
@@ -25,8 +25,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/top-closure.opam
+++ b/opam/top-closure.opam
@@ -17,8 +17,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"

--- a/opam/xdg.opam
+++ b/opam/xdg.opam
@@ -18,8 +18,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
-  ["rm" "-rf" "vendor/csexp"]
-  ["rm" "-rf" "vendor/pp"]
   [
     "dune"
     "build"


### PR DESCRIPTION
The bootstrapping process knows how to build the vendored code here and the normal build does not know about it due to the lack of dune file. Therefore this is no longer a necessary step.