### PR TITLE
Make revdep workflow reusable

### DIFF
--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -1,6 +1,14 @@
 name: Reverse Dependencies
 
 on:
+  workflow_call:
+    inputs:
+      packages:
+        required: true
+        type: string
+      dune_version:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       packages:


### PR DESCRIPTION
I thought we need to make this into an action but turns out Github supports (somewhat limited) triggering workflows from other workflows.

This change allows triggering the workflow from another workflow by passing the workflow inputs explicitely, while still allowing to run the action manually.

This change needs to be merged separately since to trigger a workflow a specific repo and revision have to be specified, thus to contribute an action that triggers this action this must be accessible as `main`. Therefore this is a separate PR with just this single change which will allow testing the future PR against this workflow.

The workflow spec looks like this

```yaml
uses: ocaml/dune/.github/workflows/revdeps.yml@main
```

Unfortunately the `main` has to be specified, it can't be left out and assumed to be the same branch. Likewise `ocaml/dune` can't be left out to specify the current repo. Quite impractical overall.