### PR TITLE
fix(scope): fix enabled_if evaluation in lib_entries_of_package

### DIFF
--- a/doc/changes/fixed/13833.md
+++ b/doc/changes/fixed/13833.md
@@ -1,0 +1,2 @@
+- Fix dependency cycle when using the `package` with a library
+  conditionally enabled via `enabled_if`. (#13833, @toots)

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -514,34 +514,41 @@ module DB = struct
         Dune_file.Memo_fold.fold_static_stanzas stanzas ~init:[] ~f:(fun d stanza acc ->
           match Stanza.repr stanza with
           | Library.T ({ enabled_if; _ } as lib) ->
-            let* enabled =
-              let* expander = Expander0.get ~dir:build_dir in
-              Expander0.eval_blang expander enabled_if
-            in
-            if not enabled
-            then Memo.return acc
-            else (
-              match lib.visibility with
-              | Private None -> Memo.return acc
-              | Private (Some pkg) ->
-                let src_dir = Dune_file.dir d in
-                let* scope = find_by_dir (Path.Build.append_source build_dir src_dir) in
-                Lib.DB.find_lib_id (libs scope) (Local (Library.to_lib_id ~src_dir lib))
-                >>| (function
-                 | None -> acc
-                 | Some lib ->
-                   let name = Package.name pkg in
-                   (name, Lib_entry.Library (Lib.Local.of_lib_exn lib)) :: acc)
-              | Public pub ->
-                let src_dir = Dune_file.dir d in
-                Lib.DB.find_lib_id public_libs (Local (Library.to_lib_id ~src_dir lib))
-                >>| (function
-                 | None -> acc
-                 | Some lib ->
-                   let package = Public_lib.package pub in
-                   let name = Package.name package in
-                   let local_lib = Lib.Local.of_lib_exn lib in
-                   (name, Lib_entry.Library local_lib) :: acc))
+            let src_dir = Dune_file.dir d in
+            let lib_dir = Path.Build.append_source build_dir src_dir in
+            (match lib.visibility with
+             | Private None -> Memo.return acc
+             | Private (Some pkg) ->
+               let* enabled =
+                 let* expander = Expander0.get ~dir:lib_dir in
+                 Expander0.eval_blang expander enabled_if
+               in
+               if not enabled
+               then Memo.return acc
+               else
+                 let* scope = find_by_dir lib_dir in
+                 Lib.DB.find_lib_id (libs scope) (Local (Library.to_lib_id ~src_dir lib))
+                 >>| (function
+                  | None -> acc
+                  | Some lib ->
+                    let name = Package.name pkg in
+                    (name, Lib_entry.Library (Lib.Local.of_lib_exn lib)) :: acc)
+             | Public pub ->
+               let* enabled =
+                 let* expander = Expander0.get ~dir:lib_dir in
+                 Expander0.eval_blang expander enabled_if
+               in
+               if not enabled
+               then Memo.return acc
+               else
+                 Lib.DB.find_lib_id public_libs (Local (Library.to_lib_id ~src_dir lib))
+                 >>| (function
+                  | None -> acc
+                  | Some lib ->
+                    let package = Public_lib.package pub in
+                    let name = Package.name package in
+                    let local_lib = Lib.Local.of_lib_exn lib in
+                    (name, Lib_entry.Library local_lib) :: acc))
           | Deprecated_library_name.T ({ old_name = old_public_name, _; _ } as d) ->
             let package = Public_lib.package old_public_name in
             let name = Package.name package in

--- a/test/blackbox-tests/test-cases/library-enabled_if-with-package.t
+++ b/test/blackbox-tests/test-cases/library-enabled_if-with-package.t
@@ -1,0 +1,55 @@
+Regression test: libraries with dynamic enabled_if should not cause a dependency
+cycle when a (package ...) directive is present in dune-project.
+
+Private library:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.21)
+  > (package (name repro) (allow_empty))
+  > EOF
+
+  $ mkdir -p optional_lib/configure
+
+  $ cat > optional_lib/dune << EOF
+  > (library
+  >  (name optional_lib)
+  >  (enabled_if (= %{read:configure/enabled} "true")))
+  > EOF
+
+  $ cat > optional_lib/configure/dune << EOF
+  > (rule
+  >  (with-stdout-to enabled (echo "true")))
+  > EOF
+
+  $ dune build
+  Error: Dependency cycle between:
+     %{read:configure/enabled} at optional_lib/dune:3
+  [1]
+
+Public library:
+
+  $ rm -rf optional_lib
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.21)
+  > (package (name repro))
+  > EOF
+
+  $ mkdir -p mylib/configure
+
+  $ cat > mylib/dune << EOF
+  > (library
+  >  (name mylib)
+  >  (public_name repro.mylib)
+  >  (enabled_if (= %{read:configure/enabled} "true")))
+  > EOF
+
+  $ cat > mylib/configure/dune << EOF
+  > (rule
+  >  (with-stdout-to enabled (echo "true")))
+  > EOF
+
+  $ dune build
+  Error: Dependency cycle between:
+     %{read:configure/enabled} at mylib/dune:4
+  [1]

--- a/test/blackbox-tests/test-cases/library-enabled_if-with-package.t
+++ b/test/blackbox-tests/test-cases/library-enabled_if-with-package.t
@@ -22,9 +22,6 @@ Private library:
   > EOF
 
   $ dune build
-  Error: Dependency cycle between:
-     %{read:configure/enabled} at optional_lib/dune:3
-  [1]
 
 Public library:
 
@@ -50,6 +47,3 @@ Public library:
   > EOF
 
   $ dune build
-  Error: Dependency cycle between:
-     %{read:configure/enabled} at mylib/dune:4
-  [1]


### PR DESCRIPTION
## Problem

A library with `enabled_if` using `%{read:...}` works fine without a `(package ...)` directive in `dune-project`, but triggers a spurious dependency cycle when a package is defined:

```
Dependency cycle between: %{read:configure/enabled} at optional_lib/dune:4
```

## Root cause

`lib_entries_of_package` in `scope.ml` calls `make_map`, which evaluated `enabled_if` for **all** library stanzas before checking their visibility. This introduced two bugs:

1. **Cycle**: `enabled_if` was evaluated even for `Private None` libraries (no package), whose result was immediately discarded. This created an unnecessary dependency on `%{read:...}` inside a memoized computation that could not resolve it without cycling.

2. **Wrong directory**: The expander was constructed with `~dir:build_dir` (the project root, e.g. `_build/default`) rather than the library's own directory (e.g. `_build/default/optional_lib`). This caused relative paths in `%{read:...}` to resolve incorrectly for all library visibilities.

## Fix

- Check `Private None` **before** evaluating `enabled_if`, short-circuiting immediately since these libraries can never belong to a package.
- Compute `lib_dir` from the library's source directory and use it when constructing the expander, so `%{read:configure/enabled}` resolves relative to the library's directory.

## Tests

Added `test/blackbox-tests/test-cases/library-enabled_if-with-package.t` covering:
- A private library with dynamic `enabled_if` and a `(package ...)` directive (the original cycle repro)
- A public library with dynamic `enabled_if` (verifies the directory fix applies correctly)