### PR TITLE
chore(CI): add CI jobs for package dependency specification and lower bounds

### DIFF
--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -5,6 +5,10 @@ name: Packaging check
 
 on:
   pull_request:
+  push:
+    branches:
+        - main
+        - 'releases/**'
   workflow_dispatch:
 
 jobs:
@@ -17,8 +21,8 @@ jobs:
 
       - id: discover
         shell: bash
-        # Discover the list of packages by reading the opam directory. We treat
-        # all the .opam files as separate packages
+        # Discover the list of packages by reading the opam directory. Each
+        # .opam file defines a separate package.
         run: |
           set -euo pipefail
           packages=$(
@@ -49,13 +53,6 @@ jobs:
       - name: Lint current package metadata
         run: opam lint "./opam/${{ matrix.package }}.opam"
 
-      - name: Get dune version
-        # Read the current version of Dune to determine the package versions in
-        # the next step. This information is absernt in development opam files,
-        # but will be present in the releases.
-        id: dune-version
-        run: echo "version=$(sed -nE 's/^\(lang dune ([0-9]+(\.[0-9]+)*)\)$/\1/p' dune-project)" >> $GITHUB_OUTPUT
-
       - name: Pin all packages without installing
         # Some packages require their sibling packages to be at the same version.
         # All packages also depend on the current version of dune. To make these
@@ -63,8 +60,11 @@ jobs:
         # installing them. This way they are pulled in only if required by the package
         # being built, without influencing the solver for unrelated dependencies.
         env:
-          version: ${{ steps.dune-version.outputs.version }}
-        run: for f in opam/*.opam; do pkg=${f##*/}; pkg=${pkg%.opam}; opam pin add "$pkg.$version" . -n; done
+          packages: ${{ needs.discover-packages.outputs.packages }}
+        run: |
+          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+            opam pin add "$pkg.dev" . -n
+          done
 
       - name: Activate opam environment
         run: |

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -1,0 +1,85 @@
+name: Packaging check
+# Check every sub-package within Dune builds in isolation. This is similar to
+# the opam-repo-ci job to check packaging in isolation, for example:
+# https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a95df9014bc79103fde668cf2adbe6680fd2f9cf/variant/compilers,5.0,fs-io.3.21.0~alpha3,tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  discover-packages:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.discover.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: discover
+        shell: bash
+        # Discover the list of packages by reading the opam directory. We treat
+        # all the .opam files as separate packages
+        run: |
+          set -euo pipefail
+          packages=$(
+            find ./opam -maxdepth 1 -name '*.opam' -printf '%f\n' \
+            | sed 's/\.opam$//' \
+            | sort \
+            | jq -R -s -c 'split("\n")[:-1]'
+          )
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+
+  packaging-check:
+    needs: discover-packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.discover-packages.outputs.packages) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.4
+          dune-cache: true
+          opam-pin: false
+
+      - name: Lint current package metadata
+        run: opam lint "./opam/${{ matrix.package }}.opam"
+
+      - name: Get dune version
+        # Read the current version of Dune to determine the package versions in
+        # the next step. This information is not present in development opam
+        # files, but will be present in the releases.
+        id: dune-version
+        run: echo "version=$(sed -nE 's/^\(lang dune ([0-9]+(\.[0-9]+)*)\)$/\1/p' dune-project)" >> $GITHUB_OUTPUT
+
+      - name: Pin all packages without installing
+        # Some packages require its sibling package be of the same version.
+        # Furthermore, all packages depend on the current version of Dune. To
+        # make all the deps available, we pin all the packages in the `opam`
+        # directory but don't install them. This way the packages will be pulled
+        # in only if they're required by the package we're building and won't
+        # influence the solver.
+        env:
+          version: ${{ steps.dune-version.outputs.version }}
+        run: for f in opam/*.opam; do pkg=${f##*/}; pkg=${pkg%.opam}; opam pin add "$pkg.$version" . -n; done
+
+      - name: Install package dependencies only
+        run: opam install "./opam/${{ matrix.package }}.opam" --deps-only --with-test -y
+
+      - name: Activate opam environment
+        run: |
+          eval $(opam env)
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Bootstrap dune
+        run: |
+          ocaml boot/bootstrap.ml
+          ./dune.exe --version
+
+      - name: Check package builds and installs in isolation
+        # Builds only the current package.
+        run: ./dune.exe build -p "${{ matrix.package }}" @install

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -51,35 +51,34 @@ jobs:
 
       - name: Get dune version
         # Read the current version of Dune to determine the package versions in
-        # the next step. This information is not present in development opam
-        # files, but will be present in the releases.
+        # the next step. This information is absernt in development opam files,
+        # but will be present in the releases.
         id: dune-version
         run: echo "version=$(sed -nE 's/^\(lang dune ([0-9]+(\.[0-9]+)*)\)$/\1/p' dune-project)" >> $GITHUB_OUTPUT
 
       - name: Pin all packages without installing
-        # Some packages require its sibling package be of the same version.
-        # Furthermore, all packages depend on the current version of Dune. To
-        # make all the deps available, we pin all the packages in the `opam`
-        # directory but don't install them. This way the packages will be pulled
-        # in only if they're required by the package we're building and won't
-        # influence the solver.
+        # Some packages require their sibling packages to be at the same version.
+        # All packages also depend on the current version of dune. To make these
+        # dependencies available, we pin all packages in the `opam` directory without
+        # installing them. This way they are pulled in only if required by the package
+        # being built, without influencing the solver for unrelated dependencies.
         env:
           version: ${{ steps.dune-version.outputs.version }}
         run: for f in opam/*.opam; do pkg=${f##*/}; pkg=${pkg%.opam}; opam pin add "$pkg.$version" . -n; done
-
-      - name: Install package dependencies only
-        run: opam install "./opam/${{ matrix.package }}.opam" --deps-only --with-test -y
 
       - name: Activate opam environment
         run: |
           eval $(opam env)
           echo "PATH=$PATH" >> $GITHUB_ENV
 
-      - name: Bootstrap dune
-        run: |
-          ocaml boot/bootstrap.ml
-          ./dune.exe --version
+      - name: Install package
+        run: opam install ${{ matrix.package }} --with-test -y
 
-      - name: Check package builds and installs in isolation
-        # Builds only the current package.
-        run: ./dune.exe build -p "${{ matrix.package }}" @install
+      - name: Lower bounds test
+        # Verify that installation succeeds with lower-bound dependencies.
+        # The package is removed first so that opam reinstalls it fresh,
+        # resolving to the oldest compatible versions rather than reusing
+        # what is already installed.
+        run: |
+          opam remove ${{ matrix.package }}
+          opam install --solver=builtin-0install "--criteria=+count[version-lag,solution]" ${{ matrix.package }}

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -4,11 +4,9 @@ name: Packaging check
 # https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a95df9014bc79103fde668cf2adbe6680fd2f9cf/variant/compilers,5.0,fs-io.3.21.0~alpha3,tests
 
 on:
-  pull_request:
   push:
     branches:
         - main
-        - 'releases/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes #13731.

This is to catch any packaging errors early. This tries to replicate the `opam-repo-ci` job, which does this (one instance here: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a95df9014bc79103fde668cf2adbe6680fd2f9cf/variant/compilers,5.0,fs-io.3.21.0~alpha3,tests), but within source.

The `opam-repo-ci` job clones the whole `opam-repository` and adds the PR as its overlay and tries to install a particular package. We do something similar here by installing dependencies of a specific package and building only that package. I tried to do it without pinning other packages within Dune, but that proved to be tricky; Most packages in the dev repo require the development version of Dune and sibling packages (where there are dependencies on sibling packages). So, I resorted to only pinning the packages and not installing them, thus making them available to the solver, but the packages themselves don't influence the solver.

Note: This matrix creates an independent job for every package. I haven't yet figured out how to make it less noisy in GitHub Actions.