### PR TITLE
fix: use regular stat for patch back

### DIFF
--- a/doc/changes/fixed/13986.md
+++ b/doc/changes/fixed/13986.md
@@ -1,0 +1,1 @@
+- Use all stat attributes to detect patch back source tree changes (#13986, @rgrinberg)

--- a/otherlibs/stdune/src/stat.ml
+++ b/otherlibs/stdune/src/stat.ml
@@ -7,4 +7,6 @@ type t =
   ; ino : int
   }
 
+let compare = Poly.compare
+
 external stat : string -> t = "dune_stat"

--- a/otherlibs/stdune/src/stat.mli
+++ b/otherlibs/stdune/src/stat.mli
@@ -7,4 +7,5 @@ type t =
   ; ino : int
   }
 
+val compare : t -> t -> Ordering.t
 val stat : string -> t

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -42,10 +42,7 @@ let init =
   fun () -> Lazy.force init
 ;;
 
-(* Snapshot used to detect modifications. We use the same algorithm as
-   [Cached_digest] given that we are trying to detect the same kind of
-   changes. *)
-type snapshot = [ `Dir | `File of Dune_digest.Reduced_stats.t ] Path.Map.t
+type snapshot = [ `Dir | `File of Stat.t ] Path.Map.t
 
 type t =
   { dir : Path.Build.t
@@ -173,7 +170,7 @@ let snapshot t =
       ~on_file:(fun ~dir fname acc ->
         let p = Path.relative root (Filename.concat dir fname) in
         let stats = Stat.stat (Path.to_string p) in
-        Path.Map.add_exn acc p (`File (Dune_digest.Reduced_stats.of_time_stat stats)))
+        Path.Map.add_exn acc p (`File stats))
       ~on_other:`Ignore
       ~on_symlink:`Ignore
       ()
@@ -346,7 +343,7 @@ let register_snapshot_promotion t (targets : Targets.Validated.t) ~old_snapshot 
           ()
         | Some `Dir, Some (`File _) -> add_copy_file p
         | Some (`File before), Some (`File after) ->
-          (match Dune_digest.Reduced_stats.compare before after with
+          (match Stat.compare before after with
            | Eq -> ()
            | Lt | Gt -> add_copy_file p)))
   in


### PR DESCRIPTION
We don't use stat in the _build directory, so there's no need to match anything