### PR TITLE
fix(rpc): wait for listener shutdown to complete

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -387,8 +387,9 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
             Session.Stage1.close entry.session))
       in
       let shutdown () =
+        let* () = Csexp_rpc.Server.stop (Lazy.force t.config.server) in
         Scheduler.shutdown ();
-        Csexp_rpc.Server.stop (Lazy.force t.config.server)
+        Fiber.return ()
       in
       Fiber.fork_and_join_unit terminate_sessions shutdown
     in

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -180,7 +180,13 @@ module Event : sig
 
     val packet_read : id:int -> success:bool -> error:string option -> t
     val packet_write : id:int -> count:int -> t
-    val accept : id:int -> stage -> success:bool option -> error:string option -> t
+
+    val accept
+      :  id:int
+      -> stage
+      -> [ `Close | `Error of Exn_with_backtrace.t | `Accept ] option
+      -> t
+
     val shutdown : id:int -> stage -> t
     val close : id:int -> t
     val dropped_write_client_disconnect : Exn.t -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -494,16 +494,13 @@ module Rpc = struct
     Event.instant ~name:"packet_write" ~args now Rpc
   ;;
 
-  let accept ~id stage ~success ~error =
+  let accept ~id stage res =
     let args =
-      let args =
-        match success with
-        | None -> []
-        | Some success -> [ "success", Arg.bool success ]
-      in
-      match error with
-      | None -> args
-      | Some err -> ("error", Arg.string err) :: args
+      match res with
+      | None -> []
+      | Some `Close -> [ "status", Arg.string "close" ]
+      | Some `Accept -> [ "status", Arg.string "accept" ]
+      | Some (`Error exn) -> [ "error", Arg.dyn (Exn_with_backtrace.to_dyn exn) ]
     in
     Event.async (Event.Id.int id) ~args ~name:"accept" (Time.now ()) stage Rpc
   ;;

--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -337,24 +337,45 @@ module Server = struct
       { sockets : (Unix.sockaddr * Fd.t) list
       ; mutable task : (Fd.t * Unix.sockaddr) Async_io.Task.t option
       ; mutable running : bool
+      ; closed : unit Fiber.Ivar.t
       }
 
     let create sockets ~backlog =
       List.iter sockets ~f:(fun (_, fd) ->
         Unix.listen (Fd.unsafe_to_unix_file_descr fd) backlog;
         Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd));
-      { sockets; task = None; running = true }
+      { sockets; task = None; running = true; closed = Fiber.Ivar.create () }
     ;;
 
-    let close t =
-      let+ () = Fiber.parallel_iter ~f:(fun (_, fd) -> Async_io.close fd) t.sockets in
-      Ok None
+    let stop t =
+      let* () = Fiber.return () in
+      match t.running with
+      | false -> Fiber.Ivar.read t.closed
+      | true ->
+        t.running <- false;
+        let* () =
+          match t.task with
+          | None -> Fiber.return ()
+          | Some task ->
+            t.task <- None;
+            let* () = Async_io.Task.cancel task in
+            let+ (_ : (Fd.t * Unix.sockaddr, [ `Cancelled | `Exn of exn ]) result) =
+              Async_io.Task.await task
+            in
+            ()
+        in
+        let* () = Fiber.parallel_iter t.sockets ~f:(fun (_, fd) -> Async_io.close fd) in
+        List.iter t.sockets ~f:(fun (addr, _) ->
+          match (addr : Unix.sockaddr) with
+          | ADDR_UNIX p -> Fpath.unlink_no_err p
+          | _ -> ());
+        Fiber.Ivar.fill t.closed ()
     ;;
 
     let rec accept t =
       let* () = Fiber.return () in
       match t.running with
-      | false -> close t
+      | false -> Fiber.return (Ok None)
       | true ->
         let task =
           Async_io.ready_one t.sockets `Read ~f:(fun _ fd ->
@@ -365,30 +386,19 @@ module Server = struct
         in
         t.task <- Some task;
         let* res = Async_io.Task.await task in
+        t.task <- None;
         (match res with
          | Error (`Exn (Unix.Unix_error (Unix.EAGAIN, _, _))) -> accept t
          | Error (`Exn exn) ->
-           let+ _ = close t in
+           let+ () = stop t in
            Error (Exn_with_backtrace.capture exn)
-         | Error `Cancelled -> close t
+         | Error `Cancelled ->
+           let+ () = stop t in
+           Ok None
          | Ok (fd, _) ->
            Socket.maybe_set_nosigpipe fd;
            Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
            Fiber.return @@ Ok (Some fd))
-    ;;
-
-    let stop t =
-      let* () = Fiber.return () in
-      t.running <- false;
-      let+ () =
-        match t.task with
-        | None -> Fiber.return ()
-        | Some task -> Async_io.Task.cancel task
-      in
-      List.iter t.sockets ~f:(fun (addr, _) ->
-        match (addr : Unix.sockaddr) with
-        | ADDR_UNIX p -> Fpath.unlink_no_err p
-        | _ -> ())
     ;;
   end
 
@@ -445,27 +455,19 @@ module Server = struct
       let+ () = Fiber.Ivar.fill t.ready () in
       let loop () =
         Dune_trace.emit Rpc (fun () ->
-          Dune_trace.Event.Rpc.accept
-            ~id:(Id.to_int t.id)
-            `Start
-            ~success:None
-            ~error:None);
-        let* accept = Transport.accept transport in
+          Dune_trace.Event.Rpc.accept ~id:(Id.to_int t.id) `Start None);
+        let+ accept = Transport.accept transport in
         Dune_trace.emit Rpc (fun () ->
-          let success, error =
+          let res =
             match accept with
-            | Error _exn ->
-              Some false, Some "RPC accept failed. Server will not accept new clients"
-            | Ok None -> Some false, Some "No more clients will be accepted"
-            | Ok (Some _) -> Some true, None
+            | Error exn -> `Error exn
+            | Ok None -> `Close
+            | Ok (Some _) -> `Accept
           in
-          Dune_trace.Event.Rpc.accept ~id:(Id.to_int t.id) `Stop ~success ~error);
+          Dune_trace.Event.Rpc.accept ~id:(Id.to_int t.id) `Stop (Some res));
         match accept with
-        | Error _exn -> Fiber.return None
-        | Ok None -> Fiber.return None
-        | Ok (Some fd) ->
-          let session = Session.create fd in
-          Fiber.return (Some session)
+        | Error _ | Ok None -> None
+        | Ok (Some fd) -> Some (Session.create fd)
       in
       Fiber.Stream.In.create loop
   ;;
@@ -477,14 +479,13 @@ module Server = struct
     | `Running _ | `Init _ ->
       Dune_trace.emit Rpc (fun () ->
         Dune_trace.Event.Rpc.shutdown ~id:(Id.to_int t.id) `Start);
-      let+ () =
+      let* () =
         match t.state with
         | `Closed -> Fiber.return ()
-        | `Running t -> Transport.stop t
-        | `Init fds ->
-          List.iter ~f:Fd.close fds;
-          Fiber.return ()
+        | `Running transport -> Transport.stop transport
+        | `Init fds -> Fiber.parallel_iter fds ~f:Async_io.close
       in
+      let+ () = Fiber.return () in
       t.state <- `Closed;
       Dune_trace.emit Rpc (fun () ->
         Dune_trace.Event.Rpc.shutdown ~id:(Id.to_int t.id) `Stop)
@@ -538,8 +539,8 @@ module Client = struct
   ;;
 
   let connect_exn t =
-    let+ res = connect t in
-    match res with
+    connect t
+    >>| function
     | Ok s -> s
     | Error e -> Exn_with_backtrace.reraise e
   ;;

--- a/src/rpc/csexp_rpc.mli
+++ b/src/rpc/csexp_rpc.mli
@@ -50,7 +50,10 @@ module Server : sig
       to the server *)
   val ready : t -> unit Fiber.t
 
+  (** [stop t] completes only after the listening sockets are closed and no new
+      clients can connect. *)
   val stop : t -> unit Fiber.t
+
   val serve : t -> Session.t Fiber.Stream.In.t Fiber.t
   val listening_address : t -> Unix.sockaddr list
 end

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -180,8 +180,12 @@ summarize_rpc_trace () {
       select(.cat == "rpc")
       | if .name == "accept"
            and .args.stage == "stop"
-           and (.args.success == false)
-        then "accept stop false"
+           and .args.status == "close"
+        then "accept stop close"
+        elif .name == "accept"
+             and .args.stage == "stop"
+             and (.args | has("error"))
+        then "accept stop error"
         elif .name == "request" and .args.meth == "build"
         then "build \(.args.stage)"
         elif .name == "shutdown"

--- a/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-shutdown-exit.t
@@ -24,4 +24,4 @@ from server exit.
   build stop
   shutdown start
   shutdown stop
-  accept stop false
+  accept stop close

--- a/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-stop.t
@@ -20,4 +20,4 @@ Minimal RPC watch shutdown after an RPC build.
   build stop
   shutdown start
   shutdown stop
-  accept stop false
+  accept stop close

--- a/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-shutdown-exit.t
@@ -14,9 +14,11 @@ Minimal RPC watch shutdown, separating the shutdown command from server exit.
 
   $ shutdown_dune_quiet
 
+  $ ! with_timeout_quiet dune rpc ping >/dev/null 2>&1
+
   $ wait_for_dune_exit_with_timeout
 
   $ summarize_rpc_trace
   shutdown start
   shutdown stop
-  accept stop false
+  accept stop close

--- a/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-start-stop.t
@@ -17,4 +17,4 @@ Minimal RPC watch startup and shutdown without an RPC build.
   $ summarize_rpc_trace
   shutdown start
   shutdown stop
-  accept stop false
+  accept stop close

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -135,3 +135,36 @@ let%expect_test "csexp server life cycle" =
     server: received (11:from client)
     server: sessions finished |}]
 ;;
+
+let%expect_test "csexp server stop rejects new connections" =
+  let tmp_dir = temp_rpc_dir () in
+  let addr : Unix.sockaddr =
+    if Sys.win32
+    then ADDR_INET (Unix.inet_addr_loopback, 0)
+    else ADDR_UNIX (Path.to_string (Path.relative tmp_dir "dunerpc.sock"))
+  in
+  let run () =
+    let server = server addr in
+    let* sessions = Server.serve server in
+    let listening_address = Csexp_rpc.Server.listening_address server |> List.hd in
+    Fiber.fork_and_join_unit
+      (fun () ->
+         let* () = Server.stop server in
+         let client = client listening_address in
+         let* res = Client.connect client in
+         let* outcome =
+           match res with
+           | Error _ ->
+             Client.stop client;
+             Fiber.return "connect failed"
+           | Ok session ->
+             let+ () = Session.close session in
+             "connected"
+         in
+         printfn "%s" outcome;
+         Fiber.return ())
+      (fun () -> Fiber.Stream.In.parallel_iter sessions ~f:(fun _ -> Fiber.return ()))
+  in
+  run_scheduler run;
+  [%expect {| connect failed |}]
+;;


### PR DESCRIPTION
Make Csexp_rpc.Server.stop wait until the listening sockets are closed and the accept loop has finished before returning.

Stop the RPC server before shutting down the scheduler, and add coverage for rejecting new connections after shutdown along with the updated watch-mode shutdown trace ordering.