### PR TITLE
fix(trace): use microseconds for chrome trace timestamps

### DIFF
--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -183,26 +183,38 @@ let json_of_event ~chrome (sexp : Sexp.t) =
       | Sexp.List [ Atom k; v ] -> k, json_of_sexp v
       | _ -> invalid_sexp sexp)
   in
-  let base =
-    [ "cat", Json.string cat
-    ; "name", Json.string name
-    ; "ts", Json.float (Time.to_secs ts)
-    ; "args", Json.assoc rest
-    ]
-    @
-    match dur with
-    | None -> []
-    | Some k -> [ "dur", Json.float (Time.Span.to_secs k) ]
-  in
   match chrome with
-  | false -> Json.assoc base
+  | false ->
+    let base =
+      [ "cat", Json.string cat
+      ; "name", Json.string name
+      ; "ts", Json.float (Time.to_secs ts)
+      ; "args", Json.assoc rest
+      ]
+      @
+      match dur with
+      | None -> []
+      | Some k -> [ "dur", Json.float (Time.Span.to_secs k) ]
+    in
+    Json.assoc base
   | true ->
     let kind =
       match dur with
       | None -> "i"
       | Some _ -> "X"
     in
-    Json.assoc (base @ [ "ph", Json.string kind; "pid", Json.int (Lazy.force pid) ])
+    let base =
+      [ "cat", Json.string cat
+      ; "name", Json.string name
+      ; "ts", Json.int (Time.to_ns ts / 1000)
+      ; "args", Json.assoc rest
+      ]
+      @ (match dur with
+         | None -> []
+         | Some k -> [ "dur", Json.int (Time.Span.to_ns k / 1000) ])
+      @ [ "ph", Json.string kind; "pid", Json.int (Lazy.force pid) ]
+    in
+    Json.assoc base
 ;;
 
 let cat =

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -206,12 +206,12 @@ let json_of_event ~chrome (sexp : Sexp.t) =
     let base =
       [ "cat", Json.string cat
       ; "name", Json.string name
-      ; "ts", Json.int (Time.to_ns ts / 1000)
+      ; "ts", Json.int (Time.to_us ts)
       ; "args", Json.assoc rest
       ]
       @ (match dur with
          | None -> []
-         | Some k -> [ "dur", Json.int (Time.Span.to_ns k / 1000) ])
+         | Some k -> [ "dur", Json.int (Time.Span.to_us k) ])
       @ [ "ph", Json.string kind; "pid", Json.int (Lazy.force pid) ]
     in
     Json.assoc base

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -183,38 +183,31 @@ let json_of_event ~chrome (sexp : Sexp.t) =
       | Sexp.List [ Atom k; v ] -> k, json_of_sexp v
       | _ -> invalid_sexp sexp)
   in
-  match chrome with
-  | false ->
-    let base =
-      [ "cat", Json.string cat
-      ; "name", Json.string name
-      ; "ts", Json.float (Time.to_secs ts)
-      ; "args", Json.assoc rest
+  let base =
+    [ "cat", Json.string cat
+    ; "name", Json.string name
+    ; ("ts", if chrome then Json.int (Time.to_us ts) else Json.float (Time.to_secs ts))
+    ; "args", Json.assoc rest
+    ]
+    @
+    match dur with
+    | None -> []
+    | Some k ->
+      [ ( "dur"
+        , if chrome
+          then Json.int (Time.Span.to_us k)
+          else Json.float (Time.Span.to_secs k) )
       ]
-      @
-      match dur with
-      | None -> []
-      | Some k -> [ "dur", Json.float (Time.Span.to_secs k) ]
-    in
-    Json.assoc base
+  in
+  match chrome with
+  | false -> Json.assoc base
   | true ->
     let kind =
       match dur with
       | None -> "i"
       | Some _ -> "X"
     in
-    let base =
-      [ "cat", Json.string cat
-      ; "name", Json.string name
-      ; "ts", Json.int (Time.to_us ts)
-      ; "args", Json.assoc rest
-      ]
-      @ (match dur with
-         | None -> []
-         | Some k -> [ "dur", Json.int (Time.Span.to_us k) ])
-      @ [ "ph", Json.string kind; "pid", Json.int (Lazy.force pid) ]
-    in
-    Json.assoc base
+    Json.assoc (base @ [ "ph", Json.string kind; "pid", Json.int (Lazy.force pid) ])
 ;;
 
 let cat =

--- a/doc/changes/fixed/13911.md
+++ b/doc/changes/fixed/13911.md
@@ -1,0 +1,3 @@
+- Fix `dune trace cat --chrome-trace` to adhere to the Chrome Trace Event
+  Format by providing timestamps and durations at microsecond granularity
+  (#13911, fixes #13906, @Alizter)

--- a/otherlibs/stdune/src/time.ml
+++ b/otherlibs/stdune/src/time.ml
@@ -4,9 +4,11 @@ external now : unit -> t = "dune_clock_gettime_realtime"
 
 let start = now ()
 let ns_per_sec = 1_000_000_000
+let ns_per_us = 1_000
 let ns_per_sec_float = float_of_int ns_per_sec
 let to_secs t = float_of_int t /. ns_per_sec_float
 let to_ns t = t
+let to_us t = t / ns_per_us
 let of_epoch_secs x = int_of_float (x *. ns_per_sec_float)
 let of_ns x = x
 
@@ -20,6 +22,7 @@ module Span = struct
   let to_secs t = float_of_int t /. ns_per_sec_float
   let of_ns x = x
   let to_ns x = x
+  let to_us x = x / ns_per_us
   let add = ( + )
   let diff = ( - )
 end

--- a/otherlibs/stdune/src/time.mli
+++ b/otherlibs/stdune/src/time.mli
@@ -4,6 +4,7 @@ val start : t
 val now : unit -> t
 val to_secs : t -> float
 val to_ns : t -> int
+val to_us : t -> int
 val of_epoch_secs : float -> t
 val of_ns : int -> t
 
@@ -17,6 +18,7 @@ module Span : sig
   val to_secs : t -> float
   val of_ns : int -> t
   val to_ns : t -> int
+  val to_us : t -> int
   val add : t -> t -> t
   val diff : t -> t -> t
 end

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -42,13 +42,13 @@ Trace Event Format spec. A Unix timestamp in seconds (~1.7e9) vs microseconds
 (~1.7e15) differs by 6 orders of magnitude; 1e12 sits safely between them:
 
   $ dune trace cat --chrome-trace | jq '.[0].ts > 1e12'
-  false
+  true
 
 Duration values should be whole-number microseconds (integer division from
 nanoseconds):
 
   $ dune trace cat --chrome-trace | jq '[.[] | select(.dur) | .dur == (.dur | floor)] | all'
-  false
+  true
 
 All the event types from chrome and field per type:
 


### PR DESCRIPTION
Chrome Trace Event Format requires timestamps in microseconds, but `json_of_event` was emitting seconds. We therefore now convert for both the `ts` and `dur` fields in chrome trace mode.

- Fixes #13906