### PR TITLE
Allow `Path.is_descendant` to work on external paths.

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -584,6 +584,7 @@ let is_descendant t ~of_ =
   match t, of_ with
   | In_source_tree t, In_source_tree of_ -> Source0.is_descendant t ~of_
   | In_build_dir t, In_build_dir of_ -> Build.is_descendant t ~of_
+  | External t, External of_ -> External.is_descendant t ~of_
   | _ -> false
 ;;
 

--- a/otherlibs/stdune/src/path_external.ml
+++ b/otherlibs/stdune/src/path_external.ml
@@ -103,7 +103,7 @@ include (
 let to_string_maybe_quoted t = String.maybe_quoted (to_string t)
 
 let is_descendant b ~of_:a =
-  is_root a || String.starts_with ~prefix:(to_string a ^ "/") (to_string b)
+  is_root a || equal a b || String.starts_with ~prefix:(to_string a ^ "/") (to_string b)
 ;;
 
 module Map = String.Map

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -135,18 +135,12 @@ true
 
 let%expect_test _ =
   is_descendant (e "/foo/bar") ~of_:(e "/foo");
-  [%expect
-    {|
-false
-|}]
+  [%expect {| true |}]
 ;;
 
 let%expect_test _ =
   is_descendant (e "/foo/bar") ~of_:(e "/foo/bar");
-  [%expect
-    {|
-false
-|}]
+  [%expect {| true |}]
 ;;
 
 let%expect_test _ =
@@ -159,18 +153,12 @@ false
 
 let%expect_test _ =
   is_descendant (e "/foo/bar/") ~of_:(e "/foo/bar");
-  [%expect
-    {|
-false
-|}]
+  [%expect {| true |}]
 ;;
 
 let%expect_test _ =
   is_descendant (e "/foo/bar") ~of_:(e "/");
-  [%expect
-    {|
-false
-|}]
+  [%expect {| true |}]
 ;;
 
 let%expect_test _ =

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -238,8 +238,7 @@ let find_corrected_files (t : real) ~deps =
             not
               (* CR-soon rgrinberg: slow for no reason. to fix. *)
               (let path = Path.build path in
-               Path.Set.exists deps ~f:(fun dep ->
-                 Path.equal dep path || Path.is_descendant path ~of_:dep))
+               Path.Set.exists deps ~f:(fun dep -> Path.is_descendant path ~of_:dep))
           then Some path
           else None
         with

--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -247,19 +247,7 @@ let fetch_local ~checksum ~target (url, url_loc) =
       Unavailable (Some (User_message.make [ Pp.text "Could not unpack:"; pp ])))
 ;;
 
-let is_descendant t ~of_ =
-  let is_desc_e t ~of_ =
-    let open Path.External in
-    is_root of_
-    || equal of_ t
-    || String.starts_with ~prefix:(to_string of_ ^ "/") (to_string t)
-  in
-  match t, of_ with
-  | Path.External t, Path.External of_ -> is_desc_e t ~of_
-  | _ -> Path.is_descendant t ~of_
-;;
-
-(* Dune's engine cannot handle symlinks to directories and Dune's shared cache
+(** Dune's engine cannot handle symlinks to directories and Dune's shared cache
    rejects directory targets containing symlinks (which project sources are).
    There are technical reasons for both limitations, but for the sake of
    building packages, resolving them as hardlinks is good enough. *)
@@ -270,9 +258,7 @@ let resolve_symlinks_in root =
     let full_name = Path.to_string relative in
     match Fpath.follow_symlink full_name with
     | Error Not_a_symlink ->
-      Code_error.raise
-        "resolve_directory_symlinks_in: not a symlink"
-        [ "name", Dyn.string name ]
+      Code_error.raise "resolve_symlinks_in: not a symlink" [ "name", Dyn.string name ]
     | Error Max_depth_exceeded ->
       User_error.raise
         [ Pp.textf "Unable to resolve symlink %s: too many levels of symbolic links" name
@@ -296,11 +282,11 @@ let resolve_symlinks_in root =
          indirections, something like _build/foo/../bar or _build/../outside.
          [Path.of_string] canonicalizes it, removing those indirections. *)
       let resolved = Path.of_string resolved in
-      if is_descendant relative ~of_:resolved
+      if Path.is_descendant relative ~of_:resolved
       then
         User_error.raise
           [ Pp.textf "Unable to resolve symlink %s, it is part of a cycle." full_name ];
-      if not (is_descendant resolved ~of_:root)
+      if not (Path.is_descendant resolved ~of_:root)
       then
         User_error.raise
           [ Pp.textf


### PR DESCRIPTION
Extracted from #13792.
Right now, `Path.is_descendant` can be called on two `Path.t`, whatever their subtype, but if at least one of them is an `External`, it will always return `false`.
This is surprising, you'd expect `is_descendant (e "/foo/bar") ~of_:(e "/");` to return `true`, to quote one test.

This PR extends `Path.is_descendant` to use the already existing `Path.External.is_descendant`, mirroring other type variants.
To further mirror other variants, `Path.External.is_descendant` is patched to include `... || a = b`.