### PR TITLE
fix: guard SIGTERM grace period in shutdown on Windows (#14302)

### DIFF
--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -121,11 +121,18 @@ type saw_shutdown =
   | Got_shutdown
 
 let kill_and_wait_for_all_processes t =
-  if Event.Queue.pending_jobs t.events > 0
+  if Sys.win32
+  then
+    (* SIGTERM is not meaningful on Windows, and [Process_watcher.wait_unix]
+       would raise because [Proc.wait] has no implementation there. Send
+       SIGKILL directly; the main drain loop below observes exits via
+       [jobs_completed] events pushed by the Win32 polling thread. *)
+    Process_watcher.killall t.process_watcher Sys.sigkill
+  else if Event.Queue.pending_jobs t.events > 0
   then (
     Dune_trace.emit Process Dune_trace.Event.process_cleanup_start;
     (* Send SIGTERM first to give processes a chance to clean up *)
-    if not Sys.win32 then Process_watcher.killall t.process_watcher Sys.sigterm;
+    Process_watcher.killall t.process_watcher Sys.sigterm;
     (* Poll until all processes exit or the grace period expires, then SIGKILL *)
     let deadline = Time.add (Time.now ()) sigterm_grace_period in
     let sent_sigkill = ref false in


### PR DESCRIPTION
## Summary

Fixes #14302.

PR #14170 added a SIGTERM-before-SIGKILL grace period to
`kill_and_wait_for_all_processes`. The new polling loop calls
`Process_watcher.wait_unix` unconditionally, which on Windows routes through
`Proc.wait` and raises `Code_error "wait4 not available on windows"`, crashing
dune on Ctrl+C.

## Fix

Since SIGTERM is not meaningful on Windows anyway — as PR #14170 itself noted
("On Windows, where SIGTERM is not meaningful, behavior is unchanged") — skip
the grace-period pre-phase on Windows and send SIGKILL directly. The existing
main drain loop already handles the Windows case correctly: job exits are
pushed to `jobs_completed` by the `run_win32` polling thread and decrement
`pending_jobs` when popped by `Event.Queue.next` (see
`src/dune_scheduler/event.ml:222` and `:187-191`).

## Changelog

Added `doc/changes/fixed/14302.md`.