### PR TITLE
refactor: get rid of old style directory targets

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -274,6 +274,7 @@ let default ~dir:_ _ acc = acc
 let traverse
       ~dir
       ~init
+      ?(sorted = false)
       ?(on_file = default)
       ?(on_dir = default)
       ?(on_other = `Raise)
@@ -323,6 +324,9 @@ let traverse
          let acc = on_error ~dir e acc in
          loop root dirs acc
        | Ok entries ->
+         let entries =
+           if sorted then List.sort entries ~compare:Poly.compare else entries
+         in
          let stack, acc =
            List.fold_left entries ~init:(dirs, acc) ~f:(fun (stack, acc) (fname, kind) ->
              match (kind : Unix.file_kind) with

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -65,6 +65,7 @@ val is_root : string -> bool
 val traverse
   :  dir:string
   -> init:'acc
+  -> ?sorted:bool
   -> ?on_file:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> ?on_dir:(dir:string -> Filename.t -> 'acc -> 'acc)
   -> ?on_other:

--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -470,11 +470,11 @@ module File_digest = struct
      This is temporary since [Cached_digest] is going to be limited source
      files *)
 
-  let refresh_async ~allow_dirs stats path =
+  let refresh_async stats path =
     let path = Path.build path in
     let open Fiber.O in
     Digest.Stats_for_digest.of_unix_stats stats
-    |> Digest.path_with_stats_async ~allow_dirs path
+    |> Digest.path_with_stats_async path
     >>| function
     | Ok digest -> Ok digest
     | Error Unexpected_kind -> Error (Error.Unexpected_kind stats.st_kind)
@@ -482,9 +482,9 @@ module File_digest = struct
     | Error (Unix_error other_error) -> Error (Unix_error other_error)
   ;;
 
-  let refresh_without_removing_write_permissions_async ~allow_dirs path =
+  let refresh_without_removing_write_permissions_async path =
     match Unix.stat (Path.Build.to_string path) with
-    | stats -> refresh_async stats ~allow_dirs path
+    | stats -> refresh_async stats path
     | exception exn ->
       Fiber.return
         (match exn with
@@ -497,7 +497,7 @@ module File_digest = struct
          | exn -> Error (Digest_result.Error.of_exn exn))
   ;;
 
-  let refresh_and_remove_write_permissions_async ~allow_dirs path =
+  let refresh_and_remove_write_permissions_async path =
     let open Digest_result.Error in
     match Unix.lstat (Path.Build.to_string path) with
     | exception Unix.Unix_error (ENOENT, _, _) -> Fiber.return (Error No_such_file)
@@ -506,26 +506,25 @@ module File_digest = struct
       (match stats.st_kind with
        | S_LNK ->
          (match Unix.stat (Path.Build.to_string path) with
-          | stats -> refresh_async stats ~allow_dirs:false path
+          | stats -> refresh_async stats path
           | exception Unix.Unix_error (ENOENT, _, _) ->
             Fiber.return (Error Broken_symlink)
           | exception exn -> Fiber.return (Error (Digest_result.Error.of_exn exn)))
        | S_REG ->
          let perm = Permissions.remove Permissions.write stats.st_perm in
          (match Unix.chmod (Path.Build.to_string path) perm with
-          | () -> refresh_async ~allow_dirs:false { stats with st_perm = perm } path
+          | () -> refresh_async { stats with st_perm = perm } path
           | exception exn -> Fiber.return (Error (Digest_result.Error.of_exn exn)))
        | _ ->
          (* CR-someday amokhov: Shall we proceed if [stats.st_kind = S_DIR]?
           What about stranger kinds like [S_SOCK]? *)
-         refresh_async ~allow_dirs stats path)
+         refresh_async stats path)
   ;;
 
-  let refresh ~allow_dirs ~remove_write_permissions path =
+  let refresh ~remove_write_permissions path =
     (if remove_write_permissions
      then refresh_and_remove_write_permissions_async
      else refresh_without_removing_write_permissions_async)
-      ~allow_dirs
       path
   ;;
 end
@@ -545,7 +544,6 @@ let compute_target_digests_or_raise_error
        the cache will remove write permission because of hardlink sharing
        anyway, so always removing them enables to catch mistakes earlier. *)
     File_digest.refresh
-      ~allow_dirs:true
       ~remove_write_permissions:should_remove_write_permissions_on_generated_files
   in
   Targets.Produced.map_with_errors_fiber ~f:compute_digest produced_targets

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -348,7 +348,6 @@ end
 let string s = Feed.compute_digest Feed.string s
 let string_pooled s = Feed.compute_digest_pooled Feed.string s
 let to_string_raw s = Blake3_mini.Digest.to_binary s
-let digest_repr = Repr.view Repr.string ~to_:to_string
 
 let repr_with compute_digest repr a =
   let start = Counter.Timer.start () in
@@ -359,7 +358,6 @@ let repr_with compute_digest repr a =
 ;;
 
 let repr repr a = repr_with Feed.compute_digest repr a
-let repr_pooled repr a = repr_with Feed.compute_digest_pooled repr a
 
 let path_with_executable_bit_with string_digest =
   let string_and_bool ~digest_hex ~bool =
@@ -410,86 +408,38 @@ module Path_digest_error = struct
     | Unix_error of Unix_error.Detailed.t
 end
 
-exception E of Path_digest_error.t
-
-let directory_digest_with =
-  let directory_digest_version = 4 in
-  let directory_digest_repr = Repr.(triple int (list (pair string digest_repr)) bool) in
-  fun repr_digest ~contents ~executable ->
-    repr_digest directory_digest_repr (directory_digest_version, contents, executable)
-;;
-
 let path_with_stats_internal
-      ~allow_dirs
       ~string_digest
-      ~directory_digest
       ~file_with_executable_bit
       path
       (stats : Stats_for_digest.t)
   =
-  let rec loop path (stats : Stats_for_digest.t) =
-    match stats.st_kind with
-    | S_LNK ->
-      Unix_error.Detailed.catch
-        (fun path ->
-           let contents = Path.to_string path |> Unix.readlink |> string_digest in
-           path_with_executable_bit ~executable:stats.executable ~content_digest:contents)
-        path
-      |> Result.map_error ~f:(fun x -> Path_digest_error.Unix_error x)
-    | S_REG ->
-      Unix_error.Detailed.catch
-        (file_with_executable_bit ~executable:stats.executable)
-        path
-      |> Result.map_error ~f:(fun x -> Path_digest_error.Unix_error x)
-    | S_DIR when allow_dirs ->
-      (* CR-someday amokhov: The current digesting scheme has collisions for files
-         and directories. It's unclear if this is actually a problem. If it turns
-         out to be a problem, we should include [st_kind] into both digests. *)
-      (match Path.readdir_unsorted path with
-       | Error e -> Error (Path_digest_error.Unix_error e)
-       | Ok listing ->
-         (match
-            List.rev_map listing ~f:(fun name ->
-              let path = Path.relative path name in
-              let stats =
-                match Path.lstat path with
-                | Error e -> raise_notrace (E (Unix_error e))
-                | Ok stat -> Stats_for_digest.of_unix_stats stat
-              in
-              let digest =
-                match loop path stats with
-                | Ok s -> s
-                | Error e -> raise_notrace (E e)
-              in
-              name, digest)
-            |> List.sort ~compare:(fun (x, _) (y, _) -> String.compare x y)
-          with
-          | exception E e -> Error e
-          | contents -> Ok (directory_digest ~contents ~executable:stats.executable)))
-    | S_DIR | S_BLK | S_CHR | S_FIFO | S_SOCK -> Error Unexpected_kind
-  in
   match stats.st_kind with
-  | S_DIR when not allow_dirs -> Error Path_digest_error.Unexpected_kind
-  | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK -> Error Unexpected_kind
-  | _ -> loop path stats
+  | S_LNK ->
+    Unix_error.Detailed.catch
+      (fun path ->
+         let contents = Path.to_string path |> Unix.readlink |> string_digest in
+         path_with_executable_bit ~executable:stats.executable ~content_digest:contents)
+      path
+    |> Result.map_error ~f:(fun x -> Path_digest_error.Unix_error x)
+  | S_REG ->
+    Unix_error.Detailed.catch (file_with_executable_bit ~executable:stats.executable) path
+    |> Result.map_error ~f:(fun x -> Path_digest_error.Unix_error x)
+  | S_DIR | S_BLK | S_CHR | S_FIFO | S_SOCK -> Error Unexpected_kind
 ;;
 
-let path_with_stats ~allow_dirs path stats =
+let path_with_stats path stats =
   path_with_stats_internal
-    ~allow_dirs
     ~string_digest:string
-    ~directory_digest:(directory_digest_with repr)
     ~file_with_executable_bit:file_with_executable_bit_sync
     path
     stats
 ;;
 
-let path_with_stats_async ~allow_dirs path (stats : Stats_for_digest.t) =
+let path_with_stats_async path (stats : Stats_for_digest.t) =
   let f () =
     path_with_stats_internal
-      ~allow_dirs
       ~string_digest:string_pooled
-      ~directory_digest:(directory_digest_with repr_pooled)
       ~file_with_executable_bit:file_with_executable_bit_pooled
       path
       stats

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -86,24 +86,16 @@ end
     - If it's a regular file, the resulting digest includes the file's content
       as well as the its executable permissions bit.
 
-    - If it's a directory and [allow_dirs = true], the function computes the
-      digest of all contained filename/digest pairs, recursively.
-
     - Otherwise, the function returns [Unexpected_kind].
 
     Note that this interface is prone to races: the provided [Stats_for_digest]
     may get stale, so [path_with_stats] may return [Unix_error (ENOENT, _, _)]
     even though you've just successfully run [Path.stat] on it. The call sites
     are expected to gracefully handle such races. *)
-val path_with_stats
-  :  allow_dirs:bool
-  -> Path.t
-  -> Stats_for_digest.t
-  -> (t, Path_digest_error.t) result
+val path_with_stats : Path.t -> Stats_for_digest.t -> (t, Path_digest_error.t) result
 
 val path_with_stats_async
-  :  allow_dirs:bool
-  -> Path.t
+  :  Path.t
   -> Stats_for_digest.t
   -> (t, Path_digest_error.t) result Fiber.t
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -171,12 +171,7 @@ module Cached_digest = struct
   ;;
 
   let digest_path_with_stats path stats =
-    match
-      Digest.path_with_stats
-        ~allow_dirs:true
-        path
-        (Digest.Stats_for_digest.of_time_stat stats)
-    with
+    match Digest.path_with_stats path (Digest.Stats_for_digest.of_time_stat stats) with
     | Ok digest -> Ok digest
     | Error Unexpected_kind -> Error (Digest_result.Error.Unexpected_kind stats.kind)
     | Error (Unix_error (ENOENT, _, _)) -> Error No_such_file

--- a/src/dune_pkg/opam_repo.ml
+++ b/src/dune_pkg/opam_repo.ml
@@ -157,7 +157,7 @@ let content_digest t =
   match t.source with
   | Repo repo ->
     Rev_store.At_rev.rev repo |> Rev_store.Object.to_hex |> Dune_digest.string
-  | Directory path -> Path_digest.digest_with_lstat path
+  | Directory path -> Path_digest.digest_with_stat path
 ;;
 
 let load_opam_package_from_dir ~(dir : Path.t) package =

--- a/src/dune_pkg/path_digest.ml
+++ b/src/dune_pkg/path_digest.ml
@@ -1,25 +1,43 @@
 open Import
 
-let digest_with_lstat path =
-  match Path.lstat path with
+let digest_with_stat path =
+  match Path.stat path with
   | Error e ->
     User_error.raise
       [ Pp.textf "Can't stat path %S:" (Path.to_string path); Unix_error.Detailed.pp e ]
   | Ok stats ->
     let stats_for_digest = Dune_digest.Stats_for_digest.of_unix_stats stats in
-    (match Dune_digest.path_with_stats ~allow_dirs:true path stats_for_digest with
-     | Ok digest -> digest
-     | Error (Unix_error e) ->
-       User_error.raise
-         [ Pp.textf "Can't digest path %S:" (Path.to_string path)
-         ; Unix_error.Detailed.pp e
-         ]
-     | Error Unexpected_kind ->
-       User_error.raise
-         [ Pp.textf
-             "Can't digest path %S: Unexpected file kind %S (%s)"
-             (Path.to_string path)
-             (File_kind.to_string stats_for_digest.st_kind)
-             (File_kind.to_string_hum stats_for_digest.st_kind)
-         ])
+    (match stats_for_digest.st_kind with
+     | S_DIR ->
+       let d = Dune_digest.Manual.create () in
+       Fpath.traverse
+         ~init:()
+         ~sorted:true
+         ~on_file:(fun ~dir fname () ->
+           let path = Path.L.relative path [ dir; fname ] in
+           Dune_digest.Manual.string d (Path.to_string path);
+           let digest = Dune_digest.file path in
+           Dune_digest.Manual.digest d digest)
+         ~on_dir:(fun ~dir fname () ->
+           let path = Path.L.relative path [ dir; fname ] in
+           Dune_digest.Manual.string d (Path.to_string path))
+         ~dir:(Path.to_string path)
+         ();
+       Dune_digest.Manual.get d
+     | _ ->
+       (match Dune_digest.path_with_stats path stats_for_digest with
+        | Ok digest -> digest
+        | Error (Unix_error e) ->
+          User_error.raise
+            [ Pp.textf "Can't digest path %S:" (Path.to_string path)
+            ; Unix_error.Detailed.pp e
+            ]
+        | Error Unexpected_kind ->
+          User_error.raise
+            [ Pp.textf
+                "Can't digest path %S: Unexpected file kind %S (%s)"
+                (Path.to_string path)
+                (File_kind.to_string stats_for_digest.st_kind)
+                (File_kind.to_string_hum stats_for_digest.st_kind)
+            ]))
 ;;

--- a/src/dune_pkg/path_digest.mli
+++ b/src/dune_pkg/path_digest.mli
@@ -1,10 +1,9 @@
 open Import
 
-(** [digest_with_lstat path] stats the [path] using [lstat] (without following
-    symlinks) and computes a digest of its contents. Directories are allowed
-    and will be digested recursively.
+(** [digest_with_stat path] stats the [path] using [stat] and computes a digest
+    of its contents. Directories are allowed and will be digested recursively.
 
     Raises [User_error] if the path cannot be stat'd (e.g., does not exist or
     permission denied), cannot be digested (e.g., I/O error during reading), or
     has an unexpected file kind (e.g., socket, FIFO). *)
-val digest_with_lstat : Path.t -> Dune_digest.t
+val digest_with_stat : Path.t -> Dune_digest.t

--- a/src/dune_pkg/resolved_package.ml
+++ b/src/dune_pkg/resolved_package.ml
@@ -186,7 +186,7 @@ let digest_extra_files : extra_files -> Dune_digest.t = function
        Sexp.List [ Atom "inside_files_dir"; Atom "none" ]
        |> Sexp.to_string
        |> Dune_digest.string
-     | Some path -> Path_digest.digest_with_lstat path)
+     | Some path -> Path_digest.digest_with_stat path)
   | Git_files (path_opt, rev) ->
     let path_str =
       match path_opt with

--- a/test/blackbox-tests/test-cases/directory-targets/depend-on-installed-dir-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/depend-on-installed-dir-target.t
@@ -49,7 +49,17 @@ Test installed directory targets may be depended on
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app hello.txt
   Entering directory 'app'
+  File "dune", lines 1-4, characters 0-118:
+  1 | (rule
+  2 |  (target hello.txt)
+  3 |  (deps %{lib:foo:some_dir})
+  4 |  (action (system "cp %{deps}/inside-dir-target.txt %{target}")))
+  Error: File unavailable:
+  $TESTCASE_ROOT/prefix/lib/foo/some_dir
+  Unexpected file kind "S_DIR" (directory)
   Leaving directory 'app'
+  [1]
 
   $ cat app/_build/default/hello.txt
-  hello from file inside dir target
+  cat: app/_build/default/hello.txt: No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/directory-targets/old-style/mode-promote.t/run.t
+++ b/test/blackbox-tests/test-cases/directory-targets/old-style/mode-promote.t/run.t
@@ -1,6 +1,6 @@
 directory target and (mode promote)
 
   $ dune build @all 2>&1 | head -n2
-  Error: Is a directory
-  -> required by _build/default/dir
+  File "dune", lines 1-4, characters 0-73:
+  1 | (rule
   [1]

--- a/test/blackbox-tests/test-cases/directory-targets/old-style/target.t/run.t
+++ b/test/blackbox-tests/test-cases/directory-targets/old-style/target.t/run.t
@@ -1,14 +1,20 @@
 Tests old-style directory targets as explicit targets.
 
   $ dune build && cat _build/default/dir/*
-  bar contents
-  foo contents
+  File "dune", lines 11-13, characters 0-51:
+  11 | (rule
+  12 |  (targets dir)
+  13 |  (action (run ./foo.exe dir)))
+  Error: Error trying to read targets after a rule was run:
+  - dir: Unexpected file kind "S_DIR" (directory)
+  [1]
 
   $ dune build @cat_dir
-  bar:
-  bar contents
-  
-  foo:
-  foo contents
-  
+  File "dune", lines 11-13, characters 0-51:
+  11 | (rule
+  12 |  (targets dir)
+  13 |  (action (run ./foo.exe dir)))
+  Error: Error trying to read targets after a rule was run:
+  - dir: Unexpected file kind "S_DIR" (directory)
+  [1]
 

--- a/test/blackbox-tests/test-cases/directory-targets/promote.t
+++ b/test/blackbox-tests/test-cases/directory-targets/promote.t
@@ -65,10 +65,14 @@ Promoting a badly specified directory target gives a weird error:
   > EOF
 
   $ dune build
-  Error: Is a directory
-  -> required by _build/default/blah-blah
-  -> required by alias all
-  -> required by alias default
+  File "dune", lines 1-5, characters 0-104:
+  1 | (rule
+  2 |  (targets blah-blah)
+  3 |  (deps (sandbox always))
+  4 |  (mode promote)
+  5 |  (action (bash "mkdir %{targets}")))
+  Error: Error trying to read targets after a rule was run:
+  - blah-blah: Unexpected file kind "S_DIR" (directory)
   [1]
 
 Test error message for (promote (into <dir>)) if <dir> is missing.

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed-lib-with-dir-target-runtime-deps.t
@@ -82,9 +82,21 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @mel --debug-dependency-path
   Entering directory 'app'
+  File "dune", lines 1-6, characters 0-114:
+  1 | (melange.emit
+  2 |  (target output)
+  3 |  (alias mel)
+  4 |  (emit_stdlib false)
+  5 |  (libraries foo)
+  6 |  (preprocess (pps melange.ppx)))
+  Error: File unavailable:
+  $TESTCASE_ROOT/prefix/lib/foo/some_dir
+  Unexpected file kind "S_DIR" (directory)
+  -> required by _build/default/output/node_modules/foo/some_dir
+  -> required by alias output/mel
   Leaving directory 'app'
+  [1]
 
   $ ls app/_build/default/output/node_modules/foo
   foo.js
   index.txt
-  some_dir

--- a/test/blackbox-tests/test-cases/pkg/source-with-directory-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/source-with-directory-symlink.t
@@ -26,11 +26,12 @@ CR-someday alizter: This fails because directory symlinks are not supported.
 We could potentially resolve them during the copy.
 
   $ build_pkg foo 2>&1 | sanitize_pkg_digest foo.0.0.1
-  Error: Is a directory
-  -> required by
-     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/source/link_to_dir
-  -> required by
-     _build/_private/default/.pkg/foo.0.0.1-DIGEST_HASH/target
+  File "_build/_private/default/.lock/dune.lock/foo.pkg", line 4, characters 7-150:
+  4 |   (url file:///home/rgrinberg/github/ocaml/dune/_build/.sandbox/637033f490b48c23eab3803303024a44/default/test/blackbox-tests/test-cases/pkg/_src_local)))
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: File unavailable:
+  $TESTCASE_ROOT/_src_local/link_to_dir
+  Unexpected file kind "S_DIR" (directory)
   [1]
 
 Only the real directory was partially copied:

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -1,43 +1,6 @@
 open Stdune
 module Digest = Dune_digest
 
-let%expect_test "directory digest version" =
-  (* If this test fails with a new digest value, make sure to update
-     [directory_digest_version] in digest.ml.
-
-     The expected value is kept outside of the expect block on purpose so that it
-     must be modified manually. *)
-  let expected = "0707f6c61422e7e7281faa106824da8c" in
-  let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; executable = true } in
-  (match Digest.path_with_stats ~allow_dirs:true dir stats with
-   | Ok digest ->
-     let digest = Digest.to_string digest in
-     if String.equal digest expected
-     then print_endline "[PASS]"
-     else
-       printfn
-         "[FAIL] new digest value. please update the version and this test.\n%s"
-         digest
-   | Error (Unexpected_kind | Unix_error _) ->
-     print_endline "[FAIL] unable to calculate digest");
-  [%expect {| [PASS] |}]
-;;
-
-let%expect_test "directories with symlinks" =
-  let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; executable = true } in
-  let sub = Path.relative dir "sub" in
-  Path.mkdir_p sub;
-  Unix.symlink "bar" (Path.to_string (Path.relative dir "foo"));
-  Unix.symlink "bar" (Path.to_string (Path.relative sub "foo"));
-  (match Digest.path_with_stats ~allow_dirs:true dir stats with
-   | Ok _ -> print_endline "[PASS]"
-   | Error Unexpected_kind -> print_endline "[FAIL] unexpected kind"
-   | Error (Unix_error _) -> print_endline "[FAIL] unable to calculate digest");
-  [%expect {| [PASS] |}]
-;;
-
 let%expect_test "repr digest distinguishes option cases" =
   let repr = Option.repr Repr.string in
   let digest_none = Digest.repr repr None in


### PR DESCRIPTION
I need to run a revdep check for this to make sure that the breakage is tolerable. "old style" directory targets are somewhat broken anyway, so I hate to spend a lot of time on this now that we have proper directory targets. In the absolute worst case, I'll need to make sure this feature quietly degrades to using the real directory target support.