### PR TITLE
test: regression guard for menhir mock-compile + sibling-module incremental rebuild on lib-cmi change

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
@@ -1,0 +1,116 @@
+Regression guard for menhir mock-compile and sibling module
+incremental rebuild when a sibling library's interface changes.
+
+When a library declares a menhir grammar whose semantic action
+references types or values from a [(libraries ...)] dep, dune emits
+two compile rules whose deps cover that library's cmis: menhir's
+[--infer] mock-compile (which runs [ocamlc -i] on a generated mock
+module to type-check the grammar's semantic actions) and the regular
+sibling-module compile that also references the dep. Both rules
+must invalidate when the dep's interface changes.
+
+This test pins the property. The menhir mock-compile path
+([menhir_rules.ml]) derives a sandboxed cctx via
+[Compilation_context.set_sandbox]; if a future change to the
+dep-graph machinery weakens cross-rule invalidation along that path
+(e.g., by sharing cached dep-info builders across cctxs in a
+sandbox-dependent way), this test surfaces the regression.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > (using menhir 3.0)
+  > EOF
+
+[dep] is a sibling library exposing a value the parent library's
+menhir grammar will reference.
+
+  $ mkdir dep
+  $ cat > dep/dune <<EOF
+  > (library (name dep))
+  > EOF
+  $ cat > dep/dep.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > dep/dep.mli <<EOF
+  > val value : int
+  > EOF
+
+[parser]: a library with a menhir grammar whose semantic action
+references [Dep.value], plus a sibling module [helper] that also
+references [Dep.value].
+
+  $ mkdir parser
+  $ cat > parser/dune <<EOF
+  > (library
+  >  (name parser)
+  >  (libraries dep))
+  > (menhir (modules grammar))
+  > EOF
+  $ cat > parser/grammar.mly <<EOF
+  > %token EOF
+  > %start <int> main
+  > %%
+  > main: EOF { Dep.value }
+  > EOF
+  $ cat > parser/helper.ml <<EOF
+  > let echo () = Dep.value
+  > EOF
+  $ cat > parser/helper.mli <<EOF
+  > val echo : unit -> int
+  > EOF
+
+Initial build.
+
+  $ dune build @check 2>&1 | head -20
+
+The mock-compile invocation is recognisable by [-i] in its argv;
+its target is [grammar__mock.mli.inferred]. The presence of this
+event positively asserts the [--infer] code path ran. The mock's
+[-I] path includes [dep]'s objdir, so the grammar's semantic action
+type-checks against [dep]:
+
+  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | {target: .target_files[0], dep_in_args: (.process_args | any(. == "dep/.dep.objs/byte"))}]'
+  [
+    {
+      "target": "_build/default/parser/grammar__mock.mli.inferred",
+      "dep_in_args": true
+    }
+  ]
+
+Modify [dep]'s interface (add a value). Both consumers — the
+menhir mock-compile and [helper]'s [.cmo] — must invalidate.
+
+  $ cat > dep/dep.mli <<EOF
+  > val value : int
+  > val extra : string
+  > EOF
+  $ cat > dep/dep.ml <<EOF
+  > let value = 42
+  > let extra = "x"
+  > EOF
+
+Second build. Assert independently that each of the two
+invariants holds: the menhir mock-compile rebuilt, and the helper
+[.cmo] rebuilt. The test stays robust whether other helper
+artefacts (cmi/cmti) also rebuild — that is governed by
+cctx-wide-vs-per-module dep filtering and isn't the property
+under guard here.
+
+  $ dune build @check 2>&1 | head -20
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("grammar__mock\\.mli\\.inferred"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/parser/grammar__mock.mli.inferred"
+      ]
+    }
+  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("/parser__Helper\\.cmo$"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/parser/.parser.objs/byte/parser__Helper.cmo",
+        "_build/default/parser/.parser.objs/byte/parser__Helper.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
@@ -65,16 +65,23 @@ Initial build.
 
 The mock-compile invocation is recognisable by [-i] in its argv;
 its target is [grammar__mock.mli.inferred]. The presence of this
-event positively asserts the [--infer] code path ran. The mock's
-[-I] path includes [dep]'s objdir, so the grammar's semantic action
-type-checks against [dep]:
+event positively asserts the [--infer] code path ran:
 
-  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | {target: .target_files[0], dep_in_args: (.process_args | any(. == "dep/.dep.objs/byte"))}]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .target_files]'
   [
-    {
-      "target": "_build/default/parser/grammar__mock.mli.inferred",
-      "dep_in_args": true
-    }
+    [
+      "_build/default/parser/grammar__mock.mli.inferred"
+    ]
+  ]
+
+The mock's [-I] path includes [dep]'s objdir, so the grammar's
+semantic action type-checks against [dep]:
+
+  $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .process_args | [.[] | select(startswith("dep/"))]]'
+  [
+    [
+      "dep/.dep.objs/byte"
+    ]
   ]
 
 Modify [dep]'s interface (add a value). Both consumers — the

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
@@ -80,6 +80,13 @@ semantic action type-checks against `dep`:
     ]
   ]
 
+The mock-compile rule's declared dep set (no `%{...}` variable
+resolves the menhir-generated mock target, hence the literal path):
+
+  $ dune rules --root . --format=json --deps _build/default/parser/grammar__mock.mli.inferred |
+  > jq -r 'include "dune"; .[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
+  In_build_dir _build/default/dep/.dep.objs/byte *.cmi
+
 Case 2: editing `dep`'s `.mli` to expose `extra` must invalidate
 both consumers — the menhir mock-compile and `helper`'s `.cmo`.
 The `.ml` already carries `extra`, so this is an interface-only

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t
@@ -2,45 +2,40 @@ Regression guard for menhir mock-compile and sibling module
 incremental rebuild when a sibling library's interface changes.
 
 When a library declares a menhir grammar whose semantic action
-references types or values from a [(libraries ...)] dep, dune emits
+references types or values from a `(libraries ...)` dep, dune emits
 two compile rules whose deps cover that library's cmis: menhir's
-[--infer] mock-compile (which runs [ocamlc -i] on a generated mock
+`--infer` mock-compile (which runs `ocamlc -i` on a generated mock
 module to type-check the grammar's semantic actions) and the regular
 sibling-module compile that also references the dep. Both rules
 must invalidate when the dep's interface changes.
 
-This test pins the property. The menhir mock-compile path
-([menhir_rules.ml]) derives a sandboxed cctx via
-[Compilation_context.set_sandbox]; if a future change to the
-dep-graph machinery weakens cross-rule invalidation along that path
-(e.g., by sharing cached dep-info builders across cctxs in a
-sandbox-dependent way), this test surfaces the regression.
+Code under test: `src/dune_rules/menhir/menhir_rules.ml`.
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.23)
+  > (lang dune 3.24)
   > (using menhir 3.0)
   > EOF
 
-[dep] is a sibling library exposing a value the parent library's
-menhir grammar will reference.
+`dep` is a sibling library exposing a value the parent library's
+menhir grammar will reference. `dep.ml` carries both `value` and
+`extra` from the start so the `.mli` edit step is interface-only.
 
-  $ mkdir dep
-  $ cat > dep/dune <<EOF
+  $ make_dir_with_dune dep <<EOF
   > (library (name dep))
   > EOF
   $ cat > dep/dep.ml <<EOF
   > let value = 42
+  > let extra = "x"
   > EOF
   $ cat > dep/dep.mli <<EOF
   > val value : int
   > EOF
 
-[parser]: a library with a menhir grammar whose semantic action
-references [Dep.value], plus a sibling module [helper] that also
-references [Dep.value].
+`parser`: a library with a menhir grammar whose semantic action
+references `Dep.value`, plus a sibling module `helper` that also
+references `Dep.value`.
 
-  $ mkdir parser
-  $ cat > parser/dune <<EOF
+  $ make_dir_with_dune parser <<EOF
   > (library
   >  (name parser)
   >  (libraries dep))
@@ -61,11 +56,12 @@ references [Dep.value].
 
 Initial build.
 
-  $ dune build @check 2>&1 | head -20
+  $ dune build @check
 
-The mock-compile invocation is recognisable by [-i] in its argv;
-its target is [grammar__mock.mli.inferred]. The presence of this
-event positively asserts the [--infer] code path ran:
+Case 1: the mock-compile ran. The invocation is recognisable by
+`-i` in its argv; its target is `grammar__mock.mli.inferred`. The
+presence of this event positively asserts the `--infer` code path
+ran:
 
   $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .target_files]'
   [
@@ -74,8 +70,8 @@ event positively asserts the [--infer] code path ran:
     ]
   ]
 
-The mock's [-I] path includes [dep]'s objdir, so the grammar's
-semantic action type-checks against [dep]:
+The mock's `-I` path includes `dep`'s objdir, so the grammar's
+semantic action type-checks against `dep`:
 
   $ dune trace cat | jq -s 'include "dune"; [.[] | progMatching("ocamlc") | select(.process_args | index("-i") != null) | .process_args | [.[] | select(startswith("dep/"))]]'
   [
@@ -84,26 +80,24 @@ semantic action type-checks against [dep]:
     ]
   ]
 
-Modify [dep]'s interface (add a value). Both consumers — the
-menhir mock-compile and [helper]'s [.cmo] — must invalidate.
+Case 2: editing `dep`'s `.mli` to expose `extra` must invalidate
+both consumers — the menhir mock-compile and `helper`'s `.cmo`.
+The `.ml` already carries `extra`, so this is an interface-only
+edit.
 
   $ cat > dep/dep.mli <<EOF
   > val value : int
   > val extra : string
   > EOF
-  $ cat > dep/dep.ml <<EOF
-  > let value = 42
-  > let extra = "x"
-  > EOF
 
 Second build. Assert independently that each of the two
 invariants holds: the menhir mock-compile rebuilt, and the helper
-[.cmo] rebuilt. The test stays robust whether other helper
+`.cmo` rebuilt. The test stays robust whether other helper
 artefacts (cmi/cmti) also rebuild — that is governed by
 cctx-wide-vs-per-module dep filtering and isn't the property
 under guard here.
 
-  $ dune build @check 2>&1 | head -20
+  $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("grammar__mock\\.mli\\.inferred"))]'
   [
     {


### PR DESCRIPTION
## Summary

Adds `test/blackbox-tests/test-cases/per-module-lib-deps/menhir-incremental-lib-cmi.t`, a regression guard for two incremental-rebuild invariants on a library that combines a menhir grammar with a sibling module, both referencing types/values from a `(libraries ...)` dep:

1. The menhir `--infer` mock-compile (`grammar__mock.mli.inferred`) rebuilds when the dep's `.cmi` changes.
2. The sibling module's `.cmo` rebuilds when the dep's `.cmi` changes.

The mock-compile path (`menhir_rules.ml`) derives a sandboxed cctx via `Compilation_context.set_sandbox` for the `ocamlc -i` action. The test asserts the two invariants independently and does not pin the full set of rebuilt artefacts, so it stays robust under cctx-wide-vs-per-module dep filtering.
