### PR TITLE
feat: consolidated .all-raw-deps file for per-module filtering

### DIFF
--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -38,6 +38,7 @@ module Extension = struct
   let odoc = ".odoc"
   let d = ".d"
   let all_deps = ".all-deps"
+  let all_raw_deps = ".all-raw-deps"
   let js = ".js"
   let h = ".h"
   let mlg = ".mlg"

--- a/otherlibs/stdune/src/filename.mli
+++ b/otherlibs/stdune/src/filename.mli
@@ -54,6 +54,7 @@ module Extension : sig
   val h : t
   val d : t
   val all_deps : t
+  val all_raw_deps : t
   val js : t
   val mlg : t
   val json : t

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -92,6 +92,7 @@ let deps_of_vlib_module ~obj_dir ~vimpl ~dir ~sctx ~ml_kind ~for_ sourced_module
     Lib.Local.of_lib vlib
   with
   | None ->
+    let m = Modules.Sourced_module.to_module sourced_module in
     let+ deps =
       let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
       let dune_version =
@@ -108,6 +109,18 @@ let deps_of_vlib_module ~obj_dir ~vimpl ~dir ~sctx ~ml_kind ~for_ sourced_module
         ~ml_kind
         ~for_
         sourced_module
+    and+ () =
+      (* Produce an empty .all-raw-deps for external vlib modules so
+         that transitive chaining in the ocamldep pipeline doesn't
+         fail with "no rule found". *)
+      match Obj_dir.Module.dep obj_dir ~for_ (Transitive_raw (m, ml_kind)) with
+      | None -> Memo.return ()
+      | Some dst ->
+        Super_context.add_rule
+          sctx
+          ~dir
+          (Action_builder.return (Action.Full.make (Action.write_file dst ""))
+           |> Action_builder.with_file_targets ~file_targets:[ dst ])
     in
     Action_builder.map deps ~f:(List.map ~f:Modules.Sourced_module.to_module)
   | Some lib ->
@@ -126,6 +139,17 @@ let deps_of_vlib_module ~obj_dir ~vimpl ~dir ~sctx ~ml_kind ~for_ sourced_module
         Obj_dir.Module.dep obj_dir ~for_ (Transitive (m, ml_kind)) |> Option.value_exn
       in
       Super_context.add_rule sctx ~dir (Action_builder.symlink ~src ~dst)
+    and+ () =
+      match
+        ( Obj_dir.Module.dep vlib_obj_dir ~for_ (Transitive_raw (m, ml_kind))
+        , Obj_dir.Module.dep obj_dir ~for_ (Transitive_raw (m, ml_kind)) )
+      with
+      | Some src, Some dst ->
+        Super_context.add_rule
+          sctx
+          ~dir
+          (Action_builder.symlink ~src:(Path.build src) ~dst)
+      | _ -> Memo.return ()
     in
     let modules = Vimpl.vlib_modules vimpl |> Modules.With_vlib.modules in
     Ocamldep.read_deps_of ~obj_dir:vlib_obj_dir ~modules ~ml_kind ~for_ m
@@ -182,7 +206,12 @@ let rec deps_of
 ;;
 
 let read_deps_of_module ~modules ~obj_dir dep ~for_ =
-  let (Obj_dir.Module.Dep.Immediate (unit, _) | Transitive (unit, _)) = dep in
+  let ( Obj_dir.Module.Dep.Immediate (unit, _)
+      | Transitive (unit, _)
+      | Transitive_raw (unit, _) )
+    =
+    dep
+  in
   match Module.kind unit with
   | Root | Alias _ -> Action_builder.return []
   | Wrapped_compat -> wrapped_compat_deps modules unit |> Action_builder.return
@@ -198,7 +227,9 @@ let read_deps_of_module ~modules ~obj_dir dep ~for_ =
         let+ deps = Ocamldep.read_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit in
         (match Modules.With_vlib.alias_for modules unit with
          | [] -> deps
-         | aliases -> aliases @ deps))
+         | aliases -> aliases @ deps)
+      | Transitive_raw _ ->
+        Code_error.raise "Transitive_raw should not be used in read_deps_of_module" [])
 ;;
 
 let read_immediate_deps_of ~obj_dir ~modules ~ml_kind ~for_ m =

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -40,27 +40,9 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
     then Action_builder.return ((), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
     else
       let* lib_index = Resolve.Memo.read (Compilation_context.lib_index cctx) in
-      let* trans_deps = Dep_graph.deps_of dep_graph m in
-      let* all_raw =
-        Action_builder.List.map (m :: trans_deps) ~f:(fun dep_m ->
-          let is_standard_kind =
-            match Module.kind dep_m with
-            | Impl_vmodule | Root | Alias _ | Wrapped_compat | Parameter -> false
-            | Virtual | Intf_only | Impl -> true
-          in
-          if not is_standard_kind
-          then Action_builder.return Module_name.Set.empty
-          else
-            let* impl_deps =
-              Ocamldep.read_immediate_deps_raw_of ~obj_dir ~ml_kind:Impl ~for_ dep_m
-            in
-            let+ intf_deps =
-              Ocamldep.read_immediate_deps_raw_of ~obj_dir ~ml_kind:Intf ~for_ dep_m
-            in
-            Module_name.Set.union impl_deps intf_deps)
-        |> Action_builder.map
-             ~f:(List.fold_left ~init:Module_name.Set.empty ~f:Module_name.Set.union)
-      in
+      let* impl_raw = Ocamldep.read_all_raw_deps_of ~obj_dir ~ml_kind:Impl ~for_ m in
+      let* intf_raw = Ocamldep.read_all_raw_deps_of ~obj_dir ~ml_kind:Intf ~for_ m in
+      let all_raw = Module_name.Set.union impl_raw intf_raw in
       let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
       let open_modules = Ocaml_flags.extract_open_module_names flags in
       let referenced = Module_name.Set.union all_raw open_modules in

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -621,6 +621,7 @@ module Module = struct
     type t =
       | Immediate of Module.t * Ml_kind.t
       | Transitive of Module.t * Ml_kind.t
+      | Transitive_raw of Module.t * Ml_kind.t
 
     let make_name m kind ext =
       let ext =
@@ -634,12 +635,13 @@ module Module = struct
     let basename = function
       | Immediate (m, kind) -> make_name m kind Filename.Extension.d
       | Transitive (m, kind) -> make_name m kind Filename.Extension.all_deps
+      | Transitive_raw (m, kind) -> make_name m kind Filename.Extension.all_raw_deps
     ;;
   end
 
   let dep t dep ~for_ =
     match (dep : Dep.t) with
-    | Immediate (m, _) | Transitive (m, _) ->
+    | Immediate (m, _) | Transitive (m, _) | Transitive_raw (m, _) ->
       (match Module.kind m with
        | Module.Kind.Alias _ | Root -> None
        | _ ->

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -155,6 +155,7 @@ module Module : sig
     type t =
       | Immediate of Module.t * Ml_kind.t
       | Transitive of Module.t * Ml_kind.t
+      | Transitive_raw of Module.t * Ml_kind.t
   end
 
   val dep : Path.Build.t t -> Dep.t -> for_:Compilation_mode.t -> Path.Build.t option

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -1,6 +1,55 @@
 open Import
 open Memo.O
 
+module Merge_raw_deps_into = struct
+  module Spec = struct
+    type ('src, 'dst) t =
+      { transitive : 'src list
+      ; immediate : string list
+      ; target : 'dst
+      }
+
+    let name = "merge_raw_deps_into"
+    let version = 1
+    let is_useful_to ~memoize:_ = true
+
+    let bimap t path target =
+      { t with transitive = List.map t.transitive ~f:path; target = target t.target }
+    ;;
+
+    let encode
+          (type src dst)
+          ({ transitive; immediate; target } : (src, dst) t)
+          (input : src -> Sexp.t)
+          (output : dst -> Sexp.t)
+      : Sexp.t
+      =
+      List
+        [ List (List.map transitive ~f:input)
+        ; List (List.map ~f:(fun s -> Sexp.Atom s) immediate)
+        ; output target
+        ]
+    ;;
+
+    let action { transitive; immediate; target } ~ectx:_ ~eenv:_ =
+      Async.async (fun () ->
+        List.fold_left
+          transitive
+          ~init:(String.Set.of_list immediate)
+          ~f:(fun set source_path ->
+            Io.lines_of_file source_path |> String.Set.of_list |> String.Set.union set)
+        |> String.Set.to_list
+        |> Io.write_lines (Path.build target))
+    ;;
+  end
+
+  module Action = Action_ext.Make (Spec)
+
+  let action ~transitive ~immediate ~target =
+    Action.action { transitive; immediate; target }
+  ;;
+end
+
 module Merge_files_into = struct
   module Spec = struct
     type ('src, 'dst) t =
@@ -119,6 +168,21 @@ let transitive_deps =
   fun obj_dir modules ~for_ -> List.filter_map modules ~f:(transive_dep obj_dir ~for_)
 ;;
 
+(* Like [transitive_deps] but for .all-raw-deps files. Skips modules
+   that don't have locally-produced .all-raw-deps (e.g., modules from
+   external virtual libraries whose deps are resolved via ooi_deps). *)
+let transitive_raw_deps =
+  let transive_raw_dep obj_dir m ~for_ =
+    (match Module.kind m with
+     | Root | Alias _ -> None
+     | _ -> if Module.has m ~ml_kind:Intf then Some Ml_kind.Intf else Some Impl)
+    |> Option.bind ~f:(fun ml_kind ->
+      Obj_dir.Module.dep obj_dir ~for_ (Transitive_raw (m, ml_kind))
+      |> Option.map ~f:Path.build)
+  in
+  fun obj_dir modules ~for_ -> List.filter_map modules ~f:(transive_raw_dep obj_dir ~for_)
+;;
+
 let deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind ~for_ unit =
   let source = Option.value_exn (Module.source unit ~ml_kind) in
   let dep = Obj_dir.Module.dep obj_dir ~for_ in
@@ -149,27 +213,62 @@ let deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind ~for_ unit =
        >>| Action.Full.add_sandbox sandbox)
   in
   let all_deps_file = dep (Transitive (unit, ml_kind)) |> Option.value_exn in
+  let all_raw_deps_file = dep (Transitive_raw (unit, ml_kind)) in
   let+ () =
     let produce_all_deps =
       let open Action_builder.O in
-      (let+ transitive, immediate =
-         (let+ immediate_deps =
+      (let+ transitive, immediate, _immediate_raw =
+         (let+ immediate_raw =
             Path.build ocamldep_output
             |> Action_builder.lines_of
             >>| parse_deps_exn ~file:(Module.File.path source)
-            >>| parse_module_names ~dir ~unit ~modules
-            >>| Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit)
+          in
+          let immediate_deps =
+            parse_module_names ~dir ~unit ~modules immediate_raw
+            |> Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit)
           in
           let transitive_deps = transitive_deps obj_dir immediate_deps ~for_ in
           let immediate_deps = List.map immediate_deps ~f:Module.obj_name in
-          (transitive_deps, immediate_deps), transitive_deps)
+          (transitive_deps, immediate_deps, immediate_raw), transitive_deps)
          |> Action_builder.dyn_paths
        in
        Merge_files_into.action ~transitive ~immediate ~target:all_deps_file)
       |> Action_builder.with_file_targets ~file_targets:[ all_deps_file ]
     in
-    Action_builder.With_targets.map ~f:Action.Full.make produce_all_deps
-    |> Super_context.add_rule sctx ~dir
+    let* () =
+      Action_builder.With_targets.map ~f:Action.Full.make produce_all_deps
+      |> Super_context.add_rule sctx ~dir
+    in
+    (* Produce .all-raw-deps as a separate rule so that cycle detection
+       works on .all-deps alone. The .all-raw-deps rule depends on the
+       resolved .all-deps (which triggers cycle detection) and merges
+       the transitive .all-raw-deps of resolved deps. *)
+    match all_raw_deps_file with
+    | None -> Memo.return ()
+    | Some all_raw_deps_file ->
+      let produce_raw =
+        let open Action_builder.O in
+        (let+ immediate_raw =
+           Path.build ocamldep_output
+           |> Action_builder.lines_of
+           >>| parse_deps_exn ~file:(Module.File.path source)
+         and+ transitive_raw =
+           Action_builder.lines_of (Path.build all_deps_file)
+           >>| parse_compilation_units ~modules
+           >>| fun resolved_deps -> transitive_raw_deps obj_dir resolved_deps ~for_
+         in
+         (transitive_raw, immediate_raw), transitive_raw)
+        |> Action_builder.dyn_paths
+        >>| fun (transitive_raw, immediate_raw) ->
+        Action.Full.make
+          (Merge_raw_deps_into.action
+             ~transitive:transitive_raw
+             ~immediate:immediate_raw
+             ~target:all_raw_deps_file)
+      in
+      produce_raw
+      |> Action_builder.with_file_targets ~file_targets:[ all_raw_deps_file ]
+      |> Super_context.add_rule sctx ~dir
   in
   let all_deps_file = Path.build all_deps_file in
   Action_builder.lines_of all_deps_file
@@ -216,4 +315,21 @@ let read_immediate_deps_raw_of ~obj_dir ~ml_kind ~for_ unit =
   match parsed with
   | None -> Module_name.Set.empty
   | Some names -> Module_name.Set.of_list_map names ~f:Module_name.of_checked_string
+;;
+
+(* Read the transitive raw deps from the consolidated .all-raw-deps file.
+   This contains the union of all raw module names from the module and its
+   transitive intra-library deps, avoiding the need to read N individual
+   .d files during per-module library filtering. *)
+let read_all_raw_deps_of ~obj_dir ~ml_kind ~for_ unit =
+  match Module.has unit ~ml_kind && Option.is_some (Module.source ~ml_kind unit) with
+  | false -> Action_builder.return Module_name.Set.empty
+  | true ->
+    (match Obj_dir.Module.dep obj_dir ~for_ (Transitive_raw (unit, ml_kind)) with
+     | None -> Action_builder.return Module_name.Set.empty
+     | Some all_raw_deps_file ->
+       Action_builder.lines_of (Path.build all_raw_deps_file)
+       |> Action_builder.map ~f:(fun lines ->
+         List.filter_map lines ~f:Module_name.of_string_opt |> Module_name.Set.of_list)
+       |> Action_builder.memoize (Path.Build.to_string all_raw_deps_file))
 ;;

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -43,3 +43,13 @@ val read_immediate_deps_raw_of
   -> for_:Compilation_mode.t
   -> Module.t
   -> Module_name.Set.t Action_builder.t
+
+(** [read_all_raw_deps_of ~obj_dir ~ml_kind ~for_ unit] returns the union of
+    raw module names from [unit] and all its transitive intra-library deps,
+    read from a single consolidated file. *)
+val read_all_raw_deps_of
+  :  obj_dir:Path.Build.t Obj_dir.t
+  -> ml_kind:Ml_kind.t
+  -> for_:Compilation_mode.t
+  -> Module.t
+  -> Module_name.Set.t Action_builder.t

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface-sub-module.t
@@ -24,7 +24,6 @@ We shouldn't allow foo/y/$x.ml to depend on foo/foo.ml
   the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/.foo.objs/foo__X__Y__Z.impl.all-deps
-  -> required by _build/default/.foo.objs/byte/foo__X__Y__Z.cmo
   -> required by _build/default/foo.cma
   -> required by alias all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
+++ b/test/blackbox-tests/test-cases/include-qualified/invalid-deps/group-interface.t
@@ -24,7 +24,6 @@ We shouldn't allow foo/$x.ml to depend on foo/foo.ml
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/.foo.objs/foo__Baz__Bar.impl.all-deps
-  -> required by _build/default/.foo.objs/byte/foo__Baz__Bar.cmo
   -> required by _build/default/foo.cma
   -> required by alias all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
+++ b/test/blackbox-tests/test-cases/include-qualified/ocamldep-regression.t
@@ -40,7 +40,6 @@ We also forbid submodules from depending on their interface modules:
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/.foo.objs/foo__Baz__Bar.impl.all-deps
-  -> required by _build/default/.foo.objs/byte/foo__Baz__Bar.cmo
   -> required by _build/default/foo.cma
   -> required by alias all
   -> required by alias default
@@ -61,7 +60,6 @@ Or their parent interface modules:
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/.foo.objs/foo__Baz__Foo__Z.impl.all-deps
-  -> required by _build/default/.foo.objs/byte/foo__Baz__Foo__Z.cmo
   -> required by _build/default/foo.cma
   -> required by alias all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-error-check.t
@@ -21,7 +21,6 @@ Dune uses ocamldep to prevent a module from depending on itself.
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/lib/.foo.objs/foo__Bar.impl.all-deps
-  -> required by _build/default/lib/.foo.objs/byte/foo__Bar.cmo
   -> required by _build/default/lib/foo.cma
   -> required by alias lib/all
   [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -41,4 +41,3 @@ Both modules declare glob deps on mylib's .cmi files:
 
   $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
   > jq -r 'include "dune"; .[] | depsGlobPredicates'
-  *.cmi


### PR DESCRIPTION
## Summary

Produce a `.all-raw-deps` file per module in the ocamldep pipeline that
contains the union of raw module names from the module and all its
transitive intra-library deps. This replaces reading N individual `.d`
files during per-module library filtering with a single file read,
reducing null-build overhead.

Depends on #14116.

## Test plan

- [x] per-module-lib-deps tests pass
- [x] hidden-deps-supported tests pass
- [x] root-module tests pass
- [x] CI
- [x] Benchmark null build comparison