### PR TITLE
fix(pkg): prefer stronger hash in lock

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -451,7 +451,7 @@ let opam_package_to_lock_file_pkg
       ( Path.Local.of_string (OpamFilename.Base.to_string opam_basename)
       , let url = Loc.none, OpamFile.URL.url opam_url in
         let checksum =
-          match OpamFile.URL.checksum opam_url with
+          match OpamHash.sort (OpamFile.URL.checksum opam_url) with
           | [] -> None
           | checksum :: _ -> Some (Loc.none, Checksum.of_opam_hash checksum)
         in
@@ -463,6 +463,7 @@ let opam_package_to_lock_file_pkg
       Option.map url ~f:(fun (url : OpamFile.URL.t) ->
         let checksum =
           OpamFile.URL.checksum url
+          |> OpamHash.sort
           |> List.hd_opt
           |> Option.map ~f:(fun hash -> Loc.none, Checksum.of_opam_hash hash)
         in

--- a/test/blackbox-tests/test-cases/pkg/hash-algos.t
+++ b/test/blackbox-tests/test-cases/pkg/hash-algos.t
@@ -7,7 +7,7 @@ Test that dune supports lockfiles with md5, sha256 and sha512 hashes.
   > url {
   >  src: "file://with-md5"
   >  checksum: [
-  >   "md5=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  >   "sha512=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   >  ]
   > }
   > EOF
@@ -30,8 +30,8 @@ Test that dune supports lockfiles with md5, sha256 and sha512 hashes.
   > }
   > EOF
 
-This package uses multiple hashing algorithms. Currently dune will just add the
-first checksum to the lockfile for this package.
+This package uses multiple hashing algorithms. Currently dune will add the
+strongest checksum to the lockfile for this package.
 
   $ mkpkg with-all <<EOF
   > url {
@@ -82,19 +82,22 @@ first checksum to the lockfile for this package.
   (source
    (fetch
     (url file://with-all)
-    (checksum md5=dddddddddddddddddddddddddddddddd)))
+    (checksum
+     sha512=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)))
   
   (extra_sources
    (fixes.patch
     (fetch
      (url https://unimportant.url/unused.patch)
-     (checksum md5=00000000000000000000000000000000))))
+     (checksum
+      sha512=22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222))))
   (version 0.0.1)
   
   (source
    (fetch
     (url file://with-md5)
-    (checksum md5=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)))
+    (checksum
+     sha512=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)))
   (version 0.0.1)
   
   (source


### PR DESCRIPTION
Closes https://github.com/ocaml/dune/issues/13818.

This is a minimal, backwards-compatible change to address the issue. As discussed in the linked issue, we may follow up with a PR to include all checksum in lockfile.