### PR TITLE
fix: deduplicate dune version bounds in generated opam files

### DIFF
--- a/doc/changes/fixed/3916.md
+++ b/doc/changes/fixed/3916.md
@@ -1,0 +1,4 @@
+- Fix duplicate dune version bounds in generated opam files. When users
+  declare `(dune (>= X.Y))` matching or exceeding the `(lang dune X.Y)`
+  version, the generated opam `depends` no longer contains redundant
+  constraints like `{>= "2.7" & >= "2.7"}`. (#3916, #11106, @robinbb)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -215,6 +215,16 @@ let package_fields package ~project =
 let dune_name = Package.Name.of_string "dune"
 let odoc_name = Package.Name.of_string "odoc"
 
+let merge_dune_constraints lang_constraint user_constraint =
+  match lang_constraint, user_constraint with
+  | ( Package_constraint.Uop (Gte, String_literal lang_v)
+    , Package_constraint.Uop (Gte, String_literal user_v) ) ->
+    if OpamVersionCompare.compare lang_v user_v <= 0
+    then user_constraint
+    else lang_constraint
+  | _ -> And [ lang_constraint; user_constraint ]
+;;
+
 let insert_dune_dep depends dune_version =
   let constraint_ : Package_constraint.t =
     let dune_version = Dune_lang.Syntax.Version.to_string dune_version in
@@ -238,7 +248,7 @@ let insert_dune_dep depends dune_version =
                 Some
                   (match dep.constraint_ with
                    | None -> constraint_
-                   | Some c -> And [ constraint_; c ])
+                   | Some c -> merge_dune_constraints constraint_ c)
             }
         in
         List.rev_append acc (dep :: rest))

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -221,7 +221,16 @@ let merge_dune_constraints lang_constraint user_constraint =
     , Package_constraint.Uop (Gte, String_literal user_v) ) ->
     if OpamVersionCompare.compare lang_v user_v <= 0
     then user_constraint
-    else lang_constraint
+    else (
+      User_warning.emit
+        [ Pp.textf
+            "The lower bound >= %s on dune in the depends field is less than the dune \
+             language version %s. The generated opam file will use >= %s instead."
+            user_v
+            lang_v
+            lang_v
+        ];
+      lang_constraint)
   | _ -> And [ lang_constraint; user_constraint ]
 ;;
 

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -226,14 +226,14 @@ let merge_dune_constraints lang_constraint user_constraint =
 ;;
 
 let insert_dune_dep depends dune_version =
-  let constraint_ : Package_constraint.t =
+  let lang_constraint : Package_constraint.t =
     let dune_version = Dune_lang.Syntax.Version.to_string dune_version in
     Uop (Gte, String_literal dune_version)
   in
   let rec loop acc = function
     | [] ->
       let dune_dep =
-        { Package_dependency.name = dune_name; constraint_ = Some constraint_ }
+        { Package_dependency.name = dune_name; constraint_ = Some lang_constraint }
       in
       dune_dep :: List.rev acc
     | (dep : Package_dependency.t) :: rest ->
@@ -247,8 +247,9 @@ let insert_dune_dep depends dune_version =
               constraint_ =
                 Some
                   (match dep.constraint_ with
-                   | None -> constraint_
-                   | Some c -> merge_dune_constraints constraint_ c)
+                   | None -> lang_constraint
+                   | Some user_constraint ->
+                     merge_dune_constraints lang_constraint user_constraint)
             }
         in
         List.rev_append acc (dep :: rest))

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -57,7 +57,7 @@ there should be no duplicate bounds (issue #3916):
   > EOF
 
   $ dune build foo.opam
-  $ grep -A3 ^depends: foo.opam
+  $ sed -n '/^depends:/,/^]/p' foo.opam
   depends: [
     "dune" {>= "2.7"}
     "odoc" {with-doc}
@@ -74,7 +74,7 @@ the more restrictive user constraint should be kept (issue #11106):
   > EOF
 
   $ dune build foo.opam
-  $ grep -A3 ^depends: foo.opam
+  $ sed -n '/^depends:/,/^]/p' foo.opam
   depends: [
     "dune" {>= "3.16.0"}
     "odoc" {with-doc}
@@ -91,7 +91,7 @@ constraint takes precedence:
   > EOF
 
   $ dune build foo.opam
-  $ grep -A3 ^depends: foo.opam
+  $ sed -n '/^depends:/,/^]/p' foo.opam
   depends: [
     "dune" {>= "2.7"}
     "odoc" {with-doc}

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -46,6 +46,57 @@ Same with version of the language >= 2.6, we now add the constraint:
     "dune" {>= "2.6"}
   ]
 
+When the user specifies a dune constraint matching the lang version,
+there should be no duplicate bounds (issue #3916):
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (dune (>= 2.7))))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A3 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-doc}
+  ]
+
+When the user specifies a higher patch version than the lang version,
+the more restrictive user constraint should be kept (issue #11106):
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (dune (>= 3.16.0))))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A3 ^depends: foo.opam
+  depends: [
+    "dune" {>= "3.16.0"}
+    "odoc" {with-doc}
+  ]
+
+When the user specifies a lower bound than the lang version, the lang
+constraint takes precedence:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (dune (>= 2.5))))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A3 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-doc}
+  ]
+
 When the version of the language >= 2.7 we use dev instead of pinned
 when calling dune subst:
 

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -57,7 +57,7 @@ there should be no duplicate bounds (issue #3916):
   > EOF
 
   $ dune build foo.opam
-  $ sed -n '/^depends:/,/^]/p' foo.opam
+  $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "2.7"}
     "odoc" {with-doc}
@@ -74,7 +74,7 @@ the more restrictive user constraint should be kept (issue #11106):
   > EOF
 
   $ dune build foo.opam
-  $ sed -n '/^depends:/,/^]/p' foo.opam
+  $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "3.16.0"}
     "odoc" {with-doc}
@@ -91,7 +91,7 @@ constraint takes precedence:
   > EOF
 
   $ dune build foo.opam
-  $ sed -n '/^depends:/,/^]/p' foo.opam
+  $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "2.7"}
     "odoc" {with-doc}

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -80,8 +80,8 @@ the more restrictive user constraint should be kept (issue #11106):
     "odoc" {with-doc}
   ]
 
-When the user specifies a lower bound than the lang version, the lang
-constraint takes precedence:
+When the user specifies a lower bound than the lang version, a warning
+is emitted and the lang constraint takes precedence:
 
   $ cat > dune-project <<EOF
   > (lang dune 2.7)

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -91,6 +91,8 @@ constraint takes precedence:
   > EOF
 
   $ dune build foo.opam
+  Warning: The lower bound >= 2.5 on dune in the depends field is less than the
+  dune language version 2.7. The generated opam file will use >= 2.7 instead.
   $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "2.7"}


### PR DESCRIPTION
## Summary

- When users declare an explicit `(dune (>= X.Y))` dependency matching or exceeding the `(lang dune X.Y)` version, the generated opam file no longer contains redundant duplicate bounds like `{>= "2.7" & >= "2.7"}` or `{>= "3.16" & >= "3.16.0"}`
- Uses `OpamVersionCompare` to keep only the more restrictive of the two `>=` bounds; other constraint shapes (`=`, `or`, `and`, etc.) continue to be combined with `&` as before
- Adds three cram test cases covering exact match, higher patch version, and lower user bound

Fixes #3916
Fixes #11106