### PR TITLE
fix: AND user-written menhir constraint with dune's required lower bound

### DIFF
--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -1,9 +1,13 @@
 - When generating opam files for `(lang dune 3.23)` or newer, AND
   the user-written menhir dep constraint with the lower bound
-  (`>= "20180523"`) that dune's menhir rules require. Take the
-  higher of two `>=` literals (warn when the user's bound is below
-  the minimum); combine with formula operators like `:with-test`.
-  The 3.23 gate also covers the bare-`(menhir)` fill from #14434
-  (previously unversioned), mirroring the fix in #14466 to avoid
-  silent changes to opam output on dune-binary upgrade.
+  (`>= "20180523"`) that dune's menhir rules require. The merge
+  descends recursively through `(and ...)` / `(or ...)` /
+  `(not ...)` to find existing `>=` literals, tightening any that
+  fall below the minimum (with a user-facing warning), and skips
+  the outer AND when the resulting expression already implies the
+  minimum on every satisfying valuation. The same recursive merge
+  is applied to dune-on-dune constraints. The 3.23 gate also
+  covers the bare-`(menhir)` fill from #14434 (previously
+  unversioned), mirroring the fix in #14466 to avoid silent
+  changes to opam output on dune-binary upgrade.
   (#14453, @robinbb)

--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -1,13 +1,9 @@
-- When generating opam files for `(lang dune 3.23)` or newer, AND
-  the user-written menhir dep constraint with the lower bound
-  (`>= "20180523"`) that dune's menhir rules require. The merge
-  descends recursively through `(and ...)` / `(or ...)` /
-  `(not ...)` to find existing `>=` literals, tightening any that
-  fall below the minimum (with a user-facing warning), and skips
-  the outer AND when the resulting expression already implies the
-  minimum on every satisfying valuation. The same recursive merge
-  is applied to dune-on-dune constraints. The 3.23 gate also
-  covers the bare-`(menhir)` fill from #14434 (previously
-  unversioned), mirroring the fix in #14466 to avoid silent
-  changes to opam output on dune-binary upgrade.
+- For `(lang dune 3.23)` or newer with `(generate_opam_files true)`,
+  the generated opam file now enforces the menhir lower bound
+  (`>= "20180523"`) that dune's menhir rules require, even when the
+  package already lists a menhir constraint. A warning is emitted when
+  the user's lower bound is below the minimum. The 3.23 gate also
+  covers the bare-`(menhir)` fill from #14434 (previously unversioned),
+  mirroring #14466 to avoid silent changes to opam output on
+  dune-binary upgrade.
   (#14453, @robinbb)

--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -1,0 +1,9 @@
+- When generating opam files for `(lang dune 3.23)` or newer, AND
+  the user-written menhir dep constraint with the lower bound
+  (`>= "20180523"`) that dune's menhir rules require. Take the
+  higher of two `>=` literals (warn when the user's bound is below
+  the minimum); combine with formula operators like `:with-test`.
+  The 3.23 gate also covers the bare-`(menhir)` fill from #14434
+  (previously unversioned), mirroring the fix in #14466 to avoid
+  silent changes to opam output on dune-binary upgrade. Follows up
+  #14434. (@robinbb)

--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -4,8 +4,8 @@
   package already lists a menhir constraint. A warning is emitted when
   the user's lower bound is below the minimum. `(lang dune 3.23)`
   projects keep the pre-existing behaviour: bare-`(menhir)` deps still
-  get the lower bound filled in (from #14434), but user-written menhir
-  constraints pass through unchanged. `(lang dune 3.22)` and earlier
-  remain entirely untouched. The tiered gate mirrors #14466 to avoid
-  silent changes to opam output on dune-binary upgrade.
+  get the lower bound filled in, but user-written menhir constraints
+  pass through unchanged. `(lang dune 3.22)` and earlier remain
+  entirely untouched. The tiered gate avoids silent changes to opam
+  output on dune-binary upgrade.
   (#14453, @robinbb)

--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -5,5 +5,5 @@
   the minimum); combine with formula operators like `:with-test`.
   The 3.23 gate also covers the bare-`(menhir)` fill from #14434
   (previously unversioned), mirroring the fix in #14466 to avoid
-  silent changes to opam output on dune-binary upgrade. Follows up
-  #14434. (@robinbb)
+  silent changes to opam output on dune-binary upgrade.
+  (#14453, @robinbb)

--- a/doc/changes/changed/menhir-merge-bound.md
+++ b/doc/changes/changed/menhir-merge-bound.md
@@ -1,9 +1,11 @@
-- For `(lang dune 3.23)` or newer with `(generate_opam_files true)`,
+- For `(lang dune 3.24)` or newer with `(generate_opam_files true)`,
   the generated opam file now enforces the menhir lower bound
   (`>= "20180523"`) that dune's menhir rules require, even when the
   package already lists a menhir constraint. A warning is emitted when
-  the user's lower bound is below the minimum. The 3.23 gate also
-  covers the bare-`(menhir)` fill from #14434 (previously unversioned),
-  mirroring #14466 to avoid silent changes to opam output on
-  dune-binary upgrade.
+  the user's lower bound is below the minimum. `(lang dune 3.23)`
+  projects keep the pre-existing behaviour: bare-`(menhir)` deps still
+  get the lower bound filled in (from #14434), but user-written menhir
+  constraints pass through unchanged. `(lang dune 3.22)` and earlier
+  remain entirely untouched. The tiered gate mirrors #14466 to avoid
+  silent changes to opam output on dune-binary upgrade.
   (#14453, @robinbb)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -281,12 +281,13 @@ let merge_dune_constraints ~min_version user_constraint =
   merge_with_min_lower_bound ~min_version ~warning user_constraint
 ;;
 
-(* Pre-#14453 [merge_dune_constraints]: simple dedup that only handles
-   the trivial [(>= "v")] / [(>= "v")] shape. Retained as the [(lang
-   dune 3.23)] tier so projects that shipped under 3.23 (with the
-   #14436 / #14466 dedup) keep that behaviour after dune-binary
-   upgrade. [(lang dune 3.24)] and newer use [merge_dune_constraints]
-   above. *)
+(* Simple dune-version constraint dedup for the [(lang dune 3.23)]
+   tier: handles only the trivial [(>= "v")] / [(>= "v")] shape. If
+   the user's lower bound is at or above the lang version, preserve
+   it; otherwise warn and substitute the lang version. Any other
+   shape falls through to a bare AND. [(lang dune 3.24)] and newer
+   use [merge_dune_constraints] above, which handles nested And/Or
+   structures and emits a single composite warning. *)
 let merge_dune_constraints_simple lang_constraint user_constraint =
   match lang_constraint, user_constraint with
   | ( Package_constraint.Uop (Gte, String_literal lang_v)
@@ -404,12 +405,13 @@ let upgrade_menhir_constraint depends =
     else dep)
 ;;
 
-(* Pre-#14453 [upgrade_menhir_constraint]: simple bare-fill only, no
-   merge of user-written constraints. Retained as the [(lang dune
-   3.23)] tier so projects that shipped under 3.23 (with the #14168 /
-   #14434 bare-fill, then unversioned) keep that behaviour after
-   dune-binary upgrade. [(lang dune 3.24)] and newer use
-   [upgrade_menhir_constraint] above. *)
+(* Simple menhir bare-fill for the [(lang dune 3.23)] tier: if the
+   package's [(depends ...)] field already lists [menhir] without a
+   constraint, fill in [menhir_constraint] as the lower bound. Existing
+   user-written constraints pass through unchanged. [(lang dune 3.24)]
+   and newer use [upgrade_menhir_constraint] above, which additionally
+   merges user-written constraints with dune's required minimum via
+   [merge_menhir_constraint]. *)
 let upgrade_menhir_constraint_simple depends =
   List.map depends ~f:(fun (dep : Package_dependency.t) ->
     if Package.Name.equal dep.name menhir_name

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -281,6 +281,31 @@ let merge_dune_constraints ~min_version user_constraint =
   merge_with_min_lower_bound ~min_version ~warning user_constraint
 ;;
 
+(* Pre-#14453 [merge_dune_constraints]: simple dedup that only handles
+   the trivial [(>= "v")] / [(>= "v")] shape. Retained as the [(lang
+   dune 3.23)] tier so projects that shipped under 3.23 (with the
+   #14436 / #14466 dedup) keep that behaviour after dune-binary
+   upgrade. [(lang dune 3.24)] and newer use [merge_dune_constraints]
+   above. *)
+let merge_dune_constraints_simple lang_constraint user_constraint =
+  match lang_constraint, user_constraint with
+  | ( Package_constraint.Uop (Gte, String_literal lang_v)
+    , Package_constraint.Uop (Gte, String_literal user_v) ) ->
+    if OpamVersionCompare.compare lang_v user_v <= 0
+    then user_constraint
+    else (
+      User_warning.emit
+        [ Pp.textf
+            "The lower bound >= %s on dune in the depends field is less than the dune \
+             language version %s. The generated opam file will use >= %s instead."
+            user_v
+            lang_v
+            lang_v
+        ];
+      lang_constraint)
+  | _ -> And [ lang_constraint; user_constraint ]
+;;
+
 let insert_dune_dep depends dune_version =
   let min_version = Dune_lang.Syntax.Version.to_string dune_version in
   let lang_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
@@ -303,8 +328,10 @@ let insert_dune_dep depends dune_version =
                   (match dep.constraint_ with
                    | None -> lang_constraint
                    | Some user_constraint ->
-                     if dune_version >= (3, 23)
+                     if dune_version >= (3, 24)
                      then merge_dune_constraints ~min_version user_constraint
+                     else if dune_version >= (3, 23)
+                     then merge_dune_constraints_simple lang_constraint user_constraint
                      else And [ lang_constraint; user_constraint ])
             }
         in
@@ -377,6 +404,22 @@ let upgrade_menhir_constraint depends =
     else dep)
 ;;
 
+(* Pre-#14453 [upgrade_menhir_constraint]: simple bare-fill only, no
+   merge of user-written constraints. Retained as the [(lang dune
+   3.23)] tier so projects that shipped under 3.23 (with the #14168 /
+   #14434 bare-fill, then unversioned) keep that behaviour after
+   dune-binary upgrade. [(lang dune 3.24)] and newer use
+   [upgrade_menhir_constraint] above. *)
+let upgrade_menhir_constraint_simple depends =
+  List.map depends ~f:(fun (dep : Package_dependency.t) ->
+    if Package.Name.equal dep.name menhir_name
+    then
+      { dep with
+        constraint_ = Some (Option.value dep.constraint_ ~default:menhir_constraint)
+      }
+    else dep)
+;;
+
 let maintenance_intent dune_version info =
   if dune_version < (3, 18)
   then None
@@ -401,12 +444,14 @@ let opam_fields project (package : Package.t) =
     else Package.map_depends package ~f:insert_odoc_dep
   in
   let package =
-    if dune_version < (3, 23)
-    then package
-    else (
-      match Dune_project.find_extension_version project Dune_lang.Menhir.syntax with
-      | None -> package
-      | Some _ -> Package.map_depends package ~f:upgrade_menhir_constraint)
+    match Dune_project.find_extension_version project Dune_lang.Menhir.syntax with
+    | None -> package
+    | Some _ ->
+      if dune_version < (3, 23)
+      then package
+      else if dune_version < (3, 24)
+      then Package.map_depends package ~f:upgrade_menhir_constraint_simple
+      else Package.map_depends package ~f:upgrade_menhir_constraint
   in
   let package_fields = package_fields package ~project in
   let open Opam_file.Create in

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -216,23 +216,64 @@ let dune_name = Package.Name.of_string "dune"
 let odoc_name = Package.Name.of_string "odoc"
 let menhir_name = Package.Name.of_string "menhir"
 
+(* Does every satisfying valuation of [c] imply the version is at
+   least [min_version]? Conservative (over-approximating false):
+   [Not], [Bop], and [Bvar] are treated as opaque, so an outer AND
+   with the minimum-version constraint is added on their behalf. *)
+let rec has_sufficient_lower_bound ~min_version : Package_constraint.t -> bool = function
+  | Uop (Gte, String_literal v) | Uop (Eq, String_literal v) ->
+    OpamVersionCompare.compare v min_version >= 0
+  | And ts -> List.exists ts ~f:(has_sufficient_lower_bound ~min_version)
+  | Or ts -> List.for_all ts ~f:(has_sufficient_lower_bound ~min_version)
+  | Uop _ | Bop _ | Bvar _ | Not _ -> false
+;;
+
+(* Walk [c] replacing each [>= "v"] literal where [v < min_version]
+   with [>= min_version]. Returns the rewritten constraint and a
+   flag indicating whether any rewrite occurred (so the caller can
+   emit a single user-facing warning). [Not], [Bop], and [Bvar]
+   pass through unchanged. *)
+let normalize_lower_bounds ~min_version c =
+  let rewrote = ref false in
+  let min_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
+  let rec loop : Package_constraint.t -> Package_constraint.t = function
+    | Uop (Gte, String_literal v) as c ->
+      if OpamVersionCompare.compare v min_version >= 0
+      then c
+      else (
+        rewrote := true;
+        min_constraint)
+    | And ts -> And (List.map ts ~f:loop)
+    | Or ts -> Or (List.map ts ~f:loop)
+    | Not t -> Not (loop t)
+    | (Uop _ | Bop _ | Bvar _) as c -> c
+  in
+  let c' = loop c in
+  c', !rewrote
+;;
+
 let merge_dune_constraints lang_constraint user_constraint =
-  match lang_constraint, user_constraint with
-  | ( Package_constraint.Uop (Gte, String_literal lang_v)
-    , Package_constraint.Uop (Gte, String_literal user_v) ) ->
-    if OpamVersionCompare.compare lang_v user_v <= 0
-    then user_constraint
-    else (
+  match lang_constraint with
+  | Package_constraint.Uop (Gte, String_literal lang_v) ->
+    let user_constraint, rewrote =
+      normalize_lower_bounds ~min_version:lang_v user_constraint
+    in
+    if rewrote
+    then
       User_warning.emit
         [ Pp.textf
-            "The lower bound >= %s on dune in the depends field is less than the dune \
-             language version %s. The generated opam file will use >= %s instead."
-            user_v
+            "A lower bound on dune in the depends field is less than the dune language \
+             version %s. The generated opam file will use >= %s instead."
             lang_v
             lang_v
         ];
-      lang_constraint)
-  | _ -> And [ lang_constraint; user_constraint ]
+    if has_sufficient_lower_bound ~min_version:lang_v user_constraint
+    then user_constraint
+    else And [ lang_constraint; user_constraint ]
+  | _ ->
+    (* [insert_dune_dep] always supplies the [Gte] shape; this arm
+       is defensive. *)
+    And [ lang_constraint; user_constraint ]
 ;;
 
 let insert_dune_dep depends dune_version =
@@ -304,27 +345,25 @@ let menhir_min_version = "20180523"
 let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal menhir_min_version)
 
 (* Merge an existing user-written menhir constraint with dune's
-   required lower bound. Mirrors [merge_dune_constraints]:
-   - two [>= "v"] literals collapse to the higher of the two
-     (warn when the user's bound is below dune's required minimum);
-   - any other shape (e.g. [{with-test}]) is ANDed with the lower
-     bound. *)
+   required lower bound. Tightens any nested [>= "v"] literal below
+   the minimum, then AND's [menhir_constraint] at the top level
+   unless the (post-tightening) expression already implies the
+   lower bound on every satisfying valuation. *)
 let merge_menhir_constraint user_constraint =
-  match user_constraint with
-  | Package_constraint.Uop (Gte, String_literal user_v) ->
-    if OpamVersionCompare.compare user_v menhir_min_version >= 0
-    then user_constraint
-    else (
-      User_warning.emit
-        [ Pp.textf
-            "The lower bound >= %s on menhir in the depends field is less than the \
-             version dune's menhir rules require. The generated opam file will use >= %s \
-             instead."
-            user_v
-            menhir_min_version
-        ];
-      menhir_constraint)
-  | _ -> And [ menhir_constraint; user_constraint ]
+  let user_constraint, rewrote =
+    normalize_lower_bounds ~min_version:menhir_min_version user_constraint
+  in
+  if rewrote
+  then
+    User_warning.emit
+      [ Pp.textf
+          "A lower bound on menhir in the depends field is less than the version dune's \
+           menhir rules require. The generated opam file will use >= %s instead."
+          menhir_min_version
+      ];
+  if has_sufficient_lower_bound ~min_version:menhir_min_version user_constraint
+  then user_constraint
+  else And [ menhir_constraint; user_constraint ]
 ;;
 
 (* If the package's [(depends ...)] field already lists [menhir],

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -226,11 +226,13 @@ let rec has_sufficient_lower_bound ~min_version : Package_constraint.t -> bool =
   | Uop _ | Bop _ | Bvar _ | Not _ -> false
 ;;
 
-(* Walk [c] replacing each [>= "v"] literal where [v < min_version]
-   with [>= min_version]. Returns the rewritten constraint and a
-   flag indicating whether any rewrite occurred (so the caller can
-   emit a single user-facing warning). [Not], [Bop], and [Bvar]
-   pass through unchanged. *)
+(* Walk [c] replacing each lower-bound literal [(>= "v")] or [(> "v")]
+   with [v < min_version] by [(>= min_version)]. Returns the rewritten
+   constraint and a flag indicating whether any rewrite occurred (so
+   the caller can emit a single user-facing warning). [Not], [Bop],
+   and [Bvar] subtrees pass through unchanged: under a [Not], a
+   [(>= v)] literal contributes to an upper bound, not a lower bound,
+   so rewriting it would loosen rather than tighten the constraint. *)
 let normalize_lower_bounds ~min_version c =
   let rewrote = ref false in
   let min_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
@@ -243,8 +245,7 @@ let normalize_lower_bounds ~min_version c =
         min_constraint)
     | And ts -> And (List.map ts ~f:loop)
     | Or ts -> Or (List.map ts ~f:loop)
-    | Not t -> Not (loop t)
-    | (Uop _ | Bop _ | Bvar _) as c -> c
+    | (Uop _ | Bop _ | Bvar _ | Not _) as c -> c
   in
   let c' = loop c in
   c', !rewrote

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -253,21 +253,24 @@ let normalize_lower_bounds ~min_version c =
 let merge_dune_constraints lang_constraint user_constraint =
   match lang_constraint with
   | Package_constraint.Uop (Gte, String_literal lang_v) ->
-    let user_constraint, rewrote =
-      normalize_lower_bounds ~min_version:lang_v user_constraint
-    in
-    if rewrote
-    then
-      User_warning.emit
-        [ Pp.textf
-            "A lower bound on dune in the depends field is less than the dune language \
-             version %s. The generated opam file will use >= %s instead."
-            lang_v
-            lang_v
-        ];
     if has_sufficient_lower_bound ~min_version:lang_v user_constraint
     then user_constraint
-    else And [ lang_constraint; user_constraint ]
+    else (
+      let user_constraint, rewrote =
+        normalize_lower_bounds ~min_version:lang_v user_constraint
+      in
+      if rewrote
+      then
+        User_warning.emit
+          [ Pp.textf
+              "A lower bound on dune in the depends field is less than the dune language \
+               version %s. The generated opam file will use >= %s instead."
+              lang_v
+              lang_v
+          ];
+      if has_sufficient_lower_bound ~min_version:lang_v user_constraint
+      then user_constraint
+      else And [ lang_constraint; user_constraint ])
   | _ ->
     (* [insert_dune_dep] always supplies the [Gte] shape; this arm
        is defensive. *)
@@ -343,25 +346,32 @@ let menhir_min_version = "20180523"
 let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal menhir_min_version)
 
 (* Merge an existing user-written menhir constraint with dune's
-   required lower bound. Tightens any nested [>= "v"] literal below
-   the minimum, then AND's [menhir_constraint] at the top level
-   unless the (post-tightening) expression already implies the
-   lower bound on every satisfying valuation. *)
+   required lower bound. If the user's expression already implies
+   the lower bound, preserve it verbatim and emit no warning —
+   even if it contains a sub-minimum literal masked by a stronger
+   sibling. Otherwise tighten any nested [>= "v"] or [> "v"] literal
+   below the minimum, then AND [menhir_constraint] at the top level
+   unless the post-tightening expression now implies the lower
+   bound. *)
 let merge_menhir_constraint user_constraint =
-  let user_constraint, rewrote =
-    normalize_lower_bounds ~min_version:menhir_min_version user_constraint
-  in
-  if rewrote
-  then
-    User_warning.emit
-      [ Pp.textf
-          "A lower bound on menhir in the depends field is less than the version dune's \
-           menhir rules require. The generated opam file will use >= %s instead."
-          menhir_min_version
-      ];
   if has_sufficient_lower_bound ~min_version:menhir_min_version user_constraint
   then user_constraint
-  else And [ menhir_constraint; user_constraint ]
+  else (
+    let user_constraint, rewrote =
+      normalize_lower_bounds ~min_version:menhir_min_version user_constraint
+    in
+    if rewrote
+    then
+      User_warning.emit
+        [ Pp.textf
+            "A lower bound on menhir in the depends field is less than the version \
+             dune's menhir rules require. The generated opam file will use >= %s \
+             instead."
+            menhir_min_version
+        ];
+    if has_sufficient_lower_bound ~min_version:menhir_min_version user_constraint
+    then user_constraint
+    else And [ menhir_constraint; user_constraint ])
 ;;
 
 (* If the package's [(depends ...)] field already lists [menhir],

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -216,10 +216,6 @@ let dune_name = Package.Name.of_string "dune"
 let odoc_name = Package.Name.of_string "odoc"
 let menhir_name = Package.Name.of_string "menhir"
 
-(* Does every satisfying valuation of [c] imply the version is at
-   least [min_version]? Conservative (over-approximating false):
-   [Not], [Bop], and [Bvar] are treated as opaque, so an outer AND
-   with the minimum-version constraint is added on their behalf. *)
 let rec has_sufficient_lower_bound ~min_version : Package_constraint.t -> bool = function
   | Uop (Gte, String_literal v) | Uop (Eq, String_literal v) ->
     OpamVersionCompare.compare v min_version >= 0

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -250,38 +250,39 @@ let normalize_lower_bounds ~min_version c =
   c', !rewrote
 ;;
 
-let merge_dune_constraints lang_constraint user_constraint =
-  match lang_constraint with
-  | Package_constraint.Uop (Gte, String_literal lang_v) ->
-    if has_sufficient_lower_bound ~min_version:lang_v user_constraint
+(* Merge a user-written constraint with a required lower bound. If
+   the user's expression already implies the bound, preserve it
+   verbatim. Otherwise tighten any nested [>= "v"] or [> "v"]
+   literal below the minimum (emitting [warning] if so), then AND
+   [>= min_version] at the top level unless the post-tightening
+   expression now implies the bound. *)
+let merge_with_min_lower_bound ~min_version ~warning user_constraint =
+  let min_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
+  if has_sufficient_lower_bound ~min_version user_constraint
+  then user_constraint
+  else (
+    let user_constraint, rewrote = normalize_lower_bounds ~min_version user_constraint in
+    if rewrote then User_warning.emit warning;
+    if has_sufficient_lower_bound ~min_version user_constraint
     then user_constraint
-    else (
-      let user_constraint, rewrote =
-        normalize_lower_bounds ~min_version:lang_v user_constraint
-      in
-      if rewrote
-      then
-        User_warning.emit
-          [ Pp.textf
-              "A lower bound on dune in the depends field is less than the dune language \
-               version %s. The generated opam file will use >= %s instead."
-              lang_v
-              lang_v
-          ];
-      if has_sufficient_lower_bound ~min_version:lang_v user_constraint
-      then user_constraint
-      else And [ lang_constraint; user_constraint ])
-  | _ ->
-    (* [insert_dune_dep] always supplies the [Gte] shape; this arm
-       is defensive. *)
-    And [ lang_constraint; user_constraint ]
+    else And [ min_constraint; user_constraint ])
+;;
+
+let merge_dune_constraints ~min_version user_constraint =
+  let warning =
+    [ Pp.textf
+        "A lower bound on dune in the depends field is less than the dune language \
+         version %s. The generated opam file will use >= %s instead."
+        min_version
+        min_version
+    ]
+  in
+  merge_with_min_lower_bound ~min_version ~warning user_constraint
 ;;
 
 let insert_dune_dep depends dune_version =
-  let lang_constraint : Package_constraint.t =
-    let dune_version = Dune_lang.Syntax.Version.to_string dune_version in
-    Uop (Gte, String_literal dune_version)
-  in
+  let min_version = Dune_lang.Syntax.Version.to_string dune_version in
+  let lang_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
   let rec loop acc = function
     | [] ->
       let dune_dep =
@@ -302,7 +303,7 @@ let insert_dune_dep depends dune_version =
                    | None -> lang_constraint
                    | Some user_constraint ->
                      if dune_version >= (3, 23)
-                     then merge_dune_constraints lang_constraint user_constraint
+                     then merge_dune_constraints ~min_version user_constraint
                      else And [ lang_constraint; user_constraint ])
             }
         in
@@ -345,33 +346,15 @@ let insert_odoc_dep depends =
 let menhir_min_version = "20180523"
 let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal menhir_min_version)
 
-(* Merge an existing user-written menhir constraint with dune's
-   required lower bound. If the user's expression already implies
-   the lower bound, preserve it verbatim and emit no warning —
-   even if it contains a sub-minimum literal masked by a stronger
-   sibling. Otherwise tighten any nested [>= "v"] or [> "v"] literal
-   below the minimum, then AND [menhir_constraint] at the top level
-   unless the post-tightening expression now implies the lower
-   bound. *)
 let merge_menhir_constraint user_constraint =
-  if has_sufficient_lower_bound ~min_version:menhir_min_version user_constraint
-  then user_constraint
-  else (
-    let user_constraint, rewrote =
-      normalize_lower_bounds ~min_version:menhir_min_version user_constraint
-    in
-    if rewrote
-    then
-      User_warning.emit
-        [ Pp.textf
-            "A lower bound on menhir in the depends field is less than the version \
-             dune's menhir rules require. The generated opam file will use >= %s \
-             instead."
-            menhir_min_version
-        ];
-    if has_sufficient_lower_bound ~min_version:menhir_min_version user_constraint
-    then user_constraint
-    else And [ menhir_constraint; user_constraint ])
+  let warning =
+    [ Pp.textf
+        "A lower bound on menhir in the depends field is less than the version dune's \
+         menhir rules require. The generated opam file will use >= %s instead."
+        menhir_min_version
+    ]
+  in
+  merge_with_min_lower_bound ~min_version:menhir_min_version ~warning user_constraint
 ;;
 
 (* If the package's [(depends ...)] field already lists [menhir],

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -300,20 +300,48 @@ let insert_odoc_dep depends =
 
 (* Menhir 20180523 added --infer-write-query and --infer-read-reply,
    which dune's menhir rules rely on unconditionally. *)
-let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal "20180523")
+let menhir_min_version = "20180523"
+let menhir_constraint : Package_constraint.t = Uop (Gte, String_literal menhir_min_version)
 
-(* If the package's [(depends ...)] field already lists [menhir]
-   without a constraint, fill in the lower bound. Existing user-
-   written constraints (whether version bounds, [{with-test}], or
-   anything else) are preserved verbatim. We do not add menhir as a
-   new dependency: doing so unconditionally is the over-injection
+(* Merge an existing user-written menhir constraint with dune's
+   required lower bound. Mirrors [merge_dune_constraints]:
+   - two [>= "v"] literals collapse to the higher of the two
+     (warn when the user's bound is below dune's required minimum);
+   - any other shape (e.g. [{with-test}]) is ANDed with the lower
+     bound. *)
+let merge_menhir_constraint user_constraint =
+  match user_constraint with
+  | Package_constraint.Uop (Gte, String_literal user_v) ->
+    if OpamVersionCompare.compare user_v menhir_min_version >= 0
+    then user_constraint
+    else (
+      User_warning.emit
+        [ Pp.textf
+            "The lower bound >= %s on menhir in the depends field is less than the \
+             version dune's menhir rules require. The generated opam file will use >= %s \
+             instead."
+            user_v
+            menhir_min_version
+        ];
+      menhir_constraint)
+  | _ -> And [ menhir_constraint; user_constraint ]
+;;
+
+(* If the package's [(depends ...)] field already lists [menhir],
+   fill in the lower bound — combining it with any user-written
+   constraint via [merge_menhir_constraint]. We do not add menhir as
+   a new dependency: doing so unconditionally is the over-injection
    bug reported in #14428. *)
 let upgrade_menhir_constraint depends =
   List.map depends ~f:(fun (dep : Package_dependency.t) ->
     if Package.Name.equal dep.name menhir_name
     then
       { dep with
-        constraint_ = Some (Option.value dep.constraint_ ~default:menhir_constraint)
+        constraint_ =
+          Some
+            (match dep.constraint_ with
+             | None -> menhir_constraint
+             | Some user_constraint -> merge_menhir_constraint user_constraint)
       }
     else dep)
 ;;
@@ -342,9 +370,12 @@ let opam_fields project (package : Package.t) =
     else Package.map_depends package ~f:insert_odoc_dep
   in
   let package =
-    match Dune_project.find_extension_version project Dune_lang.Menhir.syntax with
-    | None -> package
-    | Some _ -> Package.map_depends package ~f:upgrade_menhir_constraint
+    if dune_version < (3, 23)
+    then package
+    else (
+      match Dune_project.find_extension_version project Dune_lang.Menhir.syntax with
+      | None -> package
+      | Some _ -> Package.map_depends package ~f:upgrade_menhir_constraint)
   in
   let package_fields = package_fields package ~project in
   let open Opam_file.Create in

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -219,6 +219,8 @@ let menhir_name = Package.Name.of_string "menhir"
 let rec has_sufficient_lower_bound ~min_version : Package_constraint.t -> bool = function
   | Uop (Gte, String_literal v) | Uop (Eq, String_literal v) ->
     OpamVersionCompare.compare v min_version >= 0
+  | Not (Uop (Lt, String_literal v)) | Not (Uop (Lte, String_literal v)) ->
+    OpamVersionCompare.compare v min_version >= 0
   | And ts -> List.exists ts ~f:(has_sufficient_lower_bound ~min_version)
   | Or ts -> List.for_all ts ~f:(has_sufficient_lower_bound ~min_version)
   | Uop _ | Bop _ | Bvar _ | Not _ -> false

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -217,8 +217,8 @@ let odoc_name = Package.Name.of_string "odoc"
 let menhir_name = Package.Name.of_string "menhir"
 
 let rec has_sufficient_lower_bound ~min_version : Package_constraint.t -> bool = function
-  | Uop (Gte, String_literal v) | Uop (Eq, String_literal v) ->
-    OpamVersionCompare.compare v min_version >= 0
+  | Uop (Gte, String_literal v) | Uop (Gt, String_literal v) | Uop (Eq, String_literal v)
+    -> OpamVersionCompare.compare v min_version >= 0
   | Not (Uop (Lt, String_literal v)) | Not (Uop (Lte, String_literal v)) ->
     OpamVersionCompare.compare v min_version >= 0
   | And ts -> List.exists ts ~f:(has_sufficient_lower_bound ~min_version)
@@ -235,7 +235,7 @@ let normalize_lower_bounds ~min_version c =
   let rewrote = ref false in
   let min_constraint : Package_constraint.t = Uop (Gte, String_literal min_version) in
   let rec loop : Package_constraint.t -> Package_constraint.t = function
-    | Uop (Gte, String_literal v) as c ->
+    | (Uop (Gte, String_literal v) | Uop (Gt, String_literal v)) as c ->
       if OpamVersionCompare.compare v min_version >= 0
       then c
       else (

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -118,9 +118,8 @@ is emitted and the lang constraint takes precedence:
   > EOF
 
   $ dune build foo.opam
-  Warning: The lower bound >= 3.20 on dune in the depends field is less than
-  the dune language version 3.23. The generated opam file will use >= 3.23
-  instead.
+  Warning: A lower bound on dune in the depends field is less than the dune
+  language version 3.23. The generated opam file will use >= 3.23 instead.
   $ dune_cmd print-from 'depends' < _build/default/foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "3.23"}

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -118,8 +118,9 @@ is emitted and the lang constraint takes precedence:
   > EOF
 
   $ dune build foo.opam
-  Warning: A lower bound on dune in the depends field is less than the dune
-  language version 3.23. The generated opam file will use >= 3.23 instead.
+  Warning: The lower bound >= 3.20 on dune in the depends field is less than
+  the dune language version 3.23. The generated opam file will use >= 3.23
+  instead.
   $ dune_cmd print-from 'depends' < _build/default/foo.opam | dune_cmd print-until ']'
   depends: [
     "dune" {>= "3.23"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -333,3 +333,62 @@ expression. The combination is unsatisfiable, as in Case 13.
   [1]
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523" & !>= "20180523"}
+
+Case 16: `(not (< v))` with `v` at or above dune's minimum. The expression is
+equivalent to `(>= v)`, so it's a sufficient lower bound and is preserved
+verbatim; no warning, no extra `>= "20180523"` clause.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (not (< 20211128)))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {!< "20211128"}
+
+Case 17: `(not (<= v))` with `v` at or above dune's minimum. The expression is
+equivalent to `(> v)`, which strictly exceeds `v` and therefore exceeds dune's
+minimum; preserved verbatim, no warning.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (not (<= 20211128)))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {!<= "20211128"}
+
+Case 18: `(not (< v))` with `v` below dune's minimum. The expression is
+equivalent to `(>= v)` but `v` is too low to satisfy dune's requirement; the
+generated opam file ANDs `>= "20180523"` with the user's expression. No
+warning is emitted (the user's clause is not rewritten in place; only `>= v`
+literals are rewritten by `normalize_lower_bounds`).
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (not (< 20100101)))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20180523" & !< "20100101"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -312,9 +312,14 @@ already implies the lower bound, so the generated opam file uses it verbatim.
   $ grep menhir foo.opam
     "menhir" {= "20211128"}
 
-Case 15: a `(not (>= v))` expression with `v` below dune's minimum. Dune warns
-and the generated opam file enforces `>= "20180523"` alongside the user's
-expression. The combination is unsatisfiable, as in Case 13.
+Case 15: a `(not (>= v))` expression with `v` below dune's minimum. The
+expression is equivalent to `(< v)`, an upper bound that excludes every
+version dune's menhir rules support. `normalize_lower_bounds` does not
+recurse under `Not` — rewriting the inner `>= v` would shift the upper
+bound rather than tightening a lower bound — so the user's literal is
+preserved. Dune still ANDs `>= "20180523"` at the top level, producing
+an unsatisfiable combination that surfaces at install time (mirrors
+Cases 13 and 21). No warning, since nothing was rewritten.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -326,13 +331,10 @@ expression. The combination is unsatisfiable, as in Case 13.
   >  (allow_empty)
   >  (depends (menhir (not (>= 20100101)))))
   > EOF
-  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
-  Warning: A lower bound on menhir in the depends field is less than the
-  version dune's menhir rules require. The generated opam file will use >=
-  20180523 instead.
+  $ dune build @opam --auto-promote > /dev/null 2>&1
   [1]
-  $ grep menhir _build/default/foo.opam.generated
-    "menhir" {>= "20180523" & !>= "20180523"}
+  $ grep menhir foo.opam
+    "menhir" {>= "20180523" & !>= "20100101"}
 
 Case 16: `(not (< v))` with `v` at or above dune's minimum. The expression is
 equivalent to `(>= v)`, so it's a sufficient lower bound and is preserved

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -8,7 +8,7 @@ See https://github.com/ocaml/dune/issues/10707.
 Case 0: package does not declare menhir. Dune does not add it.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package (name foo) (allow_empty))
@@ -22,7 +22,7 @@ Case 0: package does not declare menhir. Dune does not add it.
 Case 1: bare [(depends menhir)]. Dune fills in the lower bound.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -39,7 +39,7 @@ Case 1: bare [(depends menhir)]. Dune fills in the lower bound.
 Case 2: user-written version bound is preserved verbatim.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -59,7 +59,7 @@ the lower bound on a user-declared menhir dependency that exists
 for an unrelated reason (e.g. runtime).
 
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (generate_opam_files true)
   > (package
   >  (name foo)
@@ -78,7 +78,7 @@ generated opam files must reflect this: [foo.opam] gets the lower
 bound; [bar.opam] has no [menhir] line at all.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -107,7 +107,7 @@ stanza for the existing opam file.
 
   $ rm -f bar.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -130,7 +130,7 @@ fresh.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.24)
+  > (lang dune 3.23)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -1,7 +1,7 @@
-When a package's [(depends ...)] field lists [menhir] without a
-version constraint, the generated opam file should fill in the
-lower bound [{>= "20180523"}], since dune's menhir rules rely on
-features available since menhir 20180523.
+When a package's `(depends ...)` field lists `menhir` without a version
+constraint, the generated opam file should fill in the lower bound `{>=
+"20180523"}`, since dune's menhir rules rely on features available since menhir
+20180523.
 
 See https://github.com/ocaml/dune/issues/10707.
 
@@ -19,7 +19,7 @@ Case 0: package does not declare menhir. Dune does not add it.
   $ grep menhir foo.opam
   [1]
 
-Case 1: bare [(depends menhir)]. Dune fills in the lower bound.
+Case 1: bare `(depends menhir)`. Dune fills in the lower bound.
 
   $ cat > dune-project << EOF
   > (lang dune 3.23)
@@ -53,10 +53,10 @@ Case 2: user-written version bound is preserved verbatim.
   $ grep menhir foo.opam
     "menhir" {>= "20211128"}
 
-Case 3: gate on [(using menhir ...)]. Without the menhir extension
-enabled, dune does not run menhir's rules and so must not impose
-the lower bound on a user-declared menhir dependency that exists
-for an unrelated reason (e.g. runtime).
+Case 3: gate on `(using menhir ...)`. Without the menhir extension enabled, dune
+does not run menhir's rules and so must not impose the lower bound on a
+user-declared menhir dependency that exists for an unrelated reason (e.g.
+runtime).
 
   $ cat > dune-project << EOF
   > (lang dune 3.23)
@@ -72,10 +72,10 @@ for an unrelated reason (e.g. runtime).
   $ grep menhir foo.opam
     "menhir"
 
-Case 4: multi-package regression for #14428. Package [foo] declares
-[(depends menhir)]; package [bar] declares no menhir dep. The
-generated opam files must reflect this: [foo.opam] gets the lower
-bound; [bar.opam] has no [menhir] line at all.
+Case 4: multi-package regression for #14428. Package `foo` declares `(depends
+menhir)`; package `bar` declares no menhir dep. The generated opam files must
+reflect this: `foo.opam` gets the lower bound; `bar.opam` has no `menhir` line
+at all.
 
   $ cat > dune-project << EOF
   > (lang dune 3.23)
@@ -97,13 +97,12 @@ bound; [bar.opam] has no [menhir] line at all.
   $ grep menhir bar.opam
   [1]
 
-Case 5: a [{with-test}] filter on the menhir dep is a non-version
-constraint; the generated opam file ANDs dune's required lower
-bound with it.
+Case 5: a `{with-test}` filter on the menhir dep is a non-version constraint;
+the generated opam file ANDs dune's required lower bound with it.
 
-Case 4 left a [bar.opam] behind; remove it first, otherwise dune
-errors because the new dune-project below has no [bar] package
-stanza for the existing opam file.
+Case 4 left a `bar.opam` behind; remove it first, otherwise dune errors because
+the new dune-project below has no `bar` package stanza for the existing opam
+file.
 
   $ rm -f bar.opam
   $ cat > dune-project << EOF
@@ -121,12 +120,10 @@ stanza for the existing opam file.
   $ grep menhir foo.opam
     "menhir" {>= "20180523" & with-test}
 
-Case 6: user-written lower bound below dune's required minimum.
-Dune warns and the generated opam file uses [>= "20180523"]
-instead of the user's bound.
+Case 6: user-written lower bound below dune's required minimum. Dune warns and
+the generated opam file uses `>= "20180523"` instead of the user's bound.
 
-Case 5 left [foo.opam] behind; remove it so this case starts
-fresh.
+Case 5 left `foo.opam` behind; remove it so this case starts fresh.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -139,11 +136,8 @@ fresh.
   >  (depends (menhir (>= 20100101))))
   > EOF
 
-Skip [--auto-promote]: the generated file lives at
-[_build/default/foo.opam.generated] under [(lang dune 3.23)] or
-newer, so we can read it without promoting to source. Assert two
-things: the warning is emitted with its full text, and the
-generated opam file uses dune's bound rather than the user's.
+Skip `--auto-promote` so the warning lands in stdout; read the unpromoted file
+at `_build/default/foo.opam.generated`.
 
   $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
   Warning: A lower bound on menhir in the depends field is less than the
@@ -153,13 +147,9 @@ generated opam file uses dune's bound rather than the user's.
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523"}
 
-Case 7: lang version below 3.23. Dune does nothing to the menhir
-dep constraint; the generated opam file preserves the user's input
-verbatim. The whole upgrade step is gated on [(lang dune 3.23)] or
-newer to avoid changing opam output on dune-binary upgrade for
-projects pinned to an older lang version (parallels #14466 / the
-fix for #14436). The gate also covers the bare-[(menhir)] fill
-from #14434, which previously applied unversioned.
+Case 7: with `(lang dune 3.22)`, the menhir constraint is preserved verbatim.
+The 3.23 gate avoids changing opam output on dune-binary upgrade for projects
+pinned to an older lang version (parallels #14466 / fix for #14436).
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -175,13 +165,9 @@ from #14434, which previously applied unversioned.
   $ grep menhir foo.opam
     "menhir" {>= "20100101"}
 
-Case 8: lang version below 3.23 with bare [(menhir)]. The 3.23
-gate also covers #14434's bare-fill — dune does not inject
-[>= "20180523"]; the opam file lists [menhir] without a
-constraint. Together with Case 7, this verifies both branches of
-[upgrade_menhir_constraint] are gated: the bare branch (from
-#14434) and the user-constraint branch (from this PR's merge
-logic).
+Case 8: with `(lang dune 3.22)` and a bare `(menhir)` dep, dune does not inject
+`>= "20180523"`. Together with Case 7, this verifies the gate covers both bare
+deps (from #14434) and deps with a user-written constraint.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -197,22 +183,13 @@ logic).
   $ grep menhir foo.opam
     "menhir"
 
-Cases 9-15 exercise the merge function's recursive descent into
-the user's constraint expression — see also #14453 review by
-@shonfeder. The merge walks [And]/[Or]/[Not] looking for [>= "v"]
-literals to tighten; leaf [Bvar]/[Bop] and non-[>=] [Uop] nodes
-pass through unchanged. If, after tightening, every satisfying
-valuation of the user expression implies [>= menhir_min_version],
-the merge returns the rewritten expression directly; otherwise it
-AND's [menhir_constraint] at the top level. The sufficiency
-check decomposes [And]/[Or] structurally and treats [Eq] on a
-version literal as if it were [Gte]; everything else ([Not],
-[Bop], [Bvar], non-version [Uop]s) is opaque.
+Cases 9-15 cover user-written menhir constraints with nested structure (`(and
+...)`, `(or ...)`, `(not ...)`) — the lower bound is enforced even when the
+user's `>=` is buried inside the expression.
 
-Case 9: nested lower bound below dune's minimum, combined with a
-filter via [(and ...)]. The merge descends into the [And],
-tightens the inner [>=] (warns), and returns the rewritten
-expression directly because the inner bound now suffices.
+Case 9: the user's lower bound is nested inside `(and ...)` alongside a filter,
+and is below dune's minimum. Dune warns and the generated opam file uses `>=
+"20180523"` in place of the user's low bound; the filter is preserved.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -232,9 +209,9 @@ expression directly because the inner bound now suffices.
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {with-test & >= "20180523"}
 
-Case 10: nested lower bound at or above the minimum is preserved
-verbatim; no outer AND is added (the inner bound suffices, no
-warning).
+Case 10: the user's lower bound is nested inside `(and ...)` alongside a filter,
+and is at or above dune's minimum. The user's constraint is preserved verbatim;
+no warning.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -251,11 +228,10 @@ warning).
   $ grep menhir foo.opam
     "menhir" {with-test & >= "20211128"}
 
-Case 11: an [Or] whose branches mix a (low) lower bound with a
-filter. The merge tightens the in-branch [>=] (warns); since the
-[Or] does not imply the minimum on every branch (the filter-only
-branch escapes), the outer AND with dune's bound is still
-emitted.
+Case 11: the user offers an `(or ...)` between a low lower bound and a filter.
+Dune warns and the generated opam file enforces `>= "20180523"` alongside the
+user's expression — the filter-only branch would otherwise admit pre-20180523
+versions.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -275,10 +251,9 @@ emitted.
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523" & (>= "20180523" | with-test)}
 
-Case 12: a user-declared version range whose lower end is below
-dune's minimum. The merge tightens the [>=] in place (warns) and
-preserves the upper bound. The merged range starts at dune's
-minimum.
+Case 12: the user declares a version range whose lower end is below dune's
+minimum. Dune warns; the upper bound is preserved and the lower bound becomes
+`>= "20180523"` in the generated opam file.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -298,13 +273,11 @@ minimum.
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523" & < "20300101"}
 
-Case 13: a user-declared expression that conflicts with dune's
-minimum — here [(and :with-test (< 1))] — has no inner [>=] to
-tighten. The merge AND's dune's bound at the top level; the
-result is generated faithfully but is unsatisfiable as an opam
-constraint. The conflict surfaces at install time (opam reports
-no version satisfies the combined constraints) rather than at
-opam-file generation time.
+Case 13: the user's expression conflicts with dune's minimum — here `(and
+:with-test (< 1))`. The generated opam file enforces `>= "20180523"` alongside
+the user's expression; the combination is unsatisfiable, and the conflict
+surfaces at install time (opam reports no version satisfies the combined
+constraints) rather than at opam-file generation.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -321,10 +294,8 @@ opam-file generation time.
   $ grep menhir foo.opam
     "menhir" {>= "20180523" & with-test & < "1"}
 
-Case 14: a user-declared equality pin at or above dune's minimum.
-The sufficiency check treats [= "v"] like [>= "v"] when [v] is at
-or above the minimum: the pin already implies the lower bound, so
-no outer AND is added.
+Case 14: a user-declared equality pin at or above dune's minimum. The pin
+already implies the lower bound, so the generated opam file uses it verbatim.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -341,12 +312,9 @@ no outer AND is added.
   $ grep menhir foo.opam
     "menhir" {= "20211128"}
 
-Case 15: a [(not (>= v))] expression with [v] below dune's
-minimum. The merge descends into [Not] and tightens the inner
-[>=] (warns); [Not] is opaque to the sufficiency check, so the
-outer AND is still emitted. The resulting expression is
-unsatisfiable as an opam constraint; the conflict surfaces at
-install time (as in Case 13).
+Case 15: a `(not (>= v))` expression with `v` below dune's minimum. Dune warns
+and the generated opam file enforces `>= "20180523"` alongside the user's
+expression. The combination is unsatisfiable, as in Case 13.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -375,8 +375,8 @@ minimum; preserved verbatim, no warning.
 Case 18: `(not (< v))` with `v` below dune's minimum. The expression is
 equivalent to `(>= v)` but `v` is too low to satisfy dune's requirement; the
 generated opam file ANDs `>= "20180523"` with the user's expression. No
-warning is emitted (the user's clause is not rewritten in place; only `>= v`
-literals are rewritten by `normalize_lower_bounds`).
+warning is emitted (the user's clause is not rewritten in place; only bare
+`>= v` and `> v` literals are rewritten by `normalize_lower_bounds`).
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -392,3 +392,64 @@ literals are rewritten by `normalize_lower_bounds`).
   [1]
   $ grep menhir foo.opam
     "menhir" {>= "20180523" & !< "20100101"}
+
+Case 19: `(> v)` with `v` at or above dune's minimum. The expression is a
+sufficient lower bound (everything strictly above `v` is also above the
+minimum), so it's preserved verbatim; no warning.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (> 20211128))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {> "20211128"}
+
+Case 20: `(> v)` with `v` below dune's minimum. Dune warns and rewrites the
+literal to `>= "20180523"`, mirroring the `>=`-below-min behaviour of Case 6.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (> 20100101))))
+  > EOF
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {>= "20180523"}
+
+Case 21: `(= v)` with `v` below dune's minimum. The expression is a pin to an
+unsupported version. Dune does not rewrite the pin — that would silently drop
+the user's intent — and instead ANDs `>= "20180523"` with the pin, producing
+an unsatisfiable combination that surfaces at install time. Mirrors Case 13
+and Case 15.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (= 20100101))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20180523" & = "20100101"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -98,8 +98,8 @@ bound; [bar.opam] has no [menhir] line at all.
   [1]
 
 Case 5: a [{with-test}] filter on the menhir dep is a non-version
-constraint and is preserved verbatim — the lower bound is not
-combined with it.
+constraint; the generated opam file ANDs dune's required lower
+bound with it.
 
 Case 4 left a [bar.opam] behind; remove it first, otherwise dune
 errors because the new dune-project below has no [bar] package
@@ -119,4 +119,80 @@ stanza for the existing opam file.
   $ dune build @opam --auto-promote > /dev/null 2>&1
   [1]
   $ grep menhir foo.opam
-    "menhir" {with-test}
+    "menhir" {>= "20180523" & with-test}
+
+Case 6: user-written lower bound below dune's required minimum.
+Dune warns and the generated opam file uses [>= "20180523"]
+instead of the user's bound.
+
+Case 5 left [foo.opam] behind; remove it so this case starts
+fresh.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.24)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (>= 20100101))))
+  > EOF
+
+Skip [--auto-promote]: the generated file lives at
+[_build/default/foo.opam.generated] under [(lang dune 3.23)] or
+newer, so we can read it without promoting to source. Assert two
+things: the warning is emitted with its full text, and the
+generated opam file uses dune's bound rather than the user's.
+
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: The lower bound >= 20100101 on menhir in the depends field is less
+  than the version dune's menhir rules require. The generated opam file will
+  use >= 20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {>= "20180523"}
+
+Case 7: lang version below 3.23. Dune does nothing to the menhir
+dep constraint; the generated opam file preserves the user's input
+verbatim. The whole upgrade step is gated on [(lang dune 3.23)] or
+newer to avoid changing opam output on dune-binary upgrade for
+projects pinned to an older lang version (parallels #14466 / the
+fix for #14436). The gate also covers the bare-[(menhir)] fill
+from #14434, which previously applied unversioned.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (>= 20100101))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  $ grep menhir foo.opam
+    "menhir" {>= "20100101"}
+
+Case 8: lang version below 3.23 with bare [(menhir)]. The 3.23
+gate also covers #14434's bare-fill — dune does not inject
+[>= "20180523"]; the opam file lists [menhir] without a
+constraint. Together with Case 7, this verifies both branches of
+[upgrade_menhir_constraint] are gated: the bare branch (from
+#14434) and the user-constraint branch (from this PR's merge
+logic).
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.22)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends menhir))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  $ grep menhir foo.opam
+    "menhir"

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -453,3 +453,28 @@ and Case 15.
   [1]
   $ grep menhir foo.opam
     "menhir" {>= "20180523" & = "20100101"}
+
+Case 22: `(and (>= w) (>= v))` with `w >= min_version` and `v < min_version`.
+The `>= w` branch already establishes a sufficient lower bound, so the `>= v`
+literal is masked — every satisfying valuation has version >= w >= min_version.
+Dune preserves the user's expression verbatim and does NOT warn: the warning
+("the generated opam file will use >= min_version instead") would be misleading,
+since dune ends up using neither `>= v` nor a substitute.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (and (>= 20211128) (>= 10)))))
+  > EOF
+  $ dune build @opam 2>&1 | grep -c '^Warning:'
+  0
+  [1]
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20211128" & >= "10"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -146,9 +146,9 @@ things: the warning is emitted with its full text, and the
 generated opam file uses dune's bound rather than the user's.
 
   $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
-  Warning: The lower bound >= 20100101 on menhir in the depends field is less
-  than the version dune's menhir rules require. The generated opam file will
-  use >= 20180523 instead.
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
   [1]
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523"}
@@ -196,3 +196,124 @@ logic).
   $ dune build @opam --auto-promote > /dev/null 2>&1
   $ grep menhir foo.opam
     "menhir"
+
+Cases 9-13 exercise the merge function's recursive descent into
+the user's constraint expression — see also #14453 review by
+@shonfeder. The merge walks [And]/[Or]/[Not] looking for [>= "v"]
+literals to tighten; pure-filter leaves and [Bop]/[Not] subtrees
+pass through unchanged. If, after tightening, every satisfying
+valuation of the user expression implies [>= menhir_min_version],
+the merge returns the rewritten expression directly; otherwise it
+AND's [menhir_constraint] at the top level.
+
+Case 9: nested lower bound below dune's minimum, combined with a
+filter via [(and ...)]. The merge descends into the [And],
+tightens the inner [>=] (warns), and returns the rewritten
+expression directly because the inner bound now suffices.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (and :with-test (>= 20100101)))))
+  > EOF
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {with-test & >= "20180523"}
+
+Case 10: nested lower bound at or above the minimum is preserved
+verbatim; no outer AND is added (the inner bound suffices, no
+warning).
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (and :with-test (>= 20211128)))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {with-test & >= "20211128"}
+
+Case 11: an [Or] whose branches mix a (low) lower bound with a
+filter. The merge tightens the in-branch [>=] (warns); since the
+[Or] does not imply the minimum on every branch (the filter-only
+branch escapes), the outer AND with dune's bound is still
+emitted.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (or (>= 20100101) :with-test))))
+  > EOF
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {>= "20180523" & (>= "20180523" | with-test)}
+
+Case 12: a user-declared version range whose lower end is below
+dune's minimum. The merge tightens the [>=] in place (warns) and
+preserves the upper bound. The merged range starts at dune's
+minimum.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (and (>= 20100101) (< 20300101)))))
+  > EOF
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {>= "20180523" & < "20300101"}
+
+Case 13: a user-declared expression that conflicts with dune's
+minimum — here [(and :with-test (< 1))] — has no inner [>=] to
+tighten. The merge AND's dune's bound at the top level; the
+result is generated faithfully but is unsatisfiable as an opam
+constraint. The conflict surfaces at install time (opam reports
+no version satisfies the combined constraints) rather than at
+opam-file generation time.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (and :with-test (< 1)))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20180523" & with-test & < "1"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -8,7 +8,7 @@ See https://github.com/ocaml/dune/issues/10707.
 Case 0: package does not declare menhir. Dune does not add it.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package (name foo) (allow_empty))
@@ -22,7 +22,7 @@ Case 0: package does not declare menhir. Dune does not add it.
 Case 1: bare `(depends menhir)`. Dune fills in the lower bound.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -39,7 +39,7 @@ Case 1: bare `(depends menhir)`. Dune fills in the lower bound.
 Case 2: user-written version bound is preserved verbatim.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -59,7 +59,7 @@ user-declared menhir dependency that exists for an unrelated reason (e.g.
 runtime).
 
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (generate_opam_files true)
   > (package
   >  (name foo)
@@ -78,7 +78,7 @@ reflect this: `foo.opam` gets the lower bound; `bar.opam` has no `menhir` line
 at all.
 
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -106,7 +106,7 @@ file.
 
   $ rm -f bar.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -127,7 +127,7 @@ Case 5 left `foo.opam` behind; remove it so this case starts fresh.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -147,9 +147,11 @@ at `_build/default/foo.opam.generated`.
   $ grep menhir _build/default/foo.opam.generated
     "menhir" {>= "20180523"}
 
-Case 7: with `(lang dune 3.22)`, the menhir constraint is preserved verbatim.
-The 3.23 gate avoids changing opam output on dune-binary upgrade for projects
-pinned to an older lang version (parallels #14466 / fix for #14436).
+Case 7: at `(lang dune 3.22)` (below the 3.23 menhir-injection gate added by
+#14453), `upgrade_menhir_constraint` is skipped entirely. A user-written menhir
+constraint is emitted verbatim — neither merged nor filled. Parallels the
+#14466 fix for #14436 in protecting older lang versions from silent opam
+output changes on dune-binary upgrade.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -165,9 +167,10 @@ pinned to an older lang version (parallels #14466 / fix for #14436).
   $ grep menhir foo.opam
     "menhir" {>= "20100101"}
 
-Case 8: with `(lang dune 3.22)` and a bare `(menhir)` dep, dune does not inject
-`>= "20180523"`. Together with Case 7, this verifies the gate covers both bare
-deps (from #14434) and deps with a user-written constraint.
+Case 8: at `(lang dune 3.22)` with a bare `(menhir)` dep, the lower bound
+`>= "20180523"` is not injected — the < 3.23 gate skips the bare-fill from
+#14434 entirely. Together with Case 7, this verifies the gate covers both bare
+deps and deps with a user-written constraint.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
@@ -193,7 +196,7 @@ and is below dune's minimum. Dune warns and the generated opam file uses `>=
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -215,7 +218,7 @@ no warning.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -235,7 +238,7 @@ versions.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -257,7 +260,7 @@ minimum. Dune warns; the upper bound is preserved and the lower bound becomes
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -281,7 +284,7 @@ constraints) rather than at opam-file generation.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -299,7 +302,7 @@ already implies the lower bound, so the generated opam file uses it verbatim.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -323,7 +326,7 @@ Cases 13 and 21). No warning, since nothing was rewritten.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -342,7 +345,7 @@ verbatim; no warning, no extra `>= "20180523"` clause.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -361,7 +364,7 @@ minimum; preserved verbatim, no warning.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -382,7 +385,7 @@ warning is emitted (the user's clause is not rewritten in place; only bare
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -401,7 +404,7 @@ minimum), so it's preserved verbatim; no warning.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -419,7 +422,7 @@ literal to `>= "20180523"`, mirroring the `>=`-below-min behaviour of Case 6.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -443,7 +446,7 @@ and Case 15.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -465,7 +468,7 @@ since dune ends up using neither `>= v` nor a substitute.
 
   $ rm -rf _build foo.opam
   $ cat > dune-project << EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 2.1)
   > (generate_opam_files true)
   > (package
@@ -480,3 +483,49 @@ since dune ends up using neither `>= v` nor a substitute.
   [1]
   $ grep menhir foo.opam
     "menhir" {>= "20211128" & >= "10"}
+
+Cases 23-24: at `(lang dune 3.23)` — between the 3.23 menhir-gating threshold
+(below which the bare-fill is skipped) and the 3.24 merge gate. These verify
+that 3.23 projects keep the pre-#14453 simple `upgrade_menhir_constraint`
+behaviour: bare deps still get the lower bound filled in (preserving #14434
+behaviour shipped in 3.23.x), but user-written constraints are emitted
+verbatim — the new merge-with-required-minimum logic is gated at 3.24.
+
+Case 23: at `(lang dune 3.23)`, a bare `(menhir)` dep is filled with
+`{>= "20180523"}` — same as in 3.23.x dune binaries — so no silent change to
+opam output on dune-binary upgrade.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends menhir))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20180523"}
+
+Case 24: at `(lang dune 3.23)`, a user-written menhir constraint below dune's
+required minimum is emitted verbatim — the simple bare-fill function does not
+touch existing constraints, mirroring 3.23.x behaviour. The 3.24 merge gate
+gates the new "warn-and-AND" behaviour.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (>= 20100101))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {>= "20100101"}

--- a/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
+++ b/test/blackbox-tests/test-cases/menhir/opam-menhir-dep.t
@@ -197,14 +197,17 @@ logic).
   $ grep menhir foo.opam
     "menhir"
 
-Cases 9-13 exercise the merge function's recursive descent into
+Cases 9-15 exercise the merge function's recursive descent into
 the user's constraint expression — see also #14453 review by
 @shonfeder. The merge walks [And]/[Or]/[Not] looking for [>= "v"]
-literals to tighten; pure-filter leaves and [Bop]/[Not] subtrees
+literals to tighten; leaf [Bvar]/[Bop] and non-[>=] [Uop] nodes
 pass through unchanged. If, after tightening, every satisfying
 valuation of the user expression implies [>= menhir_min_version],
 the merge returns the rewritten expression directly; otherwise it
-AND's [menhir_constraint] at the top level.
+AND's [menhir_constraint] at the top level. The sufficiency
+check decomposes [And]/[Or] structurally and treats [Eq] on a
+version literal as if it were [Gte]; everything else ([Not],
+[Bop], [Bvar], non-version [Uop]s) is opaque.
 
 Case 9: nested lower bound below dune's minimum, combined with a
 filter via [(and ...)]. The merge descends into the [And],
@@ -317,3 +320,48 @@ opam-file generation time.
   [1]
   $ grep menhir foo.opam
     "menhir" {>= "20180523" & with-test & < "1"}
+
+Case 14: a user-declared equality pin at or above dune's minimum.
+The sufficiency check treats [= "v"] like [>= "v"] when [v] is at
+or above the minimum: the pin already implies the lower bound, so
+no outer AND is added.
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (= 20211128))))
+  > EOF
+  $ dune build @opam --auto-promote > /dev/null 2>&1
+  [1]
+  $ grep menhir foo.opam
+    "menhir" {= "20211128"}
+
+Case 15: a [(not (>= v))] expression with [v] below dune's
+minimum. The merge descends into [Not] and tightens the inner
+[>=] (warns); [Not] is opaque to the sufficiency check, so the
+outer AND is still emitted. The resulting expression is
+unsatisfiable as an opam constraint; the conflict surfaces at
+install time (as in Case 13).
+
+  $ rm -rf _build foo.opam
+  $ cat > dune-project << EOF
+  > (lang dune 3.23)
+  > (using menhir 2.1)
+  > (generate_opam_files true)
+  > (package
+  >  (name foo)
+  >  (allow_empty)
+  >  (depends (menhir (not (>= 20100101)))))
+  > EOF
+  $ dune build @opam 2>&1 | dune_cmd print-from '^Warning:' | dune_cmd print-until 'instead\.$'
+  Warning: A lower bound on menhir in the depends field is less than the
+  version dune's menhir rules require. The generated opam file will use >=
+  20180523 instead.
+  [1]
+  $ grep menhir _build/default/foo.opam.generated
+    "menhir" {>= "20180523" & !>= "20180523"}

--- a/test/blackbox-tests/test-cases/menhir/with-library-deps.t
+++ b/test/blackbox-tests/test-cases/menhir/with-library-deps.t
@@ -6,7 +6,7 @@ parent library's library deps on that mock compile's [-I] search path.
 This test guards against regressions in that wiring.
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 3.0)
   > EOF
 


### PR DESCRIPTION
## Summary

Follow-up to #14434. Tightens `upgrade_menhir_constraint` in `opam_create.ml` to mirror `merge_dune_constraints`: two `>=` literals collapse to the higher (warn when the user's bound is below dune's minimum); other shapes are ANDed with the lower bound. Gated on `(lang dune 3.23)` or newer; the same gate also covers #14434's bare-fill (previously unversioned), parallelling #14466 / the fix for #14436.

~Stacked on #14466.~

### Provenance

Suggested by @Leonidas-from-XIV in #14434 (discussion_r3193896678); agreed direction in #14434 (discussion_r3196549007). Lang-version gate per @Leonidas-from-XIV's review on this PR.