### PR TITLE
Fix multi-target revdep workflow invocation

### DIFF
--- a/.github/workflows/revdeps.yml
+++ b/.github/workflows/revdeps.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: 'Packages to test (e.g., "all", "lwt", "{base,core}")'
+        description: 'Packages to test (e.g., "all", "lwt", "base core")'
         required: false
         default: 'all'
         type: string
@@ -45,10 +45,15 @@ jobs:
           nix_conf: ${{ env.EXTRA_NIX_CONFIG }}
       - name: Build OCaml reverse dependencies
         run: |
-          packages="${{ inputs.packages }}"
+          prefix=".#revdeps.x86_64-linux"
+          targets=""
+          for pkg in ${{ inputs.packages }}; do
+            targets="$targets $prefix.$pkg"
+          done
+
           dune_version="${{ inputs.dune_version }}"
           if [ "$dune_version" = "dev" ] || [ -z "$dune_version" ]; then
-            nix build .#revdeps.x86_64-linux.$packages --keep-going --override-input revdeps-dune path:.
+            nix build $targets --keep-going --override-input revdeps-dune path:.
           else
-            nix build .#revdeps.x86_64-linux.$packages --keep-going --override-input revdeps-dune "github:ocaml/dune/$dune_version"
+            nix build $targets --keep-going --override-input revdeps-dune "github:ocaml/dune/$dune_version"
           fi


### PR DESCRIPTION
Running it the revdep check using the bash syntax that is documented does not work as the `{base,core}` is not expanded for some reason.

The failure looks like this:

```
Run packages="{base,core}"
warning: not writing modified lock file of flake 'git+file:///home/runner/work/dune/dune?shallow=1':
• Updated input 'revdeps-dune':
    'github:ocaml/dune/898e0121ff1fb1b5499f9aa976ea5bfc4258cb29?narHash=sha256-1mstTMWySXgw6qwrB6Mhx3BiPSBI1wBfIvxNewnsGdA%3D' (2026-03-27)
  → 'path:/home/runner/work/dune/dune?lastModified=1775206722&narHash=sha256-DfDrJYjCed47uZ1SgXp0QVStg7ZSDkFFWz0P8We8NQY%3D' (2026-04-03)
copying path '/nix/store/0zjk4bg7bw2zsh3w0rnyn4b4hfiw0s9n-source' from 'https://cache.nixos.org'...
unpacking 'github:nix-ocaml/nix-overlays/3416a42c17fa31f6de8e40277f3b1c6e0b6f2fef?narHash=sha256-2bbvykJd8IwkmRPSfPRYLHpbAzLJTZY6SEWp%2B9me214%3D' into the Git cache...
unpacking 'github:melange-re/melange/0c7fbb6b6734d54e60b7e73d2d696ec31e90a0c8?narHash=sha256-/RWEvZeNeag3EKRFS9jIyaDLzl0kpmKEKq0htvDMg9g%3D' into the Git cache...
error: flake 'git+file:///home/runner/work/dune/dune?shallow=1' does not provide attribute 'packages.x86_64-linux.revdeps.x86_64-linux.{base,core}', 'legacyPackages.x86_64-linux.revdeps.x86_64-linux.{base,core}' or 'revdeps.x86_64-linux.{base,core}'
```

This PR changes the list of packages to be a space separated list (fairly common in shell and opam package names do not contain spaces) which gets explicitly expanded to the list of targets for `nix build`.

A run with "base core" set as packages succeeds just fine: https://github.com/Leonidas-from-XIV/dune/actions/runs/23940067487/job/69824268157