### PR TITLE
test: regression guard for menhir grammars referencing library deps

### DIFF
--- a/test/blackbox-tests/test-cases/menhir/with-library-deps.t
+++ b/test/blackbox-tests/test-cases/menhir/with-library-deps.t
@@ -1,0 +1,67 @@
+A menhir grammar's semantic actions can reference values from libraries
+declared in the parent (library)'s (libraries ...) field. Menhir's
+--infer pass invokes [ocamlc -i] on a generated mock module derived
+from the grammar; for the type inference to succeed, dune must put the
+parent library's library deps on that mock compile's [-I] search path.
+This test guards against regressions in that wiring.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (using menhir 3.0)
+  > EOF
+
+[dep] is a small library exposing a value that the parent library's
+menhir grammar will reference from a semantic action:
+
+  $ mkdir dep
+  $ cat > dep/dune <<EOF
+  > (library (name dep))
+  > EOF
+  $ cat > dep/dep.ml <<EOF
+  > let value = 42
+  > EOF
+
+[parser]: a library with [(libraries dep)] whose menhir grammar's
+semantic action references [Dep.value]. The build succeeds only if
+menhir's [--infer] pass sees [dep] on its [-I] path during the
+[ocamlc -i] inference step.
+
+  $ mkdir parser
+  $ cat > parser/dune <<EOF
+  > (library
+  >  (name parser)
+  >  (libraries dep))
+  > (menhir (modules grammar))
+  > EOF
+  $ cat > parser/grammar.mly <<EOF
+  > %token EOF
+  > %start <int> main
+  > %%
+  > main: EOF { Dep.value }
+  > EOF
+
+  $ dune build @check
+
+Confirm via the trace that menhir's [--infer] pass invoked
+[ocamlc -i] on the generated mock and produced the inferred [.mli].
+The presence of this event positively asserts that the [--infer]
+code path ran, rather than being silently skipped:
+
+  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .target_files]'
+  [
+    [
+      "_build/default/parser/grammar__mock.mli.inferred"
+    ]
+  ]
+
+The same [ocamlc -i] invocation has [dep]'s objdir on its [-I]
+search path. This is exactly the property the test guards: dune
+must propagate the parent library's [(libraries ...)] onto the
+mock compile's [-I] flags.
+
+  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .process_args | [.[] | select(startswith("dep/"))]]'
+  [
+    [
+      "dep/.dep.objs/byte"
+    ]
+  ]


### PR DESCRIPTION
## Summary

Adds a regression guard for menhir grammars whose semantic actions reference values from libraries declared in the parent library's `(libraries ...)` field. Menhir's `--infer` pass invokes `ocamlc -i` on a generated mock module to infer types, and dune must wire the parent library's library deps onto that mock compile's `-I` search path for the inference to succeed. The new test exercises the smallest such shape: a library with `(libraries dep)` whose grammar's semantic action references `Dep.value`.

## Coverage gap

Of 61 files under `test/blackbox-tests/test-cases/menhir/` on `main`, none combines `(menhir ...)`, `(library ...)`, and a non-empty `(libraries some_dep)` whose grammar references the dep from a semantic action. The closest existing tests are:

- `library-interface.t` — `(library (name foo))` with `(menhir ...)`, but `M.x` is referenced from a sibling module of the same library, not from a library dep.
- `menhir-include-subdirs.t/bar/dune`, `general.t/src/dune` — `(menhir ...)` inside a library or executable with no `(libraries ...)`.
- `menhir-dynamic-modules.t`, `include-subdirs-menhir-github1372.t` — `(library (name foo))` + `(menhir ...)` with no library-dep reference in the grammar.

A regression in dune's wiring of `(libraries ...)` onto the menhir `--infer` `ocamlc -i` rule would not be caught by any existing test.