### PR TITLE
feat: compile_commands.json generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _perf
 _coverage
 __pycache__
 *.install
+compile_commands.json
 
 # vim swap files
 *.swp

--- a/doc/changes/added/14185.md
+++ b/doc/changes/added/14185.md
@@ -1,0 +1,3 @@
+- Generate `compile_commands.json` for C/C++ foreign stubs when building
+  `@check` with `(lang dune 3.23)`. This enables `clangd`, `ccls`, and other
+  tools that consume compilation databases. (#14185, fixes #3531, @Alizter)

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -387,6 +387,34 @@ The `re2 project <https://github.com/janestreet/re2>`_ uses this method to
 build the ``re2`` C library. You can look at the file ``re2/src/re2_c/dune`` in
 this project to see a full working example.
 
+.. _compile-commands:
+
+Editor Support for C/C++ Stubs
+==============================
+
+.. versionadded:: 3.23
+
+Language servers such as `clangd <https://clangd.llvm.org/>`_ and `ccls
+<https://github.com/MaskRay/ccls>`_ need a ``compile_commands.json`` file to
+provide code navigation, completion, and diagnostics for C and C++ sources.
+Dune can generate this file for you.
+
+When using ``(lang dune 3.23)`` or later, ``dune build @check`` produces a
+`compilation database <https://clang.llvm.org/docs/JSONCompilationDatabase.html>`_
+covering all C and C++ sources declared via ``foreign_stubs``,
+``foreign_library``, and ctypes stanzas in the workspace. The file is promoted
+to the workspace root so that editors can find it without configuration. Running
+``dune clean`` removes it. You can also build the file directly with
+``dune build compile_commands.json``.
+
+Each entry records the full compiler invocation that Dune would use for that
+source file, including the C compiler, base flags from ``ocamlc -config``,
+user-specified ``(flags ...)``, ``-I`` paths for the OCaml standard library,
+library dependencies (via ``install_c_headers``), and ``(include_dirs ...)``.
+
+Since the file is a build artifact promoted to the source tree, you should add
+``compile_commands.json`` to your ``.gitignore``.
+
 .. _ctypes: https://github.com/ocamllabs/ocaml-ctypes
 .. _pkg-config: https://www.freedesktop.org/wiki/Software/pkg-config/
 .. _errno_policy: https://ocaml.org/p/ctypes/0.20.1/doc/Cstubs/index.html#type-errno_policy

--- a/doc/reference/aliases/check.rst
+++ b/doc/reference/aliases/check.rst
@@ -7,5 +7,10 @@ files so that Merlin and ``ocaml-lsp-server`` can be used in the project.
 It is also useful in the development loop because it will catch compilation
 errors without executing expensive operations such as linking executables.
 
+Starting from ``(lang dune 3.23)``, this alias also generates and promotes a
+``compile_commands.json`` file to the workspace root for projects that contain
+C or C++ foreign stubs. This file is used by ``clangd`` and ``ccls`` for code
+navigation and diagnostics. See :ref:`compile-commands` for details.
+
 .. seealso:: :doc:`ocaml-index` for a fast feedback loop that
    also indexes the project.

--- a/src/dune_rules/compile_commands.ml
+++ b/src/dune_rules/compile_commands.ml
@@ -1,0 +1,162 @@
+open Import
+
+let filename = "compile_commands.json"
+
+(* A single entry in compile_commands.json *)
+type entry =
+  { directory : Path.t
+  ; file : Path.Local.t
+  ; arguments : string list
+  }
+
+let entry_to_json { directory; file; arguments } : Json.t =
+  `Assoc
+    [ "directory", `String (Path.to_string directory)
+    ; "file", `String (Path.Local.to_string file)
+    ; "arguments", `List (List.map arguments ~f:(fun arg -> `String arg))
+    ]
+;;
+
+let build_c_command ~sctx ~dir ~expander ~include_flags (src : Foreign.Source.t) ~ext_obj =
+  let open Action_builder.O in
+  let+ ocaml = Action_builder.of_memo (Context.ocaml (Super_context.context sctx))
+  and+ args =
+    (* Expand the command args to strings, discarding file-level deps (header
+       files, include directories). Flag values flow through Memo, so changes
+       to dune files or compiler config still invalidate this rule. *)
+    Foreign_rules.c_compile_args ~sctx ~dir ~expander ~src ~include_flags
+    |> Command.expand_no_targets ~dir:(Path.build dir)
+    |> Action_builder.evaluate_and_collect_deps
+    |> Action_builder.of_memo
+    >>| fst
+    >>| Appendable_list.to_list
+  in
+  let src_relative =
+    Foreign.Source.path src |> Path.Build.basename |> Path.Local.of_string
+  in
+  { directory = Path.build dir
+  ; file = src_relative
+  ; arguments =
+      List.concat
+        [ [ Ocaml_config.c_compiler ocaml.ocaml_config ]
+        ; args
+        ; (let dst =
+             Foreign.Source.object_name src ^ Filename.Extension.to_string ext_obj
+           in
+           match ocaml.lib_config.ccomp_type with
+           | Msvc -> [ "/Fo" ^ dst ]
+           | Cc | Other _ -> [ "-o"; dst ])
+        ; [ "-c"; Path.Local.to_string src_relative ]
+        ]
+  }
+;;
+
+(* Collect entries from foreign sources in a directory.
+   [requires] is the list of library dependencies for include paths. *)
+let collect_from_foreign_sources
+      ~sctx
+      ~dir
+      ~expander
+      ~dir_contents
+      ~requires
+      foreign_sources
+  =
+  let open Action_builder.O in
+  let* ext_obj =
+    let+ ocaml = Action_builder.of_memo (Context.ocaml (Super_context.context sctx)) in
+    ocaml.lib_config.ext_obj
+  in
+  Foreign.Sources.to_list_map foreign_sources ~f:(fun _ (_, src) ->
+    let include_flags =
+      Foreign_rules.build_include_flags ~sctx ~dir ~expander ~dir_contents ~requires ~src
+    in
+    build_c_command ~sctx ~dir ~expander ~include_flags src ~ext_obj)
+  |> Action_builder.all
+;;
+
+(* Get library compile requirements for include paths *)
+let get_lib_requires ~dir ~scope (lib : Library.t) =
+  let open Memo.O in
+  Lib.DB.get_compile_info
+    (Scope.libs scope)
+    (Local (Library.to_lib_id ~src_dir:(Path.Build.drop_build_context_exn dir) lib))
+    ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
+  >>| snd
+  >>= Lib.Compile.direct_requires ~for_:Ocaml
+;;
+
+(* Collect all compile command entries from the workspace *)
+let collect_entries sctx =
+  let ctx = Super_context.context sctx in
+  let open Memo.O in
+  let* dune_files = Dune_load.dune_files (Context.name ctx) in
+  Dune_file.fold_static_stanzas dune_files ~init:[] ~f:(fun dune_file stanza acc ->
+    let dir =
+      Path.Build.append_source (Context.build_dir ctx) (Dune_file.dir dune_file)
+    in
+    (let* expander = Super_context.expander sctx ~dir
+     and* dir_contents = Dir_contents.get sctx ~dir
+     and* scope = Scope.DB.find_by_dir dir in
+     let* foreign_sources = Dir_contents.foreign_sources dir_contents in
+     match Stanza.repr stanza with
+     | Library.T lib when Buildable.has_foreign_stubs lib.buildable ->
+       Foreign_sources.for_lib_opt foreign_sources ~name:(Library.best_name lib)
+       |> (function
+        | None -> Memo.return None
+        | Some sources ->
+          get_lib_requires ~dir ~scope lib
+          >>| fun requires ->
+          Some
+            (collect_from_foreign_sources
+               ~sctx
+               ~dir
+               ~expander
+               ~dir_contents
+               ~requires
+               sources))
+     | (Executables.T exes | Tests.T { exes; _ })
+       when Buildable.has_foreign_stubs exes.buildable ->
+       let requires = Resolve.return [] in
+       Foreign_sources.for_exes_opt
+         foreign_sources
+         ~first_exe:(snd (Nonempty_list.hd exes.names))
+       |> Option.map
+            ~f:(collect_from_foreign_sources ~sctx ~dir ~expander ~dir_contents ~requires)
+       |> Memo.return
+     | Foreign_library.T lib ->
+       let requires = Resolve.return [] in
+       Foreign_sources.for_archive_opt foreign_sources ~archive_name:lib.archive_name
+       |> Option.map
+            ~f:(collect_from_foreign_sources ~sctx ~dir ~expander ~dir_contents ~requires)
+       |> Memo.return
+     | _ -> Memo.return None)
+    :: acc)
+  |> Memo.all_concurrently
+  >>| List.filter_map ~f:Fun.id
+;;
+
+let gen_rules sctx =
+  let build_dir = Super_context.context sctx |> Context.build_dir in
+  let open Memo.O in
+  let* project = Dune_load.find_project ~dir:build_dir in
+  if Dune_project.dune_version project < (3, 23)
+  then Memo.return ()
+  else
+    let* entry_builders = collect_entries sctx in
+    if List.is_empty entry_builders
+    then Memo.return ()
+    else (
+      let gen_path = Path.Build.relative build_dir filename in
+      let mode = Rule.Mode.Promote { lifetime = Until_clean; into = None; only = None } in
+      let* () =
+        Action_builder.write_file_dyn
+          gen_path
+          (let open Action_builder.O in
+           let+ entries = Action_builder.all entry_builders >>| List.concat in
+           Json.to_string (`List (List.map entries ~f:entry_to_json)))
+        |> Super_context.add_rule sctx ~mode ~dir:build_dir
+      in
+      Rules.Produce.Alias.add_deps
+        (Alias.make Alias0.check ~dir:build_dir)
+        (Action_builder.path (Path.build gen_path)))
+;;

--- a/src/dune_rules/compile_commands.mli
+++ b/src/dune_rules/compile_commands.mli
@@ -1,0 +1,2 @@
+(** Generate compile_commands.json rule for the workspace. *)
+val gen_rules : Super_context.t -> unit Memo.t

--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -259,6 +259,12 @@ module Source = struct
     | Ctypes _ -> All
   ;;
 
+  let include_dirs t =
+    match t.kind with
+    | Stubs stubs -> stubs.include_dirs
+    | Ctypes _ -> []
+  ;;
+
   let user_object_name t =
     t.path |> Path.Build.split_extension |> fst |> Path.Build.basename
   ;;

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -126,6 +126,7 @@ module Source : sig
   val language : t -> Foreign_language.t
   val mode : t -> Mode.Select.t
   val path : t -> Path.Build.t
+  val include_dirs : t -> Stubs.Include_dir.t list
 
   (** The name of the corresponding object file; for example, [name] for a
       source file [some/path/name.cpp] of [name_mode] if the stub is

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -210,53 +210,75 @@ let include_dir_flags ~expander ~dir ~include_dirs =
      Command.Args.S (List.map include_dirs_expanded ~f:args_of_include_dir))
 ;;
 
-let build_c
-      ~(kind : Foreign_language.t)
-      ~sctx
-      ~dir
-      ~expander
-      ~include_flags
-      (loc, (src : Foreign.Source.t), dst)
-  =
+let base_flags ~(kind : Foreign_language.t) ~use_standard_flags ~ctx ~ocaml_config =
+  match kind with
+  | Cxx -> Fdo.cxx_flags ctx
+  | C ->
+    (match use_standard_flags with
+     | Some true -> Fdo.c_flags ctx
+     | None | Some false ->
+       (* In dune < 2.8 flags from ocamlc_config are always added *)
+       List.concat
+         [ Ocaml_config.ocamlc_cflags ocaml_config
+         ; Ocaml_config.ocamlc_cppflags ocaml_config
+         ; Fdo.c_flags ctx
+         ])
+;;
+
+let compilation_flags ~sctx ~dir ~expander ~(src : Foreign.Source.t) =
+  let open Action_builder.O in
+  let kind = Foreign.Source.language src in
   let ctx = Super_context.context sctx in
-  let* project = Dune_load.find_project ~dir in
-  let use_standard_flags = Dune_project.use_standard_c_and_cxx_flags project in
-  let* ocaml = Context.ocaml ctx in
-  let base_flags =
-    match kind with
-    | Cxx -> Fdo.cxx_flags ctx
-    | C ->
-      (match use_standard_flags with
-       | Some true -> Fdo.c_flags ctx
-       | None | Some false ->
-         (* In dune < 2.8 flags from ocamlc_config are always added *)
-         let cfg = ocaml.ocaml_config in
-         List.concat
-           [ Ocaml_config.ocamlc_cflags cfg
-           ; Ocaml_config.ocamlc_cppflags cfg
-           ; Fdo.c_flags ctx
-           ])
-  in
-  let* with_user_and_std_flags =
-    Memo.map ~f:(Action_builder.map ~f:(List.append base_flags))
-    @@
+  let* project = Action_builder.of_memo (Dune_load.find_project ~dir) in
+  let* ocaml = Action_builder.of_memo (Context.ocaml ctx) in
+  let+ user_flags =
     match Foreign.Source.kind src with
     | Ctypes field ->
-      Memo.return
-      @@
-        (match field.build_flags_resolver with
-        | Vendored { c_flags; c_library_flags = _ } ->
-          foreign_flags sctx ~dir ~expander ~flags:c_flags ~language:C
-        | Pkg_config ->
-          let open Action_builder.O in
-          let+ default_flags =
-            let dir = Path.Build.parent_exn dst in
-            default_foreign_flags ~dir ~language:C
-          and+ pkg_config_flags =
-            let lib = External_lib_name.to_string field.external_library_name in
-            Pkg_config.Query.read ~dir (Cflags lib) sctx
-          in
-          default_flags @ pkg_config_flags)
+      (match field.build_flags_resolver with
+       | Vendored { c_flags; c_library_flags = _ } ->
+         foreign_flags sctx ~dir ~expander ~flags:c_flags ~language:C
+       | Pkg_config ->
+         let+ default_flags = default_foreign_flags ~dir ~language:C
+         and+ pkg_config_flags =
+           Pkg_config.Query.read
+             ~dir
+             (Cflags (External_lib_name.to_string field.external_library_name))
+             sctx
+         in
+         default_flags @ pkg_config_flags)
+    | Stubs { Foreign.Stubs.flags; _ } ->
+      foreign_flags sctx ~dir ~expander ~flags ~language:kind
+  in
+  base_flags
+    ~kind
+    ~use_standard_flags:(Dune_project.use_standard_c_and_cxx_flags project)
+    ~ctx
+    ~ocaml_config:ocaml.ocaml_config
+  @ user_flags
+;;
+
+let c_compile_args ~sctx ~dir ~expander ~src ~include_flags =
+  Command.Args.S
+    [ Dyn
+        (Action_builder.map (compilation_flags ~sctx ~dir ~expander ~src) ~f:(fun flags ->
+           Command.Args.As flags))
+    ; Dyn
+        (let open Action_builder.O in
+         let+ ocaml =
+           Action_builder.of_memo (Context.ocaml (Super_context.context sctx))
+         in
+         Command.Args.S [ A "-I"; Path ocaml.lib_config.stdlib_dir ])
+    ; include_flags
+    ]
+;;
+
+let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), dst) =
+  let ctx = Super_context.context sctx in
+  let* ocaml = Context.ocaml ctx in
+  (* Emit warning for Stubs case when standard flags are overridden *)
+  let* () =
+    match Foreign.Source.kind src with
+    | Ctypes _ -> Memo.return ()
     | Stubs { Foreign.Stubs.flags; _ } ->
       (* DUNE3 will have [use_standard_c_and_cxx_flags] enabled by default. To
          guide users toward this change we emit a warning when dune_lang is >=
@@ -264,6 +286,8 @@ let build_c
          [dune-project] file (thus defaulting to [true]), the [:standard] set of
          flags has been overridden and we are not in a vendored project *)
       let has_standard = Ordered_set_lang.Unexpanded.has_standard flags in
+      let* project = Dune_load.find_project ~dir in
+      let use_standard_flags = Dune_project.use_standard_c_and_cxx_flags project in
       let+ is_vendored =
         match Path.Build.drop_build_context dir with
         | Some src_dir -> Source_tree.is_vendored src_dir
@@ -286,8 +310,7 @@ let build_c
                Setting this option to `true` will effectively prevent Dune from silently \
                adding c-flags to the compiler arguments which is the new recommended \
                behaviour."
-          ];
-      foreign_flags sctx ~dir ~expander ~flags ~language:kind
+          ]
   in
   let output_param =
     match ocaml.lib_config.ccomp_type with
@@ -299,7 +322,7 @@ let build_c
     ~loc
     ~dir
     (let open Action_builder.With_targets.O in
-     let src = Path.build (Foreign.Source.path src) in
+     let src_path = Path.build (Foreign.Source.path src) in
      (* We have to execute the rule in the library directory as the .o is
         produced in the current directory *)
      let c_compiler =
@@ -316,13 +339,11 @@ let build_c
      Command.run_dyn_prog
        ~dir:(Path.build dir)
        c_compiler
-       ([ Command.Args.dyn with_user_and_std_flags
-        ; S [ A "-I"; Path stdlib_dir ]
+       ([ c_compile_args ~sctx ~dir ~expander ~src ~include_flags
         ; Hidden_deps (Dep.Set.singleton (Dep.file_selector caml_headers))
-        ; include_flags
         ]
         @ output_param
-        @ [ A "-c"; Dep src ])
+        @ [ A "-c"; Dep src_path ])
      (* With sandboxing we get errors like: bar.c:2:19: fatal error: foo.cxx:
         No such file or directory #include "foo.cxx". (These errors happen only
         when compiling c files.) *)
@@ -331,25 +352,20 @@ let build_c
 
 (* TODO: [requires] is a confusing name, probably because it's too general: it
    looks like it's a list of libraries we depend on. *)
-let build_o_files
-      ~sctx
-      ~foreign_sources
-      ~(dir : Path.Build.t)
-      ~expander
-      ~requires
-      ~dir_contents
-  =
+let header_files dir_contents =
+  let header_ext = Filename.Extension.to_string Foreign_language.header_extension in
+  Dir_contents.dirs dir_contents
+  |> List.fold_left ~init:[] ~f:(fun acc dc ->
+    Dir_contents.text_files dc
+    |> Filename.Set.fold ~init:acc ~f:(fun fn acc ->
+      if String.ends_with fn ~suffix:header_ext
+      then Path.relative (Path.build (Dir_contents.dir dc)) fn :: acc
+      else acc))
+;;
+
+let build_include_flags ~sctx ~dir ~expander ~dir_contents ~requires ~src =
   let includes =
-    let h_files =
-      let header_ext = Filename.Extension.to_string Foreign_language.header_extension in
-      Dir_contents.dirs dir_contents
-      |> List.fold_left ~init:[] ~f:(fun acc dc ->
-        Dir_contents.text_files dc
-        |> Filename.Set.fold ~init:acc ~f:(fun fn acc ->
-          if String.ends_with ~suffix:header_ext fn
-          then Path.relative (Path.build (Dir_contents.dir dc)) fn :: acc
-          else acc))
-    in
+    let h_files = header_files dir_contents in
     Command.Args.S
       [ Hidden_deps (Dep.Set.of_files h_files)
       ; Resolve.args
@@ -361,6 +377,35 @@ let build_o_files
              ])
       ]
   in
+  let extra_deps =
+    let extra_deps, sandbox =
+      match Foreign.Source.kind src with
+      | Stubs stubs ->
+        Dep_conf_eval.unnamed
+          Sandbox_config.no_special_requirements
+          stubs.extra_deps
+          ~expander
+      | Ctypes _ -> Action_builder.return (), Sandbox_config.default
+    in
+    (* We don't sandbox the C compiler, see comment in [build_c] about
+       this. *)
+    ignore sandbox;
+    Action_builder.map extra_deps ~f:(fun () -> Command.Args.empty)
+  in
+  let extra_flags =
+    include_dir_flags ~expander ~dir ~include_dirs:(Foreign.Source.include_dirs src)
+  in
+  Command.Args.S [ includes; extra_flags; Dyn extra_deps ]
+;;
+
+let build_o_files
+      ~sctx
+      ~foreign_sources
+      ~(dir : Path.Build.t)
+      ~expander
+      ~requires
+      ~dir_contents
+  =
   let* ext_obj =
     let+ ocaml =
       let ctx = Super_context.context sctx in
@@ -373,42 +418,10 @@ let build_o_files
     ~f:(fun obj (loc, (src : Foreign.Source.t)) ->
       let+ build_file =
         let include_flags =
-          let extra_deps =
-            let extra_deps, sandbox =
-              match Foreign.Source.kind src with
-              | Stubs stubs ->
-                Dep_conf_eval.unnamed
-                  Sandbox_config.no_special_requirements
-                  stubs.extra_deps
-                  ~expander
-              | Ctypes _ -> Action_builder.return (), Sandbox_config.default
-            in
-            (* We don't sandbox the C compiler, see comment in [build_file] about
-               this. *)
-            ignore sandbox;
-            Action_builder.map extra_deps ~f:(fun () -> Command.Args.empty)
-          in
-          let extra_flags =
-            include_dir_flags
-              ~expander
-              ~dir
-              ~include_dirs:
-                (match Foreign.Source.kind src with
-                 | Stubs stubs -> stubs.include_dirs
-                 | Ctypes _ -> [])
-          in
-          Command.Args.S [ includes; extra_flags; Dyn extra_deps ]
+          build_include_flags ~sctx ~dir ~expander ~dir_contents ~requires ~src
         in
         let dst = Path.Build.relative dir (obj ^ Filename.Extension.to_string ext_obj) in
-        let+ () =
-          build_c
-            ~kind:(Foreign.Source.language src)
-            ~sctx
-            ~dir
-            ~expander
-            ~include_flags
-            (loc, src, dst)
-        in
+        let+ () = build_c ~sctx ~dir ~expander ~include_flags (loc, src, dst) in
         dst
       in
       Foreign.Source.mode src, Path.build build_file)

--- a/src/dune_rules/foreign_rules.mli
+++ b/src/dune_rules/foreign_rules.mli
@@ -20,3 +20,25 @@ val build_o_files
 val foreign_flags_env
   :  dir:Path.Build.t
   -> string list Action_builder.t Foreign_language.Dict.t Memo.t
+
+(** Build the common include flags for C compilation: header hidden deps,
+    library include flags, per-source include_dir_flags, and extra_deps.
+    Shared between [build_o_files] and [Compile_commands]. *)
+val build_include_flags
+  :  sctx:Super_context.t
+  -> dir:Path.Build.t
+  -> expander:Expander.t
+  -> dir_contents:Dir_contents.t
+  -> requires:Lib.t list Resolve.t
+  -> src:Foreign.Source.t
+  -> Command.Args.without_targets Command.Args.t
+
+(** Construct Command.Args.t for C compilation (flags + stdlib include + include_flags).
+    Does not include output (-o) or source (-c) arguments. *)
+val c_compile_args
+  :  sctx:Super_context.t
+  -> dir:Path.Build.t
+  -> expander:Expander.t
+  -> src:Foreign.Source.t
+  -> include_flags:Command.Args.without_targets Command.Args.t
+  -> Command.Args.without_targets Command.Args.t

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -8,12 +8,18 @@ type t =
   }
 
 let for_lib t ~name = Lib_name.Map.find_exn t.libraries name
+let for_lib_opt t ~name = Lib_name.Map.find t.libraries name
 
 let for_archive t ~archive_name =
   Foreign.Archive.Name.Map.find_exn t.archives archive_name
 ;;
 
+let for_archive_opt t ~archive_name =
+  Foreign.Archive.Name.Map.find t.archives archive_name
+;;
+
 let for_exes t ~first_exe = String.Map.find_exn t.executables first_exe
+let for_exes_opt t ~first_exe = String.Map.find t.executables first_exe
 
 let empty =
   { libraries = Lib_name.Map.empty

--- a/src/dune_rules/foreign_sources.mli
+++ b/src/dune_rules/foreign_sources.mli
@@ -6,8 +6,11 @@ type t
 
 val empty : t
 val for_lib : t -> name:Lib_name.t -> Foreign.Sources.t
+val for_lib_opt : t -> name:Lib_name.t -> Foreign.Sources.t option
 val for_archive : t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t
+val for_archive_opt : t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t option
 val for_exes : t -> first_exe:string -> Foreign.Sources.t
+val for_exes_opt : t -> first_exe:string -> Foreign.Sources.t option
 
 val make
   :  Stanza.t list

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -592,8 +592,22 @@ let gen_rules_regular_directory (sctx : Super_context.t Memo.t) ~src_dir ~compon
                 match st_dir with
                 | None -> Memo.return Rules.empty
                 | Some st_dir -> gen_project_rules sctx st_dir
+              and+ compile_commands_rules =
+                (* Generate compile_commands.json only for the merlin
+                   context at the context root *)
+                match components with
+                | [] ->
+                  let* sctx = sctx in
+                  if Context.merlin (Super_context.context sctx)
+                  then Rules.collect_unit (fun () -> Compile_commands.gen_rules sctx)
+                  else Memo.return Rules.empty
+                | _ -> Memo.return Rules.empty
               and+ rules = rules in
-              Rules.union (Rules.union project_rules automatic_subdir_rules) rules
+              Rules.union
+                (Rules.union
+                   (Rules.union project_rules automatic_subdir_rules)
+                   compile_commands_rules)
+                rules
             in
             Gen_rules.rules_for ~dir ~directory_targets ~allowed_subdirs rules
         in

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/cxx-stubs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/cxx-stubs.t
@@ -1,0 +1,39 @@
+Test that compile_commands.json is generated for C++ stubs.
+
+  $ make_dune_project 3.23
+
+Create a library with both C and C++ stubs:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names c_stub))
+  >  (foreign_stubs (language cxx) (names cxx_stub)))
+  > EOF
+
+  $ cat >c_stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value c_stub(value unit) { return Val_int(1); }
+  > EOF
+
+  $ cat >cxx_stub.cpp <<EOF
+  > #include <caml/mlvalues.h>
+  > extern "C" value cxx_stub(value unit) { return Val_int(2); }
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > external c_fn : unit -> int = "c_stub"
+  > external cxx_fn : unit -> int = "cxx_stub"
+  > EOF
+
+Build compile_commands.json:
+
+  $ dune build compile_commands.json
+
+Check that both C and C++ files are present in the promoted file:
+
+  $ jq '[.[].file] | sort' compile_commands.json
+  [
+    "c_stub.c",
+    "cxx_stub.cpp"
+  ]

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/exe-stubs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/exe-stubs.t
@@ -1,0 +1,30 @@
+Test that compile_commands.json includes entries for executable stubs.
+
+  $ make_dune_project 3.23
+
+Create an executable with a C stub:
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+
+  $ cat >stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value my_stub(value unit) { return Val_int(42); }
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > external my_stub : unit -> int = "my_stub"
+  > let () = Printf.printf "%d\n" (my_stub ())
+  > EOF
+
+Build compile_commands.json:
+
+  $ dune build compile_commands.json
+
+Check that the executable's stub appears:
+
+  $ jq '.[0].file' compile_commands.json
+  "stub.c"

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/foreign-library.t
@@ -1,0 +1,93 @@
+Test compile_commands.json with foreign_library stanzas and include directories.
+
+  $ make_dune_project 3.23
+
+First, create a library that exposes headers:
+
+  $ mkdir -p headerslib
+  $ cat >headerslib/dune <<EOF
+  > (library
+  >  (name headerslib)
+  >  (install_c_headers myapi))
+  > EOF
+  $ cat >headerslib/myapi.h <<EOF
+  > #define API_VERSION 1
+  > EOF
+  $ cat >headerslib/headerslib.ml <<EOF
+  > let version = 1
+  > EOF
+
+Create an include directory with a header:
+
+  $ mkdir include
+  $ cat >include/myheader.h <<EOF
+  > #define MY_VALUE 42
+  > EOF
+
+Create multiple foreign_library stanzas with include_dirs:
+
+  $ cat >dune <<EOF
+  > (foreign_library
+  >  (archive_name add)
+  >  (language c)
+  >  (include_dirs include (lib headerslib))
+  >  (names add))
+  > 
+  > (foreign_library
+  >  (archive_name mul)
+  >  (language c)
+  >  (include_dirs include)
+  >  (names mul))
+  > 
+  > (library
+  >  (name calc)
+  >  (libraries headerslib)
+  >  (foreign_archives add mul))
+  > EOF
+
+  $ cat >add.c <<EOF
+  > #include <caml/mlvalues.h>
+  > #include "myheader.h"
+  > value add_stub(value x, value y) { return Val_int(Int_val(x) + Int_val(y) + MY_VALUE); }
+  > EOF
+
+  $ cat >mul.c <<EOF
+  > #include <caml/mlvalues.h>
+  > #include "myheader.h"
+  > value mul_stub(value x, value y) { return Val_int(Int_val(x) * Int_val(y) * MY_VALUE); }
+  > EOF
+
+  $ cat >calc.ml <<EOF
+  > external add : int -> int -> int = "add_stub"
+  > external mul : int -> int -> int = "mul_stub"
+  > EOF
+
+Build compile_commands.json:
+
+  $ dune build compile_commands.json
+
+Check that we have entries for both C files:
+
+  $ jq '[.[].file] | sort' compile_commands.json
+  [
+    "add.c",
+    "mul.c"
+  ]
+
+Check that include directories appear in the arguments for each file.
+mul.c should have just "include", add.c should have both "include" and "headerslib":
+
+  $ jq '.[] | {file: .file, includes: [.arguments | indices("-I") as $i | .[$i[]+1]] | map(select(contains("ocaml") | not))}' compile_commands.json
+  {
+    "file": "mul.c",
+    "includes": [
+      "include"
+    ]
+  }
+  {
+    "file": "add.c",
+    "includes": [
+      "include",
+      "headerslib"
+    ]
+  }

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/library-deps.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/library-deps.t
@@ -1,0 +1,47 @@
+Test that compile_commands.json includes -I flags for library dependencies.
+
+  $ make_dune_project 3.23
+
+Create a library that exposes C headers:
+
+  $ mkdir -p provider
+  $ cat >provider/dune <<EOF
+  > (library
+  >  (name provider)
+  >  (install_c_headers api))
+  > EOF
+  $ cat >provider/api.h <<EOF
+  > #define PROVIDER_VERSION 42
+  > EOF
+  $ cat >provider/provider.ml <<EOF
+  > let version = 42
+  > EOF
+
+Create a library with foreign stubs that depends on provider:
+
+  $ mkdir -p consumer
+  $ cat >consumer/dune <<EOF
+  > (library
+  >  (name consumer)
+  >  (libraries provider)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+  $ cat >consumer/stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > #include "api.h"
+  > value get_version(value unit) { return Val_int(PROVIDER_VERSION); }
+  > EOF
+  $ cat >consumer/consumer.ml <<EOF
+  > external get_version : unit -> int = "get_version"
+  > EOF
+
+Build compile_commands.json:
+
+  $ dune build compile_commands.json
+
+Check that compile_commands.json includes -I for provider's headers:
+
+  $ jq '.[] | select(.file == "stub.c") | .arguments | map(select(contains("provider")))' compile_commands.json
+  [
+    "../provider"
+  ]

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/not-default.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/not-default.t
@@ -1,0 +1,24 @@
+Test that compile_commands.json is not generated on dune lang < 3.23.
+
+  $ make_dune_project 3.22
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+
+  $ cat >stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value foo_stub(value unit) { return Val_int(42); }
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > external stub : unit -> int = "foo_stub"
+  > EOF
+
+  $ dune build @check
+  $ test -f _build/default/compile_commands.json
+  [1]
+  $ test -f compile_commands.json
+  [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/rebuild-on-flag-change.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/rebuild-on-flag-change.t
@@ -1,0 +1,44 @@
+Test that compile_commands.json is regenerated when flags change.
+
+  $ make_dune_project 3.23
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names stub) (flags :standard -DFOO=1)))
+  > EOF
+
+  $ cat >stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value foo_stub(value unit) { return Val_int(42); }
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > external stub : unit -> int = "foo_stub"
+  > EOF
+
+  $ dune build compile_commands.json
+
+The initial flags should contain -DFOO=1:
+
+  $ jq '.[0].arguments | map(select(startswith("-DFOO")))' compile_commands.json
+  [
+    "-DFOO=1"
+  ]
+
+Now change the flags:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names stub) (flags :standard -DFOO=2)))
+  > EOF
+
+  $ dune build compile_commands.json
+
+The flags should now contain -DFOO=2:
+
+  $ jq '.[0].arguments | map(select(startswith("-DFOO")))' compile_commands.json
+  [
+    "-DFOO=2"
+  ]

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/simple.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/simple.t
@@ -1,0 +1,45 @@
+Test that compile_commands.json is generated for C stubs.
+
+  $ make_dune_project 3.23
+
+Create a simple library with a C stub:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+
+  $ cat >stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value foo_stub(value unit) { return Val_int(42); }
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > external stub : unit -> int = "foo_stub"
+  > EOF
+
+Build compile_commands.json directly:
+
+  $ dune build compile_commands.json
+
+The file is promoted to the workspace root:
+
+  $ test -f compile_commands.json
+
+Check that the file contains our stub:
+
+  $ jq '.[0].file' compile_commands.json
+  "stub.c"
+
+Building @check also produces the file:
+
+  $ dune clean
+  $ dune build @check
+  $ test -f compile_commands.json
+
+Clean removes the promoted file:
+
+  $ dune clean
+  $ test -f compile_commands.json
+  [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/trace-comparison.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/compile-commands/trace-comparison.t
@@ -1,0 +1,50 @@
+Test that compile_commands.json matches actual C compiler invocations from trace.
+
+  $ make_dune_project 3.23
+
+Create a library with a C stub:
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+
+  $ cat >stub.c <<EOF
+  > #include <caml/mlvalues.h>
+  > value foo_stub(value unit) { return Val_int(42); }
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > external stub : unit -> int = "foo_stub"
+  > EOF
+
+Build with trace to capture actual C compiler invocation:
+
+  $ DUNE_TRACE=process dune build
+
+Extract the C compiler invocation from trace (filter for .c files):
+
+  $ dune trace cat \
+  > | jq -c 'select(.cat == "process") | select(.args.process_args // [] | any(endswith(".c"))) | .args.process_args' \
+  > | head -1 > trace_args.json
+
+Verify we captured a trace entry:
+
+  $ test -s trace_args.json
+
+Build compile_commands.json:
+
+  $ dune build compile_commands.json
+
+Extract from compile_commands.json (first entry):
+
+  $ jq '.[0].arguments[1:]' compile_commands.json > cc_args.json
+
+Verify we got args:
+
+  $ test -s cc_args.json
+
+Compare the arguments (they should match):
+
+  $ diff <(jq -S '.' trace_args.json) <(jq -S '.' cc_args.json)


### PR DESCRIPTION
We generate `compile_commonds.json` and promote it to the workspace root when dune lang is 3.23. This is a compilation database containing the flags and compiler invocations for foreign stubs and archives, used by C/C++ editor support.

- fixes https://github.com/ocaml/dune/issues/3531
- [x] changes