### PR TITLE
test: observational baseline for per-module rebuild counts

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -46,7 +46,13 @@ explicit interface so signature changes propagate through .cmi files:
   > val v : int
   > EOF
 
-consumer has a single module that references only A2 from base:
+consumer has two modules. The module of interest, [c.ml], references
+only [A2] from [base]. A second, unused module [d.ml] is present only
+to keep [consumer] a multi-module stanza: dune skips ocamldep for
+single-module stanzas with no library deps as an optimisation, and
+the per-module-lib-deps filter depends on ocamldep output. Including
+[d.ml] isolates this test from the skip-ocamldep optimisation so the
+rebuild count for [c] reflects only the per-module filter's work:
 
   $ mkdir consumer
   $ cat > consumer/dune <<EOF
@@ -54,6 +60,9 @@ consumer has a single module that references only A2 from base:
   > EOF
   $ cat > consumer/c.ml <<EOF
   > let w = A2.v
+  > EOF
+  $ cat > consumer/d.ml <<EOF
+  > let _ = ()
   > EOF
 
   $ dune build @check

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -1,0 +1,103 @@
+Baseline: consumer-module rebuild count when individual modules of
+an unwrapped dependency library change.
+
+This is an observational test. It records the number of rebuild
+targets for a single consumer module C when each of three entry
+modules (A1, A2, A3) of the dependency library [base] has its
+interface edited. C references only A2.
+
+On current main, editing any one of A1/A2/A3 causes C to rebuild
+because library-level dependency filtering (and, within that,
+per-module tightening) is not yet in place: the consumer is
+conservatively rebuilt whenever any entry module's cmi changes.
+Work on https://github.com/ocaml/dune/issues/4572 is expected to
+tighten this, at which point editing A1 or A3 leaves C untouched
+and the emitted counts are promoted.
+
+See: https://github.com/ocaml/dune/issues/4572
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.22)
+  > EOF
+
+base is an unwrapped library with three entry modules, each with an
+explicit interface so signature changes propagate through .cmi files:
+
+  $ mkdir base
+  $ cat > base/dune <<EOF
+  > (library (name base) (wrapped false))
+  > EOF
+  $ cat > base/a1.ml <<EOF
+  > let v = 1
+  > EOF
+  $ cat > base/a1.mli <<EOF
+  > val v : int
+  > EOF
+  $ cat > base/a2.ml <<EOF
+  > let v = 2
+  > EOF
+  $ cat > base/a2.mli <<EOF
+  > val v : int
+  > EOF
+  $ cat > base/a3.ml <<EOF
+  > let v = 3
+  > EOF
+  $ cat > base/a3.mli <<EOF
+  > val v : int
+  > EOF
+
+consumer has a single module that references only A2 from base:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (library (name consumer) (wrapped false) (libraries base))
+  > EOF
+  $ cat > consumer/c.ml <<EOF
+  > let w = A2.v
+  > EOF
+
+  $ dune build @check
+
+Edit A1's interface — a module C does not reference — and record
+the rebuild-target count for C:
+
+  $ cat > base/a1.mli <<EOF
+  > val v : int
+  > val extra : unit -> int
+  > EOF
+  $ cat > base/a1.ml <<EOF
+  > let v = 1
+  > let extra () = 7
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length'
+  1
+
+Same for A3:
+
+  $ cat > base/a3.mli <<EOF
+  > val v : int
+  > val other : string
+  > EOF
+  $ cat > base/a3.ml <<EOF
+  > let v = 3
+  > let other = "hi"
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length'
+  1
+
+Edit A2's interface — the one module C does reference — and check
+that the count is positive (C must rebuild):
+
+  $ cat > base/a2.mli <<EOF
+  > val v : int
+  > val new_fn : int -> int
+  > EOF
+  $ cat > base/a2.ml <<EOF
+  > let v = 2
+  > let new_fn x = x + 1
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length > 0'
+  true

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -1,112 +1,141 @@
-Baseline: consumer-module rebuild count when individual modules of
-an unwrapped dependency library change.
+Baseline: consumer-module rebuild targets when individual modules
+of an unwrapped dependency library change.
 
-This is an observational test. It records the number of rebuild
-targets for a single consumer module C when each of three entry
-modules (A1, A2, A3) of the dependency library [base] has its
-interface edited. C references only A2.
+This is an observational test. It records the rebuild targets for
+the consumer module [consumer] when each of three entry modules of
+the dependency library [dep_lib] has its interface edited.
+[consumer] references only [Referenced_dep] from [dep_lib];
+[Unread_dep_a] and [Unread_dep_b] are present but unreferenced.
 
-On current main, editing any one of A1/A2/A3 causes C to rebuild
+On current main, editing any of the three rebuilds [consumer]
 because library-level dependency filtering (and, within that,
 per-module tightening) is not yet in place: the consumer is
 conservatively rebuilt whenever any entry module's cmi changes.
 Work on https://github.com/ocaml/dune/issues/4572 is expected to
-tighten this, at which point editing A1 or A3 leaves C untouched
-and the emitted counts are promoted.
+tighten this, at which point editing [Unread_dep_a] or
+[Unread_dep_b] leaves [consumer] untouched and the emitted target
+list becomes empty.
 
 See: https://github.com/ocaml/dune/issues/4572
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.22)
+  > (lang dune 3.23)
   > EOF
 
-base is an unwrapped library with three entry modules, each with an
-explicit interface so signature changes propagate through .cmi files:
+[dep_lib] is an unwrapped library with three entry modules, each
+with an explicit interface so signature changes propagate through
+.cmi files:
 
-  $ mkdir base
-  $ cat > base/dune <<EOF
-  > (library (name base) (wrapped false))
+  $ mkdir dep_lib
+  $ cat > dep_lib/dune <<EOF
+  > (library (name dep_lib) (wrapped false))
   > EOF
-  $ cat > base/a1.ml <<EOF
+  $ cat > dep_lib/unread_dep_a.ml <<EOF
   > let v = 1
   > EOF
-  $ cat > base/a1.mli <<EOF
+  $ cat > dep_lib/unread_dep_a.mli <<EOF
   > val v : int
   > EOF
-  $ cat > base/a2.ml <<EOF
+  $ cat > dep_lib/referenced_dep.ml <<EOF
   > let v = 2
   > EOF
-  $ cat > base/a2.mli <<EOF
+  $ cat > dep_lib/referenced_dep.mli <<EOF
   > val v : int
   > EOF
-  $ cat > base/a3.ml <<EOF
+  $ cat > dep_lib/unread_dep_b.ml <<EOF
   > let v = 3
   > EOF
-  $ cat > base/a3.mli <<EOF
+  $ cat > dep_lib/unread_dep_b.mli <<EOF
   > val v : int
   > EOF
 
-consumer has two modules. The module of interest, [c.ml], references
-only [A2] from [base]. A second, unused module [d.ml] is present only
-to keep [consumer] a multi-module stanza: dune skips ocamldep for
-single-module stanzas with no library deps as an optimisation, and
-the per-module-lib-deps filter depends on ocamldep output. Including
-[d.ml] isolates this test from the skip-ocamldep optimisation so the
-rebuild count for [c] reflects only the per-module filter's work:
+[consumer_lib] has two modules. The module of interest, [consumer],
+references only [Referenced_dep] from [dep_lib]. A second, unused
+module [filler] is present only to keep [consumer_lib] a multi-
+module stanza: dune skips ocamldep for single-module stanzas with
+no library deps as an optimisation, and the per-module-lib-deps
+filter depends on ocamldep output. Including [filler] isolates
+this test from the skip-ocamldep optimisation so the rebuild
+targets for [consumer] reflect only the per-module filter's work:
 
-  $ mkdir consumer
-  $ cat > consumer/dune <<EOF
-  > (library (name consumer) (wrapped false) (libraries base))
+  $ mkdir consumer_lib
+  $ cat > consumer_lib/dune <<EOF
+  > (library (name consumer_lib) (wrapped false) (libraries dep_lib))
   > EOF
-  $ cat > consumer/c.ml <<EOF
-  > let w = A2.v
+  $ cat > consumer_lib/consumer.ml <<EOF
+  > let w = Referenced_dep.v
   > EOF
-  $ cat > consumer/d.ml <<EOF
+  $ cat > consumer_lib/filler.ml <<EOF
   > let _ = ()
   > EOF
 
   $ dune build @check
 
-Edit A1's interface — a module C does not reference — and record
-the rebuild-target count for C:
+Edit [Unread_dep_a]'s interface — a module [consumer] does not
+reference — and record the rebuild targets for [consumer]:
 
-  $ cat > base/a1.mli <<EOF
+  $ cat > dep_lib/unread_dep_a.mli <<EOF
   > val v : int
   > val extra : unit -> int
   > EOF
-  $ cat > base/a1.ml <<EOF
+  $ cat > dep_lib/unread_dep_a.ml <<EOF
   > let v = 1
   > let extra () = 7
   > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
+      ]
+    }
+  ]
 
-Same for A3:
+Same for [Unread_dep_b]:
 
-  $ cat > base/a3.mli <<EOF
+  $ cat > dep_lib/unread_dep_b.mli <<EOF
   > val v : int
   > val other : string
   > EOF
-  $ cat > base/a3.ml <<EOF
+  $ cat > dep_lib/unread_dep_b.ml <<EOF
   > let v = 3
   > let other = "hi"
   > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
+      ]
+    }
+  ]
 
-Edit A2's interface — the one module C does reference — and check
-that the count is positive (C must rebuild):
+Edit [Referenced_dep]'s interface — the one module [consumer] does
+reference — and record the rebuild targets ([consumer] must
+rebuild):
 
-  $ cat > base/a2.mli <<EOF
+  $ cat > dep_lib/referenced_dep.mli <<EOF
   > val v : int
   > val new_fn : int -> int
   > EOF
-  $ cat > base/a2.ml <<EOF
+  $ cat > dep_lib/referenced_dep.ml <<EOF
   > let v = 2
   > let new_fn x = x + 1
   > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.consumer\\.objs/byte/c\\."))] | length > 0'
-  true
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
+      ]
+    }
+  ]


### PR DESCRIPTION
## Summary

Adds a blackbox cram test that records the rebuild-target count for a
consumer module `C` when each of three entry modules (`A1`, `A2`, `A3`)
of an unwrapped dependency library has its interface edited. `C`
references only `A2`.

On current main, editing any of `A1`/`A2`/`A3` rebuilds `C` (conservative
glob dep over the dependency's object dir). The recorded counts are
`A1=1`, `A3=1`, `A2>0`. Once per-module tightening (#4572) lands, `A1`
and `A3` counts go to zero and a later PR promotes the test output.

Related: #4572, #14116