### PR TITLE
fix(time): address warning on Windows in time_stubs.c

### DIFF
--- a/otherlibs/stdune/src/time_stubs.c
+++ b/otherlibs/stdune/src/time_stubs.c
@@ -16,7 +16,7 @@ CAMLprim value dune_clock_gettime_realtime(value v_unit) {
   if (GetSystemTime == NULL) {
     HMODULE h = GetModuleHandleA("kernel32.dll");
     if (h) {
-      GetSystemTime = GetProcAddress(h, "GetSystemTimePreciseAsFileTime");
+      GetSystemTime = (VOID (WINAPI *)(LPFILETIME))GetProcAddress(h, "GetSystemTimePreciseAsFileTime");
     }
     if (GetSystemTime == NULL) { /* < Windows 8 */
       GetSystemTime = GetSystemTimeAsFileTime;


### PR DESCRIPTION
`GetProcAddress` returns `FARPROC` and therefore needs an explicit cast. This fixes the warning introduced in https://github.com/ocaml/dune/pull/13905.