### PR TITLE
fix(rocq): add error handling and hints for Rocq modules duplication

### DIFF
--- a/doc/changes/fixed/13733.md
+++ b/doc/changes/fixed/13733.md
@@ -1,0 +1,3 @@
+- Fix an internal error when a module is shared between a `rocq.theory` and
+  `rocq.extraction` stanza. The error now includes a hint pointing to the
+  conflicting stanza. (#13733, @Durbatuluk1701)

--- a/src/dune_rules/rocq/rocq_sources.ml
+++ b/src/dune_rules/rocq/rocq_sources.ml
@@ -94,36 +94,33 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
   check_no_unqualified include_subdirs;
   let modules = rocq_modules_of_files ~dirs in
   let expected_files = expected_files_of_dirs ~dirs in
-  let acc_rev_map e acc m =
-    let loc =
-      match e with
-      | `Theory rocq -> rocq.Theory.buildable.loc
-      | `Extraction extr -> extr.Extraction.buildable.loc
-    in
+  let extend_rev_map e acc m =
     Rocq_module.Map.add acc m e
     |> function
     | Ok rev_map -> rev_map
-    | Error e ->
-      User_error.raise
-        ~loc
-        ~hints:
-          (match e with
-           | `Theory thry ->
-             [ Pp.textf
-                 "The Rocq module %S is already defined in theory stanza %S."
-                 (Rocq_module.name m |> Rocq_module.Name.to_string)
-                 (thry.Theory.name |> snd |> Rocq_lib_name.to_string)
-             ]
-           | `Extraction extr ->
-             [ Pp.textf
-                 "The Rocq module %S is already defined in extraction stanza %S."
-                 (Rocq_module.name m |> Rocq_module.Name.to_string)
-                 (extr.Extraction.prelude |> snd |> Rocq_module.Name.to_string)
-             ])
+    | Error prev_e ->
+      let conf_mod_name = Rocq_module.name m |> Rocq_module.Name.to_string in
+      let loc =
+        match e with
+        | `Theory rocq -> rocq.Theory.buildable.loc
+        | `Extraction extr -> extr.Extraction.buildable.loc
+      in
+      let hints =
+        let stanza_ty, stanza_name =
+          match prev_e with
+          | `Theory ({ name = _, lib_name; _ } : Theory.t) ->
+            "rocq.theory", Rocq_lib_name.to_string lib_name
+          | `Extraction ({ prelude = _, mod_name; _ } : Extraction.t) ->
+            "rocq.extraction", Rocq_module.Name.to_string mod_name
+        in
         [ Pp.textf
-            "Duplicate Rocq module %S."
-            (Rocq_module.name m |> Rocq_module.Name.to_string)
+            "The Rocq module %S is already covered by %s stanza %S."
+            conf_mod_name
+            stanza_ty
+            stanza_name
         ]
+      in
+      User_error.raise ~loc ~hints [ Pp.textf "Duplicate Rocq module %S." conf_mod_name ]
   in
   List.fold_left stanzas ~init:{ empty with expected_files } ~f:(fun acc stanza ->
     match Stanza.repr stanza with
@@ -137,7 +134,7 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
       in
       let libraries = Rocq_lib_name.Map.add_exn acc.libraries (snd rocq.name) modules in
       let rev_map =
-        List.fold_left modules ~init:acc.rev_map ~f:(acc_rev_map (`Theory rocq))
+        List.fold_left modules ~init:acc.rev_map ~f:(extend_rev_map (`Theory rocq))
       in
       { acc with directories; libraries; rev_map }
     | Extraction.T extr ->
@@ -154,7 +151,7 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
             [ Pp.text "no Rocq source corresponding to prelude field" ]
       in
       let extract = Loc.Map.add_exn acc.extract extr.buildable.loc m in
-      let rev_map = acc_rev_map (`Extraction extr) acc.rev_map m in
+      let rev_map = extend_rev_map (`Extraction extr) acc.rev_map m in
       { acc with extract; rev_map }
     | _ -> acc)
 ;;

--- a/src/dune_rules/rocq/rocq_sources.ml
+++ b/src/dune_rules/rocq/rocq_sources.ml
@@ -94,6 +94,37 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
   check_no_unqualified include_subdirs;
   let modules = rocq_modules_of_files ~dirs in
   let expected_files = expected_files_of_dirs ~dirs in
+  let acc_rev_map e acc m =
+    let loc =
+      match e with
+      | `Theory rocq -> rocq.Theory.buildable.loc
+      | `Extraction extr -> extr.Extraction.buildable.loc
+    in
+    Rocq_module.Map.add acc m e
+    |> function
+    | Ok rev_map -> rev_map
+    | Error e ->
+      User_error.raise
+        ~loc
+        ~hints:
+          (match e with
+           | `Theory thry ->
+             [ Pp.textf
+                 "The Rocq module %S is already defined in theory stanza %S."
+                 (Rocq_module.name m |> Rocq_module.Name.to_string)
+                 (thry.Theory.name |> snd |> Rocq_lib_name.to_string)
+             ]
+           | `Extraction extr ->
+             [ Pp.textf
+                 "The Rocq module %S is already defined in extraction stanza %S."
+                 (Rocq_module.name m |> Rocq_module.Name.to_string)
+                 (extr.Extraction.prelude |> snd |> Rocq_module.Name.to_string)
+             ])
+        [ Pp.textf
+            "Duplicate Rocq module %S."
+            (Rocq_module.name m |> Rocq_module.Name.to_string)
+        ]
+  in
   List.fold_left stanzas ~init:{ empty with expected_files } ~f:(fun acc stanza ->
     match Stanza.repr stanza with
     | Theory.T rocq ->
@@ -106,17 +137,7 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
       in
       let libraries = Rocq_lib_name.Map.add_exn acc.libraries (snd rocq.name) modules in
       let rev_map =
-        List.fold_left modules ~init:acc.rev_map ~f:(fun acc m ->
-          Rocq_module.Map.add acc m (`Theory rocq)
-          |> function
-          | Ok acc -> acc
-          | Error _ ->
-            User_error.raise
-              ~loc:rocq.buildable.loc
-              [ Pp.textf
-                  "Duplicate Rocq module %S."
-                  (Rocq_module.name m |> Rocq_module.Name.to_string)
-              ])
+        List.fold_left modules ~init:acc.rev_map ~f:(acc_rev_map (`Theory rocq))
       in
       { acc with directories; libraries; rev_map }
     | Extraction.T extr ->
@@ -133,7 +154,7 @@ let of_dir stanzas ~dir ~include_subdirs ~dirs =
             [ Pp.text "no Rocq source corresponding to prelude field" ]
       in
       let extract = Loc.Map.add_exn acc.extract extr.buildable.loc m in
-      let rev_map = Rocq_module.Map.add_exn acc.rev_map m (`Extraction extr) in
+      let rev_map = acc_rev_map (`Extraction extr) acc.rev_map m in
       { acc with extract; rev_map }
     | _ -> acc)
 ;;

--- a/test/blackbox-tests/test-cases/rocq/extraction/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extract.t
@@ -75,7 +75,7 @@
   Promoting _build/default/extract.output to extract.expected.
   $ dune runtest
 
-Helpful message on theory then extraction module duplication
+Make sure that the error message is helpful if a module is both covered by a theory and an extraction stanza.
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
   > (using rocq 0.12)
@@ -105,11 +105,11 @@ Helpful message on theory then extraction module duplication
   4 |  (prelude extract)
   5 |  (extracted_modules Datatypes extract))
   Error: Duplicate Rocq module "extract".
-  Hint: The Rocq module "extract" is already defined in theory stanza
+  Hint: The Rocq module "extract" is already covered by rocq.theory stanza
   "TestExtr".
   [1]
 
-Helpful message on extraction then theory module duplication
+Make sure that the error message is helpful if a module is both covered by an extraction and a theory stanza.
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
   > (using rocq 0.12)
@@ -138,6 +138,6 @@ Helpful message on extraction then theory module duplication
   4 | (rocq.theory
   5 |  (name TestExtr))
   Error: Duplicate Rocq module "extract".
-  Hint: The Rocq module "extract" is already defined in extraction stanza
+  Hint: The Rocq module "extract" is already covered by rocq.extraction stanza
   "extract".
   [1]

--- a/test/blackbox-tests/test-cases/rocq/extraction/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extract.t
@@ -74,3 +74,70 @@
   $ dune promote
   Promoting _build/default/extract.output to extract.expected.
   $ dune runtest
+
+Helpful message on theory then extraction module duplication
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.12)
+  > EOF
+
+  $ cat >extract.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Separate Extraction nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.theory
+  >  (name TestExtr))
+  > (rocq.extraction
+  >  (prelude extract)
+  >  (extracted_modules Datatypes extract))
+  > EOF
+  $ dune build
+  File "dune", lines 3-5, characters 0-75:
+  3 | (rocq.extraction
+  4 |  (prelude extract)
+  5 |  (extracted_modules Datatypes extract))
+  Error: Duplicate Rocq module "extract".
+  Hint: The Rocq module "extract" is already defined in theory stanza
+  "TestExtr".
+  [1]
+
+Helpful message on extraction then theory module duplication
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.12)
+  > EOF
+
+  $ cat >extract.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Separate Extraction nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extract)
+  >  (extracted_modules Datatypes extract))
+  > (rocq.theory
+  >  (name TestExtr))
+  > EOF
+  $ dune build
+  File "dune", lines 4-5, characters 0-30:
+  4 | (rocq.theory
+  5 |  (name TestExtr))
+  Error: Duplicate Rocq module "extract".
+  Hint: The Rocq module "extract" is already defined in extraction stanza
+  "extract".
+  [1]

--- a/test/blackbox-tests/test-cases/rocq/theory-stanza-duplicate-module.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/theory-stanza-duplicate-module.t/run.t
@@ -12,5 +12,5 @@ Dune should warn about duplicate modules declared inside a rocq.theory stanza
   2 |  (name foo)
   3 |  (modules foo bar foo))
   Error: Duplicate Rocq module "foo".
-  Hint: The Rocq module "foo" is already defined in theory stanza "foo".
+  Hint: The Rocq module "foo" is already covered by rocq.theory stanza "foo".
   [1]

--- a/test/blackbox-tests/test-cases/rocq/theory-stanza-duplicate-module.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/theory-stanza-duplicate-module.t/run.t
@@ -12,4 +12,5 @@ Dune should warn about duplicate modules declared inside a rocq.theory stanza
   2 |  (name foo)
   3 |  (modules foo bar foo))
   Error: Duplicate Rocq module "foo".
+  Hint: The Rocq module "foo" is already defined in theory stanza "foo".
   [1]


### PR DESCRIPTION
Currently, if a `rocq.theory` stanza and `rocq.extraction` stanza use the same `module`, we can encounter an error due to the attempted duplicate add:
```
$ dune build
Internal error! Please report to https://github.com/ocaml/dune/issues,
providing the file _build/trace.csexp, if possible. This includes build
commands, message logs, and file paths.
Description:
  ("Map.add_exn: key already exists",
   { key =
       { source = In_build_dir "default/theories/FactExtr.v"
       ; prefix = []
       ; name = "FactExtr"
       }
   })
```

This PR addresses the issue by not performing an `add_exn`, as well as adding `hints` to the raised errors to provide more helpful guidance.

<details>
<summary>Example Code</summary>
Not quite "minimal" example but hopefully good enough. 
Also note: this dune file will still not *fully* compile as there seems to be some issue with having a theory and extraction in the same folder?

`FactProg.v`:
```
From Stdlib Require Import Lia.

Fixpoint fact (n : nat) : nat :=
  match n with
  | 0 => 1
  | S n' => n * fact n'
  end.

Fixpoint fact_tail (acc : nat) (n : nat) : nat :=
  match n with
  | 0 => acc
  | S n' => fact_tail (acc * n) n'
  end.
```

`FactExtr.v`:
```
Require Import FactProg.

Require Extraction.
Separate Extraction fact_tail.
```

`dune`:
```
(include_subdirs qualified)

(rocq.theory
 (name TestPkg)
 (package test-pkg)
 (theories Stdlib)
 (synopsis "A test package"))

(rocq.extraction
 (prelude FactExtr)
 (theories Stdlib)
 (extracted_modules FactProg Datatypes Nat))
 ```

</details>