### PR TITLE
fix(pkg): allow locking relative path outside the workspace

### DIFF
--- a/doc/changes/fixed/13915.md
+++ b/doc/changes/fixed/13915.md
@@ -1,0 +1,2 @@
+- Fix `dune pkg lock` failing when a `pin` stanza contains a `file://` URL with
+  a relative path outside the workspace (#13915, fixes #10254, @shunueda)

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -124,6 +124,7 @@ module Outside_build_dir : sig
   val hash : t -> int
   val relative : t -> string -> t
   val extend_basename : t -> suffix:Filename.t -> t
+  val append_local : t -> Local.t -> t
   val equal : t -> t -> bool
   val to_dyn : t -> Dyn.t
   val of_string : string -> t

--- a/src/dune_pkg/opamUrl0.ml
+++ b/src/dune_pkg/opamUrl0.ml
@@ -33,7 +33,7 @@ let is_supported_archive t = Option.is_some (Archive_driver.choose_for_filename 
 
 let classify url loc =
   match (url : t).backend with
-  | `rsync when is_local url -> `Path (Path.of_string url.path)
+  | `rsync when is_local url -> `Path (Path.of_string_allow_outside_workspace url.path)
   | `git -> `Git
   | `http when is_supported_archive url -> `Archive
   | `rsync | `http | `darcs | `hg ->

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -308,7 +308,11 @@ let source_kind (source : Dune_pkg.Source.t) =
   let loc, url = source.url in
   if OpamUrl.is_local url && url.backend = `rsync
   then (
-    let path = Path.External.of_string url.path in
+    let path =
+      Path.of_string_allow_outside_workspace url.path
+      |> Path.to_absolute_filename
+      |> Path.External.of_string
+    in
     Fs_memo.path_kind (External path)
     >>| function
     | Error (ENOENT, _, _) ->

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -309,20 +309,32 @@ let source_kind (source : Dune_pkg.Source.t) =
   if OpamUrl.is_local url && url.backend = `rsync
   then (
     let path =
-      Path.of_string_allow_outside_workspace url.path
-      |> Path.to_absolute_filename
-      |> Path.External.of_string
+      match Path.of_string_allow_outside_workspace url.path with
+      | External e -> Path.Outside_build_dir.External e
+      | In_source_tree s -> Path.Outside_build_dir.In_source_dir s
+      | In_build_dir b ->
+        User_error.raise
+          ~loc
+          [ Pp.textf
+              "package source path %s is inside the build directory"
+              (Path.Build.to_string_maybe_quoted b)
+          ]
     in
-    Fs_memo.path_kind (External path)
+    Fs_memo.path_kind path
     >>| function
     | Error (ENOENT, _, _) ->
       User_error.raise
         ~loc
-        [ Pp.textf "%s does not exist" (Path.External.to_string_maybe_quoted path) ]
+        [ Pp.textf
+            "%s does not exist"
+            (Path.Outside_build_dir.to_string_maybe_quoted path)
+        ]
     | Error exn ->
       User_error.raise
         ~loc
-        [ Pp.textf "unable to read %s" (Path.External.to_string_maybe_quoted path)
+        [ Pp.textf
+            "unable to read %s"
+            (Path.Outside_build_dir.to_string_maybe_quoted path)
         ; Unix_error.Detailed.pp exn
         ]
     | Ok S_REG -> `Local (`File, path)
@@ -332,7 +344,7 @@ let source_kind (source : Dune_pkg.Source.t) =
         ~loc
         [ Pp.textf
             "path %s is not a directory or a file"
-            (Path.External.to_string_maybe_quoted path)
+            (Path.Outside_build_dir.to_string_maybe_quoted path)
         ])
   else Memo.return `Fetch
 ;;

--- a/src/dune_rules/lock_dir.mli
+++ b/src/dune_rules/lock_dir.mli
@@ -50,4 +50,4 @@ end
 
 val source_kind
   :  Dune_pkg.Source.t
-  -> [ `Local of [ `Directory | `File ] * Path.External.t | `Fetch ] Memo.t
+  -> [ `Local of [ `Directory | `File ] * Path.Outside_build_dir.t | `Fetch ] Memo.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -479,13 +479,15 @@ module Pkg = struct
     in
     let skip_file = String.starts_with ~prefix:".#" in
     let rec loop root acc path =
-      let full_path = Path.External.append_local root path in
-      Fs_memo.dir_contents (External full_path)
+      let full_path = Path.Outside_build_dir.append_local root path in
+      Fs_memo.dir_contents full_path
       >>= function
       | Error e ->
         User_error.raise
           ~loc
-          [ Pp.textf "Unable to read %s" (Path.External.to_string_maybe_quoted full_path)
+          [ Pp.textf
+              "Unable to read %s"
+              (Path.Outside_build_dir.to_string_maybe_quoted full_path)
           ; Unix_error.Detailed.pp e
           ]
       | Ok contents ->
@@ -2086,7 +2088,7 @@ let source_rules (pkg : Pkg.t) =
          Memo.return (Dep.Set.of_files [ pkg.paths.source_dir ], [ loc, fetch ])
        | `Local (`Directory, source_root) ->
          let+ source_files, rules =
-           let source_root = Path.external_ source_root in
+           let source_root = Path.outside_build_dir source_root in
            Pkg.source_files pkg ~loc
            >>| Path.Local.Set.fold ~init:([], []) ~f:(fun file (source_files, rules) ->
              let src = Path.append_local source_root file in

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/relative-path-outside-workspace.t
@@ -1,5 +1,4 @@
-Demonstrate that you can't use a relative path referring outside the workspace
-in the pin stanza:
+Demonstrate that relative paths outside the workspace work in pin stanzas:
 
 Make a package containing a library:
   $ mkdir foo
@@ -49,7 +48,7 @@ Lock and build the second package to demonstrate that everything works so far:
   $ dune exec ./bar.exe
   foo
 
-Now change the pin to use a relative path:
+Now change the pin to use a relative path (this should also work):
   $ cat > dune-project <<EOF
   > (lang dune 3.14)
   > (pin
@@ -60,10 +59,10 @@ Now change the pin to use a relative path:
   >  (depends foo))
   > EOF
 
-Solving the project now results in an error, though it's still possible to build the project:
+Solving the project works with relative paths outside the workspace:
   $ dune clean
   $ dune_pkg_lock_normalized
-  Error: path outside the workspace: ../foo from .
-  [1]
+  Solution for dune.lock:
+  - foo.dev
   $ dune exec ./bar.exe
   foo


### PR DESCRIPTION
Closes https://github.com/ocaml/dune/issues/10254.

The linked issue has been labeled "bug", and I agree with this as (afaik) Opam allows relative paths outside the workspace, though open to discussion here.