### PR TITLE
refactor: simplify some confusing code

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -155,17 +155,5 @@ let command_alias ?orig_name cmd term name =
   Cmd.v (Cmd.info name ~docs:"COMMAND ALIASES" ~doc ~man) term
 ;;
 
-(* The build system has some global state which makes it unsafe for
-   multiple instances of it to be executed concurrently, so we ensure
-   serialization by holding this mutex while running the build system. *)
-let build_system_mutex = Fiber.Mutex.create ()
-
-let build f =
-  Hooks.End_of_build.once Dune_engine.Diff_promotion.finalize;
-  Fiber.Mutex.with_lock build_system_mutex ~f:(fun () -> Build_system.run f)
-;;
-
-let build_exn f =
-  Hooks.End_of_build.once Dune_engine.Diff_promotion.finalize;
-  Fiber.Mutex.with_lock build_system_mutex ~f:(fun () -> Build_system.run_exn f)
-;;
+let build f = Build_system.run f
+let build_exn f = Build_system.run_exn f

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1146,14 +1146,13 @@ let handle_final_exns exns =
 
 let run f =
   let open Fiber.O in
-  let* () = State.reset_progress () in
-  let* () = State.reset_errors () in
   let f () =
-    let* res =
-      Fiber.collect_errors (fun () ->
-        Memo.run_with_error_handler f ~handle_error_no_raise:report_early_exn)
-    in
-    match res with
+    Hooks.End_of_build.once Diff_promotion.finalize;
+    let* () = State.reset_progress () in
+    let* () = State.reset_errors () in
+    Fiber.collect_errors (fun () ->
+      Memo.run_with_error_handler f ~handle_error_no_raise:report_early_exn)
+    >>= function
     | Ok res ->
       let+ () = State.set Build_succeeded__now_waiting_for_changes in
       Ok res
@@ -1172,8 +1171,8 @@ let run f =
 
 let run_exn f =
   let open Fiber.O in
-  let+ res = run f in
-  match res with
+  run f
+  >>| function
   | Ok res -> res
   | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
 ;;


### PR DESCRIPTION
1. There's no need to add a mutex around Build_system.run. There's already a mutex.

2. Add the diff promotion hook in one place