### PR TITLE
fix(pkg): unify self and cross-package section variable expansion

### DIFF
--- a/doc/changes/fixed/14194.md
+++ b/doc/changes/fixed/14194.md
@@ -1,0 +1,5 @@
+- Fix section directory variables in lock file package actions expanding to
+  the section root instead of the package subdirectory. This caused files
+  installed by a package to be placed in the wrong location, making them
+  inaccessible via `%{pkg:dep:lib}` and similar cross-package references.
+  (#14194, fixes #14096, @Alizter)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -779,23 +779,6 @@ module Action_expander = struct
       | Man -> Man
     ;;
 
-    let section_dir_of_root
-          (roots : _ Install.Roots.t)
-          (section : Pform.Var.Pkg.Section.t)
-      =
-      match section with
-      | Lib -> roots.lib_root
-      | Libexec -> roots.libexec_root
-      | Bin -> roots.bin
-      | Sbin -> roots.sbin
-      | Share -> roots.share_root
-      | Etc -> roots.etc_root
-      | Doc -> roots.doc_root
-      | Man -> roots.man
-      | Toplevel -> Path.relative roots.lib_root "toplevel"
-      | Stublibs -> Path.relative roots.lib_root "stublibs"
-    ;;
-
     let sys_poll_var accessor =
       accessor Lock_dir.Sys_vars.poll
       |> Memo.Lazy.force
@@ -826,9 +809,9 @@ module Action_expander = struct
         let group = Unix.getgid () |> Unix.getgrgid in
         Memo.return [ Value.String group.gr_name ]
       | Section_dir section ->
-        let roots = Paths.install_roots paths in
-        let dir = section_dir_of_root roots section in
-        Memo.return [ Value.Dir dir ]
+        let section = dune_section_of_pform section in
+        let install_paths = Paths.install_paths paths in
+        Memo.return [ Value.Dir (Install.Paths.get install_paths section) ]
     ;;
 
     let expand_pkg_macro ~loc (paths : _ Paths.t) deps macro_invocation =

--- a/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
@@ -1,6 +1,11 @@
 Test that dependency section variables expand to correct relative paths and
 that installed artifacts are accessible through those paths.
 
+Per the opam spec, lib, libexec, share, etc, doc append the package name
+(e.g. lib -> <prefix>/lib/<pkg>), while bin, sbin, man, toplevel, stublibs
+do not. Opam also has _root variants (lib_root, share_root, etc.) that
+return the root without the package name, but dune does not implement these.
+
   $ make_lockdir
 
 Create a dependency package "dep" that installs files into every section.
@@ -54,6 +59,7 @@ Section variables expanded via (system) produce relative paths:
   >   )
   >   (system
   >    "\| cat %{pkg:dep:lib}/lib-file
+  >    "\| cat %{pkg:dep:libexec}/libexec-file
   >    "\| cat %{pkg:dep:bin}/bin-file
   >    "\| cat %{pkg:dep:sbin}/sbin-file
   >    "\| cat %{pkg:dep:share}/share-file
@@ -76,15 +82,16 @@ Section variables expanded via (system) produce relative paths:
   ../../dep.0.0.1-$DIGEST/target/man
   ../../dep.0.0.1-$DIGEST/target/lib/toplevel
   ../../dep.0.0.1-$DIGEST/target/lib/stublibs
+  lib-data
+  libexec-data
   bin-data
   sbin-data
+  share-data
+  etc-data
+  doc-data
   man-data
   toplevel-data
   stublibs-data
-  cat: ../../dep.0.0.1-$DIGEST/target/lib/dep/lib-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/share/dep/share-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/etc/dep/etc-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/doc/dep/doc-file: No such file or directory
 
 Section variables used as standalone pform args in (run) actions, as produced
 by opam translation of [ "echo" dep:lib ] to (run echo %{pkg:dep:lib}).
@@ -106,6 +113,7 @@ These currently expand to absolute paths instead of relative ones:
   >   (run echo %{pkg:dep:toplevel})
   >   (run echo %{pkg:dep:stublibs})
   >   (run cat %{pkg:dep:lib}/lib-file)
+  >   (run cat %{pkg:dep:libexec}/libexec-file)
   >   (run cat %{pkg:dep:bin}/bin-file)
   >   (run cat %{pkg:dep:sbin}/sbin-file)
   >   (run cat %{pkg:dep:share}/share-file)
@@ -127,10 +135,13 @@ These currently expand to absolute paths instead of relative ones:
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/man
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/toplevel
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/stublibs
-  File "dune.lock/run-consumer.pkg", line 15, characters 7-10:
-  15 |   (run cat %{pkg:dep:lib}/lib-file)
-              ^^^
-  Error: Logs for package run-consumer
-  cat: $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/dep/lib-file: No such file or directory
-  
-  [1]
+  lib-data
+  libexec-data
+  bin-data
+  sbin-data
+  share-data
+  etc-data
+  doc-data
+  man-data
+  toplevel-data
+  stublibs-data


### PR DESCRIPTION
`%{lib}` inside a package's own actions and `%{pkg:dep:lib}` from a consumer were using different code paths. The self-scoped path returned the section root (e.g. target/lib) while the cross-package path correctly appended the package name (e.g. target/lib/dep). Unify both to use `Install.Paths.get`.

- Fixes https://github.com/ocaml/dune/issues/14096
- [x] Depends on #14176 
- [x] changelog