### PR TITLE
refactor: ocamldep without named targets

### DIFF
--- a/bin/describe/describe_workspace.ml
+++ b/bin/describe/describe_workspace.ml
@@ -354,13 +354,19 @@ module Crawl = struct
 
   let for_ = Compilation_mode.Ocaml
 
-  let immediate_deps_of_module ~options ~obj_dir ~modules unit =
+  let immediate_deps_of_module ~sctx ~options ~obj_dir ~modules unit =
     match (options : Options.t) with
     | { with_deps = false; _ } ->
       Action_builder.return { Root.Ocaml.Ml_kind.Dict.intf = []; impl = [] }
     | { with_deps = true; _ } ->
       let deps ml_kind =
-        Dune_rules.Dep_rules.read_immediate_deps_of ~obj_dir ~modules ~ml_kind unit ~for_
+        Dune_rules.Dep_rules.read_immediate_deps_of
+          ~sandbox:(Compilation_mode.default_sandbox for_)
+          ~sctx
+          ~obj_dir
+          ~modules
+          ~ml_kind
+          unit
       in
       let open Action_builder.O in
       let+ intf, impl = Action_builder.both (deps Intf) (deps Impl) in
@@ -440,7 +446,7 @@ module Crawl = struct
       in
       let deps_of module_ =
         let module_ = pp_map module_ in
-        immediate_deps_of_module ~options ~obj_dir ~modules:modules_ module_
+        immediate_deps_of_module ~sctx ~options ~obj_dir ~modules:modules_ module_
       in
       let obj_dir = Obj_dir.of_local obj_dir in
       let* modules = modules ~obj_dir ~deps_of modules_ in
@@ -509,6 +515,7 @@ module Crawl = struct
           in
           let deps_of module_ =
             immediate_deps_of_module
+              ~sctx
               ~options
               ~obj_dir:obj_dir_
               ~modules:modules_

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -181,33 +181,34 @@ let rec deps_of
        | Impl -> Normal m))
 ;;
 
-let read_deps_of_module ~modules ~obj_dir dep ~for_ =
-  let (Obj_dir.Module.Dep.Immediate (unit, _) | Transitive (unit, _)) = dep in
+let read_transitive_deps_of_module ~modules ~obj_dir ~ml_kind ~for_ unit =
   match Module.kind unit with
   | Root | Alias _ -> Action_builder.return []
   | Wrapped_compat -> wrapped_compat_deps modules unit |> Action_builder.return
   | _ ->
     if has_single_file modules
     then Action_builder.return []
-    else (
-      match dep with
-      | Immediate (unit, ml_kind) ->
-        Ocamldep.read_immediate_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit
-      | Transitive (unit, ml_kind) ->
-        let open Action_builder.O in
-        let+ deps = Ocamldep.read_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit in
-        (match Modules.With_vlib.alias_for modules unit with
-         | [] -> deps
-         | aliases -> aliases @ deps))
+    else
+      let open Action_builder.O in
+      let+ deps = Ocamldep.read_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit in
+      (match Modules.With_vlib.alias_for modules unit with
+       | [] -> deps
+       | aliases -> aliases @ deps)
 ;;
 
-let read_immediate_deps_of ~obj_dir ~modules ~ml_kind ~for_ m =
-  read_deps_of_module ~modules ~obj_dir (Immediate (m, ml_kind)) ~for_
+let read_immediate_deps_of ~sandbox ~sctx ~obj_dir ~modules ~ml_kind m =
+  match Module.kind m with
+  | Root | Alias _ -> Action_builder.return []
+  | Wrapped_compat -> wrapped_compat_deps modules m |> Action_builder.return
+  | _ ->
+    if has_single_file modules
+    then Action_builder.return []
+    else Ocamldep.read_immediate_deps_of ~sandbox ~sctx ~obj_dir ~modules ~ml_kind m
 ;;
 
 let read_deps_of ~obj_dir ~modules ~ml_kind ~for_ m =
   if Module.has m ~ml_kind
-  then read_deps_of_module ~modules ~obj_dir (Transitive (m, ml_kind)) ~for_
+  then read_transitive_deps_of_module ~modules ~obj_dir ~ml_kind ~for_ m
   else Action_builder.return []
 ;;
 

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -24,10 +24,11 @@ val rules
   -> Dep_graph.Ml_kind.t Memo.t
 
 val read_immediate_deps_of
-  :  obj_dir:Path.Build.t Obj_dir.t
+  :  sandbox:Sandbox_config.t
+  -> sctx:Super_context.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
   -> ml_kind:Ml_kind.t
-  -> for_:Compilation_mode.t
   -> Module.t
   -> Module.t list Action_builder.t
 

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -107,6 +107,7 @@ let add_rule sctx ?mode ?loc ~dir build =
 ;;
 
 let for_ = Compilation_mode.Melange
+let sandbox = Compilation_mode.default_sandbox for_
 
 let impl_only_modules_defined_in_this_lib ~sctx ~scope lib =
   match Lib_info.modules (Lib.info lib) ~for_ with
@@ -188,12 +189,18 @@ let make_same_lib_emission_deps =
       | "--mel-no-cross-module-opt" | "-mel-no-cross-module-opt" -> false
       | _ -> enabled)
   in
-  let impl_dep_graph ~obj_dir ~modules =
+  let impl_dep_graph ~sctx ~obj_dir ~modules =
     let per_module =
       Modules.With_vlib.obj_map modules
       |> Module_name.Unique.Map.mapi ~f:(fun _ sourced_module ->
         let module_ = Modules.Sourced_module.to_module sourced_module in
-        Dep_rules.read_immediate_deps_of ~obj_dir ~modules ~ml_kind:Impl ~for_ module_)
+        Dep_rules.read_immediate_deps_of
+          ~sandbox
+          ~sctx
+          ~obj_dir
+          ~modules
+          ~ml_kind:Impl
+          module_)
     in
     Dep_graph.make ~dir:(Obj_dir.dir obj_dir) ~per_module
   in
@@ -210,12 +217,12 @@ let make_same_lib_emission_deps =
     in
     Dep.Set.union cmi cmj
   in
-  fun ~obj_dir ~modules ~(compile_flags : Ocaml_flags.t) ->
+  fun ~sctx ~obj_dir ~modules ~(compile_flags : Ocaml_flags.t) ->
     let xopt_enabled =
       Ocaml_flags.get compile_flags Melange
       |> Action_builder.map ~f:melange_cross_module_opt_enabled
     in
-    let dep_graph = impl_dep_graph ~obj_dir ~modules in
+    let dep_graph = impl_dep_graph ~sctx ~obj_dir ~modules in
     fun module_ ->
       let open Action_builder.O in
       xopt_enabled
@@ -758,7 +765,7 @@ let setup_entries_js
   let promote_in_source = should_promote_in_source scope in
   let same_lib_emission_deps =
     let modules = Modules.With_vlib.modules local_modules in
-    make_same_lib_emission_deps ~compile_flags ~modules ~obj_dir:local_obj_dir
+    make_same_lib_emission_deps ~sctx ~compile_flags ~modules ~obj_dir:local_obj_dir
   in
   let+ directory_targets =
     setup_runtime_assets_rules
@@ -809,6 +816,7 @@ let setup_js_rules_libraries =
           make_external_lib_emission_deps ~obj_dir:(Lib_info.obj_dir (Lib.info lib))
         | Some lib ->
           make_same_lib_emission_deps
+            ~sctx
             ~compile_flags
             ~modules:lib_modules
             ~obj_dir:(Lib.Local.obj_dir lib)

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -618,9 +618,7 @@ module Module = struct
   ;;
 
   module Dep = struct
-    type t =
-      | Immediate of Module.t * Ml_kind.t
-      | Transitive of Module.t * Ml_kind.t
+    type t = Transitive of Module.t * Ml_kind.t
 
     let make_name m kind ext =
       let ext =
@@ -632,14 +630,13 @@ module Module = struct
     ;;
 
     let basename = function
-      | Immediate (m, kind) -> make_name m kind Filename.Extension.d
       | Transitive (m, kind) -> make_name m kind Filename.Extension.all_deps
     ;;
   end
 
   let dep t dep ~for_ =
     match (dep : Dep.t) with
-    | Immediate (m, _) | Transitive (m, _) ->
+    | Transitive (m, _) ->
       (match Module.kind m with
        | Module.Kind.Alias _ | Root -> None
        | _ ->

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -152,9 +152,7 @@ module Module : sig
   end
 
   module Dep : sig
-    type t =
-      | Immediate of Module.t * Ml_kind.t
-      | Transitive of Module.t * Ml_kind.t
+    type t = Transitive of Module.t * Ml_kind.t
   end
 
   val dep : Path.Build.t t -> Dep.t -> for_:Compilation_mode.t -> Path.Build.t option

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -119,46 +119,71 @@ let transitive_deps =
   fun obj_dir modules ~for_ -> List.filter_map modules ~f:(transive_dep obj_dir ~for_)
 ;;
 
-let deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind ~for_ unit =
-  let source = Option.value_exn (Module.source unit ~ml_kind) in
-  let dep = Obj_dir.Module.dep obj_dir ~for_ in
-  let ocamldep_output = dep (Immediate (unit, ml_kind)) |> Option.value_exn in
-  let* () =
-    let context = Super_context.context sctx in
-    let ocamldep =
-      (let+ ocaml = Context.ocaml context in
-       ocaml.ocamldep)
-      |> Action_builder.of_memo
-    in
-    Super_context.add_rule
-      sctx
-      ~dir
-      (let open Action_builder.With_targets.O in
-       let flags, sandbox =
-         Module.pp_flags unit |> Option.value ~default:(Action_builder.return [], sandbox)
-       in
-       Command.run_dyn_prog
-         ocamldep
-         ~dir:(Path.build (Context.build_dir context))
-         ~stdout_to:ocamldep_output
-         [ A "-modules"
-         ; Command.Args.dyn flags
-         ; Command.Ml_kind.flag ml_kind
-         ; Dep (Module.File.path source)
-         ]
-       >>| Action.Full.add_sandbox sandbox)
+let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
+  let context = Super_context.context sctx in
+  let flags, sandbox =
+    Module.pp_flags unit |> Option.value ~default:(Action_builder.return [], sandbox)
   in
+  let open Action_builder.O in
+  let* ocamldep =
+    let+ ocaml = Action_builder.of_memo (Context.ocaml context) in
+    ocaml.ocamldep
+  in
+  let+ action =
+    let source = Option.value_exn (Module.source unit ~ml_kind) in
+    Command.run'
+      ~dir:(Path.build (Context.build_dir context))
+      ocamldep
+      [ A "-modules"
+      ; Command.Args.dyn flags
+      ; Command.Ml_kind.flag ml_kind
+      ; Dep (Module.File.path source)
+      ]
+  and+ env =
+    (* CR-someday rgrinberg: consider getting rid of this *)
+    Action_builder.of_memo
+      (let open Memo.O in
+       Super_context.env_node sctx ~dir >>= Env_node.external_env)
+  in
+  { Rule.Anonymous_action.action =
+      action |> Action.Full.add_env env |> Action.Full.add_sandbox sandbox
+  ; loc = Loc.none
+  ; dir
+  ; alias = None
+  }
+;;
+
+let read_immediate_deps_of ~sandbox ~sctx ~obj_dir ~modules ~ml_kind unit =
+  match Module.source ~ml_kind unit with
+  | None -> Action_builder.return []
+  | Some source ->
+    let dir = Obj_dir.dir obj_dir in
+    let memo_name =
+      sprintf
+        "%s.%s.ocamldep"
+        (Path.to_string (Module.File.path source))
+        (Ml_kind.to_string ml_kind)
+    in
+    ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit
+    |> Build_system.execute_action_stdout
+    |> Memo.map ~f:(fun output ->
+      String.split_lines output
+      |> parse_deps_exn ~file:(Module.File.path source)
+      |> parse_module_names ~dir ~unit ~modules
+      |> Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit))
+    |> Action_builder.of_memo
+    |> Action_builder.memoize memo_name
+;;
+
+let deps_of ~sandbox ~modules ~sctx ~dir ~obj_dir ~ml_kind ~for_ unit =
+  let dep = Obj_dir.Module.dep obj_dir ~for_ in
   let all_deps_file = dep (Transitive (unit, ml_kind)) |> Option.value_exn in
   let+ () =
     let produce_all_deps =
       let open Action_builder.O in
       (let+ transitive, immediate =
          (let+ immediate_deps =
-            Path.build ocamldep_output
-            |> Action_builder.lines_of
-            >>| parse_deps_exn ~file:(Module.File.path source)
-            >>| parse_module_names ~dir ~unit ~modules
-            >>| Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit)
+            read_immediate_deps_of ~sandbox ~sctx ~obj_dir ~modules ~ml_kind unit
           in
           let transitive_deps = transitive_deps obj_dir immediate_deps ~for_ in
           let immediate_deps = List.map immediate_deps ~f:Module.obj_name in
@@ -184,18 +209,4 @@ let read_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit =
   Action_builder.lines_of (Path.build all_deps_file)
   |> Action_builder.map ~f:(parse_compilation_units ~modules)
   |> Action_builder.memoize (Path.Build.to_string all_deps_file)
-;;
-
-let read_immediate_deps_of ~obj_dir ~modules ~ml_kind ~for_ unit =
-  match Module.source ~ml_kind unit with
-  | None -> Action_builder.return []
-  | Some source ->
-    let ocamldep_output =
-      Obj_dir.Module.dep obj_dir ~for_ (Immediate (unit, ml_kind)) |> Option.value_exn
-    in
-    Action_builder.lines_of (Path.build ocamldep_output)
-    |> Action_builder.map ~f:(fun lines ->
-      parse_deps_exn ~file:(Module.File.path source) lines
-      |> parse_module_names ~dir:(Obj_dir.dir obj_dir) ~unit ~modules)
-    |> Action_builder.memoize (Path.Build.to_string ocamldep_output)
 ;;

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -26,9 +26,10 @@ val read_deps_of
     kind [ml_kind] of the module [unit]. If there is no such file with kind
     [ml_kind], then an empty list of dependencies is returned. *)
 val read_immediate_deps_of
-  :  obj_dir:Path.Build.t Obj_dir.t
+  :  sandbox:Sandbox_config.t
+  -> sctx:Super_context.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
   -> ml_kind:Ml_kind.t
-  -> for_:Compilation_mode.t
   -> Module.t
   -> Module.t list Action_builder.t

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -29,6 +29,7 @@ type t =
   }
 
 let for_ = Compilation_mode.Ocaml
+let sandbox = Compilation_mode.default_sandbox for_
 
 let build_instance
       ~sctx
@@ -277,7 +278,7 @@ let build_modules ~sctx ~obj_dir ~modules_obj_dir ~dep_graph ~mode ~requires ~li
     Module_name.Map.add_exn acc (Module.name module_) instance)
 ;;
 
-let dep_graph ~ocaml_version ~preprocess ~obj_dir ~modules impl_only =
+let dep_graph ~sctx ~ocaml_version ~preprocess ~obj_dir ~modules impl_only =
   let pp_map =
     Staged.unstage
     @@ Pp_spec.pped_modules_map
@@ -291,7 +292,13 @@ let dep_graph ~ocaml_version ~preprocess ~obj_dir ~modules impl_only =
         let open Action_builder.O in
         let module_ = pp_map module_ in
         let+ deps =
-          Dep_rules.read_immediate_deps_of module_ ~modules ~obj_dir ~ml_kind:Impl ~for_
+          Dep_rules.read_immediate_deps_of
+            ~sandbox
+            ~sctx
+            ~modules
+            ~obj_dir
+            ~ml_kind:Impl
+            module_
         in
         let local_open = Modules.With_vlib.alias_for modules module_ in
         local_open @ deps
@@ -331,6 +338,7 @@ let instantiate ~sctx lib =
   let impl_only = Modules.With_vlib.impl_only modules in
   let dep_graph =
     dep_graph
+      ~sctx
       ~ocaml_version:ocaml.version
       ~preprocess:(Lib_info.preprocess ~for_ lib_info)
       ~obj_dir:deps_obj_dir
@@ -402,7 +410,7 @@ let external_dep_rules ~sctx ~dir ~scope lib_name =
     let+ (_ : Dep_graph.Ml_kind.t) =
       Dep_rules.rules
         ~sctx
-        ~sandbox:Sandbox_config.no_special_requirements
+        ~sandbox
         ~dir
         ~obj_dir:(obj_dir_for_dep_rules dir)
         ~impl:Virtual_rules.no_implements

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -240,3 +240,11 @@ def fsUpdateWithPath($path):
 
 def censorDigestDir:
   .args.dir |= (if . then sub("[0-9a-f]{32}"; "$DIGEST") else . end);
+
+def censorActionTargets:
+  if has("target_files") then
+    .target_files |= map(
+      if test("\\.actions[/\\\\][^/\\\\]+[/\\\\][0-9a-f]{32}$") then
+        sub("(?<sep>[/\\\\])[0-9a-f]{32}$"; "\(.sep)$ACTION")
+      else . end)
+  else . end;

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -80,6 +80,7 @@ Dune should be able to find it too
   > | select(.prog | contains("notocamldep-foo"))
   > | del(.pid)
   > | .rusage |= keys
+  > | censorActionTargets
   > '
   {
     "process_args": [
@@ -92,7 +93,7 @@ Dune should be able to find it too
     "dir": "_build/default.foo",
     "exit": 0,
     "target_files": [
-      "_build/default.foo/.repro.objs/repro__Foo.impl.d"
+      "_build/.actions/default.foo/$ACTION"
     ],
     "rusage": [
       "inblock",

--- a/test/blackbox-tests/test-cases/include-qualified/build-with-sandbox.t
+++ b/test/blackbox-tests/test-cases/include-qualified/build-with-sandbox.t
@@ -21,8 +21,9 @@ Test `(include_subdirs qualified)` with sandboxing
 
 Transitive deps file includes the alias module
 
-  $ cat _build/default/lib/.foo.objs/foo__Bar.impl.d
-  lib/bar.ml: Sub
+  $ cat _build/default/lib/.foo.objs/foo__Bar.impl.all-deps
+  foo__Sub
+  foo__Sub__Hello
 
   $ cat > lib/dune <<EOF
   > (include_subdirs qualified)
@@ -41,5 +42,7 @@ Transitive deps file includes the alias module
 
   $ DUNE_SANDBOX=symlink dune build
 
-  $ cat _build/default/lib/.foo.objs/foo__Bar.impl.d
-  lib/bar.ml: Sub
+  $ cat _build/default/lib/.foo.objs/foo__Bar.impl.all-deps
+  foo__Sub
+  foo__Sub__
+  foo__Sub__Hello

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -35,7 +35,6 @@ This kind of cycle has a difficult to understand error message.
   -> _build/default/.foo_simple.inline-tests/inline-test-runner.exe
   -> alias runtest-foo_simple in dune:9
   -> _build/default/bar.ml
-  -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.d
   -> _build/default/.foo_simple.objs/foo_simple__Bar.impl.all-deps
   -> required by _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmo
   -> required by _build/default/foo_simple.cma

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed.t
@@ -54,8 +54,8 @@ Test dependency on installed package
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root b @install --display=short
   Entering directory 'b'
-      ocamldep .b.objs/b__Bar.impl.d
-      ocamldep .b.objs/b__Foo.impl.d
+      ocamldep (internal)
+      ocamldep (internal)
           melc .b.objs/melange/b.{cmi,cmj,cmt}
           melc .b.objs/melange/b__Bar.{cmi,cmj,cmt}
           melc .b.objs/melange/b__Foo.{cmi,cmj,cmt}

--- a/test/blackbox-tests/test-cases/melange/emit-private.t
+++ b/test/blackbox-tests/test-cases/melange/emit-private.t
@@ -47,6 +47,7 @@ Test dependency on a private library in the same package as melange.emit
   > EOF
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build @dist --display=short 2>&1 | grep -v melange
+      ocamldep (internal)
           melc b/dist/node_modules/pkg.__private__.a/foo.js
           melc b/dist/b/bar.js
 

--- a/test/blackbox-tests/test-cases/ocamldep/ocamldep-alias-module.t
+++ b/test/blackbox-tests/test-cases/ocamldep/ocamldep-alias-module.t
@@ -13,4 +13,3 @@ We don't need to run ocamldep on ther alias module
 
   $ find _build -iname "*.d" -o -iname "*.all-deps" | sort
   _build/default/.foo.objs/foo__Bar.impl.all-deps
-  _build/default/.foo.objs/foo__Bar.impl.d

--- a/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace/trace-file.t/run.t
@@ -9,7 +9,7 @@ This captures the commands that are being run:
   > | del(.pid)
   > | .prog |= sub(".*/"; "")
   > | .rusage |= keys
-  > '
+  > ' | censor
   {
     "process_args": [
       "-config"
@@ -41,7 +41,7 @@ This captures the commands that are being run:
     "dir": "_build/default",
     "exit": 0,
     "target_files": [
-      "_build/default/.prog.eobjs/prog.impl.d"
+      "_build/.actions/default/$DIGEST"
     ],
     "rusage": [
       "inblock",


### PR DESCRIPTION
These targets are useless to end users, so let's hide them. This will allow to improve our handling of these even further later.