### PR TITLE
pkg: enable and version the rev_store cache

### DIFF
--- a/doc/changes/changed/14494.md
+++ b/doc/changes/changed/14494.md
@@ -1,0 +1,2 @@
+- The package solver now uses cached revision store lookups for improved
+  performance. (#14494, fixes #12637, @Alizter, @rgrinberg)

--- a/doc/dev/rev-store.md
+++ b/doc/dev/rev-store.md
@@ -267,9 +267,84 @@ When reading multiple files, the `content_of_files` function first checks the
 cache for each file's hash, then fetches any uncached files in a single
 batched `git show` call, and stores the results back in the cache.
 
-The cache is currently disabled by default as it lacks cache versioning, which
-means incompatible cache formats could cause issues after Dune upgrades. It can
-be enabled by setting the environment variable
-`DUNE_CONFIG__REV_STORE_CACHE=enabled`. When enabled, the cache uses up to 5GB
-of disk space.
+### Storage format
+
+The cache stores raw bytes only. The `ls-tree` map's value is the literal
+`git ls-tree -z --long -r` output (lines rejoined on the NUL separator
+that git uses), and the `objects` map's value is the raw blob content. No
+OCaml-side serialisation is involved. On a cache hit, `Entry.parse` runs
+over the cached bytes to reconstruct `File.t` and `Commit.t` values, the
+same parse that runs on a cache miss after the subprocess returns.
+
+This is a deliberate choice. Earlier iterations of the cache stored the
+parsed `File.Set.t * Commit.Set.t` via `Marshal.to_string ~sharing:true`.
+That had two failure modes:
+
+  * **OCaml compiler coupling.** `Marshal`'s binary format depends on the
+    OCaml runtime's in-memory representation, especially with sharing.
+    Two builds of the same dune source against different OCaml versions
+    could produce mutually unreadable caches.
+  * **Silent schema drift.** Any change to a type reachable from the
+    marshalled value (`File.t`, `Commit.t`, the set comparator, even the
+    representation of `Path.Local.t`) silently changed the on-disk format.
+    Structurally compatible changes did not raise; they decoded wrong
+    values.
+
+Storing the raw subprocess output sidesteps both. The trade-off is that
+parsing runs on every cache hit, but the parse is a single regex pass per
+line and the cost is dwarfed by the millisecond-scale subprocess cost the
+cache exists to avoid.
+
+### Versioning
+
+The cache directory is keyed by a manual version string:
+
+  `$DUNE_CACHE_ROOT/rev_store/<version>/`
+
+The current `version` is `v1`. Bump the constant in
+`src/dune_pkg/rev_store.ml` whenever the bytes we write to the cache
+change shape. That happens when the `git ls-tree` invocation changes
+(different flags or a different command), when a map is added or
+removed from the cache, or when the key or value `Lmdb.Conv` of an
+existing map changes. Parser-only changes to `Entry.parse` are not
+triggers, because the cached bytes are still the same git output; the
+new parser just interprets them differently. OCaml-side type or field
+renames are also not triggers, because nothing is marshalled.
+
+Older version directories left behind by previous builds are dormant;
+the running dune only ever reads and writes the current version, and
+the user can remove stale directories manually.
+
+### Future extensibility
+
+The single-cache raw-bytes design is intentionally minimal but does not
+constrain future use. There are vague plans to use LMDB for other
+parsing caches (e.g. parsed dune or opam files). Those will need a real
+encoder and decoder, since the cached value is no longer a natural
+subprocess output. When that work happens, two paths are open:
+
+  * **Add a new, independent cache.** A parsed-dune-files cache can live
+    at a different path (e.g. `$DUNE_CACHE_ROOT/dune_files/<version>/`)
+    with its own `version` constant and its own LMDB env. The rev-store
+    cache is untouched.
+  * **Migrate the rev-store cache itself.** Bump `version` from `v1` to
+    `v2`, swap the `Lmdb.Conv.string` for a typed converter, and rewrite
+    `Entry.parse` callers accordingly. Old data at `v1/` is abandoned
+    without migration code; the path-keyed versioning makes that
+    costless.
+
+Either way, the encoder/decoder choice (something like a `Repr`-driven
+binary format, canonical S-expressions, or hand-rolled per type) is a
+local decision for whatever cache introduces it, not a project-wide
+contract. The only thing that needs to stay constant for all caches is
+that **`Marshal` is not used**, so the on-disk format remains independent
+of the OCaml compiler.
+
+The cache is enabled by default on 64-bit non-Windows platforms. It
+defaults to disabled on 32-bit (the 5GB LMDB map size does not fit in
+virtual address space) and on Windows (until we can determine that LMDB
+is not detrimental to performance there). Users can override the default
+either way via `DUNE_CONFIG__REV_STORE_CACHE=enabled` or
+`DUNE_CONFIG__REV_STORE_CACHE=disabled`. When enabled, the cache uses up
+to 5GB of disk space.
 

--- a/src/dune_pkg/rev_store.ml
+++ b/src/dune_pkg/rev_store.ml
@@ -136,18 +136,40 @@ module Cache = struct
      now, we allow it to raise. It won't be visible to most users due to the
      cache size we have chosen. *)
 
-  let rev_store_cache =
-    (* CR-soon Alizter: For now the cache is disabled by default. Once we add
-       versioning to the cache it will be safe to enable by default. 
+  (* The cache is stored at [$DUNE_CACHE_ROOT/rev_store/<version>/]. Bump
+     [version] whenever the bytes we write to the cache change shape.
+     Concretely:
 
-       When we do this we should check [Int.equal Sys.word_size 64] since
-       32-bit platforms won't handle our cache size well. *)
-    Config.make_toggle ~name:"rev_store_cache" ~default:`Disabled
+       1. The [git ls-tree] invocation changes (different flags or a
+          different command) so that the cached output is a different
+          format than before.
+       2. A new LMDB map is added, or an existing one is removed.
+       3. The key or value [Lmdb.Conv] of an existing map changes (today
+          all values are plain strings, but if we ever swap to a typed
+          converter the on-disk bytes change).
+
+     Changes that are NOT triggers: parser-only changes to [Entry.parse]
+     (the cached bytes are still the same git output, the new parser just
+     interprets them), and renames of OCaml types or fields (nothing is
+     marshalled, so OCaml-side renames do not affect on-disk bytes).
+
+     Old version directories left behind by previous builds are dormant
+     and can be removed by the user if desired. *)
+  let version = "v1"
+
+  let rev_store_cache =
+    Config.make_toggle
+      ~name:"rev_store_cache"
+        (* Enabled by default on non-Windows platforms. Windows is opted out
+           until we can determine that LMDB is not detrimental to performance
+           there. CR-someday Alizter: Do this. *)
+      ~default:(if Sys.win32 then `Disabled else `Enabled)
   ;;
 
   let revision_store_dir =
     lazy
-      (let path = Path.relative (Lazy.force Dune_util.cache_root_dir) "rev_store" in
+      (let base = Path.relative (Lazy.force Dune_util.cache_root_dir) "rev_store" in
+       let path = Path.relative base version in
        let rev_store_cache = Config.get rev_store_cache in
        Log.info "Revision store cache" [ "status", Config.Toggle.to_dyn rev_store_cache ];
        match rev_store_cache with
@@ -234,21 +256,25 @@ module Cache = struct
       ;;
     end
 
-    module Value = struct
-      let conv : (File.Set.t * Commit.Set.t) Lmdb.Conv.t =
-        Lmdb.Conv.make
-          ~serialise:(fun alloc v ->
-            Marshal.to_string v ~sharing:true |> Lmdb.Conv.(serialise string alloc))
-          ~deserialise:(fun bs -> Marshal.from_string Lmdb.Conv.(deserialise string bs))
-          ()
-      ;;
-    end
-
     let map =
       lazy
         (Lazy.force db
          |> Option.map ~f:(fun env ->
-           Lmdb.Map.create Nodup ~key:Key.conv ~value:Value.conv ~name:"ls-tree" env))
+           Lmdb.Map.create Nodup ~key:Key.conv ~value:Lmdb.Conv.string ~name:"ls-tree" env)
+        )
+    ;;
+
+    (* Cached value is the raw [git ls-tree -z --long -r] output, rejoined
+       with the NUL separator that git uses. Storing the literal subprocess
+       output avoids any OCaml-side serialisation and keeps the on-disk
+       format independent of the OCaml compiler used to build dune. Lines
+       produced by [-z] never contain NUL, so encode/decode are
+       unambiguous. *)
+    let encode_lines = String.concat ~sep:"\000"
+
+    let decode_lines = function
+      | "" -> []
+      | s -> String.split ~on:'\000' s
     ;;
 
     let get key =
@@ -256,15 +282,15 @@ module Cache = struct
       let* m = Lazy.force map in
       match Lmdb.Map.get m key with
       | exception Not_found -> None
-      | v -> Some v
+      | v -> Some (decode_lines v)
     ;;
 
-    let set key value =
+    let set key lines =
       ignore
       @@
       let open Option.O in
       let+ map = Lazy.force map in
-      Lmdb.Map.set map key value
+      Lmdb.Map.set map key (encode_lines lines)
     ;;
   end
 
@@ -937,28 +963,32 @@ module At_rev = struct
     ;;
   end
 
+  let parse_ls_tree_lines lines =
+    List.fold_left
+      lines
+      ~init:(File.Set.empty, Commit.Set.empty)
+      ~f:(fun (files, commits) line ->
+        match Entry.parse line with
+        | None -> files, commits
+        | Some (File file) -> File.Set.add files file, commits
+        | Some (Commit commit) -> files, Commit.Set.add commits commit)
+  ;;
+
   let files_and_submodules repo key =
     let cached = Cache.Files_and_submodules.get key in
     if !Debug.files_and_submodules_cache
     then Debug.print "files_and_submodules" [ "cached", Dyn.option Dyn.opaque cached ];
     match cached with
-    | Some v -> Fiber.return v
+    | Some lines -> Fiber.return (parse_ls_tree_lines lines)
     | None ->
-      let+ value =
+      let+ lines =
         run_capture_zero_separated_lines
           repo
           [ "ls-tree"; "-z"; "--long"; "-r"; Object.to_hex key ]
         >>| Git_error.result_get_or_code_error
-        >>| List.fold_left
-              ~init:(File.Set.empty, Commit.Set.empty)
-              ~f:(fun (files, commits) line ->
-                match Entry.parse line with
-                | None -> files, commits
-                | Some (File file) -> File.Set.add files file, commits
-                | Some (Commit commit) -> files, Commit.Set.add commits commit)
       in
-      Cache.Files_and_submodules.set key value;
-      value
+      Cache.Files_and_submodules.set key lines;
+      parse_ls_tree_lines lines
   ;;
 
   let path_commit_map submodules =

--- a/test/expect-tests/dune_pkg/rev_store_tests.ml
+++ b/test/expect-tests/dune_pkg/rev_store_tests.ml
@@ -190,16 +190,27 @@ let%expect_test "fetching an object twice from the store" =
                                          " })
      ])
     |}];
-  (* Checking for the presence of the lmdb database. *)
+  (* Cache lives under a version-named subdirectory; the lmdb database
+     files sit inside it. *)
+  let path = Path.External.cwd () |> Path.external_ in
   Console.print
-    [ (let path = Path.External.cwd () |> Path.external_ in
-       Path.L.relative path [ ".cache"; "dune"; "rev_store" ]
-       |> Path.to_string
-       |> Sys.readdir
-       |> Array.to_list
-       |> List.sort ~compare:String.compare
-       |> Dyn.list Dyn.string
-       |> Dyn.pp)
+    [ Path.L.relative path [ ".cache"; "dune"; "rev_store" ]
+      |> Path.to_string
+      |> Sys.readdir
+      |> Array.to_list
+      |> List.sort ~compare:String.compare
+      |> Dyn.list Dyn.string
+      |> Dyn.pp
+    ];
+  [%expect {| [ "v1" ] |}];
+  Console.print
+    [ Path.L.relative path [ ".cache"; "dune"; "rev_store"; "v1" ]
+      |> Path.to_string
+      |> Sys.readdir
+      |> Array.to_list
+      |> List.sort ~compare:String.compare
+      |> Dyn.list Dyn.string
+      |> Dyn.pp
     ];
   [%expect {| [ "data.mdb"; "lock.mdb" ] |}]
 ;;


### PR DESCRIPTION
The `lmdb`-backed revision store cache is now enabled by default on 64-bit
platforms (32-bit remains opted out because the 5GB map size doesn't fit
in virtual address space, and on Windows it is disabled until we can
determine it's performance impact).

The on-disk layout is now versioned: caches live under
`$DUNE_CACHE_ROOT/rev_store/<version>/`, with the version bumped by hand
whenever the bytes we write change shape.

The `ls-tree` map's value switches from a `Marshal`-encoded
`File.Set.t * Commit.Set.t` to the raw `git ls-tree -z` subprocess output.
This removes the previous dependency on the OCaml compiler used to build
dune, since `Marshal`'s binary format is sensitive to runtime layout.

- Fixes #12637.