### PR TITLE
feat(trace): create trace backups

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1229,6 +1229,13 @@ let init_with_root ~(root : Workspace_root.t) (builder : Builder.t) =
            | `User_specified stats -> Path.of_filename_relative_to_initial_cwd stats
          in
          Path.parent trace |> Option.iter ~f:Path.mkdir_p;
+         (match trace_config with
+          | `Default ->
+            let path = Path.to_string trace in
+            (match Fpath.rename_exn path (path ^ ".old") with
+             | () -> ()
+             | exception Unix.Unix_error _ -> ())
+          | `User_specified _ -> ());
          let stats = Dune_trace.Out.create trace in
          Dune_trace.set_global stats;
          Dune_trace.Event.init

--- a/doc/changes/added/14269.md
+++ b/doc/changes/added/14269.md
@@ -1,0 +1,3 @@
+- Back up the default trace file as `trace.csexp.old` before each build,
+  preserving the previous trace for comparison. This does not apply when
+  `--trace-file` is used. (#14269, @Alizter)

--- a/test/blackbox-tests/test-cases/trace/trace-backup.t
+++ b/test/blackbox-tests/test-cases/trace/trace-backup.t
@@ -1,0 +1,54 @@
+Test that the default trace file is backed up as trace.csexp.old before each
+build.
+
+  $ make_dune_project 3.21
+
+First build creates the trace file but no backup yet:
+
+  $ dune build
+  $ test -f _build/trace.csexp
+  $ test -f _build/trace.csexp.old
+  [1]
+
+Second build should back up the previous trace:
+
+  $ dune build
+  $ test -f _build/trace.csexp
+  $ test -f _build/trace.csexp.old
+
+The backup should be a valid trace with an exit event from the previous build:
+
+  $ dune trace cat --trace-file _build/trace.csexp.old | jq 'select(.name == "exit") | {name}'
+  {
+    "name": "exit"
+  }
+
+When --trace-file is used, no backup should be created. The existing custom
+trace file is simply overwritten:
+
+  $ rm -f _build/trace.csexp.old
+  $ dune build --trace-file custom-trace.csexp
+  $ test -f custom-trace.csexp
+  $ dune trace cat --trace-file custom-trace.csexp | jq 'select(.name == "exit") | {name}'
+  {
+    "name": "exit"
+  }
+
+Write a marker into the custom trace to verify it gets overwritten:
+
+  $ echo "stale" > custom-trace.csexp
+  $ dune build --trace-file custom-trace.csexp
+  $ dune trace cat --trace-file custom-trace.csexp | jq 'select(.name == "exit") | {name}'
+  {
+    "name": "exit"
+  }
+
+No .old backup was created for the custom trace:
+
+  $ test -f custom-trace.csexp.old
+  [1]
+
+The default trace backup should not have been recreated either:
+
+  $ test -f _build/trace.csexp.old
+  [1]


### PR DESCRIPTION
When you've started a rebuild and something has gone wrong, its too late to save your old trace since it's already overwritten.

When a user isn't using `--trace-file`, we move `_build/trace.csexp` to `_build/trace.csexp.old` so that both traces are available.

Most users won't notice this, but it should be convenient enough for those that need it.

- [x] changelog