### PR TITLE
feat: symlinks on win

### DIFF
--- a/otherlibs/stdune/src/config.ml
+++ b/otherlibs/stdune/src/config.ml
@@ -169,3 +169,13 @@ let threaded_console_frames_per_second =
       | None -> Error (sprintf "could not parse %S as an integer" x))
     ~default:`Default
 ;;
+
+let symlinks_available =
+  make
+    ~name:"symlinks_available"
+    ~of_string:(function
+      | "enabled" -> Ok `Enabled
+      | "disabled" -> Ok `Disabled
+      | _ -> Error (sprintf "only %S and %S are allowed" "enabled" "disabled"))
+    ~default:`Auto
+;;

--- a/otherlibs/stdune/src/config.mli
+++ b/otherlibs/stdune/src/config.mli
@@ -63,6 +63,10 @@ val threaded_console : Toggle.t t
 (** The number of frames per second for the threaded console. *)
 val threaded_console_frames_per_second : [ `Default | `Custom of int ] t
 
+(** Whether to use symbolic links. [Auto] defers to [Unix.has_symlink].
+    Can be overridden with [DUNE_CONFIG__SYMLINKS_AVAILABLE=enabled|disabled]. *)
+val symlinks_available : [ `Enabled | `Disabled | `Auto ] t
+
 (** Before any configuration value is accessed, this function must be called
     with all the configuration values from the relevant config file
     ([dune-workspace], or [dune-config]).

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -425,10 +425,19 @@ module String_path = struct
   let copy_file = Copyfile.copyfile
 end
 
+let symlinks_available_impl = ref `Auto
+let set_symlinks_available v = symlinks_available_impl := v
+
+let symlinks_available () =
+  match !symlinks_available_impl with
+  | `Enabled -> true
+  | `Disabled -> false
+  | `Auto -> Unix.has_symlink ()
+;;
+
 let portable_symlink ~src ~dst =
-  if Stdlib.Sys.win32
-  then copy_file ~src ~dst ()
-  else (
+  if symlinks_available ()
+  then (
     let src =
       match Path.parent dst with
       | None -> Path.to_string src
@@ -439,11 +448,10 @@ let portable_symlink ~src ~dst =
     | target ->
       if target <> src
       then (
-        (* @@DRA Win32 remove read-only attribute needed when symlinking
-           enabled *)
-        Unix.unlink dst;
+        Fpath.unlink_exn dst;
         Unix.symlink src dst)
     | exception Unix.Unix_error _ -> Unix.symlink src dst)
+  else copy_file ~src ~dst ()
 ;;
 
 let portable_hardlink ~src ~dst =

--- a/otherlibs/stdune/src/io.mli
+++ b/otherlibs/stdune/src/io.mli
@@ -16,3 +16,5 @@ val portable_symlink : src:Path.t -> dst:Path.t -> unit
 val portable_hardlink : src:Path.t -> dst:Path.t -> unit
 
 val set_copy_impl : [ `Portable | `Best ] -> unit
+val set_symlinks_available : [ `Enabled | `Disabled | `Auto ] -> unit
+val symlinks_available : unit -> bool

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -679,6 +679,7 @@ module Dune_config = struct
       | Clear_on_rebuild -> Console.reset ()
       | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ());
     Stdune.Io.set_copy_impl Config.(get copy_file);
+    Stdune.Io.set_symlinks_available Config.(get symlinks_available);
     Log.verbose
     := match t.display with
        | Simple { verbosity = Verbose; _ } -> true

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -248,16 +248,7 @@ end = struct
       let evaluate_sandboxing_preference preference =
         match Sandbox_mode.Set.mem config preference with
         | false -> None
-        | true ->
-          if Sys.win32 && preference = Some Sandbox_mode.Symlink
-          then
-            User_error.raise
-              ~loc
-              [ Pp.text
-                  "Sandboxing mode symlink is not supported on Windows. Use copy or \
-                   hardlink instead."
-              ]
-          else Some preference
+        | true -> Some preference
       in
       (match List.find_map sandboxing_preference ~f:evaluate_sandboxing_preference with
        | Some choice -> choice

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -112,20 +112,22 @@ let create_dirs t ~dirs ~rule_dir =
 ;;
 
 let link_function ~(mode : Sandbox_mode.some) =
-  let win32_error mode =
+  let symlink_error mode =
     let mode = Sandbox_mode.to_string (Some mode) in
     User_error.raise
       [ Pp.textf
-          "Sandboxing mode %s is not supported on Windows. Use copy or hardlink instead."
+          "Sandboxing mode %s is not supported on this system. On Windows, enable \
+           Developer Mode in Windows Settings > Privacy & Security > For Developers, or \
+           use copy or hardlink mode instead."
           mode
       ]
   in
   Staged.stage
     (match mode with
      | Symlink ->
-       (match Sys.win32 with
-        | true -> win32_error mode
-        | false -> fun src dst -> Io.portable_symlink ~src ~dst)
+       (match Io.symlinks_available () with
+        | false -> symlink_error mode
+        | true -> fun src dst -> Io.portable_symlink ~src ~dst)
      | Copy -> fun src dst -> copy_recursively ~src ~dst
      | Hardlink -> fun src dst -> Io.portable_hardlink ~src ~dst
      | Patch_back_source_tree ->

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -107,16 +107,17 @@ module Set = struct
 end
 
 (* All user-facing modes, excluding patch_back_source_tree. Includes symlink
-   on all platforms so that Windows users get a clear error message. *)
+   on all platforms so that users get a clear error message when symlinks are
+   unavailable. *)
 let cli_options = [ None; Some Symlink; Some Copy; Some Hardlink ]
 
 (* The order of sandboxing modes in this list determines the order in which Dune
-   will try to use them when satisfying sandboxing constraints. On Windows,
-   symlink is excluded since it is not supported. *)
+   will try to use them when satisfying sandboxing constraints. Symlink is
+   excluded when the system does not support symlink creation. *)
 let all_except_patch_back_source_tree =
-  if Sys.win32
-  then List.filter cli_options ~f:(fun m -> m <> Some Symlink)
-  else cli_options
+  if Io.symlinks_available ()
+  then cli_options
+  else List.filter cli_options ~f:(fun m -> m <> Some Symlink)
 ;;
 
 let all = all_except_patch_back_source_tree @ [ Some Patch_back_source_tree ]

--- a/test/blackbox-tests/test-cases/sandbox/dune
+++ b/test/blackbox-tests/test-cases/sandbox/dune
@@ -10,6 +10,12 @@
   (= %{os_type} Win32))
  (alias runtest-windows))
 
+(cram
+ (applies_to sandbox-symlink-windows-enabled)
+ (enabled_if
+  (= %{os_type} Win32))
+ (alias runtest-windows))
+
 ; Tests disabled on Windows:
 ; sandbox-chdir: path prefix handling differences
 ; sandboxing-stale-directory-target: path prefix handling differences

--- a/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows-enabled.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows-enabled.t
@@ -1,0 +1,18 @@
+When symlinks are available on Windows (Developer Mode enabled), symlink
+sandboxing should work correctly.
+
+  $ make_dune_project 3.0
+
+  $ echo hello > input
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (target a)
+  >  (deps input (sandbox always))
+  >  (action (copy input a)))
+  > EOF
+
+  $ dune build a --sandbox symlink
+
+  $ cat _build/default/a
+  hello

--- a/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandbox-symlink-windows.t
@@ -1,17 +1,23 @@
-Symlink sandboxing is not supported on Windows. Attempting to use it should
-produce a user-facing error.
+Symlink sandboxing requires Developer Mode on Windows. Without it,
+attempting to use it should produce a user-facing error. We force symlinks
+off via the config override to test this regardless of the host configuration.
+
+  $ export DUNE_CONFIG__SYMLINKS_AVAILABLE=disabled
 
   $ make_dune_project 3.0
+
+  $ echo hello > input
 
   $ cat > dune <<EOF
   > (rule
   >  (target a)
-  >  (deps (sandbox always))
-  >  (action (with-stdout-to a (echo "hello"))))
+  >  (deps input (sandbox always))
+  >  (action (copy input a)))
   > EOF
 
   $ dune build a --sandbox symlink
   File ".dune/_unknown_", line 1, characters 0-0:
-  Error: Sandboxing mode symlink is not supported on Windows. Use copy or
-  hardlink instead.
+  Error: Sandboxing mode symlink is not supported on this system. On Windows,
+  enable Developer Mode in Windows Settings > Privacy & Security > For
+  Developers, or use copy or hardlink mode instead.
   [1]


### PR DESCRIPTION
Windows has had symlinks since Windows 10. We add the ability to use symlinks for sandboxing.

The reasons for doing so are as follows:
- Hardlinks are capped to a link number of 1024 in NTFS
- Copying files is slow
- Hardlinks don't work across drives (/devices)
- We don't have to special-case Windows as often

Symlinking addresses all of the above concerns. 

Symlinks are not available on Windows by default unless explicitly set so in the registry or if developer mode is enabled.

OCaml has has support for `Unix.has_symlinks` since way before 4.14 so dynamically checking they are available on Windows isn't too difficult.

For now we only enable symlinking when sandboxing. We can consider symlinking support for the shared cache later.

- [ ] changelog
- [ ] decide whether or not symlinking is enabled in CI or not