### PR TITLE
Avoid `@install` in `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-bootstrap-script:
 
 .PHONY: release
 release: $(BIN)
-	@$(BIN) build @install -p dune --profile dune-bootstrap
+	@$(BIN) build dune.install -p dune --profile dune-bootstrap
 
 $(BIN):
 	@ocaml boot/bootstrap.ml

--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,6 @@
               dune = (self.packages.${pkgs.stdenv.hostPlatform.system}.default).overrideAttrs {
                 postPatch = ''
                   echo '(version ${dune-version})' >> dune-project
-                  sed -i '2a version: "${dune-version}"' opam/dune.opam
                 '';
               };
               menhirPackages = import ./nix/menhir.nix {


### PR DESCRIPTION
The nightly builds have stopped working because the way they work is that they add the `version` info to the `dune-project` and then run `make release`. Since #14108 was merged, this would, instead of promoting the change automatically, create a diff and as part of it make `make release` fail.

This PR updates the `make release` invocation to avoid `@install` and use `dune.install` as target (which is the same thing that we do in the OPAM file of Dune), which does not trigger the diff action and does not trigger the diff failure.

Also updates the code introduced as a hack in #14228 as this should avoid the need to patch the OPAM file to avoid the diff failure.

Thanks for @Alizter helping with the debugging and clearing up the confusion around all of this.