### PR TITLE
test: document inter-library recompilation behavior (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -1,0 +1,65 @@
+Baseline: library dependency recompilation for a basic wrapped library.
+
+When a wrapped library's interface changes, Dune currently recompiles ALL
+modules in stanzas that depend on the library, even modules that don't
+reference it.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   print_int (No_use_lib.compute 5)
+  > EOF
+
+  $ dune build ./main.exe
+
+Change mylib's interface:
+
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
+
+No_use_lib is recompiled even though it doesn't reference Mylib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
@@ -1,0 +1,104 @@
+Baseline: library-to-library recompilation (unwrapped).
+
+When an unwrapped library A depends on an unwrapped library B with multiple
+modules, and one module in B changes, all modules in A are recompiled due to
+coarse dependency analysis.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir base_unwrapped
+  $ cat > base_unwrapped/dune <<EOF
+  > (library
+  >  (name base_unwrapped)
+  >  (wrapped false))
+  > EOF
+  $ cat > base_unwrapped/alpha.ml <<EOF
+  > let alpha_val = 1
+  > EOF
+  $ cat > base_unwrapped/alpha.mli <<EOF
+  > val alpha_val : int
+  > EOF
+  $ cat > base_unwrapped/beta.ml <<EOF
+  > let beta_val = 2
+  > EOF
+  $ cat > base_unwrapped/beta.mli <<EOF
+  > val beta_val : int
+  > EOF
+
+  $ mkdir upper_unwrapped
+  $ cat > upper_unwrapped/dune <<EOF
+  > (library
+  >  (name upper_unwrapped)
+  >  (wrapped false)
+  >  (libraries base_unwrapped))
+  > EOF
+  $ cat > upper_unwrapped/uses_alpha.ml <<EOF
+  > let from_alpha () = Alpha.alpha_val
+  > EOF
+  $ cat > upper_unwrapped/uses_alpha.mli <<EOF
+  > val from_alpha : unit -> int
+  > EOF
+  $ cat > upper_unwrapped/uses_beta.ml <<EOF
+  > let from_beta () = Beta.beta_val
+  > EOF
+  $ cat > upper_unwrapped/uses_beta.mli <<EOF
+  > val from_beta : unit -> int
+  > EOF
+  $ cat > upper_unwrapped/uses_neither.ml <<EOF
+  > let own_thing () = 0
+  > EOF
+  $ cat > upper_unwrapped/uses_neither.mli <<EOF
+  > val own_thing : unit -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries upper_unwrapped))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_alpha.from_alpha ());
+  >   print_int (Uses_beta.from_beta ());
+  >   print_int (Uses_neither.own_thing ())
+  > EOF
+
+  $ dune build ./main.exe
+
+Change only alpha.mli:
+
+  $ cat > base_unwrapped/alpha.mli <<EOF
+  > val alpha_val : int
+  > val new_alpha_fn : unit -> string
+  > EOF
+  $ cat > base_unwrapped/alpha.ml <<EOF
+  > let alpha_val = 1
+  > let new_alpha_fn () = "alpha"
+  > EOF
+
+uses_beta is recompiled even though it only references Beta, not Alpha:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_beta"))] | length'
+  2
+
+Change only beta.mli:
+
+  $ cat > base_unwrapped/beta.mli <<EOF
+  > val beta_val : int
+  > val new_beta_fn : unit -> string
+  > EOF
+  $ cat > base_unwrapped/beta.ml <<EOF
+  > let beta_val = 2
+  > let new_beta_fn () = "beta"
+  > EOF
+
+uses_alpha is recompiled even though it only references Alpha, not Beta:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_alpha"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
@@ -1,0 +1,69 @@
+Baseline: library-to-library recompilation (wrapped).
+
+When library A depends on library B, and B's interface changes, all modules
+in A are recompiled due to coarse dependency analysis.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir base_lib
+  $ cat > base_lib/dune <<EOF
+  > (library
+  >  (name base_lib))
+  > EOF
+  $ cat > base_lib/base_lib.ml <<EOF
+  > let base_value = 42
+  > EOF
+  $ cat > base_lib/base_lib.mli <<EOF
+  > val base_value : int
+  > EOF
+
+  $ mkdir middle_lib
+  $ cat > middle_lib/dune <<EOF
+  > (library
+  >  (name middle_lib)
+  >  (libraries base_lib))
+  > EOF
+  $ cat > middle_lib/uses_base.ml <<EOF
+  > let from_base () = Base_lib.base_value
+  > EOF
+  $ cat > middle_lib/uses_base.mli <<EOF
+  > val from_base : unit -> int
+  > EOF
+  $ cat > middle_lib/standalone.ml <<EOF
+  > let own_value () = 999
+  > EOF
+  $ cat > middle_lib/standalone.mli <<EOF
+  > val own_value : unit -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries middle_lib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Middle_lib.Uses_base.from_base ());
+  >   print_int (Middle_lib.Standalone.own_value ())
+  > EOF
+
+  $ dune build ./main.exe
+
+  $ cat > base_lib/base_lib.mli <<EOF
+  > val base_value : int
+  > val new_base_fn : unit -> string
+  > EOF
+  $ cat > base_lib/base_lib.ml <<EOF
+  > let base_value = 42
+  > let new_base_fn () = "hello"
+  > EOF
+
+Standalone in middle_lib is recompiled even though it doesn't use base_lib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
@@ -1,0 +1,102 @@
+Baseline: library dependency recompilation with multiple libraries.
+
+When an executable depends on two libraries and only one changes, Dune
+currently recompiles all modules, even those that only reference the unchanged
+library.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
+
+  $ mkdir lib2
+  $ cat > lib2/dune <<EOF
+  > (library
+  >  (name otherlib))
+  > EOF
+  $ cat > lib2/otherlib.ml <<EOF
+  > let other_value = 100
+  > EOF
+  $ cat > lib2/otherlib.mli <<EOF
+  > val other_value : int
+  > EOF
+
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > uses_other.ml <<EOF
+  > let get_other () = Otherlib.other_value
+  > EOF
+  $ cat > uses_other.mli <<EOF
+  > val get_other : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib otherlib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   print_int (No_use_lib.compute 5);
+  >   print_int (Uses_other.get_other ())
+  > EOF
+
+  $ dune build ./main.exe
+
+Change only mylib's interface:
+
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
+
+Uses_other is recompiled even though it only uses Otherlib, not Mylib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_other"))] | length'
+  2
+
+Change only otherlib's interface:
+
+  $ cat > lib2/otherlib.mli <<EOF
+  > val other_value : int
+  > val new_other_fn : string -> string
+  > EOF
+  $ cat > lib2/otherlib.ml <<EOF
+  > let other_value = 100
+  > let new_other_fn s = s ^ "!"
+  > EOF
+
+Uses_lib is recompiled even though it only uses Mylib, not Otherlib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_lib"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -1,0 +1,93 @@
+Baseline: opaque mode interaction with library dependency recompilation.
+
+In release profile (opaque=false), an implementation-only change triggers
+recompilation of all modules in the consuming stanza due to .cmx dependencies.
+
+In dev profile (opaque=true), local .cmx files are NOT dependencies: an
+implementation-only change triggers no module recompilation at all.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   print_int (No_use_lib.compute 5)
+  > EOF
+
+--- Release profile (opaque=false): .cmx deps are tracked ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile release)
+  > EOF
+
+  $ dune build ./main.exe
+
+Change ONLY the implementation (not the interface):
+
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 43
+  > EOF
+
+No_use_lib is recompiled even though it doesn't reference Mylib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
+  1
+
+--- Dev profile (opaque=true): .cmx deps are NOT tracked for local libs ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile dev)
+  > EOF
+
+Full rebuild due to profile change:
+
+  $ dune build ./main.exe
+
+Change ONLY the implementation again:
+
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 44
+  > EOF
+
+No modules recompile (opaque means only .cmi is a dependency, and .cmi
+didn't change):
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
@@ -1,0 +1,62 @@
+Baseline: modules using only stdlib are recompiled when a library changes.
+
+A module that uses Printf (stdlib) but not the library dependency should
+not need recompilation when the library changes.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > uses_stdlib.ml <<EOF
+  > let greet () = Printf.printf "hello\n"
+  > EOF
+  $ cat > uses_stdlib.mli <<EOF
+  > val greet : unit -> unit
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   Uses_stdlib.greet ()
+  > EOF
+
+  $ dune build ./main.exe
+
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
+
+Uses_stdlib is recompiled even though it only uses Printf, not Mylib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_stdlib"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
@@ -1,0 +1,80 @@
+Baseline: library dependency recompilation with transitive dependencies.
+
+Library A depends on Library B. When B changes, Dune currently recompiles all
+modules in the consuming stanza, even those that don't use A.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir libB
+  $ cat > libB/dune <<EOF
+  > (library
+  >  (name libB))
+  > EOF
+  $ cat > libB/libB.ml <<EOF
+  > let base_value = 1000
+  > EOF
+  $ cat > libB/libB.mli <<EOF
+  > val base_value : int
+  > EOF
+
+  $ mkdir libA
+  $ cat > libA/dune <<EOF
+  > (library
+  >  (name libA)
+  >  (libraries libB))
+  > EOF
+  $ cat > libA/a_impl.mli <<EOF
+  > val get_base : unit -> int
+  > val own_value : int
+  > EOF
+  $ cat > libA/a_impl.ml <<EOF
+  > let get_base () = LibB.base_value
+  > let own_value = 500
+  > EOF
+
+  $ cat > uses_a.ml <<EOF
+  > let call_a () = LibA.A_impl.own_value
+  > EOF
+  $ cat > uses_a.mli <<EOF
+  > val call_a : unit -> int
+  > EOF
+  $ cat > independent.ml <<EOF
+  > let standalone () = 999
+  > EOF
+  $ cat > independent.mli <<EOF
+  > val standalone : unit -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries libA))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_a.call_a ());
+  >   print_int (Independent.standalone ())
+  > EOF
+
+  $ dune build ./main.exe
+
+Change libB's interface:
+
+  $ cat > libB/libB.mli <<EOF
+  > val base_value : int
+  > val new_base_fn : unit -> string
+  > EOF
+  $ cat > libB/libB.ml <<EOF
+  > let base_value = 1000
+  > let new_base_fn () = "new"
+  > EOF
+
+Independent is recompiled even though it doesn't reference libA or libB:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Independent"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
@@ -1,0 +1,97 @@
+Baseline: library dependency recompilation for unwrapped libraries.
+
+When an unwrapped library module's interface changes, Dune currently recompiles
+all modules in stanzas that depend on the library, even those referencing
+different modules in the library.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir unwrapped
+  $ cat > unwrapped/dune <<EOF
+  > (library
+  >  (name unwrapped_lib)
+  >  (wrapped false))
+  > EOF
+  $ cat > unwrapped/helper.ml <<EOF
+  > let helper_fn x = x + 10
+  > EOF
+  $ cat > unwrapped/helper.mli <<EOF
+  > val helper_fn : int -> int
+  > EOF
+  $ cat > unwrapped/utils.ml <<EOF
+  > let utils_fn x = x * 2
+  > EOF
+  $ cat > unwrapped/utils.mli <<EOF
+  > val utils_fn : int -> int
+  > EOF
+
+  $ cat > uses_helper.ml <<EOF
+  > let call_helper () = Helper.helper_fn 5
+  > EOF
+  $ cat > uses_helper.mli <<EOF
+  > val call_helper : unit -> int
+  > EOF
+  $ cat > uses_utils.ml <<EOF
+  > let call_utils () = Utils.utils_fn 3
+  > EOF
+  $ cat > uses_utils.mli <<EOF
+  > val call_utils : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries unwrapped_lib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_helper.call_helper ());
+  >   print_int (Uses_utils.call_utils ());
+  >   print_int (No_use_lib.compute 5)
+  > EOF
+
+  $ dune build ./main.exe
+
+Change only helper.mli:
+
+  $ cat > unwrapped/helper.mli <<EOF
+  > val helper_fn : int -> int
+  > val new_helper : string -> string
+  > EOF
+  $ cat > unwrapped/helper.ml <<EOF
+  > let helper_fn x = x + 10
+  > let new_helper s = s ^ "!"
+  > EOF
+
+Uses_utils is recompiled even though it only references Utils, not Helper:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_utils"))] | length'
+  2
+
+Change only utils.mli:
+
+  $ cat > unwrapped/utils.mli <<EOF
+  > val utils_fn : int -> int
+  > val new_utils : string -> string
+  > EOF
+  $ cat > unwrapped/utils.ml <<EOF
+  > let utils_fn x = x * 2
+  > let new_utils s = s ^ "?"
+  > EOF
+
+Uses_helper is recompiled even though it only references Helper, not Utils:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_helper"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/virtual-library.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/virtual-library.t
@@ -1,0 +1,71 @@
+Baseline: library dependency recompilation with virtual libraries.
+
+When a virtual library's interface changes, Dune currently recompiles all
+modules in stanzas that depend on it, even those that don't reference it.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir vlib
+  $ cat > vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (virtual_modules vmod))
+  > EOF
+  $ cat > vlib/vmod.mli <<EOF
+  > val virtual_fn : int -> int
+  > EOF
+
+  $ mkdir vlib_impl
+  $ cat > vlib_impl/dune <<EOF
+  > (library
+  >  (name vlib_impl)
+  >  (implements vlib))
+  > EOF
+  $ cat > vlib_impl/vmod.ml <<EOF
+  > let virtual_fn x = x * 3
+  > EOF
+
+  $ cat > uses_vlib.ml <<EOF
+  > let call_vlib x = Vlib.Vmod.virtual_fn x
+  > EOF
+  $ cat > uses_vlib.mli <<EOF
+  > val call_vlib : int -> int
+  > EOF
+  $ cat > no_vlib.ml <<EOF
+  > let no_virtual () = 42
+  > EOF
+  $ cat > no_vlib.mli <<EOF
+  > val no_virtual : unit -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries vlib_impl))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_vlib.call_vlib 10);
+  >   print_int (No_vlib.no_virtual ())
+  > EOF
+
+  $ dune build ./main.exe
+
+  $ cat > vlib/vmod.mli <<EOF
+  > val virtual_fn : int -> int
+  > val new_virtual : string -> string
+  > EOF
+  $ cat > vlib_impl/vmod.ml <<EOF
+  > let virtual_fn x = x * 3
+  > let new_virtual s = s ^ "!"
+  > EOF
+
+No_vlib is recompiled even though it doesn't reference the virtual library:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_vlib"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
@@ -1,0 +1,74 @@
+Baseline: wrapped-compat module recompilation behavior.
+
+Libraries using (wrapped (transition ...)) generate wrapped-compat modules.
+Currently, all inner modules are recompiled when any library dependency changes.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ mkdir baselib
+  $ cat > baselib/dune <<EOF
+  > (library
+  >  (name baselib))
+  > EOF
+  $ cat > baselib/baselib.ml <<EOF
+  > let base_value = 42
+  > EOF
+  $ cat > baselib/baselib.mli <<EOF
+  > val base_value : int
+  > EOF
+
+  $ mkdir translib
+  $ cat > translib/dune <<EOF
+  > (library
+  >  (name translib)
+  >  (libraries baselib)
+  >  (wrapped (transition "Use Translib.X instead")))
+  > EOF
+  $ cat > translib/translib.ml <<EOF
+  > module Uses_base = Uses_base
+  > module Standalone = Standalone
+  > EOF
+  $ cat > translib/uses_base.ml <<EOF
+  > let from_base () = Baselib.base_value
+  > EOF
+  $ cat > translib/uses_base.mli <<EOF
+  > val from_base : unit -> int
+  > EOF
+  $ cat > translib/standalone.ml <<EOF
+  > let own_value () = 999
+  > EOF
+  $ cat > translib/standalone.mli <<EOF
+  > val own_value : unit -> int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries translib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Translib.Uses_base.from_base ());
+  >   print_int (Translib.Standalone.own_value ())
+  > EOF
+
+  $ dune build ./main.exe
+
+  $ cat > baselib/baselib.mli <<EOF
+  > val base_value : int
+  > val new_fn : unit -> string
+  > EOF
+  $ cat > baselib/baselib.ml <<EOF
+  > let base_value = 42
+  > let new_fn () = "hello"
+  > EOF
+
+Standalone is recompiled even though it doesn't reference Baselib:
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
+  2


### PR DESCRIPTION
## Summary

Add baseline tests documenting Dune's current inter-library recompilation
behavior, in preparation for eventually addressing #4572 (finer dependency
analysis between libraries).

Currently, Dune overapproximates by assuming that every module in a consuming
stanza depends on every module in its library dependencies. These tests
document that behavior across 9 scenarios:

- **basic-wrapped**: all modules recompile when a wrapped library changes
- **transitive**: all modules recompile when a transitive dependency changes
- **virtual-library**: all modules recompile when a virtual library changes
- **multiple-libraries**: changing one library recompiles users of all libraries
- **unwrapped**: all modules recompile when any module in an unwrapped library changes
- **lib-to-lib-wrapped**: library-to-library deps (wrapped), all inner modules recompile
- **lib-to-lib-unwrapped**: library-to-library deps (unwrapped), all inner modules recompile
- **wrapped-compat**: `(wrapped (transition ...))` library, all inner modules recompile
- **opaque**: interaction with opaque mode — release profile shows coarse recompilation; dev profile correctly avoids recompilation on implementation-only changes

No source code changes. Tests only.

## Test plan

- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/` passes
- [x] Related test suites unaffected (ocamldep, virtual-libraries, wrapped-transition, external-lib-deps)

Ref: #4572