### PR TITLE
test: regression guard for cross-lib reads of unwrapped libs with [private_modules]

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/private-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/private-modules.t
@@ -1,0 +1,44 @@
+A consumer of an unwrapped library that has [private_modules] builds
+without error.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[dep]: unwrapped library with one public entry module [Pub] and one
+private module [Priv]. Consumers can see [Pub] via [-I] search but
+not [Priv]:
+
+  $ mkdir dep
+  $ cat > dep/dune <<EOF
+  > (library
+  >  (name dep)
+  >  (wrapped false)
+  >  (private_modules priv))
+  > EOF
+  $ cat > dep/pub.ml <<EOF
+  > let greeting () = Priv.helper ^ "!"
+  > EOF
+  $ cat > dep/priv.ml <<EOF
+  > let helper = "hi"
+  > EOF
+
+[consumer]: references [Pub] from [dep]:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (library (name consumer) (wrapped false) (libraries dep))
+  > EOF
+  $ cat > consumer/c.ml <<EOF
+  > let v = Pub.greeting ()
+  > EOF
+  $ cat > consumer/d.ml <<EOF
+  > let _ = ()
+  > EOF
+
+Build must succeed. Sandbox is forced on so the test fails reliably
+if the consumer's compile rule doesn't pull the public-cmi rule into
+the sandbox; without forced sandboxing the public cmi might be found
+on disk from a sibling rule and silently mask the regression.
+
+  $ DUNE_SANDBOX=symlink dune build @check


### PR DESCRIPTION
## Summary

Adds `test-cases/per-module-lib-deps/private-modules.t`, an observational baseline asserting that a consumer of an unwrapped library that uses `private_modules` builds without error.

## Why

When an unwrapped library has `private_modules`, dune produces public modules' cmis in a separate `.objs/public_cmi` directory (via a copy rule from the internal object dir), so consumers see only the public cmis on their `-I` search path. Any future inter-library dependency tracking that emits per-module cmi deps must point at the *public* cmi path, not the internal one — otherwise the produce-public-cmi rule doesn't run and sandboxed compiles fail to find the cmi.

This pitfall surfaced during #14116 development. The test guards against the same shape of regression in any future inter-library dep-tracking change.

## Test plan

- [x] On `main` today: `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/private-modules.t` passes.
- [x] Sensitivity-checked by deliberately breaking `consumer/c.ml` to reference an unbound module — the test diffs against the resulting compile error, confirming the assertion catches build failures.

Companion to the other observational baselines under `test-cases/per-module-lib-deps/` (`transitive-unreferenced-module.t`, `cross-lib-ppx.t`, etc.): each pins a structural shape that an inter-library filter must respect.

Related: #14116