### PR TITLE
fix(pkg): set OPAMSWITCH in package build environment

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -572,6 +572,7 @@ module Pkg = struct
       ; ( "OPAM_PACKAGE_VERSION"
         , [ Value.String (Package_version.to_string t.info.version) ] )
       ; "OPAMCLI", [ Value.String "2.0" ]
+      ; "OPAMSWITCH", [ Value.String "dune" ]
       ]
   ;;
 

--- a/test/blackbox-tests/test-cases/pkg/exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/exported-env.t
@@ -19,6 +19,7 @@ Packages can export environment variables
   >           "\| echo BAR=$BAR
   >           "\| echo OPAM_PACKAGE_NAME=$OPAM_PACKAGE_NAME
   >           "\| echo OPAM_PACKAGE_VERSION=$OPAM_PACKAGE_VERSION
+  >           "\| echo OPAMSWITCH=$OPAMSWITCH
   >   )
   >   (run mkdir -p %{prefix})))
   > EOF
@@ -28,3 +29,4 @@ Packages can export environment variables
   BAR=zzz:yyy:xxx
   OPAM_PACKAGE_NAME=usetest
   OPAM_PACKAGE_VERSION=1.2.3
+  OPAMSWITCH=dune


### PR DESCRIPTION
- Fixes #13887

The relocatable compiler's (OCaml 5.5) process.sh script references $OPAMSWITCH. Since dune is not opam, set it to a value that allows the script to progress. It doesn't matter if this switch actually exists, since other mechanisms in the script will cause it to abort early and avoid cloning the compiler switch.

https://github.com/ocaml/ocaml/blob/trunk/tools/opam/process.sh

This is now being used in the opam file for the compiler:

https://github.com/ocaml/opam-repository/blob/63b7ba71be83567e54bb667df0f2bb374d74fb61/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam#L62