### PR TITLE
Stop silently hanging when build dir is locked but RPC server is not started

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -184,7 +184,7 @@ let build =
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"build"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_impl.Decl.build

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -235,7 +235,7 @@ let build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog =
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"build"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_impl.Decl.build

--- a/bin/fmt.ml
+++ b/bin/fmt.ml
@@ -48,7 +48,7 @@ let run_fmt_command ~common ~config ~preview builder =
     Scheduler_setup.no_build_no_rpc ~config (fun () ->
       Rpc.Rpc_common.fire_request
         ~name:"format"
-        ~wait:true
+        ~wait:false
         ~warn_forwarding:false
         ~lock_held_by
         builder

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -56,7 +56,7 @@ module Apply = struct
         let open Fiber.O in
         Rpc.Rpc_common.fire_request
           ~name:"promote_many"
-          ~wait:true
+          ~wait:false
           ~lock_held_by
           builder
           Dune_rpc_private.Procedures.Public.promote_many

--- a/bin/tools/tools_common.ml
+++ b/bin/tools/tools_common.ml
@@ -33,13 +33,13 @@ let build_dev_tool_directly dev_tool =
   | Ok () -> ()
 ;;
 
-let build_dev_tool_via_rpc builder lock_held_by dev_tool =
+let try_build_dev_tool_via_rpc builder lock_held_by dev_tool =
   let target = dev_tool_build_target dev_tool in
   let targets = Rpc.Rpc_common.prepare_targets [ target ] in
   let open Fiber.O in
   Rpc.Rpc_common.fire_request
     ~name:"build"
-    ~wait:true
+    ~wait:false
     ~lock_held_by
     builder
     Dune_rpc_impl.Decl.build
@@ -53,7 +53,7 @@ let lock_and_build_dev_tool ~common ~config builder dev_tool =
   | Error lock_held_by ->
     Scheduler_setup.no_build_no_rpc ~config (fun () ->
       let* () = Lock_dev_tool.lock_dev_tool dev_tool |> Memo.run in
-      build_dev_tool_via_rpc builder lock_held_by dev_tool)
+      try_build_dev_tool_via_rpc builder lock_held_by dev_tool)
   | Ok () ->
     Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
       build_dev_tool_directly dev_tool)


### PR DESCRIPTION
Fixes #12685

The `wait` argument was added (or set to true initially) to prevent the following scenario: you start an RPC server and a client (`dune build` for example) at the same time, and the server doesn't have time to set itself up before the client tries to connect to it, and fails.
The opposite scenario is what is happening right now: if the client tries to connect to a non-existent server, it will silently wait forever. This is no big deal when a server is indeed on its way, but if it is never coming for any reason (build cancelled, process killed...), the client will hang.

This PR simply flips the `wait` flag to `false` to prevent that behaviour. This is a temporary fix that does not address all problems with the RPC system