### PR TITLE
feat(trace): add load_lock_dir trace event for lock dir loading

### DIFF
--- a/src/dune_pkg/lock_dir.ml
+++ b/src/dune_pkg/lock_dir.ml
@@ -1685,6 +1685,11 @@ struct
   ;;
 
   let load lock_dir_path =
+    let event =
+      Dune_trace.(
+        Out.start (global ()) (fun () ->
+          Event.Async.pkg_load_lock_dir ~path:(Path.to_string lock_dir_path)))
+    in
     let open Io.O in
     let* ( version
          , dependency_hash
@@ -1722,16 +1727,20 @@ struct
         pkg)
       >>| Packages.of_pkg_list
     in
-    check_packages packages ~lock_dir_path
-    |> Result.map ~f:(fun () ->
-      { version
-      ; dependency_hash
-      ; packages
-      ; ocaml
-      ; repos
-      ; expanded_solver_variable_bindings
-      ; solved_for_platforms
-      })
+    let result =
+      check_packages packages ~lock_dir_path
+      |> Result.map ~f:(fun () ->
+        { version
+        ; dependency_hash
+        ; packages
+        ; ocaml
+        ; repos
+        ; expanded_solver_variable_bindings
+        ; solved_for_platforms
+        })
+    in
+    Option.iter (Dune_trace.global ()) ~f:(fun trace -> Dune_trace.Out.finish trace event);
+    result
   ;;
 
   let load_exn lock_dir_path =

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -33,6 +33,7 @@ module Event : sig
 
     val create_sandbox : loc:Loc.t -> data
     val fetch : url:string -> target:Path.t -> checksum:string option -> data
+    val pkg_load_lock_dir : path:string -> data
   end
 
   type t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -102,6 +102,11 @@ module Async = struct
     in
     { args = Some args; cat = Pkg; name = "fetch" }
   ;;
+
+  let pkg_load_lock_dir ~path =
+    let args = [ "path", Arg.string path ] in
+    { args = Some args; cat = Pkg; name = "load_lock_dir" }
+  ;;
 end
 
 type t = Event.t


### PR DESCRIPTION
Emit a pkg/load_lock_dir trace event with duration around the load function in lock_dir.ml, showing the path.

This will be used for counting how many times a lock directory is loaded in future tests and for checking how long it takes to load a lock directory.