### PR TITLE
fix(promote): clean up stale staging path before rename in register_intermediate

### DIFF
--- a/doc/changes/fixed/14371.md
+++ b/doc/changes/fixed/14371.md
@@ -1,0 +1,3 @@
+- Fix promotion failure when a target changes from a directory to a file
+  between builds, causing "Is a directory" errors.
+  (#14371, fixes #5647, fixes #6575, @Alizter)

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -129,6 +129,7 @@ let register_intermediate how ~source_file ~correction_file =
    | `Already_exists | `Created -> ()
    | `Not_a_dir ->
      Code_error.raise "dir was deleted" [ "staging_dir", Path.Build.to_dyn staging_dir ]);
+  Path.rm_rf (Path.build staging);
   (match how with
    | `Move ->
      Unix.rename (Path.Build.to_string correction_file) (Path.Build.to_string staging)

--- a/test/blackbox-tests/test-cases/cram/dir-to-file-promotion.t
+++ b/test/blackbox-tests/test-cases/cram/dir-to-file-promotion.t
@@ -1,6 +1,6 @@
-This test demonstrates a bug where changing a cram test from a directory test
-to a file test causes a build failure because the old directory-style
-.corrected path remains in _build.
+Regression test: changing a cram test from a directory test to a file test
+after producing a diff should work correctly. Previously this failed with
+"rename: Is a directory" due to a stale .corrected directory in _build.
 
   $ cat > dune-project << EOF
   > (lang dune 3.24)
@@ -30,8 +30,7 @@ Now change it from a directory cram test to a file cram test:
   >   $ echo goodbye
   > EOF
 
-Try to run it. This fails because the old .corrected directory is still in
-_build:
+Running the file test should produce a normal diff:
 
   $ dune runtest mytest.t
   File "mytest.t", line 1, characters 0-0:
@@ -40,6 +39,4 @@ _build:
   @@ -1 +1,2 @@
      $ echo goodbye
   +  goodbye
-  Error: rename(_build/default/mytest.t.corrected): Is a directory
-  -> required by alias mytest
   [1]

--- a/test/blackbox-tests/test-cases/promote/directory-diff/dir-to-file-target-change.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/dir-to-file-target-change.t
@@ -1,5 +1,6 @@
-Non-optional diff with a directory target that changes to a file target between
-builds. This exercises the Copy path in register_intermediate.
+Regression test: a non-optional diff with a directory target that changes to a
+file target between builds should produce a normal diff. Previously this failed
+with "Is a directory" due to a stale staging directory in _build.
 
   $ cat > dune-project <<'EOF'
   > (lang dune 3.24)
@@ -31,8 +32,8 @@ directory:
   +different
   [1]
 
-Now change the rule so that it produces a file target instead of a directory,
-and update expected accordingly:
+Now change the rule to produce a file target instead of a directory, and update
+expected accordingly. The diff should work normally:
 
   $ rm -r expected
   $ printf 'expected-content\n' > expected
@@ -47,8 +48,6 @@ and update expected accordingly:
   > EOF
 
   $ dune runtest
-  Error: _build/.promotion-staging/expected: Is a directory
-  -> required by alias runtest in dune:4
   File "expected", line 1, characters 0-0:
   --- expected
   +++ actual


### PR DESCRIPTION
When a promoted target changes from a directory to a file between builds, the
old staging path remains as a directory. Unix.rename and Io.copy_file cannot
overwrite a directory with a file, causing "Is a directory" errors.

Fix by unlinking the staging path before writing, using rm_rf only when it's a
directory. This handles both the Move path (cram tests, optional diffs) and the
Copy path (non-optional diffs with directory targets).

Updates dir-to-file-promotion.t and dir-to-file-target-change.t to reflect the
fix.

- fixes https://github.com/ocaml/dune/issues/5647
- fixes https://github.com/ocaml/dune/issues/6575
- [x] depends on #14370 
- [x] depends on #14369 
- [x] changes