### PR TITLE
refactor: allow dumping merlin with json

### DIFF
--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -22,8 +22,24 @@ module Selected_context = struct
   ;;
 end
 
+module Merlin = Dune_rules.Merlin
+
+module Output_format = struct
+  type t =
+    [ `Text
+    | `Json
+    ]
+
+  let all = [ "text", `Text; "json", `Json ]
+end
+
 module Server : sig
-  val dump : selected_context:Context_name.t -> string -> unit Fiber.t
+  val dump
+    :  selected_context:Context_name.t
+    -> format:Output_format.t
+    -> string
+    -> unit Fiber.t
+
   val dump_dot_merlin : selected_context:Context_name.t -> string -> unit Fiber.t
 
   (** Once started the server will wait for commands on stdin, read the
@@ -175,11 +191,11 @@ end = struct
     >>| Merlin_conf.to_stdout
   ;;
 
-  let dump ~selected_context s =
+  let dump ~selected_context ~format s =
     to_local ~selected_context s
     >>| function
     | Error mess -> Printf.eprintf "%s\n%!" mess
-    | Ok path -> get_merlin_files_paths path |> List.iter ~f:Merlin.Processed.print_file
+    | Ok path -> get_merlin_files_paths path |> Merlin.Processed.print_files format
   ;;
 
   let dump_dot_merlin ~selected_context s =
@@ -221,6 +237,11 @@ module Dump_config = struct
     let+ builder = Common.Builder.term
     (* CR-someday Alizter: document this option *)
     and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH" ~doc:None)
+    and+ format =
+      Arg.(
+        value
+        & opt (enum Output_format.all) `Text
+        & info [ "format" ] ~docv:"FORMAT" ~doc:(Some "Output format (text or json)."))
     and+ selected_context = Selected_context.arg in
     let _common, config =
       let builder =
@@ -230,7 +251,8 @@ module Dump_config = struct
       Common.init builder
     in
     (* CR-soon rgrinberg: remove pointless args *)
-    Scheduler_setup.no_build_no_rpc ~config (fun () -> Server.dump ~selected_context dir)
+    Scheduler_setup.no_build_no_rpc ~config (fun () ->
+      Server.dump ~selected_context ~format dir)
   ;;
 
   let command = Cmd.v info term

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -114,6 +114,34 @@ module Processed = struct
     ; pp_config : pp_flag option Module_name.Per_item.t
     }
 
+  type output_format =
+    [ `Text
+    | `Json
+    ]
+
+  module Dump_entry = struct
+    type t =
+      { module_name : Module_name.t
+      ; source_path : Path.Build.t
+      ; config : Sexp.t
+      }
+
+    let rec sexp_to_json = function
+      | Sexp.Atom atom -> Json.string atom
+      | Sexp.List items -> Json.list (List.map items ~f:sexp_to_json)
+    ;;
+
+    let to_json { module_name; source_path; config } =
+      let context, source_path = Path.Build.extract_build_context_exn source_path in
+      Json.assoc
+        [ "module_name", Json.string (Module_name.to_string module_name)
+        ; ( "source_path"
+          , Json.string (Filename.concat context (Path.Source.to_string source_path)) )
+        ; "config", sexp_to_json config
+        ]
+    ;;
+  end
+
   let to_dyn { config; per_file_config; pp_config } =
     let open Dyn in
     record
@@ -350,29 +378,52 @@ module Processed = struct
     to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
 
+  let dump_entries { per_file_config; pp_config; config } : Dump_entry.t list =
+    Path.Build.Map.to_list per_file_config
+    |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
+      let module_name = Module.name module_ in
+      let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
+      let pp = Module_name.Per_item.get pp_config module_name in
+      let config = to_sexp ~unit_name ~reader ~opens ~pp config in
+      Dump_entry.{ module_name; source_path; config })
+  ;;
+
+  let print_entry (Dump_entry.{ module_name; source_path; config } : Dump_entry.t) =
+    let open Pp.O in
+    let pp =
+      Pp.hvbox
+        (Pp.textf
+           "%s: %s"
+           (Module_name.to_string module_name)
+           (Path.Build.to_string source_path))
+      ++ Pp.newline
+      ++ Pp.vbox (Sexp.pp config)
+    in
+    Format.printf "%a%a@." Format.pp_set_margin 1000 Pp.to_fmt pp
+  ;;
+
   let print_file path =
     match load_file path with
     | Error msg -> Printf.eprintf "%s\n" msg
-    | Ok { per_file_config; pp_config; config } ->
-      let pp_one (source, { module_; opens; reader }) =
-        let open Pp.O in
-        let name = Module.name module_ in
-        let sexp =
-          let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
-          let pp = Module_name.Per_item.get pp_config name in
-          to_sexp ~unit_name ~reader ~opens ~pp config
-        in
-        Pp.hvbox
-          (Pp.textf "%s: %s" (Module_name.to_string name) (Path.Build.to_string source))
-        ++ Pp.newline
-        ++ Pp.vbox (Sexp.pp sexp)
-      in
-      let pp =
-        Path.Build.Map.to_list per_file_config
-        |> Pp.concat_map ~sep:Pp.cut ~f:pp_one
-        |> Pp.vbox
-      in
-      Format.printf "%a%a@." Format.pp_set_margin 1000 Pp.to_fmt pp
+    | Ok t -> dump_entries t |> List.iter ~f:print_entry
+  ;;
+
+  let print_files format paths =
+    match format with
+    | `Text -> List.iter paths ~f:print_file
+    | `Json ->
+      (match
+         Result.List.map paths ~f:(fun path ->
+           match load_file path with
+           | Error msg -> Error msg
+           | Ok t -> Ok (dump_entries t))
+       with
+       | Error msg -> Printf.eprintf "%s\n" msg
+       | Ok entries ->
+         let entries = List.concat entries in
+         Json.list (List.map entries ~f:Dump_entry.to_json)
+         |> Json.to_string
+         |> print_endline)
   ;;
 
   let print_generic_dot_merlin paths =

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -15,6 +15,11 @@ module Processed : sig
   (** Type of "processed" merlin information *)
   type t
 
+  type output_format =
+    [ `Text
+    | `Json
+    ]
+
   val to_dyn : t -> Dyn.t
 
   module Pp_kind : sig
@@ -32,6 +37,8 @@ module Processed : sig
   (** [print_file path] reads the configuration at path [path] and print it as a
       s-expression *)
   val print_file : Path.t -> unit
+
+  val print_files : output_format -> Path.t list -> unit
 
   (** [print_generic_dot_merlin paths] will merge the given configurations and
       print the resulting configuration in dot-merlin syntax. *)

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -72,6 +72,41 @@ def coqdocFlags:
   | .[]
   | rocqArg;
 
+def merlinEntry($module_name):
+  .[] | select(.module_name == $module_name);
+
+def merlinBuildPath:
+  "_build/\(.source_path)";
+
+def merlinPathSummary:
+  { module_name, source_path: merlinBuildPath };
+
+def merlinPathLine:
+  "\(.module_name): \(merlinBuildPath)";
+
+def merlinConfigItems:
+  .config[];
+
+def merlinConfigItemsNamed($names):
+  .config[] | select(.[0] as $name | $names | index($name));
+
+def merlinJsonEntry:
+  merlinPathLine,
+  (merlinConfigItems | @json);
+
+def merlinJsonEntryWithConfigNames($names):
+  merlinPathLine,
+  (merlinConfigItemsNamed($names) | @json);
+
+def merlinUnitName:
+  first(.config[] | select(.[0] == "UNIT_NAME") | .[1]);
+
+def merlinUnitNameSummary:
+  merlinPathSummary + { unit_name: merlinUnitName };
+
+def merlinConfigSummary($names):
+  merlinPathSummary + { config: [merlinConfigItemsNamed($names)] };
+
 def redactedActionTraces:
   [ .[]
   | select(.cat != "config" and .args.digest != null)

--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -17,13 +17,14 @@ Show that the merlin config knows about melange.compile_flags
   $ touch bar.ml $lib.ml
   $ dune build @check
 
-  $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  > include "dune";
+  > merlinEntry("Foo")
+  > | merlinConfigItemsNamed(["FLG"])
+  > | select(.[0] == "FLG" and (.[1] | index("+42")))
+  > | @json'
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-w","+42"]]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-w","+42"]]
 
   $ cat >dune <<EOF
   > (melange.emit
@@ -34,11 +35,11 @@ Show that the merlin config knows about melange.compile_flags
 
   $ dune build @check
 
-  $ dune ocaml merlin dump-config "$PWD" | grep -i "+42"
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -w +42))
-
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  > include "dune";
+  > merlinEntry("Melange")
+  > | merlinConfigItemsNamed(["FLG"])
+  > | select(.[0] == "FLG" and (.[1] | index("+42")))
+  > | @json'
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-w","+42"]]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-w","+42"]]

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -22,33 +22,173 @@
 
   $ touch bar.ml $lib.ml
   $ dune build @check
-  $ dune ocaml merlin dump-config "$PWD" | grep -i "$lib"
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (FLG (-open Foo__))
-   (UNIT_NAME foo__Bar))
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (FLG (-open Foo__))
-   (UNIT_NAME foo__Bar))
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (FLG (-open Foo__))
-   (UNIT_NAME foo))
-  Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (FLG (-open Foo__))
-   (UNIT_NAME foo))
-  Foo__: _build/default/foo__
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (UNIT_NAME foo__))
-  Foo__: _build/default/foo__.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/melange)
-   (UNIT_NAME foo__))
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq '
+  > include "dune";
+  > [
+  >   .[]
+  >   | merlinConfigSummary(["FLG", "UNIT_NAME"])
+  > ]
+  > | .[]'
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/bar",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/bar.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo__",
+    "source_path": "_build/default/foo__",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo__",
+    "source_path": "_build/default/foo__.ml-gen",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__"
+      ]
+    ]
+  }
 
 Paths to Melange stdlib appear in B and S entries without melange.emit stanza
 
@@ -73,11 +213,33 @@ Paths to Melange stdlib appear in B and S entries without melange.emit stanza
 
   $ touch main.ml
   $ dune build @check
-  $ dune ocaml merlin dump-config $PWD | grep -i "$target"
-  ((INDEX $TESTCASE_ROOT/_build/default/.output.mobjs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
-  ((INDEX $TESTCASE_ROOT/_build/default/.output.mobjs/cctx.ocaml-index)
-   (B $TESTCASE_ROOT/_build/default/.output.mobjs/melange)
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  > include "dune";
+  > [
+  >   .[]
+  >   | merlinConfigSummary(["UNIT_NAME"])
+  > ]
+  > | .[]'
+  {
+    "module_name": "Main",
+    "source_path": "_build/default/main",
+    "config": [
+      [
+        "UNIT_NAME",
+        "melange__Main"
+      ]
+    ]
+  }
+  {
+    "module_name": "Main",
+    "source_path": "_build/default/main.ml",
+    "config": [
+      [
+        "UNIT_NAME",
+        "melange__Main"
+      ]
+    ]
+  }
 
 Dump-dot-merlin includes the melange flags
 
@@ -129,58 +291,208 @@ Check for flag directives ordering when another preprocessor is defined
 
 User ppx flags should appear in merlin config
 
-  $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S " | censor_ppx
-  Bar: _build/default/bar
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Bar))
-  Bar: _build/default/bar.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Bar))
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (UNIT_NAME foo))
-  Foo: _build/default/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /MELC_STDLIB/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (UNIT_NAME foo))
-  Fooppx: _build/default/fooppx
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME fooppx))
-  Fooppx: _build/default/fooppx.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.fooppx.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME fooppx))
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  > include "dune";
+  > [
+  >   .[]
+  >   | merlinConfigSummary(["STDLIB", "FLG", "UNIT_NAME"])
+  > ]
+  > | .[]' | censor_ppx
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/bar",
+    "config": [
+      [
+        "STDLIB",
+        "/MELC_STDLIB/melange"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/bar.ml",
+    "config": [
+      [
+        "STDLIB",
+        "/MELC_STDLIB/melange"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "config": [
+      [
+        "STDLIB",
+        "/MELC_STDLIB/melange"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml-gen",
+    "config": [
+      [
+        "STDLIB",
+        "/MELC_STDLIB/melange"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Fooppx",
+    "source_path": "_build/default/fooppx",
+    "config": [
+      [
+        "STDLIB",
+        "/OCAMLC_WHERE"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "fooppx"
+      ]
+    ]
+  }
+  {
+    "module_name": "Fooppx",
+    "source_path": "_build/default/fooppx.ml",
+    "config": [
+      [
+        "STDLIB",
+        "/OCAMLC_WHERE"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "fooppx"
+      ]
+    ]
+  }

--- a/test/blackbox-tests/test-cases/merlin/copy-files-preprocess-flags-github2206.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/copy-files-preprocess-flags-github2206.t/run.t
@@ -1,17 +1,10 @@
 copy_files would break the generation of the preprocessing flags
   $ dune build copy_files/.merlin-conf/exe-foo
-  $ dune ocaml merlin dump-config $PWD/copy_files |
-  > grep -B 2 -A 0 "pp"
-  Foo: _build/default/copy_files/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
-  --
-   (S $TESTCASE_ROOT/copy_files/sources)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp.exe))
-   (UNIT_NAME foo))
-  Foo: _build/default/copy_files/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.pp.eobjs/cctx.ocaml-index)
-  --
-   (S $TESTCASE_ROOT/copy_files/sources)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp.exe))
+  $ dune ocaml merlin dump-config --format=json $PWD/copy_files | jq -r '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinConfigItemsNamed(["FLG"])
+  >   | select(.[0] == "FLG" and (.[1] | index("-pp")))
+  >   | @json'
+  ["FLG",["-pp","$TESTCASE_ROOT/_build/default/pp.exe"]]
+  ["FLG",["-pp","$TESTCASE_ROOT/_build/default/pp.exe"]]

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -21,11 +21,16 @@ If Merlin field is absent, default context is chosen
   ..
   lib-foo
 
-  $ dune ocaml merlin dump-config "$PWD"
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinJsonEntryWithConfigNames(["STDLIB", "UNIT_NAME"])'
   Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]
   Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]
 
 If Merlin field is present, this context is chosen
 
@@ -48,11 +53,16 @@ If Merlin field is present, this context is chosen
   $ [ ! -d _build/default/.merlin-conf ] && echo "No config in default"
   No config in default
 
-  $ dune ocaml merlin dump-config "$PWD"
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinJsonEntryWithConfigNames(["STDLIB", "UNIT_NAME"])'
   Foo: _build/cross/foo
-  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]
   Foo: _build/cross/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]
 
 If `generate_merlin_rules` field is present, rules are generated even if merlin
 is disabled in that context
@@ -78,8 +88,13 @@ is disabled in that context
   ..
   lib-foo
 
-  $ dune ocaml merlin dump-config "$PWD"
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinJsonEntryWithConfigNames(["STDLIB", "UNIT_NAME"])'
   Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]
   Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB OPAM_PREFIX) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","OPAM_PREFIX"]
+  ["UNIT_NAME","foo"]

--- a/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/dialect.t/run.t
@@ -6,114 +6,44 @@
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
 
 CRAM sanitization
-  $ dune build ./exe/.merlin-conf/exe-x --profile release
-  $ dune ocaml merlin dump-config $PWD/exe
+  $ dune build exe/.merlin-conf/exe-x --profile release
+  $ dune ocaml merlin dump-config --format=json exe | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | select(.module_name == "X" and (.source_path | startswith("default/exe/")))
+  >   | merlinJsonEntryWithConfigNames(["SUFFIX", "READER"])'
   X: _build/default/exe/x
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exe)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__X)
-   (SUFFIX ".mlx .mlx"))
+  ["SUFFIX",".mlx .mlx"]
   X: _build/default/exe/x.mlx
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exe)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__X)
-   (SUFFIX ".mlx .mlx")
-   (READER (mlx)))
+  ["SUFFIX",".mlx .mlx"]
+  ["READER",["mlx"]]
   X: _build/default/exe/x.mlx.mli
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exe)
-   (FLG (-w -40 -g))
-   (UNIT_NAME dune__exe__X)
-   (SUFFIX ".mlx .mlx"))
+  ["SUFFIX",".mlx .mlx"]
 
 CRAM sanitization
-  $ dune build ./lib/.merlin-conf/lib-x --profile release
-  $ dune ocaml merlin dump-config $PWD/lib
+  $ dune build lib/.merlin-conf/lib-x --profile release
+  $ dune ocaml merlin dump-config --format=json lib | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | select(.module_name == "X" and (.source_path | startswith("default/lib/")))
+  >   | merlinJsonEntryWithConfigNames(["SUFFIX", "READER"])'
   X: _build/default/lib/x
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (FLG (-w -40 -g))
-   (UNIT_NAME x)
-   (SUFFIX ".mlx .mlx")
-   (READER (mlx)))
+  ["SUFFIX",".mlx .mlx"]
+  ["READER",["mlx"]]
   X: _build/default/lib/x.mlx
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.x.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (FLG (-w -40 -g))
-   (UNIT_NAME x)
-   (SUFFIX ".mlx .mlx")
-   (READER (mlx)))
+  ["SUFFIX",".mlx .mlx"]
+  ["READER",["mlx"]]
 
 CRAM sanitization
-  $ dune build ./melange/.merlin-conf/lib-x_mel --profile release
-  $ dune ocaml merlin dump-config $PWD/melange
+  $ dune build melange/.merlin-conf/lib-x_mel --profile release
+  $ dune ocaml merlin dump-config --format=json melange | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | select(.module_name == "X_mel" and (.source_path | startswith("default/melange/")))
+  >   | merlinJsonEntryWithConfigNames(["SUFFIX", "READER"])'
   X_mel: _build/default/melange/x_mel
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB lib/melange/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B lib/melange/js/melange)
-   (B lib/melange/melange)
-   (B $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
-   (S lib/melange)
-   (S lib/melange/__private__/melange_mini_stdlib)
-   (S lib/melange/js)
-   (S $TESTCASE_ROOT/melange)
-   (FLG (-w -40 -g))
-   (UNIT_NAME x_mel)
-   (SUFFIX ".mlx .mlx")
-   (READER (mlx)))
+  ["SUFFIX",".mlx .mlx"]
+  ["READER",["mlx"]]
   X_mel: _build/default/melange/x_mel.mlx
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.x.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/cctx.ocaml-index)
-   (STDLIB lib/melange/melange)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B lib/melange/__private__/melange_mini_stdlib/melange/.public_cmi_melange)
-   (B lib/melange/js/melange)
-   (B lib/melange/melange)
-   (B $TESTCASE_ROOT/_build/default/melange/.x_mel.objs/melange)
-   (S lib/melange)
-   (S lib/melange/__private__/melange_mini_stdlib)
-   (S lib/melange/js)
-   (S $TESTCASE_ROOT/melange)
-   (FLG (-w -40 -g))
-   (UNIT_NAME x_mel)
-   (SUFFIX ".mlx .mlx")
-   (READER (mlx)))
+  ["SUFFIX",".mlx .mlx"]
+  ["READER",["mlx"]]

--- a/test/blackbox-tests/test-cases/merlin/future-syntax.t
+++ b/test/blackbox-tests/test-cases/merlin/future-syntax.t
@@ -16,10 +16,37 @@ Generates Merlin config for executables using `future_syntax` preprocessing.
   $ touch pp_future_syntax.ml
 
   $ dune build ./.merlin-conf/exe-pp_future_syntax --profile release
-  $ dune ocaml merlin dump-config .
-  Pp_future_syntax: _build/default/pp_future_syntax
-  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))
-  Pp_future_syntax: _build/default/pp_future_syntax.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))
-  Pp_future_syntax: _build/default/pp_future_syntax.mli
-  ((INDEX $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME dune__exe__Pp_future_syntax))
+  $ dune ocaml merlin dump-config --format=json . | \
+  >   jq -r '
+  >     include "dune";
+  >     merlinEntry("Pp_future_syntax")
+  >     | (merlinPathLine | @json),
+  >       (merlinConfigItems | @json)
+  >   '
+  "Pp_future_syntax: _build/default/pp_future_syntax"
+  ["INDEX","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","dune__exe__Pp_future_syntax"]
+  "Pp_future_syntax: _build/default/pp_future_syntax.ml"
+  ["INDEX","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","dune__exe__Pp_future_syntax"]
+  "Pp_future_syntax: _build/default/pp_future_syntax.mli"
+  ["INDEX","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.pp_future_syntax.eobjs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","dune__exe__Pp_future_syntax"]

--- a/test/blackbox-tests/test-cases/merlin/ignore-user-merlin-file-github759.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/ignore-user-merlin-file-github759.t/run.t
@@ -4,24 +4,51 @@ Ignores user `.merlin` files when generating Merlin configuration.
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build foo.cma --profile release
-  $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
-  Foo: _build/default/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinUnitNameSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "unit_name": "foo"
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml-gen",
+    "unit_name": "foo"
+  }
 
   $ rm -f .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
-  Foo: _build/default/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinUnitNameSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "unit_name": "foo"
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml-gen",
+    "unit_name": "foo"
+  }
 
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
-  Foo: _build/default/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/default/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w -40 -g)) (UNIT_NAME foo))
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinUnitNameSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "unit_name": "foo"
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml-gen",
+    "unit_name": "foo"
+  }

--- a/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
+++ b/test/blackbox-tests/test-cases/merlin/include-subdirs-qualified.t
@@ -20,167 +20,393 @@ Generates Merlin config for `(include_subdirs qualified)` libraries.
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build .merlin-conf/lib-foo
-  $ dune ocaml merlin dump-config .
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
-  Foo: _build/default/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
-  Foo__Groupintf__: _build/default/foo__Groupintf__
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo__Groupintf__))
-  Foo__Groupintf__: _build/default/foo__Groupintf__.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo__Groupintf__))
-  Utils: _build/default/foo__Utils
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo__Utils))
-  Utils: _build/default/foo__Utils.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo__Utils))
-  Calc: _build/default/groupintf/calc
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Groupintf__))
-   (UNIT_NAME foo__Groupintf__Calc))
-  Calc: _build/default/groupintf/calc.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Groupintf__))
-   (UNIT_NAME foo__Groupintf__Calc))
-  Groupintf: _build/default/groupintf/groupintf
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Groupintf__))
-   (UNIT_NAME foo__Groupintf))
-  Groupintf: _build/default/groupintf/groupintf.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Groupintf__))
-   (UNIT_NAME foo__Groupintf))
-  Main: _build/default/main
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Main))
-  Main: _build/default/main.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Main))
-  Calc: _build/default/utils/calc
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Utils))
-   (UNIT_NAME foo__Utils__Calc))
-  Calc: _build/default/utils/calc.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/groupintf)
-   (S $TESTCASE_ROOT/utils)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo -open Foo__Utils))
-   (UNIT_NAME foo__Utils__Calc))
-  $ dune ocaml merlin dump-config utils
+  $ dune ocaml merlin dump-config --format=json . | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | merlinConfigSummary(["FLG", "UNIT_NAME"])
+  >   ]
+  >   | .[]'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml-gen",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo__Groupintf__",
+    "source_path": "_build/default/foo__Groupintf__",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf__"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo__Groupintf__",
+    "source_path": "_build/default/foo__Groupintf__.ml-gen",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf__"
+      ]
+    ]
+  }
+  {
+    "module_name": "Utils",
+    "source_path": "_build/default/foo__Utils",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Utils"
+      ]
+    ]
+  }
+  {
+    "module_name": "Utils",
+    "source_path": "_build/default/foo__Utils.ml-gen",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Utils"
+      ]
+    ]
+  }
+  {
+    "module_name": "Calc",
+    "source_path": "_build/default/groupintf/calc",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Groupintf__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf__Calc"
+      ]
+    ]
+  }
+  {
+    "module_name": "Calc",
+    "source_path": "_build/default/groupintf/calc.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Groupintf__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf__Calc"
+      ]
+    ]
+  }
+  {
+    "module_name": "Groupintf",
+    "source_path": "_build/default/groupintf/groupintf",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Groupintf__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf"
+      ]
+    ]
+  }
+  {
+    "module_name": "Groupintf",
+    "source_path": "_build/default/groupintf/groupintf.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Groupintf__"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Groupintf"
+      ]
+    ]
+  }
+  {
+    "module_name": "Main",
+    "source_path": "_build/default/main",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Main"
+      ]
+    ]
+  }
+  {
+    "module_name": "Main",
+    "source_path": "_build/default/main.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Main"
+      ]
+    ]
+  }
+  {
+    "module_name": "Calc",
+    "source_path": "_build/default/utils/calc",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Utils"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Utils__Calc"
+      ]
+    ]
+  }
+  {
+    "module_name": "Calc",
+    "source_path": "_build/default/utils/calc.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo",
+          "-open",
+          "Foo__Utils"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Utils__Calc"
+      ]
+    ]
+  }
+  $ dune ocaml merlin dump-config --format=json utils | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | merlinConfigSummary(["FLG", "UNIT_NAME"])
+  >   ]
+  >   | .[]'

--- a/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/instrumentation.t/run.t
@@ -7,136 +7,33 @@ Here we test that instrumentation processing is not passed to merlin by setting
 up a project with instrumentation and testing checking the merlin config.
 
   $ dune build --instrument-with hello ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
-  $ dune ocaml merlin dump-config $PWD/lib
+  $ dune ocaml merlin dump-config --format=json $PWD/lib \
+  >   | jq -r '
+  >     include "dune";
+  >     .[]
+  >     | select(
+  >         .module_name == "Bar"
+  >         or .module_name == "Foo"
+  >         or .module_name == "Privmod"
+  >       )
+  >     | merlinJsonEntryWithConfigNames(["FLG", "UNIT_NAME"])'
   Bar: _build/default/lib/bar
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (UNIT_NAME bar))
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","bar"]
   Bar: _build/default/lib/bar.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (UNIT_NAME bar))
-  File: _build/default/lib/subdir/file
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (FLG (-open Bar))
-   (UNIT_NAME bar__File))
-  File: _build/default/lib/subdir/file.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (FLG (-open Bar))
-   (UNIT_NAME bar__File))
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","bar"]
   Foo: _build/default/lib/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","foo"]
   Foo: _build/default/lib/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (UNIT_NAME foo))
+  ["FLG",["-w","-40","-g"]]
+  ["UNIT_NAME","foo"]
   Privmod: _build/default/lib/privmod
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Privmod))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-open","Foo"]]
+  ["UNIT_NAME","foo__Privmod"]
   Privmod: _build/default/lib/privmod.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.hello_ppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/ppx/.hello.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (S $TESTCASE_ROOT/ppx)
-   (FLG (-w -40 -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Privmod))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-open","Foo"]]
+  ["UNIT_NAME","foo__Privmod"]

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -6,56 +6,62 @@ We build the project
   bar
 
 Verify that merlin configuration was generated...
-  $ dune ocaml merlin dump-config $PWD
+  $ dune ocaml merlin dump-config --format=json $PWD | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | merlinJsonEntry'
   Test: _build/default/test
-  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/411)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME dune__exe__Test))
+  ["INDEX","$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index"]
+  ["INDEX","$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.foo.objs/byte"]
+  ["B","$TESTCASE_ROOT/_build/default/.test.eobjs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["S","$TESTCASE_ROOT/411"]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","dune__exe__Test"]
   Test: _build/default/test.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/411)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME dune__exe__Test))
+  ["INDEX","$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index"]
+  ["INDEX","$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.foo.objs/byte"]
+  ["B","$TESTCASE_ROOT/_build/default/.test.eobjs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["S","$TESTCASE_ROOT/411"]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","dune__exe__Test"]
   Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/411)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
+  ["INDEX","$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index"]
+  ["INDEX","$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.foo.objs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["S","$TESTCASE_ROOT/411"]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","foo"]
   Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/411)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
+  ["INDEX","$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index"]
+  ["INDEX","$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index"]
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["SOURCE_ROOT","$TESTCASE_ROOT"]
+  ["EXCLUDE_QUERY_DIR"]
+  ["B","$TESTCASE_ROOT/_build/default/.foo.objs/byte"]
+  ["S","$TESTCASE_ROOT"]
+  ["S","$TESTCASE_ROOT/411"]
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","foo"]
 
 ...but not in the sub-folder whose content was copied
-  $ dune ocaml merlin dump-config $PWD/411
+  $ dune ocaml merlin dump-config --format=json $PWD/411 | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | merlinJsonEntry'
 
 Now we check that both querying from the root and the subfolder works
   $ FILE=$PWD/foo.ml

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -12,299 +12,769 @@ We're going create a fake findlib library for use:
 
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
-  $ dune ocaml merlin dump-config $PWD/exe | censor_ppx
-  X: _build/default/exe/x
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/exe)
-   (S $TESTCASE_ROOT/lib)
-   (FLG (-w -40 -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (UNIT_NAME x))
-  X: _build/default/exe/x.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/exe)
-   (S $TESTCASE_ROOT/lib)
-   (FLG (-w -40 -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (UNIT_NAME x))
+  $ dune ocaml merlin dump-config --format=json $PWD/exe | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | select(.module_name == "X")
+  >     | merlinConfigSummary(["B", "S", "FLG", "UNIT_NAME"])
+  >   ]
+  >   | sort_by(.source_path)
+  >   | .[]' | censor_ppx
+  {
+    "module_name": "X",
+    "source_path": "_build/default/exe/x",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exe"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-pp",
+          "$TESTCASE_ROOT/_build/default/pp/pp.exe"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "x"
+      ]
+    ]
+  }
+  {
+    "module_name": "X",
+    "source_path": "_build/default/exe/x.ml",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exe"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-pp",
+          "$TESTCASE_ROOT/_build/default/pp/pp.exe"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "x"
+      ]
+    ]
+  }
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
-  $ dune ocaml merlin dump-config $PWD/lib | censor_ppx
-  Bar: _build/default/lib/bar
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
-   (UNIT_NAME bar))
-  Bar: _build/default/lib/bar.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
-   (UNIT_NAME bar))
-  File: _build/default/lib/subdir/file
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
-   (FLG (-open Bar))
-   (UNIT_NAME bar__File))
-  File: _build/default/lib/subdir/file.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="bar"'"))
-   (FLG (-open Bar))
-   (UNIT_NAME bar__File))
-  Foo: _build/default/lib/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (UNIT_NAME foo))
-  Foo: _build/default/lib/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (UNIT_NAME foo))
-  Privmod: _build/default/lib/privmod
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Privmod))
-  Privmod: _build/default/lib/privmod.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_findlib/publicfoo)
-   (B $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S $TESTCASE_ROOT/_findlib/publicfoo)
-   (S $TESTCASE_ROOT/lib)
-   (S $TESTCASE_ROOT/lib/subdir)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="foo"'"))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Privmod))
+  $ dune ocaml merlin dump-config --format=json $PWD/lib | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | select(.module_name == "Bar" or .module_name == "File" or .module_name == "Foo" or .module_name == "Privmod")
+  >     | merlinConfigSummary(["B", "S", "FLG", "UNIT_NAME"])
+  >   ]
+  >   | sort_by(.module_name, .source_path)
+  >   | .[]' | censor_ppx
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/lib/bar",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/lib/bar.ml-gen",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "File",
+    "source_path": "_build/default/lib/subdir/file",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Bar"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "bar__File"
+      ]
+    ]
+  }
+  {
+    "module_name": "File",
+    "source_path": "_build/default/lib/subdir/file.ml",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Bar"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "bar__File"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/lib/foo",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/lib/foo.ml-gen",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Privmod",
+    "source_path": "_build/default/lib/privmod",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Privmod"
+      ]
+    ]
+  }
+  {
+    "module_name": "Privmod",
+    "source_path": "_build/default/lib/privmod.ml",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/_findlib/publicfoo"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/lib/subdir"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Privmod"
+      ]
+    ]
+  }
 
 Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
-  $ dune ocaml merlin dump-config $PWD/lib | grep ppx > /dev/null
+  $ dune ocaml merlin dump-config --format=json $PWD/lib | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | select(.module_name == "Bar" or .module_name == "Foo" or .module_name == "Privmod")
+  >     | {
+  >         module_name,
+  >         source_path: merlinBuildPath,
+  >         ppx_flags: [
+  >           .config[]
+  >           | select(.[0] == "FLG" and (.[1] | type == "array" and index("-ppx")))
+  >         ]
+  >       }
+  >     | select(.ppx_flags != [])
+  >   ]
+  >   | sort_by(.module_name, .source_path)
+  >   | .[]' | censor_ppx
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/lib/bar",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ]
+    ]
+  }
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/lib/bar.ml-gen",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+        ]
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/lib/foo",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/lib/foo.ml-gen",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ]
+    ]
+  }
+  {
+    "module_name": "Privmod",
+    "source_path": "_build/default/lib/privmod",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ]
+    ]
+  }
+  {
+    "module_name": "Privmod",
+    "source_path": "_build/default/lib/privmod.ml",
+    "ppx_flags": [
+      [
+        "FLG",
+        [
+          "-ppx",
+          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+        ]
+      ]
+    ]
+  }
 
 Make sure pp flag is correct and variables are expanded
 
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
-  $ dune ocaml merlin dump-config $PWD/pp-with-expand
-  Foobar: _build/default/pp-with-expand/foobar
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
-   (S $TESTCASE_ROOT/pp-with-expand)
-   (FLG (-w -40 -g))
-   (FLG (-pp "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"))
-   (UNIT_NAME foobar))
-  Foobar: _build/default/pp-with-expand/foobar.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
-   (S $TESTCASE_ROOT/pp-with-expand)
-   (FLG (-w -40 -g))
-   (FLG (-pp "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"))
-   (UNIT_NAME foobar))
+  $ dune ocaml merlin dump-config --format=json $PWD/pp-with-expand | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | select(.module_name == "Foobar")
+  >     | merlinConfigSummary(["FLG", "UNIT_NAME"])
+  >   ]
+  >   | sort_by(.source_path)
+  >   | .[]'
+  {
+    "module_name": "Foobar",
+    "source_path": "_build/default/pp-with-expand/foobar",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-pp",
+          "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foobar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foobar",
+    "source_path": "_build/default/pp-with-expand/foobar.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "-40",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-pp",
+          "$TESTCASE_ROOT/_build/default/pp/pp.exe -nothing"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foobar"
+      ]
+    ]
+  }
 
 Check hash of executables names if more than one
   $ dune build @exes/check
-  $ dune ocaml merlin dump-config $PWD/exes
-  X: _build/default/exes/x
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exes)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME x))
-  X: _build/default/exes/x.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exes)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME x))
-  Y: _build/default/exes/y
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exes)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME y))
-  Y: _build/default/exes/y.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/exe/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/exes/.x.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.bar.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx/.fooppx.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
-   (S $TESTCASE_ROOT/exes)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME y))
+  $ dune ocaml merlin dump-config --format=json $PWD/exes | jq '
+  >   include "dune";
+  >   [
+  >     .[]
+  >     | select(.module_name == "X" or .module_name == "Y")
+  >     | merlinConfigSummary(["B", "S", "FLG", "UNIT_NAME"])
+  >   ]
+  >   | sort_by(.module_name, .source_path)
+  >   | .[]'
+  {
+    "module_name": "X",
+    "source_path": "_build/default/exes/x",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exes"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "x"
+      ]
+    ]
+  }
+  {
+    "module_name": "X",
+    "source_path": "_build/default/exes/x.ml",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exes"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "x"
+      ]
+    ]
+  }
+  {
+    "module_name": "Y",
+    "source_path": "_build/default/exes/y",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exes"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "y"
+      ]
+    ]
+  }
+  {
+    "module_name": "Y",
+    "source_path": "_build/default/exes/y.ml",
+    "config": [
+      [
+        "B",
+        "$TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/exes"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "y"
+      ]
+    ]
+  }

--- a/test/blackbox-tests/test-cases/merlin/multiple-ppx-stanzas-github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/multiple-ppx-stanzas-github1946.t/run.t
@@ -5,56 +5,25 @@ in the same dune file, but require different ppx specifications
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build @all --profile release
-  $ dune ocaml merlin dump-config $PWD | censor_ppx
+  $ dune ocaml merlin dump-config --format=json $PWD | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | select(.module_name | test("^Usesppx"))
+  >   | merlinJsonEntryWithConfigNames(["FLG", "UNIT_NAME"])
+  > ' | censor_ppx
   Usesppx1: _build/default/usesppx1
-  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
-   (UNIT_NAME usesppx1))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
+  ["UNIT_NAME","usesppx1"]
   Usesppx1: _build/default/usesppx1.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx1"'"))
-   (UNIT_NAME usesppx1))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
+  ["UNIT_NAME","usesppx1"]
   Usesppx2: _build/default/usesppx2
-  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
-   (UNIT_NAME usesppx2))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
+  ["UNIT_NAME","usesppx2"]
   Usesppx2: _build/default/usesppx2.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.usesppx2.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/.usesppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx1/.ppx1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/ppx2/.ppx2.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w -40 -g))
-   (FLG (-ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name="usesppx2"'"))
-   (UNIT_NAME usesppx2))
+  ["FLG",["-w","-40","-g"]]
+  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
+  ["UNIT_NAME","usesppx2"]

--- a/test/blackbox-tests/test-cases/merlin/opam-context-merlin-config-github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/opam-context-merlin-config-github4125.t/run.t
@@ -21,8 +21,14 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   ..
   lib-foo
 
-  $ dune ocaml merlin dump-config "$PWD"
+  $ dune ocaml merlin dump-config --format=json "$PWD" | jq -r '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinJsonEntryWithConfigNames(["STDLIB", "UNIT_NAME"])
+  > '
   Foo: _build/cross/foo
-  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["UNIT_NAME","foo"]
   Foo: _build/cross/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/cross/.foo.objs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/_build/cross/.foo.objs/byte) (S $TESTCASE_ROOT) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME foo))
+  ["STDLIB","/OCAMLC_WHERE"]
+  ["UNIT_NAME","foo"]

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -6,46 +6,23 @@
 We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
-  $ dune ocaml merlin dump-config $PWD
+  $ dune ocaml merlin dump-config --format=json $PWD | jq -r '
+  >   include "dune";
+  >   .[]
+  >   | select(.module_name == "Bar" or .module_name == "Foo")
+  >   | merlinJsonEntryWithConfigNames(["FLG", "UNIT_NAME"])
+  > '
   Bar: _build/default/bar
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME bar))
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","bar"]
   Bar: _build/default/bar.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME bar))
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["UNIT_NAME","bar"]
   Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (UNIT_NAME foo))
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["FLG",["-pp","$TESTCASE_ROOT/_build/default/pp/pp.exe"]]
+  ["UNIT_NAME","foo"]
   Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/pp/.pp.eobjs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-pp $TESTCASE_ROOT/_build/default/pp/pp.exe))
-   (UNIT_NAME foo))
+  ["FLG",["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g"]]
+  ["FLG",["-pp","$TESTCASE_ROOT/_build/default/pp/pp.exe"]]
+  ["UNIT_NAME","foo"]

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -21,30 +21,19 @@ also has more than one src dir.
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build lib2/.merlin-conf/lib-lib2
-  $ dune ocaml merlin dump-config $PWD/lib2
+  $ dune ocaml merlin dump-config --format=json $PWD/lib2 | jq -r '
+  >   include "dune";
+  >   merlinEntry("Lib2")
+  >   | merlinJsonEntryWithConfigNames(["STDLIB", "S", "UNIT_NAME"])'
   Lib2: _build/default/lib2/lib2
-  ((INDEX $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (S $TESTCASE_ROOT/lib1)
-   (S $TESTCASE_ROOT/lib1/sub)
-   (S $TESTCASE_ROOT/lib2)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME lib2))
+  ["STDLIB","/OPAM_PREFIX"]
+  ["S","$TESTCASE_ROOT/lib1"]
+  ["S","$TESTCASE_ROOT/lib1/sub"]
+  ["S","$TESTCASE_ROOT/lib2"]
+  ["UNIT_NAME","lib2"]
   Lib2: _build/default/lib2/lib2.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/cctx.ocaml-index)
-   (STDLIB /OPAM_PREFIX)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
-   (B $TESTCASE_ROOT/_build/default/lib2/.lib2.objs/byte)
-   (S $TESTCASE_ROOT/lib1)
-   (S $TESTCASE_ROOT/lib1/sub)
-   (S $TESTCASE_ROOT/lib2)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME lib2))
+  ["STDLIB","/OPAM_PREFIX"]
+  ["S","$TESTCASE_ROOT/lib1"]
+  ["S","$TESTCASE_ROOT/lib1/sub"]
+  ["S","$TESTCASE_ROOT/lib2"]
+  ["UNIT_NAME","lib2"]

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -2,8 +2,28 @@ Tests Merlin suffix handling.
 
   $ dune build @check
 
-  $ dune ocaml merlin dump-config $PWD | grep -o '(SUFFIX [^)]*)'
-  (SUFFIX ".aml .amli")
-  (SUFFIX ".baml .bamli")
-  (SUFFIX ".aml .amli")
-  (SUFFIX ".baml .bamli")
+  $ dune ocaml merlin dump-config --format=json $PWD | jq -c '
+  > include "dune";
+  > .[] | merlinConfigItemsNamed(["SUFFIX"])
+  > '
+  ["SUFFIX",".aml .amli"]
+  ["SUFFIX",".baml .bamli"]
+  ["SUFFIX",".aml .amli"]
+  ["SUFFIX",".baml .bamli"]
+
+  $ cat >alterexe.amli <<EOF
+  > (* empty *)
+  > EOF
+
+  $ dune build .merlin-conf/exe-alterexe
+
+  $ dune ocaml merlin dump-config --format=json $PWD | jq -r '.[].source_path'
+  default/alterexe
+  default/alterexe.aml
+  default/alterexe.amli
+
+  $ dune ocaml merlin dump-config --format=json $PWD \
+  >   | jq -r '.[].source_path'
+  default/alterexe
+  default/alterexe.aml
+  default/alterexe.amli

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -10,25 +10,77 @@ directory in these tests.
 
 Absolute path with symlinks won't match with Dune's root path in which symlinks
 are resolved:
-  $ dune ocaml merlin dump-config "$PWD/realsrc" --root="."
+  $ dune ocaml merlin dump-config --format=json "$PWD/realsrc" --root="."
   Path $TESTCASE_ROOT/linkroot/realsrc is not in dune workspace ($TESTCASE_ROOT/realroot).
 
 Absolute path with resolved symlinks will match with Dune's root path:
   $ dune ocaml merlin \
-  > dump-config "$(pwd | sed 's/linkroot/realroot/')/realsrc" \
-  > --root="." | head -n 1
-  Foo: _build/default/realsrc/foo
+  > dump-config --format=json "$(pwd | sed 's/linkroot/realroot/')/realsrc" \
+  > --root="." | jq '
+  > include "dune";
+  > .[0] | merlinPathSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/realsrc/foo"
+  }
 
 
 Dune ocaml-merlin also accepts paths relative to the current directory
-  $ dune ocaml merlin dump-config "realsrc" --root="." | head -n 1
-  Foo: _build/default/realsrc/foo
+  $ dune ocaml merlin dump-config --format=json "realsrc" --root="." | jq '
+  > include "dune";
+  > .[0] | merlinPathSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/realsrc/foo"
+  }
 
   $ cd realsrc
 
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
-  $ dune ocaml merlin dump-config "." --root=".." | head -n 2
-  Foo: _build/default/realsrc/foo
-  ((INDEX $TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/cctx.ocaml-index) (STDLIB /OCAMLC_WHERE) (SOURCE_ROOT $TESTCASE_ROOT/realroot) (EXCLUDE_QUERY_DIR) (B $TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/byte) (S $TESTCASE_ROOT/realroot/realsrc) (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g)) (UNIT_NAME dune__exe__Foo))
+  $ dune ocaml merlin dump-config --format=json "." --root=".." | jq '
+  > include "dune";
+  > .[0] | merlinConfigSummary(["INDEX", "STDLIB", "SOURCE_ROOT", "B", "S", "FLG", "UNIT_NAME"])'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/realsrc/foo",
+    "config": [
+      [
+        "INDEX",
+        "$TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/cctx.ocaml-index"
+      ],
+      [
+        "STDLIB",
+        "/OCAMLC_WHERE"
+      ],
+      [
+        "SOURCE_ROOT",
+        "$TESTCASE_ROOT/realroot"
+      ],
+      [
+        "B",
+        "$TESTCASE_ROOT/realroot/_build/default/realsrc/.foo.eobjs/byte"
+      ],
+      [
+        "S",
+        "$TESTCASE_ROOT/realroot/realsrc"
+      ],
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "dune__exe__Foo"
+      ]
+    ]
+  }

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -4,75 +4,133 @@
   $ dune exec ./foo.exe
   42
 
-  $ dune ocaml merlin dump-config $PWD
-  Foo: _build/default/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME dune__exe__Foo))
-  Foo: _build/default/foo.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME dune__exe__Foo))
+  $ dune ocaml merlin dump-config --format=json $PWD | jq '
+  >   include "dune";
+  >   merlinEntry("Foo")
+  >   | merlinUnitNameSummary'
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo",
+    "unit_name": "dune__exe__Foo"
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo.ml",
+    "unit_name": "dune__exe__Foo"
+  }
 
-  $ dune ocaml merlin dump-config $PWD/foo
-  Bar: _build/default/foo/bar
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Bar))
-  Bar: _build/default/foo/bar.ml
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (FLG (-open Foo))
-   (UNIT_NAME foo__Bar))
-  Foo: _build/default/foo/foo
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
-  Foo: _build/default/foo/foo.ml-gen
-  ((INDEX $TESTCASE_ROOT/_build/default/.foo.eobjs/cctx.ocaml-index)
-   (INDEX $TESTCASE_ROOT/_build/default/foo/.foo.objs/cctx.ocaml-index)
-   (STDLIB /OCAMLC_WHERE)
-   (SOURCE_ROOT $TESTCASE_ROOT)
-   (EXCLUDE_QUERY_DIR)
-   (B $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
-   (S $TESTCASE_ROOT/foo)
-   (FLG (-w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g))
-   (UNIT_NAME foo))
+  $ dune ocaml merlin dump-config --format=json $PWD/foo | jq '
+  >   include "dune";
+  >   [
+  >     (merlinEntry("Bar")
+  >      | merlinConfigSummary(["UNIT_NAME", "FLG"])),
+  >     (merlinEntry("Foo")
+  >      | merlinConfigSummary(["UNIT_NAME", "FLG"]))
+  >   ]
+  >   | sort_by(.module_name, .source_path)
+  >   | .[]'
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/foo/bar",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Bar",
+    "source_path": "_build/default/foo/bar.ml",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "FLG",
+        [
+          "-open",
+          "Foo"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo__Bar"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo/foo",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
+  {
+    "module_name": "Foo",
+    "source_path": "_build/default/foo/foo.ml-gen",
+    "config": [
+      [
+        "FLG",
+        [
+          "-w",
+          "@1..3@5..28@30..39@43@46..47@49..57@61..62-40",
+          "-strict-sequence",
+          "-strict-formats",
+          "-short-paths",
+          "-keep-locs",
+          "-g"
+        ]
+      ],
+      [
+        "UNIT_NAME",
+        "foo"
+      ]
+    ]
+  }
 
 FIXME : module Foo is not unbound
 This test is disabled because it depends on root detection and is not reproducible.

--- a/test/blackbox-tests/utils/melc_stdlib_prefix.ml
+++ b/test/blackbox-tests/utils/melc_stdlib_prefix.ml
@@ -13,6 +13,25 @@ let command cmd args =
   | WSIGNALED _ | WSTOPPED _ -> assert false
 ;;
 
+let normalize_separators path =
+  let len = String.length path in
+  let buf = Buffer.create len in
+  let rec loop i prev_was_sep =
+    if i = len
+    then Buffer.contents buf
+    else (
+      let c = path.[i] in
+      if c = '/'
+      then (
+        if not prev_was_sep then Buffer.add_char buf c;
+        loop (i + 1) true)
+      else (
+        Buffer.add_char buf c;
+        loop (i + 1) false))
+  in
+  loop 0 false
+;;
+
 let () =
   let where = command "melc" [ "--where" ] in
   match where with
@@ -21,8 +40,13 @@ let () =
     exit 2
   | Ok where ->
     let parts =
-      List.map (Bin.parse_path where) ~f:(fun part ->
-        Format.asprintf "/MELC_STDLIB=%s" (part |> Path.parent_exn |> Path.to_string))
+      List.concat_map (Bin.parse_path where) ~f:(fun part ->
+        let path = part |> Path.parent_exn |> Path.to_string in
+        let normalized = normalize_separators path in
+        let paths =
+          if String.equal path normalized then [ path ] else [ path; normalized ]
+        in
+        List.map paths ~f:(fun path -> Format.asprintf "/MELC_STDLIB=%s" path))
     in
     Format.printf "%s" (String.concat parts ~sep:":")
 ;;


### PR DESCRIPTION
Change `dune ocaml merlin dump-config` to print sexp and use it in our tests.

This allows us to filter output easily with jq. Note that this command is only used in tests, so we don't need to announce this in CHANGES.