### PR TITLE
fix: preserve context in sandboxed cram diffs

### DIFF
--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -66,7 +66,8 @@ let get_error_from_exn = function
       match msg.dir with
       | None -> msg
       | Some path ->
-        (match Path.extract_build_context (Path.of_string path) with
+        let path = Path.of_string path |> Path.drop_optional_sandbox_root in
+        (match Path.extract_build_context path with
          | None -> msg
          | Some (ctxt, _) -> { msg with context = Some ctxt })
     in

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-inline-tests.t
@@ -92,5 +92,6 @@ Running inline tests in a specific build directory:
   File "dune", line 10, characters 1-38:
   10 |  (inline_tests (backend test_backend)))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Context: alt
   Fatal error: exception File ".mylib.inline-tests/main.ml-gen", line 2, characters 40-46: Assertion failed
   [1]

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd-sandbox-context.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd-sandbox-context.t
@@ -16,6 +16,7 @@ Sandboxed cram failures should preserve their build context.
 
   $ dune test --sandbox symlink mytest.t
   File "mytest.t", line 1, characters 0-0:
+  Context: alt
   --- mytest.t
   +++ mytest.t.corrected
   @@ -1,2 +1,2 @@

--- a/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
+++ b/test/blackbox-tests/test-cases/runtest/runtest-cmd.t
@@ -289,4 +289,3 @@ that context as expected.
   Error: Multiple contexts are defined but no default context was found. Please
   use the --context flag or specify a build directory path.
   [1]
-


### PR DESCRIPTION
Just fixes an error message for sandboxed actions from a different context.