### PR TITLE
fix(ppx): collect cookies from transitive ppx dependencies

### DIFF
--- a/doc/changes/fixed/13737.md
+++ b/doc/changes/fixed/13737.md
@@ -1,0 +1,2 @@
+- Fix cookies defined on `ppx_rewriter` being lost when that rewriter was used
+  as a dependency of another `ppx_rewriter`. (#13737, fixes #3426, @Alizter)

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -414,7 +414,9 @@ let ppx_driver_and_flags_internal
       Action_builder.List.concat_map flags ~f:(Expander.expand ~mode:Many expander)
       |> Action_builder.map
            ~f:(List.map ~f:(Value.to_string ~dir:(Path.build @@ Expander.dir expander)))
-  and+ cookies = Action_builder.of_memo (get_cookies ~loc ~lib_name ~expander libs)
+  and+ cookies =
+    let* libs = Resolve.Memo.read (Lib.closure libs ~linking:true ~for_) in
+    Action_builder.of_memo (get_cookies ~loc ~lib_name ~expander libs)
   and+ ppx_driver_exe = Action_builder.of_memo @@ ppx_driver_exe context libs in
   ppx_driver_exe, flags @ cookies
 ;;

--- a/test/blackbox-tests/test-cases/ppx/ppx-nested-cookies.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-nested-cookies.t
@@ -62,8 +62,7 @@ Using the inner ppx directly, the cookie is passed:
   > '
   ["my_cookie=\"the_value\""]
 
-Using the wrapper ppx, the cookie from inner_ppx should also be passed
-(but is currently lost due to the bug):
+Using the wrapper ppx, the cookie from inner_ppx should also be passed:
 
   $ dune build test_wrapped.cma
   $ dune trace cat | jq -c 'include "dune";
@@ -73,3 +72,4 @@ Using the wrapper ppx, the cookie from inner_ppx should also be passed
   > | map(select(startswith("my_cookie")))
   > | select(length > 0)
   > '
+  ["my_cookie=\"the_value\""]


### PR DESCRIPTION
Cookies defined on a ppx_rewriter were lost when that rewriter was used as a dependency of another ppx_rewriter. This is because get_cookies only iterated over the directly listed ppx libraries. We now compute the transitive closure before collecting cookies.

- Fixes https://github.com/ocaml/dune/issues/3426