### PR TITLE
fix(pkg): substitute version variable in string interpolation

### DIFF
--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -547,6 +547,7 @@ let rec blang_map_string_with_vars ~f = function
 
 and slang_map_string_with_vars ~f = function
   | Slang.Nil -> Slang.Nil
+  | Slang.Undefined -> Slang.Undefined
   | Literal sw -> Literal (f sw)
   | Form (loc, form) ->
     let form =

--- a/src/dune_lang/package_variable_name.ml
+++ b/src/dune_lang/package_variable_name.ml
@@ -50,8 +50,15 @@ let one_of t xs = List.mem xs ~equal t
 
 (** Returns the slang value of a variable for an absent package. Returns None
     for variables without known values or contexts where substitution shouldn't
-    occur. *)
-let absent_package_value t = if equal t installed then Some (Slang.bool false) else None
+    occur. For [version], returns empty string in string interpolation context,
+    or [Undefined] in filter context. *)
+let absent_package_value ~for_string_interp t =
+  if equal t installed
+  then Some (Slang.bool false)
+  else if equal t version
+  then Some (if for_string_interp then Slang.text "" else Slang.Undefined)
+  else None
+;;
 
 let platform_specific =
   Set.of_list [ arch; os; os_version; os_distribution; os_family; sys_ocaml_version ]

--- a/src/dune_lang/package_variable_name.mli
+++ b/src/dune_lang/package_variable_name.mli
@@ -38,7 +38,7 @@ val one_of : t -> t list -> bool
 (** Returns the slang value of a variable for an absent package. Returns None
     for variables without known values or contexts where substitution shouldn't
     occur. *)
-val absent_package_value : t -> Slang.t option
+val absent_package_value : for_string_interp:bool -> t -> Slang.t option
 
 (** The set of variable names whose values are expected to differ depending on
     the current platform. *)

--- a/src/dune_lang/slang.ml
+++ b/src/dune_lang/slang.ml
@@ -3,6 +3,7 @@ open Dune_sexp
 
 type t =
   | Nil
+  | Undefined
   | Literal of String_with_vars.t
   | Form of (Loc.t * form)
 
@@ -46,6 +47,7 @@ let rec equal a b =
   in
   match a, b with
   | Nil, Nil -> true
+  | Undefined, Undefined -> true
   | Literal a, Literal b -> String_with_vars.equal a b
   | Form a, Form b -> Tuple.T2.equal Loc.equal form_equal a b
   | _, _ -> false
@@ -73,6 +75,7 @@ let rec remove_locs t =
   in
   match t with
   | Nil -> Nil
+  | Undefined -> Undefined
   | Literal sw -> Literal (String_with_vars.remove_locs sw)
   | Form (_loc, form) -> Form (Loc.none, form_remove_locs form)
 
@@ -147,6 +150,10 @@ let rec encode t =
       (Form
          ( Loc.none
          , When (Blang.Ast.false_, Literal (String_with_vars.make_text Loc.none "")) ))
+  | Undefined ->
+    (* Undefined should be simplified away before encoding. If it reaches here,
+       encode it as something that will fail at runtime. *)
+    Code_error.raise "Undefined should not be encoded" []
   | Literal sw -> String_with_vars.encode sw
   | Form (_loc, form) ->
     (match form with
@@ -170,6 +177,7 @@ let rec encode t =
 
 let rec to_dyn = function
   | Nil -> Dyn.variant "Nil" []
+  | Undefined -> Dyn.variant "Undefined" []
   | Literal sw -> Dyn.variant "Literal" [ String_with_vars.to_dyn sw ]
   | Form (_loc, form) ->
     (match form with
@@ -190,6 +198,7 @@ and blang_to_dyn blang = Blang.Ast.to_dyn to_dyn blang
 
 let loc = function
   | Nil -> Loc.none
+  | Undefined -> Loc.none
   | Literal sw -> String_with_vars.loc sw
   | Form (loc, _form) -> loc
 ;;
@@ -198,6 +207,7 @@ let blang_map = Blang.Ast.map_string
 
 let rec map_loc ~f = function
   | Nil -> Nil
+  | Undefined -> Undefined
   | Literal sw -> Literal (String_with_vars.map_loc ~f sw)
   | Form (loc, form) ->
     let loc = f loc in
@@ -270,6 +280,7 @@ let is_nil = function
 
 let rec simplify = function
   | Nil -> Nil
+  | Undefined -> Undefined
   | Literal sw -> Literal sw
   | Form (loc, form) ->
     (match form with
@@ -360,14 +371,17 @@ and simplify_blang = function
      | Some "false" -> Const false
      | _ -> expr)
   | Expr (Form (_, Blang blang)) -> simplify_blang blang
+  | Expr Undefined -> Const false
   | Expr s ->
     (match simplify s with
+     | Undefined -> Const false
      | Form (_, Blang blang) -> simplify_blang blang
      | s -> Expr s)
   | Compare (op, lhs, rhs) ->
     let lhs = simplify lhs in
     let rhs = simplify rhs in
     (match lhs, rhs with
+     | Undefined, _ | _, Undefined -> Const false
      | Literal l, Literal r ->
        (match op, String_with_vars.text_only l, String_with_vars.text_only r with
         | Relop.Eq, Some l, Some r -> Const (String.equal l r)

--- a/src/dune_lang/slang.mli
+++ b/src/dune_lang/slang.mli
@@ -3,6 +3,7 @@ open Import
 (** Slang (string-language) is a DSL for computing lists of strings. *)
 type t =
   | Nil
+  | Undefined
   | Literal of String_with_vars.t
   (** A string literal which may contain pforms. It's possible for a single
       unquoted pform to expand to a list of multiple strings. *)

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -63,7 +63,7 @@ let opam_variable_to_slang =
     Package_variable.to_pform { Package_variable.name = variable_name; scope }
     |> Slang.pform
   in
-  fun ~loc ~packages_in_solution packages variable ->
+  fun ~loc ~packages_in_solution ~for_string_interp packages variable ->
     let variable_string = OpamVariable.to_string variable in
     let variable_name = Package_variable_name.of_string variable_string in
     let convert_with_package_name package_name =
@@ -77,7 +77,7 @@ let opam_variable_to_slang =
            if Package_name.Map.mem packages_in_solution pkg_name
            then pform
            else
-             Package_variable_name.absent_package_value variable_name
+             Package_variable_name.absent_package_value ~for_string_interp variable_name
              |> Option.value ~default:pform
          | None -> opam_var_to_pform variable_name Self)
     in
@@ -123,11 +123,18 @@ let desugar_special_string_interpolation_syntax
   | _ -> fident
 ;;
 
-let opam_fident_to_slang ~loc ~packages_in_solution fident =
+let opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp fident =
   let packages, variable, string_converter =
     OpamFilter.desugar_fident fident |> desugar_special_string_interpolation_syntax
   in
-  let slang = opam_variable_to_slang ~loc ~packages_in_solution packages variable in
+  let for_string_interp =
+    match string_converter with
+    | Some _ -> false
+    | None -> for_string_interp
+  in
+  let slang =
+    opam_variable_to_slang ~loc ~packages_in_solution ~for_string_interp packages variable
+  in
   match string_converter with
   | None -> slang
   | Some (then_, else_) ->
@@ -136,7 +143,7 @@ let opam_fident_to_slang ~loc ~packages_in_solution fident =
        convert expressions that throw undefined variable exceptions into false.
     *)
     (match slang with
-     | Form (_, Blang (Blang.Const false)) -> Slang.text else_
+     | Form (_, Blang (Blang.Const false)) | Slang.Undefined -> Slang.text else_
      | _ ->
        let condition =
          Blang.Expr (Slang.catch_undefined_var slang ~fallback:(Slang.bool false))
@@ -144,9 +151,9 @@ let opam_fident_to_slang ~loc ~packages_in_solution fident =
        Slang.if_ condition ~then_:(Slang.text then_) ~else_:(Slang.text else_))
 ;;
 
-let opam_raw_fident_to_slang ~loc ~packages_in_solution raw_ident =
+let opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp raw_ident =
   OpamTypesBase.filter_ident_of_string raw_ident
-  |> opam_fident_to_slang ~loc ~packages_in_solution
+  |> opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp
 ;;
 
 let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
@@ -160,7 +167,7 @@ let opam_string_to_slang ~packages_in_solution ~package ~loc opam_string =
          when String.starts_with ~prefix:"%{" interp
               && String.ends_with ~suffix:"}%" interp ->
          let ident = String.sub ~pos:2 ~len:(String.length interp - 4) interp in
-         opam_raw_fident_to_slang ~loc ~packages_in_solution ident
+         opam_raw_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:true ident
        | other ->
          User_error.raise
            ~loc
@@ -234,7 +241,9 @@ let filter_to_blang ~packages_in_solution ~package ~loc filter =
   let filter_to_slang (filter : OpamTypes.filter) =
     match filter with
     | FString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
-    | FIdent fident -> opam_fident_to_slang ~loc ~packages_in_solution fident
+    | FIdent fident ->
+      (* FIdent in filter context is not string interpolation *)
+      opam_fident_to_slang ~loc ~packages_in_solution ~for_string_interp:false fident
     | other ->
       Code_error.raise
         "The opam file parser should only allow identifiers and strings in places where \
@@ -304,7 +313,11 @@ let opam_commands_to_actions
                 match simple_arg with
                 | CString s -> opam_string_to_slang ~packages_in_solution ~package ~loc s
                 | CIdent ident ->
-                  opam_raw_fident_to_slang ~loc ~packages_in_solution ident
+                  opam_raw_fident_to_slang
+                    ~loc
+                    ~packages_in_solution
+                    ~for_string_interp:true
+                    ident
               in
               Slang.simplify slang
             in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -974,6 +974,7 @@ module Action_expander = struct
          let loc =
            let loc = function
              | Slang.Nil -> None
+             | Slang.Undefined -> None
              | Literal sw -> Some (String_with_vars.loc sw)
              | Form (loc, _) -> Some loc
            in

--- a/src/dune_rules/slang_expand.ml
+++ b/src/dune_rules/slang_expand.ml
@@ -19,6 +19,9 @@ let rec eval_rec (t : Slang.t) ~dir ~(f : expander)
   =
   match t with
   | Nil -> Memo.return (Ok [])
+  | Undefined ->
+    (* Undefined should be simplified away before expansion *)
+    Code_error.raise "Unexpected Undefined in slang expansion" []
   | Literal sw ->
     f sw
     >>| Result.map_error ~f:(function `Undefined_pkg_var variable_name ->

--- a/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
@@ -10,10 +10,12 @@ context:
   $ mkpkg "test-version-var" <<'EOF'
   > build: [
   >   [ "echo" absent:version ]
-  >   [ "echo" "%{absent:version}%" ]
+  >   [ "echo" "this is a long line to force breaking %{absent:version}%" ]
   >   [ "echo" "%{absent:version?yes:no}%" ]
-  >   [ "echo" "has version" ] {not-in-lock:version}
-  >   [ "echo" "no version" ] {!not-in-lock:version}
+  >   [ "echo" "old version" ] {absent:version < "1.0"}
+  >   [ "echo" "new version" ] {absent:version >= "1.0"}
+  >   [ "echo" "has version" ] {absent:version}
+  >   [ "echo" "no version" ] {!absent:version}
   > ]
   > EOF
 
@@ -21,8 +23,9 @@ context:
   Solution for dune.lock:
   - test-version-var.0.0.1
 
-Currently the variable is left as a pform. It should resolve to empty string
-at solve time:
+String interpolation contexts resolve to empty string at solve time. Truthy and
+filter contexts are left for build time evaluation where they will be undefined
+and thus falsey:
 
   $ cat dune.lock/test-version-var.0.0.1.pkg
   (version 0.0.1)
@@ -32,7 +35,10 @@ at solve time:
     ((action
       (progn
        (run echo %{pkg:absent:version})
-       (run echo %{pkg:absent:version})
+       (run echo "this is a long line to force breaking %{pkg:absent:version}")
        (run echo (if (catch_undefined_var %{pkg:absent:version} false) yes no))
-       (when %{pkg:not-in-lock:version} (run echo "has version"))
-       (when (not %{pkg:not-in-lock:version}) (run echo "no version")))))))
+       (when (< %{pkg:absent:version} 1.0) (run echo "old version"))
+       (when (>= %{pkg:absent:version} 1.0) (run echo "new version"))
+       (when %{pkg:absent:version} (run echo "has version"))
+       (when (not %{pkg:absent:version}) (run echo "no version")))))))
+

--- a/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/absent-pkg-version.t
@@ -1,6 +1,6 @@
 Test the "version" variable for packages not in the solution. In opam, absent
-packages have version="" in a string interpolation context and an error
-otherwise.
+packages have version="" in a string interpolation context and undefined in
+filter context (which evaluates to false).
 
   $ mkrepo
 
@@ -23,9 +23,9 @@ context:
   Solution for dune.lock:
   - test-version-var.0.0.1
 
-String interpolation contexts resolve to empty string at solve time. Truthy and
-filter contexts are left for build time evaluation where they will be undefined
-and thus falsey:
+The variable resolves to empty string in string interpolation and false in
+filter context at solve time. Commands with always-false conditions are removed,
+and commands with always-true conditions have their filters removed:
 
   $ cat dune.lock/test-version-var.0.0.1.pkg
   (version 0.0.1)
@@ -34,11 +34,7 @@ and thus falsey:
    (all_platforms
     ((action
       (progn
-       (run echo %{pkg:absent:version})
-       (run echo "this is a long line to force breaking %{pkg:absent:version}")
-       (run echo (if (catch_undefined_var %{pkg:absent:version} false) yes no))
-       (when (< %{pkg:absent:version} 1.0) (run echo "old version"))
-       (when (>= %{pkg:absent:version} 1.0) (run echo "new version"))
-       (when %{pkg:absent:version} (run echo "has version"))
-       (when (not %{pkg:absent:version}) (run echo "no version")))))))
-
+       (run echo "")
+       (run echo "this is a long line to force breaking ")
+       (run echo no)
+       (run echo "no version"))))))


### PR DESCRIPTION
When a package is absent from the solution, its 'version' variable is known to be empty. Substitute it at solve time in string interpolation contexts.

Split off from 
- #13466

Addresses `version` part of 
- #13660

Part of the work on:
- #13229 