### PR TITLE
test: single-module consumer unreferenced-dep regression guard

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -1,0 +1,35 @@
+Per-module library filtering for a single-module consumer that does not
+reference its dependency library.
+
+When a consumer library has one module and it does not reference any
+module from a dependency library, changing modules in that dependency
+must not trigger recompilation of the consumer.
+
+See: https://github.com/ocaml/dune/issues/4572
+See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name libA) (wrapped false) (modules modA))
+  > (library (name libB) (wrapped false) (modules modB) (libraries libA))
+  > EOF
+
+  $ cat > modA.ml <<EOF
+  > let x = 42
+  > EOF
+  $ cat > modB.ml <<EOF
+  > let x = 12
+  > EOF
+
+  $ dune build @check
+
+Modify modA only; modB does not reference modA, so modB must not be
+recompiled:
+
+  $ echo "let x = 43" > modA.ml
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("modB"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -1,35 +1,67 @@
-Per-module library filtering for a single-module consumer that does not
-reference its dependency library.
+Baseline: single-module consumer library whose only module references
+no module of its declared dependency library.
 
-When a consumer library has one module and it does not reference any
-module from a dependency library, changing modules in that dependency
-must not trigger recompilation of the consumer.
+This is an observational test. It records the number of rebuild
+targets for the consumer's [spurious_rebuild] module when the
+dependency library [dep_lib]'s only module has its interface
+edited.
+
+[consumer_lib] declares [(libraries dep_lib)] but
+[spurious_rebuild.ml] does not reference any module of [dep_lib].
+On current main this scenario still rebuilds [spurious_rebuild]:
+[consumer_lib] is a single-module stanza, so dune skips ocamldep
+as an optimisation and cannot discover that [spurious_rebuild]
+references no module of [dep_lib]; the consumer falls back to a
+glob over [dep_lib]'s object directory, which is invalidated by
+the cmi change.
+
+The zero-reference case is a distinct corner from the single-module
+consumer that references some (but not all) modules of its dep,
+which [single-module-lib.t] already documents. A future fix that
+detects "ocamldep yields no references to dep_lib" could tighten
+this corner to zero rebuilds without needing to solve the broader
+single-module-consumer skip-ocamldep limitation.
 
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > EOF
 
   $ cat > dune <<EOF
-  > (library (name libA) (wrapped false) (modules modA))
-  > (library (name libB) (wrapped false) (modules modB) (libraries libA))
+  > (library (name dep_lib) (wrapped false) (modules dep_module))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules spurious_rebuild)
+  >  (libraries dep_lib))
   > EOF
 
-  $ cat > modA.ml <<EOF
+  $ cat > dep_module.ml <<EOF
   > let x = 42
   > EOF
-  $ cat > modB.ml <<EOF
+  $ cat > dep_module.mli <<EOF
+  > val x : int
+  > EOF
+  $ cat > spurious_rebuild.ml <<EOF
   > let x = 12
   > EOF
 
   $ dune build @check
 
-Modify modA only; modB does not reference modA, so modB must not be
-recompiled:
+Edit [dep_module]'s interface. [spurious_rebuild] does not
+reference [dep_module]. Record the number of [spurious_rebuild]
+rebuild targets observed in the trace:
 
-  $ echo "let x = 43" > modA.ml
+  $ cat > dep_module.mli <<EOF
+  > val x : int
+  > val y : string
+  > EOF
+  $ cat > dep_module.ml <<EOF
+  > let x = 42
+  > let y = "hello"
+  > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("modB"))] | length'
-  0
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
+  1


### PR DESCRIPTION
## Summary

Adds a blackbox cram test recording the rebuild-target count for a
single-module consumer library whose only module references no module
of its declared dependency.

On current main the count is `1`: `consumer_lib` is a single-module
stanza, so dune skips ocamldep for it and falls back to a glob over
`dep_lib`'s object directory, which is invalidated by the cmi change.
This corner is distinct from the one documented by
`test-cases/per-module-lib-deps/single-module-lib.t` (single-module
consumer that references _some_ modules of a multi-module dep): a
future fix that drops a lib dep when ocamldep yields zero references
to it could tighten this corner to `0` without needing to solve the
broader single-module-consumer skip-ocamldep limitation.

Related: #4572, #14116