### PR TITLE
fix: auto-inject menhir lower bound in generated opam files

### DIFF
--- a/doc/changes/fixed/10707.md
+++ b/doc/changes/fixed/10707.md
@@ -1,0 +1,2 @@
+- Auto-inject `"menhir" {>= "20180523"}` into generated opam files when the
+  menhir extension is used. (#10707, @robinbb)

--- a/doc/changes/fixed/10707.md
+++ b/doc/changes/fixed/10707.md
@@ -1,2 +1,5 @@
 - Auto-inject `"menhir" {>= "20180523"}` into generated opam files when the
-  menhir extension is used. (#10707, @robinbb)
+  menhir extension is used. Dune's menhir rules rely on `--infer-write-query`
+  and `--infer-read-reply`, which require at least this version; without the
+  lower bound, builds fail with older menhir installations.
+  (#10707, @robinbb)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -276,30 +276,26 @@ let insert_odoc_dep depends =
   loop [] depends
 ;;
 
+(* Menhir 20180523 added --infer-write-query and --infer-read-reply,
+   which dune's menhir rules rely on unconditionally. *)
 let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal "20180523")
 
 let insert_menhir_dep depends =
   let menhir_dep =
     { Package_dependency.name = menhir_name; constraint_ = Some menhir_constraint }
   in
-  let rec loop acc = function
-    | [] -> List.rev (menhir_dep :: acc)
-    | (dep : Package_dependency.t) :: rest ->
+  if
+    List.exists depends ~f:(fun (dep : Package_dependency.t) ->
+      Package.Name.equal dep.name menhir_name)
+  then
+    List.map depends ~f:(fun (dep : Package_dependency.t) ->
       if Package.Name.equal dep.name menhir_name
-      then (
-        let dep =
-          { dep with
-            constraint_ =
-              Some
-                (match dep.constraint_ with
-                 | None -> menhir_constraint
-                 | Some _ -> dep.constraint_ |> Option.value_exn)
-          }
-        in
-        List.rev_append (dep :: acc) rest)
-      else loop (dep :: acc) rest
-  in
-  loop [] depends
+      then
+        { dep with
+          constraint_ = Some (Option.value dep.constraint_ ~default:menhir_constraint)
+        }
+      else dep)
+  else List.rev (menhir_dep :: List.rev depends)
 ;;
 
 let maintenance_intent dune_version info =

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -295,7 +295,7 @@ let insert_menhir_dep depends =
           constraint_ = Some (Option.value dep.constraint_ ~default:menhir_constraint)
         }
       else dep)
-  else List.rev (menhir_dep :: List.rev depends)
+  else depends @ [ menhir_dep ]
 ;;
 
 let maintenance_intent dune_version info =

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -214,6 +214,7 @@ let package_fields package ~project =
 
 let dune_name = Package.Name.of_string "dune"
 let odoc_name = Package.Name.of_string "odoc"
+let menhir_name = Package.Name.of_string "menhir"
 
 let insert_dune_dep depends dune_version =
   let constraint_ : Package_constraint.t =
@@ -275,6 +276,32 @@ let insert_odoc_dep depends =
   loop [] depends
 ;;
 
+let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal "20180523")
+
+let insert_menhir_dep depends =
+  let menhir_dep =
+    { Package_dependency.name = menhir_name; constraint_ = Some menhir_constraint }
+  in
+  let rec loop acc = function
+    | [] -> List.rev (menhir_dep :: acc)
+    | (dep : Package_dependency.t) :: rest ->
+      if Package.Name.equal dep.name menhir_name
+      then (
+        let dep =
+          { dep with
+            constraint_ =
+              Some
+                (match dep.constraint_ with
+                 | None -> menhir_constraint
+                 | Some _ -> dep.constraint_ |> Option.value_exn)
+          }
+        in
+        List.rev_append (dep :: acc) rest)
+      else loop (dep :: acc) rest
+  in
+  loop [] depends
+;;
+
 let maintenance_intent dune_version info =
   if dune_version < (3, 18)
   then None
@@ -297,6 +324,11 @@ let opam_fields project (package : Package.t) =
     if dune_version < (2, 7) || Package.Name.equal package_name odoc_name
     then package
     else Package.map_depends package ~f:insert_odoc_dep
+  in
+  let package =
+    match Dune_project.find_extension_version project Dune_lang.Menhir.syntax with
+    | None -> package
+    | Some _ -> Package.map_depends package ~f:insert_menhir_dep
   in
   let package_fields = package_fields package ~project in
   let open Opam_file.Create in

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -15,7 +15,7 @@ The generated opam file should include "menhir" {>= "20180523"}.
   > EOF
 
   $ dune build foo.opam
-  $ cat foo.opam | grep menhir
+  $ grep menhir foo.opam
     "menhir" {>= "20180523"}
 
 Case 2: user already declared menhir with a sufficient lower bound.
@@ -32,7 +32,7 @@ The auto-injected constraint should not duplicate it.
   > EOF
 
   $ dune build foo.opam
-  $ cat foo.opam | grep menhir
+  $ grep menhir foo.opam
     "menhir" {>= "20211128"}
 
 Case 3: user declared menhir with no version constraint.
@@ -49,5 +49,5 @@ The auto-injected lower bound should be merged in.
   > EOF
 
   $ dune build foo.opam
-  $ cat foo.opam | grep menhir
+  $ grep menhir foo.opam
     "menhir" {>= "20180523"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -1,0 +1,53 @@
+When a project uses (using menhir ...), the generated opam file should include
+a lower bound on the menhir version, since dune assumes menhir supports
+--infer-write-query and --infer-read-reply (available since menhir 20180523).
+
+See https://github.com/ocaml/dune/issues/10707
+
+Case 1: menhir used, no explicit menhir dependency declared.
+The generated opam file should include "menhir" {>= "20180523"}.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package (name foo) (allow_empty))
+  > EOF
+
+  $ dune build foo.opam
+  $ cat foo.opam | grep menhir
+    "menhir" {>= "20180523"}
+
+Case 2: user already declared menhir with a sufficient lower bound.
+The auto-injected constraint should not duplicate it.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (>= 20211128))))
+  > EOF
+
+  $ dune build foo.opam
+  $ cat foo.opam | grep menhir
+    "menhir" {>= "20211128"}
+
+Case 3: user declared menhir with no version constraint.
+The auto-injected lower bound should be merged in.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends menhir))
+  > EOF
+
+  $ dune build foo.opam
+  $ cat foo.opam | grep menhir
+    "menhir" {>= "20180523"}


### PR DESCRIPTION
## Summary

Fixes #10707.

When a project uses `(using menhir ...)`, dune assumes menhir supports `--infer-write-query` and `--infer-read-reply` (available since menhir 20180523), but the generated opam file includes no version constraint on menhir. This causes packages in opam-repository to frequently need manual lower-bound fixes.

This PR auto-injects `"menhir" {>= "20180523"}` into generated opam files when the menhir extension is active, following the same pattern as the existing dune and odoc auto-injected dependencies. If the user already declares a menhir dependency with a version constraint, it is preserved.