### PR TITLE
docs(agents): cram test environment and jq shadowing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,10 @@ run with a specific environment configured in
 - `DUNE_CONFIG__BACKGROUND_DIGESTS=disabled`
 - `OCAML_COLOR=always`
 
-`test/blackbox-tests/setup-script.sh` also redefines `jq` to auto-include
-`dune.jq` via `-L"$INSIDE_DUNE"/test/blackbox-tests`. When a cram test's
+`test/blackbox-tests/setup-script.sh` also redefines `jq` to add
+`test/blackbox-tests` to its library search path (via
+`-L"$INSIDE_DUNE"/test/blackbox-tests`), so `include "dune";` in
+cram-test jq expressions resolves to `dune.jq`. When a cram test's
 behavior differs from a hand-built reproduction, these environmental
 differences are the first place to check before deeper investigation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,20 @@ This output will appear in cram test diffs, making it easy to observe values.
 **Trace Inspection:** Use `dune trace cat | jq` to inspect build traces. See
 `doc/hacking.rst` for details on using jq with traces in cram tests.
 
+**Cram test environment.** Cram tests under `test/blackbox-tests/test-cases/`
+run with a specific environment configured in
+`test/blackbox-tests/test-cases/dune`:
+
+- `DUNE_JOBS=1`
+- `DUNE_CONFIG__BACKGROUND_SANDBOXES=disabled`
+- `DUNE_CONFIG__BACKGROUND_DIGESTS=disabled`
+- `OCAML_COLOR=always`
+
+`test/blackbox-tests/setup-script.sh` also redefines `jq` to auto-include
+`dune.jq` via `-L"$INSIDE_DUNE"/test/blackbox-tests`. When a cram test's
+behavior differs from a hand-built reproduction, these environmental
+differences are the first place to check before deeper investigation.
+
 ### Development Guidelines
 - Always verify changes build with `dune build @check`
 - Run `dune fmt` to ensure code formatting (requires ocamlformat)


### PR DESCRIPTION
Something like this change is required to help agents (and maybe humans) avoid confusion about why test results in CI or merely in locally run tests differ from one's (agent's) own command-line incantations.

## Summary

- Documents the environment configured for cram tests in `test/blackbox-tests/test-cases/dune`: `DUNE_JOBS=1`, `DUNE_CONFIG__BACKGROUND_SANDBOXES=disabled`, `DUNE_CONFIG__BACKGROUND_DIGESTS=disabled`, `OCAML_COLOR=always`.
- Notes the `jq` shadowing in `test/blackbox-tests/setup-script.sh` that auto-includes `dune.jq` via `-L"$INSIDE_DUNE"/test/blackbox-tests`.
- Closes with the practical takeaway: these environmental differences are the first place to check when a cram test's behavior differs from a hand-built reproduction.