### PR TITLE
chore: fix autogenerated header for ci

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-# This file is auto-generated. Edit ci/bench.yml.in instead
+# This file is auto-generated. Edit bench.yml.in instead
 name: Build time benchmarks
 
 # Do not run this workflow on pull request since this workflow has permission to modify contents.

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-# This file is auto-generated. Edit ci/workflow.yml.in instead
+# This file is auto-generated. Edit workflow.yml.in instead
 name: CI
 
 on:

--- a/ci/update_version.ml
+++ b/ci/update_version.ml
@@ -10,6 +10,6 @@ let () =
   let major, minor = Dune_rpc.Private.Version.latest in
   let version_string = sprintf "%d.%d.0" major minor in
   let content = Re.replace_string version ~by:version_string content in
-  Printf.printf "# This file is auto-generated. Edit ci/%s instead\n" filename;
+  Printf.printf "# This file is auto-generated. Edit %s instead\n" filename;
   Printf.printf "%s" content
 ;;

--- a/doc/dev/releases/release-init.sh
+++ b/doc/dev/releases/release-init.sh
@@ -86,7 +86,7 @@ To begin once all initial blockers are resolved.
 
 ${POST_RELEASE_STEPS}
 - [ ] Increase the version of Dune to the new latest minor version
-  - [ ] in the [CI workflow](https://github.com/ocaml/dune/tree/main/ci/workflow.yml.in)
+  - [ ] in the [CI workflow](https://github.com/ocaml/dune/tree/main/.github/workflows/workflow.yml.in)
   - [ ] in [dune-project](https://github.com/ocaml/dune/blob/main/dune-project#L1)
   - [ ] in the [dune-rpc](https://github.com/ocaml/dune/blob/main/otherlibs/dune-rpc/types.ml#L30)
 """


### PR DESCRIPTION
The path we pass to the script is always correct since dune may relativise it whether it lives. The old hard coded path was incorrect since we moved the .in script.