### PR TITLE
feat(boot): strip %test_module during bootstrap 

### DIFF
--- a/boot/pps.mll
+++ b/boot/pps.mll
@@ -4,6 +4,7 @@
 
 rule pp = parse
  | "let%expect_test" { skip lexbuf }
+ | "let%test_module" { skip_module 0 lexbuf }
  | _ as c { Buffer.add_char b c; pp lexbuf }
  | eof { () }
 
@@ -11,6 +12,12 @@ and skip = parse
   | ";;" { pp lexbuf }
   | _ { skip lexbuf }
   | eof { failwith "unterminated let%expect_test" }
+
+and skip_module depth = parse
+  | '(' { skip_module (depth + 1) lexbuf }
+  | ')' { if depth = 1 then skip lexbuf else skip_module (depth - 1) lexbuf }
+  | _ { skip_module depth lexbuf }
+  | eof { failwith "unterminated let%test_module" }
 
 {
   let pp s =

--- a/test/blackbox-tests/test-cases/boot/ppx-test-module.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-test-module.t
@@ -1,0 +1,47 @@
+Testing that the bootstrap preprocessor strips let%test_module blocks.
+
+  $ init_bootstrap
+
+  $ mkdir -p src/a
+
+  $ cat > src/a/a.ml <<EOF
+  > module Root = Root
+  > let x = 42
+  > let%test_module "tests" =
+  >   (module struct
+  >     let%expect_test "inner test" =
+  >       print_int x;
+  >       [%expect {| 42 |}]
+  >     ;;
+  >     let helper () = x + 1
+  >     let%expect_test "another" =
+  >       print_int (helper ());
+  >       [%expect {| 43 |}]
+  >     ;;
+  >   end)
+  > ;;
+  > let () = Printf.printf "x = %d\n" x
+  > EOF
+
+  $ make_module src/a/root.ml
+
+  $ cat > src/a/dune <<EOF
+  > (library
+  >  (name a))
+  > EOF
+
+CR-soon Alizter: Currently the bootstrap does not handle %test_module, it
+should strip this.
+
+  $ create_dune a <<EOF
+  > let () = Printf.printf "Hello, x = %d" A.x
+  > EOF
+  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
+  ./.duneboot.exe
+  cd _boot && /OCAMLOPT -c -g -no-alias-deps -w -49-23-53 -alert -unstable -I +unix -I +threads a.ml
+  File "a.ml", line 4, characters 4-15:
+  4 | let%test_module "tests" =
+          ^^^^^^^^^^^
+  Error: Uninterpreted extension 'test_module'.
+  [2]

--- a/test/blackbox-tests/test-cases/boot/ppx-test-module.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-test-module.t
@@ -30,18 +30,10 @@ Testing that the bootstrap preprocessor strips let%test_module blocks.
   >  (name a))
   > EOF
 
-CR-soon Alizter: Currently the bootstrap does not handle %test_module, it
-should strip this.
-
   $ create_dune a <<EOF
   > let () = Printf.printf "Hello, x = %d" A.x
   > EOF
   ocamllex -q -o boot/pps.ml boot/pps.mll
-  ocamlc -output-complete-exe -intf-suffix .dummy -g -o .duneboot.exe -I boot -I +unix unix.cma boot/pps.ml boot/types.ml boot/libs.ml boot/duneboot.ml
-  ./.duneboot.exe
-  cd _boot && /OCAMLOPT -c -g -no-alias-deps -w -49-23-53 -alert -unstable -I +unix -I +threads a.ml
-  File "a.ml", line 4, characters 4-15:
-  4 | let%test_module "tests" =
-          ^^^^^^^^^^^
-  Error: Uninterpreted extension 'test_module'.
-  [2]
+  ocaml -I +unix unix.cma $DUNEBOOT
+  x = 42
+  Hello, x = 42


### PR DESCRIPTION
The first commit asserts that we don't strip `%test_module` from the sources during the bootstrap process.

The second commit improves the detection so that we do.

This allows us to write inline tests with their own helpers without polluting the sources themselves.