### PR TITLE
refactor(pkg): use dune_section in pkg_rules

### DIFF
--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -23,20 +23,10 @@ module Var = struct
 
   module Pkg = struct
     module Section = struct
-      type t =
-        | Lib
-        | Libexec
-        | Bin
-        | Sbin
-        | Toplevel
-        | Share
-        | Etc
-        | Doc
-        | Stublibs
-        | Man
+      type t = Section.t
 
       let all =
-        [ Lib, "lib"
+        [ Section.Lib, "lib"
         ; Libexec, "libexec"
         ; Bin, "bin"
         ; Sbin, "sbin"
@@ -49,14 +39,12 @@ module Var = struct
         ]
       ;;
 
-      let to_string t = List.assoc all t |> Option.value_exn
+      let to_string = Section.to_string
 
-      let rec of_string x = function
-        | [] -> None
-        | (s, x') :: xs -> if x' = x then Some s else of_string x xs
+      let of_string name =
+        List.find_map all ~f:(fun (section, s) ->
+          if String.equal s name then Some section else None)
       ;;
-
-      let of_string x = of_string x all
     end
 
     type t =

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -12,17 +12,7 @@ module Var : sig
 
   module Pkg : sig
     module Section : sig
-      type t =
-        | Lib
-        | Libexec
-        | Bin
-        | Sbin
-        | Toplevel
-        | Share
-        | Etc
-        | Doc
-        | Stublibs
-        | Man
+      type t = Section.t
 
       val of_string : string -> t option
     end

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -766,19 +766,6 @@ module Action_expander = struct
       x
     ;;
 
-    let dune_section_of_pform : Pform.Var.Pkg.Section.t -> Section.t = function
-      | Lib -> Lib
-      | Libexec -> Libexec
-      | Bin -> Bin
-      | Sbin -> Sbin
-      | Toplevel -> Toplevel
-      | Share -> Share
-      | Etc -> Etc
-      | Doc -> Doc
-      | Stublibs -> Stublibs
-      | Man -> Man
-    ;;
-
     let section_dir_of_root
           (roots : _ Install.Roots.t)
           (section : Pform.Var.Pkg.Section.t)
@@ -794,6 +781,10 @@ module Action_expander = struct
       | Man -> roots.man
       | Toplevel -> Path.relative roots.lib_root "toplevel"
       | Stublibs -> Path.relative roots.lib_root "stublibs"
+      | Lib_root | Libexec_root | Share_root | Misc ->
+        Code_error.raise
+          "section_dir_of_root: unsupported section"
+          [ "section", Section.to_dyn section ]
     ;;
 
     let sys_poll_var accessor =
@@ -877,7 +868,6 @@ module Action_expander = struct
                with
                | None -> Memo.return (Error (`Undefined_pkg_var variable_name))
                | Some section ->
-                 let section = dune_section_of_pform section in
                  let install_paths = Paths.install_paths paths in
                  Memo.return @@ Ok [ Value.Dir (Install.Paths.get install_paths section) ])))
     ;;


### PR DESCRIPTION
In #14200 I would like to introduce the `%{pkg:foo:lib}` pfrom more generally outside of package management. In order to do so, it will make sharing both pforms expansions easier if the install section type used is the same.

This change will share the underlying type, whilst preserving the restrictions on "defined" vs "undefined" variables for package management.

For example with both `%{pkg-self:...}` and `%{pkg:foo:...}` we don't currently allow for `misc`, `lib_root`, `libexec_root` or `share_root`. This behaviour is preserved by this change.