### PR TITLE
Raise a user error when `dune install` is run with package management enabled.

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -526,12 +526,7 @@ let run
   if Pkg.Pkg_common.pkg_enabled ~workspace:source_workspace ~lock_dir_paths
   then
     User_error.raise
-      [ Pp.text "dune install is not supported with Dune package management." ]
-      ~hints:
-        [ Pp.concat
-            ~sep:Pp.space
-            [ Pp.text "Use"; User_message.command "opam"; Pp.text "instead." ]
-        ];
+      [ Pp.text "dune install is not supported with Dune package management." ];
   let* pkgs =
     match pkgs with
     | _ :: _ -> Fiber.return pkgs

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -517,21 +517,21 @@ let run
          User_error.raise
            [ Pp.textf "Context %S not found!" (Dune_engine.Context_name.to_string name) ])
   in
-  (match
-     List.find contexts ~f:(fun ctx ->
-       match Context.kind ctx with
-       | Context.Kind.Lock _ -> true
-       | _ -> false)
-   with
-   | Some _ ->
-     User_error.raise
-       [ Pp.text "dune install is not supported with Dune package management." ]
-       ~hints:
-         [ Pp.concat
-             ~sep:Pp.space
-             [ Pp.text "Use"; User_message.command "opam"; Pp.text "instead." ]
-         ]
-   | None -> ());
+  let* source_workspace = Memo.run (Source.Workspace.workspace ()) in
+  let lock_dir_paths =
+    Pkg.Pkg_common.Lock_dirs_arg.lock_dirs_of_workspace
+      Pkg.Pkg_common.Lock_dirs_arg.all
+      source_workspace
+  in
+  if Pkg.Pkg_common.pkg_enabled ~workspace:source_workspace ~lock_dir_paths
+  then
+    User_error.raise
+      [ Pp.text "dune install is not supported with Dune package management." ]
+      ~hints:
+        [ Pp.concat
+            ~sep:Pp.space
+            [ Pp.text "Use"; User_message.command "opam"; Pp.text "instead." ]
+        ];
   let* pkgs =
     match pkgs with
     | _ :: _ -> Fiber.return pkgs

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -517,6 +517,21 @@ let run
          User_error.raise
            [ Pp.textf "Context %S not found!" (Dune_engine.Context_name.to_string name) ])
   in
+  (match
+     List.find contexts ~f:(fun ctx ->
+       match Context.kind ctx with
+       | Context.Kind.Lock _ -> true
+       | _ -> false)
+   with
+   | Some _ ->
+     User_error.raise
+       [ Pp.text "dune install is not supported with Dune package management." ]
+       ~hints:
+         [ Pp.concat
+             ~sep:Pp.space
+             [ Pp.text "Use"; User_message.command "opam"; Pp.text "instead." ]
+         ]
+   | None -> ());
   let* pkgs =
     match pkgs with
     | _ :: _ -> Fiber.return pkgs

--- a/bin/pkg/pkg_common.ml
+++ b/bin/pkg/pkg_common.ml
@@ -207,6 +207,18 @@ module Lock_dirs_arg = struct
   ;;
 end
 
+let pkg_enabled ~(workspace : Workspace.t) ~lock_dir_paths =
+  (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
+       directories in the source tree *)
+  let any_lockdir_exists =
+    List.exists lock_dir_paths ~f:(fun p -> Fpath.exists (Path.Source.to_string p))
+  in
+  match workspace.config.pkg_enabled with
+  | Set (_, `Enabled) -> true
+  | Set (_, `Disabled) -> false
+  | Unset -> any_lockdir_exists
+;;
+
 let check_pkg_management_enabled () =
   Memo.run
   @@

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -82,11 +82,10 @@ end
     [lock_dir]. *)
 val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
 
+(** [pkg_enabled ~workspace ~lock_dir_paths] returns [true] if package management is
+    enabled. *)
+val pkg_enabled : workspace:Workspace.t -> lock_dir_paths:Path.Source.t list -> bool
+
 (** [check_pkg_management_enabled ()] checks if package management is enabled in the
     workspace configuration. Raises a user error if it is explicitly disabled. *)
-val pkg_enabled
-  :  workspace:Workspace.t
-  -> lock_dir_paths:Path.Source.t list
-  -> bool
-
 val check_pkg_management_enabled : unit -> unit Fiber.t

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -84,4 +84,9 @@ val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
 
 (** [check_pkg_management_enabled ()] checks if package management is enabled in the
     workspace configuration. Raises a user error if it is explicitly disabled. *)
+val pkg_enabled
+  :  workspace:Workspace.t
+  -> lock_dir_paths:Path.Source.t list
+  -> bool
+
 val check_pkg_management_enabled : unit -> unit Fiber.t

--- a/bin/pkg/pkg_common.mli
+++ b/bin/pkg/pkg_common.mli
@@ -82,8 +82,10 @@ end
     [lock_dir]. *)
 val pp_packages : Dune_pkg.Lock_dir.Pkg.t list -> User_message.Style.t Pp.t
 
-(** [pkg_enabled ~workspace ~lock_dir_paths] returns [true] if package management is
-    enabled. *)
+(** [pkg_enabled ~workspace ~lock_dir_paths] returns [true] if package
+      management is enabled. This is intended to be used by commands that don't
+      run the build system. For commands that do run the build system, use
+      [Dune_rules.Lock_dir.lock_dir_active]. *)
 val pkg_enabled : workspace:Workspace.t -> lock_dir_paths:Path.Source.t list -> bool
 
 (** [check_pkg_management_enabled ()] checks if package management is enabled in the

--- a/bin/pkg/pkg_enabled.ml
+++ b/bin/pkg/pkg_enabled.ml
@@ -14,17 +14,7 @@ let term =
         Pkg_common.Lock_dirs_arg.all
         workspace
     in
-    let any_lockdir_exists =
-      List.exists lock_dir_paths ~f:(fun p -> Fpath.exists (Path.Source.to_string p))
-    in
-    (* CR-Leonidas-from-XIV: change this logic when we stop detecting lock
-       directories in the source tree *)
-    let enabled =
-      match workspace.config.pkg_enabled with
-      | Set (_, `Enabled) -> true
-      | Set (_, `Disabled) -> false
-      | Unset -> any_lockdir_exists
-    in
+    let enabled = Pkg_common.pkg_enabled ~workspace ~lock_dir_paths in
     match enabled with
     | true -> ()
     | false -> exit 1)

--- a/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
+++ b/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
@@ -31,16 +31,15 @@ Build the lockdir first
 `dune install` with a --prefix argument doesn't crash.
 
   $ dune install --prefix "$PWD/_install"
+  Error: dune install is not supported with Dune package management.
+  Hint: Use 'opam' instead.
+  [1]
 
 But `dune install` without a prefix argument crashes with an internal error.
 
   $ dune install 2>&1 | head -n 6
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Unexpected build progress state (expected [Building _])",
-     { current = Initializing })
+  Error: dune install is not supported with Dune package management.
+  Hint: Use 'opam' instead.
   [1]
 
 
@@ -60,12 +59,11 @@ Again, `dune install` with prefix doesn't crash, but without a prefix argument
 crashes with the same error.
 
   $ dune install --prefix "$PWD/_install"
+  Error: dune install is not supported with Dune package management.
+  Hint: Use 'opam' instead.
+  [1]
 
   $ dune install 2>&1 | head -n 6
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Unexpected build progress state (expected [Building _])",
-     { current = Initializing })
+  Error: dune install is not supported with Dune package management.
+  Hint: Use 'opam' instead.
   [1]

--- a/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
+++ b/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
@@ -37,7 +37,7 @@ Build the lockdir first
 
 But `dune install` without a prefix argument crashes with an internal error.
 
-  $ dune install 2>&1 | head -n 6
+  $ dune install
   Error: dune install is not supported with Dune package management.
   Hint: Use 'opam' instead.
   [1]
@@ -63,7 +63,7 @@ crashes with the same error.
   Hint: Use 'opam' instead.
   [1]
 
-  $ dune install 2>&1 | head -n 6
+  $ dune install
   Error: dune install is not supported with Dune package management.
   Hint: Use 'opam' instead.
   [1]

--- a/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
+++ b/test/blackbox-tests/test-cases/pkg/install-crash-lock-context.t
@@ -32,14 +32,12 @@ Build the lockdir first
 
   $ dune install --prefix "$PWD/_install"
   Error: dune install is not supported with Dune package management.
-  Hint: Use 'opam' instead.
   [1]
 
 But `dune install` without a prefix argument crashes with an internal error.
 
   $ dune install
   Error: dune install is not supported with Dune package management.
-  Hint: Use 'opam' instead.
   [1]
 
 
@@ -60,10 +58,8 @@ crashes with the same error.
 
   $ dune install --prefix "$PWD/_install"
   Error: dune install is not supported with Dune package management.
-  Hint: Use 'opam' instead.
   [1]
 
   $ dune install
   Error: dune install is not supported with Dune package management.
-  Hint: Use 'opam' instead.
   [1]


### PR DESCRIPTION
Follow-up to #14289. Discussion on the previous PR concluded that this combination isn't supported, so this PR makes `dune install` raise a clean user error instead of crashing when package management is enabled.

Addresses the internal error from https://github.com/ocaml/dune/issues/14272