### PR TITLE
feature/fix/refactor: move storing per target digests into rule cache

### DIFF
--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -5,21 +5,43 @@ let command =
   let man =
     [ `S "DESCRIPTION"
     ; `P {|Removes files added by dune such as _build, <package>.install, and .merlin|}
+    ; `P
+        {|If one or more PATH arguments are given, only remove those paths from the build directory.|}
     ; `Blocks Common.help_secs
     ]
   in
   let term =
-    let+ builder = Common.Builder.term in
+    let+ builder = Common.Builder.term
+    and+ paths = Arg.(value & pos_all string [] & info [] ~docv:"PATH" ~doc:None) in
     (* Disable log file creation. Indeed, we are going to delete the whole build directory
        right after and that includes deleting the log file. Not only would creating the
        log file be useless but with some FS this also causes [dune clean] to fail (cf
        https://github.com/ocaml/dune/issues/2964). *)
     let builder = Common.Builder.disable_log_file builder in
-    let _common, _config = Common.init builder in
+    let common, _config = Common.init builder in
     Global_lock.lock_exn ~timeout:None;
-    Dune_engine.Target_promotion.files_in_source_tree_to_delete ()
-    |> Path.Source.Set.iter ~f:(fun p -> Fpath.unlink_no_err (Path.Source.to_string p));
-    Path.rm_rf Path.build_dir
+    match paths with
+    | [] ->
+      Dune_engine.Target_promotion.files_in_source_tree_to_delete ()
+      |> Path.Source.Set.iter ~f:(fun p -> Fpath.unlink_no_err (Path.Source.to_string p));
+      Path.rm_rf Path.build_dir
+    | paths ->
+      let build_path path =
+        let path = Path.of_string (Common.prefix_target common path) in
+        match Path.as_in_build_dir path with
+        | Some path -> path
+        | None ->
+          User_error.raise
+            [ Pp.textf
+                "%s is not inside the build directory"
+                (Path.to_string_maybe_quoted path)
+            ]
+      in
+      List.iter paths ~f:(fun path ->
+        let path = build_path path in
+        let () = Dune_engine.Rule_cache.Workspace_local.remove_target path in
+        let () = Dune_engine.Rule_cache.Workspace_local.remove_subtree path in
+        Path.rm_rf (Path.build path))
   in
   Cmd.v (Cmd.info "clean" ~doc ~man) term
 ;;

--- a/doc/changes/added/13875.md
+++ b/doc/changes/added/13875.md
@@ -1,0 +1,2 @@
+- `$ dune clean` now accepts arguments to only remove certain targets from the
+  _build directory (#13875, @rgrinberg)

--- a/doc/changes/changed/13875.md
+++ b/doc/changes/changed/13875.md
@@ -1,0 +1,3 @@
+- Dune will no longer stat paths in the _build directory. This was done as protection
+  from user rules accidentally touching things in the _build directory. This is forbidden,
+  and dune offers rule sandboxing to prevent this (#13875, @rgrinberg)

--- a/otherlibs/stdune/src/int.ml
+++ b/otherlibs/stdune/src/int.ml
@@ -48,3 +48,4 @@ let of_string s = int_of_string_opt s
 let shift_left = Stdlib.Int.shift_left
 let shift_right = Stdlib.Int.shift_right
 let max_int = Stdlib.Int.max_int
+let max (x : int) (y : int) = max x y

--- a/otherlibs/stdune/src/int.mli
+++ b/otherlibs/stdune/src/int.mli
@@ -4,6 +4,7 @@ val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val hash : t -> int
 val to_dyn : t -> Dyn.t
+val max : t -> t -> t
 
 include Comparable_intf.S with type key := t
 

--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -416,10 +416,6 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~produced_targets
       ; Pp.char ')'
       ]
   in
-  let update_cached_digests ~targets_and_digests =
-    Targets.Produced.iter_files targets_and_digests ~f:(fun path digest ->
-      Cached_digest.set (Path.Build.append_local targets_and_digests.root path) digest)
-  in
   Targets.Produced.map_with_errors
     ~f:(fun target ->
       (* All of this monad boilerplate seems unnecessary since we don't care about errors... *)
@@ -440,11 +436,9 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~produced_targets
     >>= (function
      | Stored targets_and_digests ->
        Log.info "cache store success" [ "hex", Dyn.string hex ];
-       update_cached_digests ~targets_and_digests;
        Fiber.return (Some targets_and_digests)
      | Already_present targets_and_digests ->
        Log.info "cache store skipped: already present" [ "hex", Dyn.string hex ];
-       update_cached_digests ~targets_and_digests;
        Fiber.return (Some targets_and_digests)
      | Error (Unix.Unix_error (Unix.EXDEV, "link", file)) ->
        (* We cannot hardlink across partitions so we kindly let the user know
@@ -468,6 +462,74 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~produced_targets
        Fiber.return None)
 ;;
 
+module File_digest = struct
+  module Digest_result = Cached_digest.Digest_result
+  module Error = Digest_result.Error
+
+  (* CR-soon rgrinberg: a bunch of this is duplicated from cached_digest.ml.
+     This is temporary since [Cached_digest] is going to be limited source
+     files *)
+
+  let refresh_async ~allow_dirs stats path =
+    let path = Path.build path in
+    let open Fiber.O in
+    Digest.Stats_for_digest.of_unix_stats stats
+    |> Digest.path_with_stats_async ~allow_dirs path
+    >>| function
+    | Ok digest -> Ok digest
+    | Error Unexpected_kind -> Error (Error.Unexpected_kind stats.st_kind)
+    | Error (Unix_error (ENOENT, _, _)) -> Error No_such_file
+    | Error (Unix_error other_error) -> Error (Unix_error other_error)
+  ;;
+
+  let refresh_without_removing_write_permissions_async ~allow_dirs path =
+    match Unix.stat (Path.Build.to_string path) with
+    | stats -> refresh_async stats ~allow_dirs path
+    | exception exn ->
+      Fiber.return
+        (match exn with
+         | Unix.Unix_error (ENOENT, _, _) ->
+           (* Test if this is a broken symlink for better error messages. *)
+           Digest_result.catch_fs_errors (fun () ->
+             match Unix.lstat (Path.Build.to_string path) with
+             | exception Unix.Unix_error (ENOENT, _, _) -> Error Error.No_such_file
+             | _stats_so_must_be_a_symlink -> Error Broken_symlink)
+         | exn -> Error (Digest_result.Error.of_exn exn))
+  ;;
+
+  let refresh_and_remove_write_permissions_async ~allow_dirs path =
+    let open Digest_result.Error in
+    match Unix.lstat (Path.Build.to_string path) with
+    | exception Unix.Unix_error (ENOENT, _, _) -> Fiber.return (Error No_such_file)
+    | exception exn -> Fiber.return (Error (Digest_result.Error.of_exn exn))
+    | stats ->
+      (match stats.st_kind with
+       | S_LNK ->
+         (match Unix.stat (Path.Build.to_string path) with
+          | stats -> refresh_async stats ~allow_dirs:false path
+          | exception Unix.Unix_error (ENOENT, _, _) ->
+            Fiber.return (Error Broken_symlink)
+          | exception exn -> Fiber.return (Error (Digest_result.Error.of_exn exn)))
+       | S_REG ->
+         let perm = Permissions.remove Permissions.write stats.st_perm in
+         (match Unix.chmod (Path.Build.to_string path) perm with
+          | () -> refresh_async ~allow_dirs:false { stats with st_perm = perm } path
+          | exception exn -> Fiber.return (Error (Digest_result.Error.of_exn exn)))
+       | _ ->
+         (* CR-someday amokhov: Shall we proceed if [stats.st_kind = S_DIR]?
+          What about stranger kinds like [S_SOCK]? *)
+         refresh_async ~allow_dirs stats path)
+  ;;
+
+  let refresh ~allow_dirs ~remove_write_permissions path =
+    (if remove_write_permissions
+     then refresh_and_remove_write_permissions_async
+     else refresh_without_removing_write_permissions_async)
+      ~allow_dirs
+      path
+  ;;
+end
+
 let compute_target_digests_or_raise_error
       ~should_remove_write_permissions_on_generated_files
       ~loc
@@ -482,7 +544,7 @@ let compute_target_digests_or_raise_error
        not change state once built. A very practical reason is that enabling
        the cache will remove write permission because of hardlink sharing
        anyway, so always removing them enables to catch mistakes earlier. *)
-    Cached_digest.refresh
+    File_digest.refresh
       ~allow_dirs:true
       ~remove_write_permissions:should_remove_write_permissions_on_generated_files
   in

--- a/src/dune_digest/cached_digest.ml
+++ b/src/dune_digest/cached_digest.ml
@@ -161,13 +161,6 @@ let set_with_stat path digest stat =
     }
 ;;
 
-let set path digest =
-  (* the caller of [set] ensures that the files exist *)
-  let stat = Unix.stat (Path.Build.to_string path) in
-  let path = Path.build path in
-  set_with_stat path digest stat
-;;
-
 module Digest_result = struct
   module Error = struct
     type t =
@@ -238,6 +231,12 @@ module Digest_result = struct
       | Unix_error error -> Variant ("Unix_error", [ Unix_error.Detailed.to_dyn error ])
       | Unrecognized exn -> Variant ("Unrecognized", [ String (Printexc.to_string exn) ])
     ;;
+
+    let of_exn = function
+      | Unix.Unix_error (ELOOP, _, _) -> Cyclic_symlink
+      | Unix.Unix_error (error, syscall, arg) -> Unix_error (error, syscall, arg)
+      | exn -> Unrecognized exn
+    ;;
   end
 
   type t = (Digest.t, Error.t) result
@@ -250,9 +249,7 @@ module Digest_result = struct
   let catch_fs_errors f =
     match f () with
     | result -> result
-    | exception Unix.Unix_error (error, syscall, arg) ->
-      Error (Error.Unix_error (error, syscall, arg))
-    | exception exn -> Error (Error.Unrecognized exn)
+    | exception exn -> Error (Error.of_exn exn)
   ;;
 end
 
@@ -264,25 +261,6 @@ let digest_path_with_stats ~allow_dirs path stats =
   | Error Unexpected_kind -> Error (Digest_result.Error.Unexpected_kind stats.st_kind)
   | Error (Unix_error (ENOENT, _, _)) -> Error No_such_file
   | Error (Unix_error other_error) -> Error (Unix_error other_error)
-;;
-
-let refresh_async =
-  let digest_path_with_stats_async ~allow_dirs path stats =
-    let open Fiber.O in
-    Digest.Stats_for_digest.of_unix_stats stats
-    |> Digest.path_with_stats_async ~allow_dirs path
-    >>| function
-    | Ok digest -> Ok digest
-    | Error Unexpected_kind -> Error (Digest_result.Error.Unexpected_kind stats.st_kind)
-    | Error (Unix_error (ENOENT, _, _)) -> Error No_such_file
-    | Error (Unix_error other_error) -> Error (Unix_error other_error)
-  in
-  fun ~allow_dirs stats path ->
-    let path = Path.build path in
-    let open Fiber.O in
-    let+ result = digest_path_with_stats_async ~allow_dirs path stats in
-    Digest_result.iter result ~f:(fun digest -> set_with_stat path digest stats);
-    result
 ;;
 
 (* Here we make only one [stat] call on the happy path. *)
@@ -307,67 +285,11 @@ let refresh_without_removing_write_permissions =
          | _stats_so_must_be_a_symlink -> Error Broken_symlink))
 ;;
 
-let refresh_without_removing_write_permissions_async ~allow_dirs path =
-  let open Digest_result.Error in
-  match Unix.stat (Path.Build.to_string path) with
-  | stats -> refresh_async stats ~allow_dirs path
-  | exception Unix.Unix_error (ELOOP, _, _) -> Fiber.return (Error Cyclic_symlink)
-  | exception Unix.Unix_error (ENOENT, _, _) ->
-    (* Test if this is a broken symlink for better error messages. *)
-    (match Unix.lstat (Path.Build.to_string path) with
-     | exception Unix.Unix_error (ENOENT, _, _) -> Fiber.return (Error No_such_file)
-     | exception Unix.Unix_error (error, syscall, arg) ->
-       Fiber.return (Error (Unix_error (error, syscall, arg)))
-     | exception exn -> Fiber.return (Error (Unrecognized exn))
-     | _stats_so_must_be_a_symlink -> Fiber.return (Error Broken_symlink))
-  | exception Unix.Unix_error (error, syscall, arg) ->
-    Fiber.return (Error (Unix_error (error, syscall, arg)))
-  | exception exn -> Fiber.return (Error (Unrecognized exn))
-;;
-
 (* CR-someday amokhov: We do [lstat] followed by [stat] only because we do not
    want to remove write permissions from the symbolic link's target, which may
    be outside of the build directory and not under out control. It seems like it
    should be possible to avoid paying for two system calls ([lstat] and [stat])
    here, e.g., by telling the subsequent [chmod] to not follow symlinks. *)
-
-let refresh_and_remove_write_permissions_async ~allow_dirs path =
-  let open Digest_result.Error in
-  match Unix.lstat (Path.Build.to_string path) with
-  | exception Unix.Unix_error (ENOENT, _, _) -> Fiber.return (Error No_such_file)
-  | exception Unix.Unix_error (error, syscall, arg) ->
-    Fiber.return (Error (Unix_error (error, syscall, arg)))
-  | exception exn -> Fiber.return (Error (Unrecognized exn))
-  | stats ->
-    (match stats.st_kind with
-     | S_LNK ->
-       (match Unix.stat (Path.Build.to_string path) with
-        | stats -> refresh_async stats ~allow_dirs:false path
-        | exception Unix.Unix_error (ELOOP, _, _) -> Fiber.return (Error Cyclic_symlink)
-        | exception Unix.Unix_error (ENOENT, _, _) -> Fiber.return (Error Broken_symlink)
-        | exception Unix.Unix_error (error, syscall, arg) ->
-          Fiber.return (Error (Unix_error (error, syscall, arg)))
-        | exception exn -> Fiber.return (Error (Unrecognized exn)))
-     | S_REG ->
-       let perm = Permissions.remove Permissions.write stats.st_perm in
-       (match Unix.chmod (Path.Build.to_string path) perm with
-        | () -> refresh_async ~allow_dirs:false { stats with st_perm = perm } path
-        | exception Unix.Unix_error (error, syscall, arg) ->
-          Fiber.return (Error (Unix_error (error, syscall, arg)))
-        | exception exn -> Fiber.return (Error (Unrecognized exn)))
-     | _ ->
-       (* CR-someday amokhov: Shall we proceed if [stats.st_kind = S_DIR]?
-          What about stranger kinds like [S_SOCK]? *)
-       refresh_async ~allow_dirs stats path)
-;;
-
-let refresh ~allow_dirs ~remove_write_permissions path =
-  (if remove_write_permissions
-   then refresh_and_remove_write_permissions_async
-   else refresh_without_removing_write_permissions_async)
-    ~allow_dirs
-    path
-;;
 
 let peek_file ~allow_dirs path =
   let cache = Lazy.force cache in
@@ -414,19 +336,6 @@ let peek_file ~allow_dirs path =
                 x.stats <- reduced_stats;
                 x.stats_checked <- cache.checked_key);
               digest_result)))
-;;
-
-let build_file ~allow_dirs path =
-  match peek_file ~allow_dirs (Path.build path) with
-  | Some digest_result -> Fiber.return digest_result
-  | None -> refresh_without_removing_write_permissions_async ~allow_dirs path
-;;
-
-let remove path =
-  let path = Path.build path in
-  let cache = Lazy.force cache in
-  needs_dumping := true;
-  Path.Table.remove cache.table path
 ;;
 
 module Untracked = struct

--- a/src/dune_digest/cached_digest.mli
+++ b/src/dune_digest/cached_digest.mli
@@ -4,35 +4,27 @@ open Import
 
 module Digest_result : sig
   module Error : sig
-    type t
+    type t =
+      | No_such_file
+      | Broken_symlink
+      | Cyclic_symlink
+      | Unexpected_kind of File_kind.t
+      | Unix_error of Unix_error.Detailed.t
+      | Unrecognized of exn
 
     val no_such_file : t -> bool
     val pp : t -> Path.t -> _ Pp.t
     val to_dyn : t -> Dyn.t
+    val of_exn : exn -> t
   end
 
   type t = (Digest.t, Error.t) result
 
+  val catch_fs_errors : (unit -> ('a, Error.t) result) -> ('a, Error.t) result
   val equal : t -> t -> bool
   val to_option : t -> Digest.t option
   val to_dyn : t -> Dyn.t
 end
-
-(** Digest the contents of a build artifact.
-
-    If [allow_dirs = false], this function returns [Unexpected_kind] if the path
-    points to a directory. *)
-val build_file : allow_dirs:bool -> Path.Build.t -> Digest_result.t Fiber.t
-
-(** Same as [build_file], but forces the digest of the file to be re-computed.
-
-    If [remove_write_permissions] is true, also remove write permissions on the
-    file. *)
-val refresh
-  :  allow_dirs:bool
-  -> remove_write_permissions:bool
-  -> Path.Build.t
-  -> Digest_result.t Fiber.t
 
 module Untracked : sig
   (** Digest the contents of a source or external file. This function doesn't
@@ -45,12 +37,6 @@ module Untracked : sig
 end
 
 (** {1 Managing the cache} *)
-
-(** Update the digest for a file in the cache. Records the current [stat]. *)
-val set : Path.Build.t -> Digest.t -> unit
-
-(** Remove a file from the digest cache. *)
-val remove : Path.Build.t -> unit
 
 (** Invalidate all cached [stat] values. This causes all subsequent calls to
     [build_file] or [source_or_external_file] to incur additional [stat] calls. *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -584,15 +584,13 @@ end = struct
         | None ->
           (* Step II. Remove stale targets both from the digest table and from
              the build directory. *)
-          let () =
-            Targets.Validated.iter
-              targets
-              ~file:Cached_digest.remove
-              ~dir:Cached_digest.remove
-          in
+          Rule_cache.Workspace_local.remove targets;
           let* () =
             maybe_async_rule_file_op (fun () ->
-              let remove_target_dir dir = Path.rm_rf (Path.build dir) in
+              let remove_target_dir dir =
+                let () = Rule_cache.Workspace_local.remove_subtree dir in
+                Path.rm_rf (Path.build dir)
+              in
               let remove_target_file path =
                 match Fpath.unlink (Path.Build.to_string path) with
                 | Success -> ()
@@ -664,6 +662,7 @@ end = struct
           (* We do not include target names into [targets_digest] because they
              are already included into the rule digest. *)
           Rule_cache.Workspace_local.store
+            ~targets:produced_targets
             ~head_target
             ~rule_digest
             ~dynamic_deps_stages
@@ -874,59 +873,55 @@ end = struct
           ~human_readable_description:(fun () ->
             Pp.text (Path.to_string_maybe_quoted (Path.build path)))
       in
-      (match Targets.Produced.find targets path with
-       | Some digest -> Memo.return (digest, File_target)
+      (match Targets.Produced.find_any targets path with
+       | Some (Left digest) -> Memo.return (digest, File_target)
+       | Some (Right contents) ->
+         let digest =
+           Digest.Feed.compute_digest
+             (fun hasher contents ->
+                Targets.Produced.iteri_dir_contents
+                  contents
+                  ~d:(fun d -> Digest.Feed.string hasher (Path.Local.to_string d))
+                  ~f:(fun path digest ->
+                    Digest.Feed.digest hasher digest;
+                    Digest.Feed.string hasher (Path.Local.to_string path)))
+             contents
+         in
+         Memo.return (digest, Dir_target { targets })
        | None ->
-         (* CR-soon amokhov: Here we expect [path] to be a directory target. It seems odd
-            to compute its digest here by calling to [Cached_digest.build_file]. Shouldn't
-            we do that in [execute_rule], like we do for file targets?
-
-            rleshchinskiy: Is this digest ever used? [build_dir] discards it and do we
-            (or should we) ever use [build_file] to build directories? Perhaps this could
-            be split in two memo tables, one for files and one for directories.
-
-            ElectreAAS: a lot of functions are called [build_file] or [create_file]
-            even though they also handle directories, this is expected.
-            Also yes this digest is used by [Exported.build_dep] defined above. *)
-         Memo.of_reproducible_fiber (Cached_digest.build_file ~allow_dirs:true path)
-         >>| (function
-          | Ok digest -> digest, Dir_target { targets }
-          (* Must be a directory target. *)
-          | Error _ ->
-            (* CR-someday amokhov: The most important reason we end up here is
-               [No_such_file]. I think some of the outcomes above are impossible
-               but some others will benefit from a better error. To be refined. *)
-            let target =
-              Path.Build.drop_build_context_exn path |> Path.Source.to_string_maybe_quoted
-            in
-            let matching_dirs =
-              Filename.Set.to_list_map rule.targets.dirs ~f:(fun dir ->
-                (* CR-someday rleshchinskiy: This test can probably be simplified. *)
-                let dir = Path.Build.relative rule.targets.root dir in
-                match Path.Build.is_descendant path ~of_:dir with
-                | true -> [ dir ]
-                | false -> [])
-              |> List.concat
-            in
-            let matching_target =
-              match matching_dirs with
-              | [ dir ] ->
-                Path.Build.drop_build_context_exn dir
-                |> Path.Source.to_string_maybe_quoted
-              | [] | _ :: _ ->
-                Code_error.raise
-                  "Multiple matching directory targets"
-                  [ "targets", Targets.Validated.to_dyn rule.targets ]
-            in
-            User_error.raise
-              ~loc:rule.loc
-              ~needs_stack_trace:true
-              [ Pp.textf
-                  "This rule defines a directory target %S that matches the requested \
-                   path %S but the rule's action didn't produce it"
-                  matching_target
-                  target
-              ]))
+         (* CR-someday amokhov: The most important reason we end up here is
+            [No_such_file]. I think some of the outcomes above are impossible
+            but some others will benefit from a better error. To be refined. *)
+         let target =
+           Path.Build.drop_build_context_exn path |> Path.Source.to_string_maybe_quoted
+         in
+         let matching_dirs =
+           Filename.Set.to_list_map rule.targets.dirs ~f:(fun dir ->
+             (* CR-someday rleshchinskiy: This test can probably be simplified. *)
+             let dir = Path.Build.relative rule.targets.root dir in
+             match Path.Build.is_descendant path ~of_:dir with
+             | true -> [ dir ]
+             | false -> [])
+           |> List.concat
+         in
+         let matching_target =
+           match matching_dirs with
+           | [ dir ] ->
+             Path.Build.drop_build_context_exn dir |> Path.Source.to_string_maybe_quoted
+           | [] | _ :: _ ->
+             Code_error.raise
+               "Multiple matching directory targets"
+               [ "targets", Targets.Validated.to_dyn rule.targets ]
+         in
+         User_error.raise
+           ~loc:rule.loc
+           ~needs_stack_trace:true
+           [ Pp.textf
+               "This rule defines a directory target %S that matches the requested path \
+                %S but the rule's action didn't produce it"
+               matching_target
+               target
+           ])
   ;;
 
   let execute_anonymous_action action =

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -204,8 +204,13 @@ let remove_old_artifacts
       then (
         match kind with
         | Unix.S_DIR ->
-          if not (Subdir_set.mem subdirs_to_keep fn) then Path.rm_rf (Path.build path)
-        | _ -> Fpath.unlink_exn (Path.Build.to_string path)))
+          if not (Subdir_set.mem subdirs_to_keep fn)
+          then (
+            let () = Rule_cache.Workspace_local.remove_subtree path in
+            Path.rm_rf (Path.build path))
+        | _ ->
+          let () = Rule_cache.Workspace_local.remove_target path in
+          Fpath.unlink_exn (Path.Build.to_string path)))
 ;;
 
 (* We don't remove files in there as we don't know upfront if they are stale or
@@ -218,7 +223,10 @@ let remove_old_sub_dirs_in_anonymous_actions_dir ~dir ~(subdirs_to_keep : Subdir
       let path = Path.Build.relative dir fn in
       match kind with
       | Unix.S_DIR ->
-        if not (Subdir_set.mem subdirs_to_keep fn) then Path.rm_rf (Path.build path)
+        if not (Subdir_set.mem subdirs_to_keep fn)
+        then (
+          let () = Rule_cache.Workspace_local.remove_subtree path in
+          Path.rm_rf (Path.build path))
       | _ -> ())
 ;;
 

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -21,17 +21,46 @@ module Workspace_local = struct
       ;;
     end
 
+    type digest =
+      { digest : Digest.t
+      ; siblings : Digest.t Targets.Produced.t
+      ; generation : int
+      }
+
+    let dyn_of_digest { digest; siblings; generation } =
+      Dyn.record
+        [ "digest", Digest.to_dyn digest
+        ; "siblings", Targets.Produced.to_dyn siblings
+        ; "generation", Dyn.int generation
+        ]
+    ;;
+
     (* Keyed by the first target of the rule. *)
-    type t = Entry.t Path.Table.t
+    type t =
+      { rules : Entry.t Path.Table.t
+      ; digests : digest Path.Build.Table.t
+      ; invalidated_subtrees : int Path.Build.Table.t
+        (* A digest is only valid if its generation is greater or equal to the
+           generation of all of its parents *)
+      ; mutable generation : int (* The current generation *)
+      }
 
     let file = Path.relative Path.build_dir ".db"
-    let to_dyn = Path.Table.to_dyn Entry.to_dyn
+
+    let to_dyn { rules; digests; invalidated_subtrees; generation } =
+      Dyn.record
+        [ "rules", Path.Table.to_dyn Entry.to_dyn rules
+        ; "digests", Path.Build.Table.to_dyn dyn_of_digest digests
+        ; "invalidated_subtrees", Path.Build.Table.to_dyn Dyn.int invalidated_subtrees
+        ; "generation", Dyn.int generation
+        ]
+    ;;
 
     module P = Dune_util.Persistent.Make (struct
         type nonrec t = t
 
         let name = "INCREMENTAL-DB"
-        let version = 7
+        let version = 8
         let sharing = true
         let to_dyn = to_dyn
       end)
@@ -45,7 +74,12 @@ module Workspace_local = struct
          (* This mutable table is safe: it's only used by [execute_rule_impl] to
             decide whether to rebuild a rule or not; [execute_rule_impl] ensures
             that the targets are produced deterministically. *)
-         | None -> Path.Table.create ())
+         | None ->
+           { rules = Path.Table.create ()
+           ; digests = Path.Build.Table.create 128
+           ; invalidated_subtrees = Path.Build.Table.create 16
+           ; generation = 0
+           })
     ;;
 
     let dump () =
@@ -66,20 +100,81 @@ module Workspace_local = struct
 
     let get path =
       let t = Lazy.force t in
-      Path.Table.find t path
+      Path.Table.find t.rules path
     ;;
 
-    let set path e =
+    let set path e (targets : _ Targets.Produced.t) =
       let t = Lazy.force t in
       needs_dumping := true;
-      Path.Table.set t path e
+      Path.Table.set t.rules path e;
+      let set_digest p digest =
+        let digest = { digest; siblings = targets; generation = t.generation } in
+        Path.Build.Table.set t.digests (Path.Build.append_local targets.root p) digest
+      in
+      Targets.Produced.iteri targets ~f:set_digest ~d:(fun _ -> ())
+    ;;
+
+    let remove (targets : Targets.Validated.t) =
+      let t = Lazy.force t in
+      needs_dumping := true;
+      let remove = Path.Build.Table.remove t.digests in
+      Targets.Validated.iter targets ~file:remove ~dir:remove
+    ;;
+
+    let remove_target path =
+      let t = Lazy.force t in
+      needs_dumping := true;
+      match Path.Build.Table.find t.digests path with
+      | None -> ()
+      | Some { digest = _; siblings; _ } ->
+        let head = Targets.Produced.head siblings in
+        Path.Table.remove t.rules (Path.build head);
+        Targets.Produced.iter_files siblings ~f:(fun path (_ : Digest.t) ->
+          let path = Path.Build.append_local siblings.root path in
+          Path.Build.Table.remove t.digests path)
+    ;;
+
+    let digest =
+      (* We don't need to look up all the parents. Finding one greater should be enough
+         to invalidate *)
+      let invalidation_generation t path =
+        let rec loop path acc =
+          let acc =
+            match Path.Build.Table.find t.invalidated_subtrees path with
+            | None -> acc
+            | Some generation -> Int.max acc generation
+          in
+          match Path.Build.parent path with
+          | None -> acc
+          | Some path -> loop path acc
+        in
+        loop path 0
+      in
+      fun path ->
+        let t = Lazy.force t in
+        match Path.Build.Table.find t.digests path with
+        | None -> None
+        | Some ({ generation; _ } as digest) ->
+          if generation >= invalidation_generation t path
+          then Some digest
+          else (
+            remove_target path;
+            None)
+    ;;
+
+    let remove_subtree root =
+      let t = Lazy.force t in
+      needs_dumping := true;
+      t.generation <- t.generation + 1;
+      Path.Build.Table.set t.invalidated_subtrees root t.generation
     ;;
   end
 
-  let store ~head_target ~rule_digest ~dynamic_deps_stages ~targets_digest =
+  let store ~targets ~head_target ~rule_digest ~dynamic_deps_stages ~targets_digest =
     Database.set
       (Path.build head_target)
       { rule_digest; dynamic_deps_stages; targets_digest }
+      targets
   ;;
 
   module Miss_reason = struct
@@ -119,9 +214,11 @@ module Workspace_local = struct
       Fiber.return (Miss (Miss_reason.Error_while_collecting_directory_targets error))
     | Ok targets ->
       let open Fiber.O in
-      Targets.Produced.map_with_errors
-        ~f:(Cached_digest.build_file ~allow_dirs:true)
-        targets
+      Targets.Produced.map_with_errors targets ~f:(fun file ->
+        Fiber.return
+          (match Database.digest file with
+           | None -> Error ()
+           | Some { digest; siblings = _; _ } -> Ok digest))
       >>| (function
        | Ok produced_targets -> Dune_cache.Hit_or_miss.Hit produced_targets
        | Error _ -> Miss Miss_reason.Targets_missing)
@@ -201,4 +298,8 @@ module Workspace_local = struct
       else Dune_trace.emit ~buffered:true Cache (fun () -> event ());
       None
   ;;
+
+  let remove targets = Database.remove targets
+  let remove_target = Database.remove_target
+  let remove_subtree = Database.remove_subtree
 end

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -23,9 +23,14 @@ module Workspace_local : sig
 
   (** Add a new record to the rule database. *)
   val store
-    :  head_target:Path.Build.t
+    :  targets:Digest.t Targets.Produced.t
+    -> head_target:Path.Build.t
     -> rule_digest:Digest.t
     -> dynamic_deps_stages:(Dep.Set.t * Digest.t) list
     -> targets_digest:Digest.t
     -> unit
+
+  val remove : Targets.Validated.t -> unit
+  val remove_target : Path.Build.t -> unit
+  val remove_subtree : Path.Build.t -> unit
 end

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -161,6 +161,14 @@ module Produced = struct
     ; contents : 'a dir_contents
     }
 
+  let head { root; contents = { files; subdirs } } =
+    Path.Build.relative
+      root
+      (match Filename.Map.choose files with
+       | Some (x, _) -> x
+       | None -> Filename.Map.choose subdirs |> Option.value_exn |> fst)
+  ;;
+
   let equal
         { root = root1; contents = contents1 }
         { root = root2; contents = contents2 }
@@ -345,7 +353,7 @@ module Produced = struct
            (* The order shouldn't matter, it's not possible to have both a file
               and a directory with the exact same path and name. *)
            let+ contents = Filename.Map.find subdirs final in
-           Right contents.files)
+           Right contents)
       | parent :: rest ->
         let path = Path.Local.relative path parent in
         let* subdir = Filename.Map.find subdirs parent in
@@ -368,7 +376,7 @@ module Produced = struct
 
   let find_dir t name =
     match find_any t name with
-    | Some (Right found) -> Some found
+    | Some (Right found) -> Some found.files
     | Some (Left _) | None -> None
   ;;
 
@@ -430,7 +438,7 @@ module Produced = struct
     aux Path.Local.root contents init
   ;;
 
-  let iteri { contents; root = _ } ~f ~d =
+  let iteri_dir_contents contents ~f ~d =
     let rec aux path { files; subdirs } =
       Filename.Map.iteri files ~f:(fun file_name payload ->
         let file = Path.Local.relative path file_name in
@@ -442,6 +450,8 @@ module Produced = struct
     in
     aux Path.Local.root contents
   ;;
+
+  let iteri t ~f ~d = iteri_dir_contents t.contents ~f ~d
 
   let to_list_map { contents; root = _ } ~f =
     let rec aux path { files; subdirs } =

--- a/src/dune_targets/dune_targets.mli
+++ b/src/dune_targets/dune_targets.mli
@@ -90,6 +90,7 @@ module Produced : sig
     ; contents : 'a dir_contents
     }
 
+  val head : _ t -> Path.Build.t
   val equal : 'a t -> 'a t -> equal:('a -> 'a -> bool) -> bool
 
   module Error : sig
@@ -124,7 +125,7 @@ module Produced : sig
   val mem_any : 'a t -> Path.Build.t -> bool
 
   (* Find the value associated with a file, or all the files of a subdirectory, if any. *)
-  val find_any : 'a t -> Path.Build.t -> ('a, 'a Filename.Map.t) either option
+  val find_any : 'a t -> Path.Build.t -> ('a, 'a dir_contents) either option
 
   (** Find the value associated with the file, if any. *)
   val find : 'a t -> Path.Build.t -> 'a option
@@ -147,6 +148,12 @@ module Produced : sig
   val to_list_map : 'a t -> f:(Path.Local.t -> 'a option -> 'b) -> 'b list
   val iter_files : 'a t -> f:(Path.Local.t -> 'a -> unit) -> unit
   val iter_dirs : 'a t -> f:(Path.Local.t -> unit) -> unit
+
+  val iteri_dir_contents
+    :  'a dir_contents
+    -> f:(Path.Local.t -> 'a -> unit)
+    -> d:(Path.Local.t -> unit)
+    -> unit
 
   (** Iterate on all [f]iles & [d]irs in the targets.
       All [Path.Local.t]s are relative to [t.root]. *)

--- a/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
+++ b/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
@@ -13,8 +13,11 @@ Dune currently silently ignores this.
   $ cat _build/default/data
   hello
   hello
+  hello
 
   $ dune build @x
   $ cat _build/default/data
+  hello
+  hello
   hello
   hello

--- a/test/blackbox-tests/test-cases/clean.t
+++ b/test/blackbox-tests/test-cases/clean.t
@@ -1,0 +1,37 @@
+Demonstrate the dune clean command:
+
+  $ make_dune_project "3.23"
+
+First, show that we can clean per path
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets foo)
+  >  (action (bash "touch foo && echo foo")))
+  > (rule
+  >  (targets bar)
+  >  (action (bash "touch bar && echo bar")))
+  > EOF
+
+  $ function runtest() {
+  > dune build ./foo ./bar | sort
+  > }
+
+  $ runtest
+  foo
+  bar
+
+  $ runtest
+
+  $ dune clean _build/default/foo
+
+  $ runtest
+  foo
+
+We can clean the entire workspace to re-run everything:
+
+  $ dune clean
+
+  $ runtest
+  foo
+  bar

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -105,7 +105,7 @@ all metadata entries in [meta/v4] since they are broken: remember, we moved all
 If we unlink a file in the build tree, then the corresponding file entry will be
 trimmed.
 
-  $ rm -f _build/default/target_a _build/default/beacon_a _build/default/beacon_b
+  $ dune clean _build/default/target_a _build/default/beacon_a _build/default/beacon_b
   $ dune cache trim --trimmed-size 1B
   Freed 79B (2 files removed)
   $ dune build target_a target_b
@@ -143,15 +143,16 @@ The cache deletes oldest files first.
   $ reset
   $ dune build target_a target_b
 
-The [rm] commands below update the [ctime] of the corresponding cache entries.
+The [dune clean] commands below update the [ctime] of the corresponding cache
+entries.
 By deleting [target_b] first, we make its [ctime] older. The trimmer deletes
 older entries first, which is why [target_b] is trimmed while [target_a] is not.
 We know that [target_b] was trimmed, because it had to be rebuilt as indicated
 by the existence of [beacon_b].
 
-  $ rm -f _build/default/beacon_b _build/default/target_b
+  $ dune clean _build/default/beacon_b _build/default/target_b
   $ dune_cmd wait-for-fs-clock-to-advance
-  $ rm -f _build/default/beacon_a _build/default/target_a
+  $ dune clean _build/default/beacon_a _build/default/target_a
   $ dune cache trim --trimmed-size 1B
   Freed 79B (2 files removed)
   $ dune build target_a target_b
@@ -169,9 +170,9 @@ thus making the trimmer delete [target_a] instead of [target_b] as above.
 
   $ reset
   $ dune build target_a target_b
-  $ rm -f _build/default/beacon_a _build/default/target_a
+  $ dune clean _build/default/beacon_a _build/default/target_a
   $ dune_cmd wait-for-fs-clock-to-advance
-  $ rm -f _build/default/beacon_b _build/default/target_b
+  $ dune clean _build/default/beacon_b _build/default/target_b
   $ dune cache trim --trimmed-size 1B
   Freed 79B (2 files removed)
   $ dune build target_a target_b
@@ -189,7 +190,7 @@ are part of the same rule.
 
   $ reset
   $ dune build multi_a multi_b
-  $ rm -f _build/default/multi_a _build/default/multi_b
+  $ dune clean _build/default/multi_a _build/default/multi_b
   $ dune cache trim --trimmed-size 1B
   Freed 123B (2 files removed)
 

--- a/test/blackbox-tests/test-cases/github1342.t
+++ b/test/blackbox-tests/test-cases/github1342.t
@@ -1,6 +1,9 @@
 Reproduction case for #1342. Check that when the user edits files in
 _build, things are rebuild as expected.
 
+Note that this is no longer supported. Users are not expected to edit things in
+the _build directory.
+
   $ echo 42 > x
   $ dune build x
   $ cat _build/default/x
@@ -14,4 +17,4 @@ https://github.com/ocaml/dune/pull/1359
   $ touch -t 01010000 _build/default/x
   $ dune build x
   $ cat _build/default/x
-  42
+  0

--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
@@ -60,11 +60,8 @@ File with just "#!" in the first line
   $ echo -n "#!" >"$exec"
   $ dune_cmd count-lines "$exec"
   1
-  $ dune build @pkg-install
+  $ dune build @pkg-install 2>&1 | head -1
   Error: CreateProcess(): Exec format error
-  -> required by
-     _build/_private/default/.pkg/foo.dev-5f224c017f3cf1ab04bdf8e60e90d898/target
-  -> required by alias pkg-install
   [1]
 
 Script doesn't exist


### PR DESCRIPTION
These targets need not rely on the stat cache.

Previously, actions were running unsandboxed so the extra stat'ing was a protection mechanism. Since we've moved to sandboxing rules by default, we don't need to impose this cost on everybody.

This does require us to be a lot more strict for evicting stale rule entries from the workspace local cache. This is source of most of the complexity in this PR.

There's still some cleanup remaining in Cached_digest as it can be heavily simplified since it is only responsible for sources now.