### PR TITLE
refactor: remove a bunch of dead code from the dune cache

### DIFF
--- a/src/dune_cache/dune_cache_storage.ml
+++ b/src/dune_cache/dune_cache_storage.ml
@@ -23,13 +23,6 @@ module Store_result = struct
   ;;
 
   let empty = Already_present
-
-  let of_write_result (t : Util.Write_result.t) =
-    match t with
-    | Ok -> Stored
-    | Already_present -> Already_present
-    | Error exn -> Error exn
-  ;;
 end
 
 module Restore_result = struct
@@ -124,28 +117,12 @@ let restore_metadata ~rule_or_action_digest ~of_sexp : _ Restore_result.t =
     ~of_sexp
 ;;
 
-module Raw_value = struct
-  let store_unchecked ~mode ~content ~content_digest =
-    Util.write_atomically
-      ~mode
-      ~content
-      (Lazy.force (Layout.value_path ~value_digest:content_digest))
-  ;;
-end
-
 module Value = struct
   module Metadata_file = struct
     type t =
       { metadata : Sexp.t list
       ; value_digest : Digest.t
       }
-
-    let to_sexp { metadata; value_digest } =
-      Sexp.List
-        [ List (Atom "metadata" :: metadata)
-        ; List [ Atom "value"; Sexp.Atom (Digest.to_string value_digest) ]
-        ]
-    ;;
 
     let of_sexp = function
       | Sexp.List
@@ -161,48 +138,7 @@ module Value = struct
     let restore ~action_digest =
       restore_metadata ~rule_or_action_digest:action_digest ~of_sexp
     ;;
-
-    let matches_existing_entry t ~existing_content : Matches_existing_query.t =
-      match Csexp.parse_string existing_content with
-      | Error _ -> Mismatch (Atom "Malformed value in cache")
-      | Ok sexp ->
-        (match of_sexp sexp with
-         | Error _ -> Mismatch (Atom "Malformed value in cache")
-         | Ok existing ->
-           (match Digest.equal t.value_digest existing.value_digest with
-            | true -> Match
-            | false ->
-              Mismatch
-                (Sexp.record
-                   [ "in_cache", Atom (Digest.to_string existing.value_digest)
-                   ; "computed", Atom (Digest.to_string t.value_digest)
-                   ])))
-    ;;
   end
-
-  let store ~mode ~action_digest value : Store_result.t =
-    let value_digest = Digest.string value in
-    let metadata : Metadata_file.t = { metadata = []; value_digest } in
-    match
-      store_metadata
-        ~mode
-        ~rule_or_action_digest:action_digest
-        ~metadata
-        ~to_sexp:Metadata_file.to_sexp
-        ~matches_existing_entry:Metadata_file.matches_existing_entry
-    with
-    | Will_not_store_due_to_non_determinism details ->
-      Will_not_store_due_to_non_determinism details
-    | Error e -> Error e
-    | (Already_present | Stored) as metadata_result ->
-      (* We assume that there are no hash collisions and hence omit the check
-         for non-determinism when writing values. *)
-      let value_result =
-        Raw_value.store_unchecked ~mode ~content:value ~content_digest:value_digest
-        |> Store_result.of_write_result
-      in
-      Store_result.combine metadata_result value_result
-  ;;
 
   let restore ~action_digest =
     Restore_result.bind
@@ -337,8 +273,6 @@ module Metadata = struct
   module Versioned = struct
     let restore version = restore ~metadata_path:(Layout.Versioned.metadata_path version)
   end
-
-  let restore = restore ~metadata_path:Layout.metadata_path
 end
 
 let clear () =

--- a/src/dune_cache/dune_cache_storage.mli
+++ b/src/dune_cache/dune_cache_storage.mli
@@ -49,11 +49,6 @@ module Value : sig
     val restore : action_digest:Digest.t -> t Restore_result.t
   end
 
-  (** Store a [string] value produced by an action with a given digest. If
-      successful, this operation will create one metadata entry and one value
-      entry in the cache. *)
-  val store : mode:Mode.t -> action_digest:Digest.t -> string -> Store_result.t
-
   (** Restore a [string] value produced by an action with a given digest. The
       value is restored only in memory, i.e. no new files will be created. *)
   val restore : action_digest:Digest.t -> string Restore_result.t
@@ -78,10 +73,6 @@ module Artifacts : sig
     (** Store artifacts metadata produced by a rule with a given digest. If
         successful, this operation will create one metadata entry in the cache. *)
     val store : t -> mode:Mode.t -> rule_digest:Digest.t -> Store_result.t
-
-    (** Restore artifacts metadata produced by a rule with a given digest. The
-        metadata is restored only in memory, i.e. no new files will be created. *)
-    val restore : rule_digest:Digest.t -> t Restore_result.t
   end
 
   (** List entries of a metadata file produced by a rule with a given digest.
@@ -96,10 +87,6 @@ module Metadata : sig
     | Artifacts of Artifacts.Metadata_file.t
     | Value of Value.Metadata_file.t
 
-  (** Restore metadata produced by a rule or action with a given digest. The
-      metadata is restored only in memory, i.e. no new files will be created. *)
-  val restore : rule_or_action_digest:Digest.t -> t Restore_result.t
-
   module Versioned : sig
     (** Same as the unversioned function but supports old metadata versions. *)
     val restore
@@ -107,14 +94,6 @@ module Metadata : sig
       -> rule_or_action_digest:Digest.t
       -> t Restore_result.t
   end
-end
-
-module Raw_value : sig
-  val store_unchecked
-    :  mode:Mode.t
-    -> content:string
-    -> content_digest:Digest.t
-    -> Util.Write_result.t
 end
 
 val clear : unit -> unit


### PR DESCRIPTION
All of is unnecessary since we don't store values