### PR TITLE
feat(sandbox): hardlinking on Windows

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -455,7 +455,7 @@ let shared_with_config_file ~allow_pkg_flag =
           ~doc:(Some doc))
   and+ sandboxing_preference =
     let all =
-      List.map Dune_engine.Sandbox_mode.all_except_patch_back_source_tree ~f:(fun s ->
+      List.map Dune_engine.Sandbox_mode.cli_options ~f:(fun s ->
         Dune_engine.Sandbox_mode.to_string s, s)
     in
     Arg.(

--- a/doc/changes/added/13987.md
+++ b/doc/changes/added/13987.md
@@ -1,0 +1,1 @@
+- Support hardlink sandboxing on Windows. (#13987, fixes #4362, @Alizter)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -248,7 +248,16 @@ end = struct
       let evaluate_sandboxing_preference preference =
         match Sandbox_mode.Set.mem config preference with
         | false -> None
-        | true -> Some preference
+        | true ->
+          if Sys.win32 && preference = Some Sandbox_mode.Symlink
+          then
+            User_error.raise
+              ~loc
+              [ Pp.text
+                  "Sandboxing mode symlink is not supported on Windows. Use copy or \
+                   hardlink instead."
+              ]
+          else Some preference
       in
       (match List.find_map sandboxing_preference ~f:evaluate_sandboxing_preference with
        | Some choice -> choice

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -114,13 +114,11 @@ let create_dirs t ~dirs ~rule_dir =
 let link_function ~(mode : Sandbox_mode.some) =
   let win32_error mode =
     let mode = Sandbox_mode.to_string (Some mode) in
-    Code_error.raise
-      (sprintf
-         "Don't have %ss on win32, but [%s] sandboxing mode was selected. To use  \
-          emulation via copy, the [copy] sandboxing mode should be selected."
-         mode
-         mode)
-      []
+    User_error.raise
+      [ Pp.textf
+          "Sandboxing mode %s is not supported on Windows. Use copy or hardlink instead."
+          mode
+      ]
   in
   Staged.stage
     (match mode with
@@ -129,10 +127,7 @@ let link_function ~(mode : Sandbox_mode.some) =
         | true -> win32_error mode
         | false -> fun src dst -> Io.portable_symlink ~src ~dst)
      | Copy -> fun src dst -> copy_recursively ~src ~dst
-     | Hardlink ->
-       (match Sys.win32 with
-        | true -> win32_error mode
-        | false -> fun src dst -> Io.portable_hardlink ~src ~dst)
+     | Hardlink -> fun src dst -> Io.portable_hardlink ~src ~dst
      | Patch_back_source_tree ->
        (* We need to let the action modify its dependencies, so we copy
           dependencies and make them writable. *)

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -106,12 +106,17 @@ module Set = struct
   let is_patch_back_source_tree_only t = t = patch_back_source_tree_only
 end
 
+(* All user-facing modes, excluding patch_back_source_tree. Includes symlink
+   on all platforms so that Windows users get a clear error message. *)
+let cli_options = [ None; Some Symlink; Some Copy; Some Hardlink ]
+
 (* The order of sandboxing modes in this list determines the order in which Dune
-   will try to use them when satisfying sandboxing constraints. *)
+   will try to use them when satisfying sandboxing constraints. On Windows,
+   symlink is excluded since it is not supported. *)
 let all_except_patch_back_source_tree =
   if Sys.win32
-  then [ None; Some Copy; Some Symlink; Some Hardlink ]
-  else [ None; Some Symlink; Some Copy; Some Hardlink ]
+  then List.filter cli_options ~f:(fun m -> m <> Some Symlink)
+  else cli_options
 ;;
 
 let all = all_except_patch_back_source_tree @ [ Some Patch_back_source_tree ]

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -75,6 +75,10 @@ end
     choice. Also, we want to get rid of this mode eventually. *)
 val all_except_patch_back_source_tree : t list
 
+(** All modes available in the CLI. Includes symlink on all platforms so that
+    users get a clear error message on Windows instead of "invalid value". *)
+val cli_options : t list
+
 val all : t list
 val none : t
 val symlink : t

--- a/test/blackbox-tests/test-cases/sandbox/dune
+++ b/test/blackbox-tests/test-cases/sandbox/dune
@@ -1,3 +1,20 @@
+; Tests that pass on Windows
+
+(cram
+ (applies_to sandboxing sandbox-events corrections-directory-deps)
+ (alias runtest-windows))
+
+(cram
+ (applies_to sandbox-symlink-windows)
+ (enabled_if
+  (= %{os_type} Win32))
+ (alias runtest-windows))
+
+; Tests disabled on Windows:
+; sandbox-chdir: path prefix handling differences
+; sandboxing-stale-directory-target: path prefix handling differences
+; patch-back-source-tree-include: Windows does not enforce read-only permissions
+
 (cram
  (applies_to sandboxing-stale-directory-target)
  (deps %{bin:bash}))

--- a/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows.t
@@ -1,0 +1,17 @@
+Symlink sandboxing is not supported on Windows. Attempting to use it should
+produce a user-facing error.
+
+  $ make_dune_project 3.0
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (target a)
+  >  (deps (sandbox always))
+  >  (action (with-stdout-to a (echo "hello"))))
+  > EOF
+
+  $ dune build a --sandbox symlink
+  File ".dune/_unknown_", line 1, characters 0-0:
+  Error: Sandboxing mode symlink is not supported on Windows. Use copy or
+  hardlink instead.
+  [1]

--- a/test/blackbox-tests/test-cases/sandbox/sandboxing.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandboxing.t
@@ -7,8 +7,7 @@ build. Dune fails to detect that:
   $ echo '(rule (target b) (deps) (action (bash "echo b | dune_cmd tee a > b")))' >> dune
   $ echo '(rule (target c) (deps a b) (action (bash "cat a b > c")))' >> dune
   $ dune build c
-  $ cat _build/default/c
-  b
+  $ tail -1 _build/default/c
   b
 
   $ true > dune
@@ -16,12 +15,12 @@ build. Dune fails to detect that:
   $ echo '(rule (target b) (deps) (action (bash "echo b > b")))' >> dune
   $ echo '(rule (target c) (deps a b) (action (bash "cat a b > c")))' >> dune
   $ dune build c
-  $ cat _build/default/c
-  b
+  $ tail -1 _build/default/c
   b
 
-(it's not obvious what the correct result is on the first invocation, but the second
-invocation is clearly broken (it uses a wrongly cached result))
+(The first invocation's result depends on execution order, but the second
+invocation is clearly broken — it uses a wrongly cached result since the last
+line should be "b" from rule b, yet the rules were replaced)
 
 These rules clearly depend on sandboxing. Specifying that makes the build
 well-behaved:
@@ -72,3 +71,20 @@ anyway.
   >  (action (write-file t "")))
   > EOF
   $ dune build t
+
+Verify that dependencies are hardlinked into the sandbox (not copied) by
+checking the hardlink count from inside the action. A hardlinked file will have
+nlink > 1 while a copied file would have nlink = 1.
+
+  $ cat > source <<EOF
+  > hello
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (target out)
+  >  (deps source (sandbox always))
+  >  (action (bash "dune_cmd stat hardlinks source > out")))
+  > EOF
+  $ dune build out --sandbox hardlink
+  $ cat _build/default/out
+  2


### PR DESCRIPTION
We lift the limitation of hardlinks for sandboxing on Windows. We also make attempts to use symlink sandboxing fail in a clearer way.

The core sandboxing tests are now being run on Windows.

- [x] changelog
- addresses part of https://github.com/ocaml/dune/issues/4362 the other part would be making it the default.