### PR TITLE
docs(agents): bootstrap-vs-built dune and binary-source alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,16 +87,13 @@ or `make dev`. Bootstrap is only needed for the specific circumstances above.
 - `make test-bootstrap` - Test bootstrap mechanism
 - `make dev` - Automatically bootstraps only if necessary
 
-**Bootstrap vs. built dune.** `_boot/dune.exe` (the binary behind
-`./dune.exe`) is produced by the bootstrap script — either an explicit
-`make bootstrap` or the first `make dev` after `_boot/` is missing —
-and is **not** refreshed automatically when source files change. For
-experiments that exercise dune's rule generation or build-system
-behavior — anything depending on `src/dune_rules/*` — use the
-fully-built dune at `_build/install/default/bin/dune` and run
-`make dev` first. Cram tests already use the built dune; manual
-reproductions driven by `./dune.exe` can diverge silently from the
-source being investigated.
+**Bootstrap vs. built dune.** `_boot/dune.exe` (behind `./dune.exe`)
+is not refreshed when source files change. For experiments that
+exercise dune's rule generation or build-system behavior, use the
+fully-built dune at `_build/install/default/bin/dune` (run `make dev`
+first). Cram tests already use the built dune; manual reproductions
+driven by `./dune.exe` can diverge silently from the source being
+investigated.
 
 When a test result disagrees with a manual reproduction — or CI disagrees
 with local — verify both are the same binary built from the same source:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,13 +88,15 @@ or `make dev`. Bootstrap is only needed for the specific circumstances above.
 - `make dev` - Automatically bootstraps only if necessary
 
 **Bootstrap vs. built dune.** `_boot/dune.exe` (the binary behind
-`./dune.exe`) is built once by `make bootstrap` and is **not** refreshed
-when source files change. For experiments that exercise dune's rule
-generation or build-system behavior — anything depending on
-`src/dune_rules/*` — use the fully-built dune at
-`_build/install/default/bin/dune` and run `make dev` first. Cram tests
-already use the built dune; manual reproductions driven by `./dune.exe`
-can diverge silently from the source being investigated.
+`./dune.exe`) is produced by the bootstrap script — either an explicit
+`make bootstrap` or the first `make dev` after `_boot/` is missing —
+and is **not** refreshed automatically when source files change. For
+experiments that exercise dune's rule generation or build-system
+behavior — anything depending on `src/dune_rules/*` — use the
+fully-built dune at `_build/install/default/bin/dune` and run
+`make dev` first. Cram tests already use the built dune; manual
+reproductions driven by `./dune.exe` can diverge silently from the
+source being investigated.
 
 When a test result disagrees with a manual reproduction — or CI disagrees
 with local — verify both are the same binary built from the same source:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,25 @@ or `make dev`. Bootstrap is only needed for the specific circumstances above.
 - `make test-bootstrap` - Test bootstrap mechanism
 - `make dev` - Automatically bootstraps only if necessary
 
+**Bootstrap vs. built dune.** `_boot/dune.exe` (the binary behind
+`./dune.exe`) is built once by `make bootstrap` and is **not** refreshed
+when source files change. For experiments that exercise dune's rule
+generation or build-system behavior — anything depending on
+`src/dune_rules/*` — use the fully-built dune at
+`_build/install/default/bin/dune` and run `make dev` first. Cram tests
+already use the built dune via `%{bin:dune}`; manual reproductions driven
+by `./dune.exe` can diverge silently from the source being investigated.
+
+When a test result disagrees with a manual reproduction — or CI disagrees
+with local — verify both are the same binary built from the same source:
+
+- Which `dune` is on PATH or called explicitly?
+- Is its timestamp newer than the source files being analyzed?
+- Does its build context match the source tree being analyzed?
+
+The bootstrap-vs-built mix-up is the commonest trap; checking up front
+avoids hours of reasoning about non-existent bugs.
+
 ### Test Commands
 ```bash
 dune runtest dir/           # Run tests in specific directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,8 @@ when source files change. For experiments that exercise dune's rule
 generation or build-system behavior — anything depending on
 `src/dune_rules/*` — use the fully-built dune at
 `_build/install/default/bin/dune` and run `make dev` first. Cram tests
-already use the built dune via `%{bin:dune}`; manual reproductions driven
-by `./dune.exe` can diverge silently from the source being investigated.
+already use the built dune; manual reproductions driven by `./dune.exe`
+can diverge silently from the source being investigated.
 
 When a test result disagrees with a manual reproduction — or CI disagrees
 with local — verify both are the same binary built from the same source:


### PR DESCRIPTION
I think that something like this is required to avoid having agents having to learn and re-learn the same thing about "which Dune is being built". I'm open to changes in the verbiage if you think it will improve things.

## Summary

- Adds a note in AGENTS.md's Bootstrap Process section covering the bootstrap-vs-built dune distinction: `_boot/dune.exe` (the binary behind `./dune.exe`) is built once by `make bootstrap` and is not refreshed on source changes. Experiments that exercise dune's rule generation should use `_build/install/default/bin/dune` after `make dev`.
- Includes a binary-source-alignment checklist for debugging test-vs-manual or CI-vs-local divergence — the commonest trap is running experiments with the bootstrapped `./dune.exe` while the test suite uses the fully-built dune.