### PR TITLE
test: regression guard for consumer-is-virtual-impl branch

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
@@ -1,0 +1,69 @@
+Regression: a stanza with [(implements vlib)] correctly tracks
+changes to its own [(libraries ...)] deps.
+
+For a virtual-library implementation, future per-module
+dependency filtering work (#14116) must preserve deps from the
+implementation's own [(libraries ...)] closure — otherwise the
+implementation may fail to rebuild when one of those libraries'
+interfaces changes. This test checks that an [(implements vlib)]
+consumer rebuilds correctly when a dep in its [(libraries ...)]
+field changes interface. Trunk satisfies the property today via
+cctx-wide compile-rule deps.
+
+Test structure: [vlib] declares a virtual module [vmod];
+[vlib_impl] implements [vmod] AND depends on [dep_lib]; the
+implementation of [vmod] references [Dep_module] from
+[dep_lib]. Editing [Dep_module]'s interface should rebuild
+[vlib_impl]'s [vmod].
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name dep_lib) (wrapped false) (modules dep_module))
+  > EOF
+  $ cat > dep_module.ml <<EOF
+  > let helper = "hi"
+  > EOF
+  $ cat > dep_module.mli <<EOF
+  > val helper : string
+  > EOF
+
+  $ mkdir vlib
+  $ cat > vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (virtual_modules vmod))
+  > EOF
+  $ cat > vlib/vmod.mli <<EOF
+  > val do_thing : unit -> string
+  > EOF
+
+  $ mkdir vlib_impl
+  $ cat > vlib_impl/dune <<EOF
+  > (library
+  >  (name vlib_impl)
+  >  (implements vlib)
+  >  (libraries dep_lib))
+  > EOF
+  $ cat > vlib_impl/vmod.ml <<EOF
+  > let do_thing () = Dep_module.helper
+  > EOF
+
+  $ dune build @check
+
+Edit [dep_lib]'s interface. [vlib_impl]'s implementation of
+[vmod] references [Dep_module], so it must rebuild:
+
+  $ cat > dep_module.mli <<EOF
+  > val helper : string
+  > val extra : int
+  > EOF
+  $ cat > dep_module.ml <<EOF
+  > let helper = "hi"
+  > let extra = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("vlib_impl") and test("Vmod"))] | length'
+  1


### PR DESCRIPTION
## Summary

Documents that a stanza with `(implements vlib)` correctly
rebuilds when its `(libraries ...)` dep's interface changes.

Trunk satisfies this via cctx-wide compile-rule deps. The test
asserts count = 1 and passes on `main`.

Pre-emptive regression guard for #14116's per-module dep filter.
The filter's `can_filter` check excludes virtual-library
implementations (their dep machinery is in
`Dep_rules.deps_of_vlib_module`), so they fall back to glob deps.
This test locks in the property that any future change preserving
the consumer-side virtual-impl branch keeps the implementation
rebuilding correctly.

Distinct from the existing `virtual-library.t`, which exercises
the deps-side (`has_virtual_impl`) branch.