### PR TITLE
Adding `extracted_files` field to `rocq.extraction` stanza

### DIFF
--- a/doc/changes/added/13997.md
+++ b/doc/changes/added/13997.md
@@ -1,0 +1,3 @@
+- `rocq.extraction`: Add `extracted_files` field in `(rocq 0.13)`, replacing
+  `extracted_modules`, supporting extraction to languages other than OCaml
+  (#13997, @Durbatuluk1701).

--- a/doc/rocq.rst
+++ b/doc/rocq.rst
@@ -374,6 +374,7 @@ The supported Rocq language versions (not the version of Rocq) are:
   + ``(mode native)`` is not allowed anymore. It is the default if Rocq was configured with native compute enabled.
   + ``COQPATH`` is not recognized anymore, use ``ROCQPATH``.
 - ``0.12``: Support for output tests.
+- ``0.13``: Support for ``extracted_files`` in ``rocq.extraction``.
 
 .. _rocq-lang-1.0:
 
@@ -391,7 +392,7 @@ unchanged or minimally modified.
 rocq.extraction
 ---------------
 
-Rocq may be instructed to *extract* OCaml sources as part of the compilation
+Rocq may be instructed to *extract* sources as part of the compilation
 process by using the ``rocq.extraction`` stanza:
 
 .. code:: dune
@@ -399,13 +400,22 @@ process by using the ``rocq.extraction`` stanza:
    (rocq.extraction
     (prelude <name>)
     (extracted_modules <names>)
+    (extracted_files <filenames>)
     <optional-fields>)
 
 - ``(prelude <name>)`` refers to the Rocq source that contains the extraction
   commands.
 
-- ``(extracted_modules <names>)`` is an exhaustive list of OCaml modules
-  extracted.
+- ``(extracted_modules <names>)`` is a list of OCaml modules extracted. For each
+  module name, Dune expects both a ``.ml`` and ``.mli`` file to be produced.
+
+- ``(extracted_files <filenames>)`` is a list of filenames (with extensions) that
+  will be produced by the extraction. This allows extraction to languages other
+  than OCaml, such as Haskell (``.hs``) or Scheme (``.scm``). Available since
+  ``(rocq 0.13)``.
+
+  At least one of ``extracted_modules`` or ``extracted_files`` must be specified.
+  Both can be provided simultaneously, and the targets will be merged.
 
 - ``<optional-fields>`` are ``flags``, ``stdlib``, ``theories``, and
   ``plugins``. All of these fields have the same meaning as in the

--- a/doc/rocq.rst
+++ b/doc/rocq.rst
@@ -374,7 +374,8 @@ The supported Rocq language versions (not the version of Rocq) are:
   + ``(mode native)`` is not allowed anymore. It is the default if Rocq was configured with native compute enabled.
   + ``COQPATH`` is not recognized anymore, use ``ROCQPATH``.
 - ``0.12``: Support for output tests.
-- ``0.13``: Support for ``extracted_files`` in ``rocq.extraction``.
+- ``0.13``: ``rocq.extraction`` now uses ``extracted_files`` instead of
+  ``extracted_modules``, supporting extraction to languages other than OCaml.
 
 .. _rocq-lang-1.0:
 
@@ -395,27 +396,38 @@ rocq.extraction
 Rocq may be instructed to *extract* sources as part of the compilation
 process by using the ``rocq.extraction`` stanza:
 
+For ``(rocq 0.12)`` and below:
+
 .. code:: dune
 
    (rocq.extraction
     (prelude <name>)
     (extracted_modules <names>)
+    <optional-fields>)
+
+For ``(rocq 0.13)`` and above:
+
+.. code:: dune
+
+   (rocq.extraction
+    (prelude <name>)
     (extracted_files <filenames>)
     <optional-fields>)
 
 - ``(prelude <name>)`` refers to the Rocq source that contains the extraction
   commands.
 
-- ``(extracted_modules <names>)`` is a list of OCaml modules extracted. For each
-  module name, Dune expects both a ``.ml`` and ``.mli`` file to be produced.
+- ``(extracted_modules <names>)`` specifies the OCaml modules to be extracted.
+  For each module name, Dune expects both a ``.ml`` and ``.mli`` file to be
+  produced. Available in ``(rocq 0.12)`` and below; replaced by
+  ``extracted_files`` in ``(rocq 0.13)``.
 
-- ``(extracted_files <filenames>)`` is a list of filenames (with extensions) that
-  will be produced by the extraction. This allows extraction to languages other
-  than OCaml, such as Haskell (``.hs``) or Scheme (``.scm``). Available since
-  ``(rocq 0.13)``.
-
-  At least one of ``extracted_modules`` or ``extracted_files`` must be specified.
-  Both can be provided simultaneously, and the targets will be merged.
+- ``(extracted_files <filenames>)`` is a list of filenames (with extensions)
+  that will be produced by the extraction. This allows extraction to languages
+  other than OCaml, such as Haskell (``.hs``) or Scheme (``.scm``). Available
+  since ``(rocq 0.13)``. Users upgrading from ``0.12`` should replace
+  ``(extracted_modules M1 ... Mn)`` with ``(extracted_files M1.ml M1.mli ... Mn.ml
+  Mn.mli)``.
 
 - ``<optional-fields>`` are ``flags``, ``stdlib``, ``theories``, and
   ``plugins``. All of these fields have the same meaning as in the

--- a/doc/rocq.rst
+++ b/doc/rocq.rst
@@ -396,17 +396,6 @@ rocq.extraction
 Rocq may be instructed to *extract* sources as part of the compilation
 process by using the ``rocq.extraction`` stanza:
 
-For ``(rocq 0.12)`` and below:
-
-.. code:: dune
-
-   (rocq.extraction
-    (prelude <name>)
-    (extracted_modules <names>)
-    <optional-fields>)
-
-For ``(rocq 0.13)`` and above:
-
 .. code:: dune
 
    (rocq.extraction
@@ -417,17 +406,18 @@ For ``(rocq 0.13)`` and above:
 - ``(prelude <name>)`` refers to the Rocq source that contains the extraction
   commands.
 
-- ``(extracted_modules <names>)`` specifies the OCaml modules to be extracted.
-  For each module name, Dune expects both a ``.ml`` and ``.mli`` file to be
-  produced. Available in ``(rocq 0.12)`` and below; replaced by
-  ``extracted_files`` in ``(rocq 0.13)``.
+- ``(extracted_files <filenames>)`` is the list of files Dune expects the
+  extraction to produce. Each entry is a filename with its extension, for 
+  example OCaml (``.ml``, ``.mli``), Haskell (``.hs``), or Scheme (``.scm``).
+  (Appeared in :ref:`Rocq lang 0.13<rocq-lang>`)
 
-- ``(extracted_files <filenames>)`` is a list of filenames (with extensions)
-  that will be produced by the extraction. This allows extraction to languages
-  other than OCaml, such as Haskell (``.hs``) or Scheme (``.scm``). Available
-  since ``(rocq 0.13)``. Users upgrading from ``0.12`` should replace
-  ``(extracted_modules M1 ... Mn)`` with ``(extracted_files M1.ml M1.mli ... Mn.ml
-  Mn.mli)``.
+.. note::
+
+   ``(extracted_modules <names>)`` is the predecessor to ``extracted_files``,
+   available in ``(rocq 0.12)`` and below. It accepts bare module names and
+   expects Dune to produce both a ``.ml`` and ``.mli`` file for each. Users
+   upgrading from ``0.12`` should replace ``(extracted_modules M1 ... Mn)``
+   with ``(extracted_files M1.ml M1.mli ... Mn.ml Mn.mli)``.
 
 - ``<optional-fields>`` are ``flags``, ``stdlib``, ``theories``, and
   ``plugins``. All of these fields have the same meaning as in the

--- a/doc/rocq.rst
+++ b/doc/rocq.rst
@@ -409,7 +409,9 @@ process by using the ``rocq.extraction`` stanza:
 - ``(extracted_files <filenames>)`` is the list of files Dune expects the
   extraction to produce. Each entry is a filename with its extension, for 
   example OCaml (``.ml``, ``.mli``), Haskell (``.hs``), or Scheme (``.scm``).
-  (Appeared in :ref:`Rocq lang 0.13<rocq-lang>`)
+
+  .. versionadded:: 3.23
+
 
 .. note::
 

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -177,7 +177,7 @@ end = struct
               Path.Build.set_extension mlg_file ~ext:Filename.Extension.ml
               |> Path.Build.basename)
           | Rocq_stanza.Extraction.T s ->
-            Memo.return (Rocq_stanza.Extraction.ml_target_fnames s)
+            Memo.return (Rocq_stanza.Extraction.target_fnames s)
           | Rule_conf.T rule ->
             Simple_rules.user_rule sctx rule ~dir ~expander
             >>| (function

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -1297,7 +1297,7 @@ let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.
   let* rocq_sources = Dir_contents.rocq dir_contents in
   let rocq_module = Rocq_sources.extract rocq_sources s in
   let file_targets =
-    Rocq_stanza.Extraction.ml_target_fnames s |> List.map ~f:(Path.Build.relative dir)
+    Rocq_stanza.Extraction.target_fnames s |> List.map ~f:(Path.Build.relative dir)
   in
   let loc = s.buildable.loc in
   let use_stdlib = s.buildable.use_stdlib in

--- a/src/dune_rules/rocq/rocq_stanza.ml
+++ b/src/dune_rules/rocq/rocq_stanza.ml
@@ -18,7 +18,7 @@ let rocq_syntax =
   Dune_lang.Syntax.create
     ~name:(Syntax.Name.parse "rocq")
     ~desc:"Rocq Prover build language"
-    [ (0, 11), `Since (3, 21); (0, 12), `Since (3, 22) ]
+    [ (0, 11), `Since (3, 21); (0, 12), `Since (3, 22); (0, 13), `Since (3, 22) ]
 ;;
 
 let get_rocq_syntax () = Dune_lang.Syntax.get_exn rocq_syntax
@@ -73,6 +73,7 @@ module Extraction = struct
     { (* not a list of modules because we want to preserve whatever case Rocq
          uses *)
       extracted_modules : string list
+    ; extracted_files : string list
     ; prelude : Loc.t * Rocq_module.Name.t
     ; buildable : Buildable.t
     }
@@ -81,12 +82,42 @@ module Extraction = struct
     List.concat_map t.extracted_modules ~f:(fun m -> [ m ^ ".ml"; m ^ ".mli" ])
   ;;
 
+  let target_fnames t = ml_target_fnames t @ t.extracted_files
+
   let decode =
     fields
-      (let+ extracted_modules = field "extracted_modules" (repeat string)
+      (let+ extracted_modules = field "extracted_modules" (repeat string) ~default:[]
+       and+ extracted_files =
+         field
+           "extracted_files"
+           (Dune_lang.Syntax.since rocq_syntax (0, 13) >>> repeat string)
+           ~default:[]
        and+ prelude = field "prelude" (located (string >>| Rocq_module.Name.make))
-       and+ buildable = Buildable.decode in
-       { prelude; extracted_modules; buildable })
+       and+ buildable = Buildable.decode
+       and+ loc = loc in
+       if List.is_empty extracted_modules && List.is_empty extracted_files
+       then
+         User_error.raise
+           ~loc
+           [ Pp.text
+               "At least one of (extracted_modules) or (extracted_files) must be \
+                specified"
+           ];
+       let all_targets =
+         ml_target_fnames { extracted_modules; extracted_files; prelude; buildable }
+         @ extracted_files
+       in
+       (match String.Map.of_list (List.map all_targets ~f:(fun t -> t, ())) with
+        | Ok _ -> ()
+        | Error (dup, (), ()) ->
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "Duplicate target filename %S across extracted_modules and \
+                 extracted_files"
+                dup
+            ]);
+       { prelude; extracted_modules; extracted_files; buildable })
   ;;
 
   include Stanza.Make (struct

--- a/src/dune_rules/rocq/rocq_stanza.ml
+++ b/src/dune_rules/rocq/rocq_stanza.ml
@@ -78,11 +78,10 @@ module Extraction = struct
     ; buildable : Buildable.t
     }
 
-  let ml_target_fnames t =
+  let target_fnames t =
     List.concat_map t.extracted_modules ~f:(fun m -> [ m ^ ".ml"; m ^ ".mli" ])
+    @ t.extracted_files
   ;;
-
-  let target_fnames t = ml_target_fnames t @ t.extracted_files
 
   let decode =
     fields
@@ -104,17 +103,16 @@ module Extraction = struct
                 specified"
            ];
        let all_targets =
-         ml_target_fnames { extracted_modules; extracted_files; prelude; buildable }
-         @ extracted_files
+         target_fnames { extracted_modules; extracted_files; prelude; buildable }
        in
        (match String.Map.of_list (List.map all_targets ~f:(fun t -> t, ())) with
         | Ok _ -> ()
         | Error (dup, (), ()) ->
-          User_error.raise
+          User_warning.emit
             ~loc
             [ Pp.textf
-                "Duplicate target filename %S across extracted_modules and \
-                 extracted_files"
+                "Duplicate target filename %S across (extracted_modules) and \
+                 (extracted_files)"
                 dup
             ]);
        { prelude; extracted_modules; extracted_files; buildable })

--- a/src/dune_rules/rocq/rocq_stanza.ml
+++ b/src/dune_rules/rocq/rocq_stanza.ml
@@ -18,7 +18,7 @@ let rocq_syntax =
   Dune_lang.Syntax.create
     ~name:(Syntax.Name.parse "rocq")
     ~desc:"Rocq Prover build language"
-    [ (0, 11), `Since (3, 21); (0, 12), `Since (3, 22); (0, 13), `Since (3, 22) ]
+    [ (0, 11), `Since (3, 21); (0, 12), `Since (3, 22); (0, 13), `Since (3, 23) ]
 ;;
 
 let get_rocq_syntax () = Dune_lang.Syntax.get_exn rocq_syntax

--- a/src/dune_rules/rocq/rocq_stanza.ml
+++ b/src/dune_rules/rocq/rocq_stanza.ml
@@ -70,52 +70,48 @@ end
 
 module Extraction = struct
   type t =
-    { (* not a list of modules because we want to preserve whatever case Rocq
-         uses *)
-      extracted_modules : string list
-    ; extracted_files : string list
+    { target_fnames : string list
     ; prelude : Loc.t * Rocq_module.Name.t
     ; buildable : Buildable.t
     }
 
-  let target_fnames t =
-    List.concat_map t.extracted_modules ~f:(fun m -> [ m ^ ".ml"; m ^ ".mli" ])
-    @ t.extracted_files
-  ;;
+  let target_fnames t = t.target_fnames
 
   let decode =
     fields
-      (let+ extracted_modules = field "extracted_modules" (repeat string) ~default:[]
-       and+ extracted_files =
-         field
+      (let* ver = get_rocq_syntax () in
+       let+ extracted_modules_opt =
+         field_o
+           "extracted_modules"
+           (Dune_lang.Syntax.deleted_in
+              rocq_syntax
+              (0, 13)
+              ~extra_info:
+                "Use (extracted_files ...) instead, listing each .ml and .mli file \
+                 explicitly."
+            >>> repeat string)
+       and+ extracted_files_opt =
+         field_o
            "extracted_files"
            (Dune_lang.Syntax.since rocq_syntax (0, 13) >>> repeat string)
-           ~default:[]
        and+ prelude = field "prelude" (located (string >>| Rocq_module.Name.make))
        and+ buildable = Buildable.decode
        and+ loc = loc in
-       if List.is_empty extracted_modules && List.is_empty extracted_files
-       then
-         User_error.raise
-           ~loc
-           [ Pp.text
-               "At least one of (extracted_modules) or (extracted_files) must be \
-                specified"
-           ];
-       let all_targets =
-         target_fnames { extracted_modules; extracted_files; prelude; buildable }
+       let target_fnames =
+         if ver < (0, 13)
+         then (
+           match extracted_modules_opt with
+           | None ->
+             User_error.raise ~loc [ Pp.text "Field \"extracted_modules\" is required" ]
+           | Some modules ->
+             List.concat_map modules ~f:(fun m -> [ m ^ ".ml"; m ^ ".mli" ]))
+         else (
+           match extracted_files_opt with
+           | None ->
+             User_error.raise ~loc [ Pp.text "Field \"extracted_files\" is required" ]
+           | Some files -> files)
        in
-       (match String.Map.of_list (List.map all_targets ~f:(fun t -> t, ())) with
-        | Ok _ -> ()
-        | Error (dup, (), ()) ->
-          User_warning.emit
-            ~loc
-            [ Pp.textf
-                "Duplicate target filename %S across (extracted_modules) and \
-                 (extracted_files)"
-                dup
-            ]);
-       { prelude; extracted_modules; extracted_files; buildable })
+       { target_fnames; prelude; buildable })
   ;;
 
   include Stanza.Make (struct

--- a/src/dune_rules/rocq/rocq_stanza.mli
+++ b/src/dune_rules/rocq/rocq_stanza.mli
@@ -28,11 +28,13 @@ end
 module Extraction : sig
   type t =
     { extracted_modules : string list
+    ; extracted_files : string list
     ; prelude : Loc.t * Rocq_module.Name.t
     ; buildable : Buildable.t
     }
 
   val ml_target_fnames : t -> string list
+  val target_fnames : t -> string list
 
   include Stanza.S with type t := t
 end

--- a/src/dune_rules/rocq/rocq_stanza.mli
+++ b/src/dune_rules/rocq/rocq_stanza.mli
@@ -27,8 +27,7 @@ end
 
 module Extraction : sig
   type t =
-    { extracted_modules : string list
-    ; extracted_files : string list
+    { target_fnames : string list
     ; prelude : Loc.t * Rocq_module.Name.t
     ; buildable : Buildable.t
     }

--- a/src/dune_rules/rocq/rocq_stanza.mli
+++ b/src/dune_rules/rocq/rocq_stanza.mli
@@ -33,7 +33,6 @@ module Extraction : sig
     ; buildable : Buildable.t
     }
 
-  val ml_target_fnames : t -> string list
   val target_fnames : t -> string list
 
   include Stanza.S with type t := t

--- a/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
@@ -1,0 +1,174 @@
+Test error when neither extracted_modules nor extracted_files is provided:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb := true.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-2, characters 0-33:
+  1 | (rocq.extraction
+  2 |  (prelude extr))
+  Error: At least one of (extracted_modules) or (extracted_files) must be
+  specified
+  [1]
+
+Test version gating: extracted_files requires (rocq 0.13):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.12)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files foo.hs))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 1-25:
+  3 |  (extracted_files foo.hs))
+       ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'extracted_files' is only available since version 0.13 of Rocq Prover
+  build language. Please update your dune-project file to have (using rocq
+  0.13).
+  [1]
+
+Test duplicate target filename across extracted_modules and extracted_files:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_modules foo)
+  >  (extracted_files foo.ml))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-4, characters 0-84:
+  1 | (rocq.extraction
+  2 |  (prelude extr)
+  3 |  (extracted_modules foo)
+  4 |  (extracted_files foo.ml))
+  Error: Duplicate target filename "foo.ml" across extracted_modules and
+  extracted_files
+  [1]
+
+Test using extracted_files with explicit filenames:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Separate Extraction nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files Datatypes.ml Datatypes.mli extr.ml extr.mli)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  $ ls _build/default/Datatypes.ml _build/default/extr.ml
+  _build/default/Datatypes.ml
+  _build/default/extr.ml
+
+Test using extracted_modules with Haskell outputs (expected failure):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Extraction Language Haskell.
+  > Separate Extraction nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_modules Datatypes.hs extr.hs)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-4, characters 0-129:
+  1 | (rocq.extraction
+  2 |  (prelude extr)
+  3 |  (extracted_modules Datatypes.hs extr.hs)
+  4 |  (flags (:standard -w -extraction-default-directory)))
+  Error: Rule failed to generate the following targets:
+  - Datatypes.hs.ml
+  - Datatypes.hs.mli
+  - extr.hs.ml
+  - extr.hs.mli
+  [1]
+
+Test using extracted_files with Haskell outputs (expected success):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Extraction Language Haskell.
+  > Separate Extraction nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files Datatypes.hs extr.hs)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  $ ls _build/default | sort
+  Datatypes.hs
+  extr.glob
+  extr.hs
+  extr.v
+  extr.vo
+  extr.vok
+  extr.vos

--- a/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
@@ -1,7 +1,7 @@
 Test error when extracted_files is not provided in rocq 0.13:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -24,10 +24,33 @@ Test error when extracted_files is not provided in rocq 0.13:
   Error: Field "extracted_files" is required
   [1]
 
-Test version gating: extracted_files requires (rocq 0.13):
+Test version gating: extracted_files requires (rocq 0.13 -> lang dune 3.23):
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files foo.hs))
+  > EOF
+
+  $ dune build
+  File "dune-project", line 2, characters 12-16:
+  2 | (using rocq 0.13)
+                  ^^^^
+  Error: Version 0.13 of Rocq Prover build language is not supported until
+  version 3.23 of the dune language.
+  Supported versions of this extension in version 3.22 of the dune language:
+  - 0.1 to 0.12
+  [1]
+
+Test version gating: extracted_files requires (rocq 0.13):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.23)
   > (using rocq 0.12)
   > EOF
 
@@ -49,7 +72,7 @@ Test version gating: extracted_files requires (rocq 0.13):
 Test that extracted_modules is deleted in rocq 0.13 with a helpful error message:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -72,7 +95,7 @@ Test that extracted_modules is deleted in rocq 0.13 with a helpful error message
 Test using extracted_files with explicit filenames:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -102,7 +125,7 @@ Test using extracted_files with explicit filenames:
 Test that extracted_modules in 0.13 gives deleted_in error for Haskell extraction:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -137,7 +160,7 @@ Test that extracted_modules in 0.13 gives deleted_in error for Haskell extractio
 Test using extracted_files with Haskell outputs (expected success):
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -181,7 +204,7 @@ Test rebuild does not clean extracted files:
 Test that extracted_modules in 0.13 gives deleted_in error for Scheme extraction:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 
@@ -216,7 +239,7 @@ Test that extracted_modules in 0.13 gives deleted_in error for Scheme extraction
 Test using extracted_files with Scheme outputs (expected success):
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > (using rocq 0.13)
   > EOF
 

--- a/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
@@ -1,4 +1,4 @@
-Test error when neither extracted_modules nor extracted_files is provided:
+Test error when extracted_files is not provided in rocq 0.13:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
@@ -21,8 +21,7 @@ Test error when neither extracted_modules nor extracted_files is provided:
   File "dune", lines 1-2, characters 0-33:
   1 | (rocq.extraction
   2 |  (prelude extr))
-  Error: At least one of (extracted_modules) or (extracted_files) must be
-  specified
+  Error: Field "extracted_files" is required
   [1]
 
 Test version gating: extracted_files requires (rocq 0.13):
@@ -47,7 +46,7 @@ Test version gating: extracted_files requires (rocq 0.13):
   0.13).
   [1]
 
-Test warning on duplicate target filename across extracted_modules and extracted_files:
+Test that extracted_modules is deleted in rocq 0.13 with a helpful error message:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
@@ -58,54 +57,16 @@ Test warning on duplicate target filename across extracted_modules and extracted
   > (rocq.extraction
   >  (prelude extr)
   >  (extracted_modules extr)
-  >  (extracted_files extr.ml)
   >  (flags (:standard -w -extraction-default-directory)))
   > EOF
 
   $ dune build
-  File "dune", lines 1-5, characters 0-140:
-  1 | (rocq.extraction
-  2 |  (prelude extr)
+  File "dune", line 3, characters 1-25:
   3 |  (extracted_modules extr)
-  4 |  (extracted_files extr.ml)
-  5 |  (flags (:standard -w -extraction-default-directory)))
-  Warning: Duplicate target filename "extr.ml" across (extracted_modules) and
-  (extracted_files)
-  $ ls _build/default | sort
-  Datatypes.ml
-  Datatypes.mli
-  extr.glob
-  extr.ml
-  extr.mli
-  extr.v
-  extr.vo
-  extr.vok
-  extr.vos
-
-Test completeness of both extracted_modules and extracted_files (expected failure):
-
-  $ cat >dune-project <<EOF
-  > (lang dune 3.22)
-  > (using rocq 0.13)
-  > EOF
-
-  $ cat >dune <<EOF
-  > (rocq.extraction
-  >  (prelude extr)
-  >  (extracted_modules extr)
-  >  (extracted_files fake.hs)
-  >  (flags (:standard -w -extraction-default-directory)))
-  > EOF
-
-  $ dune build
-  File "dune", lines 1-5, characters 0-140:
-  1 | (rocq.extraction
-  2 |  (prelude extr)
-  3 |  (extracted_modules extr)
-  4 |  (extracted_files fake.hs)
-  5 |  (flags (:standard -w -extraction-default-directory)))
-  Error: Rule failed to generate the following targets:
-  - fake.hs
+       ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'extracted_modules' was deleted in version 0.13 of Rocq Prover build
+  language. Use (extracted_files ...) instead, listing each .ml and .mli file
+  explicitly.
   [1]
 
 Test using extracted_files with explicit filenames:
@@ -138,7 +99,7 @@ Test using extracted_files with explicit filenames:
   _build/default/Datatypes.ml
   _build/default/extr.ml
 
-Test using extracted_modules with Haskell outputs (expected failure):
+Test that extracted_modules in 0.13 gives deleted_in error for Haskell extraction:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
@@ -165,16 +126,12 @@ Test using extracted_modules with Haskell outputs (expected failure):
   > EOF
 
   $ dune build
-  File "dune", lines 1-4, characters 0-129:
-  1 | (rocq.extraction
-  2 |  (prelude extr)
+  File "dune", line 3, characters 1-41:
   3 |  (extracted_modules Datatypes.hs extr.hs)
-  4 |  (flags (:standard -w -extraction-default-directory)))
-  Error: Rule failed to generate the following targets:
-  - Datatypes.hs.ml
-  - Datatypes.hs.mli
-  - extr.hs.ml
-  - extr.hs.mli
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'extracted_modules' was deleted in version 0.13 of Rocq Prover build
+  language. Use (extracted_files ...) instead, listing each .ml and .mli file
+  explicitly.
   [1]
 
 Test using extracted_files with Haskell outputs (expected success):
@@ -210,8 +167,6 @@ Test using extracted_files with Haskell outputs (expected success):
   extr.hs
   extr.v
   extr.vo
-  extr.vok
-  extr.vos
 
 Test rebuild does not clean extracted files:
 (NOTE: re-using above pre-built context)
@@ -223,7 +178,7 @@ Test rebuild does not clean extracted files:
   extr.v
   extr.vo
 
-Test using extracted_modules with Scheme outputs (expected failure):
+Test that extracted_modules in 0.13 gives deleted_in error for Scheme extraction:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
@@ -250,14 +205,12 @@ Test using extracted_modules with Scheme outputs (expected failure):
   > EOF
 
   $ dune build
-  File "dune", lines 1-4, characters 0-115:
-  1 | (rocq.extraction
-  2 |  (prelude extr)
+  File "dune", line 3, characters 1-27:
   3 |  (extracted_modules nb.scm)
-  4 |  (flags (:standard -w -extraction-default-directory)))
-  Error: Rule failed to generate the following targets:
-  - nb.scm.ml
-  - nb.scm.mli
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'extracted_modules' was deleted in version 0.13 of Rocq Prover build
+  language. Use (extracted_files ...) instead, listing each .ml and .mli file
+  explicitly.
   [1]
 
 Test using extracted_files with Scheme outputs (expected success):
@@ -291,6 +244,4 @@ Test using extracted_files with Scheme outputs (expected success):
   extr.glob
   extr.v
   extr.vo
-  extr.vok
-  extr.vos
   nb.scm

--- a/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
+++ b/test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t
@@ -7,6 +7,9 @@ Test error when neither extracted_modules nor extracted_files is provided:
 
   $ cat >extr.v <<EOF
   > Definition nb := true.
+  > Require Extraction.
+  > Extraction Language OCaml.
+  > Separate Extraction nb.
   > EOF
 
   $ cat >dune <<EOF
@@ -44,7 +47,7 @@ Test version gating: extracted_files requires (rocq 0.13):
   0.13).
   [1]
 
-Test duplicate target filename across extracted_modules and extracted_files:
+Test warning on duplicate target filename across extracted_modules and extracted_files:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.22)
@@ -54,18 +57,55 @@ Test duplicate target filename across extracted_modules and extracted_files:
   $ cat >dune <<EOF
   > (rocq.extraction
   >  (prelude extr)
-  >  (extracted_modules foo)
-  >  (extracted_files foo.ml))
+  >  (extracted_modules extr)
+  >  (extracted_files extr.ml)
+  >  (flags (:standard -w -extraction-default-directory)))
   > EOF
 
   $ dune build
-  File "dune", lines 1-4, characters 0-84:
+  File "dune", lines 1-5, characters 0-140:
   1 | (rocq.extraction
   2 |  (prelude extr)
-  3 |  (extracted_modules foo)
-  4 |  (extracted_files foo.ml))
-  Error: Duplicate target filename "foo.ml" across extracted_modules and
-  extracted_files
+  3 |  (extracted_modules extr)
+  4 |  (extracted_files extr.ml)
+  5 |  (flags (:standard -w -extraction-default-directory)))
+  Warning: Duplicate target filename "extr.ml" across (extracted_modules) and
+  (extracted_files)
+  $ ls _build/default | sort
+  Datatypes.ml
+  Datatypes.mli
+  extr.glob
+  extr.ml
+  extr.mli
+  extr.v
+  extr.vo
+  extr.vok
+  extr.vos
+
+Test completeness of both extracted_modules and extracted_files (expected failure):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_modules extr)
+  >  (extracted_files fake.hs)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-5, characters 0-140:
+  1 | (rocq.extraction
+  2 |  (prelude extr)
+  3 |  (extracted_modules extr)
+  4 |  (extracted_files fake.hs)
+  5 |  (flags (:standard -w -extraction-default-directory)))
+  Error: Rule failed to generate the following targets:
+  - fake.hs
   [1]
 
 Test using extracted_files with explicit filenames:
@@ -172,3 +212,85 @@ Test using extracted_files with Haskell outputs (expected success):
   extr.vo
   extr.vok
   extr.vos
+
+Test rebuild does not clean extracted files:
+(NOTE: re-using above pre-built context)
+  $ dune build
+  $ ls _build/default | sort
+  Datatypes.hs
+  extr.glob
+  extr.hs
+  extr.v
+  extr.vo
+
+Test using extracted_modules with Scheme outputs (expected failure):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Extraction Language Scheme.
+  > Extraction "nb.scm" nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_modules nb.scm)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-4, characters 0-115:
+  1 | (rocq.extraction
+  2 |  (prelude extr)
+  3 |  (extracted_modules nb.scm)
+  4 |  (flags (:standard -w -extraction-default-directory)))
+  Error: Rule failed to generate the following targets:
+  - nb.scm.ml
+  - nb.scm.mli
+  [1]
+
+Test using extracted_files with Scheme outputs (expected success):
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.22)
+  > (using rocq 0.13)
+  > EOF
+
+  $ cat >extr.v <<EOF
+  > Definition nb (b : bool) : bool :=
+  >   match b with
+  >   | false => true
+  >   | true => false
+  >   end.
+  > 
+  > Require Extraction.
+  > Extraction Language Scheme.
+  > Extraction "nb.scm" nb.
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files nb.scm)
+  >  (flags (:standard -w -extraction-default-directory)))
+  > EOF
+
+  $ dune build
+  $ ls _build/default | sort
+  extr.glob
+  extr.v
+  extr.vo
+  extr.vok
+  extr.vos
+  nb.scm


### PR DESCRIPTION
This PR adds an `extracted_files` field to the `rocq.extraction` stanza. In particular, this field is used to specify files that should be produced by extraction *other than* those purely meant for OCaml extraction (the current `extracted_modules` field behavior).

The primary motivation for this is the following behavior: given a Rocq extraction prelude `X.v` that extracts to Haskell and produces a file `X.hs`, a single `dune build` will produce this file, but subsequent `dune build` will wipe the `X.hs` from `_build/...`. 

This behavior is mitigated by this PR and specifically witnessed by the `Test rebuild does not clean extracted files:` test in `test/blackbox-tests/test-cases/rocq/extraction/extracted-files.t`

---------

It is my belief that the `extracted_files` stanza could subsume `extracted_modules`: `(extracted_modules F1 ... FN) --> (extracted_files F1.ml F1.mli ... FN.ml FN.mli)`, however for compatibility I did not do this, although maybe it is worth discussing.