### PR TITLE
chore(stdune): cleanup String compat shims

### DIFF
--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -73,13 +73,6 @@ module Caseless = Cased_functions (struct
 module StringLabels = struct
   (* functions potentially in the stdlib, depending on OCaml version *)
 
-  let[@warning "-32"] exists =
-    let rec loop s i len f =
-      if i = len then false else f (String.unsafe_get s i) || loop s (i + 1) len f
-    in
-    fun ~f s -> loop s 0 (String.length s) f
-  ;;
-
   let[@warning "-32"] for_all =
     let rec loop s i len f =
       i = len || (f (String.unsafe_get s i) && loop s (i + 1) len f)

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -73,13 +73,6 @@ module Caseless = Cased_functions (struct
 module StringLabels = struct
   (* functions potentially in the stdlib, depending on OCaml version *)
 
-  let[@warning "-32"] for_all =
-    let rec loop s i len f =
-      i = len || (f (String.unsafe_get s i) && loop s (i + 1) len f)
-    in
-    fun ~f s -> loop s 0 (String.length s) f
-  ;;
-
   let[@warning "-32"] starts_with = starts_with
   let[@warning "-32"] ends_with = ends_with
 

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -73,7 +73,6 @@ module Caseless = Cased_functions (struct
 module StringLabels = struct
   (* functions potentially in the stdlib, depending on OCaml version *)
 
-  let[@warning "-32"] starts_with = starts_with
   let[@warning "-32"] ends_with = ends_with
 
   (* overwrite them with stdlib versions if available *)

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -70,16 +70,7 @@ module Caseless = Cased_functions (struct
     let normalize = Char.lowercase_ascii
   end)
 
-module StringLabels = struct
-  (* functions potentially in the stdlib, depending on OCaml version *)
-
-  let[@warning "-32"] ends_with = ends_with
-
-  (* overwrite them with stdlib versions if available *)
-  include Stdlib.StringLabels
-end
-
-include StringLabels
+include Stdlib.StringLabels
 
 let compare a b = Ordering.of_int (String.compare a b)
 


### PR DESCRIPTION
- String.exists was introduced in OCaml 4.13.
- String.for_all was introduced in OCaml 4.13.
- String.starts_with was introduced in OCaml 4.13.
- String.ends_with was introduced in OCaml 4.13.

