### PR TITLE
feat: %{pkg:foo:lib:file} pforms for package install layouts

### DIFF
--- a/doc/changes/added/14193.md
+++ b/doc/changes/added/14193.md
@@ -1,0 +1,3 @@
+- Add `%{pkg:<package>:<section>:<path>}` pform for resolving package install
+  files. Works with workspace packages, lock-file packages, and installed
+  packages. (#14200, fixes #14193, fixes #3378, @Alizter)

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -144,6 +144,13 @@ In addition, ``(action ...)`` fields support the following special variables:
 - ``ppx:lib1+..+libn`` expands to the ppx executable with ppx libraries
   ``lib1`` to ``libn`` linked in. This form also introduces a dependency on
   this executable.
+- ``pkg:<package>:<section>:<path>`` expands to the path of a file
+  installed by ``<package>`` in ``<section>`` at the relative ``<path>``
+  within that section. Works with workspace packages, lock-file packages,
+  and installed packages. The supported sections are those listed in
+  :doc:`/reference/dune/install` (except ``misc``).
+
+  .. versionadded:: 3.24
 
 The ``%{<kind>:...}`` forms are what allows you to write custom rules that work
 transparently, whether things are installed or not.

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -692,6 +692,7 @@ module Env = struct
          ; "ocaml-config", macro Ocaml_config
          ; "env", since ~version:(1, 4) Macro.Env
          ; "ppx", since ~version:(3, 21) Macro.Ppx
+         ; "pkg", since ~version:(3, 24) Macro.Pkg
          ; "coq", macro Coq_config
          ; "rocq", macro Rocq_config
          ]

--- a/src/dune_lang/section.ml
+++ b/src/dune_lang/section.ml
@@ -2,6 +2,7 @@ open Import
 include Dune_section
 
 let compare : t -> t -> Ordering.t = Poly.compare
+let equal : t -> t -> bool = Poly.equal
 
 let to_dyn x =
   let s = Dune_section.to_string x in

--- a/src/dune_lang/section.mli
+++ b/src/dune_lang/section.mli
@@ -2,6 +2,7 @@ open Import
 include module type of Dune_section with type t = Dune_section.t
 
 val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
 
 include Comparable_intf.S with type key := t
 

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -67,7 +67,7 @@ let get_installed_binaries ~(context : Context.t) stanzas =
             ~expand:expand_str
             ~expand_partial:expand_str_partial
         in
-        let dst = Path.Local.of_string (Install.Entry.Dst.to_string p) in
+        let dst = Install.Entry.Dst.local p in
         if Path.Local.is_root (Path.Local.parent_exn dst)
         then (
           let origin = { Artifacts.binding = fb; dir; dst; enabled_if } in

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -156,7 +156,7 @@ let package loc pkg (context : Build_context.t) ~dune_version =
        Memo.parallel_map pkg.files ~f:(fun (s, l) ->
          let dir = Section.Map.find_exn pkg.sections s in
          Memo.parallel_map l ~f:(fun { kind; dst } ->
-           let path = Path.relative dir (Install.Entry.Dst.to_string dst) in
+           let path = Path.append_local dir (Install.Entry.Dst.local dst) in
            match kind with
            | File -> Memo.return [ path ]
            | Directory ->

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -45,6 +45,7 @@ end
 type value = Value.t list Deps.t
 
 let lookup_artifacts = Fdecl.create Dyn.opaque
+let resolve_pkg_install_file = Fdecl.create Dyn.opaque
 
 type t =
   { dir : Path.Build.t
@@ -628,6 +629,111 @@ let env_macro t source macro_invocation =
           Env.get env var |> Option.value ~default |> string))
 ;;
 
+let resolve_installed_pkg_file ~loc (pkg : Dune_package.t) ~section ~file =
+  let candidates =
+    List.concat_map pkg.files ~f:(fun (s, paths) ->
+      if Section.equal s section
+      then
+        List.map paths ~f:(fun (p : Dune_package.path) -> Install.Entry.Dst.local p.dst)
+      else [])
+  in
+  match List.mem candidates file ~equal:Path.Local.equal with
+  | false ->
+    let file_str = Path.Local.to_string file in
+    let candidates = List.map candidates ~f:Path.Local.to_string in
+    User_error.raise
+      ~loc
+      ~hints:(User_message.did_you_mean file_str ~candidates)
+      [ Pp.textf
+          "File %s not found in section %s of package %s"
+          file_str
+          (Section.to_string section)
+          (Package.Name.to_string pkg.name)
+      ]
+  | true ->
+    (* pkg.dir is <prefix>/lib/<pkg>, so two parent_exn calls
+       recover the opam prefix. *)
+    let install_paths =
+      let roots =
+        Path.parent_exn (Path.parent_exn pkg.dir)
+        |> Install.Roots.opam_from_prefix ~relative:Path.relative
+      in
+      Install.Paths.make ~relative:Path.relative ~package:pkg.name ~roots
+    in
+    let path = Path.append_local (Install.Paths.get install_paths section) file in
+    let open Action_builder.O in
+    let+ () = Action_builder.path path in
+    path
+;;
+
+let resolve_local_pkg_file ~loc ~context_name ~pkg_name ~section ~file =
+  let open Action_builder.O in
+  let* src =
+    Action_builder.of_memo
+      (Fdecl.get resolve_pkg_install_file ~loc context_name ~pkg:pkg_name ~section ~file)
+  in
+  let path = Path.build src in
+  let+ () = Action_builder.path path in
+  path
+;;
+
+let expand_pkg_macro ~loc { context; _ } macro_invocation =
+  let context_name = Context.name context in
+  let pkg_name, section, file =
+    match Pform.Macro_invocation.Args.split macro_invocation with
+    (* CR-someday Alizter: validate the package name *)
+    | [ pkg_name; section; file ] -> Package.Name.of_string pkg_name, section, file
+    | _ ->
+      User_error.raise
+        ~loc
+        ~hints:[ Pp.text "the syntax is %{pkg:PACKAGE:SECTION:PATH}" ]
+        [ Pp.text "%{pkg:..} requires exactly 3 arguments." ]
+  in
+  let section =
+    match Section.of_string section with
+    | Some Misc | None ->
+      let supported =
+        Section.Set.to_list Section.all
+        |> List.filter_map ~f:(fun s ->
+          if Section.equal s Misc then None else Some (Section.to_string s))
+        |> String.enumerate_and
+      in
+      User_error.raise
+        ~loc
+        ~hints:[ Pp.textf "supported sections are %s." supported ]
+        [ Pp.textf "%s is not a valid section." section ]
+    | Some section -> section
+  in
+  let file =
+    match Path.Local.of_string file with
+    | f -> f
+    | exception User_error.E _ ->
+      User_error.raise
+        ~loc
+        ~hints:[ Pp.text "the path must be relative and must not contain '..'." ]
+        [ Pp.textf "%s is not a valid file path." file ]
+  in
+  let open Action_builder.O in
+  let+ path =
+    let* found =
+      Action_builder.of_memo
+        (let open Memo.O in
+         let* package_db = Package_db.create context_name in
+         Package_db.find_package package_db pkg_name)
+    in
+    match found with
+    | None ->
+      User_error.raise
+        ~loc
+        [ Pp.textf "Package %s does not exist" (Package.Name.to_string pkg_name) ]
+    | Some (Installed pkg) -> resolve_installed_pkg_file ~loc pkg ~section ~file
+    | Some (Local _) -> resolve_local_pkg_file ~loc ~context_name ~pkg_name ~section ~file
+    | Some (Build _) ->
+      Pkg_rules.resolve_installed_file ~loc ~context_name ~pkg_name ~section ~file
+  in
+  [ Value.Path path ]
+;;
+
 let expand_pform_macro
       (context : Context.t)
       ~dir
@@ -636,7 +742,9 @@ let expand_pform_macro
   =
   let s = Pform.Macro_invocation.Args.whole macro_invocation in
   match macro_invocation.macro with
-  | Pkg -> Code_error.raise "pkg forms aren't possible here" []
+  | Pkg ->
+    let loc = Dune_lang.Template.Pform.loc source in
+    Need_full_expander (fun t -> With (expand_pkg_macro ~loc t macro_invocation))
   | Pkg_self -> Code_error.raise "pkg-self forms aren't possible here" []
   | Ocaml_config -> ocaml_config_macro source macro_invocation context
   | Env -> Need_full_expander (fun t -> env_macro t source macro_invocation)

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -131,4 +131,14 @@ val foreign_flags
       Fdecl.t
 
 val lookup_artifacts : (dir:Path.Build.t -> Artifacts_obj.t Memo.t) Fdecl.t
+
+val resolve_pkg_install_file
+  : (loc:Loc.t
+     -> Context_name.t
+     -> pkg:Package.Name.t
+     -> section:Section.t
+     -> file:Path.Local.t
+     -> Path.Build.t Memo.t)
+      Fdecl.t
+
 val to_expander0 : t -> Expander0.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -803,3 +803,11 @@ let gen_rules ctx ~dir components =
     let+ sctx_rules = gen_rules ctx (Super_context.find_exn ctx) ~dir components in
     Gen_rules.combine sctx_rules gen_pkg_alias_rule
 ;;
+
+let () =
+  Fdecl.set Expander.resolve_pkg_install_file
+  @@ fun ~loc context_name ~pkg ~section ~file ->
+  let open Memo.O in
+  let* sctx = Super_context.find_exn context_name in
+  Install_rules.resolve_package_install_file sctx ~loc ~pkg ~section ~file
+;;

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1509,6 +1509,41 @@ let gen_install_alias sctx (package : Package.t) =
 
 let stanzas_to_entries = Stanzas_to_entries.stanzas_to_entries
 
+let resolve_package_install_file ~loc sctx ~pkg ~section ~file =
+  let+ entries = Stanzas_to_entries.stanzas_to_entries sctx in
+  match Package.Name.Map.find entries pkg with
+  | None ->
+    User_error.raise
+      ~loc
+      [ Pp.textf "Package %s has no install entries." (Package.Name.to_string pkg) ]
+  | Some entries ->
+    let in_section =
+      List.filter_map entries ~f:(fun (e : Install.Entry.Sourced.Unexpanded.t) ->
+        if Section.equal e.entry.section section
+        then Some (Install.Entry.Dst.local e.entry.dst, e.entry.src)
+        else None)
+    in
+    (match
+       List.find_map in_section ~f:(fun (dst, src) ->
+         if Path.Local.equal dst file then Some src else None)
+     with
+     | Some src -> src
+     | None ->
+       let file_str = Path.Local.to_string file in
+       let candidates =
+         List.map in_section ~f:(fun (dst, _) -> Path.Local.to_string dst)
+       in
+       User_error.raise
+         ~loc
+         ~hints:(User_message.did_you_mean file_str ~candidates)
+         [ Pp.textf
+             "File %s not found in section %s of package %s."
+             file_str
+             (Section.to_string section)
+             (Package.Name.to_string pkg)
+         ])
+;;
+
 let gen_project_rules sctx project =
   let* () = meta_and_dune_package_rules sctx project in
   Dune_project.packages project

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -11,6 +11,14 @@ val stanzas_to_entries
   :  Super_context.t
   -> Install.Entry.Sourced.Unexpanded.t list Dune_lang.Package_name.Map.t Memo.t
 
+val resolve_package_install_file
+  :  loc:Loc.t
+  -> Super_context.t
+  -> pkg:Package.Name.t
+  -> section:Section.t
+  -> file:Path.Local.t
+  -> Path.Build.t Memo.t
+
 (** Generate rules for [.dune-package], [META.<package-name>] files. and
     [<package-name>.install] files. *)
 val gen_project_rules : Super_context.t -> Dune_project.t -> unit Memo.t

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -2607,6 +2607,39 @@ let find_package ctx pkg =
        ())
 ;;
 
+let resolve_installed_file ~loc ~context_name ~pkg_name ~section ~file =
+  let open Action_builder.O in
+  let* { paths; _ } =
+    Action_builder.of_memo (resolve_pkg_dep context_name (loc, pkg_name))
+  in
+  let* { files; _ } = (Pkg_installed.of_paths paths).cookie in
+  let section_dir =
+    let install_paths = Lazy.force paths.install_paths in
+    Install.Paths.get install_paths section
+  in
+  let path = Path.append_local section_dir file in
+  let installed = Section.Map.find files section |> Option.value ~default:[] in
+  match List.exists installed ~f:(Path.equal path) with
+  | true ->
+    let+ () = Action_builder.path path in
+    path
+  | false ->
+    let file_str = Path.Local.to_string file in
+    let candidates =
+      List.filter_map installed ~f:(Path.drop_prefix ~prefix:section_dir)
+      |> List.map ~f:Path.Local.to_string
+    in
+    User_error.raise
+      ~loc
+      ~hints:(User_message.did_you_mean file_str ~candidates)
+      [ Pp.textf
+          "File %s not found in section %s of package %s"
+          file_str
+          (Section.to_string section)
+          (Package.Name.to_string pkg_name)
+      ]
+;;
+
 let all_filtered_depexts context =
   let* all_project_deps = all_project_deps context in
   Memo.List.map all_project_deps ~f:(fun (pkg : Pkg.t) ->

--- a/src/dune_rules/pkg_rules.mli
+++ b/src/dune_rules/pkg_rules.mli
@@ -26,6 +26,15 @@ val exported_env : Context_name.t -> Env.t Memo.t
 val project_ocamlpath : Context_name.t -> Path.t list Memo.t
 val dev_tool_ocamlpath : Dune_pkg.Dev_tool.t -> Path.t list Memo.t
 val find_package : Context_name.t -> Package.Name.t -> unit Action_builder.t option Memo.t
+
+val resolve_installed_file
+  :  loc:Loc.t
+  -> context_name:Context_name.t
+  -> pkg_name:Package.Name.t
+  -> section:Section.t
+  -> file:Path.Local.t
+  -> Path.t Action_builder.t
+
 val dev_tool_env : Dune_pkg.Dev_tool.t -> Env.t Memo.t
 val all_filtered_depexts : Context_name.t -> string list Memo.t
 

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -6,6 +6,7 @@ module Dst : sig
   type t
 
   val to_string : t -> string
+  val local : t -> Path.Local.t
   val append_local : t -> Path.Local.t -> t
   val prepend_local : Path.Local.t -> t -> t
   val to_install_file : t -> src_basename:string -> section:Section.t -> string option
@@ -25,6 +26,7 @@ end = struct
   type t = string
 
   let to_string t = t
+  let local t = Path.Local.of_string t
   let append_local t l = Filename.concat t (Path.Local.to_string l)
   let prepend_local l t = Path.Local.to_string (Path.Local.relative l t)
   let explicit s = s

--- a/src/install/entry.mli
+++ b/src/install/entry.mli
@@ -6,6 +6,7 @@ module Dst : sig
   type t
 
   val to_string : t -> string
+  val local : t -> Path.Local.t
   val prepend_local : Path.Local.t -> t -> t
   val append_local : t -> Path.Local.t -> t
 

--- a/test/blackbox-tests/test-cases/pkg-pform/artifacts.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/artifacts.t
@@ -1,0 +1,72 @@
+Test that %{pkg:...} resolves through install renames across all sections
+and tracks source files as dependencies.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir foo
+
+  $ for section in lib lib_root libexec libexec_root bin sbin toplevel share share_root etc doc stublibs man; do
+  >   cat >>foo/dune <<EOF
+  > (install (package foo) (section $section) (files (${section}_src as ${section}_dst)))
+  > EOF
+  >   echo "$section content" > foo/${section}_src
+  > done
+
+Each section resolves the install name back to the source file:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (target out)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (progn
+  >     (cat %{pkg:foo:lib:lib_dst})
+  >     (cat %{pkg:foo:lib_root:lib_root_dst})
+  >     (cat %{pkg:foo:libexec:libexec_dst})
+  >     (cat %{pkg:foo:libexec_root:libexec_root_dst})
+  >     (cat %{pkg:foo:bin:bin_dst})
+  >     (cat %{pkg:foo:sbin:sbin_dst})
+  >     (cat %{pkg:foo:toplevel:toplevel_dst})
+  >     (cat %{pkg:foo:share:share_dst})
+  >     (cat %{pkg:foo:share_root:share_root_dst})
+  >     (cat %{pkg:foo:etc:etc_dst})
+  >     (cat %{pkg:foo:doc:doc_dst})
+  >     (cat %{pkg:foo:stublibs:stublibs_dst})
+  >     (cat %{pkg:foo:man:man_dst})))))
+  > EOF
+
+  $ dune build out 2>&1
+  $ cat _build/default/out
+  lib content
+  lib_root content
+  libexec content
+  libexec_root content
+  bin content
+  sbin content
+  toplevel content
+  share content
+  share_root content
+  etc content
+  doc content
+  stublibs content
+  man content
+
+All source files appear as dependencies (not install staging paths):
+
+  $ dune rules --format=json _build/default/out 2>&1 | jq 'include "dune"; .[] | ruleDepFilePaths' | sort
+  "_build/default/foo/bin_src"
+  "_build/default/foo/doc_src"
+  "_build/default/foo/etc_src"
+  "_build/default/foo/lib_root_src"
+  "_build/default/foo/lib_src"
+  "_build/default/foo/libexec_root_src"
+  "_build/default/foo/libexec_src"
+  "_build/default/foo/man_src"
+  "_build/default/foo/sbin_src"
+  "_build/default/foo/share_root_src"
+  "_build/default/foo/share_src"
+  "_build/default/foo/stublibs_src"
+  "_build/default/foo/toplevel_src"

--- a/test/blackbox-tests/test-cases/pkg-pform/copy-files.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/copy-files.t
@@ -1,0 +1,31 @@
+%{pkg:...} is not allowed inside (copy_files) stanzas since they use no-deps
+pform expansion.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir foo
+
+  $ cat >foo/dune <<EOF
+  > (install
+  >  (section share)
+  >  (package foo)
+  >  (files (src.txt as dest.txt)))
+  > EOF
+
+  $ cat >foo/src.txt <<EOF
+  > some data
+  > EOF
+
+  $ cat >dune <<EOF
+  > (copy_files %{pkg:foo:share:dest.txt})
+  > EOF
+
+  $ dune build 2>&1
+  File "dune", line 1, characters 12-37:
+  1 | (copy_files %{pkg:foo:share:dest.txt})
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: %{pkg:..} isn't allowed in this position.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/cross-package.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/cross-package.t
@@ -1,0 +1,44 @@
+Test that %{pkg:...} supports cross-package file references.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+  $ mkdir foo bar
+
+  $ cat >foo/dune <<EOF
+  > (install
+  >  (section share)
+  >  (package foo)
+  >  (files (foo_src.txt as foo_data.txt)))
+  > EOF
+
+  $ cat >foo/foo_src.txt <<EOF
+  > foo data
+  > EOF
+
+  $ cat >bar/dune <<EOF
+  > (install
+  >  (section share)
+  >  (package bar)
+  >  (files (bar_src.txt as bar_data.txt)))
+  > EOF
+
+  $ cat >bar/bar_src.txt <<EOF
+  > hello
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-cross-pkg)
+  >  (action
+  >   (progn
+  >    (cat %{pkg:foo:share:foo_data.txt})
+  >    (cat %{pkg:bar:share:bar_data.txt}))))
+  > EOF
+
+  $ dune build @test-cross-pkg 2>&1
+  foo data
+  hello

--- a/test/blackbox-tests/test-cases/pkg-pform/documentation.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/documentation.t
@@ -1,0 +1,27 @@
+%{pkg:...} resolves files installed by documentation stanzas.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (documentation (package foo))
+  > EOF
+
+  $ cat >foo.mld <<EOF
+  > {0 Foo}
+  > EOF
+
+The odoc-pages path resolves to the source .mld file:
+
+  $ mkdir -p test
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-doc)
+  >  (action (echo "%{pkg:foo:doc:odoc-pages/foo.mld}\n")))
+  > EOF
+
+  $ dune build @test-doc 2>&1
+  ../foo.mld

--- a/test/blackbox-tests/test-cases/pkg-pform/env.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/env.t
@@ -1,0 +1,28 @@
+Pforms are not expanded in (env-vars) fields, so %{pkg:...} is rejected:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir -p foo
+  $ cat >foo/dune <<EOF
+  > (install (section share) (package foo) (files (src.txt as dest.txt)))
+  > EOF
+  $ cat >foo/src.txt <<EOF
+  > some data
+  > EOF
+
+  $ cat >dune <<EOF
+  > (env
+  >  (_
+  >   (env-vars
+  >    (MY_FILE %{pkg:foo:share:dest.txt}))))
+  > EOF
+
+  $ dune build 2>&1
+  File "dune", line 4, characters 12-37:
+  4 |    (MY_FILE %{pkg:foo:share:dest.txt}))))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Atom or quoted string expected
+  [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/errors.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/errors.t
@@ -1,0 +1,184 @@
+Test error handling for %{pkg:...} pforms.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir -p foo
+  $ cat >foo/dune <<EOF
+  > (install (section share) (package foo) (files (src.txt as dest.txt)))
+  > EOF
+  $ cat >foo/src.txt <<EOF
+  > some data
+  > EOF
+
+CR-soon alizter: Section and argument count errors could be validated eagerly
+at pform parse time (in Pform.Env.parse) so they fire even when the rule is
+not demanded. Currently all %{pkg:..} errors are lazy.
+
+All %{pkg:..} errors are lazy and do not prevent building unrelated targets in
+the same directory. Each case below includes an unrelated rule to verify this.
+
+Non-existent packages are rejected:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-bad)
+  >  (action (echo "%{pkg:nonexistent:share:dest.txt}\n")))
+  > (rule
+  >  (with-stdout-to ok.txt (echo "hello")))
+  > EOF
+
+  $ dune build ok.txt 2>&1
+  $ dune build @test-bad 2>&1
+  File "dune", line 3, characters 16-49:
+  3 |  (action (echo "%{pkg:nonexistent:share:dest.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Package nonexistent does not exist
+  [1]
+
+File not found in a valid package is rejected:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-bad-file)
+  >  (action (echo "%{pkg:foo:share:missing.txt}\n")))
+  > (rule
+  >  (with-stdout-to ok2.txt (echo "hello")))
+  > EOF
+
+  $ dune build ok2.txt 2>&1
+  $ dune build @test-bad-file 2>&1
+  File "dune", line 3, characters 16-44:
+  3 |  (action (echo "%{pkg:foo:share:missing.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: File missing.txt not found in section share of package foo.
+  [1]
+
+A typo in the filename shows a hint:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-typo)
+  >  (action (echo "%{pkg:foo:share:dest.tx}\n")))
+  > EOF
+
+  $ dune build @test-typo 2>&1
+  File "dune", line 3, characters 16-40:
+  3 |  (action (echo "%{pkg:foo:share:dest.tx}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: File dest.tx not found in section share of package foo.
+  Hint: did you mean dest.txt?
+  [1]
+
+Invalid section name is rejected:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-bad-section)
+  >  (action (echo "%{pkg:foo:badsection:dest.txt}\n")))
+  > (rule
+  >  (with-stdout-to ok3.txt (echo "hello")))
+  > EOF
+
+  $ dune build ok3.txt 2>&1
+  $ dune build @test-bad-section 2>&1
+  File "dune", line 3, characters 16-46:
+  3 |  (action (echo "%{pkg:foo:badsection:dest.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: badsection is not a valid section.
+  Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
+  toplevel, share, share_root, etc, doc, stublibs and man.
+  [1]
+
+The misc section is rejected:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-misc)
+  >  (action (echo "%{pkg:foo:misc:dest.txt}\n")))
+  > EOF
+
+  $ dune build @test-misc 2>&1
+  File "dune", line 3, characters 16-40:
+  3 |  (action (echo "%{pkg:foo:misc:dest.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: misc is not a valid section.
+  Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
+  toplevel, share, share_root, etc, doc, stublibs and man.
+  [1]
+
+Wrong number of arguments (too few):
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-too-few)
+  >  (action (echo "%{pkg:foo:share}\n")))
+  > EOF
+
+  $ dune build @test-too-few 2>&1
+  File "dune", line 3, characters 16-32:
+  3 |  (action (echo "%{pkg:foo:share}\n")))
+                      ^^^^^^^^^^^^^^^^
+  Error: %{pkg:..} requires exactly 3 arguments.
+  Hint: the syntax is %{pkg:PACKAGE:SECTION:PATH}
+  [1]
+
+Wrong number of arguments (too many):
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-too-many)
+  >  (action (echo "%{pkg:foo:share:dest.txt:extra}\n")))
+  > EOF
+
+  $ dune build @test-too-many 2>&1
+  File "dune", line 3, characters 16-47:
+  3 |  (action (echo "%{pkg:foo:share:dest.txt:extra}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: %{pkg:..} requires exactly 3 arguments.
+  Hint: the syntax is %{pkg:PACKAGE:SECTION:PATH}
+  [1]
+
+Path escaping the workspace is rejected:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-escape)
+  >  (action (echo "%{pkg:foo:share:../../../etc/passwd}\n")))
+  > EOF
+
+  $ dune build @test-escape 2>&1
+  File "dune", line 3, characters 16-52:
+  3 |  (action (echo "%{pkg:foo:share:../../../etc/passwd}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: ../../../etc/passwd is not a valid file path.
+  Hint: the path must be relative and must not contain '..'.
+  [1]
+
+The %{pkg:...} macro requires (lang dune 3.24) or later:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.23)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-version-gate)
+  >  (action (echo "%{pkg:foo:share:dest.txt}\n")))
+  > EOF
+
+  $ dune build @test-version-gate 2>&1
+  File "dune", line 3, characters 16-41:
+  3 |  (action (echo "%{pkg:foo:share:dest.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: %{pkg:..} is only available since version 3.24 of the dune language.
+  Please update your dune-project file to have (lang dune 3.24).
+  [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/executable.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/executable.t
@@ -1,0 +1,29 @@
+%{pkg:...} resolves files installed by public executables.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (public_name foo))
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+The public name resolves to the build artifact:
+
+  $ mkdir -p test
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-exe)
+  >  (action (echo "%{pkg:foo:bin:foo}\n")))
+  > EOF
+
+  $ dune build @test-exe 2>&1
+  ../main.exe

--- a/test/blackbox-tests/test-cases/pkg-pform/install-stanza.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/install-stanza.t
@@ -1,0 +1,38 @@
+%{pkg:...} is not allowed inside (install) stanzas since they use no-deps
+pform expansion.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+  $ mkdir foo bar
+
+  $ cat >foo/dune <<EOF
+  > (install
+  >  (section share)
+  >  (package foo)
+  >  (files (src.txt as dest.txt)))
+  > EOF
+
+  $ cat >foo/src.txt <<EOF
+  > foo data
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target generated.txt)
+  >  (action (with-stdout-to %{target} (echo "generated"))))
+  > (install
+  >  (section share)
+  >  (package bar)
+  >  (files (generated.txt as %{pkg:foo:share:dest.txt}/nested.txt)))
+  > EOF
+
+  $ dune build @install 2>&1
+  File "dune", line 7, characters 26-51:
+  7 |  (files (generated.txt as %{pkg:foo:share:dest.txt}/nested.txt)))
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: %{pkg:..} isn't allowed in this position.
+  [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/installed-missing-file.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/installed-missing-file.t
@@ -1,0 +1,55 @@
+Requesting a file that doesn't exist in an installed package is rejected.
+
+  $ mkdir -p src prefix consumer
+
+  $ cat >src/dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name extpkg))
+  > EOF
+
+  $ cat >src/dune <<EOF
+  > (install (section share) (package extpkg) (files (src.txt as published.txt)))
+  > EOF
+
+  $ cat >src/src.txt <<EOF
+  > hello from installed
+  > EOF
+
+  $ dune build --root src 2>&1
+
+  $ dune install --root src --prefix $PWD/prefix --display short 2>&1
+  Installing $TESTCASE_ROOT/prefix/lib/extpkg/META
+  Installing $TESTCASE_ROOT/prefix/lib/extpkg/dune-package
+  Installing $TESTCASE_ROOT/prefix/share/extpkg/published.txt
+
+  $ cat >consumer/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+Requesting the published file works:
+
+  $ cat >consumer/dune <<EOF
+  > (rule
+  >  (alias test-ok)
+  >  (action (echo "%{pkg:extpkg:share:published.txt}\n")))
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root consumer @test-ok 2>&1
+  $TESTCASE_ROOT/prefix/share/extpkg/published.txt
+
+Requesting a file that doesn't exist is rejected:
+
+  $ cat >consumer/dune <<EOF
+  > (rule
+  >  (alias test-missing)
+  >  (action (echo "%{pkg:extpkg:share:missing.txt}\n")))
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root consumer @test-missing 2>&1
+  Entering directory 'consumer'
+  File "dune", line 3, characters 16-47:
+  3 |  (action (echo "%{pkg:extpkg:share:missing.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: File missing.txt not found in section share of package extpkg
+  Leaving directory 'consumer'
+  [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/installed.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/installed.t
@@ -1,0 +1,38 @@
+Test that %{pkg:...} works for installed packages outside the workspace.
+
+  $ mkdir -p src prefix consumer
+
+  $ cat >src/dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name extpkg))
+  > EOF
+
+  $ cat >src/dune <<EOF
+  > (install (section share) (package extpkg) (files (src.txt as published.txt)))
+  > EOF
+
+  $ cat >src/src.txt <<EOF
+  > hello from installed
+  > EOF
+
+  $ dune build --root src 2>&1
+
+  $ dune install --root src --prefix $PWD/prefix --display short 2>&1
+  Installing $TESTCASE_ROOT/prefix/lib/extpkg/META
+  Installing $TESTCASE_ROOT/prefix/lib/extpkg/dune-package
+  Installing $TESTCASE_ROOT/prefix/share/extpkg/published.txt
+
+Reference the installed file from a separate project via OCAMLPATH:
+
+  $ cat >consumer/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+  $ cat >consumer/dune <<EOF
+  > (rule
+  >  (alias test-installed-file)
+  >  (action (echo "%{pkg:extpkg:share:published.txt}\n")))
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root consumer @test-installed-file 2>&1
+  $TESTCASE_ROOT/prefix/share/extpkg/published.txt

--- a/test/blackbox-tests/test-cases/pkg-pform/library.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/library.t
@@ -1,0 +1,51 @@
+%{pkg:...} resolves files installed by public libraries.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (public_name foo))
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > let x = 42
+  > EOF
+
+The .cma archive resolves to the build output:
+
+  $ mkdir -p test
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-lib)
+  >  (action (echo "%{pkg:foo:lib:foo.cma}\n")))
+  > EOF
+
+  $ dune build @test-lib 2>&1
+  ../foo.cma
+
+The .cmi interface file should also resolve:
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-cmi)
+  >  (action (echo "%{pkg:foo:lib:foo.cmi}\n")))
+  > EOF
+
+  $ dune build @test-cmi 2>&1
+  ../.foo.objs/byte/foo.cmi
+
+The library archive appears as a build dependency:
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (target out)
+  >  (action (with-stdout-to %{target} (echo "%{pkg:foo:lib:foo.cma}"))))
+  > EOF
+
+  $ dune rules --format=json _build/default/test/out 2>&1 | jq 'include "dune"; .[] | ruleDepFilePaths' | sort
+  "_build/default/foo.cma"

--- a/test/blackbox-tests/test-cases/pkg-pform/same-dir.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/same-dir.t
@@ -1,0 +1,26 @@
+Test that %{pkg:foo:section:file} works from a rule inside the package
+directory itself.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo) (dir foo))
+  > EOF
+
+  $ mkdir foo
+
+  $ cat >foo/dune <<EOF
+  > (install
+  >  (section share)
+  >  (package foo)
+  >  (files (src.txt as dest.txt)))
+  > (rule
+  >  (alias test-self-ref)
+  >  (action (cat %{pkg:foo:share:dest.txt})))
+  > EOF
+
+  $ cat >foo/src.txt <<EOF
+  > some data
+  > EOF
+
+  $ dune build @test-self-ref 2>&1
+  some data

--- a/test/blackbox-tests/test-cases/pkg/pkg-deps-lock.t
+++ b/test/blackbox-tests/test-cases/pkg/pkg-deps-lock.t
@@ -1,0 +1,52 @@
+Test that %{pkg:...} in regular rules introduces a dependency on the
+lock-file package.
+
+  $ make_lockdir
+
+  $ make_lockpkg lockpkg <<'EOF'
+  > (version 0.0.1)
+  > (install
+  >  (progn
+  >   (run mkdir -p %{pkg-self:share})
+  >   (system "echo lock-data > %{pkg-self:share}/data.txt")))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+The rule depends on the lock-file package cookie and the resolved file:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target output)
+  >  (action (with-stdout-to %{target} (echo %{pkg:lockpkg:share:data.txt}))))
+  > EOF
+
+CR-someday alizter: dune rules --deps requires a prior build because
+Install_cookie.load_exn runs eagerly during dep evaluation.
+
+  $ dune build _build/default/output 2>&1
+
+  $ dune rules --deps _build/default/output 2>&1 | sanitize_pkg_digest lockpkg.0.0.1
+  ((File
+    (In_build_dir
+     _build/_private/default/.pkg/lockpkg.0.0.1-DIGEST_HASH/target/cookie))
+   (File
+    (In_build_dir
+     _build/_private/default/.pkg/lockpkg.0.0.1-DIGEST_HASH/target/share/lockpkg/data.txt)))
+
+Requesting a file that doesn't exist in the lock-file package is rejected:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias test-missing)
+  >  (action (echo "%{pkg:lockpkg:share:missing.txt}\n")))
+  > EOF
+
+  $ dune build @test-missing 2>&1
+  File "dune", line 3, characters 16-48:
+  3 |  (action (echo "%{pkg:lockpkg:share:missing.txt}\n")))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: File missing.txt not found in section share of package lockpkg
+  [1]

--- a/test/blackbox-tests/test-cases/rocq/pkg-pform.t/dune
+++ b/test/blackbox-tests/test-cases/rocq/pkg-pform.t/dune
@@ -1,0 +1,3 @@
+(rocq.theory
+ (name basic)
+ (package foo))

--- a/test/blackbox-tests/test-cases/rocq/pkg-pform.t/dune-project
+++ b/test/blackbox-tests/test-cases/rocq/pkg-pform.t/dune-project
@@ -1,0 +1,5 @@
+(lang dune 3.24)
+
+(using rocq 0.11)
+
+(package (name foo))

--- a/test/blackbox-tests/test-cases/rocq/pkg-pform.t/foo.opam
+++ b/test/blackbox-tests/test-cases/rocq/pkg-pform.t/foo.opam
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/blackbox-tests/test-cases/rocq/pkg-pform.t/foo.v
+++ b/test/blackbox-tests/test-cases/rocq/pkg-pform.t/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/rocq/pkg-pform.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/pkg-pform.t/run.t
@@ -1,0 +1,25 @@
+%{pkg:...} resolves files installed by Rocq theories.
+
+The compiled .vo file resolves to the build artifact:
+
+  $ mkdir -p test
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-vo)
+  >  (action (echo "%{pkg:foo:lib_root:coq/user-contrib/basic/foo.vo}\n")))
+  > EOF
+
+  $ dune build @test-vo 2>&1
+  ../foo.vo
+
+The source .v file should also resolve:
+
+  $ cat >test/dune <<EOF
+  > (rule
+  >  (alias test-v)
+  >  (action (echo "%{pkg:foo:lib_root:coq/user-contrib/basic/foo.v}\n")))
+  > EOF
+
+  $ dune build @test-v 2>&1
+  ../foo.v


### PR DESCRIPTION
We introduce `%{pkg:foo:lib:file}` macros similar to the `%{pkg:foo:lib}` macros for lock files. This allows users to inspect installed package contents directly. We support all the install sections that we understand in dune.

Depending on such a path automatically introduces dependencies on the package.

This works with ocamlfind packages, dune package management and workspace packages.

The goal is to ultimately hide `_build/install` as an implementation detail and allow users to properly depend on packages' installed contents without having to inspect them by hand.

- [ ] more docs?
- [x] changelog
- fixes https://github.com/ocaml/dune/issues/14193
- fixes https://github.com/ocaml/dune/issues/3378