### PR TITLE
fix(pkg): substitute installed variable in string interpolation

### DIFF
--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -45,7 +45,12 @@ let name = of_string "name"
 let build = of_string "build"
 let post = of_string "post"
 let dev = of_string "dev"
+let installed = of_string "installed"
 let one_of t xs = List.mem xs ~equal t
+
+(** Returns the string value of a variable for an absent package in string
+    interpolation context. Returns None for variables without known values. *)
+let absent_package_value t = if equal t installed then Some "" else None
 
 let platform_specific =
   Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]
@@ -69,6 +74,7 @@ let all_known =
   ; build
   ; post
   ; dev
+  ; installed
   ]
 ;;
 

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -32,7 +32,12 @@ val version : t
 val post : t
 val build : t
 val dev : t
+val installed : t
 val one_of : t -> t list -> bool
+
+(** Returns the string value of a variable for an absent package in string
+    interpolation context. Returns None for variables without known values. *)
+val absent_package_value : t -> string option
 
 (** The set of variable names whose values are expected to differ depending on
     the current platform. *)

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -54,40 +54,48 @@ let invalid_variable_error ~loc variable =
     [ Pp.textf "Variable %S is not supported." (OpamVariable.to_string variable) ]
 ;;
 
-let opam_variable_to_slang ~loc packages variable =
-  let variable_string = OpamVariable.to_string variable in
-  let convert_with_package_name package_name =
-    match is_valid_package_variable_name variable_string with
-    | false -> invalid_variable_error ~loc variable
-    | true ->
-      let pform =
-        let name = Package_variable_name.of_string variable_string in
-        let scope : Package_variable.Scope.t =
-          match package_name with
-          | None -> Self
-          | Some p -> Package (Package_name.of_opam_package_name p)
-        in
-        Package_variable.to_pform { Package_variable.name; scope }
-      in
-      Slang.pform pform
+let opam_variable_to_slang =
+  let opam_var_to_pform variable_name scope =
+    Package_variable.to_pform { Package_variable.name = variable_name; scope }
+    |> Slang.pform
   in
-  match packages with
-  | [] ->
-    (match is_valid_global_variable_name variable_string with
-     | false ->
-       (* Note that there's no syntactic distinction between global variables
+  fun ~loc ~packages_in_solution ~for_string_interp packages variable ->
+    let variable_string = OpamVariable.to_string variable in
+    let variable_name = Package_variable_name.of_string variable_string in
+    let convert_with_package_name package_name =
+      match is_valid_package_variable_name variable_string with
+      | false -> invalid_variable_error ~loc variable
+      | true ->
+        (match package_name with
+         | Some p ->
+           let pkg_name = Package_name.of_opam_package_name p in
+           if Package_name.Map.mem packages_in_solution pkg_name
+           then opam_var_to_pform variable_name (Package pkg_name)
+           else if for_string_interp
+           then
+             Package_variable_name.absent_package_value variable_name
+             |> Option.value ~default:""
+             |> Slang.text
+           else opam_var_to_pform variable_name (Package pkg_name)
+         | None -> opam_var_to_pform variable_name Self)
+    in
+    match packages with
+    | [] ->
+      (match is_valid_global_variable_name variable_string with
+       | false ->
+         (* Note that there's no syntactic distinction between global variables
           and package variables in the current package. This check will prevent
           invalid global variable names from being used for package variables in the
           current package where the optional qualifier "_:" is omitted. *)
-       invalid_variable_error ~loc variable
-     | true ->
-       (match Pform.Var.of_opam_global_variable_name variable_string with
-        | Some global_var -> Slang.pform (Pform.Var global_var)
-        | None -> convert_with_package_name None))
-  | [ package_name ] -> convert_with_package_name package_name
-  | many ->
-    let many = List.map many ~f:convert_with_package_name in
-    Slang.blang (Blang.And (List.map many ~f:(fun slang -> Blang.Expr slang)))
+         invalid_variable_error ~loc variable
+       | true ->
+         (match Pform.Var.of_opam_global_variable_name variable_string with
+          | Some global_var -> Slang.pform (Pform.Var global_var)
+          | None -> convert_with_package_name None))
+    | [ package_name ] -> convert_with_package_name package_name
+    | many ->
+      let many = List.map many ~f:convert_with_package_name in
+      Slang.blang (Blang.And (List.map many ~f:(fun slang -> Blang.Expr slang)))
 ;;
 
 (* Handles the special case for packages whose names contain '+' characters
@@ -113,11 +121,18 @@ let desugar_special_string_interpolation_syntax
   | _ -> fident
 ;;
 
-let opam_fident_to_slang ~loc fident =
+let opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp fident =
   let packages, variable, string_converter =
     OpamFilter.desugar_fident fident |> desugar_special_string_interpolation_syntax
   in
-  let slang = opam_variable_to_slang ~loc packages variable in
+  let for_string_interp =
+    match string_converter with
+    | Some _ -> false
+    | None -> for_string_interp
+  in
+  let slang =
+    opam_variable_to_slang ~loc ~packages_in_solution ~for_string_interp packages variable
+  in
   match string_converter with
   | None -> slang
   | Some (then_, else_) ->
@@ -131,11 +146,12 @@ let opam_fident_to_slang ~loc fident =
     Slang.if_ condition ~then_:(Slang.text then_) ~else_:(Slang.text else_)
 ;;
 
-let opam_raw_fident_to_slang ~loc raw_ident =
-  OpamTypesBase.filter_ident_of_string raw_ident |> opam_fident_to_slang ~loc
+let opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp raw_ident =
+  OpamTypesBase.filter_ident_of_string raw_ident
+  |> opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp
 ;;
 
-let opam_string_to_slang ~package ~loc opam_string =
+let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
   Re.Seq.split_full OpamFilter.string_interp_regex opam_string
   |> Seq.map ~f:(function
     | `Text text -> Slang.text text
@@ -146,7 +162,7 @@ let opam_string_to_slang ~package ~loc opam_string =
          when String.starts_with ~prefix:"%{" interp
               && String.ends_with ~suffix:"}%" interp ->
          let ident = String.sub ~pos:2 ~len:(String.length interp - 4) interp in
-         opam_raw_fident_to_slang ~loc ident
+         opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:true ident
        | other ->
          User_error.raise
            ~loc
@@ -216,11 +232,13 @@ let resolve_depopts ~resolve depopts =
    These two Slang operators are used to emulate Opam's undefined value
    semantics.
 *)
-let filter_to_blang ~package ~loc filter =
+let filter_to_blang ~packages_in_solution ~package ~loc filter =
   let filter_to_slang (filter : OpamTypes.filter) =
     match filter with
-    | FString s -> opam_string_to_slang ~package ~loc s
-    | FIdent fident -> opam_fident_to_slang ~loc fident
+    | FString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
+    | FIdent fident ->
+      (* FIdent in filter context is truthy, so don't substitute absent values *)
+      opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:false fident
     | other ->
       Code_error.raise
         "The opam file parser should only allow identifiers and strings in places where \
@@ -268,6 +286,7 @@ let filter_to_blang ~package ~loc filter =
 ;;
 
 let opam_commands_to_actions
+      ~packages_in_solution
       get_solver_var
       loc
       package
@@ -287,8 +306,13 @@ let opam_commands_to_actions
             let slang =
               let slang =
                 match simple_arg with
-                | CString s -> opam_string_to_slang ~package ~loc s
-                | CIdent ident -> opam_raw_fident_to_slang ~loc ident
+                | CString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
+                | CIdent ident ->
+                  opam_raw_fident_to_slang
+                    ~loc
+                    ~packages_in_solution
+                    ~for_string_interp:true
+                    ident
               in
               Slang.simplify slang
             in
@@ -298,8 +322,9 @@ let opam_commands_to_actions
                  | None -> slang
                  | Some filter ->
                    let filter_blang =
-                     filter_to_blang ~package ~loc filter |> Slang.simplify_blang
-                   and slang = slang in
+                     filter_to_blang ~packages_in_solution ~package ~loc filter
+                     |> Slang.simplify_blang
+                   in
                    let filter_blang_handling_undefined =
                      (* Wrap the blang filter so that if any undefined
                          variables are expanded while evaluating the filter,
@@ -324,7 +349,8 @@ let opam_commands_to_actions
           | None -> action
           | Some filter ->
             let condition =
-              filter_to_blang ~package ~loc filter |> Slang.simplify_blang
+              filter_to_blang ~packages_in_solution ~package ~loc filter
+              |> Slang.simplify_blang
             in
             Action.When (condition, action)
         in
@@ -379,12 +405,13 @@ let rec filter_vars_are_defined : OpamTypes.filter -> bool = function
 
    Depexts with filters that reference undefined variables are excluded, as
    they would error at build time. *)
-let depexts_to_conditional_external_dependencies package depexts =
+let depexts_to_conditional_external_dependencies ~packages_in_solution package depexts =
   List.filter_map depexts ~f:(fun (sys_pkgs, filter) ->
     let open Option.O in
     let* () = Option.some_if (filter_vars_are_defined filter) () in
     let condition =
-      filter_to_blang ~package ~loc:Loc.none filter |> Slang.simplify_blang
+      filter_to_blang ~packages_in_solution ~package ~loc:Loc.none filter
+      |> Slang.simplify_blang
     in
     let+ () = Option.some_if (not (Slang.Blang.equal condition Slang.Blang.false_)) () in
     let external_package_names =
@@ -489,6 +516,7 @@ let opam_package_to_lock_file_pkg
     Solver_stats.Updater.expand_variable stats_updater variable_name;
     Solver_env.get solver_env variable_name
   in
+  let packages_in_solution = version_by_package_name in
   let build_command =
     if Resolved_package.dune_build resolved_package
     then Some Lock_dir.Build_command.Dune
@@ -512,12 +540,17 @@ let opam_package_to_lock_file_pkg
           | None -> action
           | Some filter ->
             let blang =
-              filter_to_blang ~package:opam_package ~loc:Loc.none filter
+              filter_to_blang
+                ~packages_in_solution
+                ~package:opam_package
+                ~loc:Loc.none
+                filter
               |> Slang.simplify_blang
             in
             Action.When (blang, action))
       and build_step =
         opam_commands_to_actions
+          ~packages_in_solution
           get_solver_var
           loc
           opam_package
@@ -548,6 +581,7 @@ let opam_package_to_lock_file_pkg
     if portable_lock_dir
     then
       depexts_to_conditional_external_dependencies
+        ~packages_in_solution
         opam_package
         (OpamFile.OPAM.depexts opam_file)
     else (
@@ -566,7 +600,7 @@ let opam_package_to_lock_file_pkg
   in
   let install_command =
     OpamFile.OPAM.install opam_file
-    |> opam_commands_to_actions get_solver_var loc opam_package
+    |> opam_commands_to_actions ~packages_in_solution get_solver_var loc opam_package
     |> make_action
     |> Option.map ~f:(fun action -> lockfile_field_choice (build_env action))
     |> Option.value ~default:Lock_dir.Conditional_choice.empty

--- a/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
+++ b/test/blackbox-tests/test-cases/pkg/convert-opam-commands.t
@@ -40,7 +40,10 @@ Make sure we don't mess up percent signs that aren't part of variable interpolat
   > build: [ "./configure" "--prefix=%{prefix" ]
   > EOF
 
+  $ mkpkg foo
+
   $ mkpkg variable-types <<EOF
+  > depends: [ "foo" ]
   > build: [
   >   ["echo" local_var]
   >   ["echo" _:explicit_local_var]
@@ -87,6 +90,7 @@ Package which has boolean where string was expected. This should be caught while
 
   $ solve standard-dune with-interpolation with-percent-sign variable-types
   Solution for dune.lock:
+  - foo.0.0.1
   - standard-dune.0.0.1
   - variable-types.0.0.1
   - with-interpolation.0.0.1
@@ -137,6 +141,11 @@ Package which has boolean where string was expected. This should be caught while
        (run echo %{pkg-self:explicit_local_var})
        (run echo %{pkg:foo:package_var})
        (run echo %{os_family}))))))
+  
+  (depends
+   (all_platforms (foo)))
+
+
 
   $ solve with-malformed-interpolation
   File "$TESTCASE_ROOT/mock-opam-repository/packages/with-malformed-interpolation/with-malformed-interpolation.0.0.1/opam", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-installed.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-installed.t
@@ -15,15 +15,13 @@ First, test the variable in string interpolation context (command argument):
   Solution for dune.lock:
   - string-context.0.0.1
 
-Currently the variable is left as a pform. It should resolve to an empty string
-at solve time:
+The variable resolves to an empty string at solve time:
 
   $ cat dune.lock/string-context.0.0.1.pkg
   (version 0.0.1)
   
   (build
-   (all_platforms ((action (run echo %{pkg:not-in-lock:installed})))))
-
+   (all_platforms ((action (run echo "")))))
 
 Now test the variable in truthy/filter context (conditional on command):
 


### PR DESCRIPTION
When a package is absent from the solution, its 'installed' variable is known to be the empty string. Substitute it at solve time in string interpolation contexts.