### PR TITLE
chore(stdune): remove Val_none compat shim

### DIFF
--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -10,10 +10,6 @@ void dune_wait4(value v_pid, value flags) {
 
 #else
 
-#ifndef Val_none
-#define Val_none Val_int(0)
-#endif
-
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>


### PR DESCRIPTION
Val_none was added to the OCaml C API in OCaml 4.12.