### PR TITLE
rpc: add flush-file-watcher

### DIFF
--- a/bin/rpc/group.ml
+++ b/bin/rpc/group.ml
@@ -11,6 +11,11 @@ let info =
   Cmd.info "rpc" ~doc ~man
 ;;
 
-let group = Cmd.group info [ Rpc_status.cmd; Rpc_build.cmd; Rpc_ping.cmd ]
+let group =
+  Cmd.group
+    info
+    [ Rpc_status.cmd; Rpc_build.cmd; Rpc_ping.cmd; Rpc_flush_file_watcher.cmd ]
+;;
 
 module Build = Rpc_build
+module Flush_file_watcher = Rpc_flush_file_watcher

--- a/bin/rpc/group.mli
+++ b/bin/rpc/group.mli
@@ -2,3 +2,4 @@
 val group : unit Cmdliner.Cmd.t
 
 module Build = Rpc_build
+module Flush_file_watcher = Rpc_flush_file_watcher

--- a/bin/rpc/rpc.ml
+++ b/bin/rpc/rpc.ml
@@ -1,5 +1,6 @@
 module Group = Group
 module Rpc_build = Rpc_build
 module Rpc_common = Rpc_common
+module Rpc_flush_file_watcher = Rpc_flush_file_watcher
 module Rpc_ping = Rpc_ping
 module Rpc_status = Rpc_status

--- a/bin/rpc/rpc_flush_file_watcher.ml
+++ b/bin/rpc/rpc_flush_file_watcher.ml
@@ -1,0 +1,28 @@
+open Import
+
+let info =
+  let doc = "Flush pending file watcher notifications in a running watch server." in
+  Cmd.info "flush-file-watcher" ~doc
+;;
+
+let term =
+  let+ (builder : Common.Builder.t) = Common.Builder.term
+  and+ wait = Rpc_common.wait_term in
+  Rpc_common.client_term builder
+  @@ fun () ->
+  let open Fiber.O in
+  let+ response =
+    Rpc_common.fire_request
+      ~name:"flush_file_watcher_cmd"
+      ~wait
+      builder
+      Dune_rpc.Procedures.Public.flush_file_watcher
+      ()
+  in
+  match response with
+  | `Ok -> ()
+  | `Not_in_watch_mode ->
+    User_error.raise [ Pp.text "flush-file-watcher is only available in watch mode" ]
+;;
+
+let cmd = Cmd.v info term

--- a/bin/rpc/rpc_flush_file_watcher.mli
+++ b/bin/rpc/rpc_flush_file_watcher.mli
@@ -1,0 +1,3 @@
+(** [dune rpc flush-file-watcher] flushes pending file watcher notifications
+    in a running watch server. *)
+val cmd : unit Cmdliner.Cmd.t

--- a/otherlibs/dune-rpc/procedures.ml
+++ b/otherlibs/dune-rpc/procedures.ml
@@ -55,6 +55,34 @@ module Public = struct
     ;;
   end
 
+  module Flush_file_watcher = struct
+    type t =
+      [ `Ok
+      | `Not_in_watch_mode
+      ]
+
+    let sexp : (t, Conv.values) Conv.t =
+      let open Conv in
+      let ok = constr "ok" unit (fun () -> `Ok) in
+      let not_in_watch_mode =
+        constr "not_in_watch_mode" unit (fun () -> `Not_in_watch_mode)
+      in
+      sum
+        [ econstr ok; econstr not_in_watch_mode ]
+        (function
+          | `Ok -> case () ok
+          | `Not_in_watch_mode -> case () not_in_watch_mode)
+    ;;
+
+    let v1 = Decl.Request.make_current_gen ~req:Conv.unit ~resp:sexp ~version:1
+
+    let decl =
+      Decl.Request.make
+        ~method_:(Method.Name.of_string "flush-file-watcher")
+        ~generations:[ v1 ]
+    ;;
+  end
+
   module Format_dune_file = struct
     module V1 = struct
       let req =
@@ -135,6 +163,7 @@ module Public = struct
   let diagnostics = Diagnostics.decl
   let shutdown = Shutdown.decl
   let format = Format.decl
+  let flush_file_watcher = Flush_file_watcher.decl
   let format_dune_file = Format_dune_file.decl
   let promote = Promote.decl
   let promote_many = Promote_many.decl
@@ -351,6 +380,7 @@ module Builtin = struct
     ; request Public.diagnostics
     ; notification Public.shutdown
     ; request Public.format
+    ; request Public.flush_file_watcher
     ; request Public.format_dune_file
     ; request Public.promote
     ; request Public.promote_many

--- a/otherlibs/dune-rpc/procedures.mli
+++ b/otherlibs/dune-rpc/procedures.mli
@@ -6,6 +6,7 @@ module Public : sig
   val diagnostics : (unit, Diagnostic.t list) Decl.Request.t
   val shutdown : unit Decl.Notification.t
   val format : (unit, unit) Decl.Request.t
+  val flush_file_watcher : (unit, [ `Ok | `Not_in_watch_mode ]) Decl.Request.t
   val format_dune_file : (Path.t * [ `Contents of string ], string) Decl.Request.t
   val promote : (Path.t, unit) Decl.Request.t
   val promote_many : (Promote_targets.t, Build_outcome_with_diagnostics.t) Decl.Request.t

--- a/otherlibs/dune-rpc/public.ml
+++ b/otherlibs/dune-rpc/public.ml
@@ -9,6 +9,7 @@ module Request = struct
   let ping = Procedures.Public.ping.decl
   let diagnostics = Procedures.Public.diagnostics.decl
   let format = Procedures.Public.format.decl
+  let flush_file_watcher = Procedures.Public.flush_file_watcher.decl
   let format_dune_file = Procedures.Public.format_dune_file.decl
   let promote = Procedures.Public.promote.decl
   let promote_many = Procedures.Public.promote_many.decl

--- a/otherlibs/dune-rpc/v1.mli
+++ b/otherlibs/dune-rpc/v1.mli
@@ -303,6 +303,7 @@ module Request : sig
 
   val ping : (unit, unit) t
   val diagnostics : (unit, Diagnostic.t list) t
+  val flush_file_watcher : (unit, [ `Ok | `Not_in_watch_mode ]) t
 
   (** format a [dune], [dune-project], or a [dune-workspace] file. The full
       path to the file is necessary so that dune knows the formatting options

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -350,6 +350,16 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
     Handler.implement_request rpc Procedures.Public.format f
   in
   let () =
+    let f _ () =
+      if Scheduler.is_watch_mode ()
+      then
+        let+ () = Scheduler.flush_file_watcher () in
+        `Ok
+      else Fiber.return `Not_in_watch_mode
+    in
+    Handler.implement_request rpc Procedures.Public.flush_file_watcher f
+  in
+  let () =
     let rec cancel_pending_jobs () =
       match Job_queue.pop_internal (Fdecl.get t).pending_jobs with
       | None -> Fiber.return ()

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -383,6 +383,7 @@ let flush_file_watcher_impl t =
 ;;
 
 let flush_file_watcher () = flush_file_watcher_impl (t ())
+let is_watch_mode () = Run_id.State.is_watch (t ()).run_id_state
 
 module Run = struct
   exception Build_cancelled = Build_cancelled

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -141,6 +141,7 @@ val start_build : unit -> Run_id.t
 val watch_restart_files : unit -> Path.t list option
 val finish_build : stop:Time.t -> build_finish
 val flush_file_watcher : unit -> unit Fiber.t
+val is_watch_mode : unit -> bool
 
 (** [set_fs_memo_impl] registers the file system memoization callbacks.
     This must be called by dune_engine at initialization before starting

--- a/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
@@ -1,0 +1,112 @@
+The flush-file-watcher RPC waits for pending file watcher notifications to be
+handled by the watch server.
+
+  $ export DUNE_TRACE=cache
+  $ export XDG_RUNTIME_DIR="$PWD/.xdg-runtime"
+  $ mkdir -p "$XDG_RUNTIME_DIR"
+  $ chmod 700 "$XDG_RUNTIME_DIR"
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > x <<EOF
+  > original
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (target y)
+  >  (deps x)
+  >  (action (copy x y)))
+  > EOF
+
+  $ start_dune
+
+  $ build y
+  Success
+
+  $ echo updated > x
+
+This is the synchronization point: the RPC returns only after file watcher
+events preceding the request have reached the scheduler.
+
+  $ with_timeout dune rpc flush-file-watcher --wait
+
+  $ stop_dune_quiet
+
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | fsUpdateWithPath("x")
+  >        | select(.cache_type == "file_digest" and .result == "changed")
+  >        | {cache_type, path, result}
+  > ] | unique | .[]'
+  {
+    "cache_type": "file_digest",
+    "path": "x",
+    "result": "changed"
+  }
+
+The RPC reports [`Not_in_watch_mode] when the server is only running for a
+batch build. The action uses [dynamic-run] because Dune starts the batch RPC
+server before running a dynamic action. Once the helper has touched [$STARTED],
+the test can query the server without racing its startup.
+
+  $ STARTED="$PWD/started"
+  $ RELEASE="$PWD/release"
+  $ rm -f "$STARTED" "$RELEASE"
+
+  $ cat > hold.ml <<EOF
+  > open Dune_action_plugin.V1
+  > 
+  > let touch path =
+  >   let oc = open_out path in
+  >   close_out oc
+  > ;;
+  > 
+  > let rec wait_for_file path =
+  >   if not (Sys.file_exists path)
+  >   then (
+  >     ignore (Unix.select [] [] [] 0.01);
+  >     wait_for_file path)
+  > ;;
+  > 
+  > let () =
+  >   let started = Sys.argv.(1) in
+  >   let release = Sys.argv.(2) in
+  >   touch started;
+  >   wait_for_file release;
+  >   run (return ())
+  > ;;
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name hold)
+  >  (libraries dune-action-plugin unix))
+  > 
+  > (rule
+  >  (target hold-target)
+  >  (action
+  >   (progn
+  >    (dynamic-run ./hold.exe "$STARTED" "$RELEASE")
+  >    (write-file %{target} ok))))
+  > EOF
+
+  $ dune build hold-target > batch.out 2>&1 &
+  $ BATCH_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$STARTED"
+
+  $ with_timeout dune rpc flush-file-watcher --wait
+  Error: flush-file-watcher is only available in watch mode
+  [1]
+
+  $ touch "$RELEASE"
+  $ if wait_for_pid_to_exit_with_timeout "$BATCH_PID" 200; then
+  >   wait "$BATCH_PID"
+  > else
+  >   cat batch.out
+  >   kill "$BATCH_PID"
+  >   wait "$BATCH_PID"
+  > fi
+  $ cat batch.out

--- a/test/expect-tests/dune_rpc/digests.ml
+++ b/test/expect-tests/dune_rpc/digests.ml
@@ -112,6 +112,10 @@ let%expect_test "print digests for all declared RPCs" =
       Version 1:
         Request: Unit
         Response: Unit
+    flush-file-watcher
+      Version 1:
+        Request: Unit
+        Response: 14894520de5f9b49826c37876bedfaad
     format-dune-file
       Version 1:
         Request: 15eae4b546faf05a0fc3b6d03aed0c63


### PR DESCRIPTION
This is useful to make tests more reproducible. We can wait until dune ack's a file modification by sending this RPC.