### PR TITLE
time_stubs.c: add fallback for Windows 7

### DIFF
--- a/doc/changes/fixed/13905.md
+++ b/doc/changes/fixed/13905.md
@@ -1,0 +1,1 @@
+- Restore compatibility with Windows 7 (#13905, @nojb)

--- a/otherlibs/stdune/src/time_stubs.c
+++ b/otherlibs/stdune/src/time_stubs.c
@@ -12,8 +12,18 @@
 CAMLprim value dune_clock_gettime_realtime(value v_unit) {
   (void)v_unit;
   FILETIME ft;
-  GetSystemTimePreciseAsFileTime(&ft);
+  static VOID (WINAPI *GetSystemTime)(LPFILETIME) = NULL;
+  if (GetSystemTime == NULL) {
+    HMODULE h = GetModuleHandleA("kernel32.dll");
+    if (h) {
+      GetSystemTime = GetProcAddress(h, "GetSystemTimePreciseAsFileTime");
+    }
+    if (GetSystemTime == NULL) { /* < Windows 8 */
+      GetSystemTime = GetSystemTimeAsFileTime;
+    }
+  }
 
+  GetSystemTime(&ft);
   ULARGE_INTEGER li;
   li.LowPart = ft.dwLowDateTime;
   li.HighPart = ft.dwHighDateTime;


### PR DESCRIPTION
Adds a fallback for `GetSystemTimePreciseAsFileTime` for old versions of Windows (< 8).

Fixes #13871 