### PR TITLE
Update constraint to use odoc with new markdown rendering

### DIFF
--- a/opam/dune.opam
+++ b/opam/dune.opam
@@ -55,7 +55,7 @@ depends: [
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }
-  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "odoc" { with-dev-setup & >= "3.2.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }

--- a/opam/dune.opam.template
+++ b/opam/dune.opam.template
@@ -16,7 +16,7 @@ depends: [
   "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
   "menhir" { with-dev-setup & os != "win32" }
   "ocamlfind" { with-dev-setup & os != "win32" }
-  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "odoc" { with-dev-setup & >= "3.2.0" & os != "win32" }
   "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
   "spawn" { with-dev-setup }
   "ppx_inline_test" { with-dev-setup & os != "win32" }


### PR DESCRIPTION
The CI keeps failing presumably since https://github.com/ocaml/odoc/pull/1403 (released in odoc 3.2.0) was merged.

This PR
 - [X] Updates the constraint to use odoc 3.2.0+
 - [X] ~~Updates the tests to expect the new syntax~~ already done in #14505