### PR TITLE
lev: fix boxed values returned by C stubs

### DIFF
--- a/src/lev/src/lev_stubs.c
+++ b/src/lev/src/lev_stubs.c
@@ -87,7 +87,7 @@ DEF_LOOP_FLAG(notimerfd, EVFLAG_NOTIMERFD)
 #define DEF_BACKEND_SET(__name, __value)                                       \
   CAMLprim value lev_backend_##__name(value v_unit) {                          \
     CAMLparam1(v_unit);                                                        \
-    CAMLreturn(Int_val(__value()));                                            \
+    CAMLreturn(Val_int(__value()));                                            \
   }
 
 DEF_BACKEND_SET(supported, ev_supported_backends)
@@ -381,7 +381,7 @@ CAMLprim value lev_timer_remaining(value v_timer, value v_ev) {
   CAMLparam2(v_timer, v_ev);
   ev_timer *timer = Ev_timer_val(v_timer);
   struct ev_loop *ev = (struct ev_loop *)Nativeint_val(v_ev);
-  CAMLreturn(ev_timer_remaining(ev, timer));
+  CAMLreturn(caml_copy_double(ev_timer_remaining(ev, timer)));
 }
 
 CAMLprim value lev_timer_again(value v_timer, value v_ev) {

--- a/src/lev/test/lev_tests.ml
+++ b/src/lev/test/lev_tests.ml
@@ -41,6 +41,13 @@ let%expect_test "create and run" =
   [%expect {||}]
 ;;
 
+let%expect_test "supported backends include the active backend" =
+  let loop = Loop.create () in
+  let backend = Loop.backend loop in
+  printf "supported = %b\n" (Backend.Set.mem (Backend.supported ()) backend);
+  [%expect {| supported = true |}]
+;;
+
 let%expect_test "timer" =
   let loop = Loop.create () in
   let timer =
@@ -53,6 +60,16 @@ let%expect_test "timer" =
   [%expect
     {|
     fired timer |}]
+;;
+
+let%expect_test "timer remaining is boxed correctly" =
+  let loop = Loop.create () in
+  let timer = Timer.create ~after:1.0 (fun _ -> ()) in
+  Timer.start timer loop;
+  let remaining = Timestamp.to_float (Timer.remaining timer loop) in
+  printf "remaining positive = %b\n" (remaining > 0.);
+  Timer.stop timer loop;
+  [%expect {| remaining positive = true |}]
 ;;
 
 let%expect_test "timer - not repeats" =


### PR DESCRIPTION
`Backend.supported` and related stubs return immediate integers, so those results need `Val_int`.

`Timer.remaining` returns `Timestamp.t`, which is represented as a boxed float, so the stub must use `caml_copy_double`.

Add expect tests covering both cases.