### PR TITLE
fix: no sharing when serializing db for targets

### DIFF
--- a/src/dune_digest/cached_digest.ml
+++ b/src/dune_digest/cached_digest.ml
@@ -57,7 +57,8 @@ module P = Persistent.Make (struct
     type nonrec t = t
 
     let name = "DIGEST-DB"
-    let version = 7
+    let version = 8
+    let sharing = true
     let to_dyn = to_dyn
   end)
 

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -144,7 +144,8 @@ module P = Persistent.Make (struct
     type t = db
 
     let name = "TO-PROMOTE"
-    let version = 4
+    let sharing = true
+    let version = 5
     let to_dyn = Dyn.list dyn_of_op
   end)
 

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -31,7 +31,8 @@ module Workspace_local = struct
         type nonrec t = t
 
         let name = "INCREMENTAL-DB"
-        let version = 6
+        let version = 7
+        let sharing = true
         let to_dyn = to_dyn
       end)
 

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -12,7 +12,8 @@ module To_delete = struct
       type t = Path.Source.Set.t
 
       let name = "PROMOTED-TO-DELETE"
-      let version = 3
+      let sharing = true
+      let version = 4
       let to_dyn = Path.Source.Set.to_dyn
     end)
 

--- a/src/dune_rules/copy_line_directive.ml
+++ b/src/dune_rules/copy_line_directive.ml
@@ -10,7 +10,8 @@ module DB = struct
       type nonrec t = Path.Build.t Path.Build.Table.t
 
       let name = "COPY-LINE-DIRECTIVE-MAP"
-      let version = 2
+      let sharing = true
+      let version = 3
       let to_dyn = Path.Build.Table.to_dyn Path.Build.to_dyn
     end)
 

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -661,7 +661,8 @@ module Script = Persistent.Make (struct
     type nonrec t = command_out list
 
     let name = "CRAM-RESULT"
-    let version = 1
+    let sharing = false
+    let version = 2
     let to_dyn = Dyn.list dyn_of_command_out
   end)
 

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -127,6 +127,7 @@ module Processed = struct
     type nonrec t = t
 
     let name = "merlin-conf"
+    let sharing = false
     let version = 8
     let to_dyn _ = Dyn.String "Use [dune ocaml dump-dot-merlin] instead"
   end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -305,8 +305,9 @@ module Install_cookie = struct
   module Persistent = Persistent.Make (struct
       type nonrec t = (Section.t * Path.t list) list Gen.t
 
+      let sharing = false
       let name = "INSTALL-COOKIE"
-      let version = 3
+      let version = 4
 
       let to_dyn =
         let open Dyn in

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -4,6 +4,7 @@ module type Desc = sig
   type t
 
   val name : string
+  val sharing : bool
   val version : int
   val to_dyn : t -> Dyn.t
 end
@@ -51,7 +52,7 @@ module Make (D : Desc) = struct
   ;;
 
   let to_string (v : D.t) =
-    Printf.sprintf "%s%s" magic (Marshal.to_string v ~sharing:true)
+    Printf.sprintf "%s%s" magic (Marshal.to_string v ~sharing:D.sharing)
   ;;
 
   let with_record what ~file ~f =
@@ -66,7 +67,7 @@ module Make (D : Desc) = struct
     let dump file v =
       Io.with_file_out file ~f:(fun oc ->
         output_string oc magic;
-        match Marshal.to_channel oc v ~sharing:true with
+        match Marshal.to_channel oc v ~sharing:D.sharing with
         | s -> s
         | exception Invalid_argument s ->
           raise (Invalid_argument (sprintf "%s (%s)" s D.name)))

--- a/src/dune_util/persistent.mli
+++ b/src/dune_util/persistent.mli
@@ -16,6 +16,7 @@ module type Desc = sig
   type t
 
   val name : string
+  val sharing : bool
   val version : int
   val to_dyn : t -> Dyn.t
 end


### PR DESCRIPTION
We don't want the bytes to vary based on how which values are shared for producing targets.