### PR TITLE
chore(boot): remove stdlib compat shims

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -241,23 +241,6 @@ module String = struct
     loop ~acc:[] 0 0 ~last_is_cr:false
   ;;
 
-  [@@@ocaml.warning "-32"]
-
-  let ends_with t ~suffix = Filename.check_suffix t suffix
-
-  let starts_with t ~prefix =
-    let len_s = length t
-    and len_pre = length prefix in
-    let rec aux i =
-      if i = len_pre
-      then true
-      else if unsafe_get t i <> unsafe_get prefix i
-      then false
-      else aux (i + 1)
-    in
-    len_s >= len_pre && aux 0
-  ;;
-
   include String
 end
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -138,9 +138,6 @@ module List = struct
      versions allowing compatability >= 4.08 which will get shadowed when the
      stdlib version is available. *)
 
-  (* Introduced in 4.14 *)
-  let concat_map l ~f = List.map l ~f |> List.concat
-
   let partition_map t ~f =
     let rec loop l r = function
       | [] -> l, r

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -35,16 +35,6 @@ open Types
 
 (** {2 Utility functions} *)
 
-include struct
-  [@@@ocaml.warning "-32-34-37"]
-
-  module Either = struct
-    type ('l, 'r) t =
-      | Left of 'l
-      | Right of 'r
-  end
-end
-
 open Stdlib
 open StdLabels
 open MoreLabels

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -110,19 +110,6 @@ module List = struct
     | Some x -> x :: t
   ;;
 
-  [@@@ocaml.warning "-32"]
-
-  let rec compare a b ~cmp =
-    match a, b with
-    | [], [] -> 0
-    | [], _ :: _ -> -1
-    | _ :: _, [] -> 1
-    | x :: a, y :: b ->
-      (match cmp x y with
-       | 0 -> compare a b ~cmp
-       | ne -> ne)
-  ;;
-
   include List
 end
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -133,23 +133,6 @@ module List = struct
        | ne -> ne)
   ;;
 
-  (* Some list functions are introduced in later OCaml versions. There are also
-     improvements to performance in some of these. We introduce fallback
-     versions allowing compatability >= 4.08 which will get shadowed when the
-     stdlib version is available. *)
-
-  let partition_map t ~f =
-    let rec loop l r = function
-      | [] -> l, r
-      | x :: xs ->
-        (match f x with
-         | Either.Left x -> loop (x :: l) r xs
-         | Right x -> loop l (x :: r) xs)
-    in
-    let l, r = loop [] [] t in
-    List.(rev l, rev r)
-  ;;
-
   include List
 end
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -138,16 +138,6 @@ module List = struct
      versions allowing compatability >= 4.08 which will get shadowed when the
      stdlib version is available. *)
 
-  (* Introduced in 4.10 *)
-  let rec find_map l ~f =
-    match l with
-    | [] -> None
-    | x :: l ->
-      (match f x with
-       | None -> find_map l ~f
-       | Some _ as x -> x)
-  ;;
-
   (* Introduced in 4.14 *)
   let concat_map l ~f = List.map l ~f |> List.concat
 


### PR DESCRIPTION
- List.find_map was introduced in OCaml 4.10.
- List.concat_map was introduced in OCaml 4.10.
- List.partition_map was introduced in OCaml 4.12.
- The Either type was added to the stdlib in OCaml 4.12.
- List.compare was introduced in OCaml 4.12.
- String.starts_with and String.ends_with were introduced in OCaml 4.13.
