### PR TITLE
fix: include sys/wait.h on NetBSD in lev_stubs.c

### DIFF
--- a/doc/changes/fixed/14512.md
+++ b/doc/changes/fixed/14512.md
@@ -1,0 +1,3 @@
+- Fix the bootstrap on NetBSD by including `<sys/wait.h>` in `lev_stubs.c`,
+  matching the existing FreeBSD/OpenBSD guard.
+  (#14512, fixes #14484, @0-wiz-0)

--- a/src/lev/src/lev_stubs.c
+++ b/src/lev/src/lev_stubs.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #include <math.h>
-#if (defined(__FreeBSD__) || defined(__OpenBSD__))
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
 #include <sys/wait.h>
 #endif
 #define TAG_WEXITED 0


### PR DESCRIPTION
Fixes #14484.

NetBSD needs the same `<sys/wait.h>` include as FreeBSD and OpenBSD so that the `WIFEXITED`, `WEXITSTATUS`, `WIFSTOPPED`, `WSTOPSIG` and `WTERMSIG` macros are available when building `lev_stubs.c`. Without it the bootstrap fails at link time on NetBSD with undefined references to these symbols.

```
ld: /home/runner/work/dune/dune/_boot/src/lev/src/lev_stubs.c:515: undefined reference to `WIFEXITED'
ld: …:517: undefined reference to `WEXITSTATUS'
ld: …:518: undefined reference to `WIFSTOPPED'
ld: …:525: undefined reference to `WTERMSIG'
ld: …:521: undefined reference to `WSTOPSIG'
Error: Error during linking (exit code 1)
```
Failing CI run (before the fix): https://github.com/Alizter/dune/actions/runs/25815321578/job/75842142913?pr=9#step:3:403

Passing NetBSD x86-64 job on this PR (with the fix): https://github.com/ocaml/dune/actions/runs/25816678888/job/75846908855

Patch suggested by @0-wiz-0 in #14484.