### PR TITLE
fix(pkg): strip .exe from binary map keys on Windows

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1113,7 +1113,14 @@ module Action_expander = struct
             let binaries =
               Section.Map.Multi.find cookie.files Bin
               |> List.fold_left ~init:binaries ~f:(fun acc bin ->
-                Filename.Map.set acc (Path.basename bin) bin)
+                let name = Path.basename bin in
+                (* CR-soon Alizter: share .exe stripping logic with artifacts.ml *)
+                let name =
+                  if Sys.win32
+                  then Option.value ~default:name (String.drop_suffix name ~suffix:".exe")
+                  else name
+                in
+                Filename.Map.set acc name bin)
             in
             let dep_info =
               let variables =

--- a/test/blackbox-tests/test-cases/pkg/installed-binary-windows.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary-windows.t
@@ -32,9 +32,4 @@ The binary should be visible in the workspace via %{bin:foo}:
   > EOF
 
   $ dune build ./testout && cat _build/default/testout
-  File "dune", line 3, characters 7-17:
-  3 |   (run %{bin:foo} workspace-test)))
-             ^^^^^^^^^^
-  Error: Program foo not found in the tree or in PATH
-   (context: default)
-  [1]
+  workspace-test


### PR DESCRIPTION
On Windows, package-installed binaries are stored in the cookie with .exe extensions (e.g. menhir.exe), but lookups use bare names (e.g. menhir). Strip .exe from map keys when populating the binaries map, matching the existing pattern in Artifacts.create.

A follow up PR will share the `.exe` stripping logic with `artifacts.ml`.

Fixes
- https://github.com/ocaml/dune/issues/12433