### PR TITLE
test: observational baseline for an unreferenced transitive library dep

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -1,0 +1,70 @@
+Baseline: an intermediate library [intermediate_lib] declares
+[(libraries dep_lib)] but its module does not actually reference
+any of [dep_lib]'s modules. The consumer [main] uses
+[intermediate_lib] and so transitively gains [dep_lib] in its
+compilation context.
+
+Today every consumer module declares a glob over each transitively-
+reached library's public-cmi directory, so editing
+[unreferenced_dep.ml] (which no source file references) re-
+invalidates [Main]. The test records the current rebuild count of
+[Main] when [unreferenced_dep.ml] is touched.
+
+This test is observational: a tighter dependency tracker that drops
+unreferenced libraries from compile rules' deps would lower the
+count.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name dep_lib)
+  >  (wrapped false)
+  >  (modules unreferenced_dep referenced_dep))
+  > (library
+  >  (name intermediate_lib)
+  >  (wrapped false)
+  >  (modules intermediate_module)
+  >  (libraries dep_lib))
+  > (executable (name main) (modules main) (libraries intermediate_lib))
+  > EOF
+
+  $ cat > unreferenced_dep.ml <<EOF
+  > let x = 42
+  > EOF
+  $ cat > referenced_dep.ml <<EOF
+  > let x = 43
+  > EOF
+  $ cat > intermediate_module.ml <<EOF
+  > let x = 42
+  > EOF
+  $ cat > main.ml <<EOF
+  > let _ = Intermediate_module.x
+  > EOF
+
+  $ dune build @check
+
+Confirm via dune's own unused-libraries detection that [dep_lib]
+is genuinely unused. [intermediate_lib] declares
+[(libraries dep_lib)] but no module of [intermediate_lib]
+references any module of [dep_lib]:
+
+  $ dune build @unused-libs
+  File "dune", line 9, characters 12-19:
+  9 |  (libraries dep_lib))
+                  ^^^^^^^
+  Error: Unused libraries:
+  - dep_lib
+  [1]
+
+Edit [unreferenced_dep.ml]. Neither [main.ml] nor
+[intermediate_module.ml] references [Unreferenced_dep] or any
+other [dep_lib] module, so a tighter filter could leave [Main]
+untouched. Today [Main] is rebuilt:
+
+  $ echo > unreferenced_dep.ml
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -7,12 +7,18 @@ compilation context.
 Today every consumer module declares a glob over each transitively-
 reached library's public-cmi directory, so editing
 [unreferenced_dep.ml] (which no source file references) re-
-invalidates [Main]. The test records the current rebuild count of
-[Main] when [unreferenced_dep.ml] is touched.
+invalidates [Main]. The test records the current rebuild targets
+for [Main] when [unreferenced_dep.ml] is touched.
 
 This test is observational: a tighter dependency tracker that drops
-unreferenced libraries from compile rules' deps would lower the
-count.
+unreferenced libraries from compile rules' deps would shrink the
+recorded target list.
+
+[intermediate_lib] and the [main] executable each include an unused
+dummy module ([intermediate_dummy] / [main_dummy]) so that ocamldep
+runs unconditionally for both stanzas. Single-module stanzas trigger
+a short-circuit in [dep_rules.ml] that skips ocamldep, which would
+mask the per-module dependency filtering being baselined here.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -26,9 +32,12 @@ count.
   > (library
   >  (name intermediate_lib)
   >  (wrapped false)
-  >  (modules intermediate_module)
+  >  (modules intermediate_module intermediate_dummy)
   >  (libraries dep_lib))
-  > (executable (name main) (modules main) (libraries intermediate_lib))
+  > (executable
+  >  (name main)
+  >  (modules main main_dummy)
+  >  (libraries intermediate_lib))
   > EOF
 
   $ cat > unreferenced_dep.ml <<EOF
@@ -40,8 +49,14 @@ count.
   $ cat > intermediate_module.ml <<EOF
   > let x = 42
   > EOF
+  $ cat > intermediate_dummy.ml <<EOF
+  > let _ = ()
+  > EOF
   $ cat > main.ml <<EOF
   > let _ = Intermediate_module.x
+  > EOF
+  $ cat > main_dummy.ml <<EOF
+  > let _ = ()
   > EOF
 
   $ dune build @check
@@ -66,5 +81,18 @@ untouched. Today [Main] is rebuilt:
 
   $ echo > unreferenced_dep.ml
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]


### PR DESCRIPTION
## Summary

Adds a cram test for a corner that today over-invalidates: an intermediate library declares `(libraries X)` but its own source does not reference any module of `X`. A consumer that depends only on the intermediate still rebuilds whenever any of `X`'s modules change, because every consumer module carries a glob over every transitively-reached library's public-cmi directory.

The test is observational. It records the rebuild-target count for `Main` after editing one of `dep_lib`'s modules, asserting the current count of `2`.

## Why add this now

- **Baseline anchor.** The corner is mechanically simple but not currently covered by a dedicated test. Promoting it to a smaller count is the natural success criterion for a future precision improvement.
- **Sets up follow-on work in #14116.** The per-module filter introduced there narrows globs to specific cmi deps when it can prove the consumer references particular entry modules; it does not yet drop a transitively-reached library entirely when nothing of it is referenced. With the BFS in that PR, the negative evidence is available; using it is the next step. This baseline makes that improvement land as a one-line test promotion.

Reproducer originally from @nojb:
https://github.com/ocaml/dune/pull/14116#issuecomment-4319562014

## Test plan

- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t` passes on `main`.