### PR TITLE
fix: Option.hash distinguishes None from Some x when (f x = 0)

### DIFF
--- a/otherlibs/stdune/src/option.ml
+++ b/otherlibs/stdune/src/option.ml
@@ -141,8 +141,8 @@ module List = struct
 end
 
 let hash f = function
-  | None -> Stdlib.Hashtbl.hash None
-  | Some s -> Stdlib.Hashtbl.hash (f s)
+  | None -> 0
+  | Some s -> (f s * 31) + 1
 ;;
 
 let merge x y ~f =

--- a/otherlibs/stdune/test/option_tests.ml
+++ b/otherlibs/stdune/test/option_tests.ml
@@ -1,0 +1,21 @@
+open Stdune
+
+let%expect_test "Option.hash: None <> Some x when (f x = 0)" =
+  (* Bool.hash false = 0 and Unit.hash () = 0. Under the previous
+     implementation [Option.hash f (Some x)] returned
+     [Stdlib.Hashtbl.hash (f x)] and [Option.hash f None] returned
+     [Stdlib.Hashtbl.hash None]; since [None] shares OCaml's tag-0
+     representation with the integer 0, both produced the same hash
+     whenever [f x = 0]. *)
+  Printf.printf
+    "Bool.hash false: %b\n"
+    (Option.hash Bool.hash (Some false) <> Option.hash Bool.hash None);
+  Printf.printf
+    "Unit.hash ():    %b\n"
+    (Option.hash Unit.hash (Some ()) <> Option.hash Unit.hash None);
+  [%expect
+    {|
+    Bool.hash false: true
+    Unit.hash ():    true
+    |}]
+;;


### PR DESCRIPTION
## Summary

`Option.hash f None` and `Option.hash f (Some x)` previously both went through `Stdlib.Hashtbl.hash`, which gave equal results whenever `f x = 0` because `None` shares OCaml's tag-0 runtime representation with the integer 0. So under stdune's existing hashers:

- `Option.hash Bool.hash (Some false)` collided with `Option.hash Bool.hash None` (`Bool.hash false = 0`).
- `Option.hash Unit.hash (Some ())` collided with `Option.hash Unit.hash None` (`Unit.hash () = 0`).

This PR replaces the structural hash with a tagged recurrence — `None -> 0`, `Some s -> (f s * 31) + 1` — so the two cases land in disjoint buckets. Added an expect test in `otherlibs/stdune/test/option_tests.ml` covering the `Bool` and `Unit` cases that previously collided.

Discovered while surveying allocation-heavy hash sites for a follow-up to #14542.