### PR TITLE
refactor(boot): unused modules check

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -2183,6 +2183,19 @@ let build
     in
     write_args "compiled_ml_files" compiled_ml_files
   in
+  let () =
+    let unused = ref [] in
+    Hashtbl.iter table ~f:(fun ~key ~data ->
+      match data with
+      | Not_started _ -> unused := key :: !unused
+      | _ -> ());
+    match !unused with
+    | [] -> ()
+    | xs ->
+      Format.eprintf "unused modules:@.";
+      List.iter xs ~f:(fun m -> Format.eprintf "- %s@." m);
+      failwith "unused modules found"
+  in
   List.concat
     [ common_build_args name ~external_includes ~external_libraries
     ; obj_files

--- a/test/blackbox-tests/test-cases/boot/helpers.sh
+++ b/test/blackbox-tests/test-cases/boot/helpers.sh
@@ -24,6 +24,17 @@ EOF
   export BUILD_PATH_PREFIX_MAP="/OCAMLC=$ocamlc:$BUILD_PATH_PREFIX_MAP"
 }
 
+function make_module() {
+  mkdir -p "$(dirname "$1")"
+  cat >"$1" <<- EOF
+module Spawn = Spawn
+module Re = Re
+module Csexp = Csexp
+module Pp = Pp
+module Uutf = Uutf
+EOF
+}
+
 # Creates a fake dune executable that depends on [$1] and emits bootstrap info
 # which is then used to bootstrap the fake dune.
 function create_dune() {

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
@@ -7,7 +7,8 @@ it picks up the closest one.
 
   $ mkdir a
 
-  $ cat > a/foo.ml << EOF
+  $ make_module a/foo.ml
+  $ cat >> a/foo.ml << EOF
   > let msg = "shouldn't be printed"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
@@ -4,7 +4,8 @@ Testing the bootstrap of a wrapped include subdirs qualified.
 
   $ mkdir -p src/a/b
 
-  $ cat > src/a/b/x.ml <<EOF
+  $ make_module src/a/b/x.ml
+  $ cat >> src/a/b/x.ml <<EOF
   > let () = print_endline "Hello from wrapped a/b/x.ml"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -18,6 +18,8 @@ Testing the bootstrap of an unwrapped include subdirs qualified.
   > let () = Printf.printf "Hello from unwrapped a/b/c/c.ml\n"
   > EOF
 
+  $ make_module src/lib/root.ml
+
   $ cat > src/lib/dune <<EOF
   > (library
   >  (name lib)
@@ -26,6 +28,7 @@ Testing the bootstrap of an unwrapped include subdirs qualified.
   > EOF
 
   $ create_dune lib <<EOF
+  > module Root = Root
   > module M1 = X
   > module M2 = B
   > module M3 = B.C

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -4,7 +4,8 @@ Testing the bootstrap of a wrapped include subdirs qualified.
 
   $ mkdir -p src/a/b/c
 
-  $ cat > src/a/x.ml <<EOF
+  $ make_module src/a/x.ml
+  $ cat >> src/a/x.ml <<EOF
   > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
@@ -4,7 +4,8 @@ Testing the bootstrap of an unwrapped include subdirs unqualified.
 
   $ mkdir -p src/a/b/c
 
-  $ cat > src/a/x.ml <<EOF
+  $ make_module src/a/x.ml
+  $ cat >> src/a/x.ml <<EOF
   > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -4,7 +4,8 @@ Testing the bootstrap of a wrapped include subdirs unqualified.
 
   $ mkdir -p src/a/b/c
 
-  $ cat > src/a/x.ml <<EOF
+  $ make_module src/a/x.ml
+  $ cat >> src/a/x.ml <<EOF
   > let () = Printf.printf "Hello from unwrapped a/x.ml\n"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
@@ -4,7 +4,8 @@ Testing the bootstrap of singleton unwrapped libraries.
 
   $ mkdir -p src/a
 
-  $ cat > src/a/b.ml <<EOF
+  $ make_module src/a/b.ml
+  $ cat >> src/a/b.ml <<EOF
   > let () = Printf.printf "Hello from singleton unwrapped a/b.ml\n"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
@@ -4,7 +4,8 @@ Testing the bootstrap of singleton wrapped libraries.
 
   $ mkdir -p src/a
 
-  $ cat > src/a/a.ml <<EOF
+  $ make_module src/a/a.ml
+  $ cat >> src/a/a.ml <<EOF
   > let () = Printf.printf "Hello from singleton wrapped a/a.ml\n"
   > EOF
 

--- a/test/blackbox-tests/test-cases/boot/unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/unwrapped.t
@@ -17,7 +17,10 @@ Testing the bootstrap of unwrapped libraries.
   >  (wrapped false))
   > EOF
 
+  $ make_module src/a/root.ml
+
   $ create_dune a <<EOF
+  > open Root
   > open A
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -8,6 +8,8 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   > let () = Printf.printf "Hello from wrapped non-interface module a/b.ml\n"
   > EOF
 
+  $ make_module src/a/root.ml
+
   $ cat > src/a/dune <<EOF
   > (library
   >  (name a))
@@ -16,6 +18,7 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   $ create_dune a <<EOF
   > open A
   > open B
+  > open Root
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
   ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/types.ml boot/libs.ml boot/duneboot.ml

--- a/test/blackbox-tests/test-cases/boot/wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped.t
@@ -6,12 +6,15 @@ Testing the bootstrap of wrapped libraries.
 
   $ cat > src/a/a.ml <<EOF
   > module B = B
+  > module Root = Root
   > let () = Printf.printf "Hello from wrapped interface module a/a.ml\n"
   > EOF
 
   $ cat > src/a/b.ml <<EOF
   > let () = Printf.printf "Hello from wrapped module a/b.ml\n"
   > EOF
+
+  $ make_module src/a/root.ml
 
   $ cat > src/a/dune <<EOF
   > (library


### PR DESCRIPTION
A small sanity check to make sure that we aren't including code in the repo that doesn't get linked