### PR TITLE
refactor: get rid of pointless [Path.as_outside_build_dir_exn]

### DIFF
--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -427,26 +427,28 @@ let copy_lock_dir ~target ~lock_dir ~deps ~files =
 let scan_lock_directory =
   let rec scan dir =
     let open Memo.O in
-    Fs_memo.dir_contents (Path.as_outside_build_dir_exn dir)
+    Fs_memo.dir_contents dir
     >>= function
     | Error (ENOENT, _, _) -> Memo.return Path.Set.empty
     | Error unix_error ->
       User_error.raise
-        [ Pp.textf "Failed to read directory %s:" (Path.to_string_maybe_quoted dir)
+        [ Pp.textf
+            "Failed to read directory %s:"
+            (Path.Outside_build_dir.to_string_maybe_quoted dir)
         ; Unix_error.Detailed.pp unix_error
         ]
     | Ok entries ->
       Fs_memo.Dir_contents.to_list entries
       |> Memo.parallel_map ~f:(fun (entry, kind) ->
-        let path = Path.relative dir entry in
+        let path = Path.Outside_build_dir.relative dir entry in
         match (kind : File_kind.t) with
-        | S_REG -> Memo.return (Path.Set.singleton path)
+        | S_REG -> Memo.return (Path.Set.singleton (Path.outside_build_dir path))
         | S_DIR -> scan path
         | kind ->
           User_error.raise
             [ Pp.textf
                 "Lock directory contains file %S with unsupported kind %S"
-                (Path.to_string_maybe_quoted path)
+                (Path.Outside_build_dir.to_string_maybe_quoted path)
                 (File_kind.to_string kind)
             ])
       >>| Path.Set.union_all
@@ -464,7 +466,7 @@ let setup_copy_rules ~dir:target ~lock_dir =
     | false ->
       let directory_targets = Path.Build.Map.singleton target Loc.none in
       let { Action_builder.With_targets.build; targets } =
-        copy_lock_dir ~target ~lock_dir ~deps ~files
+        copy_lock_dir ~target ~lock_dir:(Path.outside_build_dir lock_dir) ~deps ~files
       in
       let rule = Rule.make ~targets build in
       directory_targets, Rules.of_rules [ rule ]
@@ -483,7 +485,7 @@ let setup_lock_rules_with_source (workspace : Workspace.t) ~dir ~lock_dir =
   match source with
   | `Source_tree lock_dir ->
     let dir = Path.Build.append_source dir lock_dir in
-    setup_copy_rules ~dir ~lock_dir:(Path.source lock_dir)
+    setup_copy_rules ~dir ~lock_dir:(Path.Outside_build_dir.In_source_dir lock_dir)
   | `Generated -> Memo.return (setup_lock_rules ~dir ~lock_dir)
 ;;
 
@@ -491,7 +493,9 @@ let setup_dev_tool_lock_rules ~dir dev_tool =
   let package_name = Dev_tool.package_name dev_tool in
   let dev_tool_name = Dune_lang.Package_name.to_string package_name in
   let dir = Path.Build.relative dir dev_tool_name in
-  let lock_dir = dev_tool |> Lock_dir.dev_tool_external_lock_dir |> Path.external_ in
+  let lock_dir =
+    Path.Outside_build_dir.External (dev_tool |> Lock_dir.dev_tool_external_lock_dir)
+  in
   setup_copy_rules ~dir ~lock_dir
 ;;
 


### PR DESCRIPTION
The same thing can be accomplished with safe api's