### PR TITLE
chore: restore benchmarks

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,4 +1,4 @@
 FROM ocaml/opam:debian-13-ocaml-5.4
-RUN opam install csexp pp re spawn uutf ppx_expect
+RUN opam install csexp pp re spawn uutf ppx_expect lwt
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -77,7 +77,7 @@ module Package = struct
   ;;
 end
 
-let duniverse = []
+let duniverse = [ { Package.org = "ocaml"; name = "dune" } ]
 
 let prepare_workspace () =
   Fiber.parallel_iter duniverse ~f:(fun (pkg : Package.t) ->


### PR DESCRIPTION
Use dune instead of patdiff as the fixture

From now on, we'll be benching dune. Not the most stable baseline, but at least it isn't an additional job to keep it running with our infra.