### PR TITLE
chore(stdune): remove Either compat shim

### DIFF
--- a/otherlibs/stdune/src/dune_either.ml
+++ b/otherlibs/stdune/src/dune_either.ml
@@ -1,5 +1,0 @@
-module Either = struct
-  type ('a, 'b) t =
-    | Left of 'a
-    | Right of 'b
-end

--- a/otherlibs/stdune/src/either.ml
+++ b/otherlibs/stdune/src/either.ml
@@ -1,8 +1,4 @@
 include struct
-  [@@@warning "-33"]
-
-  (* This open is unused with OCaml >= 4.12 since the stdlib defines an either type *)
-  open Dune_either
   open Stdlib
 
   type ('a, 'b) t = ('a, 'b) Either.t =

--- a/otherlibs/stdune/src/either.mli
+++ b/otherlibs/stdune/src/either.mli
@@ -1,10 +1,6 @@
 (** Left or right *)
 
 include sig
-  [@@@warning "-33"]
-
-  (* This open is unused with OCaml >= 4.12 since the stdlib defines an either type *)
-  open Dune_either
   open Stdlib
 
   type ('a, 'b) t = ('a, 'b) Either.t =


### PR DESCRIPTION
The Either type was added to the stdlib in OCaml 4.12.