### PR TITLE
fix(memo): check for self-dependency cycles before blocking on ivar

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -755,14 +755,35 @@ module Computation = struct
     >>= function
     | Some res -> Fiber.return (Ok res)
     | None ->
-      (match (phase : Stack_frame_with_state.phase) with
-       | Restore_from_cache -> Counter.incr Metrics.Restore.blocked
-       | Compute -> Counter.incr Metrics.Compute.blocked);
-      let dag_node = Lazy_dag_node.force dag_node ~dep_node:(Dep_node.T dep_node) in
-      Call_stack.add_path_to ~dag_node
-      >>= (function
-       | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
-       | Error _ as cycle_error -> Fiber.return cycle_error)
+      let dep_node = Dep_node.T dep_node in
+      let* immediate_self_cycle =
+        let+ stack = Call_stack.get_call_stack () in
+        let rec collect_callers_to_dep_node = function
+          | [] -> None
+          | frame :: rest ->
+            let stack_dep_node = Stack_frame_with_state.dep_node frame in
+            if Dep_node.Packed.equal stack_dep_node dep_node
+            then Some []
+            else (
+              match collect_callers_to_dep_node rest with
+              | None -> None
+              | Some callers -> Some (stack_dep_node :: callers))
+        in
+        match collect_callers_to_dep_node stack with
+        | None -> None
+        | Some callers -> Some (dep_node :: callers)
+      in
+      (match immediate_self_cycle with
+       | Some cycle -> Fiber.return (Error cycle)
+       | None ->
+         (match (phase : Stack_frame_with_state.phase) with
+          | Restore_from_cache -> Counter.incr Metrics.Restore.blocked
+          | Compute -> Counter.incr Metrics.Compute.blocked);
+         let dag_node = Lazy_dag_node.force dag_node ~dep_node in
+         Call_stack.add_path_to ~dag_node
+         >>= (function
+          | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
+          | Error _ as cycle_error -> Fiber.return cycle_error))
   ;;
 end
 

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -942,9 +942,9 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               ; backtrace = ""
               }
             ]
-    Memo graph: 8/8/1 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
-    Memo cycle detection graph: 6/5/1 nodes/edges/paths
-  |}];
+    Memo graph: 8/8/0 nodes/edges/blocked (restore), 8/7/0 nodes/edges/blocked (compute)
+    Memo cycle detection graph: 0/0/0 nodes/edges/paths
+    |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_yes_cutoff 0;
   print_metrics ();
@@ -977,9 +977,9 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               ; backtrace = ""
               }
             ]
-    Memo graph: 7/7/1 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
-    Memo cycle detection graph: 6/5/1 nodes/edges/paths
-  |}];
+    Memo graph: 7/7/0 nodes/edges/blocked (restore), 6/6/0 nodes/edges/blocked (compute)
+    Memo cycle detection graph: 0/0/0 nodes/edges/paths
+    |}];
   Memo.Metrics.reset ();
   evaluate_and_print summit_no_cutoff 2;
   print_metrics ();
@@ -1254,11 +1254,15 @@ let%expect_test "cancelling a computing node wakes waiters" =
     Started evaluating B
     Started evaluating C
     Dependency cycle detected:
-    - ("A", ())
+    - ("B", ())
     - called by ("C", ())
+    - called by ("A", ())
     Dependency cycle detected:
     - ("C", ())
     - called by ("A", ())
+    Dependency cycle detected:
+    - ("A", ())
+    - called by ("C", ())
     |}]
 ;;
 
@@ -1310,7 +1314,20 @@ let%expect_test "overlapping cycles with waiters can deadlock" =
     Started evaluating outer_repro
     Started evaluating inner_repro
     Started evaluating join_repro
-    Deadlock!
+    Dependency cycle detected:
+    - ("join_repro", ())
+    - called by ("inner_repro", ())
+    - called by ("outer_repro", ())
+    Dependency cycle detected:
+    - ("join_repro", ())
+    - called by ("inner_repro", ())
+    Dependency cycle detected:
+    - ("inner_repro", ())
+    - called by ("outer_repro", ())
+    - called by ("join_repro", ())
+    Dependency cycle detected:
+    - ("inner_repro", ())
+    - called by ("join_repro", ())
     |}]
 ;;
 


### PR DESCRIPTION
fixes #5771 