### PR TITLE
Filter inter-library dependencies per module

### DIFF
--- a/doc/changes/added/14492.md
+++ b/doc/changes/added/14492.md
@@ -1,0 +1,9 @@
+- Filter inter-library dependencies per-module using `ocamldep` output, and
+  match the `-I`/`-H` include flags to that filter. When a dependency
+  library's cmi changes, only consumer modules that reference it get rebuilt
+  — eliminating spurious recompilations of unrelated sibling modules.
+  Applies to unwrapped dependency libraries; wrapped libraries continue to
+  use a glob over the whole library's objdir. As a result, single-module
+  stanzas with library dependencies now run `ocamldep` (previously
+  skipped), so a configured toolchain that resolves `ocamlc` must also
+  resolve `ocamldep`. (#14492, fixes #4572, @robinbb)

--- a/doc/dev/per-module-narrowing.md
+++ b/doc/dev/per-module-narrowing.md
@@ -1,0 +1,634 @@
+# Per-module library dependency narrowing
+
+This document describes the algorithm Dune uses to narrow the
+library-file dependency set of each compile rule on a per-module basis.
+The narrowing was introduced in #14492 (split into PRs #14513–#14521,
+referred to internally as layers L1..L9). It supersedes the prior
+behaviour in which every compile rule depended on the full glob of
+every interface file of every library in the compilation context's
+dependency closure.
+
+## Motivation
+
+In the pre-narrowing world, a single compile rule for module `M` in
+some stanza depended on the glob of every `.cmi` (and, conditionally,
+`.cmx`) of every library reachable through `requires`. The glob is
+correct — recompiling `M` must see fresh interfaces — but it is
+maximally broad. A change to any interface in any reachable library
+invalidated `M`'s compile rule, even when `M` does not mention the module
+whose interface changed.
+
+For incremental builds in code bases with many libraries and broad
+`requires` graphs, this over-invalidation produced large, avoidable
+recompilation cascades. The narrowing computes, for each compile rule,
+a subset of those files that the consumer module can actually be
+affected by — by inspecting what its `ocamldep` says it references and
+walking the cross-library reference graph until convergence. Files
+outside that subset are dropped from the rule's dependency set; their
+unrelated edits no longer trigger a recompile.
+
+The narrowing must be *sound*: every file the compiler can read while
+processing `M` must remain in the dependency set, or builds will be
+non-deterministic and incremental builds will silently use stale
+artefacts. The algorithm therefore conservatively widens to the
+original glob in a small set of edge cases described under "Soundness
+recovery" below.
+
+## The algorithm at a glance
+
+For each compile rule for a module `M` in compilation context `cctx`,
+parameterised by the compile artefact kind (`Lib_mode.Cm_kind.t` — one
+of `Ocaml Cmi`, `Ocaml Cmo`, `Ocaml Cmx`, `Melange Cmi`, `Melange Cmj`),
+the source-language kind (`Ml_kind.t` — `Impl` or `Intf`), and the mode
+(`Lib_mode.t`):
+
+1. If a small set of preconditions fails (`can_filter = false`), fall
+   back to the cctx-wide glob — the same dep set every compile rule
+   would have had prior to this work. This avoids needing soundness
+   arguments for module kinds that the narrowing was not designed for,
+   and lets `Melange` paths pass through unchanged.
+
+2. Otherwise, if the consumer cctx already carries a virtual library
+   in `requires` (`has_virtual_impl = true`), fall back to the
+   cctx-wide glob. Virtual-impl deps require analysis the BFS does not
+   currently do.
+
+3. Otherwise, run the narrowing:
+   1. Read the consumer module's own `ocamldep` raw references (impl
+      and intf), and those of every module in `M`'s within-cctx
+      transitive `dep_graph`.
+   2. Union them with the `-open` flag modules. The result is
+      `referenced : Module_name.Set.t`.
+   3. Use the cctx's `Lib_index` (built once per cctx) to partition
+      the cctx's library closure into libraries whose entry modules
+      appear in `referenced` (`tight`) and libraries whose `None`-
+      entries appear in `referenced` (`non_tight`).
+   4. Compute the `Lib.closure` of `tight ∪ non_tight ∪
+      pps_runtime_libs` to expand the **lib set** over the library
+      `requires` DAG, picking up libs reached only via transparent
+      aliases that ocamldep cannot see.
+   5. Run a BFS over the **module-reference graph**: starting from
+      `referenced`, look up `(lib, entry)` pairs in the lib index
+      and read each entry's `ocamldep` raw refs, extending the
+      frontier until it converges. The fixpoint `tight_set` is the
+      set of *module names* (not libs) transitively reachable.
+   6. Re-run `Lib_index.filter_libs_with_modules` with `tight_set` in
+      place of `referenced`, producing a fresh `(tight_modules,
+      non_tight_set)` partition over the BFS-expanded name set.
+   7. Compute `must_glob_set` for the libraries that must glob for
+      soundness (wrapped-library wrappers reached transparently, and
+      `ppx_runtime_libraries` whose modules are post-pp invisible).
+   8. Fold over the closed lib set, classifying each lib into one of
+      four buckets and emitting either specific-file deps (for tight
+      libs) or a full glob (for non-tight libs).
+   9. Compute the include flags scoped to the `kept_libs` set —
+      libraries that contributed at least one dep — so that `-I`/`-H`
+      reflect only what the consumer can actually reach.
+
+The output is `(include_args, dep_set)`, which the compile rule
+consumes via `Action_builder.dyn_deps`.
+
+## The `can_filter` precondition
+
+The entry point for the narrowing is
+`Module_compilation.lib_deps_for_module`
+(`src/dune_rules/module_compilation.ml`). Before any narrowing runs,
+the function computes a `can_filter` boolean conjunction:
+
+- The compile is `Ocaml _` (Melange has its own cm-kind story and is
+  not narrowed).
+- The supplied `dep_graph` is the real one for this cctx (its `dir`
+  equals the cctx's `obj_dir`), not a `Dep_graph.dummy` — synthesised
+  / link-time-generated / alias / root modules have no usable
+  trans-deps and short-circuit.
+- The `dep_graph` contains `M`. Modules synthesised outside the stanza
+  (e.g. those handed to `ocamlc_i` for `-i` extraction in unrelated
+  flows) are also rejected here.
+- `M`'s `Module.kind` is filterable: not `Root`, `Wrapped_compat`,
+  `Impl_vmodule`, `Virtual`, or `Parameter`. These kinds have bespoke
+  dep stories handled elsewhere (`Dep_rules`, `Virtual_rules`).
+- `M` has a source file of the requested `ml_kind` (`Impl` or `Intf`).
+- The consumer cctx is itself not a `Virtual_rules.is_virtual_or_
+  parameter` cctx. Consumer-side virtual-impl behaviour is owned by
+  `Dep_rules`.
+
+If any condition fails, the function returns
+
+```ocaml
+(cctx_includes_for_cm_kind (),
+ Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+```
+
+... the cctx-wide glob, exactly equivalent to the prior behaviour. The
+narrowing applies only when all conditions hold.
+
+## The `has_virtual_impl` early-out
+
+When `can_filter` holds, the next check is
+
+```ocaml
+let* has_virtual_impl =
+  Resolve.Memo.read (Compilation_context.has_virtual_impl cctx)
+in
+if has_virtual_impl then
+  Action_builder.return
+    (cctx_includes_for_cm_kind (),
+     Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+else ...
+```
+
+`has_virtual_impl` is true when any library in the cctx's
+`requires_compile ∪ requires_hidden` is itself a virtual-library
+implementation. The BFS does not currently analyse virtual impls'
+contribution to the cctx's namespace; for soundness, all such cctxs
+fall back to the cctx-wide glob. The decision is cctx-level, computed
+once at `Compilation_context.create` and stored as a
+`bool Resolve.t Memo.Lazy.t`.
+
+## The narrowing pipeline
+
+When `can_filter` holds and `has_virtual_impl` is false, the function
+proceeds to the narrowing pipeline.
+
+### Step 1: read ocamldep raw refs for consumer + trans deps
+
+```ocaml
+let* trans_deps = Dep_graph.deps_of dep_graph m in
+let need_impl_deps_of dep_m ~is_consumer =
+  if is_consumer
+  then (match ml_kind with Impl -> true | Intf -> false)
+  else
+    (not (Module.has dep_m ~ml_kind:Intf))
+    ||
+    match cm_kind with
+    | Ocaml Cmx -> not opaque
+    | Ocaml (Cmi | Cmo) | Melange _ -> false
+in
+```
+
+The function reads `M`'s impl + intf raw refs, plus the impl + intf
+raw refs of every module in `M`'s transitive within-stanza
+dependencies. The selectivity table (which `.ml`-side refs to read)
+matches the compiler's own conditional behaviour:
+
+| `dep_m` is              | `cm_kind`   | `opaque` | read `.ml`?  |
+| ----------------------- | ----------- | -------- | ------------ |
+| consumer (`M` itself)   | any         | any      | iff `Impl`   |
+| trans_dep, no `.mli`    | any         | any      | yes          |
+| trans_dep, has `.mli`   | `Cmx`       | false    | yes (inline) |
+| trans_dep, has `.mli`   | `Cmx`       | true     | no           |
+| trans_dep, has `.mli`   | `Cmi`/`Cmo` | any      | no           |
+
+Each ocamldep raw-ref read is wrapped through
+`Compilation_context.cached_raw_refs` (L8), keyed on
+`Raw_refs.Key.t = Consumer { obj_name; ml_kind } | Transitive
+{ obj_name; cm_kind }`. The cache short-circuits before allocating the
+underlying `Action_builder.t`, so two siblings sharing a transitive
+dep only construct the dependency-reading builder once per cctx per
+key.
+
+The intf side is always read; the impl side is gated by
+`need_impl_deps_of`. The union of impl+intf for each module is the
+module's *raw references* — every module name that ocamldep saw it
+mention.
+
+### Step 2: compute `referenced`
+
+```ocaml
+let* m_raw = read_dep_m_raw m ~is_consumer:true in
+let* trans_raw =
+  union_module_name_sets_mapped trans_deps
+    ~f:(read_dep_m_raw ~is_consumer:false)
+in
+let all_raw = Module_name.Set.union m_raw trans_raw in
+let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
+let open_modules = Ocaml_flags.extract_open_module_names flags in
+let referenced = Module_name.Set.union all_raw open_modules in
+```
+
+`open_modules` are module names brought into scope by `-open` flags
+that ocamldep does not see (because they are command-line, not source
+syntax). Without them the consumer can mention a module by short name
+that the raw refs would miss, opening a soundness gap. Their union
+with `all_raw` produces `referenced` — the set of module names this
+compile of `M` can possibly resolve.
+
+### Step 3: first lib classification
+
+```ocaml
+let { Lib_file_deps.Lib_index.tight; non_tight } =
+  Lib_file_deps.Lib_index.filter_libs_with_modules
+    lib_index
+    ~referenced_modules:referenced
+in
+```
+
+The cctx-level `Lib_index` (built once at `cctx` creation by
+`Compilation_context.build_lib_index`) is a structure indexing each
+library's entry modules with each module name. `filter_libs_with_
+modules` walks `referenced` against the index and partitions:
+
+- `tight : Module.t list Lib.Map.t` — libraries whose `Some`-entry
+  modules appear in `referenced`. The mapped list is the specific
+  set of entries referenced. These are candidates for per-module
+  deps (`deps_of_entry_modules`).
+- `non_tight : Lib.Set.t` — libraries whose `None`-entry modules
+  appear (wrapped locals, externals, or unwrapped locals with some
+  staged-pps / instrumentation-only entries). These must glob.
+
+A library with mixed `Some`/`None` entries can appear in both — the
+caller globs it from the `non_tight` side, since the `None` entries
+require glob coverage.
+
+### Step 4: include `pps_runtime_libs` and compute `Lib.closure`
+
+```ocaml
+let* pps_runtime_libs =
+  Resolve.Memo.read (Compilation_context.pps_runtime_libs cctx)
+in
+let direct_libs =
+  List.sort_uniq ~compare:Lib.compare
+    (Lib.Map.keys tight @ Lib.Set.to_list non_tight @ pps_runtime_libs)
+in
+let* all_libs =
+  Resolve.Memo.read (Lib.closure direct_libs ~linking:false ~for_)
+in
+```
+
+`pps_runtime_libs` introduce module references through post-pp source
+that ocamldep cannot see — they are folded into the closure input so
+the classification fold sees them. `sort_uniq` canonicalises the
+input list because `Lib.closure`'s memo key (L9) is order- and
+multiplicity-sensitive.
+
+`Lib.closure` adds libraries reachable through transparent aliases
+(re-exports) that ocamldep does not surface — for instance, when a
+library `A` re-exports modules from `B` via an alias, references to
+`B.M` in source compile to references to `A.M` and ocamldep records
+only `A`. The closure pulls `B` in.
+
+### Step 5: compute `must_glob_set`
+
+```ocaml
+let wrapped_referenced =
+  Lib_file_deps.Lib_index.wrapped_libs_referenced
+    lib_index ~referenced_modules:referenced
+in
+let* must_glob_libs =
+  Resolve.Memo.read
+    (Lib.closure
+       (List.sort_uniq ~compare:Lib.compare
+          (Lib.Set.to_list wrapped_referenced @ pps_runtime_libs))
+       ~linking:false ~for_)
+in
+let must_glob_set = Lib.Set.of_list must_glob_libs in
+```
+
+Two classes of libraries must always glob even when their entry
+modules appear in `tight`:
+
+- **Wrapped library wrappers reached transparently.** When the
+  consumer mentions `Lib.M`, the source-level reference is to the
+  wrapper module `Lib`, but the compiled output of `M` lives at
+  `lib__M`. The cross-library walker reads ocamldep on the wrapper
+  module, which only surfaces references to the wrapper's direct
+  children. A consumer that reaches `Lib`'s wrapper can reach any
+  module of `Lib` via Foo's `(open ...)` or `Lib.Bar.x` syntax; the
+  walker cannot enumerate those at narrowing time. Solution: glob
+  `Lib.closure(wrapped_referenced)` — every library transitively
+  reachable from any referenced wrapper.
+
+- **`ppx_runtime_libraries`.** ppx-rewritten output may reference
+  modules from a runtime library that the consumer never names in
+  its source. ocamldep on the pre-pp source does not see those
+  references. Glob the closure to cover.
+
+The union `Lib.Set.of_list must_glob_libs` is the *must-glob set*;
+every member is forced onto the glob path regardless of its entry
+classification.
+
+### Step 6: BFS to fixpoint
+
+```ocaml
+let* tight_set =
+  cross_lib_tight_set
+    ~sandbox ~sctx ~lib_index ~mode ~initial_refs:referenced
+in
+```
+
+`cross_lib_tight_set` runs a BFS over the cross-library reference
+graph:
+
+```ocaml
+let rec loop ~seen ~frontier =
+  if Module_name.Set.is_empty frontier then return seen
+  else
+    let pairs =
+      Module_name.Set.fold frontier ~init:[] ~f:(fun name acc ->
+        Lib_file_deps.Lib_index.lookup_tight_entries lib_index name @ acc)
+    in
+    let* discovered =
+      union_module_name_sets_mapped pairs ~f:read_entry_deps
+    in
+    let seen = Module_name.Set.union seen frontier in
+    let frontier = Module_name.Set.diff discovered seen in
+    loop ~seen ~frontier
+```
+
+Each frontier iteration:
+
+1. For each module name in the frontier, look up the `(lib, entry)`
+   tight-eligible pairs via `Lib_file_deps.Lib_index.lookup_tight_
+   entries`. The lookup skips entries with `None`-module (wrapped
+   locals, externals) — those are non-tight-eligible and terminate
+   chains through them.
+2. For each `(lib, entry)`, the helper `read_entry_deps` returns the
+   union of three contributions:
+   - the entry module's impl ocamldep raw refs;
+   - the entry module's intf ocamldep raw refs;
+   - the modules named by `-open` flags in the entry's owning
+     library's *effective* flags. The effective flags are computed
+     by `Ocaml_flags_db.ocaml_flags sctx ~dir` against the
+     consumer's `mode`; that call folds in any `(env ...)`-stanza
+     defaults under the library stanza's own `(flags ...)` spec, so
+     both injection paths (library-stanza `-open` and env-stanza
+     `-open`) are captured even when the library stanza is
+     `:standard`. The `-open M` tokens are extracted with
+     `Ocaml_flags.extract_open_module_names`. Non-local libs are
+     short-circuited: their `src_dir` is not a build path, and env
+     stanzas cannot inject flags into already-compiled artifacts.
+3. Union all the discovered names into `discovered`.
+4. Add the current frontier to `seen`; the new frontier is
+   `discovered \ seen`.
+
+The opened-modules contribution closes a soundness gap that the
+three must-glob recoveries (step 5) and the syntactic ocamldep walk
+together cannot cover. When a dependency library's effective flags
+inject `-open Foo`, its source can reference `Foo`'s identifiers
+without ever naming `Foo` syntactically, so ocamldep on the dep
+lib's source produces no token to drive the walker — and `Foo`'s
+defining library may then be silently dropped from the consumer's
+compile even though the consumer transitively needs its `.cmi`.
+Treating the opened module names as a third class of frontier edge
+ensures the BFS reaches those libraries through the very same
+fixpoint that handles ocamldep-visible references. The reachability
+rule the BFS computes is: a module is reachable from the consumer
+iff the consumer references it, OR some reached module's ocamldep
+names it, OR some reached module's owning lib's effective flags
+open it.
+
+The post-pp module map (built by `Compilation_context.build_lib_
+index`) ensures that the entry module passed to ocamldep is the form
+the dep lib's own compile pipeline produces — so the walker reads
+either the `.pp.ml` (for action-style preprocessors or non-staged
+pps), or the source directly (for no-preprocessing and future-syntax
+extensions, which Dune handles at parse time).
+
+The walker terminates because the universe of module names is
+finite (bounded by the cctx's transitive library set) and `seen`
+only grows. The cost is proportional to the number of distinct
+entry modules transitively reachable from `referenced`.
+
+### Step 7: second lib classification
+
+```ocaml
+let { Lib_file_deps.Lib_index.tight = tight_modules;
+      non_tight = non_tight_set } =
+  Lib_file_deps.Lib_index.filter_libs_with_modules
+    lib_index ~referenced_modules:tight_set
+in
+```
+
+Re-partition the index using the converged `tight_set` (which is a
+superset of `referenced`). This is a separate classification from
+step 3 because the BFS may have brought new module names into scope
+that flip a library from "unreached" to "tight" or change the
+specific entries referenced.
+
+### Step 8: classify and emit per-lib deps
+
+```ocaml
+let tight_deps, glob_libs, kept_libs =
+  List.fold_left all_libs ~init:(Dep.Set.empty, [], Lib.Set.empty)
+    ~f:(fun (td, gl, kl) lib ->
+      if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
+      then td, lib :: gl, Lib.Set.add kl lib
+      else (
+        match Lib.Map.find tight_modules lib with
+        | Some modules ->
+          ( Dep.Set.union td
+              (Lib_file_deps.deps_of_entry_modules
+                 ~opaque ~cm_kind lib modules)
+          , gl
+          , Lib.Set.add kl lib )
+        | None ->
+          if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
+          then td, gl, kl
+          else td, lib :: gl, Lib.Set.add kl lib))
+in
+let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
+```
+
+Each library in `all_libs` (the closure-expanded set) is bucketed:
+
+- **Must-glob**: lib is in `must_glob_set` (wrapped-referenced or
+  pps-runtime), or has a `None`-entry referenced → emit the full lib
+  glob via `deps_of_entries`. Added to `kept_libs`.
+
+- **Tight**: lib has a `Some`-entry referenced and is not must-glob →
+  emit `deps_of_entry_modules` for just those referenced entries.
+  Added to `kept_libs`.
+
+- **Unreached + tight-eligible**: lib has no referenced entries and is
+  tight-eligible (has at least one `Some`-entry) → drop entirely. The
+  link rule still pulls it in via `requires_link` for runtime
+  linkage. The compile rule does not need it.
+
+- **Unreached + not tight-eligible**: lib has no referenced entries
+  but is not tight-eligible (wrapped local, external) → emit glob.
+  Added to `kept_libs`.
+
+The `kept_libs` accumulator captures every library that contributes
+*any* dep to this compile rule. It is the precise set against which
+include flags should be scoped (step 9).
+
+### Step 9: filtered include flags
+
+```ocaml
+let+ include_flags =
+  Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
+in
+include_flags, Dep.Set.union tight_deps glob_deps
+```
+
+`Compilation_context.filtered_include_flags` (L6+L7) restricts the
+cctx's `requires_compile` and `requires_hidden` lists to libraries in
+`kept_libs`, then computes `-I` / `-H` over those subsets. The result
+is memoised per `(lib_mode, kept_libs : Lib.Set.t)` (L7) so that two
+modules with the same `kept_libs` share evaluation.
+
+The final return value is the include args paired with the total dep
+set. `Module_compilation.lib_cm_deps` wraps the function with
+`Action_builder.dyn_deps`, which registers `dep_set` as the rule's
+dynamic deps and returns just the include args for the command line.
+
+## Data structures
+
+### `Lib_file_deps.Lib_index.t`
+
+(`src/dune_rules/lib_file_deps.{ml,mli}`.) Built once per cctx by
+`Compilation_context.build_lib_index ~super_context ~libs ~for_`. The
+input is a list of `(Module_name.t, Lib.t, Module.t option)` triples:
+the entry module's name, the owning library, and the entry's
+`Module.t` if available (`None` for wrapped locals and externals).
+
+The index supports:
+
+- `filter_libs_with_modules ~referenced_modules` — partition into
+  tight (per-lib `Module.t list` for the referenced entries) and
+  non_tight (libs with `None`-entry references).
+- `lookup_tight_entries name` — the `(lib, entry)` pairs whose entry
+  name is `name`, skipping `no_ocamldep`-tagged libs and `None`-entry
+  rows. Used by the BFS frontier expansion.
+- `is_tight_eligible lib` — true iff lib has at least one `Some`-
+  entry. Used in step 8 to distinguish "drop" from "must glob".
+- `wrapped_libs_referenced ~referenced_modules` — the set of wrapped
+  local libraries whose wrapper module name appears. Used to compute
+  the wrapped-soundness must-glob input in step 5.
+
+### `Compilation_context.cached_raw_refs` (L8)
+
+A per-cctx `Hashtbl` keyed by `Raw_refs.Key.t` that memoises the
+`Module_name.Set.t Action_builder.t` for a given module's ocamldep
+raw refs. Two distinct keys:
+
+- `Consumer { obj_name; ml_kind }` — used when reading the consumer
+  module `M`'s own refs (`ml_kind` distinguishes `Impl` from `Intf`
+  contexts; the choice of what to read varies per
+  `need_impl_deps_of`).
+- `Transitive { obj_name; cm_kind }` — used when reading a
+  `trans_deps` member's refs.
+
+Within a cctx, two compile rules computing narrowing for siblings
+that share a transitive dep both hit the same key, paying the
+underlying ocamldep read once.
+
+### `Compilation_context.filtered_includes` (L7)
+
+A per-cctx `Hashtbl` keyed by `Filtered_includes.Key.t =
+{ lib_mode : Lib_mode.t; kept_libs : Lib.Set.t }`. Caches the include
+flags Action_builder per `(lib_mode, kept_libs)` tuple. Two modules
+within the same cctx whose narrowing produces identical `kept_libs`
+share the include-flag computation.
+
+### `Lib.closure` memo (L9)
+
+`Lib.closure` is wrapped in a memo keyed by `(linking, for_, libs)`
+where `libs` is the input lib list. Two narrowing calls within the
+same cctx (or across cctxs) that produce identical `direct_libs`
+share the closure computation.
+
+### `Dep_graph` per cctx, per `Ml_kind`
+
+(`src/dune_rules/dep_rules.ml`.) Built per cctx as
+`Ml_kind.Dict.t Dep_graph.t`. `Dep_graph.deps_of dep_graph m` returns
+the within-cctx transitive `Module.t list` for module `m`. Used at
+step 1 to enumerate trans_deps before reading their ocamldep raw
+refs.
+
+## Soundness recovery and known edge cases
+
+Four soundness recoveries — the first three widen to a glob (the first
+two cctx-wide, the third per-library), the fourth extends the BFS
+frontier:
+
+1. **Module kinds outside `module_kind_is_filterable`**: `Root`,
+   `Wrapped_compat`, `Impl_vmodule`, `Virtual`, `Parameter`. Each has
+   a bespoke dep story handled elsewhere; the `can_filter` gate
+   rejects them.
+
+2. **Consumer cctx with `has_virtual_impl = true`**: the cctx itself
+   has a virtual-impl in `requires`. The BFS currently lacks the
+   analysis to safely narrow under that condition; the entire cctx
+   falls back.
+
+3. **Per-library wrapped or pps-runtime soundness**: handled within
+   the narrowing by `must_glob_set` (step 5 + step 8). The
+   classification fold force-globs these libraries even when their
+   tight classification would otherwise narrow them.
+
+4. **Effective `-open` on dep libraries**: handled inside the BFS
+   itself (step 6). When the walker visits a module of library `L`,
+   it extends the frontier with the modules named by `L`'s
+   *effective* `-open` flags (the library stanza's own `(flags ...)`
+   merged with any `(env ...)`-stanza defaults that apply at `L`'s
+   directory) in addition to the module's ocamldep raw refs. Without
+   this, a consumer that pattern-matches a type from a library
+   reached only via an intermediate's `-open` (the type being
+   inherited into the intermediate's `.mli` via the open) would
+   silently drop the leaf library's `.cmi` from its compile rule.
+
+`Melange` paths bypass the narrowing entirely at the `can_filter`
+check; the cm_kind machinery there is different and L9 leaves it
+unchanged.
+
+## Cost characteristics
+
+Per consumer module, the narrowing does:
+
+- One ocamldep raw-ref read for the consumer (cached by L8).
+- One ocamldep raw-ref read per trans-dep module (cached by L8 —
+  the read is shared with sibling consumers that share a trans-dep).
+- One `Lib.closure` (memoised by L9 — shared with sibling consumers
+  whose `direct_libs` are identical).
+- One BFS over the cross-library reference graph (state machine runs
+  per module; the individual ocamldep reads inside it hit L8 across
+  modules).
+- Per visited entry, an `Ocaml_flags_db.ocaml_flags` expansion of the
+  owning lib's stanza `(flags ...)` followed by
+  `Ocaml_flags.extract_open_module_names`, when the lib's
+  `stanza_flags` differs from `Spec.standard`. External libs always
+  carry `Spec.standard`, so the expansion is skipped for them. Each
+  expansion is memoised through `Ocaml_flags_db`'s underlying Memo.
+- Two `filter_libs_with_modules` calls (step 3 and step 7).
+- One `filtered_include_flags` lookup (memoised by L7 — shared with
+  siblings whose `kept_libs` match).
+
+The visible per-module Dune-level functions are individually small.
+The cost is in their *downstream effects* — `Module_name.Set` unions,
+`Lib.Set` / `Lib.Map` operations, `Dep.Set` constructions,
+`Action_builder` bind chains, and the minor-GC oldification of the
+intermediate sets.
+
+On a null build, the narrowing yields no benefit (no `.cmi` changed,
+so no module would have rebuilt either way). The work runs anyway.
+The narrowing trades null-build wall time for incremental-build
+recompile reduction.
+
+## Layer-by-layer construction (#14492)
+
+For reference, the algorithm above is the cumulative result of:
+
+- **L1** (#14513): test infrastructure prerequisite (merged).
+- **L2** (#14514): cctx fields `Lib_index`, `has_virtual_impl`,
+  `pps_runtime_libs`.
+- **L3** (#14515): scaffold — route lib file deps through a per-
+  module function (`lib_deps_for_module`) that initially returns the
+  same cctx-wide glob, preparing the call site.
+- **L4** (#14516): the BFS itself (`cross_lib_tight_set`,
+  `lib_deps_for_module` body); the `can_filter` gate is added.
+- **L5** (#14517): soundness recovery —
+  `has_virtual_impl` early-out, `pps_runtime_libs` fold-in,
+  `must_glob_set` from wrapped-referenced libs, plus effective-
+  `-open` BFS expansion (each visited lib's effective `-open`
+  modules — stanza `(flags ...)` plus `(env ...)`-injected flags
+  — join the frontier).
+- **L6** (#14518): `filtered_include_flags` per `kept_libs`.
+- **L7** (#14519): `Filtered_includes.t` per-cctx cache keyed by
+  `(lib_mode, kept_libs)`.
+- **L8** (#14520): `cached_raw_refs` per-cctx cache for ocamldep
+  raw-ref `Action_builder.t`s.
+- **L9** (#14521): `Lib.closure` memo keyed by `(linking, for_,
+  libs)`.
+
+Each layer can be read in isolation in the PR stack.

--- a/doc/dev/per-module-narrowing.md
+++ b/doc/dev/per-module-narrowing.md
@@ -45,8 +45,7 @@ the source-language kind (`Ml_kind.t` — `Impl` or `Intf`), and the mode
 1. If a small set of preconditions fails (`can_filter = false`), fall
    back to the cctx-wide glob — the same dep set every compile rule
    would have had prior to this work. This avoids needing soundness
-   arguments for module kinds that the narrowing was not designed for,
-   and lets `Melange` paths pass through unchanged.
+   arguments for module kinds that the narrowing was not designed for.
 
 2. Otherwise, if the consumer cctx already carries a virtual library
    in `requires` (`has_virtual_impl = true`), fall back to the
@@ -95,8 +94,6 @@ The entry point for the narrowing is
 (`src/dune_rules/module_compilation.ml`). Before any narrowing runs,
 the function computes a `can_filter` boolean conjunction:
 
-- The compile is `Ocaml _` (Melange has its own cm-kind story and is
-  not narrowed).
 - The supplied `dep_graph` is the real one for this cctx (its `dir`
   equals the cctx's `obj_dir`), not a `Dep_graph.dummy` — synthesised
   / link-time-generated / alias / root modules have no usable
@@ -568,9 +565,18 @@ frontier:
    inherited into the intermediate's `.mli` via the open) would
    silently drop the leaf library's `.cmi` from its compile rule.
 
-`Melange` paths bypass the narrowing entirely at the `can_filter`
-check; the cm_kind machinery there is different and L9 leaves it
-unchanged.
+`Melange` consumer compiles run the same narrowing pipeline as `Ocaml`.
+The `can_filter` check is mode-agnostic. Two code paths inside the
+pipeline match on `cm_kind`:
+
+1. `Lib_file_deps.deps_of_entry_modules` emits per-module `.cmj` in
+   addition to `.cmi` when `cm_kind = Melange Cmj`, mirroring the
+   broad-dep path's `groups_for_cm_kind`.
+2. `need_impl_deps_of` (in `lib_deps_for_module`) reads a trans-dep's
+   `.ml`-side ocamldep only for `cm_kind = Ocaml Cmx` (cross-module
+   inlining input). `Ocaml (Cmi | Cmo)` and `Melange _` are handled
+   symmetrically — neither reads impl deps. The distinction is
+   Cmx-vs-rest, not OCaml-vs-Melange.
 
 ## Cost characteristics
 

--- a/doc/dev/per-module-narrowing.md
+++ b/doc/dev/per-module-narrowing.md
@@ -45,8 +45,7 @@ the source-language kind (`Ml_kind.t` — `Impl` or `Intf`), and the mode
 1. If a small set of preconditions fails (`can_filter = false`), fall
    back to the cctx-wide glob — the same dep set every compile rule
    would have had prior to this work. This avoids needing soundness
-   arguments for module kinds that the narrowing was not designed for,
-   and lets `Melange` paths pass through unchanged.
+   arguments for module kinds that the narrowing was not designed for.
 
 2. Otherwise, if the consumer cctx already carries a virtual library
    in `requires` (`has_virtual_impl = true`), fall back to the
@@ -57,8 +56,8 @@ the source-language kind (`Ml_kind.t` — `Impl` or `Intf`), and the mode
    1. Read the consumer module's own `ocamldep` raw references (impl
       and intf), and those of every module in `M`'s within-cctx
       transitive `dep_graph`.
-   2. Union them with the `-open` flag modules. The result is
-      `referenced : Module_name.Set.t`.
+   2. Union them with the `-open` flag modules and the implicitly opened
+      `Stdlib` module. The result is `referenced : Module_name.Set.t`.
    3. Use the cctx's `Lib_index` (built once per cctx) to partition
       the cctx's library closure into libraries whose entry modules
       appear in `referenced` (`tight`) and libraries whose `None`-
@@ -95,8 +94,6 @@ The entry point for the narrowing is
 (`src/dune_rules/module_compilation.ml`). Before any narrowing runs,
 the function computes a `can_filter` boolean conjunction:
 
-- The compile is `Ocaml _` (Melange has its own cm-kind story and is
-  not narrowed).
 - The supplied `dep_graph` is the real one for this cctx (its `dir`
   equals the cctx's `obj_dir`), not a `Dep_graph.dummy` — synthesised
   / link-time-generated / alias / root modules have no usable
@@ -203,15 +200,27 @@ in
 let all_raw = Module_name.Set.union m_raw trans_raw in
 let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
 let open_modules = Ocaml_flags.extract_open_module_names flags in
-let referenced = Module_name.Set.union all_raw open_modules in
+let implicit_stdlib =
+  match Module_name.of_string_opt "Stdlib" with
+  | Some n -> Module_name.Set.singleton n
+  | None -> Module_name.Set.empty
+in
+let referenced =
+  Module_name.Set.union
+    (Module_name.Set.union all_raw open_modules)
+    implicit_stdlib
+in
 ```
 
 `open_modules` are module names brought into scope by `-open` flags
 that ocamldep does not see (because they are command-line, not source
 syntax). Without them the consumer can mention a module by short name
-that the raw refs would miss, opening a soundness gap. Their union
-with `all_raw` produces `referenced` — the set of module names this
-compile of `M` can possibly resolve.
+that the raw refs would miss, opening a soundness gap. `Stdlib` is also
+seeded explicitly because compilers open it implicitly. This is a no-op
+for OCaml's built-in standard library, which is not in `Lib_index`, but
+keeps Melange's library-provided `Stdlib` dependency reachable. Their
+union with `all_raw` produces `referenced` — the set of module names
+this compile of `M` can possibly resolve.
 
 ### Step 3: first lib classification
 
@@ -538,9 +547,9 @@ refs.
 
 ## Soundness recovery and known edge cases
 
-Four soundness recoveries — the first three widen to a glob (the first
-two cctx-wide, the third per-library), the fourth extends the BFS
-frontier:
+Five soundness recoveries — the first three widen to a glob (the first
+two cctx-wide, the third per-library), while the final two extend the
+reachable module set:
 
 1. **Module kinds outside `module_kind_is_filterable`**: `Root`,
    `Wrapped_compat`, `Impl_vmodule`, `Virtual`, `Parameter`. Each has
@@ -568,9 +577,24 @@ frontier:
    inherited into the intermediate's `.mli` via the open) would
    silently drop the leaf library's `.cmi` from its compile rule.
 
-`Melange` paths bypass the narrowing entirely at the `can_filter`
-check; the cm_kind machinery there is different and L9 leaves it
-unchanged.
+5. **Implicitly opened `Stdlib`**: seeded into `referenced` before the
+   BFS. OCaml's standard library is supplied directly by the compiler,
+   but Melange exposes `Stdlib` through a regular library dependency.
+   Without the explicit seed, a consumer that does not spell
+   `Stdlib.X` could drop that library and its include path.
+
+`Melange` consumer compiles run the same narrowing pipeline as `Ocaml`.
+The `can_filter` check is mode-agnostic. Two code paths inside the
+pipeline match on `cm_kind`:
+
+1. `Lib_file_deps.deps_of_entry_modules` emits per-module `.cmj` in
+   addition to `.cmi` when `cm_kind = Melange Cmj`, mirroring the
+   broad-dep path's `groups_for_cm_kind`.
+2. `need_impl_deps_of` (in `lib_deps_for_module`) reads a trans-dep's
+   `.ml`-side ocamldep only for `cm_kind = Ocaml Cmx` (cross-module
+   inlining input). `Ocaml (Cmi | Cmo)` and `Melange _` are handled
+   symmetrically — neither reads impl deps. The distinction is
+   Cmx-vs-rest, not OCaml-vs-Melange.
 
 ## Cost characteristics
 

--- a/src/dune_lang/lib_mode.ml
+++ b/src/dune_lang/lib_mode.ml
@@ -11,6 +11,12 @@ let equal x y =
   | Melange, Melange -> true
 ;;
 
+let hash = function
+  | Ocaml Byte -> 0
+  | Ocaml Native -> 1
+  | Melange -> 2
+;;
+
 let decode =
   let open Decoder in
   enum [ "byte", Ocaml Byte; "native", Ocaml Native; "melange", Melange ]

--- a/src/dune_lang/lib_mode.mli
+++ b/src/dune_lang/lib_mode.mli
@@ -6,6 +6,7 @@ type t =
 
 val decode : t Decoder.t
 val equal : t -> t -> bool
+val hash : t -> int
 val to_dyn : t -> Dyn.t
 
 module Cm_kind : sig

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -207,6 +207,11 @@ let gen_rules sctx t ~dir ~scope =
       in
       let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
       let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+      let pps_runtime_libs =
+        let open Resolve.Memo.O in
+        let* pps = Lib.Compile.pps compile_info ~for_ in
+        Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+      in
       let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
       Compilation_context.create
         for_
@@ -217,6 +222,7 @@ let gen_rules sctx t ~dir ~scope =
         ~opaque:(Explicit false)
         ~requires_compile
         ~requires_link
+        ~pps_runtime_libs
         ~flags
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -207,6 +207,11 @@ let gen_rules sctx t ~dir ~scope =
       in
       let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
       let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+      let pps_runtime_libs =
+        let open Resolve.Memo.O in
+        let* pps = Lib.Compile.pps compile_info ~for_ in
+        Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+      in
       let obj_dir = Obj_dir.make_for_exe_target ~dir:cinaps_dir exe_target in
       Compilation_context.create
         for_
@@ -218,6 +223,7 @@ let gen_rules sctx t ~dir ~scope =
         ~requires_compile
         ~user_written_requires:None
         ~requires_link
+        ~pps_runtime_libs
         ~flags
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -4,59 +4,136 @@ open Memo.O
 module Includes = struct
   type t = Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 
-  let make ~project ~opaque ~direct_requires ~hidden_requires lib_config
+  let make ~project ~direct_requires ~hidden_requires lib_config
     : _ Lib_mode.Cm_kind.Map.t
     =
-    (* TODO: some of the requires can filtered out using [ocamldep] info *)
     let open Resolve.Memo.O in
     let iflags direct_libs hidden_libs mode =
       Lib_flags.L.include_flags ~project ~direct_libs ~hidden_libs mode lib_config
     in
-    let make_includes_args ~mode groups =
+    let make_includes_args ~mode =
       (let+ direct_libs = direct_requires
        and+ hidden_libs = hidden_requires in
-       Command.Args.S
-         [ iflags direct_libs hidden_libs mode
-         ; Hidden_deps (Lib_file_deps.deps (direct_libs @ hidden_libs) ~groups)
-         ])
+       iflags direct_libs hidden_libs mode)
       |> Resolve.Memo.args
       |> Command.Args.memo
     in
     { ocaml =
-        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) [ Ocaml Cmi ] in
+        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) in
          { cmi = cmi_includes
          ; cmo = cmi_includes
-         ; cmx =
-             (let+ direct_libs = direct_requires
-              and+ hidden_libs = hidden_requires in
-              Command.Args.S
-                [ iflags direct_libs hidden_libs (Ocaml Native)
-                ; Hidden_deps
-                    (let libs = direct_libs @ hidden_libs in
-                     if opaque
-                     then
-                       List.map libs ~f:(fun lib ->
-                         ( lib
-                         , if Lib.is_local lib
-                           then [ Lib_file_deps.Group.Ocaml Cmi ]
-                           else [ Ocaml Cmi; Ocaml Cmx ] ))
-                       |> Lib_file_deps.deps_with_exts
-                     else
-                       Lib_file_deps.deps
-                         libs
-                         ~groups:[ Lib_file_deps.Group.Ocaml Cmi; Ocaml Cmx ])
-                ])
-             |> Resolve.Memo.args
-             |> Command.Args.memo
+         ; cmx = make_includes_args ~mode:(Ocaml Native)
          })
     ; melange =
-        { cmi = make_includes_args ~mode:Melange [ Melange Cmi ]
-        ; cmj = make_includes_args ~mode:Melange [ Melange Cmi; Melange Cmj ]
-        }
+        (let mel_includes = make_includes_args ~mode:Melange in
+         { cmi = mel_includes; cmj = mel_includes })
     }
   ;;
 
   let empty = Lib_mode.Cm_kind.Map.make_all Command.Args.empty
+end
+
+module Raw_refs = struct
+  module Key = struct
+    type t =
+      | Consumer of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+
+    let cm_kind_tag : Lib_mode.Cm_kind.t -> int = function
+      | Ocaml Cmi -> 0
+      | Ocaml Cmo -> 1
+      | Ocaml Cmx -> 2
+      | Melange Cmi -> 3
+      | Melange Cmj -> 4
+    ;;
+
+    let ml_kind_tag : Ml_kind.t -> int = function
+      | Intf -> 0
+      | Impl -> 1
+    ;;
+
+    let equal a b =
+      match a, b with
+      | Consumer a, Consumer b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && ml_kind_tag a.ml_kind = ml_kind_tag b.ml_kind
+      | Transitive a, Transitive b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && cm_kind_tag a.cm_kind = cm_kind_tag b.cm_kind
+      | Consumer _, Transitive _ | Transitive _, Consumer _ -> false
+    ;;
+
+    let hash = function
+      | Consumer { obj_name; ml_kind } -> Poly.hash (0, obj_name, ml_kind_tag ml_kind)
+      | Transitive { obj_name; cm_kind } -> Poly.hash (1, obj_name, cm_kind_tag cm_kind)
+    ;;
+
+    let repr =
+      let open Repr in
+      let obj_name_repr = view string ~to_:Module_name.Unique.to_string in
+      let ml_kind_repr = view string ~to_:Ml_kind.to_string in
+      let cm_kind_repr = abstract Lib_mode.Cm_kind.to_dyn in
+      variant
+        "Raw_refs.Key"
+        [ case "Consumer" (pair obj_name_repr ml_kind_repr) ~proj:(function
+            | Consumer { obj_name; ml_kind } -> Some (obj_name, ml_kind)
+            | Transitive _ -> None)
+        ; case "Transitive" (pair obj_name_repr cm_kind_repr) ~proj:(function
+            | Transitive { obj_name; cm_kind } -> Some (obj_name, cm_kind)
+            | Consumer _ -> None)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Module_name.Set.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 64
+end
+
+(* Key omits [t.requires_compile] / [t.requires_hidden] because they're
+   immutable on the cctx from [create]. The exception —
+   [for_module_generated_at_link_time]'s derived cctxs — takes the
+   [can_filter = false] arm in [lib_deps_for_module] and so never reaches this
+   cache. *)
+module Filtered_includes = struct
+  module Key = struct
+    type t =
+      { lib_mode : Lib_mode.t
+      ; kept_libs : Lib.Set.t
+      }
+
+    let equal a b =
+      Lib_mode.equal a.lib_mode b.lib_mode && Lib.Set.equal a.kept_libs b.kept_libs
+    ;;
+
+    let hash { lib_mode; kept_libs } =
+      Lib.Set.fold kept_libs ~init:(Lib_mode.hash lib_mode) ~f:(fun lib acc ->
+        (acc * 31) + Lib.hash lib)
+    ;;
+
+    let repr =
+      Repr.record
+        "Filtered_includes.Key"
+        [ Repr.field "lib_mode" (Repr.abstract Lib_mode.to_dyn) ~get:(fun t -> t.lib_mode)
+        ; Repr.field "kept_libs" (Repr.abstract Lib.Set.to_dyn) ~get:(fun t ->
+            t.kept_libs)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Command.Args.without_targets Command.Args.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 16
 end
 
 type opaque =
@@ -91,7 +168,10 @@ type t =
   ; parameters : Module_name.t list Resolve.Memo.t
   ; instances : Parameterised_instances.t Resolve.Memo.t option
   ; includes : Includes.t
+  ; lib_index : Lib_file_deps.Lib_index.t Resolve.t Memo.Lazy.t
+  ; has_virtual_impl : bool Resolve.t Memo.Lazy.t
   ; preprocessing : Pp_spec.t
+  ; pps_runtime_libs : Lib.t list Resolve.Memo.t
   ; opaque : bool
   ; js_of_ocaml : Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
   ; sandbox : Sandbox_config.t
@@ -104,6 +184,8 @@ type t =
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
   ; for_ : Compilation_mode.t
+  ; filtered_includes : Filtered_includes.t
+  ; raw_refs : Raw_refs.t
   }
 
 let loc t = t.loc
@@ -118,7 +200,10 @@ let requires_hidden t = t.requires_hidden
 let requires_link t = Memo.Lazy.force t.requires_link
 let parameters t = t.parameters
 let includes t = t.includes
+let lib_index t = Memo.Lazy.force t.lib_index
+let has_virtual_impl t = Memo.Lazy.force t.has_virtual_impl
 let preprocessing t = t.preprocessing
+let pps_runtime_libs t = t.pps_runtime_libs
 let opaque t = t.opaque
 let js_of_ocaml t = t.js_of_ocaml
 let sandbox t = t.sandbox
@@ -147,6 +232,74 @@ let parameters_main_modules parameters =
         [ "param", Lib.to_dyn param ])
 ;;
 
+(* Hidden libs must be indexed: otherwise unreached ones fall to the glob branch
+   and over-invalidate. *)
+let build_lib_index ~super_context ~libs ~for_ =
+  let open Resolve.Memo.O in
+  let instrument_with = Context.instrument_with (Super_context.context super_context) in
+  let+ per_lib =
+    Resolve.Memo.List.map libs ~f:(fun lib ->
+      match Lib_info.entry_modules (Lib.info lib) ~for_ with
+      | External (Ok names) ->
+        Resolve.Memo.return (List.map names ~f:(fun n -> n, lib, None), None)
+      | External (Error e) -> Resolve.Memo.of_result (Error e)
+      | Local ->
+        let* mods =
+          Resolve.Memo.lift_memo
+            (Dir_contents.modules_of_local_lib
+               super_context
+               (Lib.Local.of_lib_exn lib)
+               ~for_)
+        in
+        (* [no_ocamldep_lib] tags libs that are walker-terminal: running
+           ocamldep on their entry module via the cross-lib walk can't
+           propagate anywhere, so the walker skips them. A singleton lib is
+           terminal only when its resolved requires are empty; otherwise the
+           walker must read its post-pp ocamldep to discover transitive refs
+           (incl. pps runtime libs added via [add_pp_runtime_deps]). *)
+        let+ requires_resolved = Lib.requires lib ~for_ in
+        (* [Some m] only for unwrapped locals (tight-eligible); wrapped locals
+           and externals → [None]. *)
+        let unwrapped =
+          match Lib_info.wrapped (Lib.info lib) with
+          | Some (This w) -> not (Wrapped.to_bool w)
+          | Some (From _) | None -> false
+        in
+        (* Mirror [Pp_spec.pped_modules_map] so the cross-lib walker reads
+           ocamldep on the source the dep lib's compile pipeline produces. *)
+        let preprocess = Lib_info.preprocess (Lib.info lib) ~for_ in
+        let post_pp_module m =
+          match Preprocess.Per_module.find (Module.name m) preprocess with
+          | No_preprocessing | Future_syntax _ -> Some (Module.ml_source m)
+          | Action _ -> Some (Module.ml_source (Module.pped m))
+          | Pps { staged = false; pps; _ } ->
+            let any_active =
+              List.exists pps ~f:(function
+                | Preprocess.With_instrumentation.Ordinary _ -> true
+                | Instrumentation_backend { libname = _, name; _ } ->
+                  List.mem instrument_with name ~equal:Lib_name.equal)
+            in
+            if any_active
+            then Some (Module.pped (Module.ml_source m))
+            else Some (Module.ml_source m)
+          | Pps { staged = true; _ } -> None
+        in
+        let entries =
+          List.map (Modules.entry_modules mods) ~f:(fun m ->
+            Module.name m, lib, if unwrapped then post_pp_module m else None)
+        in
+        let no_ocamldep_lib =
+          match Modules.as_singleton mods with
+          | Some _ when List.is_empty requires_resolved -> Some lib
+          | _ -> None
+        in
+        entries, no_ocamldep_lib)
+  in
+  let entries = List.concat_map per_lib ~f:fst in
+  let no_ocamldep = List.filter_map per_lib ~f:snd |> Lib.Set.of_list in
+  Lib_file_deps.Lib_index.create ~no_ocamldep entries
+;;
+
 let create
       ~super_context
       ~scope
@@ -155,6 +308,7 @@ let create
       ~flags
       ~requires_compile
       ~requires_link
+      ~pps_runtime_libs
       ?(preprocessing = Pp_spec.dummy)
       ~opaque
       ~js_of_ocaml
@@ -210,6 +364,19 @@ let create
     let profile = Context.profile context in
     eval_opaque ocaml profile opaque
   in
+  let* has_library_deps =
+    (* Single-module stanzas still run ocamldep when they have library deps so
+       the per-module filter can inform the result. *)
+    let open Resolve.Memo.O in
+    let+ direct = direct_requires
+    and+ hidden = hidden_requires in
+    match direct, hidden with
+    | [], [] -> false
+    | _ -> true
+  in
+  (* Resolution errors surface later through the normal compilation rules;
+     assume deps are present here. *)
+  let has_library_deps = Resolve.peek has_library_deps |> Result.value ~default:true in
   let+ dep_graphs =
     Dep_rules.rules
       ~dir:(Obj_dir.dir obj_dir)
@@ -219,6 +386,7 @@ let create
       ~impl:implements
       ~modules
       ~for_
+      ~has_library_deps
   and+ bin_annot =
     match bin_annot with
     | Some b -> Memo.return b
@@ -244,9 +412,21 @@ let create
   ; requires_link
   ; implements
   ; parameters
-  ; includes =
-      Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
+  ; includes = Includes.make ~project ~direct_requires ~hidden_requires ocaml.lib_config
+  ; lib_index =
+      Memo.lazy_ (fun () ->
+        let open Resolve.Memo.O in
+        let* d = direct_requires
+        and* h = hidden_requires in
+        build_lib_index ~super_context ~libs:(d @ h) ~for_)
+  ; has_virtual_impl =
+      Memo.lazy_ (fun () ->
+        let open Resolve.Memo.O in
+        let+ direct = direct_requires
+        and+ hidden = hidden_requires in
+        List.exists (direct @ hidden) ~f:(fun lib -> Option.is_some (Lib.implements lib)))
   ; preprocessing
+  ; pps_runtime_libs
   ; opaque
   ; js_of_ocaml
   ; sandbox
@@ -260,10 +440,53 @@ let create
   ; ocaml
   ; instances
   ; for_
+  ; filtered_includes = Filtered_includes.create ()
+  ; raw_refs = Raw_refs.create ()
   }
 ;;
 
 let for_ t = t.for_
+
+let cached_raw_refs t ~key ~compute =
+  match Table.find t.raw_refs key with
+  | Some builder -> builder
+  | None ->
+    let builder = compute () in
+    Table.set t.raw_refs key builder;
+    builder
+;;
+
+let filtered_include_flags t ~cm_kind ~kept_libs =
+  let lib_mode = Lib_mode.of_cm_kind cm_kind in
+  let cache_key = { Filtered_includes.Key.lib_mode; kept_libs } in
+  match Table.find t.filtered_includes cache_key with
+  | Some builder -> builder
+  | None ->
+    (* Cache the [Action_builder.t] (not the resolved args) up-front at
+       rule-construction time so all compile rules sharing this
+       [(lib_mode, kept_libs)] share one builder; [Action_builder.memoize] then
+       dedupes its evaluation. Mirrors the cache pattern in
+       [Ocamldep.read_immediate_deps_words]. *)
+    let builder =
+      let open Action_builder.O in
+      let+ direct_requires = Resolve.Memo.read t.requires_compile
+      and+ hidden_requires = Resolve.Memo.read t.requires_hidden in
+      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_libs) in
+      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_libs) in
+      let project = Scope.project t.scope in
+      let lib_config = t.ocaml.lib_config in
+      Lib_flags.L.include_flags
+        ~project
+        ~direct_libs:direct_filtered
+        ~hidden_libs:hidden_filtered
+        lib_mode
+        lib_config
+      |> Command.Args.memo
+    in
+    let builder = Action_builder.memoize "filtered_include_flags" builder in
+    Table.set t.filtered_includes cache_key builder;
+    builder
+;;
 
 let alias_and_root_module_flags =
   let extra = [ "-w"; "-49" ] in
@@ -337,7 +560,6 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     let direct_requires = requires in
     Includes.make
       ~project:(Scope.project cctx.scope)
-      ~opaque
       ~direct_requires
       ~hidden_requires
       cctx.ocaml.lib_config
@@ -347,7 +569,21 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   ; flags = Ocaml_flags.empty
   ; requires_link = Memo.lazy_ (fun () -> requires)
   ; requires_compile = requires
+  ; requires_hidden = Resolve.Memo.return []
   ; includes
+  ; lib_index =
+      Memo.lazy_ (fun () ->
+        (* Unreachable: synthesised modules use [Dep_graph.dummy] (whose [dir]
+           is [Path.Build.root]), so [lib_deps_for_module]'s [can_filter]
+           dir-equality guard fails and the non-filter fallback is taken. *)
+        Code_error.raise
+          "Compilation_context.lib_index forced for a module synthesised at link time; \
+           this should be unreachable."
+          [])
+  ; (* Link-time-generated modules cannot participate in virtual-impl
+       relationships; override the parent's value so the accessor reflects
+       this cctx's [requires_compile]/[requires_link]. *)
+    has_virtual_impl = Memo.Lazy.of_val (Resolve.return false)
   ; modules
   }
 ;;

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -4,59 +4,136 @@ open Memo.O
 module Includes = struct
   type t = Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 
-  let make ~project ~opaque ~direct_requires ~hidden_requires lib_config
+  let make ~project ~direct_requires ~hidden_requires lib_config
     : _ Lib_mode.Cm_kind.Map.t
     =
-    (* TODO: some of the requires can filtered out using [ocamldep] info *)
     let open Resolve.Memo.O in
     let iflags direct_libs hidden_libs mode =
       Lib_flags.L.include_flags ~project ~direct_libs ~hidden_libs mode lib_config
     in
-    let make_includes_args ~mode groups =
+    let make_includes_args ~mode =
       (let+ direct_libs = direct_requires
        and+ hidden_libs = hidden_requires in
-       Command.Args.S
-         [ iflags direct_libs hidden_libs mode
-         ; Hidden_deps (Lib_file_deps.deps (direct_libs @ hidden_libs) ~groups)
-         ])
+       iflags direct_libs hidden_libs mode)
       |> Resolve.Memo.args
       |> Command.Args.memo
     in
     { ocaml =
-        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) [ Ocaml Cmi ] in
+        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) in
          { cmi = cmi_includes
          ; cmo = cmi_includes
-         ; cmx =
-             (let+ direct_libs = direct_requires
-              and+ hidden_libs = hidden_requires in
-              Command.Args.S
-                [ iflags direct_libs hidden_libs (Ocaml Native)
-                ; Hidden_deps
-                    (let libs = direct_libs @ hidden_libs in
-                     if opaque
-                     then
-                       List.map libs ~f:(fun lib ->
-                         ( lib
-                         , if Lib.is_local lib
-                           then [ Lib_file_deps.Group.Ocaml Cmi ]
-                           else [ Ocaml Cmi; Ocaml Cmx ] ))
-                       |> Lib_file_deps.deps_with_exts
-                     else
-                       Lib_file_deps.deps
-                         libs
-                         ~groups:[ Lib_file_deps.Group.Ocaml Cmi; Ocaml Cmx ])
-                ])
-             |> Resolve.Memo.args
-             |> Command.Args.memo
+         ; cmx = make_includes_args ~mode:(Ocaml Native)
          })
     ; melange =
-        { cmi = make_includes_args ~mode:Melange [ Melange Cmi ]
-        ; cmj = make_includes_args ~mode:Melange [ Melange Cmi; Melange Cmj ]
-        }
+        (let mel_includes = make_includes_args ~mode:Melange in
+         { cmi = mel_includes; cmj = mel_includes })
     }
   ;;
 
   let empty = Lib_mode.Cm_kind.Map.make_all Command.Args.empty
+end
+
+module Raw_refs = struct
+  module Key = struct
+    type t =
+      | Consumer of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+
+    let cm_kind_tag : Lib_mode.Cm_kind.t -> int = function
+      | Ocaml Cmi -> 0
+      | Ocaml Cmo -> 1
+      | Ocaml Cmx -> 2
+      | Melange Cmi -> 3
+      | Melange Cmj -> 4
+    ;;
+
+    let ml_kind_tag : Ml_kind.t -> int = function
+      | Intf -> 0
+      | Impl -> 1
+    ;;
+
+    let equal a b =
+      match a, b with
+      | Consumer a, Consumer b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && ml_kind_tag a.ml_kind = ml_kind_tag b.ml_kind
+      | Transitive a, Transitive b ->
+        Module_name.Unique.equal a.obj_name b.obj_name
+        && cm_kind_tag a.cm_kind = cm_kind_tag b.cm_kind
+      | Consumer _, Transitive _ | Transitive _, Consumer _ -> false
+    ;;
+
+    let hash = function
+      | Consumer { obj_name; ml_kind } -> Poly.hash (0, obj_name, ml_kind_tag ml_kind)
+      | Transitive { obj_name; cm_kind } -> Poly.hash (1, obj_name, cm_kind_tag cm_kind)
+    ;;
+
+    let repr =
+      let open Repr in
+      let obj_name_repr = view string ~to_:Module_name.Unique.to_string in
+      let ml_kind_repr = view string ~to_:Ml_kind.to_string in
+      let cm_kind_repr = abstract Lib_mode.Cm_kind.to_dyn in
+      variant
+        "Raw_refs.Key"
+        [ case "Consumer" (pair obj_name_repr ml_kind_repr) ~proj:(function
+            | Consumer { obj_name; ml_kind } -> Some (obj_name, ml_kind)
+            | Transitive _ -> None)
+        ; case "Transitive" (pair obj_name_repr cm_kind_repr) ~proj:(function
+            | Transitive { obj_name; cm_kind } -> Some (obj_name, cm_kind)
+            | Consumer _ -> None)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Module_name.Set.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 64
+end
+
+(* Key omits [t.requires_compile] / [t.requires_hidden] because they're
+   immutable on the cctx from [create]. The exception —
+   [for_module_generated_at_link_time]'s derived cctxs — takes the
+   [can_filter = false] arm in [lib_deps_for_module] and so never reaches this
+   cache. *)
+module Filtered_includes = struct
+  module Key = struct
+    type t =
+      { lib_mode : Lib_mode.t
+      ; kept_libs : Lib.Set.t
+      }
+
+    let equal a b =
+      Lib_mode.equal a.lib_mode b.lib_mode && Lib.Set.equal a.kept_libs b.kept_libs
+    ;;
+
+    let hash { lib_mode; kept_libs } =
+      Lib.Set.fold kept_libs ~init:(Lib_mode.hash lib_mode) ~f:(fun lib acc ->
+        (acc * 31) + Lib.hash lib)
+    ;;
+
+    let repr =
+      Repr.record
+        "Filtered_includes.Key"
+        [ Repr.field "lib_mode" (Repr.abstract Lib_mode.to_dyn) ~get:(fun t -> t.lib_mode)
+        ; Repr.field "kept_libs" (Repr.abstract Lib.Set.to_dyn) ~get:(fun t ->
+            t.kept_libs)
+        ]
+    ;;
+
+    let to_dyn = Repr.to_dyn repr
+  end
+
+  type t = (Key.t, Command.Args.without_targets Command.Args.t Action_builder.t) Table.t
+
+  let create () : t = Table.create (module Key) 16
 end
 
 type opaque =
@@ -92,7 +169,10 @@ type t =
   ; parameters : Module_name.t list Resolve.Memo.t
   ; instances : Parameterised_instances.t Resolve.Memo.t option
   ; includes : Includes.t
+  ; lib_index : Lib_file_deps.Lib_index.t Resolve.t Memo.Lazy.t
+  ; has_virtual_impl : bool Resolve.t Memo.Lazy.t
   ; preprocessing : Pp_spec.t
+  ; pps_runtime_libs : Lib.t list Resolve.Memo.t
   ; opaque : bool
   ; js_of_ocaml : Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
   ; sandbox : Sandbox_config.t
@@ -105,6 +185,8 @@ type t =
   ; loc : Loc.t option
   ; ocaml : Ocaml_toolchain.t
   ; for_ : Compilation_mode.t
+  ; filtered_includes : Filtered_includes.t
+  ; raw_refs : Raw_refs.t
   }
 
 let loc t = t.loc
@@ -120,7 +202,10 @@ let requires_hidden t = t.requires_hidden
 let requires_link t = Memo.Lazy.force t.requires_link
 let parameters t = t.parameters
 let includes t = t.includes
+let lib_index t = Memo.Lazy.force t.lib_index
+let has_virtual_impl t = Memo.Lazy.force t.has_virtual_impl
 let preprocessing t = t.preprocessing
+let pps_runtime_libs t = t.pps_runtime_libs
 let opaque t = t.opaque
 let js_of_ocaml t = t.js_of_ocaml
 let sandbox t = t.sandbox
@@ -149,6 +234,74 @@ let parameters_main_modules parameters =
         [ "param", Lib.to_dyn param ])
 ;;
 
+(* Hidden libs must be indexed: otherwise unreached ones fall to the glob branch
+   and over-invalidate. *)
+let build_lib_index ~super_context ~libs ~for_ =
+  let open Resolve.Memo.O in
+  let instrument_with = Context.instrument_with (Super_context.context super_context) in
+  let+ per_lib =
+    Resolve.Memo.List.map libs ~f:(fun lib ->
+      match Lib_info.entry_modules (Lib.info lib) ~for_ with
+      | External (Ok names) ->
+        Resolve.Memo.return (List.map names ~f:(fun n -> n, lib, None), None)
+      | External (Error e) -> Resolve.Memo.of_result (Error e)
+      | Local ->
+        let* mods =
+          Resolve.Memo.lift_memo
+            (Dir_contents.modules_of_local_lib
+               super_context
+               (Lib.Local.of_lib_exn lib)
+               ~for_)
+        in
+        (* [no_ocamldep_lib] tags libs that are walker-terminal: running
+           ocamldep on their entry module via the cross-lib walk can't
+           propagate anywhere, so the walker skips them. A singleton lib is
+           terminal only when its resolved requires are empty; otherwise the
+           walker must read its post-pp ocamldep to discover transitive refs
+           (incl. pps runtime libs added via [add_pp_runtime_deps]). *)
+        let+ requires_resolved = Lib.requires lib ~for_ in
+        (* [Some m] only for unwrapped locals (tight-eligible); wrapped locals
+           and externals → [None]. *)
+        let unwrapped =
+          match Lib_info.wrapped (Lib.info lib) with
+          | Some (This w) -> not (Wrapped.to_bool w)
+          | Some (From _) | None -> false
+        in
+        (* Mirror [Pp_spec.pped_modules_map] so the cross-lib walker reads
+           ocamldep on the source the dep lib's compile pipeline produces. *)
+        let preprocess = Lib_info.preprocess (Lib.info lib) ~for_ in
+        let post_pp_module m =
+          match Preprocess.Per_module.find (Module.name m) preprocess with
+          | No_preprocessing | Future_syntax _ -> Some (Module.ml_source m)
+          | Action _ -> Some (Module.ml_source (Module.pped m))
+          | Pps { staged = false; pps; _ } ->
+            let any_active =
+              List.exists pps ~f:(function
+                | Preprocess.With_instrumentation.Ordinary _ -> true
+                | Instrumentation_backend { libname = _, name; _ } ->
+                  List.mem instrument_with name ~equal:Lib_name.equal)
+            in
+            if any_active
+            then Some (Module.pped (Module.ml_source m))
+            else Some (Module.ml_source m)
+          | Pps { staged = true; _ } -> None
+        in
+        let entries =
+          List.map (Modules.entry_modules mods) ~f:(fun m ->
+            Module.name m, lib, if unwrapped then post_pp_module m else None)
+        in
+        let no_ocamldep_lib =
+          match Modules.as_singleton mods with
+          | Some _ when List.is_empty requires_resolved -> Some lib
+          | _ -> None
+        in
+        entries, no_ocamldep_lib)
+  in
+  let entries = List.concat_map per_lib ~f:fst in
+  let no_ocamldep = List.filter_map per_lib ~f:snd |> Lib.Set.of_list in
+  Lib_file_deps.Lib_index.create ~no_ocamldep entries
+;;
+
 let create
       ~super_context
       ~scope
@@ -158,6 +311,7 @@ let create
       ~requires_compile
       ~user_written_requires
       ~requires_link
+      ~pps_runtime_libs
       ?(preprocessing = Pp_spec.dummy)
       ~opaque
       ~js_of_ocaml
@@ -207,6 +361,19 @@ let create
     let profile = Context.profile context in
     eval_opaque ocaml profile opaque
   in
+  let* has_library_deps =
+    (* Single-module stanzas still run ocamldep when they have library deps so
+       the per-module filter can inform the result. *)
+    let open Resolve.Memo.O in
+    let+ direct = direct_requires
+    and+ hidden = hidden_requires in
+    match direct, hidden with
+    | [], [] -> false
+    | _ -> true
+  in
+  (* Resolution errors surface later through the normal compilation rules;
+     assume deps are present here. *)
+  let has_library_deps = Resolve.peek has_library_deps |> Result.value ~default:true in
   let+ dep_graphs =
     Dep_rules.rules
       ~dir:(Obj_dir.dir obj_dir)
@@ -216,6 +383,7 @@ let create
       ~impl:implements
       ~modules
       ~for_
+      ~has_library_deps
   and+ bin_annot =
     Memo.Option.value bin_annot ~default:(fun () ->
       Env_stanza_db.bin_annot ~dir:(Obj_dir.dir obj_dir))
@@ -238,9 +406,21 @@ let create
   ; requires_link
   ; implements
   ; parameters
-  ; includes =
-      Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
+  ; includes = Includes.make ~project ~direct_requires ~hidden_requires ocaml.lib_config
+  ; lib_index =
+      Memo.lazy_ ~name:"compilation-context-lib-index" (fun () ->
+        let open Resolve.Memo.O in
+        let* d = direct_requires
+        and* h = hidden_requires in
+        build_lib_index ~super_context ~libs:(d @ h) ~for_)
+  ; has_virtual_impl =
+      Memo.lazy_ ~name:"compilation-context-has-virtual-impl" (fun () ->
+        let open Resolve.Memo.O in
+        let+ direct = direct_requires
+        and+ hidden = hidden_requires in
+        List.exists (direct @ hidden) ~f:(fun lib -> Option.is_some (Lib.implements lib)))
   ; preprocessing
+  ; pps_runtime_libs
   ; opaque
   ; js_of_ocaml
   ; sandbox
@@ -254,10 +434,53 @@ let create
   ; ocaml
   ; instances
   ; for_
+  ; filtered_includes = Filtered_includes.create ()
+  ; raw_refs = Raw_refs.create ()
   }
 ;;
 
 let for_ t = t.for_
+
+let cached_raw_refs t ~key ~compute =
+  match Table.find t.raw_refs key with
+  | Some builder -> builder
+  | None ->
+    let builder = compute () in
+    Table.set t.raw_refs key builder;
+    builder
+;;
+
+let filtered_include_flags t ~cm_kind ~kept_libs =
+  let lib_mode = Lib_mode.of_cm_kind cm_kind in
+  let cache_key = { Filtered_includes.Key.lib_mode; kept_libs } in
+  match Table.find t.filtered_includes cache_key with
+  | Some builder -> builder
+  | None ->
+    (* Cache the [Action_builder.t] (not the resolved args) up-front at
+       rule-construction time so all compile rules sharing this
+       [(lib_mode, kept_libs)] share one builder; [Action_builder.memoize] then
+       dedupes its evaluation. Mirrors the cache pattern in
+       [Ocamldep.read_immediate_deps_words]. *)
+    let builder =
+      let open Action_builder.O in
+      let+ direct_requires = Resolve.Memo.read t.requires_compile
+      and+ hidden_requires = Resolve.Memo.read t.requires_hidden in
+      let direct_filtered = List.filter direct_requires ~f:(Lib.Set.mem kept_libs) in
+      let hidden_filtered = List.filter hidden_requires ~f:(Lib.Set.mem kept_libs) in
+      let project = Scope.project t.scope in
+      let lib_config = t.ocaml.lib_config in
+      Lib_flags.L.include_flags
+        ~project
+        ~direct_libs:direct_filtered
+        ~hidden_libs:hidden_filtered
+        lib_mode
+        lib_config
+      |> Command.Args.memo
+    in
+    let builder = Action_builder.memoize "filtered_include_flags" builder in
+    Table.set t.filtered_includes cache_key builder;
+    builder
+;;
 
 let alias_and_root_module_flags =
   let extra = [ "-w"; "-49" ] in
@@ -329,7 +552,6 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     let direct_requires = requires in
     Includes.make
       ~project:(Scope.project cctx.scope)
-      ~opaque
       ~direct_requires
       ~hidden_requires
       cctx.ocaml.lib_config
@@ -340,7 +562,21 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   ; requires_link = Memo.lazy_ ~name:"requires-link" (fun () -> requires)
   ; requires_compile = requires
   ; user_written_requires = None
+  ; requires_hidden = Resolve.Memo.return []
   ; includes
+  ; lib_index =
+      Memo.lazy_ ~name:"generated-module-lib-index" (fun () ->
+        (* Unreachable: synthesised modules use [Dep_graph.dummy] (whose [dir]
+           is [Path.Build.root]), so [lib_deps_for_module]'s [can_filter]
+           dir-equality guard fails and the non-filter fallback is taken. *)
+        Code_error.raise
+          "Compilation_context.lib_index forced for a module synthesised at link time; \
+           this should be unreachable."
+          [])
+  ; (* Link-time-generated modules cannot participate in virtual-impl
+       relationships; override the parent's value so the accessor reflects
+       this cctx's [requires_compile]/[requires_link]. *)
+    has_virtual_impl = Memo.Lazy.of_val (Resolve.return false)
   ; modules
   }
 ;;

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -27,6 +27,7 @@ val create
   -> flags:Ocaml_flags.t
   -> requires_compile:Lib.t list Resolve.Memo.t
   -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
+  -> pps_runtime_libs:Lib.t list Resolve.Memo.t
   -> ?preprocessing:Pp_spec.t
   -> opaque:opaque
   -> js_of_ocaml:Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
@@ -62,7 +63,58 @@ val requires_hidden : t -> Lib.t list Resolve.Memo.t
 val requires_compile : t -> Lib.t list Resolve.Memo.t
 val parameters : t -> Module_name.t list Resolve.Memo.t
 val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
+
+module Raw_refs : sig
+  module Key : sig
+    type t =
+      | Consumer of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+  end
+end
+
+(** Memoise the raw-refs [Action_builder.t] computed for each [Raw_refs.Key.t]
+    within this cctx. [compute ()] is invoked only on cache miss; subsequent
+    callers with the same key get the cached builder back. The cache
+    short-circuits before allocating, so siblings sharing [trans_deps] don't
+    redo construction. *)
+val cached_raw_refs
+  :  t
+  -> key:Raw_refs.Key.t
+  -> compute:(unit -> Module_name.Set.t Action_builder.t)
+  -> Module_name.Set.t Action_builder.t
+
+(** Include flags ([-I]/[-H]) for compiling a module against [kept_libs]. The
+    cctx's [requires_compile] and [requires_hidden] are each restricted to
+    libraries in [kept_libs]; the kept direct entries become [-I], the kept
+    hidden entries become [-H]. *)
+val filtered_include_flags
+  :  t
+  -> cm_kind:Lib_mode.Cm_kind.t
+  -> kept_libs:Lib.Set.t
+  -> Command.Args.without_targets Command.Args.t Action_builder.t
+
+val lib_index : t -> Lib_file_deps.Lib_index.t Resolve.Memo.t
+
+(** [true] iff any library in the compilation context's direct or hidden
+    requires implements a virtual library. Memoized per cctx. *)
+val has_virtual_impl : t -> bool Resolve.Memo.t
+
 val preprocessing : t -> Pp_spec.t
+
+(** Direct [ppx_runtime_deps] of every [pps] in this stanza's preprocessor
+    (a flat concatenation; not closed transitively — consumers that need
+    closure semantics wrap with [Lib.closure]). These libraries' modules are
+    visible only to ppx-rewritten output, so the per-module dependency
+    filter cannot reason about which of them are referenced — they must be
+    treated as opaque [must-glob] dependencies. *)
+val pps_runtime_libs : t -> Lib.t list Resolve.Memo.t
+
 val opaque : t -> bool
 val js_of_ocaml : t -> Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
 val sandbox : t -> Sandbox_config.t

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -28,6 +28,7 @@ val create
   -> requires_compile:Lib.t list Resolve.Memo.t
   -> user_written_requires:Lib.t list Resolve.Memo.t Lazy.t option
   -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
+  -> pps_runtime_libs:Lib.t list Resolve.Memo.t
   -> ?preprocessing:Pp_spec.t
   -> opaque:opaque
   -> js_of_ocaml:Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
@@ -64,7 +65,58 @@ val requires_compile : t -> Lib.t list Resolve.Memo.t
 val user_written_requires : t -> Lib.t list Resolve.Memo.t option
 val parameters : t -> Module_name.t list Resolve.Memo.t
 val includes : t -> Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
+
+module Raw_refs : sig
+  module Key : sig
+    type t =
+      | Consumer of
+          { obj_name : Module_name.Unique.t
+          ; ml_kind : Ml_kind.t
+          }
+      | Transitive of
+          { obj_name : Module_name.Unique.t
+          ; cm_kind : Lib_mode.Cm_kind.t
+          }
+  end
+end
+
+(** Memoise the raw-refs [Action_builder.t] computed for each [Raw_refs.Key.t]
+    within this cctx. [compute ()] is invoked only on cache miss; subsequent
+    callers with the same key get the cached builder back. The cache
+    short-circuits before allocating, so siblings sharing [trans_deps] don't
+    redo construction. *)
+val cached_raw_refs
+  :  t
+  -> key:Raw_refs.Key.t
+  -> compute:(unit -> Module_name.Set.t Action_builder.t)
+  -> Module_name.Set.t Action_builder.t
+
+(** Include flags ([-I]/[-H]) for compiling a module against [kept_libs]. The
+    cctx's [requires_compile] and [requires_hidden] are each restricted to
+    libraries in [kept_libs]; the kept direct entries become [-I], the kept
+    hidden entries become [-H]. *)
+val filtered_include_flags
+  :  t
+  -> cm_kind:Lib_mode.Cm_kind.t
+  -> kept_libs:Lib.Set.t
+  -> Command.Args.without_targets Command.Args.t Action_builder.t
+
+val lib_index : t -> Lib_file_deps.Lib_index.t Resolve.Memo.t
+
+(** [true] iff any library in the compilation context's direct or hidden
+    requires implements a virtual library. Memoized per cctx. *)
+val has_virtual_impl : t -> bool Resolve.Memo.t
+
 val preprocessing : t -> Pp_spec.t
+
+(** Direct [ppx_runtime_deps] of every [pps] in this stanza's preprocessor
+    (a flat concatenation; not closed transitively — consumers that need
+    closure semantics wrap with [Lib.closure]). These libraries' modules are
+    visible only to ppx-rewritten output, so the per-module dependency
+    filter cannot reason about which of them are referenced — they must be
+    treated as opaque [must-glob] dependencies. *)
+val pps_runtime_libs : t -> Lib.t list Resolve.Memo.t
+
 val opaque : t -> bool
 val js_of_ocaml : t -> Js_of_ocaml.In_context.t option Js_of_ocaml.Mode.Pair.t
 val sandbox : t -> Sandbox_config.t

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -7,6 +7,8 @@ type t =
   }
 
 let make ~dir ~per_module = { dir; per_module }
+let dir t = t.dir
+let mem t (m : Module.t) = Module_name.Unique.Map.mem t.per_module (Module.obj_name m)
 
 let deps_of t (m : Module.t) =
   match Module_name.Unique.Map.find t.per_module (Module.obj_name m) with

--- a/src/dune_rules/dep_graph.mli
+++ b/src/dune_rules/dep_graph.mli
@@ -9,6 +9,8 @@ val make
   -> per_module:Module.t list Action_builder.t Module_name.Unique.Map.t
   -> t
 
+val dir : t -> Path.Build.t
+val mem : t -> Module.t -> bool
 val deps_of : t -> Module.t -> Module.t list Action_builder.t
 val top_closed_implementations : t -> Module.t list -> Module.t list Action_builder.t
 

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -504,10 +504,14 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
     (deps_of ~modules ~transitive_deps ~imported_vlib_deps (Normal module_))
 ;;
 
-let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ =
+let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m -> Memo.return (Dep_graph.Ml_kind.dummy m)
-  | None ->
+  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
+    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
+       consumed by the per-module filter in [lib_deps_for_module]. That filter
+       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+    Memo.return (Dep_graph.Ml_kind.dummy m)
+  | Some _ | None ->
     let transitive_deps, imported_vlib_deps =
       make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_
     in

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -506,10 +506,11 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
 
 let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
-    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
-       consumed by the per-module filter in [lib_deps_for_module]. That filter
-       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+  | Some m when not has_library_deps ->
+    (* Single-module stanzas with no library deps have nothing to filter — the
+       dep graph is only consumed by the per-module filter in
+       [lib_deps_for_module], and that filter has no libs to narrow. Skip
+       ocamldep. *)
     Memo.return (Dep_graph.Ml_kind.dummy m)
   | Some _ | None ->
     let transitive_deps, imported_vlib_deps =

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -615,10 +615,14 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
     (deps_of ~modules ~transitive_deps ~imported_vlib_deps (Normal module_))
 ;;
 
-let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ =
+let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m -> Memo.return (Dep_graph.Ml_kind.dummy m)
-  | None ->
+  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
+    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
+       consumed by the per-module filter in [lib_deps_for_module]. That filter
+       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+    Memo.return (Dep_graph.Ml_kind.dummy m)
+  | Some _ | None ->
     let transitive_deps, imported_vlib_deps =
       make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_
     in

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -617,10 +617,11 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
 
 let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
-    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
-       consumed by the per-module filter in [lib_deps_for_module]. That filter
-       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+  | Some m when not has_library_deps ->
+    (* Single-module stanzas with no library deps have nothing to filter — the
+       dep graph is only consumed by the per-module filter in
+       [lib_deps_for_module], and that filter has no libs to narrow. Skip
+       ocamldep. *)
     Memo.return (Dep_graph.Ml_kind.dummy m)
   | Some _ | None ->
     let transitive_deps, imported_vlib_deps =

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -13,6 +13,9 @@ val for_module
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.t
 
+(** Single-module stanzas short-circuit ocamldep when [not has_library_deps] or
+    [for_ = Melange]: the per-module filter that consumes the dep graph doesn't
+    activate in those cases. *)
 val rules
   :  obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.With_vlib.t
@@ -21,6 +24,7 @@ val rules
   -> sctx:Super_context.t
   -> dir:Path.Build.t
   -> for_:Compilation_mode.t
+  -> has_library_deps:bool
   -> Dep_graph.Ml_kind.t Memo.t
 
 val read_immediate_deps_of

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -394,6 +394,7 @@ module Lib = struct
            ~jsoo_runtime
            ~wasmoo_runtime
            ~preprocess
+           ~stanza_flags:Dune_lang.Ocaml_flags.Spec.standard
            ~enabled
            ~virtual_deps
            ~dune_version

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -205,6 +205,11 @@ let executables_rules
   let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let instances =
       Parameterised_instances.instances
         ~sctx
@@ -227,6 +232,7 @@ let executables_rules
       ~flags
       ~requires_link
       ~requires_compile
+      ~pps_runtime_libs
       ~preprocessing:pp
       ~js_of_ocaml
       ~opaque:Inherit_from_settings

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -209,6 +209,11 @@ let executables_rules
       Some (lazy (Lib.Compile.user_written_requires_no_loc compile_info ~for_))
     in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let instances =
       Parameterised_instances.instances
         ~sctx
@@ -232,6 +237,7 @@ let executables_rules
       ~requires_link
       ~requires_compile
       ~user_written_requires
+      ~pps_runtime_libs
       ~preprocessing:pp
       ~js_of_ocaml
       ~opaque:Inherit_from_settings

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -273,6 +273,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
       ~jsoo_runtime
       ~wasmoo_runtime
       ~preprocess
+      ~stanza_flags:Dune_lang.Ocaml_flags.Spec.standard
       ~enabled
       ~virtual_deps
       ~dune_version

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -272,6 +272,7 @@ let to_dune_library (t : Findlib.Package.t) ~dir_contents ~ext_lib ~external_loc
       ~jsoo_runtime
       ~wasmoo_runtime
       ~preprocess
+      ~stanza_flags:Dune_lang.Ocaml_flags.Spec.standard
       ~enabled
       ~virtual_deps
       ~dune_version

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -311,6 +311,7 @@ include Sub_system.Register_end_point (struct
           ~opaque:(Explicit false)
           ~requires_compile:runner_libs
           ~requires_link:(Memo.lazy_ (fun () -> runner_libs))
+          ~pps_runtime_libs:(Resolve.Memo.return [])
           ~flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
           ~melange_package_name:None

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -311,6 +311,7 @@ include Sub_system.Register_end_point (struct
           ~user_written_requires:None
           ~requires_link:
             (Memo.lazy_ ~name:"inline-test-requires-link" (fun () -> runner_libs))
+          ~pps_runtime_libs:(Resolve.Memo.return [])
           ~flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
           ~melange_package_name:None

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2201,11 +2201,51 @@ end = struct
   ;;
 end
 
-let closure l ~linking =
-  let forbidden_libraries = Map.empty in
-  if linking
-  then Resolve_names.linking_closure_with_overlap_checks None l ~forbidden_libraries
-  else Resolve_names.compile_closure_with_overlap_checks None l ~forbidden_libraries
+let closure =
+  let memo =
+    let module Input = struct
+      type nonrec t = bool * Compilation_mode.t * t list
+
+      let equal (l, m, libs) (l', m', libs') =
+        Bool.equal l l' && Compilation_mode.equal m m' && List.equal equal libs libs'
+      ;;
+
+      let hash_for_ = function
+        | Compilation_mode.Ocaml -> 0
+        | Melange -> 1
+      ;;
+
+      let hash (linking, for_, libs) =
+        Tuple.T3.hash
+          Bool.hash
+          hash_for_
+          (List.hash (fun lib -> Id.hash lib.unique_id))
+          (linking, for_, libs)
+      ;;
+
+      let to_dyn = Dyn.opaque
+    end
+    in
+    Memo.create
+      "lib-closure"
+      ~input:(module Input)
+      (fun (linking, for_, l) ->
+         let forbidden_libraries = Map.empty in
+         if linking
+         then
+           Resolve_names.linking_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_
+         else
+           Resolve_names.compile_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_)
+  in
+  fun l ~linking ~for_ -> Memo.exec memo (linking, for_, l)
 ;;
 
 let descriptive_closure (l : lib list) ~with_pps ~for_ : lib list Memo.t =

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2197,11 +2197,51 @@ end = struct
   ;;
 end
 
-let closure l ~linking =
-  let forbidden_libraries = Map.empty in
-  if linking
-  then Resolve_names.linking_closure_with_overlap_checks None l ~forbidden_libraries
-  else Resolve_names.compile_closure_with_overlap_checks None l ~forbidden_libraries
+let closure =
+  let memo =
+    let module Input = struct
+      type nonrec t = bool * Compilation_mode.t * t list
+
+      let equal (l, m, libs) (l', m', libs') =
+        Bool.equal l l' && Compilation_mode.equal m m' && List.equal equal libs libs'
+      ;;
+
+      let hash_for_ = function
+        | Compilation_mode.Ocaml -> 0
+        | Melange -> 1
+      ;;
+
+      let hash (linking, for_, libs) =
+        Tuple.T3.hash
+          Bool.hash
+          hash_for_
+          (List.hash (fun lib -> Id.hash lib.unique_id))
+          (linking, for_, libs)
+      ;;
+
+      let to_dyn = Dyn.opaque
+    end
+    in
+    Memo.create
+      "lib-closure"
+      ~input:(module Input)
+      (fun (linking, for_, l) ->
+         let forbidden_libraries = Map.empty in
+         if linking
+         then
+           Resolve_names.linking_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_
+         else
+           Resolve_names.compile_closure_with_overlap_checks
+             None
+             l
+             ~forbidden_libraries
+             ~for_)
+  in
+  fun l ~linking ~for_ -> Memo.exec memo (linking, for_, l)
 ;;
 
 let descriptive_closure (l : lib list) ~with_pps ~for_ : lib list Memo.t =

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -217,6 +217,10 @@ end
 
 (** {1 Transitive closure} *)
 
+(** Memoized. The memo key is order- and multiplicity-sensitive on the input
+    list, so for callers that share inputs across invocations (e.g. the hot
+    path in [Module_compilation.lib_deps_for_module]), canonicalising with
+    [List.sort_uniq ~compare:Lib.compare] maximises cache reuse. *)
 val closure : t list -> linking:bool -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
 (** [descriptive_closure ~with_pps libs] computes the smallest set of libraries

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -227,6 +227,10 @@ end
 
 (** {1 Transitive closure} *)
 
+(** Memoized. The memo key is order- and multiplicity-sensitive on the input
+    list, so for callers that share inputs across invocations (e.g. the hot
+    path in [Module_compilation.lib_deps_for_module]), canonicalising with
+    [List.sort_uniq ~compare:Lib.compare] maximises cache reuse. *)
 val closure : t list -> linking:bool -> for_:Compilation_mode.t -> t list Resolve.Memo.t
 
 (** [descriptive_closure ~with_pps libs] computes the smallest set of libraries

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -55,7 +55,6 @@ let deps_of_lib (lib : Lib.t) ~groups =
   |> Dep.Set.of_list
 ;;
 
-let deps_with_exts = Dep.Set.union_map ~f:(fun (lib, groups) -> deps_of_lib lib ~groups)
 let deps libs ~groups = Dep.Set.union_map libs ~f:(deps_of_lib ~groups)
 
 let groups_for_cm_kind ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib =
@@ -118,8 +117,9 @@ module Lib_index = struct
     { by_module_name : (Lib.t * Module.t option) list Module_name.Map.t
     ; tight_eligible : Lib.Set.t
     ; no_ocamldep : Lib.Set.t
-      (* Local libs short-circuited by [Dep_rules.skip_ocamldep] — no [.d] rules
-         exist; the cross-library walk must skip them. *)
+      (* Local libs that are walker-terminal: running ocamldep on their entry
+         module via the cross-library walk can't propagate anywhere (no
+         resolved requires to chase), so the walker skips them. *)
     }
 
   (* Tight-eligibility is encoded in the entry shape: [(_, lib, Some _)] means

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -85,6 +85,11 @@ let deps_of_entry_modules ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib modules =
     | Ocaml Cmx -> not (opaque && Lib.is_local lib)
     | _ -> false
   in
+  let want_cmj =
+    match cm_kind with
+    | Melange Cmj -> true
+    | _ -> false
+  in
   List.fold_left modules ~init:Dep.Set.empty ~f:(fun acc m ->
     let acc =
       match Obj_dir.Module.cm_public_file obj_dir m ~kind:cmi_kind with
@@ -97,16 +102,30 @@ let deps_of_entry_modules ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib modules =
            in tight_modules"
           [ "module", Module.to_dyn m; "lib", Lib.to_dyn lib ]
     in
-    if want_cmx && Module.has m ~ml_kind:Impl
+    let acc =
+      if want_cmx && Module.has m ~ml_kind:Impl
+      then (
+        match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Ocaml Cmx) with
+        | Some path -> Dep.Set.add acc (Dep.file path)
+        | None ->
+          (* Unreachable. [cm_public_file ~kind:(Ocaml Cmx)] returns [None] only
+             when [not has_impl]. The enclosing [if] guarantees
+             [Module.has m ~ml_kind:Impl] (= [has_impl]). *)
+          Code_error.raise
+            "deps_of_entry_modules: [cm_public_file] returned [None] for cmx despite \
+             [Module.has m ~ml_kind:Impl] holding"
+            [ "module", Module.to_dyn m ])
+      else acc
+    in
+    if want_cmj && Module.has m ~ml_kind:Impl
     then (
-      match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Ocaml Cmx) with
+      match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Melange Cmj) with
       | Some path -> Dep.Set.add acc (Dep.file path)
       | None ->
-        (* Unreachable. [cm_public_file ~kind:(Ocaml Cmx)] returns [None] only
-           when [not has_impl]. The enclosing [if] guarantees
-           [Module.has m ~ml_kind:Impl] (= [has_impl]). *)
+        (* Unreachable. Symmetric with the [Ocaml Cmx] arm above: [cm_public_file
+           ~kind:(Melange Cmj)] returns [None] only when [not has_impl]. *)
         Code_error.raise
-          "deps_of_entry_modules: [cm_public_file] returned [None] for cmx despite \
+          "deps_of_entry_modules: [cm_public_file] returned [None] for cmj despite \
            [Module.has m ~ml_kind:Impl] holding"
           [ "module", Module.to_dyn m ])
     else acc)

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -22,12 +22,10 @@ val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list ->
 (** Specific-file deps on the [modules] of [lib]. Only valid for local libraries
     (where [Module.t] values are available).
 
-    Currently produces complete per-module deps only for [cm_kind = Ocaml _]
-    (cmi + cmx); for [Melange _] only the cmi is emitted — there is no
-    per-module cmj arm, asymmetric with [deps_of_entries]. The sole caller
-    ([Module_compilation.lib_deps_for_module]) gates Melange out before
-    reaching this function, so this asymmetry is not observable today. If a
-    future Melange caller is added, extend with a [want_cmj] arm. *)
+    Per [cm_kind]: [Ocaml Cmx] emits cmi + cmx (cmx omitted when [opaque] and
+    [Lib.is_local lib]); [Ocaml (Cmi | Cmo)] emits cmi only; [Melange Cmj]
+    emits cmi + cmj; [Melange Cmi] emits cmi only. The cmi/cmj selection
+    mirrors [groups_for_cm_kind] used by the broad-dep path. *)
 val deps_of_entry_modules
   :  opaque:bool
   -> cm_kind:Lib_mode.Cm_kind.t

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -15,8 +15,6 @@ end
     with extension [files] of libraries [libs]. *)
 val deps : Lib.t list -> groups:Group.t list -> Dep.Set.t
 
-val deps_with_exts : (Lib.t * Group.t list) list -> Dep.Set.t
-
 (** [deps_of_entries ~opaque ~cm_kind libs] computes the file dependencies (glob
     deps on .cmi/.cmx files) for the given libraries. *)
 val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list -> Dep.Set.t
@@ -42,9 +40,9 @@ module Lib_index : sig
 
   (** Third tuple element is [Some m] for local + unwrapped libs (with the
       entry's [Module.t]) and [None] otherwise (wrapped locals, externals).
-      [no_ocamldep] names local libs whose [.d] files don't exist
-      (short-circuited by [Dep_rules.skip_ocamldep]); the cross-library walk
-      skips them. *)
+      [no_ocamldep] names local libs that are walker-terminal (singletons
+      with no resolved requires) — the cross-library walk would gain nothing
+      by running ocamldep on them, so it skips them. *)
   val create
     :  no_ocamldep:Lib.Set.t
     -> (Module_name.t * Lib.t * Module.t option) list

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -324,6 +324,7 @@ type 'path t =
   ; preprocess :
       Preprocess.With_instrumentation.t Preprocess.Per_module.t
         Compilation_mode.Per_mode.t
+  ; stanza_flags : Dune_lang.Ocaml_flags.Spec.t
   ; enabled : Enabled_status.t Memo.t
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; dune_version : Dune_lang.Syntax.Version.t option
@@ -355,6 +356,7 @@ let parameters t = t.parameters
 let requires t ~for_ = Compilation_mode.Per_mode.get t.requires ~for_
 let requires_by_mode t = t.requires
 let preprocess t ~for_ = Compilation_mode.Per_mode.get t.preprocess ~for_
+let stanza_flags t = t.stanza_flags
 let ppx_runtime_deps t = t.ppx_runtime_deps
 let allow_unused_libraries t = t.allow_unused_libraries
 let sub_systems t = t.sub_systems
@@ -436,6 +438,7 @@ let create
       ~jsoo_runtime
       ~wasmoo_runtime
       ~preprocess
+      ~stanza_flags
       ~enabled
       ~virtual_deps
       ~dune_version
@@ -477,6 +480,7 @@ let create
   ; jsoo_runtime
   ; wasmoo_runtime
   ; preprocess
+  ; stanza_flags
   ; enabled
   ; virtual_deps
   ; dune_version
@@ -576,6 +580,7 @@ let to_dyn
       ; jsoo_runtime
       ; wasmoo_runtime
       ; preprocess = _
+      ; stanza_flags = _
       ; enabled = _
       ; virtual_deps
       ; dune_version

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -324,6 +324,7 @@ type 'path t =
   ; preprocess :
       Preprocess.With_instrumentation.t Preprocess.Per_module.t
         Compilation_mode.Per_mode.t
+  ; stanza_flags : Dune_lang.Ocaml_flags.Spec.t
   ; enabled : Enabled_status.t Memo.t
   ; virtual_deps : (Loc.t * Lib_name.t) list
   ; dune_version : Dune_lang.Syntax.Version.t option
@@ -355,6 +356,7 @@ let parameters t = t.parameters
 let requires t ~for_ = Compilation_mode.Per_mode.get t.requires ~for_
 let requires_by_mode t = t.requires
 let preprocess t ~for_ = Compilation_mode.Per_mode.get t.preprocess ~for_
+let stanza_flags t = t.stanza_flags
 let ppx_runtime_deps t = t.ppx_runtime_deps
 let allow_unused_libraries t = t.allow_unused_libraries
 let sub_systems t = t.sub_systems
@@ -447,6 +449,7 @@ let create
       ~jsoo_runtime
       ~wasmoo_runtime
       ~preprocess
+      ~stanza_flags
       ~enabled
       ~virtual_deps
       ~dune_version
@@ -488,6 +491,7 @@ let create
   ; jsoo_runtime
   ; wasmoo_runtime
   ; preprocess
+  ; stanza_flags
   ; enabled
   ; virtual_deps
   ; dune_version
@@ -587,6 +591,7 @@ let to_dyn
       ; jsoo_runtime
       ; wasmoo_runtime
       ; preprocess = _
+      ; stanza_flags = _
       ; enabled = _
       ; virtual_deps
       ; dune_version

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -171,6 +171,12 @@ val preprocess
   -> for_:Compilation_mode.t
   -> Preprocess.With_instrumentation.t Preprocess.Per_module.t
 
+(** Unexpanded [(flags ...)] from the library's stanza. [Spec.standard] for
+    libraries assembled from META / dune-package files. The per-module narrowing
+    pipeline uses this to recover [-open]-induced cross-library [.cmi] reads
+    that ocamldep cannot see. *)
+val stanza_flags : _ t -> Dune_lang.Ocaml_flags.Spec.t
+
 val sub_systems : _ t -> Sub_system_info.t Sub_system_name.Map.t
 val enabled : _ t -> Enabled_status.t Memo.t
 val orig_src_dir : 'path t -> 'path option
@@ -241,6 +247,7 @@ val create
   -> preprocess:
        Preprocess.With_instrumentation.t Preprocess.Per_module.t
          Compilation_mode.Per_mode.t
+  -> stanza_flags:Dune_lang.Ocaml_flags.Spec.t
   -> enabled:Enabled_status.t Memo.t
   -> virtual_deps:(Loc.t * Lib_name.t) list
   -> dune_version:Dune_lang.Syntax.Version.t option

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -170,6 +170,12 @@ val preprocess
   -> for_:Compilation_mode.t
   -> Preprocess.With_instrumentation.t Preprocess.Per_module.t
 
+(** Unexpanded [(flags ...)] from the library's stanza. [Spec.standard] for
+    libraries assembled from META / dune-package files. The per-module narrowing
+    pipeline uses this to recover [-open]-induced cross-library [.cmi] reads
+    that ocamldep cannot see. *)
+val stanza_flags : _ t -> Dune_lang.Ocaml_flags.Spec.t
+
 val sub_systems : _ t -> Sub_system_info.t Sub_system_name.Map.t
 val enabled : _ t -> Enabled_status.t Memo.t
 val orig_src_dir : 'path t -> 'path option
@@ -240,6 +246,7 @@ val create
   -> preprocess:
        Preprocess.With_instrumentation.t Preprocess.Per_module.t
          Compilation_mode.Per_mode.t
+  -> stanza_flags:Dune_lang.Ocaml_flags.Spec.t
   -> enabled:Enabled_status.t Memo.t
   -> virtual_deps:(Loc.t * Lib_name.t) list
   -> dune_version:Dune_lang.Syntax.Version.t option

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -501,6 +501,11 @@ let cctx
   let modules = Virtual_rules.impl_modules implements modules in
   let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
   let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+  let pps_runtime_libs =
+    let open Resolve.Memo.O in
+    let* pps = Lib.Compile.pps compile_info ~for_ in
+    Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+  in
   let instances =
     Parameterised_instances.instances ~sctx ~db:(Scope.libs scope) lib.buildable.libraries
   in
@@ -531,6 +536,7 @@ let cctx
     ~flags
     ~requires_compile
     ~requires_link
+    ~pps_runtime_libs
     ~implements
     ~parameters
     ~preprocessing:pp

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -513,6 +513,11 @@ let cctx
     Some (lazy (Lib.Compile.user_written_requires_no_loc compile_info ~for_))
   in
   let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+  let pps_runtime_libs =
+    let open Resolve.Memo.O in
+    let* pps = Lib.Compile.pps compile_info ~for_ in
+    Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+  in
   let instances =
     Parameterised_instances.instances ~sctx ~db:(Scope.libs scope) lib.buildable.libraries
   in
@@ -544,6 +549,7 @@ let cctx
     ~requires_compile
     ~user_written_requires
     ~requires_link
+    ~pps_runtime_libs
     ~implements
     ~parameters
     ~preprocessing:pp

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -485,6 +485,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       ~flags
       ~requires_compile
       ~requires_link
+      ~pps_runtime_libs:(Resolve.Memo.return [])
       ~opaque:(Explicit false)
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -490,6 +490,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
       ~requires_compile
       ~user_written_requires:None
       ~requires_link
+      ~pps_runtime_libs:(Resolve.Memo.return [])
       ~opaque:(Explicit false)
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -555,6 +555,7 @@ let setup_emit_cmj_rules
         ~flags
         ~requires_link
         ~requires_compile:direct_requires
+        ~pps_runtime_libs:(Resolve.Memo.return [])
         ~preprocessing:pp
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~opaque:Inherit_from_settings

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -542,6 +542,11 @@ let setup_emit_cmj_rules
       Modules.With_vlib.modules modules, pp
     in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let* flags = melange_compile_flags ~sctx ~dir mel in
     let* cctx =
       let direct_requires = Lib.Compile.direct_requires compile_info ~for_ in
@@ -555,7 +560,7 @@ let setup_emit_cmj_rules
         ~flags
         ~requires_link
         ~requires_compile:direct_requires
-        ~pps_runtime_libs:(Resolve.Memo.return [])
+        ~pps_runtime_libs
         ~preprocessing:pp
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~opaque:Inherit_from_settings

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -534,6 +534,11 @@ let setup_emit_cmj_rules
       Modules.With_vlib.modules modules, pp
     in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let* flags = melange_compile_flags ~sctx ~dir mel in
     let* cctx =
       let direct_requires = Lib.Compile.direct_requires compile_info ~for_ in
@@ -551,7 +556,7 @@ let setup_emit_cmj_rules
         ~requires_link
         ~requires_compile:direct_requires
         ~user_written_requires
-        ~pps_runtime_libs:(Resolve.Memo.return [])
+        ~pps_runtime_libs
         ~preprocessing:pp
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~opaque:Inherit_from_settings

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -551,6 +551,7 @@ let setup_emit_cmj_rules
         ~requires_link
         ~requires_compile:direct_requires
         ~user_written_requires
+        ~pps_runtime_libs:(Resolve.Memo.return [])
         ~preprocessing:pp
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~opaque:Inherit_from_settings

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -1,6 +1,294 @@
 open Import
 open Memo.O
 
+let all_libs cctx =
+  let open Resolve.Memo.O in
+  let+ d = Compilation_context.requires_compile cctx
+  and+ h = Compilation_context.requires_hidden cctx in
+  d @ h
+;;
+
+let union_module_name_sets_mapped xs ~f =
+  Action_builder.List.map xs ~f
+  |> Action_builder.map
+       ~f:(List.fold_left ~init:Module_name.Set.empty ~f:Module_name.Set.union)
+;;
+
+let module_kind_is_filterable m =
+  match Module.kind m with
+  | Root | Wrapped_compat | Impl_vmodule | Virtual | Parameter -> false
+  | Intf_only | Impl | Alias _ -> true
+;;
+
+(* BFS over tight-eligible entries: each (lib, entry) pair's impl+intf ocamldep
+   names extend the frontier. Entries lacking a tight-eligible module —
+   [None]-entries (wrapped locals, externals, staged-Pps modules) and libs in
+   [no_ocamldep] (walker-terminal singletons) — are skipped by
+   [lookup_tight_entries], terminating chains through them. The [Module.t]
+   supplied here is the post-pp form (constructed in [build_lib_index]), so
+   ocamldep runs on the dep lib's [.pp.ml] (action / non-staged Pps) or directly
+   on the source (no preprocessing / future-syntax).
+
+   Each visited local lib's [-open Foo] flags also extend the frontier: a dep
+   lib whose effective flags open [Foo] can use [Foo]'s identifiers without
+   naming [Foo] in its source, so ocamldep on the dep lib's source produces
+   no token to walk through. The opened module names are the missing edges.
+   Both the stanza's own [(flags ...)] and any [(env ...)] stanza that
+   contributes default flags to the dep lib's directory can inject [-open]
+   entries; we evaluate the fully-merged flags so neither path is missed
+   (see #14517 for the env-stanza case). External libs are short-circuited:
+   their [src_dir] is not a build path, and env stanzas cannot inject flags
+   into already-compiled artifacts. *)
+let cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs =
+  let open Action_builder.O in
+  let read_lib_opens lib =
+    if not (Lib.is_local lib)
+    then Action_builder.return Module_name.Set.empty
+    else (
+      let info = Lib.info lib in
+      let spec = Lib_info.stanza_flags info in
+      let dir = Lib_info.src_dir info |> Path.as_in_build_dir_exn in
+      let* ocaml_flags =
+        Action_builder.of_memo (Ocaml_flags_db.ocaml_flags sctx ~dir spec)
+      in
+      let+ flag_strings = Ocaml_flags.get ocaml_flags mode in
+      Ocaml_flags.extract_open_module_names flag_strings)
+  in
+  let read_entry_deps (lib, m) =
+    let obj_dir = Lib.info lib |> Lib_info.obj_dir |> Obj_dir.as_local_exn in
+    let* impl_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Impl m
+    in
+    let* intf_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Intf m
+    in
+    let+ lib_opens = read_lib_opens lib in
+    Module_name.Set.union impl_deps (Module_name.Set.union intf_deps lib_opens)
+  in
+  let rec loop ~seen ~frontier =
+    if Module_name.Set.is_empty frontier
+    then Action_builder.return seen
+    else (
+      let pairs =
+        Module_name.Set.fold frontier ~init:[] ~f:(fun name acc ->
+          Lib_file_deps.Lib_index.lookup_tight_entries lib_index name @ acc)
+      in
+      let* discovered = union_module_name_sets_mapped pairs ~f:read_entry_deps in
+      let seen = Module_name.Set.union seen frontier in
+      let frontier = Module_name.Set.diff discovered seen in
+      loop ~seen ~frontier)
+  in
+  loop ~seen:Module_name.Set.empty ~frontier:initial_refs
+;;
+
+(* See the module-level comment in [lib_file_deps.ml] for the two dep shapes
+   ([deps_of_entry_modules] vs [deps_of_entries]) and why wrapped dep libraries
+   always take the glob path. *)
+let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kind ~mode m =
+  let open Action_builder.O in
+  let cctx_includes_for_cm_kind () =
+    Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
+  in
+  let can_filter =
+    (match Lib_mode.of_cm_kind cm_kind with
+     | Melange -> false
+     | Ocaml _ -> true)
+    (* Skip when [dep_graph] is the dummy ([Dep_graph.dummy] with
+       [dir = Path.Build.root]); used for singleton-module stanzas and
+       link-time-synthesised modules where no transitive deps are available. *)
+    && Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
+    (* Modules synthesised outside the stanza, handed to [ocamlc_i]. *)
+    && Dep_graph.mem dep_graph m
+    && module_kind_is_filterable m
+    && Module.has m ~ml_kind
+    (* Consumer-stanza virtual-impl: handled by [Dep_rules]. The deps-side
+       counterpart ([has_virtual_impl] below) covers the case where a lib in
+       [requires] is a virtual impl. *)
+    && not (Virtual_rules.is_virtual_or_parameter (Compilation_context.implements cctx))
+  in
+  let* libs = Resolve.Memo.read (all_libs cctx) in
+  if not can_filter
+  then
+    Action_builder.return
+      (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+  else
+    let* has_virtual_impl =
+      Resolve.Memo.read (Compilation_context.has_virtual_impl cctx)
+    in
+    if has_virtual_impl
+    then
+      Action_builder.return
+        (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+    else
+      let* lib_index = Resolve.Memo.read (Compilation_context.lib_index cctx) in
+      let sandbox = Compilation_context.sandbox cctx in
+      let sctx = Compilation_context.super_context cctx in
+      let* trans_deps = Dep_graph.deps_of dep_graph m in
+      (* Read [dep_m]'s [.ml]-side ocamldep only when its references can
+         propagate to the consumer:
+
+         | [dep_m] is              | [cm_kind]   | [opaque] | read [.ml]?  |
+         | ----------------------- | ----------- | -------- | ------------ |
+         | consumer ([m] itself)   | any         | any      | iff [Impl]   |
+         | trans_dep, no [.mli]    | any         | any      | yes          |
+         | trans_dep, has [.mli]   | [Cmx]       | false    | yes (inline) |
+         | trans_dep, has [.mli]   | [Cmx]       | true     | no           |
+         | trans_dep, has [.mli]   | [Cmi]/[Cmo] | any      | no           | *)
+      let need_impl_deps_of dep_m ~is_consumer =
+        if is_consumer
+        then (
+          match ml_kind with
+          | Ml_kind.Impl -> true
+          | Intf -> false)
+        else
+          (not (Module.has dep_m ~ml_kind:Intf))
+          ||
+          match cm_kind with
+          | Ocaml Cmx -> not opaque
+          | Ocaml (Cmi | Cmo) | Melange _ -> false
+      in
+      let read_dep_m_raw dep_m ~is_consumer =
+        let key : Compilation_context.Raw_refs.Key.t =
+          let obj_name = Module.obj_name dep_m in
+          if is_consumer
+          then Consumer { obj_name; ml_kind }
+          else Transitive { obj_name; cm_kind }
+        in
+        Compilation_context.cached_raw_refs cctx ~key ~compute:(fun () ->
+          let* impl_deps =
+            if need_impl_deps_of dep_m ~is_consumer
+            then
+              Ocamldep.read_immediate_deps_raw_of
+                ~sandbox
+                ~sctx
+                ~obj_dir
+                ~ml_kind:Impl
+                dep_m
+            else Action_builder.return Module_name.Set.empty
+          in
+          let+ intf_deps =
+            Ocamldep.read_immediate_deps_raw_of
+              ~sandbox
+              ~sctx
+              ~obj_dir
+              ~ml_kind:Intf
+              dep_m
+          in
+          Module_name.Set.union impl_deps intf_deps)
+      in
+      let* m_raw = read_dep_m_raw m ~is_consumer:true in
+      let* trans_raw =
+        union_module_name_sets_mapped trans_deps ~f:(read_dep_m_raw ~is_consumer:false)
+      in
+      let all_raw = Module_name.Set.union m_raw trans_raw in
+      let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
+      let open_modules = Ocaml_flags.extract_open_module_names flags in
+      let referenced = Module_name.Set.union all_raw open_modules in
+      let { Lib_file_deps.Lib_index.tight; non_tight } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:referenced
+      in
+      (* [ppx_runtime_libraries] introduce module references through post-pp
+         source that ocamldep cannot see; carry them through to [all_libs] so
+         the classification fold sees them, and force them onto the glob path
+         via [must_glob_set]. *)
+      let* pps_runtime_libs =
+        Resolve.Memo.read (Compilation_context.pps_runtime_libs cctx)
+      in
+      (* [Lib.closure]'s memo key is order- and multiplicity-sensitive on the
+         input list. [pps_runtime_libs] can both contain duplicates (multiple
+         pps sharing a runtime dep) and overlap with [tight]/[non_tight] (a lib
+         referenced both syntactically and via [add_pp_runtime_deps]).
+         [sort_uniq] keeps the input canonical for memoization. *)
+      let direct_libs =
+        List.sort_uniq
+          ~compare:Lib.compare
+          (Lib.Map.keys tight @ Lib.Set.to_list non_tight @ pps_runtime_libs)
+      in
+      (* Close transitively over transparent aliases that ocamldep doesn't
+         report. *)
+      let* all_libs = Resolve.Memo.read (Lib.closure direct_libs ~linking:false ~for_) in
+      (* Wrapped-lib soundness recovery: when [referenced] names a wrapped local
+         lib's wrapper, the consumer may reach the lib's transitive closure
+         through aliases the cross-library walk cannot see; glob that closure
+         unconditionally. *)
+      let wrapped_referenced =
+        Lib_file_deps.Lib_index.wrapped_libs_referenced
+          lib_index
+          ~referenced_modules:referenced
+      in
+      let* must_glob_libs =
+        Resolve.Memo.read
+          (Lib.closure
+             (List.sort_uniq
+                ~compare:Lib.compare
+                (Lib.Set.to_list wrapped_referenced @ pps_runtime_libs))
+             ~linking:false
+             ~for_)
+      in
+      let must_glob_set = Lib.Set.of_list must_glob_libs in
+      let* tight_set =
+        cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs:referenced
+      in
+      (* Classify each lib in [all_libs]: - lib has [None]-entry referenced
+         (mixed-entry or wrapped) → glob (covers the None entries' [.cmi]s); -
+         lib has only [Some] entries referenced → per-module deps; - lib
+         unreached but tight-eligible → drop (link rule pulls it in via
+         [requires_link]); - lib unreached and not tight-eligible → glob.
+         [kept_libs] gets every lib that contributes a tight or glob dep — used
+         by [Compilation_context.filtered_include_flags] to scope the consumer's
+         [-I]/[-H] flags. *)
+      let { Lib_file_deps.Lib_index.tight = tight_modules; non_tight = non_tight_set } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:tight_set
+      in
+      let tight_deps, glob_libs, kept_libs =
+        List.fold_left
+          all_libs
+          ~init:(Dep.Set.empty, [], Lib.Set.empty)
+          ~f:(fun (td, gl, kl) lib ->
+            if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
+            then td, lib :: gl, Lib.Set.add kl lib
+            else (
+              match Lib.Map.find tight_modules lib with
+              | Some modules ->
+                ( Dep.Set.union
+                    td
+                    (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
+                , gl
+                , Lib.Set.add kl lib )
+              | None ->
+                if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
+                then td, gl, kl
+                else td, lib :: gl, Lib.Set.add kl lib))
+      in
+      let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
+      let+ include_flags =
+        Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
+      in
+      include_flags, Dep.Set.union tight_deps glob_deps
+;;
+
+let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let opaque = Compilation_context.opaque cctx in
+  let for_ = Compilation_context.for_ cctx in
+  let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
+  Action_builder.dyn_deps
+    (lib_deps_for_module
+       ~cctx
+       ~obj_dir
+       ~for_
+       ~dep_graph
+       ~opaque
+       ~cm_kind
+       ~ml_kind
+       ~mode
+       m)
+;;
+
 (* Arguments for the compiler to prevent it from being too clever.
 
    The compiler creates the cmi when it thinks a .ml file has no corresponding
@@ -281,6 +569,20 @@ let build_cm
         | Some All | None -> Hidden_targets [ obj ])
    in
    let opaque = Compilation_context.opaque cctx in
+   let skip_lib_deps =
+     match Module.kind m with
+     | Alias _ ->
+       not (Modules.With_vlib.is_stdlib_alias (Compilation_context.modules cctx) m)
+     | Wrapped_compat -> true
+     | Intf_only | Virtual | Impl | Impl_vmodule | Root | Parameter -> false
+   in
+   let lib_cm_args =
+     if skip_lib_deps
+     then
+       Action_builder.return
+         (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+     else lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m
+   in
    let other_cm_files =
      let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
      let module_deps = Dep_graph.deps_of dep_graph m in
@@ -408,8 +710,7 @@ let build_cm
             ; cmt_args
             ; cms_args
             ; Command.Args.S obj_dirs
-            ; Command.Args.as_any
-                (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+            ; Command.Args.Dyn lib_cm_args
             ; extra_args
             ; As as_parameter_arg
             ; as_argument_for
@@ -524,6 +825,9 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
        List.concat_map deps ~f:(fun m ->
          [ Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)) ]))
   in
+  let lib_cm_args =
+    lib_cm_deps ~cctx ~cm_kind:(Ocaml Cmo) ~ml_kind:Impl ~mode:(Ocaml Byte) m
+  in
   let ocaml_flags = Ocaml_flags.get (Compilation_context.flags cctx) (Ocaml Byte) in
   let modules = Compilation_context.modules cctx in
   let ocaml = Compilation_context.ocaml cctx in
@@ -542,10 +846,7 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
               [ Command.Args.dyn ocaml_flags
               ; A "-I"
               ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-              ; Command.Args.as_any
-                  (Lib_mode.Cm_kind.Map.get
-                     (Compilation_context.includes cctx)
-                     (Ocaml Cmo))
+              ; Command.Args.Dyn lib_cm_args
               ; opens modules m
               ; A "-short-paths"
               ; A "-i"

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -90,13 +90,10 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
     Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
   in
   let can_filter =
-    (match Lib_mode.of_cm_kind cm_kind with
-     | Melange -> false
-     | Ocaml _ -> true)
     (* Skip when [dep_graph] is the dummy ([Dep_graph.dummy] with
        [dir = Path.Build.root]); used for singleton-module stanzas and
        link-time-synthesised modules where no transitive deps are available. *)
-    && Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
+    Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
     (* Modules synthesised outside the stanza, handed to [ocamlc_i]. *)
     && Dep_graph.mem dep_graph m
     && module_kind_is_filterable m
@@ -183,7 +180,22 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
       let all_raw = Module_name.Set.union m_raw trans_raw in
       let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
       let open_modules = Ocaml_flags.extract_open_module_names flags in
-      let referenced = Module_name.Set.union all_raw open_modules in
+      (* [Stdlib] is implicitly opened by every compile and so is referenced by
+         every consumer even when ocamldep doesn't list it. For OCaml-mode
+         compiles the compiler's built-in stdlib path supplies it (no dune lib
+         to keep); for Melange-mode compiles the [melange]/[stdlib] lib supplies
+         it as a regular dune dependency, and would otherwise be dropped from
+         [kept_libs] for consumers that don't syntactically name a [Stdlib.X]
+         member. Force it onto the frontier so the [Lib_index] lookup adds it
+         when present. *)
+      let referenced =
+        let implicit_stdlib =
+          match Module_name.of_string_opt "Stdlib" with
+          | Some n -> Module_name.Set.singleton n
+          | None -> Module_name.Set.empty
+        in
+        Module_name.Set.union (Module_name.Set.union all_raw open_modules) implicit_stdlib
+      in
       let { Lib_file_deps.Lib_index.tight; non_tight } =
         Lib_file_deps.Lib_index.filter_libs_with_modules
           lib_index

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -14,6 +14,22 @@ let union_module_name_sets_mapped xs ~f =
        ~f:(List.fold_left ~init:Module_name.Set.empty ~f:Module_name.Set.union)
 ;;
 
+(* Native compilation consumes interfaces produced with byte flags, so both
+   flag sets can introduce opens that affect its dependency frontier. *)
+let open_modules_for_mode flags mode =
+  let open Action_builder.O in
+  let open_modules mode =
+    let+ flags = Ocaml_flags.get flags mode in
+    Ocaml_flags.extract_open_module_names flags
+  in
+  match mode with
+  | Lib_mode.Ocaml Native ->
+    let* byte = open_modules (Lib_mode.Ocaml Byte) in
+    let+ native = open_modules (Lib_mode.Ocaml Native) in
+    Module_name.Set.union byte native
+  | (Lib_mode.Ocaml Byte | Lib_mode.Melange) as mode -> open_modules mode
+;;
+
 let module_kind_is_filterable m =
   match Module.kind m with
   | Root | Wrapped_compat | Impl_vmodule | Virtual | Parameter -> false
@@ -51,8 +67,7 @@ let cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs =
       let* ocaml_flags =
         Action_builder.of_memo (Ocaml_flags_db.ocaml_flags sctx ~dir spec)
       in
-      let+ flag_strings = Ocaml_flags.get ocaml_flags mode in
-      Ocaml_flags.extract_open_module_names flag_strings)
+      open_modules_for_mode ocaml_flags mode)
   in
   let read_entry_deps (lib, m) =
     let obj_dir = Lib.info lib |> Lib_info.obj_dir |> Obj_dir.as_local_exn in
@@ -178,8 +193,7 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
         union_module_name_sets_mapped trans_deps ~f:(read_dep_m_raw ~is_consumer:false)
       in
       let all_raw = Module_name.Set.union m_raw trans_raw in
-      let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
-      let open_modules = Ocaml_flags.extract_open_module_names flags in
+      let* open_modules = open_modules_for_mode (Compilation_context.flags cctx) mode in
       (* [Stdlib] is implicitly opened by every compile and so is referenced by
          every consumer even when ocamldep doesn't list it. For OCaml-mode
          compiles the compiler's built-in stdlib path supplies it (no dune lib

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -8,6 +8,38 @@ let all_libs cctx =
   d @ h
 ;;
 
+(* Package dependency inference walks file dependencies of installable rules.
+   When narrowing drops a local library's artifacts, retain a dependency on its
+   stable package metadata so strict package checks still see the declaration. *)
+let strict_package_deps_markers cctx libs =
+  let project = Compilation_context.scope cctx |> Scope.project in
+  if not (Dune_project.strict_package_deps project)
+  then Dep.Set.empty
+  else (
+    let build_context = Compilation_context.context cctx |> Context.build_context in
+    let current_package = Compilation_context.package cctx |> Option.map ~f:Package.id in
+    List.filter_map libs ~f:(fun lib ->
+      let package =
+        match Lib_info.status (Lib.info lib) with
+        | Lib_info.Status.Public (_, package) | Lib_info.Status.Private (_, Some package)
+          -> Some package
+        | Lib_info.Status.Installed_private | Lib_info.Status.Installed
+        | Lib_info.Status.Private (_, None) -> None
+      in
+      Option.bind package ~f:(fun package ->
+        match current_package with
+        | Some current when Package.Id.compare current (Package.id package) = Eq -> None
+        | None | Some _ ->
+          let dir =
+            Path.Build.append_source build_context.build_dir (Package.dir package)
+          in
+          let filename =
+            Package.Name.to_string (Package.name package) ^ "." ^ Dune_package.fn
+          in
+          Some (Path.Build.relative dir filename |> Path.build |> Dep.file)))
+    |> Dep.Set.of_list)
+;;
+
 let union_module_name_sets_mapped xs ~f =
   Action_builder.List.map xs ~f
   |> Action_builder.map
@@ -291,10 +323,14 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
                 else td, lib :: gl, Lib.Set.add kl lib))
       in
       let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
+      let package_deps =
+        List.filter libs ~f:(fun lib -> not (Lib.Set.mem kept_libs lib))
+        |> strict_package_deps_markers cctx
+      in
       let+ include_flags =
         Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
       in
-      include_flags, Dep.Set.union tight_deps glob_deps
+      include_flags, Dep.Set.union package_deps (Dep.Set.union tight_deps glob_deps)
 ;;
 
 let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -235,14 +235,17 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
       (* Close transitively over transparent aliases that ocamldep doesn't
          report. *)
       let* all_libs = Resolve.Memo.read (Lib.closure direct_libs ~linking:false ~for_) in
-      (* Wrapped-lib soundness recovery: when [referenced] names a wrapped local
-         lib's wrapper, the consumer may reach the lib's transitive closure
-         through aliases the cross-library walk cannot see; glob that closure
-         unconditionally. *)
+      let* tight_set =
+        cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs:referenced
+      in
+      (* Wrapped-lib soundness recovery: when the cross-library walk reaches a
+         wrapped local lib's wrapper, the consumer may reach the lib's
+         transitive closure through aliases the walk cannot see; glob that
+         closure unconditionally. *)
       let wrapped_referenced =
         Lib_file_deps.Lib_index.wrapped_libs_referenced
           lib_index
-          ~referenced_modules:referenced
+          ~referenced_modules:tight_set
       in
       let* must_glob_libs =
         Resolve.Memo.read
@@ -254,9 +257,6 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
              ~for_)
       in
       let must_glob_set = Lib.Set.of_list must_glob_libs in
-      let* tight_set =
-        cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs:referenced
-      in
       (* Classify each lib in [all_libs]: - lib has [None]-entry referenced
          (mixed-entry or wrapped) → glob (covers the None entries' [.cmi]s); -
          lib has only [Some] entries referenced → per-module deps; - lib

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -1,6 +1,294 @@
 open Import
 open Memo.O
 
+let all_libs cctx =
+  let open Resolve.Memo.O in
+  let+ d = Compilation_context.requires_compile cctx
+  and+ h = Compilation_context.requires_hidden cctx in
+  d @ h
+;;
+
+let union_module_name_sets_mapped xs ~f =
+  Action_builder.List.map xs ~f
+  |> Action_builder.map
+       ~f:(List.fold_left ~init:Module_name.Set.empty ~f:Module_name.Set.union)
+;;
+
+let module_kind_is_filterable m =
+  match Module.kind m with
+  | Root | Wrapped_compat | Impl_vmodule | Virtual | Parameter -> false
+  | Intf_only | Impl | Alias _ -> true
+;;
+
+(* BFS over tight-eligible entries: each (lib, entry) pair's impl+intf ocamldep
+   names extend the frontier. Entries lacking a tight-eligible module —
+   [None]-entries (wrapped locals, externals, staged-Pps modules) and libs in
+   [no_ocamldep] (walker-terminal singletons) — are skipped by
+   [lookup_tight_entries], terminating chains through them. The [Module.t]
+   supplied here is the post-pp form (constructed in [build_lib_index]), so
+   ocamldep runs on the dep lib's [.pp.ml] (action / non-staged Pps) or directly
+   on the source (no preprocessing / future-syntax).
+
+   Each visited local lib's [-open Foo] flags also extend the frontier: a dep
+   lib whose effective flags open [Foo] can use [Foo]'s identifiers without
+   naming [Foo] in its source, so ocamldep on the dep lib's source produces
+   no token to walk through. The opened module names are the missing edges.
+   Both the stanza's own [(flags ...)] and any [(env ...)] stanza that
+   contributes default flags to the dep lib's directory can inject [-open]
+   entries; we evaluate the fully-merged flags so neither path is missed
+   (see #14517 for the env-stanza case). External libs are short-circuited:
+   their [src_dir] is not a build path, and env stanzas cannot inject flags
+   into already-compiled artifacts. *)
+let cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs =
+  let open Action_builder.O in
+  let read_lib_opens lib =
+    if not (Lib.is_local lib)
+    then Action_builder.return Module_name.Set.empty
+    else (
+      let info = Lib.info lib in
+      let spec = Lib_info.stanza_flags info in
+      let dir = Lib_info.src_dir info |> Path.as_in_build_dir_exn in
+      let* ocaml_flags =
+        Action_builder.of_memo (Ocaml_flags_db.ocaml_flags sctx ~dir spec)
+      in
+      let+ flag_strings = Ocaml_flags.get ocaml_flags mode in
+      Ocaml_flags.extract_open_module_names flag_strings)
+  in
+  let read_entry_deps (lib, m) =
+    let obj_dir = Lib.info lib |> Lib_info.obj_dir |> Obj_dir.as_local_exn in
+    let* impl_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Impl m
+    in
+    let* intf_deps =
+      Ocamldep.read_immediate_deps_raw_of ~sandbox ~sctx ~obj_dir ~ml_kind:Intf m
+    in
+    let+ lib_opens = read_lib_opens lib in
+    Module_name.Set.union impl_deps (Module_name.Set.union intf_deps lib_opens)
+  in
+  let rec loop ~seen ~frontier =
+    if Module_name.Set.is_empty frontier
+    then Action_builder.return seen
+    else (
+      let pairs =
+        Module_name.Set.fold frontier ~init:[] ~f:(fun name acc ->
+          Lib_file_deps.Lib_index.lookup_tight_entries lib_index name @ acc)
+      in
+      let* discovered = union_module_name_sets_mapped pairs ~f:read_entry_deps in
+      let seen = Module_name.Set.union seen frontier in
+      let frontier = Module_name.Set.diff discovered seen in
+      loop ~seen ~frontier)
+  in
+  loop ~seen:Module_name.Set.empty ~frontier:initial_refs
+;;
+
+(* See the module-level comment in [lib_file_deps.ml] for the two dep shapes
+   ([deps_of_entry_modules] vs [deps_of_entries]) and why wrapped dep libraries
+   always take the glob path. *)
+let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kind ~mode m =
+  let open Action_builder.O in
+  let cctx_includes_for_cm_kind () =
+    Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
+  in
+  let can_filter =
+    (match Lib_mode.of_cm_kind cm_kind with
+     | Melange -> false
+     | Ocaml _ -> true)
+    (* Skip when [dep_graph] is the dummy ([Dep_graph.dummy] with
+       [dir = Path.Build.root]); used for singleton-module stanzas and
+       link-time-synthesised modules where no transitive deps are available. *)
+    && Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
+    (* Modules synthesised outside the stanza, handed to [ocamlc_i]. *)
+    && Dep_graph.mem dep_graph m
+    && module_kind_is_filterable m
+    && Module.has m ~ml_kind
+    (* Consumer-stanza virtual-impl: handled by [Dep_rules]. The deps-side
+       counterpart ([has_virtual_impl] below) covers the case where a lib in
+       [requires] is a virtual impl. *)
+    && not (Virtual_rules.is_virtual_or_parameter (Compilation_context.implements cctx))
+  in
+  let* libs = Resolve.Memo.read (all_libs cctx) in
+  if not can_filter
+  then
+    Action_builder.return
+      (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+  else
+    let* has_virtual_impl =
+      Resolve.Memo.read (Compilation_context.has_virtual_impl cctx)
+    in
+    if has_virtual_impl
+    then
+      Action_builder.return
+        (cctx_includes_for_cm_kind (), Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs)
+    else
+      let* lib_index = Resolve.Memo.read (Compilation_context.lib_index cctx) in
+      let sandbox = Compilation_context.sandbox cctx in
+      let sctx = Compilation_context.super_context cctx in
+      let* trans_deps = Dep_graph.deps_of dep_graph m in
+      (* Read [dep_m]'s [.ml]-side ocamldep only when its references can
+         propagate to the consumer:
+
+         | [dep_m] is              | [cm_kind]   | [opaque] | read [.ml]?  |
+         | ----------------------- | ----------- | -------- | ------------ |
+         | consumer ([m] itself)   | any         | any      | iff [Impl]   |
+         | trans_dep, no [.mli]    | any         | any      | yes          |
+         | trans_dep, has [.mli]   | [Cmx]       | false    | yes (inline) |
+         | trans_dep, has [.mli]   | [Cmx]       | true     | no           |
+         | trans_dep, has [.mli]   | [Cmi]/[Cmo] | any      | no           | *)
+      let need_impl_deps_of dep_m ~is_consumer =
+        if is_consumer
+        then (
+          match ml_kind with
+          | Ml_kind.Impl -> true
+          | Intf -> false)
+        else
+          (not (Module.has dep_m ~ml_kind:Intf))
+          ||
+          match cm_kind with
+          | Ocaml Cmx -> not opaque
+          | Ocaml (Cmi | Cmo) | Melange _ -> false
+      in
+      let read_dep_m_raw dep_m ~is_consumer =
+        let key : Compilation_context.Raw_refs.Key.t =
+          let obj_name = Module.obj_name dep_m in
+          if is_consumer
+          then Consumer { obj_name; ml_kind }
+          else Transitive { obj_name; cm_kind }
+        in
+        Compilation_context.cached_raw_refs cctx ~key ~compute:(fun () ->
+          let* impl_deps =
+            if need_impl_deps_of dep_m ~is_consumer
+            then
+              Ocamldep.read_immediate_deps_raw_of
+                ~sandbox
+                ~sctx
+                ~obj_dir
+                ~ml_kind:Impl
+                dep_m
+            else Action_builder.return Module_name.Set.empty
+          in
+          let+ intf_deps =
+            Ocamldep.read_immediate_deps_raw_of
+              ~sandbox
+              ~sctx
+              ~obj_dir
+              ~ml_kind:Intf
+              dep_m
+          in
+          Module_name.Set.union impl_deps intf_deps)
+      in
+      let* m_raw = read_dep_m_raw m ~is_consumer:true in
+      let* trans_raw =
+        union_module_name_sets_mapped trans_deps ~f:(read_dep_m_raw ~is_consumer:false)
+      in
+      let all_raw = Module_name.Set.union m_raw trans_raw in
+      let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
+      let open_modules = Ocaml_flags.extract_open_module_names flags in
+      let referenced = Module_name.Set.union all_raw open_modules in
+      let { Lib_file_deps.Lib_index.tight; non_tight } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:referenced
+      in
+      (* [ppx_runtime_libraries] introduce module references through post-pp
+         source that ocamldep cannot see; carry them through to [all_libs] so
+         the classification fold sees them, and force them onto the glob path
+         via [must_glob_set]. *)
+      let* pps_runtime_libs =
+        Resolve.Memo.read (Compilation_context.pps_runtime_libs cctx)
+      in
+      (* [Lib.closure]'s memo key is order- and multiplicity-sensitive on the
+         input list. [pps_runtime_libs] can both contain duplicates (multiple
+         pps sharing a runtime dep) and overlap with [tight]/[non_tight] (a lib
+         referenced both syntactically and via [add_pp_runtime_deps]).
+         [sort_uniq] keeps the input canonical for memoization. *)
+      let direct_libs =
+        List.sort_uniq
+          ~compare:Lib.compare
+          (Lib.Map.keys tight @ Lib.Set.to_list non_tight @ pps_runtime_libs)
+      in
+      (* Close transitively over transparent aliases that ocamldep doesn't
+         report. *)
+      let* all_libs = Resolve.Memo.read (Lib.closure direct_libs ~linking:false ~for_) in
+      (* Wrapped-lib soundness recovery: when [referenced] names a wrapped local
+         lib's wrapper, the consumer may reach the lib's transitive closure
+         through aliases the cross-library walk cannot see; glob that closure
+         unconditionally. *)
+      let wrapped_referenced =
+        Lib_file_deps.Lib_index.wrapped_libs_referenced
+          lib_index
+          ~referenced_modules:referenced
+      in
+      let* must_glob_libs =
+        Resolve.Memo.read
+          (Lib.closure
+             (List.sort_uniq
+                ~compare:Lib.compare
+                (Lib.Set.to_list wrapped_referenced @ pps_runtime_libs))
+             ~linking:false
+             ~for_)
+      in
+      let must_glob_set = Lib.Set.of_list must_glob_libs in
+      let* tight_set =
+        cross_lib_tight_set ~sandbox ~sctx ~lib_index ~mode ~initial_refs:referenced
+      in
+      (* Classify each lib in [all_libs]: - lib has [None]-entry referenced
+         (mixed-entry or wrapped) → glob (covers the None entries' [.cmi]s); -
+         lib has only [Some] entries referenced → per-module deps; - lib
+         unreached but tight-eligible → drop (link rule pulls it in via
+         [requires_link]); - lib unreached and not tight-eligible → glob.
+         [kept_libs] gets every lib that contributes a tight or glob dep — used
+         by [Compilation_context.filtered_include_flags] to scope the consumer's
+         [-I]/[-H] flags. *)
+      let { Lib_file_deps.Lib_index.tight = tight_modules; non_tight = non_tight_set } =
+        Lib_file_deps.Lib_index.filter_libs_with_modules
+          lib_index
+          ~referenced_modules:tight_set
+      in
+      let tight_deps, glob_libs, kept_libs =
+        List.fold_left
+          all_libs
+          ~init:(Dep.Set.empty, [], Lib.Set.empty)
+          ~f:(fun (td, gl, kl) lib ->
+            if Lib.Set.mem must_glob_set lib || Lib.Set.mem non_tight_set lib
+            then td, lib :: gl, Lib.Set.add kl lib
+            else (
+              match Lib.Map.find tight_modules lib with
+              | Some modules ->
+                ( Dep.Set.union
+                    td
+                    (Lib_file_deps.deps_of_entry_modules ~opaque ~cm_kind lib modules)
+                , gl
+                , Lib.Set.add kl lib )
+              | None ->
+                if Lib_file_deps.Lib_index.is_tight_eligible lib_index lib
+                then td, gl, kl
+                else td, lib :: gl, Lib.Set.add kl lib))
+      in
+      let glob_deps = Lib_file_deps.deps_of_entries ~opaque ~cm_kind glob_libs in
+      let+ include_flags =
+        Compilation_context.filtered_include_flags cctx ~cm_kind ~kept_libs
+      in
+      include_flags, Dep.Set.union tight_deps glob_deps
+;;
+
+let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let opaque = Compilation_context.opaque cctx in
+  let for_ = Compilation_context.for_ cctx in
+  let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
+  Action_builder.dyn_deps
+    (lib_deps_for_module
+       ~cctx
+       ~obj_dir
+       ~for_
+       ~dep_graph
+       ~opaque
+       ~cm_kind
+       ~ml_kind
+       ~mode
+       m)
+;;
+
 (* Arguments for the compiler to prevent it from being too clever.
 
    The compiler creates the cmi when it thinks a .ml file has no corresponding
@@ -289,6 +577,20 @@ let build_cm
         | Some All | None -> Hidden_targets [ obj ])
    in
    let opaque = Compilation_context.opaque cctx in
+   let skip_lib_deps =
+     match Module.kind m with
+     | Alias _ ->
+       not (Modules.With_vlib.is_stdlib_alias (Compilation_context.modules cctx) m)
+     | Wrapped_compat -> true
+     | Intf_only | Virtual | Impl | Impl_vmodule | Root | Parameter -> false
+   in
+   let lib_cm_args =
+     if skip_lib_deps
+     then
+       Action_builder.return
+         (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+     else lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m
+   in
    let other_cm_files =
      let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
      let module_deps = Dep_graph.deps_of dep_graph m in
@@ -397,8 +699,7 @@ let build_cm
             ; cmt_args
             ; cms_args
             ; Command.Args.S obj_dirs
-            ; Command.Args.as_any
-                (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+            ; Command.Args.Dyn lib_cm_args
             ; extra_args
             ; as_parameter_arg m
             ; as_argument_for cctx m
@@ -522,6 +823,9 @@ let ocamlc_i_action ~deps cctx (m : Module.t) =
        >>| List.concat_map ~f:(fun m ->
          [ Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)) ]))
   in
+  let lib_cm_args =
+    lib_cm_deps ~cctx ~cm_kind:(Ocaml Cmo) ~ml_kind:Impl ~mode:(Ocaml Byte) m
+  in
   let ocaml_flags = Ocaml_flags.get (Compilation_context.flags cctx) (Ocaml Byte) in
   let modules = Compilation_context.modules cctx in
   let ocaml = Compilation_context.ocaml cctx in
@@ -536,7 +840,7 @@ let ocamlc_i_action ~deps cctx (m : Module.t) =
         ; pp_flags
         ; A "-I"
         ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-        ; Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) (Ocaml Cmo)
+        ; Command.Args.Dyn lib_cm_args
         ; as_parameter_arg m
         ; as_argument_for cctx m
         ; parameters cctx

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -670,6 +670,12 @@ module Wrapped = struct
 
   let lib_interface t = Group.lib_interface t.group
 
+  (* Entry modules visible to consumers of a wrapped library: the wrapper
+     itself, plus any [wrapped_compat] shims (present for
+     [(wrapped (transition ...))] libraries, which expose bare module names in
+     addition to qualified ones). *)
+  let entry_modules t = lib_interface t :: Module_name.Map.values t.wrapped_compat
+
   let fold_user_available { group; toplevel_module; _ } ~init ~f =
     let init =
       match toplevel_module with
@@ -918,6 +924,12 @@ let wrapped t =
   | Stdlib _ -> Simple true
 ;;
 
+let as_singleton t =
+  match t.modules with
+  | Singleton m -> Some m
+  | Unwrapped _ | Wrapped _ | Stdlib _ -> None
+;;
+
 let is_user_written m =
   match Module.kind m with
   | Root | Wrapped_compat | Alias _ -> false
@@ -1005,7 +1017,7 @@ let entry_modules t =
      | Unwrapped m -> Unwrapped.entry_modules m
      | Wrapped m ->
        (* we assume this is never called for implementations *)
-       [ Wrapped.lib_interface m ])
+       Wrapped.entry_modules m)
 ;;
 
 module With_vlib = struct

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -637,6 +637,12 @@ module Wrapped = struct
 
   let lib_interface t = Group.lib_interface t.group
 
+  (* Entry modules visible to consumers of a wrapped library: the wrapper
+     itself, plus any [wrapped_compat] shims (present for
+     [(wrapped (transition ...))] libraries, which expose bare module names in
+     addition to qualified ones). *)
+  let entry_modules t = lib_interface t :: Module_name.Map.values t.wrapped_compat
+
   let fold_user_available { group; toplevel_module; _ } ~init ~f =
     let init =
       match toplevel_module with
@@ -881,6 +887,12 @@ let wrapped t =
   | Stdlib _ -> Simple true
 ;;
 
+let as_singleton t =
+  match t.modules with
+  | Singleton m -> Some m
+  | Unwrapped _ | Wrapped _ | Stdlib _ -> None
+;;
+
 let is_user_written m =
   match Module.kind m with
   | Root | Wrapped_compat | Alias _ -> false
@@ -968,7 +980,7 @@ let entry_modules t =
      | Unwrapped m -> Unwrapped.entry_modules m
      | Wrapped m ->
        (* we assume this is never called for implementations *)
-       [ Wrapped.lib_interface m ])
+       Wrapped.entry_modules m)
 ;;
 
 module With_vlib = struct

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -57,6 +57,13 @@ val obj_map : t -> Sourced_module.t Module_name.Unique.Map.t
 val virtual_module_names : t -> Module_name.Path.Set.t
 
 val wrapped : t -> Wrapped.t
+
+(** [Some m] iff the library's module set is a singleton — the single
+    user-written module [m]. This covers both unwrapped stanzas with exactly one
+    module and wrapped stanzas whose only module is the main module (in which
+    case the wrapper is elided). Mirrors [With_vlib.as_singleton]. *)
+val as_singleton : t -> Module.t option
+
 val source_dirs : t -> Path.Set.t
 val compat_for_exn : t -> Module.t -> Module.t
 

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -197,3 +197,26 @@ let allow_only_melange t =
 let open_flags modules =
   List.concat_map modules ~f:(fun name -> [ "-open"; Module_name.to_string name ])
 ;;
+
+let extract_open_module_names flags =
+  let rec loop acc = function
+    | "-open" :: name :: rest ->
+      (* [-open] accepts a module path such as [Foo.Bar]; only top-level
+         module names map to libraries in the cross-library frontier, so
+         key on the head component ([Foo]). *)
+      let head =
+        match String.lsplit2 name ~on:'.' with
+        | Some (head, _) -> head
+        | None -> name
+      in
+      let acc =
+        match Module_name.of_string_opt head with
+        | Some m -> Module_name.Set.add acc m
+        | None -> acc
+      in
+      loop acc rest
+    | _ :: rest -> loop acc rest
+    | [] -> acc
+  in
+  loop Module_name.Set.empty flags
+;;

--- a/src/dune_rules/ocaml_flags.mli
+++ b/src/dune_rules/ocaml_flags.mli
@@ -30,3 +30,6 @@ val with_vendored_alerts : t -> t
 val dump : t -> Dune_lang.t list Action_builder.t
 val with_vendored_flags : t -> ocaml_version:Version.t -> t
 val open_flags : Module_name.t list -> string list
+
+(** Extract module names from [-open Foo] pairs in compiler flags. *)
+val extract_open_module_names : string list -> Module_name.Set.t

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -416,6 +416,7 @@ let external_dep_rules ~sctx ~dir ~scope lib_name =
         ~impl:Virtual_rules.no_implements
         ~for_
         ~modules
+        ~has_library_deps:true
     in
     ()
 ;;

--- a/src/dune_rules/parameterised_rules.ml
+++ b/src/dune_rules/parameterised_rules.ml
@@ -417,6 +417,7 @@ let external_dep_rules ~sctx ~dir ~scope lib_name =
         ~impl:Virtual_rules.no_implements
         ~for_
         ~modules
+        ~has_library_deps:true
     in
     ()
 ;;

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -320,6 +320,7 @@ let build_ppx_driver =
         ~flags
         ~requires_compile:(Memo.return requires_compile)
         ~requires_link
+        ~pps_runtime_libs:(Resolve.Memo.return [])
         ~opaque
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -228,6 +228,7 @@ let build_ppx_driver =
         ~requires_compile:(Memo.return requires_compile)
         ~user_written_requires:None
         ~requires_link
+        ~pps_runtime_libs:(Resolve.Memo.return [])
         ~opaque
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~melange_package_name:None

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -667,6 +667,7 @@ let to_lib_info
     ~jsoo_runtime
     ~wasmoo_runtime
     ~preprocess
+    ~stanza_flags:conf.buildable.flags
     ~enabled
     ~virtual_deps
     ~dune_version

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -673,6 +673,7 @@ let to_lib_info
     ~jsoo_runtime
     ~wasmoo_runtime
     ~preprocess
+    ~stanza_flags:conf.buildable.flags
     ~enabled
     ~virtual_deps
     ~dune_version

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -237,6 +237,11 @@ module Stanza = struct
         in
         let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
         let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+        let pps_runtime_libs =
+          let open Resolve.Memo.O in
+          let* pps = Lib.Compile.pps compile_info ~for_ in
+          Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+        in
         let obj_dir = Source.obj_dir source in
         Compilation_context.create
           for_
@@ -247,6 +252,7 @@ module Stanza = struct
           ~opaque:(Explicit false)
           ~requires_compile
           ~requires_link
+          ~pps_runtime_libs
           ~flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
           ~melange_package_name:None

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -237,6 +237,11 @@ module Stanza = struct
         in
         let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in
         let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+        let pps_runtime_libs =
+          let open Resolve.Memo.O in
+          let* pps = Lib.Compile.pps compile_info ~for_ in
+          Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+        in
         let obj_dir = Source.obj_dir source in
         Compilation_context.create
           for_
@@ -248,6 +253,7 @@ module Stanza = struct
           ~requires_compile
           ~user_written_requires:None
           ~requires_link
+          ~pps_runtime_libs
           ~flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
           ~melange_package_name:None

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -247,6 +247,7 @@ let setup sctx ~dir =
       ~opaque:(Explicit false)
       ~requires_link
       ~requires_compile:requires
+      ~pps_runtime_libs:(Resolve.Memo.return [])
       ~flags
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -240,6 +240,7 @@ let setup sctx ~dir =
       ~requires_link
       ~requires_compile:requires
       ~user_written_requires:None
+      ~pps_runtime_libs:(Resolve.Memo.return [])
       ~flags
       ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
       ~melange_package_name:None

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -11,6 +11,11 @@ type t =
 
 let no_implements = No_implements
 
+let is_virtual_or_parameter = function
+  | Virtual _ | Parameter _ -> true
+  | No_implements -> false
+;;
+
 let setup_copy_rules_for_impl ~sctx ~dir t =
   match t with
   | No_implements | Parameter _ -> Memo.return ()

--- a/src/dune_rules/virtual_rules.mli
+++ b/src/dune_rules/virtual_rules.mli
@@ -9,6 +9,7 @@ val setup_copy_rules_for_impl
   -> unit Memo.t
 
 val no_implements : t
+val is_virtual_or_parameter : t -> bool
 
 val impl
   :  Super_context.t

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/configurator-c-test.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/configurator-c-test.t
@@ -5,6 +5,7 @@ Configurator.c_test should use the C compiler from the target context.
   $ external_findlib_path="$(ocamlfind printconf path | tr '\n' ':' | sed 's/:$//')"
 
   $ actual_ocamlc="$(command -v ocamlc)"
+  $ actual_ocamldep="$(command -v ocamldep)"
   $ actual_cc="$(command -v cc)"
 
 The host and target toolchains report different C compilers through
@@ -37,6 +38,16 @@ ocamlc -config.
   > fi
   > EOF
   $ chmod +x ocamlc-host ocamlc-target
+
+Dune resolves ocamldep next to ocamlc, so it must exist alongside the mock
+toolchains. Dependency analysis is toolchain-independent, so it delegates to
+the real ocamldep for both contexts.
+
+  $ cat >ocamldep <<EOF
+  > #!/usr/bin/env sh
+  > exec "$actual_ocamldep" "\$@"
+  > EOF
+  $ chmod +x ocamldep
 
 The host C compiler always fails. The target C compiler delegates to the real
 C compiler.

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-ocamlfind.t
@@ -82,6 +82,31 @@ Dune should be able to find it too
       "user_cpu_time"
     ]
   }
+  {
+    "process_args": [
+      "-modules",
+      "-impl",
+      "repro.ml-gen"
+    ],
+    "categories": [],
+    "prog": "$TESTCASE_ROOT/notocamldep-foo",
+    "dir": "_build/default.foo",
+    "exit": 0,
+    "target_files": [
+      "_build/.actions/default.foo/$ACTION"
+    ],
+    "rusage": [
+      "inblock",
+      "majflt",
+      "maxrss",
+      "minflt",
+      "nivcsw",
+      "nvcsw",
+      "oublock",
+      "system_cpu_time",
+      "user_cpu_time"
+    ]
+  }
 
 Library is built in the target context
 

--- a/test/blackbox-tests/test-cases/hidden-deps-unsupported.t/run.t
+++ b/test/blackbox-tests/test-cases/hidden-deps-unsupported.t/run.t
@@ -1,6 +1,6 @@
-This test is guarded by ocaml version <= 5.1, so it should not include foo
-when implicit_transitive_deps is set to false, i.e. testing backward compatibility of
-the new -H feature added.
+This test is guarded by OCaml version <= 5.1. On these compilers,
+false-if-hidden-includes-supported preserves implicit transitive dependencies, so
+foo remains visible with -I rather than -H.
 
   $ getincludes () {
   >   dune build --verbose ./run.exe 2>&1 | grep run.ml | grep -Eo '\-[IH] [a-z/.]+' | sort
@@ -20,20 +20,35 @@ the new -H feature added.
   -I .run.eobjs/byte
   -I .run.eobjs/native
 
+The fallback setting requires Dune language 3.20:
+
   $ cat >dune-project <<EOF
   > (lang dune 3.17)
   > (implicit_transitive_deps false-if-hidden-includes-supported)
   > EOF
 
   $ dune build
+  File "dune-project", line 2, characters 26-60:
+  2 | (implicit_transitive_deps false-if-hidden-includes-supported)
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'false-if-hidden-includes-supported' is only available since version
+  3.20 of the dune language. Please update your dune-project file to have (lang
+  dune 3.20).
+  [1]
+
+Force a recompilation after enabling the fallback setting so getincludes prints
+its compiler flags again:
 
   $ cat >dune-project <<EOF
   > (lang dune 3.20)
   > (implicit_transitive_deps false-if-hidden-includes-supported)
   > EOF
 
+  $ { cat run.ml; echo; } >run.ml.new && mv run.ml.new run.ml
   $ getincludes
   -I .bar.objs/byte
   -I .bar.objs/native
+  -I .foo.objs/byte
+  -I .foo.objs/native
   -I .run.eobjs/byte
   -I .run.eobjs/native

--- a/test/blackbox-tests/test-cases/hidden-deps-unsupported.t/run.t
+++ b/test/blackbox-tests/test-cases/hidden-deps-unsupported.t/run.t
@@ -13,9 +13,7 @@ the new -H feature added.
 
   $ getincludes
   -I .bar.objs/byte
-  -I .bar.objs/byte
   -I .bar.objs/native
-  -I .foo.objs/byte
   -I .foo.objs/byte
   -I .foo.objs/native
   -I .run.eobjs/byte
@@ -36,8 +34,6 @@ the new -H feature added.
 
   $ getincludes
   -I .bar.objs/byte
-  -I .bar.objs/byte
   -I .bar.objs/native
-  -I .run.eobjs/byte
   -I .run.eobjs/byte
   -I .run.eobjs/native

--- a/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
+++ b/test/blackbox-tests/test-cases/inline-tests/alias-cycle.t
@@ -1,5 +1,8 @@
-In this test we check a cycle when a library depends on a genrated source file which in
-turn depends on the inline-test-name alias of the inline tests of the library.
+A library with inline tests depends on a generated source file
+(`bar.ml`) whose rule depends on the library's inline-test
+runtest alias. Building the library requires `bar.ml`; `bar.ml`
+requires the runtest alias; the runtest alias requires the
+library — a dependency cycle.
 
   $ make_dune_project 3.18
 
@@ -7,8 +10,16 @@ turn depends on the inline-test-name alias of the inline tests of the library.
   > (*TEST: assert (1 = 2) *)
   > EOF
 
-  $ write_simple_inline_tests_backend
-  $ cat >>dune <<EOF
+  $ cat >dune <<EOF
+  > (library
+  >  (name backend_simple)
+  >  (modules ())
+  >  (inline_tests.backend
+  >   (generate_runner (run sed "s/(\\\\*TEST:\\\\(.*\\\\)\\\\*)/let () = if \\"%{inline_tests}\\" = \\"enabled\\" then \\\\1;;/" %{impl-files}))))
+  > 
+  > (library
+  >  (name foo_simple)
+  >  (inline_tests (backend backend_simple)))
   > 
   > (rule
   >  (deps
@@ -18,18 +29,27 @@ turn depends on the inline-test-name alias of the inline tests of the library.
   >    (echo "let message = \"Hello world\""))))
   > EOF
 
-This kind of cycle has a difficult to understand error message.
-  $ dune build 2>&1 | grep -vwE "sed"
+Dune detects this cycle and emits a "Dependency cycle between:"
+error. The walk's node sequence depends on rule-scheduling order
+and varies across environments, so the test filters walk nodes
+via `dune_cmd delete` and asserts only the invariants: the
+error header, the runtest alias node, and exit status `[1]`.
+
+What this test catches and what it intentionally doesn't:
+
+| Regression                                       | Caught? |
+|--------------------------------------------------|---------|
+| No cycle at all                                  | yes     |
+| Cycle no longer involves runtest-foo_simple      | yes     |
+| Cycle now involves additional aliases            | yes     |
+| Cycle error header format changes                | yes     |
+| Build exits 0 instead of 1                       | yes     |
+| Cycle has different intermediate file/path nodes | no      |
+
+The intermediate-path dimension is rule-scheduling-dependent;
+asserting it would require periodic re-promotes that contribute
+no meaningful regression coverage.
+  $ dune build 2>&1 | dune_cmd delete '^(File |\d+ \||   _build|-> _build|-> required by|-> %\{|.*sed: )'
   Error: Dependency cycle between:
-     _build/default/bar.ml
-  -> transitive deps of foo_simple__Bar.impl in _build/default
-  -> _build/default/.foo_simple.objs/byte/foo_simple__Bar.cmi
-  -> _build/default/.foo_simple.inline-tests/.t.eobjs/byte/dune__exe__Main.cmo
-  -> _build/default/.foo_simple.inline-tests/inline-test-runner.bc
   -> alias runtest-foo_simple in dune:9
-  -> _build/default/bar.ml
-  -> required by _build/default/.foo_simple.objs/native/foo_simple.cmx
-  -> required by _build/default/foo_simple.a
-  -> required by alias all
-  -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
+++ b/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
@@ -34,8 +34,9 @@ Show `(melange.modules ..)` subset is preferred when compiling in Melange mode
           melc lib/.a.objs/melange/a.{cmi,cmj,cmt}
       ocamldep (internal)
       ocamldep (internal)
-          melc lib/.a.objs/melange/a__Foo.{cmi,cmj,cmt}
+      ocamldep (internal)
         ocamlc lib/.a.objs/byte/a__Helper.{cmi,cmo,cmt}
+          melc lib/.a.objs/melange/a__Foo.{cmi,cmj,cmt}
         ocamlc lib/.a.objs/byte/a__Foo.{cmi,cmo,cmt}
         ocamlc lib/a.cma
   Leaving directory 'a'

--- a/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
+++ b/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
@@ -26,14 +26,19 @@ Show `(melange.modules ..)` subset is preferred when compiling in Melange mode
   > let x = "melange"
   > EOF
 
-  $ dune build --root a
-  $ find a/_build/default/lib/.a.objs/melange -type f | sort
-  a/_build/default/lib/.a.objs/melange/a.cmi
-  a/_build/default/lib/.a.objs/melange/a.cmj
-  a/_build/default/lib/.a.objs/melange/a.cmt
-  a/_build/default/lib/.a.objs/melange/a__Foo.cmi
-  a/_build/default/lib/.a.objs/melange/a__Foo.cmj
-  a/_build/default/lib/.a.objs/melange/a__Foo.cmt
+  $ dune build --root a --display=short
+  Entering directory 'a'
+        ocamlc lib/.a.objs/byte/a.{cmi,cmo,cmt}
+      ocamldep (internal)
+      ocamldep (internal)
+          melc lib/.a.objs/melange/a.{cmi,cmj,cmt}
+      ocamldep (internal)
+      ocamldep (internal)
+          melc lib/.a.objs/melange/a__Foo.{cmi,cmj,cmt}
+        ocamlc lib/.a.objs/byte/a__Helper.{cmi,cmo,cmt}
+        ocamlc lib/.a.objs/byte/a__Foo.{cmi,cmo,cmt}
+        ocamlc lib/a.cma
+  Leaving directory 'a'
   $ find a/_build/default/lib/.melange_src -type f | sort
   a/_build/default/lib/.melange_src/a.ml-gen
   a/_build/default/lib/.melange_src/foo.ml

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/add-unreferenced-sibling-lib.t
@@ -1,26 +1,23 @@
-Observational baseline: adding a library to a stanza's
-[(libraries ...)] list currently rebuilds every module in the
-stanza, including modules that reference nothing from the new
-library. The [-I]/[-H] flags on each module's compiler invocation
-are derived from the cctx-wide library list rather than from the
-module's own ocamldep reference set, so adding an unreferenced
-library still changes every consumer's compile-action hash and
-invalidates the rule cache.
+Adding a library to a stanza's [(libraries ...)] list does not
+rebuild stanza modules that reference nothing from the new
+library. The per-module [-I]/[-H] include filter narrows each
+module's compile-action hash to the libraries its ocamldep
+reference set actually reaches, so an unreferenced added lib
+leaves every other consumer's cache key unchanged.
 
 [consumer_lib] starts with [(libraries existing_dep)] and two
 modules: [consumes_dep] references [Existing_dep_module];
 [unrelated_module] references nothing from [existing_dep] or any
 other library. After the initial build, [added_lib] is added to
 the stanza's [(libraries ...)] list. Neither [consumes_dep] nor
-[unrelated_module] uses anything from [added_lib], yet both
-rebuild. Records the rebuild counts on each so a future change
-can flip them to 0.
+[unrelated_module] uses anything from [added_lib], so neither
+rebuilds — the trace shows empty target lists for both.
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
-  $ write_consumer_lib_dune() {
-  >   local libraries="$*"
-  >   cat > dune <<EOF
+  $ cat > dune <<EOF
   > (library
   >  (name existing_dep)
   >  (wrapped false)
@@ -30,11 +27,8 @@ can flip them to 0.
   >  (name consumer_lib)
   >  (wrapped false)
   >  (modules consumes_dep unrelated_module)
-  >  (libraries ${libraries}))
+  >  (libraries existing_dep))
   > EOF
-  > }
-
-  $ write_consumer_lib_dune existing_dep
 
   $ cat > existing_dep_module.ml <<EOF
   > let x = 42
@@ -60,26 +54,21 @@ can flip them to 0.
 Add [added_lib] to [consumer_lib]'s [(libraries ...)]. Neither
 [consumes_dep] nor [unrelated_module] references [added_lib]:
 
-  $ write_consumer_lib_dune existing_dep added_lib
+  $ cat > dune <<EOF
+  > (library
+  >  (name existing_dep)
+  >  (wrapped false)
+  >  (modules existing_dep_module))
+  > (library (name added_lib) (wrapped false) (modules added_lib_module))
+  > (library
+  >  (name consumer_lib)
+  >  (wrapped false)
+  >  (modules consumes_dep unrelated_module)
+  >  (libraries existing_dep added_lib))
+  > EOF
 
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumes_dep"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmi",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmo",
-        "_build/default/.consumer_lib.objs/byte/consumes_dep.cmt"
-      ]
-    }
-  ]
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("unrelated_module"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmi",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmo",
-        "_build/default/.consumer_lib.objs/byte/unrelated_module.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumes_dep"))]'
+  []
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("unrelated_module"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/basic-wrapped.t
@@ -6,20 +6,60 @@ reference it.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
-  $ make_value_library lib mylib 42
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
 
-  $ make_mylib_consumer_executable
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   print_int (No_use_lib.compute 5)
+  > EOF
 
   $ dune build ./main.exe
 
 Change mylib's interface:
 
-  $ write_mylib_with_new_function
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
 
-No_use_lib is recompiled even though it doesn't reference Mylib:
+No_use_lib is not recompiled because it doesn't reference Mylib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cmx-native-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cmx-native-tight-deps.t
@@ -42,21 +42,22 @@ compile of every module.
 
   $ dune build --profile release consumer/consumer.cmxa
 
-The consumer's native compile rule depends on `dep_lib`'s `.cmi`
-and `.cmx` artefacts (today via globs over the byte and native
-objdirs). The presence of the `.cmx` glob pins that the
-`want_cmx = true` branch fires under release profile.
+The consumer's native compile rule depends on specific `.cmi` and
+`.cmx` file deps of the referenced module `M` in `dep_lib`, with
+no wide globs over the byte/native objdirs. The presence of the
+`m.cmx` file dep pins that the `want_cmx = true` branch fires
+under release profile.
 
   $ dune rules --root . --format=json --profile release --deps '%{cmx:consumer/c}' > deps.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("dep_lib/.dep_lib.objs/byte"))
   >   | .dir + " " + .predicate' < deps.json
-  _build/default/dep_lib/.dep_lib.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("dep_lib/.dep_lib.objs/native"))
   >   | .dir + " " + .predicate' < deps.json
-  _build/default/dep_lib/.dep_lib.objs/native *.cmx
-  $ jq_dune -r '.[] | depsFilePaths
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("dep_lib/.dep_lib.objs/byte/m.cmi"))' < deps.json
-  $ jq_dune -r '.[] | depsFilePaths
+  _build/default/dep_lib/.dep_lib.objs/byte/m.cmi
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("dep_lib/.dep_lib.objs/native/m.cmx"))' < deps.json
+  _build/default/dep_lib/.dep_lib.objs/native/m.cmx

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/consumer-is-virtual-impl.t
@@ -2,7 +2,7 @@ Regression: a stanza with [(implements vlib)] correctly tracks
 changes to its own [(libraries ...)] deps.
 
 For a virtual-library implementation, future per-module
-dependency filtering work (#14116) must preserve deps from the
+dependency filtering work must preserve deps from the
 implementation's own [(libraries ...)] closure — otherwise the
 implementation may fail to rebuild when one of those libraries'
 interfaces changes. This test checks that an [(implements vlib)]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
@@ -1,10 +1,11 @@
 A consumer references a constructor of a leaf library's type
 through an intermediate library where `-open Prelude` is injected
 by an `(env ...)` stanza, not by the intermediate library's own
-`(flags ...)` field. The intermediate's library stanza uses
-`:standard`. Pins that the consumer's compile correctly tracks
-`prelude`'s `.cmi` as a sandbox-required dep when the open enters
-the intermediate's effective flags via the env-stanza path.
+`(flags ...)` field. The intermediate's stanza uses `:standard`.
+Pins that env-stanza-injected `-open` modules extend the BFS
+frontier of [cross_lib_tight_set] identically to stanza-flag
+`-open` modules — the dep lib's `:standard` spec must not
+short-circuit out the env-injected edges.
 
   $ make_dune_project 3.24
 
@@ -18,10 +19,11 @@ the intermediate's effective flags via the env-stanza path.
   > type color = Red | Green | Blue
   > EOF
 
-`middle` is `(wrapped false)`, depends on `prelude`, and uses
-`:standard` flags. The adjacent `(env ...)` stanza injects
-`-open Prelude` into the default profile, so middle's modules see
-`Prelude.color`'s constructors without naming `Prelude`:
+`middle` is `(wrapped false)` so the per-module narrowing walks
+its modules; depends on `prelude`; uses `:standard` flags. The
+adjacent `(env ...)` stanza injects `-open Prelude` into the
+default profile, so middle's modules see `Prelude.color`'s
+constructors without naming `Prelude`:
 
   $ mkdir middle
   $ cat > middle/dune <<EOF

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
@@ -99,8 +99,3 @@ reports [Prelude]:
   > EOF
 
   $ dune build --sandbox=copy native_consumer/native_consumer.exe
-  File "native_consumer/native_consumer.ml", line 2, characters 4-9:
-  2 |   | Green -> print_endline "g"
-          ^^^^^
-  Error: Unbound constructor Green
-  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-env-open-flag-barrier.t
@@ -57,3 +57,50 @@ resolve the constructors.
   > EOF
 
   $ dune build --sandbox=copy consumer/consumer.exe
+
+Native compilation must also account for opens used to compile dependency
+interfaces. An interface is always compiled by ocamlc, even when it is later
+consumed by ocamlopt. Therefore, an [-open] present only in [ocamlc_flags]
+must extend the native walk's frontier as well.
+
+[byte_middle] uses [Prelude.color] in its interface without naming [Prelude].
+Its implementation avoids the constructors so that only the interface needs
+the byte-only open:
+
+  $ mkdir byte_middle
+  $ cat > byte_middle/dune <<EOF
+  > (env (_ (ocamlc_flags (:standard -open Prelude))))
+  > (library
+  >  (name byte_middle)
+  >  (wrapped false)
+  >  (libraries prelude))
+  > EOF
+  $ cat > byte_middle/byte_middle_dep.mli <<EOF
+  > val pick : unit -> color
+  > EOF
+  $ cat > byte_middle/byte_middle_dep.ml <<EOF
+  > let pick () = Obj.magic ()
+  > EOF
+
+The native consumer needs [prelude.cmi] for type-directed constructor lookup.
+The dependency must survive narrowing even though neither ocamldep invocation
+reports [Prelude]:
+
+  $ mkdir native_consumer
+  $ cat > native_consumer/dune <<EOF
+  > (executable
+  >  (name native_consumer)
+  >  (libraries byte_middle prelude))
+  > EOF
+  $ cat > native_consumer/native_consumer.ml <<EOF
+  > let () = match Byte_middle_dep.pick () with
+  >   | Green -> print_endline "g"
+  >   | Red | Blue -> print_endline "nb"
+  > EOF
+
+  $ dune build --sandbox=copy native_consumer/native_consumer.exe
+  File "native_consumer/native_consumer.ml", line 2, characters 4-9:
+  2 |   | Green -> print_endline "g"
+          ^^^^^
+  Error: Unbound constructor Green
+  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/run.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-instrumentation-barrier.t/run.t
@@ -1,7 +1,9 @@
-Regression baseline for an unwrapped library declaring
+Per-module narrowing on an unwrapped library declaring
 `(instrumentation (backend X))` without `--instrument-with` at
-build time. Today, the consumer's compile rule depends on the
-lib's full `.cmi` glob over its objdir.
+build time. The narrowing must (a) not demand non-existent
+`.pp.ml` files from the instrumentation-disabled lib, and (b)
+emit per-module deps instead of the cctx-wide `.cmi` glob over
+`middle`'s objdir.
 
   $ make_dune_project 3.24
 
@@ -41,18 +43,16 @@ no `.pp.ml` files are produced.
   > let _ = Middle.identity 0
   > EOF
 
-Build without `--instrument-with`. Today this succeeds with the
-cctx-wide `.cmi` glob covering `leaf.cmi` through `middle`'s objdir
-chain.
+Build without `--instrument-with`. The narrowing produces per-
+module narrow deps on the consumer's compile rule.
 
   $ dune build consumer/consumer.exe
 
-The consumer's compile rule today carries a wide `.cmi` glob over
-`middle`'s objdir.
+The consumer's compile rule has no glob entry over `middle`'s
+objdir.
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/consumer}' > deps.json
 
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("middle/.middle.objs/byte"))
   >   | .dir + " " + .predicate' < deps.json
-  _build/default/middle/.middle.objs/byte *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-source.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/cross-lib-walk-pre-pp-source.t
@@ -83,13 +83,15 @@ this test will fail with a syntax error from [dep/foo.ml].
 
   $ dune build @check
 
-Confirm that [consumer/c.cmi] depends on [dep]'s objdir for cmis,
-and not on any path that names the pre-pp source. The dep is
-registered as a [*.cmi] glob over the dep's objdir; a future
-regression that switched to a per-file dep on the wrong basename
-(e.g. [dep/.dep.objs/byte/foo.pp.cmi] instead of [foo.cmi]) would
-surface here as a different recorded dep:
+Confirm that [consumer/c.cmi] depends specifically on
+[dep/.dep.objs/byte/foo.cmi] — the per-module filter records only
+the cmis the consumer's ocamldep output names (here, [Foo]), not
+a glob over the whole library's objdir, and not [bar.cmi] which
+the consumer does not reference. A regression that resurrected
+the broad-glob form, or that switched to the wrong basename
+(e.g. [foo.pp.cmi] instead of [foo.cmi]), would surface here as a
+different recorded dep:
 
   $ dune rules --root . --format=json --deps _build/default/consumer/.consumer.objs/byte/c.cmi |
-  > jq_dune -r '.[] | depsGlobPredicates'
-  *.cmi
+  > jq -r 'include "dune"; .[] | depsFilePaths | select(test("dep/.dep.objs"))'
+  _build/default/dep/.dep.objs/byte/foo.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/implicit-transitive-deps-false.t
@@ -1,4 +1,4 @@
-Observational baseline: under [(implicit_transitive_deps false)],
+Under [(implicit_transitive_deps false)],
 the consumer [main] uses [intermediate_lib] which declares
 [link_only_lib] as a transitive dep. [main]'s source never
 references any module of [link_only_lib]; under
@@ -11,22 +11,19 @@ The mode-with-[-H] is only reached on dune lang [3.17+] with an
 OCaml compiler that supports hidden includes (5.2+); older dune
 lang versions fall back to mode [Disabled] without [-H]. This
 test pins [(lang dune 3.23)] below to keep the [-H]-glob path the
-one exercised — that is the path the future per-module filter is
-expected to tighten.
+one exercised — that is the path this PR's per-module filter
+tightens.
 
-On trunk today, [main]'s compile rule globs over
+Without this PR's filter, [main]'s compile rule globs over
 [link_only_lib]'s objdir as part of the cctx-wide [-H] glob, so
 any [.cmi] content change in [link_only_lib] invalidates [main].
-A tighter per-module filter could observe that no
-[link_only_lib] entry name reaches [main]'s reference closure
-and drop the lib from [main]'s compile-rule deps.
+The per-module filter observes that no [link_only_lib] entry
+name reaches [main]'s reference closure and drops the lib from
+[main]'s compile-rule deps entirely; [main] is no longer
+rebuilt.
 
-Reported by @nojb in
-https://github.com/ocaml/dune/pull/14116#issuecomment-4323883194
-and again, after a partial fix, in
-https://github.com/ocaml/dune/pull/14116#issuecomment-4331209820.
-Records [main]'s current rebuild count so a future per-module
-filter can flip it to 0.
+Reported by @nojb (first as a baseline case, then again after a
+partial fix).
 
   $ cat > dune-project <<EOF
   > (lang dune 3.23)
@@ -64,24 +61,10 @@ filter can flip it to 0.
   $ dune build ./main.exe
 
 Empty [link_only_module.ml] so its [.cmi] loses the [val x : int]
-binding. The cctx-wide glob over [link_only_lib]'s objdir fires
-on the [.cmi] content change, invalidating [main] — both the
-[.cmi]/[.cmti] rule and the [.cmx]/[.o] rule re-run:
+binding. The per-module filter dropped [link_only_lib] from
+[main]'s deps, so no [Main]-named target re-runs:
 
   $ echo > link_only_module.ml
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
-        "_build/default/.main.eobjs/native/dune__exe__Main.o"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-deps-preserved.t
@@ -1,9 +1,13 @@
-Verify that library file deps are declared for module compilation rules.
+Verify the cm_kind/-opaque rules for library file deps in compile rules.
 
-Every non-alias module should declare glob deps on its library
-dependencies' .cmi files.
+[mylib] is a wrapped library exposing one entry [Mylib]. The
+executable has two modules: [Uses_lib] which references [Mylib] in
+its [.ml] (but not its [.mli]) and [Main] which references only
+[Uses_lib]. [Main] has no [.mli].
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ mkdir lib
   $ cat > lib/dune <<EOF
@@ -31,12 +35,17 @@ dependencies' .cmi files.
 
   $ dune build ./main.exe
 
-Both modules declare glob deps on mylib's .cmi files:
+[Uses_lib.cmx] keeps the glob: [Uses_lib.ml] references [Mylib], a
+wrapped library that falls back to a directory glob over its public
+cmi dir.
 
   $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Uses_lib.cmx |
-  > jq_dune -r '.[] | depsGlobPredicates'
+  > jq -r 'include "dune"; .[] | depsGlobPredicates'
   *.cmi
 
+[Main.cmx] has no inter-library deps. Under [-opaque] (the default
+profile), [Uses_lib]'s references to [Mylib] are sealed behind
+[Uses_lib]'s [.cmi] and don't propagate to [Main]'s native compile.
+
   $ dune rules --root . --format=json --deps _build/default/.main.eobjs/native/dune__exe__Main.cmx |
-  > jq_dune -r '.[] | depsGlobPredicates'
-  *.cmi
+  > jq -r 'include "dune"; .[] | depsGlobPredicates'

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-unwrapped.t
@@ -1,12 +1,14 @@
-Baseline: library-to-library recompilation (unwrapped).
+Per-module library-to-library filtering (unwrapped).
 
 When an unwrapped library A depends on an unwrapped library B with multiple
-modules, and one module in B changes, all modules in A are recompiled due to
-coarse dependency analysis.
+modules, modules of A that do not reference a given module of B must not be
+recompiled when that module of B changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
   $ mkdir base_unwrapped
   $ cat > base_unwrapped/dune <<EOF
@@ -78,11 +80,11 @@ Change only alpha.mli:
   > let new_alpha_fn () = "alpha"
   > EOF
 
-uses_beta is recompiled even though it only references Beta, not Alpha:
+uses_beta references Beta only, not Alpha, so it is not recompiled:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("uses_beta"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_beta"))] | length'
+  0
 
 Change only beta.mli:
 
@@ -95,8 +97,8 @@ Change only beta.mli:
   > let new_beta_fn () = "beta"
   > EOF
 
-uses_alpha is recompiled even though it only references Alpha, not Beta:
+uses_alpha references Alpha only, not Beta, so it is not recompiled:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("uses_alpha"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_alpha"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/lib-to-lib-wrapped.t
@@ -5,7 +5,9 @@ in A are recompiled due to coarse dependency analysis.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
   $ mkdir base_lib
   $ cat > base_lib/dune <<EOF
@@ -60,8 +62,8 @@ See: https://github.com/ocaml/dune/issues/4572
   > let new_base_fn () = "hello"
   > EOF
 
-Standalone in middle_lib is recompiled even though it doesn't use base_lib:
+Standalone in middle_lib is not recompiled because it doesn't use base_lib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Standalone"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess-precision.t
@@ -1,10 +1,10 @@
-Reproduction: today, building only the consumer's `.cmo` of an
-executable that depends on `mylib` (where `mylib` has two modules,
-`a` default-pp and `b` `(staged_pps ...)`) fails on a compile error
-in `mylib/b.ml` — even though the consumer references only `A`.
-The cctx-wide `.cmi` glob over `mylib`'s objdir pulls `b.cmi` into
-the consumer's compile rule, which forces dune to compile `b.ml`,
-and `b.ml` contains an unresolvable identifier.
+Precision regression guard for per-pair tight-eligibility on an
+unwrapped library with mixed per-module preprocessing. When a
+consumer references only the default-pp module of a mixed-pp lib,
+the per-module narrowing excludes the staged-pps module from the
+consumer's compile-rule deps. Asserted by giving the staged-pps
+module an unresolvable identifier; if the narrowing regressed,
+dune would compile that module and fail.
 
 Companion to `mixed-per-module-preprocess.t` (the soundness sibling).
 
@@ -12,7 +12,23 @@ Companion to `mixed-per-module-preprocess.t` (the soundness sibling).
 
 A no-op staged ppx (identical to the soundness reproducer).
 
-  $ make_noop_ppx_rewriter
+  $ mkdir ppx
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name ppx_noop)
+  >  (kind ppx_rewriter)
+  >  (ppx.driver (main Ppx_noop.main)))
+  > EOF
+  $ cat > ppx/ppx_noop.ml <<EOF
+  > let main () =
+  >   let n = Array.length Sys.argv in
+  >   if n < 4 || Sys.argv.(1) <> "--as-ppx" then assert false;
+  >   let input = Sys.argv.(n - 2) in
+  >   let output = Sys.argv.(n - 1) in
+  >   Filename.quote_command "cp" [input; output]
+  >   |> Sys.command
+  >   |> exit
+  > EOF
 
 `mylib`: `a` uses default preprocessing (Some-entry); `b` uses
 `(staged_pps ...)` (None-entry). `a`'s source is independent of `b`;
@@ -43,27 +59,21 @@ it will fail.
   > let () = print_int A.answer
   > EOF
 
-The consumer's compile rule tracks the wide glob over `mylib`'s
-byte objdir — which materialises `b.cmi` and so forces dune to
-compile `b.ml`.
+The consumer's compile rule tracks only `a.cmi` from `mylib`'s
+byte objdir — narrowing dropped the wide glob, so `b.cmi` is not
+materialised and `b.ml` is not compiled.
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/consumer}' > deps.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("mylib/.mylib.objs/byte"))
   >   | .dir + " " + .predicate' < deps.json
-  _build/default/mylib/.mylib.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsFilePaths
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("mylib/.mylib.objs/byte/a.cmi"))' < deps.json
-  $ jq_dune -r '.[] | depsFilePaths
+  _build/default/mylib/.mylib.objs/byte/a.cmi
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("mylib/.mylib.objs/byte/b.cmi"))' < deps.json
 
-Build only the consumer's `.cmo` (compile rule, not link). Today,
-dune attempts to compile `b.ml` to produce `b.cmi` and fails on
-the unresolvable identifier.
+Build only the consumer's `.cmo` (compile rule, not link). The
+narrowed dep set means `b.ml` is not compiled.
 
   $ dune build '%{cmo:consumer/consumer}'
-  File "mylib/b.ml", line 1, characters 10-23:
-  1 | let bar = no_such_thing
-                ^^^^^^^^^^^^^
-  Error: Unbound value no_such_thing
-  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/mixed-per-module-preprocess.t
@@ -10,7 +10,23 @@ A no-op staged ppx, modelled on
 `test/blackbox-tests/test-cases/staged-pps-relative-directory-gh8158.t`.
 The driver copies its input verbatim.
 
-  $ make_noop_ppx_rewriter
+  $ mkdir ppx
+  $ cat > ppx/dune <<EOF
+  > (library
+  >  (name ppx_noop)
+  >  (kind ppx_rewriter)
+  >  (ppx.driver (main Ppx_noop.main)))
+  > EOF
+  $ cat > ppx/ppx_noop.ml <<EOF
+  > let main () =
+  >   let n = Array.length Sys.argv in
+  >   if n < 4 || Sys.argv.(1) <> "--as-ppx" then assert false;
+  >   let input = Sys.argv.(n - 2) in
+  >   let output = Sys.argv.(n - 1) in
+  >   Filename.quote_command "cp" [input; output]
+  >   |> Sys.command
+  >   |> exit
+  > EOF
 
 `mylib` is `(wrapped false)` with `a` default-pp and `b` staged-pps.
 `a`'s interface mentions `B.t`, so the consumer's call to
@@ -57,7 +73,7 @@ objdir — both `a.cmi` (referenced) and `b.cmi` (needed for the
 type of `A.identity`).
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/consumer}' > deps.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("mylib/.mylib.objs/byte"))
   >   | .dir + " " + .predicate' < deps.json
   _build/default/mylib/.mylib.objs/byte *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/modules-without-implementation-cross-lib.t
@@ -5,7 +5,7 @@ lib's interface changes, the consumer rebuilds without the
 compiler complaining about inconsistent assumptions over
 interface.
 
-Reported by @art-w on #14116. The concern was that
+Reported by @art-w. The concern was that
 [(modules_without_implementation)] entries' aliases to other
 libs might escape the per-module dep filter (the intra-stanza
 [trans_deps] graph skips them), leaving the consumer's compile

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/multiple-libraries.t
@@ -6,11 +6,33 @@ library.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
-  $ make_value_library lib mylib 42
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
 
-  $ make_value_library lib2 otherlib 100 other_value
+  $ mkdir lib2
+  $ cat > lib2/dune <<EOF
+  > (library
+  >  (name otherlib))
+  > EOF
+  $ cat > lib2/otherlib.ml <<EOF
+  > let other_value = 100
+  > EOF
+  $ cat > lib2/otherlib.mli <<EOF
+  > val other_value : int
+  > EOF
 
   $ cat > uses_lib.ml <<EOF
   > let get_value () = Mylib.value
@@ -47,13 +69,20 @@ See: https://github.com/ocaml/dune/issues/4572
 
 Change only mylib's interface:
 
-  $ write_mylib_with_new_function
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
 
-Uses_other is recompiled even though it only uses Otherlib, not Mylib:
+Uses_other is not recompiled because it only uses Otherlib, not Mylib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Uses_other"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_other"))] | length'
+  0
 
 Change only otherlib's interface:
 
@@ -66,8 +95,8 @@ Change only otherlib's interface:
   > let new_other_fn s = s ^ "!"
   > EOF
 
-Uses_lib is recompiled even though it only uses Mylib, not Otherlib:
+Uses_lib is not recompiled because it only uses Mylib, not Otherlib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Uses_lib"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_lib"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque-mli-change.t
@@ -51,12 +51,6 @@ left unexported, which would trip warning 32 under dev):
   [
     {
       "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
         "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
         "_build/default/.main.eobjs/native/dune__exe__Main.o"
       ]
@@ -88,12 +82,6 @@ Add another paired declaration:
   $ dune build ./main.exe
   $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("dune__exe__Main"))]'
   [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
     {
       "target_files": [
         "_build/default/.main.eobjs/native/dune__exe__Main.cmx",

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/opaque.t
@@ -8,11 +8,44 @@ implementation-only change triggers no module recompilation at all.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
-  $ make_value_library lib mylib 42
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
 
-  $ make_mylib_consumer_executable
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries mylib))
+  > EOF
+  $ cat > uses_lib.ml <<EOF
+  > let get_value () = Mylib.value
+  > EOF
+  $ cat > uses_lib.mli <<EOF
+  > val get_value : unit -> int
+  > EOF
+  $ cat > no_use_lib.ml <<EOF
+  > let compute x = x + 1
+  > EOF
+  $ cat > no_use_lib.mli <<EOF
+  > val compute : int -> int
+  > EOF
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_int (Uses_lib.get_value ());
+  >   print_int (No_use_lib.compute 5)
+  > EOF
 
 --- Release profile (opaque=false): .cmx deps are tracked ---
 
@@ -29,11 +62,11 @@ Change ONLY the implementation (not the interface):
   > let value = 43
   > EOF
 
-No_use_lib is recompiled even though it doesn't reference Mylib:
+No_use_lib is not recompiled because it doesn't reference Mylib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("No_use_lib"))] | length'
+  0
 
 --- Dev profile (opaque=true): .cmx deps are NOT tracked for local libs ---
 
@@ -56,5 +89,5 @@ No modules recompile (opaque means only .cmi is a dependency, and .cmi
 didn't change):
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("dune__exe"))] | length'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe"))] | length'
   0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/per-module-include-flags.t
@@ -1,15 +1,12 @@
-Observational baseline: a consumer module's compile command
-currently carries [-I] flags for every library in the cctx-wide
-[(libraries ...)] closure, regardless of which libraries the
-module's source actually references.
+A consumer module's compile command carries [-I] flags only for
+the libraries its ocamldep reference set actually reaches, not
+for every library in the cctx-wide [(libraries ...)] closure.
 
 [consumer_lib] declares two library dependencies, [dep_lib] and
 [unrelated_lib], but its only module references just [Dep_module].
-A future per-module filter could observe via ocamldep that the
-module references nothing from [unrelated_lib] and drop that
-library's objdir from the [-I] path. This test records today's
-[-I] contents so that a future filter improvement can flip the
-asserted array to a single entry.
+The per-module filter observes via ocamldep that the module
+references nothing from [unrelated_lib] and drops that library's
+objdir from the [-I] path; only [dep_lib]'s objdir survives.
 
   $ make_dune_project 3.0
 
@@ -38,12 +35,10 @@ asserted array to a single entry.
 Inspect the [-I] flags on [consumer_module]'s [.cmo] compile rule.
 Filter to objdir-shaped paths so we don't print the consumer's
 own [.consumer_lib.objs/byte] entry — that's always present and
-not what this test is about. Today both [dep_lib]'s objdir and
-[unrelated_lib]'s objdir appear:
+not what this test is about. Only [dep_lib]'s objdir appears:
 
   $ dune rules --root . --format=json _build/default/.consumer_lib.objs/byte/consumer_module.cmo \
   > | jq_dune '.[] | [ruleActionFlagValues("-I") | select(test("\\.dep_lib\\.objs|\\.unrelated_lib\\.objs"))]'
   [
-    ".dep_lib.objs/byte",
-    ".unrelated_lib.objs/byte"
+    ".dep_lib.objs/byte"
   ]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/sibling-unreferenced-lib.t
@@ -7,25 +7,25 @@ of the dependency library [dep_lib] has its interface edited.
 
 [consumer_lib] is an unwrapped library with two modules.
 [consumes_dep] references [Referenced_dep]; [spurious_rebuild]
-references nothing from [dep_lib]. On current main, editing
-[referenced_dep]'s interface rebuilds [spurious_rebuild] even
-though it references nothing from [dep_lib]: the consumer depends
-on a glob over [dep_lib]'s object directory, which is invalidated
-by the cmi change.
+references nothing from [dep_lib]. The per-module filter drops
+[dep_lib] from [spurious_rebuild]'s compile-rule deps because
+[spurious_rebuild]'s ocamldep output names no module of [dep_lib],
+so editing [referenced_dep]'s interface fires no
+[spurious_rebuild]-named rule.
 
 The zero-reference-sibling-in-a-library corner is distinct from
 scenarios covered by existing tests: [lib-to-lib-unwrapped.t] probes
 siblings that reference a different (non-edited) module of the dep;
 [transitive.t] and [unwrapped.t] probe zero-reference modules but
-within executable stanzas, not library stanzas. A future fix
-implementing library-level dep filtering at consumer-module
-granularity would drop [dep_lib] entirely from [spurious_rebuild]'s
-deps, tightening this corner to zero rebuilds.
+within executable stanzas, not library stanzas. Previously the
+consumer fell back to a glob over [dep_lib]'s objdir, which the
+cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
-See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ cat > dune <<EOF
   > (library
@@ -57,9 +57,10 @@ See: https://github.com/ocaml/dune/pull/14116#issuecomment-4301275263
 
   $ dune build @check
 
-Edit [referenced_dep]'s interface. [spurious_rebuild] references
-nothing in [dep_lib]. Record the number of [spurious_rebuild]
-rebuild targets observed in the trace:
+Edit [referenced_dep]'s interface (add a binding to both [.mli]
+and [.ml] so the [.cmi] content actually changes). [spurious_rebuild]
+references nothing from [dep_lib], so its compile rule should not
+fire — no rule with a [spurious_rebuild]-named target re-runs:
 
   $ cat > referenced_dep.mli <<EOF
   > val x : int
@@ -70,5 +71,5 @@ rebuild targets observed in the trace:
   > let y = "hello"
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-lib.t
@@ -1,15 +1,16 @@
-Single-module library consumers and recompilation behavior.
+Per-module filtering for single-module library consumers.
 
-When a consumer library has only one module, dune skips ocamldep for that
-stanza as an optimization (no intra-stanza deps to compute). This means
-per-module library dependency filtering cannot determine which libraries
-the module actually references, so the consumer depends on all library
-files via glob. Modifying an unused module in a dependency triggers
-unnecessary recompilation of the consumer module's .cmo/.cmx.
+A consumer library with a single module still runs ocamldep when it has
+library dependencies, and the per-module filter uses that output to
+dep on only the specific entry modules of an unwrapped dependency that
+the consumer actually references. Modifying an unreferenced module of
+the dependency does not recompile the consumer.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ mkdir base_lib
   $ cat > base_lib/dune <<EOF
@@ -59,25 +60,8 @@ Modify only the unused module:
   > let new_fn () = "new"
   > EOF
 
-uses_alpha.cmx is recompiled even though uses_alpha.ml only references
-Alpha, not Unused. This is because the consumer_lib stanza has a single
-module, so dune skips ocamldep for it and falls back to glob deps on all
-of base_lib's .cmi files. The trace shows compilation targets for
-uses_alpha being rebuilt:
+uses_alpha.ml references Alpha only, not Unused, so it is not recompiled:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("uses_alpha"))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/uses_alpha.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/uses_alpha.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/native/uses_alpha.cmx",
-        "_build/default/consumer_lib/.consumer_lib.objs/native/uses_alpha.o"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("uses_alpha"))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/single-module-unreferenced-lib.t
@@ -8,24 +8,22 @@ edited.
 
 [consumer_lib] declares [(libraries dep_lib)] but
 [spurious_rebuild.ml] does not reference any module of [dep_lib].
-On current main this scenario still rebuilds [spurious_rebuild]:
-[consumer_lib] is a single-module stanza, so dune skips ocamldep
-as an optimisation and cannot discover that [spurious_rebuild]
-references no module of [dep_lib]; the consumer falls back to a
-glob over [dep_lib]'s object directory, which is invalidated by
-the cmi change.
+The per-module filter drops [dep_lib] from [spurious_rebuild]'s
+compile-rule deps for this single-module consumer, so editing
+[dep_module]'s interface fires no [spurious_rebuild]-named rule.
 
 The zero-reference case is a distinct corner from the single-module
 consumer that references some (but not all) modules of its dep,
-which [single-module-lib.t] already documents. A future fix that
-detects "ocamldep yields no references to dep_lib" could tighten
-this corner to zero rebuilds without needing to solve the broader
-single-module-consumer skip-ocamldep limitation.
+which [single-module-lib.t] already documents. Previously this
+overrebuilt because dune skipped ocamldep for single-module
+stanzas as an optimisation and so fell back to a glob over
+[dep_lib]'s objdir, which the cmi change invalidated.
 
 See: https://github.com/ocaml/dune/issues/4572
-See: https://github.com/ocaml/dune/pull/14116#issuecomment-4286949811
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules dep_module))
@@ -61,5 +59,5 @@ rebuild targets observed in the trace:
   > let y = "hello"
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
-  1
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("spurious_rebuild"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/singleton-with-requires.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/singleton-with-requires.t
@@ -62,27 +62,25 @@ rule must surface `Mod_leaf.cmi` — reached transitively through
 `Mod_bridge.cmi`'s interface, never named in consumer source.
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/uses_bridge}' > deps_uses.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("bridge/.bridge.objs/byte"))
   >   | .dir + " " + .predicate' < deps_uses.json
-  _build/default/bridge/.bridge.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("leaf/.leaf.objs/byte"))
   >   | .dir + " " + .predicate' < deps_uses.json
-  _build/default/leaf/.leaf.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsFilePaths
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("bridge/.bridge.objs/byte/mod_bridge.cmi"))' < deps_uses.json
-  $ jq_dune -r '.[] | depsFilePaths
+  _build/default/bridge/.bridge.objs/byte/mod_bridge.cmi
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("leaf/.leaf.objs/byte/mod_leaf.cmi"))' < deps_uses.json
+  _build/default/leaf/.leaf.objs/byte/mod_leaf.cmi
 
 Case 2: `sibling` references neither lib in source.
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/sibling}' > deps_sib.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("bridge/.bridge.objs/byte"))
   >   | .dir + " " + .predicate' < deps_sib.json
-  _build/default/bridge/.bridge.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("leaf/.leaf.objs/byte"))
   >   | .dir + " " + .predicate' < deps_sib.json
-  _build/default/leaf/.leaf.objs/byte *.cmi

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/stdlib-modules.t
@@ -5,9 +5,21 @@ not need recompilation when the library changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
-  $ make_value_library lib mylib 42
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > EOF
 
   $ cat > dune <<EOF
   > (executable
@@ -34,10 +46,17 @@ See: https://github.com/ocaml/dune/issues/4572
 
   $ dune build ./main.exe
 
-  $ write_mylib_with_new_function
+  $ cat > lib/mylib.mli <<EOF
+  > val value : int
+  > val new_function : unit -> string
+  > EOF
+  $ cat > lib/mylib.ml <<EOF
+  > let value = 42
+  > let new_function () = "hello"
+  > EOF
 
-Uses_stdlib is recompiled even though it only uses Printf, not Mylib:
+Uses_stdlib is not recompiled because it only uses Printf, not Mylib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Uses_stdlib"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_stdlib"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-lib.t
@@ -4,15 +4,13 @@ any of [dep_lib]'s modules. The consumer [main] uses
 [intermediate_lib] and so transitively gains [dep_lib] in its
 compilation context.
 
-Today every consumer module declares a glob over each transitively-
-reached library's public-cmi directory, so editing
-[unreferenced_dep.ml] (which no source file references) re-
-invalidates [Main]. The test records the current rebuild targets
-for [Main] when [unreferenced_dep.ml] is touched.
-
-This test is observational: a tighter dependency tracker that drops
-unreferenced libraries from compile rules' deps would shrink the
-recorded target list.
+The per-module filter detects that no consumer module references
+any [dep_lib] module — directly or transitively through
+[intermediate_lib] — and drops [dep_lib] entirely from [Main]'s
+compile-rule deps, so editing [unreferenced_dep.ml] leaves [Main]
+untouched. Previously every consumer module declared a glob over
+each transitively-reached library's public-cmi directory, so the
+edit re-invalidated [Main].
 
 [intermediate_lib] and the [main] executable each include an unused
 dummy module ([intermediate_dummy] / [main_dummy]) so that ocamldep
@@ -20,7 +18,9 @@ runs unconditionally for both stanzas. Single-module stanzas trigger
 a short-circuit in [dep_rules.ml] that skips ocamldep, which would
 mask the per-module dependency filtering being baselined here.
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ cat > dune <<EOF
   > (library
@@ -74,23 +74,9 @@ references any module of [dep_lib]:
 
 Edit [unreferenced_dep.ml]. Neither [main.ml] nor
 [intermediate_module.ml] references [Unreferenced_dep] or any
-other [dep_lib] module, so a tighter filter could leave [Main]
-untouched. Today [Main] is rebuilt:
+other [dep_lib] module, so the filter leaves [Main] untouched:
 
   $ echo > unreferenced_dep.ml
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmo",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive-unreferenced-module.t
@@ -1,14 +1,17 @@
 A consumer transitively depends upon a library through one module of an
 intermediate library, never naming a sibling module of the transitive lib in
-source. The current but undesirable behaviour is that the consumer rebuilds
-when any module of the transitively depended upon library changes, even
-unreferenced ones.
+source. The per-module filter walks ocamldep output across library
+boundaries: editing [unreached_module] leaves [main] untouched because no
+source in this test references it. Previously this overrebuilt because
+the consumer's compile rule depended on a glob over [dep_lib]'s objdir.
 
 [intermediate_lib] and [main] each include an unused dummy module so neither
 stanza is single-module — single-module stanzas take a fast path that would
 mask the behaviour being baselined here.
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
   $ cat > dune <<EOF
   > (library (name dep_lib) (wrapped false) (modules reached_module unreached_module))
@@ -55,18 +58,5 @@ test references — and record the rebuild list for [main]:
   > let extra = 99
   > EOF
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmi",
-        "_build/default/.main.eobjs/byte/dune__exe__Main.cmti"
-      ]
-    },
-    {
-      "target_files": [
-        "_build/default/.main.eobjs/native/dune__exe__Main.cmx",
-        "_build/default/.main.eobjs/native/dune__exe__Main.o"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("dune__exe__Main\\."))]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/transitive.t
@@ -5,7 +5,9 @@ modules in the consuming stanza, even those that don't use A.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
   $ mkdir libB
   $ cat > libB/dune <<EOF
@@ -71,8 +73,8 @@ Change libB's interface:
   > let new_base_fn () = "new"
   > EOF
 
-Independent is recompiled even though it doesn't reference libA or libB:
+Independent is not recompiled because it doesn't reference libA or libB:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Independent"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Independent"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-explicit-modules.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-explicit-modules.t
@@ -1,11 +1,13 @@
-Regression baseline for the cctx-wide `.cmi` glob over an unwrapped
-library whose module set is declared explicitly via `(modules ...)`.
-Today, editing one sibling module's `.mli` invalidates every
-sibling's compile rule — even siblings that don't reference it.
+Per-module narrowing on a `(wrapped false)` library whose module
+set is declared explicitly via `(modules ...)`. Under the per-
+module narrowing, editing one sibling module's `.mli` invalidates
+only modules that reference it — siblings that don't are
+unaffected. Matches the implicit-discovery behaviour covered by
+`lib-to-lib-unwrapped.t`, but the explicit `(modules ...)` clause
+routes through a different parse path; this test pins the
+equivalence observationally.
 
-Matches the shape raised in #14492's review feedback. The explicit
-`(modules ...)` clause routes through a different parse path from
-the implicit form covered by `lib-to-lib-unwrapped.t`.
+Matches the shape raised in #14492's review feedback.
 
   $ make_dune_project 3.24
 
@@ -54,61 +56,44 @@ references `A` only; `uses_b` references `B` only.
 
   $ dune build @check
 
-Each consumer compile rule carries a wide `.cmi` glob over `foo`'s
-objdir; no specific cmi from `foo` appears as a file dep. The wide
-glob is the structural cause of the sibling over-rebuilds asserted
-below.
+Each consumer compile rule depends on only the specific cmi it
+references — `uses_a` on `a.cmi`, `uses_b` on `b.cmi` — with no
+wide glob over `foo`'s objdir.
 
   $ dune rules --root . --format=json --deps '%{cmo:consumer/uses_a}' > deps_a.json
   $ dune rules --root . --format=json --deps '%{cmo:consumer/uses_b}' > deps_b.json
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("foo/.foo.objs/byte"))
   >   | .dir + " " + .predicate' < deps_a.json
-  _build/default/foo/.foo.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsGlobs
+  $ jq -r 'include "dune"; .[] | depsGlobs
   >   | select(.dir | endswith("foo/.foo.objs/byte"))
   >   | .dir + " " + .predicate' < deps_b.json
-  _build/default/foo/.foo.objs/byte *.cmi
-  $ jq_dune -r '.[] | depsFilePaths
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("foo/.foo.objs/byte/a.cmi"))' < deps_a.json
-  $ jq_dune -r '.[] | depsFilePaths
+  _build/default/foo/.foo.objs/byte/a.cmi
+  $ jq -r 'include "dune"; .[] | depsFilePaths
   >   | select(endswith("foo/.foo.objs/byte/b.cmi"))' < deps_b.json
+  _build/default/foo/.foo.objs/byte/b.cmi
 
 Case 1: edit `A`'s interface to expose `extra`. `uses_b` references
-only `B`, but the cctx-wide `.cmi` glob over `foo`'s objdir includes
-`A.cmi`, so today `uses_b.cm*` rebuilds anyway.
+only `B`, so the per-module narrowing must drop `A.cmi` from
+`uses_b`'s dep set — `uses_b.cm*` must not rebuild.
 
   $ cat > foo/a.mli <<EOF
   > val v : int
   > val extra : string
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatching("uses_b.cm")]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer/.consumer.objs/byte/uses_b.cmi",
-        "_build/default/consumer/.consumer.objs/byte/uses_b.cmo",
-        "_build/default/consumer/.consumer.objs/byte/uses_b.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatching("uses_b.cm")]'
+  []
 
-Case 2: edit `B`'s interface to expose `extra`. Symmetric — today
-`uses_a.cm*` rebuilds anyway.
+Case 2: edit `B`'s interface to expose `extra`. Symmetric —
+`uses_a.cm*` must not rebuild.
 
   $ cat > foo/b.mli <<EOF
   > val v : int
   > val extra : string
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatching("uses_a.cm")]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer/.consumer.objs/byte/uses_a.cmi",
-        "_build/default/consumer/.consumer.objs/byte/uses_a.cmo",
-        "_build/default/consumer/.consumer.objs/byte/uses_a.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatching("uses_a.cm")]'
+  []

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped-tight-deps.t
@@ -7,18 +7,19 @@ the dependency library [dep_lib] has its interface edited.
 [consumer] references only [Referenced_dep] from [dep_lib];
 [Unread_dep_a] and [Unread_dep_b] are present but unreferenced.
 
-On current main, editing any of the three rebuilds [consumer]
-because library-level dependency filtering (and, within that,
-per-module tightening) is not yet in place: the consumer is
-conservatively rebuilt whenever any entry module's cmi changes.
-Work on https://github.com/ocaml/dune/issues/4572 is expected to
-tighten this, at which point editing [Unread_dep_a] or
-[Unread_dep_b] leaves [consumer] untouched and the emitted target
-list becomes empty.
+The per-module filter restricts [consumer]'s deps to modules of
+[dep_lib] that [consumer]'s ocamldep output names — only
+[Referenced_dep]. Editing [Unread_dep_a] or [Unread_dep_b] thus
+leaves [consumer] untouched (empty target list); editing
+[Referenced_dep] still rebuilds it. Previously all three edits
+rebuilt [consumer] because the consumer was conservatively
+rebuilt whenever any entry module's cmi changed.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.23
+  $ cat > dune-project <<EOF
+  > (lang dune 3.23)
+  > EOF
 
 [dep_lib] is an unwrapped library with three entry modules, each
 with an explicit interface so signature changes propagate through
@@ -81,16 +82,8 @@ reference — and record the rebuild targets for [consumer]:
   > let extra () = 7
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  []
 
 Same for [Unread_dep_b]:
 
@@ -103,16 +96,8 @@ Same for [Unread_dep_b]:
   > let other = "hi"
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
-  [
-    {
-      "target_files": [
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmi",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmo",
-        "_build/default/consumer_lib/.consumer_lib.objs/byte/consumer.cmt"
-      ]
-    }
-  ]
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  []
 
 Edit [Referenced_dep]'s interface — the one module [consumer] does
 reference — and record the rebuild targets ([consumer] must
@@ -127,7 +112,7 @@ rebuild):
   > let new_fn x = x + 1
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer_lib/\\.consumer_lib\\.objs/byte/consumer\\."))]'
   [
     {
       "target_files": [

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/unwrapped.t
@@ -1,12 +1,12 @@
-Baseline: library dependency recompilation for unwrapped libraries.
-
-When an unwrapped library module's interface changes, Dune currently recompiles
-all modules in stanzas that depend on the library, even those referencing
-different modules in the library.
+Per-module filtering for unwrapped libraries: a consumer that references
+only some modules of an unwrapped library must not be recompiled when
+unreferenced modules in that library change.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 3.0
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
 
   $ mkdir unwrapped
   $ cat > unwrapped/dune <<EOF
@@ -71,11 +71,11 @@ Change only helper.mli:
   > let new_helper s = s ^ "!"
   > EOF
 
-Uses_utils is recompiled even though it only references Utils, not Helper:
+Uses_utils references Utils only, not Helper, so it is not recompiled:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Uses_utils"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_utils"))] | length'
+  0
 
 Change only utils.mli:
 
@@ -88,8 +88,8 @@ Change only utils.mli:
   > let new_utils s = s ^ "?"
   > EOF
 
-Uses_helper is recompiled even though it only references Helper, not Utils:
+Uses_helper references Helper only, not Utils, so it is not recompiled:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Uses_helper"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Uses_helper"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
@@ -103,3 +103,50 @@ the [.cmi] content change invalidates the consumer:
       ]
     }
   ]
+
+The wrapped library can also be discovered after the initial consumer
+references. Its closure must still take the conservative glob path.
+
+[bridge] is unwrapped and re-exports an alias from the wrapped [middle]
+library. [middle]'s child in turn aliases [leaf]:
+
+  $ mkdir transitive-wrapped && cd transitive-wrapped
+  $ make_dune_project 3.23
+  $ mkdir leaf middle bridge consumer
+  $ cat > leaf/dune <<EOF
+  > (library (name leaf) (wrapped false))
+  > EOF
+  $ cat > leaf/leaf.ml <<EOF
+  > let value = 42
+  > EOF
+  $ cat > middle/dune <<EOF
+  > (library (name middle) (libraries leaf))
+  > EOF
+  $ cat > middle/middle_child.ml <<EOF
+  > module L = Leaf
+  > EOF
+  $ cat > bridge/dune <<EOF
+  > (library
+  >  (name bridge)
+  >  (wrapped false)
+  >  (libraries middle))
+  > EOF
+  $ cat > bridge/bridge.ml <<EOF
+  > module L = Middle.Middle_child.L
+  > EOF
+  $ cat > consumer/dune <<EOF
+  > (executable (name consumer) (libraries bridge))
+  > EOF
+  $ cat > consumer/consumer.ml <<EOF
+  > let () = print_int Bridge.L.value
+  > EOF
+
+The consumer initially references only [Bridge]. The cross-library walk then
+reaches the wrapped [Middle], whose closure includes [Leaf].
+
+  $ dune build --sandbox=copy consumer/consumer.exe
+  File "consumer/consumer.ml", line 1, characters 19-27:
+  1 | let () = print_int Bridge.L.value
+                         ^^^^^^^^
+  Error: The module Bridge.L is an alias for module Leaf, which is missing
+  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-closure-precision.t
@@ -145,8 +145,3 @@ The consumer initially references only [Bridge]. The cross-library walk then
 reaches the wrapped [Middle], whose closure includes [Leaf].
 
   $ dune build --sandbox=copy consumer/consumer.exe
-  File "consumer/consumer.ml", line 1, characters 19-27:
-  1 | let () = print_int Bridge.L.value
-                         ^^^^^^^^
-  Error: The module Bridge.L is an alias for module Leaf, which is missing
-  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-compat.t
@@ -5,7 +5,9 @@ Currently, all inner modules are recompiled when any library dependency changes.
 
 See: https://github.com/ocaml/dune/issues/4572
 
-  $ make_dune_project 2.0
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
 
   $ mkdir baselib
   $ cat > baselib/dune <<EOF
@@ -65,8 +67,8 @@ See: https://github.com/ocaml/dune/issues/4572
   > let new_fn () = "hello"
   > EOF
 
-Standalone is recompiled even though it doesn't reference Baselib:
+Standalone is not recompiled because it doesn't reference Baselib:
 
   $ dune build ./main.exe
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("Standalone"))] | length'
-  2
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("Standalone"))] | length'
+  0

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-from-vlib-soundness.t
@@ -69,7 +69,7 @@ a change to either module's interface fails to invalidate `main`.
 Glob coverage on `main.cmi`'s compile rule:
 
   $ dune rules --root . --format=json --deps '%{cmi:consumer/main}' |
-  > jq_dune -r '.[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
+  > jq -r 'include "dune"; .[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
   In_build_dir _build/default/impl/.impl.objs/byte *.cmi
 
 Case 1 (soundness): edit `helper`'s interface to expose `z`. `main`
@@ -81,7 +81,7 @@ must cover `vlib__Helper.cmi`, so `main` rebuilds:
   > val z : int
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
   [
     {
       "target_files": [
@@ -106,7 +106,7 @@ rule deps must cover `vlib__Virt_iface.cmi`, so `main` rebuilds:
   > val z : int
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
   [
     {
       "target_files": [
@@ -135,7 +135,7 @@ a library lands.
   > val w : string
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("consumer/\\.main\\.eobjs/byte/"))]'
   [
     {
       "target_files": [

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-internal-leak.t
@@ -1,30 +1,28 @@
-Observational baseline for an unsupported leak: a consumer can
-currently reach a wrapped library's internal (mangled) module name
-through the include path, because the library's object directory
-contains the mangled `Mylib__Internal.cmi` and broad `-I` flags make
-that directory reachable.
+A consumer that writes `Mylib__Internal.x` — using a wrapped
+library's mangled internal module name directly, bypassing the
+wrapper — no longer compiles. This file asserts the compile
+error.
 
-A wrapped library exposes its public API only through its wrapper
-module (`Mylib.Internal`, etc). Dune mangles the on-disk cmi of the
-wrapped internal module to `Mylib__Internal.cmi` as an implementation
-detail. Under broad per-module `-I` flags, a consumer that writes
-`Mylib__Internal.x` compiles successfully, side-stepping the wrapper.
+Why it fails: per-module rule-dep filtering (#4572)
+scopes each consumer's compile-rule deps to the libraries its
+source actually references. The consumer's ocamldep output
+names `Mylib__Internal` as a top-level module, but
+`Mylib__Internal` is not a library entry — the lib index only
+knows about `Mylib`. The filter therefore does not list
+`Mylib__Internal.cmi` among the consumer's compile-rule deps;
+dune does not order the producing rule before the consumer's
+compile, and ocamlc reports `Unbound module` because the file
+is absent from `mylib`'s objdir when the consumer's compile
+runs.
 
-This is not officially supported — consumers should reach a wrapped
-library's internals only through the wrapper API, not through the
-mangled form (see #14317 review discussion). The leak works today
-only as an implementation-detail side effect of the wrapping
-convention. In practice some packages currently depend on it, which
-is why the baseline is recorded here so any flip is visible in CI.
-
-Per-module `-I` filtering (#4572 / #14186) is expected to break this
-leak by scoping each consumer's `-I` paths to the libraries its
-source references. `Mylib__Internal` is not an entry in the lib
-index, so the filter excludes `mylib`, the objdir is dropped from
-`-I`, and the compile fails with "Unbound module Mylib__Internal".
-The flip is acceptable because the leak was never supported;
-downstream consumers depending on the mangled form should migrate
-to the wrapper API.
+Why this isn't a regression: the mangled form was never
+officially supported. Wrapped libraries expose their public API
+through the wrapper module (`Mylib.Internal.x`); the on-disk
+mangling to `Mylib__Internal.cmi` is an implementation detail.
+Under broad cctx-wide compile-rule deps the leak previously
+compiled by accident; per-module rule-dep filtering removes the
+accidental reachability. Downstream consumers depending on the
+mangled form should migrate to the wrapper API.
 
   $ make_dune_project 3.0
 
@@ -47,3 +45,8 @@ to the wrapper API.
   > EOF
 
   $ dune build ./main.exe
+  File "main.ml", line 1, characters 23-38:
+  1 | let () = print_endline Mylib__Internal.hi
+                             ^^^^^^^^^^^^^^^
+  Error: Unbound module Mylib__Internal
+  [1]

--- a/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/wrapped-transition-soundness.t
@@ -57,7 +57,7 @@ invalidate `consumer`.
 Glob coverage on `consumer.cmi`'s compile rule:
 
   $ dune rules --root . --format=json --deps '%{cmi:consumer}' |
-  > jq_dune -r '.[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
+  > jq -r 'include "dune"; .[] | depsGlobs | "\(.dir_kind) \(.dir) \(.predicate)"'
   In_build_dir _build/default/.wrapped_lib.objs/byte *.cmi
 
 Case 1 (soundness): edit `inner_a`'s interface to expose `z`.
@@ -70,7 +70,7 @@ the compile-rule deps must cover `wrapped_lib__Inner_a.cmi`, so
   > val z : int
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
   [
     {
       "target_files": [
@@ -93,7 +93,7 @@ Promote when per-module narrowing within a library lands.
   > val w : string
   > EOF
   $ dune build @check
-  $ dune trace cat | jq_dune -s '[.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
+  $ dune trace cat | jq -s 'include "dune"; [.[] | targetsMatchingFilter(test("\\.consumer\\.objs/byte/consumer\\.cm"))]'
   [
     {
       "target_files": [

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a1/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a1/x.ml
@@ -1,0 +1,1 @@
+let value = B.X.value

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a2/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/a/a2/x.ml
@@ -1,0 +1,1 @@
+let value = 0

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/b/x.ml
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/b/x.ml
@@ -1,0 +1,1 @@
+let value = A2.X.value

--- a/test/blackbox-tests/test-cases/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps.t
@@ -8,8 +8,8 @@ the package dependencies inferred by dune:
   > (package (name foo))
   > EOF
   $ mkdir foo bar
-  $ touch foo/foo.ml
-  $ touch bar/bar.ml
+  $ echo 'let () = print_int Bar.value' >foo/foo.ml
+  $ echo 'let value = 1' >bar/bar.ml
   $ cat >foo/dune <<EOF
   > (executable (public_name foo) (libraries bar) (package foo))
   > EOF
@@ -25,6 +25,9 @@ the package dependencies inferred by dune:
 
   $ cat >foo/dune <<EOF
   > (library (public_name foo) (libraries bar))
+  > EOF
+  $ cat >foo/foo.ml <<EOF
+  > let use_bar () = Bar.value
   > EOF
   $ dune build @install
   Error: Package foo is missing the following package dependencies
@@ -45,7 +48,9 @@ transitive deps.
   > (package (name bar) (depends baz))
   > (package (name foo) (depends bar))
   > EOF
-  $ touch baz.ml bar.ml foo.ml
+  $ echo 'let value = 1' >baz.ml
+  $ echo 'let chain = Baz.value' >bar.ml
+  $ echo 'let use = Bar.chain' >foo.ml
   $ cat >dune <<EOF
   > (library (public_name baz) (modules baz))
   > (library (public_name bar) (libraries baz) (modules bar))

--- a/test/blackbox-tests/test-cases/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps.t
@@ -8,8 +8,8 @@ the package dependencies inferred by dune:
   > (package (name foo))
   > EOF
   $ mkdir foo bar
-  $ echo 'let () = print_int Bar.value' >foo/foo.ml
-  $ echo 'let value = 1' >bar/bar.ml
+  $ touch foo/foo.ml
+  $ touch bar/bar.ml
   $ cat >foo/dune <<EOF
   > (executable (public_name foo) (libraries bar) (package foo))
   > EOF
@@ -26,15 +26,7 @@ the package dependencies inferred by dune:
   $ cat >foo/dune <<EOF
   > (library (public_name foo) (libraries bar))
   > EOF
-  $ cat >foo/foo.ml <<EOF
-  > let use_bar () = Bar.value
-  > EOF
   $ dune build @install
-  Error: Package foo is missing the following package dependencies
-  - bar
-  -> required by _build/default/foo.install
-  -> required by alias install
-  [1]
   $ cd ..
 
 Strict package deps reports missing dependencies because it does not check
@@ -48,17 +40,10 @@ transitive deps.
   > (package (name bar) (depends baz))
   > (package (name foo) (depends bar))
   > EOF
-  $ echo 'let value = 1' >baz.ml
-  $ echo 'let chain = Baz.value' >bar.ml
-  $ echo 'let use = Bar.chain' >foo.ml
+  $ touch baz.ml bar.ml foo.ml
   $ cat >dune <<EOF
   > (library (public_name baz) (modules baz))
   > (library (public_name bar) (libraries baz) (modules bar))
   > (library (public_name foo) (libraries bar) (modules foo))
   > EOF
   $ dune build @install
-  Error: Package foo is missing the following package dependencies
-  - baz
-  -> required by _build/default/foo.install
-  -> required by alias install
-  [1]

--- a/test/blackbox-tests/test-cases/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps.t
@@ -27,6 +27,11 @@ the package dependencies inferred by dune:
   > (library (public_name foo) (libraries bar))
   > EOF
   $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - bar
+  -> required by _build/default/foo.install
+  -> required by alias install
+  [1]
   $ cd ..
 
 Strict package deps reports missing dependencies because it does not check
@@ -47,3 +52,8 @@ transitive deps.
   > (library (public_name foo) (libraries bar) (modules foo))
   > EOF
   $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - baz
+  -> required by _build/default/foo.install
+  -> required by alias install
+  [1]

--- a/test/blackbox-tests/test-cases/strict-package-deps.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps.t
@@ -9,12 +9,12 @@ the package dependencies inferred by dune:
   > EOF
   $ mkdir foo bar
   $ touch foo/foo.ml
-  $ touch bar/bar.ml
+  $ echo 'let value = 1' >bar/bar.ml
   $ cat >foo/dune <<EOF
   > (executable (public_name foo) (libraries bar) (package foo))
   > EOF
   $ cat >bar/dune <<EOF
-  > (library (public_name bar))
+  > (library (public_name bar) (wrapped false))
   > EOF
   $ dune build @install
   Error: Package foo is missing the following package dependencies
@@ -26,6 +26,17 @@ the package dependencies inferred by dune:
   $ cat >foo/dune <<EOF
   > (library (public_name foo) (libraries bar))
   > EOF
+  $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - bar
+  -> required by _build/default/foo.install
+  -> required by alias install
+  [1]
+
+The same check must work when source references keep the library's CMI in the
+narrowed compilation dependencies:
+
+  $ echo 'let use_bar () = Bar.value' >foo/foo.ml
   $ dune build @install
   Error: Package foo is missing the following package dependencies
   - bar
@@ -47,10 +58,31 @@ transitive deps.
   > EOF
   $ touch baz.ml bar.ml foo.ml
   $ cat >dune <<EOF
-  > (library (public_name baz) (modules baz))
-  > (library (public_name bar) (libraries baz) (modules bar))
-  > (library (public_name foo) (libraries bar) (modules foo))
+  > (library (public_name baz) (wrapped false) (modules baz))
+  > (library
+  >  (public_name bar)
+  >  (wrapped false)
+  >  (libraries baz)
+  >  (modules bar))
+  > (library
+  >  (public_name foo)
+  >  (wrapped false)
+  >  (libraries bar)
+  >  (modules foo))
   > EOF
+  $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - baz
+  -> required by _build/default/foo.install
+  -> required by alias install
+  [1]
+
+Retain the transitive check when every library in the source-level chain is
+kept by per-module narrowing:
+
+  $ echo 'let value = 1' >baz.ml
+  $ echo 'let chain = Baz.value' >bar.ml
+  $ echo 'let use = Bar.chain' >foo.ml
   $ dune build @install
   Error: Package foo is missing the following package dependencies
   - baz

--- a/test/blackbox-tests/test-cases/watching/multiple-errors-output.t/run.t
+++ b/test/blackbox-tests/test-cases/watching/multiple-errors-output.t/run.t
@@ -15,10 +15,18 @@ We test the output of the watch mode client when we have multiple errors
   1 | let y = "unknown variable" ^ what
                                    ^^^^
   Unbound value what
-  Error: Build failed with 2 errors.
+  File "$TESTCASE_ROOT/src/foo.ml", line 1, characters 39-40:
+  1 | let f = Bar.x + Baz.y + invalid_syntax : ? = !
+                                             ^
+  Syntax error
+  Error: Build failed with 3 errors.
   [1]
 
   $ stop_dune
+  File "src/foo.ml", line 1, characters 39-40:
+  1 | let f = Bar.x + Baz.y + invalid_syntax : ? = !
+                                             ^
+  Error: Syntax error
   File "libs/bar.ml", line 1, characters 8-20:
   1 | let y = "type error" + 3
               ^^^^^^^^^^^^
@@ -28,4 +36,4 @@ We test the output of the watch mode client when we have multiple errors
   1 | let y = "unknown variable" ^ what
                                    ^^^^
   Error: Unbound value what
-  Had 2 errors, waiting for filesystem changes...
+  Had 3 errors, waiting for filesystem changes...


### PR DESCRIPTION
## Summary

Per-module library dependency filtering for #4572. A consumer module's compile rule now sees only the artefacts of libraries it actually references, so unrelated sibling modules no longer recompile when an unreferenced dependency library's cmi changes. User-facing detail is in the shipped changelog entry under `doc/changes/added/`.

## Predecessor PRs (now closed)

- #14472 — per-module library dep filter via ocamldep BFS.
- #14473 — per-module `-I`/`-H` include flags matching the filter.
- #14474 — `Raw_refs` `Action_builder` cache to deduplicate ocamldep results across cctxs sharing the same module sources.

Fixes #4572.