### PR TITLE
test(boot): %expect_test is stripped during bootstrap

### DIFF
--- a/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
@@ -1,0 +1,30 @@
+Testing that the bootstrap preprocessor strips let%expect_test blocks.
+
+  $ init_bootstrap
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/a.ml <<EOF
+  > module Root = Root
+  > let x = 42
+  > let%expect_test "this should be stripped" =
+  >   print_int x;
+  >   [%expect {| 42 |}]
+  > ;;
+  > let () = Printf.printf "x = %d\n" x
+  > EOF
+
+  $ make_module src/a/root.ml
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+  $ create_dune a <<EOF
+  > let () = Printf.printf "Hello, x = %d" A.x
+  > EOF
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocaml -I +unix unix.cma $DUNEBOOT
+  x = 42
+  Hello, x = 42


### PR DESCRIPTION
This was added in #13794, this test asserts this behaviour holds.