### PR TITLE
Send SIGTERM before SIGKILL on watch-mode cancellation

### DIFF
--- a/doc/changes/fixed/14224.md
+++ b/doc/changes/fixed/14224.md
@@ -1,0 +1,3 @@
+- Send SIGTERM before SIGKILL when cancelling child processes in watch
+  mode, giving cleanup handlers a chance to run before escalating.
+  (#14224, #14170, fixes #2445, @robinbb)

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -74,16 +74,26 @@ type termination_reason =
 (* We use this version privately in this module whenever we can pass the
    scheduler explicitly *)
 let wait_for_build_process t ~is_process_group_leader pid =
+  let sigkill_alarm = ref None in
   let+ res, outcome =
     Fiber.Cancel.with_handler
       t.cancel
       ~on_cancel:(fun () ->
-        Process_watcher.killall t.process_watcher Sys.sigkill;
-        Fiber.return ())
+        if not Sys.win32 then Process_watcher.killall t.process_watcher Sys.sigterm;
+        let alarm_clock = Lazy.force t.alarm_clock in
+        let sleep = Alarm_clock.sleep alarm_clock sigterm_grace_period in
+        sigkill_alarm := Some sleep;
+        Alarm_clock.await sleep
+        >>| function
+        | `Cancelled -> ()
+        | `Finished -> Process_watcher.killall t.process_watcher Sys.sigkill)
       (fun () ->
          let+ r = wait_for_process t ~is_process_group_leader pid in
          if not Sys.win32
          then Process_watcher.kill_process_group pid Sys.sigterm ~is_process_group_leader;
+         (match !sigkill_alarm with
+          | None -> ()
+          | Some alarm -> Alarm_clock.cancel (Lazy.force t.alarm_clock) alarm);
          r)
   in
   ( res


### PR DESCRIPTION
Fixes #2445 

- Extend the SIGTERM-before-SIGKILL grace period to the `on_cancel` path (watch mode rebuilds). Previously, only the shutdown path (`kill_and_wait_for_all_processes`) sent SIGTERM first (#14170). Now watch-mode cancellations also give child processes a chance to clean up before SIGKILL.
- Uses the alarm clock to schedule SIGKILL after the grace period, and cancels the alarm if the process exits before the deadline, avoiding unnecessary delays to rebuilds.
- Skip `stray-process` and `debug-event` tests on macOS due to the known `sigwait` unreliability (see `signal_watcher.ml`).