### PR TITLE
ci: Add check to detect files with incorrect line endings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,6 +68,13 @@ jobs:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#fmt -c make fmt
 
+  diff-on-checkout:
+    name: Ensure no files with CRLF line endings are committed to the repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: git diff --exit-code
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/ci/workflow.yml.in
+++ b/ci/workflow.yml.in
@@ -67,6 +67,13 @@ jobs:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - run: nix develop .#fmt -c make fmt
 
+  diff-on-checkout:
+    name: Ensure no files with CRLF line endings are committed to the repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: git diff --exit-code
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
`jj` doesn't respect git attributes for line endings and this sometimes causes files with CRLF endings to get committed to the repo when developing on Windows. Git checkout on Linux/OSX later causes the repo to be dirty. This commit adds a CI check that fails on CI if the repo is dirty on checkout.

Closes #14006