### PR TITLE
Filter inter-library dependencies per module

### DIFF
--- a/doc/changes/added/14491.md
+++ b/doc/changes/added/14491.md
@@ -1,0 +1,15 @@
+- Filter inter-library dependencies per-module using `ocamldep`
+  output. When a dependency library's cmi changes, only consumer
+  modules that reference it get rebuilt — eliminating spurious
+  recompilations of unrelated sibling modules. Applies to
+  unwrapped dependency libraries; wrapped libraries continue to
+  use a glob over the whole library's objdir. (#14491, fixes
+  #4572, @robinbb)
+- Filter `-I`/`-H` include flags per-module to match the
+  per-module inter-library dependency filter. A consumer module's
+  compile command now lists only the libraries its reference set
+  reaches, eliminating cache-key bloat (adding an unrelated
+  `(libraries ...)` entry no longer invalidates other consumers)
+  and closing a soundness gap where a missing entry in the
+  per-module dep set could be silently masked by a too-wide `-I`
+  path. (#14491, @robinbb)

--- a/doc/changes/added/14491.md
+++ b/doc/changes/added/14491.md
@@ -1,15 +1,13 @@
 - Filter inter-library dependencies per-module using `ocamldep`
-  output. When a dependency library's cmi changes, only consumer
-  modules that reference it get rebuilt — eliminating spurious
-  recompilations of unrelated sibling modules. Applies to
-  unwrapped dependency libraries; wrapped libraries continue to
-  use a glob over the whole library's objdir. (#14491, fixes
-  #4572, @robinbb)
-- Filter `-I`/`-H` include flags per-module to match the
-  per-module inter-library dependency filter. A consumer module's
+  output, and match the `-I`/`-H` include flags to that filter.
+  When a dependency library's cmi changes, only consumer modules
+  that reference it get rebuilt — eliminating spurious
+  recompilations of unrelated sibling modules. A consumer module's
   compile command now lists only the libraries its reference set
   reaches, eliminating cache-key bloat (adding an unrelated
   `(libraries ...)` entry no longer invalidates other consumers)
   and closing a soundness gap where a missing entry in the
   per-module dep set could be silently masked by a too-wide `-I`
-  path. (#14491, @robinbb)
+  path. Applies to unwrapped dependency libraries; wrapped
+  libraries continue to use a glob over the whole library's
+  objdir. (#14491, fixes #4572, @robinbb)

--- a/src/dune_lang/lib_mode.ml
+++ b/src/dune_lang/lib_mode.ml
@@ -11,6 +11,12 @@ let equal x y =
   | Melange, Melange -> true
 ;;
 
+let hash = function
+  | Ocaml Byte -> 0
+  | Ocaml Native -> 1
+  | Melange -> 2
+;;
+
 let decode =
   let open Decoder in
   enum [ "byte", Ocaml Byte; "native", Ocaml Native; "melange", Melange ]

--- a/src/dune_lang/lib_mode.mli
+++ b/src/dune_lang/lib_mode.mli
@@ -6,6 +6,7 @@ type t =
 
 val decode : t Decoder.t
 val equal : t -> t -> bool
+val hash : t -> int
 val to_dyn : t -> Dyn.t
 
 module Cm_kind : sig

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -4,59 +4,143 @@ open Memo.O
 module Includes = struct
   type t = Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 
-  let make ~project ~opaque ~direct_requires ~hidden_requires lib_config
+  let make ~project ~direct_requires ~hidden_requires lib_config
     : _ Lib_mode.Cm_kind.Map.t
     =
-    (* TODO: some of the requires can filtered out using [ocamldep] info *)
     let open Resolve.Memo.O in
     let iflags direct_libs hidden_libs mode =
       Lib_flags.L.include_flags ~project ~direct_libs ~hidden_libs mode lib_config
     in
-    let make_includes_args ~mode groups =
+    let make_includes_args ~mode =
       (let+ direct_libs = direct_requires
        and+ hidden_libs = hidden_requires in
-       Command.Args.S
-         [ iflags direct_libs hidden_libs mode
-         ; Hidden_deps (Lib_file_deps.deps (direct_libs @ hidden_libs) ~groups)
-         ])
+       iflags direct_libs hidden_libs mode)
       |> Resolve.Memo.args
       |> Command.Args.memo
     in
     { ocaml =
-        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) [ Ocaml Cmi ] in
+        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) in
          { cmi = cmi_includes
          ; cmo = cmi_includes
-         ; cmx =
-             (let+ direct_libs = direct_requires
-              and+ hidden_libs = hidden_requires in
-              Command.Args.S
-                [ iflags direct_libs hidden_libs (Ocaml Native)
-                ; Hidden_deps
-                    (let libs = direct_libs @ hidden_libs in
-                     if opaque
-                     then
-                       List.map libs ~f:(fun lib ->
-                         ( lib
-                         , if Lib.is_local lib
-                           then [ Lib_file_deps.Group.Ocaml Cmi ]
-                           else [ Ocaml Cmi; Ocaml Cmx ] ))
-                       |> Lib_file_deps.deps_with_exts
-                     else
-                       Lib_file_deps.deps
-                         libs
-                         ~groups:[ Lib_file_deps.Group.Ocaml Cmi; Ocaml Cmx ])
-                ])
-             |> Resolve.Memo.args
-             |> Command.Args.memo
+         ; cmx = make_includes_args ~mode:(Ocaml Native)
          })
     ; melange =
-        { cmi = make_includes_args ~mode:Melange [ Melange Cmi ]
-        ; cmj = make_includes_args ~mode:Melange [ Melange Cmi; Melange Cmj ]
-        }
+        (let mel_includes = make_includes_args ~mode:Melange in
+         { cmi = mel_includes; cmj = mel_includes })
     }
   ;;
 
   let empty = Lib_mode.Cm_kind.Map.make_all Command.Args.empty
+end
+
+(* Variant key: [Direct] for the consumer-side row (the module being compiled),
+   [Transitive] for trans-dep rows. Each carries only the fields that identify
+   the row's closure behaviour — [ml_kind] for [Direct], [cm_kind] for
+   [Transitive] — so cache entries collapse across irrelevant dimensions. *)
+module Raw_refs = struct
+  module Key = struct
+    type t =
+      | Direct of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+
+    let cm_kind_tag : Lib_mode.Cm_kind.t -> int = function
+      | Ocaml Cmi -> 0
+      | Ocaml Cmo -> 1
+      | Ocaml Cmx -> 2
+      | Melange Cmi -> 3
+      | Melange Cmj -> 4
+    ;;
+
+    let ml_kind_tag : Ml_kind.t -> int = function
+      | Intf -> 0
+      | Impl -> 1
+    ;;
+
+    let equal a b =
+      match a, b with
+      | Direct a, Direct b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && ml_kind_tag a.ml_kind = ml_kind_tag b.ml_kind
+      | Transitive a, Transitive b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && cm_kind_tag a.cm_kind = cm_kind_tag b.cm_kind
+      | Direct _, Transitive _ | Transitive _, Direct _ -> false
+    ;;
+
+    let hash = function
+      | Direct { obj_name; ml_kind } -> Poly.hash (0, obj_name, ml_kind_tag ml_kind)
+      | Transitive { obj_name; cm_kind } -> Poly.hash (1, obj_name, cm_kind_tag cm_kind)
+    ;;
+
+    let repr =
+      let open Repr in
+      let obj_name_repr = view string ~to_:Module_name.Unique.to_string in
+      let ml_kind_repr = view string ~to_:Ml_kind.to_string in
+      let cm_kind_repr = abstract Lib_mode.Cm_kind.to_dyn in
+      variant
+        "Raw_refs.Key"
+        [ case "Direct" (pair obj_name_repr ml_kind_repr) ~proj:(function
+            | Direct { obj_name; ml_kind } -> Some (obj_name, ml_kind)
+            | Transitive _ -> None)
+        ; case "Transitive" (pair obj_name_repr cm_kind_repr) ~proj:(function
+            | Transitive { obj_name; cm_kind } -> Some (obj_name, cm_kind)
+            | Direct _ -> None)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Module_name.Set.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 64
+end
+
+(* Per-cctx cache of [Lib_flags.L.include_flags] keyed on [(lib_mode, sorted
+   kept_libs)]; two compile rules in this cctx sharing those values share one
+   [Args.t]. Output also depends on [t.requires_compile] / [t.requires_hidden],
+   which are immutable on the cctx produced by [create]. Derived cctxs from
+   [for_module_generated_at_link_time] overwrite [requires_compile] while
+   sharing this table, but take the [can_filter = false] arm in
+   [lib_deps_for_module] and never reach the cache. *)
+module Filtered_includes = struct
+  module Key = struct
+    type t =
+      { lib_mode : Lib_mode.t
+      ; kept_libs : Lib.t list (** sorted by [Lib.compare] *)
+      }
+
+    let equal a b =
+      Lib_mode.equal a.lib_mode b.lib_mode && List.equal Lib.equal a.kept_libs b.kept_libs
+    ;;
+
+    let hash { lib_mode; kept_libs } =
+      Poly.hash (Lib_mode.hash lib_mode, List.map kept_libs ~f:Lib.hash)
+    ;;
+
+    let repr =
+      Repr.record
+        "Filtered_includes.Key"
+        [ Repr.field "lib_mode" (Repr.abstract Lib_mode.to_dyn) ~get:(fun t -> t.lib_mode)
+        ; Repr.field
+            "kept_libs"
+            (Repr.list (Repr.abstract Lib.to_dyn))
+            ~get:(fun t -> t.kept_libs)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Command.Args.without_targets Command.Args.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 16
 end
 
 type opaque =
@@ -91,7 +175,10 @@ type t =
   ; parameters : Module_name.t list Resolve.Memo.t
   ; instances : Parameterised_instances.t Resolve.Memo.t option
   ; includes : Includes.t
+  ; lib_index : Lib_file_deps.Lib_index.t Resolve.t Memo.Lazy.t
+  ; has_virtual_impl : bool Resolve.t Memo.Lazy.t
   ; preprocessing : Pp_spec.t
+  ; pps_runtime_libs : Lib.t list Resolve.Memo.t
   ; opaque : bool
   ; js_of_ocaml : Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
   ; sandbox : Sandbox_config.t
@@ -104,6 +191,8 @@ type t =
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
   ; for_ : Compilation_mode.t
+  ; filtered_includes : Filtered_includes.t
+  ; raw_refs : Raw_refs.t
   }
 
 let loc t = t.loc
@@ -118,7 +207,10 @@ let requires_hidden t = t.requires_hidden
 let requires_link t = Memo.Lazy.force t.requires_link
 let parameters t = t.parameters
 let includes t = t.includes
+let lib_index t = Memo.Lazy.force t.lib_index
+let has_virtual_impl t = Memo.Lazy.force t.has_virtual_impl
 let preprocessing t = t.preprocessing
+let pps_runtime_libs t = t.pps_runtime_libs
 let opaque t = t.opaque
 let js_of_ocaml t = t.js_of_ocaml
 let sandbox t = t.sandbox
@@ -147,6 +239,83 @@ let parameters_main_modules parameters =
         [ "param", Lib.to_dyn param ])
 ;;
 
+(* Hidden libs must be indexed: otherwise unreached ones fall to
+   the glob branch and over-invalidate. *)
+let build_lib_index ~super_context ~libs ~for_ =
+  let open Resolve.Memo.O in
+  let+ per_lib =
+    Resolve.Memo.List.map libs ~f:(fun lib ->
+      match Lib_info.entry_modules (Lib.info lib) ~for_ with
+      | External (Ok names) ->
+        Resolve.Memo.return (List.map names ~f:(fun n -> n, lib, None), None)
+      | External (Error e) -> Resolve.Memo.of_result (Error e)
+      | Local ->
+        let* mods =
+          Resolve.Memo.lift_memo
+            (Dir_contents.modules_of_local_lib
+               super_context
+               (Lib.Local.of_lib_exn lib)
+               ~for_)
+        in
+        (* [no_ocamldep_lib] mirrors [Dep_rules.skip_ocamldep]'s
+           [has_library_deps] gating: use the *resolved* requires
+           (which include pps runtime libs added via
+           [add_pp_runtime_deps]), not the static [(libraries ...)]
+           field. A single-module lib with no [(libraries ...)] but
+           with [(preprocess (pps X))] still has its ocamldep run
+           because [Lib.requires] is non-empty; classifying it as
+           [no_ocamldep] would cause the cross-library walk to skip
+           it and drop transitive [.cmi] deps reachable through its
+           post-pp ocamldep output. *)
+        let+ requires_resolved = Lib.requires lib ~for_ in
+        (* [Some m] only for unwrapped locals (tight-eligible);
+           wrapped locals and externals → [None]. *)
+        let unwrapped =
+          match Lib_info.wrapped (Lib.info lib) with
+          | Some (This w) -> not (Wrapped.to_bool w)
+          | Some (From _) | None -> false
+        in
+        (* Post-pp [Module.t]: mirror [Pp_spec.pped_modules_map]
+           so the cross-lib walker reads ocamldep on the source
+           the dep lib's compile pipeline actually produces.
+           Staged Pps entries have no materialised [.pp.ml].
+           Pps lists composed only of [Instrumentation_backend]
+           entries are conditional (active only when the build
+           enables [--instrument-with]); we cannot be sure a
+           [.pp.ml] exists at this site, so we fall back to
+           non-tight-eligible ([m_opt = None]) for those. Pps
+           with at least one [Ordinary] entry always produces
+           a [.pp.ml]. *)
+        let preprocess = Lib_info.preprocess (Lib.info lib) ~for_:Ocaml in
+        let post_pp_module m =
+          match Preprocess.Per_module.find (Module.name m) preprocess with
+          | No_preprocessing | Future_syntax _ -> Some (Module.ml_source m)
+          | Action _ -> Some (Module.ml_source (Module.pped m))
+          | Pps { staged = false; pps; _ } ->
+            if
+              List.exists pps ~f:(function
+                | Preprocess.With_instrumentation.Ordinary _ -> true
+                | Instrumentation_backend _ -> false)
+            then Some (Module.pped (Module.ml_source m))
+            else None
+          | Pps { staged = true; _ } -> None
+        in
+        let entries =
+          List.map (Modules.entry_modules mods) ~f:(fun m ->
+            Module.name m, lib, if unwrapped then post_pp_module m else None)
+        in
+        let no_ocamldep_lib =
+          match Modules.as_singleton mods with
+          | Some _ when List.is_empty requires_resolved -> Some lib
+          | _ -> None
+        in
+        entries, no_ocamldep_lib)
+  in
+  let entries = List.concat_map per_lib ~f:fst in
+  let no_ocamldep = List.filter_map per_lib ~f:snd |> Lib.Set.of_list in
+  Lib_file_deps.Lib_index.create ~no_ocamldep entries
+;;
+
 let create
       ~super_context
       ~scope
@@ -155,6 +324,7 @@ let create
       ~flags
       ~requires_compile
       ~requires_link
+      ?(pps_runtime_libs = Resolve.Memo.return [])
       ?(preprocessing = Pp_spec.dummy)
       ~opaque
       ~js_of_ocaml
@@ -210,6 +380,19 @@ let create
     let profile = Context.profile context in
     eval_opaque ocaml profile opaque
   in
+  let* has_library_deps =
+    (* Single-module stanzas still run ocamldep when they have library
+       deps so the per-module filter can inform the result. *)
+    let open Resolve.Memo.O in
+    let+ direct = direct_requires
+    and+ hidden = hidden_requires in
+    match direct, hidden with
+    | [], [] -> false
+    | _ -> true
+  in
+  (* Resolution errors surface later through the normal compilation
+     rules; assume deps are present here. *)
+  let has_library_deps = Resolve.peek has_library_deps |> Result.value ~default:true in
   let+ dep_graphs =
     Dep_rules.rules
       ~dir:(Obj_dir.dir obj_dir)
@@ -219,6 +402,7 @@ let create
       ~impl:implements
       ~modules
       ~for_
+      ~has_library_deps
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b
@@ -244,9 +428,21 @@ let create
   ; requires_link
   ; implements
   ; parameters
-  ; includes =
-      Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
+  ; includes = Includes.make ~project ~direct_requires ~hidden_requires ocaml.lib_config
+  ; lib_index =
+      Memo.lazy_ (fun () ->
+        let open Resolve.Memo.O in
+        let* d = direct_requires
+        and* h = hidden_requires in
+        build_lib_index ~super_context ~libs:(d @ h) ~for_)
+  ; has_virtual_impl =
+      Memo.lazy_ (fun () ->
+        let open Resolve.Memo.O in
+        let+ direct = direct_requires
+        and+ hidden = hidden_requires in
+        List.exists (direct @ hidden) ~f:(fun lib -> Option.is_some (Lib.implements lib)))
   ; preprocessing
+  ; pps_runtime_libs
   ; opaque
   ; js_of_ocaml
   ; sandbox
@@ -260,10 +456,55 @@ let create
   ; ocaml
   ; instances
   ; for_
+  ; filtered_includes = Filtered_includes.create ()
+  ; raw_refs = Raw_refs.create ()
   }
 ;;
 
 let for_ t = t.for_
+
+let cached_raw_refs t ~key ~compute =
+  match Table.find t.raw_refs key with
+  | Some builder -> builder
+  | None ->
+    let builder = compute () in
+    Table.set t.raw_refs key builder;
+    builder
+;;
+
+let filtered_include_flags t ~cm_kind ~kept_libs =
+  let lib_mode = Lib_mode.of_cm_kind cm_kind in
+  let cache_key =
+    { Filtered_includes.Key.lib_mode; kept_libs = Lib.Set.to_list kept_libs }
+  in
+  match Table.find t.filtered_includes cache_key with
+  | Some builder -> builder
+  | None ->
+    (* Cache the [Action_builder.t] (not the resolved args) up-front at
+       rule-construction time so all compile rules sharing this [(lib_mode,
+       kept_libs)] share one builder; [Action_builder.memoize] then dedupes its
+       evaluation. Mirrors the cache pattern in
+       [Ocamldep.read_immediate_deps_words]. *)
+    let builder =
+      let open Action_builder.O in
+      let* direct_requires = Resolve.Memo.read t.requires_compile in
+      let+ hidden_requires = Resolve.Memo.read t.requires_hidden in
+      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_libs) in
+      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_libs) in
+      let project = Scope.project t.scope in
+      let lib_config = t.ocaml.lib_config in
+      Lib_flags.L.include_flags
+        ~project
+        ~direct_libs:direct_filtered
+        ~hidden_libs:hidden_filtered
+        lib_mode
+        lib_config
+      |> Command.Args.memo
+    in
+    let builder = Action_builder.memoize "filtered_include_flags" builder in
+    Table.set t.filtered_includes cache_key builder;
+    builder
+;;
 
 let alias_and_root_module_flags =
   let extra = [ "-w"; "-49" ] in
@@ -337,7 +578,6 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     let direct_requires = requires in
     Includes.make
       ~project:(Scope.project cctx.scope)
-      ~opaque
       ~direct_requires
       ~hidden_requires
       cctx.ocaml.lib_config
@@ -348,6 +588,16 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   ; requires_link = Memo.lazy_ (fun () -> requires)
   ; requires_compile = requires
   ; includes
+  ; lib_index =
+      Memo.lazy_ (fun () ->
+        (* Unreachable: synthesised modules use [Dep_graph.dummy]
+           (whose [dir] is [Path.Build.root]), so
+           [lib_deps_for_module]'s [can_filter] dir-equality guard
+           fails and the non-filter fallback is taken. *)
+        Code_error.raise
+          "Compilation_context.lib_index forced for a module synthesised at link time; \
+           this should be unreachable."
+          [])
   ; modules
   }
 ;;

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -27,6 +27,7 @@ val create
   -> flags:Ocaml_flags.t
   -> requires_compile:Lib.t list Resolve.Memo.t
   -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
+  -> ?pps_runtime_libs:Lib.t list Resolve.Memo.t
   -> ?preprocessing:Pp_spec.t
   -> opaque:opaque
   -> js_of_ocaml:Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
@@ -62,7 +63,58 @@ val requires_hidden : t -> Lib.t list Resolve.Memo.t
 val requires_compile : t -> Lib.t list Resolve.Memo.t
 val parameters : t -> Module_name.t list Resolve.Memo.t
 val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
+
+module Raw_refs : sig
+  module Key : sig
+    type t =
+      | Direct of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+  end
+end
+
+(** Memoise the raw-refs [Action_builder.t] computed for each
+    [Raw_refs.Key.t] within this cctx. [compute ()] is invoked
+    only on cache miss; subsequent callers with the same key get
+    the cached builder back. The cache short-circuits before
+    allocating, so siblings sharing [trans_deps] don't redo
+    construction. *)
+val cached_raw_refs
+  :  t
+  -> key:Raw_refs.Key.t
+  -> compute:(unit -> Module_name.Set.t Action_builder.t)
+  -> Module_name.Set.t Action_builder.t
+
+(** Include flags ([-I]/[-H]) for compiling a module against [kept_libs]. The
+    cctx's [requires_compile] and [requires_hidden] are each restricted to
+    libraries in [kept_libs]; the kept direct entries become [-I], the kept
+    hidden entries become [-H]. *)
+val filtered_include_flags
+  :  t
+  -> cm_kind:Lib_mode.Cm_kind.t
+  -> kept_libs:Lib.Set.t
+  -> Command.Args.without_targets Command.Args.t Action_builder.t
+
+val lib_index : t -> Lib_file_deps.Lib_index.t Resolve.Memo.t
+
+(** [true] iff any library in the compilation context's direct or
+    hidden requires implements a virtual library. Memoized per cctx. *)
+val has_virtual_impl : t -> bool Resolve.Memo.t
+
 val preprocessing : t -> Pp_spec.t
+
+(** Closure of [ppx_runtime_libraries] introduced by every [pps] in
+    this stanza's preprocessor. These libraries' modules are visible
+    only to ppx-rewritten output, so the per-module dependency filter
+    cannot reason about which of them are referenced — they must be
+    treated as opaque [must-glob] dependencies. *)
+val pps_runtime_libs : t -> Lib.t list Resolve.Memo.t
+
 val opaque : t -> bool
 val js_of_ocaml : t -> Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
 val sandbox : t -> Sandbox_config.t

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -7,6 +7,8 @@ type t =
   }
 
 let make ~dir ~per_module = { dir; per_module }
+let dir t = t.dir
+let mem t (m : Module.t) = Module_name.Unique.Map.mem t.per_module (Module.obj_name m)
 
 let deps_of t (m : Module.t) =
   match Module_name.Unique.Map.find t.per_module (Module.obj_name m) with

--- a/src/dune_rules/dep_graph.mli
+++ b/src/dune_rules/dep_graph.mli
@@ -9,6 +9,8 @@ val make
   -> per_module:Module.t list Action_builder.t Module_name.Unique.Map.t
   -> t
 
+val dir : t -> Path.Build.t
+val mem : t -> Module.t -> bool
 val deps_of : t -> Module.t -> Module.t list Action_builder.t
 val top_closed_implementations : t -> Module.t list -> Module.t list Action_builder.t
 

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -504,10 +504,14 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
     (deps_of ~modules ~transitive_deps ~imported_vlib_deps (Normal module_))
 ;;
 
-let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ =
+let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m -> Memo.return (Dep_graph.Ml_kind.dummy m)
-  | None ->
+  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
+    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
+       consumed by the per-module filter in [lib_deps_for_module]. That filter
+       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+    Memo.return (Dep_graph.Ml_kind.dummy m)
+  | Some _ | None ->
     let transitive_deps, imported_vlib_deps =
       make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_
     in

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -13,6 +13,9 @@ val for_module
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.t
 
+(** Single-module stanzas short-circuit ocamldep when [not
+    has_library_deps] or [for_ = Melange]: the per-module filter
+    that consumes the dep graph doesn't activate in those cases. *)
 val rules
   :  obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
@@ -21,6 +24,7 @@ val rules
   -> sctx:Super_context.t
   -> dir:Path.Build.t
   -> for_:Compilation_mode.t
+  -> has_library_deps:bool
   -> Dep_graph.Ml_kind.t Memo.t
 
 val read_immediate_deps_of

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -193,6 +193,11 @@ let executables_rules
   let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let instances =
       Parameterised_instances.instances
         ~sctx
@@ -215,6 +220,7 @@ let executables_rules
       ~flags
       ~requires_link
       ~requires_compile
+      ~pps_runtime_libs
       ~preprocessing:pp
       ~js_of_ocaml
       ~opaque:Inherit_from_settings

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2198,11 +2198,51 @@ end = struct
   ;;
 end
 
-let closure l ~linking =
-  let forbidden_libraries = Map.empty in
-  if linking
-  then Resolve_names.linking_closure_with_overlap_checks None l ~forbidden_libraries
-  else Resolve_names.compile_closure_with_overlap_checks None l ~forbidden_libraries
+let closure =
+  let memo =
+    let module Input = struct
+      type nonrec t = bool * Compilation_mode.t * t list
+
+      let equal (l, m, libs) (l', m', libs') =
+        Bool.equal l l' && Compilation_mode.equal m m' && List.equal equal libs libs'
+      ;;
+
+      let hash_for_ = function
+        | Compilation_mode.Ocaml -> 0
+        | Melange -> 1
+      ;;
+
+      let hash (linking, for_, libs) =
+        Tuple.T3.hash
+          Bool.hash
+          hash_for_
+          (List.hash (fun lib -> Id.hash lib.unique_id))
+          (linking, for_, libs)
+      ;;
+
+      let to_dyn = Dyn.opaque
+    end
+    in
+    Memo.create
+      "lib-closure"
+      ~input:(module Input)
+      (fun (linking, for_, l) ->
+         let forbidden_libraries = Map.empty in
+         if linking
+         then
+           Resolve_names.linking_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_
+         else
+           Resolve_names.compile_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_)
+  in
+  fun l ~linking ~for_ -> Memo.exec memo (linking, for_, l)
 ;;
 
 let descriptive_closure (l : lib list) ~with_pps ~for_ : lib list Memo.t =

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -217,6 +217,10 @@ end
 
 (** {1 Transitive closure} *)
 
+(** Memoized. The memo key is order-sensitive on the input list, so
+    for callers that share inputs across invocations (e.g. the hot
+    path in [Module_compilation.lib_deps_for_module]), a canonical
+    sort (by [Lib.compare]) maximises cache reuse. *)
 val closure : t list -> linking:bool -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
 (** [descriptive_closure ~with_pps libs] computes the smallest set of libraries

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -1,6 +1,14 @@
 open Import
 open Memo.O
 
+(* This file builds dep specs for library files (cmi/cmx/cmj/header).
+   Per-module tight deps apply only to local unwrapped libraries;
+   wrapped libraries take a directory glob over their public cmi
+   dir. [ocamldep -modules] outputs only top-level module names —
+   for a consumer using [Foo.Bar.x] the output is [Foo], not
+   [Foo.Bar] — so the filter cannot distinguish [Foo.Bar] from
+   [Foo.Baz] consumers and a glob is the tightest sound dep. *)
+
 module Group = struct
   type ocaml =
     | Cmi
@@ -48,8 +56,159 @@ let deps_of_lib (lib : Lib.t) ~groups =
   |> Dep.Set.of_list
 ;;
 
-let deps_with_exts = Dep.Set.union_map ~f:(fun (lib, groups) -> deps_of_lib lib ~groups)
 let deps libs ~groups = Dep.Set.union_map libs ~f:(deps_of_lib ~groups)
+
+let groups_for_cm_kind ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib =
+  match cm_kind with
+  | Ocaml Cmi | Ocaml Cmo -> [ Group.Ocaml Cmi ]
+  | Ocaml Cmx ->
+    if opaque && Lib.is_local lib
+    then [ Group.Ocaml Cmi ]
+    else [ Group.Ocaml Cmi; Group.Ocaml Cmx ]
+  | Melange Cmi -> [ Group.Melange Cmi ]
+  | Melange Cmj -> [ Group.Melange Cmi; Group.Melange Cmj ]
+;;
+
+let deps_of_entries ~opaque ~cm_kind libs =
+  Dep.Set.union_map libs ~f:(fun lib ->
+    deps_of_lib lib ~groups:(groups_for_cm_kind ~opaque ~cm_kind lib))
+;;
+
+(* [cm_public_file] gives the cmi path consumers read via their [-I]
+   include path, which for libraries with a dedicated public cmi dir
+   ([private_modules]) differs from the internal compilation output.
+   Using it ensures the dep triggers the produce-public-cmi rule. *)
+let deps_of_entry_modules ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib modules =
+  let obj_dir = Lib.info lib |> Lib_info.obj_dir in
+  let cmi_kind = Lib_mode.Cm_kind.cmi cm_kind in
+  let want_cmx =
+    match cm_kind with
+    | Ocaml Cmx -> not (opaque && Lib.is_local lib)
+    | _ -> false
+  in
+  List.fold_left modules ~init:Dep.Set.empty ~f:(fun acc m ->
+    let acc =
+      match Obj_dir.Module.cm_public_file obj_dir m ~kind:cmi_kind with
+      | Some path -> Dep.Set.add acc (Dep.file path)
+      | None ->
+        (* Unreachable: [tight_modules] contains only public modules
+           (consumers can't reach private), so [cm_public_file] resolves. *)
+        Code_error.raise
+          "deps_of_entry_modules: [cm_public_file] returned [None] for cmi of a module \
+           in tight_modules"
+          [ "module", Module.to_dyn m; "lib", Lib.to_dyn lib ]
+    in
+    if want_cmx && Module.has m ~ml_kind:Impl
+    then (
+      match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Ocaml Cmx) with
+      | Some path -> Dep.Set.add acc (Dep.file path)
+      | None ->
+        (* Unreachable. [cm_public_file ~kind:(Ocaml Cmx)] returns
+           [None] only when [not has_impl]. The enclosing [if]
+           guarantees [Module.has m ~ml_kind:Impl] (= [has_impl]). *)
+        Code_error.raise
+          "deps_of_entry_modules: [cm_public_file] returned [None] for cmx despite \
+           [Module.has m ~ml_kind:Impl] holding"
+          [ "module", Module.to_dyn m ])
+    else acc)
+;;
+
+module Lib_index = struct
+  type t =
+    { by_module_name : (Lib.t * Module.t option) list Module_name.Map.t
+    ; tight_eligible : Lib.Set.t
+    ; no_ocamldep : Lib.Set.t
+      (* Local libs short-circuited by [Dep_rules.skip_ocamldep] — no [.d]
+         rules exist; the cross-library walk must skip them. *)
+    }
+
+  let empty =
+    { by_module_name = Module_name.Map.empty
+    ; tight_eligible = Lib.Set.empty
+    ; no_ocamldep = Lib.Set.empty
+    }
+  ;;
+
+  (* Tight-eligibility is encoded in the entry shape: [(_, lib, Some
+     _)] means the index producer has decided [lib] is tight-eligible
+     (local + unwrapped, every entry carries a [Module.t]). *)
+  let create ~no_ocamldep entries =
+    let by_module_name =
+      List.fold_left entries ~init:Module_name.Map.empty ~f:(fun map (name, lib, m) ->
+        Module_name.Map.update map name ~f:(function
+          | None -> Some [ lib, m ]
+          | Some xs -> Some ((lib, m) :: xs)))
+    in
+    let tight_eligible =
+      List.fold_left entries ~init:Lib.Set.empty ~f:(fun acc (_, lib, m_opt) ->
+        match m_opt with
+        | Some _ -> Lib.Set.add acc lib
+        | None -> acc)
+    in
+    { by_module_name; tight_eligible; no_ocamldep }
+  ;;
+
+  type classified =
+    { tight : Module.t list Lib.Map.t
+    ; non_tight : Lib.t list
+    }
+
+  (* Per-pair classification: each entry is independently tight
+     (Some) or non-tight (None). A lib whose modules have mixed
+     entries (e.g. unwrapped lib with per-module preprocessing
+     where some modules are staged-pps) lands in BOTH [tight] and
+     [non_tight]; the caller should treat such a lib as glob-only
+     to avoid dropping the None entries' [.cmi]s from compile-rule
+     deps. *)
+  let filter_libs_with_modules idx ~referenced_modules =
+    let add_entry (tight, non_tight) (lib, m_opt) =
+      match m_opt with
+      | Some m ->
+        let tight =
+          Lib.Map.update tight lib ~f:(function
+            | None -> Some [ m ]
+            | Some ms -> Some (m :: ms))
+        in
+        tight, non_tight
+      | None -> tight, Lib.Set.add non_tight lib
+    in
+    let tight, non_tight =
+      Module_name.Set.fold
+        referenced_modules
+        ~init:(Lib.Map.empty, Lib.Set.empty)
+        ~f:(fun name acc ->
+          match Module_name.Map.find idx.by_module_name name with
+          | None -> acc
+          | Some entries -> List.fold_left entries ~init:acc ~f:add_entry)
+    in
+    { tight; non_tight = Lib.Set.to_list non_tight }
+  ;;
+
+  let lookup_tight_entries idx name =
+    match Module_name.Map.find idx.by_module_name name with
+    | None -> []
+    | Some entries ->
+      List.filter_map entries ~f:(fun (lib, m_opt) ->
+        match m_opt with
+        | Some m when not (Lib.Set.mem idx.no_ocamldep lib) -> Some (lib, m)
+        | _ -> None)
+  ;;
+
+  let is_tight_eligible idx lib = Lib.Set.mem idx.tight_eligible lib
+
+  (* Wrapped local libs land in [by_module_name] with [m_opt = None];
+     externals also do, but [Lib.is_local] excludes them. *)
+  let wrapped_libs_referenced idx ~referenced_modules =
+    Module_name.Set.fold referenced_modules ~init:Lib.Set.empty ~f:(fun name acc ->
+      match Module_name.Map.find idx.by_module_name name with
+      | None -> acc
+      | Some entries ->
+        List.fold_left entries ~init:acc ~f:(fun acc (lib, m_opt) ->
+          match m_opt with
+          | None when Lib.is_local lib -> Lib.Set.add acc lib
+          | _ -> acc))
+  ;;
+end
 
 type path_specification =
   | Allow_all

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -15,7 +15,68 @@ end
     with extension [files] of libraries [libs]. *)
 val deps : Lib.t list -> groups:Group.t list -> Dep.Set.t
 
-val deps_with_exts : (Lib.t * Group.t list) list -> Dep.Set.t
+(** [deps_of_entries ~opaque ~cm_kind libs] computes the file dependencies
+    (glob deps on .cmi/.cmx files) for the given libraries. *)
+val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list -> Dep.Set.t
+
+(** Specific-file deps on the [modules] of [lib]. Only valid for
+    local libraries (where [Module.t] values are available). *)
+val deps_of_entry_modules
+  :  opaque:bool
+  -> cm_kind:Lib_mode.Cm_kind.t
+  -> Lib.t
+  -> Module.t list
+  -> Dep.Set.t
+
+module Lib_index : sig
+  type t
+
+  val empty : t
+
+  (** Third tuple element is [Some m] for local + unwrapped libs
+      (with the entry's [Module.t]) and [None] otherwise (wrapped
+      locals, externals). [no_ocamldep] names local libs whose [.d]
+      files don't exist (short-circuited by [Dep_rules.skip_ocamldep]);
+      the cross-library walk skips them. *)
+  val create
+    :  no_ocamldep:Lib.Set.t
+    -> (Module_name.t * Lib.t * Module.t option) list
+    -> t
+
+  type classified =
+    { tight : Module.t list Lib.Map.t
+      (** Per-pair tight entries: libs mapped to the [Some]-entry
+          modules referenced. Candidates for [deps_of_entry_modules]
+          unless the lib also appears in [non_tight] (mixed-entry
+          libs must glob to cover their [None] entries). *)
+    ; non_tight : Lib.t list
+      (** Libs whose [None]-entry modules appear in the input
+          (wrapped locals, externals, or unwrapped locals with
+          some staged-pps / instrumentation-only entries). The
+          caller must glob these. Sorted by [Lib.compare]. *)
+    }
+
+  (** Classify the libraries whose entry modules appear in
+      [referenced_modules]. A lib with mixed [Some]/[None] entries
+      can appear in BOTH [tight] (for its [Some] modules) AND
+      [non_tight] (for its [None] modules). *)
+  val filter_libs_with_modules : t -> referenced_modules:Module_name.Set.t -> classified
+
+  (** [(lib, entry module)] pairs for the cross-library walk;
+      excludes [no_ocamldep] libs and entries with [m_opt = None]. *)
+  val lookup_tight_entries : t -> Module_name.t -> (Lib.t * Module.t) list
+
+  (** True for libs with at least one tight-eligible ([Some]) entry.
+      Used to drop unreached libs from a consumer's compile deps:
+      if the lib is capable of tight-eligibility but no module of
+      it is referenced, the link rule still pulls it in. *)
+  val is_tight_eligible : t -> Lib.t -> bool
+
+  (** Local wrapped libs whose entry name is in [referenced_modules].
+      The consumer must glob the wrapped lib's [Lib.closure] (see
+      the file-level comment for why). *)
+  val wrapped_libs_referenced : t -> referenced_modules:Module_name.Set.t -> Lib.Set.t
+end
 
 type path_specification =
   | Allow_all

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -502,6 +502,11 @@ let cctx
   let modules = Virtual_rules.impl_modules implements modules in
   let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
   let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+  let pps_runtime_libs =
+    let open Resolve.Memo.O in
+    let* pps = Lib.Compile.pps compile_info ~for_ in
+    Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+  in
   let instances =
     Parameterised_instances.instances ~sctx ~db:(Scope.libs scope) lib.buildable.libraries
   in
@@ -532,6 +537,7 @@ let cctx
     ~flags
     ~requires_compile
     ~requires_link
+    ~pps_runtime_libs
     ~implements
     ~parameters
     ~preprocessing:pp

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -1,6 +1,272 @@
 open Import
 open Memo.O
 
+let all_libs cctx =
+  let open Resolve.Memo.O in
+  let+ d = Compilation_context.requires_compile cctx
+  and+ h = Compilation_context.requires_hidden cctx in
+  d @ h
+;;
+
+let union_module_name_sets_mapped xs ~f =
+  Action_builder.List.map xs ~f
+  |> Action_builder.map
+       ~f:(List.fold_left ~init:Module_name.Set.empty ~f:Module_name.Set.union)
+;;
+
+let module_kind_is_filterable m =
+  match Module.kind m with
+  | Root | Wrapped_compat | Impl_vmodule | Virtual | Parameter -> false
+  | Intf_only | Impl | Alias _ -> true
+;;
+
+(* BFS over tight-eligible entries: each (lib, entry) pair's
+   impl+intf ocamldep names extend the frontier. Non-tight-eligible
+   libs (wrapped locals, externals, virtual-impls, staged-Pps libs)
+   are skipped by [lookup_tight_entries], terminating chains through
+   them. The [Module.t] supplied here is the post-pp form
+   (constructed in [build_lib_index]), so ocamldep runs on the dep
+   lib's [.pp.ml] (action / non-staged Pps) or directly on the source
+   (no preprocessing / future-syntax). *)
+let cross_lib_tight_set ~sandbox ~sctx ~lib_index ~initial_refs =
+  let open Action_builder.O in
+  let read_entry_deps (lib, m) =
+    let obj_dir = Lib.info lib |> Lib_info.obj_dir |> Obj_dir.as_local_exn in
+    let* impl_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Impl m
+    in
+    let+ intf_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Intf m
+    in
+    Module_name.Set.union impl_deps intf_deps
+  in
+  let rec loop ~seen ~frontier =
+    if Module_name.Set.is_empty frontier
+    then Action_builder.return seen
+    else (
+      let pairs =
+        Module_name.Set.fold frontier ~init:[] ~f:(fun name acc ->
+          Lib_file_deps.Lib_index.lookup_tight_entries lib_index name @ acc)
+      in
+      let* discovered = union_module_name_sets_mapped pairs ~f:read_entry_deps in
+      let seen = Module_name.Set.union seen frontier in
+      let frontier = Module_name.Set.diff discovered seen in
+      loop ~seen ~frontier)
+  in
+  loop ~seen:Module_name.Set.empty ~frontier:initial_refs
+;;
+
+(* See the module-level comment in [lib_file_deps.ml] for the two
+   dep shapes ([deps_of_entry_modules] vs [deps_of_entries]) and
+   why wrapped dep libraries always take the glob path. *)
+let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kind ~mode m =
+  let open Action_builder.O in
+  let cctx_includes_for_cm_kind () =
+    Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
+  in
+  let can_filter =
+    (match Lib_mode.of_cm_kind cm_kind with
+     | Melange -> false
+     | Ocaml _ -> true)
+    (* Dummy dep graph (alias/root/link-time-synthesised module);
+       cannot supply transitive deps. *)
+    && Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
+    (* Modules synthesised outside the stanza, handed to [ocamlc_i]. *)
+    && Dep_graph.mem dep_graph m
+    && module_kind_is_filterable m
+    && Module.has m ~ml_kind
+    (* Consumer-stanza virtual-impl: handled by [Dep_rules]. The
+       deps-side counterpart ([has_virtual_impl] below) covers the
+       case where a lib in [requires] is a virtual impl. *)
+    && not (Virtual_rules.is_virtual_or_parameter (Compilation_context.implements cctx))
+  in
+  let* libs = Resolve.Memo.read (all_libs cctx) in
+  if not can_filter
+  then
+    Action_builder.return
+      (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+  else
+    let* has_virtual_impl =
+      Resolve.Memo.read (Compilation_context.has_virtual_impl cctx)
+    in
+    if has_virtual_impl
+    then
+      Action_builder.return
+        (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+    else
+      let* lib_index = Resolve.Memo.read (Compilation_context.lib_index cctx) in
+      let sandbox = Compilation_context.sandbox cctx in
+      let sctx = Compilation_context.super_context cctx in
+      let* trans_deps = Dep_graph.deps_of dep_graph m in
+      (* Read [dep_m]'s [.ml]-side ocamldep only when its references can
+         propagate to the consumer:
+
+         | [dep_m] is              | [cm_kind]   | [opaque] | read [.ml]?  |
+         | ----------------------- | ----------- | -------- | ------------ |
+         | consumer ([m] itself)   | any         | any      | iff [Impl]   |
+         | trans_dep, no [.mli]    | any         | any      | yes          |
+         | trans_dep, has [.mli]   | [Cmx]       | false    | yes (inline) |
+         | trans_dep, has [.mli]   | [Cmx]       | true     | no           |
+         | trans_dep, has [.mli]   | [Cmi]/[Cmo] | any      | no           | *)
+      let need_impl_deps_of dep_m ~is_consumer =
+        if is_consumer
+        then (
+          match ml_kind with
+          | Ml_kind.Impl -> true
+          | Intf -> false)
+        else
+          (not (Module.has dep_m ~ml_kind:Intf))
+          ||
+          match cm_kind with
+          | Ocaml Cmx -> not opaque
+          | Ocaml (Cmi | Cmo) | Melange _ -> false
+      in
+      let read_dep_m_raw dep_m ~is_consumer =
+        let key : Compilation_context.Raw_refs.Key.t =
+          let obj_name = Module.obj_name dep_m in
+          if is_consumer
+          then Direct { obj_name; ml_kind }
+          else Transitive { obj_name; cm_kind }
+        in
+        Compilation_context.cached_raw_refs cctx ~key ~compute:(fun () ->
+          let* impl_deps =
+            if need_impl_deps_of dep_m ~is_consumer
+            then
+              Ocamldep.read_immediate_deps_raw_of
+                ~sandbox
+                ~sctx
+                ~obj_dir
+                ~ml_kind:Impl
+                dep_m
+            else Action_builder.return Module_name.Set.empty
+          in
+          let+ intf_deps =
+            Ocamldep.read_immediate_deps_raw_of
+              ~sandbox
+              ~sctx
+              ~obj_dir
+              ~ml_kind:Intf
+              dep_m
+          in
+          Module_name.Set.union impl_deps intf_deps)
+      in
+      let* m_raw = read_dep_m_raw m ~is_consumer:true in
+      let* trans_raw =
+        union_module_name_sets_mapped trans_deps ~f:(read_dep_m_raw ~is_consumer:false)
+      in
+      let all_raw = Module_name.Set.union m_raw trans_raw in
+      let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
+      let open_modules = Ocaml_flags.extract_open_module_names flags in
+      let referenced = Module_name.Set.union all_raw open_modules in
+      let { Lib_file_deps.Lib_index.tight; non_tight } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:referenced
+      in
+      (* [ppx_runtime_libraries] introduce module references through
+         post-pp source that ocamldep cannot see; carry them through
+         to [all_libs] so the classification fold sees them, and
+         force them onto the glob path via [must_glob_set]. *)
+      let* pps_runtime_libs =
+        Resolve.Memo.read (Compilation_context.pps_runtime_libs cctx)
+      in
+      (* [Lib.closure]'s memo key is order- and multiplicity-sensitive
+         on the input list. [pps_runtime_libs] can both contain
+         duplicates (multiple pps sharing a runtime dep) and overlap
+         with [tight]/[non_tight] (a lib referenced both syntactically
+         and via [add_pp_runtime_deps]). [sort_uniq] keeps the input
+         canonical for memoization. *)
+      let direct_libs =
+        List.sort_uniq
+          ~compare:Lib.compare
+          (Lib.Map.keys tight @ non_tight @ pps_runtime_libs)
+      in
+      (* Close transitively over transparent aliases that ocamldep
+         doesn't report. *)
+      let* all_libs = Resolve.Memo.read (Lib.closure direct_libs ~linking:false ~for_) in
+      (* Wrapped-lib soundness recovery: when [referenced] names a
+         wrapped local lib's wrapper, the consumer may reach the
+         lib's transitive closure through aliases the cross-library
+         walk cannot see; glob that closure unconditionally. *)
+      let wrapped_referenced =
+        Lib_file_deps.Lib_index.wrapped_libs_referenced
+          lib_index
+          ~referenced_modules:referenced
+      in
+      let* must_glob_libs =
+        Resolve.Memo.read
+          (Lib.closure
+             (List.sort_uniq
+                ~compare:Lib.compare
+                (Lib.Set.to_list wrapped_referenced @ pps_runtime_libs))
+             ~linking:false
+             ~for_)
+      in
+      let must_glob_set = Lib.Set.of_list must_glob_libs in
+      let* tight_set =
+        cross_lib_tight_set ~sandbox ~sctx ~lib_index ~initial_refs:referenced
+      in
+      (* Classify each lib in [all_libs]:
+         - lib has [None]-entry referenced (mixed-entry or wrapped)
+           → glob (covers the None entries' [.cmi]s);
+         - lib has only [Some] entries referenced → per-module deps;
+         - lib unreached but tight-eligible → drop (link rule pulls
+           it in via [requires_link]);
+         - lib unreached and not tight-eligible → glob.
+         [kept_libs] gets every lib that contributes a tight or glob dep — used
+         by [Compilation_context.filtered_include_flags] to scope the
+         consumer's [-I]/[-H] flags. *)
+      let { Lib_file_deps.Lib_index.tight = tight_modules; non_tight = non_tight_libs } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:tight_set
+      in
+      let non_tight_set = Lib.Set.of_list non_tight_libs in
+      let tight_deps, glob_libs, kept_libs =
+        List.fold_left
+          all_libs
+          ~init:(Dep.Set.empty, [], Lib.Set.empty)
+          ~f:(fun (td, gl, kl) lib ->
+            if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
+            then td, lib :: gl, Lib.Set.add kl lib
+            else (
+              match Lib.Map.find tight_modules lib with
+              | Some modules ->
+                ( Dep.Set.union
+                    td
+                    (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
+                , gl
+                , Lib.Set.add kl lib )
+              | None ->
+                if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
+                then td, gl, kl
+                else td, lib :: gl, Lib.Set.add kl lib))
+      in
+      let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
+      let+ include_flags =
+        Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
+      in
+      include_flags, Dep.Set.union tight_deps glob_deps
+;;
+
+let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let opaque = Compilation_context.opaque cctx in
+  let for_ = Compilation_context.for_ cctx in
+  let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
+  Action_builder.dyn_deps
+    (lib_deps_for_module
+       ~cctx
+       ~obj_dir
+       ~for_
+       ~dep_graph
+       ~opaque
+       ~cm_kind
+       ~ml_kind
+       ~mode
+       m)
+;;
+
 (* Arguments for the compiler to prevent it from being too clever.
 
    The compiler creates the cmi when it thinks a .ml file has no corresponding
@@ -281,6 +547,20 @@ let build_cm
         | Some All | None -> Hidden_targets [ obj ])
    in
    let opaque = Compilation_context.opaque cctx in
+   let skip_lib_deps =
+     match Module.kind m with
+     | Alias _ ->
+       not (Modules.With_vlib.is_stdlib_alias (Compilation_context.modules cctx) m)
+     | Wrapped_compat -> true
+     | Intf_only | Virtual | Impl | Impl_vmodule | Root | Parameter -> false
+   in
+   let lib_cm_deps =
+     if skip_lib_deps
+     then
+       Action_builder.return
+         (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+     else lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m
+   in
    let other_cm_files =
      let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
      let module_deps = Dep_graph.deps_of dep_graph m in
@@ -407,8 +687,7 @@ let build_cm
             ; cmt_args
             ; cms_args
             ; Command.Args.S obj_dirs
-            ; Command.Args.as_any
-                (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+            ; Command.Args.Dyn lib_cm_deps
             ; extra_args
             ; As as_parameter_arg
             ; as_argument_for
@@ -524,6 +803,9 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
        List.concat_map deps ~f:(fun m ->
          [ Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)) ]))
   in
+  let lib_cm_deps =
+    lib_cm_deps ~cctx ~cm_kind:(Ocaml Cmo) ~ml_kind:Impl ~mode:(Ocaml Byte) m
+  in
   let ocaml_flags = Ocaml_flags.get (Compilation_context.flags cctx) (Ocaml Byte) in
   let modules = Compilation_context.modules cctx in
   let ocaml = Compilation_context.ocaml cctx in
@@ -541,10 +823,7 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
               [ Command.Args.dyn ocaml_flags
               ; A "-I"
               ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-              ; Command.Args.as_any
-                  (Lib_mode.Cm_kind.Map.get
-                     (Compilation_context.includes cctx)
-                     (Ocaml Cmo))
+              ; Command.Args.Dyn lib_cm_deps
               ; opens modules m
               ; A "-short-paths"
               ; A "-i"

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -670,6 +670,12 @@ module Wrapped = struct
 
   let lib_interface t = Group.lib_interface t.group
 
+  (* Entry modules visible to consumers of a wrapped library: the wrapper
+     itself, plus any [wrapped_compat] shims (present for
+     [(wrapped (transition ...))] libraries, which expose bare module names
+     in addition to qualified ones). *)
+  let entry_modules t = lib_interface t :: Module_name.Map.values t.wrapped_compat
+
   let fold_user_available { group; toplevel_module; _ } ~init ~f =
     let init =
       match toplevel_module with
@@ -918,6 +924,12 @@ let wrapped t =
   | Stdlib _ -> Simple true
 ;;
 
+let as_singleton t =
+  match t.modules with
+  | Singleton m -> Some m
+  | Unwrapped _ | Wrapped _ | Stdlib _ -> None
+;;
+
 let is_user_written m =
   match Module.kind m with
   | Root | Wrapped_compat | Alias _ -> false
@@ -1005,7 +1017,7 @@ let entry_modules t =
      | Unwrapped m -> Unwrapped.entry_modules m
      | Wrapped m ->
        (* we assume this is never called for implementations *)
-       [ Wrapped.lib_interface m ])
+       Wrapped.entry_modules m)
 ;;
 
 module With_vlib = struct

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -57,6 +57,14 @@ val obj_map : t -> Sourced_module.t Module_name.Unique.Map.t
 val virtual_module_names : t -> Module_name.Path.Set.t
 
 val wrapped : t -> Wrapped.t
+
+(** [Some m] iff the library's module set is a singleton — the
+    single user-written module [m]. This covers both unwrapped
+    stanzas with exactly one module and wrapped stanzas whose only
+    module is the main module (in which case the wrapper is
+    elided). Mirrors [With_vlib.as_singleton]. *)
+val as_singleton : t -> Module.t option
+
 val source_dirs : t -> Path.Set.t
 val compat_for_exn : t -> Module.t -> Module.t
 

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -197,3 +197,18 @@ let allow_only_melange t =
 let open_flags modules =
   List.concat_map modules ~f:(fun name -> [ "-open"; Module_name.to_string name ])
 ;;
+
+let extract_open_module_names flags =
+  let rec loop acc = function
+    | "-open" :: name :: rest ->
+      let acc =
+        match Module_name.of_string_opt name with
+        | Some m -> Module_name.Set.add acc m
+        | None -> acc
+      in
+      loop acc rest
+    | _ :: rest -> loop acc rest
+    | [] -> acc
+  in
+  loop Module_name.Set.empty flags
+;;

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -30,3 +30,6 @@ val with_vendored_alerts : t -> t
 val dump : t -> Dune_lang.t list Action_builder.t
 val with_vendored_flags : t -> ocaml_version:Version.t -> t
 val open_flags : Module_name.t list -> string list
+
+(** Extract module names from [-open Foo] pairs in compiler flags. *)
+val extract_open_module_names : string list -> Module_name.Set.t

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -22,27 +22,27 @@ let parse_module_names ~dir ~(unit : Module.t) ~modules words =
         ])
 ;;
 
-let parse_deps_exn =
-  let invalid file lines =
-    User_error.raise
-      [ Pp.textf
-          "ocamldep returned unexpected output for %s:"
-          (Path.to_string_maybe_quoted file)
-      ; Pp.vbox
-          (Pp.concat_map lines ~sep:Pp.cut ~f:(fun line ->
-             Pp.seq (Pp.verbatim "> ") (Pp.verbatim line)))
-      ]
-  in
-  fun ~file lines ->
-    match lines with
-    | [] | _ :: _ :: _ -> invalid file lines
-    | [ line ] ->
-      (match String.lsplit2 line ~on:':' with
-       | None -> invalid file lines
-       | Some (basename, deps) ->
-         let basename = Filename.basename basename in
-         if basename <> Path.basename file then invalid file lines;
-         String.extract_blank_separated_words deps)
+let invalid_ocamldep_output file lines =
+  User_error.raise
+    [ Pp.textf
+        "ocamldep returned unexpected output for %s:"
+        (Path.to_string_maybe_quoted file)
+    ; Pp.vbox
+        (Pp.concat_map lines ~sep:Pp.cut ~f:(fun line ->
+           Pp.seq (Pp.verbatim "> ") (Pp.verbatim line)))
+    ]
+;;
+
+let parse_deps_exn ~file lines =
+  match lines with
+  | [] | _ :: _ :: _ -> invalid_ocamldep_output file lines
+  | [ line ] ->
+    (match String.lsplit2 line ~on:':' with
+     | None -> invalid_ocamldep_output file lines
+     | Some (basename, deps) ->
+       let basename = Filename.basename basename in
+       if basename <> Path.basename file then invalid_ocamldep_output file lines;
+       String.extract_blank_separated_words deps)
 ;;
 
 let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
@@ -79,24 +79,57 @@ let ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit =
   }
 ;;
 
+(* Top-level cache per (source path, ml_kind): without it, each caller's
+   [Action_builder.memoize] cell has a different digest (pp-flags closure
+   identity varies), causing ocamldep to run multiply per source. *)
+let read_immediate_deps_words =
+  let cache = Table.create (module String) 64 in
+  fun ~sandbox ~sctx ~obj_dir ~ml_kind unit ->
+    match Module.source ~ml_kind unit with
+    | None -> Action_builder.return None
+    | Some source ->
+      let memo_name =
+        sprintf
+          "%s.%s.ocamldep"
+          (Path.to_string (Module.File.path source))
+          (Ml_kind.to_string ml_kind)
+      in
+      (match Table.find cache memo_name with
+       | Some builder -> builder
+       | None ->
+         let dir = Obj_dir.dir obj_dir in
+         let builder =
+           ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit
+           |> Build_system.execute_action_stdout
+           |> Memo.map ~f:(fun output ->
+             Some
+               (String.split_lines output
+                |> parse_deps_exn ~file:(Module.File.path source)))
+           |> Action_builder.of_memo
+           |> Action_builder.memoize memo_name
+         in
+         Table.set cache memo_name builder;
+         builder)
+;;
+
 let read_immediate_deps_of ~sandbox ~sctx ~obj_dir ~modules ~ml_kind unit =
-  match Module.source ~ml_kind unit with
-  | None -> Action_builder.return []
-  | Some source ->
+  let open Action_builder.O in
+  let+ words = read_immediate_deps_words ~sandbox ~sctx ~obj_dir ~ml_kind unit in
+  match words with
+  | None -> []
+  | Some words ->
     let dir = Obj_dir.dir obj_dir in
-    let memo_name =
-      sprintf
-        "%s.%s.ocamldep"
-        (Path.to_string (Module.File.path source))
-        (Ml_kind.to_string ml_kind)
-    in
-    ocamldep_action ~sandbox ~sctx ~dir ~ml_kind unit
-    |> Build_system.execute_action_stdout
-    |> Memo.map ~f:(fun output ->
-      String.split_lines output
-      |> parse_deps_exn ~file:(Module.File.path source)
-      |> parse_module_names ~dir ~unit ~modules
-      |> Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit))
-    |> Action_builder.of_memo
-    |> Action_builder.memoize memo_name
+    parse_module_names ~dir ~unit ~modules words
+    |> Stdlib.( @ ) (Modules.With_vlib.implicit_deps modules ~of_:unit)
+;;
+
+(* Returns raw module names without resolving against the stanza's module set.
+   Preserves references to external libraries, which [parse_module_names] would
+   discard. Used for per-module inter-library dependency filtering (#4572). *)
+let read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind unit =
+  let open Action_builder.O in
+  let+ words = read_immediate_deps_words ~sandbox ~sctx ~obj_dir ~ml_kind unit in
+  match words with
+  | None -> Module_name.Set.empty
+  | Some words -> Module_name.Set.of_list_map words ~f:Module_name.of_checked_string
 ;;

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -14,3 +14,15 @@ val read_immediate_deps_of
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t
+
+(** [read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind unit] returns
+    the raw module names from ocamldep output without filtering against the
+    stanza's module set. This preserves cross-library references that
+    [read_immediate_deps_of] discards. *)
+val read_immediate_deps_raw_of
+  :  sandbox:Sandbox_config.t
+  -> sctx:Super_context.t
+  -> obj_dir:Path.Build.t Obj_dir.t
+  -> ml_kind:Ml_kind.t
+  -> Module.t
+  -> Module_name.Set.t Action_builder.t

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -416,6 +416,7 @@ let external_dep_rules ~sctx ~dir ~scope lib_name =
         ~impl:Virtual_rules.no_implements
         ~for_
         ~modules
+        ~has_library_deps:true
     in
     ()
 ;;

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -11,6 +11,11 @@ type t =
 
 let no_implements = No_implements
 
+let is_virtual_or_parameter = function
+  | Virtual _ | Parameter _ -> true
+  | No_implements -> false
+;;
+
 let setup_copy_rules_for_impl ~sctx ~dir t =
   match t with
   | No_implements | Parameter _ -> Memo.return ()

--- a/src/dune_rules/virtual_rules.mli
+++ b/src/dune_rules/virtual_rules.mli
@@ -9,6 +9,7 @@ val setup_copy_rules_for_impl
   -> unit Memo.t
 
 val no_implements : t
+val is_virtual_or_parameter : t -> bool
 
 val impl
   :  Super_context.t

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -107,6 +107,31 @@ Dune should be able to find it too
       "user_cpu_time"
     ]
   }
+  {
+    "process_args": [
+      "-modules",
+      "-impl",
+      "repro.ml-gen"
+    ],
+    "categories": [],
+    "prog": "$TESTCASE_ROOT/notocamldep-foo",
+    "dir": "_build/default.foo",
+    "exit": 0,
+    "target_files": [
+      "_build/.actions/default.foo/$ACTION"
+    ],
+    "rusage": [
+      "inblock",
+      "majflt",
+      "maxrss",
+      "minflt",
+      "nivcsw",
+      "nvcsw",
+      "oublock",
+      "system_cpu_time",
+      "user_cpu_time"
+    ]
+  }
 
 Library is built in the target context
 

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -1,5 +1,8 @@
-In this test we check a cycle when a library depends on a genrated source file which in
-turn depends on the inline-test-name alias of the inline tests of the library.
+A library with inline tests depends on a generated source file
+(`bar.ml`) whose rule depends on the library's inline-test
+runtest alias. Building the library requires `bar.ml`; `bar.ml`
+requires the runtest alias; the runtest alias requires the
+library — a dependency cycle.
 
   $ make_dune_project 3.18
 
@@ -26,18 +29,27 @@ turn depends on the inline-test-name alias of the inline tests of the library.
   >    (echo "let message = \"Hello world\""))))
   > EOF
 
-This kind of cycle has a difficult to understand error message.
-  $ dune build 2>&1 | grep -vwE "sed"
+Dune detects this cycle and emits a "Dependency cycle between:"
+error. The walk's node sequence depends on rule-scheduling order
+and varies across environments, so the test filters walk nodes
+via `dune_cmd delete` and asserts only the invariants: the
+error header, the runtest alias node, and exit status `[1]`.
+
+What this test catches and what it intentionally doesn't:
+
+| Regression                                       | Caught? |
+|--------------------------------------------------|---------|
+| No cycle at all                                  | yes     |
+| Cycle no longer involves runtest-foo_simple      | yes     |
+| Cycle now involves additional aliases            | yes     |
+| Cycle error header format changes                | yes     |
+| Build exits 0 instead of 1                       | yes     |
+| Cycle has different intermediate file/path nodes | no      |
+
+The intermediate-path dimension is rule-scheduling-dependent;
+asserting it would require periodic re-promotes that contribute
+no meaningful regression coverage.
+  $ dune build 2>&1 | dune_cmd delete '^(File |\d+ \||   _build|-> _build|-> required by|-> %\{|.*sed: )'
   Error: Dependency cycle between:
-     transitive deps of foo_simple__Bar.impl in _build/default
-  -> _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmi
-  -> _build/default/.foo_simple.inline-tests/.t.eobjs/native/dune__exe__Main.cmx
-  -> _build/default/.foo_simple.inline-tests/inline-test-runner.exe
   -> alias runtest-foo_simple in dune:9
-  -> _build/default/bar.ml
-  -> transitive deps of foo_simple__Bar.impl in _build/default
-  -> required by _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmo
-  -> required by _build/default/foo_simple.cma
-  -> required by alias all
-  -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
@@ -1,20 +1,17 @@
-Observational baseline: adding a library to a stanza's
-[(libraries ...)] list currently rebuilds every module in the
-stanza, including modules that reference nothing from the new
-library. The [-I]/[-H] flags on each module's compiler invocation
-are derived from the cctx-wide library list rather than from the
-module's own ocamldep reference set, so adding an unreferenced
-library still changes every consumer's compile-action hash and
-invalidates the rule cache.
+Adding a library to a stanza's [(libraries ...)] list does not
+rebuild stanza modules that reference nothing from the new
+library. The per-module [-I]/[-H] include filter narrows each
+module's compile-action hash to the libraries its ocamldep
+reference set actually reaches, so an unreferenced added lib
+leaves every other consumer's cache key unchanged.
 
 [consumer_lib] starts with [(libraries existing_dep)] and two
 modules: [consumes_dep] references [Existing_dep_module];
 [unrelated_module] references nothing from [existing_dep] or any
 other library. After the initial build, [added_lib] is added to
 the stanza's [(libraries ...)] list. Neither [consumes_dep] nor
-[unrelated_module] uses anything from [added_lib], yet both
-rebuild. Records the rebuild counts on each so a future change
-can flip them to 0.
+[unrelated_module] uses anything from [added_lib], so neither
+rebuilds — the trace shows empty target lists for both.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -72,22 +69,6 @@ Add [added_lib] to [consumer_lib]'s [(libraries ...)]. Neither
 
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumes_dep"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmi",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmo",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmt"
-      ]
-    }
-  ]
+  []
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("unrelated_module"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmi",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmo",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmt"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -58,8 +58,8 @@ Change mylib's interface:
   > let new_function () = "hello"
   > EOF
 
-No_use_lib is recompiled even though it doesn't reference Mylib:
+No_use_lib is not recompiled because it doesn't reference Mylib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cmx-native-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cmx-native-tight-deps.t
@@ -1,0 +1,50 @@
+A consumer of a tight-eligible local library, compiled in native
+mode under [--profile release], exercises the [want_cmx = true]
+branch of [Lib_file_deps.deps_of_entry_modules] — emitting
+per-module [.cmx] deps in addition to per-module [.cmi] deps.
+
+The default [dev] profile sets [opaque = true], which makes
+[want_cmx = false] for local libs and the cmx branch is skipped
+entirely. Switching to [release] flips [opaque] off, so the
+consumer's native compile takes the per-module path with
+[cm_kind = Ocaml Cmx] and the function records cmx-file deps.
+Building [consumer.cmxa] explicitly forces the native compile,
+unlike [@check] which only materialises [.cmi]/[.cmt] artifacts.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[dep_lib]: an unwrapped tight-eligible library with two modules,
+one of them with both [.ml] and [.mli]:
+
+  $ mkdir dep_lib
+  $ cat > dep_lib/dune <<EOF
+  > (library (name dep_lib) (wrapped false))
+  > EOF
+  $ cat > dep_lib/m.ml <<EOF
+  > let v = 1
+  > EOF
+  $ cat > dep_lib/m.mli <<EOF
+  > val v : int
+  > EOF
+  $ cat > dep_lib/n.ml <<EOF
+  > let _ = ()
+  > EOF
+
+[consumer]: a library that references [M] from [dep_lib]:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (library
+  >   (name consumer)
+  >   (libraries dep_lib))
+  > EOF
+  $ cat > consumer/c.ml <<EOF
+  > let _ = M.v
+  > EOF
+
+Build the consumer's [.cmxa] under release profile, forcing
+native compile of every module:
+
+  $ dune build --profile release consumer/consumer.cmxa

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
@@ -2,7 +2,7 @@ Regression: a stanza with [(implements vlib)] correctly tracks
 changes to its own [(libraries ...)] deps.
 
 For a virtual-library implementation, future per-module
-dependency filtering work (#14116) must preserve deps from the
+dependency filtering work must preserve deps from the
 implementation's own [(libraries ...)] closure — otherwise the
 implementation may fail to rebuild when one of those libraries'
 interfaces changes. This test checks that an [(implements vlib)]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/dune
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/dune
@@ -1,0 +1,13 @@
+(library
+ (name hello_ppx)
+ (public_name hello.ppx)
+ (kind ppx_rewriter)
+ (ppx_runtime_libraries hello)
+ (libraries ppxlib)
+ (modules hello_ppx))
+
+(library
+ (public_name hello)
+ (modules hello)
+ (instrumentation.backend
+  (ppx hello.ppx)))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/dune-project
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.7)
+
+(package (name hello))

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/hello.ml
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/hello.ml
@@ -1,0 +1,1 @@
+let hello s = print_endline (Printf.sprintf "Hello from %s!" s)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/hello_ppx.ml
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/ppx/hello_ppx.ml
@@ -1,0 +1,48 @@
+open Ast_helper
+
+let place = ref None
+let file = ref None
+
+let read_file () =
+  match !file with
+  | None -> "<none>"
+  | Some s ->
+    let ic = open_in s in
+    (match input_line ic with
+     | exception End_of_file ->
+       close_in ic;
+       "<none>"
+     | s ->
+       close_in ic;
+       s)
+;;
+
+let impl str =
+  let arg =
+    match !place with
+    | None -> Exp.ident (Location.mknoloc (Longident.Lident "__MODULE__"))
+    | Some s -> Exp.constant (Const.string (Printf.sprintf "%s (%s)" s (read_file ())))
+  in
+  Str.eval
+    (Exp.apply
+       (Exp.ident
+          (Location.mknoloc
+             (Longident.Ldot
+                ( { txt = Longident.Lident "Hello"; loc = Location.none }
+                , { txt = "hello"; loc = Location.none } ))))
+       [ Nolabel, arg ])
+  :: str
+;;
+
+let () =
+  Ppxlib.Driver.add_arg
+    "-place"
+    (Arg.String (fun s -> place := Some s))
+    ~doc:"PLACE where to say hello from";
+  Ppxlib.Driver.add_arg
+    "-file"
+    (Arg.String (fun s -> file := Some s))
+    ~doc:"Add info from file"
+;;
+
+let () = Ppxlib.Driver.register_transformation_using_ocaml_current_ast ~impl "hello"

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/run.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/run.t
@@ -1,0 +1,57 @@
+Reproducer for the bug introduced by storing post-pp [Module.t] in
+[Lib_index]: a library declares [(instrumentation (backend X))]
+without any [(preprocess ...)]. Instrumentation is *disabled* at
+build time (no [--instrument-with] flag), so dune does not produce
+[.pp.ml] files. But [Lib_info.preprocess] still returns
+[Pps { pps = [Instrumentation_backend X]; ... }] (the static
+config), and [build_lib_index] currently maps that to
+[Module.pped (Module.ml_source m)] — i.e. paths like [foo.pp.ml] —
+which dune then can't find a rule for when the cross-library
+walker reads ocamldep on those modules.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+[middle] declares an instrumentation backend but no
+[(preprocess ...)]. With instrumentation disabled at build time,
+no [.pp.ml] files are produced.
+
+  $ mkdir leaf
+  $ cat > leaf/dune <<EOF
+  > (library (name leaf) (wrapped false))
+  > EOF
+  $ cat > leaf/leaf.ml <<EOF
+  > type t = int
+  > let zero : t = 0
+  > EOF
+
+  $ mkdir middle
+  $ cat > middle/dune <<EOF
+  > (library
+  >  (name middle)
+  >  (wrapped false)
+  >  (libraries leaf)
+  >  (instrumentation (backend hello)))
+  > EOF
+  $ cat > middle/middle.mli <<EOF
+  > val identity : Leaf.t -> Leaf.t
+  > EOF
+  $ cat > middle/middle.ml <<EOF
+  > let identity x = x
+  > EOF
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries middle))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let _ = Middle.identity 0
+  > EOF
+
+Build without [--instrument-with]: the cross-library walker
+should NOT demand [middle.pp.ml] / [middle.pp.mli]. With the
+buggy mapping that demands them anyway, dune reports
+"No rule found for middle.pp.ml".
+
+  $ dune build consumer/consumer.exe

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-pps-runtime-no-ocamldep-barrier.t/run.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-pps-runtime-no-ocamldep-barrier.t/run.t
@@ -1,0 +1,80 @@
+Regression guard for [build_lib_index]'s [no_ocamldep_lib]
+classification: it must mirror [Dep_rules.skip_ocamldep]'s
+[has_library_deps] gating, which uses the *resolved* requires
+(including pps runtime libs added via [add_pp_runtime_deps]),
+not the static [(libraries ...)] field. A single-module local
+lib with no [(libraries ...)] but with [(preprocess (pps X))]
+has non-empty resolved requires (X's runtime libs), so its
+ocamldep is run and classifying it as [no_ocamldep] would cause
+the cross-library walk to skip its post-pp ocamldep output —
+dropping transitive [.cmi] deps from the consumer's compile rule
+and breaking sandboxed builds.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+[hello] is the ppx runtime lib (single-module unwrapped, no library
+deps of its own — correctly classified as no-ocamldep). It exposes
+[Hello.t]:
+
+  $ mkdir hello
+  $ cat > hello/dune <<EOF
+  > (library (name hello) (wrapped false))
+  > EOF
+  $ cat > hello/hello.ml <<EOF
+  > type t = int
+  > let zero : t = 0
+  > EOF
+
+[hello_ppx] is a no-op ppx_rewriter declaring [hello] as its
+[ppx_runtime_libraries]:
+
+  $ mkdir hello_ppx
+  $ cat > hello_ppx/dune <<EOF
+  > (library
+  >  (name hello_ppx)
+  >  (kind ppx_rewriter)
+  >  (ppx_runtime_libraries hello)
+  >  (libraries ppxlib))
+  > EOF
+  $ cat > hello_ppx/hello_ppx.ml <<EOF
+  > let () =
+  >   Ppxlib.Driver.register_transformation_using_ocaml_current_ast
+  >     ~impl:(fun s -> s) "noop"
+  > EOF
+
+[middle] is single-module, has no [(libraries ...)], and uses
+[(preprocess (pps hello_ppx))]. Its interface mentions [Hello.t]:
+
+  $ mkdir middle
+  $ cat > middle/dune <<EOF
+  > (library
+  >  (name middle)
+  >  (wrapped false)
+  >  (preprocess (pps hello_ppx)))
+  > EOF
+  $ cat > middle/middle.mli <<EOF
+  > val helper : Hello.t -> Hello.t
+  > EOF
+  $ cat > middle/middle.ml <<EOF
+  > let helper x = x
+  > EOF
+
+[consumer] depends on [middle]; references [Middle.helper] but
+never names [Hello] in source:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries middle))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let _ = Middle.helper 0
+  > EOF
+
+Sandbox-forced build of the consumer succeeds: the walker visits
+[middle]'s post-pp ocamldep, surfaces [Hello] in the tight set,
+and the classification fold keeps [hello]'s [.cmi] as a compile-
+rule dep so it is pulled into the sandbox.
+
+  $ dune build --sandbox=copy consumer/consumer.exe

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-preprocess-barrier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-preprocess-barrier.t
@@ -1,0 +1,70 @@
+Regression guard for cross-library transitive [.cmi] reads
+through a preprocessed intermediate. A consumer references a
+module from a preprocessed library; that preprocessed module's
+interface mentions a type from a leaf library that the consumer
+never names syntactically. The consumer's compile must depend on
+the leaf's [.cmi] so the OCaml compiler can resolve the type
+reference imported via the intermediate's [.cmi].
+
+[build_lib_index] stores each entry's *post-pp* [Module.t]
+(mirroring [Pp_spec.pped_modules_map]), so [cross_lib_tight_set]
+reads ocamldep on the dep lib's [.pp.ml] artifact. The walker
+therefore reaches the leaf's name through the intermediate's
+interface, the classification fold places the leaf in the
+consumer's tight per-module deps, and forced sandboxing succeeds
+because [leaf]'s [.cmi] is in the sandbox.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[leaf] exposes [Leaf.t]:
+
+  $ mkdir leaf
+  $ cat > leaf/dune <<EOF
+  > (library (name leaf) (wrapped false))
+  > EOF
+  $ cat > leaf/leaf.ml <<EOF
+  > type t = int
+  > let zero : t = 0
+  > EOF
+
+[middle] depends on [leaf]; its single module is preprocessed via
+[(preprocess (action ...))], and its interface mentions [Leaf.t]:
+
+  $ mkdir middle
+  $ cat > middle/dune <<EOF
+  > (library
+  >  (name middle)
+  >  (wrapped false)
+  >  (libraries leaf)
+  >  (preprocess (action (run cat %{input-file}))))
+  > EOF
+  $ cat > middle/middle.mli <<EOF
+  > val identity : Leaf.t -> Leaf.t
+  > EOF
+  $ cat > middle/middle.ml <<EOF
+  > let identity x = x
+  > EOF
+
+[consumer] depends on [middle]; references [Middle.identity] but
+never names [Leaf] in source:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries middle))
+  > EOF
+Applying [Middle.identity] to a literal [0] forces the compiler
+to unify [int] with [Leaf.t], which requires loading [Leaf.cmi].
+ocamldep on this source still reports only [Middle] as referenced,
+since [Leaf] is not named.
+
+  $ cat > consumer/consumer.ml <<EOF
+  > let _ = Middle.identity 0
+  > EOF
+
+Sandbox-forced build of the consumer succeeds: [leaf]'s [.cmi]
+is declared as a compile-rule dep through the per-module
+filter's cross-lib walk and is therefore present in the sandbox.
+
+  $ dune build --sandbox=copy consumer/consumer.exe

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-source.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-source.t
@@ -83,13 +83,15 @@ this test will fail with a syntax error from [dep/foo.ml].
 
   $ dune build @check
 
-Confirm that [consumer/c.cmi] depends on [dep]'s objdir for cmis,
-and not on any path that names the pre-pp source. The dep is
-registered as a [*.cmi] glob over the dep's objdir; a future
-regression that switched to a per-file dep on the wrong basename
-(e.g. [dep/.dep.objs/byte/foo.pp.cmi] instead of [foo.cmi]) would
-surface here as a different recorded dep:
+Confirm that [consumer/c.cmi] depends specifically on
+[dep/.dep.objs/byte/foo.cmi] — the per-module filter records only
+the cmis the consumer's ocamldep output names (here, [Foo]), not
+a glob over the whole library's objdir, and not [bar.cmi] which
+the consumer does not reference. A regression that resurrected
+the broad-glob form, or that switched to the wrong basename
+(e.g. [foo.pp.cmi] instead of [foo.cmi]), would surface here as a
+different recorded dep:
 
   $ dune rules --root . --format=json --deps _build/default/consumer/.consumer.objs/byte/c.cmi |
-  > jq -r 'include "dune"; .[] | depsGlobPredicates'
-  *.cmi
+  > jq -r 'include "dune"; .[] | depsFilePaths | select(test("dep/.dep.objs"))'
+  _build/default/dep/.dep.objs/byte/foo.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -22,10 +22,8 @@ name reaches [main]'s reference closure and drops the lib from
 [main]'s compile-rule deps entirely; [main] is no longer
 rebuilt.
 
-Reported by @nojb in
-https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194
-and again, after a partial fix, in
-https://github.com/ocaml/dune/pull/14116#issuecomment-4331209820.
+Reported by @nojb (first as a baseline case, then again after a
+partial fix).
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -1,4 +1,4 @@
-Observational baseline: under [(implicit_transitive_deps false)],
+Under [(implicit_transitive_deps false)],
 the consumer [main] uses [intermediate_lib] which declares
 [link_only_lib] as a transitive dep. [main]'s source never
 references any module of [link_only_lib]; under
@@ -11,22 +11,21 @@ The mode-with-[-H] is only reached on dune lang [3.17+] with an
 OCaml compiler that supports hidden includes (5.2+); older dune
 lang versions fall back to mode [Disabled] without [-H]. This
 test pins [(lang dune 3.23)] below to keep the [-H]-glob path the
-one exercised — that is the path the future per-module filter is
-expected to tighten.
+one exercised — that is the path this PR's per-module filter
+tightens.
 
-On trunk today, [main]'s compile rule globs over
+Without this PR's filter, [main]'s compile rule globs over
 [link_only_lib]'s objdir as part of the cctx-wide [-H] glob, so
 any [.cmi] content change in [link_only_lib] invalidates [main].
-A tighter per-module filter could observe that no
-[link_only_lib] entry name reaches [main]'s reference closure
-and drop the lib from [main]'s compile-rule deps.
+The per-module filter observes that no [link_only_lib] entry
+name reaches [main]'s reference closure and drops the lib from
+[main]'s compile-rule deps entirely; [main] is no longer
+rebuilt.
 
 Reported by @nojb in
 https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194
 and again, after a partial fix, in
 https://github.com/ocaml/dune/pull/14116#issuecomment-4331209820.
-Records [main]'s current rebuild count so a future per-module
-filter can flip it to 0.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -64,24 +63,10 @@ filter can flip it to 0.
   $ dune build ./main.exe
 
 Empty [link_only_module.ml] so its [.cmi] loses the [val x : int]
-binding. The cctx-wide glob over [link_only_lib]'s objdir fires
-on the [.cmi] content change, invalidating [main] — both the
-[.cmi]/[.cmti] rule and the [.cmx]/[.o] rule re-run:
+binding. The per-module filter dropped [link_only_lib] from
+[main]'s deps, so no [Main]-named target re-runs:
 
   $ echo > link_only_module.ml
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
-        "_build/default/.main.eobjs/native/dune__exe__Main.o"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -1,7 +1,9 @@
-Verify that library file deps are declared for module compilation rules.
+Verify the cm_kind/-opaque rules for library file deps in compile rules.
 
-Every non-alias module should declare glob deps on its library
-dependencies' .cmi files.
+[mylib] is a wrapped library exposing one entry [Mylib]. The
+executable has two modules: [Uses_lib] which references [Mylib] in
+its [.ml] (but not its [.mli]) and [Main] which references only
+[Uses_lib]. [Main] has no [.mli].
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -33,12 +35,17 @@ dependencies' .cmi files.
 
   $ dune build ./main.exe
 
-Both modules declare glob deps on mylib's .cmi files:
+[Uses_lib.cmx] keeps the glob: [Uses_lib.ml] references [Mylib], a
+wrapped library that falls back to a directory glob over its public
+cmi dir.
 
   $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Uses_lib.cmx |
   > jq -r 'include "dune"; .[] | depsGlobPredicates'
   *.cmi
 
+[Main.cmx] has no inter-library deps. Under [-opaque] (the default
+profile), [Uses_lib]'s references to [Mylib] are sealed behind
+[Uses_lib]'s [.cmi] and don't propagate to [Main]'s native compile.
+
   $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
   > jq -r 'include "dune"; .[] | depsGlobPredicates'
-  *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
@@ -1,8 +1,8 @@
-Baseline: library-to-library recompilation (unwrapped).
+Per-module library-to-library filtering (unwrapped).
 
 When an unwrapped library A depends on an unwrapped library B with multiple
-modules, and one module in B changes, all modules in A are recompiled due to
-coarse dependency analysis.
+modules, modules of A that do not reference a given module of B must not be
+recompiled when that module of B changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
@@ -80,11 +80,11 @@ Change only alpha.mli:
   > let new_alpha_fn () = "alpha"
   > EOF
 
-uses_beta is recompiled even though it only references Beta, not Alpha:
+uses_beta references Beta only, not Alpha, so it is not recompiled:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_beta"))] | length'
-  2
+  0
 
 Change only beta.mli:
 
@@ -97,8 +97,8 @@ Change only beta.mli:
   > let new_beta_fn () = "beta"
   > EOF
 
-uses_alpha is recompiled even though it only references Alpha, not Beta:
+uses_alpha references Alpha only, not Beta, so it is not recompiled:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_alpha"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
@@ -62,8 +62,8 @@ See: https://github.com/ocaml/dune/issues/4572
   > let new_base_fn () = "hello"
   > EOF
 
-Standalone in middle_lib is recompiled even though it doesn't use base_lib:
+Standalone in middle_lib is not recompiled because it doesn't use base_lib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t/run.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t/run.t
@@ -1,0 +1,72 @@
+Precision regression guard for the per-pair tight-eligibility
+in [Lib_index]: when a consumer references only the [Some]-
+entry modules of a mixed-pp lib, the [None]-entry modules must
+NOT be pulled into the consumer's compile-rule deps.
+
+We assert precision by giving [b] (the [None]-entry module) an
+unresolvable identifier and leaving [a]'s source independent of
+[b]. If the consumer's compile rule listed [b.cmi] as a dep,
+dune would try to compile [b.ml] and fail. Building the
+consumer's [.cmo] (compile only, no link) succeeds → [b] is
+correctly excluded.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+A no-op staged ppx (identical to the soundness reproducer).
+
+  $ mkdir ppx
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name ppx_noop)
+  >  (kind ppx_rewriter)
+  >  (ppx.driver (main Ppx_noop.main)))
+  > EOF
+  $ cat > ppx/ppx_noop.ml <<EOF
+  > let main () =
+  >   let n = Array.length Sys.argv in
+  >   if n < 2 then assert false;
+  >   let input = Sys.argv.(n - 2) in
+  >   let output = Sys.argv.(n - 1) in
+  >   Filename.quote_command "cp" [input; output]
+  >   |> Sys.command
+  >   |> exit
+  > EOF
+
+[mylib]: [a] uses default (Some entry), [b] uses staged_pps
+(None entry). [a]'s source is independent of [b]; [b.ml]
+contains an unresolvable identifier so any attempt to compile
+it will fail.
+
+  $ mkdir mylib
+  $ cat > mylib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (wrapped false)
+  >  (preprocess (per_module ((staged_pps ppx_noop) b))))
+  > EOF
+  $ cat > mylib/a.ml <<EOF
+  > let answer = 42
+  > EOF
+  $ cat > mylib/b.ml <<EOF
+  > let bar = no_such_thing
+  > EOF
+
+[consumer] references only [A]:
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries mylib))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let () = print_int A.answer
+  > EOF
+
+Build only the consumer's [.cmo] (compile rule, not link). If
+per-pair tight-eligibility holds, the consumer depends on
+[a.cmi] alone and the build succeeds. If the fix regressed and
+[mylib] got globbed for the consumer, dune would attempt to
+compile [b.ml] and fail.
+
+  $ dune build consumer/.consumer.eobjs/byte/dune__exe__Consumer.cmo

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t/run.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t/run.t
@@ -1,0 +1,91 @@
+Reproducer for the soundness bug Copilot flagged in
+[Lib_index.create]: an unwrapped lib's [tight_eligible]
+membership is set on "any entry has [Some _]", which under
+per-module preprocessing can be true while *some* of the lib's
+entries have [m_opt = None]. The classification fold then
+silently drops the [None] entries' modules from the consumer's
+compile-rule deps when those modules are reached via
+[cross_lib_tight_set]'s BFS expansion.
+
+Setup. [mylib] is unwrapped with two modules. [a] uses default
+(no preprocessing) — entry [(a, mylib, Some _)]. [b] uses
+[(staged_pps ...)] — entry [(b, mylib, None)], since no
+[.pp.ml] is statically known for staged pps.
+[a]'s source references [B], so [cross_lib_tight_set]'s BFS
+walks from [a]'s ocamldep into [B]. The consumer references
+only [A], so [wrapped_libs_referenced] (which is keyed off the
+consumer's direct ocamldep, [referenced]) does NOT add [mylib]
+to [must_glob_set]. The mixed-entry bug therefore reaches the
+classification fold via [tight_set], and the fold drops [B]
+because [tight_modules_per_lib] skips its [None] entry.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+A no-op staged ppx, modeled on
+test/blackbox-tests/test-cases/staged-pps-relative-directory-gh8158.t.
+The driver copies its input verbatim, so the staged stage's
+[.pp.ml] equals the input source.
+
+  $ mkdir ppx
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name ppx_noop)
+  >  (kind ppx_rewriter)
+  >  (ppx.driver (main Ppx_noop.main)))
+  > EOF
+  $ cat > ppx/ppx_noop.ml <<EOF
+  > let main () =
+  >   let n = Array.length Sys.argv in
+  >   if n < 2 then assert false;
+  >   let input = Sys.argv.(n - 2) in
+  >   let output = Sys.argv.(n - 1) in
+  >   Filename.quote_command "cp" [input; output]
+  >   |> Sys.command
+  >   |> exit
+  > EOF
+
+[mylib] is unwrapped with two modules; only [b] is staged.
+[a]'s interface mentions [B.t], so [cross_lib_tight_set]'s BFS
+walks from [a]'s ocamldep into [b]'s name AND the consumer's
+own compile genuinely loads [b.cmi] (otherwise the bug wouldn't
+manifest at the consumer's compile site).
+
+  $ mkdir mylib
+  $ cat > mylib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (wrapped false)
+  >  (preprocess (per_module ((staged_pps ppx_noop) b))))
+  > EOF
+  $ cat > mylib/a.mli <<EOF
+  > val identity : B.t -> B.t
+  > EOF
+  $ cat > mylib/a.ml <<EOF
+  > let identity (x : B.t) = x
+  > EOF
+  $ cat > mylib/b.ml <<EOF
+  > type t = int
+  > let zero : t = 0
+  > EOF
+
+[consumer] references only [A] in source — never names [B] —
+but its call to [A.identity] forces ocamlc to load [B.cmi] to
+resolve [B.t].
+
+  $ mkdir consumer
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries mylib))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let _ = A.identity 0
+  > EOF
+
+Sandboxed build forces the missing-dep bug to surface
+deterministically: the sandbox is populated only from the
+compile-rule's declared deps, so a missing dep on
+[mylib/.mylib.objs/byte/b.cmi] fails the build with a
+"no such file" error rather than a silent race.
+
+  $ dune build --sandbox=copy consumer/consumer.exe

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
@@ -5,7 +5,7 @@ lib's interface changes, the consumer rebuilds without the
 compiler complaining about inconsistent assumptions over
 interface.
 
-Reported by @art-w on #14116. The concern was that
+Reported by @art-w. The concern was that
 [(modules_without_implementation)] entries' aliases to other
 libs might escape the per-module dep filter (the intra-stanza
 [trans_deps] graph skips them), leaving the consumer's compile

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
@@ -78,11 +78,11 @@ Change only mylib's interface:
   > let new_function () = "hello"
   > EOF
 
-Uses_other is recompiled even though it only uses Otherlib, not Mylib:
+Uses_other is not recompiled because it only uses Otherlib, not Mylib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_other"))] | length'
-  2
+  0
 
 Change only otherlib's interface:
 
@@ -95,8 +95,8 @@ Change only otherlib's interface:
   > let new_other_fn s = s ^ "!"
   > EOF
 
-Uses_lib is recompiled even though it only uses Mylib, not Otherlib:
+Uses_lib is not recompiled because it only uses Mylib, not Otherlib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_lib"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -53,12 +53,6 @@ left unexported, which would trip warning 32 under dev):
   [
     {
       "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
         "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
         "_build/default/.main.eobjs/native/dune__exe__Main.o"
       ]
@@ -90,12 +84,6 @@ Add another paired declaration:
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
   [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
     {
       "target_files": [
         "_build/default/.main.eobjs/native/dune__exe__Main.cmx",

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -62,11 +62,11 @@ Change ONLY the implementation (not the interface):
   > let value = 43
   > EOF
 
-No_use_lib is recompiled even though it doesn't reference Mylib:
+No_use_lib is not recompiled because it doesn't reference Mylib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
-  1
+  0
 
 --- Dev profile (opaque=true): .cmx deps are NOT tracked for local libs ---
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
@@ -1,15 +1,12 @@
-Observational baseline: a consumer module's compile command
-currently carries [-I] flags for every library in the cctx-wide
-[(libraries ...)] closure, regardless of which libraries the
-module's source actually references.
+A consumer module's compile command carries [-I] flags only for
+the libraries its ocamldep reference set actually reaches, not
+for every library in the cctx-wide [(libraries ...)] closure.
 
 [consumer_lib] declares two library dependencies, [dep_lib] and
 [unrelated_lib], but its only module references just [Dep_module].
-A future per-module filter could observe via ocamldep that the
-module references nothing from [unrelated_lib] and drop that
-library's objdir from the [-I] path. This test records today's
-[-I] contents so that a future filter improvement can flip the
-asserted array to a single entry.
+The per-module filter observes via ocamldep that the module
+references nothing from [unrelated_lib] and drops that library's
+objdir from the [-I] path; only [dep_lib]'s objdir survives.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
@@ -40,12 +37,10 @@ asserted array to a single entry.
 Inspect the [-I] flags on [consumer_module]'s [.cmo] compile rule.
 Filter to objdir-shaped paths so we don't print the consumer's
 own [.consumer_lib.objs/byte] entry — that's always present and
-not what this test is about. Today both [dep_lib]'s objdir and
-[unrelated_lib]'s objdir appear:
+not what this test is about. Only [dep_lib]'s objdir appears:
 
   $ dune rules --root . --format=json _build/default/.consumer_lib.objs/byte/consumer_module.cmo \
   > | jq 'include "dune"; .[] | [ruleActionFlagValues("-I") | select(test("\\.dep_lib\\.objs|\\.unrelated_lib\\.objs"))]'
   [
-    ".dep_lib.objs/byte",
-    ".unrelated_lib.objs/byte"
+    ".dep_lib.objs/byte"
   ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/ppx-runtime-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/ppx-runtime-libraries.t
@@ -1,0 +1,87 @@
+A library declared as [(kind ppx_rewriter) (ppx_runtime_libraries
+runtime_dep)] declares libraries the consumer needs at compile time
+*after* preprocessing. The runtime libraries' modules are
+referenced by ppx-rewritten output, so ocamldep on the consumer's
+source cannot reason about which of them are referenced — the
+next ppx invocation may use any module of [runtime_dep].
+
+The compile rule for any consumer of such a ppx must therefore
+have a dep that covers every cmi in the runtime library's objdir.
+A glob over the objdir is the natural shape; this test pins that
+shape, guarding against any future inter-library dep handling
+that narrows the recorded deps for ppx_runtime_libraries-induced
+libraries.
+
+  $ make_dune_project 3.24
+
+[runtime_dep] is a regular library that the ppx's expansion would
+reference at runtime.
+
+  $ mkdir runtime_dep
+  $ cat > runtime_dep/dune <<EOF
+  > (library (name runtime_dep))
+  > EOF
+  $ cat > runtime_dep/runtime_dep_mod.ml <<EOF
+  > let value = 0
+  > EOF
+
+[preprocessor] is a [ppx_rewriter] declaring [runtime_dep] as a
+runtime library. The [ppx.driver] entry lets dune treat
+[preprocessor] as a [pps] target without ppxlib; the driver
+itself is a no-op stub that satisfies dune's invocation contract
+enough for rule generation.
+
+  $ mkdir preprocessor
+  $ cat > preprocessor/dune <<EOF
+  > (library
+  >  (name preprocessor)
+  >  (kind ppx_rewriter)
+  >  (ppx_runtime_libraries runtime_dep)
+  >  (ppx.driver (main Preprocessor.main)))
+  > EOF
+  $ cat > preprocessor/preprocessor.ml <<EOF
+  > let main () =
+  >   let out = ref "" in
+  >   let args =
+  >     [ ("-o", Arg.Set_string out, "")
+  >     ; ("--impl", Arg.Set_string (ref ""), "")
+  >     ; ("--as-ppx", Arg.Set (ref false), "")
+  >     ; ("--cookie", Arg.Set (ref false), "")
+  >     ]
+  >   in
+  >   let anon _ = () in
+  >   Arg.parse (Arg.align args) anon "";
+  >   close_out (open_out !out)
+  > EOF
+
+[user] applies [preprocessor] as a ppx. [user.ml] does not
+mention [Runtime_dep_mod] textually — the ppx's runtime
+references would only appear post-pp. Without [(libraries ...)],
+[user]'s [requires_compile] is populated entirely by
+[add_pp_runtime_deps] in [src/dune_rules/lib.ml]: [preprocessor]
+(the pps) plus its runtime closure ([runtime_dep]).
+
+  $ mkdir user
+  $ cat > user/dune <<EOF
+  > (library (name user) (preprocess (pps preprocessor)))
+  > EOF
+  $ cat > user/user.ml <<EOF
+  > let _ = ()
+  > EOF
+
+The compile rule for [user.cmi] must list every cmi in
+[runtime_dep/.runtime_dep.objs/byte/] as a dep. Without that
+coverage, a change to any of [runtime_dep]'s cmis would not
+invalidate [user.cmi], and the next build could silently use a
+stale artefact.
+
+The [-I runtime_dep/.runtime_dep.objs/byte] flag is already on
+the compile command line via [requires_compile], so the initial
+build succeeds. But the flag does not cause rebuilds; only the
+recorded deps do.
+
+  $ dune rules --root . --format=json --deps _build/default/user/.user.objs/byte/user.cmi |
+  > jq -r 'include "dune"; .[] | depsGlobs
+  >   | select(.dir | endswith("runtime_dep/.runtime_dep.objs/byte"))
+  >   | .dir + " " + .predicate'
+  _build/default/runtime_dep/.runtime_dep.objs/byte *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/root-module-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/root-module-tight-deps.t
@@ -1,0 +1,44 @@
+A library declaring [(root_module ...)] alongside [(libraries
+...)] must build correctly when its modules reference the dep
+library through the Root alias.
+
+Root modules carry no ocamldep dep-rule: the kind matches
+[Root | Alias _] in [Dep_rules.read_transitive_deps_of_module]
+and [read_immediate_deps_of], both of which short-circuit to
+empty deps (avoiding the cycle that would otherwise arise from a
+Root that references itself transitively). Any future change to
+inter-library dep handling that misses this short-circuit would
+regress this scenario.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+[dep_lib]: an unwrapped dep library.
+
+  $ mkdir dep_lib
+  $ cat > dep_lib/dune <<EOF
+  > (library (name dep_lib) (wrapped false))
+  > EOF
+  $ cat > dep_lib/dep_lib.ml <<EOF
+  > let v = 1
+  > EOF
+  $ cat > dep_lib/dep_lib.mli <<EOF
+  > val v : int
+  > EOF
+
+[consumer_lib]: declares [(root_module root) (libraries dep_lib)]
+and references [Dep_lib] through [Root].
+
+  $ mkdir consumer_lib
+  $ cat > consumer_lib/dune <<EOF
+  > (library
+  >  (name consumer_lib)
+  >  (libraries dep_lib)
+  >  (root_module root))
+  > EOF
+  $ cat > consumer_lib/m.ml <<EOF
+  > let _ = Root.Dep_lib.v
+  > EOF
+
+  $ dune build @check

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -17,12 +17,11 @@ The zero-reference-sibling-in-a-library corner is distinct from
 scenarios covered by existing tests: [lib-to-lib-unwrapped.t] probes
 siblings that reference a different (non-edited) module of the dep;
 [transitive.t] and [unwrapped.t] probe zero-reference modules but
-within executable stanzas, not library stanzas. Pre-#14116 the
+within executable stanzas, not library stanzas. Previously the
 consumer fell back to a glob over [dep_lib]'s objdir, which the
 cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
-See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -7,20 +7,19 @@ of the dependency library [dep_lib] has its interface edited.
 
 [consumer_lib] is an unwrapped library with two modules.
 [consumes_dep] references [Referenced_dep]; [spurious_rebuild]
-references nothing from [dep_lib]. On current main, editing
-[referenced_dep]'s interface rebuilds [spurious_rebuild] even
-though it references nothing from [dep_lib]: the consumer depends
-on a glob over [dep_lib]'s object directory, which is invalidated
-by the cmi change.
+references nothing from [dep_lib]. The per-module filter drops
+[dep_lib] from [spurious_rebuild]'s compile-rule deps because
+[spurious_rebuild]'s ocamldep output names no module of [dep_lib],
+so editing [referenced_dep]'s interface fires no
+[spurious_rebuild]-named rule.
 
 The zero-reference-sibling-in-a-library corner is distinct from
 scenarios covered by existing tests: [lib-to-lib-unwrapped.t] probes
 siblings that reference a different (non-edited) module of the dep;
 [transitive.t] and [unwrapped.t] probe zero-reference modules but
-within executable stanzas, not library stanzas. A future fix
-implementing library-level dep filtering at consumer-module
-granularity would drop [dep_lib] entirely from [spurious_rebuild]'s
-deps, tightening this corner to zero rebuilds.
+within executable stanzas, not library stanzas. Pre-#14116 the
+consumer fell back to a glob over [dep_lib]'s objdir, which the
+cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
@@ -59,9 +58,10 @@ See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
   $ dune build @check
 
-Edit [referenced_dep]'s interface. [spurious_rebuild] references
-nothing in [dep_lib]. Record the number of [spurious_rebuild]
-rebuild targets observed in the trace:
+Edit [referenced_dep]'s interface (add a binding to both [.mli]
+and [.ml] so the [.cmi] content actually changes). [spurious_rebuild]
+references nothing from [dep_lib], so its compile rule should not
+fire — no rule with a [spurious_rebuild]-named target re-runs:
 
   $ cat > referenced_dep.mli <<EOF
   > val x : int
@@ -72,5 +72,5 @@ rebuild targets observed in the trace:
   > let y = "hello"
   > EOF
   $ dune build @check
-  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
@@ -1,11 +1,10 @@
-Single-module library consumers and recompilation behavior.
+Per-module filtering for single-module library consumers.
 
-When a consumer library has only one module, dune skips ocamldep for that
-stanza as an optimization (no intra-stanza deps to compute). This means
-per-module library dependency filtering cannot determine which libraries
-the module actually references, so the consumer depends on all library
-files via glob. Modifying an unused module in a dependency triggers
-unnecessary recompilation of the consumer module's .cmo/.cmx.
+A consumer library with a single module still runs ocamldep when it has
+library dependencies, and the per-module filter uses that output to
+dep on only the specific entry modules of an unwrapped dependency that
+the consumer actually references. Modifying an unreferenced module of
+the dependency does not recompile the consumer.
 
 See: https://github.com/ocaml/dune/issues/4572
 
@@ -61,25 +60,8 @@ Modify only the unused module:
   > let new_fn () = "new"
   > EOF
 
-uses_alpha.cmx is recompiled even though uses_alpha.ml only references
-Alpha, not Unused. This is because the consumer_lib stanza has a single
-module, so dune skips ocamldep for it and falls back to glob deps on all
-of base_lib's .cmi files. The trace shows compilation targets for
-uses_alpha being rebuilt:
+uses_alpha.ml references Alpha only, not Unused, so it is not recompiled:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_alpha"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/uses_alpha.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/uses_alpha.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/native/uses_alpha.cmx",
-        "_build/default/consumer_lib/.consumer_lib.objs/native/uses_alpha.o"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -14,13 +14,12 @@ compile-rule deps for this single-module consumer, so editing
 
 The zero-reference case is a distinct corner from the single-module
 consumer that references some (but not all) modules of its dep,
-which [single-module-lib.t] already documents. Pre-#14116 this
+which [single-module-lib.t] already documents. Previously this
 overrebuilt because dune skipped ocamldep for single-module
 stanzas as an optimisation and so fell back to a glob over
 [dep_lib]'s objdir, which the cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
-See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -8,19 +8,16 @@ edited.
 
 [consumer_lib] declares [(libraries dep_lib)] but
 [spurious_rebuild.ml] does not reference any module of [dep_lib].
-On current main this scenario still rebuilds [spurious_rebuild]:
-[consumer_lib] is a single-module stanza, so dune skips ocamldep
-as an optimisation and cannot discover that [spurious_rebuild]
-references no module of [dep_lib]; the consumer falls back to a
-glob over [dep_lib]'s object directory, which is invalidated by
-the cmi change.
+The per-module filter drops [dep_lib] from [spurious_rebuild]'s
+compile-rule deps for this single-module consumer, so editing
+[dep_module]'s interface fires no [spurious_rebuild]-named rule.
 
 The zero-reference case is a distinct corner from the single-module
 consumer that references some (but not all) modules of its dep,
-which [single-module-lib.t] already documents. A future fix that
-detects "ocamldep yields no references to dep_lib" could tighten
-this corner to zero rebuilds without needing to solve the broader
-single-module-consumer skip-ocamldep limitation.
+which [single-module-lib.t] already documents. Pre-#14116 this
+overrebuilt because dune skipped ocamldep for single-module
+stanzas as an optimisation and so fell back to a glob over
+[dep_lib]'s objdir, which the cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
 See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
@@ -64,4 +61,4 @@ rebuild targets observed in the trace:
   > EOF
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
-  1
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
@@ -55,8 +55,8 @@ See: https://github.com/ocaml/dune/issues/4572
   > let new_function () = "hello"
   > EOF
 
-Uses_stdlib is recompiled even though it only uses Printf, not Mylib:
+Uses_stdlib is not recompiled because it only uses Printf, not Mylib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_stdlib"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -4,15 +4,13 @@ any of [dep_lib]'s modules. The consumer [main] uses
 [intermediate_lib] and so transitively gains [dep_lib] in its
 compilation context.
 
-Today every consumer module declares a glob over each transitively-
-reached library's public-cmi directory, so editing
-[unreferenced_dep.ml] (which no source file references) re-
-invalidates [Main]. The test records the current rebuild targets
-for [Main] when [unreferenced_dep.ml] is touched.
-
-This test is observational: a tighter dependency tracker that drops
-unreferenced libraries from compile rules' deps would shrink the
-recorded target list.
+The per-module filter detects that no consumer module references
+any [dep_lib] module — directly or transitively through
+[intermediate_lib] — and drops [dep_lib] entirely from [Main]'s
+compile-rule deps, so editing [unreferenced_dep.ml] leaves [Main]
+untouched. Pre-#14116 every consumer module declared a glob over
+each transitively-reached library's public-cmi directory, so the
+edit re-invalidated [Main].
 
 [intermediate_lib] and the [main] executable each include an unused
 dummy module ([intermediate_dummy] / [main_dummy]) so that ocamldep
@@ -76,23 +74,9 @@ references any module of [dep_lib]:
 
 Edit [unreferenced_dep.ml]. Neither [main.ml] nor
 [intermediate_module.ml] references [Unreferenced_dep] or any
-other [dep_lib] module, so a tighter filter could leave [Main]
-untouched. Today [Main] is rebuilt:
+other [dep_lib] module, so the filter leaves [Main] untouched:
 
   $ echo > unreferenced_dep.ml
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmo",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmt"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -8,7 +8,7 @@ The per-module filter detects that no consumer module references
 any [dep_lib] module — directly or transitively through
 [intermediate_lib] — and drops [dep_lib] entirely from [Main]'s
 compile-rule deps, so editing [unreferenced_dep.ml] leaves [Main]
-untouched. Pre-#14116 every consumer module declared a glob over
+untouched. Previously every consumer module declared a glob over
 each transitively-reached library's public-cmi directory, so the
 edit re-invalidated [Main].
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -1,8 +1,9 @@
 A consumer transitively depends upon a library through one module of an
 intermediate library, never naming a sibling module of the transitive lib in
-source. The current but undesirable behaviour is that the consumer rebuilds
-when any module of the transitively depended upon library changes, even
-unreferenced ones.
+source. The per-module filter walks ocamldep output across library
+boundaries: editing [unreached_module] leaves [main] untouched because no
+source in this test references it. Pre-#14116 this overrebuilt because
+the consumer's compile rule depended on a glob over [dep_lib]'s objdir.
 
 [intermediate_lib] and [main] each include an unused dummy module so neither
 stanza is single-module — single-module stanzas take a fast path that would
@@ -58,17 +59,4 @@ test references — and record the rebuild list for [main]:
   > EOF
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
-        "_build/default/.main.eobjs/native/dune__exe__Main.o"
-      ]
-    }
-  ]
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -2,7 +2,7 @@ A consumer transitively depends upon a library through one module of an
 intermediate library, never naming a sibling module of the transitive lib in
 source. The per-module filter walks ocamldep output across library
 boundaries: editing [unreached_module] leaves [main] untouched because no
-source in this test references it. Pre-#14116 this overrebuilt because
+source in this test references it. Previously this overrebuilt because
 the consumer's compile rule depended on a glob over [dep_lib]'s objdir.
 
 [intermediate_lib] and [main] each include an unused dummy module so neither

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
@@ -73,8 +73,8 @@ Change libB's interface:
   > let new_base_fn () = "new"
   > EOF
 
-Independent is recompiled even though it doesn't reference libA or libB:
+Independent is not recompiled because it doesn't reference libA or libB:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Independent"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -11,7 +11,7 @@ The per-module filter restricts [consumer]'s deps to modules of
 [dep_lib] that [consumer]'s ocamldep output names — only
 [Referenced_dep]. Editing [Unread_dep_a] or [Unread_dep_b] thus
 leaves [consumer] untouched (empty target list); editing
-[Referenced_dep] still rebuilds it. Pre-#14116 all three edits
+[Referenced_dep] still rebuilds it. Previously all three edits
 rebuilt [consumer] because the consumer was conservatively
 rebuilt whenever any entry module's cmi changed.
 

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -7,14 +7,13 @@ the dependency library [dep_lib] has its interface edited.
 [consumer] references only [Referenced_dep] from [dep_lib];
 [Unread_dep_a] and [Unread_dep_b] are present but unreferenced.
 
-On current main, editing any of the three rebuilds [consumer]
-because library-level dependency filtering (and, within that,
-per-module tightening) is not yet in place: the consumer is
-conservatively rebuilt whenever any entry module's cmi changes.
-Work on https://github.com/ocaml/dune/issues/4572 is expected to
-tighten this, at which point editing [Unread_dep_a] or
-[Unread_dep_b] leaves [consumer] untouched and the emitted target
-list becomes empty.
+The per-module filter restricts [consumer]'s deps to modules of
+[dep_lib] that [consumer]'s ocamldep output names — only
+[Referenced_dep]. Editing [Unread_dep_a] or [Unread_dep_b] thus
+leaves [consumer] untouched (empty target list); editing
+[Referenced_dep] still rebuilds it. Pre-#14116 all three edits
+rebuilt [consumer] because the consumer was conservatively
+rebuilt whenever any entry module's cmi changed.
 
 See: https://github.com/ocaml/dune/issues/4572
 
@@ -84,15 +83,7 @@ reference — and record the rebuild targets for [consumer]:
   > EOF
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
-      ]
-    }
-  ]
+  []
 
 Same for [Unread_dep_b]:
 
@@ -106,15 +97,7 @@ Same for [Unread_dep_b]:
   > EOF
   $ dune build @check
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
-      ]
-    }
-  ]
+  []
 
 Edit [Referenced_dep]'s interface — the one module [consumer] does
 reference — and record the rebuild targets ([consumer] must

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
@@ -1,8 +1,6 @@
-Baseline: library dependency recompilation for unwrapped libraries.
-
-When an unwrapped library module's interface changes, Dune currently recompiles
-all modules in stanzas that depend on the library, even those referencing
-different modules in the library.
+Per-module filtering for unwrapped libraries: a consumer that references
+only some modules of an unwrapped library must not be recompiled when
+unreferenced modules in that library change.
 
 See: https://github.com/ocaml/dune/issues/4572
 
@@ -73,11 +71,11 @@ Change only helper.mli:
   > let new_helper s = s ^ "!"
   > EOF
 
-Uses_utils is recompiled even though it only references Utils, not Helper:
+Uses_utils references Utils only, not Helper, so it is not recompiled:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_utils"))] | length'
-  2
+  0
 
 Change only utils.mli:
 
@@ -90,8 +88,8 @@ Change only utils.mli:
   > let new_utils s = s ^ "?"
   > EOF
 
-Uses_helper is recompiled even though it only references Helper, not Utils:
+Uses_helper references Helper only, not Utils, so it is not recompiled:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_helper"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
@@ -67,8 +67,8 @@ See: https://github.com/ocaml/dune/issues/4572
   > let new_fn () = "hello"
   > EOF
 
-Standalone is recompiled even though it doesn't reference Baselib:
+Standalone is not recompiled because it doesn't reference Baselib:
 
   $ dune build ./main.exe
   $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
-  2
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
@@ -1,0 +1,87 @@
+Regression guard for soundness when a consumer depends on an
+implementation that inherits its [(wrapped ...)] setting from the
+virtual library (the implementation does not redeclare [wrapped]).
+
+[vlib] declares [(wrapped true)] with a virtual module [virt_iface]
+and a concrete sibling [helper]. [impl] implements [vlib] without
+redeclaring [wrapped]. The executable [main] depends on [impl] and
+reaches both modules via the vlib wrapper: [Vlib.Virt_iface.x] and
+[Vlib.Helper.h].
+
+The implementation's closure includes both [virt_iface]'s impl and
+[vlib]'s concrete modules. [main]'s compile rule must therefore
+cover [impl]'s [.cmi] directory. Any future per-module narrowing
+that treats inherited-wrapped libraries as ordinary local libraries
+must still keep that coverage; otherwise a change to [helper]'s
+interface fails to invalidate [main].
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ mkdir vlib impl consumer
+
+  $ cat > vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (wrapped true)
+  >  (virtual_modules virt_iface))
+  > EOF
+  $ cat > vlib/virt_iface.mli <<EOF
+  > val x : string
+  > EOF
+  $ cat > vlib/helper.ml <<EOF
+  > let h = "h"
+  > EOF
+  $ cat > vlib/helper.mli <<EOF
+  > val h : string
+  > EOF
+
+  $ cat > impl/dune <<EOF
+  > (library
+  >  (name impl)
+  >  (implements vlib))
+  > EOF
+  $ cat > impl/virt_iface.ml <<EOF
+  > let x = "impl"
+  > EOF
+
+  $ cat > consumer/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries impl))
+  > EOF
+  $ cat > consumer/main.ml <<EOF
+  > let () = print_string Vlib.Virt_iface.x; print_string Vlib.Helper.h
+  > EOF
+
+  $ dune build @check
+
+Edit [helper]'s interface (a concrete vlib module). [main] reaches
+[helper] through the vlib wrapper; the compile-rule deps must
+cover [vlib__Helper.cmi], so [main] rebuilds:
+
+  $ cat > vlib/helper.mli <<EOF
+  > val h : string
+  > val z : int
+  > EOF
+  $ cat > vlib/helper.ml <<EOF
+  > let h = "h"
+  > let z = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmi",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmti"
+      ]
+    },
+    {
+      "target_files": [
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmo",
+        "_build/default/consumer/.main.eobjs/byte/dune__exe__Main.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
@@ -1,30 +1,28 @@
-Observational baseline for an unsupported leak: a consumer can
-currently reach a wrapped library's internal (mangled) module name
-through the include path, because the library's object directory
-contains the mangled `Mylib__Internal.cmi` and broad `-I` flags make
-that directory reachable.
+A consumer that writes `Mylib__Internal.x` — using a wrapped
+library's mangled internal module name directly, bypassing the
+wrapper — no longer compiles. This file asserts the compile
+error.
 
-A wrapped library exposes its public API only through its wrapper
-module (`Mylib.Internal`, etc). Dune mangles the on-disk cmi of the
-wrapped internal module to `Mylib__Internal.cmi` as an implementation
-detail. Under broad per-module `-I` flags, a consumer that writes
-`Mylib__Internal.x` compiles successfully, side-stepping the wrapper.
+Why it fails: per-module rule-dep filtering (#4572 / #14116)
+scopes each consumer's compile-rule deps to the libraries its
+source actually references. The consumer's ocamldep output
+names `Mylib__Internal` as a top-level module, but
+`Mylib__Internal` is not a library entry — the lib index only
+knows about `Mylib`. The filter therefore does not list
+`Mylib__Internal.cmi` among the consumer's compile-rule deps;
+dune does not order the producing rule before the consumer's
+compile, and ocamlc reports `Unbound module` because the file
+is absent from `mylib`'s objdir when the consumer's compile
+runs.
 
-This is not officially supported — consumers should reach a wrapped
-library's internals only through the wrapper API, not through the
-mangled form (see #14317 review discussion). The leak works today
-only as an implementation-detail side effect of the wrapping
-convention. In practice some packages currently depend on it, which
-is why the baseline is recorded here so any flip is visible in CI.
-
-Per-module `-I` filtering (#4572 / #14186) is expected to break this
-leak by scoping each consumer's `-I` paths to the libraries its
-source references. `Mylib__Internal` is not an entry in the lib
-index, so the filter excludes `mylib`, the objdir is dropped from
-`-I`, and the compile fails with "Unbound module Mylib__Internal".
-The flip is acceptable because the leak was never supported;
-downstream consumers depending on the mangled form should migrate
-to the wrapper API.
+Why this isn't a regression: the mangled form was never
+officially supported. Wrapped libraries expose their public API
+through the wrapper module (`Mylib.Internal.x`); the on-disk
+mangling to `Mylib__Internal.cmi` is an implementation detail.
+Under broad cctx-wide compile-rule deps the leak previously
+compiled by accident; per-module rule-dep filtering removes the
+accidental reachability. Downstream consumers depending on the
+mangled form should migrate to the wrapper API.
 
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
@@ -49,3 +47,8 @@ to the wrapper API.
   > EOF
 
   $ dune build ./main.exe
+  File "main.ml", line 1, characters 23-38:
+  1 | let () = print_endline Mylib__Internal.hi
+                             ^^^^^^^^^^^^^^^
+  Error: Unbound module Mylib__Internal
+  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
@@ -3,7 +3,7 @@ library's mangled internal module name directly, bypassing the
 wrapper — no longer compiles. This file asserts the compile
 error.
 
-Why it fails: per-module rule-dep filtering (#4572 / #14116)
+Why it fails: per-module rule-dep filtering (#4572)
 scopes each consumer's compile-rule deps to the libraries its
 source actually references. The consumer's ocamldep output
 names `Mylib__Internal` as a top-level module, but

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
@@ -1,0 +1,78 @@
+Regression guard for wrapped-library soundness under
+[(wrapped (transition ...))].
+
+[wrapped_lib] uses [(wrapped (transition ...))] with inner modules
+[inner_a] and [inner_b] plus a hand-written wrapper module that
+aliases both. The library [consumer] depends on [wrapped_lib] and
+writes [Wrapped_lib.Inner_a.x] — naming the wrapper and one inner
+module but not the other.
+
+The wrapper's [.cmi] only carries an alias name; the type lives in
+the inner module's mangled artifact [wrapped_lib__Inner_a.cmi] (not
+the [inner_a.cmi] transition shim). So [consumer]'s compile rule
+must cover [wrapped_lib__Inner_a.cmi] alongside [wrapped_lib.cmi].
+Any future per-module narrowing of compile-rule deps must keep that
+coverage; otherwise a change to [inner_a]'s interface fails to
+invalidate [consumer].
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name wrapped_lib)
+  >  (wrapped (transition "use Wrapped_lib.X instead of X"))
+  >  (modules wrapped_lib inner_a inner_b))
+  > (library
+  >  (name consumer)
+  >  (modules consumer)
+  >  (libraries wrapped_lib))
+  > EOF
+
+  $ cat > wrapped_lib.ml <<EOF
+  > module Inner_a = Inner_a
+  > module Inner_b = Inner_b
+  > EOF
+  $ cat > inner_a.ml <<EOF
+  > let x = "a"
+  > EOF
+  $ cat > inner_a.mli <<EOF
+  > val x : string
+  > EOF
+  $ cat > inner_b.ml <<EOF
+  > let y = "b"
+  > EOF
+  $ cat > inner_b.mli <<EOF
+  > val y : string
+  > EOF
+
+  $ cat > consumer.ml <<EOF
+  > let _ = Wrapped_lib.Inner_a.x
+  > EOF
+
+  $ dune build @check
+
+Edit [inner_a]'s interface. [consumer] reaches [inner_a] through
+the wrapper [Wrapped_lib]; the compile-rule deps must cover
+[wrapped_lib__Inner_a.cmi], so [consumer] rebuilds:
+
+  $ cat > inner_a.mli <<EOF
+  > val x : string
+  > val z : int
+  > EOF
+  $ cat > inner_a.ml <<EOF
+  > let x = "a"
+  > let z = 42
+  > EOF
+  $ dune build @check
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
+  [
+    {
+      "target_files": [
+        "_build/default/.consumer.objs/byte/consumer.cmi",
+        "_build/default/.consumer.objs/byte/consumer.cmo",
+        "_build/default/.consumer.objs/byte/consumer.cmt"
+      ]
+    }
+  ]

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a1/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a1/x.ml
@@ -1,0 +1,1 @@
+let value = B.X.value

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a2/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a2/x.ml
@@ -1,0 +1,1 @@
+let value = 0

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/b/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/b/x.ml
@@ -1,0 +1,1 @@
+let value = A2.X.value

--- a/test/blackbox-tests/test-cases/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps.t
@@ -8,8 +8,8 @@ the package dependencies inferred by dune:
   > (package (name foo))
   > EOF
   $ mkdir foo bar
-  $ touch foo/foo.ml
-  $ touch bar/bar.ml
+  $ echo 'let () = print_int Bar.value' >foo/foo.ml
+  $ echo 'let value = 1' >bar/bar.ml
   $ cat >foo/dune <<EOF
   > (executable (public_name foo) (libraries bar) (package foo))
   > EOF
@@ -25,6 +25,9 @@ the package dependencies inferred by dune:
 
   $ cat >foo/dune <<EOF
   > (library (public_name foo) (libraries bar))
+  > EOF
+  $ cat >foo/foo.ml <<EOF
+  > let use_bar () = Bar.value
   > EOF
   $ dune build @install
   Error: Package foo is missing the following package dependencies
@@ -45,7 +48,9 @@ transitive deps.
   > (package (name bar) (depends baz))
   > (package (name foo) (depends bar))
   > EOF
-  $ touch baz.ml bar.ml foo.ml
+  $ echo 'let value = 1' >baz.ml
+  $ echo 'let chain = Baz.value' >bar.ml
+  $ echo 'let use = Bar.chain' >foo.ml
   $ cat >dune <<EOF
   > (library (public_name baz) (modules baz))
   > (library (public_name bar) (libraries baz) (modules bar))

--- a/test/blackbox-tests/test-cases/watching/multiple-errors-output.t/run.t
+++ b/test/blackbox-tests/test-cases/watching/multiple-errors-output.t/run.t
@@ -15,10 +15,18 @@ We test the output of the watch mode client when we have multiple errors
   1 | let y = "unknown variable" ^ what
                                    ^^^^
   Unbound value what
-  Error: Build failed with 2 errors.
+  File "$TESTCASE_ROOT/src/foo.ml", line 1, characters 39-40:
+  1 | let f = Bar.x + Baz.y + invalid_syntax : ? = !
+                                             ^
+  Syntax error
+  Error: Build failed with 3 errors.
   [1]
 
   $ stop_dune
+  File "src/foo.ml", line 1, characters 39-40:
+  1 | let f = Bar.x + Baz.y + invalid_syntax : ? = !
+                                             ^
+  Error: Syntax error
   File "libs/bar.ml", line 1, characters 8-20:
   1 | let y = "type error" + 3
               ^^^^^^^^^^^^
@@ -28,4 +36,4 @@ We test the output of the watch mode client when we have multiple errors
   1 | let y = "unknown variable" ^ what
                                    ^^^^
   Error: Unbound value what
-  Had 2 errors, waiting for filesystem changes...
+  Had 3 errors, waiting for filesystem changes...


### PR DESCRIPTION
## Summary

Per-module library dependency filtering for #4572. A consumer module's compile rule now sees only the artefacts of libraries it actually references, so unrelated sibling modules no longer recompile when an unreferenced dependency library's cmi changes. User-facing detail is in the shipped changelog entry (`doc/changes/added/14491.md`).

## Predecessor PRs (now closed)

- #14472 — per-module library dep filter via ocamldep BFS.
- #14473 — per-module `-I`/`-H` include flags matching the filter.
- #14474 — `Raw_refs` `Action_builder` cache to deduplicate ocamldep results across cctxs sharing the same module sources.

Fixes #4572.