### PR TITLE
trace: include dune self rusage snapshots

### DIFF
--- a/doc/changes/added/14402.md
+++ b/doc/changes/added/14402.md
@@ -1,0 +1,1 @@
+- Add dune's rusage information in start/finish build trace events (#14402, @rgrinberg)

--- a/otherlibs/stdune/src/proc.ml
+++ b/otherlibs/stdune/src/proc.ml
@@ -48,6 +48,8 @@ module Resource_usage = struct
     ; nivcsw = 0
     }
   ;;
+
+  external get_self : unit -> t option = "dune_getrusage_self"
 end
 
 module Times = struct

--- a/otherlibs/stdune/src/proc.mli
+++ b/otherlibs/stdune/src/proc.mli
@@ -27,6 +27,7 @@ module Resource_usage : sig
     }
 
   val zero : t
+  val get_self : unit -> t option
 end
 
 module Times : sig

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -8,6 +8,11 @@ void dune_wait4(value v_pid, value flags) {
   caml_failwith("wait4: not supported on windows");
 }
 
+CAMLprim value dune_getrusage_self(value unit) {
+  (void)unit;
+  return Val_none;
+}
+
 #else
 
 #include <caml/alloc.h>
@@ -38,6 +43,24 @@ static inline value caml_alloc_some_compat(value v) {
 
 CAMLextern int caml_convert_signal_number(int);
 CAMLextern int caml_rev_convert_signal_number(int);
+
+static value alloc_resource_usage(struct rusage *ru) {
+  CAMLparam0();
+  CAMLlocal1(times);
+  times = caml_alloc_tuple(9);
+  Store_field(times, 0, Val_long(((int64_t)ru->ru_utime.tv_sec * 1000000000LL) +
+                                 ((int64_t)ru->ru_utime.tv_usec * 1000LL)));
+  Store_field(times, 1, Val_long(((int64_t)ru->ru_stime.tv_sec * 1000000000LL) +
+                                 ((int64_t)ru->ru_stime.tv_usec * 1000LL)));
+  Store_field(times, 2, Val_long(ru->ru_maxrss));
+  Store_field(times, 3, Val_long(ru->ru_minflt));
+  Store_field(times, 4, Val_long(ru->ru_majflt));
+  Store_field(times, 5, Val_long(ru->ru_inblock));
+  Store_field(times, 6, Val_long(ru->ru_oublock));
+  Store_field(times, 7, Val_long(ru->ru_nvcsw));
+  Store_field(times, 8, Val_long(ru->ru_nivcsw));
+  CAMLreturn(times);
+}
 
 static value alloc_process_status(int status) {
   value st;
@@ -88,18 +111,7 @@ value dune_wait4(value v_pid, value flags) {
     }
   }
 
-  times = caml_alloc_tuple(9);
-  Store_field(times, 0, Val_long(((int64_t)ru.ru_utime.tv_sec * 1000000000LL) +
-                                 ((int64_t)ru.ru_utime.tv_usec * 1000LL)));
-  Store_field(times, 1, Val_long(((int64_t)ru.ru_stime.tv_sec * 1000000000LL) +
-                                 ((int64_t)ru.ru_stime.tv_usec * 1000LL)));
-  Store_field(times, 2, Val_long(ru.ru_maxrss));
-  Store_field(times, 3, Val_long(ru.ru_minflt));
-  Store_field(times, 4, Val_long(ru.ru_majflt));
-  Store_field(times, 5, Val_long(ru.ru_inblock));
-  Store_field(times, 6, Val_long(ru.ru_oublock));
-  Store_field(times, 7, Val_long(ru.ru_nvcsw));
-  Store_field(times, 8, Val_long(ru.ru_nivcsw));
+  times = alloc_resource_usage(&ru);
 
   res = caml_alloc_tuple(4);
   Store_field(res, 0, Val_int(pid));
@@ -107,6 +119,15 @@ value dune_wait4(value v_pid, value flags) {
   Store_field(res, 2, Val_long(time_ns));
   Store_field(res, 3, times);
   CAMLreturn(caml_alloc_some_compat(res));
+}
+
+CAMLprim value dune_getrusage_self(value unit) {
+  CAMLparam1(unit);
+  struct rusage ru;
+  if (getrusage(RUSAGE_SELF, &ru) == -1) {
+    uerror("getrusage", Nothing);
+  }
+  CAMLreturn(caml_alloc_some_compat(alloc_resource_usage(&ru)));
 }
 
 #endif

--- a/otherlibs/stdune/test/proc_tests.ml
+++ b/otherlibs/stdune/test/proc_tests.ml
@@ -1,0 +1,97 @@
+open Stdune
+
+let span_is_nonnegative span = Time.Span.compare span Time.Span.zero <> Lt
+let is_monotonic ~before ~after = Time.Span.compare before after <> Gt
+
+let usage_is_sane
+      { Proc.Resource_usage.user_cpu_time
+      ; system_cpu_time
+      ; maxrss
+      ; minflt
+      ; majflt
+      ; inblock
+      ; oublock
+      ; nvcsw
+      ; nivcsw
+      }
+  =
+  span_is_nonnegative user_cpu_time
+  && span_is_nonnegative system_cpu_time
+  && maxrss >= 0
+  && minflt >= 0
+  && majflt >= 0
+  && inblock >= 0
+  && oublock >= 0
+  && nvcsw >= 0
+  && nivcsw >= 0
+;;
+
+let usage_does_not_go_backwards
+      { Proc.Resource_usage.user_cpu_time = before_user_cpu_time
+      ; system_cpu_time = before_system_cpu_time
+      ; maxrss = before_maxrss
+      ; minflt = before_minflt
+      ; majflt = before_majflt
+      ; inblock = before_inblock
+      ; oublock = before_oublock
+      ; nvcsw = before_nvcsw
+      ; nivcsw = before_nivcsw
+      }
+      { Proc.Resource_usage.user_cpu_time = after_user_cpu_time
+      ; system_cpu_time = after_system_cpu_time
+      ; maxrss = after_maxrss
+      ; minflt = after_minflt
+      ; majflt = after_majflt
+      ; inblock = after_inblock
+      ; oublock = after_oublock
+      ; nvcsw = after_nvcsw
+      ; nivcsw = after_nivcsw
+      }
+  =
+  is_monotonic ~before:before_user_cpu_time ~after:after_user_cpu_time
+  && is_monotonic ~before:before_system_cpu_time ~after:after_system_cpu_time
+  && before_maxrss <= after_maxrss
+  && before_minflt <= after_minflt
+  && before_majflt <= after_majflt
+  && before_inblock <= after_inblock
+  && before_oublock <= after_oublock
+  && before_nvcsw <= after_nvcsw
+  && before_nivcsw <= after_nivcsw
+;;
+
+let print_bool name value = Printf.printf "%s: %b\n" name value
+
+let%expect_test "Proc.Resource_usage.get_self returns sane data" =
+  let before = Proc.Resource_usage.get_self () in
+  let busy = ref 0 in
+  for i = 1 to 100_000 do
+    busy := !busy + i
+  done;
+  ignore !busy;
+  let after = Proc.Resource_usage.get_self () in
+  let available_matches_platform =
+    Bool.equal (Option.is_some before) (not Sys.win32)
+    && Bool.equal (Option.is_some after) (not Sys.win32)
+  in
+  let values_are_sane =
+    match before, after with
+    | Some before, Some after -> usage_is_sane before && usage_is_sane after
+    | None, None -> true
+    | _ -> false
+  in
+  let values_do_not_go_backwards =
+    match before, after with
+    | Some before, Some after -> usage_does_not_go_backwards before after
+    | None, None -> true
+    | _ -> false
+  in
+  print_bool "available_matches_platform" available_matches_platform;
+  print_bool "values_are_sane" values_are_sane;
+  print_bool "values_do_not_go_backwards" values_do_not_go_backwards;
+  [%expect
+    {|
+    available_matches_platform: true
+    values_are_sane: true
+    values_do_not_go_backwards: true
+  |}]
+;;

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -143,6 +143,36 @@ let init ~version =
   Event.instant ~args ~name:"init" now Config
 ;;
 
+let make_rusage_args resource_usage =
+  match resource_usage with
+  | None -> []
+  | Some
+      { Proc.Resource_usage.user_cpu_time
+      ; system_cpu_time
+      ; maxrss
+      ; minflt
+      ; majflt
+      ; inblock
+      ; oublock
+      ; nvcsw
+      ; nivcsw
+      } ->
+    [ ( "rusage"
+      , Arg.record
+          [ "user_cpu_time", Arg.span user_cpu_time
+          ; "system_cpu_time", Arg.span system_cpu_time
+          ; "maxrss", Arg.int maxrss
+          ; "minflt", Arg.int minflt
+          ; "majflt", Arg.int majflt
+          ; "inblock", Arg.int inblock
+          ; "oublock", Arg.int oublock
+          ; "nvcsw", Arg.int nvcsw
+          ; "nivcsw", Arg.int nivcsw
+          ]
+        |> Arg.list )
+    ]
+;;
+
 let exit () =
   let now = Time.now () in
   let args =
@@ -177,6 +207,7 @@ let exit () =
       |> Arg.list
     in
     [ "gc", gc; "io", io; "digest", digest ]
+    @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.instant ~args ~name:"exit" now Config
 ;;
@@ -201,10 +232,10 @@ let process_cleanup_finish () =
 let watch_build_start ~run_id ~restart ~files ~start =
   let args =
     [ "run_id", Arg.int run_id; "restart", Arg.bool restart ]
-    @
-    match files with
-    | None -> []
-    | Some files -> [ "files", Arg.list (List.map files ~f:Arg.path) ]
+    @ (match files with
+       | None -> []
+       | Some files -> [ "files", Arg.list (List.map files ~f:Arg.path) ])
+    @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.instant ~name:"build-start" ~args start Build
 ;;
@@ -225,10 +256,10 @@ let watch_build_finish ~run_id ~outcome ~start ~stop ~restart_duration =
   in
   let args =
     [ "run_id", Arg.int run_id; "outcome", Arg.string outcome ]
-    @
-    match restart_duration with
-    | None -> []
-    | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ]
+    @ (match restart_duration with
+       | None -> []
+       | Some restart_duration -> [ "restart_duration", Arg.span restart_duration ])
+    @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.complete ~name:"build-finish" ~args ~start ~dur Build
 ;;
@@ -260,36 +291,6 @@ let args_of_targets =
   in
   fun { root; files; dirs } ->
     paths root "target_files" files @ paths root "target_dirs" dirs
-;;
-
-let make_rusage_args resource_usage =
-  match resource_usage with
-  | None -> []
-  | Some
-      { Proc.Resource_usage.user_cpu_time
-      ; system_cpu_time
-      ; maxrss
-      ; minflt
-      ; majflt
-      ; inblock
-      ; oublock
-      ; nvcsw
-      ; nivcsw
-      } ->
-    [ ( "rusage"
-      , Arg.record
-          [ "user_cpu_time", Arg.span user_cpu_time
-          ; "system_cpu_time", Arg.span system_cpu_time
-          ; "maxrss", Arg.int maxrss
-          ; "minflt", Arg.int minflt
-          ; "majflt", Arg.int majflt
-          ; "inblock", Arg.int inblock
-          ; "oublock", Arg.int oublock
-          ; "nvcsw", Arg.int nvcsw
-          ; "nivcsw", Arg.int nivcsw
-          ]
-        |> Arg.list )
-    ]
 ;;
 
 let make_exit exit =

--- a/test/blackbox-tests/test-cases/trace/first-last-events.t
+++ b/test/blackbox-tests/test-cases/trace/first-last-events.t
@@ -24,7 +24,15 @@ Demonstrate the last event:
 
   $ dune trace cat | jq -s '
   >   last
-  > | { name, cat, args: (.args | .gc |= keys | .io |= keys | .digest |= keys) }
+  > | { name
+  >   , cat
+  >   , args:
+  >       { gc: (.args.gc | keys)
+  >       , io: (.args.io | keys)
+  >       , digest: (.args.digest | keys)
+  >       , rusage: (.args.rusage | keys)
+  >       }
+  >   }
   > '
   {
     "name": "exit",
@@ -49,6 +57,17 @@ Demonstrate the last event:
       "digest": [
         "files",
         "values"
+      ],
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
       ]
     }
   }

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -1,4 +1,5 @@
-Batch and watch-mode builds emit run ids on build trace events.
+Batch and watch-mode builds emit run ids and dune's own rusage snapshots on
+build trace events.
 
   $ make_dune_project 3.22
 
@@ -30,18 +31,44 @@ Batch and watch-mode builds emit run ids on build trace events.
   >     then .args.restart_duration |= type
   >     else .
   >     end
+  >   | if .args.rusage? != null
+  >     then .args.rusage |= keys
+  >     else .
+  >     end
   > ] | .[]'
   {
     "args": {
       "run_id": 0,
-      "restart": false
+      "restart": false,
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
+      ]
     },
     "name": "build-start"
   }
   {
     "args": {
       "run_id": 0,
-      "outcome": "success"
+      "outcome": "success",
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
+      ]
     },
     "name": "build-finish"
   }
@@ -70,18 +97,44 @@ Batch and watch-mode builds emit run ids on build trace events.
   >     then .args.restart_duration |= type
   >     else .
   >     end
+  >   | if .args.rusage? != null
+  >     then .args.rusage |= keys
+  >     else .
+  >     end
   > ] | .[]'
   {
     "args": {
       "run_id": 1,
-      "restart": false
+      "restart": false,
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
+      ]
     },
     "name": "build-start"
   }
   {
     "args": {
       "run_id": 1,
-      "outcome": "success"
+      "outcome": "success",
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
+      ]
     },
     "name": "build-finish"
   }
@@ -110,6 +163,17 @@ Batch and watch-mode builds emit run ids on build trace events.
       "files": [
         "x",
         "z"
+      ],
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
       ]
     },
     "name": "build-start"
@@ -118,7 +182,38 @@ Batch and watch-mode builds emit run ids on build trace events.
     "args": {
       "run_id": 2,
       "outcome": "success",
-      "restart_duration": "number"
+      "restart_duration": "number",
+      "rusage": [
+        "inblock",
+        "majflt",
+        "maxrss",
+        "minflt",
+        "nivcsw",
+        "nvcsw",
+        "oublock",
+        "system_cpu_time",
+        "user_cpu_time"
+      ]
     },
     "name": "build-finish"
+  }
+
+  $ dune trace cat | jq -s '
+  > last
+  > | select(.name == "exit")
+  > | { name, cat, rusage: (.args.rusage | keys) }'
+  {
+    "name": "exit",
+    "cat": "config",
+    "rusage": [
+      "inblock",
+      "majflt",
+      "maxrss",
+      "minflt",
+      "nivcsw",
+      "nvcsw",
+      "oublock",
+      "system_cpu_time",
+      "user_cpu_time"
+    ]
   }


### PR DESCRIPTION
Add a Stdune binding for getrusage(RUSAGE_SELF) and attach the\nresult to build-start, build-finish, and exit trace events.