### PR TITLE
Add clarifying documentation to Io.links

### DIFF
--- a/otherlibs/stdune/src/io.mli
+++ b/otherlibs/stdune/src/io.mli
@@ -9,10 +9,16 @@ val copy_channels : in_channel -> out_channel -> unit
 include Io_intf.S with type path = Path.t
 module String_path : Io_intf.S with type path = string
 
-(** Symlink with fallback to copy on systems that don't support it. *)
+(** Symlink with fallback to copy on systems that don't support it.
+
+    [portable_symlink ~src ~dst] will create [dst] as a symbolic link pointing
+    to [src]. On Windows, it will simply copy [src] to [dst]. *)
 val portable_symlink : src:Path.t -> dst:Path.t -> unit
 
-(** Hardlink with fallback to copy on systems that don't support it. *)
+(** Hardlink with fallback to copy on systems that don't support it.
+
+    [portable_hardlink ~src ~dst] will create [dst] as a hard link pointing to
+    [src]. In case of EMLINK or EINVAL it will simply copy [src] to [dst]. *)
 val portable_hardlink : src:Path.t -> dst:Path.t -> unit
 
 val set_copy_impl : [ `Portable | `Best ] -> unit


### PR DESCRIPTION
If you're thinking of a symlink as an arrow `A -> B`, the signature `val link: src:Path.t -> dst:Path.t -> unit` might lead you to believe you should use it like so `link ~src:A ~dst:B`, but you'd be wrong!
It's the reverse you should be doing.
It threw me off for a loop, so I'm trying to improve the documentation.
Suggestions welcome