### PR TITLE
Make sure to use a POSIX shell instead of `$SHELL`

### DIFF
--- a/test/blackbox-tests/test-cases/promote/non-existent-dir.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent-dir.t
@@ -16,7 +16,7 @@ dune promote should be able to promote into directories that don't exist
   > exit 1
   > EOF
 
-  $ dune build ./foo --diff-command "$SHELL $PWD/diff.sh"
+  $ dune build ./foo --diff-command "/bin/sh $PWD/diff.sh"
   File "dir/foo", line 1, characters 0-0:
   a: /dev/null
   b: foo


### PR DESCRIPTION
The test currently fails on my system:

```
File "test/blackbox-tests/test-cases/promote/non-existent-dir.t", line 1, characters 0-0:
diff --git a/_build/default/test/blackbox-tests/test-cases/promote/non-existent-dir.t b/_build/default/test/blackbox-tests/test-cases/promote/non-existent-dir.t.corrected
index b1d647d632..e4c094a676 100644
--- a/_build/default/test/blackbox-tests/test-cases/promote/non-existent-dir.t
+++ b/_build/default/test/blackbox-tests/test-cases/promote/non-existent-dir.t.corrected
@@ -18,8 +18,8 @@ dune promote should be able to promote into directories that don't exist
 
   $ dune build ./foo --diff-command "$SHELL $PWD/diff.sh"
   File "dir/foo", line 1, characters 0-0:
-  a: /dev/null
-  b: foo
+  a:
+  b:
   [1]
 
   $ dune promote
```

It works in CI so I took a look at what is going on. Turns out that `$SHELL` evaluates to `/usr/bin/fish` on my system which apparently uses `$1` and `$2` differently. This fixes it to use `/bin/sh` which is pretty much universally a POSIX-compatible shell.

It might also be reasonable to set a custom `SHELL` value in cram tests, as ours have `(shell bash)` set, so it would be sensible to also set `SHELL` inside the cram environment. WDYT? Maybe an idea for another PR.