### PR TITLE
chore: supply missing changelog for #14443

### DIFF
--- a/doc/changes/fixed/14443.md
+++ b/doc/changes/fixed/14443.md
@@ -1,0 +1,5 @@
+- Fix the fallback to the secondary compiler, allowing recovering of support for
+  packages with upper bounds on OCaml less than 4.14. Packages depending on dune
+  2.23.1 or later and with an upper bound on the OCaml compiler that is less
+  than 4.14, will now be able to use the latest dune, but dune will be built
+  with the secondary compiler at version 4.14. (#14443, @Alizter)

--- a/doc/changes/fixed/14443.md
+++ b/doc/changes/fixed/14443.md
@@ -1,5 +1,5 @@
 - Fix the fallback to the secondary compiler, allowing recovering of support for
   packages with upper bounds on OCaml less than 4.14. Packages depending on dune
-  2.23.1 or later and with an upper bound on the OCaml compiler that is less
+  3.23.1 or later and with an upper bound on the OCaml compiler that is less
   than 4.14, will now be able to use the latest dune, but dune will be built
   with the secondary compiler at version 4.14. (#14443, @Alizter)


### PR DESCRIPTION
Required for the patch release since it announces a user-facing fix. Since this missed landing in main initially, it's not important to but it there, because it will just be deleted and moved into the `CHANGELOG.md` when the release is cut anyhow.