### PR TITLE
chore: don't pin packages for OxCaml opam tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -425,11 +425,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Pin deps
-        run: opam pin add -n . --with-version=3.23.0
-
       - name: Install deps
-        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test dune wasm_of_ocaml-compiler
+        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 
       - name: Build dune
         run: opam exec -- make bootstrap

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -424,11 +424,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Pin deps
-        run: opam pin add -n . --with-version=%%VERSION%%
-
       - name: Install deps
-        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test dune wasm_of_ocaml-compiler
+        run: opam install csexp pp re spawn uutf ppx_expect ppx_inline_test wasm_of_ocaml-compiler
 
       - name: Build dune
         run: opam exec -- make bootstrap


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/14277

AFAIU, what we want to test in the `OxCaml Tests (opam)` job is that we can build the dune codebase with oxcaml.

However, the previous logic of the tests was also pinning all the packages in our repo. As a result of OxCaml now moving to enforce use of its select patched versions of dependencies, these pins were making the subsequent installation of dependencies unsatisfiable.

The simple solution proposed here was advise by @dra27 (thanks!): if we don't pin the packages in the repo, we don't introduce the conflicts. The test is then able to pass: https://github.com/ocaml/dune/actions/runs/24756394915/job/72430637518?pr=14286 