### PR TITLE
refactor: stop using Stdune.Time.t in registry

### DIFF
--- a/otherlibs/dune-rpc/registry.ml
+++ b/otherlibs/dune-rpc/registry.ml
@@ -110,7 +110,7 @@ end
 
 type nonrec t =
   { config : Config.t
-  ; mutable last_mtime : Stdune.Time.t option
+  ; mutable last_mtime : float option
   ; mutable current : Dune.t list
   }
 
@@ -144,7 +144,7 @@ module Poll
      end)
     (IO : sig
        val scandir : string -> (string list, exn) result Fiber.t
-       val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
+       val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
        val read_file : string -> (string, exn) result Fiber.t
      end) =
 struct

--- a/otherlibs/dune-rpc/registry.mli
+++ b/otherlibs/dune-rpc/registry.mli
@@ -60,7 +60,7 @@ module Poll
      end)
     (_ : sig
        val scandir : string -> (string list, exn) result Fiber.t
-       val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
+       val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
        val read_file : string -> (string, exn) result Fiber.t
      end) : sig
   val poll : t -> (Refresh.t, exn) result Fiber.t

--- a/otherlibs/dune-rpc/v1.mli
+++ b/otherlibs/dune-rpc/v1.mli
@@ -599,7 +599,7 @@ module Registry : sig
        end)
       (_ : sig
          val scandir : string -> (string list, exn) result Fiber.t
-         val stat : string -> ([ `Mtime of Stdune.Time.t ], exn) result Fiber.t
+         val stat : string -> ([ `Mtime of float ], exn) result Fiber.t
          val read_file : string -> (string, exn) result Fiber.t
        end) : sig
     val poll : t -> (Refresh.t, exn) result Fiber.t

--- a/src/rpc/poll_active.ml
+++ b/src/rpc/poll_active.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 include
   Dune_rpc.Private.Registry.Poll
     (Fiber)
@@ -13,7 +15,7 @@ include
         Fiber.return
           (match Stdune.Stat.stat s with
            | exception exn -> Error exn
-           | stat -> Ok (`Mtime stat.mtime))
+           | stat -> Ok (`Mtime (Time.to_secs stat.mtime)))
       ;;
 
       let read_file s =


### PR DESCRIPTION
This was breaking a public API