### PR TITLE
test: observational baseline for the wrapped-closure precision gap (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
@@ -1,0 +1,107 @@
+Observational baseline: a precision gap that any per-module dep
+filter must navigate when a wrapped sibling library's wrapper
+appears in a consumer's reference set, and the consumer reaches
+one entry of the wrapper's transitive [Lib.closure] via an alias
+chain inside one of the wrapper's children.
+
+[dep_lib] is unwrapped with two entry modules: [reached_module]
+(which the consumer transitively reaches via an alias chain) and
+[unreached_module] (which no source file in the test reaches).
+[lib_re_export] is wrapped (dune auto-generates the wrapper)
+with a single child [pprint] that aliases only [reached_module].
+[consumer_lib] depends on [lib_re_export] and writes
+[Lib_re_export.Pprint.Re.x] — naming [Lib_re_export] in source.
+
+The consumer reaches [reached_module] through [pprint]'s alias
+chain. It does NOT reach [unreached_module]. A filter that walks
+ocamldep through the auto-generated wrapper's children's [.d]
+files could observe this and emit a per-module dep on
+[reached_module.cmi] alone — editing [unreached_module.mli]
+would then leave the consumer untouched.
+
+On trunk, the consumer's compile rule globs over [dep_lib]'s
+objdir (the cctx-wide [-I]/[-H] include flags), so editing
+[unreached_module.mli] invalidates the consumer through that
+glob. The same outcome holds for any per-module filter that
+conservatively globs the entire [Lib.closure] of a wrapped
+sibling in the reference set: the closure includes [dep_lib], so
+the glob still fires on [unreached_module] changes. Only a
+deeper filter that descends through wrapped libs' children to
+find the alias chain can drop the dep on [unreached_module].
+
+The conservative approach is sound (it can never miss a real
+dep) but loses precision relative to the deeper walk. This test
+records the current behaviour: editing an unreached module of a
+transitively-globbed lib still rebuilds the consumer.
+
+A future filter improvement that walks wrapped libs' children
+flips the expected target_files array to [].
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name dep_lib)
+  >  (wrapped false)
+  >  (modules reached_module unreached_module))
+  > (library
+  >  (name lib_re_export)
+  >  (modules pprint)
+  >  (libraries dep_lib))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules consumer)
+  >  (libraries lib_re_export))
+  > EOF
+
+  $ cat > reached_module.ml <<EOF
+  > let x = "reached"
+  > EOF
+  $ cat > reached_module.mli <<EOF
+  > val x : string
+  > EOF
+  $ cat > unreached_module.ml <<EOF
+  > let x = "unreached"
+  > EOF
+  $ cat > unreached_module.mli <<EOF
+  > val x : string
+  > EOF
+
+  $ cat > pprint.ml <<EOF
+  > module Re = Reached_module
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Lib_re_export.Pprint.Re.x
+  > EOF
+
+  $ dune build @check
+
+Edit [unreached_module]'s interface — a module the consumer does
+NOT reach through any alias chain ([Pprint] aliases
+[Reached_module] only). Under the conservative [Lib.closure]
+glob, [dep_lib]'s objdir is on the consumer's compile rule, so
+the [.cmi] content change invalidates the consumer:
+
+  $ cat > unreached_module.mli <<EOF
+  > val x : string
+  > val y : int
+  > EOF
+  $ cat > unreached_module.ml <<EOF
+  > let x = "unreached"
+  > let y = 1
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.consumer_lib.objs/byte/consumer.cmi",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmo",
+        "_build/default/.consumer_lib.objs/byte/consumer.cmt"
+      ]
+    }
+  ]


### PR DESCRIPTION
## Summary

Adds a cram test recording which compile-rule `target_files`
rebuild when a consumer references a wrapped sibling library
whose `Lib.closure` includes a transitively-reached unwrapped
library, and an unread module of that transitive library is
edited.

## Setup

- `dep_lib` is unwrapped with two entry modules: `reached_module`
  (transitively reached via an alias chain) and `unreached_module`
  (which no source in the test reaches).
- `lib_re_export` is wrapped (dune auto-generates the wrapper) with
  a single child `pprint` that aliases only `reached_module` of
  `dep_lib`.
- `consumer_lib` writes `Lib_re_export.Pprint.Re.x`, naming
  `Lib_re_export` in source.

## What the test records

Editing `unreached_module.mli` rebuilds the consumer on trunk
today: the cctx-wide `-I`/`-H` glob covers `dep_lib`'s objdir,
so any `.cmi` content change in `dep_lib` invalidates the
consumer regardless of whether the change is to a module the
consumer's alias chain actually reaches.

A precision-perfect filter could observe that `pprint`'s ocamldep
output names only `reached_module` and emit a per-module dep on
`reached_module.cmi` alone — leaving the consumer untouched on
`unreached_module.mli` changes.

The test asserts the current rebuild list (the consumer's
`.cmi`/`.cmti` rule re-runs) so a future filter improvement that
closes the precision gap will flip the array to `[]`.

## Relationship to #14116

#14116's per-module filter does not close this specific gap. Its
conservative wrapped-lib soundness fix globs the entire
`Lib.closure` of any wrapped sibling that appears in the
consumer's reference set, which covers `dep_lib` here — so
`unreached_module` changes still invalidate the consumer through
the glob. The deeper filter that walks ocamldep through wrapped
libs' children to extract exactly which transitive entry modules
are reached is described as follow-on work in `lib_file_deps.ml`.

This PR is purely observational; no code change. The test
companions the soundness regression guards in
[`auto-wrapped-child-reexport.t`](https://github.com/ocaml/dune/pull/14347)
and [`wrapped-reexport-via-open-flag.t`](https://github.com/ocaml/dune/pull/14346):
those assert the consumer DOES rebuild on a *reached* transitive
module's change (soundness preservation); this one asserts the
consumer rebuilds on an *unreached* transitive module's change
(precision gap).

Related: #4572, #14116