### PR TITLE
test(which): double .exe on windows

### DIFF
--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -86,6 +86,7 @@ module For_tests = struct
   module Ocamlobjinfo = Ocamlobjinfo
   module Action_unexpanded = Action_unexpanded
   module Cram_exec = Cram_exec
+  module Which = Which
 end
 
 module Coq = struct

--- a/test/unit-tests/which/dune
+++ b/test/unit-tests/which/dune
@@ -1,0 +1,12 @@
+(test
+ (name which_tests)
+ (enabled_if
+  (= %{os_type} Win32))
+ (libraries dyn dune_rules))
+
+(alias
+ (name runtest-windows)
+ (enabled_if
+  (= %{os_type} Win32))
+ (deps
+  (alias runtest-which_tests)))

--- a/test/unit-tests/which/which_tests.expected
+++ b/test/unit-tests/which/which_tests.expected
@@ -1,0 +1,5 @@
+candidates "ocamlc" = [ "ocamlc.opt.exe"; "ocamlc.exe" ]
+candidates "ocamlc.exe" = [ "ocamlc.exe.exe" ]
+candidates "OCAMLC.EXE" = [ "OCAMLC.EXE.exe" ]
+candidates "foo" = [ "foo.exe" ]
+candidates "foo.exe" = [ "foo.exe.exe" ]

--- a/test/unit-tests/which/which_tests.ml
+++ b/test/unit-tests/which/which_tests.ml
@@ -1,0 +1,26 @@
+(* Test that Which.candidates handles programs that already have .exe extension.
+   This is a regression test for https://github.com/ocaml/dune/pull/13620
+
+   On Windows, if a program name already has .exe, we should not produce
+   "prog.exe.exe". This test only runs on Windows (via enabled_if in dune). *)
+
+let test prog =
+  Dune_rules.For_tests.Which.candidates prog
+  |> Dyn.list Dyn.string
+  |> Dyn.to_string
+  |> Printf.printf "candidates %S = %s\n" prog
+;;
+
+(* See the .expected file for the output *)
+let () =
+  (* Standard case: program without .exe gets .exe added *)
+  test "ocamlc";
+  (* The key test: "ocamlc.exe" should NOT produce "ocamlc.exe.exe" *)
+  test "ocamlc.exe";
+  (* Case insensitive check *)
+  test "OCAMLC.EXE";
+  (* Non-special program (not in programs_for_which_we_prefer_opt_ext) *)
+  test "foo";
+  (* Non-special program with .exe should not get double extension *)
+  test "foo.exe"
+;;


### PR DESCRIPTION
This PR demonstrates a bug with `which` on Windows where `.exe.exe` candidates are generated and searched for. Will be fixed by:
- #13620 

Has been checked to run on Windows.

ppx_expect doesn't work on windows so we opt to use the `.expected` functionality of `(test)`. 