### PR TITLE
test: `dune build @doc` fails to find `dune tools install odoc` installed odoc

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -1,0 +1,89 @@
+Test that `dune tools install odoc` lets `dune build @doc` pick up the locked
+odoc binary without requiring DUNE_CONFIG__LOCK_DEV_TOOL=enabled, mirroring
+the behaviour of `dune tools install ocamlformat` + `dune fmt`.
+
+This documents a current bug: `odoc_program` in src/dune_rules/odoc.ml only
+inspects the compile-time `lock_dev_tools` flag and never falls back to an
+`Fs_memo.dir_exists` check on the lockdir, unlike
+`Ocamlformat.dev_tool_lock_dir_exists` in src/dune_rules/format_rules.ml.
+
+  $ mkrepo
+  $ make_mock_odoc_package
+  $ mk_ocaml 5.2.0
+  $ setup_odoc_workspace
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.16)
+  > (package
+  >  (name foo)
+  >  (depends
+  >    (ocaml (= 5.2.0))))
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (public_name foo))
+  > EOF
+
+  $ cat > foo.ml <<EOF
+  > let hello () = print_endline "hi"
+  > EOF
+
+  $ cat > foo.mli <<EOF
+  > (** A greeting. *)
+  > val hello : unit -> unit
+  > EOF
+
+  $ dune build
+
+Install odoc via `dune tools install`, which populates the dev-tool lockdir
+at _build/.dev-tools.locks/odoc:
+
+  $ dune tools install odoc
+  Solution for _build/.dev-tools.locks/odoc:
+  - ocaml-base-compiler.5.2.0
+  - ocaml-compiler.5.2.0
+  - odoc.0.0.1
+
+With DUNE_CONFIG__LOCK_DEV_TOOL=enabled, `dune build @doc` consults the
+lockdir and invokes the mock odoc (which prints "hello from fake odoc"):
+
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune build @doc
+  hello from fake odoc
+  hello from fake odoc
+  File "_doc/_html/_unknown_", line 1, characters 0-0:
+  Error: Rule failed to produce directory "_doc/_html/odoc.support"
+  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
+  Error: Rule failed to generate the following targets:
+  - _doc/_odoc/pkg/foo/page-index.odoc
+  [1]
+
+Without the feature flag, `dune build @doc` should also pick up the locked
+odoc (as `dune fmt` does with ocamlformat). Currently it instead falls back
+to a PATH lookup and fails with "Program odoc not found" — this is the bug:
+
+  $ dune build @doc
+  File "_doc/_html/_unknown_", line 1, characters 0-0:
+  Error: Program odoc not found in the tree or in PATH
+   (context: default)
+  Hint: opam install odoc
+  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
+  Error: Program odoc not found in the tree or in PATH
+   (context: default)
+  Hint: opam install odoc
+  [1]
+
+Removing the lockdir should leave `dune build @doc` in the same failing state
+(PATH lookup), confirming the locked odoc was the only possible source:
+
+  $ rm -r "${dev_tool_lock_dir}"
+  $ dune build @doc
+  File "_doc/_html/_unknown_", line 1, characters 0-0:
+  Error: Program odoc not found in the tree or in PATH
+   (context: default)
+  Hint: opam install odoc
+  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
+  Error: Program odoc not found in the tree or in PATH
+   (context: default)
+  Hint: opam install odoc
+  [1]

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -34,6 +34,18 @@ inspects the compile-time `lock_dev_tools` flag and never falls back to an
   > val hello : unit -> unit
   > EOF
 
+Shadow any system-installed odoc with a fake binary so that PATH lookups have
+known behaviour regardless of what the test environment has installed:
+
+  $ mkdir .fakebin
+  $ cat > .fakebin/odoc <<EOF
+  > #!/bin/sh
+  > echo "odoc from PATH, not pkg" >&2
+  > exit 1
+  > EOF
+  $ chmod +x .fakebin/odoc
+  $ export PATH=$(pwd)/.fakebin:$PATH
+
   $ dune build
 
 Install odoc via `dune tools install`, which populates the dev-tool lockdir
@@ -60,30 +72,22 @@ lockdir and invokes the mock odoc (which prints "hello from fake odoc"):
 
 Without the feature flag, `dune build @doc` should also pick up the locked
 odoc (as `dune fmt` does with ocamlformat). Currently it instead falls back
-to a PATH lookup and fails with "Program odoc not found" — this is the bug:
+to a PATH lookup and runs the shim from .fakebin — this is the bug:
 
   $ dune build @doc
   File "_doc/_html/_unknown_", line 1, characters 0-0:
-  Error: Program odoc not found in the tree or in PATH
-   (context: default)
-  Hint: opam install odoc
+  odoc from PATH, not pkg
   File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
-  Error: Program odoc not found in the tree or in PATH
-   (context: default)
-  Hint: opam install odoc
+  odoc from PATH, not pkg
   [1]
 
-Removing the lockdir should leave `dune build @doc` in the same failing state
-(PATH lookup), confirming the locked odoc was the only possible source:
+Removing the lockdir should leave `dune build @doc` still falling back to the
+PATH shim, confirming the locked odoc was the only possible source:
 
   $ rm -r "${dev_tool_lock_dir}"
   $ dune build @doc
   File "_doc/_html/_unknown_", line 1, characters 0-0:
-  Error: Program odoc not found in the tree or in PATH
-   (context: default)
-  Hint: opam install odoc
+  odoc from PATH, not pkg
   File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
-  Error: Program odoc not found in the tree or in PATH
-   (context: default)
-  Hint: opam install odoc
+  odoc from PATH, not pkg
   [1]

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -34,22 +34,27 @@ inspects the compile-time `lock_dev_tools` flag and never falls back to an
   > val hello : unit -> unit
   > EOF
 
-Shadow any system-installed odoc with a fake binary so that PATH lookups have
-known behaviour regardless of what the test environment has installed:
-
-  $ mkdir .fakebin
-  $ cat > .fakebin/odoc <<EOF
-  > #!/bin/sh
-  > echo "odoc from PATH, not pkg" >&2
-  > exit 1
-  > EOF
-  $ chmod +x .fakebin/odoc
-  $ export PATH=$(pwd)/.fakebin:$PATH
-
   $ dune build
 
-Install odoc via `dune tools install`, which populates the dev-tool lockdir
-at _build/.dev-tools.locks/odoc:
+Helper to extract the odoc-related file dependencies of @doc:
+
+  $ odoc_deps() {
+  >   dune rules --deps --format=json @doc 2>/dev/null \
+  >     | jq '[.. | objects | select(.File != null) | .File[1] | select(test("odoc"))] | unique'
+  > }
+
+Baseline before installing the dev-tool: no path under .dev-tool/odoc shows up
+as a dep — dune isn't sourcing odoc from a lockdir (because there isn't one):
+
+  $ odoc_deps
+  [
+    "_build/default/_doc/_html/sherlodoc.js",
+    "_build/default/_doc/_odocls/foo/foo.odocl",
+    "_build/default/_doc/_odocls/foo/page-index.odocl"
+  ]
+
+Install odoc via `dune tools install`, populating the dev-tool lockdir at
+_build/.dev-tools.locks/odoc:
 
   $ dune tools install odoc
   Solution for _build/.dev-tools.locks/odoc:
@@ -57,37 +62,25 @@ at _build/.dev-tools.locks/odoc:
   - ocaml-compiler.5.2.0
   - odoc.0.0.1
 
-With DUNE_CONFIG__LOCK_DEV_TOOL=enabled, `dune build @doc` consults the
-lockdir and invokes the mock odoc (which prints "hello from fake odoc"):
+With DUNE_CONFIG__LOCK_DEV_TOOL=enabled, the locked odoc at
+_build/_private/default/.dev-tool/odoc/target/bin/odoc now appears as a
+dependency, so the build will invoke it instead of relying on PATH:
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dune build @doc
-  hello from fake odoc
-  hello from fake odoc
-  File "_doc/_html/_unknown_", line 1, characters 0-0:
-  Error: Rule failed to produce directory "_doc/_html/odoc.support"
-  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
-  Error: Rule failed to generate the following targets:
-  - _doc/_odoc/pkg/foo/page-index.odoc
-  [1]
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled odoc_deps
+  [
+    "_build/_private/default/.dev-tool/odoc/target/bin/odoc",
+    "_build/default/_doc/_html/sherlodoc.js",
+    "_build/default/_doc/_odocls/foo/foo.odocl",
+    "_build/default/_doc/_odocls/foo/page-index.odocl"
+  ]
 
-Without the feature flag, `dune build @doc` should also pick up the locked
-odoc (as `dune fmt` does with ocamlformat). Currently it instead falls back
-to a PATH lookup and runs the shim from .fakebin — this is the bug:
+Without the flag, `dune build @doc` should also pick up the locked odoc (as
+`dune fmt` does with ocamlformat). Currently the dev-tool path is missing from
+the rule deps — odoc is sourced from PATH instead. This is the bug:
 
-  $ dune build @doc
-  File "_doc/_html/_unknown_", line 1, characters 0-0:
-  odoc from PATH, not pkg
-  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
-  odoc from PATH, not pkg
-  [1]
-
-Removing the lockdir should leave `dune build @doc` still falling back to the
-PATH shim, confirming the locked odoc was the only possible source:
-
-  $ rm -r "${dev_tool_lock_dir}"
-  $ dune build @doc
-  File "_doc/_html/_unknown_", line 1, characters 0-0:
-  odoc from PATH, not pkg
-  File "_doc/_odoc/pkg/foo/_unknown_", line 1, characters 0-0:
-  odoc from PATH, not pkg
-  [1]
+  $ odoc_deps
+  [
+    "_build/default/_doc/_html/sherlodoc.js",
+    "_build/default/_doc/_odocls/foo/foo.odocl",
+    "_build/default/_doc/_odocls/foo/page-index.odocl"
+  ]

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -36,22 +36,22 @@ inspects the compile-time `lock_dev_tools` flag and never falls back to an
 
   $ dune build
 
-Helper to extract the odoc-related file dependencies of @doc:
+Helper that returns any file dependencies of @doc whose path lives under the
+dev-tool tree. Its presence in the rule deps means dune resolved odoc to the
+locked binary; its absence means dune fell back to a PATH lookup (which can
+itself surface in the rule deps as an absolute system path, hence the narrow
+filter on the dev-tool subtree):
 
-  $ odoc_deps() {
+  $ dev_tool_odoc_deps() {
   >   dune rules --deps --format=json @doc 2>/dev/null \
-  >     | jq '[.. | objects | select(.File != null) | .File[1] | select(test("odoc"))] | unique'
+  >     | jq '[.. | objects | select(.File != null) | .File[1] | select(test("\\.dev-tool/odoc/"))] | unique'
   > }
 
-Baseline before installing the dev-tool: no path under .dev-tool/odoc shows up
-as a dep — dune isn't sourcing odoc from a lockdir (because there isn't one):
+Baseline before installing the dev-tool: nothing under .dev-tool/odoc is a
+dep, since there is no lockdir to source from:
 
-  $ odoc_deps
-  [
-    "_build/default/_doc/_html/sherlodoc.js",
-    "_build/default/_doc/_odocls/foo/foo.odocl",
-    "_build/default/_doc/_odocls/foo/page-index.odocl"
-  ]
+  $ dev_tool_odoc_deps
+  []
 
 Install odoc via `dune tools install`, populating the dev-tool lockdir at
 _build/.dev-tools.locks/odoc:
@@ -62,25 +62,17 @@ _build/.dev-tools.locks/odoc:
   - ocaml-compiler.5.2.0
   - odoc.0.0.1
 
-With DUNE_CONFIG__LOCK_DEV_TOOL=enabled, the locked odoc at
-_build/_private/default/.dev-tool/odoc/target/bin/odoc now appears as a
-dependency, so the build will invoke it instead of relying on PATH:
+With DUNE_CONFIG__LOCK_DEV_TOOL=enabled, the locked odoc binary appears as a
+dep — dune will invoke it instead of relying on PATH:
 
-  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled odoc_deps
+  $ DUNE_CONFIG__LOCK_DEV_TOOL=enabled dev_tool_odoc_deps
   [
-    "_build/_private/default/.dev-tool/odoc/target/bin/odoc",
-    "_build/default/_doc/_html/sherlodoc.js",
-    "_build/default/_doc/_odocls/foo/foo.odocl",
-    "_build/default/_doc/_odocls/foo/page-index.odocl"
+    "_build/_private/default/.dev-tool/odoc/target/bin/odoc"
   ]
 
 Without the flag, `dune build @doc` should also pick up the locked odoc (as
-`dune fmt` does with ocamlformat). Currently the dev-tool path is missing from
-the rule deps — odoc is sourced from PATH instead. This is the bug:
+`dune fmt` does with ocamlformat) — but the dev-tool path is absent from the
+rule deps, so dune falls back to PATH instead. This is the bug:
 
-  $ odoc_deps
-  [
-    "_build/default/_doc/_html/sherlodoc.js",
-    "_build/default/_doc/_odocls/foo/foo.odocl",
-    "_build/default/_doc/_odocls/foo/page-index.odocl"
-  ]
+  $ dev_tool_odoc_deps
+  []


### PR DESCRIPTION
Reproduction case for
- #14235 