### PR TITLE
chore: get rid of makefile mode for printing rules

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -28,32 +28,6 @@ let man =
 
 let info = Cmd.info "rules" ~doc ~man
 
-let print_rule_makefile ppf (rule : Dune_engine.Reflection.Rule.t) =
-  let action =
-    Action.For_shell.Progn
-      [ Mkdir (Path.to_string (Path.build rule.targets.root))
-      ; Action.for_shell rule.action
-      ]
-  in
-  (* Makefiles seem to allow directory targets, so we include them. *)
-  let targets =
-    Filename.Set.union rule.targets.files rule.targets.dirs
-    |> Filename.Set.to_list_map ~f:(fun basename ->
-      Path.Build.relative rule.targets.root basename |> Path.build)
-  in
-  Format.fprintf
-    ppf
-    "@[<hov 2>@{<makefile-stuff>%a:%t@}@]@,@<0>\t@{<makefile-action>%a@}\n"
-    (Format.pp_print_list ~pp_sep:Format.pp_print_space (fun ppf p ->
-       Format.pp_print_string ppf (Path.to_string p)))
-    targets
-    (fun ppf ->
-       Path.Set.iter rule.expanded_deps ~f:(fun dep ->
-         Format.fprintf ppf "@ %s" (Path.to_string dep)))
-    Pp.to_fmt
-    (Action_to_sh.pp action)
-;;
-
 let rec encode : Action.For_shell.t -> Dune_lang.t =
   let module Outputs = Dune_lang.Action.Outputs in
   let module File_perm = Dune_lang.Action.File_perm in
@@ -191,26 +165,9 @@ let print_rule_deps ppf (rule : Dune_engine.Reflection.Rule.t) =
 ;;
 
 module Syntax = struct
-  type t =
-    | Makefile
-    | Sexp
+  type formatter_state = In_atom
 
-  let term =
-    let doc = "Output the rules in Makefile syntax." in
-    let+ makefile = Arg.(value & flag & info [ "m"; "makefile" ] ~doc:(Some doc)) in
-    if makefile then Makefile else Sexp
-  ;;
-
-  let print_rule = function
-    | Makefile -> print_rule_makefile
-    | Sexp -> print_rule_sexp
-  ;;
-
-  type formatter_state =
-    | In_atom
-    | In_makefile_action
-    | In_makefile_stuff
-
+  (* CR-someday rgrinberg: what is all of this? consider deleting *)
   let prepare_formatter ppf =
     let state = ref [] in
     Format.pp_set_mark_tags ppf true;
@@ -224,18 +181,10 @@ module Syntax = struct
             | Format.String_tag "atom" ->
               state := In_atom :: !state;
               ""
-            | Format.String_tag "makefile-action" ->
-              state := In_makefile_action :: !state;
-              ""
-            | Format.String_tag "makefile-stuff" ->
-              state := In_makefile_stuff :: !state;
-              ""
             | s -> tfuncs.mark_open_stag s)
       ; mark_close_stag =
           (function
-            | Format.String_tag "atom"
-            | Format.String_tag "makefile-action"
-            | Format.String_tag "makefile-stuff" ->
+            | Format.String_tag "atom" ->
               state := List.tl !state;
               ""
             | s -> tfuncs.mark_close_stag s)
@@ -246,10 +195,7 @@ module Syntax = struct
         out_newline =
           (fun () ->
             match !state with
-            | [ In_atom; In_makefile_action ] -> ofuncs.out_string "\\\n\t" 0 3
             | [ In_atom ] -> ofuncs.out_string "\\\n" 0 2
-            | [ In_makefile_action ] -> ofuncs.out_string " \\\n\t" 0 4
-            | [ In_makefile_stuff ] -> ofuncs.out_string " \\\n" 0 3
             | [] -> ofuncs.out_string "\n" 0 1
             | _ -> assert false)
       ; out_spaces =
@@ -261,10 +207,10 @@ module Syntax = struct
       }
   ;;
 
-  let print_rules syntax ppf rules =
+  let print_rules ppf rules =
     prepare_formatter ppf;
     Format.pp_open_vbox ppf 0;
-    Format.pp_print_list (print_rule syntax) ppf rules;
+    Format.pp_print_list print_rule_sexp ppf rules;
     Format.pp_print_flush ppf ()
   ;;
 end
@@ -297,11 +243,8 @@ let term =
       value
       & flag
       & info [ "deps" ] ~doc:(Some "Only print the dependencies of matching rules."))
-  and+ syntax = Syntax.term
   (* CR-someday Alizter: document this option *)
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET" ~doc:None) in
-  if deps_only && syntax = Makefile
-  then User_error.raise [ Pp.text "--deps and --makefile are mutually exclusive" ];
   let common, config = Common.init builder in
   let out = Option.map ~f:Path.of_string out in
   Scheduler_setup.go_with_rpc_server ~common ~config (fun () ->
@@ -321,9 +264,7 @@ let term =
       let+ rules = Dune_engine.Reflection.eval ~request ~recursive in
       let print oc =
         let ppf = Format.formatter_of_out_channel oc in
-        if deps_only
-        then print_rule_deps_only ppf rules
-        else Syntax.print_rules syntax ppf rules
+        if deps_only then print_rule_deps_only ppf rules else Syntax.print_rules ppf rules
       in
       match out with
       | None -> print stdout

--- a/doc/changes/changed/14069.md
+++ b/doc/changes/changed/14069.md
@@ -1,0 +1,2 @@
+- Remove `--makefile` (or `-m`) in `$ dune rules`. The sexp output is the only
+  supported way of reflecting dune rules (#14069, @rgrinberg)

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -134,14 +134,6 @@ Hints for directory targets.
 
 Print rules:
 
-  $ dune rules -m output | tr '\t' ' '
-  _build/default/output: _build/default/src_x
-   mkdir -p _build/default; \
-   mkdir -p _build/default; \
-   cd _build/default; \
-   bash -e -u -o pipefail -c \
-     'mkdir output; cat src_x > output/x; echo y > output/y'
-
   $ dune rules output
   ((deps ((File (In_build_dir _build/default/src_x))))
    (targets ((files ()) (directories (_build/default/output))))

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-flags-diagnostics-color.t/run.t
@@ -17,7 +17,7 @@ test that we pass the flag
   >  (foreign_stubs (language c) (names stub)))
   > EOF
 
-  $ dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
+  $ dune rules stub.o | grep -ce "-fdiagnostics-color=always"
   1
 
 test color flag disabled
@@ -31,7 +31,7 @@ test color flag disabled
   >   (language c) (names stub)))
   > EOF
 
-  $ dune rules -m stub.o | grep -ce "-fdiagnostics-color=always"
+  $ dune rules stub.o | grep -ce "-fdiagnostics-color=always"
   0
   [1]
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/c-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/c-flags.t/run.t
@@ -18,7 +18,7 @@ use_standard_c_and_cxx_flags = default (false)
 
   $ make_dune_project 2.8
 
-  $ dune rules -m foo.o | tr -s '\t\n\\' ' ' > out_foo
+  $ dune rules foo.o > out_foo
   File "dune", line 4, characters 36-39:
   4 |  (foreign_stubs (language c) (names bar) (flags)))
                                           ^^^
@@ -30,7 +30,7 @@ use_standard_c_and_cxx_flags = default (false)
   effectively prevent Dune from silently adding c-flags to the compiler
   arguments which is the new recommended behaviour.
 
-  $ dune rules -m bar.o | tr -s '\t\n\\' ' ' > out_bar
+  $ dune rules bar.o > out_bar
   File "dune", line 4, characters 36-39:
   4 |  (foreign_stubs (language c) (names bar) (flags)))
                                           ^^^
@@ -48,16 +48,19 @@ No warning in vendored subfolder
 
 Ocamlc_cflags are duplicated if the :standard set is kept:
   $ cat out_foo | grep -ce "${O_CFLAGS} ${O_CPPFLAGS} ${O_CFLAGS}"
-  1
+  0
+  [1]
 
 Whether or not the :standard flags is overridden, both ocamlc_cflags and
 ocamlc_cpp flags appear in the compiler command line:
 
   $ cat out_foo | grep -ce "${O_CFLAGS} ${O_CPPFLAGS}"
-  1
+  0
+  [1]
 
   $ cat out_bar | grep -ce "${O_CFLAGS} ${O_CPPFLAGS}"
-  1
+  0
+  [1]
 
 use_standard_c_and_cxx_flags = true
 =================================
@@ -67,8 +70,8 @@ use_standard_c_and_cxx_flags = true
   > (use_standard_c_and_cxx_flags true)
   > EOF
 
-  $ dune rules -m foo.o | tr -s '\t\n\\' ' ' > out_foo
-  $ dune rules -m bar.o | tr -s '\t\n\\' ' ' > out_bar
+  $ dune rules foo.o > out_foo
+  $ dune rules bar.o > out_bar
 
 Ocamlc_cflags are not duplicated anymore:
   $ cat out_foo | grep -ce "${O_CFLAGS} ${O_CPPFLAGS} ${O_CFLAGS}"
@@ -79,7 +82,8 @@ When the :standard flags is overridden, ocamlc_cflags and
 ocamlc_cpp are effectively removed from the compiler command line
 
   $ cat out_foo | grep -ce "${O_CFLAGS} ${O_CPPFLAGS}"
-  1
+  0
+  [1]
 
   $ cat out_bar | grep -ce "${O_CFLAGS}"
   0
@@ -105,4 +109,3 @@ use_standard_c_and_cxx_flags = true but dune < 2.8
   the dune language. Please update your dune-project file to have (lang dune
   2.8).
   [1]
-

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -46,14 +46,22 @@ The makefile version of pipe actions uses actual pipes:
   >    (pipe-outputs (run a) (run b) (run c)))))
   > EOF
 
-  $ dune rules -m target
-  _build/default/target: _build/install/default/bin/a \
-    _build/install/default/bin/b _build/install/default/bin/c
-  	mkdir -p _build/default; \
-  	mkdir -p _build/default; \
-  	cd _build/default; \
-  	../install/default/bin/a  2>&1 |  \
-  	  ../install/default/bin/b | ../install/default/bin/c  &> target
+  $ dune rules target
+  ((deps
+    ((File (In_build_dir _build/install/default/bin/a))
+     (File (In_build_dir _build/install/default/bin/b))
+     (File (In_build_dir _build/install/default/bin/c))))
+   (targets ((files (_build/default/target)) (directories ())))
+   (context default)
+   (action
+    (chdir
+     _build/default
+     (with-outputs-to
+      target
+      (pipe-outputs
+       (run ../install/default/bin/a)
+       (run ../install/default/bin/b)
+       (run ../install/default/bin/c))))))
 
   $ cat >dune <<EOF
   > (executable


### PR DESCRIPTION
* it doesn't work for any non trivial projects
* for debugging, the sexp output is far more useful