### PR TITLE
fix(rev_store): only negotiate with relevant tips

### DIFF
--- a/doc/dev/rev-store.md
+++ b/doc/dev/rev-store.md
@@ -144,21 +144,24 @@ server needs to send. The client tells the server which objects it already has
 this negotiation to work efficiently, Git needs refs pointing to known commits.
 
 Since the revision store is a bare repository without traditional remotes, we
-create refs for each successfully fetched object, namespaced by a hash of the
-source URL:
+create refs for each successfully fetched object, namespaced by an escaped form
+of the source URL:
 
 ```
-refs/dune-pkg/<url-hash>/<object-hash>
+refs/dune-pkg/<escaped-url>/<object-hash>
 ```
 
-The URL hash is the Blake3 digest of the URL. This namespacing ensures that
-when fetching from a remote, only refs from that same remote are used for
-negotiation. Without this, Git would send "have" lines for all objects in the
-revision store, including those from unrelated repositories, which wastes
-bandwidth during the negotiation phase.
+The escaped URL replaces characters that are invalid in git refs or Windows
+filenames (everything except alphanumeric and `-`) with underscores. For
+example, `https://github.com/ocaml/dune.git` becomes
+`https___github_com_ocaml_dune_git`. This namespacing ensures that when fetching
+from a remote, only refs from that same remote are used for negotiation. Without
+this, Git would send "have" lines for all objects in the revision store,
+including those from unrelated repositories, which wastes bandwidth during the
+negotiation phase.
 
-During fetch, we use `--negotiation-tip=refs/dune-pkg/<url-hash>/*` to tell Git
-to only consider refs under the namespace for the URL being fetched. This
+During fetch, we use `--negotiation-tip=refs/dune-pkg/<escaped-url>/*` to tell
+Git to only consider refs under the namespace for the URL being fetched. This
 restricts negotiation to relevant commits only.
 
 These refs accumulate over time but are lightweight (just pointers to existing

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -536,8 +536,13 @@ let rev_parse { dir; _ } rev =
   | _, _ -> None
 ;;
 
+(* Regex matching characters invalid in git refs or Windows filenames.
+   We keep alphanumeric and hyphen, replacing everything else with underscore. *)
+let url_escape_re = Re.(compile (compl [ rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '-' ]))
+let escape_url_for_ref url = Re.replace_string url_escape_re ~by:"_" url
+
 (* Create a ref for a fetched object so git can use it for negotiation.
-   Refs are namespaced by URL: refs/dune-pkg/<url-hash>/<object-hash>.
+   Refs are namespaced by URL: refs/dune-pkg/<escaped-url>/<object-hash>.
    This allows us to use --negotiation-tip during fetch to only send
    refs relevant to the remote being fetched from. *)
 let add_object_ref { dir; _ } ~negotiation_ref_prefix obj =
@@ -765,9 +770,7 @@ let fetch_allow_failure ~env repo ~url obj =
     >>= function
     | true -> Fiber.return `Fetched
     | false ->
-      let negotiation_ref_prefix =
-        Dune_digest.string url |> Dune_digest.to_string |> sprintf "refs/dune-pkg/%s"
-      in
+      let negotiation_ref_prefix = escape_url_for_ref url |> sprintf "refs/dune-pkg/%s" in
       run_with_exit_code
         ~env
         ~allow_codes:(Int.equal 0)

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -21,9 +21,9 @@ let%expect_test "second fetch uses refs for efficient negotiation (fix #13323)" 
      git can negotiate what it already has using refs created by previous
      fetches. This avoids re-downloading objects we already have.
 
-     We also demonstrate that refs from unrelated remotes are currently used
-     for negotiation. This is probably undesirable in the long term - we may
-     want to restrict negotiation to only use refs from the relevant remote. *)
+     We also verify that refs from unrelated remotes are not used for
+     negotiation - each remote's refs are namespaced by URL hash and we use
+     --negotiation-tip to restrict to only the relevant namespace. *)
   let repo_dir = Temp.create Dir ~prefix:"git-repo-" ~suffix:"" in
   let unrelated_repo_dir = Temp.create Dir ~prefix:"git-unrelated-" ~suffix:"" in
   let trace_file = Temp.create File ~prefix:"git-trace-" ~suffix:".log" in
@@ -193,7 +193,7 @@ let%expect_test "second fetch uses refs for efficient negotiation (fix #13323)" 
         Console.print [ Pp.textf "Negotiation 'have' lines sent: %d" have_count ];
         Dune_scheduler.Scheduler.cancel_current_build ()));
   (* With refs created by previous fetches, git can tell the server what it
-     already has, avoiding redundant downloads. The count includes refs from
-     the unrelated remote. *)
-  [%expect {| Negotiation 'have' lines sent: 4 |}]
+     already has, avoiding redundant downloads. The count does not include
+     refs from the unrelated remote due to URL-based namespacing. *)
+  [%expect {| Negotiation 'have' lines sent: 3 |}]
 ;;

--- a/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
+++ b/test/expect-tests/dune_pkg/rev_store_fetch_depth/rev_store_fetch_depth_test.ml
@@ -22,7 +22,7 @@ let%expect_test "second fetch uses refs for efficient negotiation (fix #13323)" 
      fetches. This avoids re-downloading objects we already have.
 
      We also verify that refs from unrelated remotes are not used for
-     negotiation - each remote's refs are namespaced by URL hash and we use
+     negotiation - each remote's refs are namespaced by escaped URL and we use
      --negotiation-tip to restrict to only the relevant namespace. *)
   let repo_dir = Temp.create Dir ~prefix:"git-repo-" ~suffix:"" in
   let unrelated_repo_dir = Temp.create Dir ~prefix:"git-unrelated-" ~suffix:"" in


### PR DESCRIPTION
As discussed in #13671, we restrict how we negotiate from the rev_store to a server to use only the relevant tips.

- Fixes #13671

This is done by name spacing the recorded references by (the hash of) their URL. This way we can provide only the relevant references during negotiation.

This should both speed up negotiation (and hence downloads) and avoid unnecessary communication of rev_store contents.

`--negotiation-tip` is an argument that was introduced in the minimum supported Git version that we currently have.

I've updated the doc/dev/rev_store.md about this new behaviour.

