### PR TITLE
feature(boot): strip let%expect_test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -376,7 +376,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf
+        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf ppx_expect
 
       - name: Set Git User
         run: |

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,4 +1,4 @@
 FROM ocaml/opam:debian-13-ocaml-5.4
-RUN opam install csexp pp re spawn uutf
+RUN opam install csexp pp re spawn uutf ppx_expect
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -25,7 +25,8 @@ let keep_generated_files =
   !keep_generated_files
 ;;
 
-let modules = [ "boot/types"; "boot/libs"; "boot/duneboot" ]
+let pps = "boot/pps"
+let modules = pps :: [ "boot/types"; "boot/libs"; "boot/duneboot" ]
 let duneboot = ".duneboot"
 let prog = duneboot ^ ".exe"
 
@@ -40,6 +41,8 @@ let () =
   if not keep_generated_files
   then
     at_exit (fun () ->
+      (try Sys.remove "boot/pps.ml" with
+       | Sys_error _ -> ());
       Array.iter (Sys.readdir ".") ~f:(fun fn ->
         if
           String.length fn >= String.length duneboot
@@ -71,9 +74,9 @@ let read_file fn =
 
 let () =
   let v = Scanf.sscanf Sys.ocaml_version "%d.%d.%d" (fun a b c -> a, b, c) in
-  let compiler, which =
+  let compiler, ocamllex, which =
     if v >= min_supported_natively
-    then "ocamlc", None
+    then "ocamlc", "ocamllex", None
     else (
       let compiler = "ocamlfind -toolchain secondary ocamlc" in
       let output_fn, out = Filename.open_temp_file "duneboot" "ocamlfind-output" in
@@ -95,8 +98,10 @@ let () =
              a
              b);
         exit 2);
-      compiler, Some "--secondary")
+      let ocamllex = "ocamlfind -toolchain secondary ocamllex" in
+      compiler, ocamllex, Some "--secondary")
   in
+  exit_if_non_zero (runf "%s -q -o %s %s" ocamllex (pps ^ ".ml") (pps ^ ".mll"));
   exit_if_non_zero
     (runf
        "%s %s -intf-suffix .dummy -g -o %s -I boot %sunix.cma %s"

--- a/boot/dune
+++ b/boot/dune
@@ -31,6 +31,8 @@
  (action
   (diff libs.ml libs.ml.gen)))
 
+(ocamllex pps)
+
 (executable
  (name duneboot)
  (modules :standard \ configure bootstrap)

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -539,24 +539,24 @@ module Io = struct
     | Ok s -> s
   ;;
 
-  let do_then_copy ~f a b =
+  let do_then_copy ~f ~pp a b =
     let s = read_file a in
     with_file_out b ~f:(fun oc ->
       f oc;
-      output_string oc s)
+      output_string oc (if pp then Pps.pp s else s))
   ;;
 
   (* copy a file - fails if the file exists *)
-  let copy a b = do_then_copy ~f:(fun _ -> ()) a b
+  let copy a b = do_then_copy ~pp:false ~f:(fun _ -> ()) a b
 
   (* copy a file and insert a header - fails if the file exists *)
-  let copy_with_header ~header a b =
-    do_then_copy ~f:(fun oc -> output_string oc header) a b
+  let copy_with_header ~pp ~header a b =
+    do_then_copy ~pp ~f:(fun oc -> output_string oc header) a b
   ;;
 
   (* copy a file and insert a directive - fails if the file exists *)
   let copy_with_directive ~directive a b =
-    do_then_copy ~f:(fun oc -> fprintf oc "#%s 1 %S\n" directive a) a b
+    do_then_copy ~pp:false ~f:(fun oc -> fprintf oc "#%s 1 %S\n" directive a) a b
   ;;
 
   let rec rm_rf fn =
@@ -1610,8 +1610,11 @@ module Library = struct
     | Header | C _ ->
       Io.copy_with_directive ~directive:"line" fn dst;
       Fiber.return [ mangled ]
-    | Ml { kind = `Ml | `Mli; _ } ->
-      Io.copy_with_header ~header fn dst;
+    | Ml { kind = `Mli; _ } ->
+      Io.copy_with_header ~pp:false ~header fn dst;
+      Fiber.return [ mangled ]
+    | Ml { kind = `Ml; _ } ->
+      Io.copy_with_header ~pp:true ~header fn dst;
       Fiber.return [ mangled ]
     | Ml { kind = `Mll; _ } -> copy_lexer fn dst ~header >>> Fiber.return [ mangled ]
     | Ml { kind = `Mly; _ } ->

--- a/boot/pps.mli
+++ b/boot/pps.mli
@@ -1,0 +1,1 @@
+val pp : string -> string

--- a/boot/pps.mll
+++ b/boot/pps.mll
@@ -1,0 +1,21 @@
+{
+  let b = Buffer.create 512
+}
+
+rule pp = parse
+ | "let%expect_test" { skip lexbuf }
+ | _ as c { Buffer.add_char b c; pp lexbuf }
+ | eof { () }
+
+and skip = parse
+  | ";;" { pp lexbuf }
+  | _ { skip lexbuf }
+  | eof { failwith "unterminated let%expect_test" }
+
+{
+  let pp s =
+    let lb = Lexing.from_string s in
+    Buffer.clear b;
+    pp lb;
+    Buffer.contents b
+}

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -375,7 +375,7 @@ jobs:
         run: opam install --fake binaryen-bin
 
       - name: Install Wasm_of_ocaml
-        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf
+        run: opam install "wasm_of_ocaml-compiler>=6.1" csexp pp re spawn uutf ppx_expect
 
       - name: Set Git User
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -429,7 +429,9 @@
             buildInputs = with pkgs.ocamlPackages; [
               csexp
               pp
-              # re shouldn't be needed. this is an issue with the fmt rules
+              # Some additional dependencies are needed because formatting
+              # promoted files in boot/ requires building them first
+              ppx_expect
               re
               spawn
               uutf

--- a/src/dune_sexp/dune
+++ b/src/dune_sexp/dune
@@ -1,6 +1,9 @@
 (library
  (name dune_sexp)
  (synopsis "[Internal] S-expression library")
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
  (libraries stdune uutf))
 
 (ocamllex lexer versioned_file_first_line)

--- a/src/dune_sexp/escape.ml
+++ b/src/dune_sexp/escape.ml
@@ -132,3 +132,162 @@ let quoted s =
   Bytes.unsafe_set s' (n + 1) '"';
   Bytes.unsafe_to_string s'
 ;;
+
+let%expect_test "escaped - plain strings pass through unchanged" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  test "hello";
+  test "foo_bar";
+  test "123";
+  test "a/b/c";
+  [%expect
+    {|
+    "hello" -> "hello"
+    "foo_bar" -> "foo_bar"
+    "123" -> "123"
+    "a/b/c" -> "a/b/c"
+    |}]
+;;
+
+let%expect_test "escaped - special characters are escaped" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  test "has\"quote";
+  test "back\\slash";
+  test "new\nline";
+  test "tab\there";
+  test "car\rret";
+  test "back\bspace";
+  [%expect
+    {|
+    "has\"quote" -> "has\\\"quote"
+    "back\\slash" -> "back\\\\slash"
+    "new\nline" -> "new\\nline"
+    "tab\there" -> "tab\\there"
+    "car\rret" -> "car\\rret"
+    "back\bspace" -> "back\\bspace"
+    |}]
+;;
+
+let%expect_test "escaped - percent brace escaping" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  test "%{var}";
+  test "100%";
+  test "%%";
+  test "%alone";
+  [%expect
+    {|
+    "%{var}" -> "\\%{var}"
+    "100%" -> "100%"
+    "%%" -> "%%"
+    "%alone" -> "%alone"
+    |}]
+;;
+
+let%expect_test "escaped - empty string" =
+  let r = escaped "" in
+  Printf.printf "%S -> %S\n" "" r;
+  [%expect {| "" -> "" |}]
+;;
+
+let%expect_test "escaped - non-ascii bytes are octal-escaped" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  test "\x00";
+  test "\x01";
+  test "\x7f";
+  test "\xff";
+  [%expect
+    {|
+    "\000" -> "\000"
+    "\001" -> "\001"
+    "\127" -> "\127"
+    "\255" -> "\\255"
+    |}]
+;;
+
+let%expect_test "escaped - valid utf8 passes through" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  (* 2-byte: é *)
+  test "\xc3\xa9";
+  (* 3-byte: € *)
+  test "\xe2\x82\xac";
+  (* 4-byte: 𝄞 *)
+  test "\xf0\x9d\x84\x9e";
+  [%expect
+    {|
+    "\195\169" -> "\195\169"
+    "\226\130\172" -> "\226\130\172"
+    "\240\157\132\158" -> "\240\157\132\158"
+    |}]
+;;
+
+let%expect_test "quoted - wraps in double quotes" =
+  let test s =
+    let r = quoted s in
+    Printf.printf "%S -> %s\n" s r
+  in
+  test "";
+  test "hello";
+  test "has space";
+  test "has\"quote";
+  test "new\nline";
+  test "%{var}";
+  [%expect
+    {|
+    "" -> ""
+    "hello" -> "hello"
+    "has space" -> "has space"
+    "has\"quote" -> "has\"quote"
+    "new\nline" -> "new\nline"
+    "%{var}" -> "\%{var}"
+    |}]
+;;
+
+let%expect_test "quote_length - matches actual escaped length" =
+  let test s =
+    let ql = quote_length s in
+    let actual = String.length (escaped s) in
+    if ql <> actual
+    then Printf.printf "MISMATCH %S: quote_length=%d escaped_length=%d\n" s ql actual
+  in
+  test "";
+  test "hello";
+  test "has\"quote";
+  test "new\nline";
+  test "%{var}";
+  test "\x00\xff";
+  test "\xc3\xa9";
+  test "\xe2\x82\xac";
+  test "\xf0\x9d\x84\x9e";
+  print_endline "all match";
+  [%expect {| all match |}]
+;;
+
+let%expect_test "escaped - mixed content" =
+  let test s =
+    let r = escaped s in
+    Printf.printf "%S -> %S\n" s r
+  in
+  test "hello\nworld\t!";
+  test "say \"hi\" and \\go";
+  test "%{x} is 100%";
+  [%expect
+    {|
+    "hello\nworld\t!" -> "hello\\nworld\\t!"
+    "say \"hi\" and \\go" -> "say \\\"hi\\\" and \\\\go"
+    "%{x} is 100%" -> "\\%{x} is 100%"
+    |}]
+;;

--- a/test/blackbox-tests/test-cases/boot/cycle.t
+++ b/test/blackbox-tests/test-cases/boot/cycle.t
@@ -19,7 +19,8 @@ Testing cycle detection in bootstrap.
   $ create_dune a <<EOF
   > open A
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   cycle:
   - a__B.ml

--- a/test/blackbox-tests/test-cases/boot/dune
+++ b/test/blackbox-tests/test-cases/boot/dune
@@ -3,6 +3,8 @@
  (deps
   %{project_root}/boot/types.ml
   %{project_root}/boot/duneboot.ml
+  %{project_root}/boot/pps.mli
+  %{project_root}/boot/pps.mll
   %{bin:bootstrap.exe}))
 
 (env

--- a/test/blackbox-tests/test-cases/boot/helpers.sh
+++ b/test/blackbox-tests/test-cases/boot/helpers.sh
@@ -3,6 +3,8 @@ function init_bootstrap() {
   mkdir boot
   cp ../../../../boot/types.ml boot/types.ml
   cp ../../../../boot/duneboot.ml boot/duneboot.ml
+  cp ../../../../boot/pps.mll boot/pps.mll
+  cp ../../../../boot/pps.mli boot/pps.mli
 
   cat > dune-project <<EOF
 (lang dune 3.21)

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
@@ -31,6 +31,7 @@ it picks up the closest one.
   > module M1 = A.Bar.Baz
   > let () = Printf.printf "Hello from %s\n" M1.exported
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from the correct module!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
@@ -19,7 +19,8 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M2 = A.B.X
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from wrapped a/b/x.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -34,7 +34,8 @@ Testing the bootstrap of an unwrapped include subdirs qualified.
   > module M3 = B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from unwrapped a/b/c/c.ml
   Hello from unwrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -31,7 +31,8 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M4 = A.B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from wrapped a/b/c/c.ml
   Hello from wrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
@@ -30,7 +30,8 @@ Testing the bootstrap of an unwrapped include subdirs unqualified.
   > module M3 = C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from unwrapped a/b/b.ml
   Hello from unwrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -30,7 +30,8 @@ Testing the bootstrap of a wrapped include subdirs unqualified.
   > module M4 = A.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from wrapped a/b/b.ml
   Hello from wrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
@@ -19,7 +19,8 @@ Testing the bootstrap of singleton unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from singleton unwrapped a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
@@ -18,7 +18,8 @@ Testing the bootstrap of singleton wrapped libraries.
   > open A
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from singleton wrapped a/a.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/unwrapped.t
@@ -25,7 +25,8 @@ Testing the bootstrap of unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from unwrapped a/a.ml
   Hello from unwrapped a/b.ml

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -21,7 +21,8 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   > open Root
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from wrapped non-interface module a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped.t
@@ -26,7 +26,8 @@ Testing the bootstrap of wrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
   ./.duneboot.exe
   Hello from wrapped module a/b.ml
   Hello from wrapped interface module a/a.ml


### PR DESCRIPTION
allows us to write ppx_expect tests in more places without depending on the ppx itself

As an example, add some unit tests for Dune_sexp.Escape. These will be handy once we drop support for pre 4.14