### PR TITLE
Add comment explaining that `Fpath.follow_symlink` is recursive, delete `follow_symlinks`

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -108,29 +108,6 @@ let follow_symlink path =
   | Error e -> Error (Unix_error e)
 ;;
 
-let rec follow_symlinks path =
-  let parent = Filename.dirname path in
-  let file = Filename.basename path in
-  (* If we reached the root, just return the path. *)
-  if parent = path
-  then Some path
-  else if parent = Filename.current_dir_name
-  then
-    (* Only keep the initial ["."] if it was in the path. *)
-    if path = Filename.concat Filename.current_dir_name file then Some path else Some file
-  else (
-    (* Recurse on parent, and re-add toplevel file. *)
-    match follow_symlinks parent with
-    | None -> None
-    | Some parent ->
-      let path = Filename.concat parent file in
-      (* Normalize the result. *)
-      (match follow_symlink path with
-       | Ok p -> Some p
-       | Error Max_depth_exceeded -> None
-       | Error _ -> Some path))
-;;
-
 let win32_unlink fn =
   try Unix.unlink fn with
   | Unix.Unix_error (Unix.EACCES, _, _) as e ->

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -26,14 +26,9 @@ type follow_symlink_error =
   | Max_depth_exceeded
   | Unix_error of Unix_error.Detailed.t
 
+(* Resolve a symbolic link recursively until its target is not a link.
+   Does not resolve intermediate path components, just the last one. *)
 val follow_symlink : string -> (string, follow_symlink_error) result
-
-(** [follow_symlinks path] returns a file path that is equivalent to [path], but
-    free of symbolic links. The value [None] is returned if the maximum symbolic
-    link depth is reached (i.e., [follow_symlink] returns the value
-    [Error Max_depth_exceeded] on some intermediate path). *)
-val follow_symlinks : string -> string option
-
 val unlink_exn : ?chmod:bool -> string -> unit
 val unlink_no_err : string -> unit
 


### PR DESCRIPTION
The presence of both `follow_symlink` and `follow_symlinks` (with an `s`) might lead people to believe that the former will only follow a singular link once. That is not the case, the whole thread is pulled.
Since the plural one was completely unused, I removed it entirely.