### PR TITLE
fix: preserve topological lib order in shared jsoo runtime

### DIFF
--- a/doc/changes/fixed/14438.md
+++ b/doc/changes/fixed/14438.md
@@ -1,0 +1,2 @@
+- Preserve library order when building a shared jsoo standalone runtime.
+  (#14438, @vouillon)

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -530,11 +530,11 @@ end = struct
         List.filter libs ~f:(fun lib ->
           not (List.is_empty (jsoo_runtime_files ~mode [ lib ])))
       in
-      let lib_names =
-        List.sort libs_with_runtime ~compare:(fun a b ->
-          Lib_name.compare (Lib.name a) (Lib.name b))
-        |> List.map ~f:Lib.name
-      in
+      (* Keep the topological order from [requires_link]: jsoo runtime
+         contents are concatenated and later files override earlier ones,
+         so reordering (e.g. sorting by name) can change which conflicting
+         binding wins. *)
+      let lib_names = List.map libs_with_runtime ~f:Lib.name in
       let project_root = Lib.L.project_root libs_with_runtime in
       { mode; lib_names; project_root }
     ;;

--- a/test/blackbox-tests/test-cases/jsoo/shared-runtime-lib-order.t
+++ b/test/blackbox-tests/test-cases/jsoo/shared-runtime-lib-order.t
@@ -1,0 +1,43 @@
+Regression test for jsoo shared-runtime lib ordering.
+
+When two libraries on the link path each contribute a JS runtime file,
+jsoo concatenates them in the runtime and later files override earlier
+ones on colliding symbols. The shared runtime must therefore link them
+in topological order (deps before dependents) — the same order each
+consumer would have produced unshared. Sorting by name (the previous
+behaviour) flipped the order whenever alphabetical disagreed with
+topological, silently changing which conflicting binding wins.
+
+Here [lib_a] depends on [lib_z], so topological order is [lib_z] first
+then [lib_a]. Alphabetical would invert this.
+
+  $ make_dune_project 3.23
+
+  $ mkdir lib_a lib_z
+
+  $ cat > lib_z/dune <<EOF
+  > (library
+  >  (name lib_z)
+  >  (js_of_ocaml (javascript_files runtime.js)))
+  > EOF
+  $ touch lib_z/lib_z.ml lib_z/runtime.js
+
+  $ cat > lib_a/dune <<EOF
+  > (library
+  >  (name lib_a)
+  >  (libraries lib_z)
+  >  (js_of_ocaml (javascript_files runtime.js)))
+  > EOF
+  $ touch lib_a/lib_a.ml lib_a/runtime.js
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries lib_a)
+  >  (modes js))
+  > EOF
+  $ touch main.ml
+
+  $ dune build --display verbose main.bc.js 2>&1 | grep -oE 'lib_[az]/runtime\.js'
+  lib_a/runtime.js
+  lib_z/runtime.js

--- a/test/blackbox-tests/test-cases/jsoo/shared-runtime-lib-order.t
+++ b/test/blackbox-tests/test-cases/jsoo/shared-runtime-lib-order.t
@@ -39,5 +39,5 @@ then [lib_a]. Alphabetical would invert this.
   $ touch main.ml
 
   $ dune build --display verbose main.bc.js 2>&1 | grep -oE 'lib_[az]/runtime\.js'
-  lib_a/runtime.js
   lib_z/runtime.js
+  lib_a/runtime.js


### PR DESCRIPTION
The sort in `Runtime_key.Decoded.of_libs` made the digest invariant under input reordering, but it also reordered the libs fed back to `jsoo_runtime_files` in `setup_shared_runtime_rule`. Since later JS files override earlier ones in the runtime, alphabetical order produced a different runtime than the topological order each consumer would have built on its own, silently switching which conflicting binding wins.

Drop the sort. Stanzas with the same closure and the same requires_link order still share; stanzas that disagree on order get separate runtimes rather than a shared one with arbitrary contents.