### PR TITLE
rpc: replace Global Fiber.Var with a ref

### DIFF
--- a/src/rpc/global.ml
+++ b/src/rpc/global.ml
@@ -13,7 +13,13 @@ type t =
   ; mutable state : [ `Awaiting_start | `Running | `Stopped ]
   }
 
-let t = Fiber.Var.create None
+let current : t option ref = ref None
+
+let get_exn () =
+  match !current with
+  | Some t -> t
+  | None -> Code_error.raise "rpc server not available" []
+;;
 
 let stop ({ state; server; pool } as t) =
   let* () = Fiber.return () in
@@ -28,14 +34,20 @@ let stop ({ state; server; pool } as t) =
 let with_background_rpc server f =
   let pool = Fiber.Pool.create () in
   let v = { state = `Awaiting_start; server; pool } in
-  Fiber.Var.set t (Some v) (fun () ->
-    Fiber.fork_and_join_unit
-      (fun () -> Fiber.Pool.run pool)
-      (fun () -> Fiber.finalize f ~finally:(fun () -> stop v)))
+  let previous = !current in
+  current := Some v;
+  Fiber.finalize
+    (fun () ->
+       Fiber.fork_and_join_unit
+         (fun () -> Fiber.Pool.run pool)
+         (fun () -> Fiber.finalize f ~finally:(fun () -> stop v)))
+    ~finally:(fun () ->
+      current := previous;
+      Fiber.return ())
 ;;
 
 let ensure_ready () =
-  let* ({ state; server; pool } as t) = Fiber.Var.get_exn t in
+  let ({ state; server; pool } as t) = get_exn () in
   match state with
   | `Stopped -> Code_error.raise "server already stopped" []
   | `Running -> Fiber.return ()
@@ -45,7 +57,4 @@ let ensure_ready () =
     server.ready
 ;;
 
-let stop () =
-  let* t = Fiber.Var.get_exn t in
-  stop t
-;;
+let stop () = stop (get_exn ())


### PR DESCRIPTION
The RPC server handle in `Rpc.Global` does not need fiber-local dynamic scope. Replace the `Fiber.Var` with a module-level reference and restore the previous value when `with_background_rpc` exits.

This keeps the existing behavior for `ensure_ready` and `stop` while removing the extra fiber variable machinery.