### PR TITLE
ci: run packaging checks for PRs

### DIFF
--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
         - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -34,10 +35,6 @@ jobs:
   packaging-check:
     needs: discover-packages
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJson(needs.discover-packages.outputs.packages) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +46,12 @@ jobs:
           opam-pin: false
 
       - name: Lint current package metadata
-        run: opam lint "./opam/${{ matrix.package }}.opam"
+        env:
+          packages: ${{ needs.discover-packages.outputs.packages }}
+        run: |
+          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+            opam lint "./opam/$pkg.opam"
+          done
 
       - name: Pin all packages without installing
         # Some packages require their sibling packages to be at the same version.
@@ -70,13 +72,24 @@ jobs:
           echo "PATH=$PATH" >> $GITHUB_ENV
 
       - name: Install package
-        run: opam install ${{ matrix.package }} --with-test -y
+        env:
+          packages: ${{ needs.discover-packages.outputs.packages }}
+        run: |
+          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+            opam install "$pkg.dev" --with-test -y
+            opam remove "$pkg.dev" --auto-remove -y
+          done
 
       - name: Lower bounds test
         # Verify that installation succeeds with lower-bound dependencies.
         # The package is removed first so that opam reinstalls it fresh,
         # resolving to the oldest compatible versions rather than reusing
         # what is already installed.
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        env:
+          packages: ${{ needs.discover-packages.outputs.packages }}
         run: |
-          opam remove ${{ matrix.package }}
-          opam install --solver=builtin-0install "--criteria=+count[version-lag,solution]" ${{ matrix.package }}
+          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+            opam install --solver=builtin-0install "--criteria=+count[version-lag,solution]" "$pkg.dev" -y
+            opam remove "$pkg.dev" --auto-remove -y
+          done

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -8,13 +8,14 @@ on:
     branches:
         - main
   pull_request:
+    paths:
+      - 'opam/*.opam'
   workflow_dispatch:
 
 jobs:
-  discover-packages:
+  packaging-check:
     runs-on: ubuntu-latest
-    outputs:
-      packages: ${{ steps.discover.outputs.packages }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -32,13 +33,6 @@ jobs:
           )
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
-  packaging-check:
-    needs: discover-packages
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4
@@ -47,7 +41,7 @@ jobs:
 
       - name: Lint current package metadata
         env:
-          packages: ${{ needs.discover-packages.outputs.packages }}
+          packages: ${{ steps.discover.outputs.packages }}
         run: |
           for pkg in $packages; do
             opam lint "./opam/$pkg.opam"
@@ -60,7 +54,7 @@ jobs:
         # installing them. This way they are pulled in only if required by the package
         # being built, without influencing the solver for unrelated dependencies.
         env:
-          packages: ${{ needs.discover-packages.outputs.packages }}
+          packages: ${{ steps.discover.outputs.packages }}
         run: |
           for pkg in $packages; do
             opam pin add "$pkg.dev" . -n
@@ -73,7 +67,7 @@ jobs:
 
       - name: Install package
         env:
-          packages: ${{ needs.discover-packages.outputs.packages }}
+          packages: ${{ steps.discover.outputs.packages }}
         run: |
           for pkg in $packages; do
             opam install "$pkg.dev" --with-test -y
@@ -87,7 +81,7 @@ jobs:
         # what is already installed.
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         env:
-          packages: ${{ needs.discover-packages.outputs.packages }}
+          packages: ${{ steps.discover.outputs.packages }}
         run: |
           for pkg in $packages; do
             opam install --solver=builtin-0install "--criteria=+count[version-lag,solution]" "$pkg.dev" -y

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -28,7 +28,7 @@ jobs:
             find ./opam -maxdepth 1 -name '*.opam' -printf '%f\n' \
             | sed 's/\.opam$//' \
             | sort \
-            | jq -R -s -c 'split("\n")[:-1]'
+            | jq -R -s -r 'split("\n")[:-1] | join(" ")'
           )
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
@@ -49,7 +49,7 @@ jobs:
         env:
           packages: ${{ needs.discover-packages.outputs.packages }}
         run: |
-          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+          for pkg in $packages; do
             opam lint "./opam/$pkg.opam"
           done
 
@@ -62,7 +62,7 @@ jobs:
         env:
           packages: ${{ needs.discover-packages.outputs.packages }}
         run: |
-          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+          for pkg in $packages; do
             opam pin add "$pkg.dev" . -n
           done
 
@@ -75,7 +75,7 @@ jobs:
         env:
           packages: ${{ needs.discover-packages.outputs.packages }}
         run: |
-          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+          for pkg in $packages; do
             opam install "$pkg.dev" --with-test -y
             opam remove "$pkg.dev" --auto-remove -y
           done
@@ -89,7 +89,7 @@ jobs:
         env:
           packages: ${{ needs.discover-packages.outputs.packages }}
         run: |
-          echo "$packages" | jq -r '.[]' | while read -r pkg; do
+          for pkg in $packages; do
             opam install --solver=builtin-0install "--criteria=+count[version-lag,solution]" "$pkg.dev" -y
             opam remove "$pkg.dev" --auto-remove -y
           done

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
         - main
+    paths:
+        - 'opam/*.opam'
   pull_request:
     paths:
       - 'opam/*.opam'
@@ -79,7 +81,6 @@ jobs:
         # The package is removed first so that opam reinstalls it fresh,
         # resolving to the oldest compatible versions rather than reusing
         # what is already installed.
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         env:
           packages: ${{ steps.discover.outputs.packages }}
         run: |


### PR DESCRIPTION
A packaging error was caught by the CI run as described in #14070 and was fixed in #14076. It might be a good idea to run this on PRs to catch the issues early. But in the current form, we fire up a separate job for every package in `opam/`. This was done to mimic the steps done by opam-repo-ci, but with @Leonidas-from-XIV, we figured out it might be possible to do all of them in the same job, and this would avoid calling setup-ocaml ~18 times (as in once for every package).

With the changes in this patch, the packaging check would run on every PR (took about ~20 minutes, including setup time for all packages), but the lower bounds check will still only run on pushes to main.