### PR TITLE
test(top-module): reproduce over-rebuild on unreferenced lib's .mli change

### DIFF
--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -65,7 +65,7 @@ mentions [Dep_for_impl].
 
 Initial regular build, then [dune ocaml top-module mylib/m.ml]:
 
-  $ dune build @check 2>&1 | head -5
+  $ dune build @check
   $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
   $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > before-impl-edit.mtime
 

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -1,24 +1,20 @@
 Reproduction: `dune ocaml top-module` over-rebuilds when an
-unreferenced library's interface changes.
+unreferenced library's interface changes. The test passes while
+the bug is present; promote when fixed.
 
-[top_module.ml] derives a cctx via [Compilation_context.set_obj_dir]
-to a private obj_dir, then calls [Module_compilation.build_module] on
-a module value with [.mli] dropped via
-[Module.set_source ~ml_kind:Intf None]. The derived cctx's compile
-rule pulls cmi-deps from the parent library's full [(libraries ...)]
-closure rather than from the actual references in [.ml] alone, so
-editing any [(libraries ...)] dep's interface triggers a rebuild —
-even libraries referenced ONLY from the (dropped) [.mli].
+`dune ocaml top-module` synthesises a compile for `m.ml` with the
+`.mli` dropped, so only `m.ml`'s actual references should drive
+the cmi-deps. Instead, the cmi-deps come from the parent library's
+full `(libraries ...)` closure, so editing any of those deps'
+interfaces triggers a rebuild — even libraries referenced ONLY
+from the (dropped) `.mli`.
 
-This test pins the current behaviour. A future change that filters
-[top_module]'s compile-rule cmi-deps to match the [.ml]'s actual
-references would flip the final assertion from REBUILT to
-NOT REBUILT, and the test would need promotion.
+Code under test: `src/dune_rules/top_module.ml`.
 
   $ make_dune_project 3.24
 
-[dep_for_intf] is referenced from [m.mli] only. [m.ml] never
-mentions [Dep_for_intf].
+`dep_for_intf` is referenced from `m.mli` only. `m.ml` never
+mentions `Dep_for_intf`.
 
   $ mkdir dep_for_intf
   $ cat > dep_for_intf/dune <<EOF
@@ -31,8 +27,8 @@ mentions [Dep_for_intf].
   > type t = int
   > EOF
 
-[dep_for_impl] is referenced from [m.ml] only. [m.mli] never
-mentions [Dep_for_impl].
+`dep_for_impl` is referenced from `m.ml` only. `m.mli` never
+mentions `Dep_for_impl`.
 
   $ mkdir dep_for_impl
   $ cat > dep_for_impl/dune <<EOF
@@ -45,9 +41,9 @@ mentions [Dep_for_impl].
   > val value : int
   > EOF
 
-[mylib] declares both libraries in [(libraries ...)] but module
-[m] splits them: [.ml] uses only [Dep_for_impl]; [.mli] uses only
-[Dep_for_intf].
+`mylib` declares both libraries in `(libraries ...)` but module
+`m` splits them: `.ml` uses only `Dep_for_impl`; `.mli` uses only
+`Dep_for_intf`.
 
   $ mkdir mylib
   $ cat > mylib/dune <<EOF
@@ -59,18 +55,18 @@ mentions [Dep_for_impl].
   > val tag : Dep_for_intf.t
   > EOF
   $ cat > mylib/m.ml <<EOF
-  > let _ = Dep_for_impl.value
-  > let tag = 42
+  > let tag = Dep_for_impl.value
   > EOF
 
-Initial regular build, then [dune ocaml top-module mylib/m.ml]:
+Initial regular build, then `dune ocaml top-module mylib/m.ml`:
 
   $ dune build @check
   $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
 
-Control: edit [dep_for_impl]'s cmi (referenced from [m.ml]). The
-top-module compile rebuilds — expected. The trace contains the
-[mylib__M.cmo] build action.
+Control: change `dep_for_impl`'s `.mli` (the matching `.ml` change
+ensures the package builds). `m.ml` references `Dep_for_impl.value`,
+so its top-module compile depends on `dep_for_impl.cmi`. Rebuild
+expected. The trace contains the `mylib__M.cmo` build action.
 
   $ cat > dep_for_impl/dep_for_impl.ml <<EOF
   > let value = 7
@@ -90,10 +86,11 @@ top-module compile rebuilds — expected. The trace contains the
     }
   ]
 
-Probe: edit [dep_for_intf]'s cmi (NOT referenced from [m.ml] — the
-only reference was in the discarded [m.mli]). The top-module
-compile rebuilds despite the absence of any actual reference; this
-is the over-invalidation under observation.
+Probe: change `dep_for_intf`'s `.mli` (the matching `.ml` change
+ensures the package builds). `m.ml` never references
+`Dep_for_intf` — the only reference was in the discarded
+`m.mli`. The top-module compile rebuilds anyway; this is the
+over-invalidation.
 
   $ cat > dep_for_intf/dep_for_intf.ml <<EOF
   > type t = int

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -15,9 +15,7 @@ This test pins the current behaviour. A future change that filters
 references would flip the final assertion from REBUILT to
 NOT REBUILT, and the test would need promotion.
 
-  $ cat > dune-project <<EOF
-  > (lang dune 3.23)
-  > EOF
+  $ make_dune_project 3.24
 
 [dep_for_intf] is referenced from [m.mli] only. [m.ml] never
 mentions [Dep_for_intf].

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -67,10 +67,10 @@ Initial regular build, then [dune ocaml top-module mylib/m.ml]:
 
   $ dune build @check
   $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
-  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > before-impl-edit.mtime
 
 Control: edit [dep_for_impl]'s cmi (referenced from [m.ml]). The
-top-module compile rebuilds — expected.
+top-module compile rebuilds — expected. The trace contains the
+[mylib__M.cmo] build action.
 
   $ cat > dep_for_impl/dep_for_impl.ml <<EOF
   > let value = 7
@@ -80,15 +80,19 @@ top-module compile rebuilds — expected.
   > val value : int
   > val extra : string
   > EOF
-  $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
-  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > after-impl-edit.mtime
-  $ if [ "$(cat before-impl-edit.mtime)" != "$(cat after-impl-edit.mtime)" ]; then echo "REBUILT"; else echo "NOT REBUILT"; fi
-  REBUILT
-  $ cp after-impl-edit.mtime before-intf-edit.mtime
+  $ dune ocaml top-module mylib/m.ml --trace-file=_build/trace-impl.csexp > /dev/null 2>&1
+  $ dune trace cat --trace-file=_build/trace-impl.csexp | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.topmod/mylib/m\\.ml/mylib__M\\.cmo$"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.topmod/mylib/m.ml/mylib__M.cmo"
+      ]
+    }
+  ]
 
 Probe: edit [dep_for_intf]'s cmi (NOT referenced from [m.ml] — the
 only reference was in the discarded [m.mli]). The top-module
-compile rebuilds despite the absence of any actual reference. This
+compile rebuilds despite the absence of any actual reference; this
 is the over-invalidation under observation.
 
   $ cat > dep_for_intf/dep_for_intf.ml <<EOF
@@ -99,7 +103,12 @@ is the over-invalidation under observation.
   > type t = int
   > val zero : t
   > EOF
-  $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
-  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > after-intf-edit.mtime
-  $ if [ "$(cat before-intf-edit.mtime)" != "$(cat after-intf-edit.mtime)" ]; then echo "REBUILT"; else echo "NOT REBUILT"; fi
-  REBUILT
+  $ dune ocaml top-module mylib/m.ml --trace-file=_build/trace-intf.csexp > /dev/null 2>&1
+  $ dune trace cat --trace-file=_build/trace-intf.csexp | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.topmod/mylib/m\\.ml/mylib__M\\.cmo$"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.topmod/mylib/m.ml/mylib__M.cmo"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -1,0 +1,105 @@
+Observational baseline: [dune ocaml top-module] over-invalidates the
+top-module compile when an unreferenced library's interface changes.
+
+[top_module.ml] derives a cctx via [Compilation_context.set_obj_dir]
+to a private obj_dir, then calls [Module_compilation.build_module] on
+a module value with [.mli] dropped via
+[Module.set_source ~ml_kind:Intf None]. The derived cctx's compile
+rule pulls cmi-deps from the parent library's full [(libraries ...)]
+closure rather than from the actual references in [.ml] alone, so
+editing any [(libraries ...)] dep's interface triggers a rebuild —
+even libraries referenced ONLY from the (dropped) [.mli].
+
+This test pins the current behaviour. A future change that filters
+[top_module]'s compile-rule cmi-deps to match the [.ml]'s actual
+references would flip the final assertion from REBUILT to
+NOT REBUILT, and the test would need promotion.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[dep_for_intf] is referenced from [m.mli] only. [m.ml] never
+mentions [Dep_for_intf].
+
+  $ mkdir dep_for_intf
+  $ cat > dep_for_intf/dune <<EOF
+  > (library (name dep_for_intf))
+  > EOF
+  $ cat > dep_for_intf/dep_for_intf.ml <<EOF
+  > type t = Tag
+  > EOF
+  $ cat > dep_for_intf/dep_for_intf.mli <<EOF
+  > type t = Tag
+  > EOF
+
+[dep_for_impl] is referenced from [m.ml] only. [m.mli] never
+mentions [Dep_for_impl].
+
+  $ mkdir dep_for_impl
+  $ cat > dep_for_impl/dune <<EOF
+  > (library (name dep_for_impl))
+  > EOF
+  $ cat > dep_for_impl/dep_for_impl.ml <<EOF
+  > let value = 7
+  > EOF
+  $ cat > dep_for_impl/dep_for_impl.mli <<EOF
+  > val value : int
+  > EOF
+
+[mylib] declares both libraries in [(libraries ...)] but module
+[m] splits them: [.ml] uses only [Dep_for_impl]; [.mli] uses only
+[Dep_for_intf].
+
+  $ mkdir mylib
+  $ cat > mylib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (libraries dep_for_intf dep_for_impl))
+  > EOF
+  $ cat > mylib/m.mli <<EOF
+  > val tag : Dep_for_intf.t
+  > EOF
+  $ cat > mylib/m.ml <<EOF
+  > let _ = Dep_for_impl.value
+  > let tag = Dep_for_intf.Tag
+  > EOF
+
+Initial regular build, then [dune ocaml top-module mylib/m.ml]:
+
+  $ dune build @check 2>&1 | head -5
+  $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
+  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > before-impl-edit.mtime
+
+Control: edit [dep_for_impl]'s cmi (referenced from [m.ml]). The
+top-module compile rebuilds — expected.
+
+  $ cat > dep_for_impl/dep_for_impl.ml <<EOF
+  > let value = 7
+  > let extra = "x"
+  > EOF
+  $ cat > dep_for_impl/dep_for_impl.mli <<EOF
+  > val value : int
+  > val extra : string
+  > EOF
+  $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
+  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > after-impl-edit.mtime
+  $ if [ "$(cat before-impl-edit.mtime)" != "$(cat after-impl-edit.mtime)" ]; then echo "REBUILT"; else echo "NOT REBUILT"; fi
+  REBUILT
+  $ cp after-impl-edit.mtime before-intf-edit.mtime
+
+Probe: edit [dep_for_intf]'s cmi (NOT referenced from [m.ml] — the
+only reference was in the discarded [m.mli]). The top-module
+compile rebuilds despite the absence of any actual reference. This
+is the over-invalidation under observation.
+
+  $ cat > dep_for_intf/dep_for_intf.ml <<EOF
+  > type t = Tag | Other
+  > EOF
+  $ cat > dep_for_intf/dep_for_intf.mli <<EOF
+  > type t = Tag | Other
+  > EOF
+  $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
+  $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > after-intf-edit.mtime
+  $ if [ "$(cat before-intf-edit.mtime)" != "$(cat after-intf-edit.mtime)" ]; then echo "REBUILT"; else echo "NOT REBUILT"; fi
+  REBUILT

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -25,10 +25,10 @@ mentions [Dep_for_intf].
   > (library (name dep_for_intf))
   > EOF
   $ cat > dep_for_intf/dep_for_intf.ml <<EOF
-  > type t = Tag
+  > type t = int
   > EOF
   $ cat > dep_for_intf/dep_for_intf.mli <<EOF
-  > type t = Tag
+  > type t = int
   > EOF
 
 [dep_for_impl] is referenced from [m.ml] only. [m.mli] never
@@ -60,7 +60,7 @@ mentions [Dep_for_impl].
   > EOF
   $ cat > mylib/m.ml <<EOF
   > let _ = Dep_for_impl.value
-  > let tag = Dep_for_intf.Tag
+  > let tag = 42
   > EOF
 
 Initial regular build, then [dune ocaml top-module mylib/m.ml]:
@@ -92,10 +92,12 @@ compile rebuilds despite the absence of any actual reference. This
 is the over-invalidation under observation.
 
   $ cat > dep_for_intf/dep_for_intf.ml <<EOF
-  > type t = Tag | Other
+  > type t = int
+  > let zero = 0
   > EOF
   $ cat > dep_for_intf/dep_for_intf.mli <<EOF
-  > type t = Tag | Other
+  > type t = int
+  > val zero : t
   > EOF
   $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
   $ stat -c '%y' _build/default/.topmod/mylib/m.ml/mylib__M.cmo > after-intf-edit.mtime

--- a/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
+++ b/test/blackbox-tests/test-cases/top-module/cctx-wide-cmi-deps.t
@@ -1,5 +1,5 @@
-Observational baseline: [dune ocaml top-module] over-invalidates the
-top-module compile when an unreferenced library's interface changes.
+Reproduction: `dune ocaml top-module` over-rebuilds when an
+unreferenced library's interface changes.
 
 [top_module.ml] derives a cctx via [Compilation_context.set_obj_dir]
 to a private obj_dir, then calls [Module_compilation.build_module] on

--- a/test/blackbox-tests/test-cases/top-module/over-rebuild-from-intf-only-dep.t
+++ b/test/blackbox-tests/test-cases/top-module/over-rebuild-from-intf-only-dep.t
@@ -22,6 +22,7 @@ mentions `Dep_for_intf`.
   > EOF
   $ cat > dep_for_intf/dep_for_intf.ml <<EOF
   > type t = int
+  > let zero = 0
   > EOF
   $ cat > dep_for_intf/dep_for_intf.mli <<EOF
   > type t = int
@@ -36,6 +37,7 @@ mentions `Dep_for_impl`.
   > EOF
   $ cat > dep_for_impl/dep_for_impl.ml <<EOF
   > let value = 7
+  > let extra = "x"
   > EOF
   $ cat > dep_for_impl/dep_for_impl.mli <<EOF
   > val value : int
@@ -63,15 +65,11 @@ Initial regular build, then `dune ocaml top-module mylib/m.ml`:
   $ dune build @check
   $ dune ocaml top-module mylib/m.ml > /dev/null 2>&1
 
-Control: change `dep_for_impl`'s `.mli` (the matching `.ml` change
-ensures the package builds). `m.ml` references `Dep_for_impl.value`,
-so its top-module compile depends on `dep_for_impl.cmi`. Rebuild
-expected. The trace contains the `mylib__M.cmo` build action.
+Control: edit `dep_for_impl`'s `.mli` to expose `extra`. `m.ml`
+references `Dep_for_impl.value`, so its top-module compile depends
+on `dep_for_impl.cmi`. Rebuild expected. The trace contains the
+`mylib__M.cmo` build action.
 
-  $ cat > dep_for_impl/dep_for_impl.ml <<EOF
-  > let value = 7
-  > let extra = "x"
-  > EOF
   $ cat > dep_for_impl/dep_for_impl.mli <<EOF
   > val value : int
   > val extra : string
@@ -86,16 +84,11 @@ expected. The trace contains the `mylib__M.cmo` build action.
     }
   ]
 
-Probe: change `dep_for_intf`'s `.mli` (the matching `.ml` change
-ensures the package builds). `m.ml` never references
-`Dep_for_intf` — the only reference was in the discarded
-`m.mli`. The top-module compile rebuilds anyway; this is the
-over-invalidation.
+Probe: edit `dep_for_intf`'s `.mli` to expose `zero`. `m.ml` never
+references `Dep_for_intf` — the only reference was in the
+discarded `m.mli`. The top-module compile rebuilds anyway; this is
+the over-invalidation.
 
-  $ cat > dep_for_intf/dep_for_intf.ml <<EOF
-  > type t = int
-  > let zero = 0
-  > EOF
   $ cat > dep_for_intf/dep_for_intf.mli <<EOF
   > type t = int
   > val zero : t


### PR DESCRIPTION
## Summary

Adds a regression test under `test/blackbox-tests/test-cases/top-module/` that reproduces a `dune ocaml top-module` over-rebuild: editing the interface of a library referenced only from `.mli` (never from `.ml`) rebuilds the top-module artefact, even though `top-module` drops the `.mli`. The test passes today while the bug is present.

Related: #14477.