### PR TITLE
chore(ci): Build OxCaml development branch

### DIFF
--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -1,0 +1,85 @@
+# The revdeps workflow checks that released versions of reverse dependencies
+# still build correctly. This workflow instead checks that the development
+# versions of critical reverse dependencies work with the development version
+# of Dune. Currently, it only covers OxCaml.
+name: Revdeps development build
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  EXTRA_NIX_CONFIG: |
+    extra-substituters = https://anmonteiro.nix-cache.workers.dev
+    extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: OxCaml Trunk
+            repo: oxcaml/oxcaml
+            repo_name: oxcaml
+            ref: main
+            build_command: >-
+              autoconf &&
+              ./configure --prefix $PWD/_install --enable-dev --enable-runtime5 &&
+              make
+            apt_deps: autoconf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Dune
+        uses: actions/checkout@v6
+
+      - name: Set up Nix
+        uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 2G
+
+      - name: Build Dune
+        run: |
+          # OxCaml requires Dune version >= 3.13. When Dune is built from source
+          # with Nix, it doesn't report the correct version. This step sets the
+          # version explicitly so that OxCaml's version check passes.
+          version=$(sed -n 's/(lang dune \(.*\))/\1.0/p' dune-project)
+          sed -i "1a (version $version)" dune-project
+          nix develop -c make dev
+
+      - name: Install system dependencies
+        if: matrix.apt_deps != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt_deps }}
+
+      - name: Create workspace
+        run: mkdir workspace
+
+      - name: Clone ${{ matrix.repo }}
+        working-directory: workspace
+        run: |
+          git clone --depth 1 --branch ${{ matrix.ref }} \
+          https://github.com/${{ matrix.repo }}.git
+
+      - name: Build ${{ matrix.name }}
+        working-directory: workspace/${{ matrix.repo_name }}
+        run: |
+          nix develop $GITHUB_WORKSPACE#ox-trunk -c bash -c '
+            export PATH="$GITHUB_WORKSPACE/_build/install/default/bin:$PATH"
+            echo "Using dune: $(which dune)"
+            dune --version
+            ${{ matrix.build_command }}
+          '

--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -53,9 +53,9 @@ jobs:
           # OxCaml requires Dune version >= 3.13. When Dune is built from source
           # with Nix, it doesn't report the correct version. This step sets the
           # version explicitly so that OxCaml's version check passes.
-          version=$(sed -n 's/(lang dune \(.*\))/\1.0/p' dune-project)
+          version=$(grep -oP '\(lang dune \K[^)]+' dune-project)
           # Add a version if it doesn't exist.
-          grep -q '^(version' dune-project || echo "(version $version)" >> dune-project
+          grep -q '^(version' dune-project || echo "(version $version.0)" >> dune-project
           nix develop -c make dev
 
       - name: Create workspace

--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -6,7 +6,6 @@ name: Revdeps development build
 
 on:
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -6,6 +6,9 @@ name: Revdeps development build
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - '*-rc'
 
 permissions:
   contents: read

--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -20,7 +20,6 @@ jobs:
   build:
     name: ${{ matrix.name }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - name: OxCaml Trunk
@@ -31,7 +30,6 @@ jobs:
               autoconf &&
               ./configure --prefix $PWD/_install --enable-dev --enable-runtime5 &&
               make
-            apt_deps: autoconf
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dune
@@ -56,23 +54,20 @@ jobs:
           # with Nix, it doesn't report the correct version. This step sets the
           # version explicitly so that OxCaml's version check passes.
           version=$(sed -n 's/(lang dune \(.*\))/\1.0/p' dune-project)
-          sed -i "1a (version $version)" dune-project
+          # Add a version if it doesn't exist.
+          grep -q '^(version' dune-project || echo "(version $version)" >> dune-project
           nix develop -c make dev
-
-      - name: Install system dependencies
-        if: matrix.apt_deps != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.apt_deps }}
 
       - name: Create workspace
         run: mkdir workspace
 
       - name: Clone ${{ matrix.repo }}
-        working-directory: workspace
-        run: |
-          git clone --depth 1 --branch ${{ matrix.ref }} \
-          https://github.com/${{ matrix.repo }}.git
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.repo }}
+          ref: ${{ matrix.ref }}
+          path: workspace/${{ matrix.repo_name }}
+          fetch-depth: 1
 
       - name: Build ${{ matrix.name }}
         working-directory: workspace/${{ matrix.repo_name }}

--- a/flake.lock
+++ b/flake.lock
@@ -62,6 +62,25 @@
         "type": "github"
       }
     },
+    "menhir-src": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.inria.fr",
+        "lastModified": 1704030991,
+        "narHash": "sha256-veB0ORHp6jdRwCyDDAfc7a7ov8sOeHUmiELdOFf/QYk=",
+        "owner": "fpottier",
+        "repo": "menhir",
+        "rev": "d3d815e4f554da68b8c247241c8f8678926eecaa",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.inria.fr",
+        "owner": "fpottier",
+        "ref": "20231231",
+        "repo": "menhir",
+        "type": "gitlab"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -248,6 +267,7 @@
     "root": {
       "inputs": {
         "melange": "melange",
+        "menhir-src": "menhir-src",
         "nixpkgs": "nixpkgs",
         "nixpkgs-old": "nixpkgs-old",
         "ocaml-overlays": "ocaml-overlays",

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
       oxcaml,
       oxcaml-opam-repository,
       revdeps-dune,
-      menhir-src
+      menhir-src,
     }:
     let
       forAllSystems =
@@ -545,22 +545,30 @@
                 oself: osuper: {
                   menhirLib = osuper.menhirLib.overrideAttrs (old: {
                     version = "20231231";
-                    src = menhirSrc;
+                    src = menhir-src;
                     patches = [ ];
                   });
                   menhirGLR = null;
                   menhir = osuper.menhir.overrideAttrs (old: {
                     version = "20231231";
-                    src = menhirSrc;
+                    src = menhir-src;
                     patches = [ ];
                     buildInputs = builtins.filter (x: x != null) (old.buildInputs or [ ]);
+                    postInstall = (old.postInstall or "") + ''
+                      mkdir -p $out/lib/menhirLib
+                      cp ${oself.menhirLib}/lib/ocaml/*/site-lib/menhirLib/menhirLib.{ml,mli} $out/lib/menhirLib/
+                    '';
                   });
                 }
               );
             in
-            makeDuneDevShell {
-              includeTestDeps = false;
-              extraBuildInputs = _pkgs: [
+            pkgs.mkShell {
+              inherit INSIDE_NIX;
+              shellHook = ''
+                export DUNE_SOURCE_ROOT=$PWD
+              '';
+              inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
+              nativeBuildInputs = [
                 pkgs.autoconf
                 customOcamlPackages.menhir
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,10 @@
       inputs.oxcaml-opam-repository.follows = "oxcaml-opam-repository";
       inputs.revdeps-dune.follows = "revdeps-dune";
     };
+    menhir-src = {
+      url = "gitlab:fpottier/menhir/20231231?host=gitlab.inria.fr";
+      flake = false;
+    };
   };
   outputs =
     {
@@ -44,6 +48,7 @@
       oxcaml,
       oxcaml-opam-repository,
       revdeps-dune,
+      menhir-src
     }:
     let
       forAllSystems =
@@ -536,13 +541,6 @@
 
           ox-trunk =
             let
-              menhirSrc = pkgs.fetchFromGitLab {
-                domain = "gitlab.inria.fr";
-                owner = "fpottier";
-                repo = "menhir";
-                rev = "20231231";
-                sha256 = "sha256-veB0ORHp6jdRwCyDDAfc7a7ov8sOeHUmiELdOFf/QYk=";
-              };
               customOcamlPackages = pkgs.ocamlPackages.overrideScope (
                 oself: osuper: {
                   menhirLib = osuper.menhirLib.overrideAttrs (old: {

--- a/flake.nix
+++ b/flake.nix
@@ -144,22 +144,17 @@
           lib = pkgs.lib;
           dune-source = lib.cleanSourceWith {
             src = ./.;
-            filter =
-              pkgs.nix-gitignore.gitignoreFilterPure
-                (_: _: true)
-                [
-                  ".git"
-                  ./.gitignore
-                ]
-                ./.;
+            filter = pkgs.nix-gitignore.gitignoreFilterPure (_: _: true) [
+              ".git"
+              ./.gitignore
+            ] ./.;
           };
           dune-build-files =
             let
               fs = lib.fileset;
             in
-            fs.intersection
-              (fs.fromSource dune-source)
-              (fs.unions [
+            fs.intersection (fs.fromSource dune-source) (
+              fs.unions [
                 ./bin
                 ./boot
                 ./configure
@@ -170,10 +165,9 @@
                 ./vendor
                 ./otherlibs
                 ./Makefile
-                (fs.fileFilter
-                  (file: file.hasExt "opam" || file.hasExt "template")
-                  ./.)
-              ]);
+                (fs.fileFilter (file: file.hasExt "opam" || file.hasExt "template") ./.)
+              ]
+            );
           dune-static-overlay = self: super: {
             ocamlPackages = super.ocaml-ng.ocamlPackages_5_4.overrideScope (
               oself: osuper: {
@@ -357,18 +351,18 @@
 
               baseInputs =
                 if includeTestDeps then
-                  (builtins.filter
-                    (p: !builtins.elem (p.pname or p.name or "") excludeTestNativeBuildInputs)
-                    (testNativeBuildInputs pkgs')
-                  ) ++ docInputs
+                  (builtins.filter (p: !builtins.elem (p.pname or p.name or "") excludeTestNativeBuildInputs) (
+                    testNativeBuildInputs pkgs'
+                  ))
+                  ++ docInputs
                 else
-                  [];
+                  [ ];
 
               ocamlLibs =
                 if includeTestDeps then
-                  builtins.filter
-                    (p: !builtins.elem (p.pname or p.name or "") excludeOcamlLibs)
-                    (with pkgs'.ocamlPackages; [
+                  builtins.filter (p: !builtins.elem (p.pname or p.name or "") excludeOcamlLibs) (
+                    with pkgs'.ocamlPackages;
+                    [
                       ctypes
                       cinaps
                       integers
@@ -385,7 +379,8 @@
                       re
                       spawn
                       uutf
-                    ])
+                    ]
+                  )
                 else
                   [ ];
             in
@@ -525,9 +520,66 @@
             '';
           };
 
+          ox-minimal = makeDuneDevShell {
+            includeTestDeps = false;
+            packageOverrides =
+              oself: osuper:
+              (oxPackageSet oself osuper)
+              // {
+                ocaml = oxcamlCompiler;
+              };
+            meta.description = ''
+              Provides a minimal shell environment with OxCaml in order to
+              run the OxCaml tests.
+            '';
+          };
+
+          ox-trunk =
+            let
+              menhirSrc = pkgs.fetchFromGitLab {
+                domain = "gitlab.inria.fr";
+                owner = "fpottier";
+                repo = "menhir";
+                rev = "20231231";
+                sha256 = "sha256-veB0ORHp6jdRwCyDDAfc7a7ov8sOeHUmiELdOFf/QYk=";
+              };
+              customOcamlPackages = pkgs.ocamlPackages.overrideScope (
+                oself: osuper: {
+                  menhirLib = osuper.menhirLib.overrideAttrs (old: {
+                    version = "20231231";
+                    src = menhirSrc;
+                    patches = [ ];
+                  });
+                  menhirGLR = null;
+                  menhir = osuper.menhir.overrideAttrs (old: {
+                    version = "20231231";
+                    src = menhirSrc;
+                    patches = [ ];
+                    buildInputs = builtins.filter (x: x != null) (old.buildInputs or [ ]);
+                  });
+                }
+              );
+            in
+            makeDuneDevShell {
+              includeTestDeps = false;
+              extraBuildInputs = _pkgs: [
+                pkgs.autoconf
+                customOcamlPackages.menhir
+              ];
+              meta.description = ''
+                Provides a shell environment with upstream OCaml and menhir 20231231
+                for building the OxCaml trunk.
+              '';
+            };
           ox = makeDuneDevShell {
             excludeTestNativeBuildInputs = [ "opam" ];
-            excludeOcamlLibs = [ "mdx" "merlin" "ocaml-index" "ocaml-lsp-server" "odoc" ];
+            excludeOcamlLibs = [
+              "mdx"
+              "merlin"
+              "ocaml-index"
+              "ocaml-lsp-server"
+              "odoc"
+            ];
             packageOverrides =
               oself: osuper:
               (oxPackageSet oself osuper)


### PR DESCRIPTION
Fixes #13895.

Adds a workflow to test the build of OxCaml development branch, to catch any issues like #13889 early. Uses nix for faster builds. The workflow itself is more generic, such that any other critical rev deps can be added to the same workflow to test development builds.

Currently runs on `pull_request` for testing. We may only need to run this as part of release readiness later on.