### PR TITLE
Remove premature changelog entry for #14170

### DIFF
--- a/doc/changes/fixed/14170.md
+++ b/doc/changes/fixed/14170.md
@@ -1,3 +1,0 @@
-- Send SIGTERM before SIGKILL when shutting down child processes, giving
-  cleanup handlers a chance to run before the process is killed.
-  (#14170, fixes #2445, @robinbb)


### PR DESCRIPTION
## Summary
- Remove `doc/changes/fixed/14170.md` which was included prematurely in #14170