### PR TITLE
Add test for promoting over a running binary

### DIFF
--- a/test/blackbox-tests/test-cases/promote/dune
+++ b/test/blackbox-tests/test-cases/promote/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to promote-over-running-binary)
+ (enabled_if
+  (<> %{ocaml-config:system} win)))

--- a/test/blackbox-tests/test-cases/promote/promote-over-running-binary.t
+++ b/test/blackbox-tests/test-cases/promote/promote-over-running-binary.t
@@ -1,0 +1,65 @@
+Promoting a binary that is currently running should succeed. The promotion
+uses atomic rename, which replaces the directory entry while the running
+process keeps its file descriptor.
+
+Regression test for https://github.com/ocaml/dune/issues/3484
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name server)
+  >  (libraries unix)
+  >  (promote (until-clean) (into .)))
+  > EOF
+
+The server writes a ready file on startup and exits after 30 seconds to
+avoid leaking a process if the test fails.
+
+  $ cat > server.ml <<'EOF'
+  > let () =
+  >   let ready = Filename.concat (Sys.getcwd ()) "ready" in
+  >   let oc = open_out ready in
+  >   close_out oc;
+  >   print_endline "server v1";
+  >   Unix.sleepf 30.0
+  > EOF
+
+  $ dune build ./server.exe
+
+Run the promoted binary directly (not via dune exec) because the test
+is specifically about promoting over a running binary on disk.
+
+  $ ./server.exe &
+  server v1
+  $ PID=$!
+
+  $ dune_cmd wait-for-file-to-appear ready
+  $ rm -f ready
+
+Modify the source and rebuild while the promoted binary is running.
+
+  $ cat > server.ml <<'EOF'
+  > let () =
+  >   let ready = Filename.concat (Sys.getcwd ()) "ready" in
+  >   let oc = open_out ready in
+  >   close_out oc;
+  >   print_endline "server v2";
+  >   Unix.sleepf 30.0
+  > EOF
+
+  $ dune build ./server.exe
+
+The promoted binary should be updated. Kill the old server.
+
+  $ kill $PID 2>/dev/null; wait $PID 2>/dev/null || true
+
+Verify the new binary works.
+
+  $ ./server.exe &
+  server v2
+  $ NEW_PID=$!
+  $ dune_cmd wait-for-file-to-appear ready
+  $ kill $NEW_PID 2>/dev/null; wait $NEW_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary

Closes #3484

Promoting a binary via `(promote (into ...))` while it is running used to
crash with `Sys_error("Text file busy")` and a raw stacktrace. This was
fixed by the refactoring of `artifact_substitution.ml` to use atomic copy
(write to temp file, then `rename`), since `rename` replaces the directory
entry while the running process keeps its open file descriptor.

This PR adds a regression test to prevent this from breaking again.

New test added: `promote/promote-over-running-binary.t` passes
