### PR TITLE
test: sibling-module consumer unreferenced-dep regression guard

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -1,0 +1,45 @@
+Per-module library filtering within a single consumer library.
+
+When a consumer library has multiple modules, only some of which reference a
+given dependency library, changes to that dependency library must not trigger
+recompilation of consumer modules that do not reference it — even when their
+siblings do.
+
+This distinguishes the filter's granularity from the two-library case in
+multiple-libraries.t: the filter must operate at the consumer-module level,
+not merely at the consumer-library level.
+
+See: https://github.com/ocaml/dune/issues/4572
+See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name libA) (wrapped false) (modules modA1 modA2))
+  > (library (name libB) (wrapped false) (modules modB1 modB2) (libraries libA))
+  > EOF
+
+  $ cat > modA1.ml <<EOF
+  > let x = 42
+  > EOF
+  $ cat > modA2.ml <<EOF
+  > let x = 43
+  > EOF
+  $ cat > modB1.ml <<EOF
+  > let x = 12
+  > EOF
+  $ cat > modB2.ml <<EOF
+  > let x = ModA2.x
+  > EOF
+
+  $ dune build @check
+
+modB1 references nothing in libA. Even when libA's ModA2 (used by sibling
+modB2) changes, modB1 must not be recompiled:
+
+  $ echo "let x = 44" > modA2.ml
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("modB1"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -1,45 +1,76 @@
-Per-module library filtering within a single consumer library.
+Baseline: multi-module consumer library with a sibling module that
+references no module of its declared dependency library.
 
-When a consumer library has multiple modules, only some of which reference a
-given dependency library, changes to that dependency library must not trigger
-recompilation of consumer modules that do not reference it — even when their
-siblings do.
+This is an observational test. It records the number of rebuild
+targets for the consumer's [spurious_rebuild] module when a module
+of the dependency library [dep_lib] has its interface edited.
 
-This distinguishes the filter's granularity from the two-library case in
-multiple-libraries.t: the filter must operate at the consumer-module level,
-not merely at the consumer-library level.
+[consumer_lib] is an unwrapped library with two modules.
+[consumes_dep] references [Referenced_dep]; [spurious_rebuild]
+references nothing from [dep_lib]. On current main, editing
+[referenced_dep]'s interface rebuilds [spurious_rebuild] even
+though it references nothing from [dep_lib]: the consumer depends
+on a glob over [dep_lib]'s object directory, which is invalidated
+by the cmi change.
+
+The zero-reference-sibling-in-a-library corner is distinct from
+scenarios covered by existing tests: [lib-to-lib-unwrapped.t] probes
+siblings that reference a different (non-edited) module of the dep;
+[transitive.t] and [unwrapped.t] probe zero-reference modules but
+within executable stanzas, not library stanzas. A future fix
+implementing library-level dep filtering at consumer-module
+granularity would drop [dep_lib] entirely from [spurious_rebuild]'s
+deps, tightening this corner to zero rebuilds.
 
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > EOF
 
   $ cat > dune <<EOF
-  > (library (name libA) (wrapped false) (modules modA1 modA2))
-  > (library (name libB) (wrapped false) (modules modB1 modB2) (libraries libA))
+  > (library
+  >  (name dep_lib)
+  >  (wrapped false)
+  >  (modules unused_module referenced_dep))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules consumes_dep spurious_rebuild)
+  >  (libraries dep_lib))
   > EOF
 
-  $ cat > modA1.ml <<EOF
+  $ cat > unused_module.ml <<EOF
   > let x = 42
   > EOF
-  $ cat > modA2.ml <<EOF
+  $ cat > referenced_dep.ml <<EOF
   > let x = 43
   > EOF
-  $ cat > modB1.ml <<EOF
+  $ cat > referenced_dep.mli <<EOF
+  > val x : int
+  > EOF
+  $ cat > consumes_dep.ml <<EOF
+  > let x = Referenced_dep.x
+  > EOF
+  $ cat > spurious_rebuild.ml <<EOF
   > let x = 12
   > EOF
-  $ cat > modB2.ml <<EOF
-  > let x = ModA2.x
+
+  $ dune build @check
+
+Edit [referenced_dep]'s interface. [spurious_rebuild] references
+nothing in [dep_lib]. Record the number of [spurious_rebuild]
+rebuild targets observed in the trace:
+
+  $ cat > referenced_dep.mli <<EOF
+  > val x : int
+  > val y : string
   > EOF
-
+  $ cat > referenced_dep.ml <<EOF
+  > let x = 43
+  > let y = "hello"
+  > EOF
   $ dune build @check
-
-modB1 references nothing in libA. Even when libA's ModA2 (used by sibling
-modB2) changes, modB1 must not be recompiled:
-
-  $ echo "let x = 44" > modA2.ml
-  $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("modB1"))] | length'
-  0
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
+  1


### PR DESCRIPTION
## Summary

Adds a blackbox cram test recording the rebuild-target count for a
consumer module `spurious_rebuild` in a multi-module unwrapped
consumer library whose sibling `consumes_dep` references a module of
the declared dependency but `spurious_rebuild` itself references
nothing from that dependency.

On current main the count is `1`: the consumer library depends on a
glob over `dep_lib`'s object directory, which is invalidated by the
cmi change on `referenced_dep`. A future fix implementing library-
level dep filtering at consumer-module granularity would drop
`dep_lib` entirely from `spurious_rebuild`'s deps and tighten this
corner to `0`.

This zero-reference-sibling-in-a-library corner is not covered by
existing tests:
- `test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t` probes
  siblings that reference a different (non-edited) module of the dep
  — one-reference, not zero.
- `test-cases/per-module-lib-deps/transitive.t` and
  `test-cases/per-module-lib-deps/unwrapped.t` probe zero-reference
  modules but within executable stanzas, not library stanzas.

Related: #4572, #14116