### PR TITLE
test: Reproducer for refetching packages with symlinks

### DIFF
--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -420,8 +420,6 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~loc ~produced_targets
     Targets.Produced.map_with_errors
       produced_targets
       ~f:(fun target ->
-        (* All of this monad boilerplate seems unnecessary since we
-           don't care about errors... *)
         match Target.create target with
         | Some t -> Ok t
         | None -> Error ())
@@ -430,7 +428,13 @@ let try_to_store_to_shared_cache ~mode ~rule_digest ~loc ~produced_targets
         | Some _ -> Ok ()
         | None -> Error ())
   with
-  | Error _ -> Fiber.return None
+  | Error errors ->
+    Log.info
+      "cache store target creation errors"
+      [ ( "failed"
+        , Dyn.list (fun (t, _) -> Path.Build.to_dyn t) (Nonempty_list.to_list errors) )
+      ];
+    Fiber.return None
   | Ok targets ->
     store_artifacts ~mode ~rule_digest targets
     >>= (function

--- a/test/blackbox-tests/test-cases/pkg/fetch-cache-symlink.t
+++ b/test/blackbox-tests/test-cases/pkg/fetch-cache-symlink.t
@@ -1,0 +1,57 @@
+Documenting that sources with file symlinks are re-fetched every time. The
+menhir package is an example of such a package in the opam-repository. See
+`./fetch-cache.t` for a normal package test.
+
+The fetch rules are always considered safe to cache, but we make it explicit
+here. We set a custom directory for the shared cache and enable cache tracing.
+
+  $ export DUNE_CACHE=enabled
+  $ export DUNE_CACHE_ROOT=$(pwd)/dune-cache
+  $ export DUNE_TRACE=+cache
+
+Set up a project that depends on a package that is being downloaded. Note that
+the package being downloaded has a symlink.
+
+  $ make_lockdir
+  $ echo "Contents" > tar-contents
+  $ CONTENT_CHECKSUM=$(md5sum tar-contents | cut -f1 -d' ')
+  $ ln -s tar-contents tar-symlink
+  $ tar cf test.tar tar-contents tar-symlink
+  $ echo test.tar > fake-curls
+  $ SRC_PORT=1
+  $ SRC_CHECKSUM=$(md5sum test.tar | cut -f1 -d' ')
+  $ make_lockpkg test <<EOF
+  > (version 0.0.1)
+  > (source
+  >  (fetch
+  >   (url http://localhost:$SRC_PORT)
+  >   (checksum md5=$SRC_CHECKSUM)))
+  > EOF
+  $ cat > dune-project <<EOF
+  > (lang dune 3.17)
+  > (package (name my) (depends test) (allow_empty))
+  > EOF
+
+The first build should succeed, fetching the source, populating the cache and
+disabling the download of the source a second time.
+
+  $ build_pkg test
+
+We see cache store events for our targets in the trace:
+
+  $ dune trace cat | jq -s '[.[] | select(.args.message == "cache store target creation errors") ] | length'
+  1
+
+Cleaning the project to force rebuilding. This triggers an attempt to
+re-download the source, since it contains a symlink and wasn't cached:
+
+  $ dune clean
+  $ export DUNE_CACHE=enabled
+  $ build_pkg test
+  File "dune.lock/test.pkg", line 4, characters 7-25:
+  4 |   (url http://localhost:1)
+             ^^^^^^^^^^^^^^^^^^
+  Error: Download failed with code 404
+         
+  [1]
+


### PR DESCRIPTION
This commit adds a test demonstrating the fact that packages which contain symlinks are refetched on fresh builds. The bug was discovered via a project that depends on the `menhir` project.