### PR TITLE
chore: remove empty lines from changelog entries

### DIFF
--- a/doc/changes/scripts/build_changelog.sh
+++ b/doc/changes/scripts/build_changelog.sh
@@ -66,7 +66,8 @@ append_files_in_dir_if_not_empty() {
   echo "### $subheader" >> "$output"
   add_newline
   for file in $list_of_files; do
-      cat "$file" >> "$output"
+      # Remove any empty lines from each change entry and add them to the output
+      grep -v '^$' "$file" >> "$output"
       add_newline
       rm "$file"
   done


### PR DESCRIPTION
The current script leads to irregular spacing between entries in the changelog in case empty line occur before or after entries.

Contributes to https://github.com/ocaml/dune/issues/13771