### PR TITLE
test: dune must not internal-error on invalid -open argument

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t
@@ -1,0 +1,53 @@
+A [(flags ... -open <not-a-module-name> ...)] must not crash dune
+during rule generation. Names that do not parse as an OCaml
+[Module_name.t] should be tolerated by dune's flag-handling paths;
+the compiler is the authority on whether a given [-open] argument
+is acceptable, and dune should not pre-empt that decision by
+raising on syntactically invalid names.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+A trivial dependency library so the consumer's compile rule has
+inter-library deps to filter — this exercises any future code path
+that gates [-open] parsing on the presence of [(libraries ...)].
+
+  $ mkdir dep
+  $ cat > dep/dune <<EOF
+  > (library (name dep))
+  > EOF
+  $ cat > dep/dep.ml <<EOF
+  > let value = 0
+  > EOF
+
+A library with [-open] receiving an argument that is not a
+syntactically valid OCaml identifier — here, [1bad] (a leading
+digit). [foo] declares [(libraries dep)] so that the per-module
+inter-library filter is active for [foo]'s compile rule. Rule
+generation must succeed; the compiler may reject the flag at
+compile time, but that is the compiler's concern, not dune's.
+
+  $ mkdir foo
+  $ cat > foo/dune <<EOF
+  > (library (name foo) (libraries dep) (flags :standard -open 1bad))
+  > EOF
+  $ cat > foo/m.ml <<EOF
+  > let _ = ()
+  > EOF
+
+Rule generation runs to completion (dune does not raise an internal
+error and does not pre-empt the compiler's decision with its own
+validation). The build then fails because the compiler rejects the
+flag. The expected output below pins three properties at once: the
+error originates from the compiler — its [File "command line
+argument: ..."] preamble is unmistakably the compiler's CLI-parser
+diagnostic format, not anything dune emits; dune did not abort
+earlier with an internal error or its own "invalid module name"
+diagnostic; and dune did not silently drop the [-open] argument,
+which would have produced a successful build with no compiler error.
+
+  $ dune build @check 2>&1
+  File "command line argument: -open "1bad"", line 1, characters 0-4:
+  Error: Invalid literal 1bad
+  [1]


### PR DESCRIPTION
## Summary

Adds `test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t`, asserting that when a stanza's `(flags ... -open <name>)` receives a syntactically invalid OCaml identifier (e.g. starting with a digit, like `1bad`), dune does not abort with an internal error, does not pre-empt the compiler with its own "invalid module name" diagnostic, and does not silently drop the `-open` argument. Instead, the build fails with an OCaml compiler error whose `File "command line argument: ..."` preamble is unmistakably the compiler's CLI-parser diagnostic format. The test pins this exact output.

Today on `main`, no in-dune code path parses `-open` argument names through `Module_name.of_string`, so the test passes trivially. The guard is forward-looking: it pins the invariant for any future code (notably the per-module dependency filter in #14116) that reads `-open` argument names while computing rule-time module references.

## Test plan

- [x] `dune runtest test/blackbox-tests/test-cases/per-module-lib-deps/open-flag-invalid-identifier.t` passes on this branch.