### PR TITLE
chore: replace revdeps-dev-build workflow with a full nix derivation

### DIFF
--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -20,18 +20,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
-    strategy:
-      matrix:
-        include:
-          - name: OxCaml Trunk
-            repo: oxcaml/oxcaml
-            repo_name: oxcaml
-            ref: main
-            build_command: >-
-              autoconf &&
-              ./configure --prefix $PWD/_install --enable-dev --enable-runtime5 &&
-              make
+    name: OxCaml Trunk
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dune
@@ -50,33 +39,5 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
 
-      - name: Build Dune
-        run: |
-          # OxCaml requires Dune version >= 3.13. When Dune is built from source
-          # with Nix, it doesn't report the correct version. This step sets the
-          # version explicitly so that OxCaml's version check passes.
-          version=$(grep -oP '\(lang dune \K[^)]+' dune-project)
-          # Add a version if it doesn't exist.
-          grep -q '^(version' dune-project || echo "(version $version.0)" >> dune-project
-          nix develop -c make dev
-
-      - name: Create workspace
-        run: mkdir workspace
-
-      - name: Clone ${{ matrix.repo }}
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.repo }}
-          ref: ${{ matrix.ref }}
-          path: workspace/${{ matrix.repo_name }}
-          fetch-depth: 1
-
-      - name: Build ${{ matrix.name }}
-        working-directory: workspace/${{ matrix.repo_name }}
-        run: |
-          nix develop $GITHUB_WORKSPACE#ox-trunk -c bash -c '
-            export PATH="$GITHUB_WORKSPACE/_build/install/default/bin:$PATH"
-            echo "Using dune: $(which dune)"
-            dune --version
-            ${{ matrix.build_command }}
-          '
+      - name: Build OxCaml with Dune
+        run: nix build .#oxcaml-trunk-build

--- a/.github/workflows/revdeps-dev-build.yml
+++ b/.github/workflows/revdeps-dev-build.yml
@@ -15,18 +15,7 @@ permissions:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
-    strategy:
-      matrix:
-        include:
-          - name: OxCaml Trunk
-            repo: oxcaml/oxcaml
-            repo_name: oxcaml
-            ref: main
-            build_command: >-
-              autoconf &&
-              ./configure --prefix $PWD/_install --enable-dev --enable-runtime5 &&
-              make
+    name: Build OxCaml trunk with Dune
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dune
@@ -43,33 +32,5 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
           gc-max-store-size-linux: 2G
 
-      - name: Build Dune
-        run: |
-          # OxCaml requires Dune version >= 3.13. When Dune is built from source
-          # with Nix, it doesn't report the correct version. This step sets the
-          # version explicitly so that OxCaml's version check passes.
-          version=$(grep -oP '\(lang dune \K[^)]+' dune-project)
-          # Add a version if it doesn't exist.
-          grep -q '^(version' dune-project || echo "(version $version.0)" >> dune-project
-          nix develop -c make dev
-
-      - name: Create workspace
-        run: mkdir workspace
-
-      - name: Clone ${{ matrix.repo }}
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.repo }}
-          ref: ${{ matrix.ref }}
-          path: workspace/${{ matrix.repo_name }}
-          fetch-depth: 1
-
-      - name: Build ${{ matrix.name }}
-        working-directory: workspace/${{ matrix.repo_name }}
-        run: |
-          nix develop $GITHUB_WORKSPACE#ox-trunk -c bash -c '
-            export PATH="$GITHUB_WORKSPACE/_build/install/default/bin:$PATH"
-            echo "Using dune: $(which dune)"
-            dune --version
-            ${{ matrix.build_command }}
-          '
+      - name: Build OxCaml with Dune
+        run: nix build .#oxcaml-trunk-build

--- a/flake.nix
+++ b/flake.nix
@@ -222,6 +222,47 @@
             };
           dune = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
+          oxcaml-trunk-build =
+            let
+              dune-version =
+                let
+                  types = builtins.readFile ./otherlibs/dune-rpc/types.ml;
+                  match = builtins.match ".*let latest = ([0-9]+), ([0-9]+).*" types;
+                in
+                "${builtins.elemAt match 0}.${builtins.elemAt match 1}.0";
+              dune = (self.packages.${pkgs.stdenv.hostPlatform.system}.default).overrideAttrs {
+                postPatch = ''
+                  echo '(version ${dune-version})' >> dune-project
+                  sed -i '2a version: "${dune-version}"' opam/dune.opam
+                '';
+              };
+              menhirPackages = import ./nix/menhir.nix {
+                inherit pkgs menhir-src;
+              };
+            in
+            pkgs.stdenv.mkDerivation {
+              pname = "oxcaml-trunk-build";
+              version = "check";
+              src = oxcaml;
+              nativeBuildInputs = [
+                dune
+                pkgs.autoconf
+                pkgs.which
+                pkgs.ocamlPackages.ocaml
+                pkgs.ocamlPackages.findlib
+                menhirPackages.menhir
+              ];
+              strictDeps = true;
+              buildPhase = ''
+                autoconf
+                ./configure --prefix $PWD/_install --enable-dev --enable-runtime5
+                make SHELL=$SHELL
+              '';
+              installPhase = ''
+                mkdir -p $out
+                touch $out/success
+              '';
+            };
         }
       );
 
@@ -550,26 +591,9 @@
 
           ox-trunk =
             let
-              customOcamlPackages = pkgs.ocamlPackages.overrideScope (
-                oself: osuper: {
-                  menhirLib = osuper.menhirLib.overrideAttrs (old: {
-                    version = "20231231";
-                    src = menhir-src;
-                    patches = [ ];
-                  });
-                  menhirGLR = null;
-                  menhir = osuper.menhir.overrideAttrs (old: {
-                    version = "20231231";
-                    src = menhir-src;
-                    patches = [ ];
-                    buildInputs = builtins.filter (x: x != null) (old.buildInputs or [ ]);
-                    postInstall = (old.postInstall or "") + ''
-                      mkdir -p $out/lib/menhirLib
-                      cp ${oself.menhirLib}/lib/ocaml/*/site-lib/menhirLib/menhirLib.{ml,mli} $out/lib/menhirLib/
-                    '';
-                  });
-                }
-              );
+              menhirPackages = import ./nix/menhir.nix {
+                inherit pkgs menhir-src;
+              };
             in
             pkgs.mkShell {
               inherit INSIDE_NIX;
@@ -579,7 +603,7 @@
               inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
               nativeBuildInputs = [
                 pkgs.autoconf
-                customOcamlPackages.menhir
+                menhirPackages.menhir
               ];
               meta.description = ''
                 Provides a shell environment with upstream OCaml and menhir 20231231

--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,47 @@
             };
           dune = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
+          oxcaml-trunk-build =
+            let
+              dune-version =
+                let
+                  types = builtins.readFile ./otherlibs/dune-rpc/types.ml;
+                  match = builtins.match ".*let latest = ([0-9]+), ([0-9]+).*" types;
+                in
+                "${builtins.elemAt match 0}.${builtins.elemAt match 1}.0";
+              dune = (self.packages.${pkgs.stdenv.hostPlatform.system}.default).overrideAttrs {
+                postPatch = ''
+                  echo '(version ${dune-version})' >> dune-project
+                  sed -i '2a version: "${dune-version}"' opam/dune.opam
+                '';
+              };
+              menhirPackages = import ./nix/menhir.nix {
+                inherit pkgs menhir-src;
+              };
+            in
+            pkgs.stdenv.mkDerivation {
+              pname = "oxcaml-trunk-build";
+              version = "check";
+              src = oxcaml;
+              nativeBuildInputs = [
+                dune
+                pkgs.autoconf
+                pkgs.which
+                pkgs.ocamlPackages.ocaml
+                pkgs.ocamlPackages.findlib
+                menhirPackages.menhir
+              ];
+              strictDeps = true;
+              buildPhase = ''
+                autoconf
+                ./configure --prefix $PWD/_install --enable-dev --enable-runtime5
+                make SHELL=$SHELL
+              '';
+              installPhase = ''
+                mkdir -p $out
+                touch $out/success
+              '';
+            };
         }
       );
 
@@ -544,26 +585,9 @@
 
           ox-trunk =
             let
-              customOcamlPackages = pkgs.ocamlPackages.overrideScope (
-                oself: osuper: {
-                  menhirLib = osuper.menhirLib.overrideAttrs (old: {
-                    version = "20231231";
-                    src = menhir-src;
-                    patches = [ ];
-                  });
-                  menhirGLR = null;
-                  menhir = osuper.menhir.overrideAttrs (old: {
-                    version = "20231231";
-                    src = menhir-src;
-                    patches = [ ];
-                    buildInputs = builtins.filter (x: x != null) (old.buildInputs or [ ]);
-                    postInstall = (old.postInstall or "") + ''
-                      mkdir -p $out/lib/menhirLib
-                      cp ${oself.menhirLib}/lib/ocaml/*/site-lib/menhirLib/menhirLib.{ml,mli} $out/lib/menhirLib/
-                    '';
-                  });
-                }
-              );
+              menhirPackages = import ./nix/menhir.nix {
+                inherit pkgs menhir-src;
+              };
             in
             pkgs.mkShell {
               inherit INSIDE_NIX;
@@ -573,7 +597,7 @@
               inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
               nativeBuildInputs = [
                 pkgs.autoconf
-                customOcamlPackages.menhir
+                menhirPackages.menhir
               ];
               meta.description = ''
                 Provides a shell environment with upstream OCaml and menhir 20231231

--- a/nix/menhir.nix
+++ b/nix/menhir.nix
@@ -1,0 +1,31 @@
+# Menhir 20231231 — pinned version required by OxCaml.
+{
+  pkgs,
+  menhir-src,
+}:
+
+let
+  ocamlPackages = pkgs.ocamlPackages.overrideScope (
+    oself: osuper: {
+      menhirLib = osuper.menhirLib.overrideAttrs (old: {
+        version = "20231231";
+        src = menhir-src;
+        patches = [ ];
+      });
+      menhirGLR = null;
+      menhir = osuper.menhir.overrideAttrs (old: {
+        version = "20231231";
+        src = menhir-src;
+        patches = [ ];
+        buildInputs = builtins.filter (x: x != null) (old.buildInputs or [ ]);
+        postInstall = (old.postInstall or "") + ''
+          mkdir -p $out/lib/menhirLib
+          cp ${oself.menhirLib}/lib/ocaml/*/site-lib/menhirLib/menhirLib.{ml,mli} $out/lib/menhirLib/
+        '';
+      });
+    }
+  );
+in
+{
+  inherit (ocamlPackages) menhir menhirLib;
+}


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/14214

Add an oxcaml-trunk-build package that builds OxCaml trunk using the development version of Dune. This replaces the multi-step GitHub Actions workflow with a single `nix build .#oxcaml-trunk-build` invocation.

The derivation overrides the default Dune package to inject a version (extracted from otherlibs/dune-rpc/types.ml) into dune-project and the opam file, so that OxCaml's configure version check passes.

The menhir 20231231 override is extracted into nix/menhir.nix to be shared between the oxcaml-trunk-build package and the ox-trunk devShell.