### PR TITLE
fix: use device/inode for digest caching

### DIFF
--- a/doc/changes/fixed/13991.md
+++ b/doc/changes/fixed/13991.md
@@ -1,0 +1,1 @@
+- Use device and inode number for invalidating cached digests (#13991, @rgrinberg)

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -8,22 +8,30 @@ module Cached_digest = struct
       { mtime : Time.t
       ; size : int
       ; perm : Unix.file_perm
+      ; dev : int
+      ; ino : int
       }
 
-    let to_dyn { mtime; size; perm } =
-      Dyn.Record [ "mtime", Int (Time.to_ns mtime); "size", Int size; "perm", Int perm ]
+    let to_dyn { mtime; size; perm; dev; ino } =
+      Dyn.Record
+        [ "mtime", Int (Time.to_ns mtime)
+        ; "size", Int size
+        ; "perm", Int perm
+        ; "dev", Int.to_dyn dev
+        ; "ino", Int.to_dyn ino
+        ]
     ;;
 
-    let of_stat (stats : Stat.t) =
-      { mtime = stats.mtime; size = stats.size; perm = stats.perm }
+    let of_stat (stat : Stat.t) =
+      { mtime = stat.mtime
+      ; size = stat.size
+      ; perm = stat.perm
+      ; dev = stat.dev
+      ; ino = stat.dev
+      }
     ;;
 
-    let compare { mtime; size; perm } t =
-      let open Ordering.O in
-      let= () = Time.compare mtime t.mtime in
-      let= () = Int.compare size t.size in
-      Int.compare perm t.perm
-    ;;
+    let compare (t : t) x = Poly.compare t x
   end
 
   type file =
@@ -60,7 +68,7 @@ module Cached_digest = struct
       type nonrec t = t
 
       let name = "DIGEST-DB"
-      let version = 9
+      let version = 10
       let sharing = true
       let to_dyn = to_dyn
     end)

--- a/test/blackbox-tests/test-cases/digest-cache/debug-option.t
+++ b/test/blackbox-tests/test-cases/digest-cache/debug-option.t
@@ -13,6 +13,10 @@ Test the tracing of digest events
   > | .args
   > | .old_stats.mtime |= type
   > | .new_stats.mtime |= type
+  > | .new_stats.dev |= type
+  > | .new_stats.ino |= type
+  > | .old_stats.dev |= type
+  > | .old_stats.ino |= type
   > '
   {
     "path": "x",
@@ -21,11 +25,15 @@ Test the tracing of digest events
     "old_stats": {
       "mtime": "number",
       "size": 0,
-      "perm": 420
+      "perm": 420,
+      "dev": "number",
+      "ino": "number"
     },
     "new_stats": {
       "mtime": "number",
       "size": 2,
-      "perm": 420
+      "perm": 420,
+      "dev": "number",
+      "ino": "number"
     }
   }


### PR DESCRIPTION
No reason to skip these. It just reduces reliability.