### PR TITLE
Remove Signal Watching Thread

### DIFF
--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -160,8 +160,7 @@ module Dune_config : sig
   val hash : t -> int
   val equal : t -> t -> bool
 
-  (** [for_scheduler config ?watch_exclusions stats_opt ~signal_watcher]
-      creates a configuration for a scheduler from the user-visible Dune
+  (** Creates a configuration for a scheduler from the user-visible Dune
       [config]. *)
   val for_scheduler
     :  t

--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -2,6 +2,9 @@
  (name dune_scheduler)
  (library_flags
   (:include flags/sexp))
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
  (foreign_stubs
   (language c)
   (names fsevents_stubs fswatch_win_stubs))

--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -7,7 +7,7 @@
   (pps ppx_expect))
  (foreign_stubs
   (language c)
-  (names fsevents_stubs fswatch_win_stubs))
+  (names fsevents_stubs fswatch_win_stubs signal_watcher_stubs))
  (libraries
   ocaml_inotify
   lev

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -42,7 +42,7 @@ module Queue = struct
     ; mutable invalidation_events : Invalidation_event.t list
     ; mutable shutdown_reasons : Shutdown.Reason.Set.t
     ; mutex : Mutex.t
-    ; cond : Condition.t
+    ; wakeup : Semaphore.Binary.t
     ; mutable pending_jobs : int
     ; mutable pending_worker_tasks : int
     ; mutable job_complete_ready : bool
@@ -65,7 +65,7 @@ module Queue = struct
     let invalidation_events = [] in
     let shutdown_reasons = Shutdown.Reason.Set.empty in
     let mutex = Mutex.create () in
-    let cond = Condition.create () in
+    let wakeup = Semaphore.Binary.make false in
     let pending_jobs = 0 in
     let pending_worker_tasks = 0 in
     { jobs_completed
@@ -73,7 +73,7 @@ module Queue = struct
     ; invalidation_events
     ; shutdown_reasons
     ; mutex
-    ; cond
+    ; wakeup
     ; pending_jobs
     ; worker_tasks_completed
     ; pending_worker_tasks
@@ -97,13 +97,12 @@ module Queue = struct
   let cancel_work_task_started q = q.pending_worker_tasks <- q.pending_worker_tasks - 1
 
   let add_event q f =
-    Mutex.lock q.mutex;
-    f q;
-    if not q.got_event
-    then (
-      q.got_event <- true;
-      Condition.signal q.cond);
-    Mutex.unlock q.mutex
+    Mutex.protect q.mutex (fun () ->
+      f q;
+      if not q.got_event
+      then (
+        q.got_event <- true;
+        Semaphore.Binary.release q.wakeup))
   ;;
 
   let yield_if_there_are_pending_events q =
@@ -232,8 +231,15 @@ module Queue = struct
       | None -> wait ()
       | Some event -> event
     and wait () =
+      (* Keep a single pending wakeup for any number of events. A binary
+         semaphore preserves that coalescing across producer threads. The token
+         can be stale when the scheduler drained events without blocking, so
+         consume it before waiting for the next event. *)
       q.got_event <- false;
-      Condition.wait q.cond q.mutex;
+      ignore (Semaphore.Binary.try_acquire q.wakeup : bool);
+      Mutex.unlock q.mutex;
+      Semaphore.Binary.acquire q.wakeup;
+      Mutex.lock q.mutex;
       loop ()
     in
     let ev = loop () in
@@ -283,4 +289,34 @@ module Queue = struct
 
   let pending_jobs q = q.pending_jobs
   let pending_worker_tasks q = q.pending_worker_tasks
+
+  let%expect_test "wakeup is coalesced while an event is pending" =
+    let q = create () in
+    let print_wakeup label =
+      Printf.printf "%s: %b\n" label (Semaphore.Binary.try_acquire q.wakeup)
+    in
+    let print_next () =
+      match next q with
+      | Shutdown Requested -> print_endline "requested"
+      | Shutdown Timeout -> print_endline "timeout"
+      | _ -> print_endline "unexpected"
+    in
+    print_wakeup "initial";
+    send_shutdown q Requested;
+    send_shutdown q Timeout;
+    print_wakeup "after two events";
+    print_wakeup "after consuming token";
+    print_next ();
+    print_next ();
+    print_wakeup "after draining events";
+    [%expect
+      {|
+      initial: false
+      after two events: true
+      after consuming token: false
+      requested
+      timeout
+      after draining events: false
+      |}]
+  ;;
 end

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -25,7 +25,7 @@ type t =
   | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
-  | Job_complete_ready
+  | Signal_received of Signal.t
 
 module Invalidation_event = struct
   type t =
@@ -36,16 +36,31 @@ end
 module Queue = struct
   type event = t
 
+  module Wakeup = struct
+    type t
+
+    external create : unit -> t = "dune_event_wakeup_create"
+    external release : t -> unit = "dune_event_wakeup_release"
+    external acquire : t -> unit = "dune_event_wakeup_acquire"
+    external try_acquire : t -> bool = "dune_event_wakeup_try_acquire"
+    external use_for_signals : t -> unit = "dune_event_wakeup_use_for_signals"
+    external stop_using_signals : t -> unit = "dune_event_wakeup_stop_using_signals"
+  end
+
+  external next_pending_signal_number : unit -> int = "dune_signal_watcher_next_pending"
+
+  external has_pending_signal : unit -> bool = "dune_signal_watcher_has_pending"
+  [@@noalloc]
+
   type t =
     { jobs_completed : (job * Proc.Process_info.t) Queue.t
     ; file_watcher_tasks : (unit -> File_watcher.Event.t list) Queue.t
     ; mutable invalidation_events : Invalidation_event.t list
     ; mutable shutdown_reasons : Shutdown.Reason.Set.t
     ; mutex : Mutex.t
-    ; wakeup : Semaphore.Binary.t
+    ; wakeup : Wakeup.t
     ; mutable pending_jobs : int
     ; mutable pending_worker_tasks : int
-    ; mutable job_complete_ready : bool
     ; worker_tasks_completed : Fiber.fill Queue.t
     ; mutable got_event : bool
     ; mutable yield : unit Fiber.Ivar.t option
@@ -65,7 +80,7 @@ module Queue = struct
     let invalidation_events = [] in
     let shutdown_reasons = Shutdown.Reason.Set.empty in
     let mutex = Mutex.create () in
-    let wakeup = Semaphore.Binary.make false in
+    let wakeup = Wakeup.create () in
     let pending_jobs = 0 in
     let pending_worker_tasks = 0 in
     { jobs_completed
@@ -79,7 +94,6 @@ module Queue = struct
     ; pending_worker_tasks
     ; got_event = false
     ; yield = None
-    ; job_complete_ready = false
     }
   ;;
 
@@ -102,11 +116,14 @@ module Queue = struct
       if not q.got_event
       then (
         q.got_event <- true;
-        Semaphore.Binary.release q.wakeup))
+        Wakeup.release q.wakeup))
   ;;
 
+  let use_for_signal_wakeup q = Wakeup.use_for_signals q.wakeup
+  let stop_using_signal_wakeup q = Wakeup.stop_using_signals q.wakeup
+
   let yield_if_there_are_pending_events q =
-    if Execution_env.inside_dune || not q.got_event
+    if Execution_env.inside_dune || not (q.got_event || has_pending_signal ())
     then Fiber.return ()
     else (
       match q.yield with
@@ -130,13 +147,11 @@ module Queue = struct
         Shutdown reason)
     ;;
 
-    let job_complete_ready : t =
-      fun q ->
-      match q.job_complete_ready with
-      | false -> None
-      | true ->
-        q.job_complete_ready <- false;
-        Some Job_complete_ready
+    let signal : t =
+      fun _ ->
+      match next_pending_signal_number () with
+      | 0 -> None
+      | signal -> Some (Signal_received (Signal.of_int signal))
     ;;
 
     let file_watcher_task q =
@@ -210,11 +225,12 @@ module Queue = struct
        [jobs_completed] and [yield] are where the bulk of the work is done, so
        they are the lowest priority to avoid starving other things. *)
     Event_source.
-      [ shutdown
+      [ signal
+      ; shutdown
       ; file_watcher_task
       ; invalidation
       ; worker_tasks_completed
-      ; (if Sys.win32 then jobs_completed else job_complete_ready)
+      ; jobs_completed
       ; yield
       ]
   ;;
@@ -231,16 +247,18 @@ module Queue = struct
       | None -> wait ()
       | Some event -> event
     and wait () =
-      (* Keep a single pending wakeup for any number of events. A binary
-         semaphore preserves that coalescing across producer threads. The token
-         can be stale when the scheduler drained events without blocking, so
-         consume it before waiting for the next event. *)
+      (* Keep a single pending wakeup for any number of events. The token can
+         be stale when the scheduler drained events without blocking, so consume
+         it before waiting for the next event. *)
       q.got_event <- false;
-      ignore (Semaphore.Binary.try_acquire q.wakeup : bool);
-      Mutex.unlock q.mutex;
-      Semaphore.Binary.acquire q.wakeup;
-      Mutex.lock q.mutex;
-      loop ()
+      ignore (Wakeup.try_acquire q.wakeup : bool);
+      match Event_source.(run (chain events_in_order)) q with
+      | Some event -> event
+      | None ->
+        Mutex.unlock q.mutex;
+        Wakeup.acquire q.wakeup;
+        Mutex.lock q.mutex;
+        loop ()
     in
     let ev = loop () in
     Mutex.unlock q.mutex;
@@ -276,8 +294,6 @@ module Queue = struct
     add_event q (fun q -> Queue.push q.jobs_completed (job, proc_info))
   ;;
 
-  let send_job_completed_ready q = add_event q (fun q -> q.job_complete_ready <- true)
-
   let send_shutdown q signal =
     add_event q (fun q ->
       q.shutdown_reasons <- Shutdown.Reason.Set.add q.shutdown_reasons signal)
@@ -293,7 +309,7 @@ module Queue = struct
   let%expect_test "wakeup is coalesced while an event is pending" =
     let q = create () in
     let print_wakeup label =
-      Printf.printf "%s: %b\n" label (Semaphore.Binary.try_acquire q.wakeup)
+      Printf.printf "%s: %b\n" label (Wakeup.try_acquire q.wakeup)
     in
     let print_next () =
       match next q with

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -19,7 +19,7 @@ type t =
   | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
-  | Job_complete_ready
+  | Signal_received of Signal.t
 
 module Queue : sig
   type event := t
@@ -57,7 +57,8 @@ module Queue : sig
 
   val send_invalidation_event : t -> Memo.Invalidation.t -> unit
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit
-  val send_job_completed_ready : t -> unit
   val send_shutdown : t -> Shutdown.Reason.t -> unit
+  val use_for_signal_wakeup : t -> unit
+  val stop_using_signal_wakeup : t -> unit
   val yield_if_there_are_pending_events : t -> unit Fiber.t
 end

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -156,17 +156,16 @@ let kill_and_wait_for_all_processes t =
     | Shutdown reason ->
       got_shutdown reason;
       saw_signal := Got_shutdown
-    | Job_complete_ready ->
-      ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list)
+    | Signal_received signal ->
+      (match Signal_watcher.handle signal with
+       | Continue -> ()
+       | Reap_processes ->
+         ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list)
+       | Shutdown reason ->
+         got_shutdown reason;
+         saw_signal := Got_shutdown)
     | _ -> ()
   done;
-  (* This silliness is needed because we have tests that run the scheduler
-     more than once per process. Such tests require the signal watcher to be
-     reset with the correct event queue. *)
-  if not Sys.win32
-  then (
-    Unix.kill (Unix.getpid ()) (Signal.to_int Thread0.signal_watcher_interrupt);
-    Thread.join t.signal_watcher);
   !saw_signal
 ;;
 
@@ -185,11 +184,6 @@ let () =
 ;;
 
 let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
-  (* The signal watcher must be initialized first so that signals are
-     blocked in all threads. *)
-  let signal_watcher =
-    Signal_watcher.init ~print_ctrl_c_warning:config.print_ctrl_c_warning events
-  in
   let cancel = Fiber.Cancel.create () in
   let process_watcher = Process_watcher.init events in
   let async_io = Async_io.create events in
@@ -215,7 +209,6 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
     ; build_inputs_changed = Trigger.create ()
     ; cancel
     ; thread_pool = lazy (Thread_pool.create ~min_workers:4 ~max_workers:50)
-    ; signal_watcher
     ; async_io
     }
   in
@@ -266,10 +259,16 @@ module Run_once = struct
     | File_system_watcher_terminated ->
       filesystem_watcher_terminated ();
       raise (Abort Already_reported)
-    | Job_complete_ready ->
-      (match Process_watcher.wait_unix t.process_watcher with
-       | [] -> iter t
-       | fills -> fills)
+    | Signal_received signal ->
+      (match Signal_watcher.handle signal with
+       | Continue -> iter t
+       | Reap_processes ->
+         (match Process_watcher.wait_unix t.process_watcher with
+          | [] -> iter t
+          | fills -> fills)
+       | Shutdown reason ->
+         got_shutdown reason;
+         raise @@ Abort (Shutdown_requested reason))
     | Fiber_fill_ivar fill -> [ fill ]
     | Shutdown reason ->
       got_shutdown reason;
@@ -500,52 +499,56 @@ module Run = struct
         run
     =
     let events = Event_queue.create () in
-    let file_watcher =
-      match file_watcher with
-      | No_watcher -> None
-      | Automatic ->
-        Some
-          (File_watcher.create_default
-             ~scheduler:
-               { thread_safe_send_emit_events_job =
-                   (fun job -> Event_queue.send_file_watcher_task events job)
-               }
-             ~watch_exclusions:config.watch_exclusions
-             ())
-    in
-    let t = prepare config ~handler:on_event ~events ~file_watcher in
-    Option.iter file_watcher ~f:(fun dune_file_watcher ->
-      let initial_invalidation =
-        Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
-      in
-      Memo.reset initial_invalidation);
-    let result =
-      let run =
-        match timeout with
-        | None -> run
-        | Some timeout ->
-          fun () ->
-            let sleep = Async_io.sleep t.async_io timeout in
-            Fiber.fork_and_join_unit
-              (fun () ->
-                 let+ res = Async_io.Task.await sleep in
-                 match res with
-                 | Ok () -> Event_queue.send_shutdown t.events Timeout
-                 | Error `Cancelled -> ()
-                 | Error (`Exn _) -> assert false)
-              (fun () ->
-                 Fiber.finalize run ~finally:(fun () -> Async_io.Task.cancel sleep))
-      in
-      match Run_once.run_and_cleanup t run with
-      | Ok a -> Result.Ok a
-      | Error (Shutdown_requested reason) -> Error (Shutdown.E reason, None)
-      | Error Already_reported -> Error (Dune_util.Report_error.Already_reported, None)
-      | Error (Exn exn_with_bt) -> Error (exn_with_bt.exn, Some exn_with_bt.backtrace)
-    in
-    match result with
-    | Ok a -> a
-    | Error (exn, None) -> Exn.raise exn
-    | Error (exn, Some bt) -> Exn.raise_with_backtrace exn bt
+    Signal_watcher.init ~print_ctrl_c_warning:config.print_ctrl_c_warning events;
+    Exn.protect
+      ~finally:(fun () -> Signal_watcher.cleanup events)
+      ~f:(fun () ->
+        let file_watcher =
+          match file_watcher with
+          | No_watcher -> None
+          | Automatic ->
+            Some
+              (File_watcher.create_default
+                 ~scheduler:
+                   { thread_safe_send_emit_events_job =
+                       (fun job -> Event_queue.send_file_watcher_task events job)
+                   }
+                 ~watch_exclusions:config.watch_exclusions
+                 ())
+        in
+        let t = prepare config ~handler:on_event ~events ~file_watcher in
+        Option.iter file_watcher ~f:(fun dune_file_watcher ->
+          let initial_invalidation =
+            Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
+          in
+          Memo.reset initial_invalidation);
+        let result =
+          let run =
+            match timeout with
+            | None -> run
+            | Some timeout ->
+              fun () ->
+                let sleep = Async_io.sleep t.async_io timeout in
+                Fiber.fork_and_join_unit
+                  (fun () ->
+                     let+ res = Async_io.Task.await sleep in
+                     match res with
+                     | Ok () -> Event_queue.send_shutdown t.events Timeout
+                     | Error `Cancelled -> ()
+                     | Error (`Exn _) -> assert false)
+                  (fun () ->
+                     Fiber.finalize run ~finally:(fun () -> Async_io.Task.cancel sleep))
+          in
+          match Run_once.run_and_cleanup t run with
+          | Ok a -> Result.Ok a
+          | Error (Shutdown_requested reason) -> Error (Shutdown.E reason, None)
+          | Error Already_reported -> Error (Dune_util.Report_error.Already_reported, None)
+          | Error (Exn exn_with_bt) -> Error (exn_with_bt.exn, Some exn_with_bt.backtrace)
+        in
+        match result with
+        | Ok a -> a
+        | Error (exn, None) -> Exn.raise exn
+        | Error (exn, Some bt) -> Exn.raise_with_backtrace exn bt)
   ;;
 end
 

--- a/src/dune_scheduler/signal_watcher.ml
+++ b/src/dune_scheduler/signal_watcher.ml
@@ -1,17 +1,5 @@
 open Stdune
 
-let signos = List.map Thread0.interrupt_signals ~f:Signal.to_int
-
-let macos_sigchld_warning =
-  {|
-
-*************************************************************************
-* Failed to handle signal, press Control+C to perform an emergency exit *
-*************************************************************************
-
-|}
-;;
-
 let warning =
   {|
 
@@ -22,71 +10,90 @@ let warning =
 |}
 ;;
 
+let warning_bytes = Bytes.of_string warning
+let one_second = 1.0
+
 external sys_exit : int -> _ = "caml_sys_exit"
+external install : int list -> unit = "dune_signal_watcher_install"
 
-let signal_waiter () =
-  if Sys.win32
-  then (
-    let r, w = Unix.pipe ~cloexec:true () in
-    let buf = Bytes.create 1 in
-    Sys.set_signal Sys.sigint (Signal_handle (fun _ -> assert (Unix.write w buf 0 1 = 1)));
-    Staged.stage (fun () ->
-      assert (Unix.read r buf 0 1 = 1);
-      Signal.Int))
-  else Staged.stage (fun () -> Thread.wait_signal signos |> Signal.of_int)
+type action =
+  | Continue
+  | Reap_processes
+  | Shutdown of Shutdown.Reason.t
+
+let is_exit_signal = function
+  | Signal.Int | Quit | Term -> true
+  | _ -> false
 ;;
 
-let run ~print_ctrl_c_warning q : unit =
-  let last_exit_signals = Queue.create () in
-  let one_second = Time.Span.of_secs 1. in
-  let wait_signal = Staged.unstage (signal_waiter ()) in
-  while true do
-    let signal = wait_signal () in
-    Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_received signal);
-    match signal with
-    | _ when Signal.equal signal Thread0.signal_watcher_interrupt -> raise_notrace Exit
-    | _ when Signal.equal signal Thread0.signal_watcher_debug ->
-      Dune_trace.emit Diagnostics (fun () ->
-        let dump = Debug.dump () in
-        Dune_trace.Event.debug dump)
-    | Chld -> Event.Queue.send_job_completed_ready q
-    | Int | Quit | Term ->
-      Event.Queue.send_shutdown q (Signal signal);
-      let now = Time.now () in
-      Queue.push last_exit_signals now;
-      (* Discard old signals *)
-      while
-        Queue.length last_exit_signals > 0
-        && Poly.(Time.diff now (Queue.peek_exn last_exit_signals) > one_second)
-      do
-        ignore (Queue.pop_exn last_exit_signals : Time.t)
-      done;
-      let n = Queue.length last_exit_signals in
-      if n = 2 && print_ctrl_c_warning then prerr_endline warning;
-      if n = 3 then sys_exit 1
-    | _ ->
-      (* On macOS, [sigwait] can occasionally return with success, yet skip
-         setting `&signo` when waiting on a set containing [SIGCHLD]. OCaml
-         returns invalid uninitialized garbage in this case. Ignore it rather
-         than crashing the scheduler. *)
-      prerr_endline macos_sigchld_warning;
-      Event.Queue.send_job_completed_ready q
-  done
+let write_warning () =
+  try
+    ignore
+      (Unix.single_write Unix.stderr warning_bytes 0 (Bytes.length warning_bytes) : int)
+  with
+  | Unix.Unix_error _ -> ()
 ;;
 
-(* Make sure that we never have more than one signal watcher running at a time *)
-let m = Mutex.create ()
+let exit_signals = Queue.create ()
+
+let record_exit_signal ~print_ctrl_c_warning =
+  let now = Unix.gettimeofday () in
+  Queue.push exit_signals now;
+  while
+    Queue.length exit_signals > 0 && now -. Queue.peek_exn exit_signals > one_second
+  do
+    ignore (Queue.pop_exn exit_signals : float)
+  done;
+  let count = Queue.length exit_signals in
+  if count = 2 && print_ctrl_c_warning then write_warning ();
+  if count >= 3 then sys_exit 1
+;;
+
+let should_print_ctrl_c_warning = ref true
 
 let init ~print_ctrl_c_warning q =
-  Thread0.spawn ~name:"signal-watcher" (fun () ->
-    let res =
-      Mutex.protect m (fun () ->
-        try
-          run ~print_ctrl_c_warning q;
-          None
-        with
-        | Exit -> None
-        | exn -> Some exn)
-    in
-    Option.iter res ~f:raise)
+  Queue.clear exit_signals;
+  should_print_ctrl_c_warning := print_ctrl_c_warning;
+  let signals = if Sys.win32 then [ Signal.Int ] else Thread0.interrupt_signals in
+  let signal_numbers = List.map signals ~f:Signal.to_int in
+  if Sys.win32
+  then (
+    Event.Queue.use_for_signal_wakeup q;
+    install signal_numbers)
+  else (
+    ignore (Unix.sigprocmask SIG_BLOCK signal_numbers : int list);
+    Exn.protect
+      ~f:(fun () ->
+        Event.Queue.use_for_signal_wakeup q;
+        install signal_numbers)
+      ~finally:(fun () -> ignore (Unix.sigprocmask SIG_UNBLOCK signal_numbers : int list)))
+;;
+
+let cleanup q =
+  Queue.clear exit_signals;
+  if Sys.win32
+  then Event.Queue.stop_using_signal_wakeup q
+  else (
+    let signal_numbers = List.map Thread0.interrupt_signals ~f:Signal.to_int in
+    ignore (Unix.sigprocmask SIG_BLOCK signal_numbers : int list);
+    Exn.protect
+      ~f:(fun () -> Event.Queue.stop_using_signal_wakeup q)
+      ~finally:(fun () -> ignore (Unix.sigprocmask SIG_UNBLOCK signal_numbers : int list)))
+;;
+
+let handle signal =
+  if is_exit_signal signal
+  then record_exit_signal ~print_ctrl_c_warning:!should_print_ctrl_c_warning;
+  Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_received signal);
+  if Signal.equal signal Thread0.debug_signal
+  then (
+    Dune_trace.emit Diagnostics (fun () ->
+      let dump = Debug.dump () in
+      Dune_trace.Event.debug dump);
+    Continue)
+  else (
+    match signal with
+    | Chld -> Reap_processes
+    | Int | Quit | Term -> Shutdown (Signal signal)
+    | _ -> Continue)
 ;;

--- a/src/dune_scheduler/signal_watcher.mli
+++ b/src/dune_scheduler/signal_watcher.mli
@@ -1,1 +1,10 @@
-val init : print_ctrl_c_warning:bool -> Event.Queue.t -> Thread.t
+open Stdune
+
+type action =
+  | Continue
+  | Reap_processes
+  | Shutdown of Shutdown.Reason.t
+
+val init : print_ctrl_c_warning:bool -> Event.Queue.t -> unit
+val cleanup : Event.Queue.t -> unit
+val handle : Signal.t -> action

--- a/src/dune_scheduler/signal_watcher_stubs.c
+++ b/src/dune_scheduler/signal_watcher_stubs.c
@@ -1,0 +1,591 @@
+#define CAML_INTERNALS
+
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+#include <signal.h>
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#else
+
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <fcntl.h>
+#include <stdio.h>
+#define DUNE_USE_NAMED_SEMAPHORE 1
+#else
+#define DUNE_USE_NAMED_SEMAPHORE 0
+#endif
+
+#endif
+
+#ifndef NSIG
+#define NSIG 128
+#endif
+
+#define DUNE_MAX_WATCHED_SIGNALS 32
+/* Keep enough repeated deliveries to preserve the emergency Ctrl+C path, while
+   bounding the amount of scheduler work caused by a signal storm. The Unix
+   lock-free atomic implementation stores these as byte counters. */
+#define DUNE_MAX_PENDING_PER_SIGNAL 3
+
+#ifdef _WIN32
+typedef LONG signal_counter;
+static volatile signal_counter dune_pending_signals[NSIG];
+static volatile LONG signal_wakeup_pending = 0;
+
+static void pending_signal_clear(int signo)
+{
+  InterlockedExchange(&dune_pending_signals[signo], 0);
+}
+
+static void pending_signal_increment(int signo)
+{
+  LONG count = InterlockedIncrement(&dune_pending_signals[signo]);
+  if (count > DUNE_MAX_PENDING_PER_SIGNAL)
+    InterlockedExchange(&dune_pending_signals[signo], DUNE_MAX_PENDING_PER_SIGNAL);
+}
+
+static int pending_signal_take_one(int signo)
+{
+  LONG count;
+
+  do {
+    count = InterlockedCompareExchange(&dune_pending_signals[signo], 0, 0);
+    if (count <= 0) return 0;
+  } while (InterlockedCompareExchange(&dune_pending_signals[signo], count - 1,
+                                      count)
+           != count);
+
+  return 1;
+}
+
+static int pending_signal_load(int signo)
+{
+  return (int)InterlockedCompareExchange(&dune_pending_signals[signo], 0, 0);
+}
+
+static int signal_wakeup_mark_pending(void)
+{
+  return InterlockedCompareExchange(&signal_wakeup_pending, 1, 0) == 0;
+}
+
+static void signal_wakeup_clear_pending(void)
+{
+  InterlockedExchange(&signal_wakeup_pending, 0);
+}
+#elif defined(__GNUC__) && defined(__GCC_ATOMIC_CHAR_LOCK_FREE) &&              \
+    __GCC_ATOMIC_CHAR_LOCK_FREE == 2
+typedef unsigned char signal_counter;
+static signal_counter dune_pending_signals[NSIG];
+static signal_counter signal_wakeup_pending = 0;
+
+static void pending_signal_clear(int signo)
+{
+  __atomic_store_n(&dune_pending_signals[signo], 0, __ATOMIC_RELAXED);
+}
+
+static void pending_signal_increment(int signo)
+{
+  signal_counter count =
+      __atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+
+  while (count < DUNE_MAX_PENDING_PER_SIGNAL) {
+    signal_counter next = count + 1;
+    if (__atomic_compare_exchange_n(&dune_pending_signals[signo], &count, next,
+                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+      return;
+  }
+}
+
+static int pending_signal_take_one(int signo)
+{
+  signal_counter count =
+      __atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+
+  while (count > 0) {
+    signal_counter next = count - 1;
+    if (__atomic_compare_exchange_n(&dune_pending_signals[signo], &count, next,
+                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int pending_signal_load(int signo)
+{
+  return (int)__atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+}
+
+static int signal_wakeup_mark_pending(void)
+{
+  signal_counter expected = 0;
+  return __atomic_compare_exchange_n(&signal_wakeup_pending, &expected, 1, 0,
+                                     __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+static void signal_wakeup_clear_pending(void)
+{
+  __atomic_store_n(&signal_wakeup_pending, 0, __ATOMIC_RELAXED);
+}
+#else
+typedef sig_atomic_t signal_counter;
+static volatile signal_counter dune_pending_signals[NSIG];
+static volatile sig_atomic_t signal_wakeup_pending = 0;
+
+static void pending_signal_clear(int signo)
+{
+  dune_pending_signals[signo] = 0;
+}
+
+static void pending_signal_increment(int signo)
+{
+  if (dune_pending_signals[signo] < DUNE_MAX_PENDING_PER_SIGNAL)
+    dune_pending_signals[signo]++;
+}
+
+static int pending_signal_take_one(int signo)
+{
+  if (dune_pending_signals[signo] <= 0) return 0;
+  dune_pending_signals[signo]--;
+  return 1;
+}
+
+static int pending_signal_load(int signo)
+{
+  return dune_pending_signals[signo];
+}
+
+static int signal_wakeup_mark_pending(void)
+{
+  if (signal_wakeup_pending) return 0;
+  signal_wakeup_pending = 1;
+  return 1;
+}
+
+static void signal_wakeup_clear_pending(void)
+{
+  signal_wakeup_pending = 0;
+}
+#endif
+
+static int watched_count = 0;
+static int watched_signals[DUNE_MAX_WATCHED_SIGNALS];
+static int watched_ocaml_signals[DUNE_MAX_WATCHED_SIGNALS];
+static value signal_wakeup_root = Val_unit;
+static int signal_wakeup_root_registered = 0;
+
+static void register_signal_wakeup_root(void)
+{
+  if (!signal_wakeup_root_registered) {
+    caml_register_global_root(&signal_wakeup_root);
+    signal_wakeup_root_registered = 1;
+  }
+}
+
+static void dune_event_wakeup_finalize(value v_wakeup);
+
+static struct custom_operations dune_event_wakeup_ops = {
+  "build.dune.scheduler.event_wakeup",
+  dune_event_wakeup_finalize,
+  custom_compare_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default,
+  custom_fixed_length_default
+};
+
+#ifdef _WIN32
+
+struct dune_event_wakeup {
+  HANDLE event;
+  int used_for_signals;
+};
+
+static PVOID volatile signal_wakeup = NULL;
+
+#define Dune_event_wakeup_val(v) ((struct dune_event_wakeup *)Data_custom_val(v))
+
+static void dune_event_wakeup_finalize(value v_wakeup)
+{
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (wakeup->used_for_signals) return;
+  if (wakeup->event != NULL) CloseHandle(wakeup->event);
+}
+
+static void dune_signal_wakeup(void)
+{
+  DWORD saved_error = GetLastError();
+  HANDLE event =
+      (HANDLE)InterlockedCompareExchangePointer(&signal_wakeup, NULL, NULL);
+  if (event != NULL && signal_wakeup_mark_pending()) SetEvent(event);
+  SetLastError(saved_error);
+}
+
+CAMLprim value dune_event_wakeup_create(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLlocal1(v_wakeup);
+  struct dune_event_wakeup *wakeup;
+
+  v_wakeup = caml_alloc_custom(&dune_event_wakeup_ops,
+                               sizeof(struct dune_event_wakeup), 0, 1);
+  wakeup = Dune_event_wakeup_val(v_wakeup);
+  wakeup->event = NULL;
+  wakeup->used_for_signals = 0;
+  wakeup->event = CreateEvent(NULL, FALSE, FALSE, NULL);
+  if (wakeup->event == NULL) caml_failwith("CreateEvent");
+
+  CAMLreturn(v_wakeup);
+}
+
+CAMLprim value dune_event_wakeup_release(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (!SetEvent(wakeup->event)) caml_failwith("SetEvent");
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  HANDLE event = wakeup->event;
+  DWORD result;
+
+  caml_release_runtime_system();
+  result = WaitForSingleObject(event, INFINITE);
+  caml_acquire_runtime_system();
+
+  if (result != WAIT_OBJECT_0) caml_failwith("WaitForSingleObject");
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_try_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  DWORD result = WaitForSingleObject(wakeup->event, 0);
+  if (result == WAIT_OBJECT_0) {
+    signal_wakeup_clear_pending();
+    CAMLreturn(Val_true);
+  }
+  if (result == WAIT_TIMEOUT) CAMLreturn(Val_false);
+  caml_failwith("WaitForSingleObject");
+}
+
+CAMLprim value dune_event_wakeup_use_for_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  register_signal_wakeup_root();
+  signal_wakeup_root = v_wakeup;
+  wakeup->used_for_signals = 1;
+  InterlockedExchangePointer(&signal_wakeup, wakeup->event);
+  /* A previous scheduler run may have left a stale wakeup token on its
+     event. */
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_stop_using_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  PVOID previous =
+      InterlockedCompareExchangePointer(&signal_wakeup, NULL, wakeup->event);
+  if (previous == wakeup->event) {
+    signal_wakeup_clear_pending();
+    wakeup->used_for_signals = 0;
+    signal_wakeup_root = Val_unit;
+  }
+  CAMLreturn(Val_unit);
+}
+
+#else
+
+struct dune_event_wakeup {
+  sem_t *sem;
+  int used_for_signals;
+};
+
+static sem_t *volatile signal_wakeup = NULL;
+
+#define Dune_event_wakeup_val(v) ((struct dune_event_wakeup *)Data_custom_val(v))
+
+static void dune_event_wakeup_finalize(value v_wakeup)
+{
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (wakeup->used_for_signals) return;
+  if (wakeup->sem == NULL) return;
+#if DUNE_USE_NAMED_SEMAPHORE
+  sem_close(wakeup->sem);
+#else
+  sem_destroy(wakeup->sem);
+  free(wakeup->sem);
+#endif
+}
+
+static sem_t *create_semaphore(void)
+{
+#if DUNE_USE_NAMED_SEMAPHORE
+  static int semaphore_id = 0;
+  char name[64];
+  sem_t *sem;
+
+  for (int i = 0; i < 100; i++) {
+    snprintf(name, sizeof(name), "/dune-%ld-%d", (long)getpid(), semaphore_id++);
+    sem = sem_open(name, O_CREAT | O_EXCL, 0600, 0);
+    if (sem != SEM_FAILED) {
+      if (sem_unlink(name) == -1) {
+        sem_close(sem);
+        uerror("sem_unlink", Nothing);
+      }
+      return sem;
+    }
+    if (errno != EEXIST) uerror("sem_open", Nothing);
+  }
+
+  caml_failwith("sem_open");
+#else
+  sem_t *sem = malloc(sizeof(sem_t));
+  if (sem == NULL) caml_raise_out_of_memory();
+  if (sem_init(sem, 0, 0) == -1) {
+    free(sem);
+    uerror("sem_init", Nothing);
+  }
+  return sem;
+#endif
+}
+
+static void dune_signal_wakeup(void)
+{
+  int saved_errno = errno;
+  sem_t *sem = signal_wakeup;
+
+  if (sem != NULL && signal_wakeup_mark_pending()) {
+    int result = sem_post(sem);
+    if (result == -1) signal_wakeup_clear_pending();
+    (void)result;
+  }
+
+  errno = saved_errno;
+}
+
+static int wait_for_semaphore(sem_t *sem)
+{
+  int result;
+
+  do {
+    result = sem_wait(sem);
+  } while (result == -1 && errno == EINTR);
+
+  return result;
+}
+
+static int try_wait_for_semaphore(sem_t *sem)
+{
+  int result;
+
+  do {
+    result = sem_trywait(sem);
+  } while (result == -1 && errno == EINTR);
+
+  return result;
+}
+
+CAMLprim value dune_event_wakeup_create(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLlocal1(v_wakeup);
+  struct dune_event_wakeup *wakeup;
+
+  v_wakeup = caml_alloc_custom(&dune_event_wakeup_ops,
+                               sizeof(struct dune_event_wakeup), 0, 1);
+  wakeup = Dune_event_wakeup_val(v_wakeup);
+  wakeup->sem = NULL;
+  wakeup->used_for_signals = 0;
+  wakeup->sem = create_semaphore();
+
+  CAMLreturn(v_wakeup);
+}
+
+CAMLprim value dune_event_wakeup_release(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (sem_post(wakeup->sem) == -1) uerror("sem_post", Nothing);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  sem_t *sem = wakeup->sem;
+  int result;
+  int saved_errno;
+
+  caml_release_runtime_system();
+  result = wait_for_semaphore(sem);
+  saved_errno = errno;
+  caml_acquire_runtime_system();
+
+  if (result == -1) {
+    errno = saved_errno;
+    uerror("sem_wait", Nothing);
+  }
+
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_try_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (try_wait_for_semaphore(wakeup->sem) == 0) {
+    signal_wakeup_clear_pending();
+    CAMLreturn(Val_true);
+  }
+  if (errno == EAGAIN) CAMLreturn(Val_false);
+
+  uerror("sem_trywait", Nothing);
+}
+
+CAMLprim value dune_event_wakeup_use_for_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  register_signal_wakeup_root();
+  signal_wakeup_root = v_wakeup;
+  wakeup->used_for_signals = 1;
+  signal_wakeup = wakeup->sem;
+  /* A previous scheduler run may have left a stale wakeup token on its
+     semaphore. */
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_stop_using_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (signal_wakeup == wakeup->sem) {
+    signal_wakeup = NULL;
+    signal_wakeup_clear_pending();
+    wakeup->used_for_signals = 0;
+    signal_wakeup_root = Val_unit;
+  }
+  CAMLreturn(Val_unit);
+}
+
+#endif
+
+static void signal_handler(int signo)
+{
+#ifdef _WIN32
+  signal(signo, signal_handler);
+#endif
+  if (signo >= 0 && signo < NSIG) pending_signal_increment(signo);
+  dune_signal_wakeup();
+}
+
+CAMLprim value dune_signal_watcher_install(value v_signals)
+{
+  CAMLparam1(v_signals);
+
+  for (int i = 0; i < NSIG; i++) pending_signal_clear(i);
+  watched_count = 0;
+
+  for (; v_signals != Val_emptylist; v_signals = Field(v_signals, 1)) {
+    int ocaml_signal = Int_val(Field(v_signals, 0));
+    int signo = caml_convert_signal_number(ocaml_signal);
+
+    if (signo < 0 || signo >= NSIG) continue;
+    if (watched_count == DUNE_MAX_WATCHED_SIGNALS)
+      caml_invalid_argument("too many watched signals");
+
+    watched_signals[watched_count] = signo;
+    watched_ocaml_signals[watched_count] = ocaml_signal;
+    watched_count++;
+
+#ifdef _WIN32
+    if (signal(signo, signal_handler) == SIG_ERR) caml_failwith("signal");
+#else
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = signal_handler;
+    sa.sa_flags = 0;
+#ifdef SA_RESTART
+    sa.sa_flags |= SA_RESTART;
+#endif
+    if (sigaction(signo, &sa, NULL) == -1) uerror("sigaction", Nothing);
+#endif
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_signal_watcher_next_pending(value v_unit)
+{
+  CAMLparam1(v_unit);
+  int result = 0;
+
+  (void)v_unit;
+
+#ifndef _WIN32
+  sigset_t set;
+  sigset_t previous_set;
+
+  sigemptyset(&set);
+  for (int i = 0; i < watched_count; i++) sigaddset(&set, watched_signals[i]);
+  if (pthread_sigmask(SIG_BLOCK, &set, &previous_set) != 0)
+    caml_failwith("pthread_sigmask");
+#endif
+
+  for (int i = 0; i < watched_count; i++) {
+    int signo = watched_signals[i];
+    if (pending_signal_take_one(signo)) {
+      result = watched_ocaml_signals[i];
+      break;
+    }
+  }
+
+#ifndef _WIN32
+  if (pthread_sigmask(SIG_SETMASK, &previous_set, NULL) != 0)
+    caml_failwith("pthread_sigmask");
+#endif
+
+  CAMLreturn(Val_int(result));
+}
+
+CAMLprim value dune_signal_watcher_has_pending(value v_unit)
+{
+  (void)v_unit;
+
+  for (int i = 0; i < watched_count; i++) {
+    if (pending_signal_load(watched_signals[i]) > 0) return Val_true;
+  }
+
+  return Val_false;
+}

--- a/src/dune_scheduler/thread0.ml
+++ b/src/dune_scheduler/thread0.ml
@@ -4,41 +4,31 @@ type t = Thread.t
 
 let join = Thread.join
 let delay = Thread.delay
-let wait_signal = Thread.wait_signal
-let signal_watcher_interrupt : Signal.t = Usr1
-let signal_watcher_debug : Signal.t = Usr2
+let debug_signal : Signal.t = Usr2
 
 (* These are the signals that will make the scheduler attempt to terminate dune
    or signal to dune to reap a process *)
-let interrupt_signals : Signal.t list =
-  [ signal_watcher_interrupt; signal_watcher_debug; Chld; Int; Quit; Term ]
-;;
+let interrupt_signals : Signal.t list = [ Int; Quit; Term; debug_signal; Chld ]
 
 (* In addition, the scheduler also blocks some other signals so that only
    designated threads can handle them by unblocking *)
 let blocked_signals : Signal.t list = Terminal_signals.signals @ interrupt_signals
-
-let block_signals =
-  lazy
-    (let () =
-       List.iter
-         [ signal_watcher_interrupt; signal_watcher_debug; Chld ]
-         ~f:(fun signal ->
-           Sys.set_signal (Signal.to_int signal) (Signal_handle (fun _ -> ())))
-     in
-     let signos = List.map blocked_signals ~f:Signal.to_int in
-     ignore (Unix.sigprocmask SIG_BLOCK signos : int list))
-;;
+let blocked_signos = lazy (List.map blocked_signals ~f:Signal.to_int)
 
 let create =
   if Sys.win32
   then Thread.create
   else
-    (* On unix, we make sure to block signals globally before starting a
-         thread so that only the signal watcher thread can receive signals. *)
     fun f x ->
-      Lazy.force block_signals;
-      Thread.create f x
+      (* New threads inherit their creator's signal mask. Block scheduler
+         signals around [Thread.create] so the child starts with those signals
+         blocked, then restore the creator's mask so the main thread remains
+         able to handle them via the scheduler's C signal handlers. *)
+      let previous_mask = Unix.sigprocmask SIG_BLOCK (Lazy.force blocked_signos) in
+      Exn.protect
+        ~f:(fun () -> Thread.create f x)
+        ~finally:(fun () ->
+          ignore (Unix.sigprocmask SIG_SETMASK previous_mask : int list))
 ;;
 
 let spawn ~name f =

--- a/src/dune_scheduler/thread0.mli
+++ b/src/dune_scheduler/thread0.mli
@@ -2,14 +2,10 @@ open Stdune
 
 type t = Thread.t
 
-(** Magic signal to interrupt to the signal watching thread *)
-val signal_watcher_interrupt : Signal.t
-
-(** Magic signal to make dune debugging info *)
-val signal_watcher_debug : Signal.t
+(** Signal that asks dune to emit debugging info. *)
+val debug_signal : Signal.t
 
 val join : t -> unit
 val interrupt_signals : Signal.t list
 val spawn : name:string -> (unit -> unit) -> Thread.t
 val delay : float -> unit
-val wait_signal : int list -> int

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -95,7 +95,6 @@ module Scheduler = struct
     ; mutable build_inputs_changed : Trigger.t
     ; mutable cancel : Fiber.Cancel.t
     ; thread_pool : Thread_pool.t Lazy.t
-    ; signal_watcher : Thread.t
     ; async_io : Async_io.t
     }
 

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -8,6 +8,9 @@ is_linked() {
 }
 
 export XDG_CACHE_HOME="$PWD/.cache"
+export XDG_RUNTIME_DIR="$PWD/.xdg-runtime"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
 
 init_oxcaml_project() {
   cat > "dune-project" <<- EOF
@@ -226,4 +229,3 @@ censor() {
     | dune_cmd subst-unique '[0-9a-f]{32}' '$DIGEST' \
     | dune_cmd subst-unique '\.cinaps\.[0-9a-f]{8}' '.cinaps.$CINAPS'
 }
-

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -10,7 +10,6 @@ dune trace cat can be used to view the trace:
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
@@ -18,7 +17,6 @@ dune trace cat can be used to view the trace:
   ["args","cat","dur","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","dur","name","ts"]
-  ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
 

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -1,4 +1,4 @@
-The debug event can be triggered with Sigusr1
+The debug event can be triggered with SIGUSR2
 
   $ debug_events_jq='select(.name == "debug") | .name'
   $ build_request_starts_jq='select(.cat == "rpc" and .name == "request" and .args.meth == "build" and .args.stage == "start") | .name'

--- a/test/blackbox-tests/test-cases/trace/thread-event.t
+++ b/test/blackbox-tests/test-cases/trace/thread-event.t
@@ -1,4 +1,4 @@
-Dune can emit events for threads started
+Dune does not start a signal watcher thread for a plain build
 
   $ make_dune_project 3.21
 
@@ -11,4 +11,3 @@ Dune can emit events for threads started
   $ dune build @foo
 
   $ dune trace cat | jq -c 'select(.cat == "thread") | .args' | sort -u
-  {"name":"signal-watcher"}


### PR DESCRIPTION
We'd like to move away from using a signal watching thread because sigwait doesn't work well on macos. However, doing so and keeping the current CV based queue requires an extra pipe for signalling. We workaround this by switching to a semaphore instead.

The signal handler has to be written in C because an OCaml handler will not interrupt blocking on the semaphore.