### PR TITLE
refactor(lev): use Stdune.Time in the bindings

### DIFF
--- a/src/lev/src/dune
+++ b/src/lev/src/dune
@@ -18,7 +18,7 @@
 (library
  (name lev)
  (synopsis "libev bindings")
- (libraries unix)
+ (libraries stdune unix)
  (foreign_archives ev)
  (foreign_stubs
   (language c)

--- a/src/lev/src/lev.ml
+++ b/src/lev/src/lev.ml
@@ -1,3 +1,4 @@
+open Stdune
 module List = ListLabels
 
 external ev_version : unit -> int * int = "lev_version"
@@ -91,14 +92,7 @@ module Backend = struct
   external recommended : unit -> Set.t = "lev_backend_recommended"
 end
 
-module Timestamp = struct
-  type t = float
-
-  external sleep : t -> unit = "lev_sleep"
-
-  let to_float x = x
-  let of_float x = x
-end
+external sleep : Time.Span.t -> unit = "lev_sleep"
 
 module Loop = struct
   module Flag = struct
@@ -174,7 +168,7 @@ module Loop = struct
 
   let create ?(flags = flags) () = create flags
 
-  external now : t -> Timestamp.t = "lev_ev_now"
+  external now : t -> Time.t = "lev_ev_now"
   external destroy : t -> unit = "lev_loop_destroy"
   external now_update : t -> unit = "lev_loop_now_update"
   external run : t -> int -> bool = "lev_ev_run"
@@ -338,21 +332,21 @@ module Periodic = struct
 
   type kind =
     | Regular of
-        { offset : Timestamp.t
-        ; interval : Timestamp.t option
+        { offset : Time.t
+        ; interval : Time.Span.t option
         }
-    | Custom of (t -> now:Timestamp.t -> Timestamp.t)
+    | Custom of (t -> now:Time.t -> Time.t)
 
   external create_regular
     :  (t -> unit -> unit)
-    -> float
-    -> float
+    -> Time.t
+    -> Time.Span.t
     -> t
     = "lev_periodic_create_regular"
 
   external create_custom
     :  (t -> unit -> unit)
-    -> (t -> now:Timestamp.t -> Timestamp.t)
+    -> (t -> now:Time.t -> Time.t)
     -> t
     = "lev_periodic_create_custom"
 
@@ -363,7 +357,7 @@ module Periodic = struct
     | Regular { offset; interval } ->
       let interval =
         match interval with
-        | None -> 0.
+        | None -> Time.Span.zero
         | Some f -> f
       in
       create_regular f offset interval
@@ -380,11 +374,16 @@ module Timer = struct
       type nonrec t = t
     end)
 
-  external create : (t -> unit -> unit) -> float -> float -> t = "lev_timer_create"
+  external create
+    :  (t -> unit -> unit)
+    -> Time.Span.t
+    -> Time.Span.t
+    -> t
+    = "lev_timer_create"
 
-  let create ?(repeat = 0.) ~after f = create (wrap_callback f) after repeat
+  let create ?(repeat = Time.Span.zero) ~after f = create (wrap_callback f) after repeat
 
-  external remaining : t -> Loop.t -> Timestamp.t = "lev_timer_remaining"
+  external remaining : t -> Loop.t -> Time.Span.t = "lev_timer_remaining"
   external stop : t -> Loop.t -> unit = "lev_timer_stop"
   external start : t -> Loop.t -> unit = "lev_timer_start"
   external again : t -> Loop.t -> unit = "lev_timer_again"
@@ -470,10 +469,13 @@ module Stat = struct
   external destroy : t -> unit = "lev_stat_destroy"
   external stop : t -> Loop.t -> unit = "lev_stat_stop"
   external start : t -> Loop.t -> unit = "lev_stat_start"
-  external create : (t -> unit -> unit) -> string -> Timestamp.t -> t = "lev_stat_create"
+  external create : (t -> unit -> unit) -> string -> Time.Span.t -> t = "lev_stat_create"
   external stat : t -> Unix.stats = "lev_stat_stat"
 
-  let create_unix ?(interval = 0.) ~path f = create (wrap_callback f) path interval
+  let create_unix ?(interval = Time.Span.zero) ~path f =
+    create (wrap_callback f) path interval
+  ;;
+
   let create = if Sys.win32 then Error `Unimplemented else Ok create_unix
 end
 

--- a/src/lev/src/lev.mli
+++ b/src/lev/src/lev.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 (** Thin wrapper around Marc Lehmann's libev library.
 
 libev is small and performant, but this comes at a cost of a few rough edges
@@ -57,13 +59,7 @@ module Backend : sig
   val recommended : unit -> Set.t
 end
 
-module Timestamp : sig
-  type t
-
-  val sleep : t -> unit
-  val of_float : float -> t
-  val to_float : t -> float
-end
+val sleep : Time.Span.t -> unit
 
 module Loop : sig
   module Flag : sig
@@ -95,7 +91,7 @@ module Loop : sig
 
   type t
 
-  val now : t -> Timestamp.t
+  val now : t -> Stdune.Time.t
 
   (** The default event loop is the only one that can handle child watchers. *)
   val default : ?flags:Flag.Set.t -> unit -> t
@@ -160,10 +156,10 @@ module Periodic : sig
 
   type kind =
     | Regular of
-        { offset : Timestamp.t
-        ; interval : Timestamp.t option
+        { offset : Time.t
+        ; interval : Time.Span.t option
         }
-    | Custom of (t -> now:Timestamp.t -> Timestamp.t)
+    | Custom of (t -> now:Time.t -> Time.t)
 
   val create : (t -> unit) -> kind -> t
 end
@@ -202,8 +198,8 @@ end
 module Timer : sig
   include Watcher
 
-  val create : ?repeat:float -> after:float -> (t -> unit) -> t
-  val remaining : t -> Loop.t -> Timestamp.t
+  val create : ?repeat:Time.Span.t -> after:Time.Span.t -> (t -> unit) -> t
+  val remaining : t -> Loop.t -> Time.Span.t
   val again : t -> Loop.t -> unit
 end
 
@@ -214,7 +210,7 @@ module Stat : sig
   val stat : t -> Unix.stats
 
   val create
-    : ( ?interval:Timestamp.t -> path:string -> (t -> unit) -> t
+    : ( ?interval:Time.Span.t -> path:string -> (t -> unit) -> t
         , [ `Unimplemented ] )
         result
 end

--- a/src/lev/src/lev_stubs.c
+++ b/src/lev/src/lev_stubs.c
@@ -95,6 +95,24 @@ DEF_BACKEND_SET(supported, ev_supported_backends)
 DEF_BACKEND_SET(recommended, ev_recommended_backends)
 DEF_BACKEND_SET(embeddable, ev_embeddable_backends)
 
+static const ev_tstamp lev_ns_per_second = 1000000000.0;
+
+static ev_tstamp lev_time_to_seconds(value v_time) {
+  return ((ev_tstamp)Long_val(v_time)) / lev_ns_per_second;
+}
+
+static ev_tstamp lev_span_to_seconds(value v_span) {
+  return ((ev_tstamp)Long_val(v_span)) / lev_ns_per_second;
+}
+
+static value lev_time_of_seconds(ev_tstamp seconds) {
+  return Val_long((intnat)(seconds * lev_ns_per_second));
+}
+
+static value lev_span_of_seconds(ev_tstamp seconds) {
+  return Val_long((intnat)(seconds * lev_ns_per_second));
+}
+
 #define DEF_STOP(__name)                                                       \
   CAMLprim value lev_##__name##_stop(value v_w, value v_ev) {                  \
     CAMLparam2(v_w, v_ev);                                                     \
@@ -277,13 +295,13 @@ CAMLprim value lev_ev_now(value v_ev) {
   CAMLparam1(v_ev);
   struct ev_loop *loop = (struct ev_loop *)Nativeint_val(v_ev);
   ev_tstamp now = ev_now(loop);
-  CAMLreturn(caml_copy_double(now));
+  CAMLreturn(lev_time_of_seconds(now));
 }
 
 CAMLprim value lev_sleep(value v_ts) {
   CAMLparam1(v_ts);
   caml_release_runtime_system();
-  ev_sleep(Double_val(v_ts));
+  ev_sleep(lev_span_to_seconds(v_ts));
   caml_acquire_runtime_system();
   CAMLreturn(Val_unit);
 }
@@ -324,8 +342,8 @@ static ev_tstamp lev_periodic_reschedule_cb(ev_periodic *w, ev_tstamp now) {
   CAMLparam0();
   CAMLlocal1(v_stamp);
   struct periodic_cbs *cbs = (struct periodic_cbs *)w->data;
-  v_stamp = caml_callback(cbs->reschedule, caml_copy_double(now));
-  double result = Double_val(v_stamp);
+  v_stamp = caml_callback(cbs->reschedule, lev_time_of_seconds(now));
+  ev_tstamp result = lev_time_to_seconds(v_stamp);
   CAMLdrop;
   return result;
 }
@@ -393,8 +411,8 @@ CAMLprim value lev_timer_create(value v_cb, value v_after, value v_repeat) {
   CAMLparam3(v_cb, v_after, v_repeat);
   CAMLlocal2(v_timer, v_cb_applied);
   ev_timer *timer = caml_stat_alloc(sizeof(ev_timer));
-  ev_timer_init(timer, Cb_for(ev_timer), Double_val(v_after),
-                Double_val(v_repeat));
+  ev_timer_init(timer, Cb_for(ev_timer), lev_span_to_seconds(v_after),
+                lev_span_to_seconds(v_repeat));
   v_timer = caml_alloc_custom(&watcher_ops, sizeof(struct ev_timer *), 0, 1);
   Ev_timer_val(v_timer) = timer;
   v_cb_applied = caml_callback(v_cb, v_timer);
@@ -407,7 +425,7 @@ CAMLprim value lev_timer_remaining(value v_timer, value v_ev) {
   CAMLparam2(v_timer, v_ev);
   ev_timer *timer = Ev_timer_val(v_timer);
   struct ev_loop *ev = (struct ev_loop *)Nativeint_val(v_ev);
-  CAMLreturn(caml_copy_double(ev_timer_remaining(ev, timer)));
+  CAMLreturn(lev_span_of_seconds(ev_timer_remaining(ev, timer)));
 }
 
 CAMLprim value lev_timer_again(value v_timer, value v_ev) {
@@ -423,8 +441,8 @@ CAMLprim value lev_periodic_create_regular(value v_cb, value v_offset,
   CAMLparam3(v_cb, v_offset, v_interval);
   CAMLlocal2(v_periodic, v_cb_applied);
   ev_periodic *periodic = caml_stat_alloc(sizeof(ev_periodic));
-  ev_periodic_init(periodic, Cb_for(ev_periodic), Double_val(v_offset),
-                   Double_val(v_interval), NULL);
+  ev_periodic_init(periodic, Cb_for(ev_periodic), lev_time_to_seconds(v_offset),
+                   lev_span_to_seconds(v_interval), NULL);
   v_periodic =
       caml_alloc_custom(&watcher_ops, sizeof(struct ev_periodic *), 0, 1);
   Ev_periodic_val(v_periodic) = periodic;
@@ -663,7 +681,7 @@ CAMLprim value lev_stat_create(value v_cb, value v_path, value v_interval) {
   ev_stat *w = caml_stat_alloc(sizeof(ev_stat));
   struct lev_stat_data *data = caml_stat_alloc(sizeof(struct lev_stat_data));
   const char *path = caml_stat_strdup(String_val(v_path));
-  ev_stat_init(w, lev_stat_cb, path, Double_val(v_interval));
+  ev_stat_init(w, lev_stat_cb, path, lev_span_to_seconds(v_interval));
   v_w = caml_alloc_custom(&watcher_ops, sizeof(struct ev_stat *), 0, 1);
   Ev_val(ev_stat, v_w) = w;
   v_cb_applied = caml_callback(v_cb, v_w);

--- a/src/lev/test/dune
+++ b/src/lev/test/dune
@@ -4,6 +4,7 @@
  (libraries
   lev
   unix
+  stdune
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config
@@ -20,6 +21,7 @@
  (libraries
   lev
   unix
+  stdune
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/src/lev/test/lev_tests.ml
+++ b/src/lev/test/lev_tests.ml
@@ -1,8 +1,7 @@
+open Stdune
 open Printf
 open Lev
 module List = ListLabels
-
-let immediately = 0.00001
 
 let%expect_test "version" =
   let major, minor = ev_version () in
@@ -15,14 +14,17 @@ let%expect_test "default" =
   [%expect {||}]
 ;;
 
+let span_of_secs = Time.Span.of_secs
+let immediately = span_of_secs 0.00001
+
 let%expect_test "now" =
   let loop = Loop.default () in
-  let (_ : Timestamp.t) = Loop.now loop in
+  let (_ : Time.t) = Loop.now loop in
   [%expect {||}]
 ;;
 
 let%expect_test "sleep" =
-  Timestamp.sleep (Timestamp.of_float 0.1);
+  Lev.sleep (span_of_secs 0.1);
   [%expect {||}]
 ;;
 
@@ -51,7 +53,7 @@ let%expect_test "supported backends include the active backend" =
 let%expect_test "timer" =
   let loop = Loop.create () in
   let timer =
-    Timer.create ~after:0.001 (fun timer ->
+    Timer.create ~after:(span_of_secs 0.001) (fun timer ->
       print_endline "fired timer";
       Timer.stop timer loop)
   in
@@ -64,9 +66,9 @@ let%expect_test "timer" =
 
 let%expect_test "timer remaining is boxed correctly" =
   let loop = Loop.create () in
-  let timer = Timer.create ~after:1.0 (fun _ -> ()) in
+  let timer = Timer.create ~after:(span_of_secs 1.0) (fun _ -> ()) in
   Timer.start timer loop;
-  let remaining = Timestamp.to_float (Timer.remaining timer loop) in
+  let remaining = Time.Span.to_secs (Timer.remaining timer loop) in
   printf "remaining positive = %b\n" (remaining > 0.);
   Timer.stop timer loop;
   [%expect {| remaining positive = true |}]
@@ -86,7 +88,9 @@ let%expect_test "timer - not repeats" =
 
 let%expect_test "timer - cancellation with stop" =
   let loop = Loop.create () in
-  let timer = Timer.create ~after:6.5 (fun _ -> print_endline "fired timer") in
+  let timer =
+    Timer.create ~after:(span_of_secs 6.5) (fun _ -> print_endline "fired timer")
+  in
   Timer.start timer loop;
   ignore (Lev.Loop.run loop Nowait);
   Timer.stop timer loop;
@@ -98,7 +102,7 @@ let%expect_test "periodic timer" =
   let loop = Loop.create () in
   let timer =
     let count = ref 3 in
-    Timer.create ~after:0. ~repeat:0.02 (fun timer ->
+    Timer.create ~after:Time.Span.zero ~repeat:(span_of_secs 0.02) (fun timer ->
       if !count = 0
       then (
         let () = print_endline "stopping timer" in
@@ -133,7 +137,7 @@ let%expect_test "periodic - regular" =
       (fun p ->
          print_endline "periodic fired";
          Periodic.stop p loop)
-      (Regular { offset = Timestamp.of_float 0.1; interval = None })
+      (Regular { offset = Time.add (Loop.now loop) (span_of_secs 0.1); interval = None })
   in
   Periodic.start periodic loop;
   Loop.run_until_done loop;
@@ -147,10 +151,7 @@ let%expect_test "periodic - custom" =
       (fun p ->
          print_endline "periodic fired";
          Periodic.stop p loop)
-      (Custom
-         (fun _ ~now ->
-           let now = Timestamp.to_float now in
-           Timestamp.of_float (now +. 0.2)))
+      (Custom (fun _ ~now -> Time.add now (span_of_secs 0.2)))
   in
   Periodic.start periodic loop;
   Loop.run_until_done loop;
@@ -276,13 +277,13 @@ let%expect_test "timer/consecutive again" =
   let loop = Loop.create () in
   let now = Unix.time () in
   let timer =
-    Timer.create ~after:1.0 (fun t ->
+    Timer.create ~after:(span_of_secs 1.0) (fun t ->
       printf "timer fired after %f\n" (Unix.time () -. now);
       Timer.stop t loop)
   in
   let control =
     let count = ref 3 in
-    Timer.create ~after:immediately ~repeat:0.2 (fun t ->
+    Timer.create ~after:immediately ~repeat:(span_of_secs 0.2) (fun t ->
       if !count = 0
       then Timer.stop t loop
       else (

--- a/src/lev/test/lev_tests_unix.ml
+++ b/src/lev/test/lev_tests_unix.ml
@@ -1,6 +1,6 @@
+open Stdune
 open Printf
 open Lev
-module List = ListLabels
 
 let%expect_test "child" =
   let loop = Loop.default () in
@@ -187,13 +187,13 @@ let%expect_test "modify io watcher and preserve watched fd" =
 ;;
 
 let%expect_test "stat watcher reports updated file metadata" =
-  let path = Filename.temp_file "lev-stat" ".txt" in
+  let path = Stdlib.Filename.temp_file "lev-stat" ".txt" in
   let oc = open_out_bin path in
   output_string oc "a";
   close_out oc;
   let loop = Loop.create () in
   let timer =
-    Timer.create ~after:0.01 (fun timer ->
+    Timer.create ~after:(Time.Span.of_secs 0.01) (fun timer ->
       let oc = open_out_gen [ Open_wronly; Open_append ] 0o666 path in
       output_string oc "bc";
       close_out oc;


### PR DESCRIPTION
Replace Lev's float-based timestamp API with Stdune.Time and Time.Span, and add stdune as a dependency of the lev library.

Update the OCaml and C binding layers for loop time, sleep, periodic watchers, timers, and stat polling, and adjust the lev tests to use the new time types.