### PR TITLE
test: regression guard for cross-lib reads of single-module leaf libs

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t
@@ -1,0 +1,41 @@
+A multi-module consumer of a single-module leaf library builds
+without error.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[leaf]: unwrapped, single-module, no library dependencies. This is
+exactly the shape that triggers the no-ocamldep fast path:
+
+  $ mkdir leaf
+  $ cat > leaf/dune <<EOF
+  > (library (name leaf) (wrapped false))
+  > EOF
+  $ cat > leaf/mod_leaf.ml <<EOF
+  > let v = 1
+  > EOF
+  $ cat > leaf/mod_leaf.mli <<EOF
+  > val v : int
+  > EOF
+
+[consumer]: multi-module library that depends on [leaf] and
+references [Mod_leaf] from one of its modules. The consumer is
+multi-module (so it doesn't itself hit the no-ocamldep fast path);
+what we're probing is whether anything tries to read [leaf]'s
+ocamldep:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (library (name consumer) (wrapped false) (libraries leaf))
+  > EOF
+  $ cat > consumer/c.ml <<EOF
+  > let _ = Mod_leaf.v
+  > EOF
+  $ cat > consumer/d.ml <<EOF
+  > let _ = ()
+  > EOF
+
+Build must succeed:
+
+  $ dune build @check


### PR DESCRIPTION
## Summary

Adds `test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t`, an observational baseline asserting that a multi-module consumer of a single-module leaf library builds without error.

## Why

The dep is a "leaf": one `.ml` module, no library dependencies of its own. Single-module stanzas trigger a fast path in dune that skips ocamldep for the stanza, so no `.d` rule is produced for the leaf's module. Any future inter-library dependency tracking that walks consumer ocamldep into dep libraries must recognise this shape and not demand a nonexistent `.d` file — otherwise the consumer's compile fails with "No rule found" during rule evaluation.

This pitfall surfaced during #14116 development. The test guards against the same shape of regression in any future inter-library dep-tracking change.

## Test plan

- [x] On `main` today: `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/no-ocamldep-leaf-lib.t` passes.
- [x] Sensitivity-checked by deliberately breaking `consumer/c.ml` to reference an unbound module — the test diffs against the resulting compile error, confirming the assertion catches build failures.

The shape pinned here (single-module unwrapped leaf consumed by a multi-module consumer with a real cross-library reference) is not exercised by any existing test on `main`. Companion to the other observational baselines under `test-cases/per-module-lib-deps/` (`cross-lib-ppx.t`, `private-modules.t`, etc.): each pins a structural shape that an inter-library filter must respect.

Related: #14116