### PR TITLE
Fix revdep run on untagged versions

### DIFF
--- a/nix/revdeps.nix
+++ b/nix/revdeps.nix
@@ -32,6 +32,7 @@ let
             duneVersion = "3";
             dontAddPrefix = true;
             inherit buildInputs propagatedBuildInputs;
+            nativeBuildInputs = [ pkgs.git ];
           };
       in
       {
@@ -41,6 +42,7 @@ let
 
         dune_3 = osuper.dune_3.overrideAttrs (old: {
           src = revdeps-dune;
+          nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.git ];
         });
 
         # Internal dune libraries not packaged in nixpkgs


### PR DESCRIPTION
When attempting to build the revdeps the local Dune is built. If it is a tagged version this works fine as Dune then knows what version to use. However if the version is just the current checkout (the workflow refers to it as `dev`), then git is called to determine the version. However, the Nix deriviation does not contain `git` so it fails to install.