### PR TITLE
fix(pkg): lock subdirectories

### DIFF
--- a/doc/changes/fixed/14524.md
+++ b/doc/changes/fixed/14524.md
@@ -1,0 +1,3 @@
+- Fix `dune build` failing with "No rule found" when `lock_dir` paths in
+  `dune-workspace` contain a subdirectory (e.g. `(path sub/dune.lock)`).
+  (#14524, fixes #14523, @Alizter)

--- a/src/dune_rules/lock_rules.ml
+++ b/src/dune_rules/lock_rules.ml
@@ -510,6 +510,7 @@ let setup_rules ~components ~dir =
       let lock_dir = Path.Source.to_local lock_dir_path in
       let+ lock_rule = setup_lock_rules_with_source workspace ~dir ~lock_dir in
       Gen_rules.combine rules lock_rule)
+  | ".lock" :: _ :: _ -> Memo.return (Gen_rules.redirect_to_parent Gen_rules.Rules.empty)
   | [ ".dev-tool-locks" ] ->
     Memo.List.fold_left Dev_tool.all ~init:empty ~f:(fun rules dev_tool ->
       let+ dev_tool_rules = setup_dev_tool_lock_rules ~dir dev_tool in

--- a/src/source/workspace.ml
+++ b/src/source/workspace.ml
@@ -815,7 +815,8 @@ let source_path_of_lock_dir_path path =
   | In_source_tree s -> s
   | In_build_dir b ->
     (match Path.Build.explode b with
-     | [ _; _; ".lock"; lock_dir ] -> Path.Source.of_string lock_dir
+     | _ :: _ :: ".lock" :: (_ :: _ as lock_dir_segs) ->
+       Path.Source.L.relative Path.Source.root lock_dir_segs
      | [ ".dev-tools.locks"; dev_tool ] ->
        Path.Source.L.relative Path.Source.root [ "_build"; ".dev-tools.locks"; dev_tool ]
      | components ->

--- a/test/blackbox-tests/test-cases/pkg/lock-dir-subdirectory-path.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-dir-subdirectory-path.t
@@ -9,10 +9,17 @@ Lock directories in subdirectories should work.
   > EOF
   $ source_lock_dir=sub/dune.lock make_lockdir
 
-BUG: no rule is generated for the lock directory at the subdirectory path.
+  $ dune build
+
+Also with deeper nesting:
+
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.24)
+  > (lock_dir (path a/b/c.lock))
+  > (context
+  >  (default
+  >   (lock_dir a/b/c.lock)))
+  > EOF
+  $ source_lock_dir=a/b/c.lock make_lockdir
 
   $ dune build
-  Error: No rule found for default/.lock/sub/dune.lock (context _private)
-  -> required by read lock directory
-     _build/_private/default/.lock/sub/dune.lock
-  [1]


### PR DESCRIPTION
Fixes #14523.

Two places assumed single-segment lock_dir paths:

- `Lock_rules.setup_rules` only handled `components = [".lock"]` and fell through to empty rules for deeper paths. Adds a `".lock" :: _ :: _` arm that returns `redirect_to_parent`, mirroring the pattern `Pkg_rules` uses for `.pkg/<digest>` sub-paths.
- `Workspace.source_path_of_lock_dir_path` only matched a 4-component build path; generalised to any `_ :: _ :: ".lock" :: (_ :: _ as segs)`.

Builds on #14522.