### PR TITLE
Update release checklist template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,7 +17,7 @@ assignees: ''
 <!-- } else if release is Minor release use section { -->
 ## Known blockers
 
-- [ ] Something is blocking the PR because of ...
+- [ ] issue #... blocking the release because of ...
 
 <!-- } -->
 
@@ -31,13 +31,8 @@ assignees: ''
 
 ## Post-release
 
-- [ ] Merge dune changelog in `main` [link to dune PR]
-- [ ] Update ocaml.org changelog [link to ocaml.org PR]
+- [ ] Merge release branch into `main` [link to dune PR]
 - [ ] Write a post about the release on Discuss [link to post]
 - [ ] Store the revdeps error file in the [logs](https://github.com/ocaml/dune/wiki/Reverse-dependencies-CI-logs)
 <!-- If minor release uncomment this -->
 <!-- - [ ] Increase `lang dune` number   -->
-
-## Last stage
-
-- [ ] Close tracking issue


### PR DESCRIPTION
Updated release checklist to remove (now) automated ocaml.org release updates and to removed the redundant "close this issue" step.

Automation of release announcements happens via a scraper that pulls our release notes, e.g., https://github.com/ocaml/ocaml.org/pull/3498/changes#diff-2c49d3178f92df89fb598a76a5074dd46bccf3ecd7204935ea8ce7d709873d41