### PR TITLE
Show a hint when trying to build something excluded by a `dirs` stanza.

### DIFF
--- a/bin/target.ml
+++ b/bin/target.ml
@@ -110,9 +110,24 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system)
   =
   let open Memo.O in
   let checked = Util.check_path setup.contexts path in
-  let can't_build path =
-    let+ hint = target_hint setup path in
-    Error hint
+  let can't_build ?src path =
+    let open Memo.O in
+    let+ target_hint = target_hint setup path
+    and+ excluded_hint =
+      match src with
+      | None -> Memo.return []
+      | Some src ->
+        Source_tree.find_excluded_ancestor src
+        >>| (function
+         | None -> []
+         | Some (excluded, loc) ->
+           [ Pp.textf
+               "directory %s exists on disk but is excluded by a (dirs ...) stanza at %s"
+               (Path.Source.to_string_maybe_quoted excluded)
+               (Loc.to_file_colon_line loc)
+           ])
+    in
+    Error (excluded_hint @ target_hint)
   in
   let as_source_dir src =
     Source_tree.find_dir src
@@ -149,7 +164,7 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system)
        as_source_dir src
        >>= (function
         | Some res -> Memo.return (Ok res)
-        | None -> can't_build path)
+        | None -> can't_build ~src path)
      | l -> Memo.return (Ok l))
   | In_build_dir (_ctx, src) ->
     matching_target ()
@@ -159,7 +174,7 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system)
        as_source_dir src
        >>= (function
         | Some res -> Memo.return (Ok res)
-        | None -> can't_build path))
+        | None -> can't_build ~src path))
   | In_private_context _ | In_install_dir _ ->
     matching_target ()
     >>= (function

--- a/doc/changes/added/13919.md
+++ b/doc/changes/added/13919.md
@@ -1,0 +1,2 @@
+- A hint is now emitted when trying to build a target inside a directory that
+  was excluded by a `(dirs ...)` stanza.

--- a/doc/changes/added/13919.md
+++ b/doc/changes/added/13919.md
@@ -1,2 +1,2 @@
 - A hint is now emitted when trying to build a target inside a directory that
-  was excluded by a `(dirs ...)` stanza.
+  was excluded by a `(dirs ...)` stanza (#13919, @mefyl).

--- a/src/source/dune_file.ml
+++ b/src/source/dune_file.ml
@@ -501,6 +501,12 @@ let get_static_sexp t = (Dir_map.root t.plain).sexps
 let kind t = t.kind
 let path t = t.path
 let sub_dir_status t = Source_dir_status.Spec.create (Dir_map.root t.plain).subdir_status
+
+let dirs_stanza_loc t =
+  Source_dir_status.Map.find (Dir_map.root t.plain).subdir_status Normal
+  |> Option.map ~f:fst
+;;
+
 let files t = (Dir_map.root t.plain).files
 
 let load_plain sexps ~file ~from_parent ~project =

--- a/src/source/dune_file.mli
+++ b/src/source/dune_file.mli
@@ -25,6 +25,9 @@ val path : t -> Path.Source.t option
 
 val sub_dir_status : t -> Source_dir_status.Spec.t
 
+(** The location of the (dirs ...) stanza if present *)
+val dirs_stanza_loc : t -> Loc.t option
+
 module Files : sig
   type t
 

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -334,14 +334,15 @@ let find_excluded_ancestor path =
          let* child = sub_dir.sub_dir_as_t in
          loop child path
        | None ->
-         let excluded_path = Path.Source.relative dir.path sub_dir in
-         Dir_contents.of_source_path excluded_path
+         Dir_contents.of_source_path dir.path
          >>| (function
-          | Error _ -> None
-          | Ok _ ->
-            (match Option.bind dir.dune_file ~f:Dune_file.dirs_stanza_loc with
-             | None -> None
-             | Some loc -> Some (excluded_path, loc))))
+          | Ok contents
+            when List.exists (Dir_contents.dirs contents) ~f:(fun (name, _) ->
+                   String.equal name sub_dir) ->
+            dir.dune_file
+            |> Option.bind ~f:Dune_file.dirs_stanza_loc
+            |> Option.map ~f:(fun loc -> Path.Source.relative dir.path sub_dir, loc)
+          | _ -> None))
   in
   let* root = Memo.Cell.read root in
   loop root (Path.Source.explode path)

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -324,6 +324,29 @@ let find_dir =
 ;;
 
 let nearest_dir = gen_find_dir ~on_success:Memo.return ~on_last_found:Memo.return
+
+let find_excluded_ancestor path =
+  let rec loop (dir : Dir0.t) = function
+    | [] -> Memo.return None
+    | sub_dir :: path ->
+      (match Filename.Map.find dir.sub_dirs sub_dir with
+       | Some sub_dir ->
+         let* child = sub_dir.sub_dir_as_t in
+         loop child path
+       | None ->
+         let excluded_path = Path.Source.relative dir.path sub_dir in
+         Dir_contents.of_source_path excluded_path
+         >>| (function
+          | Error _ -> None
+          | Ok _ ->
+            (match Option.bind dir.dune_file ~f:Dune_file.dirs_stanza_loc with
+             | None -> None
+             | Some loc -> Some (excluded_path, loc))))
+  in
+  let* root = Memo.Cell.read root in
+  loop root (Path.Source.explode path)
+;;
+
 let root () = Memo.Cell.read root
 
 let files_of path =

--- a/src/source/source_tree.mli
+++ b/src/source/source_tree.mli
@@ -49,6 +49,10 @@ end
 
 val find_dir : Path.Source.t -> Dir.t option Memo.t
 
+(** [find_excluded_ancestor path] is the ancestor of [path] that was excluded by
+    a dirs stanza, if any. *)
+val find_excluded_ancestor : Path.Source.t -> (Path.Source.t * Loc.t) option Memo.t
+
 (** [nearest_dir t fn] returns the directory with the longest path that is an
     ancestor of [fn]. *)
 val nearest_dir : Path.Source.t -> Dir.t Memo.t

--- a/test/blackbox-tests/test-cases/dirs-with-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/dirs-with-subdir.t/run.t
@@ -17,20 +17,27 @@ children.
 
   $ dune build A/a
   Error: Don't know how to build A/a
+  Hint: directory A exists on disk but is excluded by a (dirs ...) stanza at
+  dune:1
   [1]
   $ dune build B/b
   $ dune build A/C/c
   Error: Don't know how to build A/C/c
+  Hint: directory A exists on disk but is excluded by a (dirs ...) stanza at
+  dune:1
   [1]
 
 Same for the other directory.
   $ cat > dune << EOF
+  > ; Pad to test location
   > (dirs :standard \ B)
   > EOF
 
   $ dune build A/a
   $ dune build B/b
   Error: Don't know how to build B/b
+  Hint: directory B exists on disk but is excluded by a (dirs ...) stanza at
+  dune:2
   [1]
   $ dune build A/C/c
 
@@ -51,4 +58,6 @@ This should now only fail for the excluded directory.
   $ dune build B/b
   $ dune build A/C/c
   Error: Don't know how to build A/C/c
+  Hint: directory A/C exists on disk but is excluded by a (dirs ...) stanza at
+  dune:1
   [1]


### PR DESCRIPTION
Have you ever tried to `dune build a/b/c` only for dune to respond that "Don't know how to build a/b/c", while you absolutely have an "a/b/dune" file that definitely has a rule to build "c", prompting you to angrily shake your fist at the screen while wondering what kind of sorcery is causing this, before discovering 10 exhausting minutes later that "a/b" was excluded by a "dirs" stanzas, making dune's error message not untrue per se, but borderline maliciously unhelpful?

<img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/5731a0d1-8d66-4e87-a239-47a61a43cf5c" />

Well, I do sometime, and I just did.

This MR adds a hint in such a case that one of the parent directory was ignored, with the location of the `dirs` stanzas. It should not change anything outside of the error case, especially not impact performance.

```
$ dune build A/a
Error: Don't know how to build A/a
Hint: directory A exists on disk but is excluded by a (dirs ...) stanza at
dune:1
$
```