### PR TITLE
test: cover opam generation diff-action behavior

### DIFF
--- a/test/blackbox-tests/test-cases/dune-project-meta/fresh-build.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/fresh-build.t
@@ -22,3 +22,19 @@ source tree if (generate_opam_files true) is enabled.
   $ dune build foo.install
   $ grep opam _build/default/foo.install
     "_build/install/default/lib/foo/opam"
+
+The same should hold once opam generation switches to diff actions.
+
+  $ rm -f foo.opam
+  $ cat >dune-project <<EOF
+  > (lang dune 3.23)
+  > (package
+  >  (name foo))
+  > (generate_opam_files true)
+  > EOF
+
+  $ dune build foo.install
+  $ grep opam _build/default/foo.install
+    "_build/install/default/lib/foo/opam"
+  $ if test -e foo.opam; then echo present; else echo absent; fi
+  present

--- a/test/blackbox-tests/test-cases/opam-directory/build-install-file.t
+++ b/test/blackbox-tests/test-cases/opam-directory/build-install-file.t
@@ -10,3 +10,29 @@ Generating .install files when opam files are in opam/ dir
   > EOF
 
   $ dune build foobar.install
+
+Checked-in opam files in opam/ should stay the source of truth for release
+style builds.
+
+  $ rm -rf _build opam
+  $ cat >dune-project <<EOF
+  > (lang dune 3.23)
+  > (generate_opam_files true)
+  > (opam_file_location inside_opam_directory)
+  > (package
+  >  (allow_empty)
+  >  (name foobar))
+  > EOF
+
+  $ mkdir opam
+  $ cat >opam/foobar.opam <<EOF
+  > version: "0.1"
+  > # SOURCE COPY
+  > opam-version: "2.0"
+  > EOF
+
+  $ dune build -p foobar @install _build/install/default/lib/foobar/opam
+  $ grep '^# SOURCE COPY$' _build/install/default/lib/foobar/opam
+  [1]
+  $ grep '^# SOURCE COPY$' opam/foobar.opam
+  [1]

--- a/test/blackbox-tests/test-cases/subst/dont-fail-on-opam-files.t
+++ b/test/blackbox-tests/test-cases/subst/dont-fail-on-opam-files.t
@@ -59,3 +59,30 @@ dune subst should not fail when adding the version field in opam files
     ]
   ]
   x-maintenance-intent: ["(latest)"]
+
+Release-style builds should take a checked-in opam file as-is:
+
+  $ mkdir release-profile
+  $ cd release-profile
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (name test)
+  > (version 0.1)
+  > (generate_opam_files)
+  > (package (name test) (allow_empty))
+  > EOF
+
+  $ cat > test.opam << EOF
+  > version: "0.1"
+  > # SOURCE COPY
+  > opam-version: "2.0"
+  > EOF
+
+  $ dune build @install 2>&1 | sed -n '1,3p'
+
+  $ dune build -p test @install _build/install/default/lib/test/opam
+  $ grep '^# SOURCE COPY$' _build/install/default/lib/test/opam
+  [1]
+  $ grep '^# SOURCE COPY$' test.opam
+  [1]


### PR DESCRIPTION
Extend the cram tests for generated opam files in 3.23, including fresh-build, opam/ layout, and release-style install scenarios, and update the expected results accordingly.