### PR TITLE
Run release checks on *-rc branches

### DIFF
--- a/.github/workflows/isolated-package-build-pre-release.yml
+++ b/.github/workflows/isolated-package-build-pre-release.yml
@@ -1,0 +1,11 @@
+name: Packaging check pre-release
+
+on:
+  push:
+    branches:
+      - '*-rc'
+
+jobs:
+  packaging-check:
+    name: Packaging check
+    uses: Sudha247/dune/.github/workflows/isolated-package-build.yml@ci-actions-rc

--- a/.github/workflows/isolated-package-build-pre-release.yml
+++ b/.github/workflows/isolated-package-build-pre-release.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   packaging-check:
     name: Packaging check
-    uses: Sudha247/dune/.github/workflows/isolated-package-build.yml@ci-actions-rc
+    uses: ocaml/dune/.github/workflows/isolated-package-build.yml@main

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -7,16 +7,31 @@ on:
   push:
     branches:
         - main
-    paths:
-        - 'opam/*.opam'
+        - '*-rc'
   pull_request:
     paths:
       - 'opam/*.opam'
   workflow_dispatch:
 
 jobs:
-  packaging-check:
+  opam-changes:
     runs-on: ubuntu-latest
+    outputs:
+      opam_changed: ${{ steps.filter.outputs.opam }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            opam:
+              - 'opam/*.opam'
+
+  packaging-check:
+    needs: opam-changes
+    runs-on: ubuntu-latest
+    if: ${{ endsWith(github.ref_name, '-rc') || (github.ref_name == 'main' && needs.opam-changes.outputs.opam_changed == 'true') }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -4,34 +4,20 @@ name: Packaging check
 # https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a95df9014bc79103fde668cf2adbe6680fd2f9cf/variant/compilers,5.0,fs-io.3.21.0~alpha3,tests
 
 on:
+  workflow_call:
   push:
     branches:
       - main
-      - '*-rc'
+    paths:
+      - 'opam/*.opam'
   pull_request:
     paths:
       - 'opam/*.opam'
   workflow_dispatch:
 
 jobs:
-  opam-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      opam_changed: ${{ steps.filter.outputs.opam }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - id: filter
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            opam:
-              - 'opam/*.opam'
-
   packaging-check:
-    needs: opam-changes
     runs-on: ubuntu-latest
-    if: ${{ endsWith(github.ref_name, '-rc') || ((github.ref_name == 'main' || github.event_name == 'pull_request') && needs.opam-changes.outputs.opam_changed == 'true') }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/isolated-package-build.yml
+++ b/.github/workflows/isolated-package-build.yml
@@ -6,8 +6,8 @@ name: Packaging check
 on:
   push:
     branches:
-        - main
-        - '*-rc'
+      - main
+      - '*-rc'
   pull_request:
     paths:
       - 'opam/*.opam'
@@ -19,7 +19,7 @@ jobs:
     outputs:
       opam_changed: ${{ steps.filter.outputs.opam }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: filter
         uses: dorny/paths-filter@v4
@@ -31,7 +31,7 @@ jobs:
   packaging-check:
     needs: opam-changes
     runs-on: ubuntu-latest
-    if: ${{ endsWith(github.ref_name, '-rc') || (github.ref_name == 'main' && needs.opam-changes.outputs.opam_changed == 'true') }}
+    if: ${{ endsWith(github.ref_name, '-rc') || ((github.ref_name == 'main' || github.event_name == 'pull_request') && needs.opam-changes.outputs.opam_changed == 'true') }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -2,6 +2,9 @@ name: Mirage
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - '*-rc'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #14268.

Runs the isolated package build and mirage workflows on all `rc` branches. This will reduce the step of manually triggering the workflows on release candidate branches.