### PR TITLE
chore: add $ make start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,11 @@ test-ox: $(BIN)
 check: $(BIN)
 	@$(BIN) build @check
 
+.PHONY: start
+start: $(BIN)
+	@$(BIN) init start-file
+	@$(BIN) build @start/build -w
+
 .PHONY: fmt
 fmt: $(BIN)
 	@$(BIN) fmt


### PR DESCRIPTION
To help start dune in watch mode for development.

If this doesn't work for anybody, make sure to bootstrap first.