### PR TITLE
chore: update ocaml trunk to 5.6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -157,8 +157,8 @@ jobs:
         # 4.02.x and 4.07.x in other environments
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.5.0+trunk
-            cache-prefix: ocaml-variants.5.5.0+trunk
+          - ocaml-compiler: ocaml-variants.5.6.0+trunk
+            cache-prefix: ocaml-variants.5.6.0+trunk
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -156,8 +156,8 @@ jobs:
         # 4.02.x and 4.07.x in other environments
         include:
           # OCaml trunk:
-          - ocaml-compiler: ocaml-variants.5.5.0+trunk
-            cache-prefix: ocaml-variants.5.5.0+trunk
+          - ocaml-compiler: ocaml-variants.5.6.0+trunk
+            cache-prefix: ocaml-variants.5.6.0+trunk
             os: ubuntu-latest
           # OCaml 5:
           ## ubuntu (x86)

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -31,7 +31,7 @@ struct
     len >= suffix_len && check_suffix s ~suffix suffix_len (len - suffix_len) 0
   ;;
 
-  let drop_prefix s ~prefix =
+  let drop_prefix ~prefix s =
     if starts_with ~prefix s
     then
       if length s = length prefix
@@ -46,7 +46,7 @@ struct
     | Some s -> s
   ;;
 
-  let drop_suffix s ~suffix =
+  let drop_suffix ~suffix s =
     if ends_with ~suffix s
     then
       if length s = length suffix

--- a/otherlibs/stdune/src/string.mli
+++ b/otherlibs/stdune/src/string.mli
@@ -19,9 +19,9 @@ val ends_with : suffix:t -> t -> bool
 val take : t -> int -> t
 val drop : t -> int -> t
 val split_n : t -> int -> t * t
-val drop_prefix : t -> prefix:t -> t option
+val drop_prefix : prefix:t -> t -> t option
 val drop_prefix_if_exists : t -> prefix:t -> t
-val drop_suffix : t -> suffix:t -> t option
+val drop_suffix : suffix:t -> t -> t option
 val drop_suffix_if_exists : t -> suffix:t -> t
 
 (** [drop_prefix_and_suffix t ~prefix ~suffix] Will attempt to remove [prefix]
@@ -32,9 +32,9 @@ val drop_prefix_and_suffix : t -> prefix:t -> suffix:t -> t option
 module Caseless : sig
   (** Case-insensitive matching semantics. *)
 
-  val drop_prefix : t -> prefix:t -> t option
+  val drop_prefix : prefix:t -> t -> t option
   val drop_prefix_if_exists : t -> prefix:t -> t
-  val drop_suffix : t -> suffix:t -> t option
+  val drop_suffix : suffix:t -> t -> t option
   val drop_suffix_if_exists : t -> suffix:t -> t
 end
 


### PR DESCRIPTION
As instructed by @Alizter at https://github.com/ocaml/dune/issues/13937#issuecomment-4143635714

Also includes the tweak in [4a62fae](https://github.com/ocaml/dune/pull/13950/commits/4a62fae5c356a29b273f356345ec7eac0467f9bb) to adapt to the update in the OCaml 5.6 stdlib noted in #13937 . As an alternative, we could of course instead mask this part of the signature from the include. I am not sure what the intention is with this stdlib overlay w/r/t whether backwards compat with older versions of stdune are more or less important than forward consistency with the ocaml stdlib.