### PR TITLE
test(ci): new windows runners

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -169,12 +169,12 @@ jobs:
             os: macos-15-intel
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
             cache-prefix: ocaml-compiler.5.4.0-system-msvc
             run_tests: true
           ## mingw
           - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
-            os: windows-latest
+            os: windows-2025-vs2026
             cache-prefix: ocaml-compiler.5.4.0-system-mingw
             run_tests: true
           # OCaml 4:
@@ -272,11 +272,11 @@ jobs:
 
       - name: Run test suite on Unix
         run: opam exec -- make test
-        if: ${{ matrix.os != 'windows-latest' && matrix.run_tests }}
+        if: ${{ matrix.os != 'windows-2025-vs2026' && matrix.run_tests }}
 
       - name: Run test suite on Win32
         run: opam exec -- make test-windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.run_tests }}
+        if: ${{ matrix.os == 'windows-2025-vs2026' && matrix.run_tests }}
 
       # We never build configurator
       - name: Build configurator
@@ -389,7 +389,7 @@ jobs:
 
   cygwin:
     name: Bootstrap on Cygwin
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
       - name: Setup Cygwin

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -168,12 +168,12 @@ jobs:
             os: macos-15-intel
           ## MSVC
           - ocaml-compiler: ocaml-compiler.5.4.0,system-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
             cache-prefix: ocaml-compiler.5.4.0-system-msvc
             run_tests: true
           ## mingw
           - ocaml-compiler: ocaml-base-compiler.5.4.0,system-mingw
-            os: windows-latest
+            os: windows-2025-vs2026
             cache-prefix: ocaml-compiler.5.4.0-system-mingw
             run_tests: true
           # OCaml 4:
@@ -271,11 +271,11 @@ jobs:
 
       - name: Run test suite on Unix
         run: opam exec -- make test
-        if: ${{ matrix.os != 'windows-latest' && matrix.run_tests }}
+        if: ${{ matrix.os != 'windows-2025-vs2026' && matrix.run_tests }}
 
       - name: Run test suite on Win32
         run: opam exec -- make test-windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.run_tests }}
+        if: ${{ matrix.os == 'windows-2025-vs2026' && matrix.run_tests }}
 
       # We never build configurator
       - name: Build configurator
@@ -388,7 +388,7 @@ jobs:
 
   cygwin:
     name: Bootstrap on Cygwin
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
       - name: Setup Cygwin

--- a/1q
+++ b/1q
@@ -1,0 +1,17 @@
+test(ci): new windows runners
+
+windows-latest will be ugpraded to use Visual Studio 2026, so the C++
+toolchain we rely on in msvc jobs and perhaps indirectly in the other
+Windows jobs will potentially be affected.
+
+This PR tests this future change using the already available VS2026
+runners. If there are no issues then we needn't worry. This is in
+response to a heads-up from GitHub regarding this change.
+
+Signed-off-by: Ali Caglayan <alizter@gmail.com>
+
+JJ: Change ID: zttmwyvt
+JJ: This commit contains the following changes:
+JJ:     M .github/workflows/workflow.yml.in
+JJ:
+JJ: Lines starting with "JJ:" (like this one) will be removed.


### PR DESCRIPTION
windows-latest will be ugpraded to use Visual Studio 2026, so the C++ toolchain we rely on in msvc jobs and perhaps indirectly in the other Windows jobs will potentially be affected.

This PR tests this future change using the already available VS2026 runners. If there are no issues then we needn't worry. This is in response to a heads-up from GitHub regarding this change.