### PR TITLE
test: narrow subst pattern in non-existent-branch.t to avoid matching paths

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
@@ -29,7 +29,7 @@ Reference a branch that does not exist in the pin:
   > EOF
 
   $ export BUILD_PATH_PREFIX_MAP="PWD=//$PWD:$BUILD_PATH_PREFIX_MAP"
-  $ dune pkg lock 2>&1 | dune_cmd subst '-\d+' '-eol' | dune_cmd delete '\^+'
+  $ dune pkg lock 2>&1 | dune_cmd subst 'characters 6-\d+' 'characters 6-eol' | dune_cmd delete '\^+'
   File "dune-project", line 3, characters 6-eol:
   3 |  (url "git+file:PWD/_repo#nonexistent-branch")
   revision "nonexistent-branch" not found in

--- a/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
+++ b/test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t
@@ -29,8 +29,8 @@ Reference a branch that does not exist in the pin:
   > EOF
 
   $ export BUILD_PATH_PREFIX_MAP="PWD=//$PWD:$BUILD_PATH_PREFIX_MAP"
-  $ dune pkg lock 2>&1 | dune_cmd subst 'characters 6-\d+' 'characters 6-eol' | dune_cmd delete '\^+'
-  File "dune-project", line 3, characters 6-eol:
+  $ dune pkg lock 2>&1 | dune_cmd subst 'characters \d+-\d+:' 'characters start-eol:' | dune_cmd delete '\^+'
+  File "dune-project", line 3, characters start-eol:
   3 |  (url "git+file:PWD/_repo#nonexistent-branch")
   revision "nonexistent-branch" not found in
   file:PWD/_repo


### PR DESCRIPTION
## Summary

The output post-processing in
`test/blackbox-tests/test-cases/pkg/pin-stanza/non-existent-branch.t`
uses `dune_cmd subst '-\d+' '-eol'` to normalise the variable
end-column in the `characters 6-<N>:` part of dune's error
location. The pattern is too broad: any `-<digits>` substring in
the output matches, including path components in the sandbox root.

When the repo is checked out at a worktree whose directory contains
`-<digits>` (e.g. `dune-pr-14116/`), the substitution rewrites
that path component and `BUILD_PATH_PREFIX_MAP` stripping no
longer matches, so the test output contains a raw sandbox path and
the assertion fails.

Anchor the pattern to `characters 6-\d+` so it only matches the
column range it was meant to normalise.

## Test plan

- [x] Reproduced the failure in a worktree checked out at a path
  containing `-<digits>` (e.g. `dune-pr-14116/`) on upstream/main.
- [x] Applied the fix and verified the test passes in the same
  worktree path.
- [x] Verified the test continues to pass in a worktree whose path
  does not match `-<digits>`.