### PR TITLE
fix: generate a better test target for packages with (dir ..)

### DIFF
--- a/doc/changes/fixed/13778.md
+++ b/doc/changes/fixed/13778.md
@@ -1,0 +1,2 @@
+- Improve opam file generation for packages that set `(dir ..)`. Such packages
+  will now have a test target that is limited to this directory. (#13778, @rgrinberg)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -91,11 +91,42 @@ let default_build_command =
                subst
                promote_install_files
                install)))
+  and from_3_23 ~with_subst ~with_sites ~runtest =
+    let subst = if with_subst then {|  [ "dune" "subst" ] {dev} |} else "" in
+    let promote_install_files =
+      if with_sites then {|  "--promote-install-files=false" |} else ""
+    in
+    let install =
+      if with_sites
+      then {| [ "dune" "install" "-p" name "--create-install-files" name ] |}
+      else ""
+    in
+    lazy
+      (Opam_file.parse_value
+         (Lexbuf.from_string
+            ~fname:"<internal>"
+            (Printf.sprintf
+               {|
+[
+  %s
+  [ "dune" "build" "-p" name "-j" jobs %s
+      "%s" {with-test}
+      "@doc" {with-doc}
+  ]
+  %s
+]
+|}
+               subst
+               promote_install_files
+               runtest
+               install)))
   in
-  fun project ->
+  fun project package ->
+    let version = Dune_project.dune_version project in
+    let with_subst = Toggle.enabled (snd (Dune_project.subst_config project)) in
+    let with_sites = Dune_project.(is_extension_set project dune_site_extension) in
     Lazy.force
-      (let version = Dune_project.dune_version project in
-       if version < (1, 11)
+      (if version < (1, 11)
        then before_1_11
        else if version < (2, 7)
        then from_1_11_before_2_7
@@ -103,10 +134,16 @@ let default_build_command =
        then from_2_7
        else if version < (3, 0)
        then from_2_9
-       else
-         from_3_0
-           ~with_subst:(Toggle.enabled (snd (Dune_project.subst_config project)))
-           ~with_sites:Dune_project.(is_extension_set project dune_site_extension))
+       else if version < (3, 23)
+       then from_3_0 ~with_subst ~with_sites
+       else (
+         match Package.exclusive_dir package with
+         | None -> from_3_0 ~with_subst ~with_sites
+         | Some (_loc, dir) ->
+           from_3_23
+             ~with_subst
+             ~with_sites
+             ~runtest:("@runtest/" ^ Path.Source.to_string dir)))
 ;;
 
 let var_of_sw sw : Package_constraint.Value.t =
@@ -291,7 +328,9 @@ let opam_fields project (package : Package.t) =
       | None | Some [] -> None
       | Some (_ :: _ as v) -> Some (k, string_list v))
   in
-  let fields = [ "opam-version", string "2.0"; "build", default_build_command project ] in
+  let fields =
+    [ "opam-version", string "2.0"; "build", default_build_command project package ]
+  in
   let fields = List.concat [ fields; list_fields; optional_fields; package_fields ] in
   if dune_version < (1, 11) then fields else Opam_file.Create.normalise_field_order fields
 ;;

--- a/test/blackbox-tests/test-cases/package-runtest-alias.t
+++ b/test/blackbox-tests/test-cases/package-runtest-alias.t
@@ -1,0 +1,14 @@
+Test that we generate a directory specific runtest alias if dir is set for
+a package:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (dir foo))
+  > EOF
+
+  $ dune build @check
+  $ cat foo.opam | grep -o '"@runtest/foo" {with-test}'
+  "@runtest/foo" {with-test}


### PR DESCRIPTION
Limit the test target to the package's directory