### PR TITLE
Add oxcaml-compiler to compiler packages

### DIFF
--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -133,6 +133,7 @@ let compiler_package_names =
     ; "ocaml-variants"
     ; "ocaml-compiler"
     ; "relocatable-compiler"
+    ; "oxcaml-compiler"
     ]
 ;;
 


### PR DESCRIPTION
In the recent update, the compiler package in OxCaml was changed to `oxcaml-compiler`: https://github.com/oxcaml/opam-repository/commit/e36bb6bb0cc74e51c84b7b8816e77ec410333527 and https://github.com/oxcaml/opam-repository/commit/2f927310e15239c0de502b6f33e05b08c8feede5. This patch adds the package to the list of compiler packages so that Dune treats it as a compiler when building.