### PR TITLE
improve rpc connection error handling

### DIFF
--- a/src/rpc/client.ml
+++ b/src/rpc/client.ml
@@ -15,23 +15,29 @@ include
       ;;
     end)
 
-type chan = Csexp_rpc.Session.t
-
 module Connection = struct
   type t = Csexp_rpc.Session.t
 
   let connect where =
-    let sock = Where.to_socket where in
-    let client = Csexp_rpc.Client.create sock in
-    let+ res = Csexp_rpc.Client.connect client in
-    match res with
-    | Ok s -> Ok s
-    | Error exn ->
-      Error
-        (User_error.make
-           [ Pp.textf "failed to connect to RPC server %s" (Where.to_string where)
-           ; Exn_with_backtrace.pp exn
-           ])
+    match Where.to_socket where with
+    | exception exn ->
+      Fiber.return
+        (Error
+           (User_error.make
+              [ Pp.textf "failed to connect to RPC server %s" (Where.to_string where)
+              ; Exn.pp exn
+              ]))
+    | sock ->
+      let client = Csexp_rpc.Client.create sock in
+      let+ res = Csexp_rpc.Client.connect client in
+      (match res with
+       | Ok s -> Ok s
+       | Error exn ->
+         Error
+           (User_error.make
+              [ Pp.textf "failed to connect to RPC server %s" (Where.to_string where)
+              ; Exn_with_backtrace.pp exn
+              ]))
   ;;
 
   let connect_exn where =

--- a/src/rpc/client.mli
+++ b/src/rpc/client.mli
@@ -1,5 +1,7 @@
 open Import
-include Dune_rpc.Client.S with type 'a fiber := 'a Fiber.t
+
+include
+  Dune_rpc.Client.S with type 'a fiber := 'a Fiber.t and type chan := Csexp_rpc.Session.t
 
 module Connection : sig
   type t

--- a/src/rpc/where.ml
+++ b/src/rpc/where.ml
@@ -13,7 +13,11 @@ module Where =
       end
     end)
     (struct
-      let read_file f = Ok (Io.String_path.read_file f)
+      let read_file f =
+        match Io.String_path.read_file f with
+        | contents -> Ok contents
+        | exception exn -> Error exn
+      ;;
 
       let analyze_path s =
         match (Unix.stat s).st_kind with
@@ -44,7 +48,14 @@ let default () = Where.default ~build_dir:(Lazy.force build_dir) ()
 
 let to_socket = function
   | `Unix p -> Unix.ADDR_UNIX p
-  | `Ip (`Host host, `Port port) -> Unix.ADDR_INET (Unix.inet_addr_of_string host, port)
+  | `Ip (`Host host, `Port port) ->
+    (match
+       Unix.getaddrinfo host (Int.to_string port) [ Unix.AI_SOCKTYPE Unix.SOCK_STREAM ]
+     with
+     | { Unix.ai_addr; _ } :: _ -> ai_addr
+     | [] ->
+       User_error.raise
+         [ Pp.textf "Unable to resolve dune rpc host %S" host; Pp.textf "port: %d" port ])
 ;;
 
 let to_string t = Dune_rpc.Private.Where.to_string t

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -27,8 +27,7 @@ let%expect_test "connection error includes rpc endpoint" =
      (match Stdune.User_message.to_string message |> String.split_lines with
       | [] -> ()
       | line :: _ -> print_endline line));
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| (Failure inet_addr_of_string) |}]
+  [%expect {| failed to connect to RPC server tcp:host=invalid%20host,port=8587 |}]
 ;;
 
 let%expect_test "initialize scheduler with rpc" =


### PR DESCRIPTION
Resolve RPC hosts with getaddrinfo and report socket lookup failures as user errors when connecting.