### PR TITLE
Fix location of diagnostic log in code error messages

### DIFF
--- a/doc/tutorials/dune-package-management/dependencies.md
+++ b/doc/tutorials/dune-package-management/dependencies.md
@@ -81,28 +81,9 @@ the internal dependency solver to find a solution for the set of packages to
 use. It will then use this new solution to download, build and install these
 dependencies automatically.
 
-We can check the build log in `_build/log` and see the packages that the Dune
-solver has selected:
-
-```
-...
-# Dependency solution for
-# _build/.sandbox/<sandbox-hash>/_private/default/.lock/dune.lock:
-# - base-unix.base
-# - fmt.0.11.0
-# - ocaml.5.4.0
-# - ocaml-base-compiler.5.4.0
-# - ocaml-compiler.5.4.0
-# - ocaml-config.3
-# - ocamlbuild.0.16.1+dune
-# - ocamlfind.1.9.8+dune
-# - topkg.1.1.1
-...
-```
-
 :::{note}
-The list of packages being output includes all dependencies of your project,
-including transitive dependencies.
+The installed packages will includes all the dependencies required by your
+project, including transitive dependencies.
 :::
 
 As we see, the code works and uses `fmt` to do the pretty-printing:
@@ -134,24 +115,6 @@ system is run.
 
 ```sh
 dune build
-```
-
-Checking `_build/log` again reveals that our change was taken into account:
-
-```
-...
-# Dependency solution for
-# _build/.sandbox/<sandbox-hash>/_private/default/.lock/dune.lock:
-# - base-unix.base
-# - fmt.0.9.0
-# - ocaml.5.4.0
-# - ocaml-base-compiler.5.4.0
-# - ocaml-compiler.5.4.0
-# - ocaml-config.3
-# - ocamlbuild.0.16.1+dune
-# - ocamlfind.1.9.8+dune
-# - topkg.1.1.1
-...
 ```
 
 ## Removing Dependencies

--- a/doc/tutorials/dune-package-management/pinning.md
+++ b/doc/tutorials/dune-package-management/pinning.md
@@ -35,25 +35,6 @@ the source tarball released in the `opam-repository`.
 dune build
 ```
 
-will find a new solution, quoting `_build/log`:
-
-```
-...
-
-# Dependency solution for
-# _build/.sandbox/<sandbox-hash>/_private/default/.lock/dune.lock:
-# - base-unix.base
-# - fmt.dev
-# - ocaml.5.4.0
-# - ocaml-base-compiler.5.4.0
-# - ocaml-compiler.5.4.0
-# - ocaml-config.3
-# - ocamlbuild.0.16.1+dune
-# - ocamlfind.1.9.8+dune
-# - topkg.1.1.1
-...
-```
-
 Unlike previously, the version of the `fmt` library that is picked is `dev`, to
 signify a development version.
 

--- a/doc/tutorials/dune-package-management/repos.md
+++ b/doc/tutorials/dune-package-management/repos.md
@@ -37,29 +37,6 @@ repositories at the defined revisions. These will then be used to determine the
 new solution, which will get used for downloading and building the
 dependencies.
 
-```sh
-dune build
-```
-
-will thus log a new solution in `_build/log`. Note that a lot of package
-versions are different, as the state of the opam-repository is frozen at the
-specific commit:
-
-```
-...
-# Dependency solution for
-# _build/.sandbox/<sandbox-hash>/_private/default/.lock/dune.lock:
-# - base-unix.base
-# - fmt.0.9.0
-# - ocaml.5.0.0
-# - ocaml-base-compiler.5.0.0
-# - ocaml-config.3
-# - ocamlbuild.0.16.1+dune
-# - ocamlfind.1.9.8+dune
-# - topkg.1.0.7
-...
-```
-
 :::{note}
 This feature can also be used to make sure the locked dependencies are
 reproducible, as fixing all the package repository versions will lead to

--- a/otherlibs/dune-action-plugin/test/depends-on-its-target-by-read-dir/run.t
+++ b/otherlibs/dune-action-plugin/test/depends-on-its-target-by-read-dir/run.t
@@ -13,7 +13,9 @@
   $ cp ./bin/foo.exe ./
 
   $ dune build some_file 2>&1 | awk '/Internal error/,/unable to serialize/'
-  Internal error, please report upstream including the contents of _build/log.
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
   Description:
     ("unable to serialize exception",
 

--- a/otherlibs/dune-action-plugin/test/one-absent-dependency/run.t
+++ b/otherlibs/dune-action-plugin/test/one-absent-dependency/run.t
@@ -15,6 +15,8 @@ and requires dependency that can not be build fails.
   $ cp ./bin/foo.exe ./
 
   $ dune runtest 2>&1 | awk '/Internal error/,/unable to serialize/'
-  Internal error, please report upstream including the contents of _build/log.
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
   Description:
     ("unable to serialize exception",

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -21,8 +21,9 @@ let code_error ~loc ~dyn_without_loc =
         [ Pp.tag
             User_message.Style.Error
             (Pp.textf
-               "Internal error, please report upstream including the contents of \
-                _build/log.")
+               "Internal error! Please report to https://github.com/ocaml/dune/issues, \
+                providing the file _build/trace.csexp, if possible. This includes build \
+                commands, message logs, and file paths.")
         ; Pp.text "Description:"
         ; Pp.box ~indent:2 Pp.O.(Pp.verbatim "  " ++ Dyn.pp dyn_without_loc)
         ]

--- a/test/blackbox-tests/test-cases/ctypes/gh12018.t
+++ b/test/blackbox-tests/test-cases/ctypes/gh12018.t
@@ -42,8 +42,7 @@ Reproduction case for https://github.com/ocaml/dune/issues/12018
   > EOF
 
   $ LIBEX=$(realpath "$PWD/libexample")
-  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./foo.exe 2>&1 | head -3
-  Internal error, please report upstream including the contents of _build/log.
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune exec ./foo.exe 2>&1 | grep -A 1 'Description:'
   Description:
     ("link_many: unable to find module",
   [1]

--- a/test/blackbox-tests/test-cases/install/misc-section.t
+++ b/test/blackbox-tests/test-cases/install/misc-section.t
@@ -13,7 +13,9 @@ The misc install section isn't supported:
   > EOF
 
   $ dune build xxx.install 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error, please report upstream including the contents of _build/log.
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
   Description:
     ("Install.Paths.get", {})
   Raised at Stdune__Code_error.raise in file

--- a/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
+++ b/test/blackbox-tests/test-cases/invalid-opam-file-name-github8281.t
@@ -22,7 +22,9 @@ Whenever an invalid package name is used, dune crashes when building @doc
   $ cd ..
 
   $ dune build @doc 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error, please report upstream including the contents of _build/log.
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
   Description:
     ("[gen_rules] returned rules in a directory that is not a descendant of the directory it was called for",
      { dir = In_build_dir "default/_doc/_html/x.y"

--- a/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
+++ b/test/blackbox-tests/test-cases/pkg/external-lock-dir.t
@@ -14,7 +14,9 @@ A lock directory which does not exist in the source tree:
   > EOF
 
   $ build_pkg foo 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error, please report upstream including the contents of _build/log.
+  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  providing the file _build/trace.csexp, if possible. This includes build
+  commands, message logs, and file paths.
   Description:
     ("Local.relative: received absolute path",
      { t = "."


### PR DESCRIPTION
Fixes #13679

Since `_build/log` has been removed, and diagnostid information no goes to `_build/trace.csexp`, we need to point users to this location in the code error message.

This was raised and diagnosed by @Alizter 
