### PR TITLE
test: show auto-locking updates dependency version automatically

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
@@ -101,6 +101,9 @@ Now add a newer version of foo to the repository:
   > EOF
 
 Build again - auto-locking should detect the new version and rebuild:
+
+CR-someday Sudha247: update this to use process events in the trace and remove
+--display short
   $ dune exec --display short bar 2>&1 | grep "Building"
       Building foo.0.0.2
 

--- a/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
+++ b/test/blackbox-tests/test-cases/pkg/autolock-detects-changes.t
@@ -101,7 +101,6 @@ Now add a newer version of foo to the repository:
   > EOF
 
 Build again - auto-locking should detect the new version and rebuild:
-  $ dune clean
   $ dune exec --display short bar 2>&1 | grep "Building"
       Building foo.0.0.2
 


### PR DESCRIPTION
While looking at #13011, I wanted to test out this case to check if autolocking picks up a new release of a package dependency when rebuilding without cleaning the `_build` directory first. That does seem to be the case.