### PR TITLE
feature: allow all sandboxed actions to produce corrected files

### DIFF
--- a/doc/changes/added/13813.md
+++ b/doc/changes/added/13813.md
@@ -1,0 +1,3 @@
+- Sandboxed rules are now allowed to produce diff promotions when `(corrections
+  produce)` is set on the rules. Whenever such an action produces `foo.corrected`, it will
+  be automatically registered as a promotion for `foo` (#13813, @rgrinberg)

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -5,6 +5,7 @@ type t = string
 module Extension = struct
   type t = string
 
+  let corrected = ".corrected"
   let ml = ".ml"
   let mli = ".mli"
   let vo = ".vo"

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -20,6 +20,7 @@ type t = string
 module Extension : sig
   type t
 
+  val corrected : t
   val ml : t
   val mli : t
   val mlpack : t

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -314,6 +314,7 @@ module Full = struct
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
       ; sandbox : Sandbox_config.t
+      ; corrections : Corrections.t option
       }
 
     let empty =
@@ -322,15 +323,29 @@ module Full = struct
       ; locks = []
       ; can_go_in_shared_cache = true
       ; sandbox = Sandbox_config.default
+      ; corrections = None
       }
     ;;
 
-    let combine { action; env; locks; can_go_in_shared_cache; sandbox } x =
+    let combine_corrections (x : Corrections.t option) (y : Corrections.t option) =
+      match x, y with
+      | None, x -> x
+      | x, None -> x
+      | Some Produce, Some Produce -> Some Produce
+      | Some Ignore, Some Ignore -> Some Ignore
+      | Some x, Some y ->
+        Code_error.raise
+          "incompatible corrections settings for action"
+          [ "x", Corrections.to_dyn x; "y", Corrections.to_dyn y ]
+    ;;
+
+    let combine { action; env; locks; can_go_in_shared_cache; sandbox; corrections } x =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
       ; can_go_in_shared_cache = can_go_in_shared_cache && x.can_go_in_shared_cache
       ; sandbox = Sandbox_config.inter sandbox x.sandbox
+      ; corrections = combine_corrections corrections x.corrections
       }
     ;;
   end
@@ -343,9 +358,10 @@ module Full = struct
         ?(locks = [])
         ?(can_go_in_shared_cache = !Clflags.can_go_in_shared_cache_default)
         ?(sandbox = Sandbox_config.default)
+        ?corrections
         action
     =
-    { action; env; locks; can_go_in_shared_cache; sandbox }
+    { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
   ;;
 
   let map t ~f = { t with action = f t.action }
@@ -357,4 +373,8 @@ module Full = struct
   ;;
 
   let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
+
+  let add_corrections corrections t =
+    { t with corrections = combine_corrections (Some corrections) t.corrections }
+  ;;
 end

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -147,6 +147,7 @@ module Full : sig
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
     ; sandbox : Sandbox_config.t
+    ; corrections : Corrections.t option
     }
 
   val make
@@ -155,6 +156,7 @@ module Full : sig
     -> ?can_go_in_shared_cache:bool
          (** default [!Clflags.can_fo_in_shared_cache_default] *)
     -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
+    -> ?corrections:Corrections.t (** default [Corrections.Ignore] *)
     -> action
     -> t
 
@@ -171,6 +173,7 @@ module Full : sig
   val add_locks : Path.t list -> t -> t
   val add_sandbox : Sandbox_config.t -> t -> t
   val add_can_go_in_shared_cache : bool -> t -> t
+  val add_corrections : Corrections.t -> t -> t
 
   include Monoid with type t := t
 end

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -269,7 +269,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 23
+  let rule_digest_version = 24
 
   let compute_rule_digest
         (rule : Rule.t)
@@ -283,6 +283,7 @@ end = struct
         ; locks
         ; can_go_in_shared_cache
         ; sandbox = _ (* already taken into account in [sandbox_mode] *)
+        ; corrections
         }
       =
       action
@@ -299,6 +300,7 @@ end = struct
       , Action.for_shell action
       , can_go_in_shared_cache
       , List.map locks ~f:Path.to_string
+      , corrections
       , Execution_parameters.action_stdout_on_success execution_parameters
       , Execution_parameters.action_stderr_on_success execution_parameters
       , Execution_parameters.workspace_root_to_build_path_prefix_map execution_parameters
@@ -353,7 +355,14 @@ end = struct
     : Exec_result.t Fiber.t
     =
     let open Fiber.O in
-    let { Action.Full.action; env; locks; can_go_in_shared_cache = _; sandbox = _ } =
+    let { Action.Full.action
+        ; env
+        ; locks
+        ; can_go_in_shared_cache = _
+        ; sandbox = _
+        ; corrections
+        }
+      =
       action
     in
     let deps =
@@ -368,6 +377,7 @@ end = struct
         let+ sandbox =
           Sandbox.create
             ~mode
+            (Option.value ~default:Ignore corrections)
             ~dirs:(Dep.Facts.necessary_dirs_for_sandboxing facts)
             ~deps
             ~rule_dir:targets.root
@@ -739,7 +749,7 @@ end = struct
 
   (* The current version of the action digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let action_digest_version = 3
+  let action_digest_version = 4
 
   let execute_action_generic
         ~observing_facts
@@ -773,7 +783,7 @@ end = struct
     ignore observing_facts;
     let digest =
       let { Rule.Anonymous_action.action =
-              { action; env; locks; can_go_in_shared_cache; sandbox }
+              { action; env; locks; can_go_in_shared_cache; sandbox; corrections }
           ; loc = _
           ; dir
           ; alias
@@ -806,7 +816,8 @@ end = struct
         , alias
         , capture_stdout
         , can_go_in_shared_cache
-        , sandbox )
+        , sandbox
+        , corrections )
     in
     (* It might seem superfluous to memoize the execution here, given that a
        given anonymous action will typically only appear once during a given

--- a/src/dune_engine/corrections.ml
+++ b/src/dune_engine/corrections.ml
@@ -1,0 +1,8 @@
+type t =
+  | Ignore
+  | Produce
+
+let to_dyn = function
+  | Ignore -> Dyn.variant "Ignore" []
+  | Produce -> Dyn.variant "Produce" []
+;;

--- a/src/dune_engine/corrections.mli
+++ b/src/dune_engine/corrections.mli
@@ -1,0 +1,5 @@
+type t =
+  | Ignore
+  | Produce
+
+val to_dyn : t -> Dyn.t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -1,5 +1,6 @@
 module Display = Display
 module Context_name = Context_name
+module Corrections = Corrections
 module Action_builder = Action_builder
 module Dep = Dep
 module Action = Action

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -50,6 +50,8 @@ type snapshot = [ `Dir | `File of Cached_digest.Reduced_stats.t ] Path.Map.t
 type t =
   { dir : Path.Build.t
   ; snapshot : snapshot option
+  ; corrections : Corrections.t
+  ; deps : Path.Set.t option
   ; loc : Loc.t
   }
 
@@ -182,13 +184,85 @@ let snapshot t =
   snapshot
 ;;
 
-let create ~mode ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
+let find_corrected_files (t : t) ~deps =
+  (* CR-someday rgrinberg: fuse this step with deletion *)
+  let start = Time.now () in
+  let corrected =
+    Fpath.traverse
+      ~dir:(Path.Build.to_string t.dir)
+      ~init:[]
+      ~on_dir:(fun ~dir:_ _ acc -> acc)
+      ~enter_dir:(fun ~dir:_ fname ->
+        (* We don't want to traverse the corrections produced by a nested dune *)
+        not (String.equal fname ".sandbox" || String.equal fname "_build"))
+      ~on_file:(fun ~dir fname acc ->
+        match
+          let path = Path.Build.relative t.dir (Filename.concat dir fname) in
+          if
+            let extension = Filename.extension fname in
+            Filename.Extension.Or_empty.check extension Filename.Extension.corrected
+            &&
+            let (_ : Path.Build.t option), path = Path.Build.split_sandbox_root path in
+            (* Dependencies cannot be corrections *)
+            not
+              (* CR-soon rgrinberg: slow for no reason. to fix. *)
+              (let path = Path.build path in
+               Path.Set.exists deps ~f:(fun dep ->
+                 Path.equal dep path || Path.is_descendant path ~of_:dep))
+          then Some path
+          else None
+        with
+        | None -> acc
+        | Some path -> path :: acc)
+      ~on_other:`Ignore
+      ~on_symlink:`Ignore
+      ()
+  in
+  let stop = Time.now () in
+  Dune_trace.emit ~buffered:true Sandbox (fun () ->
+    Dune_trace.Event.sandbox `Corrected ~start ~stop ~queued:None t.loc ~dir:t.dir);
+  corrected
+;;
+
+let build_path_without_corrected_suffix path =
+  let basename = Path.Build.basename path in
+  let extension = Filename.extension basename in
+  assert (Filename.Extension.Or_empty.check extension Filename.Extension.corrected);
+  let basename = Filename.remove_extension basename in
+  let parent = Path.Build.parent_exn path in
+  Path.Build.relative parent basename
+;;
+
+let register_corrected_file_promotions t ~deps =
+  find_corrected_files t ~deps
+  |> Fiber.parallel_iter ~f:(fun file2 ->
+    let (_ : Path.Build.t option), file2_without_sandbox =
+      Path.Build.split_sandbox_root file2
+    in
+    let file1 = build_path_without_corrected_suffix file2_without_sandbox |> Path.build in
+    Diff_action.exec
+      ~patch_back:(Some (Path.build t.dir))
+      t.loc
+      { Dune_util.Action.Diff.file1; file2; optional = false; mode = Text })
+;;
+
+let create
+      ~mode
+      (corrections : Corrections.t)
+      ~rule_loc
+      ~dirs
+      ~deps
+      ~rule_dir
+      ~rule_digest
+  =
   init ();
   let sandbox_dir =
     let sandbox_suffix = rule_digest |> Digest.to_string in
     Path.Build.relative sandbox_dir sandbox_suffix
   in
-  let t = { dir = sandbox_dir; snapshot = None; loc = rule_loc } in
+  let t =
+    { dir = sandbox_dir; snapshot = None; deps = None; loc = rule_loc; corrections }
+  in
   let open Fiber.O in
   let+ start, stop, queued =
     maybe_async (fun () ->
@@ -200,9 +274,19 @@ let create ~mode ~rule_loc ~dirs ~deps ~rule_dir ~rule_digest =
   in
   Dune_trace.emit ~buffered:true Sandbox (fun () ->
     Dune_trace.Event.sandbox `Create ~start ~stop ~queued t.loc ~dir:t.dir);
+  let deps =
+    match corrections, mode with
+    | Ignore, Patch_back_source_tree -> Some deps
+    | Produce, Patch_back_source_tree ->
+      Code_error.raise "a patch back sandboxed rule may not produce corrections" []
+    | _, (Symlink | Copy | Hardlink) ->
+      (match corrections with
+       | Produce -> Some deps
+       | Ignore -> None)
+  in
   match mode with
-  | Patch_back_source_tree -> { t with snapshot = Some (snapshot t) }
-  | _ -> t
+  | Patch_back_source_tree -> { t with snapshot = Some (snapshot t); deps }
+  | _ -> { t with deps }
 ;;
 
 (* Same as [rename] except that if the source doesn't exist we delete the
@@ -301,6 +385,13 @@ let move_targets_to_build_dir t ~should_be_skipped ~(targets : Targets.Validated
   =
   let open Fiber.O in
   let start = Time.now () in
+  let* () =
+    match t.corrections with
+    | Ignore -> Fiber.return ()
+    | Produce ->
+      let deps = Option.value_exn t.deps in
+      register_corrected_file_promotions t ~deps
+  in
   let+ () =
     match t.snapshot with
     | None -> Fiber.return ()

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -12,6 +12,7 @@ val map_path : t -> Path.Build.t -> Path.Build.t
 (** Create a new sandbox containing [dirs] and copy or link dependencies [deps] inside it. *)
 val create
   :  mode:Sandbox_mode.some
+  -> Corrections.t
   -> rule_loc:Loc.t
   -> dirs:Path.Build.Set.t
   -> deps:Path.Set.t

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -37,6 +37,7 @@ module Targets = Dune_targets
 
 include struct
   open Dune_engine
+  module Corrections = Corrections
   module Dir_set = Dir_set
   module Rule = Rule
   module Rules = Rules

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -88,6 +88,49 @@ let add_user_rule
   Super_context.add_rule_get_targets sctx ~dir ~mode ~loc:rule.loc action
 ;;
 
+let dep_uses_patch_back_source_tree (d : Dep_conf.t) =
+  match d with
+  | Sandbox_config config ->
+    Dep_conf.Sandbox_config.fold config ~init:false ~f:(fun mode acc ->
+      acc || Poly.equal mode `Patch_back_source_tree)
+  | _ -> false
+;;
+
+let rule_uses_patch_back_source_tree (rule : Rule_conf.t) =
+  (* CR-someday rgrinberg: early exit from fold *)
+  Bindings.fold rule.deps ~init:false ~f:(fun one acc ->
+    acc
+    ||
+    match one with
+    | Unnamed dep -> dep_uses_patch_back_source_tree dep
+    | Named (_, deps) -> List.exists deps ~f:dep_uses_patch_back_source_tree)
+;;
+
+let validate_corrections ~(rule : Rule_conf.t) =
+  match rule.corrections with
+  | None -> ()
+  | Some Ignore -> ()
+  | Some Produce ->
+    if rule_uses_patch_back_source_tree rule
+    then
+      User_error.raise
+        ~loc:rule.loc
+        [ Pp.text
+            "Only (corrections ignore) is allowed on rules using patch-back-source-tree \
+             sandboxing."
+        ]
+;;
+
+let add_corrections ~(rule : Rule_conf.t) action =
+  match rule.corrections with
+  | None -> action
+  | Some Ignore -> Action.Full.add_corrections Ignore action
+  | Some Produce ->
+    action
+    |> Action.Full.add_sandbox Sandbox_config.needs_sandboxing
+    |> Action.Full.add_corrections Produce
+;;
+
 let user_rule sctx ~dir ~expander (rule : Rule_conf.t) =
   Expander.eval_blang expander rule.enabled_if
   >>= function
@@ -116,10 +159,13 @@ let user_rule sctx ~dir ~expander (rule : Rule_conf.t) =
         Targets_spec.Static { multiplicity; targets }
     in
     let sandbox =
-      if Dune_project.dune_version (Expander.project expander) >= (3, 23)
+      if
+        rule_uses_patch_back_source_tree rule
+        || Dune_project.dune_version (Expander.project expander) >= (3, 23)
       then Sandbox_config.needs_sandboxing
       else Sandbox_config.no_special_requirements
     in
+    let () = validate_corrections ~rule in
     let* action =
       let chdir = Expander.dir expander in
       Action_unexpanded.expand
@@ -132,6 +178,7 @@ let user_rule sctx ~dir ~expander (rule : Rule_conf.t) =
         ~targets
         ~targets_dir:dir
     in
+    let action = Action_builder.With_targets.map action ~f:(add_corrections ~rule) in
     (match rule_kind ~rule ~action with
      | No_alias ->
        let+ targets = add_user_rule sctx ~dir ~rule ~action ~expander in

--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -6,10 +6,13 @@ module Mode = struct
   include Rule_mode_decoder
 end
 
+let corrections = enum [ "ignore", Corrections.Ignore; "produce", Produce ]
+
 type t =
   { targets : String_with_vars.t Targets_spec.t
   ; deps : Dep_conf.t Bindings.t
   ; action : Loc.t * Dune_lang.Action.t
+  ; corrections : Corrections.t option
   ; mode : Rule_mode.t
   ; locks : Locks.t
   ; loc : Loc.t
@@ -56,6 +59,7 @@ let atom_table =
     ; "target", Field
     ; "deps", Field
     ; "action", Field
+    ; "corrections", Field
     ; "locks", Field
     ; "fallback", Field
     ; "mode", Field
@@ -72,6 +76,7 @@ let short_form ~loc =
   { targets = Infer
   ; deps = Bindings.empty
   ; action
+  ; corrections = None
   ; mode = Standard
   ; locks = []
   ; loc
@@ -105,6 +110,8 @@ let long_form ~loc =
     (let+ action_o = field_o "action" (located Dune_lang.Action.decode_dune_file)
      and+ targets = Targets_spec.field ~allow_directory_targets
      and+ locks = Locks.field ()
+     and+ corrections =
+       field_o "corrections" (Dune_lang.Syntax.since Stanza.syntax (3, 23) >>> corrections)
      and+ () =
        let+ fallback =
          field_b
@@ -147,7 +154,17 @@ let long_form ~loc =
          in
          field_missing ~hints loc "action"
      in
-     { targets; deps; action; mode; locks; loc; enabled_if; aliases; package })
+     { targets
+     ; deps
+     ; action
+     ; corrections
+     ; mode
+     ; locks
+     ; loc
+     ; enabled_if
+     ; aliases
+     ; package
+     })
 ;;
 
 let decode =

--- a/src/dune_rules/stanzas/rule_conf.mli
+++ b/src/dune_rules/stanzas/rule_conf.mli
@@ -4,6 +4,7 @@ type t =
   { targets : String_with_vars.t Targets_spec.t
   ; deps : Dep_conf.t Bindings.t
   ; action : Loc.t * Dune_lang.Action.t
+  ; corrections : Corrections.t option
   ; mode : Rule_mode.t
   ; locks : Locks.t
   ; loc : Loc.t

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -38,7 +38,7 @@ module Event : sig
   type t
 
   val sandbox
-    :  [ `Create | `Snapshot | `Destroy | `Extract ]
+    :  [ `Create | `Snapshot | `Destroy | `Extract | `Corrected ]
     -> start:Time.t
     -> stop:Time.t
     -> queued:Time.Span.t option

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -774,6 +774,7 @@ let sandbox name ~start ~stop ~queued loc ~dir =
     | `Snapshot -> "snapshot"
     | `Create -> "create"
     | `Extract -> "extract"
+    | `Corrected -> "corrected"
   in
   Event.complete ~args ~name ~start ~dur Sandbox
 ;;

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
+  Warning: cache store error [a782b54eded560f6834c931b0a47ba50]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -120,7 +120,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
+  Warning: cache store error [a782b54eded560f6834c931b0a47ba50]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -132,7 +132,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [112e5b212dcbd75e93b87a6d9c49be66]: ((in_cache
+  Warning: cache store error [a782b54eded560f6834c931b0a47ba50]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out
-  ./62/62b3d3204298795e1dc06d2ad898320c:((8:metadata)(5:files(8:target_b32:d5b73f7b5d75090e1da54099e4458db3)))
-  ./92/9205b2a6c2a50c99556a20c05b6471f8:((8:metadata)(5:files(8:target_a32:7b362c0c7d2035084c9fc2d0e6815be5)))
+  ./04/04a6b4a32ec5bea1aaeea9246e98a485:((8:metadata)(5:files(8:target_b32:d5b73f7b5d75090e1da54099e4458db3)))
+  ./ad/ad415a0409b7cb6e4764bca72e9f0a15:((8:metadata)(5:files(8:target_a32:7b362c0c7d2035084c9fc2d0e6815be5)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/before-323.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/before-323.t
@@ -1,0 +1,16 @@
+The corrections field is rejected before Dune 3.23
+
+  $ make_dune_project 3.22
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (action (system "echo corrected > a.corrected")))
+  > EOF
+  $ dune build @runtest
+  File "dune", line 3, characters 1-22:
+  3 |  (corrections produce)
+       ^^^^^^^^^^^^^^^^^^^^^
+  Error: 'corrections' is only available since version 3.23 of the dune
+  language. Please update your dune-project file to have (lang dune 3.23).
+  [1]

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/build-dir.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/build-dir.t
@@ -1,0 +1,17 @@
+Corrections under nested _build directories are ignored
+
+  $ make_dune_project 3.23
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (targets x)
+  >  (action
+  >   (progn
+  >    (system "mkdir -p nested/_build/default")
+  >    (system "echo corrected > nested/_build/default/a.corrected")
+  >    (system "touch x"))))
+  > EOF
+  $ dune build @runtest && echo passed
+  passed
+  $ dune promotion list

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/cram-repro.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/cram-repro.t
@@ -1,0 +1,12 @@
+Nested cram tests are ignored unless a rule opts into corrections
+
+  $ mkdir inner
+  $ cat > inner/dune-project <<'EOF'
+  > (lang dune 3.23)
+  > EOF
+  $ cat > inner/repro.t <<'EOF'
+  >   $ echo existing > a.corrected
+  > EOF
+  $ dune runtest inner/repro.t && echo passed
+  passed
+  $ dune promotion list

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/dependency.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/dependency.t
@@ -1,0 +1,22 @@
+Copied corrected-file dependencies are ignored
+
+  $ mkdir inner
+  $ cat > inner/dune-project <<'EOF'
+  > (lang dune 3.23)
+  > EOF
+  $ cat > inner/dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps a.corrected)
+  >  (action (system "echo updated > a.corrected")))
+  > EOF
+  $ cat > inner/a.corrected <<'EOF'
+  > existing
+  > EOF
+
+Copying is needed because we're modifying our dependency
+  $ (cd inner && dune build @runtest --sandbox copy) && echo passed
+  passed
+  $ (cd inner && dune promotion list)
+  $ rm inner/a.corrected

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/fails-and-promotes.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/fails-and-promotes.t
@@ -1,0 +1,25 @@
+Sandboxed corrected files fail and register promotions from Dune 3.23
+
+  $ make_dune_project 3.23
+  $ echo original > a
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps a)
+  >  (action (system "echo corrected > a.corrected")))
+  > EOF
+  $ dune build @runtest
+  File "a", line 1, characters 0-0:
+  --- a
+  +++ _build/default/a.corrected
+  @@ -1 +1 @@
+  -original
+  +corrected
+  [1]
+  $ dune promotion list
+  a
+  $ dune promote
+  Promoting _build/default/a.corrected to a.
+  $ cat a
+  corrected

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/identical.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/identical.t
@@ -1,0 +1,16 @@
+Identical sandboxed corrections pass without creating promotions
+
+  $ make_dune_project 3.23
+  $ echo same > a
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps a)
+  >  (action (system "cp a a.corrected")))
+  > EOF
+  $ dune build @runtest && echo passed
+  passed
+  $ dune promotion list
+  $ cat a
+  same

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/ignore.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/ignore.t
@@ -1,0 +1,16 @@
+Explicit corrections ignore leaves corrected files alone
+
+  $ make_dune_project 3.23
+  $ echo original > a
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections ignore)
+  >  (deps a)
+  >  (action (system "echo corrected > a.corrected")))
+  > EOF
+  $ dune build @runtest && echo passed
+  passed
+  $ dune promotion list
+  $ cat a
+  original

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/multiple.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/multiple.t
@@ -1,0 +1,21 @@
+All sandbox-produced corrected files are registered
+
+  $ make_dune_project 3.23
+  $ mkdir -p sub
+  $ echo alpha > a
+  $ echo beta > sub/b
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps a sub/b)
+  >  (action
+  >   (progn
+  >    (system "echo alpha-fixed > a.corrected")
+  >    (system "echo beta-fixed > sub/b.corrected"))))
+  > EOF
+  $ dune build @runtest > /dev/null 2>&1 || echo failed
+  failed
+  $ dune promotion list
+  a
+  sub/b

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/nested-dune.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/nested-dune.t
@@ -1,0 +1,28 @@
+Nested dune sandboxes are ignored when scanning for outer corrections
+
+  $ make_dune_project 3.23
+  $ mkdir inner
+  $ cat > inner/dune-project <<'EOF'
+  > (lang dune 3.23)
+  > EOF
+  $ cat > inner/dune <<'EOF'
+  > (rule
+  >  (target y)
+  >  (action (write-file %{target} ok)))
+  > EOF
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps (source_tree inner))
+  >  (targets x)
+  >  (action
+  >   (progn
+  >    (system "cd inner && dune build y")
+  >    (system "mkdir -p inner/_build/.sandbox/hash/default")
+  >    (system "echo corrected > inner/_build/.sandbox/hash/default/a.corrected")
+  >    (system "touch x"))))
+  > EOF
+  $ dune build @runtest && echo passed
+  passed
+  $ dune promotion list

--- a/test/blackbox-tests/test-cases/sandbox/corrected-files/patch-back.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrected-files/patch-back.t
@@ -1,0 +1,29 @@
+Patch-back sandboxing only allows corrections ignore
+
+  $ make_dune_project 3.23
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections ignore)
+  >  (deps (sandbox patch_back_source_tree))
+  >  (action (system "true")))
+  > EOF
+  $ dune build @runtest && echo passed
+  passed
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps (sandbox patch_back_source_tree))
+  >  (action (system "true")))
+  > EOF
+  $ dune build @runtest
+  File "dune", lines 1-5, characters 0-113:
+  1 | (rule
+  2 |  (alias runtest)
+  3 |  (corrections produce)
+  4 |  (deps (sandbox patch_back_source_tree))
+  5 |  (action (system "true")))
+  Error: Only (corrections ignore) is allowed on rules using
+  patch-back-source-tree sandboxing.
+  [1]

--- a/test/blackbox-tests/test-cases/sandbox/corrections-directory-deps.t
+++ b/test/blackbox-tests/test-cases/sandbox/corrections-directory-deps.t
@@ -1,0 +1,18 @@
+Corrections under a copied directory dependency are still promoted
+
+  $ make_dune_project 3.23
+  $ mkdir -p inner/sub
+  $ echo original > inner/sub/b
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (corrections produce)
+  >  (deps (source_tree inner))
+  >  (action (system "echo corrected > inner/sub/b.corrected")))
+  > EOF
+
+Copying is needed because we're writing into the copied dependency tree
+  $ dune build @runtest --sandbox copy > /dev/null 2>&1 || echo failed
+  failed
+  $ dune promotion list
+  inner/sub/b


### PR DESCRIPTION
All sandboxed actions can now produce .corrected files which may be used to produce promotions that can update sources.

The advantage of this approach over diff is that we need not declare targets. The disadvantage is promotions can now overlap and we don't which rules we need to run to produce corrections for any particular file.