### PR TITLE
test: opaque profile coverage for inter-library dep tracking

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
@@ -2,10 +2,11 @@ A consumer's [.cmx] compilation rule depends on an external library's
 [.cmx] under both the release and dev profiles. Counterpart to
 [opaque-cmx-deps-local.t], which shows the dev-profile behaviour that
 omits the [.cmx] from the dep set for *local* libraries. The [unix]
-stdlib library, resolved through findlib, plays the role of "external".
+library, shipped with OCaml and resolved through findlib, plays the
+role of "external".
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > EOF
 
   $ cat > dune <<EOF
@@ -18,7 +19,7 @@ stdlib library, resolved through findlib, plays the role of "external".
 --- Release profile (opaque=false): both .cmi and .cmx globs ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile release)
   > EOF
 
@@ -31,7 +32,7 @@ stdlib library, resolved through findlib, plays the role of "external".
 --- Dev profile (opaque=true): both .cmi and .cmx globs (unchanged for external libs) ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile dev)
   > EOF
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
@@ -1,0 +1,42 @@
+Verify that the [groups_for_cm_kind] optimisation in [lib_file_deps.ml]
+is gated on [Lib.is_local lib]: a consumer's [.cmx] rule depends on an
+external library's [.cmx] regardless of profile. Counterpart to
+[opaque-cmx-deps-local.t]. The [unix] stdlib library, resolved through
+findlib, plays the role of "external".
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name main) (libraries unix))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = ignore (Unix.gettimeofday ())
+  > EOF
+
+--- Release profile (opaque=false): both .cmi and .cmx globs ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile release)
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates' | sort -u
+  *.cmi
+  *.cmx
+
+--- Dev profile (opaque=true): both .cmi and .cmx globs (unchanged for external libs) ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile dev)
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates' | sort -u
+  *.cmi
+  *.cmx

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t
@@ -1,8 +1,8 @@
-Verify that the [groups_for_cm_kind] optimisation in [lib_file_deps.ml]
-is gated on [Lib.is_local lib]: a consumer's [.cmx] rule depends on an
-external library's [.cmx] regardless of profile. Counterpart to
-[opaque-cmx-deps-local.t]. The [unix] stdlib library, resolved through
-findlib, plays the role of "external".
+A consumer's [.cmx] compilation rule depends on an external library's
+[.cmx] under both the release and dev profiles. Counterpart to
+[opaque-cmx-deps-local.t], which shows the dev-profile behaviour that
+omits the [.cmx] from the dep set for *local* libraries. The [unix]
+stdlib library, resolved through findlib, plays the role of "external".
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
@@ -4,28 +4,28 @@ A consumer's [.cmx] compilation rule depends on a local library's
 behave differently; see [opaque-cmx-deps-external.t].
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > EOF
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library (name mylib))
+  $ mkdir local_dep
+  $ cat > local_dep/dune <<EOF
+  > (library (name local_dep))
   > EOF
-  $ cat > lib/mylib.ml <<EOF
+  $ cat > local_dep/local_dep.ml <<EOF
   > let v = 42
   > EOF
 
   $ cat > dune <<EOF
-  > (executable (name main) (libraries mylib))
+  > (executable (name main) (libraries local_dep))
   > EOF
   $ cat > main.ml <<EOF
-  > let () = print_int Mylib.v
+  > let () = print_int Local_dep.v
   > EOF
 
 --- Release profile (opaque=false): both .cmi and .cmx globs ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile release)
   > EOF
 
@@ -38,7 +38,7 @@ behave differently; see [opaque-cmx-deps-external.t].
 --- Dev profile (opaque=true): only .cmi glob ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile dev)
   > EOF
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
@@ -1,9 +1,7 @@
-Verify the [groups_for_cm_kind] decision in [lib_file_deps.ml]: a
-consumer's [.cmx] rule depends on a local library's [.cmx] under the
-release profile (opaque=false), but only on the [.cmi] under the dev
-profile (opaque=true). The [Lib.is_local lib] guard means this
-optimisation applies to local libraries; see
-[opaque-cmx-deps-external.t] for the external-library case.
+A consumer's [.cmx] compilation rule depends on a local library's
+[.cmx] under the release profile (opaque=false), but only on the
+[.cmi] under the dev profile (opaque=true). External libraries
+behave differently; see [opaque-cmx-deps-external.t].
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t
@@ -1,0 +1,50 @@
+Verify the [groups_for_cm_kind] decision in [lib_file_deps.ml]: a
+consumer's [.cmx] rule depends on a local library's [.cmx] under the
+release profile (opaque=false), but only on the [.cmi] under the dev
+profile (opaque=true). The [Lib.is_local lib] guard means this
+optimisation applies to local libraries; see
+[opaque-cmx-deps-external.t] for the external-library case.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let v = 42
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name main) (libraries mylib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_int Mylib.v
+  > EOF
+
+--- Release profile (opaque=false): both .cmi and .cmx globs ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile release)
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates' | sort -u
+  *.cmi
+  *.cmx
+
+--- Dev profile (opaque=true): only .cmi glob ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile dev)
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
+  > jq -r 'include "dune"; .[] | depsGlobPredicates' | sort -u
+  *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -1,9 +1,7 @@
-Verify that a [.mli] change in a dependency library rebuilds
-consumers under both [release] (opaque=false) and [dev] (opaque=true)
-profiles. The opaque-mode optimisation in [groups_for_cm_kind] is
-purely about cross-module inlining propagation through [.cmx]; it
-does not affect [.cmi] propagation, which is what carries [.mli]
-changes to consumers.
+A [.mli] change in a dependency library rebuilds consumers under
+both the release (opaque=false) and dev (opaque=true) profiles.
+Opaque mode does not affect [.cmi] propagation; it only affects
+whether cross-module inlining tracks a dep's [.cmx].
 
 Companion to [opaque.t], which covers the [.ml]-only change axis.
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -49,8 +49,21 @@ left unexported, which would trip warning 32 under dev):
   > EOF
 
   $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
+        "_build/default/.main.eobjs/native/dune__exe__Main.o"
+      ]
+    }
+  ]
 
 --- Dev profile (opaque=true): .mli change still rebuilds consumer ---
 
@@ -75,5 +88,18 @@ Add another paired declaration:
   > EOF
 
   $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
+        "_build/default/.main.eobjs/native/dune__exe__Main.o"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -49,8 +49,8 @@ left unexported, which would trip warning 32 under dev):
   > EOF
 
   $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; ([.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length) > 0'
-  true
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
+  2
 
 --- Dev profile (opaque=true): .mli change still rebuilds consumer ---
 
@@ -75,5 +75,5 @@ Add another paired declaration:
   > EOF
 
   $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; ([.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length) > 0'
-  true
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -6,31 +6,31 @@ whether cross-module inlining tracks a dep's [.cmx].
 Companion to [opaque.t], which covers the [.ml]-only change axis.
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > EOF
 
-  $ mkdir lib
-  $ cat > lib/dune <<EOF
-  > (library (name mylib))
+  $ mkdir dep_lib
+  $ cat > dep_lib/dune <<EOF
+  > (library (name dep_lib))
   > EOF
-  $ cat > lib/mylib.ml <<EOF
+  $ cat > dep_lib/dep_lib.ml <<EOF
   > let v = 42
   > EOF
-  $ cat > lib/mylib.mli <<EOF
+  $ cat > dep_lib/dep_lib.mli <<EOF
   > val v : int
   > EOF
 
   $ cat > dune <<EOF
-  > (executable (name main) (libraries mylib))
+  > (executable (name main) (libraries dep_lib))
   > EOF
   $ cat > main.ml <<EOF
-  > let () = print_int Mylib.v
+  > let () = print_int Dep_lib.v
   > EOF
 
 --- Release profile (opaque=false): .mli change rebuilds consumer ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile release)
   > EOF
 
@@ -39,11 +39,11 @@ Companion to [opaque.t], which covers the [.ml]-only change axis.
 Add a new declaration to both [.ml] and [.mli] (paired so no value is
 left unexported, which would trip warning 32 under dev):
 
-  $ cat > lib/mylib.ml <<EOF
+  $ cat > dep_lib/dep_lib.ml <<EOF
   > let v = 42
   > let extra () = 0
   > EOF
-  $ cat > lib/mylib.mli <<EOF
+  $ cat > dep_lib/dep_lib.mli <<EOF
   > val v : int
   > val extra : unit -> int
   > EOF
@@ -55,7 +55,7 @@ left unexported, which would trip warning 32 under dev):
 --- Dev profile (opaque=true): .mli change still rebuilds consumer ---
 
   $ cat > dune-workspace <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > (profile dev)
   > EOF
 
@@ -63,12 +63,12 @@ left unexported, which would trip warning 32 under dev):
 
 Add another paired declaration:
 
-  $ cat > lib/mylib.ml <<EOF
+  $ cat > dep_lib/dep_lib.ml <<EOF
   > let v = 42
   > let extra () = 0
   > let helper x = x + 1
   > EOF
-  $ cat > lib/mylib.mli <<EOF
+  $ cat > dep_lib/dep_lib.mli <<EOF
   > val v : int
   > val extra : unit -> int
   > val helper : int -> int

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -1,0 +1,81 @@
+Verify that a [.mli] change in a dependency library rebuilds
+consumers under both [release] (opaque=false) and [dev] (opaque=true)
+profiles. The opaque-mode optimisation in [groups_for_cm_kind] is
+purely about cross-module inlining propagation through [.cmx]; it
+does not affect [.cmi] propagation, which is what carries [.mli]
+changes to consumers.
+
+Companion to [opaque.t], which covers the [.ml]-only change axis.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let v = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val v : int
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable (name main) (libraries mylib))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () = print_int Mylib.v
+  > EOF
+
+--- Release profile (opaque=false): .mli change rebuilds consumer ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile release)
+  > EOF
+
+  $ dune build ./main.exe
+
+Add a new declaration to both [.ml] and [.mli] (paired so no value is
+left unexported, which would trip warning 32 under dev):
+
+  $ cat > lib/mylib.ml <<EOF
+  > let v = 42
+  > let extra () = 0
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val v : int
+  > val extra : unit -> int
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; ([.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length) > 0'
+  true
+
+--- Dev profile (opaque=true): .mli change still rebuilds consumer ---
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (profile dev)
+  > EOF
+
+  $ dune build ./main.exe
+
+Add another paired declaration:
+
+  $ cat > lib/mylib.ml <<EOF
+  > let v = 42
+  > let extra () = 0
+  > let helper x = x + 1
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val v : int
+  > val extra : unit -> int
+  > val helper : int -> int
+  > EOF
+
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; ([.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length) > 0'
+  true


### PR DESCRIPTION
Three new cram tests under `test/blackbox-tests/test-cases/per-module-lib-deps/`:

- **`opaque-cmx-deps-local.t`** — a local lib appears in the consumer's `.cmx` dep set as `*.cmi` only under dev (opaque=true), and as both `*.cmi` and `*.cmx` under release (opaque=false).
- **`opaque-cmx-deps-external.t`** — an external library (findlib-resolved `unix`) appears as both globs under both profiles, pinning that the `Lib.is_local lib` guard in `groups_for_cm_kind` is the intended behaviour.
- **`opaque-mli-change.t`** — a `.mli` change in a dep triggers a consumer rebuild under both profiles; pins that the dev-mode optimisation is about cmx propagation, not cmi propagation.

Together with the existing `opaque.t` (which covers `.ml`-only-change rebuild behaviour) these document the four directly-observable consequences of `-opaque`. Future regressions in any of the four code paths will fail a self-explanatory test rather than slipping through.

## Test plan

- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-local.t` passes.
- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/opaque-cmx-deps-external.t` passes.
- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t` passes.