### PR TITLE
Add leaf packages with a lot of revdeps to `rc` check

### DIFF
--- a/.github/workflows/revdeps-release-coverage.yml
+++ b/.github/workflows/revdeps-release-coverage.yml
@@ -1,0 +1,18 @@
+name: Coverage of Reverse Dependencies Check for Prereleases
+
+on:
+  push:
+    branches:
+      - '*-rc'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  revdeps:
+    name: OCaml Reverse Dependencies
+    uses: ocaml/dune/.github/workflows/revdeps.yml@main
+    with:
+      dune_version: "dev"
+      packages: "bap irmin-containers dream lambdapi kicadsch git-unix caqti-async"

--- a/.github/workflows/revdeps-release-devtools.yml
+++ b/.github/workflows/revdeps-release-devtools.yml
@@ -1,4 +1,4 @@
-name: Platform Reverse Dependencies Check for Prereleases
+name: Devtool Reverse Dependencies Check for Prereleases
 
 on:
   push:


### PR DESCRIPTION
I've compiled a list of packages by revdeps by iterating over all packages in opam-repository and checking how many revdeps exist:

```
opam list --required-by "$pkg" --recursive | tail -n +2 | wc -l
```

Then I sorted it by that number and went through the list, looking at which of these packages exist in nixpkgs.

This PR uses the same mechanism as the dev-tools revdeps but checks a larger set of packages.