### PR TITLE
Fiber: make Ivar.peek synchronous

### DIFF
--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -199,11 +199,11 @@ let ready (t : _ t) =
 ;;
 
 let stop (t : _ t) =
-  Fiber.Ivar.peek t.server.config.startup_ivar
-  >>= function
-  | None -> Fiber.return ()
-  | Some (Error _) -> Fiber.return ()
-  | Some (Ok server) -> Csexp_rpc.Server.stop server
+  Fiber.of_thunk (fun () ->
+    match Fiber.Ivar.peek t.server.config.startup_ivar with
+    | None -> Fiber.return ()
+    | Some (Error _) -> Fiber.return ()
+    | Some (Ok server) -> Csexp_rpc.Server.stop server)
 ;;
 
 let get_current_diagnostic_errors () =

--- a/src/fiber/src/core.ml
+++ b/src/fiber/src/core.ml
@@ -221,11 +221,10 @@ module Ivar = struct
   let fill t x k = Fill_ivar (t, x, k)
   let create_full a = { state = Full a }
 
-  let peek t k =
-    k
-      (match t.state with
-       | Empty | Empty_with_readers _ -> None
-       | Full x -> Some x)
+  let peek t =
+    match t.state with
+    | Empty | Empty_with_readers _ -> None
+    | Full x -> Some x
   ;;
 end
 

--- a/src/fiber/src/fiber.mli
+++ b/src/fiber/src/fiber.mli
@@ -197,8 +197,8 @@ module Ivar : sig
       given ivar. *)
   val fill : 'a t -> 'a -> unit fiber
 
-  (** Return [Some x] is [fill t x] has been called previously. *)
-  val peek : 'a t -> 'a option fiber
+  (** Return [Some x] if [fill t x] has been called previously. *)
+  val peek : 'a t -> 'a option
 end
 
 (** Mailbox variables *)

--- a/src/fiber/test/fiber_tests.ml
+++ b/src/fiber/test/fiber_tests.ml
@@ -113,7 +113,7 @@ let%expect_test "execution context of ivars" =
   let run_when_filled () =
     let var = Fiber.Var.create None in
     Fiber.Var.set var (Some 42) (fun () ->
-      let* peek = Fiber.Ivar.peek ivar in
+      let peek = Fiber.Ivar.peek ivar in
       assert (peek = None);
       let* () = Fiber.Ivar.read ivar in
       let+ value = Fiber.Var.get_exn var in

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -742,8 +742,7 @@ module Computation = struct
          to let the latter get the discovered dependencies [deps_rev]. *)
       Call_stack.push_frame frame (fun () -> fiber frame)
     in
-    Fiber.Ivar.peek ivar
-    >>= function
+    match Fiber.Ivar.peek ivar with
     | Some _ -> Fiber.return result
     | None ->
       let+ () = Fiber.Ivar.fill ivar result in
@@ -751,8 +750,7 @@ module Computation = struct
   ;;
 
   let read_but_first_check_for_cycles { ivar; dag_node } ~phase ~dep_node =
-    Fiber.Ivar.peek ivar
-    >>= function
+    match Fiber.Ivar.peek ivar with
     | Some res -> Fiber.return (Ok res)
     | None ->
       let dep_node = Dep_node.T dep_node in
@@ -1213,8 +1211,7 @@ end = struct
       dep_node.state <- Cached_value (Cached_value.create_cancelled ~dependency_cycle);
       Fiber.return ()
     | Computing { compute; _ } ->
-      Fiber.Ivar.peek compute.ivar
-      >>= (function
+      (match Fiber.Ivar.peek compute.ivar with
        | Some _ -> Fiber.return ()
        | None ->
          let cancelled = Cached_value.create_cancelled ~dependency_cycle in


### PR DESCRIPTION
Fiber.Ivar.peek only inspects local ivar state, so return a option directly instead of wrapping the result in Fiber.t.

Update memo, RPC, and Fiber tests to branch on the immediate option before returning follow-up fibers.