### PR TITLE
refactor: use Repr.t for persistent descriptors

### DIFF
--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -21,7 +21,7 @@ let term =
   in
   let _common, _config = Common.init builder in
   let (Persistent.T ((module D), data)) = Persistent.load_exn (Arg.Path.path file) in
-  Console.print [ Dyn.pp (D.to_dyn data) ]
+  Console.print [ Dyn.pp (Repr.to_dyn D.repr data) ]
 ;;
 
 let command = Cmd.v info term

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -62,14 +62,14 @@ let compare { dir; name } t =
 
 let equal x y = compare x y = Eq
 let hash { dir; name } = Tuple.T2.hash Path.Build.hash Name.hash (dir, name)
+let name t = t.name
+let dir t = t.dir
 
 let to_dyn { dir; name } =
   let open Dyn in
   Record [ "dir", Path.Build.to_dyn dir; "name", Name.to_dyn name ]
 ;;
 
-let name t = t.name
-let dir t = t.dir
 let fully_qualified_name t = Path.Build.relative t.dir (Name.to_string t.name)
 
 let get_ctx (path : Path.Build.t) =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -62,15 +62,28 @@ module T = struct
     | Universe, Universe -> Ordering.Eq
   ;;
 
-  let to_dyn t =
-    let open Dyn in
-    match t with
-    | File_selector g -> variant "File_selector" [ File_selector.to_dyn g ]
-    | Env e -> variant "Env" [ string e ]
-    | File f -> variant "File" [ Path.to_dyn f ]
-    | Alias a -> variant "Alias" [ Alias.to_dyn a ]
-    | Universe -> variant "Universe" []
+  let repr =
+    Repr.variant
+      "dep"
+      [ Repr.case "File_selector" File_selector.repr ~proj:(function
+          | File_selector g -> Some g
+          | _ -> None)
+      ; Repr.case "Env" Repr.string ~proj:(function
+          | Env e -> Some e
+          | _ -> None)
+      ; Repr.case "File" Path.repr ~proj:(function
+          | File f -> Some f
+          | _ -> None)
+      ; Repr.case "Alias" (Repr.abstract Alias.to_dyn) ~proj:(function
+          | Alias a -> Some a
+          | _ -> None)
+      ; Repr.case0 "Universe" ~test:(function
+          | Universe -> true
+          | _ -> false)
+      ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 end
 
 include T

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -13,6 +13,7 @@ val universe : t
 val file_selector : File_selector.t -> t
 val alias : Alias.t -> t
 val compare : t -> t -> Ordering.t
+val repr : t Repr.t
 
 module Map : sig
   type dep := t

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -23,12 +23,12 @@ module File = struct
 
   let in_staging_area source = Path.Build.append_source staging_area source
 
-  let to_dyn { src; staging; dst } =
-    let open Dyn in
-    record
-      [ "src", Path.Build.to_dyn src
-      ; "staging", option Path.Build.to_dyn staging
-      ; "dst", Path.Source.to_dyn dst
+  let repr =
+    Repr.record
+      "promotion-file"
+      [ Repr.field "src" Path.Build.repr ~get:(fun t -> t.src)
+      ; Repr.field "staging" (Repr.option Path.Build.repr) ~get:(fun t -> t.staging)
+      ; Repr.field "dst" Path.Source.repr ~get:(fun t -> t.dst)
       ]
   ;;
 
@@ -89,11 +89,16 @@ type what =
   | `Directory
   ]
 
-let dyn_of_what =
-  let open Dyn in
-  function
-  | `File -> variant "File" []
-  | `Directory -> variant "Directory" []
+let what_repr =
+  Repr.variant
+    "promotion-what"
+    [ Repr.case0 "File" ~test:(function
+        | `File -> true
+        | `Directory -> false)
+    ; Repr.case0 "Directory" ~test:(function
+        | `Directory -> true
+        | `File -> false)
+    ]
 ;;
 
 type op =
@@ -101,10 +106,19 @@ type op =
   | Create_directory of Path.Source.t
   | Delete of what * Path.Source.t
 
-let dyn_of_op = function
-  | File f -> Dyn.variant "File" [ File.to_dyn f ]
-  | Create_directory p -> Dyn.variant "Create_directory" [ Path.Source.to_dyn p ]
-  | Delete (what, d) -> Dyn.variant "Delete" [ dyn_of_what what; Path.Source.to_dyn d ]
+let op_repr =
+  Repr.variant
+    "promotion-op"
+    [ Repr.case "File" File.repr ~proj:(function
+        | File f -> Some f
+        | _ -> None)
+    ; Repr.case "Create_directory" Path.Source.repr ~proj:(function
+        | Create_directory p -> Some p
+        | _ -> None)
+    ; Repr.case "Delete" (Repr.pair what_repr Path.Source.repr) ~proj:(function
+        | Delete (what, p) -> Some (what, p)
+        | _ -> None)
+    ]
 ;;
 
 type db = op list
@@ -148,7 +162,7 @@ module P = Persistent.Make (struct
     let name = "TO-PROMOTE"
     let sharing = true
     let version = 6
-    let to_dyn = Dyn.list dyn_of_op
+    let repr = Repr.list op_repr
   end)
 
 let db_file = Path.relative Path.build_dir ".to-promote"

--- a/src/dune_engine/diff_promotion.mli
+++ b/src/dune_engine/diff_promotion.mli
@@ -10,7 +10,6 @@ module File : sig
   val compare : t -> t -> Ordering.t
   val source : t -> Path.Source.t
   val correction_file : t -> Path.t
-  val to_dyn : t -> Dyn.t
   val in_staging_area : Path.Source.t -> Path.Build.t
 end
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -50,17 +50,16 @@ module Cached_digest = struct
     }
 
   let db_file = Path.relative Path.build_dir ".digest-db"
+  let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
 
   let file_repr =
     Repr.record
       "fs-memo-cached-digest-file"
-      [ Repr.field "digest" (Repr.abstract Digest.to_dyn) ~get:(fun t -> t.digest)
+      [ Repr.field "digest" digest_repr ~get:(fun t -> t.digest)
       ; Repr.field "stats" Reduced_stats.repr ~get:(fun t -> t.stats)
       ; Repr.field "stats_checked" Repr.int ~get:(fun t -> t.stats_checked)
       ]
   ;;
-
-  let file_to_dyn = Repr.to_dyn file_repr
 
   let repr =
     Repr.record
@@ -69,12 +68,10 @@ module Cached_digest = struct
       ; Repr.field "max_timestamp" Time.repr ~get:(fun t -> t.max_timestamp)
       ; Repr.field
           "table"
-          (Repr.abstract (Path.Table.to_dyn file_to_dyn))
+          (Repr.abstract (Path.Table.to_dyn (Repr.to_dyn file_repr)))
           ~get:(fun t -> t.table)
       ]
   ;;
-
-  let to_dyn = Repr.to_dyn repr
 
   module P = Persistent.Make (struct
       type nonrec t = t
@@ -82,7 +79,7 @@ module Cached_digest = struct
       let name = "DIGEST-DB"
       let version = 10
       let sharing = true
-      let to_dyn = to_dyn
+      let repr = repr
     end)
 
   let needs_dumping = ref false

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -4,6 +4,8 @@ open Dune_cache.Hit_or_miss
 module Workspace_local = struct
   (* Stores information for deciding if a rule needs to be re-executed. *)
   module Database = struct
+    let digest_repr = Repr.view Repr.string ~to_:Digest.to_string
+
     module Entry = struct
       type t =
         { rule_digest : Digest.t
@@ -14,19 +16,14 @@ module Workspace_local = struct
       let repr =
         Repr.record
           "rule-cache-workspace-local-entry"
-          [ Repr.field "rule_digest" (Repr.abstract Digest.to_dyn) ~get:(fun t ->
-              t.rule_digest)
+          [ Repr.field "rule_digest" digest_repr ~get:(fun t -> t.rule_digest)
           ; Repr.field
               "dynamic_deps_stages"
-              (Repr.list
-                 (Repr.pair (Repr.abstract Dep.Set.to_dyn) (Repr.abstract Digest.to_dyn)))
+              (Repr.list (Repr.pair (Repr.abstract Dep.Set.to_dyn) digest_repr))
               ~get:(fun t -> t.dynamic_deps_stages)
-          ; Repr.field "targets_digest" (Repr.abstract Digest.to_dyn) ~get:(fun t ->
-              t.targets_digest)
+          ; Repr.field "targets_digest" digest_repr ~get:(fun t -> t.targets_digest)
           ]
       ;;
-
-      let to_dyn = Repr.to_dyn repr
     end
 
     type digest =
@@ -38,14 +35,12 @@ module Workspace_local = struct
     let digest_repr =
       Repr.record
         "rule-cache-workspace-local-digest"
-        [ Repr.field "digest" (Repr.abstract Digest.to_dyn) ~get:(fun t -> t.digest)
+        [ Repr.field "digest" digest_repr ~get:(fun t -> t.digest)
         ; Repr.field "siblings" (Repr.abstract Targets.Produced.to_dyn) ~get:(fun t ->
             t.siblings)
         ; Repr.field "generation" Repr.int ~get:(fun t -> t.generation)
         ]
     ;;
-
-    let dyn_of_digest = Repr.to_dyn digest_repr
 
     (* Keyed by the first target of the rule. *)
     type t =
@@ -64,11 +59,11 @@ module Workspace_local = struct
         "rule-cache-workspace-local-database"
         [ Repr.field
             "rules"
-            (Repr.abstract (Path.Table.to_dyn Entry.to_dyn))
+            (Repr.abstract (Path.Table.to_dyn (Repr.to_dyn Entry.repr)))
             ~get:(fun t -> t.rules)
         ; Repr.field
             "digests"
-            (Repr.abstract (Path.Build.Table.to_dyn dyn_of_digest))
+            (Repr.abstract (Path.Build.Table.to_dyn (Repr.to_dyn digest_repr)))
             ~get:(fun t -> t.digests)
         ; Repr.field
             "invalidated_subtrees"
@@ -78,15 +73,13 @@ module Workspace_local = struct
         ]
     ;;
 
-    let to_dyn = Repr.to_dyn repr
-
     module P = Dune_util.Persistent.Make (struct
         type nonrec t = t
 
         let name = "INCREMENTAL-DB"
         let version = 8
         let sharing = true
-        let to_dyn = to_dyn
+        let repr = repr
       end)
 
     let needs_dumping = ref false

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -14,7 +14,7 @@ module To_delete = struct
       let name = "PROMOTED-TO-DELETE"
       let sharing = true
       let version = 4
-      let to_dyn = Path.Source.Set.to_dyn
+      let repr = Repr.abstract Path.Source.Set.to_dyn
     end)
 
   let fn = Path.relative Path.build_dir ".to-delete-in-source-tree"

--- a/src/dune_lang/section.ml
+++ b/src/dune_lang/section.ml
@@ -4,11 +4,14 @@ include Dune_section
 let compare : t -> t -> Ordering.t = Poly.compare
 let equal : t -> t -> bool = Poly.equal
 
-let to_dyn x =
-  let s = Dune_section.to_string x in
-  let open Dyn in
-  variant (String.uppercase_ascii s) []
+let repr =
+  Repr.variant
+    "section"
+    (List.map Dune_section.all ~f:(fun (section, name) ->
+       Repr.case0 (String.uppercase_ascii name) ~test:(equal section)))
 ;;
+
+let to_dyn = Repr.to_dyn repr
 
 module Key = struct
   type nonrec t = t

--- a/src/dune_lang/section.mli
+++ b/src/dune_lang/section.mli
@@ -11,6 +11,7 @@ val all : Set.t
 val parse_string : string -> (t, string) Result.t
 val decode : t Decoder.t
 val encode : t Encoder.t
+val repr : t Repr.t
 val to_dyn : t -> Dyn.t
 
 (** [true] iff the executable bit should be set for files installed in this

--- a/src/dune_rules/copy_line_directive.ml
+++ b/src/dune_rules/copy_line_directive.ml
@@ -12,7 +12,7 @@ module DB = struct
       let name = "COPY-LINE-DIRECTIVE-MAP"
       let sharing = true
       let version = 3
-      let to_dyn = Path.Build.Table.to_dyn Path.Build.to_dyn
+      let repr = Repr.abstract (Path.Build.Table.to_dyn Path.Build.to_dyn)
     end)
 
   let needs_dumping = ref false

--- a/src/dune_rules/cram/cram_exec.ml
+++ b/src/dune_rules/cram/cram_exec.ml
@@ -154,21 +154,29 @@ type metadata_entry =
   ; build_path_prefix_map : string
   }
 
-let dyn_of_metadata_entry { exit_code; build_path_prefix_map } =
-  let open Dyn in
-  record
-    [ "exit_code", int exit_code; "build_path_prefix_map", string build_path_prefix_map ]
+let metadata_entry_repr =
+  Repr.record
+    "cram-metadata-entry"
+    [ Repr.field "exit_code" Repr.int ~get:(fun t -> t.exit_code)
+    ; Repr.field "build_path_prefix_map" Repr.string ~get:(fun t ->
+        t.build_path_prefix_map)
+    ]
 ;;
 
 type metadata_result =
   | Present of metadata_entry
   | Missing_unreachable
 
-let dyn_of_metadata_result =
-  let open Dyn in
-  function
-  | Missing_unreachable -> variant "Missing_unreachable" []
-  | Present p -> variant "Present" [ dyn_of_metadata_entry p ]
+let metadata_result_repr =
+  Repr.variant
+    "cram-metadata-result"
+    [ Repr.case "Present" metadata_entry_repr ~proj:(function
+        | Present p -> Some p
+        | _ -> None)
+    ; Repr.case0 "Missing_unreachable" ~test:(function
+        | Missing_unreachable -> true
+        | _ -> false)
+    ]
 ;;
 
 type full_block_result =
@@ -305,12 +313,12 @@ type command_out =
   ; output : string option
   }
 
-let dyn_of_command_out { command; metadata; output } =
-  let open Dyn in
-  record
-    [ "command", (list string) command
-    ; "metadata", dyn_of_metadata_result metadata
-    ; "output", (option string) output
+let command_out_repr =
+  Repr.record
+    "cram-command-output"
+    [ Repr.field "command" (Repr.list Repr.string) ~get:(fun t -> t.command)
+    ; Repr.field "metadata" metadata_result_repr ~get:(fun t -> t.metadata)
+    ; Repr.field "output" (Repr.option Repr.string) ~get:(fun t -> t.output)
     ]
 ;;
 
@@ -663,7 +671,7 @@ module Script = Persistent.Make (struct
     let name = "CRAM-RESULT"
     let sharing = false
     let version = 2
-    let to_dyn = Dyn.list dyn_of_command_out
+    let repr = Repr.list command_out_repr
   end)
 
 let run_and_produce_output

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -24,11 +24,16 @@ module Processed = struct
       | Pp
       | Ppx
 
-    let to_dyn =
-      let open Dyn in
-      function
-      | Pp -> variant "Pp" []
-      | Ppx -> variant "Ppx" []
+    let repr =
+      Repr.variant
+        "merlin-pp-kind"
+        [ Repr.case0 "Pp" ~test:(function
+            | Pp -> true
+            | Ppx -> false)
+        ; Repr.case0 "Ppx" ~test:(function
+            | Ppx -> true
+            | Pp -> false)
+        ]
     ;;
 
     let to_flag = function
@@ -42,9 +47,12 @@ module Processed = struct
     ; args : string
     }
 
-  let dyn_of_pp_flag { flag; args } =
-    let open Dyn in
-    record [ "flag", Pp_kind.to_dyn flag; "args", string args ]
+  let pp_flag_repr =
+    Repr.record
+      "merlin-pp-flag"
+      [ Repr.field "flag" Pp_kind.repr ~get:(fun t -> t.flag)
+      ; Repr.field "args" Repr.string ~get:(fun t -> t.args)
+      ]
   ;;
 
   let pp_kind x = x.flag
@@ -64,31 +72,32 @@ module Processed = struct
     ; parameters : Module_name.t list
     }
 
-  let dyn_of_config
-        { stdlib_dir
-        ; source_root
-        ; obj_dirs
-        ; src_dirs
-        ; hidden_obj_dirs
-        ; hidden_src_dirs
-        ; flags
-        ; extensions
-        ; indexes
-        ; parameters
-        }
-    =
-    let open Dyn in
-    record
-      [ "stdlib_dir", option Path.to_dyn stdlib_dir
-      ; "source_root", Path.to_dyn source_root
-      ; "obj_dirs", Path.Set.to_dyn obj_dirs
-      ; "src_dirs", Path.Set.to_dyn src_dirs
-      ; "hidden_obj_dirs", Path.Set.to_dyn hidden_obj_dirs
-      ; "hidden_src_dirs", Path.Set.to_dyn hidden_src_dirs
-      ; "flags", list string flags
-      ; "extensions", list (Ml_kind.Dict.to_dyn (Dyn.option string)) extensions
-      ; "indexes", list Path.to_dyn indexes
-      ; "parameters", list Module_name.to_dyn parameters
+  let path_set_repr = Repr.abstract Path.Set.to_dyn
+
+  let ml_kind_dict_repr value_repr =
+    Repr.record
+      "ml-kind-dict"
+      [ Repr.field "impl" value_repr ~get:(fun t -> t.Ml_kind.Dict.impl)
+      ; Repr.field "intf" value_repr ~get:(fun t -> t.Ml_kind.Dict.intf)
+      ]
+  ;;
+
+  let config_repr =
+    Repr.record
+      "merlin-config"
+      [ Repr.field "stdlib_dir" (Repr.option Path.repr) ~get:(fun t -> t.stdlib_dir)
+      ; Repr.field "source_root" Path.repr ~get:(fun t -> t.source_root)
+      ; Repr.field "obj_dirs" path_set_repr ~get:(fun t -> t.obj_dirs)
+      ; Repr.field "src_dirs" path_set_repr ~get:(fun t -> t.src_dirs)
+      ; Repr.field "hidden_obj_dirs" path_set_repr ~get:(fun t -> t.hidden_obj_dirs)
+      ; Repr.field "hidden_src_dirs" path_set_repr ~get:(fun t -> t.hidden_src_dirs)
+      ; Repr.field "flags" (Repr.list Repr.string) ~get:(fun t -> t.flags)
+      ; Repr.field
+          "extensions"
+          (Repr.list (ml_kind_dict_repr (Repr.option Repr.string)))
+          ~get:(fun t -> t.extensions)
+      ; Repr.field "indexes" (Repr.list Path.repr) ~get:(fun t -> t.indexes)
+      ; Repr.field "parameters" (Repr.list Module_name.repr) ~get:(fun t -> t.parameters)
       ]
   ;;
 
@@ -98,12 +107,12 @@ module Processed = struct
     ; reader : string list option
     }
 
-  let dyn_of_module_config { opens; module_; reader } =
-    let open Dyn in
-    record
-      [ "opens", list Module_name.to_dyn opens
-      ; "module_", Module.to_dyn module_
-      ; "reader", option (list string) reader
+  let module_config_repr =
+    Repr.record
+      "merlin-module-config"
+      [ Repr.field "opens" (Repr.list Module_name.repr) ~get:(fun t -> t.opens)
+      ; Repr.field "module_" (Repr.abstract Module.to_dyn) ~get:(fun t -> t.module_)
+      ; Repr.field "reader" (Repr.option (Repr.list Repr.string)) ~get:(fun t -> t.reader)
       ]
   ;;
 
@@ -142,14 +151,22 @@ module Processed = struct
     ;;
   end
 
-  let to_dyn { config; per_file_config; pp_config } =
-    let open Dyn in
-    record
-      [ "config", dyn_of_config config
-      ; "per_file_config", Path.Build.Map.to_dyn dyn_of_module_config per_file_config
-      ; "pp_config", Module_name.Per_item.to_dyn (option dyn_of_pp_flag) pp_config
+  let repr =
+    Repr.record
+      "merlin-processed"
+      [ Repr.field "config" config_repr ~get:(fun t -> t.config)
+      ; Repr.field
+          "per_file_config"
+          (Repr.abstract (Path.Build.Map.to_dyn (Repr.to_dyn module_config_repr)))
+          ~get:(fun t -> t.per_file_config)
+      ; Repr.field
+          "pp_config"
+          (Module_name.Per_item.repr (Repr.option pp_flag_repr))
+          ~get:(fun t -> t.pp_config)
       ]
   ;;
+
+  let to_dyn = Repr.to_dyn repr
 
   module D = struct
     type nonrec t = t
@@ -157,7 +174,10 @@ module Processed = struct
     let name = "merlin-conf"
     let sharing = false
     let version = 8
-    let to_dyn _ = Dyn.String "Use [dune ocaml dump-dot-merlin] instead"
+
+    let repr =
+      Repr.view Repr.string ~to_:(fun _ -> "Use [dune ocaml dump-dot-merlin] instead")
+    ;;
   end
 
   module Persist = Dune_util.Persistent.Make (D)

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -23,13 +23,22 @@ module Variable = struct
 
   type t = Package_variable_name.t * value
 
-  let dyn_of_value : value -> Dyn.t =
-    let open Dyn in
-    function
-    | B b -> variant "Bool" [ bool b ]
-    | S s -> variant "String" [ string s ]
-    | L xs -> variant "Strings" [ list string xs ]
+  let value_repr =
+    Repr.variant
+      "package-variable-value"
+      [ Repr.case "Bool" Repr.bool ~proj:(function
+          | B b -> Some b
+          | _ -> None)
+      ; Repr.case "String" Repr.string ~proj:(function
+          | S s -> Some s
+          | _ -> None)
+      ; Repr.case "Strings" (Repr.list Repr.string) ~proj:(function
+          | L xs -> Some xs
+          | _ -> None)
+      ]
   ;;
+
+  let repr = Repr.pair Package_variable_name.repr value_repr
 
   let dune_value : value -> Value.t list = function
     | B b -> [ String (Bool.to_string b) ]
@@ -42,10 +51,6 @@ module Variable = struct
     match List.map xs ~f:(Value.to_string ~dir) with
     | [ x ] -> S x
     | xs -> L xs
-  ;;
-
-  let to_dyn (name, value) =
-    Dyn.(pair Package_variable_name.to_dyn dyn_of_value (name, value))
   ;;
 end
 
@@ -297,9 +302,12 @@ module Install_cookie = struct
       ; variables : Variable.t list
       }
 
-    let to_dyn f { files; variables } =
-      let open Dyn in
-      record [ "files", f files; "variables", list Variable.to_dyn variables ]
+    let repr files_repr =
+      Repr.record
+        "install-cookie"
+        [ Repr.field "files" files_repr ~get:(fun t -> t.files)
+        ; Repr.field "variables" (Repr.list Variable.repr) ~get:(fun t -> t.variables)
+        ]
     ;;
   end
 
@@ -311,11 +319,7 @@ module Install_cookie = struct
       let sharing = false
       let name = "INSTALL-COOKIE"
       let version = 4
-
-      let to_dyn =
-        let open Dyn in
-        Gen.to_dyn (list (pair Section.to_dyn (list Path.to_dyn)))
-      ;;
+      let repr = Gen.repr (Repr.list (Repr.pair Section.repr (Repr.list Path.repr)))
     end)
 
   let load_exn f =

--- a/src/dune_util/persistent.ml
+++ b/src/dune_util/persistent.ml
@@ -6,7 +6,7 @@ module type Desc = sig
   val name : string
   val sharing : bool
   val version : int
-  val to_dyn : t -> Dyn.t
+  val repr : t Repr.t
 end
 
 type data = ..

--- a/src/dune_util/persistent.mli
+++ b/src/dune_util/persistent.mli
@@ -18,7 +18,7 @@ module type Desc = sig
   val name : string
   val sharing : bool
   val version : int
-  val to_dyn : t -> Dyn.t
+  val repr : t Repr.t
 end
 
 type data = private ..
@@ -34,7 +34,7 @@ end
 
     There's the [dune dump <file>] command that can pretty-print the contents of
     any persistent file. This command can use the [D.name] stored in the
-    persistent file to locate the appropriate pretty printer. *)
+    persistent file to locate the appropriate representation. *)
 module Make (D : Desc) : sig
   val to_string : D.t -> string
   val dump : Path.t -> D.t -> unit


### PR DESCRIPTION
Persistent file descriptors now carry a Repr.t so generic dumping can render through the shared representation API. Convert descriptor call sites to repr values, using structural representations where practical and preserving opaque debug output for table-backed or intentionally hidden data.