### PR TITLE
Capture right dune in subshell

### DIFF
--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -8,14 +8,16 @@ The debug event can be triggered with Sigusr1
   $ wait_for_trace_events () {
   >   jq_program="$1"
   >   expected="$2"
+  >   dune="$(command -v dune)"
   >   with_timeout bash -lc '
   >     jq_program="$1"
   >     expected="$2"
-  >     while [ "$(dune trace cat | jq -r "$jq_program" | wc -l)" -lt "$expected" ]
+  >     dune="$3"
+  >     while [ "$("$dune" trace cat | jq -r "$jq_program" | wc -l)" -lt "$expected" ]
   >     do
   >       sleep 0.1
   >     done
-  >   ' bash "$jq_program" "$expected"
+  >   ' bash "$jq_program" "$expected" "$dune"
   > }
 
   $ make_dune_project 3.22


### PR DESCRIPTION
The tests inject the right dune, but if the test launches a shell script that gets `dune` from the path it might get the wrong one.

My original hypothesis in #14528 was wrong, the outer `dune` is correct and it depends on the right dune, but the inner `dune` pointed to one in my `PATH` and not to the in-development one.

Closes #14528