### PR TITLE
Revert "fix(signal-watcher): don't `assert false` on `SIGKILL` (#13370)"

### DIFF
--- a/src/dune_scheduler/signal_watcher.ml
+++ b/src/dune_scheduler/signal_watcher.ml
@@ -54,11 +54,8 @@ let run ~print_ctrl_c_warning q : unit =
       let n = Queue.length last_exit_signals in
       if n = 2 && print_ctrl_c_warning then prerr_endline warning;
       if n = 3 then sys_exit 1
-    | Kill ->
-      (* On macOS, sometimes we process a `SIGKILL` either immediately before
-         or after `SIGINT`. Given Dune is going to exit anyway, we ignore it. *)
-      ()
     | _ ->
+      (* we only blocked the signals above *)
       Code_error.raise
         "signal watcher received an unexpected signal"
         [ "signal", Signal.to_dyn signal ]


### PR DESCRIPTION
This reverts commit 27e579541442f40a13efd97ca044512f80eae3e7.


Turns out that the failure rather happens during SIGINT cleanup, where the behavior of `SIGCHLD` is not super consistent on macOS. Repro in https://github.com/ocaml/dune/pull/14023