### PR TITLE
fix(opam): gate dune-bound deduplication on (lang dune 3.23)

### DIFF
--- a/doc/changes/fixed/14436.md
+++ b/doc/changes/fixed/14436.md
@@ -1,0 +1,6 @@
+- Gate the `dune` version-bound deduplication in generated opam files
+  (introduced in 3.23) on `(lang dune 3.23)`. Projects at earlier lang
+  versions get the prior `And [...]` shape — e.g.
+  `{>= "3.17" & >= "3.20"}` — restoring 3.22 behaviour and avoiding a
+  silent change to opam output on dune-binary upgrade. (#14436,
+  @robinbb)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -259,7 +259,9 @@ let insert_dune_dep depends dune_version =
                   (match dep.constraint_ with
                    | None -> lang_constraint
                    | Some user_constraint ->
-                     merge_dune_constraints lang_constraint user_constraint)
+                     if dune_version >= (3, 23)
+                     then merge_dune_constraints lang_constraint user_constraint
+                     else And [ lang_constraint; user_constraint ])
             }
         in
         List.rev_append acc (dep :: rest))

--- a/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/dune-dep.t
@@ -46,56 +46,84 @@ Same with version of the language >= 2.6, we now add the constraint:
     "dune" {>= "2.6"}
   ]
 
-When the user specifies a dune constraint matching the lang version,
-there should be no duplicate bounds (issue #3916):
+For projects on lang versions < 3.23, no deduplication occurs: the
+lang lower bound is conjoined with the user's constraint verbatim
+(issue #14436):
 
   $ cat > dune-project <<EOF
-  > (lang dune 2.7)
+  > (lang dune 3.22)
   > (name foo)
   > (generate_opam_files true)
-  > (package (name foo) (depends (dune (>= 2.7))))
+  > (package (name foo) (depends (dune (>= 3.22))))
   > EOF
 
   $ dune build foo.opam
   $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
   depends: [
-    "dune" {>= "2.7"}
+    "dune" {>= "3.22" & >= "3.22"}
+    "odoc" {with-doc}
+  ]
+
+From `(lang dune 3.23)`, opam files are in `Generated_with_diff` mode:
+`dune build foo.opam` writes the computed opam file under `_build/`
+but does not promote to source. The blocks below remove the stale
+`foo.opam` left by earlier blocks before each rebuild and read the
+generated file from `_build/default/`.
+
+When the user specifies a dune constraint matching the lang version,
+there should be no duplicate bounds (issue #3916):
+
+  $ rm -f foo.opam
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (dune (>= 3.23))))
+  > EOF
+
+  $ dune build foo.opam
+  $ dune_cmd print-from 'depends' < _build/default/foo.opam | dune_cmd print-until ']'
+  depends: [
+    "dune" {>= "3.23"}
     "odoc" {with-doc}
   ]
 
 When the user specifies a higher patch version than the lang version,
 the more restrictive user constraint should be kept (issue #11106):
 
+  $ rm -f foo.opam
   $ cat > dune-project <<EOF
-  > (lang dune 3.16)
+  > (lang dune 3.23)
   > (name foo)
   > (generate_opam_files true)
-  > (package (name foo) (depends (dune (>= 3.16.0))))
+  > (package (name foo) (depends (dune (>= 3.23.0))))
   > EOF
 
   $ dune build foo.opam
-  $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
+  $ dune_cmd print-from 'depends' < _build/default/foo.opam | dune_cmd print-until ']'
   depends: [
-    "dune" {>= "3.16.0"}
+    "dune" {>= "3.23.0"}
     "odoc" {with-doc}
   ]
 
 When the user specifies a lower bound than the lang version, a warning
 is emitted and the lang constraint takes precedence:
 
+  $ rm -f foo.opam
   $ cat > dune-project <<EOF
-  > (lang dune 2.7)
+  > (lang dune 3.23)
   > (name foo)
   > (generate_opam_files true)
-  > (package (name foo) (depends (dune (>= 2.5))))
+  > (package (name foo) (depends (dune (>= 3.20))))
   > EOF
 
   $ dune build foo.opam
-  Warning: The lower bound >= 2.5 on dune in the depends field is less than the
-  dune language version 2.7. The generated opam file will use >= 2.7 instead.
-  $ dune_cmd print-from 'depends' < foo.opam | dune_cmd print-until ']'
+  Warning: The lower bound >= 3.20 on dune in the depends field is less than
+  the dune language version 3.23. The generated opam file will use >= 3.23
+  instead.
+  $ dune_cmd print-from 'depends' < _build/default/foo.opam | dune_cmd print-until ']'
   depends: [
-    "dune" {>= "2.7"}
+    "dune" {>= "3.23"}
     "odoc" {with-doc}
   ]
 


### PR DESCRIPTION
## Summary

Gate the dune-version-bound deduplication in generated opam files (introduced in #14175 and shipped in 3.23.0) on `(lang dune 3.23)`. Projects at earlier lang versions get the pre-14175 `And [lang; user]` shape.

Fixes #14436

Related: #14175