### PR TITLE
[Coq] disable deprecated_coq_lang before lang 3.21

### DIFF
--- a/doc/changes/fixed/14187.md
+++ b/doc/changes/fixed/14187.md
@@ -1,0 +1,3 @@
+- Remove the warning about the deprecation of the coq stanza for
+  dune lang before 3.21 since it has been introduced in this
+  version (#14187, @bobot)

--- a/src/dune_rules/coq/coq_stanza.ml
+++ b/src/dune_rules/coq/coq_stanza.ml
@@ -31,7 +31,7 @@ let _deprecated_coq_lang_lt_08 =
 
 let deprecated_coq_lang =
   Warning.make
-    ~default:(fun _version -> `Enabled)
+    ~default:(fun version -> if version >= (3, 21) then `Enabled else `Disabled)
     ~name:"deprecated_coq_lang"
     ~since:(3, 21)
 ;;


### PR DESCRIPTION
Since it is not available before 3.21, if someone wants to support dune 3.17 (current version in debian stable) it will get the warning when compiling with a dune >= 3.21 without any way of removing it.