### PR TITLE
feat: filter -I flags per-module to match dependency filtering

### DIFF
--- a/doc/changes/added/14186.md
+++ b/doc/changes/added/14186.md
@@ -1,0 +1,8 @@
+- Filter `-I`/`-H` include flags per-module to match the per-module
+  inter-library dependency filter from #14116. A consumer module's
+  compile command now lists only the libraries its reference set
+  reaches, eliminating cache-key bloat (adding an unrelated
+  `(libraries ...)` entry no longer invalidates other consumers)
+  and closing a soundness gap where a missing entry in the
+  per-module dep set could be silently masked by a too-wide `-I`
+  path. (#14186, @robinbb)

--- a/doc/changes/added/14473.md
+++ b/doc/changes/added/14473.md
@@ -1,8 +1,8 @@
 - Filter `-I`/`-H` include flags per-module to match the per-module
-  inter-library dependency filter from #14116. A consumer module's
+  inter-library dependency filter from #14472. A consumer module's
   compile command now lists only the libraries its reference set
   reaches, eliminating cache-key bloat (adding an unrelated
   `(libraries ...)` entry no longer invalidates other consumers)
   and closing a soundness gap where a missing entry in the
   per-module dep set could be silently masked by a too-wide `-I`
-  path. (#14186, @robinbb)
+  path. (#14473, @robinbb)

--- a/src/dune_lang/lib_mode.ml
+++ b/src/dune_lang/lib_mode.ml
@@ -11,6 +11,12 @@ let equal x y =
   | Melange, Melange -> true
 ;;
 
+let hash = function
+  | Ocaml Byte -> 0
+  | Ocaml Native -> 1
+  | Melange -> 2
+;;
+
 let decode =
   let open Decoder in
   enum [ "byte", Ocaml Byte; "native", Ocaml Native; "melange", Melange ]

--- a/src/dune_lang/lib_mode.mli
+++ b/src/dune_lang/lib_mode.mli
@@ -6,6 +6,7 @@ type t =
 
 val decode : t Decoder.t
 val equal : t -> t -> bool
+val hash : t -> int
 val to_dyn : t -> Dyn.t
 
 module Cm_kind : sig

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -33,6 +33,54 @@ module Includes = struct
   let empty = Lib_mode.Cm_kind.Map.make_all Command.Args.empty
 end
 
+(* Per-cctx cache of [Lib_flags.L.include_flags] keyed on [(lib_mode, sorted
+   kept_libs)]; two compile rules in this cctx sharing those values share one
+   [Args.t]. Output also depends on [t.requires_compile] / [t.requires_hidden],
+   which are immutable on the cctx produced by [create]. Derived cctxs from
+   [for_module_generated_at_link_time] overwrite [requires_compile] while
+   sharing this table, but take the [can_filter = false] arm in
+   [lib_deps_for_module] and never reach the cache. *)
+module Filtered_includes = struct
+  module Key = struct
+    type t =
+      { lib_mode : Lib_mode.t
+      ; kept_libs : Lib.t list (** sorted by [Lib.compare] *)
+      }
+
+    let lib_mode_tag : Lib_mode.t -> int = function
+      | Ocaml Byte -> 0
+      | Ocaml Native -> 1
+      | Melange -> 2
+    ;;
+
+    let equal a b =
+      lib_mode_tag a.lib_mode = lib_mode_tag b.lib_mode
+      && List.equal Lib.equal a.kept_libs b.kept_libs
+    ;;
+
+    let hash { lib_mode; kept_libs } =
+      Poly.hash (lib_mode_tag lib_mode, List.map kept_libs ~f:Lib.hash)
+    ;;
+
+    let repr =
+      Repr.record
+        "Filtered_includes.Key"
+        [ Repr.field "lib_mode" (Repr.abstract Lib_mode.to_dyn) ~get:(fun t -> t.lib_mode)
+        ; Repr.field
+            "kept_libs"
+            (Repr.list (Repr.abstract Lib.to_dyn))
+            ~get:(fun t -> t.kept_libs)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Command.Args.without_targets Command.Args.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 16
+end
+
 type opaque =
   | Explicit of bool
   | Inherit_from_settings
@@ -81,6 +129,7 @@ type t =
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
   ; for_ : Compilation_mode.t
+  ; filtered_includes : Filtered_includes.t
   }
 
 let loc t = t.loc
@@ -344,10 +393,48 @@ let create
   ; ocaml
   ; instances
   ; for_
+  ; filtered_includes = Filtered_includes.create ()
   }
 ;;
 
 let for_ t = t.for_
+
+let filtered_include_flags t ~cm_kind ~kept_libs =
+  let lib_mode = Lib_mode.of_cm_kind cm_kind in
+  let cache_key =
+    { Filtered_includes.Key.lib_mode
+    ; kept_libs = List.sort kept_libs ~compare:Lib.compare
+    }
+  in
+  match Table.find t.filtered_includes cache_key with
+  | Some builder -> builder
+  | None ->
+    (* Cache the [Action_builder.t] (not the resolved args) up-front at
+       rule-construction time so all compile rules sharing this [(lib_mode,
+       kept_libs)] share one builder; [Action_builder.memoize] then dedupes its
+       evaluation. Mirrors the cache pattern in
+       [Ocamldep.read_immediate_deps_words]. *)
+    let builder =
+      let open Action_builder.O in
+      let* direct_requires = Resolve.Memo.read t.requires_compile in
+      let+ hidden_requires = Resolve.Memo.read t.requires_hidden in
+      let kept_set = Lib.Set.of_list kept_libs in
+      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_set) in
+      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_set) in
+      let project = Scope.project t.scope in
+      let lib_config = t.ocaml.lib_config in
+      Lib_flags.L.include_flags
+        ~project
+        ~direct_libs:direct_filtered
+        ~hidden_libs:hidden_filtered
+        lib_mode
+        lib_config
+      |> Command.Args.memo
+    in
+    let builder = Action_builder.memoize "filtered_include_flags" builder in
+    Table.set t.filtered_includes cache_key builder;
+    builder
+;;
 
 let alias_and_root_module_flags =
   let extra = [ "-w"; "-49" ] in

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -395,9 +395,7 @@ let for_ t = t.for_
 let filtered_include_flags t ~cm_kind ~kept_libs =
   let lib_mode = Lib_mode.of_cm_kind cm_kind in
   let cache_key =
-    { Filtered_includes.Key.lib_mode
-    ; kept_libs = List.sort kept_libs ~compare:Lib.compare
-    }
+    { Filtered_includes.Key.lib_mode; kept_libs = Lib.Set.to_list kept_libs }
   in
   match Table.find t.filtered_includes cache_key with
   | Some builder -> builder
@@ -411,9 +409,8 @@ let filtered_include_flags t ~cm_kind ~kept_libs =
       let open Action_builder.O in
       let* direct_requires = Resolve.Memo.read t.requires_compile in
       let+ hidden_requires = Resolve.Memo.read t.requires_hidden in
-      let kept_set = Lib.Set.of_list kept_libs in
-      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_set) in
-      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_set) in
+      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_libs) in
+      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_libs) in
       let project = Scope.project t.scope in
       let lib_config = t.ocaml.lib_config in
       Lib_flags.L.include_flags

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -47,19 +47,12 @@ module Filtered_includes = struct
       ; kept_libs : Lib.t list (** sorted by [Lib.compare] *)
       }
 
-    let lib_mode_tag : Lib_mode.t -> int = function
-      | Ocaml Byte -> 0
-      | Ocaml Native -> 1
-      | Melange -> 2
-    ;;
-
     let equal a b =
-      lib_mode_tag a.lib_mode = lib_mode_tag b.lib_mode
-      && List.equal Lib.equal a.kept_libs b.kept_libs
+      Lib_mode.equal a.lib_mode b.lib_mode && List.equal Lib.equal a.kept_libs b.kept_libs
     ;;
 
     let hash { lib_mode; kept_libs } =
-      Poly.hash (lib_mode_tag lib_mode, List.map kept_libs ~f:Lib.hash)
+      Poly.hash (Lib_mode.hash lib_mode, List.map kept_libs ~f:Lib.hash)
     ;;
 
     let repr =

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -63,6 +63,17 @@ val requires_hidden : t -> Lib.t list Resolve.Memo.t
 val requires_compile : t -> Lib.t list Resolve.Memo.t
 val parameters : t -> Module_name.t list Resolve.Memo.t
 val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
+
+(** Include flags ([-I]/[-H]) for compiling a module against [kept_libs]. The
+    cctx's [requires_compile] and [requires_hidden] are each restricted to
+    libraries in [kept_libs]; the kept direct entries become [-I], the kept
+    hidden entries become [-H]. *)
+val filtered_include_flags
+  :  t
+  -> cm_kind:Lib_mode.Cm_kind.t
+  -> kept_libs:Lib.t list
+  -> Command.Args.without_targets Command.Args.t Action_builder.t
+
 val lib_index : t -> Lib_file_deps.Lib_index.t Resolve.Memo.t
 
 (** [true] iff any library in the compilation context's direct or

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -71,7 +71,7 @@ val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind
 val filtered_include_flags
   :  t
   -> cm_kind:Lib_mode.Cm_kind.t
-  -> kept_libs:Lib.t list
+  -> kept_libs:Lib.Set.t
   -> Command.Args.without_targets Command.Args.t Action_builder.t
 
 val lib_index : t -> Lib_file_deps.Lib_index.t Resolve.Memo.t

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -61,6 +61,9 @@ let cross_lib_tight_set ~sandbox ~sctx ~lib_index ~initial_refs =
    why wrapped dep libraries always take the glob path. *)
 let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kind ~mode m =
   let open Action_builder.O in
+  let cctx_includes_for_cm_kind () =
+    Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
+  in
   let can_filter =
     (match Lib_mode.of_cm_kind cm_kind with
      | Melange -> false
@@ -79,13 +82,17 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
   in
   let* libs = Resolve.Memo.read (all_libs cctx) in
   if not can_filter
-  then Action_builder.return ((), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+  then
+    Action_builder.return
+      (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
   else
     let* has_virtual_impl =
       Resolve.Memo.read (Compilation_context.has_virtual_impl cctx)
     in
     if has_virtual_impl
-    then Action_builder.return ((), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+    then
+      Action_builder.return
+        (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
     else
       let* lib_index = Resolve.Memo.read (Compilation_context.lib_index cctx) in
       let sandbox = Compilation_context.sandbox cctx in
@@ -184,7 +191,7 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
              ~for_)
       in
       let must_glob_set = Lib.Set.of_list must_glob_libs in
-      let+ tight_set =
+      let* tight_set =
         cross_lib_tight_set ~sandbox ~sctx ~lib_index ~initial_refs:referenced
       in
       (* Classify each lib in [all_libs]:
@@ -193,34 +200,38 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
          - lib has only [Some] entries referenced → per-module deps;
          - lib unreached but tight-eligible → drop (link rule pulls
            it in via [requires_link]);
-         - lib unreached and not tight-eligible → glob. *)
+         - lib unreached and not tight-eligible → glob.
+         [kept_libs] gets every lib that contributes a tight or glob dep — used
+         by [Compilation_context.filtered_include_flags] to scope the
+         consumer's [-I]/[-H] flags. *)
       let { Lib_file_deps.Lib_index.tight = tight_modules; non_tight = non_tight_libs } =
         Lib_file_deps.Lib_index.filter_libs_with_modules
           lib_index
           ~referenced_modules:tight_set
       in
       let non_tight_set = Lib.Set.of_list non_tight_libs in
-      let tight_deps, glob_libs =
-        List.fold_left all_libs ~init:(Dep.Set.empty, []) ~f:(fun (td, gl) lib ->
-          (* [must_glob_set] (alias-reachable libs the walk can't
-             see) and [non_tight_set] (lib has a [None]-entry
-             module reached by the BFS) both force glob. *)
+      let tight_deps, glob_libs, kept_libs =
+        List.fold_left all_libs ~init:(Dep.Set.empty, [], []) ~f:(fun (td, gl, kl) lib ->
           if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
-          then td, lib :: gl
+          then td, lib :: gl, lib :: kl
           else (
             match Lib.Map.find tight_modules lib with
             | Some modules ->
               ( Dep.Set.union
                   td
                   (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
-              , gl )
+              , gl
+              , lib :: kl )
             | None ->
               if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
-              then td, gl
-              else td, lib :: gl))
+              then td, gl, kl
+              else td, lib :: gl, lib :: kl))
       in
       let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
-      (), Dep.Set.union tight_deps glob_deps
+      let+ include_flags =
+        Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
+      in
+      include_flags, Dep.Set.union tight_deps glob_deps
 ;;
 
 let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =
@@ -530,7 +541,9 @@ let build_cm
    in
    let lib_cm_deps =
      if skip_lib_deps
-     then Action_builder.return ()
+     then
+       Action_builder.return
+         (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
      else lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m
    in
    let other_cm_files =
@@ -651,7 +664,6 @@ let build_cm
      ?loc:(Compilation_context.loc cctx)
      (let open Action_builder.With_targets.O in
       Action_builder.with_no_targets other_cm_files
-      >>> Action_builder.with_no_targets lib_cm_deps
       >>> Command.run
             ~dir:(Path.build (Context.build_dir ctx))
             compiler
@@ -660,8 +672,7 @@ let build_cm
             ; cmt_args
             ; cms_args
             ; Command.Args.S obj_dirs
-            ; Command.Args.as_any
-                (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+            ; Command.Args.Dyn lib_cm_deps
             ; extra_args
             ; As as_parameter_arg
             ; as_argument_for
@@ -790,7 +801,6 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
        ~file_targets:[ output ]
        (let open Action_builder.With_targets.O in
         Action_builder.with_no_targets cm_deps
-        >>> Action_builder.with_no_targets lib_cm_deps
         >>> Command.run
               (Ok ocaml.ocamlc)
               ~dir:(Path.build (Context.build_dir ctx))
@@ -798,10 +808,7 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
               [ Command.Args.dyn ocaml_flags
               ; A "-I"
               ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-              ; Command.Args.as_any
-                  (Lib_mode.Cm_kind.Map.get
-                     (Compilation_context.includes cctx)
-                     (Ocaml Cmo))
+              ; Command.Args.Dyn lib_cm_deps
               ; opens modules m
               ; A "-short-paths"
               ; A "-i"

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -211,21 +211,24 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
       in
       let non_tight_set = Lib.Set.of_list non_tight_libs in
       let tight_deps, glob_libs, kept_libs =
-        List.fold_left all_libs ~init:(Dep.Set.empty, [], []) ~f:(fun (td, gl, kl) lib ->
-          if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
-          then td, lib :: gl, lib :: kl
-          else (
-            match Lib.Map.find tight_modules lib with
-            | Some modules ->
-              ( Dep.Set.union
-                  td
-                  (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
-              , gl
-              , lib :: kl )
-            | None ->
-              if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
-              then td, gl, kl
-              else td, lib :: gl, lib :: kl))
+        List.fold_left
+          all_libs
+          ~init:(Dep.Set.empty, [], Lib.Set.empty)
+          ~f:(fun (td, gl, kl) lib ->
+            if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
+            then td, lib :: gl, Lib.Set.add kl lib
+            else (
+              match Lib.Map.find tight_modules lib with
+              | Some modules ->
+                ( Dep.Set.union
+                    td
+                    (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
+                , gl
+                , Lib.Set.add kl lib )
+              | None ->
+                if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
+                then td, gl, kl
+                else td, lib :: gl, Lib.Set.add kl lib))
       in
       let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
       let+ include_flags =

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
@@ -1,20 +1,17 @@
-Observational baseline: adding a library to a stanza's
-[(libraries ...)] list currently rebuilds every module in the
-stanza, including modules that reference nothing from the new
-library. The [-I]/[-H] flags on each module's compiler invocation
-are derived from the cctx-wide library list rather than from the
-module's own ocamldep reference set, so adding an unreferenced
-library still changes every consumer's compile-action hash and
-invalidates the rule cache.
+Adding a library to a stanza's [(libraries ...)] list does not
+rebuild stanza modules that reference nothing from the new
+library. The per-module [-I]/[-H] include filter narrows each
+module's compile-action hash to the libraries its ocamldep
+reference set actually reaches, so an unreferenced added lib
+leaves every other consumer's cache key unchanged.
 
 [consumer_lib] starts with [(libraries existing_dep)] and two
 modules: [consumes_dep] references [Existing_dep_module];
 [unrelated_module] references nothing from [existing_dep] or any
 other library. After the initial build, [added_lib] is added to
 the stanza's [(libraries ...)] list. Neither [consumes_dep] nor
-[unrelated_module] uses anything from [added_lib], yet both
-rebuild. Records the rebuild counts on each so a future change
-can flip them to 0.
+[unrelated_module] uses anything from [added_lib], so neither
+rebuilds — the trace shows empty target lists for both.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -72,22 +69,6 @@ Add [added_lib] to [consumer_lib]'s [(libraries ...)]. Neither
 
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumes_dep"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmi",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmo",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmt"
-      ]
-    }
-  ]
+  []
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("unrelated_module"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmi",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmo",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmt"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
@@ -1,15 +1,12 @@
-Observational baseline: a consumer module's compile command
-currently carries [-I] flags for every library in the cctx-wide
-[(libraries ...)] closure, regardless of which libraries the
-module's source actually references.
+A consumer module's compile command carries [-I] flags only for
+the libraries its ocamldep reference set actually reaches, not
+for every library in the cctx-wide [(libraries ...)] closure.
 
 [consumer_lib] declares two library dependencies, [dep_lib] and
 [unrelated_lib], but its only module references just [Dep_module].
-A future per-module filter could observe via ocamldep that the
-module references nothing from [unrelated_lib] and drop that
-library's objdir from the [-I] path. This test records today's
-[-I] contents so that a future filter improvement can flip the
-asserted array to a single entry.
+The per-module filter observes via ocamldep that the module
+references nothing from [unrelated_lib] and drops that library's
+objdir from the [-I] path; only [dep_lib]'s objdir survives.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
@@ -40,12 +37,10 @@ asserted array to a single entry.
 Inspect the [-I] flags on [consumer_module]'s [.cmo] compile rule.
 Filter to objdir-shaped paths so we don't print the consumer's
 own [.consumer_lib.objs/byte] entry — that's always present and
-not what this test is about. Today both [dep_lib]'s objdir and
-[unrelated_lib]'s objdir appear:
+not what this test is about. Only [dep_lib]'s objdir appears:
 
   $ dune rules --root . --format=json _build/default/.consumer_lib.objs/byte/consumer_module.cmo \
   > | jq 'include "dune"; .[] | [ruleActionFlagValues("-I") | select(test("\\.dep_lib\\.objs|\\.unrelated_lib\\.objs"))]'
   [
-    ".dep_lib.objs/byte",
-    ".unrelated_lib.objs/byte"
+    ".dep_lib.objs/byte"
   ]


### PR DESCRIPTION
Follow-up to #14472. Narrows the `-I`/`-H` compiler flags per module to match the per-module dependency-filter result. Previously #14472 narrowed only the rule's `Hidden_deps`; the compiler invocation still used the cctx-wide `direct_requires`/`hidden_requires` paths.

## Why

Two consequences of leaving `-I`/`-H` cctx-wide:

1. **Soundness gap**: a missing entry in the per-module dep set is silently masked because `ocamlc` can still resolve the symbol via a too-wide `-I` path. With per-module narrowing, a wrong filter produces a compile error rather than a silent success.

2. **Cache-key bloat**: adding a library to a stanza changed every consumer's compile-rule cache key (the `-I` list grew), invalidating modules that don't actually reference the new lib.

## How

The existing per-module reference set computed in `lib_deps_for_module` (`module_compilation.ml`) already partitions each cctx library into one of three buckets: `tight_modules` (specific module references), tight-eligible-unreached (drop), and `glob_libs` (fall back to glob). The kept libs — those with tight entries or in `glob_libs` — are then filtered against the cctx's `requires_compile` and `requires_hidden` to preserve the direct/hidden classification per lib, and `Lib_flags.L.include_flags` produces the per-module `Includes.t` spliced into the compile command via `Args.Dyn` in place of the previous cctx-wide injection.

## Fallbacks

When the dep filter falls back, so do the include flags: `can_filter` false (Melange, dummy dep_graph, non-filterable module kind, virtual-impl consumer), `has_virtual_impl` true on deps, or `skip_lib_deps` (Alias-not-stdlib, Wrapped_compat) — all return the cctx-wide `Includes.t` for the cm_kind.

One additional fallback applies to preprocessed dep modules. The cross-lib walker (`cross_lib_tight_set`) cannot run ocamldep on a foreign lib's pre-pp source, so it stops at any dep whose entry module is preprocessed. The walker reports those stopped libs and the caller takes their `Lib.closure`, which splits two ways:

- **The pp-stopped libs themselves stay on the tight per-module path.** The consumer's own ocamldep names which modules in such a lib it references, so specific `.cmi` deps suffice — no broadening of the rule's file-dep set for them.
- **Their transitive closure** (libs reachable only through a pp-stopped entry's `.cmi`) goes through `must_glob_set`, since the walker cannot observe types those entries re-export.

Both groups stay in `kept_libs` so their `-I`/`-H` survive the per-module include filter. Test: `per-module-lib-deps/cross-lib-walk-pre-pp-implicit-transitive.t`.

## Tests

The commit promotes two observational baselines that already lived on `main` to reflect the new behavior:

- `per-module-lib-deps/per-module-include-flags.t`: `consumer_module`'s compile-rule `-I` flags now list only `.dep_lib.objs/byte` (was also listing `.unrelated_lib.objs/byte`).

- `per-module-lib-deps/add-unreferenced-sibling-lib.t`: rebuild lists for `consumes_dep` and `unrelated_module` are now `[]` (was one rule each), recording that adding an unreferenced library to a stanza's `(libraries ...)` no longer rebuilds modules that don't reference it.

See: https://github.com/ocaml/dune/pull/14116#discussion_r3142443361
