### PR TITLE
fix: revert --diff-command behavior

### DIFF
--- a/doc/changes/fixed/14098.md
+++ b/doc/changes/fixed/14098.md
@@ -1,0 +1,3 @@
+- Revert the change in behavior of `--diff-command` back to 3.21. Non-existent
+  files are now passed to this command instead of being replaced with /dev/null
+  (#14098, fixes 13891, @rgrinberg)

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -177,8 +177,6 @@ let prepare_with_labels
              (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path2))
          ])
   in
-  let path1 = noent_to_dev_null path1 in
-  let path2 = noent_to_dev_null path2 in
   match !Clflags.diff_command with
   | Some "-" -> fallback
   | Some cmd ->
@@ -213,17 +211,28 @@ let prepare_with_labels
       | None -> fallback
       | Some diff -> With_fallback.run diff ~fallback
     in
+    let builtin_path1 = noent_to_dev_null path1 in
+    let builtin_path2 = noent_to_dev_null path2 in
     let diff =
-      External.diff ~skip_trailing_cr ~dir promotion loc (label1, path1) (label2, path2)
+      External.diff
+        ~skip_trailing_cr
+        ~dir
+        promotion
+        loc
+        (label1, builtin_path1)
+        (label2, builtin_path2)
     in
     if Execution_env.inside_dune
     then or_fallback ~fallback diff
     else (
       let fallback =
-        Option.first_some (External.git ~skip_trailing_cr promotion loc path1 path2) diff
+        Option.first_some
+          (External.git ~skip_trailing_cr promotion loc builtin_path1 builtin_path2)
+          diff
         |> or_fallback ~fallback
       in
-      External.patdiff ~dir promotion loc path1 path2 |> or_fallback ~fallback)
+      External.patdiff ~dir promotion loc builtin_path1 builtin_path2
+      |> or_fallback ~fallback)
 ;;
 
 let prepare ~skip_trailing_cr promotion path1 path2 =

--- a/test/blackbox-tests/test-cases/promote/non-existent-dir.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent-dir.t
@@ -18,7 +18,7 @@ dune promote should be able to promote into directories that don't exist
 
   $ dune build ./foo --diff-command "/bin/sh $PWD/diff.sh"
   File "dir/foo", line 1, characters 0-0:
-  a: /dev/null
+  a: dir/foo
   b: foo
   [1]
 


### PR DESCRIPTION
Pass non-existent files and directories to the --diff-command