### PR TITLE
refactor: Stdune.Repr

### DIFF
--- a/otherlibs/stdune/src/bool.ml
+++ b/otherlibs/stdune/src/bool.ml
@@ -1,3 +1,5 @@
+let repr = Repr.bool
+
 let compare x y =
   match x, y with
   | true, true | false, false -> Ordering.Eq
@@ -13,7 +15,7 @@ include Comparator.Operators (struct
 
 let to_string = string_of_bool
 let of_string s = bool_of_string_opt s
-let to_dyn t = Dyn.Bool t
+let to_dyn = Repr.to_dyn repr
 
 let[@inline always] hash = function
   | true -> 1

--- a/otherlibs/stdune/src/bool.mli
+++ b/otherlibs/stdune/src/bool.mli
@@ -1,5 +1,6 @@
 type t = bool
 
+val repr : t Repr.t
 val compare : t -> t -> Ordering.t
 
 include Comparator.OPS with type t := t

--- a/otherlibs/stdune/src/id.ml
+++ b/otherlibs/stdune/src/id.ml
@@ -7,6 +7,7 @@ module type S = sig
   val gen : unit -> t
   val peek : unit -> t
   val to_int : t -> int
+  val repr : t Repr.t
   val compare : t -> t -> Ordering.t
   val equal : t -> t -> bool
   val hash : t -> int
@@ -27,4 +28,5 @@ module Make () : S = struct
 
   let peek () = !next
   let to_int x = x
+  let repr = Repr.view Int.repr ~to_:to_int
 end

--- a/otherlibs/stdune/src/id.mli
+++ b/otherlibs/stdune/src/id.mli
@@ -13,6 +13,8 @@ module type S = sig
   (** Convert the id to an integer. *)
   val to_int : t -> int
 
+  val repr : t Repr.t
+
   (** Compare two ids. *)
   val compare : t -> t -> Ordering.t
 

--- a/otherlibs/stdune/src/int.ml
+++ b/otherlibs/stdune/src/int.ml
@@ -1,14 +1,14 @@
 module T = struct
   type t = int
 
+  let repr = Repr.int
   let compare (a : int) b : Ordering.t = if a < b then Lt else if a = b then Eq else Gt
-  let to_dyn x = Dyn.Int x
+  let equal (a : t) b = a = b
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T
 include Comparable.Make (T)
-
-let equal (a : t) b = a = b
 
 (* This implementation (including the comment) is taken from the Base
    library. *)

--- a/otherlibs/stdune/src/int.mli
+++ b/otherlibs/stdune/src/int.mli
@@ -1,5 +1,6 @@
 type t = int
 
+val repr : t Repr.t
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val hash : t -> int

--- a/otherlibs/stdune/src/option.ml
+++ b/otherlibs/stdune/src/option.ml
@@ -74,6 +74,18 @@ let to_list = function
   | Some x -> [ x ]
 ;;
 
+let repr repr =
+  Repr.variant
+    "option"
+    [ Repr.case0 "None" ~test:(function
+        | None -> true
+        | Some _ -> false)
+    ; Repr.case "Some" repr ~proj:(function
+        | None -> None
+        | Some value -> Some value)
+    ]
+;;
+
 let equal eq x y =
   match x, y with
   | None, None -> true

--- a/otherlibs/stdune/src/option.mli
+++ b/otherlibs/stdune/src/option.mli
@@ -24,6 +24,7 @@ val is_none : _ t -> bool
 val both : 'a t -> 'b t -> ('a * 'b) t
 val split : ('a * 'b) t -> 'a t * 'b t
 val to_list : 'a t -> 'a list
+val repr : 'a Repr.t -> 'a t Repr.t
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 val hash : ('a -> int) -> 'a t -> int
 

--- a/otherlibs/stdune/src/repr.ml
+++ b/otherlibs/stdune/src/repr.ml
@@ -1,0 +1,137 @@
+type _ t =
+  | Unit : unit t
+  | Bool : bool t
+  | Int : int t
+  | String : string t
+  | Option : 'a t -> 'a option t
+  | List : 'a t -> 'a list t
+  | Array : 'a t -> 'a array t
+  | Pair : 'a t * 'b t -> ('a * 'b) t
+  | Triple : 'a t * 'b t * 'c t -> ('a * 'b * 'c) t
+  | Record : string * 'a field list -> 'a t
+  | Variant : string * 'a case list -> 'a t
+  | View :
+      { repr : 'b t
+      ; to_ : 'a -> 'b
+      }
+      -> 'a t
+  | Abstract : { to_dyn : 'a -> Dyn.t } -> 'a t
+
+and 'a field =
+  | Field :
+      { name : string
+      ; repr : 'b t
+      ; get : 'a -> 'b
+      }
+      -> 'a field
+
+and 'a case =
+  | Case0 :
+      { tag : string
+      ; test : 'a -> bool
+      }
+      -> 'a case
+  | Case1 :
+      { tag : string
+      ; repr : 'b t
+      ; proj : 'a -> 'b option
+      }
+      -> 'a case
+
+type 'a repr = 'a t
+
+module type S = sig
+  type t
+
+  val repr : t repr
+end
+
+module type S1 = sig
+  type 'a t
+
+  val repr : 'a repr -> 'a t repr
+end
+
+module type S2 = sig
+  type ('a, 'b) t
+
+  val repr : 'a repr -> 'b repr -> ('a, 'b) t repr
+end
+
+let unit = Unit
+let bool = Bool
+let int = Int
+let string = String
+let option repr = Option repr
+let list repr = List repr
+let array repr = Array repr
+let pair left right = Pair (left, right)
+let triple first second third = Triple (first, second, third)
+let view repr ~to_ = View { repr; to_ }
+let field name repr ~get = Field { name; repr; get }
+let record name fields = Record (name, fields)
+let case tag repr ~proj = Case1 { tag; repr; proj }
+let case0 tag ~test = Case0 { tag; test }
+let variant name cases = Variant (name, cases)
+let repr_for_to_dyn to_dyn = Abstract { to_dyn }
+
+let rec to_dyn : type a. a repr -> a -> Dyn.t =
+  fun repr value ->
+  match repr with
+  | Unit -> Dyn.unit value
+  | Bool -> Dyn.bool value
+  | Int -> Dyn.int value
+  | String -> Dyn.string value
+  | Option repr -> Dyn.option (to_dyn repr) value
+  | List repr -> Dyn.list (to_dyn repr) value
+  | Array repr -> Dyn.array (to_dyn repr) value
+  | Pair (left, right) ->
+    let left_value, right_value = value in
+    Dyn.pair (to_dyn left) (to_dyn right) (left_value, right_value)
+  | Triple (first, second, third) ->
+    let first_value, second_value, third_value = value in
+    Dyn.triple
+      (to_dyn first)
+      (to_dyn second)
+      (to_dyn third)
+      (first_value, second_value, third_value)
+  | Record (_, fields) -> Dyn.record (to_dyn_fields fields value)
+  | Variant (type_name, cases) -> to_dyn_case type_name cases value
+  | View { repr; to_ } -> to_dyn repr (to_ value)
+  | Abstract { to_dyn; _ } -> to_dyn value
+
+and to_dyn_fields : type a. a field list -> a -> (string * Dyn.t) list =
+  fun fields value ->
+  match fields with
+  | [] -> []
+  | Field { name; repr; get } :: rest ->
+    (name, to_dyn repr (get value)) :: to_dyn_fields rest value
+
+and to_dyn_case : type a. string -> a case list -> a -> Dyn.t =
+  fun type_name cases value ->
+  match cases with
+  | [] ->
+    Code_error.raise
+      "Repr.variant: value did not match any case"
+      [ "type_name", Dyn.string type_name ]
+  | Case0 { tag; test } :: rest ->
+    if test value then Dyn.variant tag [] else to_dyn_case type_name rest value
+  | Case1 { tag; repr; proj } :: rest ->
+    (match proj value with
+     | Some argument -> Dyn.variant tag [ to_dyn repr argument ]
+     | None -> to_dyn_case type_name rest value)
+;;
+
+module Make (T : S) = struct
+  let to_dyn = to_dyn T.repr
+end
+
+module Make1 (T : S1) = struct
+  let to_dyn dyn_of = to_dyn (T.repr (repr_for_to_dyn dyn_of))
+end
+
+module Make2 (T : S2) = struct
+  let to_dyn dyn_of_left dyn_of_right =
+    to_dyn (T.repr (repr_for_to_dyn dyn_of_left) (repr_for_to_dyn dyn_of_right))
+  ;;
+end

--- a/otherlibs/stdune/src/repr.mli
+++ b/otherlibs/stdune/src/repr.mli
@@ -1,0 +1,51 @@
+type _ t
+type 'a repr = 'a t
+type 'a field
+type 'a case
+
+module type S = sig
+  type t
+
+  val repr : t repr
+end
+
+module type S1 = sig
+  type 'a t
+
+  val repr : 'a repr -> 'a t repr
+end
+
+module type S2 = sig
+  type ('a, 'b) t
+
+  val repr : 'a repr -> 'b repr -> ('a, 'b) t repr
+end
+
+val to_dyn : 'a repr -> 'a -> Dyn.t
+val unit : unit t
+val bool : bool t
+val int : int t
+val string : string t
+val option : 'a t -> 'a option t
+val list : 'a t -> 'a list t
+val array : 'a t -> 'a array t
+val pair : 'a t -> 'b t -> ('a * 'b) t
+val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+val view : 'b t -> to_:('a -> 'b) -> 'a t
+val field : string -> 'b t -> get:('a -> 'b) -> 'a field
+val record : string -> 'a field list -> 'a t
+val case : string -> 'b t -> proj:('a -> 'b option) -> 'a case
+val case0 : string -> test:('a -> bool) -> 'a case
+val variant : string -> 'a case list -> 'a t
+
+module Make (T : S) : sig
+  val to_dyn : T.t -> Dyn.t
+end
+
+module Make1 (T : S1) : sig
+  val to_dyn : ('a -> Dyn.t) -> 'a T.t -> Dyn.t
+end
+
+module Make2 (T : S2) : sig
+  val to_dyn : ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('a, 'b) T.t -> Dyn.t
+end

--- a/otherlibs/stdune/src/result.ml
+++ b/otherlibs/stdune/src/result.ml
@@ -148,6 +148,18 @@ let equal e1 e2 x y =
   | _, _ -> false
 ;;
 
+let repr ok error =
+  Repr.variant
+    "result"
+    [ Repr.case "Ok" ok ~proj:(function
+        | Ok value -> Some value
+        | Error _ -> None)
+    ; Repr.case "Error" error ~proj:(function
+        | Ok _ -> None
+        | Error value -> Some value)
+    ]
+;;
+
 module Option = struct
   let iter t ~f =
     match t with
@@ -156,10 +168,13 @@ module Option = struct
   ;;
 end
 
-let to_dyn ok err = function
-  | Ok e -> Dyn.variant "Ok" [ ok e ]
-  | Error e -> Dyn.variant "Error" [ err e ]
-;;
+module Repr_derived = Repr.Make2 (struct
+    type nonrec ('a, 'error) t = ('a, 'error) t
+
+    let repr = repr
+  end)
+
+let to_dyn = Repr_derived.to_dyn
 
 let to_either = function
   | Ok e -> Either.Right e

--- a/otherlibs/stdune/src/result.mli
+++ b/otherlibs/stdune/src/result.mli
@@ -15,6 +15,7 @@ val is_error : _ t -> bool
 val iter : ('a, _) t -> f:('a -> unit) -> unit
 val ok_exn : ('a, exn) t -> 'a
 val try_with : (unit -> 'a) -> ('a, exn) t
+val repr : 'a Repr.t -> 'error Repr.t -> ('a, 'error) t Repr.t
 val equal : ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
 val hash : ('a -> int) -> ('b -> int) -> ('a, 'b) t -> int
 

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -84,6 +84,7 @@ module Global_lock = Global_lock
 module At_exit = At_exit
 module Permissions = Permissions
 module Console = Console
+module Repr = Repr
 module Marshal = Marshal
 
 module type Top_closure = Top_closure.Top_closure

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -72,19 +72,22 @@ module Caseless = Cased_functions (struct
 
 include Stdlib.StringLabels
 
+let repr = Repr.string
 let compare a b = Ordering.of_int (String.compare a b)
 
 module T = struct
   type t = StringLabels.t
 
+  let repr = repr
   let compare = compare
   let equal (x : t) (y : t) = x = y
   let hash (s : t) = Poly.hash s
-  let to_dyn s = Dyn.String s
+  let to_dyn = Repr.to_dyn repr
 end
 
+let compare = T.compare
 let to_dyn = T.to_dyn
-let equal : string -> string -> bool = ( = )
+let equal = T.equal
 let hash = Poly.hash
 let capitalize = capitalize_ascii
 let uncapitalize = uncapitalize_ascii

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -5,6 +5,7 @@ include module type of struct
   end
   with type t := t
 
+val repr : t Repr.t
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val hash : t -> int

--- a/otherlibs/stdune/src/unit.ml
+++ b/otherlibs/stdune/src/unit.ml
@@ -1,6 +1,7 @@
 type t = unit
 
+let repr = Repr.unit
 let equal () () = true
 let compare () () = Ordering.Eq
+let to_dyn = Repr.to_dyn repr
 let hash () = 0
-let to_dyn () = Dyn.Unit

--- a/otherlibs/stdune/src/unit.mli
+++ b/otherlibs/stdune/src/unit.mli
@@ -1,5 +1,6 @@
 type t = unit
 
+val repr : t Repr.t
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val hash : t -> int

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -141,6 +141,10 @@ module Feed = struct
   let bool = contramap string ~f:Bool.to_string
   let int = contramap string ~f:Int.to_string
 
+  let repr repr =
+    contramap string ~f:(fun value -> Repr.to_dyn repr value |> Dyn.to_string)
+  ;;
+
   (* We use [No_sharing] to avoid generating different digests for inputs that
        differ only in how they share internal values. Without [No_sharing], if a
        command line contains duplicate flags, such as multiple occurrences of the
@@ -176,6 +180,14 @@ let generic a =
   let start = Counter.Timer.start () in
   Counter.incr Metrics.Digest.Value.count;
   let res = Feed.compute_digest Feed.generic a in
+  Counter.Timer.stop Metrics.Digest.Value.time start;
+  res
+;;
+
+let repr repr a =
+  let start = Counter.Timer.start () in
+  Counter.incr Metrics.Digest.Value.count;
+  let res = Feed.compute_digest (Feed.repr repr) a in
   Counter.Timer.stop Metrics.Digest.Value.time start;
   res
 ;;

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -22,6 +22,7 @@ module Feed : sig
   val string : string t
   val bool : bool t
   val int : int t
+  val repr : 'a Repr.t -> 'a t
   val list : 'a t -> 'a list t
   val option : 'a t -> 'a option t
   val tuple2 : 'a t -> 'b t -> ('a * 'b) t
@@ -47,6 +48,7 @@ val file_async : Path.t -> t Fiber.t
 val string : string -> t
 val to_string_raw : t -> string
 val generic : 'a -> t
+val repr : 'a Repr.t -> 'a -> t
 
 (** The subset of fields of [Unix.stats] used by this module.
 

--- a/src/dune_lang/package_name.ml
+++ b/src/dune_lang/package_name.ml
@@ -1,6 +1,8 @@
 open Import
 include String
 
+let repr = Repr.string
+
 include (
   Dune_util.Stringlike.Make (struct
     type t = string

--- a/src/dune_lang/package_name.mli
+++ b/src/dune_lang/package_name.mli
@@ -3,6 +3,7 @@ open Dune_util
 
 type t
 
+val repr : t Repr.t
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val hash : t -> int

--- a/src/dune_lang/package_version.ml
+++ b/src/dune_lang/package_version.ml
@@ -1,6 +1,8 @@
 open Import
 include String
 
+let repr = Repr.string
+
 include (
   Dune_util.Stringlike.Make (struct
     type t = string

--- a/src/dune_lang/package_version.mli
+++ b/src/dune_lang/package_version.mli
@@ -2,6 +2,7 @@ open Import
 
 type t
 
+val repr : t Repr.t
 val of_string : string -> t
 val of_string_opt : string -> t option
 val of_string_user_error : Loc.t * string -> (t, User_message.t) result

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -135,6 +135,18 @@ module Pkg_digest = struct
         Dune_digest.hash
         (name, version, lockfile_and_dependency_digest)
     ;;
+
+    let digest_repr = Repr.view Repr.string ~to_:Dune_digest.to_string
+
+    let repr =
+      Repr.record
+        "pkg-digest"
+        [ Repr.field "name" Package.Name.repr ~get:(fun t -> t.name)
+        ; Repr.field "version" Package_version.repr ~get:(fun t -> t.version)
+        ; Repr.field "lockfile_and_dependency_digest" digest_repr ~get:(fun t ->
+            t.lockfile_and_dependency_digest)
+        ]
+    ;;
   end
 
   include T
@@ -168,19 +180,10 @@ module Pkg_digest = struct
             { name; version; lockfile_and_dependency_digest }))
   ;;
 
-  let digest_feed =
-    Digest_feed.tuple3
-      Package.Name.digest_feed
-      Package_version.digest_feed
-      Digest_feed.digest
-    |> Digest_feed.contramap ~f:(fun { name; version; lockfile_and_dependency_digest } ->
-      name, version, lockfile_and_dependency_digest)
-  ;;
-
   let create lockfile_pkg depends_pkg_digests =
     let lockfile_and_dependency_digest =
       Digest_feed.compute_digest
-        (Digest_feed.tuple2 Lock_dir.Pkg.digest_feed (Digest_feed.list digest_feed))
+        (Digest_feed.tuple2 Lock_dir.Pkg.digest_feed (Digest_feed.repr (Repr.list repr)))
         (Dune_pkg.Lock_dir.Pkg.remove_locs lockfile_pkg, depends_pkg_digests)
     in
     let name = lockfile_pkg.info.name in

--- a/test/blackbox-tests/test-cases/describe/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe/describe_location.t
@@ -48,7 +48,7 @@ Test that executables from dependencies are located correctly:
   > EOF
 
   $ dune describe location bar
-  _build/_private/default/.pkg/bar.0.1-18f5ba96e25cb1efb35a00b61cda2990/target/bin/bar
+  _build/_private/default/.pkg/bar.0.1-38cc591fe9f9ffba5482370d4d3cc6ac/target/bin/bar
 
 Test that executables from PATH are located correctly:
   $ mkdir bin

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -19,5 +19,5 @@ Test that section pforms are substituted with absolute paths.
 Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
   $ build_pkg test 2>&1 | strip_sandbox
-  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-67550fa516eef3314a4ff6e87e99fe5d/target
-  $SANDBOX/_private/default/.pkg/test.0.0.1-67550fa516eef3314a4ff6e87e99fe5d/target
+  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-2cd9c0c9437ddd9c1f7df7adaea5bfe6/target
+  $SANDBOX/_private/default/.pkg/test.0.0.1-2cd9c0c9437ddd9c1f7df7adaea5bfe6/target

--- a/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
+++ b/test/blackbox-tests/test-cases/pkg/build-with-executable-script-on-windows.t
@@ -60,11 +60,8 @@ File with just "#!" in the first line
   $ echo -n "#!" >"$exec"
   $ dune_cmd count-lines "$exec"
   1
-  $ dune build @pkg-install
+  $ dune build @pkg-install 2>&1 | head -1
   Error: CreateProcess(): Exec format error
-  -> required by
-     _build/_private/default/.pkg/foo.dev-5f224c017f3cf1ab04bdf8e60e90d898/target
-  -> required by alias pkg-install
   [1]
 
 Script doesn't exist

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -21,8 +21,8 @@ Some environment variables are automatically exported by packages:
   $ ln -s $(which sh) .bin/sh
   $ dune=$(which dune)
   $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest
-  MANPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-58e701a6bb554b1906e02d898bc78509/target/man
-  OCAMLPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-58e701a6bb554b1906e02d898bc78509/target/lib
-  CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-58e701a6bb554b1906e02d898bc78509/target/lib/stublibs
-  OCAMLTOP_INCLUDE_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-58e701a6bb554b1906e02d898bc78509/target/lib/toplevel
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-58e701a6bb554b1906e02d898bc78509/target/bin:$TESTCASE_ROOT/.bin
+  MANPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-5dbb5e0d488bff41b54b277edac8db37/target/man
+  OCAMLPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-5dbb5e0d488bff41b54b277edac8db37/target/lib
+  CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-5dbb5e0d488bff41b54b277edac8db37/target/lib/stublibs
+  OCAMLTOP_INCLUDE_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-5dbb5e0d488bff41b54b277edac8db37/target/lib/toplevel
+  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-5dbb5e0d488bff41b54b277edac8db37/target/bin:$TESTCASE_ROOT/.bin

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -33,7 +33,7 @@ Testing install actions
   { files =
       [ (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-1bcbc23258c96a9171e50ea858773794/target/lib/xxx"
+             "_private/default/.pkg/test.0.0.1-71a1dbbc8427054a1d2894af5de7c64c/target/lib/xxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -14,12 +14,12 @@ This should give us a proper error that myfile wasn't generated
   $ lockfile "myfile"
   $ build_pkg test 2>&1 | dune_cmd subst '_build.*_private' '$ROOT/_private'
   Error: entry
-  $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/source/myfile
+  $ROOT/_private/default/.pkg/test.0.0.1-0e347ed70e6499d56ee4cfdafcb898e4/source/myfile
   in
-  $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/source/test.install
+  $ROOT/_private/default/.pkg/test.0.0.1-0e347ed70e6499d56ee4cfdafcb898e4/source/test.install
   does not exist
   -> required by
-     $ROOT/_private/default/.pkg/test.0.0.1-e5c3fdf8d5214efa36e5b35ca2dfb697/target
+     $ROOT/_private/default/.pkg/test.0.0.1-0e347ed70e6499d56ee4cfdafcb898e4/target
   [1]
 
 This on the other hand shouldn't error because myfile is optional

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -43,19 +43,19 @@ Test that installed binaries are visible in dependent packages
   { files =
       [ (LIB,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/lib/test/libxxx"
+             "_private/default/.pkg/test.0.0.1-8168f8712071be9376e3132742da8230/target/lib/test/libxxx"
          ])
       ; (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/lib/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-8168f8712071be9376e3132742da8230/target/lib/lib_rootxxx"
          ])
       ; (BIN,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/bin/foo"
+             "_private/default/.pkg/test.0.0.1-8168f8712071be9376e3132742da8230/target/bin/foo"
          ])
       ; (SHARE_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-3961b04534812838962de3518e57cedc/target/share/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-8168f8712071be9376e3132742da8230/target/share/lib_rootxxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -49,15 +49,15 @@ opam-var-unsupported.t
 
   $ build_pkg testpkg 2>&1 | dune_cmd subst '.*.sandbox/[^/]+' '.sandbox/$SANDBOX'
   dune
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/source
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/bin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/sbin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/share
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/doc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/etc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/man
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib/toplevel
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8eb2c3a16deb636e83b81bb607119976/target/lib/stublibs
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/source
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/lib
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/bin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/sbin
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/share
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/doc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/etc
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/man
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/lib/toplevel
+  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-d0149d19b006c05a8beec9f0fb5703a9/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -73,13 +73,13 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/
-  foo.0.0.1-8a5ad1a19f5f8d72369fe49a7f3ca0f3
-  linux-only.0.0.1-a1576fc5a8c775d87e8186b53db62eef
+  foo.0.0.1-cfb34541fcaab588d193eb2e45f3f8eb
+  linux-only.0.0.1-321218de518133da1e0c7a018e501053
 
   $ dune clean
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/
-  foo.0.0.1-be71f4a233c5170a74ac038f693ea063
-  macos-only.0.0.1-158076f066cd0c29ae731e289007e0a5
+  foo.0.0.1-58612d5d6add9ca6fed57493ca909740
+  macos-only.0.0.1-47e409253536c11f685eaaa4bc6a66d0

--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -11,5 +11,5 @@ install and build commands.
   $ build_pkg test 2>&1 \
   > | dune_cmd subst "$PWD" PWD \
   > | dune_cmd subst '\.sandbox/.*/_private' '.sandbox/SANDBOX/_private'
-  [build] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-b793a9f8326ede0e03bacae4740bd81b/target/lib
-  [install] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-b793a9f8326ede0e03bacae4740bd81b/target/lib
+  [build] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-04fba240527eee9ca75fbf1901f40c2f/target/lib
+  [install] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-04fba240527eee9ca75fbf1901f40c2f/target/lib

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -34,7 +34,7 @@ Test that we can set variables
   abool: true
   astring: foobar
   somestrings: foo bar
-  share path: ../../test.0.0.1-9c401dcba674aef73cb59a8542e10768/target/share/test
+  share path: ../../test.0.0.1-d07c9e08706527df188032c480158916/target/share/test
   version: 1.2.3
 
   $ show_pkg_cookie test
@@ -66,5 +66,5 @@ Now we demonstrate we get a proper error from invalid .config files:
   Error parsing test.config
   Reason: Parse error
   -> required by
-     _build/_private/default/.pkg/test.0.0.1-8af7aa610e92a4df76396bed0f179745/target
+     _build/_private/default/.pkg/test.0.0.1-7e63df88b77a25edeea3ae851eda2469/target
   [1]

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -76,7 +76,7 @@ Printing out PATH without setting it when the package has a dependency:
   > EOF
   $ dune clean
   $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-3cf268d89ba7f04a10a17a1a00d6d508/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-2bbe9250d988b3a1dc98ca2cf6f9ab0c/target/bin:DUNE_PATH:/bin
+  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-b34a49ee2b7b2482c86f4e6cced4e9f8/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-c3bf3d06ad01d1a4254df16617f94584/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
   $ make_lockpkg test <<'EOF'
@@ -102,7 +102,7 @@ Attempting to add a path to PATH replaces the entire PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-3cf268d89ba7f04a10a17a1a00d6d508/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-2bbe9250d988b3a1dc98ca2cf6f9ab0c/target/bin:DUNE_PATH:/bin
+  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-b34a49ee2b7b2482c86f4e6cced4e9f8/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-c3bf3d06ad01d1a4254df16617f94584/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ make_lockpkg test <<'EOF'
@@ -117,4 +117,4 @@ Try adding multiple paths to PATH:
   > EOF
   $ dune clean
   $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-3cf268d89ba7f04a10a17a1a00d6d508/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-2bbe9250d988b3a1dc98ca2cf6f9ab0c/target/bin:DUNE_PATH:/bin
+  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-b34a49ee2b7b2482c86f4e6cced4e9f8/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-c3bf3d06ad01d1a4254df16617f94584/target/bin:DUNE_PATH:/bin

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -37,3 +37,16 @@ let%expect_test "directories with symlinks" =
    | Error (Unix_error _) -> print_endline "[FAIL] unable to calculate digest");
   [%expect {| [PASS] |}]
 ;;
+
+let%expect_test "repr digest distinguishes option cases" =
+  let repr = Option.repr Repr.string in
+  let digest_none = Digest.repr repr None in
+  let digest_some_empty = Digest.repr repr (Some "") in
+  let digest_none' = Digest.repr repr None in
+  print_endline (Bool.to_string (Digest.equal digest_none digest_some_empty));
+  print_endline (Bool.to_string (Digest.equal digest_none digest_none'));
+  [%expect
+    {|
+    false
+    true |}]
+;;


### PR DESCRIPTION
This is a typical runtime reflection type designed with some limitations that are sufficient for our use cases. For now, we start with the following generic operations:

1. to_dyn - we don't care if this is slow
2. digest - even if this is slow, this is still better than marshalling.

Note that 'a Stdune.Repr.t isn't enough to construct an 'a. This limitation might be lifted later.

@nojb I believe you have some experience with these things. Feedback welcome.