### PR TITLE
test(show): dune show targets does not accept build-only dirs

### DIFF
--- a/test/blackbox-tests/test-cases/describe/targets.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/targets.t/run.t
@@ -70,6 +70,16 @@ We cannot see inside directory targets
   Error: Directory d is a directory target. This command does not support the
   inspection of directory targets.
 
+We cannot show targets in build-only directories that don't exist in the source
+tree, like .simple.objs:
+
+  $ dune show targets .simple.objs
+  Error: Directory .simple.objs does not exist.
+
+CR-soon Alizter: This should work
+  $ dune show targets _build/default/.simple.objs
+  Error: Directory _build/default/.simple.objs does not exist.
+
 And we error on non-existent directories
 
   $ dune show targets non-existent


### PR DESCRIPTION
Reproduces issue in:
- https://github.com/ocaml/dune/issues/13782