### PR TITLE
Add (archived <bool>) field to (library) stanza, introduce "unarchived" libraries

### DIFF
--- a/doc/reference/dune/library.rst
+++ b/doc/reference/dune/library.rst
@@ -121,6 +121,29 @@ order to declare a multi-directory library, you need to use the
    Use this to provide extra features without adding hard dependencies to your
    project.
 
+.. describe:: (archived <boolean>)
+
+   .. version:: 3.23
+
+   Controls whether Dune builds OCaml library archives for the stanza.
+
+   The default is ``true``. When set to ``false``, Dune still compiles the
+   library's modules and allows other libraries and executables in the same
+   workspace to depend on it via ``(libraries ...)``, but it does not build
+   ``.cma``, ``.cmxa``, or ``.cmxs`` files for the library.
+
+   Instead, dependents link the library by using its individual compiled
+   modules.
+
+   ``(archived false)`` libraries are currently restricted to private,
+   workspace-only use:
+
+   - They may not have a ``public_name``.
+   - They may not be attached to a ``package``.
+   - They may not be virtual libraries.
+   - They may not use ``foreign_stubs``, ``foreign_archives``,
+     ``extra_objects``, or ``ctypes``.
+
 .. describe:: (foreign_stubs <foreign-stubs-spec>)
 
    Specifies foreign source files, e.g., C or C++ stubs, to be compiled and

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -294,6 +294,7 @@ module Lib = struct
            ~lib_id
            ~kind
            ~status
+           ~archived:true
            ~src_dir
            ~orig_src_dir
            ~obj_dir

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -246,6 +246,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
       ~lib_id
       ~kind
       ~status
+      ~archived:true
       ~src_dir
       ~orig_src_dir
       ~obj_dir

--- a/src/dune_rules/lib_flags.ml
+++ b/src/dune_rules/lib_flags.ml
@@ -12,7 +12,7 @@ module Link_params = struct
        not appear on the command line *)
     }
 
-  let get sctx (t : Lib.t) (mode : Link_mode.t) (lib_config : Lib_config.t) =
+  let get_archived sctx (t : Lib.t) (mode : Link_mode.t) (lib_config : Lib_config.t) =
     let info = Lib.info t in
     let lib_files = Lib_info.foreign_archives info
     and dll_files = Lib_info.foreign_dll_files info in
@@ -77,6 +77,13 @@ module Link_params = struct
            :: hidden_deps)
     in
     { deps; hidden_deps; include_dirs }
+  ;;
+
+  let get sctx t mode lib_config =
+    let info = Lib.info t in
+    if Lib_info.archived info
+    then get_archived sctx t mode lib_config
+    else Memo.return { deps = []; hidden_deps = []; include_dirs = [] }
   ;;
 end
 
@@ -322,11 +329,32 @@ module Lib_and_module = struct
   module L = struct
     type nonrec t = t list
 
+    let expand_archived_libs sctx ts =
+      if
+        List.for_all ts ~f:(function
+          | Lib lib -> Lib_info.archived (Lib.info lib)
+          | Module _ -> true)
+      then Memo.return ts
+      else
+        Memo.List.concat_map ts ~f:(function
+          | Module _ as x -> Memo.return [ x ]
+          | Lib lib as x ->
+            if Lib_info.archived (Lib.info lib)
+            then Memo.return [ x ]
+            else
+              let+ modules = Dir_contents.modules_of_lib sctx lib ~for_:Ocaml in
+              let obj_dir = Lib_info.obj_dir (Lib.info lib) in
+              List.map
+                (Modules.With_vlib.impl_only (Option.value_exn modules))
+                ~f:(fun module_ -> Module (obj_dir, module_)))
+    ;;
+
     let link_flags sctx ts ~(lib_config : Lib_config.t) ~mode =
       let open Action_builder.O in
       let build_dir = Context.build_dir (Super_context.context sctx) in
       Command.Args.Dyn
-        (let+ l =
+        (let* ts = Action_builder.of_memo (expand_archived_libs sctx ts) in
+         let+ l =
            Action_builder.List.map ts ~f:(function
              | Lib t ->
                let t =

--- a/src/dune_rules/lib_flags.mli
+++ b/src/dune_rules/lib_flags.mli
@@ -9,6 +9,8 @@ module Lib_and_module : sig
   module L : sig
     type nonrec t = t list
 
+    val expand_archived_libs : Super_context.t -> t -> t Memo.t
+
     val link_flags
       :  Super_context.t
       -> t

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -303,6 +303,7 @@ type 'path t =
   ; lib_id : Lib_id.t
   ; kind : Lib_kind.t
   ; status : Status.t
+  ; archived : bool
   ; src_dir : 'path
   ; orig_src_dir : 'path option
   ; obj_dir : 'path Obj_dir.t
@@ -349,6 +350,7 @@ let name t = t.name
 let lib_id t = t.lib_id
 let version t = t.version
 let dune_version t = t.dune_version
+let archived t = t.archived
 let loc t = t.loc
 let parameters t = t.parameters
 let requires t ~for_ = Compilation_mode.By_mode.get t.requires ~for_
@@ -413,6 +415,7 @@ let create
       ~lib_id
       ~kind
       ~status
+      ~archived
       ~src_dir
       ~orig_src_dir
       ~obj_dir
@@ -455,6 +458,7 @@ let create
   ; lib_id
   ; kind
   ; status
+  ; archived
   ; src_dir
   ; orig_src_dir
   ; obj_dir
@@ -554,6 +558,7 @@ let to_dyn
       ; lib_id
       ; kind
       ; status
+      ; archived
       ; src_dir
       ; orig_src_dir
       ; obj_dir
@@ -600,6 +605,7 @@ let to_dyn
     ; "lib_id", Lib_id.to_dyn lib_id
     ; "kind", Lib_kind.to_dyn kind
     ; "status", Status.to_dyn status
+    ; "archived", bool archived
     ; "src_dir", path src_dir
     ; "orig_src_dir", option path orig_src_dir
     ; "obj_dir", Obj_dir.to_dyn obj_dir

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -175,6 +175,7 @@ val enabled : _ t -> Enabled_status.t Memo.t
 val orig_src_dir : 'path t -> 'path option
 val version : _ t -> Package_version.t option
 val dune_version : _ t -> Dune_lang.Syntax.Version.t option
+val archived : _ t -> bool
 val dynlink_supported : _ t -> bool
 
 (** Directory where the source files for the library are located. Returns the
@@ -215,6 +216,7 @@ val create
   -> lib_id:Lib_id.t
   -> kind:Lib_kind.t
   -> status:Status.t
+  -> archived:bool
   -> src_dir:'a
   -> orig_src_dir:'a option
   -> obj_dir:'a Obj_dir.t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -403,6 +403,22 @@ let iter_modes_concurrently (t : _ Ocaml.Mode.Dict.t) ~(f : Ocaml.Mode.t -> unit
   ()
 ;;
 
+let add_unarchived_modules_to_all_alias cctx =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let dir = Compilation_context.dir cctx in
+  let project = Compilation_context.scope cctx |> Scope.project in
+  let modes = Compilation_context.modes cctx in
+  let dirs =
+    Obj_dir.byte_dir obj_dir
+    :: (if Obj_dir.need_dedicated_public_dir obj_dir
+        then [ Obj_dir.public_cmi_ocaml_dir obj_dir ]
+        else [])
+    @ if modes.ocaml.native then [ Obj_dir.native_dir obj_dir ] else []
+  in
+  Memo.parallel_iter dirs ~f:(fun predicate_dir ->
+    Alias_builder.define_all_alias ~project ~predicate_dir ~js_targets:[] dir)
+;;
+
 let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~lib_info =
   let obj_dir = Compilation_context.obj_dir cctx in
   let flags = Compilation_context.flags cctx in
@@ -461,7 +477,8 @@ let setup_build_archives (lib : Library.t) ~top_sorted_modules ~cctx ~expander ~
         build_lib lib ~native_archives ~dir ~sctx ~expander ~flags ~mode ~cm_files)
   in
   Memo.when_
-    (Lib_info.dynlink_supported lib_info
+    (Library.archived lib
+     && Lib_info.dynlink_supported lib_info
      && Dynlink_supported.By_the_os.get natdynlink_supported
      && modes.ocaml.native)
     (fun () -> build_shared ~native_archives ~sctx lib ~dir ~flags)
@@ -579,7 +596,11 @@ let library_rules
       Ocaml_index.cctx_rules cctx)
   and+ () =
     Memo.when_
-      (not (Library.is_virtual lib))
+      (not (Library.archived lib))
+      (fun () -> add_unarchived_modules_to_all_alias cctx)
+  and+ () =
+    Memo.when_
+      (Library.archived lib && not (Library.is_virtual lib))
       (fun () -> setup_build_archives lib ~lib_info ~top_sorted_modules ~cctx ~expander)
   and+ () =
     let vlib_stubs_o_files = Virtual_rules.stubs_o_files implements in

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -262,6 +262,7 @@ let findlib_dynload cctx lib loc =
 let handle_special_libs cctx =
   let ( let& ) m f = Resolve.Memo.bind m ~f in
   let& all_libs = Compilation_context.requires_link cctx in
+  let sctx = Compilation_context.super_context cctx in
   let obj_dir = Compilation_context.obj_dir cctx |> Obj_dir.of_local in
   let open Memo.O in
   let dune_site_plugin_code =
@@ -326,5 +327,12 @@ let handle_special_libs cctx =
               ~to_link_rev:(Lib lib :: Module (obj_dir, module_) :: to_link_rev)
               ~force_linkall:true))
   in
-  process_libs all_libs ~to_link_rev:[] ~force_linkall:false
+  let& { to_link; force_linkall } =
+    process_libs all_libs ~to_link_rev:[] ~force_linkall:false
+  in
+  let open Resolve.Memo.O in
+  let+ to_link =
+    Resolve.Memo.lift_memo (Lib_flags.Lib_and_module.L.expand_archived_libs sctx to_link)
+  in
+  { to_link; force_linkall }
 ;;

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -69,6 +69,7 @@ type t =
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; wrapped : Wrapped.t Lib_info.Inherited.t
   ; optional : bool
+  ; archived : bool
   ; buildable : Buildable.t
   ; dynlink : Dynlink_supported.t
   ; project : Dune_project.t
@@ -151,6 +152,11 @@ let decode =
        in
        virtual_modules, kind
      and+ optional = field_b "optional"
+     and+ archived =
+       field
+         "archived"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 23) >>> bool)
+         ~default:true
      and+ no_dynlink = field_b "no_dynlink"
      and+ () =
        let check =
@@ -283,6 +289,32 @@ let decode =
           ~loc
           [ Pp.text "Only virtual libraries can specify a default implementation." ]
       | _ -> ());
+     (match virtual_modules with
+      | Some virtual_modules when not archived ->
+        User_error.raise
+          ~loc:(Ordered_set_lang.Unexpanded.loc virtual_modules |> Option.value_exn)
+          [ Pp.text "(archived false) may not be used on virtual libraries." ]
+      | None | Some _ -> ());
+     if not archived
+     then (
+       (match visibility with
+        | Public p ->
+          User_error.raise
+            ~loc:(Public_lib.loc p)
+            [ Pp.text "(archived false) libraries must be private." ]
+        | Private (Some (package : Package.t)) ->
+          User_error.raise
+            ~loc:(Package.loc package)
+            [ Pp.text "(archived false) libraries may not be attached to a package." ]
+        | Private None -> ());
+       if Buildable.has_foreign buildable
+       then
+         User_error.raise
+           ~loc:buildable.loc
+           [ Pp.text
+               "(archived false) libraries may not use foreign stubs, foreign \
+                archives, extra objects, or ctypes."
+           ]);
      { name
      ; visibility
      ; synopsis
@@ -296,6 +328,7 @@ let decode =
      ; virtual_deps
      ; wrapped
      ; optional
+     ; archived
      ; buildable
      ; dynlink = Dynlink_supported.of_bool (not no_dynlink)
      ; project
@@ -403,6 +436,7 @@ let best_name t =
   | Public p -> snd p.name
 ;;
 
+let archived t = t.archived
 let is_virtual t = t.kind = Virtual
 let is_impl t = Option.is_some t.implements
 
@@ -506,7 +540,7 @@ let to_lib_info
   in
   let native_archives =
     let archive = archive ext_lib in
-    if virtual_ || not modes.ocaml.native
+    if (not conf.archived) || virtual_ || not modes.ocaml.native
     then Lib_info.Files []
     else if
       Option.is_some conf.implements
@@ -519,7 +553,7 @@ let to_lib_info
   let exit_module = Option.bind conf.stdlib ~f:(fun x -> x.exit_module) in
   let foreign_objects = Lib_info.Source.Local in
   let archives, plugins =
-    if virtual_
+    if virtual_ || not conf.archived
     then Mode.Dict.make_both [], Mode.Dict.make_both []
     else (
       let plugins =
@@ -620,6 +654,7 @@ let to_lib_info
     ~lib_id
     ~kind
     ~status
+    ~archived:conf.archived
     ~src_dir
     ~orig_src_dir
     ~obj_dir

--- a/src/dune_rules/stanzas/library.mli
+++ b/src/dune_rules/stanzas/library.mli
@@ -23,6 +23,7 @@ type t =
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; wrapped : Wrapped.t Lib_info.Inherited.t
   ; optional : bool
+  ; archived : bool
   ; buildable : Buildable.t
   ; dynlink : Dynlink_supported.t
   ; project : Dune_project.t
@@ -73,6 +74,7 @@ val foreign_lib_files
 val archive : t -> dir:Path.Build.t -> ext:Filename.Extension.t -> Path.Build.t
 
 val best_name : t -> Lib_name.t
+val archived : t -> bool
 val is_virtual : t -> bool
 val is_impl : t -> bool
 val obj_dir : dir:Path.Build.t -> t -> Path.Build.t Obj_dir.t

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -46,6 +46,7 @@ let to_library t =
   ; instrumentation_backend = None
   ; melange_runtime_deps = loc, []
   ; optional = t.optional
+  ; archived = true
   }
 ;;
 

--- a/test/blackbox-tests/test-cases/library-archived.t/run.t
+++ b/test/blackbox-tests/test-cases/library-archived.t/run.t
@@ -1,0 +1,174 @@
+Libraries with (archived false) compile modules without producing archives.
+
+  $ mkdir all
+  $ cat >all/dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+  $ cat >all/dune <<EOF
+  > (library
+  >  (name base)
+  >  (modules base)
+  >  (archived false))
+  > EOF
+  $ cat >all/base.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ dune build --root all @all
+  Entering directory 'all'
+  Leaving directory 'all'
+  $ find all/_build/default -name '*.cm*' | sort
+  all/_build/default/.base.objs/byte/base.cmi
+  all/_build/default/.base.objs/byte/base.cmo
+  all/_build/default/.base.objs/byte/base.cmt
+  all/_build/default/.base.objs/native/base.cmx
+
+  $ mkdir ok
+  $ cat >ok/dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+  $ cat >ok/dune <<EOF
+  > (library
+  >  (name base)
+  >  (modules base)
+  >  (archived false))
+  > (library
+  >  (name middle)
+  >  (modules middle)
+  >  (libraries base))
+  > (executable
+  >  (name main)
+  >  (modules main)
+  >  (libraries middle))
+  > EOF
+  $ cat >ok/base.ml <<EOF
+  > let message = "base"
+  > EOF
+  $ cat >ok/middle.ml <<EOF
+  > let message = Base.message ^ "+middle"
+  > EOF
+  $ cat >ok/main.ml <<EOF
+  > print_endline Middle.message
+  > EOF
+
+  $ dune exec --root ok ./main.exe
+  Entering directory 'ok'
+  Leaving directory 'ok'
+  base+middle
+  $ dune build --root ok @all
+  Entering directory 'ok'
+  Leaving directory 'ok'
+  $ find ok/_build/default -name '*.cm*a' | sort
+  ok/_build/default/middle.cma
+  ok/_build/default/middle.cmxa
+
+(archived false) libraries must remain private.
+
+  $ mkdir public
+  $ cat >public/dune-project <<EOF
+  > (lang dune 3.23)
+  > (package
+  >  (name foo))
+  > EOF
+  $ cat >public/dune <<EOF
+  > (library
+  >  (name base)
+  >  (public_name foo.base)
+  >  (archived false))
+  > EOF
+  $ cat >public/base.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ dune build --root public
+  Entering directory 'public'
+  File "dune", line 3, characters 14-22:
+  3 |  (public_name foo.base)
+                    ^^^^^^^^
+  Error: (archived false) libraries must be private.
+  Leaving directory 'public'
+  [1]
+
+(archived false) libraries may not be attached to a package.
+
+  $ mkdir package
+  $ cat >package/dune-project <<EOF
+  > (lang dune 3.23)
+  > (package
+  >  (name foo))
+  > EOF
+  $ cat >package/dune <<EOF
+  > (library
+  >  (name base)
+  >  (package foo)
+  >  (archived false))
+  > EOF
+  $ cat >package/base.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ dune build --root package
+  Entering directory 'package'
+  File "dune-project", lines 2-3, characters 0-21:
+  2 | (package
+  3 |  (name foo))
+  Error: (archived false) libraries may not be attached to a package.
+  Leaving directory 'package'
+  [1]
+
+(archived false) libraries may not use foreign stubs.
+
+  $ mkdir foreign
+  $ cat >foreign/dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+  $ cat >foreign/dune <<EOF
+  > (library
+  >  (name base)
+  >  (archived false)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names stub)))
+  > EOF
+  $ cat >foreign/base.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ dune build --root foreign
+  Entering directory 'foreign'
+  File "dune", lines 1-6, characters 0-87:
+  1 | (library
+  2 |  (name base)
+  3 |  (archived false)
+  4 |  (foreign_stubs
+  5 |   (language c)
+  6 |   (names stub)))
+  Error: (archived false) libraries may not use foreign stubs, foreign
+  archives, extra objects, or ctypes.
+  Leaving directory 'foreign'
+  [1]
+
+(archived false) may not be used on virtual libraries.
+
+  $ mkdir virtual
+  $ cat >virtual/dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+  $ cat >virtual/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (virtual_modules vlib)
+  >  (archived false))
+  > EOF
+  $ cat >virtual/vlib.mli <<EOF
+  > val x : int
+  > EOF
+
+  $ dune build --root virtual
+  Entering directory 'virtual'
+  File "dune", line 3, characters 18-22:
+  3 |  (virtual_modules vlib)
+                        ^^^^
+  Error: (archived false) may not be used on virtual libraries.
+  Leaving directory 'virtual'
+  [1]


### PR DESCRIPTION
This PR is a possible approach to the direction discussed in https://github.com/ocaml/dune/pull/13682#issuecomment-4222223490.

We introduce a new field in the library stanza, `(archived <bool>)`. Archived libraries (value `true`) are the default and they correspond to today's libraries. When `false` ("unarchived libraries"), the behavior is identical to archived libraries, except that:

1) Unarchived libraries do not define linking rules to generate archive files (hence the name): `.cma`, `.cmxa`, `.cmxs`
2) When an executable depends on un unarchived library, all the objects of the library are linked, individually (no intermediate archive file is used).

Other than that, an unarchived library is similar to an archived library: it can be wrapped, unwrapped, used as a dependency, etc. Note that as a consequence of 2), all modules of the unarchived library end up being linked into the final executable. This is because when the compiler driver is passed an archive on the command-line, it implicitly applies module-level dead-code elimination (it does not link in archive members which are not referenced), but this is no longer the case if one passes the library members individually. This is a limitation of the compiler driver, and one can imagine extending it to support module-level dead-code elimination even when passing library members individually if there was demand for it.

Currently, `(archived false)` is only allowed for non-public libraries without stubs. As far as I can see there is no technical obstacle to allowing the feature also for public libraries and/or stubs, but I wanted to advance slowly.

cc @alainfrisch @rgrinberg 