### PR TITLE
refactor: remove a lot of compare/equal boilerplate

### DIFF
--- a/otherlibs/stdune/src/char.ml
+++ b/otherlibs/stdune/src/char.ml
@@ -1,5 +1,7 @@
 include Stdlib.Char
 
+let repr = Repr.char
+
 let is_digit = function
   | '0' .. '9' -> true
   | _non_digit_char -> false
@@ -12,3 +14,4 @@ let is_lowercase_hex = function
 
 let[@inline always] hash c = Int.hash (code c)
 let compare x y = Ordering.of_int (compare x y)
+let to_dyn = Repr.to_dyn repr

--- a/otherlibs/stdune/src/char.mli
+++ b/otherlibs/stdune/src/char.mli
@@ -2,6 +2,8 @@ include module type of struct
   include Stdlib.Char
 end
 
+val repr : t Repr.t
+
 (** Check if a character belongs to the set [{'0'..'9'}]. *)
 val is_digit : t -> bool
 
@@ -10,3 +12,4 @@ val is_lowercase_hex : t -> bool
 
 val hash : t -> int
 val compare : t -> t -> Ordering.t
+val to_dyn : t -> Dyn.t

--- a/otherlibs/stdune/src/config.ml
+++ b/otherlibs/stdune/src/config.ml
@@ -31,17 +31,23 @@ module Toggle = struct
     | `Disabled
     ]
 
-  let all : (string * t) list = [ "enabled", `Enabled; "disabled", `Disabled ]
-
-  let equal x y =
-    match x, y with
-    | `Enabled, `Enabled -> true
-    | `Enabled, _ | _, `Enabled -> false
-    | `Disabled, `Disabled -> true
+  let repr =
+    Repr.variant
+      "config-toggle"
+      [ Repr.case0 "Enabled" ~test:(function
+          | `Enabled -> true
+          | `Disabled -> false)
+      ; Repr.case0 "Disabled" ~test:(function
+          | `Disabled -> true
+          | `Enabled -> false)
+      ]
   ;;
 
+  let all : (string * t) list = [ "enabled", `Enabled; "disabled", `Disabled ]
+  let equal, _ = Repr.make_compare repr
+
   let to_string t =
-    List.find_map all ~f:(fun (k, v) -> if Poly.equal v t then Some k else None)
+    List.find_map all ~f:(fun (k, v) -> if equal v t then Some k else None)
     |> Option.value_exn
   ;;
 
@@ -51,12 +57,7 @@ module Toggle = struct
     | None -> Error (sprintf "only %S and %S are allowed" "enabled" "disabled")
   ;;
 
-  let to_dyn =
-    let open Dyn in
-    function
-    | `Enabled -> variant "Enabled" []
-    | `Disabled -> variant "Disabled" []
-  ;;
+  let to_dyn = Repr.to_dyn repr
 end
 
 let init values =

--- a/otherlibs/stdune/src/file_kind.ml
+++ b/otherlibs/stdune/src/file_kind.ml
@@ -27,21 +27,32 @@ let to_string_hum = function
   | S_SOCK -> "socket"
 ;;
 
-let equal x y =
-  match x, y with
-  | S_REG, S_REG -> true
-  | S_REG, _ | _, S_REG -> false
-  | S_DIR, S_DIR -> true
-  | S_DIR, _ | _, S_DIR -> false
-  | S_CHR, S_CHR -> true
-  | S_CHR, _ | _, S_CHR -> false
-  | S_BLK, S_BLK -> true
-  | S_BLK, _ | _, S_BLK -> false
-  | S_LNK, S_LNK -> true
-  | S_LNK, _ | _, S_LNK -> false
-  | S_FIFO, S_FIFO -> true
-  | S_FIFO, _ | _, S_FIFO -> false
-  | S_SOCK, S_SOCK -> true
+let repr =
+  Repr.variant
+    "file-kind"
+    [ Repr.case0 "S_REG" ~test:(function
+        | S_REG -> true
+        | _ -> false)
+    ; Repr.case0 "S_DIR" ~test:(function
+        | S_DIR -> true
+        | _ -> false)
+    ; Repr.case0 "S_CHR" ~test:(function
+        | S_CHR -> true
+        | _ -> false)
+    ; Repr.case0 "S_BLK" ~test:(function
+        | S_BLK -> true
+        | _ -> false)
+    ; Repr.case0 "S_LNK" ~test:(function
+        | S_LNK -> true
+        | _ -> false)
+    ; Repr.case0 "S_FIFO" ~test:(function
+        | S_FIFO -> true
+        | _ -> false)
+    ; Repr.case0 "S_SOCK" ~test:(function
+        | S_SOCK -> true
+        | _ -> false)
+    ]
 ;;
 
-let to_dyn t = Dyn.String (to_string t)
+let equal, _ = Repr.make_compare repr
+let to_dyn = Repr.to_dyn repr

--- a/otherlibs/stdune/src/float.ml
+++ b/otherlibs/stdune/src/float.ml
@@ -1,12 +1,16 @@
 type t = float
 
+let repr = Repr.float
+
 let of_string f =
   try Some (float_of_string f) with
   | _ -> None
 ;;
 
 let to_string = string_of_float
+let equal = Stdlib.Float.equal
 let compare x y = Ordering.of_int (compare x y)
+let to_dyn = Repr.to_dyn repr
 
 let max x y =
   match compare x y with

--- a/otherlibs/stdune/src/float.mli
+++ b/otherlibs/stdune/src/float.mli
@@ -1,6 +1,9 @@
 type t = float
 
+val repr : t Repr.t
 val of_string : string -> t option
 val to_string : t -> string
+val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val max : t -> t -> t
+val to_dyn : t -> Dyn.t

--- a/otherlibs/stdune/src/platform.ml
+++ b/otherlibs/stdune/src/platform.ml
@@ -10,7 +10,37 @@ module OS = struct
     | Haiku
     | Other
 
-  let equal = Poly.equal
+  let repr =
+    Repr.variant
+      "platform"
+      [ Repr.case0 "Darwin" ~test:(function
+          | Darwin -> true
+          | _ -> false)
+      ; Repr.case0 "Linux" ~test:(function
+          | Linux -> true
+          | _ -> false)
+      ; Repr.case0 "Windows" ~test:(function
+          | Windows -> true
+          | _ -> false)
+      ; Repr.case0 "FreeBSD" ~test:(function
+          | FreeBSD -> true
+          | _ -> false)
+      ; Repr.case0 "NetBSD" ~test:(function
+          | NetBSD -> true
+          | _ -> false)
+      ; Repr.case0 "OpenBSD" ~test:(function
+          | OpenBSD -> true
+          | _ -> false)
+      ; Repr.case0 "Haiku" ~test:(function
+          | Haiku -> true
+          | _ -> false)
+      ; Repr.case0 "Other" ~test:(function
+          | Other -> true
+          | _ -> false)
+      ]
+  ;;
+
+  let equal, _ = Repr.make_compare repr
 
   external is_darwin : unit -> bool = "stdune_is_darwin"
   external is_freebsd : unit -> bool = "stdune_is_freebsd"
@@ -18,16 +48,7 @@ module OS = struct
   external is_openbsd : unit -> bool = "stdune_is_openbsd"
   external is_haiku : unit -> bool = "stdune_is_haiku"
 
-  let to_dyn : t -> Dyn.t = function
-    | Windows -> Dyn.variant "Windows" []
-    | Darwin -> Dyn.variant "Darwin" []
-    | Linux -> Dyn.variant "Linux" []
-    | FreeBSD -> Dyn.variant "FreeBSD" []
-    | NetBSD -> Dyn.variant "NetBSD" []
-    | OpenBSD -> Dyn.variant "OpenBSD" []
-    | Haiku -> Dyn.variant "Haiku" []
-    | Other -> Dyn.variant "Other" []
-  ;;
+  let to_dyn = Repr.to_dyn repr
 
   let is_linux () =
     try

--- a/otherlibs/stdune/src/repr.ml
+++ b/otherlibs/stdune/src/repr.ml
@@ -2,12 +2,19 @@ type _ t =
   | Unit : unit t
   | Bool : bool t
   | Int : int t
+  | Int32 : int32 t
+  | Int64 : int64 t
+  | Nativeint : nativeint t
   | String : string t
+  | Bytes : bytes t
+  | Char : char t
+  | Float : float t
   | Option : 'a t -> 'a option t
   | List : 'a t -> 'a list t
   | Array : 'a t -> 'a array t
   | Pair : 'a t * 'b t -> ('a * 'b) t
   | Triple : 'a t * 'b t * 'c t -> ('a * 'b * 'c) t
+  | Quadruple : 'a t * 'b t * 'c t * 'd t -> ('a * 'b * 'c * 'd) t
   | Fix : 'a t Lazy.t -> 'a t
   | Record : string * 'a field list -> 'a t
   | Variant : string * 'a case list -> 'a t
@@ -68,18 +75,19 @@ end
 module T4 = struct
   type ('a, 'b, 'c, 'd) t = 'a * 'b * 'c * 'd
 
-  let repr first second third fourth =
-    View
-      { repr = Pair (first, Triple (second, third, fourth))
-      ; to_ = (fun (first, second, third, fourth) -> first, (second, third, fourth))
-      }
-  ;;
+  let repr first second third fourth = Quadruple (first, second, third, fourth)
 end
 
 let unit = Unit
 let bool = Bool
 let int = Int
+let int32 = Int32
+let int64 = Int64
+let nativeint = Nativeint
 let string = String
+let bytes = Bytes
+let char = Char
+let float = Float
 let option repr = Option repr
 let list repr = List repr
 let array repr = Array repr
@@ -106,7 +114,13 @@ let rec to_dyn : type a. a repr -> a -> Dyn.t =
   | Unit -> Dyn.unit value
   | Bool -> Dyn.bool value
   | Int -> Dyn.int value
+  | Int32 -> Dyn.int32 value
+  | Int64 -> Dyn.int64 value
+  | Nativeint -> Dyn.nativeint value
   | String -> Dyn.string value
+  | Bytes -> Dyn.Bytes value
+  | Char -> Dyn.char value
+  | Float -> Dyn.float value
   | Option repr -> Dyn.option (to_dyn repr) value
   | List repr -> Dyn.list (to_dyn repr) value
   | Array repr -> Dyn.array (to_dyn repr) value
@@ -120,6 +134,14 @@ let rec to_dyn : type a. a repr -> a -> Dyn.t =
       (to_dyn second)
       (to_dyn third)
       (first_value, second_value, third_value)
+  | Quadruple (first, second, third, fourth) ->
+    let first_value, second_value, third_value, fourth_value = value in
+    Dyn.Tuple
+      [ to_dyn first first_value
+      ; to_dyn second second_value
+      ; to_dyn third third_value
+      ; to_dyn fourth fourth_value
+      ]
   | Fix repr -> to_dyn (Lazy.force repr) value
   | Record (_, fields) -> Dyn.record (to_dyn_fields fields value)
   | Variant (type_name, cases) -> to_dyn_case type_name cases value
@@ -146,6 +168,64 @@ and to_dyn_case : type a. string -> a case list -> a -> Dyn.t =
     (match proj value with
      | Some argument -> Dyn.variant tag [ to_dyn repr argument ]
      | None -> to_dyn_case type_name rest value)
+;;
+
+let make_compare repr =
+  let phys_equal left right = Stdlib.( == ) left right in
+  let fail ~path ~repr_kind =
+    Code_error.raise
+      "Repr.make_compare: repr is not sound for polymorphic comparison"
+      [ "path", Dyn.list Dyn.string (List.rev path); "repr_kind", Dyn.string repr_kind ]
+  in
+  let rec validate : type a. path:string list -> seen:Obj.t list -> a t -> unit =
+    fun ~path ~seen repr ->
+    match repr with
+    | Unit | Bool | Int | Int32 | Int64 | Nativeint | String | Bytes | Char -> ()
+    | Float -> fail ~path ~repr_kind:"float"
+    | Option repr -> validate ~path:("option" :: path) ~seen repr
+    | List repr -> validate ~path:("list" :: path) ~seen repr
+    | Array repr -> validate ~path:("array" :: path) ~seen repr
+    | Pair (left, right) ->
+      validate ~path:("pair:left" :: path) ~seen left;
+      validate ~path:("pair:right" :: path) ~seen right
+    | Triple (first, second, third) ->
+      validate ~path:("triple:first" :: path) ~seen first;
+      validate ~path:("triple:second" :: path) ~seen second;
+      validate ~path:("triple:third" :: path) ~seen third
+    | Quadruple (first, second, third, fourth) ->
+      validate ~path:("quadruple:first" :: path) ~seen first;
+      validate ~path:("quadruple:second" :: path) ~seen second;
+      validate ~path:("quadruple:third" :: path) ~seen third;
+      validate ~path:("quadruple:fourth" :: path) ~seen fourth
+    | Fix repr ->
+      let key = Obj.repr repr in
+      if List.exists seen ~f:(fun seen -> phys_equal seen key)
+      then ()
+      else validate ~path ~seen:(key :: seen) (Lazy.force repr)
+    | Record (_, fields) -> validate_fields ~path ~seen fields
+    | Variant (_, cases) -> validate_cases ~path ~seen cases
+    | View _ -> fail ~path ~repr_kind:"view"
+    | Abstract _ -> fail ~path ~repr_kind:"abstract"
+  and validate_fields
+    : type a. path:string list -> seen:Obj.t list -> a field list -> unit
+    =
+    fun ~path ~seen fields ->
+    match fields with
+    | [] -> ()
+    | Field { name; repr; _ } :: rest ->
+      validate ~path:(("field:" ^ name) :: path) ~seen repr;
+      validate_fields ~path ~seen rest
+  and validate_cases : type a. path:string list -> seen:Obj.t list -> a case list -> unit =
+    fun ~path ~seen cases ->
+    match cases with
+    | [] -> ()
+    | Case0 _ :: rest -> validate_cases ~path ~seen rest
+    | Case1 { tag; repr; _ } :: rest ->
+      validate ~path:(("case:" ^ tag) :: path) ~seen repr;
+      validate_cases ~path ~seen rest
+  in
+  validate ~path:[ "root" ] ~seen:[] repr;
+  Poly.equal, Poly.compare
 ;;
 
 module Make (T : S) = struct

--- a/otherlibs/stdune/src/repr.mli
+++ b/otherlibs/stdune/src/repr.mli
@@ -2,12 +2,19 @@ type _ t = private
   | Unit : unit t
   | Bool : bool t
   | Int : int t
+  | Int32 : int32 t
+  | Int64 : int64 t
+  | Nativeint : nativeint t
   | String : string t
+  | Bytes : bytes t
+  | Char : char t
+  | Float : float t
   | Option : 'a t -> 'a option t
   | List : 'a t -> 'a list t
   | Array : 'a t -> 'a array t
   | Pair : 'a t * 'b t -> ('a * 'b) t
   | Triple : 'a t * 'b t * 'c t -> ('a * 'b * 'c) t
+  | Quadruple : 'a t * 'b t * 'c t * 'd t -> ('a * 'b * 'c * 'd) t
   | Fix : 'a t Lazy.t -> 'a t
   | Record : string * 'a field list -> 'a t
   | Variant : string * 'a case list -> 'a t
@@ -75,7 +82,13 @@ val to_dyn : 'a repr -> 'a -> Dyn.t
 val unit : unit t
 val bool : bool t
 val int : int t
+val int32 : int32 t
+val int64 : int64 t
+val nativeint : nativeint t
 val string : string t
+val bytes : bytes t
+val char : char t
+val float : float t
 val option : 'a t -> 'a option t
 val list : 'a t -> 'a list t
 val array : 'a t -> 'a array t
@@ -89,6 +102,7 @@ val case : string -> 'b t -> proj:('a -> 'b option) -> 'a case
 val case0 : string -> test:('a -> bool) -> 'a case
 val variant : string -> 'a case list -> 'a t
 val abstract : ('a -> Dyn.t) -> 'a t
+val make_compare : 'a t -> ('a -> 'a -> bool) * ('a -> 'a -> Ordering.t)
 
 module Make (T : S) : sig
   val to_dyn : T.t -> Dyn.t

--- a/otherlibs/stdune/src/sexp.ml
+++ b/otherlibs/stdune/src/sexp.ml
@@ -34,23 +34,7 @@ let rec pp = function
 ;;
 
 let hash = Stdlib.Hashtbl.hash
-let string_equal (x : string) (y : string) = x = y
-
-let rec equal x y =
-  match x, y with
-  | Atom x, Atom y -> string_equal x y
-  | List x, List y -> equal_list x y
-  | _, _ -> false
-
-and equal_list xs ys =
-  (* replicating List.equal to avoid circular deps *)
-  match xs, ys with
-  | [], [] -> true
-  | x :: xs, y :: ys -> equal x y && equal_list xs ys
-  | _, _ -> false
-;;
-
-let compare x y = Ordering.of_int (compare x y)
+let equal, compare = Repr.make_compare repr
 
 let rec of_dyn : Dyn.t -> t = function
   | Opaque -> Atom "<opaque>"

--- a/otherlibs/stdune/test/repr_tests.ml
+++ b/otherlibs/stdune/test/repr_tests.ml
@@ -1,0 +1,92 @@
+open Stdune
+
+type sample =
+  { label : string
+  ; score : int option
+  ; marks : char array
+  ; tags : string list
+  }
+
+let sample_repr =
+  Repr.record
+    "sample"
+    [ Repr.field "label" Repr.string ~get:(fun { label; _ } -> label)
+    ; Repr.field "score" Repr.(option int) ~get:(fun { score; _ } -> score)
+    ; Repr.field "marks" Repr.(array char) ~get:(fun { marks; _ } -> marks)
+    ; Repr.field "tags" Repr.(list string) ~get:(fun { tags; _ } -> tags)
+    ]
+;;
+
+type tree =
+  | Leaf of int
+  | Node of tree list
+
+let tree_repr =
+  Repr.fix (fun repr ->
+    Repr.variant
+      "tree"
+      [ Repr.case "Leaf" Repr.int ~proj:(function
+          | Leaf value -> Some value
+          | Node _ -> None)
+      ; Repr.case "Node" (Repr.list repr) ~proj:(function
+          | Leaf _ -> None
+          | Node children -> Some children)
+      ])
+;;
+
+let print_code_error thunk =
+  match thunk () with
+  | () -> print_endline "ok"
+  | exception Code_error.E e ->
+    print_endline (Dyn.to_string (Code_error.to_dyn_without_loc e))
+;;
+
+let%expect_test "make_compare accepts structural reprs" =
+  let equal_sample, compare_sample = Repr.make_compare sample_repr in
+  let left =
+    { label = "a"; score = Some 1; marks = [| 'x'; 'y' |]; tags = [ "m"; "n" ] }
+  in
+  let right =
+    { label = "a"; score = Some 1; marks = [| 'x'; 'y' |]; tags = [ "m"; "n" ] }
+  in
+  let later = { label = "b"; score = None; marks = [| 'z' |]; tags = [ "m" ] } in
+  print_endline (Bool.to_string (equal_sample left right));
+  print_endline (Ordering.to_string (compare_sample left later));
+  let equal_tree, compare_tree = Repr.make_compare tree_repr in
+  let tree = Node [ Leaf 1; Node [ Leaf 2 ] ] in
+  print_endline (Bool.to_string (equal_tree tree tree));
+  print_endline (Ordering.to_string (compare_tree (Leaf 1) (Node [ Leaf 1 ])));
+  let equal_t4, compare_t4 =
+    Repr.make_compare (Repr.T4.repr Repr.int Repr.string Repr.bool Repr.char)
+  in
+  print_endline (Bool.to_string (equal_t4 (1, "x", true, 'z') (1, "x", true, 'z')));
+  print_endline (Ordering.to_string (compare_t4 (1, "x", true, 'a') (2, "x", true, 'a')));
+  [%expect
+    {|
+    true
+    <
+    true
+    <
+    true
+    <
+  |}]
+;;
+
+let%expect_test "make_compare rejects floats view and abstract reprs" =
+  print_code_error (fun () -> ignore (Repr.make_compare Repr.float));
+  print_code_error (fun () -> ignore (Repr.make_compare Repr.(option float)));
+  print_code_error (fun () ->
+    ignore (Repr.make_compare (Repr.view Repr.string ~to_:string_of_int)));
+  print_code_error (fun () -> ignore (Repr.make_compare (Repr.abstract Dyn.int)));
+  [%expect
+    {|
+    ("Repr.make_compare: repr is not sound for polymorphic comparison",
+     { path = [ "root" ]; repr_kind = "float" })
+    ("Repr.make_compare: repr is not sound for polymorphic comparison",
+     { path = [ "root"; "option" ]; repr_kind = "float" })
+    ("Repr.make_compare: repr is not sound for polymorphic comparison",
+     { path = [ "root" ]; repr_kind = "view" })
+    ("Repr.make_compare: repr is not sound for polymorphic comparison",
+     { path = [ "root" ]; repr_kind = "abstract" })
+  |}]
+;;

--- a/src/dune_cache/config.ml
+++ b/src/dune_cache/config.ml
@@ -8,10 +8,25 @@ module Reproducibility_check = struct
     | Check_with_probability of float
     | Check
 
+  let repr =
+    Repr.variant
+      "reproducibility-check"
+      [ Repr.case0 "Skip" ~test:(function
+          | Skip -> true
+          | Check_with_probability _ | Check -> false)
+      ; Repr.case "Check_with_probability" Repr.float ~proj:(function
+          | Check_with_probability p -> Some p
+          | Skip | Check -> None)
+      ; Repr.case0 "Check" ~test:(function
+          | Check -> true
+          | Skip | Check_with_probability _ -> false)
+      ]
+  ;;
+
   let equal a b =
     match a, b with
     | Skip, Skip | Check, Check -> true
-    | Check_with_probability a, Check_with_probability b -> a = b
+    | Check_with_probability a, Check_with_probability b -> Float.equal a b
     | _, _ -> false
   ;;
 
@@ -21,11 +36,7 @@ module Reproducibility_check = struct
     | Check -> true
   ;;
 
-  let to_dyn = function
-    | Skip -> Dyn.Variant ("Skip", [])
-    | Check_with_probability p -> Dyn.Variant ("Check_with_probability", [ Dyn.Float p ])
-    | Check -> Dyn.Variant ("Check", [])
-  ;;
+  let to_dyn = Repr.to_dyn repr
 
   let check_with_probability ?loc p =
     let error () =

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -22,12 +22,29 @@ module Dune_config = struct
       ; license : string list option
       }
 
-    let equal t { authors; maintainers; maintenance_intent; license } =
-      Option.equal (List.equal String.equal) t.authors authors
-      && Option.equal (List.equal String.equal) t.maintainers maintainers
-      && Option.equal (List.equal String.equal) t.maintenance_intent maintenance_intent
-      && Option.equal (List.equal String.equal) t.license license
+    let repr =
+      Repr.record
+        "project-defaults"
+        [ Repr.field
+            "authors"
+            (Repr.option (Repr.list Repr.string))
+            ~get:(fun t -> t.authors)
+        ; Repr.field
+            "maintainers"
+            (Repr.option (Repr.list Repr.string))
+            ~get:(fun t -> t.maintainers)
+        ; Repr.field
+            "maintenance_intent"
+            (Repr.option (Repr.list Repr.string))
+            ~get:(fun t -> t.maintenance_intent)
+        ; Repr.field
+            "license"
+            (Repr.option (Repr.list Repr.string))
+            ~get:(fun t -> t.license)
+        ]
     ;;
+
+    let equal, _ = Repr.make_compare repr
 
     let decode =
       fields
@@ -39,15 +56,7 @@ module Dune_config = struct
          { authors; maintainers; maintenance_intent; license })
     ;;
 
-    let to_dyn t =
-      let f = Dyn.(option (list string)) in
-      Dyn.record
-        [ "authors", f t.authors
-        ; "maintainers", f t.maintainers
-        ; "maintenance_intent", f t.maintenance_intent
-        ; "license", f t.license
-        ]
-    ;;
+    let to_dyn = Repr.to_dyn repr
   end
 
   module Pkg_enabled = struct
@@ -56,16 +65,16 @@ module Dune_config = struct
         | Cli
         | Loc of Loc.t
 
-      let equal x y =
-        match x, y with
-        | Cli, Cli -> true
-        | Loc x, Loc y -> Loc.equal x y
-        | _, _ -> false
-      ;;
-
-      let to_dyn = function
-        | Cli -> Dyn.variant "Cli" []
-        | Loc loc -> Dyn.variant "Loc" [ Loc.to_dyn loc ]
+      let repr =
+        Repr.variant
+          "pkg-enabled-where"
+          [ Repr.case0 "Cli" ~test:(function
+              | Cli -> true
+              | Loc _ -> false)
+          ; Repr.case "Loc" Loc.repr ~proj:(function
+              | Loc loc -> Some loc
+              | Cli -> None)
+          ]
       ;;
     end
 
@@ -77,25 +86,37 @@ module Dune_config = struct
       | Set of where * Config.Toggle.t
       | Unset
 
+    let repr =
+      let toggle_repr =
+        Repr.variant
+          "config-toggle"
+          [ Repr.case0 "Enabled" ~test:(function
+              | `Enabled -> true
+              | `Disabled -> false)
+          ; Repr.case0 "Disabled" ~test:(function
+              | `Disabled -> true
+              | `Enabled -> false)
+          ]
+      in
+      Repr.variant
+        "pkg-enabled"
+        [ Repr.case "Set" (Repr.pair Where.repr toggle_repr) ~proj:(function
+            | Set (where, toggle) -> Some (where, toggle)
+            | Unset -> None)
+        ; Repr.case0 "Unset" ~test:(function
+            | Unset -> true
+            | Set _ -> false)
+        ]
+    ;;
+
     let decode =
       let open Dune_lang.Decoder in
       let+ loc, value = located (enum Config.Toggle.all) in
       Set (Loc loc, value)
     ;;
 
-    let equal x y =
-      match x, y with
-      | Set (x_loc, x_toggle), Set (y_loc, y_toggle) ->
-        Where.equal x_loc y_loc && Config.Toggle.equal x_toggle y_toggle
-      | Unset, Unset -> true
-      | _, _ -> false
-    ;;
-
-    let to_dyn = function
-      | Set (loc, toggle) ->
-        Dyn.variant "Set" [ Where.to_dyn loc; Config.Toggle.to_dyn toggle ]
-      | Unset -> Dyn.variant "Unset" []
-    ;;
+    let equal, _ = Repr.make_compare repr
+    let to_dyn = Repr.to_dyn repr
 
     let all where =
       [ "enabled", Set (where, `Enabled); "disabled", Set (where, `Disabled) ]
@@ -108,6 +129,21 @@ module Dune_config = struct
       | Clear_on_rebuild
       | Clear_on_rebuild_and_flush_history
 
+    let repr =
+      Repr.variant
+        "terminal-persistence"
+        [ Repr.case0 "Preserve" ~test:(function
+            | Preserve -> true
+            | Clear_on_rebuild | Clear_on_rebuild_and_flush_history -> false)
+        ; Repr.case0 "Clear_on_rebuild" ~test:(function
+            | Clear_on_rebuild -> true
+            | Preserve | Clear_on_rebuild_and_flush_history -> false)
+        ; Repr.case0 "Clear_on_rebuild_and_flush_history" ~test:(function
+            | Clear_on_rebuild_and_flush_history -> true
+            | Preserve | Clear_on_rebuild -> false)
+        ]
+    ;;
+
     let all =
       [ "preserve", Preserve
       ; "clear-on-rebuild", Clear_on_rebuild
@@ -115,21 +151,8 @@ module Dune_config = struct
       ]
     ;;
 
-    let equal a b =
-      match a, b with
-      | Preserve, Preserve
-      | Clear_on_rebuild, Clear_on_rebuild
-      | Clear_on_rebuild_and_flush_history, Clear_on_rebuild_and_flush_history -> true
-      | _, _ -> false
-    ;;
-
-    let to_dyn = function
-      | Preserve -> Dyn.Variant ("Preserve", [])
-      | Clear_on_rebuild -> Dyn.Variant ("Clear_on_rebuild", [])
-      | Clear_on_rebuild_and_flush_history ->
-        Variant ("Clear_on_rebuild_and_flush_history", [])
-    ;;
-
+    let equal, _ = Repr.make_compare repr
+    let to_dyn = Repr.to_dyn repr
     let decode = enum all
   end
 
@@ -138,13 +161,19 @@ module Dune_config = struct
       | Fixed of int
       | Auto
 
-    let equal a b =
-      match a, b with
-      | Fixed a, Fixed b -> Int.equal a b
-      | Auto, Auto -> true
-      | _, _ -> false
+    let repr =
+      Repr.variant
+        "concurrency"
+        [ Repr.case "Fixed" Repr.int ~proj:(function
+            | Fixed n -> Some n
+            | Auto -> None)
+        ; Repr.case0 "Auto" ~test:(function
+            | Auto -> true
+            | Fixed _ -> false)
+        ]
     ;;
 
+    let equal, _ = Repr.make_compare repr
     let error = Error "invalid concurrency value, must be 'auto' or a positive number"
 
     let of_string = function
@@ -167,10 +196,7 @@ module Dune_config = struct
       | Fixed n -> string_of_int n
     ;;
 
-    let to_dyn = function
-      | Auto -> Dyn.Variant ("Auto", [])
-      | Fixed n -> Dyn.Variant ("Fixed", [ Int n ])
-    ;;
+    let to_dyn = Repr.to_dyn repr
   end
 
   module Sandboxing_preference = struct
@@ -198,13 +224,22 @@ module Dune_config = struct
         | Enabled_except_user_rules
         | Enabled
 
-      let equal a b =
-        match a, b with
-        | Disabled, Disabled
-        | Enabled_except_user_rules, Enabled_except_user_rules
-        | Enabled, Enabled -> true
-        | _, _ -> false
+      let repr =
+        Repr.variant
+          "cache-toggle"
+          [ Repr.case0 "Disabed" ~test:(function
+              | Disabled -> true
+              | Enabled_except_user_rules | Enabled -> false)
+          ; Repr.case0 "Enabled_except_user_rules" ~test:(function
+              | Enabled_except_user_rules -> true
+              | Disabled | Enabled -> false)
+          ; Repr.case0 "Enabled" ~test:(function
+              | Enabled -> true
+              | Disabled | Enabled_except_user_rules -> false)
+          ]
       ;;
+
+      let equal, _ = Repr.make_compare repr
 
       let to_string = function
         | Disabled -> "disabled"
@@ -228,11 +263,7 @@ module Dune_config = struct
           ]
       ;;
 
-      let to_dyn = function
-        | Disabled -> Dyn.variant "Disabed" []
-        | Enabled_except_user_rules -> Dyn.variant "Enabled_except_user_rules" []
-        | Enabled -> Dyn.variant "Enabled" []
-      ;;
+      let to_dyn = Repr.to_dyn repr
     end
 
     module Transport_deprecated = struct

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -182,6 +182,25 @@ let feed_repr hasher =
     | String ->
       feed_int hasher scratch 4;
       feed_string hasher scratch value
+    | Int32 ->
+      feed_int hasher scratch 12;
+      feed_int64 hasher scratch (Int64.of_int32 value)
+    | Int64 ->
+      feed_int hasher scratch 13;
+      feed_int64 hasher scratch value
+    | Nativeint ->
+      feed_int hasher scratch 14;
+      feed_int64 hasher scratch (Int64.of_nativeint value)
+    | Bytes ->
+      feed_int hasher scratch 15;
+      feed_int hasher scratch (Bytes.length value);
+      feed_bytes_raw hasher value ~len:(Bytes.length value)
+    | Char ->
+      feed_int hasher scratch 16;
+      feed_int hasher scratch (Char.code value)
+    | Float ->
+      feed_int hasher scratch 17;
+      feed_int64 hasher scratch (Int64.bits_of_float value)
     | Option repr ->
       feed_int hasher scratch 5;
       (match value with
@@ -208,6 +227,13 @@ let feed_repr hasher =
       loop first first_value;
       loop second second_value;
       loop third third_value
+    | Quadruple (first, second, third, fourth) ->
+      feed_int hasher scratch 18;
+      let first_value, second_value, third_value, fourth_value = value in
+      loop first first_value;
+      loop second second_value;
+      loop third third_value;
+      loop fourth fourth_value
     | Fix repr -> loop (Lazy.force repr) value
     | Record (_, fields) ->
       feed_int hasher scratch 10;

--- a/src/dune_lang/binary_kind.ml
+++ b/src/dune_lang/binary_kind.ml
@@ -7,22 +7,28 @@ type t =
   | Shared_object
   | Plugin
 
-let compare x y =
-  match x, y with
-  | C, C -> Eq
-  | C, _ -> Lt
-  | _, C -> Gt
-  | Exe, Exe -> Eq
-  | Exe, _ -> Lt
-  | _, Exe -> Gt
-  | Object, Object -> Eq
-  | Object, _ -> Lt
-  | _, Object -> Gt
-  | Shared_object, Shared_object -> Eq
-  | Shared_object, _ -> Lt
-  | _, Shared_object -> Gt
-  | Plugin, Plugin -> Eq
+let repr =
+  Repr.variant
+    "binary-kind"
+    [ Repr.case0 "c" ~test:(function
+        | C -> true
+        | _ -> false)
+    ; Repr.case0 "exe" ~test:(function
+        | Exe -> true
+        | _ -> false)
+    ; Repr.case0 "object" ~test:(function
+        | Object -> true
+        | _ -> false)
+    ; Repr.case0 "shared_object" ~test:(function
+        | Shared_object -> true
+        | _ -> false)
+    ; Repr.case0 "plugin" ~test:(function
+        | Plugin -> true
+        | _ -> false)
+    ]
 ;;
+
+let _, compare = Repr.make_compare repr
 
 let decode =
   let open Decoder in
@@ -43,6 +49,6 @@ let to_string = function
   | Plugin -> "plugin"
 ;;
 
-let to_dyn t = Dyn.variant (to_string t) []
+let to_dyn = Repr.to_dyn repr
 let encode t = Dune_sexp.atom (to_string t)
 let all = [ C; Exe; Object; Shared_object; Plugin ]

--- a/src/dune_lang/foreign_language.ml
+++ b/src/dune_lang/foreign_language.ml
@@ -5,25 +5,20 @@ module T = struct
     | C
     | Cxx
 
-  let compare x y =
-    match x, y with
-    | C, C -> Eq
-    | C, _ -> Lt
-    | _, C -> Gt
-    | Cxx, Cxx -> Eq
+  let repr =
+    Repr.variant
+      "foreign-language"
+      [ Repr.case0 "C" ~test:(function
+          | C -> true
+          | Cxx -> false)
+      ; Repr.case0 "Cxx" ~test:(function
+          | Cxx -> true
+          | C -> false)
+      ]
   ;;
 
-  let equal x y =
-    match x, y with
-    | C, C -> true
-    | Cxx, Cxx -> true
-    | _, _ -> false
-  ;;
-
-  let to_dyn = function
-    | C -> Dyn.Variant ("C", [])
-    | Cxx -> Dyn.Variant ("Cxx", [])
-  ;;
+  let equal, compare = Repr.make_compare repr
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_lang/js_of_ocaml.ml
+++ b/src/dune_lang/js_of_ocaml.ml
@@ -9,20 +9,24 @@ module Mode = struct
     | JS
     | Wasm
 
-  let equal (a : t) b = Poly.equal a b
+  let repr =
+    Repr.variant
+      "js-of-ocaml-mode"
+      [ Repr.case0 "js" ~test:(function
+          | JS -> true
+          | Wasm -> false)
+      ; Repr.case0 "wasm" ~test:(function
+          | Wasm -> true
+          | JS -> false)
+      ]
+  ;;
+
+  let equal, compare = Repr.make_compare repr
 
   let select ~mode ~js ~wasm =
     match mode with
     | JS -> js
     | Wasm -> wasm
-  ;;
-
-  let compare m m' =
-    match m, m' with
-    | JS, JS -> Eq
-    | JS, _ -> Lt
-    | _, JS -> Gt
-    | Wasm, Wasm -> Eq
   ;;
 
   let decode =
@@ -31,7 +35,7 @@ module Mode = struct
   ;;
 
   let to_string mode = select ~mode ~js:"js" ~wasm:"wasm"
-  let to_dyn t = Dyn.variant (to_string t) []
+  let to_dyn = Repr.to_dyn repr
   let all = [ JS; Wasm ]
 
   module Pair = struct
@@ -63,6 +67,21 @@ module Sourcemap = struct
     | Inline
     | File
 
+  let repr =
+    Repr.variant
+      "js-of-ocaml-sourcemap"
+      [ Repr.case0 "No" ~test:(function
+          | No -> true
+          | Inline | File -> false)
+      ; Repr.case0 "Inline" ~test:(function
+          | Inline -> true
+          | No | File -> false)
+      ; Repr.case0 "File" ~test:(function
+          | File -> true
+          | No | Inline -> false)
+      ]
+  ;;
+
   let decode ~mode =
     let open Decoder in
     match (mode : Mode.t) with
@@ -70,13 +89,7 @@ module Sourcemap = struct
     | Wasm -> enum [ "no", No; "inline", Inline ]
   ;;
 
-  let equal x y =
-    match x, y with
-    | No, No -> true
-    | Inline, Inline -> true
-    | File, File -> true
-    | No, _ | Inline, _ | File, _ -> false
-  ;;
+  let equal, _ = Repr.make_compare repr
 end
 
 module Flags = struct
@@ -158,17 +171,23 @@ module Compilation_mode = struct
     | Whole_program
     | Separate_compilation
 
+  let repr =
+    Repr.variant
+      "js-of-ocaml-compilation-mode"
+      [ Repr.case0 "Whole_program" ~test:(function
+          | Whole_program -> true
+          | Separate_compilation -> false)
+      ; Repr.case0 "Separate_compilation" ~test:(function
+          | Separate_compilation -> true
+          | Whole_program -> false)
+      ]
+  ;;
+
   let decode =
     Decoder.enum [ "whole_program", Whole_program; "separate", Separate_compilation ]
   ;;
 
-  let equal x y =
-    match x, y with
-    | Separate_compilation, Separate_compilation -> true
-    | Whole_program, Whole_program -> true
-    | Separate_compilation, _ -> false
-    | Whole_program, _ -> false
-  ;;
+  let equal, _ = Repr.make_compare repr
 end
 
 module In_buildable = struct

--- a/src/dune_lang/profile.ml
+++ b/src/dune_lang/profile.ml
@@ -8,6 +8,21 @@ type t =
   | Release
   | User_defined of string
 
+let repr =
+  Repr.variant
+    "profile"
+    [ Repr.case0 "Dev" ~test:(function
+        | Dev -> true
+        | Release | User_defined _ -> false)
+    ; Repr.case0 "Release" ~test:(function
+        | Release -> true
+        | Dev | User_defined _ -> false)
+    ; Repr.case "User_defined" Repr.string ~proj:(function
+        | User_defined s -> Some s
+        | Dev | Release -> None)
+    ]
+;;
+
 include (
   Stringlike.Make (struct
     type nonrec t = t
@@ -35,14 +50,7 @@ include (
   end) :
     Stringlike with type t := t)
 
-let equal x y =
-  match x, y with
-  | Dev, Dev -> true
-  | Release, Release -> true
-  | User_defined x, User_defined y -> String.equal x y
-  | _, _ -> false
-;;
-
+let equal, _ = Repr.make_compare repr
 let default = Dev
 
 let is_dev = function
@@ -60,10 +68,4 @@ let is_inline_test = function
   | _ -> true
 ;;
 
-let to_dyn =
-  let open Dyn in
-  function
-  | Dev -> variant "Dev" []
-  | Release -> variant "Release" []
-  | User_defined s -> variant "User_defined" [ string s ]
-;;
+let to_dyn = Repr.to_dyn repr

--- a/src/dune_lang/relop.ml
+++ b/src/dune_lang/relop.ml
@@ -11,29 +11,33 @@ type t =
 (* Define an arbitrary ordering on [t] to allow a package constraint to be
    used as the key of a map or set. The order from lowest to highest is:
    [Eq, Gte, Lte, Gt, Lt, Neq] *)
-let compare a b : Ordering.t =
-  match a, b with
-  | Eq, Eq -> Eq
-  | Eq, _ -> Lt
-  | _, Eq -> Gt
-  | Gte, Gte -> Eq
-  | Gte, _ -> Lt
-  | _, Gte -> Gt
-  | Lte, Lte -> Eq
-  | Lte, _ -> Lt
-  | _, Lte -> Gt
-  | Gt, Gt -> Eq
-  | Gt, _ -> Lt
-  | _, Gt -> Gt
-  | Lt, Lt -> Eq
-  | Lt, _ -> Lt
-  | _, Lt -> Gt
-  | Neq, Neq -> Eq
+let repr =
+  Repr.variant
+    "relop"
+    [ Repr.case0 "=" ~test:(function
+        | Eq -> true
+        | _ -> false)
+    ; Repr.case0 ">=" ~test:(function
+        | Gte -> true
+        | _ -> false)
+    ; Repr.case0 "<=" ~test:(function
+        | Lte -> true
+        | _ -> false)
+    ; Repr.case0 ">" ~test:(function
+        | Gt -> true
+        | _ -> false)
+    ; Repr.case0 "<" ~test:(function
+        | Lt -> true
+        | _ -> false)
+    ; Repr.case0 "<>" ~test:(function
+        | Neq -> true
+        | _ -> false)
+    ]
 ;;
 
-let equal a b = Ordering.is_eq (compare a b)
+let equal, compare = Repr.make_compare repr
 let map = [ "=", Eq; ">=", Gte; "<=", Lte; ">", Gt; "<", Lt; "<>", Neq ]
-let to_dyn t = Dyn.variant (fst (List.find_exn ~f:(fun (_, op) -> equal t op) map)) []
+let to_dyn = Repr.to_dyn repr
 
 let to_string x =
   let f (_, op) = equal x op in

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -12,18 +12,43 @@ type t =
   | Ocaml_index
   | Merlin
 
-let to_dyn = function
-  | Ocamlformat -> Dyn.variant "Ocamlformat" []
-  | Odoc -> Dyn.variant "Odoc" []
-  | Ocamllsp -> Dyn.variant "Ocamllsp" []
-  | Utop -> Dyn.variant "Utop" []
-  | Ocamlearlybird -> Dyn.variant "Ocamlearlybird" []
-  | Odig -> Dyn.variant "Odig" []
-  | Opam_publish -> Dyn.variant "Opam_publish" []
-  | Dune_release -> Dyn.variant "Dune_release" []
-  | Ocaml_index -> Dyn.variant "Ocaml_index" []
-  | Merlin -> Dyn.variant "Merlin" []
+let repr =
+  Repr.variant
+    "dev-tool"
+    [ Repr.case0 "Ocamlformat" ~test:(function
+        | Ocamlformat -> true
+        | _ -> false)
+    ; Repr.case0 "Odoc" ~test:(function
+        | Odoc -> true
+        | _ -> false)
+    ; Repr.case0 "Ocamllsp" ~test:(function
+        | Ocamllsp -> true
+        | _ -> false)
+    ; Repr.case0 "Utop" ~test:(function
+        | Utop -> true
+        | _ -> false)
+    ; Repr.case0 "Ocamlearlybird" ~test:(function
+        | Ocamlearlybird -> true
+        | _ -> false)
+    ; Repr.case0 "Odig" ~test:(function
+        | Odig -> true
+        | _ -> false)
+    ; Repr.case0 "Opam_publish" ~test:(function
+        | Opam_publish -> true
+        | _ -> false)
+    ; Repr.case0 "Dune_release" ~test:(function
+        | Dune_release -> true
+        | _ -> false)
+    ; Repr.case0 "Ocaml_index" ~test:(function
+        | Ocaml_index -> true
+        | _ -> false)
+    ; Repr.case0 "Merlin" ~test:(function
+        | Merlin -> true
+        | _ -> false)
+    ]
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 let all =
   [ Ocamlformat
@@ -39,31 +64,7 @@ let all =
   ]
 ;;
 
-let equal a b =
-  match a, b with
-  | Ocamlformat, Ocamlformat -> true
-  | Ocamlformat, _ | _, Ocamlformat -> false
-  | Odoc, Odoc -> true
-  | Odoc, _ | _, Odoc -> false
-  | Ocamllsp, Ocamllsp -> true
-  | Ocamllsp, _ | _, Ocamllsp -> false
-  | Utop, Utop -> true
-  | Utop, _ | _, Utop -> false
-  | Ocamlearlybird, Ocamlearlybird -> true
-  | Ocamlearlybird, _ | _, Ocamlearlybird -> false
-  | Odig, Odig -> true
-  | Odig, _ | _, Odig -> false
-  | Opam_publish, Opam_publish -> true
-  | Opam_publish, _ -> false
-  | _, Opam_publish -> false
-  | Dune_release, Dune_release -> true
-  | Dune_release, _ -> false
-  | _, Dune_release -> false
-  | Ocaml_index, Ocaml_index -> true
-  | Ocaml_index, _ | _, Ocaml_index -> false
-  | Merlin, Merlin -> true
-;;
-
+let equal, _ = Repr.make_compare repr
 let hash = Poly.hash
 
 let package_name = function

--- a/src/dune_pkg/version_preference.ml
+++ b/src/dune_pkg/version_preference.ml
@@ -4,18 +4,26 @@ type t =
   | Newest
   | Oldest
 
-let equal a b =
-  match a, b with
-  | Newest, Newest | Oldest, Oldest -> true
-  | _ -> false
+let repr =
+  Repr.variant
+    "version-preference"
+    [ Repr.case0 "newest" ~test:(function
+        | Newest -> true
+        | Oldest -> false)
+    ; Repr.case0 "oldest" ~test:(function
+        | Oldest -> true
+        | Newest -> false)
+    ]
 ;;
+
+let equal, _ = Repr.make_compare repr
 
 let to_string = function
   | Newest -> "newest"
   | Oldest -> "oldest"
 ;;
 
-let to_dyn t = Dyn.variant (to_string t) []
+let to_dyn = Repr.to_dyn repr
 let default = Newest
 let all = [ Newest; Oldest ]
 let all_by_string = List.map all ~f:(fun t -> to_string t, t)

--- a/src/source/dir_contents.ml
+++ b/src/source/dir_contents.ml
@@ -8,16 +8,16 @@ module File = struct
       ; dev : int
       }
 
-    let to_dyn { ino; dev } =
-      let open Dyn in
-      record [ "ino", Int.to_dyn ino; "dev", Int.to_dyn dev ]
+    let repr =
+      Repr.record
+        "dir-contents-file"
+        [ Repr.field "ino" Repr.int ~get:(fun t -> t.ino)
+        ; Repr.field "dev" Repr.int ~get:(fun t -> t.dev)
+        ]
     ;;
 
-    let compare { ino; dev } t =
-      match Int.compare ino t.ino with
-      | Ordering.Eq -> Int.compare dev t.dev
-      | _ as e -> e
-    ;;
+    let to_dyn = Repr.to_dyn repr
+    let _, compare = Repr.make_compare repr
   end
 
   include T

--- a/src/source/opam_switch.ml
+++ b/src/source/opam_switch.ml
@@ -5,13 +5,16 @@ type t =
   ; switch : string
   }
 
-let to_dyn { root; switch } =
-  Dyn.(record [ "root", option string root; "switch", string switch ])
+let repr =
+  Repr.record
+    "opam-switch"
+    [ Repr.field "root" (Repr.option Repr.string) ~get:(fun t -> t.root)
+    ; Repr.field "switch" Repr.string ~get:(fun t -> t.switch)
+    ]
 ;;
 
-let equal { root; switch } t =
-  Option.equal String.equal root t.root && String.equal switch t.switch
-;;
+let to_dyn = Repr.to_dyn repr
+let equal, _ = Repr.make_compare repr
 
 let hash { root; switch } =
   Tuple.T2.hash (Option.hash String.hash) String.hash (root, switch)


### PR DESCRIPTION
Use polymorphic equality with type annotations to remove this pointless boilerplate.

We write a `Repr.t` for all of the types we need not write our own comparison or equality. This will ensure that we only compare types that are safe to compare in this way.