### PR TITLE
refactor: proper equal function for module names

### DIFF
--- a/src/dune_lang/module_name.ml
+++ b/src/dune_lang/module_name.ml
@@ -28,12 +28,7 @@ module Unchecked = struct
       }
 
     let compare t1 t2 = String.compare t1.name t2.name
-
-    let equal t1 t2 =
-      match compare t1 t2 with
-      | Eq -> true
-      | Gt | Lt -> false
-    ;;
+    let equal t1 t2 = String.equal t1.name t2.name
 
     let to_dyn t =
       Dyn.record


### PR DESCRIPTION
There's no need to rely on compare for this