### PR TITLE
test: extend wrapped-transition to cover alert-silencing success path

### DIFF
--- a/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
@@ -1,4 +1,11 @@
-Reports wrapped-transition compatibility modules as deprecated.
+A library declared with `(wrapped (transition "..."))` exposes each
+public module under two names: the wrapped form (e.g. `Mylib.Foo`)
+and a bare-name compat shim (e.g. `Foo`). The shim lets downstream
+code keep using the bare name during migration; any reference to it
+raises a deprecation alert carrying the library's transition message.
+
+Without alert silencing, a consumer that reaches for the bare name
+fails to build:
 
   $ dune build 2>&1 | grep -v ocamlc
   File "fooexe.ml", line 3, characters 0-3:
@@ -19,3 +26,16 @@ Reports wrapped-transition compatibility modules as deprecated.
   Error (alert deprecated): module Intf_only
   Will be removed past 2020-20-20. Use Mylib.Intf_only instead.
   [1]
+
+Silencing `-alert -deprecated` on the consumer lets the migration
+proceed: the consumer builds, reaching the bare-name compat shims
+and thereby the library's internal modules.
+
+  $ rm dune
+  $ cat > dune <<EOF
+  > (executable
+  >  (name fooexe)
+  >  (libraries mylib)
+  >  (flags (:standard -alert -deprecated)))
+  > EOF
+  $ dune build


### PR DESCRIPTION
## Summary

Per discussion on #14307 (closed): the new test added there was
redundant with `wrapped-transition.t/run.t`. Taking @rgrinberg's
suggestion to combine the two, this PR extends the existing
`wrapped-transition.t/run.t` in place rather than introducing a new
file.

The existing test covered only the failure mode: a consumer that
reaches for the bare-name compat shim without silencing deprecation
alerts fails to build with three errors.

This PR extends the test to also cover the success path: after
observing the failure, overwrite `dune` with a consumer that silences
`-alert -deprecated` and verify the build succeeds. One file, two
sides of the migration recipe.

Also clarifies the intro prose to describe `(wrapped (transition "..."))`
behaviour and the two-sided test structure.

Related: closed #14307