### PR TITLE
Print diffs on patch back source tree diff failures

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -264,7 +264,7 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Produce.t =
     Done
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
   | Diff diff ->
-    let+ () = Produce.of_fiber (Diff_action.exec ectx.rule_loc diff) in
+    let+ () = Produce.of_fiber (Diff_action.exec ~patch_back:None ectx.rule_loc diff) in
     Done
   | Extension (module A) -> Produce.of_fiber @@ A.Spec.action A.v ~ectx ~eenv
 

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -21,7 +21,7 @@ let compare_files { Diff.optional; mode; file1; file2 } =
     | false, true -> `Eq false)
 ;;
 
-let exec loc ({ Diff.optional; file1; file2; mode } as diff) =
+let exec loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
   let remove_intermediate_file () =
     if optional
     then (
@@ -66,6 +66,7 @@ let exec loc ({ Diff.optional; file1; file2; mode } as diff) =
              ]
          else
            Print_diff.print
+             ~patch_back
              promotion
              file1
              (Path.build file2)

--- a/src/dune_engine/diff_action.mli
+++ b/src/dune_engine/diff_action.mli
@@ -1,3 +1,7 @@
 open Import
 
-val exec : Loc.t -> (Path.t, Path.Build.t) Dune_util.Action.Diff.t -> unit Fiber.t
+val exec
+  :  Loc.t
+  -> patch_back:Path.t option
+  -> (Path.t, Path.Build.t) Dune_util.Action.Diff.t
+  -> unit Fiber.t

--- a/src/dune_engine/print_diff.mli
+++ b/src/dune_engine/print_diff.mli
@@ -3,6 +3,7 @@ open Import
 (** Diff two files that are expected not to match. *)
 val print
   :  skip_trailing_cr:bool
+  -> patch_back:Path.t option
   -> User_message.Diff_annot.t
   -> Path.t
   -> Path.t

--- a/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree.t
@@ -34,6 +34,13 @@ All modified dependencies are promoted
 
   $ echo blah > x
   $ dune build
+  File "x", line 1, characters 0-0:
+  --- x
+  +++ _build/default/x
+  @@ -1 +1 @@
+  -blah
+  +Hello, world!
+  [1]
 
   $ dune trace cat | jq '
   > include "dune";
@@ -82,6 +89,12 @@ All other new files are copied
   > EOF
 
   $ dune build
+  File "y", line 1, characters 0-0:
+  --- y
+  +++ _build/default/y
+  @@ -0,0 +1 @@
+  +Hello, world!
+  [1]
   $ dune promote
   Promoting _build/default/y to y.
   $ cat y
@@ -98,6 +111,12 @@ Directories are created if needed
   > EOF
 
   $ dune build
+  File "z/z", line 1, characters 0-0:
+  --- z/z
+  +++ _build/default/z/z
+  @@ -0,0 +1 @@
+  +Hello, world!
+  [1]
   $ dune promote
   Promoting _build/default/z/z to z/z.
   $ cat z/z
@@ -116,6 +135,13 @@ Actions are allowed to delete files
   > EOF
 
   $ dune build
+  File "dune", lines 1-4, characters 0-96:
+  1 | (rule
+  2 |  (deps foo (sandbox patch_back_source_tree))
+  3 |  (alias default)
+  4 |  (action (system "rm foo")))
+  Error: File foo should be deleted
+  [1]
   $ dune promote
   $ [[ ! -f foo ]] && echo foo has been deleted
   foo has been deleted
@@ -134,6 +160,25 @@ Actions are allowed to delete directories
   > EOF
 
   $ dune build
+  File "dune", lines 1-4, characters 0-116:
+  1 | (rule
+  2 |  (deps todelete/y/foo (sandbox patch_back_source_tree))
+  3 |  (alias default)
+  4 |  (action (system "rm -rf todelete")))
+  Error: Directory todelete should be deleted
+  File "dune", lines 1-4, characters 0-116:
+  1 | (rule
+  2 |  (deps todelete/y/foo (sandbox patch_back_source_tree))
+  3 |  (alias default)
+  4 |  (action (system "rm -rf todelete")))
+  Error: Directory todelete/y should be deleted
+  File "dune", lines 1-4, characters 0-116:
+  1 | (rule
+  2 |  (deps todelete/y/foo (sandbox patch_back_source_tree))
+  3 |  (alias default)
+  4 |  (action (system "rm -rf todelete")))
+  Error: File todelete/y/foo should be deleted
+  [1]
 
   $ dune promote
   $ [[ ! -d todelete ]] && echo todelete has been deleted
@@ -198,12 +243,27 @@ the rule:
   > }
 
   $ test_with copy
+  File "x", line 1, characters 0-0:
+  --- x
+  +++ _build/default/x
+  @@ -0,0 +1 @@
+  +Hello, world!
   Promoting _build/default/x to x.
   Hello, world!
   $ test_with hardlink
+  File "x", line 1, characters 0-0:
+  --- x
+  +++ _build/default/x
+  @@ -0,0 +1 @@
+  +Hello, world!
   Promoting _build/default/x to x.
   Hello, world!
   $ test_with symlink
+  File "x", line 1, characters 0-0:
+  --- x
+  +++ _build/default/x
+  @@ -0,0 +1 @@
+  +Hello, world!
   Promoting _build/default/x to x.
   Hello, world!
 
@@ -227,6 +287,13 @@ If a source file is read-only, the action sees it as writable:
 
   $ dune build
   writable
+  File "x", line 1, characters 0-0:
+  --- x
+  +++ _build/default/x
+  @@ -1 +1 @@
+  -xx
+  +blah
+  [1]
 
 And as the action modified `x`, its permissions have now changed
 inside the source tree:


### PR DESCRIPTION
Whenever we introduce a promotion due to patch back, we fail the action and make sure that a diff is printed. This is consistent with how we handle diffs elsewhere.

This PR is best read after https://github.com/ocaml/dune/pull/13696