### PR TITLE
test(cache): do no tamper with _build/ dir

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/config.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t
@@ -46,7 +46,7 @@ Switch to the 'hardlink' mode now
 
 Build succeeds and the 'hardlink' mode is respected
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   3
@@ -141,7 +141,7 @@ So, we comply and delete it
 
 Build succeeds and the 'copy' mode is respected
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   1
@@ -156,7 +156,7 @@ Switch to the 'hardlink' mode now
 
 Build succeeds and the 'hardlink' mode is respected
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   3
@@ -172,7 +172,7 @@ Let's disable the cache
 Test that in this mode the shared cache directory is not created
 
   $ rm -rf $DUNE_CACHE_ROOT
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   1
@@ -181,7 +181,7 @@ Test that in this mode the shared cache directory is not created
 
 Test that the cache can be enabled via the environment variable
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ DUNE_CACHE=enabled dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   3
@@ -191,7 +191,7 @@ Test that the cache can be enabled via the environment variable
 Test that we can override the environment variable from the command line
 
   $ rm -rf $DUNE_CACHE_ROOT
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ DUNE_CACHE=enabled dune build --config-file config target --cache=disabled
   $ dune_cmd stat hardlinks _build/default/target
   1
@@ -206,7 +206,7 @@ Test that we can override the storage mode via the environment variable
   > (cache-storage-mode hardlink)
   > EOF
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ DUNE_CACHE_STORAGE_MODE=copy dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
   1
@@ -214,7 +214,7 @@ Test that we can override the storage mode via the environment variable
 Test that we can override the environment variable from the command line
 
   $ rm -rf $DUNE_CACHE_ROOT
-  $ rm -rf _build/default
+  $ rm -rf _build
   $ DUNE_CACHE_STORAGE_MODE=copy dune build --config-file config target --cache-storage-mode=hardlink
   $ dune_cmd stat hardlinks _build/default/target
   3

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -76,7 +76,7 @@ Verify we see cache miss events for our targets in the trace:
 Test that rebuilding works. Now we expect to see only workspace-local cache
 misses, because we've cleaned _build/default but not the shared cache.
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file=config target1
 
 Verify we see only workspace-local miss events for our targets (shared cache hits should not appear as misses):
@@ -85,12 +85,12 @@ Verify we see only workspace-local miss events for our targets (shared cache hit
   {
     "name": "workspace_local_miss",
     "target": "_build/default/source",
-    "reason": "target missing from build dir"
+    "reason": "never seen this target before"
   }
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
-    "reason": "target missing from build dir"
+    "reason": "never seen this target before"
   }
 
   $ dune_cmd stat hardlinks _build/default/source

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -71,7 +71,7 @@ Verify we see cache miss events for our targets in the trace:
 Test that rebuilding works. Now we expect to see only workspace-local cache
 misses, because we've cleaned _build/default but not the shared cache.
 
-  $ rm -rf _build/default
+  $ rm -rf _build/
   $ dune build --config-file=config target1
 
 Verify we see only workspace-local miss events for our targets (shared cache hits should not appear as misses):
@@ -80,12 +80,12 @@ Verify we see only workspace-local miss events for our targets (shared cache hit
   {
     "name": "workspace_local_miss",
     "target": "_build/default/source",
-    "reason": "target missing from build dir"
+    "reason": "never seen this target before"
   }
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
-    "reason": "target missing from build dir"
+    "reason": "never seen this target before"
   }
 
   $ dune_cmd stat hardlinks _build/default/source

--- a/test/blackbox-tests/test-cases/rule/digest.t/run.t
+++ b/test/blackbox-tests/test-cases/rule/digest.t/run.t
@@ -30,7 +30,7 @@ Let's add a comment to the dune file. It shouldn't affect the rule digest.
 
 ... and it doesn't.
 
-  $ rm _build/default/target target
+  $ rm -rf _build/
   $ dune build @default
   running...
   digest: $1

--- a/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
+++ b/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
@@ -6,11 +6,12 @@ Test that Dune mkdirs the right set of directories in the sandbox.
   $ echo "(lang dune 2.0)" > dune-project
 
   $ mkdir test
+  $ touch test/baz
   $ cat >test/dune <<EOF
   > (rule
   >  (target target)
   >  (mode promote)
-  >  (deps (sandbox always))
+  >  (deps (sandbox always) baz)
   >  (action (chdir subdir (system "echo hello > ../target; pwd"))))
   > EOF
 
@@ -24,7 +25,7 @@ Test that Dune mkdirs the right set of directories in the sandbox.
 Now force a rebuild. This succeeds (in the past it could fail due to [mkdir]
 memoization).
 
-  $ rm _build/default/test/target test/target
+  $ echo foo > test/baz
   $ build test
   Success
 


### PR DESCRIPTION
This is no longer supported, and the test should delete the dir in its entirety.