### PR TITLE
fix: improved mtime precision

### DIFF
--- a/doc/changes/changed/13962.md
+++ b/doc/changes/changed/13962.md
@@ -1,0 +1,2 @@
+- Improve mtime precision by no longer approximating them with floats (#13962,
+  @rgrinberg).

--- a/otherlibs/dune-rpc/registry.ml
+++ b/otherlibs/dune-rpc/registry.ml
@@ -110,7 +110,7 @@ end
 
 type nonrec t =
   { config : Config.t
-  ; mutable last_mtime : float option
+  ; mutable last_mtime : Stdune.Time.t option
   ; mutable current : Dune.t list
   }
 
@@ -144,7 +144,7 @@ module Poll
      end)
     (IO : sig
        val scandir : string -> (string list, exn) result Fiber.t
-       val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
+       val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
        val read_file : string -> (string, exn) result Fiber.t
      end) =
 struct

--- a/otherlibs/dune-rpc/registry.mli
+++ b/otherlibs/dune-rpc/registry.mli
@@ -60,7 +60,7 @@ module Poll
      end)
     (_ : sig
        val scandir : string -> (string list, exn) result Fiber.t
-       val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
+       val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
        val read_file : string -> (string, exn) result Fiber.t
      end) : sig
   val poll : t -> (Refresh.t, exn) result Fiber.t

--- a/otherlibs/dune-rpc/v1.mli
+++ b/otherlibs/dune-rpc/v1.mli
@@ -599,7 +599,7 @@ module Registry : sig
        end)
       (_ : sig
          val scandir : string -> (string list, exn) result Fiber.t
-         val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
+         val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
          val read_file : string -> (string, exn) result Fiber.t
        end) : sig
     val poll : t -> (Refresh.t, exn) result Fiber.t

--- a/otherlibs/stdune/src/stat.ml
+++ b/otherlibs/stdune/src/stat.ml
@@ -1,0 +1,10 @@
+type t =
+  { mtime : Time.t
+  ; size : int
+  ; perm : Unix.file_perm
+  ; kind : Unix.file_kind
+  ; dev : int
+  ; ino : int
+  }
+
+external stat : string -> t = "dune_stat"

--- a/otherlibs/stdune/src/stat.mli
+++ b/otherlibs/stdune/src/stat.mli
@@ -1,0 +1,10 @@
+type t =
+  { mtime : Time.t
+  ; size : int
+  ; perm : Unix.file_perm
+  ; kind : Unix.file_kind
+  ; dev : int
+  ; ino : int
+  }
+
+val stat : string -> t

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -74,6 +74,7 @@ module Pid = Pid
 module Applicative = Applicative
 module Json = Json
 module Log = Log
+module Stat = Stat
 module Time = Time
 module Escape0 = Escape
 module Debug = Debug

--- a/otherlibs/stdune/src/time.ml
+++ b/otherlibs/stdune/src/time.ml
@@ -3,6 +3,8 @@ type t = int
 external now : unit -> t = "dune_clock_gettime_realtime"
 
 let start = now ()
+let compare = Int.compare
+let max = Int.max
 let ns_per_sec = 1_000_000_000
 let ns_per_us = 1_000
 let ns_per_sec_float = float_of_int ns_per_sec

--- a/otherlibs/stdune/src/time.mli
+++ b/otherlibs/stdune/src/time.mli
@@ -2,6 +2,8 @@ type t
 
 val start : t
 val now : unit -> t
+val compare : t -> t -> Ordering.t
+val max : t -> t -> t
 val to_secs : t -> float
 val to_ns : t -> int
 val to_us : t -> int

--- a/otherlibs/stdune/src/time_stubs.c
+++ b/otherlibs/stdune/src/time_stubs.c
@@ -1,9 +1,108 @@
+#if defined(__APPLE__)
+#ifndef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE 1
+#endif
+#endif
+
+#if !defined(_WIN32) \
+    && !defined(__APPLE__) \
+    && !defined(__FreeBSD__) \
+    && !defined(__NetBSD__) \
+    && !defined(__OpenBSD__) \
+    && !defined(__DragonFly__)
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+#endif
+
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
+#include <caml/osdeps.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+
+#include <sys/stat.h>
 
 #include "dune_clock.h"
 
 CAMLprim value dune_clock_gettime_realtime(value v_unit) {
   (void)v_unit;
   return Val_long(dune_clock_gettime_ns());
+}
+
+#ifdef _WIN32
+typedef struct _stati64 dune_time_stat_buf;
+#else
+typedef struct stat dune_time_stat_buf;
+#endif
+
+static int64_t dune_time_stat_mtime_ns(const dune_time_stat_buf *stat)
+{
+#ifdef _WIN32
+  return ((int64_t) stat->st_mtime) * 1000000000LL;
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) \
+   || defined(__OpenBSD__) || defined(__DragonFly__)
+  return ((int64_t) stat->st_mtimespec.tv_sec * 1000000000LL)
+         + (int64_t) stat->st_mtimespec.tv_nsec;
+#elif defined(__HAIKU__)
+  return ((int64_t) stat->st_mtime) * 1000000000LL;
+#else
+  return ((int64_t) stat->st_mtim.tv_sec * 1000000000LL)
+         + (int64_t) stat->st_mtim.tv_nsec;
+#endif
+}
+
+static value dune_time_stat_file_kind(int mode)
+{
+#ifdef _WIN32
+  if ((mode & _S_IFMT) == _S_IFDIR) return Val_int(1);
+  if ((mode & _S_IFMT) == _S_IFCHR) return Val_int(2);
+  if ((mode & _S_IFMT) == _S_IFIFO) return Val_int(5);
+  return Val_int(0);
+#else
+  if (S_ISDIR(mode)) return Val_int(1);
+  if (S_ISCHR(mode)) return Val_int(2);
+#ifdef S_ISBLK
+  if (S_ISBLK(mode)) return Val_int(3);
+#endif
+#ifdef S_ISLNK
+  if (S_ISLNK(mode)) return Val_int(4);
+#endif
+  if (S_ISFIFO(mode)) return Val_int(5);
+#ifdef S_ISSOCK
+  if (S_ISSOCK(mode)) return Val_int(6);
+#endif
+  return Val_int(0);
+#endif
+}
+
+static value dune_time_alloc_stat(const dune_time_stat_buf *stat)
+{
+  CAMLparam0();
+  CAMLlocal1(v_stat);
+  v_stat = caml_alloc_small(6, 0);
+  Field(v_stat, 0) = Val_long(dune_time_stat_mtime_ns(stat));
+  Field(v_stat, 1) = Val_long(stat->st_size);
+  Field(v_stat, 2) = Val_long(stat->st_mode & 07777);
+  Field(v_stat, 3) = dune_time_stat_file_kind(stat->st_mode);
+  Field(v_stat, 4) = Val_long(stat->st_dev);
+  Field(v_stat, 5) = Val_long(stat->st_ino);
+  CAMLreturn(v_stat);
+}
+
+CAMLprim value dune_stat(value v_path) {
+  CAMLparam1(v_path);
+  caml_unix_check_path(v_path, "stat");
+  char_os *path = caml_stat_strdup_to_os(String_val(v_path));
+  dune_time_stat_buf statbuf;
+  int rc;
+  caml_release_runtime_system();
+  rc = stat_os(path, &statbuf);
+  caml_acquire_runtime_system();
+  caml_stat_free(path);
+  if (rc == -1) {
+    uerror("stat", v_path);
+  }
+  CAMLreturn(dune_time_alloc_stat(&statbuf));
 }

--- a/otherlibs/stdune/test/stat_tests.ml
+++ b/otherlibs/stdune/test/stat_tests.ml
@@ -1,0 +1,74 @@
+open Stdune
+open Dune_tests_common
+
+let () = init ()
+let stat path = Stat.stat (Path.to_string path)
+let print_bool name value = Printf.printf "%s: %b\n" name value
+let ordering_of_float x y = Ordering.of_int (Stdlib.Float.compare x y)
+
+let%expect_test "Stat.stat matches Unix.stat on stable fields" =
+  let dir = Temp.create Dir ~prefix:"stat" ~suffix:"test" in
+  let path = Path.relative dir "file" in
+  Io.write_file path "hello";
+  let stat = stat path in
+  let unix = Unix.stat (Path.to_string path) in
+  print_bool "size_matches" (Int.equal stat.size unix.st_size);
+  print_bool "perm_matches" (Int.equal stat.perm unix.st_perm);
+  print_bool "kind_matches" (File_kind.equal stat.kind unix.st_kind);
+  print_bool "mtime_is_positive" (Time.compare stat.mtime (Time.of_ns 0) = Gt);
+  [%expect
+    {|
+    size_matches: true
+    perm_matches: true
+    kind_matches: true
+    mtime_is_positive: true
+  |}]
+;;
+
+let%expect_test "Stat.stat observes mtime updates" =
+  let dir = Temp.create Dir ~prefix:"stat" ~suffix:"test" in
+  let path = Path.relative dir "file" in
+  Io.write_file path "hello";
+  let now = Unix.gettimeofday () +. 5.0 in
+  let later = now +. 2.0 in
+  Unix.utimes (Path.to_string path) now now;
+  let first = stat path in
+  Unix.utimes (Path.to_string path) later later;
+  let second = stat path in
+  print_bool "mtime_changed" (Time.compare first.mtime second.mtime <> Eq);
+  print_bool "mtime_increases" (Time.compare first.mtime second.mtime = Lt);
+  [%expect
+    {|
+    mtime_changed: true
+    mtime_increases: true
+  |}]
+;;
+
+let%expect_test "Stat.stat keeps same-second directory mtime changes seen by Unix.stat" =
+  let dir = Temp.create Dir ~prefix:"stat" ~suffix:"test" in
+  let path = Path.to_string dir in
+  let base = Stdlib.Float.floor (Unix.gettimeofday ()) +. 5.0 in
+  let first_mtime = base +. 0.25 in
+  let second_mtime = base +. 0.75 in
+  Unix.utimes path first_mtime first_mtime;
+  let first_unix = Unix.stat path in
+  let first = Stat.stat path in
+  Unix.utimes path second_mtime second_mtime;
+  let second_unix = Unix.stat path in
+  let second = Stat.stat path in
+  let unix_order = ordering_of_float first_unix.st_mtime second_unix.st_mtime in
+  let stat_order = Time.compare first.mtime second.mtime in
+  let unix_changed = not (Ordering.is_eq unix_order) in
+  print_bool
+    "does_not_drop_unix_mtime_changes"
+    ((not unix_changed) || not (Ordering.is_eq stat_order));
+  print_bool
+    "preserves_unix_mtime_ordering"
+    ((not unix_changed)
+     || Int.equal (Ordering.to_int unix_order) (Ordering.to_int stat_order));
+  [%expect
+    {|
+    does_not_drop_unix_mtime_changes: true
+    preserves_unix_mtime_ordering: true
+  |}]
+;;

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -254,10 +254,18 @@ module Stats_for_digest = struct
     ; executable : bool
     }
 
-  let of_unix_stats (stats : Unix.stats) =
+  let of_kind_and_perm ~st_kind ~perm =
     (* Check if any of the +x bits are set, ignore read and write *)
-    let executable = 0o111 land stats.st_perm <> 0 in
-    { st_kind = stats.st_kind; executable }
+    let executable = 0o111 land perm <> 0 in
+    { st_kind; executable }
+  ;;
+
+  let of_unix_stats (stats : Unix.stats) =
+    of_kind_and_perm ~st_kind:stats.st_kind ~perm:stats.st_perm
+  ;;
+
+  let of_time_stat (stats : Stat.t) =
+    of_kind_and_perm ~st_kind:stats.kind ~perm:stats.perm
   ;;
 end
 

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -74,6 +74,7 @@ module Stats_for_digest : sig
     }
 
   val of_unix_stats : Unix.stats -> t
+  val of_time_stat : Stat.t -> t
 end
 
 module Path_digest_error : sig

--- a/src/dune_digest/reduced_stats.ml
+++ b/src/dune_digest/reduced_stats.ml
@@ -1,22 +1,29 @@
 open Import
 
 type t =
-  { mtime : float
+  { mtime : Time.t
   ; size : int
   ; perm : Unix.file_perm
   }
 
 let to_dyn { mtime; size; perm } =
-  Dyn.Record [ "mtime", Float mtime; "size", Int size; "perm", Int perm ]
+  Dyn.Record [ "mtime", Int (Time.to_ns mtime); "size", Int size; "perm", Int perm ]
 ;;
 
 let of_unix_stats (stats : Unix.stats) =
-  { mtime = stats.st_mtime; size = stats.st_size; perm = stats.st_perm }
+  { mtime = Time.of_epoch_secs stats.st_mtime
+  ; size = stats.st_size
+  ; perm = stats.st_perm
+  }
+;;
+
+let of_time_stat (stats : Stat.t) =
+  { mtime = stats.mtime; size = stats.size; perm = stats.perm }
 ;;
 
 let compare { mtime; size; perm } t =
   let open Ordering.O in
-  let= () = Float.compare mtime t.mtime in
+  let= () = Time.compare mtime t.mtime in
   let= () = Int.compare size t.size in
   Int.compare perm t.perm
 ;;

--- a/src/dune_digest/reduced_stats.mli
+++ b/src/dune_digest/reduced_stats.mli
@@ -1,11 +1,12 @@
 (** The reduced set of file stats this module inspects to decide whether a file
     changed or not *)
 type t =
-  { mtime : float
+  { mtime : Stdune.Time.t
   ; size : int
   ; perm : Unix.file_perm
   }
 
 val to_dyn : t -> Dyn.t
 val of_unix_stats : Unix.stats -> t
+val of_time_stat : Stdune.Stat.t -> t
 val compare : t -> t -> Ordering.t

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -11,7 +11,7 @@ module Cached_digest = struct
 
   type t =
     { mutable checked_key : int
-    ; mutable max_timestamp : float
+    ; mutable max_timestamp : Time.t
     ; table : file Path.Table.t
     }
 
@@ -28,7 +28,7 @@ module Cached_digest = struct
   let to_dyn { checked_key; max_timestamp; table } =
     Dyn.Record
       [ "checked_key", Int checked_key
-      ; "max_timestamp", Float max_timestamp
+      ; "max_timestamp", Int (Time.to_ns max_timestamp)
       ; "table", Path.Table.to_dyn dyn_of_file table
       ]
   ;;
@@ -37,7 +37,7 @@ module Cached_digest = struct
       type nonrec t = t
 
       let name = "DIGEST-DB"
-      let version = 8
+      let version = 9
       let sharing = true
       let to_dyn = to_dyn
     end)
@@ -52,7 +52,8 @@ module Cached_digest = struct
   let cache =
     lazy
       (match P.load db_file with
-       | None -> { checked_key = 0; table = Path.Table.create (); max_timestamp = 0. }
+       | None ->
+         { checked_key = 0; table = Path.Table.create (); max_timestamp = Time.of_ns 0 }
        | Some cache ->
          cache.checked_key <- cache.checked_key + 1;
          cache)
@@ -61,7 +62,7 @@ module Cached_digest = struct
   let get_current_filesystem_time () =
     let special_path = Path.relative Path.build_dir ".filesystem-clock" in
     Io.write_file special_path "<dummy>";
-    (Unix.stat (Path.to_string special_path)).st_mtime
+    (Stat.stat (Path.to_string special_path)).mtime
   ;;
 
   let wait_for_fs_clock_to_advance () =
@@ -80,11 +81,11 @@ module Cached_digest = struct
     (* We can only trust digests with timestamps in the past. We had issues in
        the past with file systems having a slow internal clock, where we cached
        digests too aggressively. *)
-    match Float.compare cache.max_timestamp now with
+    match Time.compare cache.max_timestamp now with
     | Lt -> ()
     | Eq | Gt ->
       let filter (data : file) =
-        match Float.compare data.stats.mtime now with
+        match Time.compare data.stats.mtime now with
         | Lt -> true
         | Gt | Eq -> false
       in
@@ -124,8 +125,8 @@ module Cached_digest = struct
     delete_very_recent_entries ()
   ;;
 
-  let set_max_timestamp cache (stat : Unix.stats) =
-    cache.max_timestamp <- Float.max cache.max_timestamp stat.st_mtime
+  let set_max_timestamp cache (stat : Stat.t) =
+    cache.max_timestamp <- Time.max cache.max_timestamp stat.mtime
   ;;
 
   let set_with_stat path digest stat =
@@ -136,18 +137,20 @@ module Cached_digest = struct
       cache.table
       path
       { digest
-      ; stats = Dune_digest.Reduced_stats.of_unix_stats stat
+      ; stats = Dune_digest.Reduced_stats.of_time_stat stat
       ; stats_checked = cache.checked_key
       }
   ;;
 
   let digest_path_with_stats path stats =
     match
-      Digest.Stats_for_digest.of_unix_stats stats
-      |> Digest.path_with_stats ~allow_dirs:true path
+      Digest.path_with_stats
+        ~allow_dirs:true
+        path
+        (Digest.Stats_for_digest.of_time_stat stats)
     with
     | Ok digest -> Ok digest
-    | Error Unexpected_kind -> Error (Digest_result.Error.Unexpected_kind stats.st_kind)
+    | Error Unexpected_kind -> Error (Digest_result.Error.Unexpected_kind stats.kind)
     | Error (Unix_error (ENOENT, _, _)) -> Error No_such_file
     | Error (Unix_error other_error) -> Error (Unix_error other_error)
   ;;
@@ -163,12 +166,13 @@ module Cached_digest = struct
       result
     in
     fun path ->
+      let path_string = Path.to_string path in
       Digest_result.catch_fs_errors (fun () ->
-        match Unix.stat (Path.to_string path) with
+        match Stat.stat path_string with
         | stats -> refresh_sync stats path
         | exception Unix.Unix_error (ENOENT, _, _) ->
           (* Test if this is a broken symlink for better error messages. *)
-          (match Unix.lstat (Path.to_string path) with
+          (match Unix.lstat path_string with
            | exception Unix.Unix_error (ENOENT, _, _) -> Error No_such_file
            | _stats_so_must_be_a_symlink -> Error Broken_symlink))
   ;;
@@ -183,15 +187,16 @@ module Cached_digest = struct
          then Ok x.digest
          else (
            (* The [stat] below follows symlinks. *)
+           let path_string = Path.to_string path in
            match
              Dune_digest.Digest_result.catch_fs_errors (fun () ->
-               match Unix.stat (Path.to_string path) with
+               match Stat.stat path_string with
                | exception Unix.Unix_error (ENOENT, _, _) -> Error No_such_file
                | stats -> Ok stats)
            with
            | Error e -> Error e
            | Ok stats ->
-             let reduced_stats = Dune_digest.Reduced_stats.of_unix_stats stats in
+             let reduced_stats = Dune_digest.Reduced_stats.of_time_stat stats in
              (match Dune_digest.Reduced_stats.compare x.stats reduced_stats with
               | Eq ->
                 (* Even though we're modifying the [stats_checked] field, we don't

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -172,8 +172,8 @@ let snapshot t =
         Path.Map.add_exn acc path `Dir)
       ~on_file:(fun ~dir fname acc ->
         let p = Path.relative root (Filename.concat dir fname) in
-        let stats = Unix.stat (Path.to_string p) in
-        Path.Map.add_exn acc p (`File (Dune_digest.Reduced_stats.of_unix_stats stats)))
+        let stats = Stat.stat (Path.to_string p) in
+        Path.Map.add_exn acc p (`File (Dune_digest.Reduced_stats.of_time_stat stats)))
       ~on_other:`Ignore
       ~on_symlink:`Ignore
       ()

--- a/src/dune_rpc_impl/dune_rpc_impl.ml
+++ b/src/dune_rpc_impl/dune_rpc_impl.ml
@@ -26,9 +26,9 @@ module Poll_active =
 
       let stat s =
         Fiber.return
-          (match Unix.stat s with
+          (match Stdune.Stat.stat s with
            | exception exn -> Error exn
-           | s -> Ok (`Mtime s.st_mtime))
+           | stat -> Ok (`Mtime stat.mtime))
       ;;
 
       let read_file s =

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -217,7 +217,7 @@ module Event : sig
       -> new_stats:Dyn.t
       -> t
 
-    val dropped_stale_mtimes : Path.t list -> fs_now:float -> t
+    val dropped_stale_mtimes : Path.t list -> fs_now:Time.t -> t
   end
 
   val debug : (string * Dyn.t) list -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -729,7 +729,7 @@ module Digest = struct
   let dropped_stale_mtimes paths ~fs_now =
     let now = Time.now () in
     let args =
-      [ "fs_now", Arg.float fs_now; "paths", Arg.list (List.map paths ~f:Arg.path) ]
+      [ "fs_now", Arg.time fs_now; "paths", Arg.list (List.map paths ~f:Arg.path) ]
     in
     Event.instant ~args ~name:"dropped_stale_mtimes" now Digest
   ;;


### PR DESCRIPTION
On linux, precision can be up to a nanosecond. Unfortunately, ocaml's unix bindings approximate it by turning it to a float.

Let's write our own bindings and use our typed time to boot.