### PR TITLE
feature: allocation profiling

### DIFF
--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -57,6 +57,7 @@ depends: [
   "ocamlfind" { with-dev-setup & os != "win32" }
   "odoc" { with-dev-setup & >= "3.2.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "ppx_optcomp" {with-dev-setup}
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind" { with-dev-setup & os != "win32" }
   "odoc" { with-dev-setup & >= "3.2.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "ppx_optcomp" {with-dev-setup}
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }
   "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1121,6 +1121,7 @@ let run f =
         ~restart:(Option.is_some files)
         ~files
         ~start);
+    Dune_trace.reset_alloc_profile ();
     (* CR-someday amokhov: Currently we invalidate cached timestamps on every
        incremental rebuild. This conservative approach helps us to work around
        some [mtime] resolution problems (e.g. on Mac OS). It would be nice to
@@ -1165,6 +1166,9 @@ let run f =
     (match Scheduler.finish_build ~stop with
      | Restarting -> ()
      | Finished { restart_duration } ->
+       let alloc_summary =
+         Dune_trace.capture_alloc_profile (`Build (Run_id.to_int run_id))
+       in
        Dune_trace.emit Build (fun () ->
          Dune_trace.Event.watch_build_finish
            ~run_id:(Run_id.to_int run_id)
@@ -1174,7 +1178,8 @@ let run f =
               | Error `Already_reported -> `Failure)
            ~start
            ~stop
-           ~restart_duration));
+           ~restart_duration);
+       Option.iter alloc_summary ~f:Dune_trace.always_emit);
     outcome
   in
   Fiber.Mutex.with_lock State.build_mutex ~f

--- a/src/dune_trace/alloc.ml
+++ b/src/dune_trace/alloc.ml
@@ -1,0 +1,291 @@
+open Stdune
+
+module Memprof = struct
+  [@@@ocaml.warning "-69-32-34"]
+
+  type t = unit
+  type allocation_source = |
+
+  type allocation =
+    { n_samples : int
+    ; size : int
+    ; source : allocation_source
+    ; callstack : Printexc.raw_backtrace
+    }
+
+  type ('major, 'minor) tracker =
+    { alloc_minor : allocation -> 'minor option
+    ; alloc_major : allocation -> 'major option
+    ; promote : 'minor -> 'major option
+    ; dealloc_minor : 'minor -> unit
+    }
+
+  let null_tracker =
+    { alloc_minor = (fun _ -> None)
+    ; alloc_major = (fun _ -> None)
+    ; promote = (fun _ -> None)
+    ; dealloc_minor = (fun _ -> ())
+    }
+  ;;
+
+  let start ~sampling_rate:_ ?callstack_size:_ (_ : (_, _) tracker) = ()
+end
+
+[%%if ocaml_version >= (5, 4, 0)]
+
+open Gc
+
+[%%else]
+
+(* The [alloc] field is never mutated if it's disabled *)
+[@@@ocaml.warning "-69"]
+
+[%%endif]
+
+let sampling_rate = 1e-4
+let callstack_size = 10
+let top_entry_count = 10
+
+module Trace = struct
+  type t =
+    | Unknown
+    | Trace of Printexc.raw_backtrace_slot array
+
+  let equal t t' =
+    match t, t' with
+    | Unknown, Unknown -> true
+    | Trace slots, Trace slots' ->
+      let len = Array.length slots in
+      Int.equal len (Array.length slots')
+      &&
+      let rec loop i = i = len || (Poly.equal slots.(i) slots'.(i) && loop (i + 1)) in
+      loop 0
+    | Unknown, Trace _ | Trace _, Unknown -> false
+  ;;
+
+  let hash = function
+    | Unknown -> 0
+    | Trace slots ->
+      Array.fold_left slots ~init:(Array.length slots) ~f:(fun acc slot ->
+        acc * 65599 lxor Poly.hash slot)
+  ;;
+
+  let to_dyn = function
+    | Unknown -> Dyn.string "<unknown>"
+    | Trace _ -> Dyn.opaque ()
+  ;;
+end
+
+module Trace_table = Hashtbl.Make (Trace)
+
+type tracked_minor =
+  { trace : Trace.t
+  ; n_samples : int
+  }
+
+type heap =
+  { mutable total_samples : int
+  ; mutable by_trace : int Trace_table.t
+  }
+
+type t =
+  { mutex : Mutex.t
+  ; minor : heap
+  ; major : heap
+  ; promoted : heap
+  ; mutable profile : Memprof.t option
+  }
+
+let create_heap () = { total_samples = 0; by_trace = Trace_table.create 64 }
+
+let create () =
+  { mutex = Mutex.create ()
+  ; minor = create_heap ()
+  ; major = create_heap ()
+  ; promoted = create_heap ()
+  ; profile = None
+  }
+;;
+
+let place_of_slot slot =
+  let name = Printexc.Slot.name slot in
+  match Printexc.Slot.location slot with
+  | None -> Option.value name ~default:"<unknown>"
+  | Some { filename; line_number; start_char; _ } ->
+    (match name with
+     | None -> sprintf "%s:%d:%d" filename line_number start_char
+     | Some name -> sprintf "%s:%d:%d %s" filename line_number start_char name)
+;;
+
+let trace_to_strings = function
+  | Trace.Unknown -> [ "<unknown>" ]
+  | Trace slots ->
+    Array.to_list slots
+    |> List.map ~f:(fun slot -> Printexc.convert_raw_backtrace_slot slot |> place_of_slot)
+;;
+
+let trace_of_callstack callstack =
+  let length = Printexc.raw_backtrace_length callstack in
+  let rec add_inlined slot remaining acc =
+    if remaining = 0
+    then acc, remaining
+    else (
+      let acc, remaining = slot :: acc, remaining - 1 in
+      if remaining = 0
+      then acc, remaining
+      else (
+        match Printexc.get_raw_backtrace_next_slot slot with
+        | None -> acc, remaining
+        | Some slot -> add_inlined slot remaining acc))
+  in
+  let rec loop i remaining acc =
+    if i = length || remaining = 0
+    then (
+      match List.rev acc with
+      | [] -> Trace.Unknown
+      | slots -> Trace (Array.of_list slots))
+    else (
+      let acc, remaining =
+        add_inlined (Printexc.get_raw_backtrace_slot callstack i) remaining acc
+      in
+      loop (i + 1) remaining acc)
+  in
+  loop 0 callstack_size []
+;;
+
+let record_sample t heap ~trace ~n_samples =
+  Mutex.protect t.mutex (fun () ->
+    heap.total_samples <- heap.total_samples + n_samples;
+    match Trace_table.find heap.by_trace trace with
+    | None -> Trace_table.set heap.by_trace trace n_samples
+    | Some samples -> Trace_table.set heap.by_trace trace (samples + n_samples))
+;;
+
+let tracker t =
+  { Memprof.null_tracker with
+    alloc_minor =
+      (fun { Memprof.n_samples; callstack; _ } ->
+        let trace = trace_of_callstack callstack in
+        record_sample t t.minor ~trace ~n_samples;
+        Some { trace; n_samples })
+  ; alloc_major =
+      (fun { Memprof.n_samples; callstack; _ } ->
+        let trace = trace_of_callstack callstack in
+        record_sample t t.major ~trace ~n_samples;
+        None)
+  ; promote =
+      (fun { trace; n_samples } ->
+        record_sample t t.promoted ~trace ~n_samples;
+        None)
+  }
+;;
+
+let start () =
+  let t = create () in
+  let profile = Memprof.start ~sampling_rate ~callstack_size (tracker t) in
+  t.profile <- Some profile;
+  t
+;;
+
+[%%if ocaml_version >= (5, 4, 0)]
+
+let stop t =
+  Option.iter t.profile ~f:(fun profile ->
+    Memprof.stop ();
+    Memprof.discard profile;
+    t.profile <- None)
+;;
+
+[%%else]
+
+let stop t = t.profile <- None
+
+[%%endif]
+
+let estimated_words_of_samples samples =
+  int_of_float ((float_of_int samples /. sampling_rate) +. 0.5)
+;;
+
+let take_top_entries entries =
+  let rec take acc n = function
+    | _ when n <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: xs -> take (x :: acc) (n - 1) xs
+  in
+  take [] top_entry_count entries
+;;
+
+let insert_top_entry entry entries =
+  let _, samples = entry in
+  let rec insert = function
+    | [] -> [ entry ]
+    | ((_, samples') as entry') :: entries ->
+      if samples > samples' then entry :: entry' :: entries else entry' :: insert entries
+  in
+  insert entries |> take_top_entries
+;;
+
+let top_entries by_trace =
+  Trace_table.foldi by_trace ~init:[] ~f:(fun trace samples entries ->
+    insert_top_entry (trace, samples) entries)
+  |> List.map ~f:(fun (trace, samples) ->
+    let estimated_words = estimated_words_of_samples samples in
+    ({ trace = trace_to_strings trace; estimated_words; samples } : Event.alloc_entry))
+;;
+
+let summary_of_heap total_samples by_trace =
+  let total_words = estimated_words_of_samples total_samples in
+  ({ total_words; total_samples; top = top_entries by_trace } : Event.alloc_heap)
+;;
+
+let swap t =
+  let fresh_minor = Trace_table.create 64 in
+  let fresh_major = Trace_table.create 64 in
+  let fresh_promoted = Trace_table.create 64 in
+  Mutex.protect t.mutex (fun () ->
+    let minor_total_samples = t.minor.total_samples in
+    let minor_by_trace = t.minor.by_trace in
+    let major_total_samples = t.major.total_samples in
+    let major_by_trace = t.major.by_trace in
+    let promoted_total_samples = t.promoted.total_samples in
+    let promoted_by_trace = t.promoted.by_trace in
+    t.minor.total_samples <- 0;
+    t.minor.by_trace <- fresh_minor;
+    t.major.total_samples <- 0;
+    t.major.by_trace <- fresh_major;
+    t.promoted.total_samples <- 0;
+    t.promoted.by_trace <- fresh_promoted;
+    ( minor_total_samples
+    , minor_by_trace
+    , major_total_samples
+    , major_by_trace
+    , promoted_total_samples
+    , promoted_by_trace ))
+;;
+
+type snapshot =
+  { minor : Event.alloc_heap
+  ; major : Event.alloc_heap
+  ; promoted : Event.alloc_heap
+  }
+
+let snapshot t =
+  let ( minor_total_samples
+      , minor_by_trace
+      , major_total_samples
+      , major_by_trace
+      , promoted_total_samples
+      , promoted_by_trace )
+    =
+    swap t
+  in
+  let minor = summary_of_heap minor_total_samples minor_by_trace in
+  let major = summary_of_heap major_total_samples major_by_trace in
+  let promoted = summary_of_heap promoted_total_samples promoted_by_trace in
+  { minor; major; promoted }
+;;
+
+let reset t =
+  ignore
+    (swap t : int * int Trace_table.t * int * int Trace_table.t * int * int Trace_table.t)
+;;

--- a/src/dune_trace/alloc.mli
+++ b/src/dune_trace/alloc.mli
@@ -1,0 +1,12 @@
+type t
+
+type snapshot =
+  { minor : Event.alloc_heap
+  ; major : Event.alloc_heap
+  ; promoted : Event.alloc_heap
+  }
+
+val start : unit -> t
+val reset : t -> unit
+val stop : t -> unit
+val snapshot : t -> snapshot

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -3,6 +3,7 @@ open Stdune
 type t =
   | Rpc
   | Gc
+  | Alloc
   | Fd
   | Sandbox
   | Persistent
@@ -27,6 +28,7 @@ type t =
 let all =
   [ Rpc
   ; Gc
+  ; Alloc
   ; Fd
   ; Sandbox
   ; Persistent
@@ -53,6 +55,7 @@ let all =
 let to_string = function
   | Rpc -> "rpc"
   | Gc -> "gc"
+  | Alloc -> "alloc"
   | Fd -> "fd"
   | Sandbox -> "sandbox"
   | Persistent -> "persistent"
@@ -91,26 +94,27 @@ module Set = Bit_set.Make (struct
     let to_int = function
       | Rpc -> 0
       | Gc -> 1
-      | Fd -> 2
-      | Sandbox -> 3
-      | Persistent -> 4
-      | Process -> 5
-      | Rules -> 6
-      | Pkg -> 7
-      | Scheduler -> 8
-      | Promote -> 9
-      | Build -> 10
-      | Debug -> 11
-      | Config -> 12
-      | File_watcher -> 13
-      | Diagnostics -> 14
-      | Log -> 15
-      | Cram -> 16
-      | Action -> 17
-      | Cache -> 18
-      | Digest -> 19
-      | Artifact_substitution -> 20
-      | Thread -> 21
+      | Alloc -> 2
+      | Fd -> 3
+      | Sandbox -> 4
+      | Persistent -> 5
+      | Process -> 6
+      | Rules -> 7
+      | Pkg -> 8
+      | Scheduler -> 9
+      | Promote -> 10
+      | Build -> 11
+      | Debug -> 12
+      | Config -> 13
+      | File_watcher -> 14
+      | Diagnostics -> 15
+      | Log -> 16
+      | Cram -> 17
+      | Action -> 18
+      | Cache -> 19
+      | Digest -> 20
+      | Artifact_substitution -> 21
+      | Thread -> 22
     ;;
   end)
 

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -1,6 +1,7 @@
 type t =
   | Rpc
   | Gc
+  | Alloc
   | Fd
   | Sandbox
   | Persistent

--- a/src/dune_trace/dune
+++ b/src/dune_trace/dune
@@ -1,5 +1,7 @@
 (library
  (name dune_trace)
+ (preprocess
+  (pps ppx_optcomp))
  (foreign_stubs
   (language c)
   (names dune_trace_stubs))

--- a/src/dune_trace/dune_trace.ml
+++ b/src/dune_trace/dune_trace.ml
@@ -60,11 +60,35 @@ end
 
 let global = ref None
 
+let reset_alloc_profile () =
+  Option.iter !global ~f:(fun (out : Out.t) -> Option.iter out.alloc ~f:Alloc.reset)
+;;
+
+let capture_alloc_profile kind =
+  match
+    match !global with
+    | None -> None
+    | Some (global : Out.t) -> global.alloc
+  with
+  | None -> None
+  | Some alloc ->
+    let { Alloc.minor; major; promoted } = Alloc.snapshot alloc in
+    let phase, run_id =
+      match kind with
+      | `Build run_id -> `Build, Some run_id
+      | `Exit -> `Exit, None
+    in
+    Some (Event.alloc_summary ~phase ~run_id ~minor ~major ~promoted)
+;;
+
 let at_exit =
   At_exit.at_exit Global_lock.at_exit (fun () ->
     match !global with
     | None -> ()
     | Some t ->
+      let alloc_summary = capture_alloc_profile `Exit in
+      Option.iter t.alloc ~f:Alloc.stop;
+      Option.iter alloc_summary ~f:(Out.emit t);
       Out.emit t (Event.exit ());
       Out.close t;
       (match Env.(get initial Dune_action_trace.Private.trace_dir_env_var) with

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -4,6 +4,7 @@ module Category : sig
   type t =
     | Rpc
     | Gc
+    | Alloc
     | Fd
     | Sandbox
     | Persistent
@@ -37,6 +38,18 @@ module Event : sig
   end
 
   type t
+
+  type alloc_entry =
+    { trace : string list
+    ; estimated_words : int
+    ; samples : int
+    }
+
+  type alloc_heap =
+    { total_words : int
+    ; total_samples : int
+    ; top : alloc_entry list
+    }
 
   val sandbox
     :  [ `Create | `Snapshot | `Destroy | `Extract | `Corrected ]
@@ -131,6 +144,14 @@ module Event : sig
     -> start:Time.t
     -> stop:Time.t
     -> restart_duration:Time.Span.t option
+    -> t
+
+  val alloc_summary
+    :  phase:[ `Build | `Exit ]
+    -> run_id:int option
+    -> minor:alloc_heap
+    -> major:alloc_heap
+    -> promoted:alloc_heap
     -> t
 
   val init : version:string option -> t
@@ -278,6 +299,8 @@ val enabled : Category.t -> bool
 val emit : ?buffered:bool -> Category.t -> (unit -> Event.t) -> unit
 val emit_all : ?buffered:bool -> Category.t -> (unit -> Event.t list) -> unit
 val flush : unit -> unit
+val reset_alloc_profile : unit -> unit
+val capture_alloc_profile : [ `Build of int | `Exit ] -> Event.t option
 val at_exit : At_exit.t
 
 module Private : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -111,6 +111,18 @@ end
 
 type t = Event.t
 
+type alloc_entry =
+  { trace : string list
+  ; estimated_words : int
+  ; samples : int
+  }
+
+type alloc_heap =
+  { total_words : int
+  ; total_samples : int
+  ; top : alloc_entry list
+  }
+
 let scan_source ~name ~start ~stop ~dir =
   let dur = Time.diff stop start in
   let args = [ "dir", Arg.source_path dir ] in
@@ -262,6 +274,42 @@ let watch_build_finish ~run_id ~outcome ~start ~stop ~restart_duration =
     @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.complete ~name:"build-finish" ~args ~start ~dur Build
+;;
+
+let alloc_summary ~phase ~run_id ~minor ~major ~promoted =
+  let now = Time.now () in
+  let entry { trace; estimated_words; samples } =
+    Arg.record
+      [ "trace", Arg.list (List.map trace ~f:Arg.string)
+      ; "estimated_words", Arg.int estimated_words
+      ; "samples", Arg.int samples
+      ]
+    |> Arg.list
+  in
+  let heap { total_words; total_samples; top } =
+    Arg.record
+      [ "total_words", Arg.int total_words
+      ; "total_samples", Arg.int total_samples
+      ; "top", Arg.list (List.map top ~f:entry)
+      ]
+    |> Arg.list
+  in
+  let args =
+    [ ( "phase"
+      , Arg.string
+          (match phase with
+           | `Build -> "build"
+           | `Exit -> "exit") )
+    ; "minor", heap minor
+    ; "major", heap major
+    ; "promoted", heap promoted
+    ]
+    @
+    match run_id with
+    | None -> []
+    | Some run_id -> [ "run_id", Arg.int run_id ]
+  in
+  Event.instant ~name:"summary" ~args now Alloc
 ;;
 
 module Exit_status = struct

--- a/src/dune_trace/out.ml
+++ b/src/dune_trace/out.ml
@@ -23,6 +23,7 @@ type t =
   ; cats : Category.Set.t
   ; mutex : Mutex.t
   ; path : Path.t
+  ; mutable alloc : Alloc.t option
   }
 
 (* CR-someday rgrinberg: remove this once we drop support for < 5.2 *)
@@ -78,7 +79,8 @@ let create cats path =
   in
   let cats = Category.Set.of_list cats in
   let buf = Buffer.create (1 lsl 16) in
-  { fd; cats; buf; mutex = Mutex.create (); path }
+  let alloc = if Category.Set.mem cats Alloc then Some (Alloc.start ()) else None in
+  { fd; cats; buf; mutex = Mutex.create (); path; alloc }
 ;;
 
 let to_buffer t sexp =

--- a/src/dune_trace/out.mli
+++ b/src/dune_trace/out.mli
@@ -6,6 +6,7 @@ type t =
   ; cats : Category.Set.t
   ; mutex : Mutex.t
   ; path : Stdune.Path.t
+  ; mutable alloc : Alloc.t option
   }
 
 val emit : ?buffered:bool -> t -> Event.t -> unit

--- a/test/blackbox-tests/test-cases/trace/alloc.t
+++ b/test/blackbox-tests/test-cases/trace/alloc.t
@@ -1,0 +1,82 @@
+  $ cat > dune-project <<'EOF'
+  > (lang dune 1.6)
+  > EOF
+  $ cat > dune <<'EOF'
+  > (executable
+  >  (name prog))
+  > EOF
+  $ cat > prog.ml <<'EOF'
+  > let () = print_endline "hello, world"
+  > EOF
+
+The alloc sampler is only enabled when the alloc trace category is requested:
+
+  $ export DUNE_TRACE="+alloc"
+  $ dune build prog.exe
+  $ dune trace cat | jq -s '
+  >   [ .[]
+  >   | select(.cat == "alloc")
+  >   | { name
+  >     , phase: .args.phase
+  >     , has_run_id: (.args.run_id != null)
+  >     , heaps:
+  >         { minor: (.args.minor | keys)
+  >         , major: (.args.major | keys)
+  >         , promoted: (.args.promoted | keys)
+  >         }
+  >     , top_entries_are_traces:
+  >         (all((.args.minor.top + .args.major.top + .args.promoted.top)[]?;
+  >           ((keys | sort) == ["estimated_words", "samples", "trace"]
+  >            and (.trace | type == "array")
+  >            and (.trace | length <= 10)
+  >            and all(.trace[]; type == "string"))))
+  >     }
+  >   ]'
+  [
+    {
+      "name": "summary",
+      "phase": "build",
+      "has_run_id": true,
+      "heaps": {
+        "minor": [
+          "top",
+          "total_samples",
+          "total_words"
+        ],
+        "major": [
+          "top",
+          "total_samples",
+          "total_words"
+        ],
+        "promoted": [
+          "top",
+          "total_samples",
+          "total_words"
+        ]
+      },
+      "top_entries_are_traces": true
+    },
+    {
+      "name": "summary",
+      "phase": "exit",
+      "has_run_id": false,
+      "heaps": {
+        "minor": [
+          "top",
+          "total_samples",
+          "total_words"
+        ],
+        "major": [
+          "top",
+          "total_samples",
+          "total_words"
+        ],
+        "promoted": [
+          "top",
+          "total_samples",
+          "total_words"
+        ]
+      },
+      "top_entries_are_traces": true
+    }
+  ]


### PR DESCRIPTION
Add a poor man's allocation tracker. This is far away from what memtrace provides, but at least it has almost no barrier to entry. It can be turned on with `DUNE_TRACE=+alloc`. Results are dumped into the trace.