### PR TITLE
refactor: remove source copying rules

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -305,7 +305,10 @@ module File_ops_real (W : sig
     let chmod = if executable then fun _ -> 0o755 else fun _ -> 0o644 in
     let plain_copy () = Io.copy_file ~chmod ~src ~dst () in
     match kind with
-    | Substitute -> Artifact_substitution.copy_file ~conf ~src ~dst ~chmod ()
+    | Substitute ->
+      let open Fiber.O in
+      let+ (_ : bool) = Artifact_substitution.copy_file ~conf ~src ~dst ~chmod () in
+      ()
     | Special sf ->
       let open Fiber.O in
       let ic, oc = Io.setup_copy ~chmod ~src ~dst () in

--- a/otherlibs/stdune/src/permissions.ml
+++ b/otherlibs/stdune/src/permissions.ml
@@ -7,4 +7,5 @@ let execute = { current_user = 0o100; all_users = 0o111 }
 let write = { current_user = 0o200; all_users = 0o222 }
 let add t perm = perm lor t.current_user
 let test t perm = perm land t.current_user <> 0
+let test_any t perm = perm land t.all_users <> 0
 let remove t perm = perm land lnot t.all_users

--- a/otherlibs/stdune/src/permissions.mli
+++ b/otherlibs/stdune/src/permissions.mli
@@ -12,5 +12,8 @@ val add : t -> int -> int
 (** Test permissions of a given mask for the current user. *)
 val test : t -> int -> bool
 
+(** Test permissions of a given mask for any user. *)
+val test_any : t -> int -> bool
+
 (** Remove permissions from a given mask for all users. *)
 val remove : t -> int -> int

--- a/src/dune_cache/shared.ml
+++ b/src/dune_cache/shared.ml
@@ -65,7 +65,7 @@ module Target = struct
     match Unix.lstat path with
     | { Unix.st_kind = Unix.S_REG; st_perm; _ } ->
       Unix.chmod path (Permissions.remove Permissions.write st_perm);
-      let executable = Permissions.test Permissions.execute st_perm in
+      let executable = Permissions.test_any Permissions.execute st_perm in
       Some (File { executable })
     | { Unix.st_kind = Unix.S_DIR; st_perm; _ } ->
       (* Adding "executable" permissions to directories mean we can traverse them. *)

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -225,18 +225,3 @@ let create_memo name ~input ?cutoff ?human_readable_description f =
 let push_stack_frame ~human_readable_description f =
   Push_stack_frame (human_readable_description, f)
 ;;
-
-module Expert = struct
-  let record_dep_on_source_file_exn res ~loc (src_path : Path.Source.t) =
-    let path : Path.t = Path.source src_path in
-    let dep = Dep.file path in
-    let f _ =
-      let open Memo.O in
-      let+ digest =
-        Fs_memo.file_digest_exn ~loc (Path.Outside_build_dir.In_source_dir src_path)
-      in
-      Dep.Fact.file path digest
-    in
-    record res (Dep.Set.singleton dep) ~f
-  ;;
-end

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -65,20 +65,6 @@ val record : 'a -> Dep.Set.t -> f:(Dep.t -> Dep.Fact.t Memo.t) -> 'a t
     until the action's dependencies need to be determined. *)
 val record_success : unit Memo.t -> unit t
 
-module Expert : sig
-  (** Like [record] but records a dependency on a *source* file. Evaluating the resulting
-      [t] in the [Eager] mode will raise a user error if the file can't be digested.
-
-      This function is in the [Expert] module because depending on files in the source
-      directory is usually a mistake. As of 2023-11-14, we use this function only for
-      setting up the rules that copy files from the source to the build directory. *)
-  val record_dep_on_source_file_exn
-    :  'a
-    -> loc:(unit -> Loc.t option Memo.t)
-    -> Path.Source.t
-    -> 'a t
-end
-
 (** {1 Evaluation} *)
 
 (** Evaluate a [t] and collect the set of its dependencies. This avoids doing the build

--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -85,6 +85,7 @@ module type Source_tree = sig
   end
 
   val find_dir : Path.Source.t -> Dir.t option Memo.t
+  val copy_source : src:Path.Source.t -> dst:Path.Build.t -> unit Fiber.t
 end
 
 type t =

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -93,6 +93,7 @@ module type Source_tree = sig
   end
 
   val find_dir : Path.Source.t -> Dir.t option Memo.t
+  val copy_source : src:Path.Source.t -> dst:Path.Build.t -> unit Fiber.t
 end
 
 (** Initialise the build system. This must be called before running the build

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -126,6 +126,20 @@ type rule_execution_result =
   }
 
 module Internal = struct
+  module Source_file_copy = struct
+    type t =
+      { src : Path.Source.t
+      ; dst : Path.Build.t
+      }
+
+    let equal { src; dst } t = Path.Source.equal src t.src && Path.Build.equal dst t.dst
+    let hash { src; dst } = Tuple.T2.hash Path.Source.hash Path.Build.hash (src, dst)
+
+    let to_dyn { src; dst } =
+      Dyn.record [ "src", Path.Source.to_dyn src; "dst", Path.Build.to_dyn dst ]
+    ;;
+  end
+
   let file_selector_stack_frame_description file_selector =
     Pp.concat [ Pp.text (File_selector.to_dyn file_selector |> Dyn.to_string) ]
   ;;
@@ -550,7 +564,7 @@ module Internal = struct
           | Anonymous_action a -> a.attached_to_alias
         in
         let force_rerun = !Clflags.force && is_test in
-        force_rerun || Dep.Map.has_universe facts
+        force_rerun || Dep.Map.has_universe facts || Dep.Facts.has_source_tree_paths facts
       in
       let rule_digest =
         compute_rule_digest rule ~facts ~action ~sandbox_mode ~execution_parameters
@@ -824,6 +838,11 @@ module Internal = struct
     Load_rules.get_rule_or_source path
     >>= function
     | Source digest -> Memo.return (digest, File_target)
+    | Source_file_copy { src; dst } ->
+      let+ digest =
+        Memo.exec (Lazy.force build_source_file_copy_memo) { Source_file_copy.src; dst }
+      in
+      digest, File_target
     | Rule (path, rule) ->
       let* { facts = _; targets } =
         Memo.push_stack_frame
@@ -871,6 +890,38 @@ module Internal = struct
                target
            ])
 
+  and build_source_file_copy_impl { Source_file_copy.src; dst } =
+    let module Source_tree = (val (Build_config.get ()).source_tree) in
+    Memo.of_reproducible_fiber
+      (let open Fiber.O in
+       (match Path.Untracked.stat (Path.build dst) with
+        | Ok { st_kind = S_DIR; _ } -> Rule_cache.Workspace_local.remove_subtree dst
+        | Ok _ | Error _ -> ());
+       Rule_cache.Workspace_local.remove_target dst;
+       let* () = Source_tree.copy_source ~src ~dst in
+       let path = Path.build dst in
+       let executable =
+         match Unix.stat (Path.to_string path) with
+         | { st_kind = S_REG; st_perm; _ } ->
+           Permissions.test_any Permissions.execute st_perm
+         | { st_kind; _ } ->
+           User_error.raise
+             [ Pp.textf
+                 "Expected source copy target %s to be a file, but got %s"
+                 (Path.to_string_maybe_quoted path)
+                 (File_kind.to_string_hum st_kind)
+             ]
+         | exception Unix.Unix_error (e, _, _) ->
+           User_error.raise
+             [ Pp.textf
+                 "Failed to copy source file %s to %s: %s"
+                 (Path.Source.to_string_maybe_quoted src)
+                 (Path.Build.to_string_maybe_quoted dst)
+                 (Unix.error_message e)
+             ]
+       in
+       Digest.file_with_executable_bit ~executable path)
+
   and execute_anonymous_action action =
     let* action, facts = Action_builder.evaluate_and_collect_facts action in
     execute_action action ~observing_facts:facts
@@ -911,15 +962,12 @@ module Internal = struct
       let only_generated_files = File_selector.only_generated_files g in
       (* We look only at [by_file_targets] because [File_selector] does not
          match directories. *)
-      Path.Build.Map.foldi
-        ~init:[]
-        rules_here.by_file_targets
-        ~f:(fun path { Rule.info; _ } acc ->
-          match info with
-          | Rule.Info.Source_file_copy _ when only_generated_files -> acc
-          | _ ->
-            let basename = Path.Build.basename path in
-            if File_selector.test_basename g ~basename then basename :: acc else acc)
+      Path.Build.Map.foldi ~init:[] rules_here.by_file_targets ~f:(fun path target acc ->
+        match target with
+        | Source_file_copy _ when only_generated_files -> acc
+        | Rule _ | Source_file_copy _ ->
+          let basename = Path.Build.basename path in
+          if File_selector.test_basename g ~basename then basename :: acc else acc)
       |> List.rev
       |> Filename.Array.Set.of_sorted_list
       |> Filename_set.create ~dir
@@ -967,6 +1015,14 @@ module Internal = struct
          ~input:(module File_selector)
          ~cutoff:Filename_set.equal
          eval_pred_impl)
+
+  and build_source_file_copy_memo =
+    lazy
+      (Memo.create
+         "build-source-file-copy"
+         ~input:(module Source_file_copy)
+         ~cutoff:Digest.equal
+         build_source_file_copy_impl)
 
   and build_file_memo =
     lazy

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -400,6 +400,23 @@ module Facts = struct
         Path.Build.Set.union_all [ acc; Fact.Files.necessary_dirs_for_sandboxing facts ])
   ;;
 
+  let path_is_in_source_tree = function
+    | Path.In_source_tree _ -> true
+    | External _ | In_build_dir _ -> false
+  ;;
+
+  let fact_files_has_source_tree_paths { Fact.Files.files; empty_dirs = _; digest = _ } =
+    Path.Set.exists files ~f:path_is_in_source_tree
+  ;;
+
+  let has_source_tree_paths t =
+    Map.exists t ~f:(function
+      | Fact.Nothing -> false
+      | File (p, _digest) -> path_is_in_source_tree p
+      | File_selector { file_selector_digest = _; facts } | Alias facts ->
+        fact_files_has_source_tree_paths facts)
+  ;;
+
   let digest t digest ~env =
     Map.iteri t ~f:(fun dep fact ->
       match dep with

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -104,6 +104,7 @@ module Facts : sig
       directory. Needed for sandboxing *)
   val necessary_dirs_for_sandboxing : t -> Path.Build.Set.t
 
+  val has_source_tree_paths : t -> bool
   val digest : t -> Digest.Manual.t -> env:Env.t -> unit
   val to_dyn : t -> Dyn.t
 end

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -257,8 +257,8 @@ let promote_one dst srcs =
 
        amokhov: I removed this logic. In the current state of the world, files
        in the build directory should be redigested automatically (plus we do
-       not promote into the build directory anyway), and source digests should
-       be correctly invalidated via [fs_memo]. If that doesn't happen, we
+       not promote into the build directory anyway), and source paths should be
+       invalidated via [fs_memo] change tracking. If that doesn't happen, we
        should fix [fs_memo] instead of manually resetting the caches here. *)
     (match
        List.find srcs ~f:(function

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -99,7 +99,7 @@ module Cached_digest = struct
       type nonrec t = t
 
       let name = "DIGEST-DB"
-      let version = 11
+      let version = 12
       let sharing = true
       let repr = repr
     end)
@@ -483,22 +483,29 @@ module Debug = struct
     }
 
   let current_digest path =
-    let path_string = Path.to_string path in
-    match
-      Digest_result.catch_fs_errors (fun () ->
-        match Stat.stat path_string with
-        | stats ->
-          Ok
-            ( Some (Cached_digest.Reduced_stats.of_stat stats)
-            , Cached_digest.digest_path_with_stats path stats )
-        | exception Unix.Unix_error (ENOENT, _, _) ->
-          (match Unix.lstat path_string with
+    match Path.as_in_source_tree path with
+    | Some _ ->
+      ( None
+      , Error
+          (Digest_result.Error.Unrecognized
+             (Sys_error "source-tree digests are not checked")) )
+    | None ->
+      let path_string = Path.to_string path in
+      (match
+         Digest_result.catch_fs_errors (fun () ->
+           match Stat.stat path_string with
+           | stats ->
+             Ok
+               ( Some (Cached_digest.Reduced_stats.of_stat stats)
+               , Cached_digest.digest_path_with_stats path stats )
            | exception Unix.Unix_error (ENOENT, _, _) ->
-             Error Digest_result.Error.No_such_file
-           | _ -> Error Digest_result.Error.Broken_symlink))
-    with
-    | Ok current -> current
-    | Error error -> None, Error error
+             (match Unix.lstat path_string with
+              | exception Unix.Unix_error (ENOENT, _, _) ->
+                Error Digest_result.Error.No_such_file
+              | _ -> Error Digest_result.Error.Broken_symlink))
+       with
+       | Ok current -> current
+       | Error error -> None, Error error)
   ;;
 
   let finding_repr =
@@ -661,6 +668,10 @@ module Watcher : sig
      a lot smaller than the number of files. *)
   val watch : try_to_watch_via_parent:bool -> Path.Outside_build_dir.t -> unit Memo.t
 
+  (* Track changes to a file without sampling its digest. *)
+  val track_file_changes : Path.Outside_build_dir.t -> unit Memo.t
+  val file_change_version : Path.Outside_build_dir.t -> int
+
   (* Invalidate a path after receiving an event from the file watcher. *)
   val invalidate : Path.Outside_build_dir.t -> Memo.Invalidation.t
 end = struct
@@ -761,17 +772,40 @@ end = struct
          Memo.return ())
   ;;
 
+  let watch_via_parent accessed_path =
+    let path_to_watch =
+      Option.value (Path.Outside_build_dir.parent accessed_path) ~default:accessed_path
+    in
+    watch_or_record_path ~accessed_path ~path_to_watch
+  ;;
+
   let memo_for_watching_via_parent =
     Memo.create
       "fs_memo_for_watching_via_parent"
       ~input:(module Path.Outside_build_dir)
       (fun accessed_path ->
-         let path_to_watch =
-           Option.value
-             (Path.Outside_build_dir.parent accessed_path)
-             ~default:accessed_path
-         in
-         watch_or_record_path ~accessed_path ~path_to_watch;
+         watch_via_parent accessed_path;
+         Memo.return ())
+  ;;
+
+  let tracked_file_change_versions = Path.Outside_build_dir.Table.create 128
+
+  let file_change_version path =
+    Path.Outside_build_dir.Table.find tracked_file_change_versions path
+    |> Option.value ~default:0
+  ;;
+
+  let memo_for_file_changes =
+    Memo.create
+      "fs_memo_for_file_changes"
+      ~input:(module Path.Outside_build_dir)
+      (fun accessed_path ->
+         if
+           not
+             (Path.Outside_build_dir.Table.mem tracked_file_change_versions accessed_path)
+         then
+           Path.Outside_build_dir.Table.set tracked_file_change_versions accessed_path 0;
+         watch_via_parent accessed_path;
          Memo.return ())
   ;;
 
@@ -781,11 +815,17 @@ end = struct
     | true -> Memo.exec memo_for_watching_via_parent path
   ;;
 
+  let track_file_changes path = Memo.exec memo_for_file_changes path
+
   let update_all p =
     Cached_digest.Untracked.invalidate_cached_timestamp_file p;
     Cached_digest.Untracked.invalidate_cached_timestamp_dirs p;
     let dir_contents = Fs_cache.(update Untracked.dir_contents) p in
-    let digest = Fs_cache.(update Untracked.file_digest) p in
+    let digest =
+      match p with
+      | Path.Outside_build_dir.In_source_dir _ -> `Skipped
+      | Path.Outside_build_dir.External _ -> Fs_cache.(update Untracked.file_digest) p
+    in
     let stat = Fs_cache.(update Untracked.path_stat) p in
     List.fold_left [ stat; digest; dir_contents ] ~init:`Skipped ~f:(fun x y ->
       match x, y with
@@ -800,15 +840,24 @@ end = struct
      operation, or even better use [Fs_cache] tables in Memo directory, e.g. via
      [Memo.create_with_store]. *)
   let invalidate path =
+    let reason : Memo.Invalidation.Reason.t =
+      Path_changed (Path.outside_build_dir path)
+    in
+    let file_changes =
+      match Path.Outside_build_dir.Table.find tracked_file_change_versions path with
+      | None -> Memo.Invalidation.empty
+      | Some version ->
+        Path.Outside_build_dir.Table.set tracked_file_change_versions path (version + 1);
+        Memo.Cell.invalidate (Memo.cell memo_for_file_changes path) ~reason
+    in
     match update_all path with
-    | `Skipped | `Unchanged -> Memo.Invalidation.empty
+    | `Skipped | `Unchanged -> file_changes
     | `Changed ->
-      let reason : Memo.Invalidation.Reason.t =
-        Path_changed (Path.outside_build_dir path)
-      in
       Memo.Invalidation.combine
-        (Memo.Cell.invalidate (Memo.cell memo_for_watching_directly path) ~reason)
-        (Memo.Cell.invalidate (Memo.cell memo_for_watching_via_parent path) ~reason)
+        file_changes
+        (Memo.Invalidation.combine
+           (Memo.Cell.invalidate (Memo.cell memo_for_watching_directly path) ~reason)
+           (Memo.Cell.invalidate (Memo.cell memo_for_watching_via_parent path) ~reason))
   ;;
 
   let init ~dune_file_watcher =
@@ -916,6 +965,148 @@ let dir_exists path =
   | Error (_ : Unix_error.Detailed.t) -> false
 ;;
 
+let file_changed_event_cutoffs = Path.Outside_build_dir.Table.create 128
+let direct_file_change_trackers = Path.Outside_build_dir.Table.create 128
+let promoted_file_change_trackers = Path.Outside_build_dir.Table.create 128
+let source_file_copy_targets = Path.Source.Table.create 128
+
+let source_file_copy_is_up_to_date ~src ~dst =
+  let src_path = Path.source src in
+  let dst_path = Path.build dst in
+  match Stat.stat (Path.to_string src_path), Stat.stat (Path.to_string dst_path) with
+  | { kind = S_REG; perm = src_perm; _ }, { kind = S_REG; perm = dst_perm; _ } ->
+    let executable perm = Permissions.test_any Permissions.execute perm in
+    executable src_perm = executable dst_perm
+    &&
+      (match Io.compare_files src_path dst_path with
+      | Eq -> true
+      | Lt | Gt -> false
+      | exception (_ : exn) -> false)
+  | _ -> false
+  | exception (_ : exn) -> false
+;;
+
+let track_file_changes path =
+  Path.Outside_build_dir.Table.set direct_file_change_trackers path ();
+  Watcher.track_file_changes path
+;;
+
+let track_promoted_file_changes src =
+  let path = Path.Outside_build_dir.In_source_dir src in
+  Path.Outside_build_dir.Table.set promoted_file_change_trackers path ();
+  Watcher.track_file_changes path
+;;
+
+let track_source_file_copy ~src ~dst =
+  let targets =
+    match Path.Source.Table.find source_file_copy_targets src with
+    | None -> Path.Build.Set.singleton dst
+    | Some targets -> Path.Build.Set.add targets dst
+  in
+  Path.Source.Table.set source_file_copy_targets src targets;
+  Watcher.track_file_changes (In_source_dir src)
+;;
+
+let ignore_file_changed_events_if path ~f =
+  Path.Outside_build_dir.Table.set file_changed_event_cutoffs path f
+;;
+
+let source_file_copy_targets_status src =
+  match Path.Source.Table.find source_file_copy_targets src with
+  | None -> `No_targets
+  | Some targets ->
+    let all_up_to_date =
+      Path.Build.Set.to_list targets
+      |> List.for_all ~f:(fun dst -> source_file_copy_is_up_to_date ~src ~dst)
+    in
+    if all_up_to_date then `Up_to_date else `Stale
+;;
+
+let should_ignore_file_change_event path =
+  match Path.Outside_build_dir.Table.find file_changed_event_cutoffs path with
+  | None -> false
+  | Some f ->
+    (match f () with
+     | true -> true
+     | false ->
+       Path.Outside_build_dir.Table.remove file_changed_event_cutoffs path;
+       false
+     | exception (_ : exn) ->
+       Path.Outside_build_dir.Table.remove file_changed_event_cutoffs path;
+       false)
+;;
+
+let source_copy_targets_status_for_path = function
+  | Path.Outside_build_dir.In_source_dir src -> source_file_copy_targets_status src
+  | External _ -> `No_targets
+;;
+
+let source_copy_targets_are_not_stale = function
+  | `No_targets | `Up_to_date -> true
+  | `Stale -> false
+;;
+
+let make_source_path_change_stamp path (stats : Stat.t) ~version =
+  let d = Digest.Manual.create () in
+  Digest.Manual.string d "source-path-change-stamp-v1";
+  Digest.Manual.string d (Path.Outside_build_dir.to_string path);
+  Digest.Manual.int d version;
+  Digest.Manual.repr d Time.repr stats.mtime;
+  Digest.Manual.int d stats.size;
+  Digest.Manual.int d stats.perm;
+  Digest.Manual.repr d File_kind.repr stats.kind;
+  Digest.Manual.int d stats.dev;
+  Digest.Manual.int d stats.ino;
+  Digest.Manual.get d
+;;
+
+let source_path_change_stamp path =
+  let* () = track_file_changes path in
+  let version = Watcher.file_change_version path in
+  let path_for_stat = Path.outside_build_dir path in
+  let path_string = Path.to_string path_for_stat in
+  match
+    Digest_result.catch_fs_errors (fun () ->
+      match Stat.stat path_string with
+      | exception Unix.Unix_error (ENOENT, _, _) ->
+        (match Unix.lstat path_string with
+         | exception Unix.Unix_error (ENOENT, _, _) ->
+           Error Digest_result.Error.No_such_file
+         | _ -> Error Digest_result.Error.Broken_symlink)
+      | stats ->
+        (match stats.kind with
+         | S_REG -> Ok (`File (make_source_path_change_stamp path stats ~version))
+         | S_DIR -> Ok (`Dir (make_source_path_change_stamp path stats ~version))
+         | kind -> Error (Digest_result.Error.Unexpected_kind kind)))
+  with
+  | Ok (`File digest) -> Memo.return (Ok digest)
+  | Ok (`Dir digest) ->
+    let+ () = Watcher.watch ~try_to_watch_via_parent:false path in
+    Ok digest
+  | Error _ as error -> Memo.return error
+;;
+
+let source_path_change_stamp_exn ~loc source =
+  let path = Path.Outside_build_dir.In_source_dir source in
+  let report_user_error details =
+    let+ loc = loc () in
+    User_error.raise
+      ?loc
+      ([ Pp.textf
+           "File unavailable: %s"
+           (Path.Outside_build_dir.to_string_maybe_quoted path)
+       ]
+       @ details)
+  in
+  source_path_change_stamp path
+  >>= function
+  | Ok digest -> Memo.return digest
+  | Error e ->
+    if Digest_result.Error.no_such_file e
+    then report_user_error []
+    else report_user_error [ Digest_result.Error.pp e (Path.outside_build_dir path) ]
+;;
+
 (* CR-someday amokhov: It is unclear if we got the layers of abstraction right
    here. One could argue that caching is a higher-level concept compared to file
    watching, and we should expose this function from the [Cached_digest] module
@@ -923,12 +1114,18 @@ let dir_exists path =
    file system access functions in one place, and exposing an uncached version
    of [file_digest] seems error-prone. We may need to rethink this decision. *)
 let file_digest ?(force_update = false) path =
-  if force_update
-  then (
-    Cached_digest.Untracked.invalidate_cached_timestamp_file path;
-    Fs_cache.evict Fs_cache.Untracked.file_digest path);
-  let+ () = Watcher.watch ~try_to_watch_via_parent:true path in
-  Fs_cache.read Fs_cache.Untracked.file_digest path
+  match path with
+  | Path.Outside_build_dir.In_source_dir _ ->
+    Code_error.raise
+      "Fs_memo.file_digest called on a source-tree path"
+      [ "path", Path.Outside_build_dir.to_dyn path ]
+  | Path.Outside_build_dir.External _ ->
+    if force_update
+    then (
+      Cached_digest.Untracked.invalidate_cached_timestamp_file path;
+      Fs_cache.evict Fs_cache.Untracked.file_digest path);
+    let+ () = Watcher.watch ~try_to_watch_via_parent:true path in
+    Fs_cache.read Fs_cache.Untracked.file_digest path
 ;;
 
 let file_digest_exn ~loc path =
@@ -973,21 +1170,36 @@ let tracking_file_digest path =
   ()
 ;;
 
+let track_file_for_read path =
+  match path with
+  | Path.Outside_build_dir.In_source_dir _ -> track_file_changes path
+  | Path.Outside_build_dir.External _ -> tracking_file_digest path
+;;
+
 let with_lexbuf_from_file path ~f =
-  let+ () = tracking_file_digest path in
+  let+ () = track_file_for_read path in
   Io.Untracked.with_lexbuf_from_file (Path.outside_build_dir path) ~f
 ;;
 
 let file_contents path =
-  let+ () = tracking_file_digest path in
+  let+ () = track_file_for_read path in
   Io.read_file (Path.outside_build_dir path)
 ;;
 
-(* When a file or directory is created or deleted, we need to also invalidate
-   the parent directory, so that the [dir_contents] queries are re-executed. *)
-let invalidate_path_and_its_parent path =
+let invalidate_path_and_its_parent_after_file_change path =
+  let file_invalidation =
+    if Path.Outside_build_dir.Table.mem direct_file_change_trackers path
+    then Watcher.invalidate path
+    else (
+      let source_copy_status = source_copy_targets_status_for_path path in
+      if
+        source_copy_targets_are_not_stale source_copy_status
+        && should_ignore_file_change_event path
+      then Memo.Invalidation.empty
+      else Watcher.invalidate path)
+  in
   Memo.Invalidation.combine
-    (Watcher.invalidate path)
+    file_invalidation
     (match Path.Outside_build_dir.parent path with
      | None -> Memo.Invalidation.empty
      | Some path -> Watcher.invalidate path)
@@ -1017,8 +1229,25 @@ let handle_fs_event ({ kind; path } : Dune_scheduler.File_watcher.Fs_memo_event.
     Memo.Invalidation.empty
   | `Outside path ->
     (match kind with
-     | File_changed -> Watcher.invalidate path
-     | Created | Deleted | Unknown -> invalidate_path_and_its_parent path)
+     | File_changed ->
+       if Path.Outside_build_dir.Table.mem direct_file_change_trackers path
+       then Watcher.invalidate path
+       else (
+         let source_copy_status = source_copy_targets_status_for_path path in
+         if
+           source_copy_targets_are_not_stale source_copy_status
+           && should_ignore_file_change_event path
+         then Memo.Invalidation.empty
+         else (
+           match path, source_copy_status with
+           | In_source_dir _, `Up_to_date
+             when not
+                    (Path.Outside_build_dir.Table.mem promoted_file_change_trackers path)
+             -> Memo.Invalidation.empty
+           | In_source_dir _, (`No_targets | `Stale | `Up_to_date) | External _, _ ->
+             Watcher.invalidate path))
+     | Created | Deleted | Unknown ->
+       invalidate_path_and_its_parent_after_file_change path)
 ;;
 
 let init = Watcher.init
@@ -1027,6 +1256,15 @@ let init = Watcher.init
 let () = Dune_scheduler.Scheduler.set_fs_memo_impl ~handle_fs_event ~init
 
 module Untracked = struct
-  let file_digest = Fs_cache.read Fs_cache.Untracked.file_digest
+  let file_digest path =
+    match path with
+    | Path.Outside_build_dir.In_source_dir _ ->
+      Code_error.raise
+        "Fs_memo.Untracked.file_digest called on a source-tree path"
+        [ "path", Path.Outside_build_dir.to_dyn path ]
+    | Path.Outside_build_dir.External _ ->
+      Fs_cache.read Fs_cache.Untracked.file_digest path
+  ;;
+
   let path_stat = Fs_cache.read Fs_cache.Untracked.path_stat
 end

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -40,12 +40,41 @@ val path_kind
   :  Path.Outside_build_dir.t
   -> (File_kind.t, Unix_error.Detailed.t) result Memo.t
 
-(** Digest the contents of a source or external file and declare a dependency on
-    it. When [force_update = true], evict the file from all digest caches and
-    force the recomputation of the digest. This can be useful if Dune made a
-    change to the file and therefore knows that the cached digest is stale and
-    is about to be invalidated by an incoming file-system event. By not using
-    the cache in this situation, it's possible to avoid unnecessary restarts. *)
+(** Track a promoted source file without digesting it. Unlike
+    direct source readers, this does not mark the file as directly read by the
+    build, so Dune's self-generated promotion events can still be suppressed
+    when the promoted file is up to date. *)
+val track_promoted_file_changes : Path.Source.t -> unit Memo.t
+
+(** Track a source file that is copied into the build directory. File-change
+    events for the source may be ignored when all registered build-directory
+    copies already have the same contents and executable bit, and there are no
+    direct source readers for the path. *)
+val track_source_file_copy : src:Path.Source.t -> dst:Path.Build.t -> unit Memo.t
+
+(** Check whether a source-copy target is already up to date. This does not
+    register a dependency. *)
+val source_file_copy_is_up_to_date : src:Path.Source.t -> dst:Path.Build.t -> bool
+
+(** Ignore file-change events for [path] while [f] returns [true]. This is used
+    for source-tree files that Dune updates itself and can validate without
+    computing source-tree content digests. *)
+val ignore_file_changed_events_if : Path.Outside_build_dir.t -> f:(unit -> bool) -> unit
+
+(** Track a source-tree path and return a change stamp without digesting its
+    contents. *)
+val source_path_change_stamp_exn
+  :  loc:(unit -> Loc.t option Memo.t)
+  -> Path.Source.t
+  -> Digest.t Memo.t
+
+(** Digest the contents of an external file and declare a dependency on it.
+    [In_source_dir] paths are not allowed. When [force_update = true], evict the
+    file from all digest caches and force the recomputation of the digest. This
+    can be useful if Dune made a change to the file and therefore knows that the
+    cached digest is stale and is about to be invalidated by an incoming
+    file-system event. By not using the cache in this situation, it's possible
+    to avoid unnecessary restarts. *)
 val file_digest
   :  ?force_update:bool
   -> Path.Outside_build_dir.t

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -18,8 +18,14 @@ module Loaded = struct
   (* CR-someday amokhov: Loaded rules are relative to the directory passed to [load_dir],
      so these maps should probably be indexed by [Filename.t]s rather than [Path.t]s. We
      could add [Filename_map.t] anchored to a specific directory like [Filename_set.t]. *)
+  module File_target = struct
+    type t =
+      | Rule of Rule.t
+      | Source_file_copy of Path.Source.t
+  end
+
   type rules_here =
-    { by_file_targets : Rule.t Path.Build.Map.t
+    { by_file_targets : File_target.t Path.Build.Map.t
     ; by_directory_targets : Rule.t Path.Build.Map.t
     }
 
@@ -130,22 +136,40 @@ let get_dir_triage ~dir =
        Dir_triage.Build_directory { dir; context_name; context_type; sub_dir })
 ;;
 
-let describe_rule (rule : Rule.t) =
-  Pp.text
-  @@
-  match rule.info with
-  | From_dune_file loc ->
-    let start = Loc.start loc in
-    start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
-  | Internal -> "<internal location>"
-  | Source_file_copy _ -> "file present in source tree"
-;;
+module Target_producer = struct
+  type t =
+    | Rule of Rule.t
+    | Source_file_copy of Path.Source.t
+
+  let of_file_target (file_target : Loaded.File_target.t) =
+    match file_target with
+    | Rule rule -> Rule rule
+    | Source_file_copy source -> Source_file_copy source
+  ;;
+
+  let describe = function
+    | Rule rule ->
+      Pp.text
+      @@
+        (match rule.info with
+        | From_dune_file loc ->
+          let start = Loc.start loc in
+          start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
+        | Internal -> "<internal location>")
+    | Source_file_copy _ -> Pp.text "file present in source tree"
+  ;;
+
+  let is_source_file_copy = function
+    | Source_file_copy _ -> true
+    | Rule _ -> false
+  ;;
+end
 
 let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
   let loc =
     match rule.info with
     | From_dune_file loc -> loc
-    | Internal | Source_file_copy _ ->
+    | Internal ->
       let dir =
         match Path.Build.drop_build_context dir with
         | None -> Path.build dir
@@ -170,20 +194,22 @@ let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
       ]
 ;;
 
-let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
+let report_rule_conflict fn rule' rule =
   let fn = Path.build fn in
   User_error.raise
     [ Pp.textf "Multiple rules generated for %s:" (Path.to_string_maybe_quoted fn)
-    ; Pp.enumerate ~f:describe_rule [ rule'; rule ]
+    ; Pp.enumerate ~f:Target_producer.describe [ rule'; rule ]
     ]
     ~hints:
-      (match rule.info, rule'.info with
-       | Source_file_copy _, _ | _, Source_file_copy _ ->
+      (if
+         Target_producer.is_source_file_copy rule
+         || Target_producer.is_source_file_copy rule'
+       then
          [ Pp.textf
              "rm -f %s"
              (Path.to_string_maybe_quoted (Path.drop_optional_build_context fn))
          ]
-       | _ -> [])
+       else [])
 ;;
 
 let remove_old_artifacts
@@ -285,31 +311,14 @@ module rec Load_rules : sig
 end = struct
   open Load_rules
 
-  let copy_source_action ~src_path ~build_path : Action.Full.t Action_builder.t =
-    let action =
-      Action.Full.make
-        (Action.copy (Path.source src_path) build_path)
-        (* Sandboxing this action doesn't make much sense: if we can copy [src_path] to
-           the sandbox, we might as well copy it to the build directory directly. *)
-        ~sandbox:Sandbox_config.no_sandboxing
-    in
-    Action_builder.Expert.record_dep_on_source_file_exn
-      action
-      ~loc:Current_rule_loc.get
-      src_path
-  ;;
-
-  let create_copy_rules ~dir ~ctx_dir ~non_target_source_filenames =
+  let create_source_file_copies ~dir ~ctx_dir ~non_target_source_filenames =
     Filename.Array.Set.to_list_map non_target_source_filenames ~f:(fun filename ->
       let src_path = Path.Source.relative dir filename in
       let build_path = Path.Build.append_source ctx_dir src_path in
-      Rule.make
-        ~info:(Source_file_copy src_path)
-        ~targets:(Targets.File.create build_path)
-        (copy_source_action ~src_path ~build_path))
+      build_path, Loaded.File_target.Source_file_copy src_path)
   ;;
 
-  let compile_rules ~dir ~source_dirs rules =
+  let compile_rules ~dir ~source_dirs ~source_file_copies rules =
     let file_targets, directory_targets =
       let check_for_source_dir_conflict rule target =
         if Filename.Array.Set.mem source_dirs target
@@ -319,18 +328,24 @@ end = struct
         assert (Path.Build.( = ) dir rule.Rule.targets.root);
         ( Filename.Set.to_list_map rule.targets.files ~f:(fun target ->
             check_for_source_dir_conflict rule target;
-            Path.Build.relative rule.targets.root target, rule)
+            Path.Build.relative rule.targets.root target, Loaded.File_target.Rule rule)
         , Filename.Set.to_list_map rule.targets.dirs ~f:(fun target ->
             check_for_source_dir_conflict rule target;
             Path.Build.relative rule.targets.root target, rule) ))
       |> List.unzip
     in
     let by_file_targets =
-      List.concat file_targets |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
+      List.concat file_targets @ source_file_copies
+      |> Path.Build.Map.of_list_reducei ~f:(fun path a b ->
+        report_rule_conflict
+          path
+          (Target_producer.of_file_target a)
+          (Target_producer.of_file_target b))
     in
     let by_directory_targets =
       List.concat directory_targets
-      |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
+      |> Path.Build.Map.of_list_reducei ~f:(fun path a b ->
+        report_rule_conflict path (Target_producer.Rule a) (Target_producer.Rule b))
     in
     Path.Build.Map.iter2
       by_file_targets
@@ -338,7 +353,11 @@ end = struct
       ~f:(fun target rule1 rule2 ->
         match rule1, rule2 with
         | None, _ | _, None -> ()
-        | Some rule1, Some rule2 -> report_rule_conflict target rule1 rule2);
+        | Some rule1, Some rule2 ->
+          report_rule_conflict
+            target
+            (Target_producer.of_file_target rule1)
+            (Target_producer.Rule rule2));
     { Loaded.by_file_targets; by_directory_targets }
   ;;
 
@@ -850,9 +869,9 @@ end = struct
           in
           source_files_and_dirs source_paths_to_ignore sub_dir
       in
-      let copy_rules =
+      let source_file_copies =
         let ctx_dir = Context_name.build_dir context_name in
-        create_copy_rules
+        create_source_file_copies
           ~dir:sub_dir
           ~ctx_dir
           ~non_target_source_filenames:source_filenames
@@ -865,12 +884,12 @@ end = struct
           (* If there are no source files to copy, fallback rules are
              automatically kept *)
           rules
-        else add_non_fallback_rules ~init:copy_rules ~dir ~source_filenames rules
+        else add_non_fallback_rules ~init:[] ~dir ~source_filenames rules
       in
       let* descendants_to_keep =
         descendants_to_keep build_dir build_dir_only_sub_dirs ~source_dirs rules_produced
       in
-      let rules_here = compile_rules ~dir ~source_dirs rules in
+      let rules_here = compile_rules ~dir ~source_dirs ~source_file_copies rules in
       validate_directory_targets
         ~dir
         ~real_directory_targets:(Rules.directory_targets rules_produced)
@@ -931,23 +950,43 @@ end
 
 include Load_rules
 
-let get_rule_internal path =
+let get_file_target_internal path =
   let dir = Path.Build.parent_exn path in
   load_dir ~dir:(Path.build dir)
   >>= function
   | External _ | Source _ -> assert false
   | Build { rules_here; _ } ->
-    Memo.return
-      (match Path.Build.Map.find rules_here.by_file_targets path with
-       | Some _ as rule -> rule
-       | None -> Path.Build.Map.find rules_here.by_directory_targets path)
+    Memo.return (Path.Build.Map.find rules_here.by_file_targets path)
   | Build_under_directory_target { directory_target_ancestor } ->
     load_dir ~dir:(Path.build (Path.Build.parent_exn directory_target_ancestor))
     >>= (function
      | External _ | Source _ | Build_under_directory_target _ -> assert false
      | Build { rules_here; _ } ->
        Memo.return
-         (Path.Build.Map.find rules_here.by_directory_targets directory_target_ancestor))
+         (Path.Build.Map.find rules_here.by_file_targets directory_target_ancestor))
+;;
+
+let get_rule_internal path =
+  get_file_target_internal path
+  >>= function
+  | Some (Rule rule) -> Memo.return (Some rule)
+  | Some (Source_file_copy _) -> Memo.return None
+  | None ->
+    let dir = Path.Build.parent_exn path in
+    load_dir ~dir:(Path.build dir)
+    >>= (function
+     | External _ | Source _ -> assert false
+     | Build { rules_here; _ } ->
+       Memo.return (Path.Build.Map.find rules_here.by_directory_targets path)
+     | Build_under_directory_target { directory_target_ancestor } ->
+       load_dir ~dir:(Path.build (Path.Build.parent_exn directory_target_ancestor))
+       >>= (function
+        | External _ | Source _ | Build_under_directory_target _ -> assert false
+        | Build { rules_here; _ } ->
+          Memo.return
+            (Path.Build.Map.find
+               rules_here.by_directory_targets
+               directory_target_ancestor)))
 ;;
 
 let get_rule path =
@@ -959,19 +998,31 @@ let get_rule path =
 type rule_or_source =
   | Source of Digest.t
   | Rule of Path.Build.t * Rule.t
+  | Source_file_copy of
+      { src : Path.Source.t
+      ; dst : Path.Build.t
+      }
 
 let get_rule_or_source path =
   match Path.destruct_build_dir path with
-  | `Outside path ->
+  | `Outside (In_source_dir path) ->
+    let+ digest = Fs_memo.source_path_change_stamp_exn ~loc:Current_rule_loc.get path in
+    Source digest
+  | `Outside (External _ as path) ->
     let+ digest = Fs_memo.file_digest_exn ~loc:Current_rule_loc.get path in
     Source digest
   | `Inside path ->
-    get_rule_internal path
+    get_file_target_internal path
     >>= (function
-     | Some rule -> Memo.return (Rule (path, rule))
+     | Some (Rule rule) -> Memo.return (Rule (path, rule))
+     | Some (Source_file_copy src) -> Memo.return (Source_file_copy { src; dst = path })
      | None ->
-       let* loc = Current_rule_loc.get () in
-       no_rule_found ~loc path)
+       get_rule_internal path
+       >>= (function
+        | Some rule -> Memo.return (Rule (path, rule))
+        | None ->
+          let* loc = Current_rule_loc.get () in
+          no_rule_found ~loc path))
 ;;
 
 let get_alias_definition alias =

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -6,8 +6,14 @@ open Import
 val set_current_rule_loc : (unit -> Loc.t option Memo.t) -> unit
 
 module Loaded : sig
+  module File_target : sig
+    type t =
+      | Rule of Rule.t
+      | Source_file_copy of Path.Source.t
+  end
+
   type rules_here =
-    { by_file_targets : Rule.t Path.Build.Map.t
+    { by_file_targets : File_target.t Path.Build.Map.t
     ; by_directory_targets : Rule.t Path.Build.Map.t
     }
 
@@ -71,5 +77,9 @@ val is_under_directory_target : Path.t -> bool Memo.t
 type rule_or_source =
   | Source of Digest.t
   | Rule of Path.Build.t * Rule.t
+  | Source_file_copy of
+      { src : Path.Source.t
+      ; dst : Path.Build.t
+      }
 
 val get_rule_or_source : Path.t -> rule_or_source Memo.t

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -4,7 +4,6 @@ module Info = struct
   type t =
     | From_dune_file of Loc.t
     | Internal
-    | Source_file_copy of Path.Source.t
 
   let of_loc_opt = function
     | None -> Internal
@@ -14,7 +13,6 @@ module Info = struct
   let to_dyn : t -> Dyn.t = function
     | From_dune_file loc -> Dyn.Variant ("From_dune_file", [ Loc.to_dyn loc ])
     | Internal -> Dyn.Variant ("Internal", [])
-    | Source_file_copy p -> Dyn.Variant ("Source_file_copy", [ Path.Source.to_dyn p ])
   ;;
 end
 
@@ -76,7 +74,7 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
     | From_dune_file loc ->
       let pp = [ Pp.text message ] @ extra_pp in
       User_error.raise ~loc pp
-    | Internal | Source_file_copy _ ->
+    | Internal ->
       Code_error.raise
         message
         [ "info", Info.to_dyn info; "targets", Targets.to_dyn targets ]
@@ -104,7 +102,6 @@ let make ?(mode = Mode.Standard) ?(info = Info.Internal) ~targets action =
       Loc.in_file
         (Path.drop_optional_build_context
            (Path.build (Path.Build.relative targets.root "_unknown_")))
-    | Source_file_copy p -> Loc.in_file (Path.source p)
   in
   { id = Id.gen (); targets; action; mode; info; loc }
 ;;

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -7,7 +7,6 @@ module Info : sig
   type t =
     | From_dune_file of Loc.t
     | Internal
-    | Source_file_copy of Path.Source.t
 
   val of_loc_opt : Loc.t option -> t
 end

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -276,14 +276,17 @@ module Workspace_local = struct
         | (deps, old_digest) :: rest ->
           let open Fiber.O in
           let* deps = Memo.run (build_deps deps) in
-          let new_digest =
-            let d = Digest.Manual.create () in
-            Dep.Facts.digest deps d ~env;
-            Digest.Manual.get d
-          in
-          if Digest.equal old_digest new_digest
-          then loop rest
-          else Fiber.return (Miss Miss_reason.Dynamic_deps_changed)
+          if Dep.Facts.has_source_tree_paths deps
+          then Fiber.return (Miss Miss_reason.Dynamic_deps_changed)
+          else (
+            let new_digest =
+              let d = Digest.Manual.create () in
+              Dep.Facts.digest deps d ~env;
+              Digest.Manual.get d
+            in
+            if Digest.equal old_digest new_digest
+            then loop rest
+            else Fiber.return (Miss Miss_reason.Dynamic_deps_changed))
       in
       loop prev_trace.dynamic_deps_stages
   ;;

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -49,52 +49,50 @@ end
 let save = To_delete.dump
 let files_in_source_tree_to_delete () = To_delete.get_db ()
 
-let promote_target_if_not_up_to_date
-      ~src
-      ~src_digest
-      ~dst
-      ~promote_source
-      ~promote_until_clean
-  =
+let promoted_file_is_up_to_date ~src ~dst =
+  let src = Path.build src in
+  let dst = Path.source dst in
+  match Path.Untracked.stat src, Path.Untracked.stat dst with
+  | ( Ok { st_kind = S_REG; st_perm = src_perm; _ }
+    , Ok { st_kind = S_REG; st_perm = dst_perm; _ } ) ->
+    let executable perm = Permissions.test_any Permissions.execute perm in
+    executable src_perm = executable dst_perm
+    &&
+      (match Io.compare_files src dst with
+      | Eq -> true
+      | Lt | Gt -> false
+      | exception (_ : exn) -> false)
+  | _ -> false
+;;
+
+let promote_target_if_not_up_to_date ~src ~dst ~promote_source ~promote_until_clean =
   let open Fiber.O in
-  (* It is OK to use [Fs_memo.Untracked.file_digest] here because below we use
-     the tracked [Fs_memo.file_digest] to subscribe to the promotion result. *)
-  let* promoted =
-    match
-      Fs_memo.Untracked.file_digest (In_source_dir dst)
-      |> Dune_digest.Digest_result.to_option
-    with
-    | Some dst_digest when Digest.equal src_digest dst_digest ->
-      (* CR-someday amokhov: We skip promotion if [src_digest = dst_digest] but
-         this only works if [src] has no artifact substitution placeholders.
-         Artifact substitution changes [dst]'s contents and digest, which makes
-         this equality check ineffective. As a result, Dune currently executes
-         [promote_source] on all such targets on every start-up. We should fix
-         this, perhaps, by making artifact substitution a field of [promote]. *)
-      Fiber.return false
-    | _ ->
+  let ignore_promoted_file_changed_events () =
+    Fs_memo.ignore_file_changed_events_if (In_source_dir dst) ~f:(fun () ->
+      promoted_file_is_up_to_date ~src ~dst)
+  in
+  ignore_promoted_file_changed_events ();
+  let* () =
+    if promoted_file_is_up_to_date ~src ~dst
+    then
+      (* CR-someday amokhov: We skip promotion if [src] and [dst] have the same
+         bytes and executable bit, but this only works if [src] has no artifact
+         substitution placeholders. Artifact substitution changes [dst]'s
+         contents, which makes this equality check ineffective. As a result,
+         Dune currently executes [promote_source] on all such targets on every
+         start-up. We should fix this, perhaps, by making artifact substitution
+         a field of [promote]. *)
+      Fiber.return ()
+    else (
       Dune_trace.emit Promote (fun () -> Dune_trace.Event.Promote.promote src dst);
       if promote_until_clean then To_delete.add dst;
       (* The file in the build directory might be read-only if it comes from the
          shared cache. However, we want the file in the source tree to be
          writable by the user, so we explicitly set the user writable bit. *)
       let chmod = Permissions.add Permissions.write in
-      let+ () = promote_source ~chmod ~delete_dst_if_it_is_a_directory:true ~src ~dst in
-      true
+      promote_source ~chmod ~delete_dst_if_it_is_a_directory:true ~src ~dst)
   in
-  let+ dst_digest_result =
-    Memo.run (Fs_memo.file_digest ~force_update:promoted (In_source_dir dst))
-  in
-  match Dune_digest.Digest_result.to_option dst_digest_result with
-  | Some dst_digest ->
-    (* It's tempting to assert [src_digest = dst_digest] here but it turns out
-       this is not necessarily true: artifact substitution can change the
-       contents of promoted files. *)
-    ignore dst_digest
-  | None ->
-    Code_error.raise
-      (sprintf "Could not compute digest of promoted file %S" (Path.Source.to_string dst))
-      [ "dst_digest_result", Dune_digest.Digest_result.to_dyn dst_digest_result ]
+  Memo.run (Fs_memo.track_promoted_file_changes dst)
 ;;
 
 (* CR-someday amokhov: If a build causes N file promotions, Dune can potentially
@@ -184,20 +182,13 @@ let promote ~(targets : _ Targets.Produced.t) ~(promote : Rule.Promote.t) ~promo
     | Unlimited -> false
   in
   let* () =
-    Fiber.sequential_iter_seq
-      (Targets.Produced.all_files_seq targets)
-      ~f:(fun (src, src_digest) ->
-        match selected_for_promotion src with
-        | false -> Fiber.return ()
-        | true ->
-          let src = Path.Build.append_local targets.root src in
-          let dst = relocate src in
-          promote_target_if_not_up_to_date
-            ~src
-            ~src_digest
-            ~dst
-            ~promote_source
-            ~promote_until_clean)
+    Fiber.sequential_iter_seq (Targets.Produced.all_files_seq targets) ~f:(fun (src, _) ->
+      match selected_for_promotion src with
+      | false -> Fiber.return ()
+      | true ->
+        let src = Path.Build.append_local targets.root src in
+        let dst = relocate src in
+        promote_target_if_not_up_to_date ~src ~dst ~promote_source ~promote_until_clean)
   in
   (* There can be some files or directories left over from earlier builds, so we
      need to remove them from [targets]. *)

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -176,7 +176,7 @@ module Conf = struct
       let executable =
         match Path.Untracked.stat file with
         | Error _ -> false
-        | Ok { st_perm; _ } -> Permissions.test Permissions.execute st_perm
+        | Ok { st_perm; _ } -> Permissions.test_any Permissions.execute st_perm
       in
       if executable
       then
@@ -645,9 +645,14 @@ let copy_file_non_atomic ~conf ?chmod ~src ~dst () =
 ;;
 
 (** This is just an optimisation: skip the renaming if the destination exists
-    and has the right digest. The optimisation is useful to avoid unnecessary
-    retriggering of Dune and other file-watching systems. *)
+    and has the right contents and executable bit. The optimisation is useful to
+    avoid unnecessary retriggering of Dune and other file-watching systems. *)
 let replace_if_different ~delete_dst_if_it_is_a_directory ~src ~dst =
+  let files_are_up_to_date src_stats dst_stats =
+    let executable stats = Permissions.test_any Permissions.execute stats.Unix.st_perm in
+    Bool.equal (executable src_stats) (executable dst_stats)
+    && Io.compare_files src dst = Eq
+  in
   let up_to_date =
     match Path.Untracked.stat dst with
     | Ok { st_kind = S_DIR; _ } ->
@@ -662,12 +667,18 @@ let replace_if_different ~delete_dst_if_it_is_a_directory ~src ~dst =
                (Path.to_string dst)
            ])
     | Error (_ : Unix_error.Detailed.t) -> false
-    | Ok (_ : Unix.stats) ->
-      let temp_file_digest = Digest.file src in
-      let dst_digest = Digest.file dst in
-      Digest.equal temp_file_digest dst_digest
+    | Ok ({ st_kind = S_REG; _ } as dst_stats) ->
+      (match Path.Untracked.stat src with
+       | Ok ({ st_kind = S_REG; _ } as src_stats) ->
+         files_are_up_to_date src_stats dst_stats
+       | Ok _ | Error _ -> false)
+    | Ok _ -> false
   in
-  if not up_to_date then Unix.rename (Path.to_string src) (Path.to_string dst)
+  if up_to_date
+  then false
+  else (
+    Unix.rename (Path.to_string src) (Path.to_string dst);
+    true)
 ;;
 
 let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst () =

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -50,7 +50,8 @@ val decode : string -> t option
 
 (** Copy a file, performing all required substitutions. The operation is atomic,
     i.e., the contents is first copied to a temporary file in the same directory
-    and then atomically renamed to [dst]. *)
+    and then atomically renamed to [dst]. Returns [true] if [dst] was
+    replaced. *)
 val copy_file
   :  conf:Conf.t
   -> ?chmod:(int -> int)
@@ -58,7 +59,7 @@ val copy_file
   -> src:Path.t
   -> dst:Path.t
   -> unit
-  -> unit Fiber.t
+  -> bool Fiber.t
 
 type status =
   | Some_substitution

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -81,6 +81,7 @@ let init ~sandboxing_preference () : unit =
       ~dst
       ~conf
       ()
+    >>| ignore
   in
   Build_config.set
     ~sandboxing_preference

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -22,6 +22,7 @@ type t =
   | Cache
   | Digest
   | Artifact_substitution
+  | Source_copy
   | Thread
 
 let all =
@@ -46,6 +47,7 @@ let all =
   ; Cache
   ; Digest
   ; Artifact_substitution
+  ; Source_copy
   ; Thread
   ]
 ;;
@@ -72,6 +74,7 @@ let to_string = function
   | Cache -> "cache"
   | Digest -> "digest"
   | Artifact_substitution -> "artifact_subtitution"
+  | Source_copy -> "source_copy"
   | Thread -> "thread"
 ;;
 
@@ -110,7 +113,8 @@ module Set = Bit_set.Make (struct
       | Cache -> 18
       | Digest -> 19
       | Artifact_substitution -> 20
-      | Thread -> 21
+      | Source_copy -> 21
+      | Thread -> 22
     ;;
   end)
 

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -20,6 +20,7 @@ type t =
   | Cache
   | Digest
   | Artifact_substitution
+  | Source_copy
   | Thread
 
 val to_string : t -> string

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -23,6 +23,7 @@ module Category : sig
     | Cache
     | Digest
     | Artifact_substitution
+    | Source_copy
     | Thread
 end
 
@@ -260,6 +261,14 @@ module Event : sig
 
   val debug : (string * Dyn.t) list -> t
   val artifact_substitution : file:Path.t -> placeholder:Dyn.t -> value:string -> t
+
+  val source_copy
+    :  src:Path.Source.t
+    -> dst:Path.Build.t
+    -> start:Time.t
+    -> stop:Time.t
+    -> result:[ `Already_up_to_date | `Copied ]
+    -> t
 end
 
 module Out : sig

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -823,6 +823,19 @@ let artifact_substitution ~file ~placeholder ~value =
   Event.instant ~args ~name:"debug" now Artifact_substitution
 ;;
 
+let source_copy ~src ~dst ~start ~stop ~result =
+  let dur = Time.diff stop start in
+  let result =
+    match result with
+    | `Already_up_to_date -> "already_up_to_date"
+    | `Copied -> "copied"
+  in
+  let args =
+    [ "src", Arg.source_path src; "dst", Arg.build_path dst; "result", Arg.string result ]
+  in
+  Event.complete ~name:"copy" ~args ~start ~dur Source_copy
+;;
+
 let spawn_thread ~name =
   let now = Time.now () in
   let args = [ "name", Arg.string name ] in

--- a/src/source/dune
+++ b/src/source/dune
@@ -4,6 +4,7 @@
   dune_config_file
   dune_digest
   dune_engine
+  fiber
   dune_glob
   dune_lang
   dune_pkg

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -321,6 +321,70 @@ let find_dir =
     ~on_last_found:(fun _ -> Memo.return None)
 ;;
 
+let raise_source_file_unavailable ~src details =
+  User_error.raise
+    ~loc:(Loc.in_file (Path.source src))
+    (Pp.textf "File unavailable: %s" (Path.Source.to_string_maybe_quoted src) :: details)
+;;
+
+let raise_source_file_unavailable_for_exception ~src src_path exn =
+  let details_from_exception () =
+    match exn with
+    | Unix.Unix_error (error, syscall, arg) ->
+      [ Unix_error.Detailed.pp (Unix_error.Detailed.create error ~syscall ~arg) ]
+    | Sys_error message -> [ Pp.text message ]
+    | _ -> Exn.reraise exn
+  in
+  let details =
+    match Unix.stat (Path.to_string src_path) with
+    | _ -> details_from_exception ()
+    | exception Unix.Unix_error (error, syscall, arg) ->
+      (match error with
+       | ENOENT ->
+         (match Unix.lstat (Path.to_string src_path) with
+          | { st_kind = S_LNK; _ } -> [ Pp.text "Broken symbolic link" ]
+          | _ -> []
+          | exception Unix.Unix_error (ENOENT, _, _) -> []
+          | exception Unix.Unix_error (error, syscall, arg) ->
+            [ Unix_error.Detailed.pp (Unix_error.Detailed.create error ~syscall ~arg) ])
+       | _ -> [ Unix_error.Detailed.pp (Unix_error.Detailed.create error ~syscall ~arg) ])
+  in
+  raise_source_file_unavailable ~src details
+;;
+
+let copy_source ~src ~dst =
+  let open Fiber.O in
+  let* () = Memo.run (Fs_memo.track_source_file_copy ~src ~dst) in
+  let src_path = Path.source src in
+  let dst_path = Path.build dst in
+  let start = Time.now () in
+  let result = ref `Already_up_to_date in
+  let+ () =
+    Fiber.of_thunk (fun () ->
+      if not (Fs_memo.source_file_copy_is_up_to_date ~src ~dst)
+      then (
+        result := `Copied;
+        Path.parent dst_path |> Option.iter ~f:Path.mkdir_p;
+        (match Fpath.unlink (Path.to_string dst_path) with
+         | Success | Does_not_exist -> ()
+         | Is_a_directory -> Path.rm_rf dst_path
+         | Error exn -> Exn.reraise exn);
+        match Io.copy_file ~src:src_path ~dst:dst_path () with
+        | () -> ()
+        | exception ((Unix.Unix_error (_, _, arg) | Sys_error arg) as exn) ->
+          let src_path_string = Path.to_string src_path in
+          if
+            String.equal arg src_path_string
+            || String.starts_with arg ~prefix:(src_path_string ^ ":")
+          then raise_source_file_unavailable_for_exception ~src src_path exn
+          else Exn.reraise exn);
+      Fiber.return ())
+  in
+  let stop = Time.now () in
+  Dune_trace.emit Source_copy (fun () ->
+    Dune_trace.Event.source_copy ~src ~dst ~start ~stop ~result:!result)
+;;
+
 let nearest_dir = gen_find_dir ~on_success:Memo.return ~on_last_found:Memo.return
 
 let find_excluded_ancestor path =

--- a/src/source/source_tree.mli
+++ b/src/source/source_tree.mli
@@ -48,6 +48,7 @@ module Make_map_reduce_with_progress (M : Memo.S) (Outcome : Monoid) : sig
 end
 
 val find_dir : Path.Source.t -> Dir.t option Memo.t
+val copy_source : src:Path.Source.t -> dst:Path.Build.t -> unit Fiber.t
 
 (** [find_excluded_ancestor path] is the ancestor of [path] that was excluded by
     a dirs stanza, if any. *)

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -283,7 +283,7 @@ def cacheMisses:
 
 def cacheMissesMatching($path):
     [ .[] | cacheMisses ]
-  | map(select((.args.target // .args.head) | test("source|target1")))
+  | map(select((.args.target // .args.head) | test($path)))
   | sort_by(.args.target // .args.head)
   | .[] | {name, target: (.args.target // .args.head), reason: .args.reason};
 

--- a/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
+++ b/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
@@ -1,7 +1,7 @@
-In this test the "x" alias depends on the file "data" but the action
-associated to "x" appends a line to "data". The expected behavior is
-an error from Dune telling the user that this is not allowed, however
-Dune currently silently ignores this.
+In this test the "x" alias depends on the file "data" but the action associated
+to "x" appends a line to "data". Dune should eventually reject this, but for now
+the test documents that source-copy dependencies are refreshed from the source
+tree before the alias action runs.
 
   $ echo hello > data
   $ dune build @x
@@ -9,15 +9,11 @@ Dune currently silently ignores this.
   hello
   hello
 
-  $ dune build @x
-  $ cat _build/default/data
-  hello
-  hello
-  hello
+Rebuilding refreshes the source-copy dependency from the source tree before the
+alias action runs again, so the build-directory copy does not keep accumulating
+appended lines.
 
   $ dune build @x
   $ cat _build/default/data
-  hello
-  hello
   hello
   hello

--- a/test/blackbox-tests/test-cases/digest-cache/debug-option.t
+++ b/test/blackbox-tests/test-cases/digest-cache/debug-option.t
@@ -7,36 +7,15 @@ Test the tracing of digest events
   $ dune build x --wait-for-filesystem-clock
   $ echo 1 > x
   $ dune build x --wait-for-filesystem-clock
+  $ cat _build/default/x
+  1
 
-  $ dune trace cat | jq '
-  >   select(.cat == "digest")
-  > | .args
-  > | .old_stats.mtime |= type
-  > | .new_stats.mtime |= type
-  > | .new_stats.dev |= type
-  > | .new_stats.ino |= type
-  > | .old_stats.dev |= type
-  > | .old_stats.ino |= type
-  > '
-  {
-    "path": "x",
-    "old_digest": "662cf3f7d59f76428301690d4ead67ae",
-    "new_digest": "f31e1f1c33564e07cd02ad2c52f4df85",
-    "old_stats": {
-      "mtime": "number",
-      "size": 0,
-      "perm": 420,
-      "dev": "number",
-      "ino": "number"
-    },
-    "new_stats": {
-      "mtime": "number",
-      "size": 2,
-      "perm": 420,
-      "dev": "number",
-      "ino": "number"
-    }
-  }
+Source-backed targets do not emit content digest events for source files.
+
+  $ dune trace cat | jq -s '
+  > [ .[] | select(.cat == "digest" and .name == "redigest" and .args.path == "x") ]
+  > | length'
+  0
 
   $ mkdir dir
   $ touch dir/one.in

--- a/test/blackbox-tests/test-cases/dune-cache/config.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t
@@ -15,12 +15,8 @@ Check that old cache configuration format works fine with an old language
   > EOF
   $ cat > dune <<EOF
   > (rule
-  >   (deps source)
   >   (targets target)
-  >   (action (copy source target)))
-  > EOF
-  $ cat > source <<EOF
-  > \_o< COIN
+  >   (action (with-stdout-to target (echo target))))
   > EOF
 
 Test that DUNE_CACHE_ROOT can be used to control the cache location
@@ -49,7 +45,7 @@ Build succeeds and the 'hardlink' mode is respected
   $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
-  3
+  2
 
 Now repeat the tests with the old configuration format but 3.0 language
 
@@ -159,7 +155,7 @@ Build succeeds and the 'hardlink' mode is respected
   $ rm -rf _build/
   $ dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
-  3
+  2
 
 Let's disable the cache
 
@@ -184,7 +180,7 @@ Test that the cache can be enabled via the environment variable
   $ rm -rf _build/
   $ DUNE_CACHE=enabled dune build --config-file config target
   $ dune_cmd stat hardlinks _build/default/target
-  3
+  2
   $ dune_cmd exists $DUNE_CACHE_ROOT
   true
 
@@ -217,4 +213,4 @@ Test that we can override the environment variable from the command line
   $ rm -rf _build
   $ DUNE_CACHE_STORAGE_MODE=copy dune build --config-file config target --cache-storage-mode=hardlink
   $ dune_cmd stat hardlinks _build/default/target
-  3
+  2

--- a/test/blackbox-tests/test-cases/dune-cache/dedup.t
+++ b/test/blackbox-tests/test-cases/dune-cache/dedup.t
@@ -19,18 +19,15 @@ Test deduplication of build artifacts when using Dune cache with hard links.
 Here we build [target], which is a copy of [source]. After the build, the same
 file will appear in the build directory twice: (i) as [_build/default/source],
 because all sources are first copied to the build directory, and (ii) as
-[_build/default/target], as the build result. Furthermore, the same file will
-also be stored to the build cache, somewhere in the [files/v4] directory. Dune
-cache will recognise that all three files are identical and will use hard links
-to share them on disk, hence the hard link counts of 3.
+[_build/default/target], as the build result. The source copy is a build-system
+primitive and is not shared with the cache, while the generated [target] is
+stored in the build cache and hardlinked with its cache entry.
 
   $ dune build target
   $ cat _build/default/target
   \_o< COIN
-  $ dune_cmd stat hardlinks _build/default/source
-  3
   $ dune_cmd stat hardlinks _build/default/target
-  3
+  2
 
 Demonstrate that sharing of build artifacts can be abused to corrupt the cache.
 
@@ -48,8 +45,6 @@ Test that by using the [copy] mode we can disable the sharing.
   $ dune build target --cache-storage-mode=copy
   $ cat _build/default/target
   \_o< COIN
-  $ dune_cmd stat hardlinks _build/default/source
-  1
   $ dune_cmd stat hardlinks _build/default/target
   1
 

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -40,19 +40,9 @@ and shared cache misses, because we've never built target1 before.
   $ export DUNE_TRACE=cache
   $ dune build --config-file=config target1
 
-Verify we see cache miss events for our targets in the trace:
+Verify we see cache miss events for the generated target in the trace:
 
-  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("source|target1")'
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/default/source",
-    "reason": "never seen this target before"
-  }
-  {
-    "name": "miss",
-    "target": "_build/default/source",
-    "reason": "not found in cache"
-  }
+  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("target1")'
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
@@ -63,6 +53,10 @@ Verify we see cache miss events for our targets in the trace:
     "target": "_build/default/target1",
     "reason": "not found in cache"
   }
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | cacheMisses | select((.args.target // .args.head) == "_build/default/source") ]
+  > | length'
+  0
 
   $ dune_cmd stat hardlinks _build/default/source
   1
@@ -79,19 +73,19 @@ misses, because we've cleaned _build/default but not the shared cache.
   $ rm -rf _build/
   $ dune build --config-file=config target1
 
-Verify we see only workspace-local miss events for our targets (shared cache hits should not appear as misses):
+Verify we see only workspace-local miss events for the generated target (shared
+cache hits should not appear as misses):
 
-  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("source|target1")'
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/default/source",
-    "reason": "never seen this target before"
-  }
+  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("target1")'
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
     "reason": "never seen this target before"
   }
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | cacheMisses | select((.args.target // .args.head) == "_build/default/source") ]
+  > | length'
+  0
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -26,8 +26,9 @@ It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
   > \_o< COIN
   > EOF
 
-Test that after the build, the files in the build directory have the hard link
-counts greater than 1, because they are shared with the corresponding cache entries.
+Test that after the build, the generated targets are shared with their cache
+entries. The source copy is a build-system primitive and is not shared with the
+cache.
 
 Build target1 with cache tracing enabled. We expect to see both workspace-local
 and shared cache misses, because we've never built target1 before.
@@ -35,19 +36,9 @@ and shared cache misses, because we've never built target1 before.
   $ export DUNE_TRACE=cache
   $ dune build --config-file=config target1
 
-Verify we see cache miss events for our targets in the trace:
+Verify we see cache miss events for the generated target in the trace:
 
-  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("source|target1")'
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/default/source",
-    "reason": "never seen this target before"
-  }
-  {
-    "name": "miss",
-    "target": "_build/default/source",
-    "reason": "not found in cache"
-  }
+  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("target1")'
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
@@ -58,11 +49,15 @@ Verify we see cache miss events for our targets in the trace:
     "target": "_build/default/target1",
     "reason": "not found in cache"
   }
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | cacheMisses | select((.args.target // .args.head) == "_build/default/source") ]
+  > | length'
+  0
 
   $ dune_cmd stat hardlinks _build/default/source
-  3
+  1
   $ dune_cmd stat hardlinks _build/default/target1
-  3
+  2
   $ dune_cmd stat hardlinks _build/default/target2
   2
   $ dune_cmd exists _build/default/beacon
@@ -74,24 +69,24 @@ misses, because we've cleaned _build/default but not the shared cache.
   $ rm -rf _build/
   $ dune build --config-file=config target1
 
-Verify we see only workspace-local miss events for our targets (shared cache hits should not appear as misses):
+Verify we see only workspace-local miss events for the generated target (shared
+cache hits should not appear as misses):
 
-  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("source|target1")'
-  {
-    "name": "workspace_local_miss",
-    "target": "_build/default/source",
-    "reason": "never seen this target before"
-  }
+  $ dune trace cat | jq -s 'include "dune"; cacheMissesMatching("target1")'
   {
     "name": "workspace_local_miss",
     "target": "_build/default/target1",
     "reason": "never seen this target before"
   }
+  $ dune trace cat | jq -s 'include "dune";
+  > [ .[] | cacheMisses | select((.args.target // .args.head) == "_build/default/source") ]
+  > | length'
+  0
 
   $ dune_cmd stat hardlinks _build/default/source
-  3
+  1
   $ dune_cmd stat hardlinks _build/default/target1
-  3
+  2
   $ dune_cmd stat hardlinks _build/default/target2
   2
   $ dune_cmd exists _build/default/beacon
@@ -103,6 +98,64 @@ Verify we see only workspace-local miss events for our targets (shared cache hit
   $ cat _build/default/target2
   \_o< COIN
   \_o< COIN
+
+Shared-cache keys for rules depending on source-copy primitives are stable
+across workspaces.
+
+  $ runs="$PWD/cross-workspace-runs"
+  $ mkdir ws1 ws2
+  $ for dir in ws1 ws2; do
+  > cat > $dir/dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+  > cat > $dir/dune <<EOF
+  > (rule
+  >  (deps source (sandbox none))
+  >  (target result)
+  >  (action (bash "cat source > result; echo running >> $runs")))
+  > EOF
+  > printf same > $dir/source
+  > done
+  $ (cd ws1 && dune build --config-file=../config result)
+  $ (cd ws2 && dune build --config-file=../config result)
+  $ cat cross-workspace-runs
+  running
+  $ cat ws2/_build/default/result
+  same
+
+Rules with direct source-tree dependency facts must not use source metadata
+stamps as cache keys. A same-size content edit with the original mtime restored
+should still rebuild instead of restoring stale output from the shared cache.
+
+  $ mkdir direct-source-tree-cache
+  $ cd direct-source-tree-cache
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+  $ mkdir tree
+  $ printf one > tree/a
+  $ touch -t 200001010000 tree/a
+  $ runs="$PWD/direct-source-runs"
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (source_tree tree) (sandbox none))
+  >  (target result)
+  >  (action
+  >   (bash "cat tree/a > result; printf 'running:%s\n' \"\$(cat tree/a)\" >> $runs")))
+  > EOF
+  $ dune build --config-file=../config result
+  $ cat _build/default/result
+  one
+  $ printf two > tree/a
+  $ touch -t 200001010000 tree/a
+  $ rm -rf _build
+  $ dune build --config-file=../config result
+  $ cat _build/default/result
+  two
+  $ cat direct-source-runs
+  running:one
+  running:two
+  $ cd ..
 
 Test that the zero build is indeed a zero build (nothing should be rebuilt).
 No cache misses should appear in the trace.

--- a/test/blackbox-tests/test-cases/dune-cache/symlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/symlink.t
@@ -22,19 +22,19 @@ produced symbolic links work correctly and are appropriately cached.
   > EOF
   $ dune build target
 
-Dune cache contains entries for [source] and [target] but not for [link]
+Dune cache contains an entry for [target] but not for the source-copy primitive
+or the symbolic link.
 
   $ (cd "$DUNE_CACHE_ROOT/db/meta/v5"; grep -rs . -e 'source' | dune_cmd count-lines)
-  1
+  0
+  [1]
   $ (cd "$DUNE_CACHE_ROOT/db/meta/v5"; grep -rs . -e 'target' | dune_cmd count-lines)
   1
   $ (cd "$DUNE_CACHE_ROOT/db/meta/v5"; grep -rs . -e 'link' | dune_cmd count-lines)
   0
   [1]
 
-The files in the build directory are shared with the cache entries
+The generated target is shared with its cache entry
 
-  $ dune_cmd stat hardlinks _build/default/source
-  2
   $ dune_cmd stat hardlinks _build/default/target
   2

--- a/test/blackbox-tests/test-cases/engine/editing-build-artifacts-github1342.t
+++ b/test/blackbox-tests/test-cases/engine/editing-build-artifacts-github1342.t
@@ -4,17 +4,49 @@ _build, things are rebuild as expected.
 Note that this is no longer supported. Users are not expected to edit things in
 the _build directory.
 
+This case now specifically checks that a source-backed build copy is repaired
+when the corresponding build artifact is edited.
+
   $ echo 42 > x
   $ dune build x
   $ cat _build/default/x
   42
+
+A source-backed file can replace a build-directory target directory. When that
+happens, stale workspace-local cache entries for the old directory's descendants
+must be invalidated.
+
+  $ mkdir dir-to-file
+  $ cd dir-to-file
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (using directory-targets 0.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir foo))
+  >  (action (bash "mkdir foo; echo generated > foo/child")))
+  > EOF
+  $ dune build foo/child
+  $ cat _build/default/foo/child
+  generated
+  $ echo > dune
+  $ echo source > foo
+  $ dune build foo
+  $ cat _build/default/foo
+  source
+  $ rm foo
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir foo))
+  >  (action (bash "mkdir foo; echo generated > foo/child")))
+  > EOF
+  $ dune build foo/child
+  $ cat _build/default/foo/child
+  generated
+  $ cd ..
   $ chmod u+w _build/default/x
   $ echo 0 > _build/default/x
-
-To force the mtime to change:
-https://github.com/ocaml/dune/pull/1359
-
-  $ touch -t 01010000 _build/default/x
   $ dune build x
   $ cat _build/default/x
-  0
+  42

--- a/test/blackbox-tests/test-cases/internal/digest-db.t
+++ b/test/blackbox-tests/test-cases/internal/digest-db.t
@@ -1,4 +1,4 @@
-Test the "dune internal digest-db" command.
+Source-backed targets do not cache content digests for source-tree files.
 
   $ echo '(lang dune 3.0)' > dune-project
   $ mkdir -p dir/sub
@@ -9,36 +9,42 @@ Test the "dune internal digest-db" command.
   $ touch -t 200001010000 invalid.txt
   $ dune build invalid.txt stale.txt dir/a dir/sub/b
 
-The full dump includes cached entries:
+The persistent digest database has no source-tree file entries after building
+source-backed targets.
 
-  $ dune internal digest-db dump 2>&1 | grep -o 'In_source_tree "invalid.txt"'
-  In_source_tree "invalid.txt"
+  $ dune internal digest-db dump > dump.out 2>&1
+  $ grep -o 'entries = \[\]' dump.out
+  entries = []
 
-Dumping a file only shows its exact entry:
-
-  $ dune internal digest-db dump invalid.txt 2>&1 | grep -o 'In_source_tree "invalid.txt"'
-  In_source_tree "invalid.txt"
-  $ dune internal digest-db dump invalid.txt 2>&1 | grep 'In_source_tree "stale.txt"'
-  [1]
-
-Dumping a directory only shows its direct children:
-
-  $ dune internal digest-db dump dir 2>&1 | grep -o 'In_source_tree "dir/a"'
-  In_source_tree "dir/a"
-  $ dune internal digest-db dump dir 2>&1 | grep 'In_source_tree "dir/sub/b"'
-  [1]
-
-Modify one file without changing the cached stats and another one normally.
+Modifying source files cannot produce invalid or stale source digest reports
+because source files are tracked without content digests.
 
   $ printf z > invalid.txt
   $ touch -t 200001010000 invalid.txt
   $ printf yz > stale.txt
+  $ dune internal digest-db check invalid.txt stale.txt
+  []
 
-Only actual digest mismatches are reported, classified as invalid or stale.
+External files are still content-digested, and the digest-db commands still
+report cached and stale external entries.
 
-  $ dune internal digest-db check invalid.txt stale.txt 2>&1 \
-  > | sed -n 's/.*status = /status = /p;s/.*path = /path = /p'
-  status = "invalid"
-  path = In_source_tree "invalid.txt"
-  status = "stale"
-  path = In_source_tree "stale.txt"
+  $ external="$PWD/../external.txt"
+  $ printf external > "$external"
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps $external)
+  >  (target external-copy)
+  >  (action (copy $external external-copy)))
+  > EOF
+  $ dune build external-copy
+  $ dune internal digest-db dump > external-dump.out 2>&1
+  $ grep -A1 'External' external-dump.out
+            External
+              "$TESTCASE_ROOT/../external.txt"
+  $ printf changed > "$external"
+  $ dune internal digest-db check > external-check.out 2>&1 || true
+  $ grep 'status = "stale"' external-check.out
+  [ { status = "stale"
+  $ grep -A1 'External' external-check.out
+        External
+          "$TESTCASE_ROOT/../external.txt"

--- a/test/blackbox-tests/test-cases/watching/copy-rules.t
+++ b/test/blackbox-tests/test-cases/watching/copy-rules.t
@@ -77,3 +77,193 @@ We're done.
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
+
+A source copy that happens to match the source in one context must not suppress
+invalidations for another context that has a stale copy. This simulates the case
+where the file-watcher event for [data] is delivered after one copy has already
+been updated, but before another copy has been invalidated.
+
+  $ mkdir stale-copy-contexts
+  $ cd stale-copy-contexts
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (context default)
+  > (context
+  >  (default
+  >   (name other)))
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps data)
+  >  (target result)
+  >  (action (copy data result)))
+  > EOF
+  $ echo one > data
+  $ start_dune
+  $ build _build/default/result _build/other/result
+  Success
+  $ cat _build/default/result _build/other/result
+  one
+  one
+  $ echo two > _build/default/data
+  $ echo two > data
+  $ build _build/other/result
+  Success
+  $ cat _build/other/result
+  two
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  $ cd ..
+
+The same suppression must not mask direct source readers, such as included dune
+files, that are unrelated to the source-copy target.
+
+  $ mkdir source-copy-and-read
+  $ cd source-copy-and-read
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps data.inc)
+  >  (target copy-result)
+  >  (action (copy data.inc copy-result)))
+  > (include data.inc)
+  > EOF
+  $ cat > data.inc <<EOF
+  > (rule
+  >  (target read-result)
+  >  (action (write-file read-result "one")))
+  > EOF
+  $ start_dune
+  $ build copy-result read-result
+  Success
+  $ cat _build/default/copy-result
+  (rule
+   (target read-result)
+   (action (write-file read-result "one")))
+  $ cat _build/default/read-result
+  one
+  $ cat > _build/default/data.inc <<EOF
+  > (rule
+  >  (target read-result)
+  >  (action (write-file read-result "two")))
+  > EOF
+  $ cat > data.inc <<EOF
+  > (rule
+  >  (target read-result)
+  >  (action (write-file read-result "two")))
+  > EOF
+  $ build read-result
+  Success
+  $ cat _build/default/read-result
+  two
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  $ cd ..
+
+Executable-bit changes are part of source-copy target digests. A copy that
+already has the new executable bit in one context must not hide a stale copy in
+another context.
+
+  $ mkdir executable-source-copy
+  $ cd executable-source-copy
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune-workspace <<EOF
+  > (lang dune 3.0)
+  > (context default)
+  > (context
+  >  (default
+  >   (name other)))
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps script.sh)
+  >  (target mode)
+  >  (action
+  >   (bash "dune_cmd stat permissions script.sh > mode")))
+  > EOF
+  $ printf '#!/bin/sh\n' > script.sh
+  $ start_dune
+  $ build _build/default/mode _build/other/mode
+  Success
+  $ cat _build/default/mode _build/other/mode
+  644
+  644
+  $ chmod 655 _build/default/script.sh
+  $ chmod 655 script.sh
+  $ touch script.sh
+  $ build _build/other/mode
+  Success
+  $ cat _build/other/mode
+  655
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  $ cd ..
+
+For [(source_tree ...)] dependencies, same-content edits should not rerun
+dependent rules, while content edits should rerun them.
+
+  $ mkdir source-tree-copy-cutoff
+  $ cd source-tree-copy-cutoff
+  $ echo '(lang dune 3.0)' > dune-project
+  $ mkdir tree
+  $ printf one > tree/a
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps (source_tree tree) (sandbox none))
+  >  (target result)
+  >  (action
+  >   (bash "cat tree/a >> ../../runs; printf '\n' >> ../../runs; cat tree/a > result")))
+  > (alias
+  >  (name idle))
+  > EOF
+  $ start_dune @idle
+  $ build result
+  Success
+  $ cat runs
+  one
+  $ printf one > tree/a
+  $ build result
+  Success
+  $ cat runs
+  one
+  $ printf two > tree/a
+  $ build result
+  Success
+  $ cat runs
+  one
+  two
+  $ cat _build/default/result
+  two
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  $ cd ..
+
+Source copy trace events are available when the [source_copy] trace category is
+enabled.
+
+  $ mkdir source-copy-trace
+  $ cd source-copy-trace
+  $ echo '(lang dune 3.0)' > dune-project
+  $ printf trace > source
+  $ export DUNE_TRACE=source_copy
+  $ dune build source
+  $ dune trace cat | jq 'select(.cat == "source_copy" and .name == "copy") | {src: .args.src, dst: .args.dst, result: .args.result}'
+  {
+    "src": "source",
+    "dst": "_build/default/source",
+    "result": "copied"
+  }
+  $ dune build source
+  $ dune trace cat | jq 'select(.cat == "source_copy" and .name == "copy") | {src: .args.src, dst: .args.dst, result: .args.result}'
+  {
+    "src": "source",
+    "dst": "_build/default/source",
+    "result": "already_up_to_date"
+  }
+  $ unset DUNE_TRACE

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -40,7 +40,7 @@ Remove a file and rebuild.
 
 Remove a directory and rebuild.
 
-  $ rm -rf d2
+  $ rm -rf d1/d2
   $ build d1
   Success
   $ cat d1/a d1/b d1/d2/c
@@ -109,7 +109,6 @@ Now test file-system events generated during directory target promotion.
   $ start_dune
   $ build d1
   Success
-
   $ stop_dune > /dev/null
 
 Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
@@ -117,11 +116,6 @@ Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
   $ dune trace cat | jq 'include "dune"; cacheEvent("dune-workspace")'
   {
     "cache_type": "dir_contents",
-    "path": "dune-workspace",
-    "result": "skipped"
-  }
-  {
-    "cache_type": "file_digest",
     "path": "dune-workspace",
     "result": "skipped"
   }
@@ -140,33 +134,21 @@ Dune correctly notices that the contents of . changed because [d1] was created.
     "result": "changed"
   }
   {
-    "cache_type": "file_digest",
-    "path": ".",
-    "result": "skipped"
-  }
-  {
     "cache_type": "path_stat",
     "path": ".",
     "result": "unchanged"
   }
 
 
-Here [path_stat] of [d1] changed, because it didn't exist before the build. Dune
-later recomputed [path_stat] once again, when [d1/b] was modified, and the
-result remained unchanged (because fields like [mtime] are ignored). The result
-of [dir_contents] also remained unchanged because Dune fixed the listing of [d1]
-by re-promoting the directory target.
+Here [path_stat] of [d1] changed, because it didn't exist before the build. The
+result of [dir_contents] remained unchanged because Dune fixed the listing of
+[d1] by promoting the directory target.
 
   $ dune trace cat | jq 'include "dune"; cacheEvent("d1")'
   {
     "cache_type": "dir_contents",
     "path": "d1",
     "result": "unchanged"
-  }
-  {
-    "cache_type": "file_digest",
-    "path": "d1",
-    "result": "skipped"
   }
   {
     "cache_type": "path_stat",
@@ -179,19 +161,26 @@ by re-promoting the directory target.
     "result": "unchanged"
   }
   {
-    "cache_type": "file_digest",
-    "path": "d1",
-    "result": "skipped"
-  }
-  {
     "cache_type": "path_stat",
     "path": "d1",
     "result": "unchanged"
   }
 
-Events below occurred because we replaced file [d1/b] with a directory. Dune
-undid this change to bring the promoted directory target up to date, which
-explains why [file_digest] remained unchanged.
+Replacing file [d1/b] with a directory is fixed by re-promoting the directory
+target. Trace that replacement separately so the [d1/b] events are not hidden
+behind the initial promotion.
+
+  $ export DUNE_TRACE=cache
+  $ start_dune
+  $ build d1/b
+  Success
+  $ rm d1/b
+  $ mkdir d1/b
+  $ build d1/b
+  Success
+  $ cat d1/b
+  +
+  $ stop_dune > /dev/null
 
   $ dune trace cat | jq 'include "dune"; cacheEvent("d1/b")'
   {
@@ -200,9 +189,14 @@ explains why [file_digest] remained unchanged.
     "result": "skipped"
   }
   {
-    "cache_type": "file_digest",
+    "cache_type": "path_stat",
     "path": "d1/b",
-    "result": "unchanged"
+    "result": "skipped"
+  }
+  {
+    "cache_type": "dir_contents",
+    "path": "d1/b",
+    "result": "skipped"
   }
   {
     "cache_type": "path_stat",

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-permissions.t
@@ -21,7 +21,7 @@ events. This is a known bug.
   >   echo "------------------------------------------"
   >   echo "result = '$before' -> '$between' -> '$after'"
   >   echo "------------------------------------------"
-  >   dune trace cat | jq -c 'select(.name == "fs_update") | .args' | sort
+  >   dune trace cat | jq -c 'select(.name == "fs_update") | .args | select(.path != "dune-workspace")' | sort
   >   rm .#tmp
   > }
 
@@ -60,9 +60,6 @@ of failing.
   ------------------------------------------
   result = '' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
 If we repeat the test, we finally see the failure.
 
@@ -78,9 +75,6 @@ If we repeat the test, we finally see the failure.
   ------------------------------------------
   result = '13' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
 Same problem in the other direction.
 
@@ -95,9 +89,6 @@ Same problem in the other direction.
   ------------------------------------------
   result = '13' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
   $ test "echo How about now?"
   ------------------------------------------
@@ -107,9 +98,6 @@ Same problem in the other direction.
   ------------------------------------------
   result = '13' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
 Same problem for files.
 
@@ -120,9 +108,6 @@ Same problem for files.
   ------------------------------------------
   result = '13' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
   $ test "chmod +r file-1"
   ------------------------------------------
@@ -139,6 +124,3 @@ Same problem for files.
   ------------------------------------------
   result = '13' -> '13' -> '13'
   ------------------------------------------
-  {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo-symlinks.t
@@ -62,9 +62,6 @@ First, create a symbolic link. Dune correctly updates the [result].
   {"cache_type":"dir_contents","path":"dir","result":"changed"}
   {"cache_type":"dir_contents","path":"dir/file-6","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-6","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/file-6","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
@@ -83,9 +80,6 @@ reruns the affected action.
   {"cache_type":"dir_contents","path":"dir","result":"changed"}
   {"cache_type":"dir_contents","path":"dir/file-6","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-6","result":"changed"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/file-6","result":"changed"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
@@ -111,10 +105,6 @@ and re-execute the rule.
   {"cache_type":"dir_contents","path":"dir/file-7","result":"skipped"}
   {"cache_type":"dir_contents","path":"dir/file-7","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-7","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-7","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/file-7","result":"skipped"}
   {"cache_type":"path_stat","path":"dir/file-7","result":"skipped"}
@@ -133,9 +123,6 @@ Deleting [dir] triggers a rebuild.
   {"cache_type":"dir_contents","path":".","result":"changed"}
   {"cache_type":"dir_contents","path":"dir","result":"changed"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"changed"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
@@ -153,9 +140,6 @@ Restoring the symlink is correctly noticed.
   {"cache_type":"dir_contents","path":".","result":"changed"}
   {"cache_type":"dir_contents","path":"dir","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
@@ -177,11 +161,6 @@ However, deleting [another-dir] isn't handled correctly.
   {"cache_type":"dir_contents","path":"dir","result":"changed"}
   {"cache_type":"dir_contents","path":"dir/file-7","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"another-dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-7","result":"changed"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"another-dir","result":"changed"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
@@ -202,7 +181,5 @@ should fix this too.
   ------------------------------------------
   {"cache_type":"dir_contents","path":"dep","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dep","result":"changed"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dep","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}

--- a/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/file-watcher/fs-memo.t
@@ -60,10 +60,6 @@ and then the contents is written to it.
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-2","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-2","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-2","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-2","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
   {"cache_type":"path_stat","path":"file-2","result":"skipped"}
@@ -87,15 +83,12 @@ the glob remains unchanged.
   {"cache_type":"dir_contents","path":".","result":"changed"}
   {"cache_type":"dir_contents","path":"dir","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
-We create [dir/file-3] before running Dune, so we only observe a single
-[file_digest] change event with the file watcher.
+We create [dir/file-3] before running Dune. Source file changes are tracked
+without content digests, so the trace only shows change tracking for the path.
 
   $ echo -n '?' > dir/file-3
   $ test "echo -n 3 > dir/file-3"
@@ -109,12 +102,11 @@ We create [dir/file-3] before running Dune, so we only observe a single
   ------------------------------------------
   {"cache_type":"dir_contents","path":"dir/file-3","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-3","result":"changed"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir/file-3","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
 
-Now, Dune similarly updates [file_digest] for [file-2].
+Now, Dune similarly tracks the source-file change for [file-2] without
+digesting it.
 
   $ test "echo -n '*' > file-2"
   ------------------------------------------
@@ -126,8 +118,6 @@ Now, Dune similarly updates [file_digest] for [file-2].
   ------------------------------------------
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-2","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-2","result":"changed"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
   {"cache_type":"path_stat","path":"file-2","result":"skipped"}
 
@@ -144,15 +134,12 @@ On deletion of a file, we receive events for the file and the parent directory.
   {"cache_type":"dir_contents","path":".","result":"changed"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-2","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-2","result":"changed"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
   {"cache_type":"path_stat","path":"file-2","result":"skipped"}
 
-Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
-[dir/file-3]'s digest changed (from a digest to the error about missing file).
+Dune notices that [dir_contents] of both [dir] and [.] changed, and also tracks
+the source-file changes for the moved paths without digesting them.
 
   $ test "mv dir/file-3 ."
   ------------------------------------------
@@ -167,11 +154,6 @@ Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
   {"cache_type":"dir_contents","path":"dir/file-3","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-3","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/file-3","result":"changed"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-3","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/file-3","result":"skipped"}
@@ -188,9 +170,6 @@ Dune notices that [dir_contents] of both [dir] and [.] changed, and also that
   {"cache_type":"dir_contents","path":"dir","result":"changed"}
   {"cache_type":"dir_contents","path":"dir/subdir","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/subdir","result":"skipped"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}
@@ -209,10 +188,6 @@ Again, there are two events for [file-4]: for creation and modification.
   {"cache_type":"dir_contents","path":"dir/subdir/file-4","result":"skipped"}
   {"cache_type":"dir_contents","path":"dir/subdir/file-4","result":"skipped"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir/file-4","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir/file-4","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
   {"cache_type":"path_stat","path":"dir/subdir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir/subdir/file-4","result":"skipped"}
   {"cache_type":"path_stat","path":"dir/subdir/file-4","result":"skipped"}
@@ -236,13 +211,6 @@ because we watch each of them both directly and via their parents.
   {"cache_type":"dir_contents","path":"dir/subdir","result":"unchanged"}
   {"cache_type":"dir_contents","path":"dune-workspace","result":"skipped"}
   {"cache_type":"dir_contents","path":"subdir","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dir/subdir","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"subdir","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
   {"cache_type":"path_stat","path":"dir","result":"unchanged"}
@@ -270,12 +238,6 @@ then creating a file.
   {"cache_type":"dir_contents","path":"file-1","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-5","result":"skipped"}
   {"cache_type":"dir_contents","path":"file-5","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":".","result":"skipped"}
-  {"cache_type":"file_digest","path":"dune-workspace","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-1","result":"changed"}
-  {"cache_type":"file_digest","path":"file-5","result":"skipped"}
-  {"cache_type":"file_digest","path":"file-5","result":"skipped"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":".","result":"unchanged"}
   {"cache_type":"path_stat","path":"dune-workspace","result":"unchanged"}

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -4,6 +4,7 @@ Bad rule! You are not supposed to modify the source tree. No ice-cream for you!
 
   $ mkdir test
   $ cd test
+  $ setup_xdg_runtime_dir
 
   $ echo '(lang dune 3.0)' > dune-project
   $ cat > dune <<EOF
@@ -32,3 +33,76 @@ i.e. the empty file.
 
   $ stop_dune
   Success, waiting for filesystem changes...
+
+  $ cd ..
+
+Touching a source file while a build is running does not restart the build.
+A content edit should restart the running build.
+
+  $ mkdir source-copy-change-cutoff
+  $ cd source-copy-change-cutoff
+  $ export DUNE_TRACE=build,rpc
+  $ setup_xdg_runtime_dir
+  $ started="$PWD/../started"
+  $ release="$PWD/../release"
+  $ rm -f "$started" "$release"
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ printf one > data
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps data)
+  >  (target result)
+  >  (action
+  >   (bash "\| if [ \"\$(cat data)\" = one ]; then
+  >          "\|   touch '$started'
+  >          "\|   while [ ! -f '$release' ]; do sleep 0.01; done
+  >          "\| fi
+  >          "\| cat data > result
+  > )))
+  > EOF
+
+  $ start_dune
+  $ build result > build.out 2>&1 &
+  $ BUILD_PID=$!
+  $ with_timeout dune_cmd wait-for-file-to-appear "$started"
+
+  $ restarts_before_touch=$(dune trace cat | jq -s '
+  > [ .[] | select(.cat == "build"
+  >                and .name == "build-start"
+  >                and .args.restart == true) ]
+  > | length')
+  $ touch data
+  $ with_timeout dune rpc flush-file-watcher --wait
+  $ restarts_after_touch=$(dune trace cat | jq -s '
+  > [ .[] | select(.cat == "build"
+  >                and .name == "build-start"
+  >                and .args.restart == true) ]
+  > | length')
+  $ [ "$restarts_after_touch" = "$restarts_before_touch" ] && echo true
+  true
+
+  $ printf two > data
+  $ with_timeout dune rpc flush-file-watcher --wait
+  $ if wait_for_pid_to_exit_with_timeout "$BUILD_PID" 200; then
+  >   wait "$BUILD_PID"
+  > else
+  >   echo "build did not restart"
+  >   cat build.out
+  >   touch "$release"
+  >   wait "$BUILD_PID"
+  > fi
+  $ cat build.out
+  Success
+  $ cat _build/default/result
+  two
+  $ dune trace cat | jq -s --argjson restarts_after_touch "$restarts_after_touch" '
+  > [ .[] | select(.cat == "build"
+  >                and .name == "build-start"
+  >                and .args.restart == true) ] as $restarts
+  > | $restarts[$restarts_after_touch:] as $new_restarts
+  > | ($new_restarts | length >= 1)
+  >   and ([ $new_restarts[] | .args.files[]? ] | index("data") != null)'
+  true
+
+  $ stop_dune > /dev/null

--- a/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
+++ b/test/blackbox-tests/test-cases/watching/rpc-flush-file-watcher.t
@@ -1,7 +1,7 @@
 The flush-file-watcher RPC waits for pending file watcher notifications to be
 handled by the watch server.
 
-  $ export DUNE_TRACE=cache
+  $ export DUNE_TRACE=cache,rpc
   $ setup_xdg_runtime_dir
 
   $ cat > dune-project <<EOF
@@ -34,16 +34,20 @@ events preceding the request have reached the scheduler.
 
   $ stop_dune_quiet
 
-  $ dune trace cat | jq -s 'include "dune";
-  > [ .[] | fsUpdateWithPath("x")
-  >        | select(.cache_type == "file_digest" and .result == "changed")
-  >        | {cache_type, path, result}
-  > ] | unique | .[]'
-  {
-    "cache_type": "file_digest",
-    "path": "x",
-    "result": "changed"
-  }
+The source event should have been processed before the flush RPC returned, not
+later during shutdown.
+
+  $ dune trace cat | jq -s '
+  > ([ .[] | select(.name == "fs_update" and .args.path == "x") | .ts ] | max) as $last_fs_update
+  > | ([ .[]
+  >      | select(.cat == "rpc"
+  >               and .name == "request"
+  >               and .args.meth == "flush-file-watcher"
+  >               and .args.stage == "stop")
+  >      | .ts
+  >    ] | min) as $flush_done
+  > | ($last_fs_update != null and $flush_done != null and $last_fs_update <= $flush_done)'
+  true
 
 The RPC reports [`Not_in_watch_mode] when the server is only running for a
 batch build. The action uses [dynamic-run] because Dune starts the batch RPC

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -22,6 +22,8 @@ Test target promotion in file-watching mode.
   Success
   $ cat promoted
   hi
+  $ cat _build/default/promoted
+  hi
   $ cat _build/default/result
   hi
   hi
@@ -147,6 +149,55 @@ We're done.
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
 
+Promoting a source file must not suppress events that are needed to refresh a
+source-copy target for the same source path.
+
+  $ mkdir promote-and-source-copy
+  $ cd promote-and-source-copy
+  $ echo '(lang dune 3.23)' > dune-project
+  $ mkdir sub
+  $ printf old > data
+  $ runs="$PWD/runs"
+  $ cat > dune <<EOF
+  > (rule
+  >  (deps data)
+  >  (target result)
+  >  (action
+  >   (bash "cat data > result; printf 'copy:%s\n' \"\$(cat data)\" >> $runs")))
+  > (alias
+  >  (name idle))
+  > EOF
+  $ cat > sub/dune <<EOF
+  > (rule
+  >  (mode (promote (into ..)))
+  >  (target data)
+  >  (action (bash "printf new > data; printf 'promote\n' >> $runs")))
+  > EOF
+  $ start_dune @idle
+  $ build result
+  Success
+  $ cat _build/default/result
+  old
+  $ build sub/data
+  Success
+  $ with_timeout dune rpc flush-file-watcher --wait
+  $ cat data
+  new
+  $ build result
+  Success
+  $ cat _build/default/result
+  new
+  $ cat runs
+  copy:old
+  copy:old
+  promote
+  copy:new
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  $ cd ..
+
 Now test file-system events generated during target promotion.
 
   $ cat > dune <<EOF
@@ -168,6 +219,8 @@ Now test file-system events generated during target promotion.
   Success
   $ cat promoted
   bye
+  $ cat _build/default/promoted
+  bye
 
   $ stop_dune > /dev/null
 
@@ -180,38 +233,18 @@ Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
     "result": "skipped"
   }
   {
-    "cache_type": "file_digest",
-    "path": "dune-workspace",
-    "result": "skipped"
-  }
-  {
     "cache_type": "path_stat",
     "path": "dune-workspace",
     "result": "unchanged"
   }
 
 Show that Dune ignores "promoted" events. Events for ".#promoted.dune-temp" are
-filtered out by Dune's file watcher and don't show up here. The [path_digest]
-event for [promoted] is more interesting: the file's content did change from "hi"
-to "bye" but Dune subscribed to it *after* making the promotion, precisely to
-avoid unnecessarily restarting after receiving the event that it caused itself.
+filtered out by Dune's file watcher and don't show up here. The event for
+[promoted] is more interesting: the file's content did change from "hi" to
+"bye" but Dune subscribed to it *after* making the promotion, precisely to avoid
+unnecessarily restarting after receiving the event that it caused itself.
 
   $ dune trace cat | jq 'include "dune"; fsUpdateWithPath("promoted")'
-  {
-    "cache_type": "dir_contents",
-    "path": "promoted",
-    "result": "skipped"
-  }
-  {
-    "cache_type": "file_digest",
-    "path": "promoted",
-    "result": "unchanged"
-  }
-  {
-    "cache_type": "path_stat",
-    "path": "promoted",
-    "result": "skipped"
-  }
 
 Show that Dune ignores events for the . directory: [dir_contents] didn't change
 because [promoted] existed before running the build. Also, the subset of fields
@@ -225,12 +258,105 @@ change but [fs_memo] does not provide a way to subscribe to it).
     "result": "unchanged"
   }
   {
-    "cache_type": "file_digest",
-    "path": ".",
-    "result": "skipped"
-  }
-  {
     "cache_type": "path_stat",
     "path": ".",
     "result": "unchanged"
   }
+
+File-system events caused by promotion should not run the promotion rule twice.
+Same-content events for promoted source files should not rerun dependent rules,
+but real content changes should still be restored by promotion.
+
+  $ mkdir promotion-same-content
+  $ cd promotion-same-content
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (mode promote)
+  >  (deps original (sandbox none))
+  >  (target promoted)
+  >  (action
+  >   (bash "cp original promoted; printf 'promote\n' >> ../runs")))
+  > (rule
+  >  (deps promoted (sandbox none))
+  >  (target result)
+  >  (action
+  >   (bash "cat promoted > result; printf 'result\n' >> ../runs")))
+  > (alias
+  >  (name idle))
+  > EOF
+  $ echo one > original
+  $ echo stale > promoted
+  $ start_dune @idle
+  $ build result
+  Success
+  $ cat _build/runs
+  promote
+  result
+  $ touch promoted
+  $ build result
+  Success
+  $ cat _build/runs
+  promote
+  result
+  $ echo changed > promoted
+  $ build result
+  Success
+  $ cat promoted
+  one
+  $ cat _build/runs
+  promote
+  result
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+
+Promotion up-to-date checks must include the executable bit, not just bytes.
+
+  $ cd ..
+  $ mkdir promotion-executable-bit
+  $ cd promotion-executable-bit
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (mode promote)
+  >  (deps original (sandbox none))
+  >  (target promoted)
+  >  (action
+  >   (bash "cp original promoted; chmod 655 promoted; printf 'promote\n' >> ../runs")))
+  > (rule
+  >  (deps promoted (sandbox none))
+  >  (target result)
+  >  (action
+  >   (bash "dune_cmd stat permissions promoted > result; cat result >> ../runs")))
+  > (alias
+  >  (name idle))
+  > EOF
+  $ echo one > original
+  $ echo one > promoted
+  $ chmod 644 promoted
+  $ start_dune @idle
+  $ build result
+  Success
+  $ dune_cmd stat permissions promoted
+  655
+  $ cat _build/default/result
+  455
+  $ cat _build/runs
+  promote
+  455
+  $ chmod 644 promoted
+  $ touch promoted
+  $ build result
+  Success
+  $ dune_cmd stat permissions promoted
+  655
+  $ cat _build/default/result
+  455
+  $ cat _build/runs
+  promote
+  455
+  $ stop_dune
+  Success, waiting for filesystem changes...
+  Success, waiting for filesystem changes...


### PR DESCRIPTION
Making source copying a rule turns out to have numerous disadvantages:

1. requires digesting the source files
2. adds a bunch of overhead to the engine
3. complicates the guarantees we provide for all other rules. Ideally, build inputs for all rules should be immutable. Source copying rules immediately break that.