### PR TITLE
Adding version filtering to `rocq` cram tests for robustness

### DIFF
--- a/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/coqtop/coqtop-root.t/run.t
@@ -11,7 +11,7 @@ All dune commands work when you run them in sub-directories, so this should be n
   $ cd theories
 
 This test is currently broken due to the workspace resolution being faulty #5899.
-  $ dune rocq top --toplevel=echo -- foo.v
+  $ dune rocq top --toplevel=echo -- foo.v 2>&1 | sed "s/(using rocq .*)/(using rocq <version>)/"
   File ".", line 1, characters 0-0:
   Warning: No dune-project file has been found in directory ".". A default one
   is assumed but the project might break when dune is upgraded. Please create a
@@ -21,6 +21,6 @@ This test is currently broken due to the workspace resolution being faulty #5899
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project or workspace file. You must enable it using (using rocq 0.12) in
+  dune-project or workspace file. You must enable it using (using rocq <version>) in
   the file.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/github3624.t
+++ b/test/blackbox-tests/test-cases/rocq/github3624.t
@@ -7,7 +7,7 @@ good when the coq extension is not enabled.
   > (rocq.theory
   >  (name foo))
   > EOF
-  $ dune build
+  $ dune build 2>&1 | sed "s/(using rocq .*)/(using rocq <version>)/"
   File ".", line 1, characters 0-0:
   Warning: No dune-project file has been found in directory ".". A default one
   is assumed but the project might break when dune is upgraded. Please create a
@@ -17,6 +17,6 @@ good when the coq extension is not enabled.
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project or workspace file. You must enable it using (using rocq 0.12) in
+  dune-project or workspace file. You must enable it using (using rocq <version>) in
   the file.
   [1]

--- a/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/rocq-native/coqtop/coqtop-root.t/run.t
@@ -12,7 +12,7 @@ All dune commands work when you run them in sub-directories, so this should be n
   $ cd theories
 
 This test is currently broken due to the workspace resolution being faulty #5899.
-  $ dune rocq top --toplevel=echo -- foo.v
+  $ dune rocq top --toplevel=echo -- foo.v 2>&1 | sed "s/(using rocq .*)/(using rocq <version>)/"
   File ".", line 1, characters 0-0:
   Warning: No dune-project file has been found in directory ".". A default one
   is assumed but the project might break when dune is upgraded. Please create a
@@ -22,6 +22,6 @@ This test is currently broken due to the workspace resolution being faulty #5899
   1 | (rocq.theory
   2 |  (name foo))
   Error: 'rocq.theory' is available only when rocq is enabled in the
-  dune-project or workspace file. You must enable it using (using rocq 0.12) in
+  dune-project or workspace file. You must enable it using (using rocq <version>) in
   the file.
   [1]


### PR DESCRIPTION
This PR filters out the specific Rocq language version number and replaces it with `<version>` to allow robustness for future Rocq language version changes