### PR TITLE
typo in DUNE_TRACE slug: artifact_subStitution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Revert the change in behavior of `--diff-command` back to 3.21. Non-existent
   files are now passed to this command instead of being replaced with /dev/null
   (#14098, fixes 13891, @rgrinberg)
+- Fixed spelling one of the DUNE_TRACE envvar values: `artifact_substitution`
+  (@hraban)
 
 3.22.1 (2026-04-01)
 -------------------

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -71,7 +71,7 @@ let to_string = function
   | Action -> "action"
   | Cache -> "cache"
   | Digest -> "digest"
-  | Artifact_substitution -> "artifact_subtitution"
+  | Artifact_substitution -> "artifact_substitution"
   | Thread -> "thread"
 ;;
 

--- a/test/blackbox-tests/test-cases/version-corruption.t
+++ b/test/blackbox-tests/test-cases/version-corruption.t
@@ -116,7 +116,7 @@ which corresponds to `~min_len` in Link_time_code_gen.
 
   $ dune build
 
-  $ dune trace cat | jq 'select(.cat == "artifact_subtitution") | .args'
+  $ dune trace cat | jq 'select(.cat == "artifact_substitution") | .args'
   {
     "file": "_build/default/gen_lifecycle.exe",
     "placeholder": [


### PR DESCRIPTION
Technically speaking this is a backwards incompatible change... what do you think; does it need a backwards compatible layer, or does nobody use this envvar?