### PR TITLE
chore: disable flake on macos

### DIFF
--- a/test/blackbox-tests/test-cases/actions/dune
+++ b/test/blackbox-tests/test-cases/actions/dune
@@ -2,5 +2,10 @@
  (deps bin/sub_process.exe))
 
 (cram
+ (applies_to stray-process)
+ (enabled_if
+  (= %{system} macosx)))
+
+(cram
  (applies_to concurrent)
  (enabled_if false))


### PR DESCRIPTION
Re-enable this once there's a workaround for sigwait