### PR TITLE
refactor: wrap Stdlib's marshal api

### DIFF
--- a/otherlibs/stdune/src/marshal.ml
+++ b/otherlibs/stdune/src/marshal.ml
@@ -1,0 +1,6 @@
+include Stdlib.Marshal
+
+let make_sharing f = if f then [] else [ No_sharing ]
+let to_string t ~sharing = to_string t (make_sharing sharing)
+let to_channel chan t ~sharing = to_channel chan t (make_sharing sharing)
+let from_string s = from_string s 0

--- a/otherlibs/stdune/src/marshal.mli
+++ b/otherlibs/stdune/src/marshal.mli
@@ -1,0 +1,4 @@
+val to_string : 'a -> sharing:bool -> string
+val to_channel : out_channel -> 'a -> sharing:bool -> unit
+val from_channel : in_channel -> 'a
+val from_string : string -> 'a

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -84,6 +84,7 @@ module Global_lock = Global_lock
 module At_exit = At_exit
 module Permissions = Permissions
 module Console = Console
+module Marshal = Marshal
 
 module type Top_closure = Top_closure.Top_closure
 

--- a/otherlibs/stdune/test/user_error_tests.ml
+++ b/otherlibs/stdune/test/user_error_tests.ml
@@ -5,6 +5,6 @@ let () = Printexc.record_backtrace false
 let%expect_test "user errors are serializable" =
   let loc = Loc.none in
   let error = User_error.make ~loc [ Pp.text "testing" ] in
-  let (_ : string) = Marshal.to_string error [] in
+  let (_ : string) = Marshal.to_string error ~sharing:true in
   [%expect {||}]
 ;;

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -147,10 +147,7 @@ module Feed = struct
        flag [-I], then [Marshal.to_string] will produce different digests depending
        on whether the corresponding strings ["-I"] point to the same memory location
        or to different memory locations. *)
-  let generic hasher x =
-    contramap string ~f:(fun x -> Marshal.to_string x [ No_sharing ]) hasher x
-  ;;
-
+  let generic hasher x = contramap string ~f:(Marshal.to_string ~sharing:false) hasher x
   let list feed_x hasher xs = List.iter xs ~f:(feed_x hasher)
   let option feed_x hasher option_x = Option.iter option_x ~f:(feed_x hasher)
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -238,8 +238,8 @@ module Cache = struct
       let conv : (File.Set.t * Commit.Set.t) Lmdb.Conv.t =
         Lmdb.Conv.make
           ~serialise:(fun alloc v ->
-            Marshal.to_string v [] |> Lmdb.Conv.(serialise string alloc))
-          ~deserialise:(fun bs -> Marshal.from_string Lmdb.Conv.(deserialise string bs) 0)
+            Marshal.to_string v ~sharing:true |> Lmdb.Conv.(serialise string alloc))
+          ~deserialise:(fun bs -> Marshal.from_string Lmdb.Conv.(deserialise string bs))
           ()
       ;;
     end

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -50,7 +50,9 @@ module Make (D : Desc) = struct
       end : Desc_with_data)
   ;;
 
-  let to_string (v : D.t) = Printf.sprintf "%s%s" magic (Marshal.to_string v [])
+  let to_string (v : D.t) =
+    Printf.sprintf "%s%s" magic (Marshal.to_string v ~sharing:true)
+  ;;
 
   let with_record what ~file ~f =
     let start = Time.now () in
@@ -64,7 +66,7 @@ module Make (D : Desc) = struct
     let dump file v =
       Io.with_file_out file ~f:(fun oc ->
         output_string oc magic;
-        match Marshal.to_channel oc v [] with
+        match Marshal.to_channel oc v ~sharing:true with
         | s -> s
         | exception Invalid_argument s ->
           raise (Invalid_argument (sprintf "%s (%s)" s D.name)))


### PR DESCRIPTION
It's highly unsafe, and we're going to introduce something a bit safer. This first step is just an interface that codifies the existing functionality.