### PR TITLE
path: appending local paths to external paths

### DIFF
--- a/doc/changes/changed/14278.md
+++ b/doc/changes/changed/14278.md
@@ -1,0 +1,2 @@
+- Use `/` as directory separator when appending local paths to external paths,
+  making path construction consistent across platforms. (#14278, @Alizter)

--- a/doc/changes/changed/14278.md
+++ b/doc/changes/changed/14278.md
@@ -1,2 +1,5 @@
 - Use `/` as directory separator when appending local paths to external paths,
   making path construction consistent across platforms. (#14278, @Alizter)
+- On Windows, normalise process paths to `\` before passing them to
+  `CreateProcessW` so that programs which scan `argv[0]` (notably `cmd.exe`)
+  do not misparse mixed separators. (#14278, @Alizter)

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -27,7 +27,24 @@ let to_dyn t = Dyn.variant "External" [ Dyn.string t ]
 let relative x y =
   match y with
   | "." -> x
-  | _ -> Filename.concat x y
+  | _ ->
+    let y =
+      if String.length y >= 2 && y.[0] = '.' && is_dir_sep y.[1]
+      then String.drop y 2
+      else y
+    in
+    (match y with
+     | "" | "." -> x
+     | _ ->
+       (* Strip a trailing directory separator from [x] so we don't produce
+          double slashes (e.g. "/root/" + "foo" -> "/root/foo"). We use
+          [is_dir_sep] so that on Windows a trailing '\' is also removed,
+          normalising the join to always use '/'. *)
+       let x =
+         let len = String.length x in
+         if len > 0 && is_dir_sep x.[len - 1] then String.take x (len - 1) else x
+       in
+       String.concat ~sep:"/" [ x; y ])
 ;;
 
 let append_local t local = relative t (Local.to_string local)

--- a/otherlibs/stdune/test/path_external_build_tests.ml
+++ b/otherlibs/stdune/test/path_external_build_tests.ml
@@ -41,42 +41,27 @@ let%expect_test "Build.to_string relative" =
 
 let%expect_test "to_absolute_filename source path" =
   Path.to_absolute_filename (Path.relative Path.root "src/main.ml") |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /workspace\src/main.ml |}
-    ~unix:{| /workspace/src/main.ml |}
+  [%expect {| /workspace/src/main.ml |}]
 ;;
 
 let%expect_test "to_absolute_filename build path" =
   Path.to_absolute_filename (Path.relative Path.build_dir "foo/bar") |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /external-build\foo/bar |}
-    ~unix:{| /external-build/foo/bar |}
+  [%expect {| /external-build/foo/bar |}]
 ;;
 
 let%expect_test "reach build from source" =
   Path.reach (Path.relative Path.build_dir "foo") ~from:Path.root |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /external-build\foo |}
-    ~unix:{| /external-build/foo |}
+  [%expect {| /external-build/foo |}]
 ;;
 
 let%expect_test "reach source from build" =
   Path.reach (Path.relative Path.root "src") ~from:(Path.relative Path.build_dir "foo")
   |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /workspace\src |}
-    ~unix:{| /workspace/src |}
+  [%expect {| /workspace/src |}]
 ;;
 
 let%expect_test "reach_for_running build from source" =
   Path.reach_for_running (Path.relative Path.build_dir "foo/bar") ~from:Path.root
   |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /external-build\foo/bar |}
-    ~unix:{| /external-build/foo/bar |}
+  [%expect {| /external-build/foo/bar |}]
 ;;

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -663,7 +663,7 @@ let%expect_test "external relative plain" =
 
 let%expect_test "external relative dot-slash multi" =
   external_relative "/root" "./foo/bar";
-  [%expect {| /root/./foo/bar |}]
+  [%expect {| /root/foo/bar |}]
 ;;
 
 let%expect_test "external relative dot" =
@@ -683,7 +683,7 @@ let%expect_test "external relative deep" =
 
 let%expect_test "external relative dot-slash single" =
   external_relative "/root" "./foo";
-  [%expect {| /root/./foo |}]
+  [%expect {| /root/foo |}]
 ;;
 
 let%expect_test "external append_local multi" =
@@ -698,7 +698,7 @@ let%expect_test "external append_local root" =
 
 let%expect_test "path relative external dot-slash" =
   relative (Path.of_string "/ext") "./foo/bar";
-  [%expect {| External "/ext/./foo/bar" |}]
+  [%expect {| External "/ext/foo/bar" |}]
 ;;
 
 let%expect_test "path relative external plain" =
@@ -711,14 +711,12 @@ let%expect_test "external relative trailing slash" =
   [%expect {| /root/foo/bar |}]
 ;;
 
-(* CR-soon Alizter: should strip "./" and produce "/root/foo" *)
 let%expect_test "external relative trailing slash dot-slash" =
   external_relative "/root/" "./foo";
-  [%expect {| /root/./foo |}]
+  [%expect {| /root/foo |}]
 ;;
 
-(* CR-soon Alizter: should return "/root" *)
 let%expect_test "external relative dot-slash only" =
   external_relative "/root" "./";
-  [%expect {| /root/./ |}]
+  [%expect {| /root |}]
 ;;

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -909,6 +909,14 @@ let spawn
     | _ -> (None, stdout), (None, stderr)
   in
   let prog_str = Path.reach_for_running ?from:dir prog in
+  (* Normalise to backslashes on Windows. Dune's path representation uses '/'
+     across platforms for consistency, but some Windows programs (notably
+     cmd.exe, which scans argv[0] for '/c') misparse mixed separators.
+     Backslashes are the native form on Windows, so we normalise here at the
+     boundary between Dune's path representation and the OS. *)
+  let prog_str =
+    if Sys.win32 then String.replace_char prog_str ~from:'/' ~to_:'\\' else prog_str
+  in
   let args, response_file =
     if Sys.win32 && cmdline_approximate_length prog_str args >= 1024
     then (

--- a/test/blackbox-tests/test-cases/optional-executable.t
+++ b/test/blackbox-tests/test-cases/optional-executable.t
@@ -167,7 +167,7 @@ Optional on the executable should be respected:
   > EOF
 
   $ PATH=./bin:$PATH dune build @run-x
-  binary path: $TESTCASE_ROOT/optional-binary-absent/./bin/dunetestbar
+  binary path: $TESTCASE_ROOT/optional-binary-absent/bin/dunetestbar
 
 In the same way as enabled_if:
 
@@ -179,7 +179,7 @@ In the same way as enabled_if:
   > EOF
 
   $ PATH=./bin:$PATH dune build @run-x --force
-  binary path: $TESTCASE_ROOT/optional-binary-absent/./bin/dunetestbar
+  binary path: $TESTCASE_ROOT/optional-binary-absent/bin/dunetestbar
 
   $ cd ..
 


### PR DESCRIPTION
Rather than using `Filename.concat` we use `/` as a directory separator on all platforms for paths that we construct. We already do this for local paths, so appending to external paths shouldn't be any different. This makes path behaviour homogeneous across platforms.

Importantly on Windows something like:

```
C:\foo\bar + ./baz/zaz
``` 
used to be 
```
C:\foo\bar\./baz/zaz
```
and is now 
```
C:\foo\bar/baz/zaz
```
Notice that the prefix is untouched, since we don't control it. When scrubbing prefixes with `BUILD_PATH_PREFIX_MAP` this will mean that `$PREFIX/baz/zaz` will be the same on all platforms. That will be addressed in a later PR.

We do however touch the prefix if it ends in a trailing directory separator. Before appending we make sure that this separator is stripped if it exists.


- [x] changelog
- [x] check docs and fixup
- [x] update rocq tests
- [x] update oxcaml tests
- [x] update other tests
- [x] #14279 

Addresses parts of
- https://github.com/ocaml/dune/issues/10176