### PR TITLE
refactor: replace to_dyn with repr in rule_cache

### DIFF
--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -11,14 +11,22 @@ module Workspace_local = struct
         ; targets_digest : Digest.t
         }
 
-      let to_dyn { rule_digest; dynamic_deps_stages; targets_digest } =
-        Dyn.Record
-          [ "rule_digest", Digest.to_dyn rule_digest
-          ; ( "dynamic_deps_stages"
-            , Dyn.list (Dyn.pair Dep.Set.to_dyn Digest.to_dyn) dynamic_deps_stages )
-          ; "targets_digest", Digest.to_dyn targets_digest
+      let repr =
+        Repr.record
+          "rule-cache-workspace-local-entry"
+          [ Repr.field "rule_digest" (Repr.abstract Digest.to_dyn) ~get:(fun t ->
+              t.rule_digest)
+          ; Repr.field
+              "dynamic_deps_stages"
+              (Repr.list
+                 (Repr.pair (Repr.abstract Dep.Set.to_dyn) (Repr.abstract Digest.to_dyn)))
+              ~get:(fun t -> t.dynamic_deps_stages)
+          ; Repr.field "targets_digest" (Repr.abstract Digest.to_dyn) ~get:(fun t ->
+              t.targets_digest)
           ]
       ;;
+
+      let to_dyn = Repr.to_dyn repr
     end
 
     type digest =
@@ -27,13 +35,17 @@ module Workspace_local = struct
       ; generation : int
       }
 
-    let dyn_of_digest { digest; siblings; generation } =
-      Dyn.record
-        [ "digest", Digest.to_dyn digest
-        ; "siblings", Targets.Produced.to_dyn siblings
-        ; "generation", Dyn.int generation
+    let digest_repr =
+      Repr.record
+        "rule-cache-workspace-local-digest"
+        [ Repr.field "digest" (Repr.abstract Digest.to_dyn) ~get:(fun t -> t.digest)
+        ; Repr.field "siblings" (Repr.abstract Targets.Produced.to_dyn) ~get:(fun t ->
+            t.siblings)
+        ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
         ]
     ;;
+
+    let dyn_of_digest = Repr.to_dyn digest_repr
 
     (* Keyed by the first target of the rule. *)
     type t =
@@ -47,14 +59,26 @@ module Workspace_local = struct
 
     let file = Path.relative Path.build_dir ".db"
 
-    let to_dyn { rules; digests; invalidated_subtrees; generation } =
-      Dyn.record
-        [ "rules", Path.Table.to_dyn Entry.to_dyn rules
-        ; "digests", Path.Build.Table.to_dyn dyn_of_digest digests
-        ; "invalidated_subtrees", Path.Build.Table.to_dyn Dyn.int invalidated_subtrees
-        ; "generation", Dyn.int generation
+    let repr =
+      Repr.record
+        "rule-cache-workspace-local-database"
+        [ Repr.field
+            "rules"
+            (Repr.abstract (Path.Table.to_dyn Entry.to_dyn))
+            ~get:(fun t -> t.rules)
+        ; Repr.field
+            "digests"
+            (Repr.abstract (Path.Build.Table.to_dyn dyn_of_digest))
+            ~get:(fun t -> t.digests)
+        ; Repr.field
+            "invalidated_subtrees"
+            (Repr.abstract (Path.Build.Table.to_dyn Dyn.int))
+            ~get:(fun t -> t.invalidated_subtrees)
+        ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
         ]
     ;;
+
+    let to_dyn = Repr.to_dyn repr
 
     module P = Dune_util.Persistent.Make (struct
         type nonrec t = t


### PR DESCRIPTION
Add repr definitions for the workspace-local rule cache records and derive their dynamic printers from Repr.to_dyn instead of constructing Dyn records manually.

Wrap existing to_dyn-only leaf fields with Repr.abstract so the change stays behavior-preserving.