### PR TITLE
fix: resolve %{lib:...} for packages with only install stanzas

### DIFF
--- a/doc/changes/fixed/14139.md
+++ b/doc/changes/fixed/14139.md
@@ -1,0 +1,4 @@
+- Fix `%{lib:pkg:file}` failing with "Library not found" when the
+  package only has `(install)` stanzas and no `(library)` definition.
+  The variable now falls back to the package install path.
+  (#14139, fixes #3378, @robinbb)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -415,9 +415,6 @@ let expand_lib_variable t source ~lib ~file ~lib_exec ~lib_private =
         Lib.DB.available (Scope.libs scope) lib
         |> Resolve.Memo.lift_memo
         >>= function
-        | false ->
-          let+ (_ : Path.t) = p in
-          assert false
         | true ->
           Resolve.Memo.fail
             (User_error.make
@@ -427,8 +424,22 @@ let expand_lib_variable t source ~lib ~file ~lib_exec ~lib_private =
                     file's installation path which is not defined for private libraries."
                    (Lib_name.to_string lib)
                    (if lib_exec then "exec" else "")
-               ]))
-     |> Resolve.Memo.read)
+               ])
+        | false ->
+          let package = Lib_name.package_name lib in
+          let packages = Dune_project.packages project in
+          if Package.Name.Map.mem packages package
+          then
+            let+ context =
+              Resolve.Memo.lift_memo (Memo.return t.context) >>| Context.name
+            in
+            let dir = Install.Context.lib_dir ~context ~package in
+            Path.build (Path.Build.relative dir file)
+          else
+            let+ (_ : Path.t) = p in
+            assert false)
+     |> Resolve.Memo.read
+     |> Action_builder.bind ~f:dep)
   |> Action_builder.of_memo_join
 ;;
 

--- a/test/blackbox-tests/test-cases/lib-pform-install-only.t
+++ b/test/blackbox-tests/test-cases/lib-pform-install-only.t
@@ -1,0 +1,34 @@
+%{lib:pkg:file} should work for packages that only have install stanzas
+and no library definition (#3378).
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (name foo)
+  > (package (name foo) (allow_empty))
+  > EOF
+
+  $ cat > data.txt <<EOF
+  > some data
+  > EOF
+
+  $ cat > dune <<EOF
+  > (install
+  >  (section lib)
+  >  (files data.txt)
+  >  (package foo))
+  > 
+  > (rule
+  >  (target out.txt)
+  >  (action (with-stdout-to %{target} (echo %{lib:foo:data.txt}))))
+  > EOF
+
+Currently fails because %{lib:...} only looks up library stanzas:
+
+  $ dune build out.txt
+  File "dune", line 8, characters 41-60:
+  8 |  (action (with-stdout-to %{target} (echo %{lib:foo:data.txt}))))
+                                               ^^^^^^^^^^^^^^^^^^^
+  Error: Library "foo" not found.
+  -> required by %{lib:foo:data.txt} at dune:8
+  -> required by _build/default/out.txt
+  [1]

--- a/test/blackbox-tests/test-cases/lib-pform-install-only.t
+++ b/test/blackbox-tests/test-cases/lib-pform-install-only.t
@@ -22,13 +22,9 @@ and no library definition (#3378).
   >  (action (with-stdout-to %{target} (echo %{lib:foo:data.txt}))))
   > EOF
 
-Currently fails because %{lib:...} only looks up library stanzas:
+The build succeeds — %{lib:...} falls back to the package install path:
 
   $ dune build out.txt
-  File "dune", line 8, characters 41-60:
-  8 |  (action (with-stdout-to %{target} (echo %{lib:foo:data.txt}))))
-                                               ^^^^^^^^^^^^^^^^^^^
-  Error: Library "foo" not found.
-  -> required by %{lib:foo:data.txt} at dune:8
-  -> required by _build/default/out.txt
-  [1]
+
+  $ cat _build/default/out.txt
+  ../install/default/lib/foo/data.txt


### PR DESCRIPTION
## Summary

Fixes #3378.

`%{lib:pkg:file}` fails with "Library not found" when the package only has `(install)` stanzas and no `(library)` definition. For example:

```dune
(install
 (section lib)
 (files data.txt)
 (package foo))

(rule
 (target out.txt)
 (action (with-stdout-to %{target} (echo %{lib:foo:data.txt}))))
```

This produces `Error: Library "foo" not found` even though `data.txt` is being installed to the `lib` section of package `foo`.

The fix adds a fallback in `expand_lib_variable`: when `Lib.DB.resolve` fails and the library is not in the database, check if the *package* exists in the project. If so, compute the install path directly from the package name using `Install.Context.lib_dir`, matching how the path would be computed for a library with a matching name.