### PR TITLE
Add depext to install `git-daemon` on Fedora

### DIFF
--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -65,3 +65,8 @@ depends: [
   "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
   "uutf" { with-dev-setup }
 ]
+depexts: [
+  # the rev store negotiation test launches a git daemon, needs it to be
+  # installed, which is not the case on Fedora by default
+  "git-daemon" { with-test & os-family = "fedora" }
+]

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -26,3 +26,8 @@ depends: [
   "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
   "uutf" { with-dev-setup }
 ]
+depexts: [
+  # the rev store negotiation test launches a git daemon, needs it to be
+  # installed, which is not the case on Fedora by default
+  "git-daemon" { with-test & os-family = "fedora" }
+]


### PR DESCRIPTION
#14060 detects that `git-daemon` is available, but we also need to make sure the package is actually available. For this we add a depext here.

There's no `conf-git-daemon` package, so unless we submit it to opam-repository we'd need to ship the depext with us.

Closes #14027