### PR TITLE
test(fswatch): run fswatch tests on windows

### DIFF
--- a/test/unit-tests/fswatch_win/dune
+++ b/test/unit-tests/fswatch_win/dune
@@ -10,6 +10,13 @@
   (run ./fswatch_win_tests.exe)))
 
 (alias
+ (name runtest-windows)
+ (enabled_if
+  (= %{os_type} Win32))
+ (deps
+  (alias fswatch_win_tests)))
+
+(alias
  (name runtest)
  (enabled_if
   (= %{os_type} Win32))


### PR DESCRIPTION
These were not being run at all. They may need fixing.