### PR TITLE
test: regression guard for modules_without_implementation cross-lib alias

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
@@ -1,0 +1,68 @@
+Regression: a [(modules_without_implementation)] entry whose
+interface aliases a module from another library propagates the
+dep correctly through the per-module filter — when the aliased
+lib's interface changes, the consumer rebuilds without the
+compiler complaining about inconsistent assumptions over
+interface.
+
+Reported by @art-w on #14116. The concern was that
+[(modules_without_implementation)] entries' aliases to other
+libs might escape the per-module dep filter (the intra-stanza
+[trans_deps] graph skips them), leaving the consumer's compile
+rule without a dep on the aliased lib's [.cmi] — which surfaces
+as a hard build error on rebuild.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name dep_lib) (wrapped false) (modules original_name))
+  > (library
+  >  (name wrapper_lib)
+  >  (wrapped false)
+  >  (modules foo bar)
+  >  (modules_without_implementation foo)
+  >  (libraries dep_lib))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules consumer)
+  >  (libraries wrapper_lib))
+  > EOF
+
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > EOF
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > EOF
+
+  $ cat > foo.mli <<EOF
+  > module Re = Original_name
+  > EOF
+  $ cat > bar.ml <<EOF
+  > let placeholder = ()
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Foo.Re.x
+  > EOF
+
+  $ dune build @check
+
+Edit [dep_lib]'s interface. [consumer] reaches [Original_name]
+through [Foo.Re], so it must rebuild — and must rebuild cleanly,
+not error out with "inconsistent assumptions over interface":
+
+  $ cat > original_name.mli <<EOF
+  > val x : string
+  > val y : int
+  > EOF
+  $ cat > original_name.ml <<EOF
+  > let x = "hello"
+  > let y = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer"))] | length'
+  1


### PR DESCRIPTION
## Summary

Documents that a stanza with `(modules_without_implementation foo)`
whose `foo.mli` aliases a module from another library produces a
sound rebuild when the aliased lib's interface changes — the
consumer must rebuild without "inconsistent assumptions over
interface" errors.

Trunk satisfies this property today via cctx-wide compile-rule
deps. The test asserts count = 1 and passes on `main`.

Pre-emptive regression guard for future per-module dep-filter
work (see #14116). The concern was raised by @art-w during review:
the intra-stanza `trans_deps` graph skips
`(modules_without_implementation)` entries, so a per-module filter
that relied on it could miss the cross-lib alias and leave the
consumer's rule without a dep on the aliased lib's `.cmi` —
surfacing on rebuild as an "inconsistent assumptions" error.