### PR TITLE
test: document broad-include leak of wrapped-library internal names

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
@@ -1,0 +1,51 @@
+Observational baseline for an unsupported leak: a consumer can
+currently reach a wrapped library's internal (mangled) module name
+through the include path, because the library's object directory
+contains the mangled `Mylib__Internal.cmi` and broad `-I` flags make
+that directory reachable.
+
+A wrapped library exposes its public API only through its wrapper
+module (`Mylib.Internal`, etc). Dune mangles the on-disk cmi of the
+wrapped internal module to `Mylib__Internal.cmi` as an implementation
+detail. Under broad per-module `-I` flags, a consumer that writes
+`Mylib__Internal.x` compiles successfully, side-stepping the wrapper.
+
+This is not officially supported — consumers should reach a wrapped
+library's internals only through the wrapper API, not through the
+mangled form (see #14317 review discussion). The leak works today
+only as an implementation-detail side effect of the wrapping
+convention. In practice some packages currently depend on it, which
+is why the baseline is recorded here so any flip is visible in CI.
+
+Per-module `-I` filtering (#4572 / #14186) is expected to break this
+leak by scoping each consumer's `-I` paths to the libraries its
+source references. `Mylib__Internal` is not an entry in the lib
+index, so the filter excludes `mylib`, the objdir is dropped from
+`-I`, and the compile fails with "Unbound module Mylib__Internal".
+The flip is acceptable because the leak was never supported;
+downstream consumers depending on the mangled form should migrate
+to the wrapper API.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir mylib
+  $ cat > mylib/dune <<EOF
+  > (library (name mylib))
+  > EOF
+  $ cat > mylib/mylib.ml <<EOF
+  > module Internal = Internal
+  > EOF
+  $ cat > mylib/internal.ml <<EOF
+  > let hi = "hi"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name main) (libraries mylib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_endline Mylib__Internal.hi
+  > EOF
+
+  $ dune build ./main.exe


### PR DESCRIPTION
## Summary

Adds an observational cram test recording that a consumer currently
compiles successfully when it writes the mangled internal name of a
wrapped library's private module (e.g. `Mylib__Internal.x`). Broad
per-compile `-I` flags make the library's object directory reachable,
and the mangled `Mylib__Internal.cmi` is physically present there as
part of dune's wrapping convention, so the access succeeds and
silently side-steps the library's declared wrapper API.

## Status of the documented behaviour

This behaviour is **not officially supported**. As @rgrinberg
clarified in review, users should reach a wrapped library's internals
only through the wrapper API, not through the mangled form, and we
are free to break the mangled access if convenient. In practice some
packages currently depend on it (a test in #14116 surfaced this when
a code change happened to flip the behaviour), so the baseline is
recorded here as a tripwire: any future change that flips it shows
up as a visible cram diff rather than silently breaking those
consumers, giving us the chance to provide migration patches
upstream.

## Future direction

Per-module `-I` filtering (#4572 / #14186) is expected to break this
leak deliberately by scoping each consumer's `-I` paths to the
libraries its source references. `Mylib__Internal` is not an entry
in the lib index, so the filter excludes `mylib`, the objdir is
dropped from `-I`, and the compile fails with "Unbound module
Mylib__Internal". The flip is acceptable because the leak was never
supported; downstream consumers depending on the mangled form should
migrate to the wrapper API.

Related: #4572, #14186