### PR TITLE
test: observational baseline for wrapped re-export via -open flag (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
@@ -1,0 +1,77 @@
+Observational baseline: a consumer reaches a dep library's modules
+through a transparent alias declared inside a wrapped sibling
+library, where the wrapped library is opened via the [-open]
+compiler flag rather than named in source. On trunk, [consumer]
+correctly rebuilds when the dep library's interface changes,
+because the cctx-wide compile-rule deps cover every library in the
+stanza's [(libraries ...)] closure.
+
+This is the structural shape of menhir's [base]/[middle]
+arrangement: [base] re-exports [Vendored_pprint] through aliases,
+[middle] uses [-open Base] in its compile flags, and modules of
+[middle] reference [Vendored_pprint]'s contents through unqualified
+names brought into scope by the open. Records the consumer's
+rebuild count as a regression guard for changes that narrow
+compile-rule deps per module.
+
+Structure: [dep_lib] is unwrapped with module [Original_name];
+[lib_re_export] is wrapped with a hand-written wrapper containing
+[module Re = Original_name]; [consumer_lib] depends on [lib_re_export]
+and uses [-open Lib_re_export] in its flags; [consumer.ml] writes
+[Re.x] without naming [dep_lib] or [lib_re_export] in source.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name dep_lib) (wrapped false) (modules original_name))
+  > (library
+  >  (name lib_re_export)
+  >  (modules lib_re_export some_inner)
+  >  (libraries dep_lib))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules consumer)
+  >  (libraries lib_re_export)
+  >  (flags (:standard -open Lib_re_export)))
+  > EOF
+
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > EOF
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > EOF
+
+  $ cat > lib_re_export.ml <<EOF
+  > module Some_inner = Some_inner
+  > module Re = Original_name
+  > EOF
+  $ cat > some_inner.ml <<EOF
+  > let placeholder = ()
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Re.x
+  > EOF
+
+  $ dune build @check
+
+Edit [dep_lib]'s interface. [consumer] reaches [dep_lib]'s
+[Original_name] through the alias chain in the wrapped
+[Lib_re_export] wrapper. The cctx-wide compile-rule deps include
+[dep_lib], so [consumer] rebuilds:
+
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > val y : int
+  > EOF
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > let y = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer"))] | length'
+  1

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-reexport-via-open-flag.t
@@ -73,5 +73,13 @@ Edit [dep_lib]'s interface. [consumer] reaches [dep_lib]'s
   > let y = 42
   > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer"))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmt"
+      ]
+    }
+  ]


### PR DESCRIPTION
Records the rebuild count for a consumer module that reaches a dep
library's modules through a transparent alias declared inside a
wrapped sibling library, where the wrapped library is opened via
the `-open` compiler flag rather than named in source. On trunk the
consumer correctly rebuilds when the dep library's interface
changes (count = `1`) because the cctx-wide compile-rule deps cover
every library in the stanza's `(libraries ...)` closure.

This is the structural shape of menhir's `base`/`middle`
arrangement: `base` re-exports `Vendored_pprint` through aliases,
`middle` uses `-open Base` in its compile flags, and modules of
`middle` reference `Vendored_pprint`'s contents through unqualified
names brought into scope by the open.

This is an observational test only; no code change. Pairs with
#14116 — its per-module dep-filter narrows compile-rule deps per
module, and on its current state drops `dep_lib` from the
consumer's deps in this scenario, leaving `consumer.cmo` stale
when `dep_lib`'s interface changes (count flips to `0`). The fix
on that PR's BFS will restore the count to `1`, and this test acts
as the regression guard.

See: #14116
See: #14186