### PR TITLE
feature: introduce DUNE_PROJECT_ROOT

### DIFF
--- a/doc/changes/added/13934.md
+++ b/doc/changes/added/13934.md
@@ -1,0 +1,2 @@
+- Actions are now able to observe their project directory via
+  `DUNE_PROJECT_ROOT` (#13934, @rgrinberg)

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -410,6 +410,19 @@ let exec
           (* TODO generify *)
           [ Some { source = Path.to_absolute_filename root; target } ]
     in
+    let env =
+      match Execution_parameters.action_project_root execution_parameters with
+      | None -> Env.remove env ~var:"DUNE_PROJECT_ROOT"
+      | Some project_root ->
+        (match Path.as_in_build_dir root with
+         | None -> env
+         | Some root ->
+           let project_root = Path.Build.append_source root project_root in
+           Env.add
+             env
+             ~var:"DUNE_PROJECT_ROOT"
+             ~value:(Path.to_absolute_filename (Path.build project_root)))
+    in
     { working_dir = Path.root
     ; env
     ; stdout_to =

--- a/src/dune_engine/build_context.ml
+++ b/src/dune_engine/build_context.ml
@@ -11,7 +11,8 @@ let create ~name =
 ;;
 
 let of_build_path p =
-  match Dpath.analyse_target p with
-  | Regular (name, _) | Alias (name, _) | Anonymous_action name -> Some (create ~name)
-  | Other _ -> None
+  match Dpath.Target_dir.of_target p with
+  | Regular (With_context (name, _)) | Anonymous_action (With_context (name, _)) ->
+    Some (create ~name)
+  | Regular Root | Anonymous_action Root | Invalid _ -> None
 ;;

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -275,7 +275,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 25
+  let rule_digest_version = 26
 
   let compute_rule_digest
         (rule : Rule.t)
@@ -321,6 +321,9 @@ end = struct
         d
         (Execution_parameters.workspace_root_to_build_path_prefix_map
            execution_parameters);
+      Digest.Manual.generic
+        d
+        (Execution_parameters.action_project_root execution_parameters);
       Digest.Manual.generic
         d
         (Execution_parameters.expand_aliases_in_sandbox execution_parameters);

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -54,6 +54,7 @@ type t =
   ; action_stderr_limit : Action_output_limit.t
   ; expand_aliases_in_sandbox : bool
   ; workspace_root_to_build_path_prefix_map : Workspace_root_for_build_prefix_map.t
+  ; action_project_root : Path.Source.t option
   ; should_remove_write_permissions_on_generated_files : bool
   }
 
@@ -64,6 +65,7 @@ let equal
       ; action_stderr_limit
       ; expand_aliases_in_sandbox
       ; workspace_root_to_build_path_prefix_map
+      ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       }
       t
@@ -76,6 +78,7 @@ let equal
   && Workspace_root_for_build_prefix_map.equal
        workspace_root_to_build_path_prefix_map
        t.workspace_root_to_build_path_prefix_map
+  && Option.equal Path.Source.equal action_project_root t.action_project_root
   && Bool.equal
        should_remove_write_permissions_on_generated_files
        t.should_remove_write_permissions_on_generated_files
@@ -88,6 +91,7 @@ let hash
       ; action_stderr_limit
       ; expand_aliases_in_sandbox
       ; workspace_root_to_build_path_prefix_map
+      ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       }
   =
@@ -98,6 +102,7 @@ let hash
     , action_stderr_limit
     , expand_aliases_in_sandbox
     , workspace_root_to_build_path_prefix_map
+    , action_project_root
     , should_remove_write_permissions_on_generated_files )
 ;;
 
@@ -108,6 +113,7 @@ let to_dyn
       ; action_stderr_limit
       ; expand_aliases_in_sandbox
       ; workspace_root_to_build_path_prefix_map
+      ; action_project_root
       ; should_remove_write_permissions_on_generated_files
       }
   =
@@ -120,6 +126,7 @@ let to_dyn
     ; ( "workspace_root_to_build_path_prefix_map"
       , Workspace_root_for_build_prefix_map.to_dyn workspace_root_to_build_path_prefix_map
       )
+    ; "action_project_root", Dyn.option Path.Source.to_dyn action_project_root
     ; ( "should_remove_write_permissions_on_generated_files"
       , Bool should_remove_write_permissions_on_generated_files )
     ]
@@ -132,6 +139,7 @@ let builtin_default =
   ; action_stderr_limit = Action_output_limit.default
   ; expand_aliases_in_sandbox = true
   ; workspace_root_to_build_path_prefix_map = Set "/workspace_root"
+  ; action_project_root = None
   ; should_remove_write_permissions_on_generated_files = true
   }
 ;;
@@ -146,6 +154,8 @@ let set_workspace_root_to_build_path_prefix_map x t =
   { t with workspace_root_to_build_path_prefix_map = x }
 ;;
 
+let set_action_project_root x t = { t with action_project_root = x }
+
 let set_should_remove_write_permissions_on_generated_files x t =
   { t with should_remove_write_permissions_on_generated_files = x }
 ;;
@@ -156,6 +166,7 @@ let action_stdout_on_success t = t.action_stdout_on_success
 let action_stderr_on_success t = t.action_stderr_on_success
 let action_stdout_limit t = t.action_stdout_limit
 let action_stderr_limit t = t.action_stderr_limit
+let action_project_root t = t.action_project_root
 
 let should_remove_write_permissions_on_generated_files t =
   t.should_remove_write_permissions_on_generated_files

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -1,10 +1,14 @@
 (** Parameters that influence rule execution *)
 
+open Import
+
 (** Such as:
 
     - should targets be set read-only?
 
     - should aliases be expanded when sandboxing rules?
+
+    - should actions receive a project-root path via [DUNE_PROJECT_ROOT]?
 
     These often depend on the version of the Dune language used, which is
     written in the [dune-project] file. Depending on the execution parameters
@@ -68,6 +72,7 @@ val set_workspace_root_to_build_path_prefix_map
   -> t
   -> t
 
+val set_action_project_root : Path.Source.t option -> t -> t
 val set_should_remove_write_permissions_on_generated_files : bool -> t -> t
 
 (** As configured by [init] *)
@@ -82,6 +87,7 @@ val action_stderr_on_success : t -> Action_output_on_success.t
 val action_stdout_limit : t -> Action_output_limit.t
 val action_stderr_limit : t -> Action_output_limit.t
 val workspace_root_to_build_path_prefix_map : t -> Workspace_root_for_build_prefix_map.t
+val action_project_root : t -> Path.Source.t option
 
 (** {1 Initialisation} *)
 

--- a/src/dune_lang/dune_project.ml
+++ b/src/dune_lang/dune_project.ml
@@ -780,6 +780,8 @@ let update_execution_parameters t ep =
   |> Execution_parameters.set_expand_aliases_in_sandbox t.expand_aliases_in_sandbox
   |> Execution_parameters.set_workspace_root_to_build_path_prefix_map
        (if t.map_workspace_root then Set "/workspace_root" else Unset)
+  |> Execution_parameters.set_action_project_root
+       (if t.dune_version >= (3, 23) then Some t.root else None)
   |> Execution_parameters.set_should_remove_write_permissions_on_generated_files
        (t.dune_version >= (2, 4))
 ;;

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -26,15 +26,28 @@ let implicit_default_alias dir =
 ;;
 
 let execution_parameters =
+  let source_backed_dir path =
+    match Dpath.Target_dir.of_target path with
+    | Regular (With_context (context, source))
+    | Anonymous_action (With_context (context, source)) ->
+      (match Install.Context.analyze_path context source with
+       | Normal (_, source) -> Some source
+       | Install _ | Invalid -> None)
+    | Regular Root | Anonymous_action Root | Invalid _ -> None
+  in
   let f context path =
-    let path = Path.Build.drop_build_context_exn path in
     let open Memo.O in
     let* ep = Execution_parameters.default in
-    if Context_name.equal context Private_context.t.name
+    if
+      Context_name.equal context Private_context.t.name
+      || Context_name.equal context Fetch_rules.context.name
     then Memo.return ep
-    else
-      let+ dir = Source_tree.nearest_dir path in
-      Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep
+    else (
+      match source_backed_dir path with
+      | None -> Memo.return ep
+      | Some path ->
+        let+ dir = Source_tree.nearest_dir path in
+        Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep)
   in
   let memo =
     let module Input = struct

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [d0520ec17a9161b7406891d897b950ff]: ((in_cache
+  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -120,7 +120,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [d0520ec17a9161b7406891d897b950ff]: ((in_cache
+  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -132,7 +132,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [d0520ec17a9161b7406891d897b950ff]: ((in_cache
+  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out | censor
-  ./6b/$DIGEST:((8:metadata)(5:files(8:target_b32:$DIGEST)))
-  ./f8/$DIGEST:((8:metadata)(5:files(8:target_a32:$DIGEST)))
+  ./04/$DIGEST:((8:metadata)(5:files(8:target_b32:$DIGEST)))
+  ./20/$DIGEST:((8:metadata)(5:files(8:target_a32:$DIGEST)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/project-root-env/alias-action.t
+++ b/test/blackbox-tests/test-cases/project-root-env/alias-action.t
@@ -1,0 +1,20 @@
+Anonymous actions can discover their project root from DUNE_PROJECT_ROOT.
+
+  $ mkdir -p proj/sub
+  $ cat > proj/dune-project <<'EOF'
+  > (lang dune 3.23)
+  > EOF
+  $ cat > proj/sub/dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (bash "test \"$DUNE_PROJECT_ROOT\" = \"$(dirname \"$PWD\")\" && echo ok")))
+  > EOF
+
+  $ dune build --root proj @sub/runtest
+  Entering directory 'proj'
+  ok
+  Leaving directory 'proj'
+
+  $ dune build @proj/sub/runtest
+  ok

--- a/test/blackbox-tests/test-cases/project-root-env/before-323.t
+++ b/test/blackbox-tests/test-cases/project-root-env/before-323.t
@@ -1,0 +1,17 @@
+DUNE_PROJECT_ROOT is not set before dune lang 3.23.
+
+  $ mkdir -p proj/sub
+
+  $ cat > proj/dune-project <<'EOF'
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > proj/sub/dune <<'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (action
+  >   (bash "test \"${DUNE_PROJECT_ROOT-unset}\" = unset && echo ok")))
+  > EOF
+
+  $ dune build @proj/sub/runtest
+  ok

--- a/test/blackbox-tests/test-cases/project-root-env/sandboxed-rule.t
+++ b/test/blackbox-tests/test-cases/project-root-env/sandboxed-rule.t
@@ -1,0 +1,24 @@
+Sandboxed actions see the sandboxed project root.
+
+  $ mkdir -p proj/sub
+  $ cat > proj/dune-project <<'EOF'
+  > (lang dune 3.23)
+  > EOF
+  $ cat > proj/sub/dune <<'EOF'
+  > (rule
+  >  (target root.txt)
+  >  (deps %{project_root}/dune-project)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (bash "cat $DUNE_PROJECT_ROOT/dune-project > root.txt"))))
+  > EOF
+  $ dune build --root proj sub/root.txt
+  Entering directory 'proj'
+  Leaving directory 'proj'
+  $ cat proj/_build/default/sub/root.txt
+  (lang dune 3.23)
+
+  $ dune build proj/sub/root.txt
+
+  $ cat _build/default/proj/sub/root.txt
+  (lang dune 3.23)


### PR DESCRIPTION
Quite often, actions want to run or look up something relative to their project root rather than the directory when they're defined. The standard workaround is to %{project_root} to these actions. However, this workaround comes with some downsides:

1. One has to pass this variable manually, and this is rather inconvenient for some actions (like preprocessors)

2. Passing the %{project_root} this way records the directory in the action's digest. We shouldn't be encouraging actions from observing the project root in this way.