### PR TITLE
refactor: remove [spawn_thread] from file watcher

### DIFF
--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -48,10 +48,7 @@ module Event = struct
 end
 
 module Scheduler = struct
-  type t =
-    { spawn_thread : (unit -> unit) -> Thread.t
-    ; thread_safe_send_emit_events_job : (unit -> Event.t list) -> unit
-    }
+  type t = { thread_safe_send_emit_events_job : (unit -> Event.t list) -> unit }
 end
 
 module Watch_trie : sig
@@ -426,7 +423,6 @@ let spawn_external_watcher ~root ~backend ~watch_exclusions =
 
 let create_inotifylib_watcher ~sync_table ~(scheduler : Scheduler.t) should_exclude =
   Inotify.create
-    ~spawn_thread:scheduler.spawn_thread
     ~modify_event_selector:`Closed_writable_fd
     ~send_emit_events_job_to_scheduler:(fun f ->
       scheduler.thread_safe_send_emit_events_job (fun () ->
@@ -482,7 +478,9 @@ let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend ~watch_exclusi
       scheduler.thread_safe_send_emit_events_job job
     done
   in
-  let (_ : Thread.t) = scheduler.spawn_thread (fun () -> worker_thread pipe) in
+  let (_ : Thread.t) =
+    Thread0.spawn ~name:"file-watcher" (fun () -> worker_thread pipe)
+  in
   { kind = Fswatch { pid; wait_for_watches_established = wait }; sync_table }
 ;;
 
@@ -497,7 +495,7 @@ let with_buffering ~create ~(scheduler : Scheduler.t) ~debounce_interval =
       Condition.signal event_cv;
       Mutex.unlock event_mtx
     in
-    let scheduler = { scheduler with thread_safe_send_emit_events_job } in
+    let scheduler = { Scheduler.thread_safe_send_emit_events_job } in
     create ~scheduler
   in
   (* The buffer thread is used to avoid flooding the main thread with file
@@ -525,7 +523,7 @@ let with_buffering ~create ~(scheduler : Scheduler.t) ~debounce_interval =
     Thread.delay debounce_interval;
     buffer_thread ()
   in
-  let (_ : Thread.t) = scheduler.spawn_thread buffer_thread in
+  let (_ : Thread.t) = Thread0.spawn ~name:"file-watcher" buffer_thread in
   res
 ;;
 
@@ -618,7 +616,7 @@ let create_fsevents
   let dispatch_queue_ref = ref None in
   let mutex = Mutex.create () in
   let (_ : Thread.t) =
-    scheduler.spawn_thread (fun () ->
+    Thread0.spawn ~name:"file-watcher" (fun () ->
       let dispatch_queue = Fsevents.Dispatch_queue.create () in
       Mutex.lock mutex;
       dispatch_queue_ref := Some dispatch_queue;
@@ -683,7 +681,7 @@ let create_fswatch_win ~(scheduler : Scheduler.t) ~debounce_interval:sleep ~shou
   let t = Fswatch_win.create () in
   Fswatch_win.add t (Path.to_absolute_filename Path.root);
   let (_ : Thread.t) =
-    scheduler.spawn_thread (fun () ->
+    Thread0.spawn ~name:"file-watcher" (fun () ->
       while true do
         let events = Fswatch_win.wait t ~sleep in
         List.iter ~f:(fswatch_win_callback ~scheduler ~sync_table ~should_exclude) events

--- a/src/dune_scheduler/file_watcher.mli
+++ b/src/dune_scheduler/file_watcher.mli
@@ -48,10 +48,7 @@ end
 module Scheduler : sig
   (** Hook into the fiber scheduler. *)
   type t =
-    { spawn_thread : (unit -> unit) -> Thread.t
-      (** We spawn threads through this function in case the scheduler wants
-        to block signals *)
-    ; thread_safe_send_emit_events_job : (unit -> Event.t list) -> unit
+    { thread_safe_send_emit_events_job : (unit -> Event.t list) -> unit
       (** Send some events to the scheduler. The events are sent in the form
         of a thunk to be executed on the scheduler thread, so that we can
         do some bookkeeping that needs to happen there. *)

--- a/src/dune_scheduler/inotify.ml
+++ b/src/dune_scheduler/inotify.ml
@@ -140,10 +140,10 @@ let process_raw_events t events =
      | Some (_, fn) -> Moved (Away fn) :: actions)
 ;;
 
-let pump_events t ~spawn_thread =
+let pump_events t =
   let fd = t.fd in
   let (_ : Thread.t) =
-    spawn_thread (fun () ->
+    Thread0.spawn ~name:"file-watcher" (fun () ->
       while true do
         match UnixLabels.select ~read:[ fd ] ~write:[] ~except:[] ~timeout:(-1.) with
         | _, _, _ ->
@@ -155,7 +155,7 @@ let pump_events t ~spawn_thread =
   ()
 ;;
 
-let create ~spawn_thread ~modify_event_selector ~send_emit_events_job_to_scheduler =
+let create ~modify_event_selector ~send_emit_events_job_to_scheduler =
   let fd = Inotify.create () in
   let watch_table = Table.create (module Inotify_watch) 10 in
   let modify_selector : Inotify.selector =
@@ -172,6 +172,6 @@ let create ~spawn_thread ~modify_event_selector ~send_emit_events_job_to_schedul
     ; send_emit_events_job_to_scheduler
     }
   in
-  pump_events t ~spawn_thread;
+  pump_events t;
   t
 ;;

--- a/src/dune_scheduler/inotify.mli
+++ b/src/dune_scheduler/inotify.mli
@@ -59,8 +59,7 @@ type modify_event_selector =
     [send_emit_events_job_to_scheduler f] is expected to run the job [f] in the
     scheduler, and then process the events returned by that job. *)
 val create
-  :  spawn_thread:((unit -> unit) -> Thread.t)
-  -> modify_event_selector:modify_event_selector
+  :  modify_event_selector:modify_event_selector
   -> send_emit_events_job_to_scheduler:((unit -> Event.t list) -> unit)
   -> t
 

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -523,8 +523,7 @@ module Run = struct
         Some
           (File_watcher.create_default
              ~scheduler:
-               { spawn_thread = spawn_thread ~name:"file-watcher"
-               ; thread_safe_send_emit_events_job =
+               { thread_safe_send_emit_events_job =
                    (fun job -> Event_queue.send_file_watcher_task events job)
                }
              ~watch_exclusions:config.watch_exclusions

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -9,8 +9,7 @@ let%expect_test _ =
   let watcher =
     Dune_scheduler.File_watcher.create_default
       ~scheduler:
-        { spawn_thread = (fun f -> Thread.create f ())
-        ; thread_safe_send_emit_events_job =
+        { thread_safe_send_emit_events_job =
             (fun job ->
               critical_section mutex ~f:(fun () ->
                 let events = job () in

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -10,8 +10,7 @@ let%expect_test _ =
     Dune_scheduler.File_watcher.create_default
       ~fsevents_debounce:(Time.Span.of_secs 0.)
       ~scheduler:
-        { spawn_thread = (fun f -> Thread.create f ())
-        ; thread_safe_send_emit_events_job =
+        { thread_safe_send_emit_events_job =
             (fun job ->
               critical_section mutex ~f:(fun () ->
                 let events = job () in

--- a/test/expect-tests/inotify_tests/inotify_tests.ml
+++ b/test/expect-tests/inotify_tests/inotify_tests.ml
@@ -55,7 +55,6 @@ let watch, collect_events =
   let cond = Condition.create () in
   let inotify =
     Inotify.create
-      ~spawn_thread:(fun f -> Thread.create f ())
       ~modify_event_selector:`Closed_writable_fd
       ~send_emit_events_job_to_scheduler:(fun f ->
         Mutex.lock mutex;


### PR DESCRIPTION
This should produce an appropriate trace event for the thread as well