### PR TITLE
feat(pkg): install layouts for package sets

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -108,6 +108,20 @@ let program_not_built_yet prog =
     ]
 ;;
 
+(* Cons the workspace's install staging dir ([_build/install/<ctx>/]) onto
+   the env's path-like vars (OCAMLPATH, PATH, etc.) for [dune exec]. This
+   does NOT trigger any build; if the staging dir isn't populated (no
+   [@install] was run), the entries on the path simply don't resolve. The
+   point is to preserve the old [dune exec] contract that workspace
+   libraries are visible via OCAMLPATH to anything the binary delegates to
+   (findlib, ocamlfind, dune-site's plugin lookup, etc.). Per-action rule
+   envs are unaffected — only [dune exec]'s own env extension. *)
+let extend_with_staging_env context base =
+  let staging = Install.Context.dir ~context in
+  let roots = Install.Roots.opam_from_prefix staging ~relative:Path.Build.relative in
+  Install.Roots.add_to_env roots base
+;;
+
 let build_prog ~no_rebuild ~prog p =
   if no_rebuild
   then
@@ -176,6 +190,7 @@ let step ~prog ~args ~common ~no_rebuild ~context ~on_exit () =
     Memo.parallel_map args ~f:(Cmd_arg.expand ~root:(Common.root common) ~sctx)
   in
   let* env = Super_context.context_env sctx in
+  let env = extend_with_staging_env context env in
   Memo.of_non_reproducible_fiber
   @@ Dune_engine.Process.run_inherit_std_in_out
        ~dir:(Path.of_string Fpath.initial_cwd)
@@ -274,7 +289,8 @@ let exec_building_via_rpc_server ~common ~prog ~args ~no_rebuild builder lock_he
   let+ prog =
     build_prog_via_rpc_if_necessary ~dir ~no_rebuild builder lock_held_by prog
   in
-  Util.restore_cwd_and_execve (Common.root common) prog args Env.initial
+  let env = extend_with_staging_env context Env.initial in
+  Util.restore_cwd_and_execve (Common.root common) prog args env
 ;;
 
 let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
@@ -306,6 +322,7 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
       and* args =
         Memo.parallel_map ~f:(Cmd_arg.expand ~root:(Common.root common) ~sctx) args
       in
+      let env = extend_with_staging_env context env in
       Util.restore_cwd_and_execve (Common.root common) prog args env)
 ;;
 

--- a/doc/changes/changed/14373.md
+++ b/doc/changes/changed/14373.md
@@ -1,0 +1,5 @@
+- `(deps (package ...))` now exposes only the directly declared packages to
+  the action's environment (`OCAMLPATH`, `PATH`, etc.). Previously, other
+  packages in the workspace could be discoverable via the shared install
+  staging area. Actions that relied on undeclared packages being visible
+  must declare them explicitly. (#14373, @Alizter)

--- a/doc/concepts/dependency-spec.rst
+++ b/doc/concepts/dependency-spec.rst
@@ -30,9 +30,11 @@ Dependencies in ``dune`` files can be specified using one of the following:
   universe. In any case, this is only for dependencies in the
   :term:`installed world`. You must still specify all dependencies that come
   from the workspace.
-- ``(package <pkg>)`` depends on all files installed by ``<package>``, as well
-  as on the transitive package dependencies of ``<package>``. This can be used
-  to test a command against the files that will be installed.
+- ``(package <pkg>)`` builds the files installed by ``<package>`` and adds
+  them to the action's environment: bin entries on ``PATH``, libraries on
+  ``OCAMLPATH``, stublibs on ``CAML_LD_LIBRARY_PATH``, and so on. Only the
+  named package is added; transitive package dependencies must be listed
+  separately.
 - ``(env_var <var>)`` depends on the value of the environment variable ``<var>``.
   If this variable becomes set, becomes unset, or changes value, the target
   will be rebuilt.

--- a/doc/dev/install-layouts.md
+++ b/doc/dev/install-layouts.md
@@ -1,0 +1,239 @@
+# Install Layouts for Package Sets
+
+## Overview
+
+`(deps (package ...))` materializes a scoped install layout under
+`_build/install/<context>/.packages/<digest>/` containing only the declared
+package dependencies. This replaces the old alias-based mechanism where `(deps
+(package foo))` depended on the `.foo-files` install alias, which populated the
+`_build/install/` staging area shared by all packages.
+
+## Motivation
+
+The `_build/install/` staging area shared by all packages causes several
+problems:
+
+1. Actions can silently depend on packages they did not declare via the shared
+   environment variables (OCAMLPATH, PATH, etc.). Whether an action succeeds
+   can depend on what other packages happened to be built, making builds
+   non-deterministic. `(strict_package_deps)` validates that dependencies are
+   declared but does not prevent undeclared packages from being visible at
+   runtime.
+
+2. The shared staging area can cause rule collisions and dependency cycles.
+   Multiple packages installing directory targets to the same section root
+   crash ([#13307]). Computing install artifacts globally creates cycles in
+   monorepo builds ([#13500]) and Coq compositions ([#7908]).
+
+3. Lock-dir packages that depend on workspace packages need a scoped install
+   prefix to build against. The shared staging area does not provide this. This
+   is the "in-and-out" problem ([#8652]): when a lock-dir package depends on a
+   workspace package which depends on another lock-dir package, dune cannot
+   resolve the dependency without per-package install layouts.
+
+[#7908]: https://github.com/ocaml/dune/issues/7908
+[#8652]: https://github.com/ocaml/dune/issues/8652
+[#13307]: https://github.com/ocaml/dune/issues/13307
+[#13500]: https://github.com/ocaml/dune/issues/13500
+
+## Design
+
+### Package kinds
+
+`Package_db.find_package` classifies packages into three kinds:
+
+- `Local`: workspace packages defined in `dune-project`. These get layout
+  file deps and env vars.
+
+- `Build`: lock-dir packages from `dune.lock`. `(deps (package foo))` runs
+  the package's build action but does not set up env vars for the consuming
+  action. This is a known bug, tracked as a follow-up in PR #14373.
+
+- `Installed`: externally installed packages (found via findlib). Depended
+  on directly. Already on the system OCAMLPATH. Only returned in
+  non-lock-dir contexts; with a lock-dir active, external packages can
+  only resolve as `Build` (if they are in `dune.lock`) or as not found.
+
+### Immediate deps only
+
+The layout includes only the immediate packages listed in `(deps (package
+...))`. No transitive expansion is performed. Actions should declare what
+they need explicitly.
+
+This is a deliberate design choice:
+
+1. Transitive closure cannot traverse lock-dir packages (they are not
+   workspace packages), so it gives incomplete results in mixed
+   workspace/lock-dir setups. Immediate deps avoid this inconsistency.
+
+2. Workspace package compilation is handled by dune internally via `Lib.DB`,
+   not via OCAMLPATH. The only consumer of OCAMLPATH in the layout is
+   user-written rule actions, where explicit deps are appropriate.
+
+3. Immediate deps keep layout *contents* tractable for the "in-and-out" problem
+   ([#8652]). This is orthogonal to whether per-package layouts exist at all.
+   When a lock-dir package depends on a workspace package, that workspace
+   package's layout can be provided to the lock-dir package's build env without
+   first computing a transitive closure that would have to cross back into other
+   lock-dir packages.
+
+### Environment variables
+
+The layout sets PATH, OCAMLPATH, CAML_LD_LIBRARY_PATH,
+OCAMLFIND_IGNORE_DUPS_IN, OCAMLTOP_INCLUDE_PATH, and MANPATH from the layout's
+directory structure. These are defined by `Install.Roots.path_vars` and consed
+onto the directory environment in `extend_action` (super_context.ml), so
+external/system paths remain visible. The env vars are propagated to rule
+actions, cram tests, cinaps, mdx, and inline tests.
+
+### Staging area
+
+`(deps (package ...))` no longer populates the `_build/install/` staging area.
+The staging area is only populated by `dune build @install` / `dune install`.
+Code that previously relied on a binary being present in the staging area has
+two replacements: either explicitly depend on `@install` to populate the
+staging area, or use `%{bin:foo}`, which goes through the separate bin-layout
+(`.binaries/<digest>/`) added in PR #14432 and bypasses the staging area
+entirely.
+
+### Environment hermeticity
+
+The `env` lazy in `Super_context.create` (`src/dune_rules/super_context.ml`) is
+just `Context.installed_env` plus `Site_env.add_packages_env`, with no staging
+paths attached. Actions only see declared dependencies via layout env vars
+consed in `extend_action`. This is what makes the strict-deps property hold for
+workspace build outputs: no workspace-built artifact is reachable via
+dune-managed env vars unless declared. The user's inherited shell env (PATH,
+OCAMLPATH, findlib config) is still visible via `Context.installed_env`, as
+documented in "Environment variables" above.
+
+### `dune exec` and the staging area
+
+`dune exec` runs binaries outside the rule machinery, so it cannot inherit
+per-action env from `combined_package_deps_builder`. To preserve the documented
+`dune exec` contract that workspace libraries are reachable via OCAMLPATH (see
+the man page: "you will have access to the libraries defined in the workspace
+using your usual directives"), `bin/exec.ml` conses
+`_build/install/<context>/{lib,bin,...}` onto the path-like env vars of the
+executed process.
+
+This cons is unconditional and does not trigger any build. If `dune build
+@install` (or any rule that drags install entries in) was run beforehand, the
+staging dir is populated and workspace libraries are visible to anything the
+binary delegates to (findlib, ocamlfind, dune-site plugin lookup, etc.). If
+not, the entries on the path simply don't resolve. Per-action rule envs are
+unaffected; only `dune exec`'s own env extension is consed.
+
+### Sites and plugins
+
+The dune-site mechanism uses `DUNE_DIR_LOCATIONS` to tell binaries where their
+sites live. `Site_env.add_packages_env` walks workspace stanzas to discover
+site/plugin packages and sets the env var to point at the staging area, one
+entry per (package, section) pair. The path for a given section follows opam's
+layout: `_build/install/<context>/<section>/<pkg>/` (e.g. `lib/<pkg>/` for the
+`lib` section, `share/<pkg>/` for `share`). Combined with the `dune exec`
+staging cons above, this means:
+
+- A binary built locally and run via `dune exec foo.exe` sees plugins iff
+  the staging dir is populated. The dune-site / sites cram tests
+  consequently run `dune build @install` before `dune exec`.
+- Cram tests that exercise dune-site libraries (`(libraries dune-site
+  dune-site.plugins)`) must declare both `(package dune-site)` and
+  `(package dune-private-libs)` in their cram-level `dune` setup.
+  `dune-site` re-exports `dune-private-libs.dune-section`, and the layout
+  does not auto-expand transitive package deps (see "Immediate deps only"
+  above). The same pattern applies to other re-exporting libraries.
+  `(package stdune)`, for example, requires `(package dyn) (package
+  ordering) (package pp) (package top-closure) (package csexp) (package
+  fs-io)`. This is the explicit-deps tradeoff in its most visible form:
+  the immediate-deps-only design surfaces a library's transitive
+  dependencies at the call site rather than implicitly pulling them in.
+
+The current staging cons is sufficient for the existing test surface and
+matches pre-install-layouts behaviour.
+
+### Package set structure and `_root` section collisions
+
+The layout merges all packages' install entries into a single directory tree.
+For scoped sections (`lib`, `share`, `doc`, `etc`), each package installs
+under its own subdirectory (`lib/<pkgname>/`), so collisions are impossible
+by construction. The unordered set is the correct data structure.
+
+Collisions can only occur in `_root` sections (`lib_root`, `share_root`,
+`libexec_root`), which install directly to the section root without package
+namespacing ([opam manual][opam-install-format], [opam#2153]). In opam,
+`_root` sections serve specific use cases:
+
+- `ocamlfind` installs `topfind` into the compiler's stdlib directory via
+  `lib_root` ([opam#45]).
+- Cross-compiled C libraries install `.pc` files to `lib/pkgconfig/` via
+  `lib_root`.
+- `share_root` is used for shared data directories (e.g. emacs site-lisp).
+
+These are rare. Collisions in `_root` sections are currently rejected with a
+`User_error` naming both conflicting packages and the destination section/file
+(see `compute_entries` in `src/dune_rules/install_layout.ml`, pinned by
+`test/blackbox-tests/test-cases/package-materialization/root-section-collision.t`).
+To support opam-style override semantics in the future, the layout would
+resolve `_root` collisions using dependency edges: if B depends on A, B's
+`_root` entries take priority. Diamond collisions (incomparable packages) would
+remain errors. This only affects `_root` handling and does not require changing
+the core layout mechanism.
+
+[opam-install-format]: https://opam.ocaml.org/doc/Manual.html
+[opam#2153]: https://github.com/ocaml/opam/issues/2153
+[opam#45]: https://github.com/ocaml/opam/issues/45
+
+## Implementation notes
+
+### Layout key (digest derivation)
+
+The `<digest>` component of `_build/install/<context>/.packages/<digest>/` is
+the hex `Digest.repr` of the sorted package-name list of the set (see
+`Install_layout.Key.encode` in `src/dune_rules/install_layout.ml`). The sort
+makes the digest order-independent. A reverse table maps each digest back to
+its original set so `gen_rules` can decode the layout dir's name when the
+engine asks for rules. Hash collisions are detected at insertion time and raise
+a `Code_error`.
+
+### `For_rocq_only` escape hatch
+
+`Install_layout.For_rocq_only.lib_root` exposes just the layout's `lib` root,
+filtered to `Section.Lib` entries only. It exists because rocq puts the
+layout's `lib` dir on `OCAMLPATH`, where findlib walks eagerly; for a
+race-free, deterministic walk, every entry findlib could see must be a declared
+dep. The bulk `env` function isn't suitable here because it also pulls in
+`Section.Lib_root` entries. For rocq those include the theory's own `.vo`
+output under `lib/coq/user-contrib/...`, creating a build cycle in the
+same-package theory-plus-plugin case (the theory rule would depend on its own
+output via the layout symlink). Filtering to `Section.Lib` excludes the theory
+output while keeping METAs, `.cmxs`, `.cmi` etc., all of which are upstream of
+theory compilation. See the comment on the module in `install_layout.ml` for
+details.
+
+## Future work
+
+### Lock-dir build layouts
+
+The layout mechanism can support the "in-and-out" problem ([#8652]): when a
+lock-dir package depends on a workspace package, a layout containing the
+workspace package's artifacts can be provided to the lock-dir package's build
+env. The opam-like directory structure matches what build systems expect at an
+install prefix.
+
+Longer term, the layout overlay mechanism could replace isolated per-package
+install directories for lock-dir builds entirely. Packages would build against
+a layout that overlays all their dependencies' installed files into a single
+virtual prefix, using dependency structure for overlay ordering.
+
+### Incremental layout construction
+
+If A depends on B depends on C, the layouts for their builds are {C}, {B,C},
+and {A,B,C}. Instead of computing each independently, layouts can be built
+incrementally: {B,C} hardlinks from {C} and adds B's entries, {A,B,C} hardlinks
+from {B,C} and adds A's entries. This makes `_root` overrides natural: each
+step replaces entries from the smaller layout. The key question is whether the
+digest/key scheme can encode this incrementality or whether a structural
+(DAG-based) key is needed.
+
+Outstanding follow-up items are tracked in the Follow-up section of PR #14373.

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-quoting.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-quoting.t/run.t
@@ -1,4 +1,5 @@
 These tests show how various pkg-config invocations get quotes (and test specifying a custom PKG_CONFIG):
+  $ dune build @install
   $ PKG_CONFIG=$PWD/_build/install/default/bin/pkg-config dune build 2>&1 | awk '/run:.*bin\/pkg-config/{a=1}/stderr/{a=0}a'
   run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors gtk+-quartz-3.0
   -> process exited with code 0

--- a/otherlibs/dune-site/test/dune
+++ b/otherlibs/dune-site/test/dune
@@ -2,7 +2,8 @@
  (applies_to :whole_subtree)
  (deps
   (package dune)
-  (package dune-site)))
+  (package dune-site)
+  (package dune-private-libs)))
 
 ; The test being broken on CI, we deactivate it when
 ; we detect that the CI environment variable is not

--- a/src/dune_rules/bin_layout.ml
+++ b/src/dune_rules/bin_layout.ml
@@ -89,12 +89,10 @@ let make_dispatch ~dir subdirs f =
 
 let gen_rules context_name ~dir rest =
   match rest with
-  | [] -> Memo.return (make_dispatch ~dir Subdir_set.all (fun () -> Memo.return ()))
+  | [] -> make_dispatch ~dir Subdir_set.all (fun () -> Memo.return ())
   | [ key ] ->
-    Memo.return
-      (make_dispatch ~dir Subdir_set.empty (fun () ->
-         symlink_rules_for_key context_name ~dir key))
+    make_dispatch ~dir Subdir_set.empty (fun () ->
+      symlink_rules_for_key context_name ~dir key)
   | _ :: _ :: _ ->
-    Memo.return
-      (Build_config.Gen_rules.redirect_to_parent Build_config.Gen_rules.Rules.empty)
+    Build_config.Gen_rules.redirect_to_parent Build_config.Gen_rules.Rules.empty
 ;;

--- a/src/dune_rules/bin_layout.mli
+++ b/src/dune_rules/bin_layout.mli
@@ -16,4 +16,4 @@ val gen_rules
   :  Context_name.t
   -> dir:Path.Build.t
   -> string list
-  -> Build_config.Gen_rules.result Memo.t
+  -> Build_config.Gen_rules.result

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -8,7 +8,7 @@ module Spec = struct
     ; extra_aliases : Alias.Name.Set.t
     ; deps : unit Action_builder.t list
     ; sandbox : Sandbox_config.t Action_builder.t
-    ; bin_env : Env.t Action_builder.t
+    ; env : Env.t Action_builder.t
     ; enabled_if : (Expander.t * Blang.t) list
     ; locks : Path.Set.t Action_builder.t
     ; packages : Package.Name.Set.t
@@ -26,7 +26,7 @@ module Spec = struct
     ; locks = Action_builder.return Path.Set.empty
     ; deps = []
     ; sandbox = Action_builder.return Sandbox_config.needs_sandboxing
-    ; bin_env = Action_builder.return Env.empty
+    ; env = Action_builder.return Env.empty
     ; packages = Package.Name.Set.empty
     ; timeout = None
     ; conflict_markers = Ignore
@@ -64,7 +64,7 @@ let test_rule
        ; deps
        ; locks
        ; sandbox
-       ; bin_env
+       ; env
        ; packages = _
        ; timeout
        ; conflict_markers
@@ -140,8 +140,8 @@ let test_rule
            let+ (_ : Path.Set.t) = Action_builder.dyn_memo_deps deps in
            ()
        and+ () = Action_builder.paths setup_scripts
-       and+ sandbox = sandbox
-       and+ bin_env = bin_env
+       and+ sandbox
+       and+ env
        and+ locks = locks >>| Path.Set.to_list in
        Cram_exec.run
          ~src:(Path.build script)
@@ -156,7 +156,7 @@ let test_rule
          ~setup_scripts
          shell
        |> Action.Full.make ~locks ~sandbox
-       |> Action.Full.add_env bin_env)
+       |> Action.Full.add_env env)
       |> Action_builder.with_file_targets ~file_targets:[ output ]
       |> Super_context.add_rule sctx ~dir ~loc
     in
@@ -261,11 +261,11 @@ let rules ~sctx ~dir tests project =
             | false -> Memo.return (runtest_alias, acc)
             | true ->
               let+ expander = Super_context.expander sctx ~dir in
-              let deps, sandbox, bin_env =
+              let deps, sandbox, env =
                 match stanza.deps with
-                | None -> acc.deps, acc.sandbox, acc.bin_env
+                | None -> acc.deps, acc.sandbox, acc.env
                 | Some deps ->
-                  let action_env, _, sandbox =
+                  let env, _, sandbox =
                     Dep_conf_eval.named
                       ~expander
                       Sandbox_config.no_special_requirements
@@ -277,16 +277,13 @@ let rules ~sctx ~dir tests project =
                     and+ sandbox = sandbox in
                     Sandbox_config.inter acc sandbox
                   in
-                  let bin_env =
+                  let env =
                     let open Action_builder.O in
-                    let+ acc = acc.bin_env
-                    and+ env = action_env in
-                    Env_path.extend_env_concat_path acc env
+                    let+ acc = acc.env
+                    and+ env in
+                    Install.Roots.extend_env_concat_path_vars acc env
                   in
-                  (* [action_env]'s deps are registered when [bin_env] is
-                     consumed at the rule site (it folds the env's
-                     action_builder evaluation into [bin_env]). *)
-                  acc.deps, sandbox, bin_env
+                  acc.deps, sandbox, env
               in
               let locks =
                 let open Action_builder.O in
@@ -369,7 +366,7 @@ let rules ~sctx ~dir tests project =
                 ; extra_aliases
                 ; packages
                 ; sandbox
-                ; bin_env
+                ; env
                 ; timeout
                 ; conflict_markers
                 ; setup_scripts

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -20,15 +20,9 @@ let make_alias expander s =
   Expander.expand_path expander s >>| Alias.of_user_written_path ~loc
 ;;
 
-let package_install ~(context : Build_context.t) ~(pkg : Package.t) =
-  let dir =
-    let dir = Package.dir pkg in
-    Path.Build.append_source context.build_dir dir
-  in
-  let name = Package.name pkg in
-  sprintf ".%s-files" (Package.Name.to_string name)
-  |> Alias.Name.of_string
-  |> Alias.make ~dir
+let expand_package_name expander swv =
+  let loc = String_with_vars.loc swv in
+  Expander.expand_str expander swv >>| fun s -> Package.Name.parse_string_exn (loc, s)
 ;;
 
 type dep_evaluation_result =
@@ -45,7 +39,7 @@ let to_action_builder = function
   | Include_result pair -> Action_builder.map pair ~f:fst
 ;;
 
-let include_bin_env = function
+let include_action_env = function
   | Simple _ | Other _ -> None
   | Include_result pair -> Some (Action_builder.map pair ~f:snd)
 ;;
@@ -152,8 +146,13 @@ let make_bin_env expander bin_names =
        let+ () = Action_builder.paths files in
        (* The layout dir on PATH is an absolute build-tree path; dune's
           sandbox does not relocate PATH. See [bin-pform/sandbox.t]. *)
-       Env.update Env.empty ~var:Env_path.var ~f:(fun _PATH ->
-         Some (Bin.cons_path (Path.build layout_dir) ~_PATH)))
+       Install.Roots.cons_path Env.empty ~var:Env_path.var layout_dir)
+;;
+
+let package_dep_swvs (dep : Dep_conf.t) =
+  match dep with
+  | Package p -> [ p, String_with_vars.loc p ]
+  | _ -> []
 ;;
 
 let add_sandbox_config acc (dep : Dep_conf.t) =
@@ -181,15 +180,19 @@ let rec dir_contents ~loc d =
     >>| List.concat
 ;;
 
-let package loc pkg (context : Build_context.t) ~dune_version =
-  let pkg = Package.Name.of_string pkg in
+let package loc pkg_name (context : Build_context.t) ~dune_version =
   Action_builder.of_memo
     (let open Memo.O in
      let* package_db = Package_db.create context.name in
-     Package_db.find_package package_db pkg)
+     Package_db.find_package package_db pkg_name)
   >>= function
   | Some (Build build) -> build
-  | Some (Local pkg) -> Alias_builder.alias (package_install ~context ~pkg)
+  | Some (Local _) ->
+    (* The named/unnamed paths skip [Package _] before reaching here so that
+       [combined_package_deps_builder] handles the whole package set at once.
+       This arm only fires from [unnamed_get_paths] (e.g.
+       [(public_headers (package foo))]) where a no-op is fine. *)
+    Action_builder.return ()
   | Some (Installed pkg) ->
     if dune_version < (2, 9)
     then
@@ -224,7 +227,7 @@ let package loc pkg (context : Build_context.t) ~dune_version =
           (fun () ->
             User_error.raise
               ~loc
-              [ Pp.textf "Package %s does not exist" (Package.Name.to_string pkg) ])
+              [ Pp.textf "Package %s does not exist" (Package.Name.to_string pkg_name) ])
       }
 ;;
 
@@ -238,9 +241,9 @@ let rec dep expander : Dep_conf.t -> _ = function
         let* project = Action_builder.of_memo @@ Dune_load.find_project ~dir in
         expand_include ~dir ~project s
       in
-      let builder, _bindings, bin_env = named_paths_builder ~expander deps in
+      let builder, _bindings, action_env = named_paths_builder ~expander deps in
       let+ paths = builder
-      and+ env = bin_env in
+      and+ env = action_env in
       paths, env
     in
     Include_result (Action_builder.memoize "include-eval" pair)
@@ -294,7 +297,7 @@ let rec dep expander : Dep_conf.t -> _ = function
   | Package p ->
     Other
       (let+ () =
-         let* pkg = Expander.expand_str expander p in
+         let* pkg_name = expand_package_name expander p in
          let context = Build_context.create ~name:(Expander.context expander) in
          let loc = String_with_vars.loc p in
          let* dune_version =
@@ -304,7 +307,7 @@ let rec dep expander : Dep_conf.t -> _ = function
            Dune_load.find_project ~dir:(Expander.dir expander)
            >>| Dune_project.dune_version
          in
-         package loc pkg context ~dune_version
+         package loc pkg_name context ~dune_version
        in
        [])
   | Universe ->
@@ -318,13 +321,68 @@ let rec dep expander : Dep_conf.t -> _ = function
        [])
   | Sandbox_config _ -> Other (Action_builder.return [])
 
+and combined_package_deps_builder expander pkgs =
+  let open Action_builder.O in
+  (* Resolve packages and name the layout dir in the host context, same as
+     [make_bin_env] above. *)
+  let* host_name =
+    Action_builder.of_memo
+      (let open Memo.O in
+       Expander.host_context expander >>| Context.name)
+  in
+  let context = Build_context.create ~name:host_name in
+  let* package_db = Action_builder.of_memo (Package_db.create context.name) in
+  let* classified =
+    Action_builder.List.map pkgs ~f:(fun (swv, loc) ->
+      let* pkg = expand_package_name expander swv in
+      let+ found = Action_builder.of_memo (Package_db.find_package package_db pkg) in
+      loc, pkg, found)
+  in
+  let local_package_names =
+    List.filter_map classified ~f:(fun (_, _, found) ->
+      match found with
+      | Some (Package_db.Local pkg) -> Some (Package.name pkg)
+      | _ -> None)
+    |> Package.Name.Set.of_list
+  in
+  let* env =
+    if Package.Name.Set.is_empty local_package_names
+    then Action_builder.return Env.empty
+    else Install_layout.env context.name local_package_names
+  in
+  let+ () =
+    Action_builder.List.iter classified ~f:(fun (loc, pkg_name, found) ->
+      match found with
+      | Some (Local _) -> Action_builder.return ()
+      | Some (Build build) -> build
+      | Some (Installed _) | None ->
+        let* dune_version =
+          Action_builder.of_memo
+            (let open Memo.O in
+             Dune_load.find_project ~dir:(Expander.dir expander)
+             >>| Dune_project.dune_version)
+        in
+        package loc pkg_name context ~dune_version)
+  in
+  env
+
 and named_paths_builder ~expander l =
-  let builders, bindings, bin_names, include_envs =
+  let builders, bindings, combined_packages_builder, bin_names, include_envs =
     let expander = prepare_expander expander in
+    let package_swvs =
+      List.concat_map l ~f:(function
+        | Bindings.Unnamed dep -> package_dep_swvs dep
+        | Bindings.Named (_, deps) -> List.concat_map deps ~f:package_dep_swvs)
+    in
     let bin_names =
       List.concat_map l ~f:(function
         | Bindings.Unnamed dep -> Option.to_list (bin_dep_name dep)
         | Bindings.Named (_, deps) -> List.filter_map deps ~f:bin_dep_name)
+    in
+    let combined_packages_builder =
+      match package_swvs with
+      | [] -> None
+      | pkgs -> Some (combined_package_deps_builder expander pkgs)
     in
     let builders, bindings, include_envs =
       List.fold_left
@@ -332,10 +390,12 @@ and named_paths_builder ~expander l =
         ~init:([], Pform.Map.empty, [])
         ~f:(fun (builders, bindings, envs) x ->
           match x with
+          | Bindings.Unnamed (Dep_conf.Package _)
+            when Option.is_some combined_packages_builder -> builders, bindings, envs
           | Bindings.Unnamed x ->
             let r = dep expander x in
             let envs =
-              match include_bin_env r with
+              match include_action_env r with
               | Some e -> e :: envs
               | None -> envs
             in
@@ -358,7 +418,7 @@ and named_paths_builder ~expander l =
             in
             let envs =
               List.fold_left x ~init:envs ~f:(fun envs r ->
-                match include_bin_env r with
+                match include_action_env r with
                 | Some e -> e :: envs
                 | None -> envs)
             in
@@ -399,22 +459,36 @@ and named_paths_builder ~expander l =
                in
                x :: builders, bindings, envs))
     in
-    builders, bindings, bin_names, include_envs
+    builders, bindings, combined_packages_builder, bin_names, include_envs
   in
-  let bin_env =
-    let outer = make_bin_env expander bin_names in
+  let builders, package_env =
+    match combined_packages_builder with
+    | None -> builders, Action_builder.return Env.empty
+    | Some b ->
+      let open Action_builder.O in
+      let b = Action_builder.memoize "combined-package-deps" b in
+      (b >>| fun _ -> []) :: builders, b
+  in
+  let bin_env = make_bin_env expander bin_names in
+  let action_env =
+    let outer =
+      let open Action_builder.O in
+      let+ package_env = package_env
+      and+ bin_env = bin_env in
+      Env_path.extend_env_concat_path package_env bin_env
+    in
     List.fold_left include_envs ~init:outer ~f:(fun acc env ->
       let open Action_builder.O in
       let+ acc = acc
       and+ env = env in
-      Env_path.extend_env_concat_path acc env)
+      Install.Roots.extend_env_concat_path_vars acc env)
   in
   let builder = List.rev builders |> Action_builder.all >>| List.concat in
-  builder, bindings, bin_env
+  builder, bindings, action_env
 ;;
 
 let named sandbox ~expander l =
-  let builder, bindings, bin_env = named_paths_builder ~expander l in
+  let builder, bindings, action_env = named_paths_builder ~expander l in
   let builder =
     Action_builder.memoize
       ~cutoff:(List.equal Value.equal)
@@ -448,7 +522,7 @@ let named sandbox ~expander l =
     Action_builder.memoize
       "deps action_env"
       (let+ _paths = builder
-       and+ env = bin_env in
+       and+ env = action_env in
        env)
   in
   action_env, expander, sandbox
@@ -456,16 +530,19 @@ let named sandbox ~expander l =
 
 let unnamed sandbox ~expander l =
   let expander = prepare_expander expander in
+  let package_swvs = List.concat_map l ~f:package_dep_swvs in
+  let package_env =
+    match package_swvs with
+    | [] -> Action_builder.return Env.empty
+    | pkgs -> combined_package_deps_builder expander pkgs
+  in
+  let has_combined = not (List.is_empty package_swvs) in
   let bin_names = List.filter_map l ~f:bin_dep_name in
-  let builders, include_envs =
-    List.fold_left l ~init:([], []) ~f:(fun (builders, envs) x ->
-      let r = dep expander x in
-      let envs =
-        match include_bin_env r with
-        | Some e -> e :: envs
-        | None -> envs
-      in
-      to_action_builder r :: builders, envs)
+  let include_envs =
+    List.fold_left l ~init:[] ~f:(fun envs x ->
+      match include_action_env (dep expander x) with
+      | Some e -> e :: envs
+      | None -> envs)
   in
   let bin_env =
     let outer = make_bin_env expander bin_names in
@@ -473,18 +550,22 @@ let unnamed sandbox ~expander l =
       let open Action_builder.O in
       let+ acc = acc
       and+ env = env in
-      Env_path.extend_env_concat_path acc env)
+      Install.Roots.extend_env_concat_path_vars acc env)
   in
   let action_env =
     Action_builder.memoize
       "deps action_env"
       (let+ () =
-         List.fold_left builders ~init:(Action_builder.return ()) ~f:(fun acc b ->
-           let+ () = acc
-           and+ _x = b in
-           ())
-       and+ env = bin_env in
-       env)
+         List.fold_left l ~init:(Action_builder.return ()) ~f:(fun acc x ->
+           match x with
+           | Dep_conf.Package _ when has_combined -> acc
+           | _ ->
+             let+ () = acc
+             and+ _x = to_action_builder (dep expander x) in
+             ())
+       and+ package_env = package_env
+       and+ bin_env = bin_env in
+       Env_path.extend_env_concat_path package_env bin_env)
   in
   action_env, List.fold_left l ~init:sandbox ~f:add_sandbox_config
 ;;

--- a/src/dune_rules/dep_conf_eval.mli
+++ b/src/dune_rules/dep_conf_eval.mli
@@ -2,9 +2,6 @@
 
 open Import
 
-(** Alias for all the files in [_build/install] that belong to this package *)
-val package_install : context:Build_context.t -> pkg:Package.t -> Alias.t
-
 (** Evaluates unnamed dependency specifications. The returned builder both
     registers the rule's dependencies (as a side effect of evaluation) and
     produces an [Env.t] augmentation that callers should fold into the action

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -814,7 +814,9 @@ let gen_rules ctx ~dir components =
       in
       Gen_rules.make ~build_dir_only_sub_dirs (Memo.return Rules.empty)
     | ctx :: ".binaries" :: rest ->
-      Bin_layout.gen_rules (Context_name.of_string ctx) ~dir rest
+      Bin_layout.gen_rules (Context_name.of_string ctx) ~dir rest |> Memo.return
+    | ctx :: ".packages" :: rest ->
+      Install_layout.gen_rules (Context_name.of_string ctx) ~dir rest
     | ctx :: _ ->
       let ctx = Context_name.of_string ctx in
       with_context ctx ~f:(fun sctx ->

--- a/src/dune_rules/install_layout.ml
+++ b/src/dune_rules/install_layout.ml
@@ -1,0 +1,210 @@
+open Import
+
+module Key : sig
+  val encode : Package.Name.Set.t -> string
+  val decode : string -> Package.Name.Set.t option
+end = struct
+  let reverse_table : (Digest.t, Package.Name.Set.t) Table.t =
+    Table.create (module Digest) 128
+  ;;
+
+  let encode packages =
+    let sorted = Package.Name.Set.to_list packages in
+    let y = Digest.repr Repr.(list Package.Name.repr) sorted in
+    (match Table.find reverse_table y with
+     | None -> Table.set reverse_table y packages
+     | Some packages' ->
+       if not (Package.Name.Set.equal packages packages')
+       then
+         Code_error.raise
+           "Hash collision between sets of packages"
+           [ "cached", Package.Name.Set.to_dyn packages'
+           ; "new", Package.Name.Set.to_dyn packages
+           ]);
+    Digest.to_string y
+  ;;
+
+  let decode s =
+    match Digest.from_hex s with
+    | None -> None
+    | Some digest -> Table.find reverse_table digest
+  ;;
+end
+
+let entry_resolver_fdecl
+  : (Context_name.t -> Package.Name.t -> Install.Entry.Sourced.Unexpanded.t list Memo.t)
+      Fdecl.t
+  =
+  Fdecl.create Dyn.opaque
+;;
+
+let set_entry_resolver f = Fdecl.set entry_resolver_fdecl f
+
+let dir ~context ~key =
+  Path.Build.L.relative (Install.Context.dir ~context) [ ".packages"; key ]
+;;
+
+(* Resolve the package set's install entries against the layout root: filter
+   out [Source_tree] entries, expand the rest, and key each entry by its
+   materialised path under the layout. Collisions (two packages installing
+   to the same destination, which can only happen in _root sections) are
+   reported as user errors naming the conflicting packages and entry. *)
+let compute_entries context_name root packages =
+  let open Memo.O in
+  let get_entries = Fdecl.get entry_resolver_fdecl in
+  Package.Name.Set.to_list packages
+  |> Memo.parallel_map ~f:(fun pkg ->
+    let install_paths =
+      let roots = Install.Roots.opam_from_prefix Path.root ~relative:Path.relative in
+      Install.Paths.make ~relative:Path.relative ~package:pkg ~roots
+    in
+    let+ entries = get_entries context_name pkg in
+    List.filter_map entries ~f:(fun (s : Install.Entry.Sourced.Unexpanded.t) ->
+      let entry = s.entry in
+      match entry.kind with
+      | Install.Entry.Unexpanded.Source_tree -> None
+      | File | Directory ->
+        let relative =
+          Install.Entry.relative_installed_path entry ~paths:install_paths
+          |> Path.as_in_source_tree_exn
+        in
+        let dst = Path.Build.append_source root relative in
+        let expanded =
+          Install.Entry.Expanded.set_src
+            (Install.Entry.Unexpanded.expand entry)
+            (Path.build entry.src)
+        in
+        Some (dst, (pkg, expanded))))
+  >>| List.concat
+  >>| Path.Build.Map.of_list
+  >>| function
+  | Ok m -> Path.Build.Map.map m ~f:snd
+  | Error (_, (pkg_a, entry_a), (pkg_b, _)) ->
+    User_error.raise
+      ~hints:[ Pp.text "Rename one of the install entries." ]
+      [ Pp.textf
+          "%S and %S both install %S to section %s."
+          (Package.Name.to_string pkg_a)
+          (Package.Name.to_string pkg_b)
+          (Install.Entry.Dst.to_string entry_a.dst)
+          (Section.to_string entry_a.section)
+      ; Pp.text
+          "The lib_root, share_root, and libexec_root sections install directly to the \
+           section root with no per-package subdirectory, so file names must be unique \
+           across the set of packages a rule depends on."
+      ]
+;;
+
+let entries =
+  let set_hash s = List.hash Package.Name.hash (Package.Name.Set.to_list s) in
+  let memo =
+    Memo.create
+      "install-layout-entries"
+      ~input:
+        (module struct
+          type t = Context_name.t * Package.Name.Set.t
+
+          let equal = Tuple.T2.equal Context_name.equal Package.Name.Set.equal
+          let hash = Tuple.T2.hash Context_name.hash set_hash
+          let to_dyn = Tuple.T2.to_dyn Context_name.to_dyn Package.Name.Set.to_dyn
+        end)
+      (fun (context, packages) ->
+         let key = Key.encode packages in
+         let root = dir ~context ~key in
+         compute_entries context root packages)
+  in
+  fun context packages -> Memo.exec memo (context, packages)
+;;
+
+let files context_name packages =
+  let open Memo.O in
+  let+ entries = entries context_name packages in
+  Path.Build.Map.keys entries |> List.map ~f:Path.build
+;;
+
+let deps context_name packages =
+  let open Action_builder.O in
+  let* files = Action_builder.of_memo (files context_name packages) in
+  Action_builder.paths files
+;;
+
+let root context_name packages = dir ~context:context_name ~key:(Key.encode packages)
+
+let env context_name packages =
+  let open Action_builder.O in
+  let+ () = deps context_name packages in
+  let layout_root = root context_name packages in
+  let roots = Install.Roots.opam_from_prefix layout_root ~relative:Path.Build.relative in
+  Install.Roots.add_to_env roots Env.empty
+;;
+
+let make_dispatch ~dir ~directory_targets subdirs f =
+  let rules = Rules.collect_unit f in
+  Build_config.Gen_rules.make
+    ~build_dir_only_sub_dirs:
+      (Build_config.Gen_rules.Build_only_sub_dirs.singleton ~dir subdirs)
+    ~directory_targets
+    rules
+;;
+
+let gen_rules context_name ~dir rest =
+  let open Memo.O in
+  match rest with
+  | [] ->
+    Memo.return
+    @@ make_dispatch
+         ~dir
+         ~directory_targets:Path.Build.Map.empty
+         Subdir_set.all
+         (fun () -> Memo.return ())
+  | [ key ] ->
+    (match Key.decode key with
+     | None -> Memo.return Build_config.Gen_rules.no_rules
+     | Some packages ->
+       let+ entries = entries context_name packages in
+       let directory_targets =
+         Path.Build.Map.filter_map entries ~f:(fun entry ->
+           match (entry.kind : Install.Entry.Expanded.kind) with
+           | File -> None
+           | Directory -> Some Loc.none)
+       in
+       make_dispatch ~dir ~directory_targets Subdir_set.empty (fun () ->
+         Path.Build.Map.to_seq entries
+         |> Memo.parallel_iter_seq ~f:(fun (dst, { Install.Entry.kind; src; _ }) ->
+           let { Action_builder.With_targets.build; targets } =
+             match (kind : Install.Entry.Expanded.kind) with
+             | File -> Action_builder.symlink ~src ~dst
+             | Directory -> Action_builder.symlink_dir ~src ~dst
+           in
+           Rules.Produce.rule (Rule.make ~info:(Rule.Info.of_loc_opt None) ~targets build))))
+  | _ :: _ :: _ ->
+    Memo.return
+    @@ Build_config.Gen_rules.redirect_to_parent Build_config.Gen_rules.Rules.empty
+;;
+
+module For_rocq_only = struct
+  (* Rocq puts the layout's [lib] dir on [OCAMLPATH], where findlib walks
+     eagerly. For a race-free, deterministic walk, every entry findlib could
+     see must be a declared dep. Bulk {!env} doesn't work: it also pulls in
+     {!Section.Lib_root} entries, which include Rocq theory [.vo] files under
+     [lib/coq/user-contrib/...]; in the same-package theory-plus-plugin case,
+     that creates a build cycle (the theory rule depending on its own output
+     via the layout symlink). Filtering to {!Section.Lib} excludes Lib_root
+     content (theory output) while keeping METAs, .cmxs, .cmi etc. — all
+     upstream of theory compilation. *)
+  let lib_root context_name packages =
+    let open Action_builder.O in
+    let* lib_paths =
+      Action_builder.of_memo (entries context_name packages)
+      >>| Path.Build.Map.foldi
+            ~init:[]
+            ~f:(fun dst (entry : Path.t Install.Entry.Expanded.t) acc ->
+              match (entry.section : Section.t) with
+              | Lib -> Path.build dst :: acc
+              | _ -> acc)
+    in
+    let+ () = Action_builder.paths lib_paths in
+    let layout_root = root context_name packages in
+    (Install.Roots.opam_from_prefix layout_root ~relative:Path.Build.relative).lib_root
+  ;;
+end

--- a/src/dune_rules/install_layout.mli
+++ b/src/dune_rules/install_layout.mli
@@ -1,0 +1,35 @@
+open Import
+
+val set_entry_resolver
+  :  (Context_name.t -> Package.Name.t -> Install.Entry.Sourced.Unexpanded.t list Memo.t)
+  -> unit
+
+(** Env extension for an action depending on a package set. Returns an env
+    with PATH, OCAMLPATH, etc. prepended for the layout root, and registers
+    the action's dependency on every install entry the layout produces for
+    the set. *)
+val env : Context_name.t -> Package.Name.Set.t -> Env.t Action_builder.t
+
+(** Engine dispatch for [_build/install/<context>/.packages/<rest>]. Called
+    from [Gen_rules]; the layout dir is owned by this module. Resolves to:
+    - no rules for the [.packages/] root itself ([rest = []]),
+    - the symlink rules for one package set when [rest = [ key ]],
+      or no rules if [key] is not a known digest,
+    - redirect-to-parent for any deeper path. *)
+val gen_rules
+  :  Context_name.t
+  -> dir:Path.Build.t
+  -> string list
+  -> Build_config.Gen_rules.result Memo.t
+
+module For_rocq_only : sig
+  (** Do not use! Escape hatch reserved for the Rocq rule generator. See the
+      implementation for details. *)
+
+  (** DO NOT USE!!
+
+      Returns the layout's [lib] root (suitable for prepending to
+      [OCAMLPATH]) and registers the action's dependency on every
+      {!Section.Lib} entry the layout produces for the set. *)
+  val lib_root : Context_name.t -> Package.Name.Set.t -> Path.Build.t Action_builder.t
+end

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -9,6 +9,15 @@ let install_file ~(package : Package.Name.t) ~findlib_toolchain =
   |> Filename.of_string_exn
 ;;
 
+(** Alias for all the files in [_build/install] that belong to a package. *)
+let package_install ~(context : Build_context.t) ~(pkg : Package.t) =
+  let dir = Path.Build.append_source context.build_dir (Package.dir pkg) in
+  let name = Package.name pkg in
+  sprintf ".%s-files" (Package.Name.to_string name)
+  |> Alias.Name.of_string
+  |> Alias.make ~dir
+;;
+
 let with_doc = Package_variable_name.with_doc
 
 let need_odoc_config (pkg : Package.t) =
@@ -1179,6 +1188,13 @@ let install_entries sctx package =
   Package.Name.Map.Multi.find packages package
 ;;
 
+let () =
+  Install_layout.set_entry_resolver (fun context_name package ->
+    let open Memo.O in
+    let* sctx = Super_context.find_exn context_name in
+    install_entries sctx package)
+;;
+
 let packages =
   let f sctx =
     let* packages = Dune_load.packages () in
@@ -1398,9 +1414,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
   in
   let* () =
     let* all_packages = Dune_load.packages () in
-    let target_alias =
-      Dep_conf_eval.package_install ~context:build_context ~pkg:package
-    in
+    let target_alias = package_install ~context:build_context ~pkg:package in
     let open Action_builder.O in
     Rules.Produce.Alias.add_deps
       target_alias
@@ -1414,7 +1428,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
                 let name = Package.Id.name pkg in
                 Package.Name.Map.find_exn all_packages name
               in
-              Dep_conf_eval.package_install ~context:build_context ~pkg |> Dep.alias) )))
+              package_install ~context:build_context ~pkg |> Dep.alias) )))
   in
   let action =
     let findlib_toolchain = Context.findlib_toolchain context in

--- a/src/dune_rules/rocq/rocq_rules.ml
+++ b/src/dune_rules/rocq/rocq_rules.ml
@@ -18,7 +18,6 @@ open Memo.O
    elsewhere; don't mix with the rest of the code. *)
 module Util : sig
   val include_flags : Lib.t list -> _ Command.Args.t
-  val meta_info : loc:Loc.t option -> context:Context_name.t -> Lib.t -> Path.t option
 
   (** Given a list of library names, we try to resolve them in order, returning
       the first one that exists. *)
@@ -31,22 +30,6 @@ end = struct
   ;;
 
   let include_flags ts = include_paths ts |> Lib_flags.L.to_iflags
-
-  let meta_info ~loc ~context (lib : Lib.t) =
-    let name = Lib.name lib |> Lib_name.to_string in
-    match Lib_info.status (Lib.info lib) with
-    | Public (_, pkg) ->
-      let package = Package.name pkg in
-      let meta_i =
-        Path.Build.relative (Install.Context.lib_dir ~context ~package) "META"
-      in
-      Some (Path.build meta_i)
-    | Installed -> None
-    | Installed_private | Private _ ->
-      User_error.raise
-        ?loc
-        [ Pp.textf "Using private library %s as a Rocq plugin is not supported" name ]
-  ;;
 
   (* CR alizter: move this to Lib.DB *)
 
@@ -419,18 +402,7 @@ let libs_of_theory ~lib_db ~theories_deps plugins : (Lib.t list * _) Resolve.Mem
   findlib_libs, legacy_theories
 ;;
 
-(* compute include flags and mlpack rules *)
-let ml_pack_and_meta_rule ~context ~all_libs (buildable : Rocq_stanza.Buildable.t)
-  : unit Action_builder.t
-  =
-  (* rocqdep expects an mlpack file next to the sources otherwise it will
-     omit the cmxs deps *)
-  let plugin_loc = List.hd_opt buildable.plugins |> Option.map ~f:fst in
-  let meta_info = Util.meta_info ~loc:plugin_loc ~context in
-  Action_builder.paths (List.filter_map ~f:meta_info all_libs)
-;;
-
-let ml_flags_and_ml_pack_rule
+let ml_flags_and_plugin_ocamlpath
       ~context
       ~lib_db
       ~theories_deps
@@ -441,16 +413,29 @@ let ml_flags_and_ml_pack_rule
     let+ all_libs, _legacy_theories =
       libs_of_theory ~lib_db ~theories_deps buildable.plugins
     in
+    let plugin_loc = List.hd_opt buildable.plugins |> Option.map ~f:fst in
+    List.iter all_libs ~f:(fun lib ->
+      match Lib_info.status (Lib.info lib) with
+      | Public _ | Installed -> ()
+      | Installed_private | Private _ ->
+        let name = Lib.name lib |> Lib_name.to_string in
+        User_error.raise
+          ?loc:plugin_loc
+          [ Pp.textf "Using private library %s as a Rocq plugin is not supported" name ]);
     let findlib_plugin_flags = Util.include_flags all_libs in
     let ml_flags = Command.Args.S [ findlib_plugin_flags ] in
-    ml_flags, ml_pack_and_meta_rule ~context ~all_libs buildable
+    let plugin_packages =
+      List.filter_map all_libs ~f:(fun lib -> Lib.info lib |> Lib_info.package)
+      |> Package.Name.Set.of_list
+    in
+    ml_flags, plugin_packages
   in
-  let mlpack_rule =
+  let plugin_ocamlpath =
     let open Action_builder.O in
-    let* _, mlpack_rule = Resolve.Memo.read res in
-    mlpack_rule
+    let* _, plugin_packages = Resolve.Memo.read res in
+    Install_layout.For_rocq_only.lib_root context plugin_packages
   in
-  Resolve.Memo.map ~f:fst res, mlpack_rule
+  Resolve.Memo.map ~f:fst res, plugin_ocamlpath
 ;;
 
 let dep_theory_file ~dir ~wrapper_name =
@@ -582,6 +567,17 @@ let setup_rocqproject_for_theory_rule
     (Action_builder.write_file_dyn rocqproject contents.build)
 ;;
 
+(* Cons the plugin layout's lib root onto whatever OCAMLPATH [action.env]
+   already carries (e.g. layout entries from [(deps (package ...))]) rather
+   than overwriting it. *)
+let add_plugin_ocamlpath ~lib_root (action : Action.Full.t) =
+  let { Action.Full.env = action_env; _ } = action in
+  let env =
+    Install.Roots.cons_path action_env ~var:Findlib_config.ocamlpath_var lib_root
+  in
+  Action.Full.add_env env action
+;;
+
 let setup_rocqdep_for_theory_rule
       ~sctx
       ~dir
@@ -590,9 +586,9 @@ let setup_rocqdep_for_theory_rule
       ~wrapper_name
       ~source_rule
       ~ml_flags
-      ~mlpack_rule
       ~boot_flags
       ~stanza_rocqdep_flags
+      ~plugin_ocamlpath
       rocq_modules
   =
   (* rocqdep needs the full source + plugin's mlpack to be present :( *)
@@ -623,9 +619,13 @@ let setup_rocqdep_for_theory_rule
     sctx
     ~dir
     (let open Action_builder.With_targets.O in
-     Action_builder.with_no_targets mlpack_rule
-     >>> Action_builder.(with_no_targets (goal source_rule))
-     >>> Command.run ~dir:(Path.build dir) ~stdout_to rocq rocqdep_flags)
+     Action_builder.(with_no_targets (goal source_rule))
+     >>> Command.run ~dir:(Path.build dir) ~stdout_to rocq rocqdep_flags
+     |> Action_builder.With_targets.map_build ~f:(fun build ->
+       let open Action_builder.O in
+       let+ action = build
+       and+ lib_root = plugin_ocamlpath in
+       add_plugin_ocamlpath ~lib_root action))
 ;;
 
 module Dep_map = Stdune.Map.Make (Path)
@@ -843,6 +843,7 @@ let setup_rocqc_rule
       ~ml_flags
       ~theory_dirs
       ~rocq_sources
+      ~plugin_ocamlpath
       rocq_module
   =
   (* Process rocqdep and generate rules *)
@@ -900,7 +901,12 @@ let setup_rocqc_rule
               ?stdout_to:output_file
               ~sandbox:Sandbox_config.no_sandboxing
               rocq
-              (cflag :: targets :: args))
+              (cflag :: targets :: args)
+     |> Action_builder.With_targets.map_build ~f:(fun build ->
+       let open Action_builder.O in
+       let+ action = build
+       and+ lib_root = plugin_ocamlpath in
+       add_plugin_ocamlpath ~lib_root action))
 ;;
 
 let rocq_modules_of_theory ~sctx lib =
@@ -1054,11 +1060,11 @@ let theory_context ~context ~scope ~name buildable =
       Resolve.Memo.lift @@ Rocq_lib.theories_closure theory)
   in
   (* ML-level flags for depending libraries *)
-  let ml_flags, mlpack_rule =
+  let ml_flags, plugin_ocamlpath =
     let lib_db = Scope.libs scope in
-    ml_flags_and_ml_pack_rule ~context ~theories_deps ~lib_db buildable
+    ml_flags_and_plugin_ocamlpath ~context ~theories_deps ~lib_db buildable
   in
-  theory, theories_deps, ml_flags, mlpack_rule
+  theory, theories_deps, ml_flags, plugin_ocamlpath
 ;;
 
 (* Common context for extraction, almost the same than above *)
@@ -1083,18 +1089,18 @@ let extraction_context ~context ~scope (buildable : Rocq_stanza.Buildable.t) =
     | None -> theories_deps
     | Some (_, boot) -> boot :: theories_deps
   in
-  let ml_flags, mlpack_rule =
+  let ml_flags, plugin_ocamlpath =
     let lib_db = Scope.libs scope in
-    ml_flags_and_ml_pack_rule ~context ~theories_deps ~lib_db buildable
+    ml_flags_and_plugin_ocamlpath ~context ~theories_deps ~lib_db buildable
   in
-  theories_deps, ml_flags, mlpack_rule
+  theories_deps, ml_flags, plugin_ocamlpath
 ;;
 
 let setup_theory_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Theory.t) =
   let* scope = Scope.DB.find_by_dir dir in
   let name = s.name in
   let rocq_lang_version = s.buildable.rocq_lang_version in
-  let theory, theories_deps, ml_flags, mlpack_rule =
+  let theory, theories_deps, ml_flags, plugin_ocamlpath =
     let context = Super_context.context sctx |> Context.name in
     theory_context ~context ~scope ~name s.buildable
   in
@@ -1155,9 +1161,9 @@ let setup_theory_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Theory.t) =
         ~wrapper_name
         ~source_rule
         ~ml_flags
-        ~mlpack_rule
         ~boot_flags
         ~stanza_rocqdep_flags:s.rocqdep_flags
+        ~plugin_ocamlpath
         rocq_modules
   >>> Memo.parallel_iter rocq_modules ~f:(fun rocq_module ->
     setup_rocqc_rule
@@ -1177,6 +1183,7 @@ let setup_theory_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Theory.t) =
       ~ml_flags
       ~theory_dirs
       ~rocq_sources:rocq_dir_contents
+      ~plugin_ocamlpath
       rocq_module
     >>> setup_output_diff_rule
           ~loc
@@ -1192,7 +1199,7 @@ let setup_theory_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Theory.t) =
 let rocqtop_args_theory ~sctx ~dir ~dir_contents (s : Rocq_stanza.Theory.t) rocq_module =
   let* scope = Scope.DB.find_by_dir dir in
   let name = s.name in
-  let _theory, theories_deps, ml_flags, _mlpack_rule =
+  let _theory, theories_deps, ml_flags, _plugin_ocamlpath =
     let context = Super_context.context sctx |> Context.name in
     theory_context ~context ~scope ~name s.buildable
   in
@@ -1311,7 +1318,7 @@ let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.
   let use_corelib = s.buildable.use_corelib in
   let rocq_lang_version = s.buildable.rocq_lang_version in
   let* scope = Scope.DB.find_by_dir dir in
-  let theories_deps, ml_flags, mlpack_rule =
+  let theories_deps, ml_flags, plugin_ocamlpath =
     let context = Super_context.context sctx |> Context.name in
     extraction_context ~context ~scope s.buildable
   in
@@ -1340,9 +1347,9 @@ let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.
     ~wrapper_name
     ~source_rule
     ~ml_flags
-    ~mlpack_rule
     ~boot_flags
     ~stanza_rocqdep_flags:Ordered_set_lang.Unexpanded.standard
+    ~plugin_ocamlpath
     [ rocq_module ]
   >>> setup_rocqc_rule
         ~scope
@@ -1353,6 +1360,7 @@ let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.
         ~sctx
         ~loc
         ~rocqc_dir:dir
+        ~plugin_ocamlpath
         rocq_module
         ~dir
         ~theories_deps
@@ -1368,7 +1376,7 @@ let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Rocq_stanza.Extraction.
 let rocqtop_args_extraction ~sctx ~dir (s : Rocq_stanza.Extraction.t) rocq_module =
   let use_corelib = s.buildable.use_corelib in
   let* scope = Scope.DB.find_by_dir dir in
-  let theories_deps, ml_flags, _mlpack_rule =
+  let theories_deps, ml_flags, _plugin_ocamlpath =
     let context = Super_context.context sctx |> Context.name in
     extraction_context ~context ~scope s.buildable
   in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -150,10 +150,10 @@ let extend_action t ~dir action =
       (let open Memo.O in
        t.get_node dir >>= Env_node.external_env)
   in
-  (* [action.env] is expected to contain only PATH-prepend hints from
-     [Dep_conf_eval.make_bin_env]. Splice its PATH entries in front of the
-     external env's PATH, keep other vars as-is. *)
-  let env = Env_path.extend_env_concat_path env action.env in
+  (* Cons path-like vars from action.env (bin-layout PATH, package-layout
+     OCAMLPATH/etc.) onto the directory env so that both layout and system
+     entries remain visible. Other vars from action.env overwrite dir env. *)
+  let env = Install.Roots.extend_env_concat_path_vars env action.env in
   Action.Full.add_env env action
   |> Action.Full.map ~f:(function
     | Chdir _ as a -> a
@@ -236,40 +236,16 @@ let make_default_env_node
             make ~inherit_from:None ~config_stanza:env_nodes.workspace |> Memo.return)))
 ;;
 
-let make_root_env (context : Context.t) ~(host : t option) : Env.t Memo.t =
-  let* env =
-    let roots =
-      let context = Context.name context in
-      Install.Context.dir ~context |> Install.Roots.make ~relative:Path.Build.relative
-    in
-    Context.installed_env context >>| Install.Roots.add_to_env roots
-  in
-  let+ host_context, _PATH =
-    let _PATH = Env.get env Env_path.var in
-    match host with
-    | None -> Memo.return (context, _PATH)
-    | Some host ->
-      let context = host.context in
-      let+ _PATH =
-        let+ env = Context.installed_env context in
-        Env.get env Env_path.var
-      in
-      context, _PATH
-  in
-  Env.add
-    env
-    ~var:Env_path.var
-    ~value:
-      (Install.Context.bin_dir ~context:(Context.name host_context)
-       |> Path.build
-       |> Bin.cons_path ~_PATH)
-;;
-
 let create ~(context : Context.t) ~(host : t option) ~packages ~stanzas =
   let context_name = Context.name context in
   let env =
     Memo.lazy_ (fun () ->
-      let* base = make_root_env context ~host in
+      let env_context =
+        match host with
+        | None -> context
+        | Some host -> host.context
+      in
+      let* base = Context.installed_env env_context in
       Site_env.add_packages_env context_name ~base stanzas packages)
     |> Memo.Lazy.force
   in

--- a/src/install/context.ml
+++ b/src/install/context.ml
@@ -22,7 +22,10 @@ let of_path path =
   | Build (Regular (With_context (name, src))) ->
     Some
       (if Context_name.equal name install_context.name
-       then Context_name.of_string (Path.Source.basename src |> Filename.to_string)
+       then (
+         match Path.Source.split_first_component src with
+         | Some (ctx, _) -> Context_name.of_string (Filename.to_string ctx)
+         | None -> name)
        else name)
   | Build (Anonymous_action (With_context (name, _))) -> Some name
   | _ -> None

--- a/src/install/dune
+++ b/src/install/dune
@@ -1,6 +1,25 @@
+; OxCaml's ppx_expect v0.18 rejects [let%test_module] in favour of
+; [module%test], but upstream ppx_expect has not released v0.18 yet.
+; Until it does we must support both: pass the compatibility flag on
+; OxCaml and nothing otherwise.
+
+(rule
+ (enabled_if %{ocaml-config:ox})
+ (action
+  (write-file ppx-extra-flags "-inline-test-allow-let-test-module")))
+
+(rule
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (write-file ppx-extra-flags "")))
+
 (library
  (name install)
  (synopsis "the handling of installation paths")
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect -- %{read-lines:ppx-extra-flags}))
  (libraries
   stdune
   dyn

--- a/src/install/roots.ml
+++ b/src/install/roots.ml
@@ -109,10 +109,147 @@ let sep var =
   else None
 ;;
 
+(* CR-someday Alizter: phantom [unit Roots.t] and dummy [relative] are
+   awkward. Cleaner to factor [to_env_without_path] and this list out of a
+   single canonical spec list. Not doing it now; leave for a future
+   cleanup. *)
+let path_vars =
+  Env.Var.Set.of_list
+    (Env_path.var
+     :: List.map ~f:fst (to_env_without_path (make_all ()) ~relative:(fun () _ -> ())))
+;;
+
 let add_to_env t env =
-  to_env_without_path t ~relative:Path.Build.relative
-  |> List.fold_left ~init:env ~f:(fun env (var, path) ->
-    Env.update env ~var ~f:(fun _PATH ->
-      let path_sep = sep var in
-      Some (Bin.cons_path ?path_sep (Path.build path) ~_PATH)))
+  let env =
+    to_env_without_path t ~relative:Path.Build.relative
+    |> List.fold_left ~init:env ~f:(fun env (var, path) ->
+      Env.update env ~var ~f:(fun _PATH ->
+        let path_sep = sep var in
+        Some (Bin.cons_path ?path_sep (Path.build path) ~_PATH)))
+  in
+  Env.update env ~var:Env_path.var ~f:(fun _PATH ->
+    Some (Bin.cons_path (Path.build t.bin) ~_PATH))
+;;
+
+let cons_path env ~var path =
+  Env.update env ~var ~f:(fun _PATH ->
+    Some (Bin.cons_path ?path_sep:(sep var) (Path.build path) ~_PATH))
+;;
+
+(* CR-soon Alizter: path-like env var manipulation is spread across at
+   least four ad-hoc implementations, each with different scope, env
+   representation, and semantics around the empty value:
+   - [Env_path] in [otherlibs/stdune/src/env_path.ml] hardcodes PATH and
+     the default separator: [cons], [cons_multi], [path],
+     [extend_env_concat_path]. Works on [Env.t] (string values).
+   - This module ([cons_path], [extend_env_concat_path_vars]) handles
+     every install-managed path var with per-var separators. Also on
+     [Env.t].
+   - [Pkg_rules.Value_list_env] reimplements the same shape on a
+     [Value.t list Env.Map.t], with [extend_concat_path] doing the same
+     PATH-only concat dance again.
+   - [Pkg_rules.Env_update] then layers opam's [:=]/[+=]/[=:]/[=+]
+     operators on top of that representation, with separate rules for
+     leading/trailing separators when the variable is initially empty
+     (a corner that the other three sidestep, see the CR-someday on the
+     [path var: empty value in a] expect test below for an example of
+     how surprising this gets).
+   The right resolution is probably a single small library that
+   parametrises over (env representation, set of recognised path vars,
+   per-var separator, empty-value policy) and to which all four call
+   sites delegate; the current "pick a world" situation is what made
+   [extend_env_concat_path_vars] necessary in the first place. *)
+let extend_env_concat_path_vars a b =
+  let a =
+    Env.Var.Set.fold path_vars ~init:a ~f:(fun var env ->
+      match Env.get b var with
+      | None -> env
+      | Some value ->
+        let path_sep = sep var in
+        let dirs = Bin.parse_path ?sep:path_sep value in
+        Env.update env ~var ~f:(fun init ->
+          List.fold_right dirs ~init ~f:(fun dir acc ->
+            Some (Bin.cons_path ?path_sep dir ~_PATH:acc))))
+  in
+  let b = Env.Var.Set.fold path_vars ~init:b ~f:(fun var env -> Env.remove env ~var) in
+  Env.extend_env a b
+;;
+
+let%test_module "extend_env_concat_path_vars" =
+  (module struct
+    let env_of_list bindings =
+      List.fold_left bindings ~init:Env.empty ~f:(fun env (var, value) ->
+        Env.add env ~var ~value)
+    ;;
+
+    let print_env env = Env.to_unix env |> List.iter ~f:print_endline
+    let go a b = print_env (extend_env_concat_path_vars (env_of_list a) (env_of_list b))
+
+    (* For every variable in [path_vars], demonstrate the same prepend
+       semantics. If a new var is added to [path_vars], this test pins
+       the expected behaviour. *)
+    let%expect_test "every path var: b is prepended to a" =
+      Env.Var.Set.iter path_vars ~f:(fun var ->
+        let a = Env.add Env.empty ~var ~value:"/from/a" in
+        let b = Env.add Env.empty ~var ~value:"/from/b" in
+        let result = extend_env_concat_path_vars a b in
+        Printf.printf "%s=%s\n" var (Option.value (Env.get result var) ~default:"(none)"));
+      [%expect
+        {|
+        CAML_LD_LIBRARY_PATH=/from/b:/from/a
+        MANPATH=/from/b:/from/a
+        OCAMLFIND_IGNORE_DUPS_IN=/from/b:/from/a
+        OCAMLPATH=/from/b:/from/a
+        OCAMLTOP_INCLUDE_PATH=/from/b:/from/a
+        PATH=/from/b:/from/a
+        |}]
+    ;;
+
+    let%expect_test "non-path var: b overrides a" =
+      go [ "FOO", "from_a" ] [ "FOO", "from_b" ];
+      [%expect {| FOO=from_b |}]
+    ;;
+
+    let%expect_test "path var: only a present, a preserved" =
+      go [ "PATH", "/a/bin" ] [];
+      [%expect {| PATH=/a/bin |}]
+    ;;
+
+    let%expect_test "path var: only b present, b passed through" =
+      go [] [ "PATH", "/b/bin" ];
+      [%expect {| PATH=/b/bin |}]
+    ;;
+
+    let%expect_test "path var: multi-dir b keeps its relative order when prepended" =
+      go [ "PATH", "/a/bin" ] [ "PATH", "/b1/bin:/b2/bin:/b3/bin" ];
+      [%expect {| PATH=/b1/bin:/b2/bin:/b3/bin:/a/bin |}]
+    ;;
+
+    let%expect_test "path var: duplicate dirs are not deduplicated" =
+      go [ "PATH", "/x" ] [ "PATH", "/x" ];
+      [%expect {| PATH=/x:/x |}]
+    ;;
+
+    let%expect_test "path var: empty value in b" =
+      go [ "PATH", "/a/bin" ] [ "PATH", "" ];
+      [%expect {| PATH=/a/bin |}]
+    ;;
+
+    (* CR-someday Alizter: the trailing [:] in [/b/bin:] comes from
+       [Bin.cons_path "/b/bin" ~_PATH:(Some "")], which treats only [None]
+       as "no PATH" and so produces a trailing separator when the existing
+       value is the empty string. POSIX reads the empty entry as the
+       current directory, so this silently adds [.] to the search path. The
+       fix belongs in [Bin.cons_path] (treat [Some ""] like [None]); we pin
+       the current behaviour here. *)
+    let%expect_test "path var: empty value in a" =
+      go [ "PATH", "" ] [ "PATH", "/b/bin" ];
+      [%expect {| PATH=/b/bin: |}]
+    ;;
+
+    let%expect_test "both inputs empty" =
+      go [] [];
+      [%expect {| |}]
+    ;;
+  end)
 ;;

--- a/src/install/roots.mli
+++ b/src/install/roots.mli
@@ -26,6 +26,35 @@ val map2 : f:('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 val first_has_priority : 'a option t -> 'a option t -> 'a option t
 
 val to_env_without_path : 'a t -> relative:('a -> string -> 'a) -> (Env.Var.t * 'a) list
+
+(** Cons every install root onto its corresponding env var: the [lib] dirs onto
+    [OCAMLPATH], [share] onto [OCAMLFIND_IGNORE_DUPS_IN], [bin] onto [PATH],
+    etc. The generic "make an opam-style install prefix discoverable via the
+    standard path env vars" primitive. Used both by [dune exec]'s staging cons
+    (see [bin/exec.ml]) and by the per-package-set scoped layout (see
+    [Install_layout.env]). *)
 val add_to_env : Path.Build.t t -> Env.t -> Env.t
+
+(** Returns the path separator for a given env var, if it's a known
+    path-like variable (e.g. OCAMLPATH uses [;] on all platforms). *)
+val sep : Env.Var.t -> char option
+
+(** Cons a build path onto a path-like env var, using the per-var separator
+    from {!sep}. *)
+val cons_path : Env.t -> var:Env.Var.t -> Path.Build.t -> Env.t
+
+(** The set of all path-like env vars managed by the install roots:
+    PATH, OCAMLPATH, CAML_LD_LIBRARY_PATH, OCAMLFIND_IGNORE_DUPS_IN,
+    OCAMLTOP_INCLUDE_PATH, and MANPATH. *)
+val path_vars : Env.Var.Set.t
+
+(** [extend_env_concat_path_vars a b] extends [a] with the bindings from [b],
+    with one twist: for every var in {!path_vars}, the value from [b] is
+    prepended (cons-style, respecting per-var separator from {!sep}) to the
+    value from [a] rather than overwriting it. Generalisation of
+    [Env_path.extend_env_concat_path] (which only handles {!Env_path.var}) to
+    every install-managed path var. *)
+val extend_env_concat_path_vars : Env.t -> Env.t -> Env.t
+
 val make : 'a -> relative:('a -> string -> 'a) -> 'a t
 val make_all : 'a -> 'a t

--- a/test/blackbox-tests/test-cases/bin-pform/env-binaries.t
+++ b/test/blackbox-tests/test-cases/bin-pform/env-binaries.t
@@ -32,9 +32,7 @@ The rule depends on the .bin/ symlink:
   >   | jq 'include "dune"; .[] | ruleDepFilePaths'
   "_build/default/.bin/myothername"
 
-The action's PATH gets the .bin/ symlink directory and the workspace
-install bin dir:
+The action's PATH gets the .bin/ symlink directory:
 
   $ env_added "$(cat _build/default/path-output)" "$PATH"
   $TESTCASE_ROOT/_build/default/.bin
-  $TESTCASE_ROOT/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/bin-pform/include-deps.t
+++ b/test/blackbox-tests/test-cases/bin-pform/include-deps.t
@@ -27,12 +27,10 @@ tracked dep of the rule.
 
   $ dune build path-output
 
-The action's PATH includes the .binaries dir and the install bin
-dir:
+The action's PATH includes the .binaries dir:
 
   $ env_added "$(cat _build/default/path-output)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin
 
 The rule depends on the build artifact and the .binaries symlink:
 

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests-include.t
@@ -47,4 +47,3 @@ collection to drain the env contribution from Include_result.
 
   $ env_added "$(cat path.out)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
+++ b/test/blackbox-tests/test-cases/bin-pform/inline-tests.t
@@ -1,4 +1,4 @@
-%{bin:...} in (inline_tests (deps ...)) adds the install bin dir to
+%{bin:...} in (inline_tests (deps ...)) adds a bin-layout dir to
 the test runner's PATH.
 
   $ cat >dune-project <<EOF
@@ -42,4 +42,3 @@ sandbox:
   $ dune runtest 2>&1
   $ env_added "$(cat path.out)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/bin-pform/multiple-bins.t
+++ b/test/blackbox-tests/test-cases/bin-pform/multiple-bins.t
@@ -24,13 +24,11 @@ Multiple %{bin:...} deps in a single rule.
   >    (bash "echo $PATH"))))
   > EOF
 
-PATH gets a .binaries dir (with symlinks to both bins) plus the
-install bin dir:
+PATH gets a .binaries dir with symlinks to both bins:
 
   $ dune build path-output
   $ env_added "$(cat _build/default/path-output)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin
 
 The rule depends on each binary via two paths: the build artifact
 (from the pform expansion) and the .binaries symlink (from the PATH

--- a/test/blackbox-tests/test-cases/bin-pform/run-action.t
+++ b/test/blackbox-tests/test-cases/bin-pform/run-action.t
@@ -1,6 +1,5 @@
 %{bin:NAME} as a (run ...) target invokes the binary; as a deps
-entry it adds a .binaries dir to the action's PATH (plus the
-always-on install bin dir).
+entry it adds a .binaries dir to the action's PATH.
 
   $ cat >dune-project <<EOF
   > (lang dune 3.24)
@@ -24,7 +23,6 @@ always-on install bin dir).
   hello from mybin
   $ env_added "$(cat _build/default/path-output)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin
 
 The rule's deps include the build artifact and the .binaries
 symlink:

--- a/test/blackbox-tests/test-cases/bin-pform/shared-layout.t
+++ b/test/blackbox-tests/test-cases/bin-pform/shared-layout.t
@@ -34,7 +34,5 @@ $DIGEST2):
 
   $ env_added "$(cat _build/default/out1)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin
   $ env_added "$(cat _build/default/out2)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/bin-pform/test-stanza.t
+++ b/test/blackbox-tests/test-cases/bin-pform/test-stanza.t
@@ -32,4 +32,3 @@ mytest.exe.output, which we then read.
   [1]
   $ env_added "$(cat _build/default/mytest.exe.output)" "$PATH" | censor
   $PWD/_build/install/default/.binaries/$DIGEST
-  $PWD/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/bin-pform-context-expansion.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/bin-pform-context-expansion.t
@@ -31,4 +31,3 @@ dir and the install bin dir, both under the host context.
 
   $ env_added "$(cat _build/target/path-output)" "$PATH" | censor
   $PWD/_build/install/host/.binaries/$DIGEST
-  $PWD/_build/install/host/bin

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/package-deps-context-expansion.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/package-deps-context-expansion.t
@@ -1,0 +1,39 @@
+(deps (package NAME)) in a cross-compilation context. The install
+layout dir should sit under the host context's install tree.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 3.24)
+  > (context (default (name host)))
+  > (context (default (name target) (host host)))
+  > EOF
+
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (enabled_if (= %{context_name} target))
+  >  (deps (package mypkg))
+  >  (action
+  >   (with-stdout-to out (echo "ok"))))
+  > EOF
+
+  $ dune build _build/target/out
+
+The layout dir should be under install/host/ (the layout for a
+target-context action uses host artifacts):
+
+  $ dune rules --format=json _build/target/out \
+  >   | jq 'include "dune"; .[] | ruleDepFilePaths' \
+  >   | grep dune-package | censor
+  "_build/install/host/.packages/$DIGEST/lib/mypkg/dune-package"

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -42,6 +42,11 @@
  (applies_to windows-diff staged-pps-with-sandboxing-gh6644)
  (alias runtest-windows))
 
+(cram
+ (applies_to empty-meta-version-gh9176)
+ (deps
+  (package dune-build-info)))
+
 ;; DISABLED TESTS
 
 (cram

--- a/test/blackbox-tests/test-cases/dune-site/dune
+++ b/test/blackbox-tests/test-cases/dune-site/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to :whole_subtree)
+ (deps
+  (package dune-site)
+  (package dune-private-libs)))

--- a/test/blackbox-tests/test-cases/dune-site/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/dune-site/sites-plugin.t
@@ -70,7 +70,7 @@ Test sites plugins (example from the manual)
   > Queue.add (fun () -> print_endline "Plugin1 is doing something...") Registration.todo
   > EOF
 
-  $ dune build @all 2>&1 | dune_cmd sanitize
+  $ dune build @install 2>&1 | dune_cmd sanitize
   $ dune exec ./app.exe
   Registration of Plugin1
   Main app starts...

--- a/test/blackbox-tests/test-cases/inline-tests/dune
+++ b/test/blackbox-tests/test-cases/inline-tests/dune
@@ -13,4 +13,10 @@
 (cram
  (applies_to clicolor-force-inline-tests-github6607)
  (deps
-  (package stdune)))
+  (package stdune)
+  (package dyn)
+  (package ordering)
+  (package pp)
+  (package top-closure)
+  (package csexp)
+  (package fs-io)))

--- a/test/blackbox-tests/test-cases/package-dep-invalid-name.t
+++ b/test/blackbox-tests/test-cases/package-dep-invalid-name.t
@@ -1,0 +1,108 @@
+Documents what dune accepts as a (deps (package ...)) name. The only
+validation at the boundary is "non-empty"; anything else passes through
+and ultimately fails as "Package X does not exist". See the strict
+decoder-level validation in package-name-strict.t for the dune-project
+(package (name ...)) side.
+
+  $ make_dune_project 3.24
+
+  $ test() {
+  > cat > dune << EOF
+  > (rule
+  >  (deps (package $1))
+  >  (target out)
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+  > dune build out
+  > }
+
+Literal empty name:
+
+  $ test '""'
+  File "dune", line 2, characters 16-18:
+  2 |  (deps (package ""))
+                      ^^
+  Error: "" is an invalid package name.
+  [1]
+
+Expansion that resolves to the empty string:
+
+  $ unset NOPE; test '%{env:NOPE=}'
+  File "dune", line 2, characters 16-28:
+  2 |  (deps (package %{env:NOPE=}))
+                      ^^^^^^^^^^^^
+  Error: "" is an invalid package name.
+  [1]
+
+Whitespace-only name passes the name check and reaches the lookup:
+
+  $ test '" "'
+  File "dune", line 2, characters 16-19:
+  2 |  (deps (package " "))
+                      ^^^
+  Error: Package   does not exist
+  [1]
+
+Characters opam would reject (e.g. '&') are accepted by dune:
+
+  $ test '"foo&bar"'
+  File "dune", line 2, characters 16-25:
+  2 |  (deps (package "foo&bar"))
+                      ^^^^^^^^^
+  Error: Package foo&bar does not exist
+  [1]
+
+A dot is also accepted, even though opam would reject it:
+
+  $ test '"foo.bar"'
+  File "dune", line 2, characters 16-25:
+  2 |  (deps (package "foo.bar"))
+                      ^^^^^^^^^
+  Error: Package foo.bar does not exist
+  [1]
+
+All-numeric (no letter) is accepted, even though opam would reject it:
+
+  $ test 123
+  File "dune", line 2, characters 16-19:
+  2 |  (deps (package 123))
+                      ^^^
+  Error: Package 123 does not exist
+  [1]
+
+Uppercase letters are accepted:
+
+  $ test FOO
+  File "dune", line 2, characters 16-19:
+  2 |  (deps (package FOO))
+                      ^^^
+  Error: Package FOO does not exist
+  [1]
+
+Leading dash is accepted:
+
+  $ test '"-foo"'
+  File "dune", line 2, characters 16-22:
+  2 |  (deps (package "-foo"))
+                      ^^^^^^
+  Error: Package -foo does not exist
+  [1]
+
+A normal-looking but non-existent name reaches the same lookup error:
+
+  $ test nonexistent
+  File "dune", line 2, characters 16-27:
+  2 |  (deps (package nonexistent))
+                      ^^^^^^^^^^^
+  Error: Package nonexistent does not exist
+  [1]
+
+Whitespace inside an expansion fails at expansion time, not at the name
+check:
+
+  $ test '%{env:X=foo bar}'
+  File "dune", line 2, characters 27-28:
+  2 |  (deps (package %{env:X=foo bar}))
+                                 ^
+  Error: The character ' ' is not allowed inside %{...} forms
+  [1]

--- a/test/blackbox-tests/test-cases/package-dep.t
+++ b/test/blackbox-tests/test-cases/package-dep.t
@@ -33,7 +33,7 @@ Tests package-scoped library dependencies.
   >   (echo "let () = Printf.printf \"%d %s\" Foo.x Bar.x")))
   > 
   > (rule
-  >  (deps    test.ml (package bar))
+  >  (deps    test.ml (package foo) (package bar))
   >  (targets test.exe)
   >  (action  (run ocamlfind ocamlc -linkpkg -package bar -o test.exe test.ml)))
   > 

--- a/test/blackbox-tests/test-cases/package-materialization/cram-integration.t
+++ b/test/blackbox-tests/test-cases/package-materialization/cram-integration.t
@@ -1,0 +1,67 @@
+Test that (deps (package ...)) in a cram stanza sets up all layout env vars.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library
+  >  (public_name mypkg)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >src/stub.c <<'EOF'
+  > #include <caml/mlvalues.h>
+  > CAMLprim value mypkg_stub(value unit) { return Val_unit; }
+  > EOF
+
+Capture baselines into a setup script for the inner test:
+
+  $ mkdir tests
+  $ cat >tests/setup.sh <<EOF
+  > $(declare -f env_added)
+  > BASELINE_PATH='$PATH'
+  > BASELINE_OCAMLPATH='$OCAMLPATH'
+  > BASELINE_CAML_LD_LIBRARY_PATH='$CAML_LD_LIBRARY_PATH'
+  > BASELINE_OCAMLFIND_IGNORE_DUPS_IN='$OCAMLFIND_IGNORE_DUPS_IN'
+  > BASELINE_OCAMLTOP_INCLUDE_PATH='$OCAMLTOP_INCLUDE_PATH'
+  > BASELINE_MANPATH='$MANPATH'
+  > EOF
+  $ cat >tests/dune <<EOF
+  > (cram
+  >  (shell bash)
+  >  (deps (package mypkg))
+  >  (setup_scripts setup.sh))
+  > EOF
+  $ cat >tests/check-env.t <<'EOF'
+  >   $ env_added "$PATH" "$BASELINE_PATH"
+  >   $ env_added "$OCAMLPATH" "$BASELINE_OCAMLPATH"
+  >   $ env_added "$CAML_LD_LIBRARY_PATH" "$BASELINE_CAML_LD_LIBRARY_PATH"
+  >   $ env_added "$OCAMLFIND_IGNORE_DUPS_IN" "$BASELINE_OCAMLFIND_IGNORE_DUPS_IN"
+  >   $ env_added "$OCAMLTOP_INCLUDE_PATH" "$BASELINE_OCAMLTOP_INCLUDE_PATH"
+  >   $ env_added "$MANPATH" "$BASELINE_MANPATH"
+  > EOF
+
+The inner test fails showing exactly what the package dep added to each var:
+
+  $ dune runtest tests 2>&1 | censor
+  File "tests/check-env.t", line 1, characters 0-0:
+  --- tests/check-env.t
+  +++ tests/check-env.t.corrected
+  @@ -1,6 +1,12 @@
+     $ env_added "$PATH" "$BASELINE_PATH"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/bin
+     $ env_added "$OCAMLPATH" "$BASELINE_OCAMLPATH"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/lib
+     $ env_added "$CAML_LD_LIBRARY_PATH" "$BASELINE_CAML_LD_LIBRARY_PATH"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/lib/stublibs
+     $ env_added "$OCAMLFIND_IGNORE_DUPS_IN" "$BASELINE_OCAMLFIND_IGNORE_DUPS_IN"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/lib
+     $ env_added "$OCAMLTOP_INCLUDE_PATH" "$BASELINE_OCAMLTOP_INCLUDE_PATH"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/lib/toplevel
+     $ env_added "$MANPATH" "$BASELINE_MANPATH"
+  +  $TESTCASE_ROOT/_build/install/default/.packages/$DIGEST/man
+  [1]

--- a/test/blackbox-tests/test-cases/package-materialization/cycle.t
+++ b/test/blackbox-tests/test-cases/package-materialization/cycle.t
@@ -1,0 +1,66 @@
+Declared circular `depends` between packages does not block rule-level
+`(deps (package ...))`. The cycle is in opam metadata only; the build
+artifacts form a DAG, so there is no build cycle to report.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name a) (depends b))
+  > (package (name b) (depends a))
+  > EOF
+  $ mkdir a-src b-src
+  $ cat >a-src/dune <<EOF
+  > (library (public_name a))
+  > EOF
+  $ cat >a-src/a.ml <<EOF
+  > let x = 1
+  > EOF
+  $ cat >b-src/dune <<EOF
+  > (library (public_name b))
+  > EOF
+  $ cat >b-src/b.ml <<EOF
+  > let y = 2
+  > EOF
+
+Non-strict, single package:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package a))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+  $ dune build out 2>&1
+
+Non-strict, both packages:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package a) (package b))
+  >  (action (with-stdout-to out2 (echo "ok"))))
+  > EOF
+  $ dune build out2 2>&1
+
+Strict, single package:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (strict_package_deps true)
+  > (package (name a) (depends b))
+  > (package (name b) (depends a))
+  > EOF
+  $ rm -rf _build
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package a))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+  $ dune build out 2>&1
+
+Strict, both packages:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package a) (package b))
+  >  (action (with-stdout-to out2 (echo "ok"))))
+  > EOF
+  $ rm -rf _build
+  $ dune build out2 2>&1

--- a/test/blackbox-tests/test-cases/package-materialization/dune
+++ b/test/blackbox-tests/test-cases/package-materialization/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to ocamlfind no-transitive-through-targets installed-package)
+ (deps %{bin:ocamlfind}))

--- a/test/blackbox-tests/test-cases/package-materialization/env/caml-ld-library-path.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/caml-ld-library-path.t
@@ -1,0 +1,29 @@
+Test that (deps (package ...)) adds lib/stublibs/ to CAML_LD_LIBRARY_PATH.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library
+  >  (public_name mypkg)
+  >  (foreign_stubs (language c) (names stub)))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >src/stub.c <<'EOF'
+  > #include <caml/mlvalues.h>
+  > CAMLprim value mypkg_stub(value unit) { return Val_unit; }
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (bash "echo $CAML_LD_LIBRARY_PATH"))))
+  > EOF
+
+  $ baseline=$CAML_LD_LIBRARY_PATH
+  $ dune build out
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/lib/stublibs

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamlfind-ignore-dups-in.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamlfind-ignore-dups-in.t
@@ -1,0 +1,23 @@
+Test that (deps (package ...)) adds lib/ to OCAMLFIND_IGNORE_DUPS_IN.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (bash "echo $OCAMLFIND_IGNORE_DUPS_IN"))))
+  > EOF
+
+  $ baseline=$OCAMLFIND_IGNORE_DUPS_IN
+  $ dune build out
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/lib

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamlpath.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamlpath.t
@@ -1,0 +1,23 @@
+Test that (deps (package ...)) adds the package's lib/ to OCAMLPATH.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (bash "echo $OCAMLPATH"))))
+  > EOF
+
+  $ baseline=$OCAMLPATH
+  $ dune build out
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/lib

--- a/test/blackbox-tests/test-cases/package-materialization/env/ocamltop-include-path.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/ocamltop-include-path.t
@@ -1,0 +1,23 @@
+Test that (deps (package ...)) adds lib/toplevel/ to OCAMLTOP_INCLUDE_PATH.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (bash "echo $OCAMLTOP_INCLUDE_PATH"))))
+  > EOF
+
+  $ baseline=$OCAMLTOP_INCLUDE_PATH
+  $ dune build out
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/lib/toplevel

--- a/test/blackbox-tests/test-cases/package-materialization/env/path.t
+++ b/test/blackbox-tests/test-cases/package-materialization/env/path.t
@@ -1,0 +1,27 @@
+Test that (deps (package ...)) adds the package's bin/ to PATH.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (executable (name mytool) (public_name mytool) (package mypkg) (modules mytool))
+  > (library (public_name mypkg) (modules mypkg))
+  > EOF
+  $ cat >src/mytool.ml <<'EOF'
+  > let () = print_endline "hello"
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (bash "echo $PATH"))))
+  > EOF
+
+  $ baseline=$PATH
+  $ dune build out
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/bin

--- a/test/blackbox-tests/test-cases/package-materialization/include-deps.t
+++ b/test/blackbox-tests/test-cases/package-materialization/include-deps.t
@@ -1,0 +1,47 @@
+(package ...) inside (include ...) deps is processed: the package's
+layout lib/ dir gets added to the action's OCAMLPATH alongside outer
+(package ...) entries.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name outer))
+  > (package (name inner))
+  > EOF
+
+  $ mkdir outer-src inner-src
+
+  $ cat >outer-src/dune <<EOF
+  > (library (public_name outer))
+  > EOF
+  $ cat >outer-src/outer.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >inner-src/dune <<EOF
+  > (library (public_name inner))
+  > EOF
+  $ cat >inner-src/inner.ml <<EOF
+  > let x = 2
+  > EOF
+
+  $ cat >inner-deps.sexp <<'EOF'
+  > ((package inner))
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package outer) (include inner-deps.sexp))
+  >  (action
+  >   (with-stdout-to out
+  >    (bash "echo $OCAMLPATH"))))
+  > EOF
+
+  $ baseline=$OCAMLPATH
+  $ dune build out
+
+The action's OCAMLPATH includes the outer and the included package's
+layout lib/ dirs:
+
+  $ env_added "$(cat _build/default/out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST1/lib
+  $PWD/_build/install/default/.packages/$DIGEST2/lib

--- a/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
+++ b/test/blackbox-tests/test-cases/package-materialization/inline-tests.t
@@ -1,0 +1,44 @@
+Test that (inline_tests (deps (package ...))) sets up layout env vars
+for the test runner.
+
+  $ make_dune_project 3.24
+  $ cat >>dune-project <<EOF
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+
+Custom backend that writes OCAMLPATH to a file outside the sandbox:
+
+  $ cat >dump_ocamlpath.ml <<EOF
+  > let () =
+  >   let oc = open_out "$PWD/ocamlpath.out" in
+  >   output_string oc (Sys.getenv "OCAMLPATH");
+  >   close_out oc
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (name check_backend)
+  >  (modules ())
+  >  (inline_tests.backend
+  >   (generate_runner (cat dump_ocamlpath.ml))))
+  > (library
+  >  (name testlib)
+  >  (inline_tests
+  >   (backend check_backend)
+  >   (deps (package mypkg))))
+  > EOF
+
+  $ cat >testlib.ml <<EOF
+  > EOF
+
+  $ baseline=$OCAMLPATH
+  $ dune runtest 2>&1
+  $ env_added "$(cat ocamlpath.out)" "$baseline" | censor
+  $PWD/_build/install/default/.packages/$DIGEST/lib

--- a/test/blackbox-tests/test-cases/package-materialization/install-dirs.t
+++ b/test/blackbox-tests/test-cases/package-materialization/install-dirs.t
@@ -1,0 +1,53 @@
+Regression test: when a package installs a built directory target via
+`(install (dirs ...))`, a consumer rule with `(deps (package ...))` must
+not crash. The layout has to symlink the directory entry with
+`Action_builder.symlink_dir`, not plain `symlink`.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name dirpkg))
+  > EOF
+
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name dirpkg))
+  > (rule
+  >  (target (dir generated))
+  >  (action
+  >   (progn (system "mkdir %{target}")
+  >          (system "echo top > %{target}/a.txt")
+  >          (system "mkdir %{target}/sub")
+  >          (system "echo nested > %{target}/sub/b.txt"))))
+  > (install (section share) (package dirpkg) (dirs generated))
+  > EOF
+  $ cat >src/dirpkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+
+A rule that depends on the package must build without crashing. Without
+the kind-aware dispatch, the layout's `share/dirpkg/generated` symlink
+would be created as a file pointing at a directory; the action then asks
+for `generated` as a file and the engine reports "No rule found".
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (deps (package dirpkg))
+  >  (action (with-stdout-to out (echo ok))))
+  > EOF
+
+  $ dune build out
+  $ cat _build/default/out
+  ok
+
+Spot-check that the installed directory is reachable as a path via
+`%{pkg:...}`:
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias check-dir)
+  >  (deps (package dirpkg))
+  >  (action (bash "cat %{pkg:dirpkg:share:generated}/a.txt")))
+  > EOF
+
+  $ dune build @check-dir
+  top

--- a/test/blackbox-tests/test-cases/package-materialization/installed-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/installed-package.t
@@ -1,0 +1,43 @@
+Test that (deps (package ...)) works with externally installed packages.
+Installed packages (found via findlib) go through the Installed codepath,
+not the layout. The layout only applies to Local (workspace) packages.
+
+Install package "a" into a prefix:
+
+  $ mkdir a consumer prefix
+
+  $ cat >a/dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name a))
+  > EOF
+
+  $ cat >a/dune <<EOF
+  > (library (public_name a))
+  > EOF
+
+  $ cat >a/a.ml <<EOF
+  > let msg = "hello from lib a"
+  > EOF
+
+  $ dune build --root a @install
+  $ dune install --root a --prefix $PWD/prefix 2>/dev/null
+  $ test -f prefix/lib/a/META
+
+Now create a consumer project that depends on the installed package.
+The consumer uses (deps (package a)) and ocamlfind to verify the
+package is findable:
+
+  $ cat >consumer/dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+  $ cat >consumer/dune <<'EOF'
+  > (rule
+  >  (deps (package a))
+  >  (action (with-stdout-to out
+  >   (run ocamlfind query a))))
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root consumer out
+  $ cat consumer/_build/default/out
+  $TESTCASE_ROOT/prefix/lib/a

--- a/test/blackbox-tests/test-cases/package-materialization/mixed-deps.t
+++ b/test/blackbox-tests/test-cases/package-materialization/mixed-deps.t
@@ -1,0 +1,30 @@
+Test that package deps and file deps work together in the same (deps ...).
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir src
+
+  $ cat >src/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+
+  $ cat >src/mylib.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package foo) (file src/mylib.ml))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+  $ dune build out
+
+The layout deps include foo, and the file dep is also present:
+
+  $ dune rules --format=json _build/default/out | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep -E 'dune-package|src/mylib' | sort
+  "_build/default/src/mylib.ml"
+  "_build/install/default/.packages/$DIGEST/lib/foo/dune-package"

--- a/test/blackbox-tests/test-cases/package-materialization/no-transitive-through-targets.t
+++ b/test/blackbox-tests/test-cases/package-materialization/no-transitive-through-targets.t
@@ -1,0 +1,62 @@
+Package dependencies do not propagate transitively through build
+targets. If rule A depends on (package pkga) and rule B depends on A
+and (package pkgb), then B's layout only contains pkgb, not pkga.
+Declare what you need explicitly.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name pkga))
+  > (package (name pkgb))
+  > EOF
+
+  $ mkdir a-src b-src
+
+  $ cat >a-src/dune <<EOF
+  > (library (public_name pkga))
+  > EOF
+
+  $ cat >a-src/alib.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >b-src/dune <<EOF
+  > (library (public_name pkgb))
+  > EOF
+
+  $ cat >b-src/blib.ml <<EOF
+  > let y = 2
+  > EOF
+
+Rule A declares (package pkga). Rule B depends on target-a and
+declares (package pkgb), but B's action tries to find pkga via
+ocamlfind. ocamlfind fails because pkga is not in B's package set:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package pkga))
+  >  (action (with-stdout-to target-a (echo "built with pkga"))))
+  > (rule
+  >  (deps target-a (package pkgb))
+  >  (action (with-stdout-to target-b
+  >   (run ocamlfind query pkga))))
+  > EOF
+
+  $ dune build target-b 2>&1
+  File "dune", lines 4-7, characters 0-103:
+  4 | (rule
+  5 |  (deps target-a (package pkgb))
+  6 |  (action (with-stdout-to target-b
+  7 |   (run ocamlfind query pkga))))
+  ocamlfind: Package `pkga' not found
+  [1]
+
+pkgb IS findable because B declared it. The build succeeds.
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package pkgb))
+  >  (action (with-stdout-to target-ok
+  >   (run ocamlfind query pkgb))))
+  > EOF
+
+  $ dune build target-ok

--- a/test/blackbox-tests/test-cases/package-materialization/nonexistent-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/nonexistent-package.t
@@ -1,0 +1,19 @@
+Test that depending on a non-existent package produces an error with a
+proper source location.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (deps (package nonexistent))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+  $ dune build out 2>&1
+  File "dune", line 2, characters 16-27:
+  2 |  (deps (package nonexistent))
+                      ^^^^^^^^^^^
+  Error: Package nonexistent does not exist
+  [1]

--- a/test/blackbox-tests/test-cases/package-materialization/ocamlfind.t
+++ b/test/blackbox-tests/test-cases/package-materialization/ocamlfind.t
@@ -1,0 +1,74 @@
+Test that the install layout sets OCAMLPATH correctly so that ocamlfind
+can locate declared packages, and only those.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mylib) (depends myutil))
+  > (package (name myutil))
+  > EOF
+
+  $ mkdir mylib-src myutil-src
+
+  $ cat >myutil-src/dune <<EOF
+  > (library (public_name myutil))
+  > EOF
+
+  $ cat >myutil-src/myutil.ml <<EOF
+  > let greeting = "Hello from myutil"
+  > EOF
+
+  $ cat >mylib-src/dune <<EOF
+  > (library (public_name mylib) (libraries myutil))
+  > EOF
+
+  $ cat >mylib-src/mylib.ml <<EOF
+  > let msg = Myutil.greeting ^ "!"
+  > EOF
+
+Declaring (package mylib): ocamlfind finds mylib via the layout. The
+build succeeding is the observational signal that ocamlfind resolved
+the query against the layout's OCAMLPATH.
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mylib))
+  >  (action
+  >   (with-stdout-to out
+  >    (run ocamlfind query mylib))))
+  > EOF
+
+  $ dune build out
+
+Immediate-deps-only: myutil is mylib's declared opam dependency but is
+NOT in the layout for (deps (package mylib)). ocamlfind fails to find
+it.
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mylib))
+  >  (action
+  >   (with-stdout-to out2
+  >    (run ocamlfind query myutil))))
+  > EOF
+
+  $ dune build out2
+  File "dune", lines 1-5, characters 0-96:
+  1 | (rule
+  2 |  (deps (package mylib))
+  3 |  (action
+  4 |   (with-stdout-to out2
+  5 |    (run ocamlfind query myutil))))
+  ocamlfind: Package `myutil' not found
+  [1]
+
+Declaring both packages explicitly makes both visible.
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mylib) (package myutil))
+  >  (action
+  >   (with-stdout-to out3
+  >    (run ocamlfind query myutil))))
+  > EOF
+
+  $ dune build out3

--- a/test/blackbox-tests/test-cases/package-materialization/root-section-collision.t
+++ b/test/blackbox-tests/test-cases/package-materialization/root-section-collision.t
@@ -1,0 +1,43 @@
+When two packages in the same (deps (package ...)) set install a file
+to the same un-namespaced destination in a _root section (lib_root,
+share_root, libexec_root), the layout materialization fails with a
+user error naming the conflicting packages and entry.
+
+  $ make_dune_project 3.24
+  $ cat >>dune-project <<'EOF'
+  > (package (name pkg-a))
+  > (package (name pkg-b))
+  > EOF
+
+  $ mkdir pkg-a-src pkg-b-src
+
+Both packages install a file named "topfind" to lib_root:
+
+  $ echo "from pkg-a" > pkg-a-src/topfind
+  $ cat >pkg-a-src/dune <<'EOF'
+  > (install (section lib_root) (files topfind) (package pkg-a))
+  > EOF
+
+  $ echo "from pkg-b" > pkg-b-src/topfind
+  $ cat >pkg-b-src/dune <<'EOF'
+  > (install (section lib_root) (files topfind) (package pkg-b))
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package pkg-a) (package pkg-b))
+  >  (target out)
+  >  (action (with-stdout-to %{target} (echo "ok"))))
+  > EOF
+
+The materialization step fails with a user error naming the two
+conflicting packages and the install entry:
+
+  $ dune build out 2>&1 | censor
+  Error: "pkg-a" and "pkg-b" both install "topfind" to section lib_root.
+  The lib_root, share_root, and libexec_root sections install directly to the
+  section root with no per-package subdirectory, so file names must be unique
+  across the set of packages a rule depends on.
+  -> required by _build/default/out
+  Hint: Rename one of the install entries.
+  [1]

--- a/test/blackbox-tests/test-cases/package-materialization/single-package.t
+++ b/test/blackbox-tests/test-cases/package-materialization/single-package.t
@@ -1,0 +1,65 @@
+(deps (package foo)) resolves to precise file-level deps in a materialized
+install layout under _build/install/<context>/.packages/<digest>/.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+  $ mkdir src src2
+
+  $ cat >src/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+
+  $ cat >src/mylib.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >src2/dune <<EOF
+  > (library (public_name bar))
+  > EOF
+
+  $ cat >src2/mylib2.ml <<EOF
+  > let y = 2
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package foo))
+  >  (action (with-stdout-to out1 (echo "ok"))))
+  > (rule
+  >  (deps (package foo) (package bar))
+  >  (action (with-stdout-to out2 (echo "ok"))))
+  > (rule
+  >  (deps (package bar) (package foo))
+  >  (action (with-stdout-to out_rev (echo "ok"))))
+  > (rule
+  >  (deps (package bar))
+  >  (action (with-stdout-to out3 (echo "ok"))))
+  > EOF
+
+  $ dune build out1 out2 out_rev out3
+
+Single package dep only includes that package:
+
+  $ dune rules --format=json _build/default/out1 | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep dune-package | sort
+  "_build/install/default/.packages/$DIGEST/lib/foo/dune-package"
+
+Two packages coalesce into a single layout directory:
+
+  $ dune rules --format=json _build/default/out2 | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep dune-package | sort
+  "_build/install/default/.packages/$DIGEST/lib/bar/dune-package"
+  "_build/install/default/.packages/$DIGEST/lib/foo/dune-package"
+
+Order of package deps does not matter. Same deps regardless of order:
+
+  $ dune rules --format=json _build/default/out2 | jq 'include "dune"; .[] | ruleDepFilePaths' | sort > deps_fwd.txt
+  $ dune rules --format=json _build/default/out_rev | jq 'include "dune"; .[] | ruleDepFilePaths' | sort > deps_rev.txt
+  $ diff deps_fwd.txt deps_rev.txt
+
+Different package set produces a different layout directory:
+
+  $ dune rules --format=json _build/default/out3 | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep dune-package | sort
+  "_build/install/default/.packages/$DIGEST/lib/bar/dune-package"

--- a/test/blackbox-tests/test-cases/package-materialization/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/package-materialization/strict-package-deps.t
@@ -1,0 +1,50 @@
+Test that (strict_package_deps) does not affect the install layout. The
+layout always uses immediate deps only. strict_package_deps controls
+validation in install_rules, not layout closure.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (strict_package_deps true)
+  > (package (name foo) (depends bar))
+  > (package (name bar) (depends baz))
+  > (package (name baz))
+  > EOF
+
+  $ mkdir foo-src bar-src baz-src
+
+  $ cat >foo-src/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+
+  $ cat >foo-src/foo.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >bar-src/dune <<EOF
+  > (library (public_name bar))
+  > EOF
+
+  $ cat >bar-src/bar.ml <<EOF
+  > let y = 2
+  > EOF
+
+  $ cat >baz-src/dune <<EOF
+  > (library (public_name baz))
+  > EOF
+
+  $ cat >baz-src/baz.ml <<EOF
+  > let z = 3
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package foo))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+  $ dune build out
+
+Only foo appears, same as without strict_package_deps:
+
+  $ dune rules --format=json _build/default/out | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep dune-package | sort
+  "_build/install/default/.packages/$DIGEST/lib/foo/dune-package"

--- a/test/blackbox-tests/test-cases/package-materialization/transitive-closure.t
+++ b/test/blackbox-tests/test-cases/package-materialization/transitive-closure.t
@@ -1,0 +1,49 @@
+Test that (deps (package foo)) only includes foo in the layout, not its
+transitive package dependencies. Actions should declare what they need.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name foo) (depends bar))
+  > (package (name bar) (depends baz))
+  > (package (name baz))
+  > EOF
+
+  $ mkdir foo-src bar-src baz-src
+
+  $ cat >foo-src/dune <<EOF
+  > (library (public_name foo))
+  > EOF
+
+  $ cat >foo-src/foo.ml <<EOF
+  > let x = 1
+  > EOF
+
+  $ cat >bar-src/dune <<EOF
+  > (library (public_name bar))
+  > EOF
+
+  $ cat >bar-src/bar.ml <<EOF
+  > let y = 2
+  > EOF
+
+  $ cat >baz-src/dune <<EOF
+  > (library (public_name baz))
+  > EOF
+
+  $ cat >baz-src/baz.ml <<EOF
+  > let z = 3
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package foo))
+  >  (action (with-stdout-to out (echo "ok"))))
+  > EOF
+
+  $ dune build out
+
+Only foo appears, neither bar nor baz, even though foo declares
+(depends bar) and bar declares (depends baz):
+
+  $ dune rules --format=json _build/default/out | jq 'include "dune"; .[] | ruleDepFilePaths' | censor | grep dune-package | sort
+  "_build/install/default/.packages/$DIGEST/lib/foo/dune-package"

--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -31,6 +31,12 @@
  (applies_to autolock-with-watch-server))
 
 (cram
+ (applies_to sites-plugin)
+ (deps
+  (package dune-site)
+  (package dune-private-libs)))
+
+(cram
  (applies_to rev-store-lock-linux)
  (enabled_if
   (= %{system} linux))

--- a/test/blackbox-tests/test-cases/pkg/sites-plugin.t
+++ b/test/blackbox-tests/test-cases/pkg/sites-plugin.t
@@ -66,6 +66,7 @@ Make an executable using dune-site (example mostly from the manual)
   > 
   > (rule
   >  (alias runtest)
+  >  (deps (package app) (package plugin1))
   >  (action
   >   (run app)))
   > EOF

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -5,12 +5,6 @@ start running things. In the past, the error was only reported during
 the second run of dune.
 
   $ dune build @package-cycle
-  Error: Dependency cycle between:
-     alias a/.a-files
-  -> alias b/.b-files
-  -> alias a/.a-files
-  -> required by alias package-cycle in dune:1
-  [1]
 
   $ dune build @simple-repro-case
   Error: Dependency cycle between:

--- a/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/rocq/plugin-meta.t/run.t
@@ -10,6 +10,6 @@ The META file for plugins is built before calling coqdep
   > EOF
 
   $ dune build .bar.theory.d
-  $ ls _build/install/default/lib/bar
-  META
+  $ find _build/install/default/.packages -name META | censor
+  _build/install/default/.packages/$DIGEST/lib/bar/META
 

--- a/test/blackbox-tests/test-cases/sandbox/sandboxing-package-deps.t
+++ b/test/blackbox-tests/test-cases/sandbox/sandboxing-package-deps.t
@@ -1,15 +1,13 @@
 Test sandboxing when depending on things from the install context using
-(package ..).
+(package ...).
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.11)
+  > (lang dune 3.16)
   > (package (name foo))
   > EOF
-
-  $ mkdir foo/
+  $ mkdir foo
   $ cat >foo/dune <<EOF
   > (executable
-  >  (package foo)
   >  (public_name mybin))
   > EOF
   $ cat >foo/mybin.ml <<EOF
@@ -23,8 +21,8 @@ Test sandboxing when depending on things from the install context using
   >  (action (bash "pwd; command -v mybin; echo %{bin:mybin}; mybin")))
   > EOF
 
-  $ dune build --sandbox symlink @foo 2>&1 | sed -E 's#.*.sandbox/[^/]+/#.sandbox/$SANDBOX/#g'
-  .sandbox/$SANDBOX/default
-  .sandbox/$SANDBOX/install/default/bin/mybin
+  $ dune build --sandbox symlink @foo 2>&1 | censor
+  $PWD/_build/.sandbox/$DIGEST1/default
+  $PWD/_build/install/default/.packages/$DIGEST2/bin/mybin
   foo/mybin.exe
   hello from package foo

--- a/test/blackbox-tests/test-cases/stanzas/env/env-bins/nested-env.t/run.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-bins/nested-env.t/run.t
@@ -4,14 +4,11 @@ Nest env binaries
   PATH:
   	$TESTCASE_ROOT/_build/default/using-priv/nested/.bin
   	$TESTCASE_ROOT/_build/default/using-priv/.bin
-  	$TESTCASE_ROOT/_build/install/default/bin
   Executing priv as priv-renamed
   PATH:
   	$TESTCASE_ROOT/_build/default/using-priv/nested/.bin
   	$TESTCASE_ROOT/_build/default/using-priv/.bin
-  	$TESTCASE_ROOT/_build/install/default/bin
   Executing priv as priv-renamed-nested
   PATH:
   	$TESTCASE_ROOT/_build/default/using-priv/nested/.bin
   	$TESTCASE_ROOT/_build/default/using-priv/.bin
-  	$TESTCASE_ROOT/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/stanzas/env/env-bins/private-bin-import.t/run.t
+++ b/test/blackbox-tests/test-cases/stanzas/env/env-bins/private-bin-import.t/run.t
@@ -4,8 +4,6 @@ Basic test that we can use private binaries as public ones
   Executing priv as priv
   PATH:
   	$TESTCASE_ROOT/_build/default/using-priv/.bin
-  	$TESTCASE_ROOT/_build/install/default/bin
   Executing priv as priv-renamed
   PATH:
   	$TESTCASE_ROOT/_build/default/using-priv/.bin
-  	$TESTCASE_ROOT/_build/install/default/bin

--- a/test/blackbox-tests/test-cases/toplevel-plugin/dune
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to :whole_subtree)
+ (deps
+  (package dune-site)
+  (package dune-private-libs)))

--- a/test/blackbox-tests/test-cases/watching/dune
+++ b/test/blackbox-tests/test-cases/watching/dune
@@ -24,6 +24,20 @@
   (<> %{ocaml-config:system} win)))
 
 (cram
+ (applies_to rpc-flush-file-watcher rpc-registry)
+ (deps
+  (package dune-action-plugin)
+  (package dune-rpc)
+  (package stdune)
+  (package dune-glob)
+  (package top-closure)
+  (package ordering)
+  (package dyn)
+  (package fs-io)
+  (package ocamlc-loc)
+  (package xdg)))
+
+(cram
  (applies_to
   promotion-event-suppression
   promotion-executable-bit


### PR DESCRIPTION
`(deps (package ...))` materializes a scoped install layout under `_build/install/<context>/.packages/<digest>/` containing only the declared package dependencies. This replaces the old alias-based mechanism where `(deps (package foo))` populated the shared `_build/install/` staging area, making every package in the workspace discoverable regardless of what was declared.

The layout includes only immediate deps (no transitive closure). Actions should declare what they need explicitly. Environment variables (`PATH`, `OCAMLPATH`, `CAML_LD_LIBRARY_PATH`, `OCAMLFIND_IGNORE_DUPS_IN`, `OCAMLTOP_INCLUDE_PATH`, `MANPATH`) are set from the layout directory and consed onto the directory env via `extend_action`.

The layout only applies to workspace packages. Lock-dir packages and the site/plugin system are unaffected.

See `doc/dev/install-layouts.md` for design details.

Related:

- #7908
- #8652
- #13307
- #13500
- Depends on #14432
- [x] changelog
- [x] documentation (`doc/dev/install-layouts.md`)

## Follow-up

- [ ] refactor the env helpers
- [ ] document env propagation in dune generally
- [ ] exhaustively test env propagation
- [ ] extend the staging-env cons to `dune utop`, `dune rocq top`, and `dune ocaml top`/`top-module`
- [ ] lock-dir packages classify as `Build` and don't set up layout env vars
- [ ] sandbox PATH non-relocation for layout dirs (#10294)
- [ ] ~~extract a `Digest_key` functor to dedupe `Install_layout.Key` / `Bin_layout.Key` / `Ppx_driver.Key`~~
- [ ] factor the `Context.for_host` fallback into a single helper
- [ ] missing test for mixed workspace + lock-dir package deps
- [ ] dep expander invoked twice on the `(deps (package ...))` path