### PR TITLE
fix: check lockdir even if lock_dev_tools is disabled when invoking odoc

### DIFF
--- a/doc/changes/fixed/14426.md
+++ b/doc/changes/fixed/14426.md
@@ -1,0 +1,3 @@
+- Make `dune build @doc` pick up an odoc installed via `dune tools install
+  odoc` even without `DUNE_CONFIG__LOCK_DEV_TOOL=enabled`, mirroring how
+  `dune fmt` consumes a locked ocamlformat (#14426, fixes #14235, @mt-caret)

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -282,12 +282,18 @@ let odoc_dev_tool_exe_path_building_if_necessary () =
 ;;
 
 let odoc_program sctx dir =
-  let odoc_dev_tool_lock_dir_exists =
-    match Config.get Compile_time.lock_dev_tools with
-    | `Enabled -> true
-    | `Disabled -> false
+  let open Action_builder.O in
+  let* lock_dir_exists =
+    Action_builder.of_memo
+      (match Config.get Compile_time.lock_dev_tools with
+       | `Enabled -> Memo.return true
+       | `Disabled ->
+         (* even if lock_dev_tools is disabled, there might be a lock dir
+            created by `dune tools install odoc` *)
+         let path = Lock_dir.dev_tool_external_lock_dir Odoc in
+         Fs_memo.dir_exists (Path.Outside_build_dir.External path))
   in
-  match odoc_dev_tool_lock_dir_exists with
+  match lock_dir_exists with
   | true -> odoc_dev_tool_exe_path_building_if_necessary ()
   | false ->
     Super_context.resolve_program

--- a/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
+++ b/test/blackbox-tests/test-cases/pkg/odoc/dev-tool-odoc-dune-tools-install.t
@@ -2,11 +2,6 @@ Test that `dune tools install odoc` lets `dune build @doc` pick up the locked
 odoc binary without requiring DUNE_CONFIG__LOCK_DEV_TOOL=enabled, mirroring
 the behaviour of `dune tools install ocamlformat` + `dune fmt`.
 
-This documents a current bug: `odoc_program` in src/dune_rules/odoc.ml only
-inspects the compile-time `lock_dev_tools` flag and never falls back to an
-`Fs_memo.dir_exists` check on the lockdir, unlike
-`Ocamlformat.dev_tool_lock_dir_exists` in src/dune_rules/format_rules.ml.
-
   $ mkrepo
   $ make_mock_odoc_package
   $ mk_ocaml 5.2.0
@@ -70,9 +65,19 @@ dep — dune will invoke it instead of relying on PATH:
     "_build/_private/default/.dev-tool/odoc/target/bin/odoc"
   ]
 
-Without the flag, `dune build @doc` should also pick up the locked odoc (as
-`dune fmt` does with ocamlformat) — but the dev-tool path is absent from the
-rule deps, so dune falls back to PATH instead. This is the bug:
+Without the flag, `dune build @doc` also picks up the locked odoc (mirroring
+how `dune fmt` works with ocamlformat) — the dev-tool path is present in the
+rule deps:
 
+  $ dev_tool_odoc_deps
+  [
+    "_build/_private/default/.dev-tool/odoc/target/bin/odoc"
+  ]
+
+Removing the lockdir reverts the rule graph to the baseline — with no lockdir
+to source from, dune falls back to a PATH lookup and the dev-tool path drops
+out of the deps:
+
+  $ rm -r "${dev_tool_lock_dir}"
   $ dev_tool_odoc_deps
   []


### PR DESCRIPTION
Closes:
- #14235 