### PR TITLE
fix(runtest): don't run in all contexts

### DIFF
--- a/bin/runtest_common.ml
+++ b/bin/runtest_common.ml
@@ -184,7 +184,20 @@ let make_request ~scontexts ~to_cwd ~test_paths =
         let dir =
           Path.Source.L.relative Path.Source.root (to_cwd @ Path.Source.explode dir)
         in
-        Context_name.Map.find_exn scontexts Context_name.default, contexts, dir
+        let sctx =
+          match Context_name.Map.find scontexts Context_name.default with
+          | Some sctx -> sctx
+          | None ->
+            (match Context_name.Map.to_list scontexts with
+             | [ (_, sctx) ] -> sctx
+             | _ ->
+               User_error.raise
+                 [ Pp.text
+                     "Multiple contexts are defined but no default context was found. \
+                      Please use the --context flag or specify a build directory path."
+                 ])
+        in
+        sctx, [ Super_context.context sctx ], dir
       | In_private_context _ | In_install_dir _ ->
         User_error.raise
           [ Pp.textf "This path is internal to dune: %s" (Path.to_string_maybe_quoted dir)

--- a/doc/changes/fixed/13930.md
+++ b/doc/changes/fixed/13930.md
@@ -1,0 +1,4 @@
+- `dune test` now runs tests in the default context only. When there is a
+  single context, it is treated as the default. This fixes a crash when the
+  workspace has no context named "default".
+  (#13930, fixes #13904, @Alizter)

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
@@ -77,13 +77,9 @@ Test with multiple contexts:
   > (context (default (name alt)))
   > EOF
 
-Running inline tests in multiple contexts:
+Running inline tests defaults to the default context:
 
   $ dune test lib.ml
-  File "dune", line 10, characters 1-38:
-  10 |  (inline_tests (backend test_backend)))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Fatal error: exception File ".mylib.inline-tests/main.ml-gen", line 2, characters 40-46: Assertion failed
   File "dune", line 10, characters 1-38:
   10 |  (inline_tests (backend test_backend)))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
@@ -206,17 +206,9 @@ Here we test behaviour for running tests in specific contexts.
   > (context (default (name alt)))
   > EOF
 
-- Building a specific test now will run them in both contexts.
+- Building a specific test will run it in the default context.
 
   $ dune test mytest.t
-  File "mytest.t", line 1, characters 0-0:
-  Context: alt
-  --- mytest.t
-  +++ mytest.t.corrected
-  @@ -1,2 +1,2 @@
-     $ echo "Hello, world!"
-  -  "Goodbye, world!"
-  +  Hello, world!
   File "mytest.t", line 1, characters 0-0:
   --- mytest.t
   +++ mytest.t.corrected
@@ -247,11 +239,54 @@ that context as expected.
   > (context (default (name main)))
   > EOF
 
-  $ dune test mytest.t 2>&1 | grep "Internal error"
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  $ dune test mytest.t
+  File "mytest.t", line 1, characters 0-0:
+  Context: main
+  --- mytest.t
+  +++ mytest.t.corrected
+  @@ -1,2 +1,2 @@
+     $ echo "Hello, world!"
+  -  "Goodbye, world!"
+  +  Hello, world!
   [1]
 
-  $ dune test 2>&1 | grep "Internal error"
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
+  $ dune test
+  File "mytest.t", line 1, characters 0-0:
+  Context: main
+  --- mytest.t
+  +++ mytest.t.corrected
+  @@ -1,2 +1,2 @@
+     $ echo "Hello, world!"
+  -  "Goodbye, world!"
+  +  Hello, world!
+  File "tests/filetest.t", line 1, characters 0-0:
+  Context: main
+  --- tests/filetest.t
+  +++ tests/filetest.t.corrected
+  @@ -1,2 +1,2 @@
+     $ echo "Hello, world!"
+  -  "Goodbye, world!"
+  +  Hello, world!
+  File "tests/myothertest.t/run.t", line 1, characters 0-0:
+  Context: main
+  --- tests/myothertest.t/run.t
+  +++ tests/myothertest.t/run.t.corrected
+  @@ -1,2 +1,2 @@
+     $ cat hello.world
+  -  "Goodbye, world!"
+  +  Hello, world!
+  [1]
+
+- Running tests in a workspace with multiple non-default contexts should error.
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.23)
+  > (context (default (name ctx1)))
+  > (context (default (name ctx2)))
+  > EOF
+
+  $ dune test mytest.t
+  Error: Multiple contexts are defined but no default context was found. Please
+  use the --context flag or specify a build directory path.
   [1]
 


### PR DESCRIPTION
When choosing which context to find and run our tests, we always choose the default context and if that is not available a unique context. When there is no good choice we error.

- Fixes https://github.com/ocaml/dune/issues/13904
- [x] Changelog