### PR TITLE
chore(rocq): update to rocq 9.2

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -291,7 +291,7 @@ jobs:
           key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
   rocq:
-    name: Rocq 9.1
+    name: Rocq 9.2
     needs: nix-build
     runs-on: ubuntu-latest
     steps:
@@ -308,7 +308,7 @@ jobs:
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
-    name: Rocq 9.1 (native)
+    name: Rocq 9.2 (native)
     needs: nix-build
     runs-on: ubuntu-latest
     steps:

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -290,7 +290,7 @@ jobs:
           key: opam-${{ matrix.os }}-${{ matrix.cache-prefix }}-${{ hashFiles('**.opam') }}
 
   rocq:
-    name: Rocq 9.1
+    name: Rocq 9.2
     needs: nix-build
     runs-on: ubuntu-latest
     steps:
@@ -307,7 +307,7 @@ jobs:
       - run: nix develop .#rocq -c make test-rocq
 
   rocq-native:
-    name: Rocq 9.1 (native)
+    name: Rocq 9.2 (native)
     needs: nix-build
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1774855581,
+        "narHash": "sha256-YkreHeMgTCYvJ5fESV0YyqQK49bHGe2B51tH6claUh4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "15c6719d8c604779cf59e03c245ea61d3d7ab69b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,41 +76,30 @@
                       src = odoc-src;
                       doCheck = false;
                     });
-                    rocq-core = super.rocqPackages_9_1.rocq-core.override {
+                    rocq-core = super.rocqPackages_9_2.rocq-core.override {
                       customOCamlPackages = oself;
                     };
-                    mkRocqDerivation = super.rocqPackages_9_1.mkRocqDerivation.override {
+                    mkRocqDerivation = super.rocqPackages_9_2.mkRocqDerivation.override {
                       rocq-core = oself.rocq-core;
                     };
-                    rocq-stdlib = super.rocqPackages_9_1.stdlib.override {
+                    rocq-stdlib = super.rocqPackages_9_2.stdlib.override {
                       rocq-core = oself.rocq-core;
                       mkRocqDerivation = oself.mkRocqDerivation;
                     };
-                    # Native compilation requires OCaml 4.14
-                    ocamlPackages_4_14 = super.ocaml-ng.ocamlPackages_4_14.overrideScope (
-                      oself414: osuper414: {
-                        ocaml = osuper414.ocaml.override {
-                          flambdaSupport = false;
-                        };
-                        rocq-core =
-                          (super.rocqPackages_9_1.rocq-core.override {
-                            customOCamlPackages = oself414;
-                          }).overrideAttrs
-                            (a: {
-                              configureFlags = (a.configureFlags or [ ]) ++ [
-                                "-native-compiler"
-                                "yes"
-                              ];
-                            });
-                        mkRocqDerivation = super.rocqPackages_9_1.mkRocqDerivation.override {
-                          rocq-core = oself414.rocq-core;
-                        };
-                        rocq-stdlib = super.rocqPackages_9_1.stdlib.override {
-                          rocq-core = oself414.rocq-core;
-                          mkRocqDerivation = oself414.mkRocqDerivation;
-                        };
-                      }
-                    );
+                    # Native compilation
+                    rocq-core-native = oself.rocq-core.overrideAttrs (a: {
+                      configureFlags = (a.configureFlags or [ ]) ++ [
+                        "-native-compiler"
+                        "yes"
+                      ];
+                    });
+                    mkRocqDerivation-native = oself.mkRocqDerivation.override {
+                      rocq-core = oself.rocq-core-native;
+                    };
+                    rocq-stdlib-native = oself.rocq-stdlib.override {
+                      rocq-core = oself.rocq-core-native;
+                      mkRocqDerivation = oself.mkRocqDerivation-native;
+                    };
                   }
                 );
               })
@@ -456,30 +445,16 @@
             '';
           };
 
-          rocq-native =
-            let
-              ocaml414 = pkgs.ocamlPackages.ocamlPackages_4_14;
-            in
-            pkgs.mkShell {
-              inherit INSIDE_NIX;
-              nativeBuildInputs = (testNativeBuildInputs pkgs) ++ [
-                ocaml414.ocaml
-                ocaml414.findlib
-              ];
-              buildInputs = [
-                ocaml414.csexp
-                ocaml414.pp
-                ocaml414.re
-                ocaml414.spawn
-                ocaml414.uutf
-                ocaml414.rocq-core
-                ocaml414.rocq-stdlib
-              ];
-              meta.description = ''
-                Provides a minimal shell environment built purely from nixpkgs
-                that can build Dune and run the Rocq testsuite with native compilation.
-              '';
-            };
+          rocq-native = makeDuneDevShell {
+            extraBuildInputs = pkgs: [
+              pkgs.ocamlPackages.rocq-core-native
+              pkgs.ocamlPackages.rocq-stdlib-native
+            ];
+            meta.description = ''
+              Provides a minimal shell environment built purely from nixpkgs
+              that can build Dune and run the Rocq testsuite with native compilation.
+            '';
+          };
 
           bootstrap-check = pkgs.mkShell {
             inherit INSIDE_NIX;

--- a/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/config-no-coqc.t/run.t
@@ -15,8 +15,6 @@ We first test the package builds as normal, when both are in scope:
   Extract.glob
   Extract.v
   Extract.vo
-  Extract.vok
-  Extract.vos
   Foo.ml
   Foo.mli
   patch.sh

--- a/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc-with-boot.t/run.t
@@ -7,8 +7,6 @@ Testing coqdoc when composed with a boot library
   a.glob
   a.v
   a.vo
-  a.vok
-  a.vos
 
 Dune should be passing '--coqlib' to coqdoc, but it doesn't. This is a bug.
 

--- a/test/blackbox-tests/test-cases/rocq/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqdoc.t/run.t
@@ -27,13 +27,9 @@ Note that this currently works due to a bug in @all detecting directory targets.
   bar.glob
   bar.v
   bar.vo
-  bar.vok
-  bar.vos
   base.dune-package
   base.install
   foo.glob
   foo.v
   foo.vo
-  foo.vok
-  foo.vos
 

--- a/test/blackbox-tests/test-cases/rocq/extraction/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extract.t
@@ -49,8 +49,6 @@
   extract.mli
   extract.v
   extract.vo
-  extract.vok
-  extract.vos
   foo.exe
   foo.ml
   foo.mli

--- a/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/multiple-extraction.t
@@ -30,13 +30,9 @@
   Extr1.glob
   Extr1.v
   Extr1.vo
-  Extr1.vok
-  Extr1.vos
   Extr2.glob
   Extr2.v
   Extr2.vo
-  Extr2.vok
-  Extr2.vos
   Mod1.ml
   Mod1.mli
   Mod2.ml

--- a/test/blackbox-tests/test-cases/rocq/failed-config.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/failed-config.t/run.t
@@ -104,7 +104,7 @@ Here we query the version of Coq. Due to the expansion of %{coq:_} macros we nee
 Succeeds after PR #10631
   $ FAIL_CONFIG=1 \
   > dune build @version
-  9.1.1
+  9.2
 
 Should fail.
   $ FAIL_VERSION=1 \

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/coqdoc.t/run.t
@@ -35,13 +35,9 @@ Note that this currently works due to a bug in @all detecting directory targets.
   bar.glob
   bar.v
   bar.vo
-  bar.vok
-  bar.vos
   base.dune-package
   base.install
   foo.glob
   foo.v
   foo.vo
-  foo.vok
-  foo.vos
 

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/extract.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/extract.t
@@ -53,8 +53,6 @@
   extract.mli
   extract.v
   extract.vo
-  extract.vok
-  extract.vos
   foo.exe
   foo.ml
   foo.mli


### PR DESCRIPTION
This lets us drop OCaml 4 from rocq support. This should unblock things like https://github.com/ocaml/dune/pull/13794.