### PR TITLE
Fix OxCaml trunk build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,23 +225,6 @@
         "type": "github"
       }
     },
-    "oxcaml-trunk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1776893883,
-        "narHash": "sha256-+64raykCl17Cz6Bw5iarqQVziHQ8yVvENjUuU9zXsUM=",
-        "owner": "oxcaml",
-        "repo": "oxcaml",
-        "rev": "eff62247f474ac0227dd6fc7db9256ffc68ab39d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxcaml",
-        "ref": "main",
-        "repo": "oxcaml",
-        "type": "github"
-      }
-    },
     "revdeps-dune": {
       "inputs": {
         "melange": [
@@ -296,7 +279,6 @@
         "odoc-src": "odoc-src",
         "oxcaml": "oxcaml",
         "oxcaml-opam-repository": "oxcaml-opam-repository",
-        "oxcaml-trunk": "oxcaml-trunk",
         "revdeps-dune": "revdeps-dune"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -225,6 +225,23 @@
         "type": "github"
       }
     },
+    "oxcaml-trunk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776893883,
+        "narHash": "sha256-+64raykCl17Cz6Bw5iarqQVziHQ8yVvENjUuU9zXsUM=",
+        "owner": "oxcaml",
+        "repo": "oxcaml",
+        "rev": "eff62247f474ac0227dd6fc7db9256ffc68ab39d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxcaml",
+        "ref": "main",
+        "repo": "oxcaml",
+        "type": "github"
+      }
+    },
     "revdeps-dune": {
       "inputs": {
         "melange": [
@@ -279,6 +296,7 @@
         "odoc-src": "odoc-src",
         "oxcaml": "oxcaml",
         "oxcaml-opam-repository": "oxcaml-opam-repository",
+        "oxcaml-trunk": "oxcaml-trunk",
         "revdeps-dune": "revdeps-dune"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,6 @@
     oxcaml = {
       url = "github:oxcaml/oxcaml/5.2.0minus-31";
     };
-    oxcaml-trunk = {
-      url = "github:oxcaml/oxcaml/main";
-      flake = false;
-    };
     oxcaml-opam-repository = {
       url = "github:oxcaml/opam-repository/231c88c2e564fdca40e15e750aacad5fb0887435";
       flake = false;
@@ -57,7 +53,6 @@
       ocaml-overlays,
       odoc-src,
       oxcaml,
-      oxcaml-trunk,
       oxcaml-opam-repository,
       revdeps-dune,
       menhir-src,
@@ -244,10 +239,14 @@
                 inherit pkgs menhir-src;
               };
             in
+            # nix build .#oxcaml-trunk-build --no-link --impure
             pkgs.stdenv.mkDerivation {
               pname = "oxcaml-trunk-build";
               version = "check";
-              src = oxcaml-trunk;
+              src = builtins.fetchGit {
+                url = "https://github.com/oxcaml/oxcaml.git";
+                ref = "main";
+              };
               nativeBuildInputs = [
                 dune
                 pkgs.autoconf

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
     oxcaml = {
       url = "github:oxcaml/oxcaml/5.2.0minus-31";
     };
+    oxcaml-trunk = {
+      url = "github:oxcaml/oxcaml/main";
+      flake = false;
+    };
     oxcaml-opam-repository = {
       url = "github:oxcaml/opam-repository/231c88c2e564fdca40e15e750aacad5fb0887435";
       flake = false;
@@ -53,6 +57,7 @@
       ocaml-overlays,
       odoc-src,
       oxcaml,
+      oxcaml-trunk,
       oxcaml-opam-repository,
       revdeps-dune,
       menhir-src,
@@ -242,7 +247,7 @@
             pkgs.stdenv.mkDerivation {
               pname = "oxcaml-trunk-build";
               version = "check";
-              src = oxcaml;
+              src = oxcaml-trunk;
               nativeBuildInputs = [
                 dune
                 pkgs.autoconf
@@ -254,7 +259,7 @@
               strictDeps = true;
               buildPhase = ''
                 autoconf
-                ./configure --prefix $PWD/_install --enable-dev --enable-runtime5
+                ./configure --prefix $PWD/_install --enable-runtime5 --disable-warn-error
                 make SHELL=$SHELL
               '';
               installPhase = ''


### PR DESCRIPTION
A failure was reported here:
https://github.com/ocaml/dune/actions/runs/24758181925/job/72566949652?pr=14212, and I realised we're building the oxcaml-compiler.5.2.0minus31 in the trunk build job. I've updated it to OxCaml trunk in this patch.