### PR TITLE
chore(ci): fix dco for oxcaml update

### DIFF
--- a/.github/workflows/update-oxcaml.yml
+++ b/.github/workflows/update-oxcaml.yml
@@ -63,4 +63,4 @@ jobs:
           commit-message: |
             Update OxCaml to ${{ steps.check.outputs.latest }}
 
-            Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+            Signed-off-by: Ali Caglayan <alizter@gmail.com>


### PR DESCRIPTION
I'm using my signoff here. If others dispatch this workflow it will fail on the dco, so it should be something that they explicitly configure in the workflow themselves. The cron job will use my commit authorship by default since I set up the workflow, therefore these commits will be signed correctly.