### PR TITLE
test: make censor disambiguate digests

### DIFF
--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -116,6 +116,15 @@ everywhere. When platform-specific functionality is needed, Cram tests can use
 operations: file statistics, waiting for files to appear, waiting for
 filesystem clocks to advance, and a subset of sed features with clearer syntax.
 
+The ``censor`` helper replaces hex digests and other values subject to change
+with stable labels. Distinct digests get distinct labels:
+
+.. code::
+
+   $ echo paths | censor
+   _build/.sandbox/$DIGEST1/foo.txt
+   _build/default/.ppx/$DIGEST2/ppx.exe
+
 .. _ppx_expect:      https://github.com/janestreet/ppx_expect
 
 .. seealso::

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -218,24 +218,12 @@ file_status() {
 }
 
 censor() {
-  # we want to substitute it to $DIGEST
+  # Strip $PWD first so that sandbox hashes in the cram test's own path
+  # aren't caught as digests. Each unique remaining digest gets a distinct
+  # label ($DIGEST when unique, $DIGEST1/$DIGEST2/etc. when multiple).
   # shellcheck disable=SC2016
-  dune_cmd subst '[0-9a-f]{32}' '$DIGEST'
+  dune_cmd subst "$PWD" '$PWD' \
+    | dune_cmd subst-unique '[0-9a-f]{32}' '$DIGEST' \
+    | dune_cmd subst-unique '\.cinaps\.[0-9a-f]{8}' '.cinaps.$CINAPS'
 }
 
-censor_ppx() {
-  # shellcheck disable=SC2016
-  dune_cmd subst '[0-9a-f]{32}/ppx.exe' '$DIGEST/ppx.exe'
-}
-
-censor_cinaps() {
-  # shellcheck disable=SC2016
-  dune_cmd subst '\.cinaps\.[0-9a-f]+/' '$CINAPS/'
-}
-
-# CR-someday rgrinberg: get rid of this one or fuse it into censor
-strip_sandbox() {
-  # we want to substitute it to $SANDBOX
-  # shellcheck disable=SC2016
-  dune_cmd subst '[^ ]*.sandbox[/\\][^/\\]+' '$SANDBOX'
-}

--- a/test/blackbox-tests/test-cases/cinaps/link-flags.t
+++ b/test/blackbox-tests/test-cases/cinaps/link-flags.t
@@ -24,8 +24,8 @@ Link-time flags for running cinaps
   > | .[]
   > | select(endswith(".exe"))
   > EOF
-  $ dune trace cat | jq -f $jqScript | censor_cinaps
-  "$CINAPS/cinaps.exe"
+  $ dune trace cat | jq -f $jqScript | censor
+  ".cinaps.$CINAPS/cinaps.exe"
 
 Check that the version guard is correct.
 

--- a/test/blackbox-tests/test-cases/cinaps/multiple-cinaps.t
+++ b/test/blackbox-tests/test-cases/cinaps/multiple-cinaps.t
@@ -19,9 +19,9 @@ Multiple cinaps stanzas in the same dune file
   > (cinaps (files foo.ml))
   > (cinaps (files *oo.ml))
   > EOF
-  $ dune runtest --diff-command diff 2>&1 | censor_cinaps
+  $ dune runtest --diff-command diff 2>&1 | censor
   Error: Multiple rules generated for
-  _build/default/$CINAPS/cinaps.ml-gen:
+  _build/default/.cinaps.$CINAPS/cinaps.ml-gen:
   - dune:1
   - dune:2
   -> required by alias cinaps in dune:1

--- a/test/blackbox-tests/test-cases/cram/junction-cleanup.t
+++ b/test/blackbox-tests/test-cases/cram/junction-cleanup.t
@@ -21,11 +21,11 @@ Create a cram test that creates a junction inside its working directory:
   >   $ cmd /c "mklink /j junction file" > /dev/null
   > EOF
 
-  $ dune runtest 2>&1 | strip_sandbox
+  $ dune runtest 2>&1 | censor
   Error: failed to delete sandbox in
-  $SANDBOX
+  _build/.sandbox/$DIGEST
   Reason:
-  $SANDBOX\default): Directory not empty
+  rmdir(_build/.sandbox/$DIGEST\default): Directory not empty
   -> required by _build/default/.cram.junction.t/cram.out
   -> required by alias junction
   -> required by alias runtest

--- a/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
+++ b/test/blackbox-tests/test-cases/describe/describe-workspace-pp.t
@@ -102,21 +102,21 @@ not stable across different setups.
    (executables
     ((names (exe))
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST1
+       $DIGEST2
+       $DIGEST3
+       $DIGEST4
+       $DIGEST5
+       $DIGEST6
+       $DIGEST7
+       $DIGEST8
+       $DIGEST9
+       $DIGEST10
+       $DIGEST11
+       $DIGEST12
+       $DIGEST13
+       $DIGEST14
+       $DIGEST15))
      (modules
       (((name Exe)
         (impl (_build/default/exe/exe.ml))
@@ -126,7 +126,7 @@ not stable across different setups.
      (include_dirs (_build/default/exe/.exe.eobjs/byte))))
    (library
     ((name compiler-libs)
-     (uid $DIGEST)
+     (uid $DIGEST1)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -134,20 +134,20 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST2)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST1))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid $DIGEST)
+     (uid $DIGEST15)
      (local true)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST6
+       $DIGEST13
+       $DIGEST14))
      (source_dir _build/default/dummy_ppx)
      (modules
       (((name Dummy_ppx)
@@ -158,15 +158,15 @@ not stable across different setups.
      (include_dirs (_build/default/dummy_ppx/.dummy_ppx.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST3)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST2))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid $DIGEST)
+     (uid $DIGEST7)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -174,7 +174,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name ppx_derivers)
-     (uid $DIGEST)
+     (uid $DIGEST9)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -182,43 +182,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid $DIGEST)
+     (uid $DIGEST13)
      (local false)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST6
+       $DIGEST7
+       $DIGEST4
+       $DIGEST8
+       $DIGEST9
+       $DIGEST10
+       $DIGEST12
+       $DIGEST5
+       $DIGEST11
+       $DIGEST2))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid $DIGEST)
+     (uid $DIGEST6)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST4 $DIGEST5))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid $DIGEST)
+     (uid $DIGEST4)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST3 $DIGEST2))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid $DIGEST)
+     (uid $DIGEST8)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -226,16 +226,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid $DIGEST)
+     (uid $DIGEST12)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST11 $DIGEST5))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid $DIGEST)
+     (uid $DIGEST10)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -243,7 +243,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name sexplib0)
-     (uid $DIGEST)
+     (uid $DIGEST11)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -251,7 +251,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name static_lib)
-     (uid $DIGEST)
+     (uid $DIGEST14)
      (local true)
      (requires ())
      (source_dir _build/default/static_lib)
@@ -264,7 +264,7 @@ not stable across different setups.
      (include_dirs (_build/default/static_lib/.static_lib.objs/byte))))
    (library
     ((name stdlib-shims)
-     (uid $DIGEST)
+     (uid $DIGEST5)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
@@ -276,7 +276,7 @@ not stable across different setups.
    (build_context _build/default)
    (library
     ((name compiler-libs)
-     (uid $DIGEST)
+     (uid $DIGEST1)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -284,20 +284,20 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST2)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST1))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid $DIGEST)
+     (uid $DIGEST3)
      (local true)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST4
+       $DIGEST5
+       $DIGEST6))
      (source_dir _build/default/dummy_ppx)
      (modules
       (((name Dummy_ppx)
@@ -308,7 +308,7 @@ not stable across different setups.
      (include_dirs (_build/default/dummy_ppx/.dummy_ppx.objs/byte))))
    (library
     ((name lib)
-     (uid $DIGEST)
+     (uid $DIGEST7)
      (local true)
      (requires ())
      (source_dir _build/default/lib)
@@ -321,15 +321,15 @@ not stable across different setups.
      (include_dirs (_build/default/lib/.lib.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST8)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST2))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid $DIGEST)
+     (uid $DIGEST9)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -337,7 +337,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name ppx_derivers)
-     (uid $DIGEST)
+     (uid $DIGEST10)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -345,43 +345,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid $DIGEST)
+     (uid $DIGEST5)
      (local false)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST4
+       $DIGEST9
+       $DIGEST11
+       $DIGEST12
+       $DIGEST10
+       $DIGEST13
+       $DIGEST14
+       $DIGEST15
+       $DIGEST16
+       $DIGEST2))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid $DIGEST)
+     (uid $DIGEST4)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST11 $DIGEST15))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid $DIGEST)
+     (uid $DIGEST11)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST8 $DIGEST2))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid $DIGEST)
+     (uid $DIGEST12)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -389,16 +389,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid $DIGEST)
+     (uid $DIGEST14)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST16 $DIGEST15))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid $DIGEST)
+     (uid $DIGEST13)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -406,7 +406,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name sexplib0)
-     (uid $DIGEST)
+     (uid $DIGEST16)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -414,7 +414,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name static_lib)
-     (uid $DIGEST)
+     (uid $DIGEST6)
      (local true)
      (requires ())
      (source_dir _build/default/static_lib)
@@ -427,7 +427,7 @@ not stable across different setups.
      (include_dirs (_build/default/static_lib/.static_lib.objs/byte))))
    (library
     ((name stdlib-shims)
-     (uid $DIGEST)
+     (uid $DIGEST15)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)

--- a/test/blackbox-tests/test-cases/describe/describe.t
+++ b/test/blackbox-tests/test-cases/describe/describe.t
@@ -241,7 +241,7 @@ not stable across different setups.
    (executables
     ((names (main))
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST1 $DIGEST2))
      (modules
       (((name Main)
         (impl (_build/default/main.ml))
@@ -252,7 +252,7 @@ not stable across different setups.
    (executables
     ((names (main2))
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST1 $DIGEST2))
      (modules
       (((name Main2_aux4)
         (impl ())
@@ -287,7 +287,7 @@ not stable across different setups.
      (include_dirs (_build/default/.main2.eobjs/byte))))
    (executables
     ((names (main3))
-     (requires ($DIGEST))
+     (requires ($DIGEST3))
      (modules
       (((name Main3)
         (impl (_build/default/main3.ml))
@@ -348,7 +348,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_exe.eobjs/byte))))
    (library
     ((name bar)
-     (uid $DIGEST)
+     (uid $DIGEST4)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -371,7 +371,7 @@ not stable across different setups.
      (include_dirs (_build/default/.bar.objs/byte))))
    (library
     ((name cmdliner)
-     (uid $DIGEST)
+     (uid $DIGEST3)
      (local false)
      (requires ())
      (source_dir /FINDLIB/cmdliner)
@@ -379,7 +379,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/cmdliner))))
    (library
     ((name compiler-libs)
-     (uid $DIGEST)
+     (uid $DIGEST5)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -387,18 +387,18 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST6)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST5))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid $DIGEST)
+     (uid $DIGEST7)
      (local true)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST8 $DIGEST9))
      (source_dir _build/default)
      (modules
       (((name Dummy_ppx)
@@ -409,9 +409,9 @@ not stable across different setups.
      (include_dirs (_build/default/.dummy_ppx.objs/byte))))
    (library
     ((name foo)
-     (uid $DIGEST)
+     (uid $DIGEST2)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST1))
      (source_dir _build/default)
      (modules
       (((name Foo)
@@ -422,7 +422,7 @@ not stable across different setups.
      (include_dirs (_build/default/.foo.objs/byte))))
    (library
     ((name foo.x)
-     (uid $DIGEST)
+     (uid $DIGEST1)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -435,15 +435,15 @@ not stable across different setups.
      (include_dirs (_build/default/.foo_x.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST10)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST6))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid $DIGEST)
+     (uid $DIGEST11)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -451,7 +451,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name per_module_action_exe)
-     (uid $DIGEST)
+     (uid $DIGEST12)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -483,7 +483,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_exe.objs/byte))))
    (library
     ((name per_module_action_lib)
-     (uid $DIGEST)
+     (uid $DIGEST13)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -509,7 +509,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_lib.objs/byte))))
    (library
     ((name per_module_pp_lib)
-     (uid $DIGEST)
+     (uid $DIGEST14)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -535,7 +535,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_pp_lib.objs/byte))))
    (library
     ((name ppx_derivers)
-     (uid $DIGEST)
+     (uid $DIGEST15)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -543,43 +543,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid $DIGEST)
+     (uid $DIGEST9)
      (local false)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST8
+       $DIGEST11
+       $DIGEST16
+       $DIGEST17
+       $DIGEST15
+       $DIGEST18
+       $DIGEST19
+       $DIGEST20
+       $DIGEST21
+       $DIGEST6))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid $DIGEST)
+     (uid $DIGEST8)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST16 $DIGEST20))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid $DIGEST)
+     (uid $DIGEST16)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST10 $DIGEST6))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid $DIGEST)
+     (uid $DIGEST17)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -587,16 +587,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid $DIGEST)
+     (uid $DIGEST19)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST21 $DIGEST20))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid $DIGEST)
+     (uid $DIGEST18)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -604,7 +604,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name re_lib)
-     (uid $DIGEST)
+     (uid $DIGEST22)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -627,7 +627,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_lib.objs/byte))))
    (library
     ((name sexplib0)
-     (uid $DIGEST)
+     (uid $DIGEST21)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -635,7 +635,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name stdlib-shims)
-     (uid $DIGEST)
+     (uid $DIGEST20)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
@@ -643,7 +643,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/stdlib-shims))))
    (library
     ((name subfolder_lib)
-     (uid $DIGEST)
+     (uid $DIGEST23)
      (local true)
      (requires ())
      (source_dir _build/default/subdir/subfolder)
@@ -657,7 +657,7 @@ not stable across different setups.
      (include_dirs (_build/default/subdir/subfolder/.subfolder_lib.objs/byte))))
    (library
     ((name virtual)
-     (uid $DIGEST)
+     (uid $DIGEST24)
      (local true)
      (requires ())
      (source_dir _build/default/virtual)
@@ -670,9 +670,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual/.virtual.objs/byte))))
    (library
     ((name virtual_impl1)
-     (uid $DIGEST)
+     (uid $DIGEST25)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST24))
      (source_dir _build/default/virtual_impl1)
      (modules
       (((name Virtual)
@@ -690,9 +690,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
    (library
     ((name virtual_impl2)
-     (uid $DIGEST)
+     (uid $DIGEST26)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST24))
      (source_dir _build/default/virtual_impl2)
      (modules
       (((name Virtual)
@@ -726,7 +726,7 @@ not stable across different setups.
    (executables
     ((names (main))
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST1 $DIGEST2))
      (modules
       (((name Main)
         (impl (_build/default/main.ml))
@@ -738,7 +738,7 @@ not stable across different setups.
    (executables
     ((names (main2))
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST1 $DIGEST2))
      (modules
       (((name Main2_aux4)
         (impl ())
@@ -793,7 +793,7 @@ not stable across different setups.
      (include_dirs (_build/default/.main2.eobjs/byte))))
    (executables
     ((names (main3))
-     (requires ($DIGEST))
+     (requires ($DIGEST3))
      (modules
       (((name Main3)
         (impl (_build/default/main3.ml))
@@ -880,7 +880,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_exe.eobjs/byte))))
    (library
     ((name bar)
-     (uid $DIGEST)
+     (uid $DIGEST4)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -912,7 +912,7 @@ not stable across different setups.
      (include_dirs (_build/default/.bar.objs/byte))))
    (library
     ((name cmdliner)
-     (uid $DIGEST)
+     (uid $DIGEST3)
      (local false)
      (requires ())
      (source_dir /FINDLIB/cmdliner)
@@ -920,7 +920,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/cmdliner))))
    (library
     ((name compiler-libs)
-     (uid $DIGEST)
+     (uid $DIGEST5)
      (local false)
      (requires ())
      (source_dir /FINDLIB/compiler-libs)
@@ -928,18 +928,18 @@ not stable across different setups.
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST6)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST5))
      (source_dir /FINDLIB/compiler-libs)
      (modules ())
      (include_dirs (/FINDLIB/compiler-libs))))
    (library
     ((name dummy_ppx)
-     (uid $DIGEST)
+     (uid $DIGEST7)
      (local true)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST8 $DIGEST9))
      (source_dir _build/default)
      (modules
       (((name Dummy_ppx)
@@ -951,9 +951,9 @@ not stable across different setups.
      (include_dirs (_build/default/.dummy_ppx.objs/byte))))
    (library
     ((name foo)
-     (uid $DIGEST)
+     (uid $DIGEST2)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST1))
      (source_dir _build/default)
      (modules
       (((name Foo)
@@ -965,7 +965,7 @@ not stable across different setups.
      (include_dirs (_build/default/.foo.objs/byte))))
    (library
     ((name foo.x)
-     (uid $DIGEST)
+     (uid $DIGEST1)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -979,15 +979,15 @@ not stable across different setups.
      (include_dirs (_build/default/.foo_x.objs/byte))))
    (library
     ((name ocaml-compiler-libs.common)
-     (uid $DIGEST)
+     (uid $DIGEST10)
      (local false)
-     (requires ($DIGEST))
+     (requires ($DIGEST6))
      (source_dir /FINDLIB/ocaml-compiler-libs/common)
      (modules ())
      (include_dirs (/FINDLIB/ocaml-compiler-libs/common))))
    (library
     ((name ocaml-compiler-libs.shadow)
-     (uid $DIGEST)
+     (uid $DIGEST11)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ocaml-compiler-libs/shadow)
@@ -995,7 +995,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ocaml-compiler-libs/shadow))))
    (library
     ((name per_module_action_exe)
-     (uid $DIGEST)
+     (uid $DIGEST12)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1040,7 +1040,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_exe.objs/byte))))
    (library
     ((name per_module_action_lib)
-     (uid $DIGEST)
+     (uid $DIGEST13)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1075,7 +1075,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_action_lib.objs/byte))))
    (library
     ((name per_module_pp_lib)
-     (uid $DIGEST)
+     (uid $DIGEST14)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1110,7 +1110,7 @@ not stable across different setups.
      (include_dirs (_build/default/.per_module_pp_lib.objs/byte))))
    (library
     ((name ppx_derivers)
-     (uid $DIGEST)
+     (uid $DIGEST15)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppx_derivers)
@@ -1118,43 +1118,43 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppx_derivers))))
    (library
     ((name ppxlib)
-     (uid $DIGEST)
+     (uid $DIGEST9)
      (local false)
      (requires
-      ($DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST
-       $DIGEST))
+      ($DIGEST8
+       $DIGEST11
+       $DIGEST16
+       $DIGEST17
+       $DIGEST15
+       $DIGEST18
+       $DIGEST19
+       $DIGEST20
+       $DIGEST21
+       $DIGEST6))
      (source_dir /FINDLIB/ppxlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib))))
    (library
     ((name ppxlib.ast)
-     (uid $DIGEST)
+     (uid $DIGEST8)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST16 $DIGEST20))
      (source_dir /FINDLIB/ppxlib/ast)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/ast))))
    (library
     ((name ppxlib.astlib)
-     (uid $DIGEST)
+     (uid $DIGEST16)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST10 $DIGEST6))
      (source_dir /FINDLIB/ppxlib/astlib)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/astlib))))
    (library
     ((name ppxlib.print_diff)
-     (uid $DIGEST)
+     (uid $DIGEST17)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/print_diff)
@@ -1162,16 +1162,16 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/print_diff))))
    (library
     ((name ppxlib.stdppx)
-     (uid $DIGEST)
+     (uid $DIGEST19)
      (local false)
      (requires
-      ($DIGEST $DIGEST))
+      ($DIGEST21 $DIGEST20))
      (source_dir /FINDLIB/ppxlib/stdppx)
      (modules ())
      (include_dirs (/FINDLIB/ppxlib/stdppx))))
    (library
     ((name ppxlib.traverse_builtins)
-     (uid $DIGEST)
+     (uid $DIGEST18)
      (local false)
      (requires ())
      (source_dir /FINDLIB/ppxlib/traverse_builtins)
@@ -1179,7 +1179,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/ppxlib/traverse_builtins))))
    (library
     ((name re_lib)
-     (uid $DIGEST)
+     (uid $DIGEST22)
      (local true)
      (requires ())
      (source_dir _build/default)
@@ -1211,7 +1211,7 @@ not stable across different setups.
      (include_dirs (_build/default/.re_lib.objs/byte))))
    (library
     ((name sexplib0)
-     (uid $DIGEST)
+     (uid $DIGEST21)
      (local false)
      (requires ())
      (source_dir /FINDLIB/sexplib0)
@@ -1219,7 +1219,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/sexplib0))))
    (library
     ((name stdlib-shims)
-     (uid $DIGEST)
+     (uid $DIGEST20)
      (local false)
      (requires ())
      (source_dir /FINDLIB/stdlib-shims)
@@ -1227,7 +1227,7 @@ not stable across different setups.
      (include_dirs (/FINDLIB/stdlib-shims))))
    (library
     ((name subfolder_lib)
-     (uid $DIGEST)
+     (uid $DIGEST23)
      (local true)
      (requires ())
      (source_dir _build/default/subdir/subfolder)
@@ -1242,7 +1242,7 @@ not stable across different setups.
      (include_dirs (_build/default/subdir/subfolder/.subfolder_lib.objs/byte))))
    (library
     ((name virtual)
-     (uid $DIGEST)
+     (uid $DIGEST24)
      (local true)
      (requires ())
      (source_dir _build/default/virtual)
@@ -1256,9 +1256,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual/.virtual.objs/byte))))
    (library
     ((name virtual_impl1)
-     (uid $DIGEST)
+     (uid $DIGEST25)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST24))
      (source_dir _build/default/virtual_impl1)
      (modules
       (((name Virtual)
@@ -1282,9 +1282,9 @@ not stable across different setups.
      (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
    (library
     ((name virtual_impl2)
-     (uid $DIGEST)
+     (uid $DIGEST26)
      (local true)
-     (requires ($DIGEST))
+     (requires ($DIGEST24))
      (source_dir _build/default/virtual_impl2)
      (modules
       (((name Virtual)

--- a/test/blackbox-tests/test-cases/dune-build-info-in-ppx-github3336.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-build-info-in-ppx-github3336.t/run.t
@@ -11,5 +11,5 @@ Here we demonstrate that such a ppx .exe is built successfully.
   - executable/exec.pp.ml
   [1]
 
-  $ find _build | grep \.exe$ | censor_ppx
+  $ find _build | grep \.exe$ | censor
   _build/default/.ppx/$DIGEST/ppx.exe

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -43,8 +43,8 @@ the current digests for both files match those computed by Jenga.
   $ dune build exe non-exe
 
   $ (cd "$PWD/.xdg-cache/dune/db/files/v4"; grep -rws . -e 'content' | sort | censor)
-  ./5e/$DIGEST:content
-  ./e2/$DIGEST:content
+  ./5e/$DIGEST1:content
+  ./e2/$DIGEST2:content
 
 Move all current entries to v3 and v4 to test trimming of old versions of cache.
 
@@ -78,8 +78,8 @@ entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort ) > out
   $ cat out | censor
-  ./59/$DIGEST:((8:metadata)(5:files(8:target_b32:$DIGEST)))
-  ./78/$DIGEST:((8:metadata)(5:files(8:target_a32:$DIGEST)))
+  ./59/$DIGEST1:((8:metadata)(5:files(8:target_b32:$DIGEST2)))
+  ./78/$DIGEST3:((8:metadata)(5:files(8:target_a32:$DIGEST4)))
 
   $ digest="$(awk -F: '/target_b/ { digest=$1 } END { print digest }' < out)"
 

--- a/test/blackbox-tests/test-cases/melange/dune
+++ b/test/blackbox-tests/test-cases/melange/dune
@@ -11,6 +11,7 @@
 (cram
  (deps %{bin:melc_stdlib_prefix})
  (enabled_if
+  ; CR-soon Alizter: re-enable this test inside Nix
   (not %{env:INSIDE_NIX=false}))
  (applies_to merlin))
 

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -297,7 +297,7 @@ User ppx flags should appear in merlin config
   >   .[]
   >   | merlinConfigSummary(["STDLIB", "FLG", "UNIT_NAME"])
   > ]
-  > | .[]' | censor_ppx
+  > | .[]' | censor
   {
     "module_name": "Foo",
     "source_path": "_build/default/.melange_src/foo",
@@ -322,7 +322,7 @@ User ppx flags should appear in merlin config
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -355,7 +355,7 @@ User ppx flags should appear in merlin config
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -388,7 +388,7 @@ User ppx flags should appear in merlin config
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -428,7 +428,7 @@ User ppx flags should appear in merlin config
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -20,34 +20,34 @@ CRAM sanitization
   >     | merlinConfigSummary(["B", "S", "FLG", "UNIT_NAME"])
   >   ]
   >   | sort_by(.source_path)
-  >   | .[]' | censor_ppx
+  >   | .[]' | censor
   {
     "module_name": "X",
     "source_path": "_build/default/exe/x",
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte"
+        "$PWD/_build/default/exe/.x.eobjs/byte"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi"
+        "$PWD/_build/default/lib/.foo.objs/public_cmi"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/exe"
+        "$PWD/exe"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "FLG",
@@ -61,7 +61,7 @@ CRAM sanitization
         "FLG",
         [
           "-pp",
-          "$TESTCASE_ROOT/_build/default/pp/pp.exe"
+          "$PWD/_build/default/pp/pp.exe"
         ]
       ],
       [
@@ -76,27 +76,27 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte"
+        "$PWD/_build/default/exe/.x.eobjs/byte"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi"
+        "$PWD/_build/default/lib/.foo.objs/public_cmi"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/exe"
+        "$PWD/exe"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "FLG",
@@ -110,7 +110,7 @@ CRAM sanitization
         "FLG",
         [
           "-pp",
-          "$TESTCASE_ROOT/_build/default/pp/pp.exe"
+          "$PWD/_build/default/pp/pp.exe"
         ]
       ],
       [
@@ -129,22 +129,22 @@ CRAM sanitization
   >     | merlinConfigSummary(["B", "S", "FLG", "UNIT_NAME"])
   >   ]
   >   | sort_by(.module_name, .source_path)
-  >   | .[]' | censor_ppx
+  >   | .[]' | censor
   {
     "module_name": "Bar",
     "source_path": "_build/default/lib/bar",
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+        "$PWD/_build/default/lib/.bar.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -158,7 +158,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ],
       [
@@ -173,15 +173,15 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+        "$PWD/_build/default/lib/.bar.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -195,7 +195,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ],
       [
@@ -210,15 +210,15 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+        "$PWD/_build/default/lib/.bar.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -232,7 +232,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ],
       [
@@ -254,15 +254,15 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.bar.objs/byte"
+        "$PWD/_build/default/lib/.bar.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -276,7 +276,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ],
       [
@@ -298,23 +298,23 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+        "$PWD/_build/default/lib/.foo.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -328,7 +328,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -343,23 +343,23 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+        "$PWD/_build/default/lib/.foo.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -373,7 +373,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -388,23 +388,23 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+        "$PWD/_build/default/lib/.foo.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -418,7 +418,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -440,23 +440,23 @@ CRAM sanitization
     "config": [
       [
         "B",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "B",
-        "$TESTCASE_ROOT/_build/default/lib/.foo.objs/byte"
+        "$PWD/_build/default/lib/.foo.objs/byte"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/_findlib/publicfoo"
+        "$PWD/_findlib/publicfoo"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib"
+        "$PWD/lib"
       ],
       [
         "S",
-        "$TESTCASE_ROOT/lib/subdir"
+        "$PWD/lib/subdir"
       ],
       [
         "FLG",
@@ -470,7 +470,7 @@ CRAM sanitization
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ],
       [
@@ -504,7 +504,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
   >     | select(.ppx_flags != [])
   >   ]
   >   | sort_by(.module_name, .source_path)
-  >   | .[]' | censor_ppx
+  >   | .[]' | censor
   {
     "module_name": "Bar",
     "source_path": "_build/default/lib/bar",
@@ -513,7 +513,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ]
     ]
@@ -526,7 +526,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"bar\"'"
         ]
       ]
     ]
@@ -539,7 +539,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ]
     ]
@@ -552,7 +552,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ]
     ]
@@ -565,7 +565,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ]
     ]
@@ -578,7 +578,7 @@ Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
         "FLG",
         [
           "-ppx",
-          "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
+          "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'"
         ]
       ]
     ]

--- a/test/blackbox-tests/test-cases/merlin/multiple-ppx-stanzas-github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/multiple-ppx-stanzas-github1946.t/run.t
@@ -10,20 +10,20 @@ in the same dune file, but require different ppx specifications
   >   .[]
   >   | select(.module_name | test("^Usesppx"))
   >   | merlinJsonEntryWithConfigNames(["FLG", "UNIT_NAME"])
-  > ' | censor_ppx
+  > ' | censor
   Usesppx1: _build/default/usesppx1
   ["FLG",["-w","-40","-g"]]
-  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
+  ["FLG",["-ppx","$PWD/_build/default/.ppx/$DIGEST1/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
   ["UNIT_NAME","usesppx1"]
   Usesppx1: _build/default/usesppx1.ml-gen
   ["FLG",["-w","-40","-g"]]
-  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
+  ["FLG",["-ppx","$PWD/_build/default/.ppx/$DIGEST1/ppx.exe --as-ppx --cookie 'library-name=\"usesppx1\"'"]]
   ["UNIT_NAME","usesppx1"]
   Usesppx2: _build/default/usesppx2
   ["FLG",["-w","-40","-g"]]
-  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
+  ["FLG",["-ppx","$PWD/_build/default/.ppx/$DIGEST2/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
   ["UNIT_NAME","usesppx2"]
   Usesppx2: _build/default/usesppx2.ml-gen
   ["FLG",["-w","-40","-g"]]
-  ["FLG",["-ppx","$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
+  ["FLG",["-ppx","$PWD/_build/default/.ppx/$DIGEST2/ppx.exe --as-ppx --cookie 'library-name=\"usesppx2\"'"]]
   ["UNIT_NAME","usesppx2"]

--- a/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
+++ b/test/blackbox-tests/test-cases/pkg/absolute-paths-in-sections.t
@@ -18,6 +18,6 @@ Test that section pforms are substituted with absolute paths.
 
 Note that currently dune incorrectly substitutes relative paths for pforms that
 appear in string interpolations.
-  $ build_pkg test 2>&1 | strip_sandbox | censor
-  --prefix $SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target
-  $SANDBOX/_private/default/.pkg/test.0.0.1-$DIGEST/target
+  $ build_pkg test 2>&1 | censor
+  --prefix $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/test.0.0.1-$DIGEST2/target
+  --prefix=$PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/test.0.0.1-$DIGEST2/target

--- a/test/blackbox-tests/test-cases/pkg/default-exported-env.t
+++ b/test/blackbox-tests/test-cases/pkg/default-exported-env.t
@@ -20,9 +20,9 @@ Some environment variables are automatically exported by packages:
   $ ln -s $(which ocamlc) .bin/ocamlc
   $ ln -s $(which sh) .bin/sh
   $ dune=$(which dune)
-  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest 2>&1 | strip_sandbox | censor
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/man
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/stublibs
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/toplevel
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/.bin
+  $ MANPATH="" OCAMLPATH="" CAML_LD_LIBRARY_PATH="" OCAMLTOP_INCLUDE_PATH="" PATH="$PWD/.bin" build_pkg usetest 2>&1 | censor
+  MANPATH=$PWD/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/man
+  OCAMLPATH=$PWD/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib
+  CAML_LD_LIBRARY_PATH=$PWD/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/stublibs
+  OCAMLTOP_INCLUDE_PATH=$PWD/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/toplevel
+  PATH=$PWD/_build/_private/default/.pkg/test.0.0.1-$DIGEST/target/bin:$PWD/.bin

--- a/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
+++ b/test/blackbox-tests/test-cases/pkg/dep-section-variables.t
@@ -123,17 +123,17 @@ These currently expand to absolute paths instead of relative ones:
   >   (run cat %{pkg:dep:stublibs}/stublibs-file)))
   > EOF
 
-  $ build_pkg run-consumer 2>&1 | strip_sandbox | censor | dune_cmd subst '/[^ ]*/cat:' 'cat:'
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/dep
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/dep
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/bin
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/sbin
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/share/dep
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/etc/dep
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/doc/dep
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/man
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/toplevel
-  $SANDBOX/_private/default/.pkg/dep.0.0.1-$DIGEST/target/lib/stublibs
+  $ build_pkg run-consumer 2>&1 | censor | dune_cmd subst '/[^ ]*/cat:' 'cat:'
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/lib/dep
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/lib/dep
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/bin
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/sbin
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/share/dep
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/etc/dep
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/doc/dep
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/man
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/lib/toplevel
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/dep.0.0.1-$DIGEST2/target/lib/stublibs
   lib-data
   libexec-data
   bin-data

--- a/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-var/opam-var-switch.t
@@ -47,17 +47,17 @@ opam-var-unsupported.t
        (run echo %{toplevel})
        (run echo %{stublibs}))))))
 
-  $ build_pkg testpkg 2>&1 | strip_sandbox | censor
+  $ build_pkg testpkg 2>&1 | censor
   dune
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/source
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/bin
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/sbin
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/share
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/doc
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/etc
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/man
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib/toplevel
-  $SANDBOX/_private/default/.pkg/testpkg.0.0.1-$DIGEST/target/lib/stublibs
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/source
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/lib
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/lib
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/bin
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/sbin
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/share
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/doc
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/etc
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/man
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/lib/toplevel
+  $PWD/_build/.sandbox/$DIGEST1/_private/default/.pkg/testpkg.0.0.1-$DIGEST2/target/lib/stublibs

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-dependencies.t
@@ -73,13 +73,13 @@ A package that conditionally depends on packages depending on the OS:
 Build the project as if we were on linux and confirm that only the linux-specific dependency is installed:
   $ DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11 dune build
   $ ls $pkg_root/ | censor
-  foo.0.0.1-$DIGEST
-  linux-only.0.0.1-$DIGEST
+  foo.0.0.1-$DIGEST1
+  linux-only.0.0.1-$DIGEST2
 
   $ dune clean
 
 Build the project as if we were on macos and confirm that only the macos-specific dependency is installed:
   $ DUNE_CONFIG__OS=macos DUNE_CONFIG__ARCH=x86_64 DUNE_CONFIG__OS_FAMILY=homebrew DUNE_CONFIG__OS_DISTRIBUTION=homebrew DUNE_CONFIG__OS_VERSION=15.3.1 dune build
   $ ls $pkg_root/ | censor
-  foo.0.0.1-$DIGEST
-  macos-only.0.0.1-$DIGEST
+  foo.0.0.1-$DIGEST1
+  macos-only.0.0.1-$DIGEST2

--- a/test/blackbox-tests/test-cases/pkg/withenv-path.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv-path.t
@@ -75,8 +75,8 @@ Printing out PATH without setting it when the package has a dependency:
   >  (system "echo PATH=$PATH"))
   > EOF
   $ dune clean
-  $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin
+  $ OCAMLRUNPARAM=b PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | censor
+  PATH=$PWD/_build/_private/default/.pkg/hello2.0.0.1-$DIGEST1/target/bin:$PWD/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST2/target/bin:DUNE_PATH:/bin
 
 Setting PATH to a specific value:
   $ make_lockpkg test <<'EOF'
@@ -101,8 +101,8 @@ Attempting to add a path to PATH replaces the entire PATH:
   >   (system "echo PATH=$PATH")))
   > EOF
   $ dune clean
-  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | censor
+  PATH=/tmp/bin:$PWD/_build/_private/default/.pkg/hello2.0.0.1-$DIGEST1/target/bin:$PWD/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST2/target/bin:DUNE_PATH:/bin
 
 Try adding multiple paths to PATH:
   $ make_lockpkg test <<'EOF'
@@ -116,5 +116,5 @@ Try adding multiple paths to PATH:
   >   (system "echo PATH=$PATH")))
   > EOF
   $ dune clean
-  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | strip_sandbox | censor
-  $SANDBOX/default/test/blackbox-tests/test-cases/pkg/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST/target/bin:DUNE_PATH:/bin
+  $ PATH=$DUNE_PATH:/bin build_pkg test 2>&1 | $DUNE_CMD subst "$DUNE_PATH" 'DUNE_PATH' | censor
+  PATH=/bar/bin:/foo/bin:/tmp/bin:$PWD/_build/_private/default/.pkg/hello2.0.0.1-$DIGEST1/target/bin:$PWD/_build/_private/default/.pkg/hello1.0.0.1-$DIGEST2/target/bin:DUNE_PATH:/bin

--- a/test/blackbox-tests/test-cases/top-module/load-with-ppx.t
+++ b/test/blackbox-tests/test-cases/top-module/load-with-ppx.t
@@ -23,9 +23,9 @@ Load a module that requires ppx
   $ cat >foo.ml <<EOF
   > let () = ()
   > EOF
-  $ dune ocaml top-module foo.ml | censor_ppx
-  #directory "$TESTCASE_ROOT/_build/default/.topmod/foo.ml";;
-  #load "$TESTCASE_ROOT/_build/default/.topmod/foo.ml/foo.cmo";;
-  #ppx "$TESTCASE_ROOT/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'";;
+  $ dune ocaml top-module foo.ml | censor
+  #directory "$PWD/_build/default/.topmod/foo.ml";;
+  #load "$PWD/_build/default/.topmod/foo.ml/foo.cmo";;
+  #ppx "$PWD/_build/default/.ppx/$DIGEST/ppx.exe --as-ppx --cookie 'library-name=\"foo\"'";;
   $ basename $(ls _build/default/.ppx/*/*.exe)
   ppx.exe

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -437,6 +437,10 @@ module Sed = struct
         { rex : Re.re
         ; replacement : string
         }
+    | Subst_unique of
+        { rex : Re.re
+        ; replacement : string
+        }
     | Delete of Re.re
     | Delete_between of
         { from : Re.re
@@ -458,6 +462,12 @@ module Sed = struct
   let subst ?file ~rex ~replacement () =
     let io = io file in
     let action = Subst { rex; replacement } in
+    { io; action }
+  ;;
+
+  let subst_unique ?file ~rex ~replacement () =
+    let io = io file in
+    let action = Subst_unique { rex; replacement } in
     { io; action }
   ;;
 
@@ -493,6 +503,35 @@ module Sed = struct
     | Subst { rex; replacement } ->
       List.map inputs ~f:(fun line ->
         Re.Pcre.substitute ~rex ~subst:(fun _ -> replacement) line)
+    | Subst_unique { rex; replacement } ->
+      let tbl = Table.create (module String) 16 in
+      let count =
+        List.fold_left inputs ~init:0 ~f:(fun counter line ->
+          List.fold_left
+            (Re.Pcre.full_split ~rex line)
+            ~init:counter
+            ~f:(fun counter token ->
+              match token with
+              | Re.Pcre.Delim matched ->
+                (match Table.find tbl matched with
+                 | Some _ -> counter
+                 | None ->
+                   let n = counter + 1 in
+                   Table.set tbl matched n;
+                   n)
+              | _ -> counter))
+      in
+      List.map inputs ~f:(fun line ->
+        Re.Pcre.full_split ~rex line
+        |> List.map ~f:(fun token ->
+          match token with
+          | Re.Pcre.Text s -> s
+          | Re.Pcre.Delim matched ->
+            let n = Table.find_exn tbl matched in
+            if count <= 1 then replacement else Printf.sprintf "%s%d" replacement n
+          | Re.Pcre.Group (_, s) -> s
+          | Re.Pcre.NoGroup -> "")
+        |> String.concat ~sep:"")
     | Delete rex -> List.filter inputs ~f:(fun line -> not @@ Re.Pcre.pmatch ~rex line)
     | Delete_between { from; to' } ->
       inputs
@@ -584,6 +623,23 @@ module Subst = Run_sed (struct
           | _ :: _ :: _ -> raise (Arg.Bad "Too many arguments")
         in
         Sed.subst ?file ~rex ~replacement ()
+      | _ -> raise (Arg.Bad "Required arguments are <pattern> <replacement> [file]")
+    ;;
+  end)
+
+module Subst_unique = Run_sed (struct
+    let name = "subst-unique"
+
+    let of_args = function
+      | pattern :: replacement :: optional ->
+        let rex = Re.Pcre.regexp pattern in
+        let file =
+          match optional with
+          | [] -> None
+          | [ filename ] -> Some (Path.of_filename_relative_to_initial_cwd filename)
+          | _ :: _ :: _ -> raise (Arg.Bad "Too many arguments")
+        in
+        Sed.subst_unique ?file ~rex ~replacement ()
       | _ -> raise (Arg.Bad "Required arguments are <pattern> <replacement> [file]")
     ;;
   end)


### PR DESCRIPTION
We cleanup all our `censor`-style helpers into a single one that works for all cases and disambiguates between distinct matches.

This reveals some erroneous censorship that we have partaken in with various tests.

- [x] finish updating various tests
- [x] document in hacking.rst