### PR TITLE
feat(rpc): add DUNE_CONFIG__RPC_ADDRESS to override RPC transport

### DIFF
--- a/otherlibs/dune-rpc/import.ml
+++ b/otherlibs/dune-rpc/import.ml
@@ -16,6 +16,7 @@ include struct
   module Fdecl = Fdecl
   module Univ_map = Univ_map
   module Comparable_intf = Comparable_intf
+  module Config = Config
 
   module Path = struct
     (* we don't want to depend on build or source directories here *)

--- a/otherlibs/dune-rpc/where.ml
+++ b/otherlibs/dune-rpc/where.ml
@@ -60,6 +60,16 @@ let of_string s : (t, exn) result =
 let rpc_socket_relative_to_build_dir = ".rpc/dune"
 let env_var = "DUNE_RPC"
 
+let rpc_address =
+  Config.make
+    ~name:"rpc_address"
+    ~of_string:(fun s ->
+      match of_string s with
+      | Ok w -> Ok (Some w)
+      | Error exn -> Error (Printexc.to_string exn))
+    ~default:None
+;;
+
 let to_dbus : t -> Dbus_address.t = function
   | `Unix p -> { name = "unix"; args = [ "path", p ] }
   | `Ip (`Host host, `Port port) ->
@@ -128,9 +138,13 @@ module Make
          -> ([ `Unix_socket | `Normal_file | `Other ], exn) result Fiber.t
      end) : S with type 'a fiber := 'a Fiber.t = struct
   let default ?(win32 = win32) ~build_dir () =
-    if win32
-    then `Ip (`Host (Unix.string_of_inet_addr Unix.inet_addr_loopback), `Port default_port)
-    else `Unix (Filename.concat build_dir rpc_socket_relative_to_build_dir)
+    match Config.get rpc_address with
+    | Some w -> w
+    | None ->
+      if win32
+      then
+        `Ip (`Host (Unix.string_of_inet_addr Unix.inet_addr_loopback), `Port default_port)
+      else `Unix (Filename.concat build_dir rpc_socket_relative_to_build_dir)
   ;;
 
   let ( let** ) x f =

--- a/otherlibs/dune-rpc/where.mli
+++ b/otherlibs/dune-rpc/where.mli
@@ -11,6 +11,7 @@ val compare : t -> t -> Ordering.t
 val to_dyn : t -> Dyn.t
 val sexp : t Conv.value
 val env_var : Env.Var.t
+val rpc_address : t option Config.t
 val add_to_env : t -> Env.t -> Env.t
 val of_env : Env.t -> (t, [ `Exn of exn | `Missing ]) result
 

--- a/test/blackbox-tests/test-cases/watching/rpc-tcp.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-tcp.t
@@ -1,0 +1,31 @@
+Test that the RPC server can listen on TCP when DUNE_CONFIG__RPC_ADDRESS is set.
+
+  $ echo '(lang dune 3.21)' > dune-project
+  $ touch foo.ml
+
+  $ export DUNE_CONFIG__RPC_ADDRESS='tcp:host=127.0.0.1,port=8587'
+
+  $ start_dune
+
+  $ dune rpc ping --wait
+  Server appears to be responding normally
+
+Verify that the RPC address file contains a TCP address, not a Unix socket.
+
+  $ cat _build/.rpc/dune
+  tcp:host=127.0.0.1,port=8587
+
+  $ stop_dune
+
+Invalid addresses should be rejected.
+
+  $ DUNE_CONFIG__RPC_ADDRESS='garbage' dune build
+  Error: Invalid value for "DUNE_CONFIG__RPC_ADDRESS"
+  Invalid RPC address: invalid address format garbage
+  [1]
+
+Pinging the wrong port should fail.
+
+  $ DUNE_CONFIG__RPC_ADDRESS='tcp:host=127.0.0.1,port=9999' dune rpc ping
+  Error: RPC server not running.
+  [1]


### PR DESCRIPTION
Allow configuring the RPC server address via the internal config system (DUNE_CONFIG__RPC_ADDRESS env var). This enables using TCP instead of Unix domain sockets, which is needed in sandboxed environments like Codex that restrict AF_UNIX sockets.

This replaces the previous internal, broken and undocumented DUNE_RPC env var.

Note that TCP was the default behaviour on Windows, however I am not certain it works correctly.

Example: DUNE_CONFIG__RPC_ADDRESS='tcp:host=127.0.0.1,port=8587'

This allows dune watch mode to be used in sandboxed environments such as those found in codex without running into sandbox restrictions foudn with standard unix sockets.