### PR TITLE
Set Git configuration to default during tests ~~Disable GPG signing tags during tests~~

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -73,6 +73,9 @@ export GIT_AUTHOR_NAME="Test Name"
 export GIT_AUTHOR_EMAIL="test@example.com"
 export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
 export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+# Set various GIT variables to ensure git behaves as "default" as possible in the tests
+export GIT_CONFIG_GLOBAL="/dev/null"
+export GIT_CONFIG_SYSTEM="/dev/null"
 
 export DUNE_RUNNING=0
 


### PR DESCRIPTION
When running the tests on a clean `main` branch, I ran into some issues related to lightweight `git tag` commands. In particular, because I have `tag.gpgSign` set globally, it always expects a message and breaks the tests.

For example: 
https://github.com/ocaml/dune/blob/86928708c8e7eb8d689067f1be4a2186b90a9c83/test/blackbox-tests/test-cases/pkg/opam-repository-download.t#L161
Would try to open my `git.config.core.editor` and break the rest of the test:
```
+|  Vim: Warning: Output is not to a terminal
+|  Vim: Warning: Input is not from a terminal
<pkg/mock-opam-repository/.git/TAG_EDITMSG" 5L, 81B  1                                                                               2 #
+|    3 # Write a message for tag:
+|    4 #   1.0
+|    5 # Lines starting with '#' will be ignored.
+|  ~                                                                               Vim: Error reading input, exiting...
+|  Vim: Finished.
+|   with the editor 'vim'.
+|  Please supply the message using either -m or -F option.
+|  [1]
```

-----------------------

Not sure if this is a problem that I should just be solving locally, but the change is relatively minimal so I thought I'd open this and at least it can be documented for those who might encounter it in the future.