### PR TITLE
chore: update bench to 5.4

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,5 +1,4 @@
-FROM ocaml/opam:debian-12-ocaml-4.14
-RUN opam depext -u patdiff.v0.15.0
+FROM ocaml/opam:debian-13-ocaml-5.4
 RUN opam install csexp pp re spawn uutf
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -61,7 +61,6 @@ module Package = struct
     }
 
   let uri { org; name } = sprintf "https://github.com/%s/%s" org name
-  let make org name = { org; name }
 
   let clone t =
     let stdout_to = make_stdout () in
@@ -78,10 +77,7 @@ module Package = struct
   ;;
 end
 
-let duniverse =
-  let pkg = Package.make in
-  [ pkg "ocaml-dune" "dune-bench" ]
-;;
+let duniverse = []
 
 let prepare_workspace () =
   Fiber.parallel_iter duniverse ~f:(fun (pkg : Package.t) ->


### PR DESCRIPTION
Unfortunately, we need to update https://github.com/ocaml-dune/dune-bench to be able to build things on 5.4

@Alizter could you update this please? For now, I've disabled the benchmarks. 4.14 results aren't relevant anyway.