### PR TITLE
test: observational baseline for auto-wrapped child re-export (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
@@ -1,0 +1,98 @@
+Observational baseline: a consumer reaches a dep library's modules
+through a child of an auto-wrapped sibling library, where the
+sibling is opened via the [-open] compiler flag and the child's
+source includes the dep library's module via [include]. On trunk,
+[consumer] correctly rebuilds when the dep library's interface
+changes, because the cctx-wide compile-rule deps cover every
+library in the stanza's [(libraries ...)] closure.
+
+This is the structural shape of menhir's [base]/[middle]
+arrangement: [base] is auto-wrapped (no [base.ml] in the source,
+dune generates the wrapper), with a child [PPrint.ml] containing
+[include Vendored_pprint]. [middle] uses [-open Base] in flags and
+references [PPrint.foo] in source. The reference chain crosses
+library boundaries through the auto-wrapped sibling's child, not
+through a hand-written wrapper.
+
+Records the consumer's rebuild count as a regression guard for
+changes that narrow compile-rule deps per module.
+
+Structure: [lib_a] is unwrapped with module [Original_name].
+[lib_re_export] is wrapped by dune defaults (no [lib_re_export.ml]
+file — dune auto-generates the wrapper); child [pprint.ml]
+contains a transparent alias [module Re = Original_name];
+[filler.ml] is just there to keep the lib non-singleton. [lib_b]
+depends on [lib_re_export] and uses [-open Lib_re_export] in its
+flags; [consumer.ml] writes [Pprint.Re.x] without naming
+[lib_a], [lib_re_export], or any of its children in source.
+
+The transparent-alias shape (rather than [include]) is what makes
+[lib_a] genuinely invisible to a per-module dep filter that only
+walks the auto-generated wrapper: with [-no-alias-deps], [Pprint]'s
+[.cmi] content does not depend on [Original_name.cmi], so a glob
+over [lib_re_export]'s objdir does not capture [Original_name.mli]
+changes either. The cctx-wide compile-rule deps still cover
+[lib_a] on trunk, so [consumer] rebuilds.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name lib_a) (wrapped false) (modules original_name))
+  > (library
+  >  (name lib_re_export)
+  >  (modules pprint filler)
+  >  (libraries lib_a))
+  > (library
+  >  (name lib_b)
+  >  (wrapped false)
+  >  (modules consumer)
+  >  (libraries lib_re_export)
+  >  (flags (:standard -open Lib_re_export)))
+  > EOF
+
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > EOF
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > EOF
+
+  $ cat > pprint.ml <<EOF
+  > module Re = Original_name
+  > EOF
+  $ cat > filler.ml <<EOF
+  > let placeholder = ()
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Pprint.Re.x
+  > EOF
+
+  $ dune build @check
+
+Edit [lib_a]'s interface. [consumer] reaches [lib_a]'s
+[Original_name] through [Pprint] (child of auto-wrapped
+[Lib_re_export]). The cctx-wide compile-rule deps include
+[lib_a], so [consumer] rebuilds:
+
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > val y : int
+  > EOF
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > let y = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.lib_b.objs/byte/consumer.cmi",
+        "_build/default/.lib_b.objs/byte/consumer.cmo",
+        "_build/default/.lib_b.objs/byte/consumer.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/auto-wrapped-child-reexport.t
@@ -1,51 +1,54 @@
 Observational baseline: a consumer reaches a dep library's modules
-through a child of an auto-wrapped sibling library, where the
-sibling is opened via the [-open] compiler flag and the child's
-source includes the dep library's module via [include]. On trunk,
+through a child of an auto-wrapped sibling library. The sibling is
+opened via the [-open] compiler flag and the child's source exposes
+the dep library through a transparent module alias. On trunk,
 [consumer] correctly rebuilds when the dep library's interface
 changes, because the cctx-wide compile-rule deps cover every
 library in the stanza's [(libraries ...)] closure.
 
-This is the structural shape of menhir's [base]/[middle]
-arrangement: [base] is auto-wrapped (no [base.ml] in the source,
-dune generates the wrapper), with a child [PPrint.ml] containing
-[include Vendored_pprint]. [middle] uses [-open Base] in flags and
-references [PPrint.foo] in source. The reference chain crosses
-library boundaries through the auto-wrapped sibling's child, not
-through a hand-written wrapper.
+The structural shape mirrors menhir's [base]/[middle] arrangement:
+[base] is auto-wrapped (no [base.ml] in source — dune generates
+the wrapper) with a child module that re-exports a third-party
+dep; [middle] uses [-open Base] and reaches the dep through that
+child. Menhir uses [include Vendored_pprint]; this test uses a
+transparent alias instead, for the precision-bug reason described
+below. The reference chain still crosses library boundaries
+through the auto-wrapped sibling's child, not through a
+hand-written wrapper.
 
 Records the consumer's rebuild count as a regression guard for
 changes that narrow compile-rule deps per module.
 
-Structure: [lib_a] is unwrapped with module [Original_name].
+Structure: [dep_lib] is unwrapped with module [Original_name].
 [lib_re_export] is wrapped by dune defaults (no [lib_re_export.ml]
 file — dune auto-generates the wrapper); child [pprint.ml]
 contains a transparent alias [module Re = Original_name];
-[filler.ml] is just there to keep the lib non-singleton. [lib_b]
+[filler.ml] is just there to keep the lib non-singleton. [consumer_lib]
 depends on [lib_re_export] and uses [-open Lib_re_export] in its
-flags; [consumer.ml] writes [Pprint.Re.x] without naming
-[lib_a], [lib_re_export], or any of its children in source.
+flags; [consumer.ml] writes [Pprint.Re.x] — naming the wrapped
+lib's child [Pprint] but not [dep_lib] or the wrapper
+[Lib_re_export].
 
 The transparent-alias shape (rather than [include]) is what makes
-[lib_a] genuinely invisible to a per-module dep filter that only
+[dep_lib] genuinely invisible to a per-module dep filter that only
 walks the auto-generated wrapper: with [-no-alias-deps], [Pprint]'s
 [.cmi] content does not depend on [Original_name.cmi], so a glob
 over [lib_re_export]'s objdir does not capture [Original_name.mli]
 changes either. The cctx-wide compile-rule deps still cover
-[lib_a] on trunk, so [consumer] rebuilds.
+[dep_lib] on trunk, so [consumer] rebuilds.
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.0)
+  > (lang dune 3.23)
   > EOF
 
   $ cat > dune <<EOF
-  > (library (name lib_a) (wrapped false) (modules original_name))
+  > (library (name dep_lib) (wrapped false) (modules original_name))
   > (library
   >  (name lib_re_export)
   >  (modules pprint filler)
-  >  (libraries lib_a))
+  >  (libraries dep_lib))
   > (library
-  >  (name lib_b)
+  >  (name consumer_lib)
   >  (wrapped false)
   >  (modules consumer)
   >  (libraries lib_re_export)
@@ -72,10 +75,10 @@ changes either. The cctx-wide compile-rule deps still cover
 
   $ dune build @check
 
-Edit [lib_a]'s interface. [consumer] reaches [lib_a]'s
+Edit [dep_lib]'s interface. [consumer] reaches [dep_lib]'s
 [Original_name] through [Pprint] (child of auto-wrapped
 [Lib_re_export]). The cctx-wide compile-rule deps include
-[lib_a], so [consumer] rebuilds:
+[dep_lib], so [consumer] rebuilds:
 
   $ cat > original_name.mli <<EOF
   > val x : string
@@ -90,9 +93,9 @@ Edit [lib_a]'s interface. [consumer] reaches [lib_a]'s
   [
     {
       "target_files": [
-        "_build/default/.lib_b.objs/byte/consumer.cmi",
-        "_build/default/.lib_b.objs/byte/consumer.cmo",
-        "_build/default/.lib_b.objs/byte/consumer.cmt"
+        "_build/default/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmt"
       ]
     }
   ]


### PR DESCRIPTION
Records the rebuild targets for a consumer module that reaches a
dep library's modules through a child of an auto-wrapped sibling
library. The sibling is opened via the `-open` compiler flag and
the child's source exposes the dep library through a transparent
module alias. On trunk the consumer correctly rebuilds when the
dep library's interface changes (exactly one `consumer`-named
rule fires, producing `consumer.cmi` / `.cmo` / `.cmt`) because
the cctx-wide compile-rule deps cover every library in the
stanza's `(libraries ...)` closure.

The structural shape mirrors menhir's `base`/`middle` arrangement:
`base` is auto-wrapped (no `base.ml` in source — dune generates
the wrapper) with a child module that re-exports a third-party
dep; `middle` uses `-open Base` and reaches the dep through that
child. Menhir uses `include Vendored_pprint`; this test uses a
transparent alias instead, because the alias shape exposes the
precision gap a future per-module dep filter (#14116) must
handle. The reference chain still crosses library boundaries
through the auto-wrapped sibling's child, not through a
hand-written wrapper.

This is an observational test only; no code change. Pairs with
future work on the per-module dep filter (#14116). Distinct from
#14346 (where the alias lives in a hand-written wrapper) — the
auto-wrapped case has the cross-library reference inside a child
module whose ocamldep is not directly read by walks rooted at the
wrapper, so a per-module filter must descend into wrapped libs'
children to remain sound.

See: #14116
See: #14346