### PR TITLE
refactor: use repr to digest everything

### DIFF
--- a/otherlibs/stdune/src/repr.mli
+++ b/otherlibs/stdune/src/repr.mli
@@ -1,7 +1,45 @@
-type _ t
+type _ t = private
+  | Unit : unit t
+  | Bool : bool t
+  | Int : int t
+  | String : string t
+  | Option : 'a t -> 'a option t
+  | List : 'a t -> 'a list t
+  | Array : 'a t -> 'a array t
+  | Pair : 'a t * 'b t -> ('a * 'b) t
+  | Triple : 'a t * 'b t * 'c t -> ('a * 'b * 'c) t
+  | Fix : 'a t Lazy.t -> 'a t
+  | Record : string * 'a field list -> 'a t
+  | Variant : string * 'a case list -> 'a t
+  | View :
+      { repr : 'b t
+      ; to_ : 'a -> 'b
+      }
+      -> 'a t
+  | Abstract : { to_dyn : 'a -> Dyn.t } -> 'a t
+
+and 'a field = private
+  | Field :
+      { name : string
+      ; repr : 'b t
+      ; get : 'a -> 'b
+      }
+      -> 'a field
+
+and 'a case = private
+  | Case0 :
+      { tag : string
+      ; test : 'a -> bool
+      }
+      -> 'a case
+  | Case1 :
+      { tag : string
+      ; repr : 'b t
+      ; proj : 'a -> 'b option
+      }
+      -> 'a case
+
 type 'a repr = 'a t
-type 'a field
-type 'a case
 
 module type S = sig
   type t

--- a/otherlibs/stdune/src/sexp.ml
+++ b/otherlibs/stdune/src/sexp.ml
@@ -3,6 +3,19 @@ module List = ListLabels
 module String = StringLabels
 include Csexp
 
+let repr =
+  Repr.fix (fun repr ->
+    Repr.variant
+      "sexp"
+      [ Repr.case "Atom" Repr.string ~proj:(function
+          | Atom string -> Some string
+          | List _ -> None)
+      ; Repr.case "List" (Repr.list repr) ~proj:(function
+          | List list -> Some list
+          | Atom _ -> None)
+      ])
+;;
+
 let rec to_string = function
   | Atom s -> Escape.quote_if_needed s
   | List l -> Printf.sprintf "(%s)" (List.map ~f:to_string l |> String.concat ~sep:" ")

--- a/otherlibs/stdune/src/sexp.mli
+++ b/otherlibs/stdune/src/sexp.mli
@@ -4,6 +4,7 @@ type t = Csexp.t =
   | Atom of string
   | List of t list
 
+val repr : t Repr.t
 val to_string : t -> string
 val pp : t -> 'a Pp.t
 val hash : t -> int

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -128,6 +128,122 @@ let file p = file (Path.to_string p)
 let file_async p = file_async (Path.to_string p)
 let from_hex s = Blake3_mini.Digest.of_hex s
 
+let feed_string_raw hasher s =
+  Counter.add Metrics.Digest.Value.bytes (String.length s);
+  Blake3_mini.feed_string hasher s ~pos:0 ~len:(String.length s)
+;;
+
+let feed_bytes_raw hasher bytes ~len =
+  Counter.add Metrics.Digest.Value.bytes len;
+  Blake3_mini.feed_string hasher (Bytes.unsafe_to_string bytes) ~pos:0 ~len
+;;
+
+let feed_int64 hasher scratch i =
+  for byte = 0 to 7 do
+    let shift = 8 * byte in
+    let value = Int64.(to_int (logand (shift_right_logical i shift) 0xffL)) in
+    Bytes.set scratch byte (Char.chr value)
+  done;
+  feed_bytes_raw hasher scratch ~len:8
+;;
+
+let feed_bool hasher scratch b =
+  Bytes.set scratch 0 (if b then '\001' else '\000');
+  feed_bytes_raw hasher scratch ~len:1
+;;
+
+let feed_int hasher scratch i = feed_int64 hasher scratch (Int64.of_int i)
+
+let feed_string hasher scratch s =
+  feed_int hasher scratch (String.length s);
+  feed_string_raw hasher s
+;;
+
+let feed_repr hasher =
+  let scratch = Bytes.create 8 in
+  let rec loop : type a. a Repr.t -> a -> unit =
+    fun repr value ->
+    match repr with
+    | Unit ->
+      feed_int hasher scratch 1;
+      feed_bool hasher scratch false
+    | Bool ->
+      feed_int hasher scratch 2;
+      feed_bool hasher scratch value
+    | Int ->
+      feed_int hasher scratch 3;
+      feed_int hasher scratch value
+    | String ->
+      feed_int hasher scratch 4;
+      feed_string hasher scratch value
+    | Option repr ->
+      feed_int hasher scratch 5;
+      (match value with
+       | None -> feed_bool hasher scratch false
+       | Some x ->
+         feed_bool hasher scratch true;
+         loop repr x)
+    | List repr ->
+      feed_int hasher scratch 6;
+      feed_int hasher scratch (List.length value);
+      List.iter value ~f:(loop repr)
+    | Array repr ->
+      feed_int hasher scratch 7;
+      feed_int hasher scratch (Array.length value);
+      Array.iter value ~f:(loop repr)
+    | Pair (left, right) ->
+      feed_int hasher scratch 8;
+      let left_value, right_value = value in
+      loop left left_value;
+      loop right right_value
+    | Triple (first, second, third) ->
+      feed_int hasher scratch 9;
+      let first_value, second_value, third_value = value in
+      loop first first_value;
+      loop second second_value;
+      loop third third_value
+    | Fix repr -> loop (Lazy.force repr) value
+    | Record (_, fields) ->
+      feed_int hasher scratch 10;
+      loop_fields fields value
+    | Variant (_, cases) ->
+      feed_int hasher scratch 11;
+      loop_cases cases value
+    | View { repr; to_ } -> loop repr (to_ value)
+    | Abstract _ ->
+      Code_error.raise
+        "Digest.repr does not support Repr.abstract"
+        [ "repr", Dyn.string "<abstract>" ]
+  and loop_fields : type a. a Repr.field list -> a -> unit =
+    fun fields value ->
+    feed_int hasher scratch (List.length fields);
+    List.iter fields ~f:(fun (Repr.Field { name; repr; get }) ->
+      feed_string hasher scratch name;
+      loop repr (get value))
+  and loop_cases : type a. a Repr.case list -> a -> unit =
+    fun cases value ->
+    match cases with
+    | [] ->
+      Code_error.raise
+        "Repr.variant: value did not match any case"
+        [ "value", Dyn.string "<opaque>" ]
+    | Repr.Case0 { tag; test } :: rest ->
+      if test value
+      then (
+        feed_string hasher scratch tag;
+        feed_bool hasher scratch false)
+      else loop_cases rest value
+    | Repr.Case1 { tag; repr; proj } :: rest ->
+      (match proj value with
+       | Some argument ->
+         feed_string hasher scratch tag;
+         feed_bool hasher scratch true;
+         loop repr argument
+       | None -> loop_cases rest value)
+  in
+  loop
+;;
+
 module Feed = struct
   type hasher = Hasher.t
   type 'a t = hasher -> 'a -> unit
@@ -141,10 +257,7 @@ module Feed = struct
 
   let bool = contramap string ~f:Bool.to_string
   let int = contramap string ~f:Int.to_string
-
-  let repr repr =
-    contramap string ~f:(fun value -> Repr.to_dyn repr value |> Dyn.to_string)
-  ;;
+  let repr repr hasher value = feed_repr hasher repr value
 
   (* We use [No_sharing] to avoid generating different digests for inputs that
        differ only in how they share internal values. Without [No_sharing], if a
@@ -153,7 +266,12 @@ module Feed = struct
        on whether the corresponding strings ["-I"] point to the same memory location
        or to different memory locations. *)
   let generic hasher x = contramap string ~f:(Marshal.to_string ~sharing:false) hasher x
-  let list feed_x hasher xs = List.iter xs ~f:(feed_x hasher)
+
+  let list feed_x hasher xs =
+    int hasher (List.length xs);
+    List.iter xs ~f:(feed_x hasher)
+  ;;
+
   let option feed_x hasher option_x = Option.iter option_x ~f:(feed_x hasher)
 
   let tuple2 feed_a feed_b hasher (a, b) =
@@ -176,17 +294,55 @@ end
 module Manual = struct
   type t = unit
 
+  let scratch = Bytes.create 8
   let create () = ()
 
-  let string () s =
+  let feed_string_raw s =
     Blake3_mini.feed_string ~pos:0 ~len:(String.length s) (Lazy.force Hasher.singleton) s
   ;;
 
-  let generic () s = string () (Marshal.to_string ~sharing:false s)
+  let feed_int64 i =
+    for byte = 0 to 7 do
+      let shift = 8 * byte in
+      let value = Int64.(to_int (logand (shift_right_logical i shift) 0xffL)) in
+      Bytes.set scratch byte (Char.chr value)
+    done;
+    feed_string_raw (Bytes.unsafe_to_string scratch)
+  ;;
+
+  let bool () b =
+    Bytes.set scratch 0 (if b then '\001' else '\000');
+    Blake3_mini.feed_string
+      ~pos:0
+      ~len:1
+      (Lazy.force Hasher.singleton)
+      (Bytes.unsafe_to_string scratch)
+  ;;
+
+  let int () i = feed_int64 (Int64.of_int i)
+
+  let string () s =
+    int () (String.length s);
+    feed_string_raw s
+  ;;
+
+  let option t ~f = function
+    | None -> bool t false
+    | Some x ->
+      bool t true;
+      f t x
+  ;;
+
+  let list t ~f xs =
+    int t (List.length xs);
+    List.iter xs ~f:(f t)
+  ;;
+
+  let repr () repr value = Feed.repr repr (Lazy.force Hasher.singleton) value
 
   let digest () s =
     let s = Blake3_mini.Digest.to_binary s in
-    string () s
+    feed_string_raw s
   ;;
 
   let get () =

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -36,8 +36,12 @@ module Manual : sig
   type t
 
   val create : unit -> t
+  val bool : t -> bool -> unit
+  val int : t -> int -> unit
   val string : t -> string -> unit
-  val generic : t -> 'a -> unit
+  val option : t -> f:(t -> 'a -> unit) -> 'a option -> unit
+  val list : t -> f:(t -> 'a -> unit) -> 'a list -> unit
+  val repr : t -> 'a Repr.t -> 'a -> unit
   val digest : t -> digest -> unit
   val get : t -> digest
 end
@@ -54,7 +58,6 @@ val file : Path.t -> t
 val file_async : Path.t -> t Fiber.t
 val string : string -> t
 val to_string_raw : t -> string
-val generic : 'a -> t
 val repr : 'a Repr.t -> 'a -> t
 
 (** The subset of fields of [Unix.stats] used by this module.

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -183,6 +183,130 @@ let for_shell t =
       | Error e -> e.program)
 ;;
 
+let digest =
+  let open Dune_digest.Manual in
+  let digest_outputs d outputs = repr d Outputs.repr outputs in
+  let digest_inputs d inputs = repr d Inputs.repr inputs in
+  let digest_file_perm d perm = repr d File_perm.repr perm in
+  let digest_mode d mode = repr d Diff.Mode.repr mode in
+  let digest_program d ~dir (program : Prog.t) =
+    match program with
+    | Ok p -> string d (Path.reach p ~from:dir)
+    | Error e -> string d e.program
+  in
+  let digest_path d ~dir path = string d (Path.reach path ~from:dir) in
+  let digest_target d ~dir target = string d (Path.reach (Path.build target) ~from:dir) in
+  let digest_ext d ~dir ((module A) : Encode_ext.t) =
+    repr
+      d
+      Sexp.repr
+      (A.Spec.encode
+         A.v
+         (fun p -> Sexp.Atom (Path.reach p ~from:dir))
+         (fun p -> Sexp.Atom (Path.reach (Path.build p) ~from:dir)))
+  in
+  let rec loop d t ~dir =
+    match t with
+    | Run (prog, args) ->
+      int d 0;
+      digest_program d ~dir prog;
+      int d (Array.Immutable.length args);
+      for i = 0 to Array.Immutable.length args - 1 do
+        string d (Array.Immutable.get args i)
+      done
+    | With_accepted_exit_codes (pred, t) ->
+      int d 1;
+      repr d (Predicate_lang.repr Repr.int) pred;
+      loop d t ~dir
+    | Chdir (path, t) ->
+      int d 2;
+      digest_path d ~dir path;
+      loop d t ~dir:path
+    | Setenv (var, value, t) ->
+      int d 3;
+      string d var;
+      string d value;
+      loop d t ~dir
+    | Redirect_out (outputs, target, perm, t) ->
+      int d 4;
+      digest_outputs d outputs;
+      digest_target d ~dir target;
+      digest_file_perm d perm;
+      loop d t ~dir
+    | Redirect_in (inputs, path, t) ->
+      int d 5;
+      digest_inputs d inputs;
+      digest_path d ~dir path;
+      loop d t ~dir
+    | Ignore (outputs, t) ->
+      int d 6;
+      digest_outputs d outputs;
+      loop d t ~dir
+    | Progn ts ->
+      int d 7;
+      list d ts ~f:(fun d t -> loop d t ~dir)
+    | Concurrent ts ->
+      int d 8;
+      list d ts ~f:(fun d t -> loop d t ~dir)
+    | Echo xs ->
+      int d 9;
+      list d xs ~f:string
+    | Cat paths ->
+      int d 10;
+      list d paths ~f:(fun d path -> digest_path d ~dir path)
+    | Copy (src, dst) ->
+      int d 11;
+      digest_path d ~dir src;
+      digest_target d ~dir dst
+    | Symlink (src, dst) ->
+      int d 12;
+      let src =
+        match Path.Build.parent dst with
+        | None -> Path.to_string src
+        | Some from -> Path.reach ~from:(Path.build from) src
+      in
+      string d src;
+      digest_target d ~dir dst
+    | Hardlink (src, dst) ->
+      int d 13;
+      digest_path d ~dir src;
+      digest_target d ~dir dst
+    | Bash s ->
+      int d 14;
+      string d s
+    | Write_file (target, perm, contents) ->
+      int d 15;
+      digest_target d ~dir target;
+      digest_file_perm d perm;
+      string d contents
+    | Rename (src, dst) ->
+      int d 16;
+      digest_target d ~dir src;
+      digest_target d ~dir dst
+    | Remove_tree target ->
+      int d 17;
+      digest_target d ~dir target
+    | Mkdir target ->
+      int d 18;
+      digest_target d ~dir target
+    | Pipe (outputs, ts) ->
+      int d 19;
+      digest_outputs d outputs;
+      list d ts ~f:(fun d t -> loop d t ~dir)
+    | Diff { optional; mode; directory_diffs; file1; file2 } ->
+      int d 20;
+      bool d optional;
+      digest_mode d mode;
+      bool d directory_diffs;
+      digest_path d ~dir file1;
+      digest_target d ~dir file2
+    | Extension ext ->
+      int d 21;
+      digest_ext d ~dir ext
+  in
+  fun d t -> loop d t ~dir:Path.root
+;;
+
 let fold_one_step t ~init:acc ~f =
   match t with
   | Chdir (_, t)

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -109,6 +109,8 @@ end
 (** Convert the action to a format suitable for printing *)
 val for_shell : t -> For_shell.t
 
+val digest : Dune_digest.Manual.t -> t -> unit
+
 (** Return the list of directories the action chdirs to *)
 val chdirs : t -> Path.Build.Set.t
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -273,9 +273,56 @@ end = struct
            ])
   ;;
 
+  let digest_target_paths d (rule : Rule.t) =
+    let digest_target_path name =
+      Path.Build.relative rule.targets.root name
+      |> Path.Build.to_string
+      |> Digest.Manual.string d
+    in
+    Digest.Manual.int
+      d
+      (Filename.Set.cardinal rule.targets.files + Filename.Set.cardinal rule.targets.dirs);
+    Filename.Set.iter rule.targets.files ~f:digest_target_path;
+    Filename.Set.iter rule.targets.dirs ~f:digest_target_path
+  ;;
+
+  let digest_locks d locks =
+    Digest.Manual.list d locks ~f:(fun d path ->
+      Digest.Manual.string d (Path.to_string path))
+  ;;
+
+  let digest_sandbox_config d sandbox =
+    let flags =
+      (if Sandbox_config.mem sandbox None then 1 lsl 0 else 0)
+      lor (if Sandbox_config.mem sandbox (Some Sandbox_mode.Symlink) then 1 lsl 1 else 0)
+      lor (if Sandbox_config.mem sandbox (Some Sandbox_mode.Copy) then 1 lsl 2 else 0)
+      lor (if Sandbox_config.mem sandbox (Some Sandbox_mode.Hardlink) then 1 lsl 3 else 0)
+      lor
+      if Sandbox_config.mem sandbox (Some Sandbox_mode.Patch_back_source_tree)
+      then 1 lsl 4
+      else 0
+    in
+    Digest.Manual.int d flags
+  ;;
+
+  let digest_env_subset d deps env =
+    let count =
+      Dep.Set.fold deps ~init:0 ~f:(fun dep acc ->
+        match dep with
+        | Env _ -> acc + 1
+        | _ -> acc)
+    in
+    Digest.Manual.int d count;
+    Dep.Set.iter deps ~f:(function
+      | Env var ->
+        Digest.Manual.string d var;
+        Digest.Manual.option d ~f:Digest.Manual.string (Env.get env var)
+      | _ -> ())
+  ;;
+
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 26
+  let rule_digest_version = 27
 
   let compute_rule_digest
         (rule : Rule.t)
@@ -294,39 +341,18 @@ end = struct
       =
       action
     in
-    let target_paths names =
-      Filename.Set.to_list_map names ~f:(fun name ->
-        Path.Build.relative rule.targets.root name |> Path.Build.to_string)
-    in
     let digest =
       let d = Digest.Manual.create () in
-      Digest.Manual.generic d rule_digest_version;
+      Digest.Manual.int d rule_digest_version;
       (* Update when changing the rule digest scheme. *)
-      Digest.Manual.generic d sandbox_mode;
+      Digest.Manual.repr d Sandbox_mode.repr sandbox_mode;
       Dep.Facts.digest facts d ~env;
-      Digest.Manual.generic
-        d
-        (target_paths rule.targets.files @ target_paths rule.targets.dirs);
-      Digest.Manual.generic d (Action.for_shell action);
-      Digest.Manual.generic d can_go_in_shared_cache;
-      Digest.Manual.generic d (List.map locks ~f:Path.to_string);
-      Digest.Manual.generic d corrections;
-      Digest.Manual.generic
-        d
-        (Execution_parameters.action_stdout_on_success execution_parameters);
-      Digest.Manual.generic
-        d
-        (Execution_parameters.action_stderr_on_success execution_parameters);
-      Digest.Manual.generic
-        d
-        (Execution_parameters.workspace_root_to_build_path_prefix_map
-           execution_parameters);
-      Digest.Manual.generic
-        d
-        (Execution_parameters.action_project_root execution_parameters);
-      Digest.Manual.generic
-        d
-        (Execution_parameters.expand_aliases_in_sandbox execution_parameters);
+      digest_target_paths d rule;
+      Action.digest d action;
+      Digest.Manual.bool d can_go_in_shared_cache;
+      digest_locks d locks;
+      Digest.Manual.repr d Repr.(option Corrections.repr) corrections;
+      Digest.Manual.digest d (Execution_parameters.digest execution_parameters);
       Digest.Manual.get d
     in
     digest
@@ -774,7 +800,7 @@ end = struct
 
   (* The current version of the action digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let action_digest_version = 5
+  let action_digest_version = 6
 
   let execute_action_generic
         ~observing_facts
@@ -816,7 +842,9 @@ end = struct
         =
         act
       in
-      let env =
+      let digest =
+        let d = Digest.Manual.create () in
+        Digest.Manual.int d action_digest_version;
         (* Here we restrict the environment to only the variables we depend on,
            so that we don't re-execute all actions when some irrelevant
            environment variable changes.
@@ -825,25 +853,19 @@ end = struct
            command, however that might be tedious to do in practice. See this
            ticket for a longer discussion about the management of the
            environment: https://github.com/ocaml/dune/issues/4382 *)
-        Dep.Set.fold deps ~init:Env.Map.empty ~f:(fun dep acc ->
-          match dep with
-          | Env var -> Env.Map.set acc var (Env.get env var)
-          | _ -> acc)
-        |> Env.Map.to_list
-      in
-      let digest =
-        let d = Digest.Manual.create () in
-        Digest.Manual.generic d action_digest_version;
-        Digest.Manual.generic d env;
+        digest_env_subset d deps env;
         Dep.Set.digest deps d;
-        Digest.Manual.generic d (Action.for_shell action);
-        Digest.Manual.generic d (List.map locks ~f:Path.to_string);
-        Digest.Manual.generic d dir;
-        Digest.Manual.generic d alias;
-        Digest.Manual.generic d capture_stdout;
-        Digest.Manual.generic d can_go_in_shared_cache;
-        Digest.Manual.generic d sandbox;
-        Digest.Manual.generic d corrections;
+        Action.digest d action;
+        digest_locks d locks;
+        Digest.Manual.string d (Path.Build.to_string dir);
+        Digest.Manual.option
+          d
+          ~f:(fun d alias -> Digest.Manual.string d (Alias.Name.to_string alias))
+          alias;
+        Digest.Manual.bool d capture_stdout;
+        Digest.Manual.bool d can_go_in_shared_cache;
+        digest_sandbox_config d sandbox;
+        Digest.Manual.repr d Repr.(option Corrections.repr) corrections;
         Digest.Manual.get d
       in
       digest

--- a/src/dune_engine/corrections.ml
+++ b/src/dune_engine/corrections.ml
@@ -1,8 +1,19 @@
+open Import
+
 type t =
   | Ignore
   | Produce
 
-let to_dyn = function
-  | Ignore -> Dyn.variant "Ignore" []
-  | Produce -> Dyn.variant "Produce" []
+let repr =
+  Repr.variant
+    "corrections"
+    [ Repr.case0 "Ignore" ~test:(function
+        | Ignore -> true
+        | Produce -> false)
+    ; Repr.case0 "Produce" ~test:(function
+        | Produce -> true
+        | Ignore -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr

--- a/src/dune_engine/corrections.mli
+++ b/src/dune_engine/corrections.mli
@@ -1,5 +1,8 @@
+open Import
+
 type t =
   | Ignore
   | Produce
 
+val repr : t Repr.t
 val to_dyn : t -> Dyn.t

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -20,6 +20,23 @@ module T = struct
           }
       | File_selector of Digest.t (* Digest of the underlying [File_selector.t] *)
       | Universe
+
+    let digest d = function
+      | Env var ->
+        Digest.Manual.int d 0;
+        Digest.Manual.string d var
+      | File digest ->
+        Digest.Manual.int d 1;
+        Digest.Manual.digest d digest
+      | Alias { dir; name } ->
+        Digest.Manual.int d 2;
+        Digest.Manual.string d dir;
+        Digest.Manual.string d name
+      | File_selector digest ->
+        Digest.Manual.int d 3;
+        Digest.Manual.digest d digest
+      | Universe -> Digest.Manual.int d 4
+    ;;
   end
 
   let env e = Env e
@@ -95,10 +112,14 @@ module Fact = struct
 
     (* The caller should ensure that [files] and [digests] are listed in the same order *)
     let combined_digest ?empty_dir (files : Path.t list) (digests : Digest.t list) =
-      let files = List.map files ~f:Path.to_string in
-      match empty_dir with
-      | None -> Digest.generic (files, digests)
-      | Some empty_dir -> Digest.generic (empty_dir, files, digests)
+      let d = Digest.Manual.create () in
+      Digest.Manual.option
+        d
+        ~f:(fun d path -> Digest.Manual.repr d Path.Build.repr path)
+        empty_dir;
+      Digest.Manual.list d files ~f:(fun d path -> Digest.Manual.repr d Path.repr path);
+      Digest.Manual.list d digests ~f:Digest.Manual.digest;
+      Digest.Manual.get d
     ;;
 
     let create files ~build_file =
@@ -142,7 +163,10 @@ module Fact = struct
     let empty =
       { files = Path.Set.empty
       ; empty_dirs = Path.Build.Set.empty
-      ; digest = Digest.generic []
+      ; digest =
+          (let d = Digest.Manual.create () in
+           Digest.Manual.list d [] ~f:Digest.Manual.digest;
+           Digest.Manual.get d)
       }
     ;;
 
@@ -160,7 +184,13 @@ module Fact = struct
       | ts ->
         { files = Path.Set.union_map ts ~f:(fun t -> t.files)
         ; empty_dirs = Path.Build.Set.union_map ts ~f:(fun t -> t.empty_dirs)
-        ; digest = Digest.generic (List.map ts ~f:(fun t -> t.digest))
+        ; digest =
+            (let d = Digest.Manual.create () in
+             Digest.Manual.list
+               d
+               (List.map ts ~f:(fun t -> t.digest))
+               ~f:Digest.Manual.digest;
+             Digest.Manual.get d)
         }
     ;;
   end
@@ -203,6 +233,24 @@ module Fact = struct
           ; facts_digest : Digest.t
           }
       | Alias of Digest.t
+
+    let digest d = function
+      | Env (var, value) ->
+        Digest.Manual.int d 0;
+        Digest.Manual.string d var;
+        Digest.Manual.option d ~f:Digest.Manual.string value
+      | File { path_digest; file_digest } ->
+        Digest.Manual.int d 1;
+        Digest.Manual.digest d path_digest;
+        Digest.Manual.digest d file_digest
+      | File_selector { file_selector_digest; facts_digest } ->
+        Digest.Manual.int d 2;
+        Digest.Manual.digest d file_selector_digest;
+        Digest.Manual.digest d facts_digest
+      | Alias digest ->
+        Digest.Manual.int d 3;
+        Digest.Manual.digest d digest
+    ;;
   end
 
   let compare a b =
@@ -265,18 +313,18 @@ module Set = struct
   let digest t digest =
     iter t ~f:(fun dep ->
       match dep with
-      | Env var -> Digest.Manual.generic digest (Stable_for_digest.Env var)
-      | Universe -> Digest.Manual.generic digest Stable_for_digest.Universe
+      | Env var -> Stable_for_digest.digest digest (Stable_for_digest.Env var)
+      | Universe -> Stable_for_digest.digest digest Stable_for_digest.Universe
       | File p ->
-        Digest.Manual.generic
+        Stable_for_digest.digest
           digest
           (Stable_for_digest.File (Path.to_string p |> Digest.string))
       | File_selector fs ->
-        Digest.Manual.generic
+        Stable_for_digest.digest
           digest
           (Stable_for_digest.File_selector (File_selector.digest fs))
       | Alias a ->
-        Digest.Manual.generic
+        Stable_for_digest.digest
           digest
           (Stable_for_digest.Alias
              { dir = Path.Build.to_string (Alias.dir a)
@@ -343,22 +391,24 @@ module Facts = struct
     Map.iteri t ~f:(fun dep fact ->
       match dep with
       | Env var ->
-        Digest.Manual.generic digest (Fact.Stable_for_digest.Env (var, Env.get env var))
+        Fact.Stable_for_digest.digest
+          digest
+          (Fact.Stable_for_digest.Env (var, Env.get env var))
       | Universe -> ()
       | File _ | File_selector _ | Alias _ ->
         (match (fact : Fact.t) with
          | Nothing -> ()
          | File (p, d) ->
-           Digest.Manual.generic
+           Fact.Stable_for_digest.digest
              digest
              (Fact.Stable_for_digest.File
                 { path_digest = Digest.string (Path.to_string p); file_digest = d })
          | File_selector { file_selector_digest; facts } ->
-           Digest.Manual.generic
+           Fact.Stable_for_digest.digest
              digest
              (Fact.Stable_for_digest.File_selector
                 { file_selector_digest; facts_digest = facts.digest })
          | Alias ps ->
-           Digest.Manual.generic digest (Fact.Stable_for_digest.Alias ps.digest)))
+           Fact.Stable_for_digest.digest digest (Fact.Stable_for_digest.Alias ps.digest)))
   ;;
 end

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -6,16 +6,26 @@ module Action_output_on_success = struct
     | Swallow
     | Must_be_empty
 
-  let all = [ "print", Print; "swallow", Swallow; "must-be-empty", Must_be_empty ]
-
-  let to_dyn = function
-    | Print -> Dyn.Variant ("Print", [])
-    | Swallow -> Variant ("Swallow", [])
-    | Must_be_empty -> Variant ("Must_be_empty", [])
+  let for_digest = function
+    | Print -> 0
+    | Swallow -> 1
+    | Must_be_empty -> 2
   ;;
 
+  let all = [ "print", Print; "swallow", Swallow; "must-be-empty", Must_be_empty ]
   let equal = Poly.equal
   let hash = Poly.hash
+
+  let repr =
+    Repr.variant
+      "action-output-on-success"
+      [ Repr.case0 "Print" ~test:(equal Print)
+      ; Repr.case0 "Swallow" ~test:(equal Swallow)
+      ; Repr.case0 "Must_be_empty" ~test:(equal Must_be_empty)
+      ]
+  ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 module Action_output_limit = struct
@@ -23,8 +33,9 @@ module Action_output_limit = struct
 
   let default = 100_000
   let to_string = Int.to_string
-  let to_dyn = Dyn.int
   let equal = Int.equal
+  let repr = Repr.int
+  let to_dyn = Repr.to_dyn repr
 end
 
 module Workspace_root_for_build_prefix_map = struct
@@ -39,12 +50,22 @@ module Workspace_root_for_build_prefix_map = struct
     | Set x, Set y -> String.equal x y
   ;;
 
-  let to_dyn =
-    let open Dyn in
-    function
-    | Unset -> variant "Unset" []
-    | Set s -> variant "Set" [ string s ]
+  let to_option = function
+    | Unset -> None
+    | Set root -> Some root
   ;;
+
+  let repr =
+    Repr.variant
+      "workspace-root-for-build-prefix-map"
+      [ Repr.case0 "Unset" ~test:(equal Unset)
+      ; Repr.case "Set" Repr.string ~proj:(function
+          | Unset -> None
+          | Set root -> Some root)
+      ]
+  ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 type t =
@@ -106,7 +127,90 @@ let hash
     , should_remove_write_permissions_on_generated_files )
 ;;
 
-let to_dyn
+let bool_to_int b = if b then 1 else 0
+
+let digest_fields
+      ~action_stdout_on_success
+      ~action_stderr_on_success
+      ~action_stdout_limit
+      ~action_stderr_limit
+      ~expand_aliases_in_sandbox
+      ~workspace_root_to_build_path_prefix_map
+      ~action_project_root
+      ~should_remove_write_permissions_on_generated_files
+  =
+  let d = Digest.Manual.create () in
+  let root =
+    Workspace_root_for_build_prefix_map.to_option workspace_root_to_build_path_prefix_map
+  in
+  let flags =
+    Action_output_on_success.for_digest action_stdout_on_success
+    lor (Action_output_on_success.for_digest action_stderr_on_success lsl 2)
+    lor (bool_to_int expand_aliases_in_sandbox lsl 4)
+    lor (bool_to_int (Option.is_some root) lsl 5)
+    lor (bool_to_int should_remove_write_permissions_on_generated_files lsl 6)
+  in
+  Digest.Manual.int d flags;
+  Digest.Manual.int d action_stdout_limit;
+  Digest.Manual.int d action_stderr_limit;
+  Option.iter root ~f:(Digest.Manual.string d);
+  Digest.Manual.option
+    d
+    ~f:(fun d root -> Digest.Manual.string d (Path.Source.to_string root))
+    action_project_root;
+  Digest.Manual.get d
+;;
+
+let make
+      ~action_stdout_on_success
+      ~action_stderr_on_success
+      ~action_stdout_limit
+      ~action_stderr_limit
+      ~expand_aliases_in_sandbox
+      ~workspace_root_to_build_path_prefix_map
+      ~action_project_root
+      ~should_remove_write_permissions_on_generated_files
+  =
+  { action_stdout_on_success
+  ; action_stderr_on_success
+  ; action_stdout_limit
+  ; action_stderr_limit
+  ; expand_aliases_in_sandbox
+  ; workspace_root_to_build_path_prefix_map
+  ; action_project_root
+  ; should_remove_write_permissions_on_generated_files
+  }
+;;
+
+let repr =
+  Repr.record
+    "execution-parameters"
+    [ Repr.field "action_stdout_on_success" Action_output_on_success.repr ~get:(fun t ->
+        t.action_stdout_on_success)
+    ; Repr.field "action_stderr_on_success" Action_output_on_success.repr ~get:(fun t ->
+        t.action_stderr_on_success)
+    ; Repr.field "action_stdout_limit" Action_output_limit.repr ~get:(fun t ->
+        t.action_stdout_limit)
+    ; Repr.field "action_stderr_limit" Action_output_limit.repr ~get:(fun t ->
+        t.action_stderr_limit)
+    ; Repr.field "expand_aliases_in_sandbox" Repr.bool ~get:(fun t ->
+        t.expand_aliases_in_sandbox)
+    ; Repr.field
+        "workspace_root_to_build_path_prefix_map"
+        Workspace_root_for_build_prefix_map.repr
+        ~get:(fun t -> t.workspace_root_to_build_path_prefix_map)
+    ; Repr.field
+        "action_project_root"
+        Repr.(option Path.Source.repr)
+        ~get:(fun t -> t.action_project_root)
+    ; Repr.field
+        "should_remove_write_permissions_on_generated_files"
+        Repr.bool
+        ~get:(fun t -> t.should_remove_write_permissions_on_generated_files)
+    ]
+;;
+
+let digest
       { action_stdout_on_success
       ; action_stderr_on_success
       ; action_stdout_limit
@@ -117,31 +221,30 @@ let to_dyn
       ; should_remove_write_permissions_on_generated_files
       }
   =
-  Dyn.Record
-    [ "action_stdout_on_success", Action_output_on_success.to_dyn action_stdout_on_success
-    ; "action_stderr_on_success", Action_output_on_success.to_dyn action_stderr_on_success
-    ; "action_stdout_limit", Action_output_limit.to_dyn action_stdout_limit
-    ; "action_stderr_limit", Action_output_limit.to_dyn action_stderr_limit
-    ; "expand_aliases_in_sandbox", Bool expand_aliases_in_sandbox
-    ; ( "workspace_root_to_build_path_prefix_map"
-      , Workspace_root_for_build_prefix_map.to_dyn workspace_root_to_build_path_prefix_map
-      )
-    ; "action_project_root", Dyn.option Path.Source.to_dyn action_project_root
-    ; ( "should_remove_write_permissions_on_generated_files"
-      , Bool should_remove_write_permissions_on_generated_files )
-    ]
+  digest_fields
+    ~action_stdout_on_success
+    ~action_stderr_on_success
+    ~action_stdout_limit
+    ~action_stderr_limit
+    ~expand_aliases_in_sandbox
+    ~workspace_root_to_build_path_prefix_map
+    ~action_project_root
+    ~should_remove_write_permissions_on_generated_files
 ;;
 
+let to_dyn = Repr.to_dyn repr
+
 let builtin_default =
-  { action_stdout_on_success = Print
-  ; action_stderr_on_success = Print
-  ; action_stdout_limit = Action_output_limit.default
-  ; action_stderr_limit = Action_output_limit.default
-  ; expand_aliases_in_sandbox = true
-  ; workspace_root_to_build_path_prefix_map = Set "/workspace_root"
-  ; action_project_root = None
-  ; should_remove_write_permissions_on_generated_files = true
-  }
+  make
+    ~action_stdout_on_success:Print
+    ~action_stderr_on_success:Print
+    ~action_stdout_limit:Action_output_limit.default
+    ~action_stderr_limit:Action_output_limit.default
+    ~expand_aliases_in_sandbox:true
+    ~workspace_root_to_build_path_prefix_map:
+      (Workspace_root_for_build_prefix_map.Set "/workspace_root")
+    ~action_project_root:None
+    ~should_remove_write_permissions_on_generated_files:true
 ;;
 
 let set_action_stdout_on_success x t = { t with action_stdout_on_success = x }

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -21,6 +21,8 @@ type t
 
 val equal : t -> t -> bool
 val hash : t -> int
+val repr : t Repr.t
+val digest : t -> Digest.t
 val to_dyn : t -> Dyn.t
 
 module Action_output_on_success : sig
@@ -36,6 +38,7 @@ module Action_output_on_success : sig
   val all : (string * t) list
   val equal : t -> t -> bool
   val hash : t -> int
+  val repr : t Repr.t
   val to_dyn : t -> Dyn.t
 end
 
@@ -48,6 +51,7 @@ module Action_output_limit : sig
   val default : t
   val to_string : t -> string
   val equal : t -> t -> bool
+  val repr : t Repr.t
   val to_dyn : t -> Dyn.t
 end
 
@@ -58,6 +62,9 @@ module Workspace_root_for_build_prefix_map : sig
   type t =
     | Unset (** Do not set the workspace root; only used by external Dune rules *)
     | Set of string (** [Set root] substitute the root with [root] *)
+
+  val repr : t Repr.t
+  val to_dyn : t -> Dyn.t
 end
 
 val builtin_default : t

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -13,9 +13,16 @@ let dir t = t.dir
 let only_generated_files t = t.only_generated_files
 let predicate t = t.predicate
 
-let digest { dir; predicate; only_generated_files } =
-  Digest.generic (dir, Predicate_lang.Glob.digest predicate, only_generated_files)
+let repr =
+  Repr.record
+    "file-selector"
+    [ Repr.field "dir" Path.repr ~get:dir
+    ; Repr.field "predicate" Predicate_lang.Glob.repr ~get:predicate
+    ; Repr.field "only_generated_files" Repr.bool ~get:only_generated_files
+    ]
 ;;
+
+let digest t = Digest.repr repr t
 
 let compare { dir; predicate; only_generated_files } t =
   let open Ordering.O in
@@ -29,15 +36,7 @@ let of_predicate_lang ~dir ?(only_generated_files = false) predicate =
 ;;
 
 let of_glob ~dir glob = of_predicate_lang ~dir (Predicate_lang.Glob.of_glob glob)
-
-let to_dyn { dir; predicate; only_generated_files } =
-  Dyn.Record
-    [ "dir", Path.to_dyn dir
-    ; "predicate", Predicate_lang.Glob.to_dyn predicate
-    ; "only_generated_files", Bool only_generated_files
-    ]
-;;
-
+let to_dyn = Repr.to_dyn repr
 let equal x y = compare x y = Eq
 
 let hash { dir; predicate; only_generated_files } =

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -20,10 +20,11 @@ val equal : t -> t -> bool
 val hash : t -> int
 val compare : t -> t -> Ordering.t
 
-(** [to_dyn] is used as a marshallable representation of [t] (to compute
+(** [repr] is used as a marshallable representation of [t] (to compute
     digests), so it must be injective *)
-val to_dyn : t -> Dyn.t
+val repr : t Repr.t
 
+val to_dyn : t -> Dyn.t
 val test : t -> Path.t -> bool
 val test_basename : t -> basename:string -> bool
 val digest : t -> Digest.t

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -30,6 +30,17 @@ let equal a b =
   | Lt | Gt -> false
 ;;
 
+let repr =
+  Repr.variant
+    "sandbox-mode"
+    [ Repr.case0 "None" ~test:(equal None)
+    ; Repr.case0 "Symlink" ~test:(equal (Some Symlink))
+    ; Repr.case0 "Copy" ~test:(equal (Some Copy))
+    ; Repr.case0 "Hardlink" ~test:(equal (Some Hardlink))
+    ; Repr.case0 "Patch_back_source_tree" ~test:(equal (Some Patch_back_source_tree))
+    ]
+;;
+
 let to_dyn =
   Dyn.option (function
     | Symlink -> Variant ("Symlink", [])

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -84,5 +84,6 @@ val none : t
 val symlink : t
 val copy : t
 val hardlink : t
+val repr : t Repr.t
 val to_string : t -> string
 val to_dyn : t -> Dyn.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -660,7 +660,7 @@ module Substitute = struct
       }
 
     let name = "substitute"
-    let version = 3
+    let version = 4
     let bimap t f g = { t with src = f t.src; dst = g t.dst }
     let is_useful_to ~memoize = memoize
 

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -508,13 +508,14 @@ module Produced = struct
   ;;
 
   let digest { contents; root = _ } =
-    let digest_repr = Repr.view Repr.string ~to_:Digest.to_string in
     let rec all_digests { files; subdirs } =
       let ffiles = Filename.Map.values files in
       List.concat
         (ffiles :: Filename.Map.to_list_map subdirs ~f:(fun _ dir -> all_digests dir))
     in
-    Digest.repr Repr.(list digest_repr) (all_digests contents)
+    let d = Digest.Manual.create () in
+    Digest.Manual.list d (all_digests contents) ~f:Digest.Manual.digest;
+    Digest.Manual.get d
   ;;
 
   (* The odd type of [d] and [f] is due to the fact that [map_with_errors]

--- a/src/dune_util/action.ml
+++ b/src/dune_util/action.ml
@@ -1,15 +1,24 @@
+open Stdune
+
 module Diff = struct
   module Mode = struct
     type t =
       | Binary
       | Text
 
-    let to_dyn =
-      let open Dyn in
-      function
-      | Binary -> variant "Binary" []
-      | Text -> variant "Text" []
+    let repr =
+      Repr.variant
+        "diff-mode"
+        [ Repr.case0 "Binary" ~test:(function
+            | Binary -> true
+            | Text -> false)
+        ; Repr.case0 "Text" ~test:(function
+            | Text -> true
+            | Binary -> false)
+        ]
     ;;
+
+    let to_dyn = Repr.to_dyn repr
   end
 
   type ('path, 'target) t =
@@ -40,6 +49,21 @@ module Outputs = struct
     | Stderr
     | Outputs
 
+  let repr =
+    Repr.variant
+      "outputs"
+      [ Repr.case0 "Stdout" ~test:(function
+          | Stdout -> true
+          | Stderr | Outputs -> false)
+      ; Repr.case0 "Stderr" ~test:(function
+          | Stderr -> true
+          | Stdout | Outputs -> false)
+      ; Repr.case0 "Outputs" ~test:(function
+          | Outputs -> true
+          | Stdout | Stderr -> false)
+      ]
+  ;;
+
   let to_string = function
     | Stdout -> "stdout"
     | Stderr -> "stderr"
@@ -50,6 +74,8 @@ end
 module Inputs = struct
   type t = Stdin
 
+  let repr = Repr.variant "inputs" [ Repr.case0 "Stdin" ~test:(fun Stdin -> true) ]
+
   let to_string = function
     | Stdin -> "stdin"
   ;;
@@ -59,6 +85,18 @@ module File_perm = struct
   type t =
     | Normal
     | Executable
+
+  let repr =
+    Repr.variant
+      "file-perm"
+      [ Repr.case0 "Normal" ~test:(function
+          | Normal -> true
+          | Executable -> false)
+      ; Repr.case0 "Executable" ~test:(function
+          | Executable -> true
+          | Normal -> false)
+      ]
+  ;;
 
   let suffix = function
     | Normal -> ""

--- a/src/dune_util/action.mli
+++ b/src/dune_util/action.mli
@@ -1,8 +1,12 @@
+open Stdune
+
 module Diff : sig
   module Mode : sig
     type t =
       | Binary (** no diffing, just raw comparison *)
       | Text (** diffing after newline normalization *)
+
+    val repr : t Repr.t
   end
 
   type nonrec ('path, 'target) t =
@@ -23,12 +27,14 @@ module Outputs : sig
     | Stderr
     | Outputs (** Both Stdout and Stderr *)
 
+  val repr : t Repr.t
   val to_string : t -> string
 end
 
 module Inputs : sig
   type t = Stdin
 
+  val repr : t Repr.t
   val to_string : t -> string
 end
 
@@ -40,6 +46,7 @@ module File_perm : sig
     | Normal
     | Executable
 
+  val repr : t Repr.t
   val suffix : t -> string
   val to_unix_perm : t -> int
 end

--- a/src/predicate_lang/predicate_lang.ml
+++ b/src/predicate_lang/predicate_lang.ml
@@ -36,19 +36,6 @@ let and_ = function
   | _ :: _ :: _ as xs -> And xs
 ;;
 
-let map t ~f =
-  let rec loop = function
-    | True -> True
-    | False -> False
-    | Element a -> Element (f a)
-    | Not a -> Not (loop a)
-    | Standard -> Standard
-    | Or xs -> Or (List.map ~f:loop xs)
-    | And xs -> And (List.map ~f:loop xs)
-  in
-  loop t
-;;
-
 let rec decode_one =
   let not_or a = not (Or a) in
   fun f ->
@@ -115,6 +102,34 @@ let rec encode f =
   | And xs -> constr "and" (list (encode f)) xs
 ;;
 
+let repr elt =
+  Repr.fix (fun repr ->
+    Repr.variant
+      "predicate-lang"
+      [ Repr.case0 "True" ~test:(function
+          | True -> true
+          | False | Element _ | Not _ | Standard | Or _ | And _ -> false)
+      ; Repr.case0 "False" ~test:(function
+          | False -> true
+          | True | Element _ | Not _ | Standard | Or _ | And _ -> false)
+      ; Repr.case "Element" elt ~proj:(function
+          | Element a -> Some a
+          | True | False | Not _ | Standard | Or _ | And _ -> None)
+      ; Repr.case "Not" repr ~proj:(function
+          | Not a -> Some a
+          | True | False | Element _ | Standard | Or _ | And _ -> None)
+      ; Repr.case0 "Standard" ~test:(function
+          | Standard -> true
+          | True | False | Element _ | Not _ | Or _ | And _ -> false)
+      ; Repr.case "Or" (Repr.list repr) ~proj:(function
+          | Or xs -> Some xs
+          | True | False | Element _ | Not _ | Standard | And _ -> None)
+      ; Repr.case "And" (Repr.list repr) ~proj:(function
+          | And xs -> Some xs
+          | True | False | Element _ | Not _ | Standard | Or _ -> None)
+      ])
+;;
+
 let rec to_dyn f =
   let open Dyn in
   function
@@ -163,6 +178,12 @@ let rec compare f x y =
   | False, False -> Eq
 ;;
 
+module Repr_derived = Repr.Make1 (struct
+    type nonrec 'a t = 'a t
+
+    let repr = repr
+  end)
+
 module Glob = struct
   module Glob = Dune_glob.V1
 
@@ -191,14 +212,24 @@ module Glob = struct
       | Glob of Proxy.t
       | Literal of string
 
+    let repr =
+      let glob_repr =
+        Repr.view Repr.string ~to_:(fun glob -> Glob.to_string (unproxy glob))
+      in
+      Repr.variant
+        "glob-element"
+        [ Repr.case "Glob" glob_repr ~proj:(function
+            | Glob glob -> Some glob
+            | Literal _ -> None)
+        ; Repr.case "Literal" Repr.string ~proj:(function
+            | Literal string -> Some string
+            | Glob _ -> None)
+        ]
+    ;;
+
     let to_dyn = function
       | Literal s -> Dyn.variant "Literal" [ Dyn.string s ]
       | Glob g -> Dyn.variant "Glob" [ Glob.to_dyn (unproxy g) ]
-    ;;
-
-    let digest = function
-      | Literal s -> Dune_digest.generic (0, s)
-      | Glob g -> Dune_digest.generic (1, Glob.to_string (unproxy g))
     ;;
 
     let encode t =
@@ -242,6 +273,7 @@ module Glob = struct
 
   type nonrec t = Element.t t
 
+  let repr = repr Element.repr
   let to_dyn t = to_dyn Element.to_dyn t
   let test (t : t) ~standard elem = test t ~standard ~test:Element.test elem
 
@@ -264,5 +296,5 @@ module Glob = struct
   let hash t = Poly.hash t
   let decode = decode Element.decode
   let encode t = encode Element.encode t
-  let digest t = map t ~f:Element.digest |> Dune_digest.generic
+  let digest t = Dune_digest.repr repr t
 end

--- a/src/predicate_lang/predicate_lang.mli
+++ b/src/predicate_lang/predicate_lang.mli
@@ -16,6 +16,7 @@ val true_ : 'a t
 val decode_one : 'a Decoder.t -> 'a t Decoder.t
 val decode : 'a Decoder.t -> 'a t Decoder.t
 val encode : 'a Encoder.t -> 'a t Encoder.t
+val repr : 'a Repr.t -> 'a t Repr.t
 val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 val test : 'a t -> standard:'a t -> test:('a -> 'b -> bool) -> 'b -> bool
 val false_ : 'a t
@@ -28,6 +29,7 @@ module Glob : sig
 
   type nonrec t = Element.t t
 
+  val repr : t Repr.t
   val to_dyn : t -> Dyn.t
   val test : t -> standard:t -> string -> bool
   val of_glob : Dune_glob.V1.t -> t

--- a/test/blackbox-tests/test-cases/directory-targets/copy-files.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-files.t
@@ -25,7 +25,7 @@ Dune loads all the rules of a directory at once.
   Error: Dependency cycle between:
      Computing directory contents of _build/default
   -> { dir = In_build_dir "default/foo"
-     ; predicate = Glob (Glob "*")
+     ; predicate = Element (Glob "*")
      ; only_generated_files = false
      }
   -> Computing directory contents of _build/default

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
+  Warning: cache store error [5e64608154a3ed6c86e3d606ac67f24b]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -120,7 +120,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
+  Warning: cache store error [5e64608154a3ed6c86e3d606ac67f24b]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -132,7 +132,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [2572e15a6b60a03c34f05517e60da8fd]: ((in_cache
+  Warning: cache store error [5e64608154a3ed6c86e3d606ac67f24b]: ((in_cache
   ((non-reproducible 7378fb2d7d80dc4468d6558d864f0897))) (computed
   ((non-reproducible 074ebdc1c3853f27c68566d8d183032c)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out | censor
-  ./04/$DIGEST:((8:metadata)(5:files(8:target_b32:$DIGEST)))
-  ./20/$DIGEST:((8:metadata)(5:files(8:target_a32:$DIGEST)))
+  ./5d/$DIGEST:((8:metadata)(5:files(8:target_a32:$DIGEST)))
+  ./6a/$DIGEST:((8:metadata)(5:files(8:target_b32:$DIGEST)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 


### PR DESCRIPTION
The main goal is to stop relying on marshal for digests. It is fragile, and easy to break. Instead, use repr to derive digest functions semi automatically.

It is also faster to boot.