### PR TITLE
pkg: improve unsupported opam variable translation errors

### DIFF
--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -51,7 +51,9 @@ let is_valid_package_variable_name = function
 let invalid_variable_error ~loc variable =
   User_error.raise
     ~loc
-    [ Pp.textf "Variable %S is not supported." (OpamVariable.to_string variable) ]
+    [ Pp.textf "Cannot translate opam variable %S." (OpamVariable.to_string variable)
+    ; Pp.text "Dune only supports a subset of opam variables when translating opam files."
+    ]
 ;;
 
 (* CR-someday Alizter: This function is very mysterious and does a lot of

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-unsupported.t
@@ -18,32 +18,40 @@ These should all have nice error messages explaining that they are not supported
 # opam-version
   $ fail_solve opam-version
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "opam-version" is not supported.
+  Error: Cannot translate opam variable "opam-version".
+  Dune only supports a subset of opam variables when translating opam files.
 # root
   $ fail_solve root 
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "root" is not supported.
+  Error: Cannot translate opam variable "root".
+  Dune only supports a subset of opam variables when translating opam files.
 # _:hash
   $ fail_solve _:hash
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "hash" is not supported.
+  Error: Cannot translate opam variable "hash".
+  Dune only supports a subset of opam variables when translating opam files.
 # misc
   $ fail_solve misc
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "misc" is not supported.
+  Error: Cannot translate opam variable "misc".
+  Dune only supports a subset of opam variables when translating opam files.
 # _:misc
   $ fail_solve _:misc
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "misc" is not supported.
+  Error: Cannot translate opam variable "misc".
+  Dune only supports a subset of opam variables when translating opam files.
 # _:depends
   $ fail_solve _:depends
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "depends" is not supported.
+  Error: Cannot translate opam variable "depends".
+  Dune only supports a subset of opam variables when translating opam files.
 # _:build
   $ fail_solve _:build
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "build" is not supported.
+  Error: Cannot translate opam variable "build".
+  Dune only supports a subset of opam variables when translating opam files.
 # _:opamfile
   $ fail_solve _:opamfile
   File "$TESTCASE_ROOT/mock-opam-repository/packages/testpkg/testpkg.0.0.1/opam", line 1, characters 0-0:
-  Error: Variable "opamfile" is not supported.
+  Error: Cannot translate opam variable "opamfile".
+  Dune only supports a subset of opam variables when translating opam files.


### PR DESCRIPTION
Improves error messages for unsupported opam variables during opam-to-dune translation.

Instead of only saying a variable is “not supported,” Dune now explains that it cannot translate that opam variable and clarifies that only a subset of opam variables is currently supported. This gives users clearer context when errors point to generated/internal opam locations.

Includes updated blackbox test expectations for unsupported variable cases.

Fixes #13784