### PR TITLE
feature: watch mode trace events

### DIFF
--- a/doc/changes/added/14163.md
+++ b/doc/changes/added/14163.md
@@ -1,0 +1,1 @@
+- Add trace events for build start/stop/restarts (#14163 , @rgrinberg)

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -56,6 +56,7 @@ type t =
   { alarm_clock : Alarm_clock.t Lazy.t
   ; mutable status : status
   ; mutable invalidation : Memo.Invalidation.t
+  ; mutable watch_restart_started_at : Time.t option
   ; handler : Handler.t
   ; job_throttle : Fiber.Throttle.t
   ; events : Event.Queue.t
@@ -215,6 +216,7 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
            mode, which is even weirder. *)
         Building cancel
     ; invalidation = Memo.Invalidation.empty
+    ; watch_restart_started_at = None
     ; job_throttle = Fiber.Throttle.create config.concurrency
     ; process_watcher
     ; events
@@ -289,6 +291,12 @@ module Run_once = struct
     if Memo.Invalidation.is_empty invalidation
     then iter t
     else (
+      let now = Time.now () in
+      let reasons = Memo.Invalidation.details_hum ~max_elements:max_int invalidation in
+      if Option.is_none t.watch_restart_started_at
+      then t.watch_restart_started_at <- Some now;
+      Dune_trace.emit Build (fun () ->
+        Dune_trace.Event.watch_build_restart ~reasons ~at:now);
       t.invalidation <- Memo.Invalidation.combine t.invalidation invalidation;
       let fills =
         match t.status with
@@ -404,6 +412,21 @@ module Run = struct
   module Event_queue = Event.Queue
   module Event = Handler.Event
 
+  let emit_watch_build_finish t ~started_at ~outcome =
+    let stop = Time.now () in
+    let restart_duration =
+      Option.map t.watch_restart_started_at ~f:(fun restart_started_at ->
+        Time.diff stop restart_started_at)
+    in
+    t.watch_restart_started_at <- None;
+    Dune_trace.emit Build (fun () ->
+      Dune_trace.Event.watch_build_finish
+        ~outcome
+        ~start:started_at
+        ~stop
+        ~restart_duration)
+  ;;
+
   let rec poll_iter t step =
     if Memo.Invalidation.is_empty t.invalidation
     then Memo.Metrics.reset ()
@@ -413,6 +436,11 @@ module Run = struct
       Memo.reset t.invalidation;
       t.invalidation <- Memo.Invalidation.empty;
       t.build_inputs_changed <- Trigger.create ());
+    let started_at = Time.now () in
+    Dune_trace.emit Build (fun () ->
+      Dune_trace.Event.watch_build_start
+        ~restart:(Option.is_some t.watch_restart_started_at)
+        ~start:started_at);
     let cancel = Fiber.Cancel.create () in
     t.status <- Building cancel;
     t.cancel <- cancel;
@@ -424,6 +452,13 @@ module Run = struct
         | Error `Already_reported -> Failure
         | Ok () -> Success
       in
+      emit_watch_build_finish
+        t
+        ~started_at
+        ~outcome:
+          (match res with
+           | Success -> `Success
+           | Failure -> `Failure);
       t.handler (Build_finish res);
       Fiber.return res
     | Restarting_build -> poll_iter t step
@@ -434,6 +469,13 @@ module Run = struct
         | Ok () -> Success
       in
       t.status <- Standing_by;
+      emit_watch_build_finish
+        t
+        ~started_at
+        ~outcome:
+          (match res with
+           | Success -> `Success
+           | Failure -> `Failure);
       t.handler (Build_finish res);
       Fiber.return res
   ;;

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -112,6 +112,16 @@ module Event : sig
 
   val scan_source : name:string -> start:Time.t -> stop:Time.t -> dir:Path.Source.t -> t
   val scheduler_idle : unit -> t
+  val watch_build_start : restart:bool -> start:Time.t -> t
+  val watch_build_restart : reasons:string list -> at:Time.t -> t
+
+  val watch_build_finish
+    :  outcome:[ `Success | `Failure ]
+    -> start:Time.t
+    -> stop:Time.t
+    -> restart_duration:Time.Span.t option
+    -> t
+
   val init : version:string option -> t
   val gc : unit -> t
   val fd_count : unit -> t option

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -186,6 +186,33 @@ let scheduler_idle () =
   Event.instant ~name:"watch mode iteration" now Scheduler
 ;;
 
+let watch_build_start ~restart ~start =
+  let args = [ "restart", Arg.bool restart ] in
+  Event.instant ~name:"build-start" ~args start Build
+;;
+
+let watch_build_restart ~reasons ~at =
+  let args = [ "reasons", Arg.list (List.map reasons ~f:Arg.string) ] in
+  Event.instant ~name:"build-restart" ~args at Build
+;;
+
+let watch_build_finish ~outcome ~start ~stop ~restart_duration =
+  let dur = Time.diff stop start in
+  let outcome =
+    match outcome with
+    | `Success -> "success"
+    | `Failure -> "failure"
+  in
+  let args =
+    [ "outcome", Arg.string outcome ]
+    @
+    match restart_duration with
+    | None -> []
+    | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ]
+  in
+  Event.complete ~name:"build-finish" ~args ~start ~dur Build
+;;
+
 module Exit_status = struct
   type error =
     | Failed of int

--- a/test/blackbox-tests/test-cases/trace/dune
+++ b/test/blackbox-tests/test-cases/trace/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to watch-build-events)
+ (enabled_if
+  (= %{system} linux)))

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -1,0 +1,72 @@
+Watch-mode builds emit start, restart, and finish trace events.
+
+  $ make_dune_project 3.22
+
+  $ cat >x <<EOF
+  > original
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target y)
+  >  (deps x)
+  >  (action (system "cat x > y")))
+  > EOF
+
+  $ start_dune
+
+  $ build y
+  Success
+
+  $ echo updated > x
+
+  $ build y
+  Success
+
+  $ stop_dune > /dev/null
+
+  $ dune trace cat | jq -s '
+  > [ .[]
+  >   | select(
+  >       .cat == "build"
+  >       and (.name == "build-start" or .name == "build-restart" or .name == "build-finish")
+  >     )
+  >   | { args, name }
+  >   | if .args.restart_duration? != null
+  >     then .args.restart_duration |= type
+  >     else .
+  >     end
+  > ] | .[]'
+  {
+    "args": {
+      "restart": false
+    },
+    "name": "build-start"
+  }
+  {
+    "args": {
+      "outcome": "success"
+    },
+    "name": "build-finish"
+  }
+  {
+    "args": {
+      "reasons": [
+        "x changed"
+      ]
+    },
+    "name": "build-restart"
+  }
+  {
+    "args": {
+      "restart": true
+    },
+    "name": "build-start"
+  }
+  {
+    "args": {
+      "outcome": "success",
+      "restart_duration": "number"
+    },
+    "name": "build-finish"
+  }


### PR DESCRIPTION
We'd like events for:

1. Starting a new build iteration
2. Restarting a build
3. Finishing a build