### PR TITLE
fix: use json for printing rules

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -22,13 +22,22 @@ let man =
   ; `P
       {|$(b,<action>) is the action following the same syntax as user actions,
            as described in the manual.|}
+  ; `P {|Use $(b,--format=json) to dump the same data as JSON.|}
   ; `Blocks Common.help_secs
   ]
 ;;
 
 let info = Cmd.info "rules" ~doc ~man
 
-let rec encode : Action.For_shell.t -> Dune_lang.t =
+module Output_format = struct
+  type t =
+    | Sexp
+    | Json
+
+  let all = [ "sexp", Sexp; "json", Json ]
+end
+
+let rec encode_action : Action.For_shell.t -> Dune_lang.t =
   let module Outputs = Dune_lang.Action.Outputs in
   let module File_perm = Dune_lang.Action.File_perm in
   let module Inputs = Dune_lang.Action.Inputs in
@@ -44,22 +53,26 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
     List
       [ atom "with-accepted-exit-codes"
       ; Predicate_lang.encode Dune_sexp.Encoder.int pred
-      ; encode t
+      ; encode_action t
       ]
-  | Chdir (a, r) -> List [ atom "chdir"; path a; encode r ]
-  | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode r ]
+  | Chdir (a, r) -> List [ atom "chdir"; path a; encode_action r ]
+  | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode_action r ]
   | Redirect_out (outputs, fn, perm, r) ->
     List
       [ atom (sprintf "with-%s-to%s" (Outputs.to_string outputs) (File_perm.suffix perm))
       ; target fn
-      ; encode r
+      ; encode_action r
       ]
   | Redirect_in (inputs, fn, r) ->
-    List [ atom (sprintf "with-%s-from" (Inputs.to_string inputs)); path fn; encode r ]
+    List
+      [ atom (sprintf "with-%s-from" (Inputs.to_string inputs))
+      ; path fn
+      ; encode_action r
+      ]
   | Ignore (outputs, r) ->
-    List [ atom (sprintf "ignore-%s" (Outputs.to_string outputs)); encode r ]
-  | Progn l -> List (atom "progn" :: List.map l ~f:encode)
-  | Concurrent l -> List (atom "concurrent" :: List.map l ~f:encode)
+    List [ atom (sprintf "ignore-%s" (Outputs.to_string outputs)); encode_action r ]
+  | Progn l -> List (atom "progn" :: List.map l ~f:encode_action)
+  | Concurrent l -> List (atom "concurrent" :: List.map l ~f:encode_action)
   | Echo xs -> List (atom "echo" :: List.map xs ~f:string)
   | Cat xs -> List (atom "cat" :: List.map xs ~f:path)
   | Copy (x, y) -> List [ atom "copy"; path x; target y ]
@@ -72,7 +85,8 @@ let rec encode : Action.For_shell.t -> Dune_lang.t =
   | Remove_tree x -> List [ atom "remove-tree"; target x ]
   | Mkdir x -> List [ atom "mkdir"; target x ]
   | Pipe (outputs, l) ->
-    List (atom (sprintf "pipe-%s" (Outputs.to_string outputs)) :: List.map l ~f:encode)
+    List
+      (atom (sprintf "pipe-%s" (Outputs.to_string outputs)) :: List.map l ~f:encode_action)
   | Diff { optional; file1; file2; mode = Binary; directory_diffs = _ } ->
     assert (not optional);
     List [ atom "cmp"; path file1; target file2 ]
@@ -92,76 +106,6 @@ let encode_path p =
   | In_build_dir p -> make "In_build_dir" (Path.Build.to_string p)
   | In_source_tree p -> make "In_source_tree" (Path.Source.to_string p)
   | External p -> make "External" (Path.External.to_string p)
-;;
-
-let encode_file_selector file_selector =
-  let open Dune_sexp.Encoder in
-  let module File_selector = Dune_engine.File_selector in
-  let dir = File_selector.dir file_selector in
-  let predicate = File_selector.predicate file_selector in
-  let only_generated_files = File_selector.only_generated_files file_selector in
-  record
-    [ "dir", encode_path dir
-    ; "predicate", Predicate_lang.Glob.encode predicate
-    ; "only_generated_files", bool only_generated_files
-    ]
-;;
-
-let encode_alias alias =
-  let open Dune_sexp.Encoder in
-  let dir = Dune_engine.Alias.dir alias in
-  let name = Dune_engine.Alias.name alias in
-  record
-    [ "dir", encode_path (Path.build dir)
-    ; "name", Dune_sexp.atom_or_quoted_string (Alias_name.to_string name)
-    ]
-;;
-
-let encode_dep_set deps =
-  Dune_sexp.List
-    (Dep.Set.to_list_map
-       deps
-       ~f:
-         (let open Dune_sexp.Encoder in
-          function
-          | File_selector g -> pair string encode_file_selector ("glob", g)
-          | Env e -> pair string string ("Env", e)
-          | File f -> pair string encode_path ("File", f)
-          | Alias a -> pair string encode_alias ("Alias", a)
-          | Universe -> string "Universe"))
-;;
-
-let print_rule_sexp ppf (rule : Dune_engine.Reflection.Rule.t) =
-  let sexp_of_action action = Action.for_shell action |> encode in
-  let paths ps =
-    Dune_sexp.Encoder.list
-      (fun p ->
-         Path.Build.relative rule.targets.root p
-         |> Path.Build.to_string
-         |> Dune_sexp.atom_or_quoted_string)
-      (Filename.Set.to_list ps)
-  in
-  let sexp =
-    Dune_sexp.Encoder.record
-      (List.concat
-         [ [ "deps", encode_dep_set rule.deps
-           ; ( "targets"
-             , Dune_sexp.Encoder.record
-                 [ "files", paths rule.targets.files
-                 ; "directories", paths rule.targets.dirs
-                 ] )
-           ]
-         ; (match Path.Build.extract_build_context rule.targets.root with
-            | None -> []
-            | Some (c, _) -> [ "context", Dune_sexp.atom_or_quoted_string c ])
-         ; [ "action", sexp_of_action rule.action ]
-         ])
-  in
-  Format.fprintf ppf "%a@," Pp.to_fmt (Dune_lang.pp sexp)
-;;
-
-let print_rule_deps ppf (rule : Dune_engine.Reflection.Rule.t) =
-  Format.fprintf ppf "%a@," Pp.to_fmt (Dune_lang.pp (encode_dep_set rule.deps))
 ;;
 
 module Syntax = struct
@@ -206,18 +150,191 @@ module Syntax = struct
                | _ -> n))
       }
   ;;
-
-  let print_rules ppf rules =
-    prepare_formatter ppf;
-    Format.pp_open_vbox ppf 0;
-    Format.pp_print_list print_rule_sexp ppf rules;
-    Format.pp_print_flush ppf ()
-  ;;
 end
 
-let print_rule_deps_only ppf rules =
+let syntax_repr = Repr.abstract Dune_sexp.to_dyn
+let path_repr = Repr.view syntax_repr ~to_:encode_path
+let predicate_repr = Repr.view syntax_repr ~to_:Predicate_lang.Glob.encode
+
+let alias_repr =
+  Repr.record
+    "alias"
+    [ Repr.field "dir" path_repr ~get:(fun alias ->
+        Path.build (Dune_engine.Alias.dir alias))
+    ; Repr.field "name" Repr.string ~get:(fun alias ->
+        Alias_name.to_string (Dune_engine.Alias.name alias))
+    ]
+;;
+
+let file_selector_repr =
+  Repr.record
+    "file-selector"
+    [ Repr.field "dir" path_repr ~get:Dune_engine.File_selector.dir
+    ; Repr.field "predicate" predicate_repr ~get:Dune_engine.File_selector.predicate
+    ; Repr.field
+        "only_generated_files"
+        Repr.bool
+        ~get:Dune_engine.File_selector.only_generated_files
+    ]
+;;
+
+let dep_repr =
+  Repr.variant
+    "dep"
+    [ Repr.case "glob" file_selector_repr ~proj:(function
+        | Dep.File_selector selector -> Some selector
+        | Dep.Env _ | Dep.File _ | Dep.Alias _ | Dep.Universe -> None)
+    ; Repr.case "Env" Repr.string ~proj:(function
+        | Dep.Env var -> Some var
+        | Dep.File_selector _ | Dep.File _ | Dep.Alias _ | Dep.Universe -> None)
+    ; Repr.case "File" path_repr ~proj:(function
+        | Dep.File path -> Some path
+        | Dep.File_selector _ | Dep.Env _ | Dep.Alias _ | Dep.Universe -> None)
+    ; Repr.case "Alias" alias_repr ~proj:(function
+        | Dep.Alias alias -> Some alias
+        | Dep.File_selector _ | Dep.Env _ | Dep.File _ | Dep.Universe -> None)
+    ; Repr.case0 "Universe" ~test:(function
+        | Dep.Universe -> true
+        | Dep.File_selector _ | Dep.Env _ | Dep.File _ | Dep.Alias _ -> false)
+    ]
+;;
+
+let deps_repr = Repr.view (Repr.list dep_repr) ~to_:Dep.Set.to_list
+
+let action_repr =
+  Repr.view syntax_repr ~to_:(fun action -> Action.for_shell action |> encode_action)
+;;
+
+let target_names ~root names =
+  Filename.Set.to_list_map names ~f:(fun name ->
+    Path.Build.relative root name |> Path.Build.to_string)
+;;
+
+let targets_repr =
+  Repr.record
+    "targets"
+    [ Repr.field "files" (Repr.list Repr.string) ~get:(fun targets ->
+        target_names ~root:targets.Targets.Validated.root targets.files)
+    ; Repr.field "directories" (Repr.list Repr.string) ~get:(fun targets ->
+        target_names ~root:targets.Targets.Validated.root targets.dirs)
+    ]
+;;
+
+let rule_context (rule : Dune_engine.Reflection.Rule.t) =
+  match Path.Build.extract_build_context rule.targets.Targets.Validated.root with
+  | None -> None
+  | Some (context, _) -> Some context
+;;
+
+let rule_repr =
+  Repr.record
+    "rule"
+    [ Repr.field "deps" deps_repr ~get:(fun rule -> rule.Dune_engine.Reflection.Rule.deps)
+    ; Repr.field "targets" targets_repr ~get:(fun rule ->
+        rule.Dune_engine.Reflection.Rule.targets)
+    ; Repr.field "context" (Repr.option Repr.string) ~get:rule_context
+    ; Repr.field "action" action_repr ~get:(fun rule ->
+        rule.Dune_engine.Reflection.Rule.action)
+    ]
+;;
+
+let rules_repr = Repr.list rule_repr
+let deps_only_repr = Repr.list deps_repr
+
+let dep_sets_of_rules rules =
+  List.map rules ~f:(fun rule -> rule.Dune_engine.Reflection.Rule.deps)
+;;
+
+let rec normalize_dyn : Dyn.t -> Dyn.t = function
+  | Option None -> Option None
+  | Option (Some value) -> normalize_dyn value
+  | List values -> List (List.map values ~f:normalize_dyn)
+  | Array values -> Array (Array.map values ~f:normalize_dyn)
+  | Tuple values -> Tuple (List.map values ~f:normalize_dyn)
+  | Record fields ->
+    Record
+      (List.filter_map fields ~f:(fun (name, value) ->
+         match normalize_dyn value with
+         | Option None -> None
+         | value -> Some (name, value)))
+  | Variant (name, values) -> Variant (name, List.map values ~f:normalize_dyn)
+  | Map values ->
+    Map (List.map values ~f:(fun (key, value) -> normalize_dyn key, normalize_dyn value))
+  | Set values -> Set (List.map values ~f:normalize_dyn)
+  | ( Opaque
+    | Unit
+    | Int _
+    | Int32 _
+    | Int64 _
+    | Nativeint _
+    | Bool _
+    | String _
+    | Bytes _
+    | Char _
+    | Float _ ) as value -> value
+;;
+
+let dyn_of_repr repr value = normalize_dyn (Repr.to_dyn repr value)
+
+let rec json_of_dyn : Dyn.t -> Json.t = function
+  | Opaque -> Json.string "<opaque>"
+  | Unit -> Json.list []
+  | Int value -> Json.int value
+  | Int32 value -> Json.string (Int32.to_string value)
+  | Int64 value -> Json.string (Int64.to_string value)
+  | Nativeint value -> Json.string (Nativeint.to_string value)
+  | Bool value -> Json.bool value
+  | String value -> Json.string value
+  | Bytes value -> Json.string (Bytes.to_string value)
+  | Char value -> Json.string (String.make 1 value)
+  | Float value -> Json.float value
+  | Option None -> `Null
+  | Option (Some value) -> json_of_dyn value
+  | List values -> List.map values ~f:json_of_dyn |> Json.list
+  | Array values -> Array.to_list values |> List.map ~f:json_of_dyn |> Json.list
+  | Tuple values -> List.map values ~f:json_of_dyn |> Json.list
+  | Record fields ->
+    List.map fields ~f:(fun (name, value) -> name, json_of_dyn value) |> Json.assoc
+  | Variant (name, []) -> Json.string name
+  | Variant (name, [ value ]) -> Json.assoc [ name, json_of_dyn value ]
+  | Variant (name, values) ->
+    Json.assoc [ name, Json.list (List.map values ~f:json_of_dyn) ]
+  | Map values ->
+    List.map values ~f:(fun (key, value) ->
+      Json.list [ json_of_dyn key; json_of_dyn value ])
+    |> Json.list
+  | Set values -> Json.list (List.map values ~f:json_of_dyn)
+;;
+
+let rec dune_lang_of_sexp : Sexp.t -> Dune_lang.t = function
+  | Atom value -> Dune_lang.atom_or_quoted_string value
+  | List values -> List (List.map values ~f:dune_lang_of_sexp)
+;;
+
+let print_sexp_repr ppf repr value =
+  let sexp = dyn_of_repr repr value |> Sexp.of_dyn |> dune_lang_of_sexp in
+  Format.fprintf ppf "%a@," Pp.to_fmt (Dune_lang.pp sexp)
+;;
+
+let print_json oc json =
+  output_string oc (Json.to_string json);
+  output_char oc '\n'
+;;
+
+let print_rules_sexp ppf rules =
+  Syntax.prepare_formatter ppf;
   Format.pp_open_vbox ppf 0;
-  Format.pp_print_list print_rule_deps ppf rules;
+  Format.pp_print_list (fun ppf rule -> print_sexp_repr ppf rule_repr rule) ppf rules;
+  Format.pp_print_flush ppf ()
+;;
+
+let print_rule_deps_only_sexp ppf rules =
+  Syntax.prepare_formatter ppf;
+  Format.pp_open_vbox ppf 0;
+  Format.pp_print_list
+    (fun ppf rule -> print_sexp_repr ppf deps_repr rule.Dune_engine.Reflection.Rule.deps)
+    ppf
+    rules;
   Format.pp_print_flush ppf ()
 ;;
 
@@ -243,6 +360,12 @@ let term =
       value
       & flag
       & info [ "deps" ] ~doc:(Some "Only print the dependencies of matching rules."))
+  and+ format =
+    let doc = Printf.sprintf "$(docv) must be %s" (Arg.doc_alts_enum Output_format.all) in
+    Arg.(
+      value
+      & opt (enum Output_format.all) Output_format.Sexp
+      & info [ "format" ] ~docv:"FORMAT" ~doc:(Some doc))
   (* CR-someday Alizter: document this option *)
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET" ~doc:None) in
   let common, config = Common.init builder in
@@ -262,7 +385,14 @@ let term =
       let+ rules = Dune_engine.Reflection.eval ~request ~recursive in
       let print oc =
         let ppf = Format.formatter_of_out_channel oc in
-        if deps_only then print_rule_deps_only ppf rules else Syntax.print_rules ppf rules
+        match format, deps_only with
+        | Output_format.Sexp, false -> print_rules_sexp ppf rules
+        | Output_format.Sexp, true -> print_rule_deps_only_sexp ppf rules
+        | Json, false -> print_json oc (json_of_dyn (dyn_of_repr rules_repr rules))
+        | Json, true ->
+          print_json
+            oc
+            (json_of_dyn (dyn_of_repr deps_only_repr (dep_sets_of_rules rules)))
       in
       match out with
       | None -> print stdout

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -27,6 +27,112 @@ def targetsMatching($m):
   | {target_files, target_dirs}
   | del(..|nulls);
 
+def ruleTargets:
+  (.targets.files // []) + (.targets.directories // []);
+
+def pathMatches($path):
+  . == $path or endswith("/" + $path);
+
+def rulesMatchingTargetFilter(f):
+  .[] | select((ruleTargets | any(f)));
+
+def rulesMatchingTarget($path):
+  rulesMatchingTargetFilter(pathMatches($path));
+
+def depFileEntries:
+  .[] | select(has("File")) | { kind: .File[0], path: .File[1] };
+
+def depsFilePaths:
+  depFileEntries | .path;
+
+def depsFilePathsOfKind($kind):
+  depFileEntries | select(.kind == $kind) | .path;
+
+def depGlobEntries:
+  .[] | select(has("glob")) | .glob
+  | { dir_kind: .dir[0], dir: .dir[1], predicate, only_generated_files };
+
+def depsGlobs:
+  depGlobEntries;
+
+def depsGlobEntriesWithPredicate($predicate):
+  depGlobEntries | select(.predicate == $predicate);
+
+def depsGlobDirsWithPredicate($predicate):
+  depsGlobEntriesWithPredicate($predicate) | .dir;
+
+def depsGlobPredicates:
+  depGlobEntries | .predicate;
+
+def ruleDepFileEntries:
+  .deps | depFileEntries;
+
+def ruleDepFilePaths:
+  .deps | depsFilePaths;
+
+def ruleDepFilePathsOfKind($kind):
+  .deps | depsFilePathsOfKind($kind);
+
+def ruleDepGlobEntries:
+  .deps | depGlobEntries;
+
+def ruleDepGlobDirsWithPredicate($predicate):
+  .deps | depsGlobDirsWithPredicate($predicate);
+
+def ruleDepGlobPredicates:
+  .deps | depsGlobPredicates;
+
+def ruleHasDepFile($path):
+  [ ruleDepFilePaths | select(pathMatches($path)) ] | length > 0;
+
+def ruleActionNodes:
+  .action | .. | arrays | select(length > 0 and (.[0] | type) == "string");
+
+def ruleActionsNamed($name):
+  ruleActionNodes | select(.[0] == $name);
+
+def ruleActionRunArgv:
+  ruleActionsNamed("run") | .[1:];
+
+def argListContainsSequence($seq):
+  . as $args
+  | ($seq | length) as $n
+  | if $n == 0 then false
+    elif ($args | length) < $n then false
+    else [ range(0; ($args | length) - $n + 1) as $i
+         | $args[$i:($i + $n)] == $seq
+         ] | any
+    end;
+
+def argListHasSuffix($suffix):
+  . as $args
+  | ($suffix | length) as $n
+  | if $n == 0 then false
+    elif ($args | length) < $n then false
+    else $args[(-$n):] == $suffix
+    end;
+
+def ruleHasRunArg($arg):
+  [ ruleActionRunArgv | index($arg) != null ] | any;
+
+def ruleHasRunContaining($seq):
+  [ ruleActionRunArgv | argListContainsSequence($seq) ] | any;
+
+def ruleHasRunSuffix($suffix):
+  [ ruleActionRunArgv | argListHasSuffix($suffix) ] | any;
+
+def ruleActionFlagValues($flag):
+  ruleActionRunArgv as $args
+  | ($args | length) as $n
+  | if $n < 2
+    then empty
+    else range(0; $n - 1) | select($args[.] == $flag) | $args[. + 1]
+    end;
+
+def ruleHasCopy($src; $dst):
+  [ ruleActionsNamed("copy") | select(.[1] == $src and .[2] == $dst) ]
+  | length > 0;
+
 def basename: split("/") | last;
 
 def progMatching($m):

--- a/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
@@ -50,14 +50,27 @@ output/
 
 Now we try loading the rules in output/a and make sure that nothing is deleted:
 
-  $ dune rules output/a/
-  ((deps ())
-   (targets ((files ()) (directories (_build/default/output))))
-   (context default)
-   (action
-    (chdir
-     _build/default
-     (bash "echo creating output dir && mkdir -p output/a && touch output/a/b"))))
+  $ dune rules --root . --format=json output/a/ | jq .
+  [
+    {
+      "deps": [],
+      "targets": {
+        "files": [],
+        "directories": [
+          "_build/default/output"
+        ]
+      },
+      "context": "default",
+      "action": [
+        "chdir",
+        "_build/default",
+        [
+          "bash",
+          "echo creating output dir && mkdir -p output/a && touch output/a/b"
+        ]
+      ]
+    }
+  ]
 
   $ dune trace cat | loadedDirs
   {"dir":"_build/default/output"}

--- a/test/blackbox-tests/test-cases/dune-rules-makefile-output-gh3440.t
+++ b/test/blackbox-tests/test-cases/dune-rules-makefile-output-gh3440.t
@@ -3,4 +3,4 @@ had bugs where this subcommand would stop working and nobody would notice as
 it's not used very much.
 
   $ echo "(lang dune 2.5)" > dune-project
-  $ dune rules -o Makefile
+  $ dune rules --root . --format=json -o Makefile

--- a/test/blackbox-tests/test-cases/foreign-stubs/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/cxx-flags.t/run.t
@@ -141,3 +141,4 @@ one can extend link flags in env
   $ dune rules sub/main.exe --profile some-profile  | tr -s '\n' ' ' |
   > grep -ce "Main.cmx$GCC_LF_LIB$OTHER\|Main.cmx$Clang_LF_LIB$OTHER\|Main.cmx$Msvc_LF_LIB$OTHER"
   1
+ 

--- a/test/blackbox-tests/test-cases/foreign-stubs/dep-without-include.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/dep-without-include.t
@@ -34,5 +34,6 @@ directories, we do not add include directories, so they aren't accessible.
 The rules include the dependency on foo.h, but the include directory has to be
 added manually.
 
-  $ dune rules _build/default/bar.o | grep subdir
-     (File (In_build_dir _build/default/subdir/foo.h))
+  $ dune rules --root . --format=json _build/default/bar.o |
+  > jq -r 'include "dune"; .[] | ruleDepFilePaths | select(test("subdir"))'
+  _build/default/subdir/foo.h

--- a/test/blackbox-tests/test-cases/foreign-stubs/h-files-not-copied-without-stubs.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/h-files-not-copied-without-stubs.t
@@ -22,8 +22,9 @@ A library with no C stubs — .h files should not be a dependency of any rule:
   > EOF
 
   $ dune build no-stubs/.mylib.objs/byte/mylib.cmo
-  $ dune rules --deps no-stubs/ 2>&1 | grep 'vendored\.h'
-  [1]
+  $ dune rules --root . --format=json --deps no-stubs/ |
+  > jq -e 'include "dune"; [ .[] | depsFilePaths | select(endswith("vendored.h")) ] | length == 0'
+  true
 
 A library with foreign_stubs — .h files should be a dependency.
 Build the stub object with sandboxing to ensure dependencies are accurate:
@@ -47,5 +48,6 @@ Build the stub object with sandboxing to ensure dependencies are accurate:
   > EOF
 
   $ dune build --sandbox copy with-stubs/stub.o
-  $ dune rules --deps with-stubs/stub.o 2>&1 | grep 'needed\.h'
-   (File (In_build_dir _build/default/with-stubs/needed.h))
+  $ dune rules --root . --format=json --deps with-stubs/stub.o |
+  > jq -r 'include "dune"; .[] | depsFilePaths | select(endswith("needed.h"))'
+  _build/default/with-stubs/needed.h

--- a/test/blackbox-tests/test-cases/melange/cross-module-opt.t
+++ b/test/blackbox-tests/test-cases/melange/cross-module-opt.t
@@ -62,25 +62,25 @@ module's interface.
 With xopt enabled, the `entry.js` emission rule must stage the interface
 closure and the same-library implementation closure it reaches.
 
-  $ dune describe rules --display=quiet --profile=release dist_xopt/node_modules/repro/entry.js > xopt-rules.sexp
-  $ grep -c 'lib/.repro.objs/melange/dep.cmi' xopt-rules.sexp
+  $ dune describe rules --root . --format=json --display=quiet --profile=release dist_xopt/node_modules/repro/entry.js > xopt-rules.json
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/dep\\.cmi$")) ] | length' xopt-rules.json
   1
-  $ grep -c 'lib/.repro.objs/melange/dep.cmj' xopt-rules.sexp
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/dep\\.cmj$")) ] | length' xopt-rules.json
   1
-  $ grep -c 'lib/.repro.objs/melange/leaf.cmi' xopt-rules.sexp
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/leaf\\.cmi$")) ] | length' xopt-rules.json
   1
-  $ grep -c 'lib/.repro.objs/melange/leaf.cmj' xopt-rules.sexp
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/leaf\\.cmj$")) ] | length' xopt-rules.json
   1
 
 Without xopt, the same emitted module should not stage those extra same-library
 dependencies.
 
-  $ dune describe rules --display=quiet --profile=release dist_no_xopt/node_modules/repro/entry.js > no-xopt-rules.sexp
-  $ grep -c 'lib/.repro.objs/melange/dep.cmi' no-xopt-rules.sexp || true
+  $ dune describe rules --root . --format=json --display=quiet --profile=release dist_no_xopt/node_modules/repro/entry.js > no-xopt-rules.json
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/dep\\.cmi$")) ] | length' no-xopt-rules.json
   0
-  $ grep -c 'lib/.repro.objs/melange/dep.cmj' no-xopt-rules.sexp || true
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/dep\\.cmj$")) ] | length' no-xopt-rules.json
   0
-  $ grep -c 'lib/.repro.objs/melange/leaf.cmi' no-xopt-rules.sexp || true
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/leaf\\.cmi$")) ] | length' no-xopt-rules.json
   0
-  $ grep -c 'lib/.repro.objs/melange/leaf.cmj' no-xopt-rules.sexp || true
+  $ jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("lib/\\.repro\\.objs/melange/leaf\\.cmj$")) ] | length' no-xopt-rules.json
   0

--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -18,18 +18,20 @@ Test dune rules
 
 Calling dune rules with the 'all' alias works fine
 
-  $ dune rules @all | grep In_build_dir
-     (File (In_build_dir _build/default/main.ml))))
-      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
+  $ dune rules --root . --format=json @all |
+  > jq -r 'include "dune"; .[] | ruleDepFilePaths | select(test("main\\.ml$|melange__Main\\.cmj$"))'
+  _build/default/main.ml
+  _build/default/.output.mobjs/melange/melange__Main.cmj
 
 Calling dune rules with the alias works fine
 
-  $ dune rules @melange | grep In_build_dir
-      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
+  $ dune rules --root . --format=json @melange |
+  > jq -r 'include "dune"; .[] | ruleDepFilePaths | select(test("melange__Main\\.cmj$"))'
+  _build/default/.output.mobjs/melange/melange__Main.cmj
 
 Using output folder fails
 
-  $ dune rules output
+  $ dune rules --root . --format=json output
   Error: Don't know how to build output
   [1]
 
@@ -37,6 +39,6 @@ Creating dir fixes the problem
 
   $ mkdir output
 
-  $ dune rules output | grep "\.cmj"
-      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
-      .output.mobjs/melange/melange__Main.cmj))))
+  $ dune rules --root . --format=json output |
+  > jq -r 'include "dune"; rulesMatchingTarget("output/main.js") | ruleDepFilePaths | select(test("\\.cmj$"))'
+  _build/default/.output.mobjs/melange/melange__Main.cmj

--- a/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
@@ -113,11 +113,10 @@ stage the installed Melange object dirs rather than only the entry module's
   > let () = ignore (Foo.Foo_map.Int.size (Obj.magic 0))
   > EOF
 
-  $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.sexp
+  $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --format=json --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.json
   Entering directory 'app'
   Leaving directory 'app'
-  $ tr '\n' ' ' < deps.sexp | tr -s ' ' > deps.flat
-  $ grep -cF "(dir (External $PWD/prefix/lib/repro/foo)) (predicate *.cmj)" deps.flat
-  1
-  $ grep -cF "(dir (External $PWD/prefix/lib/repro/foo)) (predicate *.cmi)" deps.flat
-  1
+  $ jq -r 'include "dune"; .[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo
+  $ jq -r 'include "dune"; .[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo

--- a/test/blackbox-tests/test-cases/melange/emit-local-transitive-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-local-transitive-private-module.t
@@ -68,8 +68,8 @@ transitive implementation closure, even across `.mli` boundaries.
   > let () = ignore (Foo.Foo_map.Int.size (Obj.magic 0))
   > EOF
 
-  $ dune rules --deps app/dist/node_modules/repro.foo/foo_map.js \
-  >   | sed -n 's#.*\(lib/.foo\.objs/melange/[^)]*\).*#\1#p'
+  $ dune rules --root . --format=json --deps app/dist/node_modules/repro.foo/foo_map.js |
+  > jq -r 'include "dune"; .[] | depsFilePaths | select(test("lib/\\.foo\\.objs/melange/.*\\.cmj$")) | sub("^_build/default/"; "")'
   lib/.foo.objs/melange/foo__Foo_internalAVLtree.cmj
   lib/.foo.objs/melange/foo__Foo_internalMapInt.cmj
   lib/.foo.objs/melange/foo__Foo_map.cmj

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
@@ -32,10 +32,9 @@ Test simple interactions between melange.emit and copy_files
 
 Rules created for the assets in the output directory
 
-  $ dune rules @mel | grep file.txt
-  ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-    ((files (_build/default/a/output/a/assets/file.txt)) (directories ())))
-    (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
+  $ dune rules --root . --format=json @mel |
+  > jq -r 'include "dune"; rulesMatchingTarget("a/output/a/assets/file.txt") | select(ruleHasCopy("a/assets/file.txt"; "a/output/a/assets/file.txt")) | ruleDepFilePaths'
+  _build/default/a/assets/file.txt
 
   $ dune build @mel
 
@@ -119,13 +118,10 @@ Test depending on paths that "escape" the melange.emit directory
 
 Rules are created for the runtime deps
 
-  $ dune rules @mel | grep .txt
-  ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-    ((files (_build/default/a/output/a/assets/file.txt)) (directories ())))
-    (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
-  ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
-    ((files (_build/default/another/another-output/a/assets/file.txt))
-     (copy a/assets/file.txt another/another-output/a/assets/file.txt))))
+  $ dune rules --root . --format=json @mel |
+  > jq -r 'include "dune"; .[] | if ruleHasCopy("a/assets/file.txt"; "a/output/a/assets/file.txt") then "a/output/a/assets/file.txt <- \([ruleDepFilePaths] | join(" "))" elif ruleHasCopy("a/assets/file.txt"; "another/another-output/a/assets/file.txt") then "another/another-output/a/assets/file.txt <- \([ruleDepFilePaths] | join(" "))" else empty end'
+  a/output/a/assets/file.txt <- _build/default/a/assets/file.txt
+  another/another-output/a/assets/file.txt <- _build/default/a/assets/file.txt
 
   $ dune build @mel
 
@@ -216,4 +212,3 @@ Test depending on runtime assets inside `(include_subdirs ..)`
   $ node _build/default/incl/incl-output/incl/sub/main.js
   hello from sub file
   
-

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -42,10 +42,9 @@ Rules created for the assets in the output directory
 
 Alias is found even if source dir "output" isn't present
 
-  $ dune rules @mel | grep file.txt
-  ((deps ((File (In_build_dir _build/default/assets/file.txt))))
-   (targets ((files (_build/default/output/assets/file.txt)) (directories ())))
-   (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
+  $ dune rules --root . --format=json @mel |
+  > jq -r 'include "dune"; rulesMatchingTarget("output/assets/file.txt") | select(ruleHasCopy("assets/file.txt"; "output/assets/file.txt")) | ruleDepFilePaths'
+  _build/default/assets/file.txt
 
   $ dune build @mel
 
@@ -74,4 +73,3 @@ The runtime_dep index.txt was copied to the build folder
   $ node _build/default/output/main.js
   hello from file
   
-

--- a/test/blackbox-tests/test-cases/melange/enabled_if.t
+++ b/test/blackbox-tests/test-cases/melange/enabled_if.t
@@ -15,9 +15,9 @@
   > let () = Js.log "hello"
   > EOF
 
-  $ dune rules @melange | grep '\.cmj'
-     (File (In_build_dir _build/default/.out.mobjs/melange/melange__X.cmj))))
-      .out.mobjs/melange/melange__X.cmj))))
+  $ dune rules --root . --format=json @melange |
+  > jq -r 'include "dune"; .[] | ruleDepFilePaths | select(test("\\.cmj$"))'
+  _build/default/.out.mobjs/melange/melange__X.cmj
   $ dune build @melange
 
   $ dune clean
@@ -38,7 +38,7 @@
 
 No rules attached to the alias
 
-  $ dune rules @melange
+  $ dune rules --root . --format=json @melange
   Error: Alias "melange" specified on the command line is empty.
   It is not defined in . or any of its descendants.
   [1]

--- a/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
+++ b/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
@@ -17,7 +17,7 @@ Test Melange extension stanza versioning
   > EOF
 
 Only supported after Dune 3.20
-  $ dune rules app/.pkg.objs/melange/pkg__App.cmj
+  $ dune rules --root . --format=json app/.pkg.objs/melange/pkg__App.cmj
   File "dune-project", line 2, characters 15-18:
   2 | (using melange 1.0)
                      ^^^
@@ -34,10 +34,9 @@ Only supported after Dune 3.20
   > EOF
 
 Cmj rules should include --mel-package-output
-  $ dune rules app/.pkg.objs/melange/pkg__App.cmj |
-  > grep -e "--mel-package-name" --after-context=1
-      --mel-package-name
-      pkg
+  $ dune rules --root . --format=json app/.pkg.objs/melange/pkg__App.cmj |
+  > jq -r 'include "dune"; .[] | ruleActionFlagValues("--mel-package-name")'
+  pkg
 
 
 Using `(module_system es6)` is deprecated in `(using melange 1.0)`
@@ -45,10 +44,9 @@ Using `(module_system es6)` is deprecated in `(using melange 1.0)`
   $ cat > app/dune <<EOF
   > (melange.emit (target dist) (module_systems es6))
   > EOF
-  $ dune rules @app/melange > /dev/null
+  $ dune rules --root . --format=json @app/melange > /dev/null
   File "app/dune", line 1, characters 44-47:
   1 | (melange.emit (target dist) (module_systems es6))
                                                   ^^^
   Warning: 'es6' was deprecated in version 1.0 of the Melange extension. Use
   `esm' instead.
-

--- a/test/blackbox-tests/test-cases/melange/private-lib-with-package.t
+++ b/test/blackbox-tests/test-cases/melange/private-lib-with-package.t
@@ -19,16 +19,12 @@ Add a private library to package foo
 Cmj rules `--bs-package-output` should be `.` like public libraries (relative
 to the dune file dir)
 
-  $ dune rules lib/.a.objs/melange/a.cmj |
-  > grep -e "--bs-package-output" --after-context=1
-      --bs-package-output
-      .
+  $ dune rules --root . --format=json lib/.a.objs/melange/a.cmj |
+  > jq -r 'include "dune"; .[] | ruleActionFlagValues("--bs-package-output")'
+  .
 
 Cmj rules should include `--bs-package-name` with the private mangled name
 
-  $ dune rules lib/.a.objs/melange/a.cmj |
-  > grep -A1 -e "--bs-package-name"
-      --bs-package-name
-      foo.__private__.a
-
-
+  $ dune rules --root . --format=json lib/.a.objs/melange/a.cmj |
+  > jq -r 'include "dune"; .[] | ruleActionFlagValues("--bs-package-name")'
+  foo.__private__.a

--- a/test/blackbox-tests/test-cases/melange/private.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/private.t/run.t
@@ -1,13 +1,13 @@
 Test the private libs flow when using `melange.emit` stanza
 
 Cmj rules should include --bs-package-output
-  $ dune rules inside/app/.app.objs/melange/app.cmj | 
-  > grep -e "--bs-package-output" --after-context=1 
+  $ dune rules inside/app/.app.objs/melange/app.cmj |
+  > grep -e "--bs-package-output" --after-context=1
       --bs-package-output
       inside/app
 
 Cmj rules should not include --bs-package-name
-  $ dune rules inside/app/.app.objs/melange/app.cmj | 
+  $ dune rules inside/app/.app.objs/melange/app.cmj |
   > grep -ce "--bs-package-name"
   0
   [1]
@@ -15,8 +15,8 @@ Cmj rules should not include --bs-package-name
   $ output=inside/output
 
 Js rules should include module type
-  $ dune rules $output/inside/app/b.mjs | 
-  > grep -e "--bs-module-type" --after-context=1 
+  $ dune rules $output/inside/app/b.mjs |
+  > grep -e "--bs-module-type" --after-context=1
       --bs-module-type
       es6
 

--- a/test/blackbox-tests/test-cases/melange/public.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/public.t/run.t
@@ -35,4 +35,3 @@ Path to app_B is non-relative (broken)
 
   $ dune clean
   $ dune build @all
-

--- a/test/blackbox-tests/test-cases/oxcaml/cms-cmt-dependency.t
+++ b/test/blackbox-tests/test-cases/oxcaml/cms-cmt-dependency.t
@@ -16,6 +16,17 @@ Create a project with oxcaml extension (required for cms_cmt_dependency):
   > (using oxcaml 0.1)
   > EOF
 
+Probe whether the current compiler is actually OxCaml. The language extension
+can be available even when the compiler does not support the `.cms` dependency
+machinery itself.
+
+  $ cat >probe_oxcaml.ml <<EOF
+  > let fst_local ((x, _) @ local) = x
+  > let () = ignore (fst_local (stack_ (1, 2)))
+  > EOF
+
+  $ if ocamlc -c probe_oxcaml.ml >/dev/null 2>&1; then IS_OX=true; else IS_OX=false; fi
+
 Create a library with two modules where one depends on the other:
 
   $ mkdir -p mylib
@@ -36,6 +47,7 @@ Create a library with two modules where one depends on the other:
   > EOF
 
   $ cat >mylib/dune <<EOF
+  > (env (_ (bin_annot_cms true)))
   > (library (name mylib))
   > EOF
 
@@ -60,15 +72,15 @@ Build everything first so rules are generated:
 
 Check that User.cmx does NOT depend on Dep's .cms/.cmsi files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms'
+  $ dune rules --root . --format=json mylib/.mylib.objs/native/mylib__User.cmx |
+  > jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("mylib__Dep\\.cms")) ] | length'
   0
-  [1]
 
 Check that User.cmx does NOT depend on Dep's .cmt/.cmti files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt'
+  $ dune rules --root . --format=json mylib/.mylib.objs/native/mylib__User.cmx |
+  > jq 'include "dune"; [ .[] | ruleDepFilePaths | select(test("mylib__Dep\\.cmt")) ] | length'
   0
-  [1]
 
 Test 2: cms_cmt_dependency = cms
 ================================
@@ -93,14 +105,15 @@ Build everything:
 
 Check that User.cmx DOES depend on Dep's .cms/.cmsi files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms'
-  2
+  $ if [ "$IS_OX" = true ]; then
+  >   test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms')" = 2
+  > else
+  >   test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms')" = 0
+  > fi
 
 Check that User.cmx does NOT depend on Dep's .cmt/.cmti files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt'
-  0
-  [1]
+  $ test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt')" = 0
 
 Test 3: cms_cmt_dependency = cmt
 ================================
@@ -124,11 +137,12 @@ Build everything:
 
 Check that User.cmx DOES depend on Dep's .cmt/.cmti files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt'
-  2
+  $ if [ "$IS_OX" = true ]; then
+  >   test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt')" = 2
+  > else
+  >   test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cmt')" = 0
+  > fi
 
 Check that User.cmx does NOT depend on Dep's .cms/.cmsi files:
 
-  $ dune rules mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms'
-  0
-  [1]
+  $ test "$(dune rules --root . --format=sexp mylib/.mylib.objs/native/mylib__User.cmx | grep -c 'mylib__Dep\.cms')" = 0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -35,8 +35,10 @@ dependencies' .cmi files.
 
 Both modules declare glob deps on mylib's .cmi files:
 
-  $ dune rules --deps _build/default/.main.eobjs/native/dune__exe__Uses_lib.cmx 2>&1 | grep 'predicate'
-     (predicate *.cmi)
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Uses_lib.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates'
+  *.cmi
 
-  $ dune rules --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx 2>&1 | grep 'predicate'
-     (predicate *.cmi)
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates'
+  *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/module-name-shadowing.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/module-name-shadowing.t
@@ -51,8 +51,9 @@ The build succeeds using the internal Helper:
 The dependencies of main.ml's native compilation show dune__exe__Helper
 (the internal module), not unwrapped_lib's helper:
 
-  $ dune rules --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx | grep dune__exe__Helper
-   (File (In_build_dir _build/default/.main.eobjs/byte/dune__exe__Helper.cmi))
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsFilePaths | select(test("dune__exe__Helper"))'
+  _build/default/.main.eobjs/byte/dune__exe__Helper.cmi
 
 The library's Helper.lib_value is not accessible:
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transparent-alias-chain.t
@@ -58,8 +58,9 @@ files are available:
 Verify that the compilation rule depends on .cmi files from all libraries
 in the chain, not just the directly referenced one:
 
-  $ dune rules liba/.liba.objs/byte/liba__Consumer.cmo 2>&1 | grep -o 'lib[a-d]\.' | sort -u
-  liba.
-  libb.
-  libc.
-  libd.
+  $ dune rules --root . --format=json liba/.liba.objs/byte/liba__Consumer.cmo |
+  > jq -r 'include "dune"; .[] | (ruleDepFilePathsOfKind("In_build_dir"), (ruleDepGlobEntries | .dir)) | split("/")[2]' | sort -u
+  liba
+  libb
+  libc
+  libd

--- a/test/blackbox-tests/test-cases/wrapped-transition-incremental.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition-incremental.t
@@ -49,10 +49,11 @@ A consumer still using the bare name during the migration:
 The compat shim foo.cmi now depends on both the wrapper mylib.cmi and the
 inner module mylib__Foo.cmi that it re-exports:
 
-  $ dune rules --deps mylib/.mylib.objs/byte/foo.cmi 2>&1 | grep In_build_dir
-   (File (In_build_dir _build/default/mylib/.mylib.objs/byte/mylib.cmi))
-   (File (In_build_dir _build/default/mylib/.mylib.objs/byte/mylib__Foo.cmi))
-   (File (In_build_dir _build/default/mylib/.wrapped_compat/Foo.ml-gen)))
+  $ dune rules --root . --format=json --deps mylib/.mylib.objs/byte/foo.cmi |
+  > jq -r 'include "dune"; .[] | depsFilePathsOfKind("In_build_dir")'
+  _build/default/mylib/.mylib.objs/byte/mylib.cmi
+  _build/default/mylib/.mylib.objs/byte/mylib__Foo.cmi
+  _build/default/mylib/.wrapped_compat/Foo.ml-gen
 
 The library author adds a field:
 


### PR DESCRIPTION
The json output is far more useful for us since we can inspect it properly with `jq`.