### PR TITLE
fix: store inode corectly for cached source digests

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -27,7 +27,7 @@ module Cached_digest = struct
       ; size = stat.size
       ; perm = stat.perm
       ; dev = stat.dev
-      ; ino = stat.dev
+      ; ino = stat.ino
       }
     ;;
 


### PR DESCRIPTION
previously, the device would be stored instead