### PR TITLE
test: regression guard for include-flag soundness through pre-pp entry

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
@@ -1,0 +1,93 @@
+Regression guard for cross-library dependency tracking through a
+preprocessed entry module.
+
+A consumer compiled against a library with a preprocessed entry
+module must still see the [.cmi] of any transitive library whose
+type signature leaks through that entry module's interface — even
+when the consumer never names the transitive library
+syntactically.
+
+The cross-library walker (used to compute per-module dependency
+sets) stops at preprocessed entry modules because ocamldep on the
+pre-preprocessing source can fail; the neighbour test
+[cross-lib-walk-pre-pp-source.t] guards that stopping behaviour.
+When the preprocessed module's [.mli] mentions a type from another
+library, the walker cannot observe the link. Any per-module
+filtering of include flags must be conservative enough to keep the
+transitive library on the consumer's include path; otherwise
+type-checking the consumer fails the moment it touches the
+transitive type.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+A pass-through preprocessor: its sole effect is to mark
+[pp_dep]'s modules as preprocessed so the cross-library walker
+treats them as opaque.
+
+  $ mkdir pp
+  $ cat > pp/dune <<EOF
+  > (executable (name pp))
+  > EOF
+  $ cat > pp/pp.ml <<'EOF'
+  > let () =
+  >   let ic = open_in_bin Sys.argv.(1) in
+  >   try while true do print_endline (input_line ic) done
+  >   with End_of_file -> ()
+  > EOF
+
+[other_dep] is unwrapped (so tight-eligible) and exposes a record
+type:
+
+  $ mkdir other_dep
+  $ cat > other_dep/dune <<EOF
+  > (library (name other_dep) (wrapped false))
+  > EOF
+  $ cat > other_dep/other.ml <<EOF
+  > type t = { x : int; y : string }
+  > let make x y = { x; y }
+  > EOF
+  $ cat > other_dep/other.mli <<EOF
+  > type t = { x : int; y : string }
+  > val make : int -> string -> t
+  > EOF
+
+[pp_dep] is unwrapped + preprocessed. Its [.mli] mentions
+[Other.t]; this is the implicit-transitive link from consumer to
+[other_dep] that ocamldep on the consumer cannot observe.
+
+  $ mkdir pp_dep
+  $ cat > pp_dep/dune <<EOF
+  > (library
+  >  (name pp_dep)
+  >  (wrapped false)
+  >  (libraries other_dep)
+  >  (preprocess (action (run %{exe:../pp/pp.exe} %{input-file}))))
+  > EOF
+  $ cat > pp_dep/d.ml <<EOF
+  > let make_thing () = Other.make 1 "hi"
+  > EOF
+  $ cat > pp_dep/d.mli <<EOF
+  > val make_thing : unit -> Other.t
+  > EOF
+
+Consumer references [D.make_thing] and accesses its [.x] field.
+The field access forces the type checker to load [other.cmi]
+even though [Other] is never named in [c.ml].
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (library (name consumer) (wrapped false) (libraries pp_dep))
+  > EOF
+  $ cat > consumer/c.ml <<EOF
+  > let v = D.make_thing ()
+  > let _ = v.x
+  > EOF
+
+Build the consumer. The build must succeed. If a future change
+narrows [c.ml]'s compile rule to drop [other_dep]'s [-I]/[-H] on
+the basis of the walker's tight set alone, this fails with
+"Unbound record field x".
+
+  $ dune build @check

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
@@ -1,29 +1,31 @@
-Regression guard for cross-library dependency tracking through a
-preprocessed entry module.
+Regression test for cross-library dependency tracking through a
+preprocessed library's interface.
 
-A consumer compiled against a library with a preprocessed entry
-module must still see the [.cmi] of any transitive library whose
-type signature leaks through that entry module's interface — even
-when the consumer never names the transitive library
-syntactically.
+Three libraries, all unwrapped. [other_dep] defines a record
+type [Other.t]. [pp_dep] is preprocessed, depends on
+[other_dep], and re-exports [Other.t] in its [.mli]. [consumer]
+depends only on [pp_dep] and accesses a field of a value of
+type [Other.t] without ever naming [Other].
 
-The cross-library walker (used to compute per-module dependency
-sets) stops at preprocessed entry modules because ocamldep on the
-pre-preprocessing source can fail; the neighbour test
-[cross-lib-walk-pre-pp-source.t] guards that stopping behaviour.
-When the preprocessed module's [.mli] mentions a type from another
-library, the walker cannot observe the link. Any per-module
-filtering of include flags must be conservative enough to keep the
-transitive library on the consumer's include path; otherwise
-type-checking the consumer fails the moment it touches the
-transitive type.
+The consumer's compile must find [other.cmi] on its include
+path; otherwise the field access fails with "Unbound record
+field x".
+
+Dune normally discovers cross-library type leaks by running
+ocamldep on each module's source. For preprocessed modules,
+ocamldep can fail on the pre-preprocessing source, so dune
+skips it — see neighbour test
+[cross-lib-walk-pre-pp-source.t]. As a result, dune cannot
+observe the implicit dependency from [consumer] to [other_dep]
+through [pp_dep]'s interface. The consumer's include flags
+must therefore conservatively retain [other_dep]'s [-I]/[-H]
+even though dune sees no direct link.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > EOF
 
-[other_dep] is unwrapped (so tight-eligible) and exposes a record
-type:
+[other_dep]:
 
   $ mkdir other_dep
   $ cat > other_dep/dune <<EOF
@@ -38,9 +40,7 @@ type:
   > val make : int -> string -> t
   > EOF
 
-[pp_dep] is unwrapped + preprocessed. Its [.mli] mentions
-[Other.t]; this is the implicit-transitive link from consumer to
-[other_dep] that ocamldep on the consumer cannot observe.
+[pp_dep]:
 
   $ mkdir pp_dep
   $ cat > pp_dep/dune <<EOF
@@ -57,9 +57,9 @@ type:
   > val make_thing : unit -> Other.t
   > EOF
 
-Consumer references [D.make_thing] and accesses its [.x] field.
-The field access forces the type checker to load [other.cmi]
-even though [Other] is never named in [c.ml].
+[consumer] accesses [.x] on a [D.make_thing ()] value, forcing
+the type checker to load [other.cmi] even though [Other] is
+never named in [c.ml]:
 
   $ mkdir consumer
   $ cat > consumer/dune <<EOF
@@ -70,9 +70,6 @@ even though [Other] is never named in [c.ml].
   > let _ = v.x
   > EOF
 
-Build the consumer. The build must succeed. If a future change
-narrows [c.ml]'s compile rule to drop [other_dep]'s [-I]/[-H] on
-the basis of the walker's tight set alone, this fails with
-"Unbound record field x".
+The build must succeed:
 
   $ dune build @check

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t
@@ -22,21 +22,6 @@ transitive type.
   > (lang dune 3.0)
   > EOF
 
-A pass-through preprocessor: its sole effect is to mark
-[pp_dep]'s modules as preprocessed so the cross-library walker
-treats them as opaque.
-
-  $ mkdir pp
-  $ cat > pp/dune <<EOF
-  > (executable (name pp))
-  > EOF
-  $ cat > pp/pp.ml <<'EOF'
-  > let () =
-  >   let ic = open_in_bin Sys.argv.(1) in
-  >   try while true do print_endline (input_line ic) done
-  >   with End_of_file -> ()
-  > EOF
-
 [other_dep] is unwrapped (so tight-eligible) and exposes a record
 type:
 
@@ -63,7 +48,7 @@ type:
   >  (name pp_dep)
   >  (wrapped false)
   >  (libraries other_dep)
-  >  (preprocess (action (run %{exe:../pp/pp.exe} %{input-file}))))
+  >  (preprocess (action (run cat %{input-file}))))
   > EOF
   $ cat > pp_dep/d.ml <<EOF
   > let make_thing () = Other.make 1 "hi"


### PR DESCRIPTION
## Summary

Adds a cross-library cram test: a consumer reaches a transitive type only through a *preprocessed* library's `.mli`, where the type is never syntactically named in the consumer's source.

Three libraries:

- `other_dep` — unwrapped, exposes `type t = { x : int; y : string }`.
- `pp_dep` — unwrapped + preprocessed, depends on `other_dep`, exposes `val make_thing : unit -> Other.t`.
- `consumer` — depends on `pp_dep`, accesses `(D.make_thing ()).x`.

`consumer/c.ml` never mentions `Other`, but the field access forces the type checker to load `other.cmi`. The test asserts `dune build @check` succeeds.

Sibling to #14400's `cross-lib-walk-pre-pp-source.t`. That test exercises behaviour at a preprocessed entry directly; this one exercises the *transitive* leg — where the preprocessed entry's `.mli` re-exports a type from a deeper library.