### PR TITLE
feature: allow diffing directories

### DIFF
--- a/doc/changes/added/13880.md
+++ b/doc/changes/added/13880.md
@@ -1,0 +1,1 @@
+- Allow for the `diff` action to diff entire directories (#13880, fixes #3567, @rgrinberg)

--- a/src/dune_engine/diff_action.ml
+++ b/src/dune_engine/diff_action.ml
@@ -1,7 +1,7 @@
 open Import
 module Diff = Dune_util.Action.Diff
 
-let compare_files = function
+let compare_file_paths = function
   | Diff.Mode.Binary -> Io.compare_files
   | Text -> Io.compare_text_files
 ;;
@@ -15,13 +15,282 @@ let compare_files { Diff.optional; mode; file1; file2 } =
   else (
     let file1_exists = Fpath.exists (Path.to_string file1) in
     match file1_exists, Lazy.force file2_exists with
-    | true, true -> `Eq (compare_files mode file1 (Path.build file2) = Eq)
+    | true, true -> `Eq (compare_file_paths mode file1 (Path.build file2) = Eq)
     | false, false -> `Eq true
     | true, false -> if optional then `Eq true else `Delete
     | false, true -> `Eq false)
 ;;
 
-let exec loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
+type kind =
+  | Missing
+  | File
+  | Directory
+
+type file_diff =
+  { source_file : Path.Source.t
+  ; file1 : Path.t
+  ; file2 : Path.t
+  ; kind : Diff.Mode.t
+  }
+
+type change =
+  | File_diff of file_diff
+  | Message of User_message.Style.t Pp.t list
+
+type promotion =
+  | Promote_file of
+      { source_file : Path.Source.t
+      ; correction_file : Path.Build.t
+      }
+  | Delete of [ `File | `Directory ] * Path.Source.t
+  | Create_directory of Path.Source.t
+
+let remove_intermediate_target path =
+  match Fpath.unlink (Path.Build.to_string path) with
+  | Success | Does_not_exist -> ()
+  | Is_a_directory -> Path.rm_rf (Path.build path)
+  | Error e ->
+    User_error.raise
+      [ Pp.textf
+          "Failed to remove intermediate target %s"
+          (Path.Build.to_string_maybe_quoted path)
+      ; Exn.pp e
+      ]
+;;
+
+let is_copied_from_source_tree file =
+  match Path.extract_build_context_dir_maybe_sandboxed file with
+  | None -> false
+  | Some (_, file) ->
+    (* CR-someday rgrinberg: isn't this racy? *)
+    Fpath.exists (Path.to_string (Path.source file))
+;;
+
+let in_source_or_target file =
+  is_copied_from_source_tree file || not (Fpath.exists (Path.to_string file))
+;;
+
+let source_root file =
+  Path.as_in_build_dir_exn file |> Path.Build.drop_build_context_maybe_sandboxed_exn
+;;
+
+let promotion source_file =
+  { User_message.Diff_annot.in_source = source_file
+  ; in_build = Diff_promotion.File.in_staging_area source_file
+  }
+;;
+
+let run_change loc ~patch_back = function
+  | Message messages -> User_error.raise ~loc messages
+  | File_diff { source_file; file1; file2; kind } ->
+    (match kind with
+     | Text ->
+       Print_diff.print
+         ~patch_back
+         (promotion source_file)
+         file1
+         file2
+         ~skip_trailing_cr:Sys.win32
+     | Binary ->
+       User_error.raise
+         ~promotion:(promotion source_file)
+         ~loc
+         [ Pp.textf
+             "Files %s and %s differ."
+             (Path.to_string_maybe_quoted file1)
+             (Path.to_string_maybe_quoted file2)
+         ])
+;;
+
+let register_promotions how promotions =
+  List.iter promotions ~f:(function
+    | Promote_file { source_file; correction_file } ->
+      Diff_promotion.register_intermediate how ~source_file ~correction_file
+    | Delete (what, source_file) -> Diff_promotion.register_delete what source_file
+    | Create_directory source_dir -> Diff_promotion.register_create_directory source_dir)
+;;
+
+let kind_of_path ~loc path =
+  match Path.Untracked.stat path with
+  | Error ((ENOENT | ENOTDIR), _, _) -> Missing
+  | Ok { Unix.st_kind = S_REG; _ } -> File
+  | Ok { Unix.st_kind = S_DIR; _ } -> Directory
+  | Ok { Unix.st_kind; _ } ->
+    User_error.raise
+      ~loc
+      [ Pp.textf
+          "Unsupported path kind %S in directory diff for %s"
+          (File_kind.to_string_hum st_kind)
+          (Path.to_string_maybe_quoted path)
+      ]
+  | Error e ->
+    User_error.raise
+      ~loc
+      [ Pp.textf "Unable to stat %s" (Path.to_string_maybe_quoted path)
+      ; Unix_error.Detailed.pp_reason e
+      ]
+;;
+
+let list_directory ~loc path =
+  match Path.Untracked.readdir_unsorted_with_kinds path with
+  | Ok entries ->
+    List.sort entries ~compare:(fun (x, _) (y, _) -> Filename.compare x y)
+    |> List.map ~f:fst
+  | Error e ->
+    User_error.raise
+      ~loc
+      [ Pp.textf "Unable to read directory %s" (Path.to_string_maybe_quoted path)
+      ; Unix_error.Detailed.pp_reason e
+      ]
+;;
+
+let exec_directory loc ~patch_back { Diff.optional; mode; file1; file2 } =
+  let source_root = source_root file1 in
+  let source_file rel =
+    if String.equal rel "" then source_root else Path.Source.relative source_root rel
+  in
+  let source_path rel = Path.source (source_file rel) in
+  let target_path rel =
+    let path = if String.equal rel "" then file2 else Path.Build.relative file2 rel in
+    Path.build path
+  in
+  let target_file rel =
+    if String.equal rel "" then file2 else Path.Build.relative file2 rel
+  in
+  let path_name rel = Path.Source.to_string_maybe_quoted (source_file rel) in
+  let append_rel rel name = if String.equal rel "" then name else rel ^ "/" ^ name in
+  let promotions = ref [] in
+  let changes = ref [] in
+  let add_message message = changes := Message [ message ] :: !changes in
+  let add_promote_file rel =
+    promotions
+    := Promote_file { source_file = source_file rel; correction_file = target_file rel }
+       :: !promotions
+  in
+  let add_file_diff rel =
+    let source_file = source_file rel in
+    add_promote_file rel;
+    changes
+    := File_diff
+         { source_file; file1 = source_path rel; file2 = target_path rel; kind = mode }
+       :: !changes
+  in
+  let add_delete what rel =
+    promotions := Delete (what, source_file rel) :: !promotions;
+    let what =
+      match what with
+      | `File -> "File"
+      | `Directory -> "Directory"
+    in
+    add_message (Pp.textf "%s %s should be deleted" what (path_name rel))
+  in
+  let add_create_directory rel =
+    promotions := Create_directory (source_file rel) :: !promotions
+  in
+  let source_kind_of rel = kind_of_path ~loc (source_path rel) in
+  let target_kind_of rel = kind_of_path ~loc (target_path rel) in
+  let rec collect_target_only rel target_kind =
+    match target_kind with
+    | Missing -> ()
+    | File -> add_promote_file rel
+    | Directory ->
+      add_create_directory rel;
+      List.iter
+        (list_directory ~loc (target_path rel))
+        ~f:(fun name ->
+          let rel = append_rel rel name in
+          collect_target_only rel (target_kind_of rel))
+  in
+  let rec loop rel source_kind target_kind =
+    match source_kind, target_kind with
+    | Missing, Missing -> ()
+    | File, File ->
+      if compare_file_paths mode (source_path rel) (target_path rel) <> Eq
+      then add_file_diff rel
+    | Missing, File -> add_file_diff rel
+    | Directory, File ->
+      add_promote_file rel;
+      add_message (Pp.textf "Directory %s should be replaced with a file" (path_name rel))
+    | File, Missing -> add_delete `File rel
+    | Directory, Missing -> add_delete `Directory rel
+    | Missing, Directory ->
+      let entries = list_directory ~loc (target_path rel) in
+      add_create_directory rel;
+      if List.is_empty entries
+      then add_message (Pp.textf "Directory %s should be created" (path_name rel))
+      else
+        List.iter entries ~f:(fun name ->
+          let rel = append_rel rel name in
+          loop rel Missing (target_kind_of rel))
+    | File, Directory ->
+      add_create_directory rel;
+      add_message (Pp.textf "File %s should be replaced with a directory" (path_name rel));
+      list_directory ~loc (target_path rel)
+      |> List.iter ~f:(fun name ->
+        let rel = append_rel rel name in
+        collect_target_only rel (target_kind_of rel))
+    | Directory, Directory ->
+      let rec merge source_entries target_entries =
+        match source_entries, target_entries with
+        | [], [] -> ()
+        | name :: source_entries, [] ->
+          let rel = append_rel rel name in
+          loop rel (source_kind_of rel) Missing;
+          merge source_entries []
+        | [], name :: target_entries ->
+          let rel = append_rel rel name in
+          loop rel Missing (target_kind_of rel);
+          merge [] target_entries
+        | source_name :: source_entries, target_name :: target_entries ->
+          (match Filename.compare source_name target_name with
+           | Lt ->
+             let rel = append_rel rel source_name in
+             loop rel (source_kind_of rel) Missing;
+             merge source_entries (target_name :: target_entries)
+           | Eq ->
+             let rel = append_rel rel source_name in
+             loop rel (source_kind_of rel) (target_kind_of rel);
+             merge source_entries target_entries
+           | Gt ->
+             let rel = append_rel rel target_name in
+             loop rel Missing (target_kind_of rel);
+             merge (source_name :: source_entries) target_entries)
+      in
+      merge
+        (list_directory ~loc (source_path rel))
+        (list_directory ~loc (target_path rel))
+  in
+  let source_kind = source_kind_of "" in
+  let target_kind = target_kind_of "" in
+  if optional && target_kind = Missing
+  then Fiber.return ()
+  else (
+    loop "" source_kind target_kind;
+    match List.rev !changes with
+    | [] ->
+      if optional then remove_intermediate_target file2;
+      Fiber.return ()
+    | changes ->
+      let promotions = List.rev !promotions in
+      let in_source_or_target = in_source_or_target file1 in
+      let target_is_copied_from_source_tree =
+        is_copied_from_source_tree (Path.build file2)
+      in
+      Fiber.finalize
+        (fun () -> Fiber.parallel_iter changes ~f:(run_change loc ~patch_back))
+        ~finally:(fun () ->
+          (match optional with
+           | false ->
+             if in_source_or_target && not target_is_copied_from_source_tree
+             then register_promotions `Copy promotions
+           | true ->
+             if in_source_or_target
+             then register_promotions `Move promotions
+             else remove_intermediate_target file2);
+          Fiber.return ()))
+;;
+
+let exec_file loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
   let remove_intermediate_file () =
     if optional
     then (
@@ -34,30 +303,14 @@ let exec loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
     Fiber.return ()
   | `Eq false | `Delete ->
     (* CR-soon rgrinberg: handle deletion *)
-    let is_copied_from_source_tree file =
-      match Path.extract_build_context_dir_maybe_sandboxed file with
-      | None -> false
-      | Some (_, file) ->
-        (* CR-someday rgrinberg: isn't this racy? *)
-        Fpath.exists (Path.to_string (Path.source file))
-    in
-    let in_source_or_target =
-      is_copied_from_source_tree file1 || not (Fpath.exists (Path.to_string file1))
-    in
-    let source_file =
-      Path.as_in_build_dir_exn file1 |> Path.Build.drop_build_context_maybe_sandboxed_exn
-    in
+    let in_source_or_target = in_source_or_target file1 in
+    let source_file = source_root file1 in
     Fiber.finalize
       (fun () ->
-         let promotion =
-           { User_message.Diff_annot.in_source = source_file
-           ; in_build = Diff_promotion.File.in_staging_area source_file
-           }
-         in
          if mode = Binary
          then
            User_error.raise
-             ~promotion
+             ~promotion:(promotion source_file)
              ~loc
              [ Pp.textf
                  "Files %s and %s differ."
@@ -67,7 +320,7 @@ let exec loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
          else
            Print_diff.print
              ~patch_back
-             promotion
+             (promotion source_file)
              file1
              (Path.build file2)
              ~skip_trailing_cr:(mode = Text && Sys.win32))
@@ -84,4 +337,10 @@ let exec loc ~patch_back ({ Diff.optional; file1; file2; mode } as diff) =
          | true ->
            if in_source_or_target then register `Move else remove_intermediate_file ());
         Fiber.return ())
+;;
+
+let exec loc ~patch_back ({ Diff.file1; file2; _ } as diff) =
+  match kind_of_path ~loc file1, kind_of_path ~loc (Path.build file2) with
+  | Directory, _ | _, Directory -> exec_directory loc ~patch_back diff
+  | _ -> exec_file loc ~patch_back diff
 ;;

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -98,10 +98,12 @@ let dyn_of_what =
 
 type op =
   | File of File.t
+  | Create_directory of Path.Source.t
   | Delete of what * Path.Source.t
 
 let dyn_of_op = function
   | File f -> Dyn.variant "File" [ File.to_dyn f ]
+  | Create_directory p -> Dyn.variant "Create_directory" [ Path.Source.to_dyn p ]
   | Delete (what, d) -> Dyn.variant "Delete" [ dyn_of_what what; Path.Source.to_dyn d ]
 ;;
 
@@ -145,7 +147,7 @@ module P = Persistent.Make (struct
 
     let name = "TO-PROMOTE"
     let sharing = true
-    let version = 5
+    let version = 6
     let to_dyn = Dyn.list dyn_of_op
   end)
 
@@ -163,20 +165,74 @@ let dump_db (db : db) =
 
 let load_db () = Option.value ~default:[] (P.load db_file)
 
+let compare_what a b =
+  match a, b with
+  | `File, `File | `Directory, `Directory -> Eq
+  | `File, `Directory -> Lt
+  | `Directory, `File -> Gt
+;;
+
+let compare_op a b =
+  let open Ordering.O in
+  match a, b with
+  | File a, File b -> File.compare a b
+  | File _, _ -> Lt
+  | _, File _ -> Gt
+  | Create_directory a, Create_directory b -> Path.Source.compare a b
+  | Create_directory _, _ -> Lt
+  | _, Create_directory _ -> Gt
+  | Delete (what_a, path_a), Delete (what_b, path_b) ->
+    let= () = compare_what what_a what_b in
+    Path.Source.compare path_a path_b
+;;
+
 let group_by_targets db =
   List.map db ~f:(fun op ->
     match op with
+    | Create_directory p -> p, op
     | Delete (_, f) -> f, op
     | File { File.src = _; staging = _; dst } -> dst, op)
   |> Path.Source.Map.of_list_multi
   (* Sort the list of possible sources for deterministic behavior *)
-  |> Path.Source.Map.map ~f:(List.sort ~compare:Poly.compare)
+  |> Path.Source.Map.map ~f:(List.sort ~compare:compare_op)
+;;
+
+let create_directory dst =
+  let path = Path.source dst in
+  match Path.Untracked.stat path with
+  | Ok { Unix.st_kind = S_DIR; _ } -> ()
+  | Error (ENOENT, _, _) -> Path.mkdir_p path
+  | Ok _ ->
+    (match Fpath.unlink (Path.Source.to_string dst) with
+     | Success | Does_not_exist -> ()
+     | Is_a_directory -> assert false
+     | Error e ->
+       User_error.raise
+         [ Pp.textf "failed to create directory %s" (Path.Source.to_string dst)
+         ; Exn.pp e
+         ]);
+    Path.mkdir_p path
+  | Error e ->
+    User_error.raise
+      [ Pp.textf "failed to create directory %s" (Path.Source.to_string dst)
+      ; Unix_error.Detailed.pp_reason e
+      ]
 ;;
 
 let promote_one dst srcs =
+  let ignored others =
+    List.iter others ~f:(fun op ->
+      let path =
+        match op with
+        | File f -> Path.build f.src
+        | Create_directory _ | Delete _ -> Path.source dst
+      in
+      Console.print
+        [ Pp.textf " -> ignored %s." (Path.to_string_maybe_quoted path); Pp.space ])
+  in
   match srcs with
   | [] -> assert false
-  | op :: others ->
+  | srcs ->
     (* We used to remove promoted files from the digest cache, to force Dune
        to redigest them on the next run. We did this because on OSX [mtime] is
        not precise enough and if a file is modified and promoted quickly, it
@@ -190,18 +246,37 @@ let promote_one dst srcs =
        not promote into the build directory anyway), and source digests should
        be correctly invalidated via [fs_memo]. If that doesn't happen, we
        should fix [fs_memo] instead of manually resetting the caches here. *)
-    (match op with
-     | File f -> File.promote f
-     | Delete (`File, _) -> Fpath.unlink_exn (Path.Source.to_string dst)
-     | Delete (`Directory, _) -> Fpath.rm_rf (Path.Source.to_string dst));
-    List.iter others ~f:(fun op ->
-      let path =
-        match op with
-        | File f -> Path.build f.src
-        | Delete _ -> Path.source dst
-      in
-      Console.print
-        [ Pp.textf " -> ignored %s." (Path.to_string_maybe_quoted path); Pp.space ])
+    (match
+       List.find srcs ~f:(function
+         | File _ -> true
+         | _ -> false)
+     with
+     | Some (File f) ->
+       File.promote f;
+       ignored (List.filter srcs ~f:(fun op -> not (compare_op op (File f) = Eq)))
+     | Some _ -> assert false
+     | None ->
+       (match
+          List.find srcs ~f:(function
+            | Create_directory _ -> true
+            | _ -> false)
+        with
+        | Some (Create_directory _) ->
+          create_directory dst;
+          ignored
+            (List.filter srcs ~f:(function
+               | Create_directory _ -> false
+               | _ -> true))
+        | Some _ -> assert false
+        | None ->
+          (match srcs with
+           | Delete (`File, _) :: others ->
+             Fpath.unlink_exn (Path.Source.to_string dst);
+             ignored others
+           | Delete (`Directory, _) :: others ->
+             Fpath.rm_rf (Path.Source.to_string dst);
+             ignored others
+           | _ -> assert false)))
 ;;
 
 let do_promote_all db = group_by_targets db |> Path.Source.Map.iteri ~f:promote_one
@@ -297,10 +372,10 @@ type all =
     - The files absent from [db] as [Path]s. *)
 let partition_db (db : db) files_to_promote =
   let db =
-    (* CR-soon rgrinberg: communicate deletions to the user *)
+    (* CR-soon rgrinberg: communicate deletions and directory creation to the user *)
     List.filter_map db ~f:(function
       | File f -> Some f
-      | Delete _ -> None)
+      | Create_directory _ | Delete _ -> None)
   in
   let present, missing =
     match files_to_promote with
@@ -315,3 +390,4 @@ let partition_db (db : db) files_to_promote =
 ;;
 
 let register_delete what src = db := Delete (what, src) :: !db
+let register_create_directory src = db := Create_directory src :: !db

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -43,3 +43,4 @@ val register_intermediate
   -> unit
 
 val register_delete : [ `File | `Directory ] -> Path.Source.t -> unit
+val register_create_directory : Path.Source.t -> unit

--- a/test/blackbox-tests/test-cases/promote/directory-diff/add-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/add-file.t
@@ -1,0 +1,32 @@
+Directory diff promotes files that are missing from the source directory.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir expected
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'hello\n' > actual/new-file")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "expected/new-file", line 1, characters 0-0:
+  --- expected/new-file
+  +++ _build/default/actual/new-file
+  @@ -0,0 +1 @@
+  +hello
+  [1]
+
+  $ dune promote
+  Promoting _build/default/actual/new-file to expected/new-file.
+
+  $ cat expected/new-file
+  hello

--- a/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/cli-commands.t
@@ -1,0 +1,61 @@
+Directory diff integrates with the promotion CLI.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+Deletion promotions are visible to `dune promotion list` and `diff`.
+
+  $ mkdir expected
+  $ printf 'keep\n' > expected/keep
+  $ printf 'delete me\n' > expected/delete
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: File expected/delete should be deleted
+  [1]
+
+  $ dune promotion list
+
+  $ dune promotion diff expected/delete
+  Warning: Nothing to promote for expected/delete.
+
+`dune promotion show` still previews file promotions from a directory diff.
+
+  $ rm -rf expected
+  $ mkdir expected
+  $ printf 'before\n' > expected/changed
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'after\n' > actual/changed")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "expected/changed", line 1, characters 0-0:
+  --- expected/changed
+  +++ _build/default/actual/changed
+  @@ -1 +1 @@
+  -before
+  +after
+  [1]
+
+  $ dune promotion show expected/changed | sed -n '1p'
+  after

--- a/test/blackbox-tests/test-cases/promote/directory-diff/create-empty-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/create-empty-directory.t
@@ -1,0 +1,30 @@
+Directory diff can create an empty directory.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir expected
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual/empty")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: Directory expected/empty should be created
+  [1]
+
+  $ dune promote
+
+  $ test -d expected/empty && echo created
+  created

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-directory.t
@@ -1,0 +1,36 @@
+Directory diff records directory deletions.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir -p expected/stale
+  $ printf 'keep\n' > expected/keep
+  $ printf 'stale\n' > expected/stale/file
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: Directory expected/stale should be deleted
+  [1]
+
+  $ dune promote
+
+  $ test ! -d expected/stale && echo deleted
+  deleted
+
+  $ cat expected/keep
+  keep

--- a/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/delete-file.t
@@ -1,0 +1,36 @@
+Directory diff records file deletions.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir expected
+  $ printf 'keep\n' > expected/keep
+  $ printf 'delete me\n' > expected/delete
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: File expected/delete should be deleted
+  [1]
+
+  $ dune promote
+
+  $ test ! -e expected/delete && echo deleted
+  deleted
+
+  $ cat expected/keep
+  keep

--- a/test/blackbox-tests/test-cases/promote/directory-diff/multiple-file-promotions.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/multiple-file-promotions.t
@@ -1,0 +1,43 @@
+Directory diff promotes each changed file separately.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir expected
+  $ printf 'old a\n' > expected/a
+  $ printf 'old b\n' > expected/b
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'new a\n' > actual/a && printf 'new b\n' > actual/b")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "expected/a", line 1, characters 0-0:
+  --- expected/a
+  +++ _build/default/actual/a
+  @@ -1 +1 @@
+  -old a
+  +new a
+  File "expected/b", line 1, characters 0-0:
+  --- expected/b
+  +++ _build/default/actual/b
+  @@ -1 +1 @@
+  -old b
+  +new b
+  [1]
+
+  $ dune promote
+  Promoting _build/default/actual/a to expected/a.
+  Promoting _build/default/actual/b to expected/b.
+
+  $ cat expected/a expected/b
+  new a
+  new b

--- a/test/blackbox-tests/test-cases/promote/directory-diff/replace-directory-with-file.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/replace-directory-with-file.t
@@ -1,0 +1,38 @@
+Directory diff can replace a directory with a file.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir -p expected/node
+  $ printf 'child\n' > expected/node/file
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'file\n' > actual/node")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: Directory expected/node should be replaced with a file
+  [1]
+
+  $ dune promote
+  Promoting _build/default/actual/node to expected/node.
+
+  $ test -f expected/node && echo file
+  file
+
+  $ test ! -d expected/node && echo not-a-directory
+  not-a-directory
+
+  $ cat expected/node
+  file

--- a/test/blackbox-tests/test-cases/promote/directory-diff/replace-file-with-directory.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/replace-file-with-directory.t
@@ -1,0 +1,39 @@
+Directory diff can replace a file with a directory.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ mkdir expected
+  $ printf 'file\n' > expected/node
+
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual/node && printf 'child\n' > actual/node/file")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest
+  File "dune", lines 5-7, characters 0-56:
+  5 | (rule
+  6 |  (alias runtest)
+  7 |  (action (diff expected actual)))
+  Error: File expected/node should be replaced with a directory
+  [1]
+
+  $ dune promote
+  Promoting _build/default/actual/node/file to expected/node/file.
+
+  $ test -d expected/node && echo directory
+  directory
+
+  $ test ! -f expected/node && echo not-a-file
+  not-a-file
+
+  $ cat expected/node/file
+  child

--- a/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/targeted-promotion.t
@@ -1,0 +1,68 @@
+Targeted promotion works for directory creation and deletion.
+
+  $ cat > dune-project <<'EOF'
+  > (lang dune 3.22)
+  > (using directory-targets 0.1)
+  > EOF
+
+Prefix promotion can create a directory subtree without promoting siblings.
+
+  $ mkdir expected
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action
+  >   (system
+  >    "mkdir -p actual/node \
+  >     && printf 'child\n' > actual/node/file \
+  >     && printf 'other\n' > actual/other")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest > /dev/null 2>&1 || echo failed
+  failed
+
+  $ dune promote expected/node
+  Promoting _build/default/actual/node/file to expected/node/file.
+
+  $ test -d expected/node && echo directory
+  directory
+
+  $ cat expected/node/file
+  child
+
+  $ test ! -e expected/other && echo other-pending
+  other-pending
+
+  $ dune promotion list
+  expected/other
+
+Prefix promotion can also delete just the requested stale subtree.
+
+  $ rm -rf expected
+  $ mkdir -p expected/stale
+  $ printf 'keep\n' > expected/keep
+  $ printf 'stale\n' > expected/stale/file
+  $ cat > dune <<'EOF'
+  > (rule
+  >  (targets (dir actual))
+  >  (action (system "mkdir -p actual && printf 'keep\n' > actual/keep")))
+  > 
+  > (rule
+  >  (alias runtest)
+  >  (action (diff expected actual)))
+  > EOF
+
+  $ dune runtest > /dev/null 2>&1 || echo failed
+  failed
+
+  $ dune promote expected/stale
+
+  $ test ! -d expected/stale && echo deleted
+  deleted
+
+  $ cat expected/keep
+  keep

--- a/test/blackbox-tests/test-cases/promote/overlapping-diff.t
+++ b/test/blackbox-tests/test-cases/promote/overlapping-diff.t
@@ -58,6 +58,4 @@ Test how overlapping diff actions are handled
 
   $ dune promote && cat foo
   Promoting _build/default/foo.expected to foo.
-   -> ignored _build/default/foo.expected.
-   
   two


### PR DESCRIPTION
Allow the `diff` action to diff directories. Some situations where such an action is useful:

1. We'd like to introduce a generic "test" rule that will read test cases from a directory and produce test output for every individual test case.

2. We have a code generator that produces for multiple source files.