### PR TITLE
fix(signal_watcher): throw a `Code_error` instead of `assert false`

### DIFF
--- a/src/dune_scheduler/signal_watcher.ml
+++ b/src/dune_scheduler/signal_watcher.ml
@@ -58,7 +58,10 @@ let run ~print_ctrl_c_warning q : unit =
       (* On macOS, sometimes we process a `SIGKILL` either immediately before
          or after `SIGINT`. Given Dune is going to exit anyway, we ignore it. *)
       ()
-    | _ -> (* we only blocked the signals above *) assert false
+    | _ ->
+      Code_error.raise
+        "signal watcher received an unexpected signal"
+        [ "signal", Signal.to_dyn signal ]
   done
 ;;
 


### PR DESCRIPTION
on macOS, upon interrupting a process, sometimes I hit this assertion, and it's really hard to figure out which signal we should be handling here.