### PR TITLE
test: verify library file deps in compilation rules and sandboxed builds (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -1,0 +1,42 @@
+Verify that library file deps are declared for module compilation rules.
+
+Every non-alias module should declare glob deps on its library
+dependencies' .cmi files.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name main) (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get : unit -> int
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_int (Uses_lib.get ())
+  > EOF
+
+  $ dune build ./main.exe
+
+Both modules declare glob deps on mylib's .cmi files:
+
+  $ dune rules --deps _build/default/.main.eobjs/native/dune__exe__Uses_lib.cmx 2>&1 | grep 'predicate'
+     (predicate *.cmi)
+
+  $ dune rules --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx 2>&1 | grep 'predicate'
+     (predicate *.cmi)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sandbox-lib-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sandbox-lib-deps.t
@@ -1,0 +1,36 @@
+Sandboxed package builds need library file deps declared properly.
+
+When building with DUNE_SANDBOX=symlink and -p (release/package mode),
+dependency libraries' .cmi files must be available in the sandbox. If
+library file deps are not declared, the sandbox won't contain them and
+compilation will fail.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (package (name mypkg) (allow_empty))
+  > EOF
+
+  $ mkdir types_lib
+  $ cat > types_lib/dune <<EOF
+  > (library (name types_lib) (public_name mypkg.types_lib))
+  > EOF
+  $ cat > types_lib/types_lib.ml <<EOF
+  > type expr = Int of int | Add of expr * expr
+  > EOF
+
+  $ mkdir consumer_lib
+  $ cat > consumer_lib/dune <<EOF
+  > (library
+  >  (name consumer_lib)
+  >  (public_name mypkg.consumer_lib)
+  >  (libraries types_lib))
+  > EOF
+  $ cat > consumer_lib/consumer_lib.ml <<EOF
+  > let make_int i : Types_lib.expr = Int i
+  > let make_add a b : Types_lib.expr = Add (a, b)
+  > EOF
+
+The build must succeed — the sandbox must contain types_lib's .cmi files:
+
+  $ DUNE_SANDBOX=symlink dune build -p mypkg 2>&1 | grep -i error
+  [1]


### PR DESCRIPTION
## Summary
- Add baseline tests documenting existing behavior before the refactor that moves `Hidden_deps` from `Includes` to per-module in `build_cm`
- `lib-deps-preserved.t`: every non-alias module declares glob deps on its library dependencies' `.cmi` files
- `sandbox-lib-deps.t`: sandboxed package builds have dependency libraries' `.cmi` files available when a library depends on another library

These tests pass on `main` today and establish a baseline for the refactor in #14030.

Ref: #4572