### PR TITLE
Place default trace file in the build directory

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -62,19 +62,17 @@ let default_build_dir = "_build"
 let trace_file_name = "trace.csexp"
 
 let find_default_trace_file () =
-  let root =
-    Workspace_root.create
-      ~from:Filename.current_dir_name
-      ~default_is_cwd:true
-      ~specified_by_user:None
-      ()
+  let trace_file = Filename.concat default_build_dir trace_file_name in
+  let cwd = Sys.getcwd () in
+  let rec loop dir =
+    let candidate = Filename.concat dir trace_file in
+    if Sys.file_exists candidate
+    then candidate
+    else (
+      let parent = Filename.dirname dir in
+      if parent = dir then Filename.concat cwd trace_file else loop parent)
   in
-  let root_dir =
-    match root with
-    | Some root -> root.dir
-    | None -> Filename.current_dir_name
-  in
-  Filename.concat (Filename.concat root_dir default_build_dir) trace_file_name
+  loop cwd
 ;;
 
 module Package = Dune_lang.Package

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -58,7 +58,24 @@ open struct
   module Manpage = Manpage
 end
 
-let default_trace_file = Path.Local.of_string "_build/trace.csexp"
+let default_build_dir = "_build"
+let trace_file_name = "trace.csexp"
+
+let find_default_trace_file () =
+  let root =
+    Workspace_root.create
+      ~from:Filename.current_dir_name
+      ~default_is_cwd:true
+      ~specified_by_user:None
+      ()
+  in
+  let root_dir =
+    match root with
+    | Some root -> root.dir
+    | None -> Filename.current_dir_name
+  in
+  Filename.concat (Filename.concat root_dir default_build_dir) trace_file_name
+;;
 
 module Package = Dune_lang.Package
 open Let_syntax
@@ -74,8 +91,6 @@ let debug_backtraces =
         ~docs:copts_sect
         ~doc:(Some "Always print exception backtraces."))
 ;;
-
-let default_build_dir = "_build"
 
 let one_of term1 term2 =
   Term.ret
@@ -584,7 +599,7 @@ module Builder = struct
     ; watch_exclusions : string list
     ; build_dir : string
     ; root : string option
-    ; trace_file : string option
+    ; trace_file : [ `Default | `User_specified of string ] option
     ; allow_builds : bool
     ; default_root_is_cwd : bool
     ; target_exec : string option
@@ -614,7 +629,7 @@ module Builder = struct
     Buffer.contents b
   ;;
 
-  let make_term ~trace ~allow_pkg_flag =
+  let make_term ~(trace : bool) ~allow_pkg_flag =
     let docs = copts_sect in
     let+ config_from_command_line = shared_with_config_file ~allow_pkg_flag
     and+ debug_dep_path =
@@ -793,7 +808,7 @@ module Builder = struct
     and+ trace_file =
       Arg.(
         value
-        & opt (some string) trace
+        & opt (some string) None
         & info
             [ "trace-file" ]
             ~docs
@@ -952,21 +967,18 @@ module Builder = struct
     ; watch_exclusions
     ; build_dir = Option.value ~default:default_build_dir build_dir
     ; root
-    ; trace_file
+    ; trace_file =
+        (match trace_file with
+         | Some s -> Some (`User_specified s)
+         | None -> if trace then Some `Default else None)
     ; allow_builds = true
     ; default_root_is_cwd = false
     ; target_exec
     }
   ;;
 
-  let term_no_trace_no_pkg = make_term ~trace:None ~allow_pkg_flag:false
-
-  let term =
-    make_term
-      ~trace:(Some (Stdune.Path.Local.to_string default_trace_file))
-      ~allow_pkg_flag:true
-  ;;
-
+  let term_no_trace_no_pkg = make_term ~trace:false ~allow_pkg_flag:false
+  let term = make_term ~trace:true ~allow_pkg_flag:true
   let default = Term.eval_no_args_empty_env term
 
   let equal
@@ -1029,7 +1041,14 @@ module Builder = struct
     && List.equal String.equal t.watch_exclusions watch_exclusions
     && String.equal t.build_dir build_dir
     && Option.equal String.equal t.root root
-    && Option.equal String.equal t.trace_file trace_file
+    && Option.equal
+         (fun a b ->
+            match a, b with
+            | `Default, `Default -> true
+            | `User_specified a, `User_specified b -> String.equal a b
+            | _ -> false)
+         t.trace_file
+         trace_file
     && Bool.equal t.allow_builds allow_builds
     && Bool.equal t.default_root_is_cwd default_root_is_cwd
     && Option.equal String.equal t.target_exec target_exec
@@ -1171,20 +1190,24 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   let () =
     match builder.trace_file with
     | None -> Log.init No_log_file
-    | Some stats ->
+    | Some trace_config ->
       (match
          (* For default location, try to acquire lock first to avoid corrupting
            an existing trace from another dune process *)
-         if String.equal stats (Stdune.Path.Local.to_string default_trace_file)
-         then (
-           match Global_lock.lock ~timeout:None with
-           | Ok () -> `Create
-           | Error _ -> `Skip)
-         else `Create
+         match trace_config with
+         | `Default ->
+           (match Global_lock.lock ~timeout:None with
+            | Ok () -> `Create
+            | Error _ -> `Skip)
+         | `User_specified _ -> `Create
        with
        | `Skip -> Log.init No_log_file
        | `Create ->
-         let trace = Path.of_filename_relative_to_initial_cwd stats in
+         let trace =
+           match trace_config with
+           | `Default -> Path.build (Path.Build.relative Path.Build.root trace_file_name)
+           | `User_specified stats -> Path.of_filename_relative_to_initial_cwd stats
+         in
          Path.parent trace |> Option.iter ~f:Path.mkdir_p;
          let stats = Dune_trace.Out.create trace in
          Dune_trace.set_global stats;

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -1,5 +1,4 @@
 open Dune_config_file
-open Stdune
 
 type t
 
@@ -20,7 +19,7 @@ val watch_exclusions : t -> string list
 val watch : t -> Dune_rpc_impl.Watch_mode_config.t
 val file_watcher : t -> Dune_scheduler.Scheduler.Run.file_watcher
 val prefix_target : t -> string -> string
-val default_trace_file : Path.Local.t
+val find_default_trace_file : unit -> string
 
 (** [Builder] describes how to initialize Dune. *)
 module Builder : sig

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -264,7 +264,7 @@ let cat =
     let trace_file =
       match trace_file with
       | Some s -> s
-      | None -> Path.Local.to_string Common.default_trace_file
+      | None -> Common.find_default_trace_file ()
     in
     if follow
     then iter_sexps_follow trace_file ~f:print_with_flush
@@ -294,7 +294,7 @@ let commands =
     let trace_file =
       match trace_file with
       | Some s -> s
-      | None -> Path.Local.to_string Common.default_trace_file
+      | None -> Common.find_default_trace_file ()
     in
     iter_sexps trace_file ~f:(fun sexp ->
       match parse_process_event sexp with

--- a/doc/changes/fixed/13735.md
+++ b/doc/changes/fixed/13735.md
@@ -1,0 +1,3 @@
+- Place the default trace file inside the build directory at the
+  workspace root, rather than relative to the current directory.
+  (#13735, @vouillon)

--- a/test/blackbox-tests/test-cases/custom-build-dir.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-build-dir.t/run.t
@@ -2,6 +2,7 @@
   _foobar
   _foobar/default
   _foobar/default/foo
+  _foobar/trace.csexp
 
   $ rm -rf _foobar
 
@@ -34,6 +35,7 @@ Test with build directory being an absolute path
   build
   build/default
   build/default/foo
+  build/trace.csexp
 
   $ rm -rf build
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -77,7 +77,7 @@ Dune should be able to find it too
   Entering directory 'app'
   Leaving directory 'app'
 
-  $ dune trace cat | jq '
+  $ dune trace cat --trace-file app/_build/trace.csexp | jq '
   > include "dune";
   >    processes
   > | .args

--- a/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec/exec-cmd.t/run.t
@@ -29,4 +29,3 @@
   $ ls -a test/_build
   .
   ..
-  trace.csexp

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -111,7 +111,7 @@ But when lang dune is 3.3 or higher the warning becomes an error:
   Entering directory 'outer'
   Leaving directory 'outer'
 
-  $ dune trace cat | jq 'include "dune";
+  $ dune trace cat --trace-file outer/_build/trace.csexp | jq 'include "dune";
   >   processes
   > | .args
   > | select(.target_files and (.target_files | any(contains(".cmx"))))

--- a/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/compose-installed-compat.t/run.t
@@ -48,7 +48,7 @@ Next we go into our Dune project and build it.
 
 Now we check the flags that were passed to coqdep and coqc:
 
-  $ dune trace cat | jq 'include "dune"; coqcCoqdepFlags'
+  $ dune trace cat --trace-file A/_build/trace.csexp | jq 'include "dune"; coqcCoqdepFlags'
   {
     "name": "rocq",
     "args": [

--- a/test/blackbox-tests/test-cases/rocq/coq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coq/compose-installed-compat.t/run.t
@@ -58,7 +58,7 @@ Next we go into our Dune project and build it.
 
 Now we check the flags that were passed to coqdep and coqc:
 
-  $ dune trace cat | jq 'include "dune"; rocqFlags'
+  $ dune trace cat --trace-file A/_build/trace.csexp | jq 'include "dune"; rocqFlags'
   {
     "name": "coqc",
     "args": [

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/compose-installed-compat.t/run.t
@@ -50,7 +50,7 @@ Next we go into our Dune project and build it.
 
 Now we check the flags that were passed to coqdep and coqc:
 
-  $ dune trace cat | jq 'include "dune"; coqcCoqdepFlags'
+  $ dune trace cat --trace-file A/_build/trace.csexp | jq 'include "dune"; coqcCoqdepFlags'
   {
     "name": "rocq",
     "args": [

--- a/test/blackbox-tests/test-cases/trace/trace-subdir.t
+++ b/test/blackbox-tests/test-cases/trace/trace-subdir.t
@@ -1,0 +1,33 @@
+Test that trace files are written to the correct location when running dune from
+a subdirectory.
+
+  $ make_dune_project 3.21
+  $ mkdir -p src
+
+Run dune build from the subdirectory:
+
+  $ (cd src && dune build --root ..)
+  Entering directory '..'
+  Leaving directory '..'
+
+Check that the trace file is not written in the incorrect location:
+(Currently this is the case)
+
+  $ test -f src/_build/trace.csexp
+
+The trace file should be written in the correct location:
+(Currently this is not the case)
+
+  $ test -f _build/trace.csexp
+  [1]
+
+dune trace cat should work from both the root and subdirectory:
+
+  $ dune trace cat | jq 'select(.name == "exit") | {name}'
+  Error: _build/trace.csexp: No such file or directory
+  [1]
+
+  $ (cd src && dune trace cat | jq 'select(.name == "exit") | {name}')
+  {
+    "name": "exit"
+  }

--- a/test/blackbox-tests/test-cases/trace/trace-subdir.t
+++ b/test/blackbox-tests/test-cases/trace/trace-subdir.t
@@ -11,23 +11,21 @@ Run dune build from the subdirectory:
   Leaving directory '..'
 
 Check that the trace file is not written in the incorrect location:
-(Currently this is the case)
 
   $ test -f src/_build/trace.csexp
+  [1]
 
 The trace file should be written in the correct location:
-(Currently this is not the case)
 
   $ test -f _build/trace.csexp
-  [1]
 
 dune trace cat should work from both the root and subdirectory:
 
   $ dune trace cat | jq 'select(.name == "exit") | {name}'
-  Error: _build/trace.csexp: No such file or directory
-  [1]
-
-  $ (cd src && dune trace cat | jq 'select(.name == "exit") | {name}')
   {
     "name": "exit"
   }
+
+  $ (cd src && dune trace cat | jq 'select(.name == "exit") | {name}')
+  Error: ./_build/trace.csexp: No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/trace/trace-subdir.t
+++ b/test/blackbox-tests/test-cases/trace/trace-subdir.t
@@ -27,5 +27,6 @@ dune trace cat should work from both the root and subdirectory:
   }
 
   $ (cd src && dune trace cat | jq 'select(.name == "exit") | {name}')
-  Error: ./_build/trace.csexp: No such file or directory
-  [1]
+  {
+    "name": "exit"
+  }


### PR DESCRIPTION
The default trace file path was hardcoded to `_build/trace.csexp`, resolved relative to the initial working directory. This meant it could end up outside the build directory when invoking dune from a subdirectory or when using a custom `--build-dir`.

Use `Path.Build.root` to resolve the default trace file path, placing it correctly inside the workspace's build directory. `dune trace cat` and `dune trace commands` now also find the trace file at the workspace root.