### PR TITLE
Run revdeps action with dev tools on `rc` branches

### DIFF
--- a/.github/workflows/revdeps-release-platform.yml
+++ b/.github/workflows/revdeps-release-platform.yml
@@ -1,0 +1,18 @@
+name: Platform Reverse Dependencies Check for Prereleases
+
+on:
+  push:
+    branches:
+      - '*-rc'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  revdeps:
+    name: OCaml Reverse Dependencies
+    uses: ocaml/dune/.github/workflows/revdeps.yml@main
+    with:
+      dune_version: "dev"
+      packages: "dune-release utop mdx"

--- a/.github/workflows/revdeps-release-platform.yml
+++ b/.github/workflows/revdeps-release-platform.yml
@@ -15,4 +15,4 @@ jobs:
     uses: ocaml/dune/.github/workflows/revdeps.yml@main
     with:
       dune_version: "dev"
-      packages: "dune-release utop mdx"
+      packages: "ocamlformat odoc lsp utop earlybird odig dune-release index merlin"


### PR DESCRIPTION
This PR automatically runs revdeps on `rc` branches to make sure these reverse dependencies work with the about to be released Dune release

A successful run can be seen [on this action](https://github.com/Leonidas-from-XIV/dune/actions/runs/24029629586) where I push an empty commit to my `3.22.2-rc` branch, which then triggers the `revdeps` Github workflow with a predetermined set of packages.

The workflow is written to be purposefully minimal and push as much work as possible to the `revdep` workflow so additional workflows can also be set up in a similar way with minimal amount of effort. This PR is meant to build the "key" packages mentioned in #13897, with another workflow for the "leaf" packages to be created upon determining the set of leaf packages.