### PR TITLE
feature: allow promoting prefixes with [$ dune promote]

### DIFF
--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -34,6 +34,11 @@ module Apply = struct
            you might use $(b,(diff file.expected file.generated)) and then call
            $(b,dune promote) to promote the generated file.
          |}
+      ; `P
+          {|When FILE arguments are provided, dune promote matches pending
+           promotions recursively under those paths. Use $(b,--file) to require
+           exact file matching instead.
+         |}
       ; `Blocks Common.help_secs
       ]
     in
@@ -42,15 +47,24 @@ module Apply = struct
 
   let term =
     let+ builder = Common.Builder.term
+    and+ exact =
+      Arg.(
+        value
+        & flag
+        & info [ "file" ] ~doc:(Some "Require each FILE argument to match exactly."))
     and+ files =
       (* CR-someday Alizter: document this option *)
-      Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE" ~doc:None)
+      Arg.(value & pos_all Arg.path [] & info [] ~docv:"FILE" ~doc:None)
     in
     let common, config = Common.init builder in
-    let files_to_promote = files_to_promote ~common files in
+    let files_to_promote = List.map files ~f:Arg.Path.arg |> files_to_promote ~common in
+    let matching : Dune_rpc.Promote_targets.Matching.t =
+      if exact then Exact else Prefix
+    in
     match Global_lock.lock ~timeout:None with
     | Ok () ->
-      Diff_promotion.promote_files_registered_in_last_run files_to_promote |> on_missing
+      Diff_promotion.promote_files_registered_in_last_run ~matching files_to_promote
+      |> on_missing
     | Error lock_held_by ->
       Scheduler_setup.no_build_no_rpc ~config (fun () ->
         let open Fiber.O in
@@ -60,7 +74,7 @@ module Apply = struct
           ~lock_held_by
           builder
           Dune_rpc.Procedures.Public.promote_many
-          files_to_promote
+          { Dune_rpc.Promote_targets.files = files_to_promote; matching }
         >>| Rpc.Rpc_common.wrap_build_outcome_exn ~print_on_success:true)
   ;;
 

--- a/doc/changes/added/13876.md
+++ b/doc/changes/added/13876.md
@@ -1,0 +1,3 @@
+- `$ dune promote` now promotes all paths that are a prefix of the path provided.
+  For example, `$ dune promote foo` will promote `foo`, `foo/bar`, `foo/bar/baz`
+  (but not `foobar`). (#13876, @rgrinberg)

--- a/otherlibs/dune-rpc/exported_types.ml
+++ b/otherlibs/dune-rpc/exported_types.ml
@@ -862,3 +862,30 @@ module Files_to_promote = struct
     iso (list Path.sexp) to_ from
   ;;
 end
+
+module Promote_targets = struct
+  module Matching = struct
+    type t =
+      | Exact
+      | Prefix
+
+    let sexp =
+      let open Conv in
+      enum [ "exact", Exact; "prefix", Prefix ]
+    ;;
+  end
+
+  type t =
+    { files : Files_to_promote.t
+    ; matching : Matching.t
+    }
+
+  let sexp =
+    let open Conv in
+    let files = field "files" (required Files_to_promote.sexp) in
+    let matching = field "matching" (required Matching.sexp) in
+    let to_ (files, matching) = { files; matching } in
+    let from { files; matching } = files, matching in
+    iso (record (both files matching)) to_ from
+  ;;
+end

--- a/otherlibs/dune-rpc/exported_types.mli
+++ b/otherlibs/dune-rpc/exported_types.mli
@@ -271,3 +271,20 @@ module Files_to_promote : sig
 
   val sexp : t Conv.value
 end
+
+module Promote_targets : sig
+  module Matching : sig
+    type t =
+      | Exact
+      | Prefix
+
+    val sexp : t Conv.value
+  end
+
+  type t =
+    { files : Files_to_promote.t
+    ; matching : Matching.t
+    }
+
+  val sexp : t Conv.value
+end

--- a/otherlibs/dune-rpc/procedures.ml
+++ b/otherlibs/dune-rpc/procedures.ml
@@ -86,16 +86,27 @@ module Public = struct
 
   module Promote_many = struct
     let v1 =
-      Decl.Request.make_current_gen
+      Decl.Request.make_gen
         ~req:Files_to_promote.sexp
         ~resp:Build_outcome_with_diagnostics.sexp
         ~version:1
+        ~upgrade_req:(fun files -> { Promote_targets.files; matching = Exact })
+        ~downgrade_req:(fun { Promote_targets.files; _ } -> files)
+        ~upgrade_resp:Fun.id
+        ~downgrade_resp:Fun.id
+    ;;
+
+    let v2 =
+      Decl.Request.make_current_gen
+        ~req:Promote_targets.sexp
+        ~resp:Build_outcome_with_diagnostics.sexp
+        ~version:2
     ;;
 
     let decl =
       Decl.Request.make
         ~method_:(Method.Name.of_string "promote_many")
-        ~generations:[ v1 ]
+        ~generations:[ v1; v2 ]
     ;;
   end
 

--- a/otherlibs/dune-rpc/procedures.mli
+++ b/otherlibs/dune-rpc/procedures.mli
@@ -8,7 +8,7 @@ module Public : sig
   val format : (unit, unit) Decl.Request.t
   val format_dune_file : (Path.t * [ `Contents of string ], string) Decl.Request.t
   val promote : (Path.t, unit) Decl.Request.t
-  val promote_many : (Files_to_promote.t, Build_outcome_with_diagnostics.t) Decl.Request.t
+  val promote_many : (Promote_targets.t, Build_outcome_with_diagnostics.t) Decl.Request.t
   val build_dir : (unit, Path.t) Decl.Request.t
   val runtest : (string list, Build_outcome_with_diagnostics.t) Decl.Request.t
 end

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -216,10 +216,8 @@ let promote_one dst srcs =
 
 let do_promote_all db = group_by_targets db |> Path.Source.Map.iteri ~f:promote_one
 
-let do_promote_these db files =
-  let by_targets = group_by_targets db in
+let do_promote_exact by_targets files =
   let by_targets, missing =
-    let files = Path.Source.Set.of_list files in
     Path.Source.Set.fold files ~init:(by_targets, []) ~f:(fun fn (map, missing) ->
       match Path.Source.Map.find map fn with
       | None -> map, fn :: missing
@@ -238,11 +236,45 @@ let do_promote_these db files =
   remaining, sorted_missing
 ;;
 
-let do_promote db = function
+let do_promote_by_prefix by_targets files =
+  let remaining, matched =
+    Path.Source.Map.foldi
+      by_targets
+      ~init:([], Path.Source.Set.empty)
+      ~f:(fun dst srcs (remaining, matched) ->
+        let files =
+          Path.Source.Set.filter files ~f:(fun requested ->
+            Path.Source.is_descendant ~of_:requested dst)
+        in
+        if Path.Source.Set.is_empty files
+        then srcs :: remaining, matched
+        else (
+          promote_one dst srcs;
+          let matched = Path.Source.Set.union files matched in
+          remaining, matched))
+  in
+  let remaining = List.rev remaining |> List.concat in
+  let missing =
+    Path.Source.Set.filter files ~f:(fun requested ->
+      not (Path.Source.Set.mem matched requested))
+    |> Path.Source.Set.to_list
+  in
+  remaining, missing
+;;
+
+let do_promote_these ~(matching : Dune_rpc.Promote_targets.Matching.t) db files =
+  (match matching with
+   | Exact -> do_promote_exact
+   | Prefix -> do_promote_by_prefix)
+    (group_by_targets db)
+    (Path.Source.Set.of_list files)
+;;
+
+let do_promote ~matching db = function
   | Files_to_promote.All ->
     do_promote_all db;
     [], []
-  | These files -> do_promote_these db files
+  | These files -> do_promote_these ~matching db files
 ;;
 
 let finalize () =
@@ -258,9 +290,9 @@ let finalize () =
 
 (* Returns the list of files that were in [files_to_promote]
    but not present in the promotion database. *)
-let promote_files_registered_in_last_run files_to_promote =
+let promote_files_registered_in_last_run ~matching files_to_promote =
   let db = load_db () in
-  let remaining, missing = do_promote db files_to_promote in
+  let remaining, missing = do_promote ~matching db files_to_promote in
   dump_db remaining;
   missing
 ;;

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -28,7 +28,11 @@ type all =
   }
 
 val partition_db : db -> Files_to_promote.t -> all
-val promote_files_registered_in_last_run : Files_to_promote.t -> Path.Source.t list
+
+val promote_files_registered_in_last_run
+  :  matching:Dune_rpc.Promote_targets.Matching.t
+  -> Files_to_promote.t
+  -> Path.Source.t list
 
 (** Register an intermediate file to promote. The build path may point to the
     sandbox and the file will be moved to the staging area. *)

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -6,6 +6,7 @@ module Compound_user_error = Dune_rpc.Private.Compound_user_error
 module Stringlike = Dune_util.Stringlike
 module Files_to_promote = Dune_rpc.Private.Files_to_promote
 include Dune_scheduler
+module Dune_rpc = Dune_rpc.Private
 
 module type Stringlike = Dune_util.Stringlike
 

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -364,6 +364,7 @@ let handler (t : _ t Fdecl.t) : 'build_arg Dune_rpc_server.Handler.t =
       | Failure ->
         (match
            Diff_promotion.promote_files_registered_in_last_run
+             ~matching:Exact
              Dune_rpc.Files_to_promote.All
          with
          | [] -> ()
@@ -422,8 +423,8 @@ let handler (t : _ t Fdecl.t) : 'build_arg Dune_rpc_server.Handler.t =
     Handler.implement_request rpc Procedures.Public.diagnostics f
   in
   let () =
-    let f _ files =
-      match Diff_promotion.promote_files_registered_in_last_run files with
+    let f _ { Dune_rpc.Promote_targets.files; matching } =
+      match Diff_promotion.promote_files_registered_in_last_run ~matching files with
       | [] -> Fiber.return Dune_rpc.Build_outcome_with_diagnostics.Success
       | missing ->
         let warnings =
@@ -446,7 +447,9 @@ let handler (t : _ t Fdecl.t) : 'build_arg Dune_rpc_server.Handler.t =
     let f _ path =
       let files = For_handlers.source_path_of_string path in
       let _ignored : Path.Source.t list =
-        Diff_promotion.promote_files_registered_in_last_run (These [ files ])
+        Diff_promotion.promote_files_registered_in_last_run
+          ~matching:Exact
+          (These [ files ])
       in
       Fiber.return ()
     in

--- a/test/blackbox-tests/test-cases/promote/promotion-apply.t
+++ b/test/blackbox-tests/test-cases/promote/promotion-apply.t
@@ -33,3 +33,68 @@
   Promoting _build/default/a.actual to a.expected.
   $ cat a.expected
   Actual
+
+`dune promote` should accept a path that prefixes promoted files, recursively,
+without matching sibling names such as [foobar]. The old exact-file behaviour is
+available with [--file].
+
+  $ cat > dune << EOF
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (diff foo/bar.expected bar.actual)))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (diff foo/baz.expected baz.actual)))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (diff foo/bar/baz.expected deep.actual)))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (diff foobar.expected foobar.actual)))
+  > 
+  > (rule
+  >  (write-file bar.actual bar))
+  > 
+  > (rule
+  >  (write-file baz.actual baz))
+  > 
+  > (rule
+  >  (write-file deep.actual deep))
+  > 
+  > (rule
+  >  (write-file foobar.actual foobar-new))
+  > EOF
+
+  $ rm -f a.expected
+  $ rm -rf foo
+  $ echo foobar-old > foobar.expected
+
+  $ if dune runtest --diff-command - > /dev/null 2>&1; then echo ok; else echo failed; fi
+  failed
+
+  $ if test -e foo; then echo exists; else echo missing; fi
+  missing
+
+  $ dune promote --file foo 2>&1
+  Warning: Nothing to promote for foo.
+
+  $ if test -e foo; then echo exists; else echo missing; fi
+  missing
+
+  $ dune promote foo > /dev/null 2>&1
+
+  $ cat foo/bar.expected
+  bar
+  $ cat foo/baz.expected
+  baz
+  $ cat foo/bar/baz.expected
+  deep
+  $ cat foobar.expected
+  foobar-old


### PR DESCRIPTION
Currently, $ dune promote foo will only promote the file foo.

With this change, it will now promote foo and all descendants of foo/

The old behavior can be recovered with the --file flag.

RPC is adjusted accordingly.