### PR TITLE
Show RPC client count in status line

### DIFF
--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -103,11 +103,12 @@ let go_with_rpc_server_and_console_status_reporting
       ~config:dune_config
       run
   =
-  let server =
+  let rpc_server =
     match Common.rpc common with
-    | `Allow server -> rpc server
+    | `Allow server -> server
     | `Forbid_builds -> Code_error.raise "rpc must be enabled in polling mode" []
   in
+  let server = rpc rpc_server in
   let config =
     let watch_exclusions = Common.watch_exclusions common in
     Dune_config.for_scheduler dune_config ~print_ctrl_c_warning:true ~watch_exclusions

--- a/doc/changes/added/14489.md
+++ b/doc/changes/added/14489.md
@@ -1,0 +1,2 @@
+- Show the number of connected RPC clients in the watch mode status line
+  (#14489, @rgrinberg)

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -110,6 +110,7 @@ module Clients = struct
     Session.Id.Map.remove t id
   ;;
 
+  let cardinal = Session.Id.Map.cardinal
   let to_list = Session.Id.Map.to_list
   let to_list_map = Session.Id.Map.to_list_map
 
@@ -184,6 +185,20 @@ type 'build_arg t =
   ; pending_jobs : 'build_arg pending_action Job_queue.t
   }
 
+let client_count t = Clients.cardinal t.server.clients
+
+let pp_client_count t =
+  match client_count t with
+  | 0 -> Pp.nop
+  | count -> Pp.textf "[rpc %d]" count
+;;
+
+let refresh_client_count_status_line t =
+  match t.server.config.registry with
+  | `Skip -> ()
+  | `Add -> Console.Status_line.refresh ()
+;;
+
 let () =
   Debug.register ~name:"rpc" (fun () ->
     match !current with
@@ -221,11 +236,13 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
     let t = Fdecl.get t in
     let client = () in
     t.server.clients <- Clients.add_session t.server.clients session;
+    refresh_client_count_status_line t;
     Fiber.return client
   in
   let on_terminate session =
     let t = Fdecl.get t in
     t.server.clients <- Clients.remove_session t.server.clients session;
+    refresh_client_count_status_line t;
     Fiber.return ()
   in
   let rpc = Handler.create ~on_terminate ~on_init ~version:Dune_rpc.Version.latest () in
@@ -514,5 +531,16 @@ let create ~lock_timeout ~registry ~root =
   res
 ;;
 
-let run t = Run.run t.server.config
+let run t =
+  match t.server.config.registry with
+  | `Skip -> Run.run t.server.config
+  | `Add ->
+    let section = Console.Status_line.add_section (Live (fun () -> pp_client_count t)) in
+    Fiber.finalize
+      (fun () -> Run.run t.server.config)
+      ~finally:(fun () ->
+        Console.Status_line.remove_section section;
+        Fiber.return ())
+;;
+
 let pending_action t = Job_queue.read t.pending_jobs

--- a/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-build-status-line.t
@@ -10,10 +10,21 @@ Forwarded builds display a rich status line once connected over RPC.
   >  (action (write-file %{target} ok)))
   > EOF
 
-  $ start_dune
+  $ export INSIDE_EMACS=1
+  $ export DUNE_CONFIG__THREADED_CONSOLE=disabled
+
+  $ start_dune --display progress
+  $ : > .#dune-output
+  $ with_timeout_quiet dune rpc ping
+  $ tr '\r' '\n' < .#dune-output | grep -a -m 1 "\[rpc 0\]"
+  [1]
+
+  $ : > .#dune-output
   $ INSIDE_EMACS=1 DUNE_CONFIG__THREADED_CONSOLE=disabled \
   >   with_timeout dune build --display progress x > output 2>&1
   $ tr '\r' '\n' < output | grep -m 1 "Connected to RPC server"
   Connected to RPC server
+  $ tr '\r' '\n' < .#dune-output | grep -a -m 1 "\[rpc 1\]"
+  [rpc 1]
 
   $ stop_dune_quiet


### PR DESCRIPTION
Display an `[rpc $number-of-clients]` section in the status line when there are active clients.