### PR TITLE
debug: include active RPC requests in debug dump

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -112,6 +112,12 @@ module Clients = struct
 
   let to_list = Session.Id.Map.to_list
   let to_list_map = Session.Id.Map.to_list_map
+
+  let repr =
+    let session_repr = Repr.abstract (Session.Stage1.to_dyn Client.to_dyn) in
+    Repr.view (Repr.list session_repr) ~to_:(fun t ->
+      Session.Id.Map.values t |> List.map ~f:(fun { session } -> session))
+  ;;
 end
 
 (** Primitive unbounded FIFO channel. Reads are blocking. Writes are not
@@ -161,21 +167,39 @@ end = struct
   ;;
 end
 
-type 'build_arg t =
+type server =
   { config : Run.t
-  ; pending_jobs : 'build_arg pending_action Job_queue.t
   ; mutable clients : Clients.t
   }
 
+let repr =
+  Repr.record "rpc" [ Repr.field "connections" Clients.repr ~get:(fun t -> t.clients) ]
+;;
+
+let to_dyn = Repr.to_dyn repr
+let current : server option ref = ref None
+
+type 'build_arg t =
+  { server : server
+  ; pending_jobs : 'build_arg pending_action Job_queue.t
+  }
+
+let () =
+  Debug.register ~name:"rpc" (fun () ->
+    match !current with
+    | None -> Dyn.Option None
+    | Some server -> to_dyn server)
+;;
+
 let ready (t : _ t) =
-  Fiber.Ivar.read t.config.startup_ivar
+  Fiber.Ivar.read t.server.config.startup_ivar
   >>= function
   | Ok server -> Csexp_rpc.Server.ready server
   | Error _exn -> raise Dune_util.Report_error.Already_reported
 ;;
 
 let stop (t : _ t) =
-  Fiber.Ivar.peek t.config.startup_ivar
+  Fiber.Ivar.peek t.server.config.startup_ivar
   >>= function
   | None -> Fiber.return ()
   | Some (Error _) -> Fiber.return ()
@@ -196,12 +220,12 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
   let on_init session (_ : Initialize.Request.t) =
     let t = Fdecl.get t in
     let client = () in
-    t.clients <- Clients.add_session t.clients session;
+    t.server.clients <- Clients.add_session t.server.clients session;
     Fiber.return client
   in
   let on_terminate session =
     let t = Fdecl.get t in
-    t.clients <- Clients.remove_session t.clients session;
+    t.server.clients <- Clients.remove_session t.server.clients session;
     Fiber.return ()
   in
   let rpc = Handler.create ~on_terminate ~on_init ~version:Dune_rpc.Version.latest () in
@@ -361,11 +385,11 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
       let t = Fdecl.get t in
       let terminate_sessions () =
         Fiber.fork_and_join_unit cancel_pending_jobs (fun () ->
-          Fiber.parallel_iter (Clients.to_list t.clients) ~f:(fun (_, entry) ->
+          Fiber.parallel_iter (Clients.to_list t.server.clients) ~f:(fun (_, entry) ->
             Session.Stage1.close entry.session))
       in
       let shutdown () =
-        let* () = Csexp_rpc.Server.stop (Lazy.force t.config.server) in
+        let* () = Csexp_rpc.Server.stop (Lazy.force t.server.config.server) in
         Scheduler.shutdown ();
         Fiber.return ()
       in
@@ -377,7 +401,7 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
     let f _ () =
       let t = Fdecl.get t in
       let clients =
-        Clients.to_list_map t.clients ~f:(fun _id (entry : Clients.entry) ->
+        Clients.to_list_map t.server.clients ~f:(fun _id (entry : Clients.entry) ->
           ( Initialize.Request.id (Session.Stage1.initialize entry.session)
           , match Session.Stage1.menu entry.session with
             | None -> Status.Menu.Uninitialized
@@ -473,17 +497,12 @@ let create ~lock_timeout ~registry ~root =
     ; startup_ivar = Fiber.Ivar.create ()
     }
   in
-  let res =
-    let pending_jobs = Job_queue.create () in
-    { config; pending_jobs; clients = Clients.empty }
-  in
+  let server = { config; clients = Clients.empty } in
+  let res = { server; pending_jobs = Job_queue.create () } in
+  current := Some server;
   Fdecl.set t res;
   res
 ;;
 
-let run t =
-  let* () = Fiber.return () in
-  Run.run t.config
-;;
-
+let run t = Run.run t.server.config
 let pending_action t = Job_queue.read t.pending_jobs

--- a/src/rpc/server.ml
+++ b/src/rpc/server.ml
@@ -40,6 +40,15 @@ module type Session = Server_intf.Session
 module Session = struct
   module Id = Session_id
 
+  let rpc_id_repr = Repr.abstract Dune_rpc.Private.Id.to_dyn
+  let rpc_call_repr = Repr.abstract Dune_rpc.Private.Call.to_dyn
+
+  let request_repr =
+    Repr.record
+      "Request"
+      [ Repr.field "id" rpc_id_repr ~get:fst; Repr.field "call" rpc_call_repr ~get:snd ]
+  ;;
+
   module Close = struct
     type t =
       { ivar : unit Fiber.Ivar.t
@@ -84,6 +93,28 @@ module Session = struct
       | Closed
   end
 
+  module Pending_request = struct
+    type t =
+      { request : Request.t
+      ; ivar : Pending_response.t Fiber.Ivar.t
+      }
+
+    let create request ivar = { request; ivar }
+    let repr = Repr.view request_repr ~to_:(fun { request; ivar = _ } -> request)
+  end
+
+  let initialize_request_repr =
+    Repr.record
+      "Initialize.Request"
+      [ Repr.field "id" rpc_id_repr ~get:Initialize.Request.id
+      ; Repr.field
+          "dune_version"
+          (Repr.pair Repr.int Repr.int)
+          ~get:Initialize.Request.dune_version
+      ; Repr.field "protocol_version" Repr.int ~get:Initialize.Request.protocol_version
+      ]
+  ;;
+
   type 's chan' = (module Session with type t = 's) * 's
   type chan = Chan : 's chan' -> chan
 
@@ -96,9 +127,10 @@ module Session = struct
       ; mutable menu : Menu.t option
       ; pool : Fiber.Pool.t
       ; mutable state : 'a state
-      ; pending : (Dune_rpc.Private.Id.t, Pending_response.t Fiber.Ivar.t) Table.t
+      ; pending : (Dune_rpc.Private.Id.t, Pending_request.t) Table.t
         (** Pending requests sent to the client. When a response is
           received, the ivar for the response will be filled. *)
+      ; mutable requests_in_flight : Request.t Dune_rpc.Private.Id.Map.t
       ; name : string
       }
 
@@ -123,7 +155,7 @@ module Session = struct
     let close_pending_requests pending =
       let pending_list = Table.to_list pending in
       Table.clear pending;
-      Fiber.parallel_iter pending_list ~f:(fun (_, ivar) ->
+      Fiber.parallel_iter pending_list ~f:(fun (_, { Pending_request.ivar; _ }) ->
         Fiber.Ivar.fill ivar Pending_response.Closed)
     ;;
 
@@ -146,6 +178,7 @@ module Session = struct
       ; id = Id.gen ()
       ; pool
       ; pending
+      ; requests_in_flight = Dune_rpc.Private.Id.Map.empty
       ; name
       }
     ;;
@@ -187,7 +220,7 @@ module Session = struct
            None)
     ;;
 
-    let request t ((id, call) as req) =
+    let request t ((id, _) as req) =
       match t.close.state with
       | `Closing | `Closed ->
         Fiber.return (Fiber.Ivar.create_full Pending_response.Closed)
@@ -196,12 +229,10 @@ module Session = struct
          | Some _ ->
            Code_error.raise
              "request with this id is already pending"
-             [ "id", Dune_rpc.Private.Id.to_dyn id
-             ; "call", Dune_rpc.Private.Call.to_dyn call
-             ]
+             [ "request", Repr.to_dyn request_repr req ]
          | None ->
            let ivar = Fiber.Ivar.create () in
-           Table.add_exn t.pending id ivar;
+           Table.add_exn t.pending id (Pending_request.create req ivar);
            let+ () =
              Fiber.Pool.task t.pool ~f:(fun () ->
                let+ (_ : [> `Closed | `Ok ]) = write t (Request req) in
@@ -222,9 +253,24 @@ module Session = struct
                "unexpected response from rpc client"
                [ "response", Response.to_dyn response ]);
            Close.close t.close)
-      | Some ivar ->
+      | Some { Pending_request.ivar; _ } ->
         Table.remove t.pending id;
         Fiber.Ivar.fill ivar (Pending_response.Response response)
+    ;;
+
+    let request_started t ((id, _) as request) =
+      match Dune_rpc.Private.Id.Map.find t.requests_in_flight id with
+      | Some _ ->
+        Code_error.raise
+          "request with this id is already in flight"
+          [ "request", Repr.to_dyn request_repr request ]
+      | None ->
+        t.requests_in_flight
+        <- Dune_rpc.Private.Id.Map.add_exn t.requests_in_flight id request
+    ;;
+
+    let request_finished t id =
+      t.requests_in_flight <- Dune_rpc.Private.Id.Map.remove t.requests_in_flight id
     ;;
 
     let compare x y = Id.compare x.id y.id
@@ -234,13 +280,36 @@ module Session = struct
       function
       | Uninitialized -> variant "Uninitialized" []
       | Initialized { init; state } ->
-        let record = record [ "init", opaque init; "state", f state ] in
+        let record =
+          record [ "init", Repr.to_dyn initialize_request_repr init; "state", f state ]
+        in
         variant "Initialized" [ record ]
+    ;;
+
+    let pending_requests_repr =
+      Repr.view (Repr.list Pending_request.repr) ~to_:(fun pending ->
+        Table.to_list pending
+        |> Dune_rpc.Private.Id.Map.of_list_exn
+        |> Dune_rpc.Private.Id.Map.values)
+    ;;
+
+    let requests_in_flight_repr =
+      Repr.view (Repr.list request_repr) ~to_:Dune_rpc.Private.Id.Map.values
     ;;
 
     let to_dyn
           f
-          { id; version = _; state; close; chan = _; pool = _; pending = _; menu; name }
+          { id
+          ; version = _
+          ; state
+          ; close
+          ; chan = _
+          ; pool = _
+          ; pending
+          ; requests_in_flight
+          ; menu
+          ; name
+          }
       =
       let open Dyn in
       record
@@ -249,6 +318,8 @@ module Session = struct
         ; "menu", Dyn.option Menu.to_dyn menu
         ; "name", Dyn.string name
         ; "close", Close.to_dyn close
+        ; "requests_in_flight", Repr.to_dyn requests_in_flight_repr requests_in_flight
+        ; "pending_requests", Repr.to_dyn pending_requests_repr pending
         ]
     ;;
 
@@ -428,26 +499,38 @@ module H = struct
   let dispatch_request (type a) (t : a t) (session : a Session.t) meth_ r id =
     let kind = Request id in
     Event.emit (Message { kind; meth_; stage = `Start }) (Session.id session);
-    let* response =
-      let+ result =
-        Fiber.collect_errors (fun () ->
-          V.Handler.handle_request t.handler session (id, r))
-      in
-      match result with
-      | Ok r -> r
-      | Error [ { Exn_with_backtrace.exn = Response.Error.E e; backtrace = _ } ] ->
-        Error e
-      | Error xs ->
-        let payload =
-          Sexp.List (List.map xs ~f:(fun x -> Exn_with_backtrace.to_dyn x |> Sexp.of_dyn))
-        in
-        Error (Response.Error.create ~kind:Code_error ~message:"server error" ~payload ())
-    in
-    Event.emit (Message { kind; meth_; stage = `Stop }) (Session.id session);
-    let+ (_ : [> `Closed | `Ok ]) =
-      Session.Stage1.write session.base (Response (id, response))
-    in
-    ()
+    let () = Session.Stage1.request_started session.base (id, r) in
+    Fiber.finalize
+      (fun () ->
+         let* response =
+           let+ result =
+             Fiber.collect_errors (fun () ->
+               V.Handler.handle_request t.handler session (id, r))
+           in
+           match result with
+           | Ok r -> r
+           | Error [ { Exn_with_backtrace.exn = Response.Error.E e; backtrace = _ } ] ->
+             Error e
+           | Error xs ->
+             let payload =
+               Sexp.List
+                 (List.map xs ~f:(fun x -> Exn_with_backtrace.to_dyn x |> Sexp.of_dyn))
+             in
+             Error
+               (Response.Error.create
+                  ~kind:Code_error
+                  ~message:"server error"
+                  ~payload
+                  ())
+         in
+         Event.emit (Message { kind; meth_; stage = `Stop }) (Session.id session);
+         let+ (_ : [> `Closed | `Ok ]) =
+           Session.Stage1.write session.base (Response (id, response))
+         in
+         ())
+      ~finally:(fun () ->
+        Session.Stage1.request_finished session.base id;
+        Fiber.return ())
   ;;
 
   let run_session (type a) (t : a t) (session : a Session.t) =

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -1,5 +1,23 @@
 The debug event can be triggered with Sigusr1
 
+  $ debug_events_jq='select(.name == "debug") | .name'
+  $ build_request_starts_jq='select(.cat == "rpc" and .name == "request" and .args.meth == "build" and .args.stage == "start") | .name'
+  $ count_trace_events () {
+  >   dune trace cat | jq -r "$1" | wc -l
+  > }
+  $ wait_for_trace_events () {
+  >   jq_program="$1"
+  >   expected="$2"
+  >   with_timeout bash -lc '
+  >     jq_program="$1"
+  >     expected="$2"
+  >     while [ "$(dune trace cat | jq -r "$jq_program" | wc -l)" -lt "$expected" ]
+  >     do
+  >       sleep 0.1
+  >     done
+  >   ' bash "$jq_program" "$expected"
+  > }
+
   $ make_dune_project 3.22
 
   $ ready=$(mktemp -d)/ready
@@ -16,12 +34,16 @@ The debug event can be triggered with Sigusr1
   $ read line < $ready
 
   $ pid=$(dune trace cat | jq '.args.pid' -r | head -1)
+  $ debug_events=$(count_trace_events "$debug_events_jq")
 
   $ kill -s sigusr2 -- $pid
+  $ wait_for_trace_events "$debug_events_jq" $((debug_events + 1))
 
-  $ dune trace cat | jq '
-  >   select(.name == "debug")
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.name == "debug") ]
+  > | last
   > | .args
+  > | { scheduler: .scheduler }
   > | .scheduler.process_watcher |= keys
   > | .scheduler.events.pending_jobs |= type
   > '
@@ -41,3 +63,62 @@ The debug event can be triggered with Sigusr1
   $ kill $pid
 
   $ wait
+
+The debug event also includes active RPC connections and in-flight requests.
+
+  $ make_dune_project 3.23
+
+  $ ready=$(mktemp -d)/ready
+  $ mkfifo $ready
+
+  $ cat >dune << EOF
+  > (rule
+  >  (target x)
+  >  (action (bash "echo done > $ready; sleep 5")))
+  > EOF
+
+  $ export DUNE_TRACE=rpc,diagnostics,config
+  $ start_dune
+
+  $ build_request_starts=$(count_trace_events "$build_request_starts_jq")
+  $ output1=$(mktemp)
+  $ output2=$(mktemp)
+  $ dune rpc build --wait x >"$output1" 2>&1 &
+  $ build1_pid=$!
+  $ dune rpc build --wait x >"$output2" 2>&1 &
+  $ build2_pid=$!
+
+Wait for both RPC requests to be accepted before dumping state.
+
+  $ wait_for_trace_events "$build_request_starts_jq" $((build_request_starts + 2))
+
+  $ read line < $ready
+
+  $ pid=$(dune trace cat | jq '.args.pid' -r | head -1)
+  $ debug_events=$(count_trace_events "$debug_events_jq")
+
+  $ kill -s sigusr2 -- $pid
+  $ wait_for_trace_events "$debug_events_jq" $((debug_events + 1))
+
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.name == "debug") ]
+  > | last
+  > | .args.rpc
+  > | { connections:
+  >       ([.connections[] | .requests_in_flight | map(.call.method_)] | sort)
+  >   }
+  > '
+  {
+    "connections": [
+      [
+        "build"
+      ],
+      [
+        "build"
+      ]
+    ]
+  }
+
+  $ stop_dune_quiet
+  $ wait "$build1_pid" || true
+  $ wait "$build2_pid" || true


### PR DESCRIPTION
Track in-flight RPC requests per session and include all active RPC connections plus queued RPC jobs in the SIGUSR2 debug event. Add a blackbox test covering concurrent RPC clients.