### PR TITLE
cram: allow boolean expressions in runtest_alias

### DIFF
--- a/doc/changes/added/14425.md
+++ b/doc/changes/added/14425.md
@@ -1,0 +1,1 @@
+- Allow blang expressions in the `runtest_alias` field in the `cram` stanza (#14425, @rgrinberg)

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -242,7 +242,7 @@ let rules ~sctx ~dir tests project =
       in
       let test_name_alias = Alias.Name.of_string name in
       let init = None, Spec.make_empty ~test_name_alias in
-      let+ runtest_alias, acc =
+      let* runtest_alias, acc =
         Memo.List.fold_left
           stanzas
           ~init
@@ -286,8 +286,8 @@ let rules ~sctx ~dir tests project =
                 | None -> None
                 | Some (loc, set) ->
                   (match runtest_alias with
-                   | None -> Some (loc, set)
-                   | Some (loc', _) ->
+                   | None -> Some (loc, expander, set)
+                   | Some (loc', _, _) ->
                      let main_message =
                        [ Pp.text
                            "enabling or disabling the runtest alias for a cram test may \
@@ -361,11 +361,14 @@ let rules ~sctx ~dir tests project =
                 ; shell
                 } ))
       in
-      let extra_aliases =
-        let to_add =
-          match runtest_alias with
-          | None | Some (_, true) -> Alias.Name.Set.singleton Alias0.runtest
-          | Some (_, false) -> Alias.Name.Set.empty
+      let+ extra_aliases =
+        let+ to_add =
+          (match runtest_alias with
+           | None -> Memo.return true
+           | Some (_, expander, set) -> Expander.eval_blang expander set)
+          >>| function
+          | true -> Alias.Name.Set.singleton Alias0.runtest
+          | false -> Alias.Name.Set.empty
         in
         Alias.Name.Set.union to_add acc.extra_aliases
       in

--- a/src/dune_rules/cram/cram_stanza.ml
+++ b/src/dune_rules/cram/cram_stanza.ml
@@ -49,6 +49,19 @@ module Shell = struct
   let decode = enum all
 end
 
+let decode_runtest_alias =
+  let* () = Dune_lang.Syntax.since Stanza.syntax (3, 12) in
+  let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
+  let decode =
+    if dune_version >= (3, 24)
+    then Blang.decode
+    else
+      let+ set = bool in
+      if set then Blang.true_ else Blang.false_
+  in
+  located decode
+;;
+
 type t =
   { loc : Loc.t
   ; applies_to : applies_to
@@ -58,7 +71,7 @@ type t =
   ; locks : Locks.t
   ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
-  ; runtest_alias : (Loc.t * bool) option
+  ; runtest_alias : (Loc.t * Blang.t) option
   ; timeout : (Loc.t * Time.Span.t) option
   ; setup_scripts : (Loc.t * string) list
   ; shell : Shell.t option
@@ -97,10 +110,7 @@ let decode =
      and+ package =
        Stanza_pkg.field_opt ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8)) ()
        >>| Option.map ~f:snd
-     and+ runtest_alias =
-       field_o
-         "runtest_alias"
-         (Dune_lang.Syntax.since Stanza.syntax (3, 12) >>> located bool)
+     and+ runtest_alias = field_o "runtest_alias" decode_runtest_alias
      and+ timeout =
        field_o
          "timeout"

--- a/src/dune_rules/cram/cram_stanza.mli
+++ b/src/dune_rules/cram/cram_stanza.mli
@@ -29,7 +29,7 @@ type t =
   ; locks : Locks.t
   ; conflict_markers : Conflict_markers.t option
   ; package : Package.t option
-  ; runtest_alias : (Loc.t * bool) option
+  ; runtest_alias : (Loc.t * Blang.t) option
   ; timeout : (Loc.t * Time.Span.t) option
   ; setup_scripts : (Loc.t * string) list
   ; shell : Shell.t option

--- a/test/blackbox-tests/test-cases/cram/runtest_alias.t
+++ b/test/blackbox-tests/test-cases/cram/runtest_alias.t
@@ -27,6 +27,38 @@ This should run the test
   +  foo
   [1]
 
+Before 3.24, the runtest alias still only accepts literal booleans:
+
+  $ make_dune_project 3.23
+  $ cat >dune <<EOF
+  > (cram
+  >  (runtest_alias (not false)))
+  > EOF
+  $ dune runtest
+  File "dune", line 2, characters 16-27:
+  2 |  (runtest_alias (not false)))
+                      ^^^^^^^^^^^
+  Error: Atom expected
+  [1]
+
+The runtest alias can be controlled with a boolean expression starting from 3.24:
+
+  $ make_dune_project 3.24
+  $ rm -f foo.t.corrected
+  $ cat >dune <<EOF
+  > (cram
+  >  (runtest_alias %{env:RUN_CRAM_RUNTEST_ALIAS=false}))
+  > EOF
+  $ RUN_CRAM_RUNTEST_ALIAS=false dune runtest
+  $ RUN_CRAM_RUNTEST_ALIAS=true dune runtest
+  File "foo.t", line 1, characters 0-0:
+  --- foo.t
+  +++ foo.t.corrected
+  @@ -1 +1,2 @@
+     $ echo foo
+  +  foo
+  [1]
+
 Now we try setting runtest alias default twice. This should be impossible:
 
   $ cat >dune <<EOF


### PR DESCRIPTION
Decode cram runtest_alias as a boolean expression and evaluate it when deciding whether to attach cram tests to @runtest. This preserves literal true/false while allowing environment-sensitive aliases such as %{env:...}.