### PR TITLE
test: observational baseline for over-rebuilds under implicit_transitive_deps=false

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -1,19 +1,25 @@
-Regression: under [(implicit_transitive_deps false)], a transitive
-link-only library must not invalidate the consumer when the consumer
-cannot see it through [-I] or [-H].
+Observational baseline: under [(implicit_transitive_deps false)],
+the consumer [main] uses [intermediate_lib] which declares
+[link_only_lib] as a transitive dep. [main]'s source never
+references any module of [link_only_lib]; under
+[(implicit_transitive_deps false)] (with [-H] support, mode
+[Disabled_with_hidden_includes]), [link_only_lib] is on [main]'s
+[-H] include path so the compiler can read its [.cmi] files via
+alias chains, but [main] does not use any of them.
 
-[link_only_lib] is a transitive dep of [main]: [main] depends on
-[intermediate_lib] which declares [link_only_lib]. With
-[(implicit_transitive_deps false)], [link_only_lib]'s modules are
-not on [main]'s [-I] path; [main]'s source cannot reference
-[Link_only_module] at all. The per-module dependency computation
-in #14116 must therefore not surface [link_only_lib] as a
-compile-rule dep — an earlier iteration of that PR did, via a
-glob over the lib's objdir, causing spurious [Main] recompiles
-when [link_only_module] changed.
+On trunk today, [main]'s compile rule globs over
+[link_only_lib]'s objdir as part of the cctx-wide [-H] glob, so
+any [.cmi] content change in [link_only_lib] invalidates [main].
+A tighter per-module filter could observe that no
+[link_only_lib] entry name reaches [main]'s reference closure
+and drop the lib from [main]'s compile-rule deps.
 
 Reported by @nojb in
-https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194.
+https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194
+and again, after a partial fix, in
+https://github.com/ocaml/dune/pull/14116#issuecomment-4331209820.
+Records [main]'s current rebuild count so a future per-module
+filter can flip it to 0.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -48,18 +54,13 @@ https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194.
   > let _ = Intermediate_module.x
   > EOF
 
-  $ dune build ./main.exe
+  $ dune build @check
 
-Edit [link_only_module]. [Main] doesn't reference it, and the
-compiler cannot see [link_only_lib] under
-[(implicit_transitive_deps false)], so [Main] must not be
-recompiled (the executable may still relink because
-[link_only_module.cmx] changes, but [Main.cmo] / [Main.cmx] must
-not):
+Empty [link_only_module.ml] so its [.cmi] loses the [val x : int]
+binding. The cctx-wide glob over [link_only_lib]'s objdir fires
+on the [.cmi] content change, invalidating [main]:
 
-  $ cat > link_only_module.ml <<EOF
-  > let x = 43
-  > EOF
-  $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
-  []
+  $ echo > link_only_module.ml
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
+  2

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -1,0 +1,65 @@
+Regression: under [(implicit_transitive_deps false)], a transitive
+link-only library must not invalidate the consumer when the consumer
+cannot see it through [-I] or [-H].
+
+[link_only_lib] is a transitive dep of [main]: [main] depends on
+[intermediate_lib] which declares [link_only_lib]. With
+[(implicit_transitive_deps false)], [link_only_lib]'s modules are
+not on [main]'s [-I] path; [main]'s source cannot reference
+[Link_only_module] at all. The per-module dependency computation
+in #14116 must therefore not surface [link_only_lib] as a
+compile-rule dep — an earlier iteration of that PR did, via a
+glob over the lib's objdir, causing spurious [Main] recompiles
+when [link_only_module] changed.
+
+Reported by @nojb in
+https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (implicit_transitive_deps false)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name link_only_lib)
+  >  (wrapped false)
+  >  (modules link_only_module))
+  > (library
+  >  (name intermediate_lib)
+  >  (wrapped false)
+  >  (modules intermediate_module)
+  >  (libraries link_only_lib))
+  > (executable
+  >  (name main)
+  >  (modules main)
+  >  (libraries intermediate_lib))
+  > EOF
+
+  $ cat > link_only_module.ml <<EOF
+  > let x = 42
+  > EOF
+
+  $ cat > intermediate_module.ml <<EOF
+  > let x = 42
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let _ = Intermediate_module.x
+  > EOF
+
+  $ dune build ./main.exe
+
+Edit [link_only_module]. [Main] doesn't reference it, and the
+compiler cannot see [link_only_lib] under
+[(implicit_transitive_deps false)], so [Main] must not be
+recompiled (the executable may still relink because
+[link_only_module.cmx] changes, but [Main.cmo] / [Main.cmx] must
+not):
+
+  $ cat > link_only_module.ml <<EOF
+  > let x = 43
+  > EOF
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -58,9 +58,23 @@ filter can flip it to 0.
 
 Empty [link_only_module.ml] so its [.cmi] loses the [val x : int]
 binding. The cctx-wide glob over [link_only_lib]'s objdir fires
-on the [.cmi] content change, invalidating [main]:
+on the [.cmi] content change, invalidating [main] — both the
+[.cmi]/[.cmti] rule and the [.cmo]/[.cmt] rule re-run:
 
   $ echo > link_only_module.ml
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -54,15 +54,15 @@ filter can flip it to 0.
   > let _ = Intermediate_module.x
   > EOF
 
-  $ dune build @check
+  $ dune build ./main.exe
 
 Empty [link_only_module.ml] so its [.cmi] loses the [val x : int]
 binding. The cctx-wide glob over [link_only_lib]'s objdir fires
 on the [.cmi] content change, invalidating [main] — both the
-[.cmi]/[.cmti] rule and the [.cmo]/[.cmt] rule re-run:
+[.cmi]/[.cmti] rule and the [.cmx]/[.o] rule re-run:
 
   $ echo > link_only_module.ml
-  $ dune build @check
+  $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
   [
     {
@@ -73,8 +73,8 @@ on the [.cmi] content change, invalidating [main] — both the
     },
     {
       "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmo",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmt"
+        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
+        "_build/default/.main.eobjs/native/dune__exe__Main.o"
       ]
     }
   ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -7,6 +7,13 @@ references any module of [link_only_lib]; under
 [-H] include path so the compiler can read its [.cmi] files via
 alias chains, but [main] does not use any of them.
 
+The mode-with-[-H] is only reached on dune lang [3.17+] with an
+OCaml compiler that supports hidden includes (5.2+); older dune
+lang versions fall back to mode [Disabled] without [-H]. This
+test pins [(lang dune 3.23)] below to keep the [-H]-glob path the
+one exercised — that is the path the future per-module filter is
+expected to tighten.
+
 On trunk today, [main]'s compile rule globs over
 [link_only_lib]'s objdir as part of the cctx-wide [-H] glob, so
 any [.cmi] content change in [link_only_lib] invalidates [main].


### PR DESCRIPTION
## Summary

Observational baseline. Under `(implicit_transitive_deps false)`, a
transitive link-only library should not trigger a consumer rebuild
when its source changes — the consumer cannot see it through `-I`
or `-H`, so the compile rule should not depend on its objdir.

Trunk does **not** yet satisfy this property: the cctx-wide glob
over `link_only_lib`'s objdir invalidates Main on any `.cmi`
content change in the link-only library. This test records the
current rebuild targets for Main as a baseline that a future
per-module dep filter (#14116) can promote to `[]`.

The earlier draft of this PR asserted `count = 0` and was reported
to pass on `main`; commit `9948ed896` ("strengthen the `.cmi`
perturbation") replaced the weak edit (`let x = 42` → `let x = 43`,
which produces an identical `.cmi`) with `echo > link_only_module.ml`
(which empties the binding). Under the strengthened perturbation
the property fails on trunk, and the test was reframed as an
observational baseline rather than a regression guard.

Reported by @nojb in
https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194,
where an early version of #14116 violated this property and was
later fixed.