### PR TITLE
test: guards for wrapped-lib soundness under non-trivial wrapping

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
@@ -1,0 +1,152 @@
+Regression guards for soundness, with a forward-looking pin on
+current behaviour, all when a consumer depends on an implementation
+that inherits its `(wrapped ...)` setting from the virtual library
+(the implementation does not redeclare `wrapped`).
+
+`vlib` declares `(wrapped true)` with a virtual module `virt_iface`
+and concrete siblings `helper` and `unused`. `impl` implements
+`vlib` without redeclaring `wrapped`. The executable `main` depends
+on `impl` and reaches `virt_iface` and `helper` via the vlib
+wrapper: `Vlib.Virt_iface.x` and `Vlib.Helper.h`. `main` does not
+reference `unused`.
+
+The implementation's closure includes `virt_iface`'s impl and
+`vlib`'s concrete modules. `main`'s compile rule must therefore
+cover `vlib__Virt_iface.cmi` and `vlib__Helper.cmi`. Any future
+per-module narrowing that treats inherited-wrapped libraries as
+ordinary local libraries must still keep that coverage; otherwise
+a change to either module's interface fails to invalidate `main`.
+
+  $ make_dune_project 3.24
+
+  $ mkdir vlib impl consumer
+
+  $ cat > vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (wrapped true)
+  >  (virtual_modules virt_iface))
+  > EOF
+  $ cat > vlib/virt_iface.mli <<EOF
+  > val x : string
+  > EOF
+  $ cat > vlib/helper.ml <<EOF
+  > let h = "h"
+  > let z = 42
+  > EOF
+  $ cat > vlib/helper.mli <<EOF
+  > val h : string
+  > EOF
+  $ cat > vlib/unused.ml <<EOF
+  > let u = "u"
+  > let w = "w"
+  > EOF
+  $ cat > vlib/unused.mli <<EOF
+  > val u : string
+  > EOF
+
+  $ cat > impl/dune <<EOF
+  > (library
+  >  (name impl)
+  >  (implements vlib))
+  > EOF
+  $ cat > impl/virt_iface.ml <<EOF
+  > let x = "impl"
+  > let z = 42
+  > EOF
+
+  $ cat > consumer/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries impl))
+  > EOF
+  $ cat > consumer/main.ml <<EOF
+  > let () = print_string Vlib.Virt_iface.x; print_string Vlib.Helper.h
+  > EOF
+
+  $ dune build @check
+
+Glob coverage on `main.cmi`'s compile rule:
+
+  $ dune rules --root . --format=json --deps '%{cmi:consumer/main}' |
+  > jq -r 'include "dune"; .[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
+  In_build_dir _build/default/impl/.impl.objs/byte *.cmi
+
+Case 1 (soundness): edit `helper`'s interface to expose `z`. `main`
+reaches `helper` through the vlib wrapper; the compile-rule deps
+must cover `vlib__Helper.cmi`, so `main` rebuilds:
+
+  $ cat > vlib/helper.mli <<EOF
+  > val h : string
+  > val z : int
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]
+
+Case 2 (soundness): edit `virt_iface`'s interface to expose `z`.
+`main` reaches `virt_iface` through the vlib wrapper; the compile-
+rule deps must cover `vlib__Virt_iface.cmi`, so `main` rebuilds:
+
+  $ cat > vlib/virt_iface.mli <<EOF
+  > val x : string
+  > val z : int
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]
+
+Case 3 (forward-looking pin on current behaviour): edit `unused`'s
+interface to expose `w`. `main` does not reference `unused`, so
+under a future per-module narrowing this edit would not rebuild
+`main`. Today, the per-library filter rebuilds `main` anyway
+because `impl`'s `.cmi` glob covers every module of the
+implementation's closure. Promote when per-module narrowing within
+a library lands.
+
+  $ cat > vlib/unused.mli <<EOF
+  > val u : string
+  > val w : string
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
@@ -1,0 +1,105 @@
+Regression guard for wrapped-library soundness, with a forward-
+looking pin on current behaviour, both under
+`(wrapped (transition ...))`.
+
+`wrapped_lib` uses `(wrapped (transition ...))` with inner modules
+`inner_a` and `inner_b` plus a hand-written wrapper module that
+aliases both. The library `consumer` depends on `wrapped_lib` and
+writes `Wrapped_lib.Inner_a.x` — naming the wrapper and one inner
+module but not the other.
+
+The wrapper's `.cmi` only carries an alias name; the type lives in
+the inner module's mangled artifact `wrapped_lib__Inner_a.cmi` (not
+the `inner_a.cmi` transition shim). So `consumer`'s compile rule
+must cover `wrapped_lib__Inner_a.cmi` alongside `wrapped_lib.cmi`.
+Any future per-module narrowing of compile-rule deps must keep that
+coverage; otherwise a change to `inner_a`'s interface fails to
+invalidate `consumer`.
+
+  $ make_dune_project 3.24
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name wrapped_lib)
+  >  (wrapped (transition "use Wrapped_lib.X instead of X"))
+  >  (modules wrapped_lib inner_a inner_b))
+  > (library
+  >  (name consumer)
+  >  (modules consumer)
+  >  (libraries wrapped_lib))
+  > EOF
+
+  $ cat > wrapped_lib.ml <<EOF
+  > module Inner_a = Inner_a
+  > module Inner_b = Inner_b
+  > EOF
+  $ cat > inner_a.ml <<EOF
+  > let x = "a"
+  > let z = 42
+  > EOF
+  $ cat > inner_a.mli <<EOF
+  > val x : string
+  > EOF
+  $ cat > inner_b.ml <<EOF
+  > let y = "b"
+  > let w = "w"
+  > EOF
+  $ cat > inner_b.mli <<EOF
+  > val y : string
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Wrapped_lib.Inner_a.x
+  > EOF
+
+  $ dune build @check
+
+Glob coverage on `consumer.cmi`'s compile rule:
+
+  $ dune rules --root . --format=json --deps '%{cmi:consumer}' |
+  > jq -r 'include "dune"; .[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
+  In_build_dir _build/default/.wrapped_lib.objs/byte *.cmi
+
+Case 1 (soundness): edit `inner_a`'s interface to expose `z`.
+`consumer` reaches `inner_a` through the wrapper `Wrapped_lib`;
+the compile-rule deps must cover `wrapped_lib__Inner_a.cmi`, so
+`consumer` rebuilds:
+
+  $ cat > inner_a.mli <<EOF
+  > val x : string
+  > val z : int
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.consumer.objs/byte/consumer.cmi",
+        "_build/default/.consumer.objs/byte/consumer.cmo",
+        "_build/default/.consumer.objs/byte/consumer.cmt"
+      ]
+    }
+  ]
+
+Case 2 (forward-looking pin on current behaviour): edit `inner_b`'s
+interface to expose `w`. `consumer` does not reference `inner_b`,
+so under a future per-module narrowing this edit would not rebuild
+`consumer`. Today, the per-library filter rebuilds `consumer`
+anyway because `wrapped_lib`'s `.cmi` glob covers every module.
+Promote when per-module narrowing within a library lands.
+
+  $ cat > inner_b.mli <<EOF
+  > val y : string
+  > val w : string
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.consumer.objs/byte/consumer.cmi",
+        "_build/default/.consumer.objs/byte/consumer.cmo",
+        "_build/default/.consumer.objs/byte/consumer.cmt"
+      ]
+    }
+  ]


### PR DESCRIPTION
## Summary

Two forward-looking cram guards under
`test/blackbox-tests/test-cases/per-module-lib-deps/`:

- `wrapped-transition-soundness.t` — soundness for `(wrapped (transition ...))` consumers reaching an inner module through the wrapper alias.
- `wrapped-from-vlib-soundness.t` — soundness for consumers of a vlib implementation that inherits `(wrapped ...)` from the vlib.

Both pass trivially on `main`; they fail only when future per-module narrowing of compile-rule deps drops the relevant `.cmi` coverage. See each test's prose header for the full soundness argument.