### PR TITLE
fix(pkg): autolocking detects (depends) changes in watch mode

### DIFF
--- a/doc/changes/fixed/14066.md
+++ b/doc/changes/fixed/14066.md
@@ -1,0 +1,2 @@
+- Fix autolocking to correctly detect changes to `(depends)` in watch mode
+  (#14066, fixes #13234, @Alizter)

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -215,7 +215,9 @@ let get_with_path =
            Pp.textf "read lock directory %s" (Path.to_string_maybe_quoted p))
          "read-lock-dir"
          ~input:(module Path)
-         Load.load)
+         (fun path ->
+            let* () = Build_system.build_dir path in
+            Load.load path))
   in
   Per_context.create_by_name ~name:"lock-dir-get" (fun ctx ->
     Memo.lazy_ (fun () ->
@@ -228,7 +230,6 @@ let get_with_path =
             "No lock dir path for context available"
             [ "context", Context_name.to_dyn ctx ]
       in
-      let* () = Build_system.build_dir path in
       read_lockdir path
       >>= function
       | Error e -> Memo.return (Error e)

--- a/test/blackbox-tests/test-cases/pkg/autolock-with-watch-server.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-with-watch-server.t
@@ -46,13 +46,10 @@ Add new dependency c:
 Run build:
 
   $ build a.exe
-  Failure
+  Success
 
 Stop the watch server
 
   $ stop_dune
   Success, waiting for filesystem changes...
-  File "dune.lock/lock.dune", line 1, characters 0-0:
-  Error: The lock dir is not sync with your dune-project
-  Hint: run dune pkg lock
-  Had 1 error, waiting for filesystem changes...
+  Success, waiting for filesystem changes...


### PR DESCRIPTION
Correctly build and then depend on the internal lock file. We also don't break the invariant tested in #14065.

- Fixes https://github.com/ocaml/dune/issues/13234
- [x] changelog