### PR TITLE
update backport.sh script

### DIFF
--- a/doc/dev/releases/backport.sh
+++ b/doc/dev/releases/backport.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Script name: backport.sh
 # Description: This script creates backport PRs into a release candidate branch.
@@ -71,8 +71,9 @@ then
     fi
 
     git checkout -b "${backport_branch}"
-    git push -u "${DUNE_REMOTE}" HEAD
     git cherry-pick --mainline 1 --signoff -x "${commit}"
+    git push -u "${DUNE_REMOTE}" HEAD
+
 fi
 
 gh pr create \


### PR DESCRIPTION
This patch has a couple of minor updates:
* Make the default shell bash: Ubuntu uses dash by default when you invoke `sh`, and it doesn't support `set -o pipefail`.
* Change the ordering of cherry-pick to be done before pushing the remote. This way we don't have an empty branch if cherry-pick fails for some reason.