### PR TITLE
rpc: clarify error when another dune instance is running

### DIFF
--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -2,10 +2,19 @@ open Import
 module Client = Dune_rpc_client.Client
 module Rpc_error = Dune_rpc.Response.Error
 
-let active_server () =
+let no_running_server_error ~lock_held_by =
+  match lock_held_by with
+  | Global_lock.Lock_held_by.Unknown ->
+    User_error.make [ Pp.paragraph "RPC server not running." ]
+  | Global_lock.Lock_held_by.Pid_from_lockfile _ ->
+    User_error.make
+      [ Pp.paragraph "Another Dune instance is currently running. Aborting..." ]
+;;
+
+let active_server ?(lock_held_by = Global_lock.Lock_held_by.Unknown) () =
   match Dune_rpc_impl.Where.get () with
   | Some p -> Ok p
-  | None -> Error (User_error.make [ Pp.paragraph "RPC server not running." ])
+  | None -> Error (no_running_server_error ~lock_held_by)
 ;;
 
 let active_server_exn () = active_server () |> User_error.ok_exn
@@ -63,15 +72,10 @@ let wait_term =
   Arg.(value & flag & info [ "wait" ] ~doc:(Some doc))
 ;;
 
-let establish_connection () =
-  match active_server () with
+let establish_connection ?(lock_held_by = Global_lock.Lock_held_by.Unknown) () =
+  match active_server ~lock_held_by () with
   | Error e -> Fiber.return (Error e)
   | Ok where -> Client.Connection.connect where
-;;
-
-let establish_connection_exn () =
-  let open Fiber.O in
-  establish_connection () >>| User_error.ok_exn
 ;;
 
 let establish_connection_with_retry () =
@@ -88,8 +92,11 @@ let establish_connection_with_retry () =
   loop ()
 ;;
 
-let establish_client_session ~wait =
-  if wait then establish_connection_with_retry () else establish_connection_exn ()
+let establish_client_session ~wait ~lock_held_by =
+  let open Fiber.O in
+  if wait
+  then establish_connection_with_retry ()
+  else establish_connection ~lock_held_by () >>| User_error.ok_exn
 ;;
 
 let prepare_targets targets =
@@ -132,7 +139,7 @@ let fire_request
       arg
   =
   let open Fiber.O in
-  let* connection = establish_client_session ~wait in
+  let* connection = establish_client_session ~wait ~lock_held_by in
   if should_warn ~warn_forwarding builder then warn_ignore_arguments lock_held_by;
   send_request connection name ~f:(fun client -> request_exn client request arg)
 ;;
@@ -147,7 +154,7 @@ let fire_notification
       arg
   =
   let open Fiber.O in
-  let* connection = establish_client_session ~wait in
+  let* connection = establish_client_session ~wait ~lock_held_by in
   if should_warn ~warn_forwarding builder then warn_ignore_arguments lock_held_by;
   send_request connection name ~f:(fun client -> notify_exn client notification arg)
 ;;

--- a/bin/rpc/rpc_common.ml
+++ b/bin/rpc/rpc_common.ml
@@ -2,11 +2,11 @@ open Import
 module Client = Dune_rpc_client.Client
 module Rpc_error = Dune_rpc.Response.Error
 
-let no_running_server_error ~lock_held_by =
+let no_running_server_error (lock_held_by : Global_lock.Lock_held_by.t) =
   match lock_held_by with
   | Global_lock.Lock_held_by.Unknown ->
     User_error.make [ Pp.paragraph "RPC server not running." ]
-  | Global_lock.Lock_held_by.Pid_from_lockfile _ ->
+  | Pid_from_lockfile _ ->
     User_error.make
       [ Pp.paragraph "Another Dune instance is currently running. Aborting..." ]
 ;;
@@ -14,7 +14,7 @@ let no_running_server_error ~lock_held_by =
 let active_server ?(lock_held_by = Global_lock.Lock_held_by.Unknown) () =
   match Dune_rpc_impl.Where.get () with
   | Some p -> Ok p
-  | None -> Error (no_running_server_error ~lock_held_by)
+  | None -> Error (no_running_server_error lock_held_by)
 ;;
 
 let active_server_exn () = active_server () |> User_error.ok_exn

--- a/test/blackbox-tests/test-cases/cram/custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/cram/custom-build-dir.t
@@ -15,7 +15,7 @@ path
   @@ -1,2 +1,4 @@
      $ echo "  $ echo bar" >bar.t
      $ dune runtest
-  +  Error: RPC server not running.
+  +  Error: Another Dune instance is currently running. Aborting...
   +  [1]
   Promoting
     $TESTCASE_ROOT/tmp/default/foo.t.corrected
@@ -24,5 +24,5 @@ path
   $ cat foo.t
     $ echo "  $ echo bar" >bar.t
     $ dune runtest
-    Error: RPC server not running.
+    Error: Another Dune instance is currently running. Aborting...
     [1]


### PR DESCRIPTION
## Summary
- improve forwarded-command error when another dune instance holds the global lock but RPC endpoint is unavailable
- emit a clearer user-facing message: "Another Dune instance is currently running. Aborting..."
- keep behavior deterministic (no pid in message) for stable cram expectations
- update cram test expectation in custom-build-dir case

## Validation
- opam exec -- ./dune.exe runtest test/blackbox-tests/test-cases/cram/custom-build-dir.t

Fixes #13902 
