### PR TITLE
fix: %{cmi:...} and other module artifact pforms under (include_subdirs qualified)

### DIFF
--- a/doc/changes/fixed/14498.md
+++ b/doc/changes/fixed/14498.md
@@ -1,0 +1,5 @@
+- Fix crash when expanding module pforms (`%{cmi:..}` etc.) with
+  `(include_subdirs qualified)`. Module compilation units can now be
+  referenced by their source path, e.g. `%{cmi:sub_a/foo}` for
+  `sub_a/foo.ml`.
+  (#14498, fixes #14496, @Alizter)

--- a/src/dune_rules/artifacts_obj.ml
+++ b/src/dune_rules/artifacts_obj.ml
@@ -3,12 +3,25 @@ open Memo.O
 
 type t =
   { libraries : Lib_info.local Lib_name.Map.t
-  ; modules : (Path.Build.t Obj_dir.t * Module.t) Module_name.Map.t
+  ; modules : (Path.Build.t Obj_dir.t * Module.t) Path.Build.Map.t
   }
 
-let empty = { libraries = Lib_name.Map.empty; modules = Module_name.Map.empty }
-let lookup_module { modules; libraries = _ } = Module_name.Map.find modules
-let lookup_library { libraries; modules = _ } = Lib_name.Map.find libraries
+let empty = { libraries = Lib_name.Map.empty; modules = Path.Build.Map.empty }
+let lookup_module { modules; _ } = Path.Build.Map.find modules
+let lookup_library { libraries; _ } = Lib_name.Map.find libraries
+
+(* The source file build path of a module, with the [.ml]/[.mli] extension
+   stripped. This matches the form a user writes in a module artifact pform
+   (e.g. [%{cmi:sub_a/group}] for a source file [sub_a/group.ml]). *)
+let module_source_path_without_extension m =
+  let source =
+    match Module.source_without_pp m ~ml_kind:Impl with
+    | Some _ as p -> p
+    | None -> Module.source_without_pp m ~ml_kind:Intf
+  in
+  Option.bind source ~f:Path.as_in_build_dir
+  |> Option.map ~f:(fun p -> fst (Path.Build.split_extension p))
+;;
 
 let make ~dir ~expander ~lib_config ~libs ~exes =
   let+ libraries =
@@ -22,16 +35,18 @@ let make ~dir ~expander ~lib_config ~libs ~exes =
     >>| Lib_name.Map.of_list_exn
   in
   let modules =
-    let by_name modules obj_dir =
+    let by_path modules obj_dir =
       Modules.fold_user_available ~init:modules ~f:(fun m modules ->
-        Module_name.Map.add_exn modules (Module.name m) (obj_dir, m))
+        match module_source_path_without_extension m with
+        | None -> modules
+        | Some key -> Path.Build.Map.add_exn modules key (obj_dir, m))
     in
     let init =
-      List.fold_left exes ~init:Module_name.Map.empty ~f:(fun modules (m, obj_dir) ->
-        by_name modules obj_dir m)
+      List.fold_left exes ~init:Path.Build.Map.empty ~f:(fun modules (m, obj_dir) ->
+        by_path modules obj_dir m)
     in
     List.fold_left libs ~init ~f:(fun modules (_, m, obj_dir) ->
-      by_name modules obj_dir m)
+      by_path modules obj_dir m)
   in
   { libraries; modules }
 ;;

--- a/src/dune_rules/artifacts_obj.mli
+++ b/src/dune_rules/artifacts_obj.mli
@@ -12,5 +12,5 @@ val make
   -> exes:(Modules.t * Path.Build.t Obj_dir.t) list
   -> t Memo.t
 
-val lookup_module : t -> Module_name.t -> (Path.Build.t Obj_dir.t * Module.t) option
+val lookup_module : t -> Path.Build.t -> (Path.Build.t Obj_dir.t * Module.t) option
 val lookup_library : t -> Lib_name.t -> Lib_info.local option

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -186,13 +186,12 @@ let expand_artifact ~source t artifact arg =
   in
   match artifact with
   | Pform.Artifact.Mod kind ->
-    let name =
-      Module_name.of_string_allow_invalid
-        (Dune_lang.Template.Pform.loc source, Filename.to_string name)
-      |> Module_name.Unchecked.allow_invalid
-    in
-    (match Artifacts_obj.lookup_module artifacts name with
-     | None -> does_not_exist ~what:"Module" (Module_name.to_string name)
+    (match Artifacts_obj.lookup_module artifacts path with
+     | None ->
+       Module_name.of_string_allow_invalid (loc, Filename.to_string name)
+       |> Module_name.Unchecked.allow_invalid
+       |> Module_name.to_string
+       |> does_not_exist ~what:"Module"
      | Some (t, m) ->
        (match
           match kind with

--- a/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
+++ b/test/blackbox-tests/test-cases/include-qualified/module-artifact-targets.t
@@ -21,45 +21,41 @@ A normal build succeeds:
 
   $ dune build @check
 
-Asking for any module artifact of a module in the stanza crashes with the
-same internal error:
+A module artifact target for the top-level module works:
 
-  $ dune build %{cmi:main} 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Map.add_exn: key already exists", { key = "Group" })
+  $ dune build %{cmi:main}
+  $ dune build %{cmo:main}
+  $ dune build %{cmx:main}
+  $ dune build %{cmt:main}
+  $ dune build %{cmti:main}
+
+A module artifact target for a module in a qualified subdirectory works:
+
+  $ dune build %{cmi:sub_a/group}
+  $ dune build %{cmi:sub_b/group}
+  $ dune build %{cmo:sub_a/group}
+  $ dune build %{cmo:sub_b/group}
+
+An unqualified leaf name [group] is not the module path of any module
+(the modules are [Sub_a.Group] and [Sub_b.Group]), so it is reported as
+missing:
+
+  $ dune build %{cmi:group}
+  File "command line", line 1, characters 0-12:
+  Error: Module Group does not exist.
   [1]
 
-  $ dune build %{cmo:main} 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Map.add_exn: key already exists", { key = "Group" })
-  [1]
+A (rule ...) in a subdir dune file that references a module artifact
+pform with a leaf name %{cmi:group}:
 
-  $ dune build %{cmx:main} 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Map.add_exn: key already exists", { key = "Group" })
-  [1]
+  $ cat > sub_a/dune <<EOF
+  > (rule (with-stdout-to out.txt (echo %{cmi:group})))
+  > EOF
+  $ dune build sub_a/out.txt
 
-  $ dune build %{cmt:main} 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Map.add_exn: key already exists", { key = "Group" })
-  [1]
+Using a dot separator [sub_a.group] instead of a slash:
 
-  $ dune build %{cmti:main} 2>&1 | head -5
-  Internal error! Please report to https://github.com/ocaml/dune/issues,
-  providing the file _build/trace.csexp, if possible. This includes build
-  commands, message logs, and file paths.
-  Description:
-    ("Map.add_exn: key already exists", { key = "Group" })
+  $ dune build %{cmi:sub_a.group}
+  File "command line", line 1, characters 0-18:
+  Error: Module Sub_a.group does not exist.
   [1]


### PR DESCRIPTION
- Fixes #14496
- Depends on #14497

Under `(include_subdirs qualified)`, building any module artifact pform target (`%{cmi:...}`, `%{cmo:...}`, `%{cmx:...}`, `%{cmt:...}`, `%{cmti:...}`) crashes with `Map.add_exn: key already exists` when two qualified subdirectories define modules with the same name.

Also reproduces in this repo: `dune build %{cmi:bin/main}` now works (`bin/` uses `(include_subdirs qualified)` and contains four `group.ml` files in different qualified subdirs).