### PR TITLE
feature: add --debug-backtraces to dune {promote,cache,trace}

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -2,6 +2,16 @@ open Import
 
 (* CR-someday amokhov: Implement other commands supported by Jenga. *)
 
+let debug_backtraces =
+  Arg.(
+    value
+    & flag
+    & info
+        [ "debug-backtraces" ]
+        ~docs:"COMMON OPTIONS"
+        ~doc:(Some "Always print exception backtraces."))
+;;
+
 let trim =
   let info =
     let doc = "Trim the Dune cache." in
@@ -21,7 +31,8 @@ let trim =
     Cmd.info "trim" ~doc ~man
   in
   Cmd.v info
-  @@ let+ trimmed_size =
+  @@ let+ debug_backtraces = debug_backtraces
+     and+ trimmed_size =
        Arg.(
          value
          & opt (some bytes) None
@@ -46,6 +57,7 @@ let trim =
                            ~f:(fun (units, _) -> List.hd units)
                            Bytes_unit.conversion_table)))))
      in
+     Common.No_build.set_debug_backtraces debug_backtraces;
      Log.init No_log_file;
      let open Result.O in
      match
@@ -81,7 +93,8 @@ let size =
     Cmd.info "size" ~doc ~man
   in
   Cmd.v info
-  @@ let+ machine_readable =
+  @@ let+ debug_backtraces = debug_backtraces
+     and+ machine_readable =
        Arg.(
          value
          & flag
@@ -89,6 +102,7 @@ let size =
              [ "machine-readable" ]
              ~doc:(Some "Outputs size as a plain number of bytes."))
      in
+     Common.No_build.set_debug_backtraces debug_backtraces;
      let size = Dune_cache.Trimmer.overhead_size () in
      if machine_readable
      then User_message.print (User_message.make [ Pp.textf "%Ld" size ])
@@ -101,7 +115,10 @@ let clear =
     let man = [ `P "Remove any traces of the Dune cache." ] in
     Cmd.info "clear" ~doc ~man
   in
-  Cmd.v info @@ Term.(const Dune_cache.Trimmer.clear $ const ())
+  Cmd.v info
+  @@ let+ debug_backtraces = debug_backtraces in
+     Common.No_build.set_debug_backtraces debug_backtraces;
+     Dune_cache.Trimmer.clear ()
 ;;
 
 let command =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -80,7 +80,7 @@ open Let_syntax
 
 let copts_sect = "COMMON OPTIONS"
 
-let debug_backtraces =
+let debug_backtraces_term =
   Arg.(
     value
     & flag
@@ -133,6 +133,30 @@ let build_info =
        List.iter libs ~f:(fun (name, v) -> pr "- %-*s %s" longest name v));
     exit 0)
 ;;
+
+module No_build = struct
+  type t = { debug_backtraces : bool }
+
+  let equal t { debug_backtraces } = Bool.equal t.debug_backtraces debug_backtraces
+  let debug_backtraces = debug_backtraces_term
+
+  let set_debug_backtraces debug_backtraces =
+    Dune_engine.Clflags.debug_backtraces debug_backtraces
+  ;;
+
+  let set { debug_backtraces } = set_debug_backtraces debug_backtraces
+
+  let term =
+    let+ () = build_info
+    and+ debug_backtraces = debug_backtraces in
+    { debug_backtraces }
+  ;;
+
+  let term_and_set =
+    let+ t = term in
+    set t
+  ;;
+end
 
 module Options_implied_by_dash_p = struct
   type t =
@@ -571,8 +595,8 @@ let shared_with_config_file ~allow_pkg_flag =
 
 module Builder = struct
   type t =
-    { debug_dep_path : bool
-    ; debug_backtraces : bool
+    { no_build : No_build.t
+    ; debug_dep_path : bool
     ; debug_package_logs : bool
     ; wait_for_filesystem_clock : bool
     ; only_packages : Only_packages.Clflags.t
@@ -603,6 +627,7 @@ module Builder = struct
     ; target_exec : string option
     }
 
+  let set_no_build t no_build = { t with no_build }
   let root t = t.root
   let set_root t root = { t with root = Some root }
   let forbid_builds t = { t with allow_builds = false; no_print_directory = true }
@@ -629,7 +654,8 @@ module Builder = struct
 
   let make_term ~(trace : bool) ~allow_pkg_flag =
     let docs = copts_sect in
-    let+ config_from_command_line = shared_with_config_file ~allow_pkg_flag
+    let+ no_build = No_build.term
+    and+ config_from_command_line = shared_with_config_file ~allow_pkg_flag
     and+ debug_dep_path =
       Arg.(
         value
@@ -641,7 +667,6 @@ module Builder = struct
               (Some
                  "In case of error, print the dependency path from the targets on the \
                   command line to the rule that failed."))
-    and+ debug_backtraces = debug_backtraces
     and+ debug_package_logs =
       let doc = "Always print the standard logs when building packages" in
       Arg.(
@@ -833,7 +858,6 @@ module Builder = struct
             ~docs
             ~env:(Cmd.Env.info ~doc "DUNE_STORE_ORIG_SOURCE_DIR")
             ~doc:(Some doc))
-    and+ () = build_info
     and+ instrument_with =
       let doc =
         "Enable instrumentation by $(b,BACKENDS). $(b,BACKENDS) is a comma-separated \
@@ -929,8 +953,8 @@ module Builder = struct
             [ "stop-on-first-error" ]
             ~doc:(Some "Stop the build as soon as an error is encountered."))
     in
-    { debug_dep_path
-    ; debug_backtraces
+    { no_build
+    ; debug_dep_path
     ; debug_package_logs
     ; wait_for_filesystem_clock
     ; only_packages
@@ -981,8 +1005,8 @@ module Builder = struct
 
   let equal
         t
-        { debug_dep_path
-        ; debug_backtraces
+        { no_build
+        ; debug_dep_path
         ; debug_package_logs
         ; wait_for_filesystem_clock
         ; only_packages
@@ -1013,8 +1037,8 @@ module Builder = struct
         ; target_exec
         }
     =
-    Bool.equal t.debug_dep_path debug_dep_path
-    && Bool.equal t.debug_backtraces debug_backtraces
+    No_build.equal t.no_build no_build
+    && Bool.equal t.debug_dep_path debug_dep_path
     && Bool.equal t.debug_package_logs debug_package_logs
     && Bool.equal t.wait_for_filesystem_clock wait_for_filesystem_clock
     && Only_packages.Clflags.equal t.only_packages only_packages
@@ -1182,6 +1206,7 @@ let maybe_init_cache (cache_config : Dune_cache.Config.t) =
 
 let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   let c = build root builder in
+  No_build.set c.builder.no_build;
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
   Path.set_root (normalize_path (Path.External.cwd ()));
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string c.builder.build_dir);
@@ -1263,7 +1288,6 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
   Only_packages.Clflags.set c.builder.only_packages;
   Report_error.print_memo_stacks := c.builder.debug_dep_path;
   Dune_engine.Clflags.report_errors_config := c.builder.report_errors_config;
-  Dune_engine.Clflags.debug_backtraces c.builder.debug_backtraces;
   Dune_rules.Clflags.debug_package_logs := c.builder.debug_package_logs;
   Dune_digest.Clflags.wait_for_filesystem_clock := c.builder.wait_for_filesystem_clock;
   Dune_engine.Clflags.capture_outputs := c.builder.capture_outputs;

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -21,11 +21,24 @@ val file_watcher : t -> Dune_scheduler.Scheduler.Run.file_watcher
 val prefix_target : t -> string -> string
 val find_default_trace_file : unit -> string
 
+(** [No_build] describes the most basic command-line flags that don't affect
+    workspace or build configuration. *)
+module No_build : sig
+  type t
+
+  val debug_backtraces : bool Cmdliner.Term.t
+  val set_debug_backtraces : bool -> unit
+  val term : t Cmdliner.Term.t
+  val set : t -> unit
+  val term_and_set : unit Cmdliner.Term.t
+end
+
 (** [Builder] describes how to initialize Dune. *)
 module Builder : sig
   type t
 
   val equal : t -> t -> bool
+  val set_no_build : t -> No_build.t -> t
   val root : t -> string option
   val set_root : t -> string -> t
   val forbid_builds : t -> t
@@ -67,7 +80,6 @@ val command_synopsis : string list -> Cmdliner.Manpage.block list
 val help_secs : Cmdliner.Manpage.block list
 val footer : Cmdliner.Manpage.block
 val envs : Cmdliner.Cmd.Env.info list
-val debug_backtraces : bool Cmdliner.Term.t
 val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 val display_term : Dune_config.Display.t option Cmdliner.Term.t
 val context_arg : doc:string option -> Dune_engine.Context_name.t Cmdliner.Term.t

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -45,17 +45,7 @@ module Apply = struct
     Cmd.info ~doc ~man "apply"
   ;;
 
-  let term =
-    let+ builder = Common.Builder.term
-    and+ exact =
-      Arg.(
-        value
-        & flag
-        & info [ "file" ] ~doc:(Some "Require each FILE argument to match exactly."))
-    and+ files =
-      (* CR-someday Alizter: document this option *)
-      Arg.(value & pos_all Arg.path [] & info [] ~docv:"FILE" ~doc:None)
-    in
+  let run ~(builder : Common.Builder.t) ~exact ~files =
     let common, config = Common.init builder in
     let files_to_promote = List.map files ~f:Arg.Path.arg |> files_to_promote ~common in
     let matching : Dune_rpc.Promote_targets.Matching.t =
@@ -76,6 +66,28 @@ module Apply = struct
           Dune_rpc.Procedures.Public.promote_many
           { Dune_rpc.Promote_targets.files = files_to_promote; matching }
         >>| Rpc.Rpc_common.wrap_build_outcome_exn ~print_on_success:true)
+  ;;
+
+  let term_with_builder builder =
+    let+ builder
+    and+ exact =
+      Arg.(
+        value
+        & flag
+        & info [ "file" ] ~doc:(Some "Require each FILE argument to match exactly."))
+    and+ files =
+      (* CR-someday Alizter: document this option *)
+      Arg.(value & pos_all Arg.path [] & info [] ~docv:"FILE" ~doc:None)
+    in
+    run ~builder ~exact ~files
+  ;;
+
+  let term = term_with_builder Common.Builder.term
+
+  let promote_term =
+    term_with_builder
+      (let+ no_build = Common.No_build.term in
+       Common.Builder.set_no_build Common.Builder.default no_build)
   ;;
 
   let command = Cmd.v info term
@@ -192,5 +204,9 @@ let info =
 let group = Cmd.group info [ Files.command; Apply.command; Diff.command; Show.command ]
 
 let promote =
-  Util.command_alias ~orig_name:"promotion apply" Apply.command Apply.term "promote"
+  Util.command_alias
+    ~orig_name:"promotion apply"
+    Apply.command
+    Apply.promote_term
+    "promote"
 ;;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -520,8 +520,7 @@ let man =
 let info = Cmd.info "subst" ~doc ~man
 
 let term =
-  let+ () = Common.build_info
-  and+ debug_backtraces = Common.debug_backtraces in
+  let+ () = Common.No_build.term_and_set in
   let config : Dune_config.t =
     { Dune_config.default with
       display = Dune_config.Display.quiet
@@ -533,7 +532,6 @@ let term =
      correctly. It should not be necessary, so we should probably make the
      package loading lazier. *)
   Dune_rules.Only_packages.Clflags.set No_restriction;
-  Dune_engine.Clflags.debug_backtraces debug_backtraces;
   Path.set_root (Path.External.cwd ());
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string Common.default_build_dir);
   Dune_config.init config ~watch:false;

--- a/bin/trace.ml
+++ b/bin/trace.ml
@@ -1,5 +1,15 @@
 open Import
 
+let debug_backtraces =
+  Arg.(
+    value
+    & flag
+    & info
+        [ "debug-backtraces" ]
+        ~docs:"COMMON OPTIONS"
+        ~doc:(Some "Always print exception backtraces."))
+;;
+
 let iter_sexps file ~f =
   Io.String_path.with_file_in ~binary:true file ~f:(fun chan ->
     let rec loop () =
@@ -213,7 +223,8 @@ let json_of_event ~chrome (sexp : Sexp.t) =
 let cat =
   let info = Cmd.info "cat" in
   let term =
-    let+ sexp =
+    let+ debug_backtraces = debug_backtraces
+    and+ sexp =
       Arg.(
         value
         & flag
@@ -236,6 +247,7 @@ let cat =
         & flag
         & info [ "follow"; "f" ] ~doc:(Some "follow the trace file until the exit event"))
     in
+    Common.No_build.set_debug_backtraces debug_backtraces;
     let mode =
       match chrome_trace, sexp with
       | true, true ->
@@ -287,7 +299,8 @@ let commands =
     Cmd.info "commands" ~doc
   in
   let term =
-    let+ trace_file =
+    let+ debug_backtraces = debug_backtraces
+    and+ trace_file =
       Arg.(
         value
         & opt (some string) None
@@ -296,6 +309,7 @@ let commands =
             ~docv:"FILE"
             ~doc:(Some "Read this trace file (default: _build/trace.json)"))
     in
+    Common.No_build.set_debug_backtraces debug_backtraces;
     let trace_file =
       match trace_file with
       | Some s -> s

--- a/doc/changes/added/13933.md
+++ b/doc/changes/added/13933.md
@@ -1,0 +1,1 @@
+- Add --debug-backtraces to `$ dune {promote,trace,cache}` (#13933, @rgrinberg)

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -61,6 +61,9 @@ Testing the output of `dune cache size --machine-readable`
              Outputs size as a plain number of bytes.
   
   COMMON OPTIONS
+         --debug-backtraces
+             Always print exception backtraces.
+  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
@@ -81,6 +84,21 @@ Testing the output of `dune cache size --machine-readable`
   SEE ALSO
          dune(1)
   
+
+Testing the output of dune cache clear.
+
+  $ dune cache clear --help=plain | grep -- '--debug-backtraces'
+         --debug-backtraces
+
+Commands that now expose the shared no-build backtrace flag:
+
+  $ dune promote --help=plain | grep -- '--debug-backtraces'
+         --debug-backtraces
+  $ dune trace cat --help=plain | grep -- '--debug-backtraces'
+         --debug-backtraces
+  $ dune trace commands --help=plain | grep -- '--debug-backtraces'
+         --debug-backtraces
+
 Testing the output of dune cache trim.
 
   $ dune cache trim --help=plain
@@ -102,6 +120,9 @@ Testing the output of dune cache trim.
              Size to trim from the cache. BYTES is the same as for --size.
   
   COMMON OPTIONS
+         --debug-backtraces
+             Always print exception backtraces.
+  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain


### PR DESCRIPTION
We don't want to take all of Common.t, but allowing backtraces is useful for debugging