### PR TITLE
fix: reject (package ...) inside named dependency bindings

### DIFF
--- a/doc/changes/fixed/14499.md
+++ b/doc/changes/fixed/14499.md
@@ -1,0 +1,3 @@
+- Reject `(package ...)` inside a named dependency binding
+  (`(deps (:name (package foo)))`). Previously this was silently accepted but
+  `%{name}` would resolve to an empty path list. (#14499, @Alizter)

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -341,7 +341,21 @@ and named_paths_builder ~expander l =
             in
             to_action_builder r :: builders, bindings, envs
           | Named (name, x) ->
-            let x = List.map x ~f:(dep expander) in
+            let x =
+              List.map x ~f:(function
+                | Dep_conf.Package p ->
+                  User_error.raise
+                    ~loc:(String_with_vars.loc p)
+                    ~hints:
+                      [ Pp.text "Place the (package ...) entry in the deps list directly."
+                      ]
+                    [ Pp.textf
+                        "(package ...) is not supported inside a named dependency \
+                         binding (:%s)."
+                        name
+                    ]
+                | d -> dep expander d)
+            in
             let envs =
               List.fold_left x ~init:envs ~f:(fun envs r ->
                 match include_bin_env r with

--- a/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
+++ b/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
@@ -1,0 +1,39 @@
+Writing `(package ...)` inside a named dependency binding like
+`(:name (package foo))` is rejected: the binding would resolve to an
+empty path list, which is rarely what the user intended.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name mypkg))
+  > EOF
+  $ mkdir src
+  $ cat >src/dune <<EOF
+  > (library (public_name mypkg))
+  > EOF
+  $ cat >src/mypkg.ml <<'EOF'
+  > let x = 1
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (:pkg (package mypkg)))
+  >  (action (with-stdout-to out (echo %{pkg}))))
+  > EOF
+
+  $ dune build out 2>&1
+  File "dune", line 2, characters 22-27:
+  2 |  (deps (:pkg (package mypkg)))
+                            ^^^^^
+  Error: (package ...) is not supported inside a named dependency binding
+  (:pkg).
+  Hint: Place the (package ...) entry in the deps list directly.
+  [1]
+
+Putting the package outside the named binding works:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (deps (package mypkg))
+  >  (action (with-stdout-to out (echo done))))
+  > EOF
+  $ dune build out


### PR DESCRIPTION
`(deps (:name (package foo)))` is silently accepted by the parser but `%{name}` resolves to an empty path list. The package contributes no paths to the binding, only env vars (when `(package ...)` is allowed by the surrounding code). This is rarely what users intend.

We now reject the construct in `named_paths_builder` with a clear error pointing at the `(package ...)` location and a hint to move the entry out of the binding.

This was pre-existing behaviour; not specific to the install-layout PR #14373 but found while reviewing.