### PR TITLE
fix: use open_out_bin in configure to avoid CRLF on Windows

### DIFF
--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -117,7 +117,7 @@ let () =
   (match !libexecdir with
    | None -> libexecdir := !library_destdir
    | Some _ -> ());
-  let oc = open_out out in
+  let oc = open_out_bin out in
   let pr fmt = fprintf oc (fmt ^^ "\n") in
   pr "let library_path = %s\n" ((list string) !library_path);
   pr "let roots : string option Install.Roots.t =";


### PR DESCRIPTION
`open_out` will replace newlines with carriage return new lines on Windows. We can avoid this by using `open_out_bin` instead. This avoid unnecessary promotions that happen on Windows where carriage returns are added to `src/dune_rules/setup.defaults.ml`.