### PR TITLE
chore: skip install tests for dune-action-trace

### DIFF
--- a/opam/dune
+++ b/opam/dune
@@ -45,3 +45,9 @@
 
 (rule
  (copy dune-private-libs.opam.template top-closure.opam.template))
+
+; FIXME(shonfeder): workaround for broken `--with-test` installation
+; see https://github.com/ocaml/dune/issues/13732
+
+(rule
+ (copy dune-private-libs.opam.template dune-action-trace.opam.template))

--- a/opam/dune-action-trace.opam
+++ b/opam/dune-action-trace.opam
@@ -14,6 +14,8 @@ depends: [
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -24,9 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocaml/dune.git"
-x-maintenance-intent: ["none"]


### PR DESCRIPTION
Workaround for https://github.com/ocaml/dune/issues/13732

this workaround sanctioned by @rgrinberg here: https://github.com/ocaml/dune/pull/13730#pullrequestreview-3896247798

Tested in a fresh switch with

```
opam pin dune-action-trace.dev git@github.com:ocaml/dune.git#shonfeder/dune-action-trace-disable-install-tests --with-test --verbose
```

Related: #13731 , which can help us prevent merging misconfigured packages in the future.
