### PR TITLE
test(pkg): disable ocamlformat-patch-extra-files.t

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
+++ b/test/blackbox-tests/test-cases/pkg/ocamlformat/dune
@@ -7,6 +7,8 @@
  (applies_to ocamlformat-e2e))
 
 (cram
+ ; Disabled due to racey nature of dev tools
+ (enabled_if false)
  (deps %{bin:md5sum})
  (applies_to ocamlformat-patch-extra-files))
 


### PR DESCRIPTION
This test breaks when we tweak the build order of the lock directory. This is due to the dev tools relying on some racey behaviour when setting up. This should be fixed eventually but for now can be avoided by disabling the test.

- pr where this will break #13595 
- pr where this will be fixed #13648 