### PR TITLE
test(pkg): clean up unknown variable in depext test

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
+++ b/test/blackbox-tests/test-cases/pkg/depexts/unknown-variable.t
@@ -1,24 +1,23 @@
 Solving with an unknown variable on depexts:
 
   $ mkrepo
-  $ add_mock_repo_if_needed
 
 The "foobar" variable is not defined:
   $ mkpkg foo <<EOF
   > depexts: [[ "unzip" ] {foobar}]
   > EOF
 
-Make a project that uses the foo library:
-  $ cat > dune-project <<EOF
+Make a project that uses the foo library. Locking should succeed and not include
+the "unzip" package since the filter variable is undefined.
+
+  $ solve_project <<EOF
   > (lang dune 3.13)
   > (package
   >  (name bar)
   >  (depends foo))
   > EOF
-
-Locking should succeed and not include the "unzip" package
-  $ dune pkg lock 2>&1 | head -n 1
-  Solution for dune.lock
+  Solution for dune.lock:
+  - foo.0.0.1
 
   $ cat ${default_lock_dir}/foo.0.0.1.pkg
   (version 0.0.1)


### PR DESCRIPTION
Cleaning up and clarifying this test case. Is a repro/demo of #13699. Seems that this behaviour match was missed in #12680.

Fix will follow.