### PR TITLE
test: observational baseline for transitive-unreferenced-module (#4572)

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -1,0 +1,75 @@
+A consumer reaches a transitive dep library through one module
+of an intermediate library, never naming a sibling module of
+the transitive lib in source. Today the consumer rebuilds when
+any module of the transitive lib changes, even unreferenced
+ones.
+
+Setup. [dep_lib] is unwrapped with two modules: [reached_module]
+and [unreached_module]; nothing references [unreached_module]
+from outside [dep_lib]. [intermediate_lib] depends on [dep_lib]
+and references only [Reached_module] from it. [main] depends on
+[intermediate_lib] and references only [Intermediate_module];
+[main]'s source never names [unreached_module].
+
+This test records [main]'s current rebuild list so a future
+per-module filter can flip it to empty.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library (name dep_lib) (wrapped false) (modules reached_module unreached_module))
+  > (library (name intermediate_lib) (wrapped false) (modules intermediate_module) (libraries dep_lib))
+  > (executable (name main) (modules main) (libraries intermediate_lib))
+  > EOF
+
+  $ cat > reached_module.ml <<EOF
+  > let v = 42
+  > EOF
+  $ cat > reached_module.mli <<EOF
+  > val v : int
+  > EOF
+  $ cat > unreached_module.ml <<EOF
+  > let v = 43
+  > EOF
+  $ cat > unreached_module.mli <<EOF
+  > val v : int
+  > EOF
+  $ cat > intermediate_module.ml <<EOF
+  > let v = Reached_module.v
+  > EOF
+  $ cat > main.ml <<EOF
+  > let _ = Intermediate_module.v
+  > EOF
+
+  $ dune build ./main.exe
+
+Edit [unreached_module] (both [.mli] and [.ml]) — a module no
+source in this test references — and record the rebuild list for
+[main]:
+
+  $ cat > unreached_module.mli <<EOF
+  > val v : int
+  > val extra : int
+  > EOF
+  $ cat > unreached_module.ml <<EOF
+  > let v = 43
+  > let extra = 99
+  > EOF
+  $ dune build ./main.exe
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
+        "_build/default/.main.eobjs/native/dune__exe__Main.o"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -1,18 +1,12 @@
-A consumer reaches a transitive dep library through one module
-of an intermediate library, never naming a sibling module of
-the transitive lib in source. Today the consumer rebuilds when
-any module of the transitive lib changes, even unreferenced
-ones.
+A consumer transitively depends upon a library through one module of an
+intermediate library, never naming a sibling module of the transitive lib in
+source. The current but undesirable behaviour is that the consumer rebuilds
+when any module of the transitively depended upon library changes, even
+unreferenced ones.
 
-Setup. [dep_lib] is unwrapped with two modules: [reached_module]
-and [unreached_module]; nothing references [unreached_module]
-from outside [dep_lib]. [intermediate_lib] depends on [dep_lib]
-and references only [Reached_module] from it. [main] depends on
-[intermediate_lib] and references only [Intermediate_module];
-[main]'s source never names [unreached_module].
-
-This test records [main]'s current rebuild list so a future
-per-module filter can flip it to empty.
+[intermediate_lib] and [main] each include an unused dummy module so neither
+stanza is single-module — single-module stanzas take a fast path that would
+mask the behaviour being baselined here.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -20,8 +14,8 @@ per-module filter can flip it to empty.
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules reached_module unreached_module))
-  > (library (name intermediate_lib) (wrapped false) (modules intermediate_module) (libraries dep_lib))
-  > (executable (name main) (modules main) (libraries intermediate_lib))
+  > (library (name intermediate_lib) (wrapped false) (modules intermediate_module intermediate_dummy) (libraries dep_lib))
+  > (executable (name main) (modules main main_dummy) (libraries intermediate_lib))
   > EOF
 
   $ cat > reached_module.ml <<EOF
@@ -39,15 +33,20 @@ per-module filter can flip it to empty.
   $ cat > intermediate_module.ml <<EOF
   > let v = Reached_module.v
   > EOF
+  $ cat > intermediate_dummy.ml <<EOF
+  > let _ = ()
+  > EOF
   $ cat > main.ml <<EOF
   > let _ = Intermediate_module.v
+  > EOF
+  $ cat > main_dummy.ml <<EOF
+  > let _ = ()
   > EOF
 
   $ dune build ./main.exe
 
-Edit [unreached_module] (both [.mli] and [.ml]) — a module no
-source in this test references — and record the rebuild list for
-[main]:
+Edit [unreached_module] (both [.mli] and [.ml]) — a module no source in this
+test references — and record the rebuild list for [main]:
 
   $ cat > unreached_module.mli <<EOF
   > val v : int
@@ -58,7 +57,7 @@ source in this test references — and record the rebuild list for
   > let extra = 99
   > EOF
   $ dune build ./main.exe
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
   [
     {
       "target_files": [


### PR DESCRIPTION
## Summary

Adds `test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t` — an observational baseline recording the current rebuild list when an unreferenced module of a transitively-reached library is edited. A consumer (`main`) reaches `dep_lib` through one module of `intermediate_lib`; editing `dep_lib`'s sibling module that nothing in the test references still rebuilds `main`, because the cctx-wide compile-rule deps glob over each lib's objdir.

The test asserts `main`'s current `target_files` arrays (the `.cmi`/`.cmti` byte rule + `.cmx`/`.o` native rule). A future per-module filter that observes via ocamldep that `unreached_module` is never reached can flip the arrays to `[]`.

Companions to the other observational baselines under this cluster (`implicit-transitive-deps-false.t`, `wrapped-closure-precision.t`, `add-unreferenced-sibling-lib.t`): each records a distinct angle of the over-rebuild surface that #14116's per-module filter is expected to tighten. This one exercises the *transitive-module* angle (consumer doesn't even directly reference the lib) which is structurally distinct from `implicit-transitive-deps-false.t`'s `-H`-via-implicit-transitive case.

Related: #4572, #14116