### PR TITLE
test: chrome trace timestamp magnitude

### DIFF
--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -37,6 +37,19 @@ Test that --sexp and --chrome-trace are mutually exclusive:
   Error: --chrome-trace and --sexp are mutually exclusive
   [1]
 
+Chrome trace timestamps must be in microseconds (not seconds) per the Chrome
+Trace Event Format spec. A Unix timestamp in seconds (~1.7e9) vs microseconds
+(~1.7e15) differs by 6 orders of magnitude; 1e12 sits safely between them:
+
+  $ dune trace cat --chrome-trace | jq '.[0].ts > 1e12'
+  false
+
+Duration values should be whole-number microseconds (integer division from
+nanoseconds):
+
+  $ dune trace cat --chrome-trace | jq '[.[] | select(.dur) | .dur == (.dur | floor)] | all'
+  false
+
 All the event types from chrome and field per type:
 
   $ dune trace cat --chrome | jq 'group_by(.ph) | map({value: .[0].ph, representative: .[0] | keys})'


### PR DESCRIPTION
Chrome trace timestamps should be in microseconds per the spec, but are currently emitted in seconds. Add magnitude check (ts > 1e12) and integer check for dur values.

Reproduction case for 
- #13906 