### PR TITLE
test: remove digests from tests

### DIFF
--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -128,6 +128,16 @@ censor() {
   dune_cmd subst '[0-9a-f]{32}' '$DIGEST'
 }
 
+censor_ppx() {
+  # shellcheck disable=SC2016
+  dune_cmd subst '[0-9a-f]{32}/ppx.exe' '$DIGEST/ppx.exe'
+}
+
+censor_cinaps() {
+  # shellcheck disable=SC2016
+  dune_cmd subst '\.cinaps\.[0-9a-f]+/' '$CINAPS/'
+}
+
 # CR-someday rgrinberg: get rid of this one or fuse it into censor
 strip_sandbox() {
   # we want to substitute it to $SANDBOX

--- a/test/blackbox-tests/test-cases/cinaps/link-flags.t
+++ b/test/blackbox-tests/test-cases/cinaps/link-flags.t
@@ -24,8 +24,8 @@ Link-time flags for running cinaps
   > | .[]
   > | select(endswith(".exe"))
   > EOF
-  $ dune trace cat | jq -f $jqScript
-  ".cinaps.edaf9873/cinaps.exe"
+  $ dune trace cat | jq -f $jqScript | censor_cinaps
+  "$CINAPS/cinaps.exe"
 
 Check that the version guard is correct.
 

--- a/test/blackbox-tests/test-cases/cinaps/multiple-cinaps.t
+++ b/test/blackbox-tests/test-cases/cinaps/multiple-cinaps.t
@@ -19,9 +19,9 @@ Multiple cinaps stanzas in the same dune file
   > (cinaps (files foo.ml))
   > (cinaps (files *oo.ml))
   > EOF
-  $ dune runtest --diff-command diff 2>&1
+  $ dune runtest --diff-command diff 2>&1 | censor_cinaps
   Error: Multiple rules generated for
-  _build/default/.cinaps.f0d91a31/cinaps.ml-gen:
+  _build/default/$CINAPS/cinaps.ml-gen:
   - dune:1
   - dune:2
   -> required by alias cinaps in dune:1

--- a/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
+++ b/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
@@ -79,12 +79,12 @@ not stable across different setups.
         (cmti ()))))
      (include_dirs (_build/default/exe/.exe.eobjs/byte)))))
 
-  $ dune describe workspace --lang 0.1 --sanitize-for-tests lib
+  $ dune describe workspace --lang 0.1 --sanitize-for-tests lib | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (library
     ((name lib)
-     (uid 48f89f472eed42cfe8a7ae83e2c8c1ce)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/lib)
@@ -96,27 +96,27 @@ not stable across different setups.
         (cmti ()))))
      (include_dirs (_build/default/lib/.lib.objs/byte)))))
 
-  $ dune describe workspace --lang 0.1 --sanitize-for-tests --with-pps exe
+  $ dune describe workspace --lang 0.1 --sanitize-for-tests --with-pps exe | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (executables
     ((names (exe))
      (requires
-      (25fa301af563256248c5dadd60078c6e
-       b3f1696f67e77afbbf90bbd4ff4db3f7
-       3238f110cc121b8de5fb94811b5395f0
-       aa150dea272f13137145f9b1336e6f89
-       dc50e9309dbe56e9ba5a145dd0c7d272
-       c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e
-       9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1
-       b6a38388b521e9d788bf8c241c8b7131
-       e7b78a2ef3334358a41a86855c8739c2
-       1513262a352b79a04ff483cd84ebd966
-       2c25d00eb24f552a85fba122b2d45dd1
-       12c434f04237f2f66660cf4ef9d28bac
-       d4bbc5a64c5463ce6eb84f54a61aa8b8))
+      ($DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST))
      (modules
       (((name Exe)
         (impl (_build/default/exe/exe.ml))
@@ -126,7 +126,7 @@ not stable across different setups.
      (include_dirs (_build/default/exe/.exe.eobjs/byte))))
    (library
     ((name compiler-libs)
-     (uid 25fa301af563256248c5dadd60078c6e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -134,20 +134,20 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid b3f1696f67e77afbbf90bbd4ff4db3f7)
+     (uid $DIGEST)
      (local false)
-     (requires (25fa301af563256248c5dadd60078c6e))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid d4bbc5a64c5463ce6eb84f54a61aa8b8)
+     (uid $DIGEST)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       2c25d00eb24f552a85fba122b2d45dd1
-       12c434f04237f2f66660cf4ef9d28bac))
+      ($DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir _build/default/dummy_ppx)
      (modules
       (((name Dummy_ppx)
@@ -158,15 +158,15 @@ not stable across different setups.
      (include_dirs (_build/default/dummy_ppx/.dummy_ppx.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid 3238f110cc121b8de5fb94811b5395f0)
+     (uid $DIGEST)
      (local false)
-     (requires (b3f1696f67e77afbbf90bbd4ff4db3f7))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid 5df1715b4499126654748a00e0142c5e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -174,7 +174,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name ppx_derivers)
-     (uid 3e0806da37ceb5ee0d783c15826db0e1)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -182,43 +182,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid 2c25d00eb24f552a85fba122b2d45dd1)
+     (uid $DIGEST)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89
-       9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1
-       b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966
-       dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2
-       b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid c1f4a4a8fcca6a7045ebee5b639dc729)
+     (uid $DIGEST)
      (local false)
      (requires
-      (aa150dea272f13137145f9b1336e6f89 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid aa150dea272f13137145f9b1336e6f89)
+     (uid $DIGEST)
      (local false)
      (requires
-      (3238f110cc121b8de5fb94811b5395f0 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid 9087f2ff68e06ebafea537cd921b2b75)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -226,16 +226,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid 1513262a352b79a04ff483cd84ebd966)
+     (uid $DIGEST)
      (local false)
      (requires
-      (e7b78a2ef3334358a41a86855c8739c2 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid b6a38388b521e9d788bf8c241c8b7131)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -243,7 +243,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name sexplib0)
-     (uid e7b78a2ef3334358a41a86855c8739c2)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -251,7 +251,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name static_lib)
-     (uid 12c434f04237f2f66660cf4ef9d28bac)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/static_lib)
@@ -264,19 +264,19 @@ not stable across different setups.
      (include_dirs (_build/default/static_lib/.static_lib.objs/byte))))
    (library
     ((name stdlib-shims)
-     (uid dc50e9309dbe56e9ba5a145dd0c7d272)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
      (modules ())
      (include_dirs (/FINDLIB/stdlib-shims)))))
 
-  $ dune describe workspace --lang 0.1 --sanitize-for-tests --with-pps lib
+  $ dune describe workspace --lang 0.1 --sanitize-for-tests --with-pps lib | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (library
     ((name compiler-libs)
-     (uid 25fa301af563256248c5dadd60078c6e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -284,20 +284,20 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid b3f1696f67e77afbbf90bbd4ff4db3f7)
+     (uid $DIGEST)
      (local false)
-     (requires (25fa301af563256248c5dadd60078c6e))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid d4bbc5a64c5463ce6eb84f54a61aa8b8)
+     (uid $DIGEST)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       2c25d00eb24f552a85fba122b2d45dd1
-       12c434f04237f2f66660cf4ef9d28bac))
+      ($DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir _build/default/dummy_ppx)
      (modules
       (((name Dummy_ppx)
@@ -308,7 +308,7 @@ not stable across different setups.
      (include_dirs (_build/default/dummy_ppx/.dummy_ppx.objs/byte))))
    (library
     ((name lib)
-     (uid 48f89f472eed42cfe8a7ae83e2c8c1ce)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/lib)
@@ -321,15 +321,15 @@ not stable across different setups.
      (include_dirs (_build/default/lib/.lib.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid 3238f110cc121b8de5fb94811b5395f0)
+     (uid $DIGEST)
      (local false)
-     (requires (b3f1696f67e77afbbf90bbd4ff4db3f7))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid 5df1715b4499126654748a00e0142c5e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -337,7 +337,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name ppx_derivers)
-     (uid 3e0806da37ceb5ee0d783c15826db0e1)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -345,43 +345,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid 2c25d00eb24f552a85fba122b2d45dd1)
+     (uid $DIGEST)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89
-       9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1
-       b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966
-       dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2
-       b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid c1f4a4a8fcca6a7045ebee5b639dc729)
+     (uid $DIGEST)
      (local false)
      (requires
-      (aa150dea272f13137145f9b1336e6f89 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid aa150dea272f13137145f9b1336e6f89)
+     (uid $DIGEST)
      (local false)
      (requires
-      (3238f110cc121b8de5fb94811b5395f0 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid 9087f2ff68e06ebafea537cd921b2b75)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -389,16 +389,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid 1513262a352b79a04ff483cd84ebd966)
+     (uid $DIGEST)
      (local false)
      (requires
-      (e7b78a2ef3334358a41a86855c8739c2 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid b6a38388b521e9d788bf8c241c8b7131)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -406,7 +406,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name sexplib0)
-     (uid e7b78a2ef3334358a41a86855c8739c2)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -414,7 +414,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name static_lib)
-     (uid 12c434f04237f2f66660cf4ef9d28bac)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/static_lib)
@@ -427,7 +427,7 @@ not stable across different setups.
      (include_dirs (_build/default/static_lib/.static_lib.objs/byte))))
    (library
     ((name stdlib-shims)
-     (uid dc50e9309dbe56e9ba5a145dd0c7d272)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)

--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -225,7 +225,7 @@ are reproducible, and are kept consistent between different machines.
 ``dune describe workspace`` may indeed print absolute paths, that are
 not stable across different setups.
 
-  $ dune describe workspace --lang 0.1 --sanitize-for-tests
+  $ dune describe workspace --lang 0.1 --sanitize-for-tests | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (executables
@@ -241,7 +241,7 @@ not stable across different setups.
    (executables
     ((names (main))
      (requires
-      (5a9c5cdc441305690411419a4a5e3f34 536b4af2ace976f46343f6b47c2c32f2))
+      ($DIGEST $DIGEST))
      (modules
       (((name Main)
         (impl (_build/default/main.ml))
@@ -252,7 +252,7 @@ not stable across different setups.
    (executables
     ((names (main2))
      (requires
-      (5a9c5cdc441305690411419a4a5e3f34 536b4af2ace976f46343f6b47c2c32f2))
+      ($DIGEST $DIGEST))
      (modules
       (((name Main2_aux4)
         (impl ())
@@ -287,7 +287,7 @@ not stable across different setups.
      (include_dirs (_build/default/.main2.eobjs/byte))))
    (executables
     ((names (main3))
-     (requires (a392325be68958876f9598a822187d55))
+     (requires ($DIGEST))
      (modules
       (((name Main3)
         (impl (_build/default/main3.ml))
@@ -348,7 +348,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_exe.eobjs/byte))))
    (library
     ((name bar)
-     (uid 7dc7853647f347467f62c91edc898b00)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -371,7 +371,7 @@ not stable across different setups.
      (include_dirs (_build/default/.bar.objs/byte))))
    (library
     ((name cmdliner)
-     (uid a392325be68958876f9598a822187d55)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/cmdliner)
@@ -379,7 +379,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/cmdliner))))
    (library
     ((name compiler-libs)
-     (uid 25fa301af563256248c5dadd60078c6e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -387,18 +387,18 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid b3f1696f67e77afbbf90bbd4ff4db3f7)
+     (uid $DIGEST)
      (local false)
-     (requires (25fa301af563256248c5dadd60078c6e))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid ff1580960f48a57430e95cef762bf472)
+     (uid $DIGEST)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 2c25d00eb24f552a85fba122b2d45dd1))
+      ($DIGEST $DIGEST))
      (source_dir _build/default)
      (modules
       (((name Dummy_ppx)
@@ -409,9 +409,9 @@ not stable across different setups.
      (include_dirs (_build/default/.dummy_ppx.objs/byte))))
    (library
     ((name foo)
-     (uid 536b4af2ace976f46343f6b47c2c32f2)
+     (uid $DIGEST)
      (local true)
-     (requires (5a9c5cdc441305690411419a4a5e3f34))
+     (requires ($DIGEST))
      (source_dir _build/default)
      (modules
       (((name Foo)
@@ -422,7 +422,7 @@ not stable across different setups.
      (include_dirs (_build/default/.foo.objs/byte))))
    (library
     ((name foo.x)
-     (uid 5a9c5cdc441305690411419a4a5e3f34)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -435,15 +435,15 @@ not stable across different setups.
      (include_dirs (_build/default/.foo_x.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid 3238f110cc121b8de5fb94811b5395f0)
+     (uid $DIGEST)
      (local false)
-     (requires (b3f1696f67e77afbbf90bbd4ff4db3f7))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid 5df1715b4499126654748a00e0142c5e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -451,7 +451,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name per_module_action_exe)
-     (uid fa77b53b2ba88e3d4371707df82dbd13)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -483,7 +483,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_exe.objs/byte))))
    (library
     ((name per_module_action_lib)
-     (uid 40a11de60c0aa7eb6cbe99a43d4acc3e)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -509,7 +509,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_lib.objs/byte))))
    (library
     ((name per_module_pp_lib)
-     (uid 5e6b5e06d15bbba69a481ad64dbed48d)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -535,7 +535,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_pp_lib.objs/byte))))
    (library
     ((name ppx_derivers)
-     (uid 3e0806da37ceb5ee0d783c15826db0e1)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -543,43 +543,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid 2c25d00eb24f552a85fba122b2d45dd1)
+     (uid $DIGEST)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89
-       9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1
-       b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966
-       dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2
-       b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid c1f4a4a8fcca6a7045ebee5b639dc729)
+     (uid $DIGEST)
      (local false)
      (requires
-      (aa150dea272f13137145f9b1336e6f89 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid aa150dea272f13137145f9b1336e6f89)
+     (uid $DIGEST)
      (local false)
      (requires
-      (3238f110cc121b8de5fb94811b5395f0 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid 9087f2ff68e06ebafea537cd921b2b75)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -587,16 +587,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid 1513262a352b79a04ff483cd84ebd966)
+     (uid $DIGEST)
      (local false)
      (requires
-      (e7b78a2ef3334358a41a86855c8739c2 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid b6a38388b521e9d788bf8c241c8b7131)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -604,7 +604,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name re_lib)
-     (uid 70105dd95724ac832af7c89df2e2ff65)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -627,7 +627,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_lib.objs/byte))))
    (library
     ((name sexplib0)
-     (uid e7b78a2ef3334358a41a86855c8739c2)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -635,7 +635,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name stdlib-shims)
-     (uid dc50e9309dbe56e9ba5a145dd0c7d272)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
@@ -643,7 +643,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/stdlib-shims))))
    (library
     ((name subfolder_lib)
-     (uid 3ce0ac7acd90d422db7ffc54ebbdee57)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/subdir/subfolder)
@@ -657,7 +657,7 @@ not stable across different setups.
      (include_dirs (_build/default/subdir/subfolder/.subfolder_lib.objs/byte))))
    (library
     ((name virtual)
-     (uid f6cee13b744e81f71621346d08c8df22)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/virtual)
@@ -670,9 +670,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual/.virtual.objs/byte))))
    (library
     ((name virtual_impl1)
-     (uid 9bf1effa3fd6524dd5b76957e6245f85)
+     (uid $DIGEST)
      (local true)
-     (requires (f6cee13b744e81f71621346d08c8df22))
+     (requires ($DIGEST))
      (source_dir _build/default/virtual_impl1)
      (modules
       (((name Virtual)
@@ -690,9 +690,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
    (library
     ((name virtual_impl2)
-     (uid 8fd0490dfc3b56d3874fbbf6eb4abbac)
+     (uid $DIGEST)
      (local true)
-     (requires (f6cee13b744e81f71621346d08c8df22))
+     (requires ($DIGEST))
      (source_dir _build/default/virtual_impl2)
      (modules
       (((name Virtual)
@@ -709,7 +709,7 @@ not stable across different setups.
         (cmti ()))))
      (include_dirs (_build/default/virtual_impl2/.virtual_impl2.objs/byte)))))
 
-  $ dune describe workspace --lang 0.1 --with-deps --sanitize-for-tests
+  $ dune describe workspace --lang 0.1 --with-deps --sanitize-for-tests | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (executables
@@ -726,7 +726,7 @@ not stable across different setups.
    (executables
     ((names (main))
      (requires
-      (5a9c5cdc441305690411419a4a5e3f34 536b4af2ace976f46343f6b47c2c32f2))
+      ($DIGEST $DIGEST))
      (modules
       (((name Main)
         (impl (_build/default/main.ml))
@@ -738,7 +738,7 @@ not stable across different setups.
    (executables
     ((names (main2))
      (requires
-      (5a9c5cdc441305690411419a4a5e3f34 536b4af2ace976f46343f6b47c2c32f2))
+      ($DIGEST $DIGEST))
      (modules
       (((name Main2_aux4)
         (impl ())
@@ -793,7 +793,7 @@ not stable across different setups.
      (include_dirs (_build/default/.main2.eobjs/byte))))
    (executables
     ((names (main3))
-     (requires (a392325be68958876f9598a822187d55))
+     (requires ($DIGEST))
      (modules
       (((name Main3)
         (impl (_build/default/main3.ml))
@@ -880,7 +880,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_exe.eobjs/byte))))
    (library
     ((name bar)
-     (uid 7dc7853647f347467f62c91edc898b00)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -912,7 +912,7 @@ not stable across different setups.
      (include_dirs (_build/default/.bar.objs/byte))))
    (library
     ((name cmdliner)
-     (uid a392325be68958876f9598a822187d55)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/cmdliner)
@@ -920,7 +920,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/cmdliner))))
    (library
     ((name compiler-libs)
-     (uid 25fa301af563256248c5dadd60078c6e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -928,18 +928,18 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid b3f1696f67e77afbbf90bbd4ff4db3f7)
+     (uid $DIGEST)
      (local false)
-     (requires (25fa301af563256248c5dadd60078c6e))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid ff1580960f48a57430e95cef762bf472)
+     (uid $DIGEST)
      (local true)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729 2c25d00eb24f552a85fba122b2d45dd1))
+      ($DIGEST $DIGEST))
      (source_dir _build/default)
      (modules
       (((name Dummy_ppx)
@@ -951,9 +951,9 @@ not stable across different setups.
      (include_dirs (_build/default/.dummy_ppx.objs/byte))))
    (library
     ((name foo)
-     (uid 536b4af2ace976f46343f6b47c2c32f2)
+     (uid $DIGEST)
      (local true)
-     (requires (5a9c5cdc441305690411419a4a5e3f34))
+     (requires ($DIGEST))
      (source_dir _build/default)
      (modules
       (((name Foo)
@@ -965,7 +965,7 @@ not stable across different setups.
      (include_dirs (_build/default/.foo.objs/byte))))
    (library
     ((name foo.x)
-     (uid 5a9c5cdc441305690411419a4a5e3f34)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -979,15 +979,15 @@ not stable across different setups.
      (include_dirs (_build/default/.foo_x.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid 3238f110cc121b8de5fb94811b5395f0)
+     (uid $DIGEST)
      (local false)
-     (requires (b3f1696f67e77afbbf90bbd4ff4db3f7))
+     (requires ($DIGEST))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid 5df1715b4499126654748a00e0142c5e)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -995,7 +995,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name per_module_action_exe)
-     (uid fa77b53b2ba88e3d4371707df82dbd13)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1040,7 +1040,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_exe.objs/byte))))
    (library
     ((name per_module_action_lib)
-     (uid 40a11de60c0aa7eb6cbe99a43d4acc3e)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1075,7 +1075,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_lib.objs/byte))))
    (library
     ((name per_module_pp_lib)
-     (uid 5e6b5e06d15bbba69a481ad64dbed48d)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1110,7 +1110,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_pp_lib.objs/byte))))
    (library
     ((name ppx_derivers)
-     (uid 3e0806da37ceb5ee0d783c15826db0e1)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -1118,43 +1118,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid 2c25d00eb24f552a85fba122b2d45dd1)
+     (uid $DIGEST)
      (local false)
      (requires
-      (c1f4a4a8fcca6a7045ebee5b639dc729
-       5df1715b4499126654748a00e0142c5e
-       aa150dea272f13137145f9b1336e6f89
-       9087f2ff68e06ebafea537cd921b2b75
-       3e0806da37ceb5ee0d783c15826db0e1
-       b6a38388b521e9d788bf8c241c8b7131
-       1513262a352b79a04ff483cd84ebd966
-       dc50e9309dbe56e9ba5a145dd0c7d272
-       e7b78a2ef3334358a41a86855c8739c2
-       b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST
+       $DIGEST))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid c1f4a4a8fcca6a7045ebee5b639dc729)
+     (uid $DIGEST)
      (local false)
      (requires
-      (aa150dea272f13137145f9b1336e6f89 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid aa150dea272f13137145f9b1336e6f89)
+     (uid $DIGEST)
      (local false)
      (requires
-      (3238f110cc121b8de5fb94811b5395f0 b3f1696f67e77afbbf90bbd4ff4db3f7))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid 9087f2ff68e06ebafea537cd921b2b75)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -1162,16 +1162,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid 1513262a352b79a04ff483cd84ebd966)
+     (uid $DIGEST)
      (local false)
      (requires
-      (e7b78a2ef3334358a41a86855c8739c2 dc50e9309dbe56e9ba5a145dd0c7d272))
+      ($DIGEST $DIGEST))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid b6a38388b521e9d788bf8c241c8b7131)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -1179,7 +1179,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name re_lib)
-     (uid 70105dd95724ac832af7c89df2e2ff65)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1211,7 +1211,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_lib.objs/byte))))
    (library
     ((name sexplib0)
-     (uid e7b78a2ef3334358a41a86855c8739c2)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -1219,7 +1219,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name stdlib-shims)
-     (uid dc50e9309dbe56e9ba5a145dd0c7d272)
+     (uid $DIGEST)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
@@ -1227,7 +1227,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/stdlib-shims))))
    (library
     ((name subfolder_lib)
-     (uid 3ce0ac7acd90d422db7ffc54ebbdee57)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/subdir/subfolder)
@@ -1242,7 +1242,7 @@ not stable across different setups.
      (include_dirs (_build/default/subdir/subfolder/.subfolder_lib.objs/byte))))
    (library
     ((name virtual)
-     (uid f6cee13b744e81f71621346d08c8df22)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default/virtual)
@@ -1256,9 +1256,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual/.virtual.objs/byte))))
    (library
     ((name virtual_impl1)
-     (uid 9bf1effa3fd6524dd5b76957e6245f85)
+     (uid $DIGEST)
      (local true)
-     (requires (f6cee13b744e81f71621346d08c8df22))
+     (requires ($DIGEST))
      (source_dir _build/default/virtual_impl1)
      (modules
       (((name Virtual)
@@ -1282,9 +1282,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
    (library
     ((name virtual_impl2)
-     (uid 8fd0490dfc3b56d3874fbbf6eb4abbac)
+     (uid $DIGEST)
      (local true)
-     (requires (f6cee13b744e81f71621346d08c8df22))
+     (requires ($DIGEST))
      (source_dir _build/default/virtual_impl2)
      (modules
       (((name Virtual)

--- a/test/blackbox-tests/test-cases/describe/gh12997.t
+++ b/test/blackbox-tests/test-cases/describe/gh12997.t
@@ -23,12 +23,12 @@
   > let x = 1
   > EOF
 
-  $ dune describe workspace --sanitize-for-tests
+  $ dune describe workspace --sanitize-for-tests | censor
   ((root /WORKSPACE_ROOT)
    (build_context _build/default)
    (library
     ((name alive)
-     (uid b8a14a61f9163d57810cc01c7f39d084)
+     (uid $DIGEST)
      (local true)
      (requires ())
      (source_dir _build/default)

--- a/test/blackbox-tests/test-cases/github3336.t/run.t
+++ b/test/blackbox-tests/test-cases/github3336.t/run.t
@@ -11,5 +11,5 @@ Here we demonstrate that such a ppx .exe is built successfully.
   - executable/exec.pp.ml
   [1]
 
-  $ find _build | grep \.exe$
-  _build/default/.ppx/0747fa92c6bc2f7f4818823e4f8871ab/ppx.exe
+  $ find _build | grep \.exe$ | censor_ppx
+  _build/default/.ppx/$DIGEST/ppx.exe

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -26,11 +26,13 @@ specify js mode (#1940).
   $ dune trace cat | jq -r 'include "dune";
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
-  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
+  > | sort \
+  > | censor
   .b.eobjs/jsoo/b.cmo.js
   .e.eobjs/jsoo/e.cmo.js
   .foo.objs/jsoo/default/foo.cma.js
-  .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/default/.runtime/$DIGEST/runtime.bc.runtime.js
   .js/default/stdlib/std_exit.cmo.js
   .js/default/stdlib/stdlib.cma.js
   b.bc.js

--- a/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/jsoo-config.t/run.t
@@ -4,14 +4,16 @@ tests js_of_ocaml conigs
   $ dune trace cat | jq -r 'include "dune";
   >   processes
   > | select(.args.prog | test("js_of_ocaml$"))
-  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' | sort
-  .js/!use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  > | .args | targets | .[] | sub("^_build/[^/]+/"; "")' \
+  > | sort \
+  > | censor
+  .js/!use-js-string/.runtime/$DIGEST/runtime.bc.runtime.js
   .js/!use-js-string/stdlib/std_exit.cmo.js
   .js/!use-js-string/stdlib/stdlib.cma.js
-  .js/default/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/default/.runtime/$DIGEST/runtime.bc.runtime.js
   .js/default/stdlib/std_exit.cmo.js
   .js/default/stdlib/stdlib.cma.js
-  .js/use-js-string/.runtime/69326c30fc4a6ffc800b0a8e0b822993/runtime.bc.runtime.js
+  .js/use-js-string/.runtime/$DIGEST/runtime.bc.runtime.js
   .js/use-js-string/stdlib/std_exit.cmo.js
   .js/use-js-string/stdlib/stdlib.cma.js
   bin/.bin1.eobjs/jsoo/dune__exe__Bin1.cmo.js

--- a/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github1946.t/run.t
@@ -5,7 +5,7 @@ in the same dune file, but require different ppx specifications
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build @all --profile release
-  $ dune ocaml merlin dump-config $PWD
+  $ dune ocaml merlin dump-config $PWD | censor_ppx
   Usesppx1: _build/default/usesppx1
   ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
@@ -17,7 +17,7 @@ in the same dune file, but require different ppx specifications
    (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
    (S $TESTCASE_ROOT)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/e5a600482cb65dfcb14104c728a9df4a/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
    (UNIT_NAME usesppx1))
   Usesppx1: _build/default/usesppx1.ml-gen
   ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
@@ -30,7 +30,7 @@ in the same dune file, but require different ppx specifications
    (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
    (S $TESTCASE_ROOT)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/e5a600482cb65dfcb14104c728a9df4a/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
    (UNIT_NAME usesppx1))
   Usesppx2: _build/default/usesppx2
   ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
@@ -43,7 +43,7 @@ in the same dune file, but require different ppx specifications
    (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
    (S $TESTCASE_ROOT)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/f455412d08561f269148a48a55f3aef7/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
    (UNIT_NAME usesppx2))
   Usesppx2: _build/default/usesppx2.ml-gen
   ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
@@ -56,5 +56,5 @@ in the same dune file, but require different ppx specifications
    (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
    (S $TESTCASE_ROOT)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/f455412d08561f269148a48a55f3aef7/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
    (UNIT_NAME usesppx2))

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -12,7 +12,7 @@ We're going create a fake findlib library for use:
 
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
-  $ dune ocaml merlin dump-config $PWD/exe
+  $ dune ocaml merlin dump-config $PWD/exe | censor_ppx
   X: _build/default/exe/x
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
@@ -55,7 +55,7 @@ CRAM sanitization
    (UNIT_NAME x))
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
-  $ dune ocaml merlin dump-config $PWD/lib
+  $ dune ocaml merlin dump-config $PWD/lib | censor_ppx
   Bar: _build/default/lib/bar
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
    (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
@@ -71,7 +71,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (UNIT_NAME bar))
   Bar: _build/default/lib/bar.ml-gen
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
@@ -88,7 +88,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (UNIT_NAME bar))
   File: _build/default/lib/subdir/file
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
@@ -105,7 +105,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-open Bar))
    (UNIT_NAME bar__File))
   File: _build/default/lib/subdir/file.ml
@@ -123,7 +123,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
    (FLG (-open Bar))
    (UNIT_NAME bar__File))
   Foo: _build/default/lib/foo
@@ -143,7 +143,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (UNIT_NAME foo))
   Foo: _build/default/lib/foo.ml-gen
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
@@ -162,7 +162,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (UNIT_NAME foo))
   Privmod: _build/default/lib/privmod
   ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
@@ -181,7 +181,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-open Foo))
    (UNIT_NAME foo__Privmod))
   Privmod: _build/default/lib/privmod.ml
@@ -201,7 +201,7 @@ CRAM sanitization
    (S $TESTCASE_ROOT/lib)
    (S $TESTCASE_ROOT/lib/subdir)
    (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/3a8685470d9b5edd99690707a29a2b1a/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
+   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
    (FLG (-open Foo))
    (UNIT_NAME foo__Privmod))
 

--- a/test/blackbox-tests/test-cases/odoc/new/multiple-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/new/multiple-private-libs.t/run.t
@@ -6,6 +6,8 @@ This test checks that there is no clash when two private libraries have the same
   File "page-a.odoc":
   Warning: Failed to lookup child page dummy
 
-  $ dune trace cat | jq -c 'include "dune"; targetsMatching("docs/test")'
-  {"target_dirs":["_build/default/_doc_new/html/docs/test@38f98c954b37/Test"]}
-  {"target_files":["_build/default/_doc_new/html/docs/test@38f98c954b37/index.html"]}
+  $ dune trace cat \
+  > | jq -c 'include "dune"; targetsMatching("docs/test")' \
+  > | dune_cmd subst 'test@[a-f0-9]+/' 'test@$DIGEST/'
+  {"target_dirs":["_build/default/_doc_new/html/docs/test@$DIGEST/Test"]}
+  {"target_files":["_build/default/_doc_new/html/docs/test@$DIGEST/index.html"]}

--- a/test/blackbox-tests/test-cases/ppx/ppx-driver/basic.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-driver/basic.t/run.t
@@ -41,8 +41,8 @@ Same, but with error pointing to .ppx
 
 Test the argument syntax
 
-  $ dune build test_ppx_args.cma
-  .ppx/7e2e4f08e99331b1c723b81d3aa870ba/ppx.exe
+  $ dune build test_ppx_args.cma 2>&1 | censor
+  .ppx/$DIGEST/ppx.exe
   -arg1
   -arg2
   -arg3=Oreo

--- a/test/blackbox-tests/test-cases/ppx/ppx-driver/installed.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-driver/installed.t/run.t
@@ -3,9 +3,9 @@ Test using installed drivers
   $ dune build --root driver @install
   Entering directory 'driver'
   Leaving directory 'driver'
-  $ OCAMLPATH=driver/_build/install/default/lib dune build --root use-external-driver driveruser.cma
+  $ OCAMLPATH=driver/_build/install/default/lib dune build --root use-external-driver driveruser.cma 2>&1 | censor
   Entering directory 'use-external-driver'
-  .ppx/d1c2c0cf2b61b462226db18f72732070/ppx.exe
+  .ppx/$DIGEST/ppx.exe
   -arg1
   -arg2
   -foo
@@ -25,10 +25,10 @@ Test using installed drivers
   Leaving directory 'use-external-driver'
   [1]
 
-  $ OCAMLPATH=driver/_build/install/default/lib dune build --root replaces driveruser.cma
+  $ OCAMLPATH=driver/_build/install/default/lib dune build --root replaces driveruser.cma 2>&1 | censor
   Entering directory 'replaces'
   replacesdriver
-  .ppx/5c2c5102d9f019e3d5eee93d6abe2029/ppx.exe
+  .ppx/$DIGEST/ppx.exe
   -arg1
   -arg2
   -foo
@@ -51,10 +51,10 @@ Test using installed drivers
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root driver-replaces @install
   Entering directory 'driver-replaces'
   Leaving directory 'driver-replaces'
-  $ OCAMLPATH=driver/_build/install/default/lib:driver-replaces/_build/install/default/lib dune build --root replaces-external driveruser.cma
+  $ OCAMLPATH=driver/_build/install/default/lib:driver-replaces/_build/install/default/lib dune build --root replaces-external driveruser.cma 2>&1 | censor
   Entering directory 'replaces-external'
   replacesdriver
-  .ppx/5c2c5102d9f019e3d5eee93d6abe2029/ppx.exe
+  .ppx/$DIGEST/ppx.exe
   -arg1
   -arg2
   -foo

--- a/test/blackbox-tests/test-cases/ppx/ppx-driver/list-args.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-driver/list-args.t/run.t
@@ -1,7 +1,7 @@
 Test the argument syntax with list expansion allowed (dune > 3.2)
 
-  $ dune build
-  .ppx/7e2e4f08e99331b1c723b81d3aa870ba/ppx.exe
+  $ dune build 2>&1 | censor
+  .ppx/$DIGEST/ppx.exe
   -arg1
   -arg2
   -arg3=Oreo

--- a/test/blackbox-tests/test-cases/ppx/ppx-pform.t
+++ b/test/blackbox-tests/test-cases/ppx/ppx-pform.t
@@ -38,8 +38,8 @@ Create a rule that uses the ppx pform
 
 Run the test
 
-  $ dune build @test-ppx
-  .ppx/1b1fa3a921019504476f74bb87685798/ppx.exe
+  $ dune build @test-ppx 2>&1 | censor
+  .ppx/$DIGEST/ppx.exe
 
 Test that the order of libraries doesn't matter
 

--- a/test/blackbox-tests/test-cases/top-module/load-with-ppx.t
+++ b/test/blackbox-tests/test-cases/top-module/load-with-ppx.t
@@ -23,9 +23,9 @@ Load a module that requires ppx
   $ cat >foo.ml <<EOF
   > let () = ()
   > EOF
-  $ dune ocaml top-module foo.ml
+  $ dune ocaml top-module foo.ml | censor_ppx
   #directory "$TESTCASE_ROOT/_build/default/.topmod/foo.ml";;
   #load "$TESTCASE_ROOT/_build/default/.topmod/foo.ml/foo.cmo";;
-  #ppx "$TESTCASE_ROOT/_build/default/.ppx/70f69f007f7d5814898c75dac997e15a/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'";;
+  #ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'";;
   $ basename $(ls _build/default/.ppx/*/*.exe)
   ppx.exe


### PR DESCRIPTION
Digests can change for many reasons and therefore create churn for the tests.