### PR TITLE
feature: add tiny syntax for adding/removing trace flags

### DIFF
--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -6,6 +6,7 @@
  (libraries
   stdune
   dune_action_trace
+  re
   csexp
   bigstringaf
   threads.posix

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -6,15 +6,53 @@ module Out = struct
   include Out
 
   let create path =
+    let of_string_exn x =
+      match Category.of_string x with
+      | Some x -> x
+      | None -> User_error.raise [ Pp.textf "unrecognized trace category %S" x ]
+    in
     let cats =
       match Sys.getenv_opt "DUNE_TRACE" with
       | None -> Category.default
       | Some s ->
-        String.split ~on:',' s
-        |> List.map ~f:(fun x ->
-          match Category.of_string x with
-          | Some s -> s
-          | None -> User_error.raise [ Pp.textf "unrecognized trace category %S" x ])
+        let tokens =
+          let dune_trace_re = Re.compile (Re.set ",+-") in
+          Re.split_full dune_trace_re s
+          |> List.map ~f:(function
+            | `Text s -> `Category (of_string_exn s)
+            | `Delim g ->
+              (match Re.Group.get g 0 with
+               | "," -> `Comma
+               | "+" -> `Add
+               | "-" -> `Remove
+               | _ -> assert false))
+        in
+        if
+          List.for_all tokens ~f:(function
+            | `Category _ | `Comma -> true
+            | _ -> false)
+        then
+          (* We can do better validation here *)
+          List.filter_map tokens ~f:(function
+            | `Category x -> Some x
+            | _ -> None)
+        else (
+          let rec loop acc = function
+            | `Add :: `Category cat :: xs ->
+              let acc = cat :: acc in
+              loop acc xs
+            | `Remove :: `Category cat :: xs ->
+              let acc = List.filter acc ~f:(fun x -> x <> cat) in
+              loop acc xs
+            | [] -> acc
+            | _ :: _ ->
+              User_error.raise
+                [ Pp.text
+                    "invalid DUNE_TRACE. Either specify categories by only ',' or a mix \
+                     of '+', and '-' "
+                ]
+          in
+          loop Category.default tokens)
     in
     create cats path
   ;;

--- a/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
@@ -187,3 +187,24 @@ As well as data about the garbage collector:
     "stack_size",
     "top_heap_words"
   ]
+
+The [DUNE_TRACE] syntax can also update the default categories left to right:
+
+  $ check () {
+  >   rm -rf _build
+  >   export DUNE_TRACE="$1"
+  >   dune build prog.exe
+  >   dune trace cat | jq -sc --arg trace "$1" \
+  >     '{ trace: $trace
+  >      , process: any(.[]; .cat == "process")
+  >      , gc: any(.[]; .cat == "gc")
+  >      }'
+  > }
+  $ check gc
+  {"trace":"gc","process":false,"gc":true}
+  $ check +gc
+  {"trace":"+gc","process":true,"gc":true}
+  $ check +gc-process
+  {"trace":"+gc-process","process":false,"gc":true}
+  $ check -process+process
+  {"trace":"-process+process","process":true,"gc":false}


### PR DESCRIPTION
Add remove individual flags with `+foo` and `-bar` instead of having to specify the entire trace set.