### PR TITLE
fix: only generate @ocaml-index alias for merlin-enabled contexts

### DIFF
--- a/doc/changes/fixed/14137.md
+++ b/doc/changes/fixed/14137.md
@@ -1,0 +1,4 @@
+- Fix `@ocaml-index` alias being generated for all contexts, causing build
+  errors in multi-context workspaces where some libraries are disabled in
+  non-default contexts. The alias is now only generated for the merlin context.
+  (#14137, fixes #12007, @robinbb)

--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -157,18 +157,16 @@ let context_indexes =
 ;;
 
 let project_rule sctx project =
-  let ocaml_index_alias =
-    let dir =
-      let build_dir =
-        let ctx = Super_context.context sctx in
-        Context.build_dir ctx
+  let ctx = Super_context.context sctx in
+  Memo.when_ (Context.merlin ctx) (fun () ->
+    let ocaml_index_alias =
+      let dir =
+        Path.Build.append_source (Context.build_dir ctx) @@ Dune_project.root project
       in
-      Path.Build.append_source build_dir @@ Dune_project.root project
+      Alias.make Alias0.ocaml_index ~dir
     in
-    Alias.make Alias0.ocaml_index ~dir
-  in
-  Rules.Produce.Alias.add_deps
-    ocaml_index_alias
-    (let open Action_builder.O in
-     Super_context.context sctx |> context_indexes >>= Action_builder.paths_existing)
+    Rules.Produce.Alias.add_deps
+      ocaml_index_alias
+      (let open Action_builder.O in
+       context_indexes ctx >>= Action_builder.paths_existing))
 ;;

--- a/test/blackbox-tests/test-cases/describe/aliases.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/aliases.t/run.t
@@ -180,7 +180,6 @@ These are context sensitive:
   default
   fmt
   mytest
-  ocaml-index
   pkg-install
   revdep
   revdep-check

--- a/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
@@ -1,0 +1,122 @@
+@ocaml-index should not build more than necessary (#12007).
+
+In particular, it should not try to index stanzas in alternative contexts
+that are not relevant to the default build.
+
+Setup mock ocaml-index:
+
+  $ mkdir bin
+  $ ln -s $(which ocaml_index) bin/ocaml-index
+  $ export PATH=$PWD/bin:$PATH
+
+Test 1: @ocaml-index indexes alternative contexts it shouldn't
+==============================================================
+
+A project with a default context and an alt context. The main executable
+depends on defaultlib which is only enabled in the default context.
+
+@ocaml-index should only index the default context, but instead it
+tries to index the alt context too — and fails because defaultlib
+is hidden there.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.23)
+  > (context default)
+  > (context
+  >  (default
+  >   (name alt)))
+  > EOF
+
+  $ mkdir -p defaultlib altlib
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries defaultlib))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let () = print_endline Defaultlib.greeting
+  > EOF
+
+  $ cat > defaultlib/dune <<EOF
+  > (library
+  >  (name defaultlib)
+  >  (enabled_if (= %{context_name} "default")))
+  > EOF
+
+  $ cat > defaultlib/defaultlib.ml <<EOF
+  > let greeting = "hello from default"
+  > EOF
+
+  $ cat > altlib/dune <<EOF
+  > (library
+  >  (name altlib)
+  >  (enabled_if (= %{context_name} "alt")))
+  > EOF
+
+  $ cat > altlib/altlib.ml <<EOF
+  > let greeting = "hello from alt"
+  > EOF
+
+@ocaml-index errors because it tries to index the alt context where
+defaultlib is disabled:
+
+  $ dune build @ocaml-index 2>&1
+  File "dune", line 3, characters 12-22:
+  3 |  (libraries defaultlib))
+                  ^^^^^^^^^^
+  Error: Library "defaultlib" in _build/alt/defaultlib is hidden (unsatisfied
+  'enabled_if').
+  -> required by _build/alt/.main.eobjs/byte/dune__exe__Main.cmt
+  -> required by _build/alt/.main.eobjs/cctx.ocaml-index
+  -> required by alias ocaml-index (context alt)
+  [1]
+
+It also indexed altlib in the alt context (shouldn't have):
+
+  $ find _build -name '*.ocaml-index' | sort
+  _build/alt/altlib/.altlib.objs/cctx.ocaml-index
+  _build/default/.main.eobjs/cctx.ocaml-index
+  _build/default/defaultlib/.defaultlib.objs/cctx.ocaml-index
+
+  $ rm -rf _build dune dune-project dune-workspace main.ml defaultlib altlib
+
+Test 2: @ocaml-index correctly skips disabled stanzas (not a bug)
+=================================================================
+
+Verify that (enabled_if false) libraries are already correctly
+excluded from indexing.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modules main))
+  > (library
+  >  (name disabled_lib)
+  >  (modules disabled_lib)
+  >  (enabled_if false))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+  $ cat > disabled_lib.ml <<EOF
+  > let x = 42
+  > EOF
+
+  $ dune build @ocaml-index 2>&1
+
+Only main is indexed, disabled_lib is correctly skipped:
+
+  $ find _build -name '*.ocaml-index' | sort
+  _build/default/.main.eobjs/cctx.ocaml-index

--- a/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/builds-too-much.t
@@ -63,24 +63,11 @@ is hidden there.
   > let greeting = "hello from alt"
   > EOF
 
-@ocaml-index errors because it tries to index the alt context where
-defaultlib is disabled:
+@ocaml-index should only index the default context, not alt:
 
-  $ dune build @ocaml-index 2>&1
-  File "dune", line 3, characters 12-22:
-  3 |  (libraries defaultlib))
-                  ^^^^^^^^^^
-  Error: Library "defaultlib" in _build/alt/defaultlib is hidden (unsatisfied
-  'enabled_if').
-  -> required by _build/alt/.main.eobjs/byte/dune__exe__Main.cmt
-  -> required by _build/alt/.main.eobjs/cctx.ocaml-index
-  -> required by alias ocaml-index (context alt)
-  [1]
-
-It also indexed altlib in the alt context (shouldn't have):
+  $ dune build @ocaml-index
 
   $ find _build -name '*.ocaml-index' | sort
-  _build/alt/altlib/.altlib.objs/cctx.ocaml-index
   _build/default/.main.eobjs/cctx.ocaml-index
   _build/default/defaultlib/.defaultlib.objs/cctx.ocaml-index
 


### PR DESCRIPTION
## Summary

Partially addresses #12007.

`@ocaml-index` was generating indexing rules for all contexts, including alternative contexts where some libraries may be disabled by `enabled_if`. This caused build errors when a stanza in an alt context depended on a library only available in the default context:

```
Error: Library "defaultlib" in _build/alt/defaultlib is hidden (unsatisfied
'enabled_if').
-> required by _build/alt/.main.eobjs/cctx.ocaml-index
-> required by alias ocaml-index (context alt)
```

The fix guards `Ocaml_index.project_rule` with `Context.merlin`, so the `@ocaml-index` alias is only created for the context that has merlin support enabled (typically the default context). This matches the intent of the indexing feature, which exists to support editor tooling in the primary development context.

The second part of #12007 (indexing unreferenced files not linked by any stanza) is not addressed here, as it shares a root cause with #9724 and requires deeper changes to how `context_indexes` collects stanzas.