### PR TITLE
refactor: route lib file deps through [lib_deps_for_module]

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -4,55 +4,29 @@ open Memo.O
 module Includes = struct
   type t = Command.Args.without_targets Command.Args.t Lib_mode.Cm_kind.Map.t
 
-  let make ~project ~opaque ~direct_requires ~hidden_requires lib_config
+  let make ~project ~direct_requires ~hidden_requires lib_config
     : _ Lib_mode.Cm_kind.Map.t
     =
-    (* TODO: some of the requires can filtered out using [ocamldep] info *)
     let open Resolve.Memo.O in
     let iflags direct_libs hidden_libs mode =
       Lib_flags.L.include_flags ~project ~direct_libs ~hidden_libs mode lib_config
     in
-    let make_includes_args ~mode groups =
+    let make_includes_args ~mode =
       (let+ direct_libs = direct_requires
        and+ hidden_libs = hidden_requires in
-       Command.Args.S
-         [ iflags direct_libs hidden_libs mode
-         ; Hidden_deps (Lib_file_deps.deps (direct_libs @ hidden_libs) ~groups)
-         ])
+       iflags direct_libs hidden_libs mode)
       |> Resolve.Memo.args
       |> Command.Args.memo
     in
     { ocaml =
-        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) [ Ocaml Cmi ] in
+        (let cmi_includes = make_includes_args ~mode:(Ocaml Byte) in
          { cmi = cmi_includes
          ; cmo = cmi_includes
-         ; cmx =
-             (let+ direct_libs = direct_requires
-              and+ hidden_libs = hidden_requires in
-              Command.Args.S
-                [ iflags direct_libs hidden_libs (Ocaml Native)
-                ; Hidden_deps
-                    (let libs = direct_libs @ hidden_libs in
-                     if opaque
-                     then
-                       List.map libs ~f:(fun lib ->
-                         ( lib
-                         , if Lib.is_local lib
-                           then [ Lib_file_deps.Group.Ocaml Cmi ]
-                           else [ Ocaml Cmi; Ocaml Cmx ] ))
-                       |> Lib_file_deps.deps_with_exts
-                     else
-                       Lib_file_deps.deps
-                         libs
-                         ~groups:[ Lib_file_deps.Group.Ocaml Cmi; Ocaml Cmx ])
-                ])
-             |> Resolve.Memo.args
-             |> Command.Args.memo
+         ; cmx = make_includes_args ~mode:(Ocaml Native)
          })
     ; melange =
-        { cmi = make_includes_args ~mode:Melange [ Melange Cmi ]
-        ; cmj = make_includes_args ~mode:Melange [ Melange Cmi; Melange Cmj ]
-        }
+        (let mel_includes = make_includes_args ~mode:Melange in
+         { cmi = mel_includes; cmj = mel_includes })
     }
   ;;
 
@@ -319,8 +293,7 @@ let create
   ; requires_link
   ; implements
   ; parameters
-  ; includes =
-      Includes.make ~project ~opaque ~direct_requires ~hidden_requires ocaml.lib_config
+  ; includes = Includes.make ~project ~direct_requires ~hidden_requires ocaml.lib_config
   ; lib_index =
       Memo.lazy_ (fun () ->
         let open Resolve.Memo.O in
@@ -425,7 +398,6 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     let direct_requires = requires in
     Includes.make
       ~project:(Scope.project cctx.scope)
-      ~opaque
       ~direct_requires
       ~hidden_requires
       cctx.ocaml.lib_config

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -55,7 +55,6 @@ let deps_of_lib (lib : Lib.t) ~groups =
   |> Dep.Set.of_list
 ;;
 
-let deps_with_exts = Dep.Set.union_map ~f:(fun (lib, groups) -> deps_of_lib lib ~groups)
 let deps libs ~groups = Dep.Set.union_map libs ~f:(deps_of_lib ~groups)
 
 let groups_for_cm_kind ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib =

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -15,8 +15,6 @@ end
     with extension [files] of libraries [libs]. *)
 val deps : Lib.t list -> groups:Group.t list -> Dep.Set.t
 
-val deps_with_exts : (Lib.t * Group.t list) list -> Dep.Set.t
-
 (** [deps_of_entries ~opaque ~cm_kind libs] computes the file dependencies (glob
     deps on .cmi/.cmx files) for the given libraries. *)
 val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list -> Dep.Set.t

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -1,6 +1,54 @@
 open Import
 open Memo.O
 
+let all_libs cctx =
+  let open Resolve.Memo.O in
+  let+ d = Compilation_context.requires_compile cctx
+  and+ h = Compilation_context.requires_hidden cctx in
+  d @ h
+;;
+
+(* Returns the include flags and lib-file deps for compiling [m]. The scaffold
+   form is glob-only: include flags come from the cctx's [Includes] (-I/-H over
+   the full lib list) and deps come from [deps_of_entries] over the same list.
+   The per-module tight filter activates in a follow-up; arguments unused by
+   this form are reserved for that filter. *)
+let lib_deps_for_module
+      ~cctx
+      ~obj_dir:_
+      ~for_:_
+      ~dep_graph:_
+      ~opaque
+      ~cm_kind
+      ~ml_kind:(_ : Ml_kind.t)
+      ~mode:(_ : Lib_mode.t)
+      _m
+  =
+  let open Action_builder.O in
+  let* libs = Resolve.Memo.read (all_libs cctx) in
+  Action_builder.return
+    ( Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
+    , Lib_file_deps.deps_of_entries ~opaque ~cm_kind libs )
+;;
+
+let lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m =
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let opaque = Compilation_context.opaque cctx in
+  let for_ = Compilation_context.for_ cctx in
+  let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
+  Action_builder.dyn_deps
+    (lib_deps_for_module
+       ~cctx
+       ~obj_dir
+       ~for_
+       ~dep_graph
+       ~opaque
+       ~cm_kind
+       ~ml_kind
+       ~mode
+       m)
+;;
+
 (* Arguments for the compiler to prevent it from being too clever.
 
    The compiler creates the cmi when it thinks a .ml file has no corresponding
@@ -281,6 +329,20 @@ let build_cm
         | Some All | None -> Hidden_targets [ obj ])
    in
    let opaque = Compilation_context.opaque cctx in
+   let skip_lib_deps =
+     match Module.kind m with
+     | Alias _ ->
+       not (Modules.With_vlib.is_stdlib_alias (Compilation_context.modules cctx) m)
+     | Wrapped_compat -> true
+     | Intf_only | Virtual | Impl | Impl_vmodule | Root | Parameter -> false
+   in
+   let lib_cm_args =
+     if skip_lib_deps
+     then
+       Action_builder.return
+         (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+     else lib_cm_deps ~cctx ~cm_kind ~ml_kind ~mode m
+   in
    let other_cm_files =
      let dep_graph = Ml_kind.Dict.get (Compilation_context.dep_graphs cctx) ml_kind in
      let module_deps = Dep_graph.deps_of dep_graph m in
@@ -407,8 +469,7 @@ let build_cm
             ; cmt_args
             ; cms_args
             ; Command.Args.S obj_dirs
-            ; Command.Args.as_any
-                (Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind)
+            ; Command.Args.Dyn lib_cm_args
             ; extra_args
             ; As as_parameter_arg
             ; as_argument_for
@@ -524,6 +585,9 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
        List.concat_map deps ~f:(fun m ->
          [ Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi)) ]))
   in
+  let lib_cm_args =
+    lib_cm_deps ~cctx ~cm_kind:(Ocaml Cmo) ~ml_kind:Impl ~mode:(Ocaml Byte) m
+  in
   let ocaml_flags = Ocaml_flags.get (Compilation_context.flags cctx) (Ocaml Byte) in
   let modules = Compilation_context.modules cctx in
   let ocaml = Compilation_context.ocaml cctx in
@@ -541,10 +605,7 @@ let ocamlc_i ~deps cctx (m : Module.t) ~output =
               [ Command.Args.dyn ocaml_flags
               ; A "-I"
               ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-              ; Command.Args.as_any
-                  (Lib_mode.Cm_kind.Map.get
-                     (Compilation_context.includes cctx)
-                     (Ocaml Cmo))
+              ; Command.Args.Dyn lib_cm_args
               ; opens modules m
               ; A "-short-paths"
               ; A "-i"


### PR DESCRIPTION
Layer 3 of 9 of #14492. Behaviour-equivalent refactor.

`Compilation_context.Includes.make` drops `~opaque` and stops emitting `Hidden_deps`; `Includes.t` carries only `-I`/`-H` flags. `Module_compilation.lib_deps_for_module` (scaffold form: always-glob) and `lib_cm_deps` wire the dep set back in via `deps_of_entries`. `build_cm` and `ocamlc_i` are switched to consume `lib_cm_deps`; `Alias` / `Wrapped_compat` short-circuit to the cctx's now-flag-only `Includes`. `Lib_file_deps.deps_with_exts` removed — only used by the old `Cmx` arm of `Includes.make`.

Combined effect: same `-I` / `-H`, same lib file deps.

Stack: rebases on #14514. Next: #14516.

Part of #14492. Related to #4572.