### PR TITLE
revert: lower minimal OCaml version to 4.11

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -87,6 +87,25 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
+  nix-build-4-11:
+    name: Bootstrap with OCaml 4.11
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 2G
+      - run: nix develop -i .#bootstrap-check_4_11 -c make test-bootstrap
+
   nix-build-4-14:
     name: Bootstrap with OCaml 4.14
     strategy:

--- a/.github/workflows/workflow.yml.in
+++ b/.github/workflows/workflow.yml.in
@@ -86,6 +86,25 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v34
       - run: nix develop -i .#bootstrap-check -c make test-bootstrap-script
 
+  nix-build-4-11:
+    name: Bootstrap with OCaml 4.11
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: |
+            nix-${{ runner.os }}-${{ github.job }}--${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}--
+          gc-max-store-size-linux: 2G
+      - run: nix develop -i .#bootstrap-check_4_11 -c make test-bootstrap
+
   nix-build-4-14:
     name: Bootstrap with OCaml 4.14
     strategy:

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
 version=0.29.0
 profile=janestreet
-ocaml-version=4.14.0
+ocaml-version=4.11.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,7 +163,8 @@
   (#13394, grants #13378, @Alizter)
 
 - Bump the minimal OCaml version required to build Dune from 4.08 to 4.14.
-  (#13533, @Alizter)
+  (#13533, @Alizter) (Note: this was later revised to 4.11 in 3.23.1; see
+  #14502.)
 
 - Starting from 3.23, user rules are sandboxed by default (#13805, @rgrinberg)
 

--- a/bin/promotion.ml
+++ b/bin/promotion.ml
@@ -69,7 +69,7 @@ module Apply = struct
   ;;
 
   let term_with_builder builder =
-    let+ builder
+    let+ builder = builder
     and+ exact =
       Arg.(
         value

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -4,7 +4,7 @@ open Printf
 (* This program performs version checking of the compiler and switches to the
    secondary compiler if necessary. The script should execute in OCaml 4.02! *)
 
-let min_supported_natively = 4, 14, 0
+let min_supported_natively = 4, 11, 0
 
 let keep_generated_files =
   let anon s = raise (Arg.Bad (sprintf "don't know what to do with %s\n" s)) in
@@ -91,7 +91,7 @@ let secondary_error () =
 (* Locate the secondary compiler's bin directory via ocamlfind. We query
    ocamlfind rather than invoking [ocamlfind -toolchain secondary ocaml]
    directly because ocamlfind does not support the [ocaml] toplevel as a
-   subcommand — it only wraps compiler tools like [ocamlc] and [ocamlopt]. *)
+   subcommand; it only wraps compiler tools like [ocamlc] and [ocamlopt]. *)
 let find_secondary_bin_dir () =
   let output_fn, out = Filename.open_temp_file "duneboot" "ocamlfind-output" in
   let n =

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -89,7 +89,28 @@ module Map = struct
   end
 end
 
+(* CR-soon Alizter: When bumping the minimal version to 4.12, remove. *)
+module Either = struct
+  [@@@warning "-37"]
+
+  type ('a, 'b) t =
+    | Left of 'a
+    | Right of 'b
+end
+
 module List = struct
+  (* CR-soon Alizter: When bumping the minimal version to 4.12, remove. *)
+  let[@warning "-32"] partition_map t ~f =
+    let rec loop l r = function
+      | [] -> List.rev l, List.rev r
+      | x :: xs ->
+        (match f x with
+         | Either.Left x -> loop (x :: l) r xs
+         | Either.Right x -> loop l (x :: r) xs)
+    in
+    loop [] [] t
+  ;;
+
   let partition_map_skip t ~f =
     let rec loop l m r = function
       | [] -> l, m, r
@@ -108,6 +129,17 @@ module List = struct
     match x with
     | None -> t
     | Some x -> x :: t
+  ;;
+
+  (* CR-soon Alizter: When bumping the minimal version to 4.12, remove. *)
+  let[@warning "-32"] rec compare ~cmp xs ys =
+    match xs, ys with
+    | [], [] -> 0
+    | [], _ :: _ -> -1
+    | _ :: _, [] -> 1
+    | x :: xs, y :: ys ->
+      let c = cmp x y in
+      if c <> 0 then c else compare ~cmp xs ys
   ;;
 
   include List
@@ -203,6 +235,21 @@ end
 
 module String = struct
   include String
+
+  (* CR-soon Alizter: When bumping the minimal version to 4.13, remove. *)
+  let[@warning "-32"] ends_with ~suffix s =
+    let sl = String.length s in
+    let xl = String.length suffix in
+    sl >= xl && String.sub s ~pos:(sl - xl) ~len:xl = suffix
+  ;;
+
+  (* CR-soon Alizter: When bumping the minimal version to 4.13, remove. *)
+  let[@warning "-32"] starts_with ~prefix s =
+    let sl = String.length s in
+    let pl = String.length prefix in
+    sl >= pl && String.sub s ~pos:0 ~len:pl = prefix
+  ;;
+
   module Set = Set.Make (String)
 
   module Map = struct

--- a/doc/changes/changed/14502.md
+++ b/doc/changes/changed/14502.md
@@ -1,4 +1,3 @@
 - Lower the minimal OCaml version required to build Dune from 4.14 back to
-  4.11, reverting the bump introduced in 3.23.0 (#13533). Users on older
-  switches no longer need to install `ocamlfind-secondary`.
+  4.11, reverting the bump introduced in 3.23.0 (#13533).
   (#14502, @Alizter)

--- a/doc/changes/changed/14502.md
+++ b/doc/changes/changed/14502.md
@@ -1,0 +1,4 @@
+- Lower the minimal OCaml version required to build Dune from 4.14 back to
+  4.11, reverting the bump introduced in 3.23.0 (#13533). Users on older
+  switches no longer need to install `ocamlfind-secondary`.
+  (#14502, @Alizter)

--- a/flake.nix
+++ b/flake.nix
@@ -554,6 +554,18 @@
             '';
           };
 
+          bootstrap-check_4_11 = pkgs.mkShell {
+            inherit INSIDE_NIX;
+            buildInputs = [
+              pkgs.gnumake
+              pkgs.ocaml-ng.ocamlPackages_4_11.ocaml
+            ];
+            meta.description = ''
+              Provides a minimal shell environment with OCaml 4.11 in order
+              to test the bootstrapping script.
+            '';
+          };
+
           bootstrap-check_4_14 = pkgs.mkShell {
             inherit INSIDE_NIX;
             buildInputs = [

--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.14"} | ("ocaml" {>= "4.02" & < "4.14~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.14"}))
+  ("ocaml" {>= "4.11"} | ("ocaml" {>= "4.02" & < "4.11~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.11"}))
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -5,7 +5,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.14"} | ("ocaml" {>= "4.02" & < "4.14~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.14"}))
+  ("ocaml" {>= "4.11"} | ("ocaml" {>= "4.02" & < "4.11~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.11"}))
   "base-unix"
   "base-threads"
   "lwt" { with-dev-setup & os != "win32" }

--- a/otherlibs/stdune/src/array.ml
+++ b/otherlibs/stdune/src/array.ml
@@ -7,6 +7,17 @@ let swap arr i j =
 ;;
 
 module T = struct
+  (* CR-soon Alizter: When bumping the minimal version to 4.13, remove this
+     polyfill. [Stdlib.ArrayLabels] provides it natively. *)
+  let[@warning "-32"] find_opt ~f a =
+    let len = Stdlib.Array.length a in
+    let rec loop i =
+      if i = len then None else if f a.(i) then Some a.(i) else loop (i + 1)
+    in
+    loop 0
+  ;;
+
+  (* overwrite with stdlib version if available *)
   include ArrayLabels
 
   let equal f x y =

--- a/otherlibs/stdune/src/either.ml
+++ b/otherlibs/stdune/src/either.ml
@@ -1,4 +1,19 @@
+(* CR-soon Alizter: When bumping the minimal version to 4.12, remove
+   [Dune_either]. [Stdlib.Either] provides this natively. *)
+module Dune_either = struct
+  module Either = struct
+    type ('a, 'b) t =
+      | Left of 'a
+      | Right of 'b
+  end
+end
+
 include struct
+  [@@@warning "-33"]
+
+  (* This open is unused with OCaml >= 4.12 since the stdlib defines an either
+     type. *)
+  open Dune_either
   open Stdlib
 
   type ('a, 'b) t = ('a, 'b) Either.t =

--- a/otherlibs/stdune/src/either.mli
+++ b/otherlibs/stdune/src/either.mli
@@ -1,6 +1,21 @@
 (** Left or right *)
 
+(* CR-soon Alizter: When bumping the minimal version to 4.12, remove
+   [Dune_either]. [Stdlib.Either] provides this natively. *)
+module Dune_either : sig
+  module Either : sig
+    type ('a, 'b) t =
+      | Left of 'a
+      | Right of 'b
+  end
+end
+
 include sig
+  [@@@warning "-33"]
+
+  (* This open is unused with OCaml >= 4.12 since the stdlib defines an either
+     type. *)
+  open Dune_either
   open Stdlib
 
   type ('a, 'b) t = ('a, 'b) Either.t =

--- a/otherlibs/stdune/src/string.ml
+++ b/otherlibs/stdune/src/string.ml
@@ -70,7 +70,29 @@ module Caseless = Cased_functions (struct
     let normalize = Char.lowercase_ascii
   end)
 
-include Stdlib.StringLabels
+(* CR-soon Alizter: When bumping the minimal version to 4.13, remove this
+   module. [Stdlib.StringLabels] provides these natively. *)
+module StringLabels = struct
+  let[@warning "-32"] exists ~f s =
+    let len = String.length s in
+    let rec loop i = i < len && (f s.[i] || loop (i + 1)) in
+    loop 0
+  ;;
+
+  let[@warning "-32"] for_all ~f s =
+    let len = String.length s in
+    let rec loop i = i = len || (f s.[i] && loop (i + 1)) in
+    loop 0
+  ;;
+
+  let[@warning "-32"] starts_with = starts_with
+  let[@warning "-32"] ends_with = ends_with
+
+  (* overwrite with stdlib versions if available *)
+  include Stdlib.StringLabels
+end
+
+include StringLabels
 
 let repr = Repr.string
 let compare a b = Ordering.of_int (String.compare a b)

--- a/otherlibs/stdune/src/wait4_stubs.c
+++ b/otherlibs/stdune/src/wait4_stubs.c
@@ -1,5 +1,10 @@
 #include <caml/mlvalues.h>
 
+/* CR-soon Alizter: When bumping the minimal version to 4.12, remove. */
+#ifndef Val_none
+#define Val_none Val_int(0)
+#endif
+
 #ifdef _WIN32
 #include <caml/fail.h>
 

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -843,7 +843,7 @@ let report_process_finished
       ~dir
       ~stdout
       ~stderr
-      ~(times : Proc.Times.t))
+      ~times:(times : Proc.Times.t))
 ;;
 
 let await ~timeout { response_file; pid; is_process_group_leader; _ } =


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/14506

Users are complaining. We will bump this 4.14 in a year or so anyway probably.

We reintroduce a bunch of polyfills so that dune bootstraps on 4.11.