### PR TITLE
feat(pkg): prefer libarchive tar over unzip for zip extraction

### DIFF
--- a/src/dune_pkg/archive_driver.ml
+++ b/src/dune_pkg/archive_driver.ml
@@ -124,20 +124,19 @@ let rec find_libarchive_tar = function
 let zip =
   let command =
     Fiber.Lazy.create (fun () ->
-      match which "unzip" with
-      | Some bin -> Fiber.return { Command.bin; make_args = make_zip_args }
+      (* Prefer libarchive/bsdtar over unzip, bsdtar can extract zip natively *)
+      find_libarchive_tar [ "bsdtar"; "tar" ]
+      >>| function
+      | Some bin -> { Command.bin; make_args = make_tar_args ~tar_impl:Libarchive }
       | None ->
-        (* Only libarchive can extract zip, so find a tar that is libarchive *)
-        let* program = find_libarchive_tar [ "bsdtar"; "tar" ] in
-        (match program with
-         | Some bin ->
-           Fiber.return { Command.bin; make_args = make_tar_args ~tar_impl:Libarchive }
+        (* Fall back to unzip if no libarchive tar found *)
+        (match which "unzip" with
+         | Some bin -> { Command.bin; make_args = make_zip_args }
          | None ->
-           Fiber.return
-           @@ User_error.raise
-                [ Pp.text "No program found to extract zip file. Tried:"
-                ; Pp.enumerate [ "unzip"; "bsdtar"; "tar" ] ~f:Pp.verbatim
-                ]))
+           User_error.raise
+             [ Pp.text "No program found to extract zip file. Tried:"
+             ; Pp.enumerate [ "bsdtar"; "tar"; "unzip" ] ~f:Pp.verbatim
+             ]))
   in
   { command; suffixes = [ ".zip" ] }
 ;;

--- a/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-extract-fail.t
@@ -42,8 +42,7 @@ captured
   [1]
 
 Now try another local package but this time of zip format to test if stderr is
-captured from the unzip tool. Note that preprocessing here makes the unzip
-error message a bit less clear
+captured from the zip extraction tool (bsdtar on macOS, unzip on Linux).
 
   $ echo "corrupted zip" > corrupted.zip
 
@@ -58,7 +57,7 @@ error message a bit less clear
   Solution for dune.lock:
   - foo.0.0.1
 
-  $ build_pkg foo 2>&1 | dune_cmd print-from 'Error:' | dune_cmd print-until '^Reason' | dune_cmd subst "'[0-9]*'" X
+  $ build_pkg foo 2>&1 | dune_cmd print-from 'Error:' | dune_cmd print-until '^Reason' | dune_cmd subst "'[0-9]*'" X | dune_cmd subst "'(unzip|bsdtar|tar)'" ZIP_TOOL
   Error: failed to extract 'corrupted.zip'
-  Reason: 'unzip' failed with non-zero exit code X and output:
+  Reason: ZIP_TOOL failed with non-zero exit code X and output:
   [1]

--- a/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
+++ b/test/blackbox-tests/test-cases/pkg/zip-extract-fail.t
@@ -89,9 +89,9 @@ variable can escape to subseqent shell invocations on MacOS.)
   basename cp dune sh
   $ (PATH=.fakebin build_pkg foo 2>&1 | grep '^Error:' -A 3)
   Error: No program found to extract zip file. Tried:
-  - unzip
   - bsdtar
   - tar
+  - unzip
   [1]
 
 Build with only GNU tar that can't extract ZIP archives:
@@ -101,9 +101,9 @@ Build with only GNU tar that can't extract ZIP archives:
   basename cp dune sh tar
   $ (PATH=.fakebin build_pkg foo 2>&1 | grep '^Error:' -A 3)
   Error: No program found to extract zip file. Tried:
-  - unzip
   - bsdtar
   - tar
+  - unzip
   [1]
 
 Build with bsdtar that can extract ZIP archives, without unzip. It should work:
@@ -133,7 +133,7 @@ Build with unzip only:
   $ (PATH=.fakebin build_pkg foo)
 
 Build with both bsdtar (as tar) and unzip available.
-Currently the code prefers unzip over bsdtar:
+The code prefers bsdtar over unzip since bsdtar can extract zip natively:
 
   $ ln -s ../.binaries/bsdtar .fakebin/tar
   $ show_path
@@ -147,4 +147,5 @@ Use a fresh package to ensure extraction actually runs (not cached from earlier)
 Check which tool was used for extraction:
 
   $ dune trace cat | jq -c 'include "dune"; processes | .args.prog | split("/") | .[-1]'
-  "unzip"
+  "tar"
+  "tar"


### PR DESCRIPTION
The libarchive implementation of tar can extract zip files natively. Therefore such implementations of tar do not require an extra unzipping step nor binary.