### PR TITLE
test(path): more tests with differing workspace and build dir

### DIFF
--- a/otherlibs/stdune/test/dune
+++ b/otherlibs/stdune/test/dune
@@ -1,5 +1,6 @@
 (library
  (name stdune_unit_tests)
+ (modules :standard \ path_external_build_tests)
  (inline_tests
   (deps
    (source_tree ../unit-tests/findlib-db)
@@ -16,3 +17,22 @@
   ppx_inline_test.config)
  (preprocess
   (pps ppx_expect)))
+
+(library
+ (name stdune_external_build_tests)
+ (modules path_external_build_tests)
+ (inline_tests)
+ (libraries
+  stdune
+  unix
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))
+
+(alias
+ (name runtest-windows)
+ (deps
+  (alias runtest-stdune_external_build_tests)))

--- a/otherlibs/stdune/test/path_external_build_tests.ml
+++ b/otherlibs/stdune/test/path_external_build_tests.ml
@@ -1,0 +1,82 @@
+open Stdune
+
+(* Tests for path operations when the build directory is an external (absolute)
+   path. The existing stdune_unit_tests set build dir to "_build" (In_source_dir),
+   so the [External b] branch of [Build.to_string] and cross-tree [reach] are
+   never exercised there. This library has its own init because [set_root] and
+   [Build.set_build_dir] can only be called once per process.
+
+   CR-someday Alizter: After the fix to use [External.append_local] instead of
+   [Filename.concat], the conditional Windows expectations can be consolidated
+   with the Unix ones. *)
+
+let check_on_win_or_unix output ~wind ~unix =
+  let expected = String.trim (if Sys.win32 then wind else unix) in
+  let output = String.trim output in
+  if not (String.equal output expected)
+  then
+    Code_error.raise
+      "output mismatch"
+      [ "expected", String expected; "got", String output ]
+;;
+
+let () =
+  Printexc.record_backtrace false;
+  Path.set_root (Path.External.of_string "/workspace");
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string "/external-build")
+;;
+
+let%expect_test "Build.to_string root" =
+  Path.Build.to_string Path.Build.root |> print_endline;
+  [%expect {| /external-build |}]
+;;
+
+let%expect_test "Build.to_string relative" =
+  Path.Build.to_string (Path.Build.relative Path.Build.root "foo/bar") |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /external-build\foo/bar |}
+    ~unix:{| /external-build/foo/bar |}
+;;
+
+let%expect_test "to_absolute_filename source path" =
+  Path.to_absolute_filename (Path.relative Path.root "src/main.ml") |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /workspace\src/main.ml |}
+    ~unix:{| /workspace/src/main.ml |}
+;;
+
+let%expect_test "to_absolute_filename build path" =
+  Path.to_absolute_filename (Path.relative Path.build_dir "foo/bar") |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /external-build\foo/bar |}
+    ~unix:{| /external-build/foo/bar |}
+;;
+
+let%expect_test "reach build from source" =
+  Path.reach (Path.relative Path.build_dir "foo") ~from:Path.root |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /external-build\foo |}
+    ~unix:{| /external-build/foo |}
+;;
+
+let%expect_test "reach source from build" =
+  Path.reach (Path.relative Path.root "src") ~from:(Path.relative Path.build_dir "foo")
+  |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /workspace\src |}
+    ~unix:{| /workspace/src |}
+;;
+
+let%expect_test "reach_for_running build from source" =
+  Path.reach_for_running (Path.relative Path.build_dir "foo/bar") ~from:Path.root
+  |> print_endline;
+  check_on_win_or_unix
+    [%expect.output]
+    ~wind:{| /external-build\foo/bar |}
+    ~unix:{| /external-build/foo/bar |}
+;;

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -11,6 +11,18 @@ let of_filename_relative_to_initial_cwd s =
   Path.of_filename_relative_to_initial_cwd s |> Path.to_dyn |> print_dyn
 ;;
 
+let external_relative a b =
+  Path.External.relative (Path.External.of_string a) b
+  |> Path.External.to_string
+  |> print_endline
+;;
+
+let external_append_local a b =
+  Path.External.append_local (Path.External.of_string a) b
+  |> Path.External.to_string
+  |> print_endline
+;;
+
 let descendant p ~of_ = Dyn.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
 let is_descendant p ~of_ = Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
 
@@ -642,4 +654,54 @@ let%expect_test "drop prefix with a trailing /" =
   |> Dyn.option Path.Local.to_dyn
   |> print_dyn;
   [%expect {| Some "d/e" |}]
+;;
+
+let%expect_test "external relative plain" =
+  external_relative "/root" "foo/bar";
+  [%expect {| /root/foo/bar |}]
+;;
+
+let%expect_test "external relative dot-slash multi" =
+  external_relative "/root" "./foo/bar";
+  [%expect {| /root/./foo/bar |}]
+;;
+
+let%expect_test "external relative dot" =
+  external_relative "/root" ".";
+  [%expect {| /root |}]
+;;
+
+let%expect_test "external relative single" =
+  external_relative "/root" "foo";
+  [%expect {| /root/foo |}]
+;;
+
+let%expect_test "external relative deep" =
+  external_relative "/root/sub" "foo/bar/baz";
+  [%expect {| /root/sub/foo/bar/baz |}]
+;;
+
+let%expect_test "external relative dot-slash single" =
+  external_relative "/root" "./foo";
+  [%expect {| /root/./foo |}]
+;;
+
+let%expect_test "external append_local multi" =
+  external_append_local "/root" (Path.Local.of_string "foo/bar");
+  [%expect {| /root/foo/bar |}]
+;;
+
+let%expect_test "external append_local root" =
+  external_append_local "/root" Path.Local.root;
+  [%expect {| /root |}]
+;;
+
+let%expect_test "path relative external dot-slash" =
+  relative (Path.of_string "/ext") "./foo/bar";
+  [%expect {| External "/ext/./foo/bar" |}]
+;;
+
+let%expect_test "path relative external plain" =
+  relative (Path.of_string "/ext") "foo";
+  [%expect {| External "/ext/foo" |}]
 ;;


### PR DESCRIPTION
These tests exercise some untested parts of `path.ml` whilst keeping cross-platformity. I intend to change how paths are handled on Windows which will mean these will be the same accross platforms.

These expect tests are run on unix and windows.