### PR TITLE
sandbox: honor sandbox config from included deps

### DIFF
--- a/doc/changes/fixed/13898.md
+++ b/doc/changes/fixed/13898.md
@@ -1,0 +1,2 @@
+- Honor sandbox settings specified inside `(:include ..)` expressions in the `deps` field
+  (#13898, @rgrinberg)

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -629,6 +629,7 @@ let expand_no_targets t sandbox ~loc ~chdir ~deps:deps_written_by_user ~expander
       ; pp_targets targets
       ];
   let+ () = deps_builder
+  and+ sandbox = sandbox
   and+ action = build in
   let action = Action.Chdir (Path.build chdir, action) in
   Action.Full.make action ~sandbox
@@ -689,6 +690,7 @@ let expand
   in
   let build =
     let+ () = deps_builder
+    and+ sandbox = sandbox
     and+ action = build in
     Action.Full.make (Action.Chdir (Path.build chdir, action)) ~sandbox
   in

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -7,7 +7,7 @@ module Spec = struct
     ; test_name_alias : Alias.Name.t
     ; extra_aliases : Alias.Name.Set.t
     ; deps : unit Action_builder.t list
-    ; sandbox : Sandbox_config.t
+    ; sandbox : Sandbox_config.t Action_builder.t
     ; enabled_if : (Expander.t * Blang.t) list
     ; locks : Path.Set.t Action_builder.t
     ; packages : Package.Name.Set.t
@@ -24,7 +24,7 @@ module Spec = struct
     ; enabled_if = []
     ; locks = Action_builder.return Path.Set.empty
     ; deps = []
-    ; sandbox = Sandbox_config.needs_sandboxing
+    ; sandbox = Action_builder.return Sandbox_config.needs_sandboxing
     ; packages = Package.Name.Set.empty
     ; timeout = None
     ; conflict_markers = Ignore
@@ -137,6 +137,7 @@ let test_rule
            let+ (_ : Path.Set.t) = Action_builder.dyn_memo_deps deps in
            ()
        and+ () = Action_builder.paths setup_scripts
+       and+ sandbox = sandbox
        and+ locks = locks >>| Path.Set.to_list in
        Cram_exec.run
          ~src:(Path.build script)
@@ -265,7 +266,13 @@ let rules ~sctx ~dir tests project =
                       Sandbox_config.no_special_requirements
                       deps
                   in
-                  deps :: acc.deps, Sandbox_config.inter acc.sandbox sandbox
+                  let sandbox =
+                    let open Action_builder.O in
+                    let+ acc = acc.sandbox
+                    and+ sandbox = sandbox in
+                    Sandbox_config.inter acc sandbox
+                  in
+                  deps :: acc.deps, sandbox
               in
               let locks =
                 let open Action_builder.O in

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -76,27 +76,31 @@ let dep_on_alias_rec alias ~loc =
            ])
 ;;
 
-let expand_include ~dir ~project s =
-  Path.Build.relative dir s
-  |> Path.build
-  |> Action_builder.read_sexp
-  >>| function
-  | List (_loc, asts) ->
-    let dep_parser =
-      Dune_lang.Syntax.set
-        Stanza.syntax
-        (Active (Dune_project.dune_version project))
-        (String_with_vars.set_decoding_env
-           (* CR-someday rgrinberg: this environment looks fishy *)
-           (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
-           (Bindings.decode Dep_conf.decode))
-    in
-    List.concat_map ~f:(Dune_lang.Decoder.parse dep_parser Univ_map.empty) asts
-  | ast ->
-    let loc = Dune_lang.Ast.loc ast in
-    User_error.raise
-      ~loc
-      [ Pp.text "Dependency specification in `(include <filename>)` must be a list" ]
+let expand_include =
+  (* CR-someday rgrinberg: move this into [Dune_project]? *)
+  let dep_parser project =
+    Dune_lang.Syntax.set
+      Stanza.syntax
+      (Active (Dune_project.dune_version project))
+      (String_with_vars.set_decoding_env
+         (* CR-someday rgrinberg: this environment looks fishy *)
+         (Pform.Env.initial ~stanza:Stanza.latest_version ~extensions:[])
+         (Bindings.decode Dep_conf.decode))
+  in
+  fun ~dir ~project s ->
+    Path.Build.relative dir s
+    |> Path.build
+    |> Action_builder.read_sexp
+    >>| function
+    | Dune_lang.Ast.List (_loc, asts) ->
+      List.concat_map
+        asts
+        ~f:(Dune_lang.Decoder.parse (dep_parser project) Univ_map.empty)
+    | ast ->
+      let loc = Dune_lang.Ast.loc ast in
+      User_error.raise
+        ~loc
+        [ Pp.text "Dependency specification in `(include <filename>)` must be a list" ]
 ;;
 
 let prepare_expander expander = Expander.set_expanding_what expander Deps_like_field
@@ -179,12 +183,12 @@ let rec dep expander : Dep_conf.t -> _ = function
        unnamed expansion *)
     let dir = Expander.dir expander in
     Other
-      (let* project = Action_builder.of_memo @@ Dune_load.find_project ~dir in
-       let deps = expand_include ~dir ~project s in
-       let* deps = deps in
+      (let* deps =
+         let* project = Action_builder.of_memo @@ Dune_load.find_project ~dir in
+         expand_include ~dir ~project s
+       in
        let builder, _bindings = named_paths_builder ~expander deps in
-       let+ paths = builder in
-       paths)
+       builder)
   | File s ->
     (match Expander.With_deps_if_necessary.expand_path expander s with
      | Without paths ->
@@ -311,20 +315,35 @@ and named_paths_builder ~expander l =
 let named sandbox ~expander l =
   let builder, bindings = named_paths_builder ~expander l in
   let builder =
-    let builder =
-      let+ paths = builder in
-      Value.L.paths paths
-    in
-    Action_builder.memoize ~cutoff:(List.equal Value.equal) "deps" builder
+    Action_builder.memoize
+      ~cutoff:(List.equal Value.equal)
+      "deps"
+      (builder >>| Value.L.paths)
   in
   let bindings = Pform.Map.set bindings (Var Deps) (Expander.Deps.With builder) in
   let expander = Expander.add_bindings_full expander ~bindings in
-  ( Action_builder.ignore builder
-  , expander
-  , Bindings.fold l ~init:sandbox ~f:(fun one acc ->
-      match one with
-      | Unnamed dep -> add_sandbox_config acc dep
-      | Named (_, l) -> List.fold_left l ~init:acc ~f:add_sandbox_config) )
+  let sandbox =
+    let open Action_builder.O in
+    let rec sandbox_dep acc = function
+      | Dep_conf.Include s ->
+        let* deps =
+          let dir = Expander.dir expander in
+          let* project = Action_builder.of_memo (Dune_load.find_project ~dir) in
+          expand_include ~dir ~project s
+        in
+        sandbox_bindings acc deps
+      | dep -> Action_builder.return (add_sandbox_config acc dep)
+    and sandbox_bindings acc deps =
+      Bindings.fold deps ~init:(Action_builder.return acc) ~f:(fun one acc ->
+        let* acc = acc in
+        match one with
+        | Unnamed dep -> sandbox_dep acc dep
+        | Named (_, deps) -> Action_builder.List.fold_left deps ~init:acc ~f:sandbox_dep)
+    in
+    sandbox_bindings sandbox l
+    |> Action_builder.memoize ~cutoff:Sandbox_config.equal "deps sandbox"
+  in
+  Action_builder.ignore builder, expander, sandbox
 ;;
 
 let unnamed sandbox ~expander l =

--- a/src/dune_rules/dep_conf_eval.mli
+++ b/src/dune_rules/dep_conf_eval.mli
@@ -26,4 +26,4 @@ val named
   :  Sandbox_config.t
   -> expander:Expander.t
   -> Dep_conf.t Bindings.t
-  -> unit Action_builder.t * Expander.t * Sandbox_config.t
+  -> unit Action_builder.t * Expander.t * Sandbox_config.t Action_builder.t

--- a/test/blackbox-tests/test-cases/dynamic-dependencies.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies.t
@@ -108,4 +108,3 @@ Multiple `(include)` nesting
 
   $ dune build @nested
   metadeps: depB another_dep
-

--- a/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree-include.t
+++ b/test/blackbox-tests/test-cases/sandbox/patch-back-source-tree-include.t
@@ -15,8 +15,12 @@ Patch-back sandboxing from an included deps file is treated like direct patch-ba
   >  (action (system "echo foo > mod")))
   > EOF
 
-  $ dune runtest 2>&1 | grep -o "Permission denied"
-  Permission denied
+  $ dune runtest
+  File "mod", line 1, characters 0-0:
+  --- mod
+  +++ _build/default/mod
+  @@ -0,0 +1 @@
+  +foo
   [1]
 
   $ cat > dune <<'EOF'


### PR DESCRIPTION
`(deps (:include foo.sexp))` would ignore sandbox specification.