### PR TITLE
fix: run inline tests for byte-only libraries

### DIFF
--- a/doc/changes/fixed/9757.md
+++ b/doc/changes/fixed/9757.md
@@ -1,0 +1,3 @@
+- Fix inline tests not being executed for byte-only libraries. When a library
+  has `(modes byte)`, the inline test runner is now linked in byte mode so the
+  library's test code is included. (#9757, @robinbb)

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -311,11 +311,21 @@ include Sub_system.Register_end_point (struct
         let+ jsoo_enabled_modes =
           Jsoo_rules.jsoo_enabled_modes ~expander ~dir ~in_context:js_of_ocaml
         in
+        let ocaml = Compilation_context.ocaml cctx in
+        let lib_has_native =
+          let { Lib_config.has_native; _ } = ocaml.lib_config in
+          let lib_modes = Dune_lang.Mode_conf.Lib.Set.eval lib.modes ~has_native in
+          lib_modes.ocaml.native
+        in
         Mode_conf.Set.to_list info.modes
-        |> List.filter ~f:(fun (mode : Mode_conf.t) ->
+        |> List.filter_map ~f:(fun (mode : Mode_conf.t) ->
           match mode with
-          | Native | Best | Byte -> true
-          | Jsoo mode -> Js_of_ocaml.Mode.Pair.select ~mode jsoo_enabled_modes)
+          | Best -> Some (if lib_has_native then mode else Mode_conf.Byte)
+          | Native | Byte -> Some mode
+          | Jsoo mode ->
+            if Js_of_ocaml.Mode.Pair.select ~mode jsoo_enabled_modes
+            then Some (Jsoo mode)
+            else None)
       in
       let* (_ : Exe.dep_graphs) =
         let* linkages =

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -322,10 +322,8 @@ include Sub_system.Register_end_point (struct
           match mode with
           | Best -> Some (if lib_has_native then mode else Mode_conf.Byte)
           | Native | Byte -> Some mode
-          | Jsoo mode ->
-            if Js_of_ocaml.Mode.Pair.select ~mode jsoo_enabled_modes
-            then Some (Jsoo mode)
-            else None)
+          | Jsoo mode as v ->
+            if Js_of_ocaml.Mode.Pair.select ~mode jsoo_enabled_modes then Some v else None)
       in
       let* (_ : Exe.dep_graphs) =
         let* linkages =

--- a/test/blackbox-tests/test-cases/test-modes-byte.t
+++ b/test/blackbox-tests/test-cases/test-modes-byte.t
@@ -20,5 +20,8 @@ Dune should execute inline tests whose only mode is `byte`.
 The test should fail:
 
   $ dune runtest test_bytecode_repro.ml
+  File "test_bytecode_repro.ml", line 2, characters 1-26: <<(fact 5) = 121>> is false.
+  
+  FAILED 1 / 1 tests
+  [1]
 
-Currently does not because it is not being run.


### PR DESCRIPTION
## Summary

Fixes #9757.

When a library has `(modes byte)` and `(inline_tests)`, the default inline test mode `Best` resolves to native linkage. But the byte-only library has no `.cmxa` archive, so its test registration code is never linked into the native runner. The runner starts with zero tests and exits 0 — silently skipping all tests.

The fix consults the library's available modes when resolving `Best`: if the library doesn't support native, `Best` falls back to `Byte`, so the test runner is linked in byte mode where the library's `.cma` is available.

Supersedes the test-only PR #13199 by @Alizter, which documented the broken behavior.