### PR TITLE
refactor: simplify sandbox handling

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -193,11 +193,7 @@ let create
     | None -> Resolve.Memo.return []
     | Some parameters -> parameters_main_modules parameters
   in
-  let sandbox =
-    match for_ with
-    | Compilation_mode.Ocaml -> Sandbox_config.no_special_requirements
-    | Compilation_mode.Melange -> Sandbox_config.needs_sandboxing
-  in
+  let sandbox = Compilation_mode.default_sandbox for_ in
   let modes =
     let default = { Lib_mode.Map.ocaml = Mode.Dict.make_both true; melange = false } in
     Option.value ~default modes

--- a/src/dune_rules/compilation_mode.ml
+++ b/src/dune_rules/compilation_mode.ml
@@ -33,6 +33,11 @@ let of_mode_set (modes : Lib_mode.Map.Set.t) =
   | false, false, false -> { modes = []; for_merlin = Ocaml }
 ;;
 
+let default_sandbox = function
+  | Ocaml -> Sandbox_config.no_special_requirements
+  | Melange -> Sandbox_config.needs_sandboxing
+;;
+
 module By_mode = struct
   type nonrec 'a t =
     { ocaml : 'a

--- a/src/dune_rules/compilation_mode.mli
+++ b/src/dune_rules/compilation_mode.mli
@@ -14,6 +14,7 @@ type modes =
 
 val of_lib_mode : Lib_mode.t -> t
 val of_mode_set : Lib_mode.Map.Set.t -> modes
+val default_sandbox : t -> Sandbox_config.t
 
 module By_mode : sig
   type mode := t

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -204,17 +204,12 @@ let build_cm
   let ctx = Super_context.context sctx in
   let mode = Lib_mode.of_cm_kind cm_kind in
   let sandbox =
-    let default =
-      match mode with
-      | Melange -> Sandbox_config.needs_sandboxing
-      | Ocaml _ -> Compilation_context.sandbox cctx
-    in
     match Module.kind m with
     | Root ->
       (* This is need to guarantee that no local modules shadow the modules
          referenced by the root module *)
       Sandbox_config.needs_sandboxing
-    | _ -> default
+    | _ -> Compilation_context.sandbox cctx
   in
   let ocaml = Compilation_context.ocaml cctx in
   let* compiler =


### PR DESCRIPTION
Always use whatever Compilation_context is setting.

cc @anmonteiro 