### PR TITLE
chore(win): disable flaky fswatch_win test in CI

### DIFF
--- a/test/unit-tests/fswatch_win/dune
+++ b/test/unit-tests/fswatch_win/dune
@@ -11,8 +11,9 @@
 
 (alias
  (name runtest-windows)
- (enabled_if
-  (= %{os_type} Win32))
+ ; Disabled due to flakiness
+ ; CR-someday Alizter: fix this
+ (enabled_if false)
  (deps
   (alias fswatch_win_tests)))
 


### PR DESCRIPTION
Unfortunately this test being run in CI (see #13830) was short-lived. We frequently run into interleaving of the output in both the msvc and mingw jobs such as:

<details>
<summary>Example</summary>

```
* FAILURE **
ACTUAL:
[ { action = "added"; path = "new-file" } ]
EXPECTED:
[ { action = "added"; path = "new-file" }
; { action = "added"; path = "new-dir" }
; { action = "removed"; path = "new-dir" }
; { action = "removed"; path = "new-file" }
; { action = "modified"; path = "f1" }
; { action = "modified"; path = "f2" }
; { action = "modified"; path = "f3" }
; { action = "added"; path = "d1\\new-file" }
; { action = "added"; path = "d1\\new-dir" }
; { action = "removed"; path = "d1\\new-dir" }
; { action = "removed"; path = "d1\\new-file" }
; { action = "modified"; path = "d1\\f1" }
; { action = "modified"; path = "d1\\f2" }
; { action = "modified"; path = "d1\\f3" }
; { action = "added"; path = "d1\\d1\\new-file" }
; { action = "added"; path = "d1\\d1\\new-dir" }
; { action = "removed"; path = "d1\\d1\\new-dir" }
; { action = "removed"; path = "d1\\d1\\new-file" }
; { action = "modified"; path = "d1\\d1\\f1" }
; { action = "modified"; path = "d1\\d1\\f2" }
; { action = "modified"; path = "d1\\d1\\f3" }
; { action = "added"; path = "d1\\d2\\new-file" }
; { action = "added"; path = "d1\\d2\\new-dir" }
; { action = "removed"; path = "d1\\d2\\new-dir" }
; { action = "removed"; path = "d1\\d2\\new-file" }
; { action = "modified"; path = "d1\\d2\\f1" }
; { action = "modified"; path = "d1\\d2\\f2" }
; { action = "modified"; path = "d1\\d2\\f3" }
; { action = "added"; path = "d2\\new-file" }
; { action = "added"; path = "d2\\new-dir" }
; { action = "removed"; path = "d2\\new-dir" }
; { action = "removed"; path = "d2\\new-file" }
; { action = "modified"; path = "d2\\f1" }
; { action = "modified"; path = "d2\\f2" }
; { action = "modified"; path = "d2\\f3" }
; { action = "added"; path = "d2\\d1\\new-file" }
; { action = "added"; path = "d2\\d1\\new-dir" }
; { action = "removed"; path = "d2\\d1\\new-dir" }
; { action = "removed"; path = "d2\\d1\\new-file" }
; { action = "modified"; path = "d2\\d1\\f1" }
; { action = "modified"; path = "d2\\d1\\f2" }
; { action = "modified"; path = "d2\\d1\\f3" }
; { action = "added"; path = "d2\\d2\\new-file" }
; { action = "added"; path = "d2\\d2\\new-dir" }
; { action = "removed"; path = "d2\\d2\\new-dir" }
; { action = "removed"; path = "d2\\d2\\new-file" }
; { action = "modified"; path = "d2\\d2\\f1" }
; { action = "modified"; path = "d2\\d2\\f2" }
; { action = "modified"; path = "d2\\d2\\f3" }
]
```


</details>

We therefore disable this test (in CI) for the time being.

@nojb am I correct in thinking that asking for the order to be preserved between different watchers will never work properly due to interleaving? Should we perhaps fix this test so that we check the order within a directory, i.e. reported by a single watcher?