### PR TITLE
Dune cache: use hard links on Windows

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -455,33 +455,30 @@ let portable_hardlink ~src ~dst =
       ; User_error.reason (Pp.verbatim msg)
       ]
   in
-  (* CR-someday amokhov: Instead of always falling back to copying, we could
-     detect if hardlinking works on Windows and if yes, use it. We do this in
-     the Dune cache implementation, so we can share some code. *)
-  match Stdlib.Sys.win32 with
-  | true -> copy_file ~src ~dst ()
-  | false ->
-    let src =
-      match Fpath.follow_symlink (Path.to_string src) with
-      | Ok path -> Path.of_string path
-      | Error Not_a_symlink -> src
-      | Error Max_depth_exceeded ->
-        user_error "Too many indirections; is this a cyclic symbolic link?"
-      | Error (Unix_error error) -> user_error (Unix_error.Detailed.to_string_hum error)
-    in
-    (try Fpath.link (Path.to_string src) (Path.to_string dst) with
-     | Unix.Unix_error (Unix.EEXIST, _, _) ->
-       (* CR-someday amokhov: Investigate why we need to occasionally clear the
-          destination (we also do this in the symlink case above). Perhaps, the
-          list of dependencies may have duplicates? If yes, it may be better to
-          filter out the duplicates first. *)
-       let src = Path.to_string src in
-       let dst = Path.to_string dst in
-       Fpath.unlink_exn dst;
-       Fpath.link src dst
-     | Unix.Unix_error (Unix.EMLINK, _, _) ->
-       (* If we can't make a new hard link because we reached the limit on the
-          number of hard links per file, we fall back to copying. We expect
-          that this happens very rarely (probably only for empty files). *)
-       copy_file ~src ~dst ())
+  let src =
+    match Fpath.follow_symlink (Path.to_string src) with
+    | Ok path -> Path.of_string path
+    | Error Not_a_symlink -> src
+    | Error Max_depth_exceeded ->
+      user_error "Too many indirections; is this a cyclic symbolic link?"
+    | Error (Unix_error error) -> user_error (Unix_error.Detailed.to_string_hum error)
+  in
+  try Fpath.link (Path.to_string src) (Path.to_string dst) with
+  | Unix.Unix_error (Unix.EEXIST, _, _) ->
+    (* CR-someday amokhov: Investigate why we need to occasionally clear the
+        destination (we also do this in the symlink case above). Perhaps, the
+        list of dependencies may have duplicates? If yes, it may be better to
+        filter out the duplicates first. *)
+    let src = Path.to_string src in
+    let dst = Path.to_string dst in
+    Fpath.unlink_exn dst;
+    Fpath.link src dst
+  | Unix.Unix_error (Unix.EINVAL, _, _)
+  (* If the file system do not support hard links. Should not really happen in
+      practice (NTFS and ReFS do support hard links on windows.) *)
+  | Unix.Unix_error (Unix.EMLINK, _, _) ->
+    (* If we can't make a new hard link because we reached the limit on the
+        number of hard links per file, we fall back to copying. We expect
+        that this happens very rarely (probably only for empty files). *)
+    copy_file ~src ~dst ()
 ;;

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -39,15 +39,8 @@
  (timeout 60))
 
 (cram
- (applies_to windows-diff github6644 dedup mode-hardlink)
+ (applies_to windows-diff github6644)
  (alias runtest-windows))
-
-(subdir
- dune-cache
- (cram
-  (applies_to dedup mode-hardlink)
-  (alias runtest-windows))
-)
 
 ;; DISABLED TESTS
 

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -39,8 +39,15 @@
  (timeout 60))
 
 (cram
- (applies_to windows-diff github6644)
+ (applies_to windows-diff github6644 dedup mode-hardlink)
  (alias runtest-windows))
+
+(subdir
+ dune-cache
+ (cram
+  (applies_to dedup mode-hardlink)
+  (alias runtest-windows))
+)
 
 ;; DISABLED TESTS
 

--- a/test/blackbox-tests/test-cases/dune-cache/dedup.t
+++ b/test/blackbox-tests/test-cases/dune-cache/dedup.t
@@ -1,7 +1,7 @@
 Test deduplication of build artifacts when using Dune cache with hard links.
 
   $ export DUNE_CACHE=enabled
-  $ export DUNE_CACHE_ROOT=$PWD/.cache
+  $ export DUNE_CACHE_ROOT=$(dune_cmd native-path $PWD/.cache)
 
   $ cat > dune-project <<EOF
   > (lang dune 2.1)

--- a/test/blackbox-tests/test-cases/dune-cache/dune
+++ b/test/blackbox-tests/test-cases/dune-cache/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to dedup mode-hardlink)
+ (alias runtest-windows))

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -3,8 +3,8 @@ Test basic cache store/restore functionality in the default [hardlink] mode.
 Dune supports setting the cache directory in two ways, via the [XDG_CACHE_HOME]
 variable, and via the [DUNE_CACHE_ROOT] variable. Here we test the former.
 
-  $ export XDG_RUNTIME_DIR=$PWD/.xdg-runtime
-  $ export XDG_CACHE_HOME=$PWD/.xdg-cache
+  $ export XDG_RUNTIME_DIR=$(dune_cmd native-path $PWD/.xdg-runtime)
+  $ export XDG_CACHE_HOME=$(dune_cmd native-path $PWD/.xdg-cache)
 
   $ cat > config <<EOF
   > (lang dune 2.1)

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -58,6 +58,38 @@ module Stat = struct
   let () = register name of_args run
 end
 
+module NativePath = struct
+  let name = "native-path"
+
+  let native_path =
+    if not Sys.win32
+    then fun fn -> print_endline fn
+    else
+      fun fn ->
+        let cygpath =
+          let path = Env_path.path Env.initial in
+          Bin.which ~path "cygpath"
+        in
+        match cygpath with
+        | None -> User_error.raise [ Pp.text "Unable to find cygpath in PATH" ]
+        | Some cygpath ->
+          let cygpath = Path.to_string cygpath in
+          ignore
+            (Unix.create_process
+               cygpath
+               [|cygpath; "-wl"; fn|]
+               Unix.stdin
+               Unix.stdout
+               Unix.stderr)
+
+  let of_args = function
+    | [fn] -> fn
+    | _ -> raise (Arg.Bad ("Usage: dune_cmd " ^ name ^ " <path>"))
+
+  let run fn = native_path fn
+  let () = register name of_args run
+end
+
 module Wait_for_fs_clock_to_advance = struct
   let name = "wait-for-fs-clock-to-advance"
 

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -77,14 +77,16 @@ module NativePath = struct
           ignore
             (Unix.create_process
                cygpath
-               [|cygpath; "-wl"; fn|]
+               [| cygpath; "-wl"; fn |]
                Unix.stdin
                Unix.stdout
                Unix.stderr)
+  ;;
 
   let of_args = function
-    | [fn] -> fn
+    | [ fn ] -> fn
     | _ -> raise (Arg.Bad ("Usage: dune_cmd " ^ name ^ " <path>"))
+  ;;
 
   let run fn = native_path fn
   let () = register name of_args run


### PR DESCRIPTION
The `Io.portable_hardlink` function was systematically copying files on Windows instead of trying to create hard links. Hard links have been available for a while on NTFS and have also been available for ReFS for a coupe of years. This availability is not tied to developer mode capabilities (unlike symlinks), which means we can generally expect a Windows environment to be able to create hard links.

This PR removes the systematic copy and adds the `EINVAL` error as a fallback signal in case Dune tries to create a hard link on a filesystem that does not support it. The later reduces the risk of a breaking change. Note that a copy fallback could be used when a cross-filesystem link is attempted (resulting in an `EXDEV` error), but this hasn't been added since the same error can happen on Unix and is already unhandled there.

This change completely fixes the `dedup.t` test on Windows. 

This change also seems to address excessive cache duplication encountered on windows (see #13713).