### PR TITLE
fix(dune-site): remove extra entering/leaving directory logs in tests

### DIFF
--- a/otherlibs/dune-site/test/run.t
+++ b/otherlibs/dune-site/test/run.t
@@ -353,12 +353,8 @@ Test compiling an external plugin
   > EOF
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH dune build --root=e
-  Entering directory 'e'
-  Leaving directory 'e'
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH PATH=$(pwd)/_install/bin:$PATH dune exec  --root=e -- c
-  Entering directory 'e'
-  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -430,8 +426,6 @@ Test %{version:installed-pkg}
   > EOF
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
-  Entering directory 'f'
-  Leaving directory 'f'
   $ cat $(pwd)/f/_build/default/test.target
   a = 0.a
   e = 

--- a/otherlibs/dune-site/test/run_2_9.t
+++ b/otherlibs/dune-site/test/run_2_9.t
@@ -338,12 +338,8 @@ Test compiling an external plugin
   > EOF
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH dune build --root=e
-  Entering directory 'e'
-  Leaving directory 'e'
 
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH PATH=$PWD/_install/bin:$PATH dune exec  --root=e -- c
-  Entering directory 'e'
-  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -415,8 +411,6 @@ Test %{version:installed-pkg}
   > EOF
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
-  Entering directory 'f'
-  Leaving directory 'f'
   $ cat $PWD/f/_build/default/test.target
   a = 0.a
   e = 


### PR DESCRIPTION
It looks like the CI/nix isn't running on those tests, but @shonfeder and @ElectreAAS have also reported the same spurious broken tests.