### PR TITLE
fix rpc io buffer compaction

### DIFF
--- a/src/rpc/io_buffer.ml
+++ b/src/rpc/io_buffer.ml
@@ -26,17 +26,18 @@ let maybe_resize_to_fit t write_size =
   let capacity = buf_len - t.pos_w in
   if capacity < write_size
   then (
-    let bytes =
-      let new_size =
-        let needed =
-          let free_space = capacity + t.pos_r in
-          buf_len + max 0 (write_size - free_space)
-        in
-        max (min max_buffer_size (buf_len * 2)) needed
-      in
-      Bytes.create new_size
-    in
     let len = length t in
+    let free_space = capacity + t.pos_r in
+    let bytes =
+      if free_space >= write_size
+      then t.bytes
+      else (
+        let new_size =
+          let needed = buf_len + max 0 (write_size - free_space) in
+          max (min max_buffer_size (buf_len * 2)) needed
+        in
+        Bytes.create new_size)
+    in
     Bytes.blit ~src:t.bytes ~src_pos:t.pos_r ~dst:bytes ~dst_pos:0 ~len;
     t.bytes <- bytes;
     t.pos_w <- len;
@@ -50,8 +51,8 @@ let write_char_exn t c =
 ;;
 
 let write_string_exn t src =
-  assert (t.pos_w < Bytes.length t.bytes);
   let len = String.length src in
+  assert (t.pos_w + len <= Bytes.length t.bytes);
   Bytes.blit_string ~src ~src_pos:0 ~dst:t.bytes ~dst_pos:t.pos_w ~len;
   t.pos_w <- t.pos_w + len
 ;;

--- a/test/expect-tests/csexp_rpc/io_buffer_tests.ml
+++ b/test/expect-tests/csexp_rpc/io_buffer_tests.ml
@@ -27,8 +27,7 @@ let%expect_test "empty atom exact-fit write" =
   let buf = Io_buffer.create ~size:2 in
   Io_buffer.write_csexps buf [ Csexp.Atom "" ];
   print_dyn buf;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| "Assert_failure src/rpc/io_buffer.ml:53:2" |}]
+  [%expect {| { total_written = 0; contents = "0:"; pos_w = 2; pos_r = 0 } |}]
 ;;
 
 let%expect_test "compaction does not grow the buffer" =
@@ -42,7 +41,7 @@ let%expect_test "compaction does not grow the buffer" =
   [%expect
     {|
     capacity before: 8
-    capacity after: 16
+    capacity after: 8
     { total_written = 4; contents = "cde1:x"; pos_w = 6; pos_r = 0 }
     |}]
 ;;


### PR DESCRIPTION
Compact unread bytes before growing the buffer and tighten exact-fit writes.