### PR TITLE
test: fixup dep section variables test

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
@@ -1,6 +1,10 @@
 Test that dependency section variables expand to correct relative paths and
 that installed artifacts are accessible through those paths.
 
+Per the opam spec, lib, libexec, share, etc, doc append the package name
+(e.g. lib -> <prefix>/lib/<pkg>), while bin, sbin, man, toplevel, stublibs
+do not.
+
   $ make_lockdir
 
 Create a dependency package "dep" that installs files into every section.
@@ -9,27 +13,27 @@ Create a dependency package "dep" that installs files into every section.
   > (version 0.0.1)
   > (install
   >  (progn
-  >   (run mkdir -p %{lib})
-  >   (run mkdir -p %{libexec})
-  >   (run mkdir -p %{bin})
-  >   (run mkdir -p %{sbin})
-  >   (run mkdir -p %{share})
-  >   (run mkdir -p %{etc})
-  >   (run mkdir -p %{doc})
-  >   (run mkdir -p %{man})
-  >   (run mkdir -p %{toplevel})
-  >   (run mkdir -p %{stublibs})
+  >   (run mkdir -p %{pkg-self:lib})
+  >   (run mkdir -p %{pkg-self:libexec})
+  >   (run mkdir -p %{pkg-self:bin})
+  >   (run mkdir -p %{pkg-self:sbin})
+  >   (run mkdir -p %{pkg-self:share})
+  >   (run mkdir -p %{pkg-self:etc})
+  >   (run mkdir -p %{pkg-self:doc})
+  >   (run mkdir -p %{pkg-self:man})
+  >   (run mkdir -p %{pkg-self:toplevel})
+  >   (run mkdir -p %{pkg-self:stublibs})
   >   (system
-  >    "\| echo lib-data > %{lib}/lib-file
-  >    "\| echo libexec-data > %{libexec}/libexec-file
-  >    "\| echo bin-data > %{bin}/bin-file
-  >    "\| echo sbin-data > %{sbin}/sbin-file
-  >    "\| echo share-data > %{share}/share-file
-  >    "\| echo etc-data > %{etc}/etc-file
-  >    "\| echo doc-data > %{doc}/doc-file
-  >    "\| echo man-data > %{man}/man-file
-  >    "\| echo toplevel-data > %{toplevel}/toplevel-file
-  >    "\| echo stublibs-data > %{stublibs}/stublibs-file
+  >    "\| echo lib-data > %{pkg-self:lib}/lib-file
+  >    "\| echo libexec-data > %{pkg-self:libexec}/libexec-file
+  >    "\| echo bin-data > %{pkg-self:bin}/bin-file
+  >    "\| echo sbin-data > %{pkg-self:sbin}/sbin-file
+  >    "\| echo share-data > %{pkg-self:share}/share-file
+  >    "\| echo etc-data > %{pkg-self:etc}/etc-file
+  >    "\| echo doc-data > %{pkg-self:doc}/doc-file
+  >    "\| echo man-data > %{pkg-self:man}/man-file
+  >    "\| echo toplevel-data > %{pkg-self:toplevel}/toplevel-file
+  >    "\| echo stublibs-data > %{pkg-self:stublibs}/stublibs-file
   >   )))
   > EOF
 
@@ -54,6 +58,7 @@ Section variables expanded via (system) produce relative paths:
   >   )
   >   (system
   >    "\| cat %{pkg:dep:lib}/lib-file
+  >    "\| cat %{pkg:dep:libexec}/libexec-file
   >    "\| cat %{pkg:dep:bin}/bin-file
   >    "\| cat %{pkg:dep:sbin}/sbin-file
   >    "\| cat %{pkg:dep:share}/share-file
@@ -76,15 +81,16 @@ Section variables expanded via (system) produce relative paths:
   ../../dep.0.0.1-$DIGEST/target/man
   ../../dep.0.0.1-$DIGEST/target/lib/toplevel
   ../../dep.0.0.1-$DIGEST/target/lib/stublibs
+  lib-data
+  libexec-data
   bin-data
   sbin-data
+  share-data
+  etc-data
+  doc-data
   man-data
   toplevel-data
   stublibs-data
-  cat: ../../dep.0.0.1-$DIGEST/target/lib/dep/lib-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/share/dep/share-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/etc/dep/etc-file: No such file or directory
-  cat: ../../dep.0.0.1-$DIGEST/target/doc/dep/doc-file: No such file or directory
 
 Section variables used as standalone pform args in (run) actions, as produced
 by opam translation of [ "echo" dep:lib ] to (run echo %{pkg:dep:lib}).
@@ -106,6 +112,7 @@ These currently expand to absolute paths instead of relative ones:
   >   (run echo %{pkg:dep:toplevel})
   >   (run echo %{pkg:dep:stublibs})
   >   (run cat %{pkg:dep:lib}/lib-file)
+  >   (run cat %{pkg:dep:libexec}/libexec-file)
   >   (run cat %{pkg:dep:bin}/bin-file)
   >   (run cat %{pkg:dep:sbin}/sbin-file)
   >   (run cat %{pkg:dep:share}/share-file)
@@ -127,10 +134,13 @@ These currently expand to absolute paths instead of relative ones:
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/man
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/toplevel
   $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/stublibs
-  File "dune.lock/run-consumer.pkg", line 15, characters 7-10:
-  15 |   (run cat %{pkg:dep:lib}/lib-file)
-              ^^^
-  Error: Logs for package run-consumer
-  cat: $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/dep/lib-file: No such file or directory
-  
-  [1]
+  lib-data
+  libexec-data
+  bin-data
+  sbin-data
+  share-data
+  etc-data
+  doc-data
+  man-data
+  toplevel-data
+  stublibs-data


### PR DESCRIPTION
The previous iteration of this test was confused with the global rather than pkg-self variants. Everything here appears to be working correctly, the only difference is the absolute paths in the sandbox.