### PR TITLE
[3.32.1 backport] fix: include sys/wait.h on NetBSD in lev_stubs.c (#14512)

### DIFF
--- a/doc/changes/fixed/14512.md
+++ b/doc/changes/fixed/14512.md
@@ -1,0 +1,3 @@
+- Fix the bootstrap on NetBSD by including `<sys/wait.h>` in `lev_stubs.c`,
+  matching the existing FreeBSD/OpenBSD guard.
+  (#14512, fixes #14484, @0-wiz-0)

--- a/src/lev/src/lev_stubs.c
+++ b/src/lev/src/lev_stubs.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #include <math.h>
-#if (defined(__FreeBSD__) || defined(__OpenBSD__))
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
 #include <sys/wait.h>
 #endif
 #define TAG_WEXITED 0


### PR DESCRIPTION
Backport of #14512 onto 3.32.1