### PR TITLE
fix(ci): pin windows setup-ocaml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -213,7 +213,7 @@ jobs:
         run: sudo apt update
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3.4.8
+        uses: ocaml/setup-ocaml@fix-cygwin-path-append
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -212,7 +212,7 @@ jobs:
         run: sudo apt update
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3.4.8
+        uses: ocaml/setup-ocaml@fix-cygwin-path-append
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 


### PR DESCRIPTION
Should fix the Windows CI.

Currently testing out https://github.com/ocaml/setup-ocaml/pull/1085. Waiting for a release to bump CI.