### PR TITLE
feature: source files changed event

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -62,6 +62,7 @@ let run_build_command_once ~(common : Common.t) ~config ~request =
       Dune_trace.Event.watch_build_start
         ~run_id:(Run_id.to_int run_id)
         ~restart:false
+        ~files:None
         ~start);
     let+ res = run_build_system ~request in
     let stop = Time.now () in

--- a/doc/changes/added/14396.md
+++ b/doc/changes/added/14396.md
@@ -1,0 +1,2 @@
+- Add changed source files to the `build-start` trace event for watch-mode
+  restarts, showing the paths that triggered the rebuild (#14396, @rgrinberg)

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -406,9 +406,13 @@ module Run = struct
     run_id
   ;;
 
-  let emit_build_start ~run_id ~restart ~start =
+  let emit_build_start ~run_id ~restart ~files ~start =
     Dune_trace.emit ~buffered:true Build (fun () ->
-      Dune_trace.Event.watch_build_start ~run_id:(Run_id.to_int run_id) ~restart ~start)
+      Dune_trace.Event.watch_build_start
+        ~run_id:(Run_id.to_int run_id)
+        ~restart
+        ~files
+        ~start)
   ;;
 
   let emit_build_finish ~run_id ~start ~stop ~outcome ~restart_duration =
@@ -422,19 +426,26 @@ module Run = struct
   ;;
 
   let rec poll_iter t step =
-    if Memo.Invalidation.is_empty t.invalidation
-    then Memo.Metrics.reset ()
-    else (
-      let details_hum = Memo.Invalidation.details_hum t.invalidation in
-      t.handler (Source_files_changed { details_hum });
-      Memo.reset t.invalidation;
-      t.invalidation <- Memo.Invalidation.empty;
-      t.build_inputs_changed <- Trigger.create ());
+    let files =
+      if Memo.Invalidation.is_empty t.invalidation
+      then (
+        Memo.Metrics.reset ();
+        None)
+      else (
+        let files = Memo.Invalidation.changed_paths t.invalidation in
+        let details_hum = Memo.Invalidation.details_hum t.invalidation in
+        t.handler (Source_files_changed { details_hum });
+        Memo.reset t.invalidation;
+        t.invalidation <- Memo.Invalidation.empty;
+        t.build_inputs_changed <- Trigger.create ();
+        Some files)
+    in
     let started_at = Time.now () in
     let run_id = allocate_run_id t in
     emit_build_start
       ~run_id
       ~restart:(Option.is_some t.watch_restart_started_at)
+      ~files
       ~start:started_at;
     let cancel = Fiber.Cancel.create () in
     t.status <- Building cancel;

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -115,7 +115,14 @@ module Event : sig
   val process_cleanup_start : unit -> t
   val process_cleanup_sigkill : unit -> t
   val process_cleanup_finish : unit -> t
-  val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
+
+  val watch_build_start
+    :  run_id:int
+    -> restart:bool
+    -> files:Path.t list option
+    -> start:Time.t
+    -> t
+
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 
   val watch_build_finish

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -198,8 +198,14 @@ let process_cleanup_finish () =
   Event.instant ~name:"process-cleanup-finish" (Time.now ()) Process
 ;;
 
-let watch_build_start ~run_id ~restart ~start =
-  let args = [ "run_id", Arg.int run_id; "restart", Arg.bool restart ] in
+let watch_build_start ~run_id ~restart ~files ~start =
+  let args =
+    [ "run_id", Arg.int run_id; "restart", Arg.bool restart ]
+    @
+    match files with
+    | None -> []
+    | Some files -> [ "files", Arg.list (List.map files ~f:Arg.path) ]
+  in
   Event.instant ~name:"build-start" ~args start Build
 ;;
 

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1502,6 +1502,15 @@ module Invalidation = struct
        | Some (all_but_last, last) -> all_but_last @ [ last ^ extra_message ])
   ;;
 
+  let changed_paths t =
+    List.filter_map (to_list t) ~f:(fun ({ Leaf.reason; _ } : Leaf.t) ->
+      match reason with
+      | Path_changed path -> Some path
+      | Unknown | Event_queue_overflow | Upgrade | Test | Variable_changed _ -> None)
+    |> Path.Set.of_list
+    |> Path.Set.to_list
+  ;;
+
   let execute x = execute x []
 
   let is_empty = function

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -198,6 +198,10 @@ module Invalidation : sig
       The list is truncated to [max_elements] elements, with [max_elements = 1]
       by default. Raises if [max_elements <= 0]. *)
   val details_hum : ?max_elements:int -> t -> string list
+
+  (** The list of changed paths that contributed [Path_changed] invalidations.
+      The list is deduplicated and not truncated. *)
+  val changed_paths : t -> Path.t list
 end
 
 (** Notify the memoization system that the build system has restarted. This

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -6,11 +6,15 @@ Batch and watch-mode builds emit run ids on build trace events.
   > original
   > EOF
 
+  $ cat >z <<EOF
+  > first
+  > EOF
+
   $ cat >dune <<EOF
   > (rule
   >  (target y)
-  >  (deps x)
-  >  (action (system "cat x > y")))
+  >  (deps x z)
+  >  (action (system "cat x z > y")))
   > EOF
 
   $ dune build y
@@ -48,6 +52,7 @@ Batch and watch-mode builds emit run ids on build trace events.
   Success
 
   $ echo updated > x
+  $ echo second > z
 
   $ build y
   Success
@@ -92,7 +97,20 @@ Batch and watch-mode builds emit run ids on build trace events.
   {
     "args": {
       "run_id": 2,
-      "restart": true
+      "reasons": [
+        "z changed"
+      ]
+    },
+    "name": "build-restart"
+  }
+  {
+    "args": {
+      "run_id": 2,
+      "restart": true,
+      "files": [
+        "x",
+        "z"
+      ]
     },
     "name": "build-start"
   }


### PR DESCRIPTION
The files changed message is truncated and flashes too quickly in the terminal. Use a trace event to display it as well for debugging.