### PR TITLE
test(pkg): remove more digests

### DIFF
--- a/test/blackbox-tests/test-cases/describe/describe_location.t
+++ b/test/blackbox-tests/test-cases/describe/describe_location.t
@@ -47,8 +47,8 @@ Test that executables from dependencies are located correctly:
   >  (depends bar))
   > EOF
 
-  $ dune describe location bar
-  _build/_private/default/.pkg/bar.0.1-db52031820dfa460a96ce95be8b416d0/target/bin/bar
+  $ dune describe location bar 2>&1 | censor
+  _build/_private/default/.pkg/bar.0.1-$DIGEST/target/bin/bar
 
 Test that executables from PATH are located correctly:
   $ mkdir bin

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -18,6 +18,6 @@ Test that section pforms are substituted with absolute paths.
 
 Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
-  $ build_pkg test 2>&1 | strip_sandbox
-  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-1ea966948fe62458dfee9efe3b115cba/target
-  $SANDBOX/_private/default/.pkg/test.0.0.1-1ea966948fe62458dfee9efe3b115cba/target
+  $ build_pkg test 2>&1 | strip_sandbox | censor
+  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target
+  $SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -20,9 +20,9 @@ Some environment variables are automatically exported by packages:
   $ ln -s $(which ocamlc) .bin/ocamlc
   $ ln -s $(which sh) .bin/sh
   $ dune=$(which dune)
-  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest
-  MANPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-1335a850f360f47161c77fd265ddaf99/target/man
-  OCAMLPATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-1335a850f360f47161c77fd265ddaf99/target/lib
-  CAML_LD_LIBRARY_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-1335a850f360f47161c77fd265ddaf99/target/lib/stublibs
-  OCAMLTOP_INCLUDE_PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-1335a850f360f47161c77fd265ddaf99/target/lib/toplevel
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/test.0.0.1-1335a850f360f47161c77fd265ddaf99/target/bin:$TESTCASE_ROOT/.bin
+  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest 2>&1 | strip_sandbox | censor
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/man
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/stublibs
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/toplevel
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/.bin

--- a/test/blackbox-tests/test-cases/pkg/helpers.sh
+++ b/test/blackbox-tests/test-cases/pkg/helpers.sh
@@ -64,7 +64,7 @@ show_pkg_targets() {
 
 show_pkg_cookie() {
   local pkg=$1
-  $dune internal dump "$(get_build_pkg_dir "$pkg")/target/cookie"
+  $dune internal dump "$(get_build_pkg_dir "$pkg")/target/cookie" 2>&1 | censor
 }
 
 mkrepo() {

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -33,7 +33,7 @@ Testing install actions
   { files =
       [ (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-0d81cce744444ce7e8e1c710ab100040/target/lib/xxx"
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -12,14 +12,14 @@ Test missing entries in the .install file
 This should give us a proper error that myfile wasn't generated
 
   $ lockfile "myfile"
-  $ build_pkg test 2>&1 | dune_cmd subst '_build.*_private' '$ROOT/_private'
+  $ build_pkg test 2>&1 | dune_cmd subst '_build.*_private' '$ROOT/_private' | censor
   Error: entry
-  $ROOT/_private/default/.pkg/test.0.0.1-14cf8b955e694dcf79c50e1c47a4d853/source/myfile
+  $ROOT/_private/default/.pkg/test.0.0.1-$DIGEST/source/myfile
   in
-  $ROOT/_private/default/.pkg/test.0.0.1-14cf8b955e694dcf79c50e1c47a4d853/source/test.install
+  $ROOT/_private/default/.pkg/test.0.0.1-$DIGEST/source/test.install
   does not exist
   -> required by
-     $ROOT/_private/default/.pkg/test.0.0.1-14cf8b955e694dcf79c50e1c47a4d853/target
+     $ROOT/_private/default/.pkg/test.0.0.1-$DIGEST/target
   [1]
 
 This on the other hand shouldn't error because myfile is optional

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -43,19 +43,19 @@ Test that installed binaries are visible in dependent packages
   { files =
       [ (LIB,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-100cf7b8687cb006f4cd39e8728417bd/target/lib/test/libxxx"
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/test/libxxx"
          ])
       ; (LIB_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-100cf7b8687cb006f4cd39e8728417bd/target/lib/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/lib_rootxxx"
          ])
       ; (BIN,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-100cf7b8687cb006f4cd39e8728417bd/target/bin/foo"
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/bin/foo"
          ])
       ; (SHARE_ROOT,
          [ In_build_dir
-             "_private/default/.pkg/test.0.0.1-100cf7b8687cb006f4cd39e8728417bd/target/share/lib_rootxxx"
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/share/lib_rootxxx"
          ])
       ]
   ; variables = []

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -47,17 +47,17 @@ opam-var-unsupported.t
        (run echo %{toplevel})
        (run echo %{stublibs}))))))
 
-  $ build_pkg testpkg 2>&1 | dune_cmd subst '.*.sandbox/[^/]+' '.sandbox/$SANDBOX'
+  $ build_pkg testpkg 2>&1 | strip_sandbox | censor
   dune
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/source
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/lib
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/bin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/sbin
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/share
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/doc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/etc
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/man
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/lib/toplevel
-  .sandbox/$SANDBOX/_private/default/.pkg/testpkg.0.0.1-8a78b4e4b2a5a90d80622925984eacbc/target/lib/stublibs
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/source
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/bin
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/sbin
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/share
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/doc
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/etc
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/man
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib/toplevel
+  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -72,14 +72,14 @@ A package that conditionally depends on packages depending on the OS:
 
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
-  $ ls $pkg_root/
-  foo.0.0.1-c2b956a8203892bfa7b45e595e1ddedd
-  linux-only.0.0.1-758a08ac654cab621cf492933f741368
+  $ ls $pkg_root/ | censor
+  foo.0.0.1-$DIGEST
+  linux-only.0.0.1-$DIGEST
 
   $ dune clean
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
-  $ ls $pkg_root/
-  foo.0.0.1-eaf6f59b80b859488722c562ba55562a
-  macos-only.0.0.1-cca34386743cf91827905ba6e657e104
+  $ ls $pkg_root/ | censor
+  foo.0.0.1-$DIGEST
+  macos-only.0.0.1-$DIGEST

--- a/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
+++ b/test/blackbox-tests/test-cases/pkg/set-ocamlfind-destdir.t
@@ -10,6 +10,7 @@ install and build commands.
 
   $ build_pkg test 2>&1 \
   > | dune_cmd subst "$PWD" PWD \
-  > | dune_cmd subst '\.sandbox/.*/_private' '.sandbox/SANDBOX/_private'
-  [build] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-72bb31d43e47c1ce47f5cbd1c7042f7c/target/lib
-  [install] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-72bb31d43e47c1ce47f5cbd1c7042f7c/target/lib
+  > | dune_cmd subst '\.sandbox/.*/_private' '.sandbox/SANDBOX/_private' \
+  > | censor
+  [build] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib
+  [install] OCAMLFIND_DESTDIR=PWD/_build/.sandbox/SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib

--- a/test/blackbox-tests/test-cases/pkg/variables.t
+++ b/test/blackbox-tests/test-cases/pkg/variables.t
@@ -30,11 +30,11 @@ Test that we can set variables
   >   (run mkdir -p %{prefix})))
   > EOF
 
-  $ build_pkg usetest
+  $ build_pkg usetest 2>&1 | censor
   abool: true
   astring: foobar
   somestrings: foo bar
-  share path: ../../test.0.0.1-3a3321e9f4dbd25a0f126d5bd0af0efd/target/share/test
+  share path: ../../test.0.0.1-$DIGEST/target/share/test
   version: 1.2.3
 
   $ show_pkg_cookie test
@@ -58,7 +58,7 @@ Now we demonstrate we get a proper error from invalid .config files:
   >  ))
   > EOF
 
-  $ build_pkg test 2>&1 | dune_cmd subst 'File .*:' 'File $REDACTED:'
+  $ build_pkg test 2>&1 | dune_cmd subst 'File .*:' 'File $REDACTED:' | censor
   Error:
   File $REDACTED:
   1 | this is dummy text
@@ -66,5 +66,5 @@ Now we demonstrate we get a proper error from invalid .config files:
   Error parsing test.config
   Reason: Parse error
   -> required by
-     _build/_private/default/.pkg/test.0.0.1-560f9c84dc947e51028f7f2d7e857f1c/target
+     _build/_private/default/.pkg/test.0.0.1-$DIGEST/target
   [1]

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -75,8 +75,8 @@ Printing out PATH without setting it when the package has a dependency:
   >  (system "echo PATH=$PATH"))
   > EOF
   $ dune clean
-  $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-7bc3297e8754e814eeb96b6a14cdff0b/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-152f143bf3c360296ba5dd5afe9798dd/target/bin:DUNE_PATH:/bin
+  $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
   $ make_lockpkg test <<'EOF'
@@ -101,8 +101,8 @@ Attempting to add a path to PATH replaces the entire PATH:
   >   (system "echo PATH=$PATH")))
   > EOF
   $ dune clean
-  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-7bc3297e8754e814eeb96b6a14cdff0b/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-152f143bf3c360296ba5dd5afe9798dd/target/bin:DUNE_PATH:/bin
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ make_lockpkg test <<'EOF'
@@ -116,5 +116,5 @@ Try adding multiple paths to PATH:
   >   (system "echo PATH=$PATH")))
   > EOF
   $ dune clean
-  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH'
-  PATH=/bar/bin:/foo/bin:/tmp/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello2.0.0.1-7bc3297e8754e814eeb96b6a14cdff0b/target/bin:$TESTCASE_ROOT/_build/_private/default/.pkg/hello1.0.0.1-152f143bf3c360296ba5dd5afe9798dd/target/bin:DUNE_PATH:/bin
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
+  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin


### PR DESCRIPTION
Digests are rather fragile, and change for unrelated reasons. Let's not include them unless it's necessary for the test.