### PR TITLE
test: document ocamldep behavior with transparent alias chains

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
@@ -1,0 +1,65 @@
+Transparent module aliases create cross-library .cmi reads that ocamldep
+does not report. This test documents the behavior: ocamldep only sees the
+direct library reference, but the compiler follows alias chains and reads
+.cmi files from transitive libraries at compile time.
+
+Any per-module inter-library dependency optimization must account for this.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+Set up a chain: libA -> libB -> libC -> libD, where each intermediate
+library creates a transparent alias to the next.
+
+  $ mkdir libd
+  $ cat > libd/dune <<EOF
+  > (library (name libd))
+  > EOF
+  $ cat > libd/leaf.ml <<EOF
+  > let v = 99
+  > EOF
+
+  $ mkdir libc
+  $ cat > libc/dune <<EOF
+  > (library (name libc) (libraries libd))
+  > EOF
+  $ cat > libc/mid.ml <<EOF
+  > module L = Libd.Leaf
+  > EOF
+
+  $ mkdir libb
+  $ cat > libb/dune <<EOF
+  > (library (name libb) (libraries libc))
+  > EOF
+  $ cat > libb/bridge.ml <<EOF
+  > module M = Libc.Mid
+  > EOF
+
+  $ mkdir liba
+  $ cat > liba/dune <<EOF
+  > (library (name liba) (libraries libb))
+  > EOF
+  $ cat > liba/consumer.ml <<EOF
+  > let y = Libb.Bridge.M.L.v
+  > EOF
+
+ocamldep only reports the direct reference (Libb), not the transitive
+libraries reached through aliases:
+
+  $ ocamldep -modules liba/consumer.ml
+  liba/consumer.ml: Libb
+
+But the build succeeds because dune ensures all transitive library .cmi
+files are available:
+
+  $ dune build liba/.liba.objs/byte/liba__Consumer.cmo
+
+Verify that the compilation rule depends on .cmi files from all libraries
+in the chain, not just the directly referenced one:
+
+  $ dune rules liba/.liba.objs/byte/liba__Consumer.cmo 2>&1 | grep -o 'lib[a-d]\.' | sort -u
+  liba.
+  libb.
+  libc.
+  libd.


### PR DESCRIPTION
## Summary

Document the interaction between `ocamldep` and transparent module aliases
across libraries.

When a module uses a transparent alias chain (e.g., `Libb.Bridge.M.L.v`
where `Bridge` aliases into `Libc` which aliases into `Libd`), `ocamldep`
only reports the direct library reference (`Libb`). However, the compiler
follows the alias chain at compile time and reads `.cmi` files from all
transitive libraries.

This property is critical for the correctness of any future per-module
inter-library dependency optimization (#4572): filtering deps based solely
on `ocamldep` output would miss transitive libraries reached through
aliases, causing "inconsistent assumptions over interface" errors on
rebuilds.

- New cram test `per-module-lib-deps/transparent-alias-chain.t`
