### PR TITLE
fix: defer no-ocamlfind error for unused cross-compile contexts

### DIFF
--- a/doc/changes/fixed/10399.md
+++ b/doc/changes/fixed/10399.md
@@ -1,0 +1,2 @@
+- Defer the `ocamlfind`-required check for unused cross-compile contexts.
+  (#10399, @robinbb)

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -374,21 +374,10 @@ module Build_environment_kind = struct
     | Some findlib -> Findlib_config.ocamlpath findlib
     | None ->
       (match t with
-       | Cross_compilation_using_findlib_toolchain toolchain ->
-         User_error.raise
-           [ Pp.textf
-               "Could not find `ocamlfind' in PATH or an environment variable \
-                `OCAMLFIND_CONF' while cross-compiling with toolchain `%s'"
-               (Context_name.to_string toolchain)
-           ]
-           ~hints:
-             [ Pp.enumerate
-                 [ "`opam install ocamlfind' and/or:"
-                 ; "Point `OCAMLFIND_CONF' to the findlib configuration that defines \
-                    this toolchain"
-                 ]
-                 ~f:Pp.text
-             ]
+       | Cross_compilation_using_findlib_toolchain _ ->
+         (* Defer to library resolution: an empty path lets unused
+            cross-compile contexts load. See ocaml/dune#10399. *)
+         []
        | Hardcoded_path l -> List.map l ~f:Path.of_filename_relative_to_initial_cwd
        | Opam2_environment opam_prefix ->
          let p = Path.of_filename_relative_to_initial_cwd opam_prefix in

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
@@ -1,43 +1,73 @@
-Dune shows an error message when ocamlfind isn't in PATH and OCAMLFIND_CONF
-isn't set
+A `-x` cross-compile build no longer requires [ocamlfind] in PATH or
+[OCAMLFIND_CONF] set when no findlib library resolution is needed in
+the cross-compile context. When a stanza in the cross-compile context
+does need an opam-installed library, dune fails with a "Library X not
+found" error that points at the offending stanza and context. See
+ocaml/dune#10399. (For the case where the cross-compile context goes
+entirely unused, see [no-ocamlfind-unused-toolchain-context.t].)
+
+  $ unset OCAMLFIND_TOOLCHAIN
+  $ unset OCAMLFIND_CONF
+
+Set up a project with a single private library that has no external
+library dependencies, so building it for a cross-compile context
+doesn't need findlib:
 
   $ cat > dune-project <<EOF
   > (lang dune 3.7)
-  > (package (name repro))
   > EOF
   $ cat > dune <<EOF
-  > (executable
-  >  (name gen)
-  >  (modules gen)
-  >  (enabled_if
-  >   (= %{context_name} "default"))
-  >  (libraries libdep))
-  > (rule
-  >  (with-stdout-to
-  >   gen.ml
-  >   (echo "let () = Format.printf \"let x = 1\"")))
-  > (library
-  >  (name repro)
-  >  (public_name repro)
-  >  (modules))
+  > (library (name only_stdlib))
+  > EOF
+  $ cat > only_stdlib.ml <<EOF
+  > let x = 42
   > EOF
 
+Wrappers for the OCaml toolchain tools dune resolves as siblings of
+[ocamlc] ([ocamlc], [ocamldep], [ocamlopt], [ocaml], [ocamlmklib],
+[ocamlobjinfo]). Each wrapper restores the original PATH before
+exec'ing the real tool, so the build sees the full environment while
+dune's PATH-based discovery sees only [ocaml-bin] — which lacks
+[ocamlfind]. Wrapping every sibling keeps the test robust if it
+later grows to exercise more compile rules:
+
   $ mkdir ocaml-bin
-  $ cat > ocaml-bin/ocamlc <<EOF
+  $ cat > ocaml-bin/wrapper <<EOF
   > #!/usr/bin/env sh
   > export PATH="\$ORIG_PATH"
-  > exec ocamlc "\$@"
+  > exec "\$(basename "\$0")" "\$@"
   > EOF
-  $ chmod +x ocaml-bin/ocamlc
+  $ chmod +x ocaml-bin/wrapper
+  $ for tool in ocamlc ocamldep ocamlopt ocaml ocamlmklib ocamlobjinfo; do
+  >   ln -s wrapper ocaml-bin/$tool
+  > done
 
   $ DUNE_PATH=$(dirname `which dune`)
   $ SH_PATH=$(dirname `which sh`)
-  $ env ORIG_PATH="$PATH" PATH="$SH_PATH:$DUNE_PATH:$PWD/ocaml-bin" dune build @install -x foo
-  Error: Could not find `ocamlfind' in PATH or an environment variable
-  `OCAMLFIND_CONF' while cross-compiling with toolchain `foo'
-  Hint:
-  - `opam install ocamlfind' and/or:
-  - Point `OCAMLFIND_CONF' to the findlib configuration that defines this
-    toolchain
+
+Cross-compile [-x foo] without ocamlfind. The library only depends on
+the stdlib, so no findlib lookup is needed — the build succeeds:
+
+  $ env ORIG_PATH="$PATH" PATH="$SH_PATH:$DUNE_PATH:$PWD/ocaml-bin" dune build -x foo
+
+Now add an opam-resolved library dependency. Library resolution fires
+in the cross-compile context, can't find the library (because
+ocamlfind is unavailable), and dune reports the offending stanza:
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name only_stdlib)
+  >  (libraries cmdliner))
+  > EOF
+  $ env ORIG_PATH="$PATH" PATH="$SH_PATH:$DUNE_PATH:$PWD/ocaml-bin" dune build -x foo
+  File "dune", line 3, characters 12-20:
+  3 |  (libraries cmdliner))
+                  ^^^^^^^^
+  Error: Library "cmdliner" not found.
+  -> required by library "only_stdlib" in _build/default.foo
+  -> required by _build/default.foo/.only_stdlib.objs/native/only_stdlib.cmx
+  -> required by _build/default.foo/only_stdlib.a
+  -> required by alias all (context default.foo)
+  -> required by alias default (context default.foo)
   [1]
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-unused-toolchain-context.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-unused-toolchain-context.t
@@ -1,0 +1,45 @@
+A workspace declaring a cross-compile context via `(toolchain ...)`
+that no rule actually uses must not require `ocamlfind` in PATH at
+workspace setup. samoht's exact scenario from #10399.
+
+  $ unset OCAMLFIND_TOOLCHAIN
+  $ unset OCAMLFIND_CONF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+
+The toolchain name [solo5] mirrors samoht's #10399 repro; any name
+works, the test does not exercise solo5-specific tooling.
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.7)
+  > (context (default))
+  > (context (default (name solo5) (host default) (toolchain solo5)))
+  > EOF
+
+Wrappers for the OCaml toolchain tools dune resolves as siblings of
+[ocamlc] ([ocamlc], [ocamldep], [ocamlopt], [ocaml], [ocamlmklib],
+[ocamlobjinfo]). Each wrapper restores the original PATH before
+exec'ing the real tool, so the build sees the full environment while
+dune's PATH-based discovery sees only [ocaml-bin] — which lacks
+[ocamlfind]:
+
+  $ mkdir ocaml-bin
+  $ cat > ocaml-bin/wrapper <<EOF
+  > #!/usr/bin/env sh
+  > export PATH="\$ORIG_PATH"
+  > exec "\$(basename "\$0")" "\$@"
+  > EOF
+  $ chmod +x ocaml-bin/wrapper
+  $ for tool in ocamlc ocamldep ocamlopt ocaml ocamlmklib ocamlobjinfo; do
+  >   ln -s wrapper ocaml-bin/$tool
+  > done
+
+  $ DUNE_PATH=$(dirname `which dune`)
+  $ SH_PATH=$(dirname `which sh`)
+
+There's nothing in this project to build. The build succeeds without
+`ocamlfind` available:
+
+  $ env ORIG_PATH="$PATH" PATH="$SH_PATH:$DUNE_PATH:$PWD/ocaml-bin" dune build


### PR DESCRIPTION
Fixes #10399.

**_Important note: I have no opinion about whether this change's ramifications beyond merely resolving the issue are desirable, and I request product-level input from @rgrinberg or others (@Alizter?). If this implementation/feature does not make sense from a "do we want this" perspective, I'd be happy to withdraw the PR._**

Cross-compile contexts declared via `(toolchain ...)` no longer require `ocamlfind` (or `OCAMLFIND_CONF`) at workspace setup. The check is deferred to library resolution: a cross-compile-context stanza that needs an opam-resolved library now fails with `Error: Library "X" not found ... (context Y)`, and workspaces that declare a cross-compile context but don't use it load without ocamlfind.

The deferred error is less specific than the original "ocamlfind missing" one. The diagnostic still points at the offending stanza and the cross-compile context; threading the original hint through to library-resolution would be a separate polish.

- [x] changelog