### PR TITLE
scheduler: use semaphore for event wakeups

### DIFF
--- a/otherlibs/stdune/src/terminal_signals.ml
+++ b/otherlibs/stdune/src/terminal_signals.ml
@@ -5,8 +5,22 @@ let signals : Signal.t list =
   ]
 ;;
 
+let signal_numbers = lazy (List.map ~f:Signal.to_int signals)
+
+type mask = int list option
+
+let block () =
+  if Sys.win32
+  then None
+  else Some (Unix.sigprocmask SIG_BLOCK (Lazy.force signal_numbers))
+;;
+
+let restore = function
+  | None -> ()
+  | Some mask -> ignore (Unix.sigprocmask SIG_SETMASK mask : int list)
+;;
+
 let unblock () =
   if not Sys.win32
-  then
-    ignore (Unix.sigprocmask SIG_UNBLOCK (List.map ~f:Signal.to_int signals) : int list)
+  then ignore (Unix.sigprocmask SIG_UNBLOCK (Lazy.force signal_numbers) : int list)
 ;;

--- a/otherlibs/stdune/src/terminal_signals.mli
+++ b/otherlibs/stdune/src/terminal_signals.mli
@@ -2,4 +2,8 @@
     events. *)
 val signals : Signal.t list
 
+type mask
+
+val block : unit -> mask
+val restore : mask -> unit
 val unblock : unit -> unit

--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -2,9 +2,12 @@
  (name dune_scheduler)
  (library_flags
   (:include flags/sexp))
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
  (foreign_stubs
   (language c)
-  (names fsevents_stubs fswatch_win_stubs))
+  (names fsevents_stubs fswatch_win_stubs signal_watcher_stubs))
  (libraries
   ocaml_inotify
   lev

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -25,7 +25,7 @@ type t =
   | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
-  | Job_complete_ready
+  | Signal_received of Signal.t
 
 module Invalidation_event = struct
   type t =
@@ -36,16 +36,31 @@ end
 module Queue = struct
   type event = t
 
+  module Wakeup = struct
+    type t
+
+    external create : unit -> t = "dune_event_wakeup_create"
+    external release : t -> unit = "dune_event_wakeup_release"
+    external acquire : t -> unit = "dune_event_wakeup_acquire"
+    external try_acquire : t -> bool = "dune_event_wakeup_try_acquire"
+    external use_for_signals : t -> unit = "dune_event_wakeup_use_for_signals"
+    external stop_using_signals : t -> unit = "dune_event_wakeup_stop_using_signals"
+  end
+
+  external next_pending_signal_number : unit -> int = "dune_signal_watcher_next_pending"
+
+  external has_pending_signal : unit -> bool = "dune_signal_watcher_has_pending"
+  [@@noalloc]
+
   type t =
     { jobs_completed : (job * Proc.Process_info.t) Queue.t
     ; file_watcher_tasks : (unit -> File_watcher.Event.t list) Queue.t
     ; mutable invalidation_events : Invalidation_event.t list
     ; mutable shutdown_reasons : Shutdown.Reason.Set.t
     ; mutex : Mutex.t
-    ; cond : Condition.t
+    ; wakeup : Wakeup.t
     ; mutable pending_jobs : int
     ; mutable pending_worker_tasks : int
-    ; mutable job_complete_ready : bool
     ; worker_tasks_completed : Fiber.fill Queue.t
     ; mutable got_event : bool
     ; mutable yield : unit Fiber.Ivar.t option
@@ -65,7 +80,7 @@ module Queue = struct
     let invalidation_events = [] in
     let shutdown_reasons = Shutdown.Reason.Set.empty in
     let mutex = Mutex.create () in
-    let cond = Condition.create () in
+    let wakeup = Wakeup.create () in
     let pending_jobs = 0 in
     let pending_worker_tasks = 0 in
     { jobs_completed
@@ -73,13 +88,12 @@ module Queue = struct
     ; invalidation_events
     ; shutdown_reasons
     ; mutex
-    ; cond
+    ; wakeup
     ; pending_jobs
     ; worker_tasks_completed
     ; pending_worker_tasks
     ; got_event = false
     ; yield = None
-    ; job_complete_ready = false
     }
   ;;
 
@@ -97,17 +111,25 @@ module Queue = struct
   let cancel_work_task_started q = q.pending_worker_tasks <- q.pending_worker_tasks - 1
 
   let add_event q f =
-    Mutex.lock q.mutex;
-    f q;
-    if not q.got_event
-    then (
-      q.got_event <- true;
-      Condition.signal q.cond);
-    Mutex.unlock q.mutex
+    Mutex.protect q.mutex (fun () ->
+      f q;
+      if not q.got_event
+      then (
+        q.got_event <- true;
+        Wakeup.release q.wakeup))
+  ;;
+
+  let use_for_signal_wakeup q = Wakeup.use_for_signals q.wakeup
+  let stop_using_signal_wakeup q = Wakeup.stop_using_signals q.wakeup
+
+  let next_signal () =
+    match next_pending_signal_number () with
+    | 0 -> None
+    | signal -> Some (Signal.of_int signal)
   ;;
 
   let yield_if_there_are_pending_events q =
-    if Execution_env.inside_dune || not q.got_event
+    if Execution_env.inside_dune || not (q.got_event || has_pending_signal ())
     then Fiber.return ()
     else (
       match q.yield with
@@ -131,13 +153,8 @@ module Queue = struct
         Shutdown reason)
     ;;
 
-    let job_complete_ready : t =
-      fun q ->
-      match q.job_complete_ready with
-      | false -> None
-      | true ->
-        q.job_complete_ready <- false;
-        Some Job_complete_ready
+    let signal : t =
+      fun _q -> Option.map (next_signal ()) ~f:(fun signal -> Signal_received signal)
     ;;
 
     let file_watcher_task q =
@@ -211,11 +228,12 @@ module Queue = struct
        [jobs_completed] and [yield] are where the bulk of the work is done, so
        they are the lowest priority to avoid starving other things. *)
     Event_source.
-      [ shutdown
+      [ signal
+      ; shutdown
       ; file_watcher_task
       ; invalidation
       ; worker_tasks_completed
-      ; (if Sys.win32 then jobs_completed else job_complete_ready)
+      ; jobs_completed
       ; yield
       ]
   ;;
@@ -232,9 +250,18 @@ module Queue = struct
       | None -> wait ()
       | Some event -> event
     and wait () =
+      (* Keep a single pending wakeup for any number of events. The token can
+         be stale when the scheduler drained events without blocking, so consume
+         it before waiting for the next event. *)
       q.got_event <- false;
-      Condition.wait q.cond q.mutex;
-      loop ()
+      ignore (Wakeup.try_acquire q.wakeup : bool);
+      match Event_source.(run (chain events_in_order)) q with
+      | Some event -> event
+      | None ->
+        Mutex.unlock q.mutex;
+        Wakeup.acquire q.wakeup;
+        Mutex.lock q.mutex;
+        loop ()
     in
     let ev = loop () in
     Mutex.unlock q.mutex;
@@ -270,8 +297,6 @@ module Queue = struct
     add_event q (fun q -> Queue.push q.jobs_completed (job, proc_info))
   ;;
 
-  let send_job_completed_ready q = add_event q (fun q -> q.job_complete_ready <- true)
-
   let send_shutdown q signal =
     add_event q (fun q ->
       q.shutdown_reasons <- Shutdown.Reason.Set.add q.shutdown_reasons signal)
@@ -283,4 +308,34 @@ module Queue = struct
 
   let pending_jobs q = q.pending_jobs
   let pending_worker_tasks q = q.pending_worker_tasks
+
+  let%expect_test "wakeup is coalesced while an event is pending" =
+    let q = create () in
+    let print_wakeup label =
+      Printf.printf "%s: %b\n" label (Wakeup.try_acquire q.wakeup)
+    in
+    let print_next () =
+      match next q with
+      | Shutdown Requested -> print_endline "requested"
+      | Shutdown Timeout -> print_endline "timeout"
+      | _ -> print_endline "unexpected"
+    in
+    print_wakeup "initial";
+    send_shutdown q Requested;
+    send_shutdown q Timeout;
+    print_wakeup "after two events";
+    print_wakeup "after consuming token";
+    print_next ();
+    print_next ();
+    print_wakeup "after draining events";
+    [%expect
+      {|
+      initial: false
+      after two events: true
+      after consuming token: false
+      requested
+      timeout
+      after draining events: false
+      |}]
+  ;;
 end

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -19,7 +19,7 @@ type t =
   | File_system_watcher_terminated
   | Shutdown of Shutdown.Reason.t
   | Fiber_fill_ivar of Fiber.fill
-  | Job_complete_ready
+  | Signal_received of Signal.t
 
 module Queue : sig
   type event := t
@@ -57,7 +57,9 @@ module Queue : sig
 
   val send_invalidation_event : t -> Memo.Invalidation.t -> unit
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit
-  val send_job_completed_ready : t -> unit
   val send_shutdown : t -> Shutdown.Reason.t -> unit
+  val use_for_signal_wakeup : t -> unit
+  val stop_using_signal_wakeup : t -> unit
+  val next_signal : unit -> Signal.t option
   val yield_if_there_are_pending_events : t -> unit Fiber.t
 end

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -65,6 +65,7 @@ let wait_for_process t ~is_process_group_leader pid =
 
 (* Grace period before escalating from SIGTERM to SIGKILL *)
 let sigterm_grace_period = Time.Span.of_secs 0.2
+let signal_interrupt_window = Time.Span.of_secs 1.0
 
 type termination_reason =
   | Normal
@@ -118,11 +119,55 @@ let filesystem_watcher_terminated () =
   Log.info "Shutdown" [ "reason", Dyn.string "Filesystem watcher terminated" ]
 ;;
 
+let record_signal_interruption t signal =
+  if Signal_watcher.is_exit_signal signal
+  then (
+    let now = Time.now () in
+    let { timestamps; print_ctrl_c_warning } = t.signal_interruptions in
+    Queue.push timestamps now;
+    while
+      (not (Queue.is_empty timestamps))
+      && Time.Span.compare
+           (Time.diff now (Queue.peek_exn timestamps))
+           signal_interrupt_window
+         = Gt
+    do
+      ignore (Queue.pop_exn timestamps : Time.t)
+    done;
+    match Queue.length timestamps with
+    | 2 -> if print_ctrl_c_warning then Signal_watcher.print_ctrl_c_warning ()
+    | n when n >= 3 -> Signal_watcher.emergency_exit ()
+    | _ -> ())
+;;
+
+let handle_signal t signal =
+  record_signal_interruption t signal;
+  Signal_watcher.handle signal
+;;
+
 type saw_shutdown =
   | Ok
   | Got_shutdown
 
 let kill_and_wait_for_all_processes t =
+  let saw_shutdown = ref Ok in
+  let mark_shutdown () = saw_shutdown := Got_shutdown in
+  let handle_cleanup_signal signal =
+    match handle_signal t signal with
+    | Continue -> ()
+    | Reap_processes ->
+      ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list)
+    | Shutdown reason ->
+      got_shutdown reason;
+      mark_shutdown ()
+  in
+  let rec drain_pending_signals () =
+    match Event.Queue.next_signal () with
+    | None -> ()
+    | Some signal ->
+      handle_cleanup_signal signal;
+      drain_pending_signals ()
+  in
   if Sys.win32
   then
     (* SIGTERM is not meaningful on Windows, and [Process_watcher.wait_unix]
@@ -139,6 +184,7 @@ let kill_and_wait_for_all_processes t =
     let deadline = Time.add (Time.now ()) sigterm_grace_period in
     let sent_sigkill = ref false in
     while Event.Queue.pending_jobs t.events > 0 do
+      drain_pending_signals ();
       ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list);
       if Event.Queue.pending_jobs t.events > 0
       then
@@ -147,27 +193,20 @@ let kill_and_wait_for_all_processes t =
           Dune_trace.emit Process Dune_trace.Event.process_cleanup_sigkill;
           Process_watcher.killall t.process_watcher Sys.sigkill;
           sent_sigkill := true)
-        else Unix.sleepf 0.01
+        else (
+          Unix.sleepf 0.01;
+          drain_pending_signals ())
     done;
     Dune_trace.emit Process Dune_trace.Event.process_cleanup_finish);
-  let saw_signal = ref Ok in
   while Event.Queue.pending_jobs t.events > 0 do
     match Event.Queue.next t.events with
     | Shutdown reason ->
       got_shutdown reason;
-      saw_signal := Got_shutdown
-    | Job_complete_ready ->
-      ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list)
+      mark_shutdown ()
+    | Signal_received signal -> handle_cleanup_signal signal
     | _ -> ()
   done;
-  (* This silliness is needed because we have tests that run the scheduler
-     more than once per process. Such tests require the signal watcher to be
-     reset with the correct event queue. *)
-  if not Sys.win32
-  then (
-    Unix.kill (Unix.getpid ()) (Signal.to_int Thread0.signal_watcher_interrupt);
-    Thread.join t.signal_watcher);
-  !saw_signal
+  !saw_shutdown
 ;;
 
 let to_dyn { events; process_watcher; _ } =
@@ -185,11 +224,6 @@ let () =
 ;;
 
 let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
-  (* The signal watcher must be initialized first so that signals are
-     blocked in all threads. *)
-  let signal_watcher =
-    Signal_watcher.init ~print_ctrl_c_warning:config.print_ctrl_c_warning events
-  in
   let cancel = Fiber.Cancel.create () in
   let process_watcher = Process_watcher.init events in
   let async_io = Async_io.create events in
@@ -215,8 +249,11 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
     ; build_inputs_changed = Trigger.create ()
     ; cancel
     ; thread_pool = lazy (Thread_pool.create ~min_workers:4 ~max_workers:50)
-    ; signal_watcher
     ; async_io
+    ; signal_interruptions =
+        { timestamps = Queue.create ()
+        ; print_ctrl_c_warning = config.print_ctrl_c_warning
+        }
     }
   in
   current := Some t;
@@ -266,10 +303,16 @@ module Run_once = struct
     | File_system_watcher_terminated ->
       filesystem_watcher_terminated ();
       raise (Abort Already_reported)
-    | Job_complete_ready ->
-      (match Process_watcher.wait_unix t.process_watcher with
-       | [] -> iter t
-       | fills -> fills)
+    | Signal_received signal ->
+      (match handle_signal t signal with
+       | Continue -> iter t
+       | Reap_processes ->
+         (match Process_watcher.wait_unix t.process_watcher with
+          | [] -> iter t
+          | fills -> fills)
+       | Shutdown reason ->
+         got_shutdown reason;
+         raise @@ Abort (Shutdown_requested reason))
     | Fiber_fill_ivar fill -> [ fill ]
     | Shutdown reason ->
       got_shutdown reason;
@@ -500,52 +543,53 @@ module Run = struct
         run
     =
     let events = Event_queue.create () in
-    let file_watcher =
-      match file_watcher with
-      | No_watcher -> None
-      | Automatic ->
-        Some
-          (File_watcher.create_default
-             ~scheduler:
-               { thread_safe_send_emit_events_job =
-                   (fun job -> Event_queue.send_file_watcher_task events job)
-               }
-             ~watch_exclusions:config.watch_exclusions
-             ())
-    in
-    let t = prepare config ~handler:on_event ~events ~file_watcher in
-    Option.iter file_watcher ~f:(fun dune_file_watcher ->
-      let initial_invalidation =
-        Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
+    Signal_watcher.with_ events ~f:(fun () ->
+      let file_watcher =
+        match file_watcher with
+        | No_watcher -> None
+        | Automatic ->
+          Some
+            (File_watcher.create_default
+               ~scheduler:
+                 { thread_safe_send_emit_events_job =
+                     (fun job -> Event_queue.send_file_watcher_task events job)
+                 }
+               ~watch_exclusions:config.watch_exclusions
+               ())
       in
-      Memo.reset initial_invalidation);
-    let result =
-      let run =
-        match timeout with
-        | None -> run
-        | Some timeout ->
-          fun () ->
-            let sleep = Async_io.sleep t.async_io timeout in
-            Fiber.fork_and_join_unit
-              (fun () ->
-                 let+ res = Async_io.Task.await sleep in
-                 match res with
-                 | Ok () -> Event_queue.send_shutdown t.events Timeout
-                 | Error `Cancelled -> ()
-                 | Error (`Exn _) -> assert false)
-              (fun () ->
-                 Fiber.finalize run ~finally:(fun () -> Async_io.Task.cancel sleep))
+      let t = prepare config ~handler:on_event ~events ~file_watcher in
+      Option.iter file_watcher ~f:(fun dune_file_watcher ->
+        let initial_invalidation =
+          Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
+        in
+        Memo.reset initial_invalidation);
+      let result =
+        let run =
+          match timeout with
+          | None -> run
+          | Some timeout ->
+            fun () ->
+              let sleep = Async_io.sleep t.async_io timeout in
+              Fiber.fork_and_join_unit
+                (fun () ->
+                   let+ res = Async_io.Task.await sleep in
+                   match res with
+                   | Ok () -> Event_queue.send_shutdown t.events Timeout
+                   | Error `Cancelled -> ()
+                   | Error (`Exn _) -> assert false)
+                (fun () ->
+                   Fiber.finalize run ~finally:(fun () -> Async_io.Task.cancel sleep))
+        in
+        match Run_once.run_and_cleanup t run with
+        | Ok a -> Result.Ok a
+        | Error (Shutdown_requested reason) -> Error (Shutdown.E reason, None)
+        | Error Already_reported -> Error (Dune_util.Report_error.Already_reported, None)
+        | Error (Exn exn_with_bt) -> Error (exn_with_bt.exn, Some exn_with_bt.backtrace)
       in
-      match Run_once.run_and_cleanup t run with
-      | Ok a -> Result.Ok a
-      | Error (Shutdown_requested reason) -> Error (Shutdown.E reason, None)
-      | Error Already_reported -> Error (Dune_util.Report_error.Already_reported, None)
-      | Error (Exn exn_with_bt) -> Error (exn_with_bt.exn, Some exn_with_bt.backtrace)
-    in
-    match result with
-    | Ok a -> a
-    | Error (exn, None) -> Exn.raise exn
-    | Error (exn, Some bt) -> Exn.raise_with_backtrace exn bt
+      match result with
+      | Ok a -> a
+      | Error (exn, None) -> Exn.raise exn
+      | Error (exn, Some bt) -> Exn.raise_with_backtrace exn bt)
   ;;
 end
 

--- a/src/dune_scheduler/signal_watcher.ml
+++ b/src/dune_scheduler/signal_watcher.ml
@@ -1,17 +1,5 @@
 open Stdune
 
-let signos = List.map Thread0.interrupt_signals ~f:Signal.to_int
-
-let macos_sigchld_warning =
-  {|
-
-*************************************************************************
-* Failed to handle signal, press Control+C to perform an emergency exit *
-*************************************************************************
-
-|}
-;;
-
 let warning =
   {|
 
@@ -22,71 +10,83 @@ let warning =
 |}
 ;;
 
+let warning_bytes = Bytes.of_string warning
+let signals = if Sys.win32 then [ Signal.Int ] else Thread0.interrupt_signals
+let signal_numbers = lazy (List.map signals ~f:Signal.to_int)
+
 external sys_exit : int -> _ = "caml_sys_exit"
+external install : int list -> unit = "dune_signal_watcher_install"
+external uninstall : unit -> unit = "dune_signal_watcher_uninstall"
 
-let signal_waiter () =
+type action =
+  | Continue
+  | Reap_processes
+  | Shutdown of Shutdown.Reason.t
+
+let shutdown_reason = function
+  | (Signal.Int | Quit | Term) as signal -> Some (Shutdown.Reason.Signal signal)
+  | _ -> None
+;;
+
+let is_exit_signal signal = Option.is_some (shutdown_reason signal)
+
+let print_ctrl_c_warning () =
+  try
+    ignore
+      (Unix.single_write Unix.stderr warning_bytes 0 (Bytes.length warning_bytes) : int)
+  with
+  | Unix.Unix_error _ -> ()
+;;
+
+let emergency_exit () = sys_exit 1
+
+let with_signals_blocked f =
   if Sys.win32
+  then f ()
+  else (
+    let previous_mask = Unix.sigprocmask SIG_BLOCK (Lazy.force signal_numbers) in
+    Exn.protect ~f ~finally:(fun () ->
+      ignore (Unix.sigprocmask SIG_SETMASK previous_mask : int list)))
+;;
+
+let uninstall_and_stop q =
+  Exn.protect ~f:uninstall ~finally:(fun () -> Event.Queue.stop_using_signal_wakeup q)
+;;
+
+let init q =
+  let install_with_cleanup () =
+    Event.Queue.use_for_signal_wakeup q;
+    match install (Lazy.force signal_numbers) with
+    | () -> ()
+    | exception exn ->
+      (match uninstall_and_stop q with
+       | () -> ()
+       | exception _ -> ());
+      Exn.raise exn
+  in
+  with_signals_blocked install_with_cleanup
+;;
+
+let cleanup q = with_signals_blocked (fun () -> uninstall_and_stop q)
+
+let with_ q ~f =
+  init q;
+  Exn.protect ~finally:(fun () -> cleanup q) ~f
+;;
+
+let handle signal =
+  Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_received signal);
+  if Signal.equal signal Thread0.debug_signal
   then (
-    let r, w = Unix.pipe ~cloexec:true () in
-    let buf = Bytes.create 1 in
-    Sys.set_signal Sys.sigint (Signal_handle (fun _ -> assert (Unix.write w buf 0 1 = 1)));
-    Staged.stage (fun () ->
-      assert (Unix.read r buf 0 1 = 1);
-      Signal.Int))
-  else Staged.stage (fun () -> Thread.wait_signal signos |> Signal.of_int)
-;;
-
-let run ~print_ctrl_c_warning q : unit =
-  let last_exit_signals = Queue.create () in
-  let one_second = Time.Span.of_secs 1. in
-  let wait_signal = Staged.unstage (signal_waiter ()) in
-  while true do
-    let signal = wait_signal () in
-    Dune_trace.emit Process (fun () -> Dune_trace.Event.signal_received signal);
+    Dune_trace.emit Diagnostics (fun () ->
+      let dump = Debug.dump () in
+      Dune_trace.Event.debug dump);
+    Continue)
+  else (
     match signal with
-    | _ when Signal.equal signal Thread0.signal_watcher_interrupt -> raise_notrace Exit
-    | _ when Signal.equal signal Thread0.signal_watcher_debug ->
-      Dune_trace.emit Diagnostics (fun () ->
-        let dump = Debug.dump () in
-        Dune_trace.Event.debug dump)
-    | Chld -> Event.Queue.send_job_completed_ready q
-    | Int | Quit | Term ->
-      Event.Queue.send_shutdown q (Signal signal);
-      let now = Time.now () in
-      Queue.push last_exit_signals now;
-      (* Discard old signals *)
-      while
-        Queue.length last_exit_signals > 0
-        && Poly.(Time.diff now (Queue.peek_exn last_exit_signals) > one_second)
-      do
-        ignore (Queue.pop_exn last_exit_signals : Time.t)
-      done;
-      let n = Queue.length last_exit_signals in
-      if n = 2 && print_ctrl_c_warning then prerr_endline warning;
-      if n = 3 then sys_exit 1
-    | _ ->
-      (* On macOS, [sigwait] can occasionally return with success, yet skip
-         setting `&signo` when waiting on a set containing [SIGCHLD]. OCaml
-         returns invalid uninitialized garbage in this case. Ignore it rather
-         than crashing the scheduler. *)
-      prerr_endline macos_sigchld_warning;
-      Event.Queue.send_job_completed_ready q
-  done
-;;
-
-(* Make sure that we never have more than one signal watcher running at a time *)
-let m = Mutex.create ()
-
-let init ~print_ctrl_c_warning q =
-  Thread0.spawn ~name:"signal-watcher" (fun () ->
-    let res =
-      Mutex.protect m (fun () ->
-        try
-          run ~print_ctrl_c_warning q;
-          None
-        with
-        | Exit -> None
-        | exn -> Some exn)
-    in
-    Option.iter res ~f:raise)
+    | Chld -> Reap_processes
+    | signal ->
+      (match shutdown_reason signal with
+       | Some reason -> Shutdown reason
+       | None -> Continue))
 ;;

--- a/src/dune_scheduler/signal_watcher.mli
+++ b/src/dune_scheduler/signal_watcher.mli
@@ -1,1 +1,12 @@
-val init : print_ctrl_c_warning:bool -> Event.Queue.t -> Thread.t
+open Stdune
+
+type action =
+  | Continue
+  | Reap_processes
+  | Shutdown of Shutdown.Reason.t
+
+val with_ : Event.Queue.t -> f:(unit -> 'a) -> 'a
+val handle : Signal.t -> action
+val is_exit_signal : Signal.t -> bool
+val print_ctrl_c_warning : unit -> unit
+val emergency_exit : unit -> 'a

--- a/src/dune_scheduler/signal_watcher_stubs.c
+++ b/src/dune_scheduler/signal_watcher_stubs.c
@@ -1,0 +1,692 @@
+#define CAML_INTERNALS
+
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+#include <signal.h>
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#else
+
+#include <pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <fcntl.h>
+#include <stdio.h>
+#define DUNE_USE_NAMED_SEMAPHORE 1
+#else
+#define DUNE_USE_NAMED_SEMAPHORE 0
+#endif
+
+#endif
+
+#ifndef NSIG
+#define NSIG 128
+#endif
+
+#define DUNE_MAX_WATCHED_SIGNALS 32
+/* Keep enough repeated deliveries to preserve the emergency Ctrl+C path, while
+   bounding the amount of scheduler work caused by a signal storm. The Unix
+   lock-free atomic implementation stores these as byte counters. */
+#define DUNE_MAX_PENDING_PER_SIGNAL 3
+
+#if defined(__GNUC__) && defined(__GCC_ATOMIC_CHAR_LOCK_FREE)                  \
+    && __GCC_ATOMIC_CHAR_LOCK_FREE == 2                                        \
+    && defined(__GCC_ATOMIC_INT_LOCK_FREE)                                     \
+    && __GCC_ATOMIC_INT_LOCK_FREE == 2                                         \
+    && defined(__GCC_ATOMIC_POINTER_LOCK_FREE)                                 \
+    && __GCC_ATOMIC_POINTER_LOCK_FREE == 2
+#define DUNE_HAS_GCC_LOCK_FREE_ATOMICS 1
+#else
+#define DUNE_HAS_GCC_LOCK_FREE_ATOMICS 0
+#endif
+
+#if !defined(_WIN32) && !DUNE_HAS_GCC_LOCK_FREE_ATOMICS
+#error "dune signal watcher requires lock-free GCC atomics on Unix"
+#endif
+
+#ifdef _WIN32
+typedef LONG signal_counter;
+static volatile signal_counter dune_pending_signals[NSIG];
+static volatile LONG signal_wakeup_pending = 0;
+static volatile LONG active_signal_handlers = 0;
+static volatile LONG signal_handlers_enabled = 0;
+
+static void pending_signal_clear(int signo)
+{
+  InterlockedExchange(&dune_pending_signals[signo], 0);
+}
+
+static void pending_signal_increment(int signo)
+{
+  LONG count = InterlockedIncrement(&dune_pending_signals[signo]);
+  if (count > DUNE_MAX_PENDING_PER_SIGNAL)
+    InterlockedExchange(&dune_pending_signals[signo], DUNE_MAX_PENDING_PER_SIGNAL);
+}
+
+static int pending_signal_take_one(int signo)
+{
+  LONG count;
+
+  do {
+    count = InterlockedCompareExchange(&dune_pending_signals[signo], 0, 0);
+    if (count <= 0) return 0;
+  } while (InterlockedCompareExchange(&dune_pending_signals[signo], count - 1,
+                                      count)
+           != count);
+
+  return 1;
+}
+
+static int pending_signal_load(int signo)
+{
+  return (int)InterlockedCompareExchange(&dune_pending_signals[signo], 0, 0);
+}
+
+static int signal_wakeup_mark_pending(void)
+{
+  return InterlockedCompareExchange(&signal_wakeup_pending, 1, 0) == 0;
+}
+
+static void signal_wakeup_clear_pending(void)
+{
+  InterlockedExchange(&signal_wakeup_pending, 0);
+}
+
+static void signal_handler_enter(void)
+{
+  InterlockedIncrement(&active_signal_handlers);
+}
+
+static void signal_handler_leave(void)
+{
+  InterlockedDecrement(&active_signal_handlers);
+}
+
+static int signal_handlers_are_active(void)
+{
+  return InterlockedCompareExchange(&active_signal_handlers, 0, 0) > 0;
+}
+
+static void wait_for_signal_handlers(void)
+{
+  while (signal_handlers_are_active()) Sleep(0);
+}
+
+static int signal_handlers_are_enabled(void)
+{
+  return InterlockedCompareExchange(&signal_handlers_enabled, 0, 0) != 0;
+}
+
+static void signal_handlers_enable(void)
+{
+  InterlockedExchange(&signal_handlers_enabled, 1);
+}
+
+static void signal_handlers_disable(void)
+{
+  InterlockedExchange(&signal_handlers_enabled, 0);
+}
+#elif DUNE_HAS_GCC_LOCK_FREE_ATOMICS
+typedef unsigned char signal_counter;
+static signal_counter dune_pending_signals[NSIG];
+static signal_counter signal_wakeup_pending = 0;
+static unsigned int active_signal_handlers = 0;
+
+static void pending_signal_clear(int signo)
+{
+  __atomic_store_n(&dune_pending_signals[signo], 0, __ATOMIC_RELAXED);
+}
+
+static void pending_signal_increment(int signo)
+{
+  signal_counter count =
+      __atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+
+  while (count < DUNE_MAX_PENDING_PER_SIGNAL) {
+    signal_counter next = count + 1;
+    if (__atomic_compare_exchange_n(&dune_pending_signals[signo], &count, next,
+                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+      return;
+  }
+}
+
+static int pending_signal_take_one(int signo)
+{
+  signal_counter count =
+      __atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+
+  while (count > 0) {
+    signal_counter next = count - 1;
+    if (__atomic_compare_exchange_n(&dune_pending_signals[signo], &count, next,
+                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int pending_signal_load(int signo)
+{
+  return (int)__atomic_load_n(&dune_pending_signals[signo], __ATOMIC_RELAXED);
+}
+
+static int signal_wakeup_mark_pending(void)
+{
+  signal_counter expected = 0;
+  return __atomic_compare_exchange_n(&signal_wakeup_pending, &expected, 1, 0,
+                                     __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+static void signal_wakeup_clear_pending(void)
+{
+  __atomic_store_n(&signal_wakeup_pending, 0, __ATOMIC_RELAXED);
+}
+
+static void signal_handler_enter(void)
+{
+  (void)__atomic_add_fetch(&active_signal_handlers, 1, __ATOMIC_ACQUIRE);
+}
+
+static void signal_handler_leave(void)
+{
+  (void)__atomic_sub_fetch(&active_signal_handlers, 1, __ATOMIC_RELEASE);
+}
+
+static int signal_handlers_are_active(void)
+{
+  return __atomic_load_n(&active_signal_handlers, __ATOMIC_ACQUIRE) > 0;
+}
+
+static void wait_for_signal_handlers(void)
+{
+  while (signal_handlers_are_active()) sched_yield();
+}
+#endif
+
+static int watched_count = 0;
+static int watched_signals[DUNE_MAX_WATCHED_SIGNALS];
+static int watched_ocaml_signals[DUNE_MAX_WATCHED_SIGNALS];
+static value signal_wakeup_root = Val_unit;
+static int signal_wakeup_root_registered = 0;
+static int installed_handlers[NSIG];
+
+#ifdef _WIN32
+typedef void (*dune_signal_handler_t)(int);
+static dune_signal_handler_t previous_signal_handlers[NSIG];
+#else
+static struct sigaction previous_sigactions[NSIG];
+#endif
+
+static void register_signal_wakeup_root(void)
+{
+  if (!signal_wakeup_root_registered) {
+    caml_register_global_root(&signal_wakeup_root);
+    signal_wakeup_root_registered = 1;
+  }
+}
+
+static void dune_event_wakeup_finalize(value v_wakeup);
+
+static struct custom_operations dune_event_wakeup_ops = {
+  "build.dune.scheduler.event_wakeup",
+  dune_event_wakeup_finalize,
+  custom_compare_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default,
+  custom_fixed_length_default
+};
+
+#ifdef _WIN32
+
+struct dune_event_wakeup {
+  HANDLE event;
+  int used_for_signals;
+};
+
+static PVOID volatile signal_wakeup = NULL;
+
+#define Dune_event_wakeup_val(v) ((struct dune_event_wakeup *)Data_custom_val(v))
+
+static void dune_event_wakeup_finalize(value v_wakeup)
+{
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (wakeup->used_for_signals) return;
+  if (wakeup->event != NULL) CloseHandle(wakeup->event);
+}
+
+static void dune_signal_wakeup(void)
+{
+  DWORD saved_error = GetLastError();
+  HANDLE event =
+      (HANDLE)InterlockedCompareExchangePointer(&signal_wakeup, NULL, NULL);
+  if (event != NULL && signal_wakeup_mark_pending()) SetEvent(event);
+  SetLastError(saved_error);
+}
+
+CAMLprim value dune_event_wakeup_create(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLlocal1(v_wakeup);
+  struct dune_event_wakeup *wakeup;
+
+  v_wakeup = caml_alloc_custom(&dune_event_wakeup_ops,
+                               sizeof(struct dune_event_wakeup), 0, 1);
+  wakeup = Dune_event_wakeup_val(v_wakeup);
+  wakeup->event = NULL;
+  wakeup->used_for_signals = 0;
+  wakeup->event = CreateEvent(NULL, FALSE, FALSE, NULL);
+  if (wakeup->event == NULL) caml_failwith("CreateEvent");
+
+  CAMLreturn(v_wakeup);
+}
+
+CAMLprim value dune_event_wakeup_release(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (!SetEvent(wakeup->event)) caml_failwith("SetEvent");
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  HANDLE event = wakeup->event;
+  DWORD result;
+
+  caml_release_runtime_system();
+  result = WaitForSingleObject(event, INFINITE);
+  caml_acquire_runtime_system();
+
+  if (result != WAIT_OBJECT_0) caml_failwith("WaitForSingleObject");
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_try_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  DWORD result = WaitForSingleObject(wakeup->event, 0);
+  if (result == WAIT_OBJECT_0) {
+    signal_wakeup_clear_pending();
+    CAMLreturn(Val_true);
+  }
+  if (result == WAIT_TIMEOUT) CAMLreturn(Val_false);
+  caml_failwith("WaitForSingleObject");
+}
+
+CAMLprim value dune_event_wakeup_use_for_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  register_signal_wakeup_root();
+  signal_wakeup_root = v_wakeup;
+  wakeup->used_for_signals = 1;
+  InterlockedExchangePointer(&signal_wakeup, wakeup->event);
+  /* A previous scheduler run may have left a stale wakeup token on its
+     event. */
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_stop_using_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  PVOID previous =
+      InterlockedCompareExchangePointer(&signal_wakeup, NULL, wakeup->event);
+  if (previous == wakeup->event) {
+    wait_for_signal_handlers();
+    signal_wakeup_clear_pending();
+    wakeup->used_for_signals = 0;
+    signal_wakeup_root = Val_unit;
+  }
+  CAMLreturn(Val_unit);
+}
+
+#else
+
+struct dune_event_wakeup {
+  sem_t *sem;
+  int used_for_signals;
+};
+
+static sem_t *signal_wakeup = NULL;
+
+#define Dune_event_wakeup_val(v) ((struct dune_event_wakeup *)Data_custom_val(v))
+
+static sem_t *signal_wakeup_get(void)
+{
+  return __atomic_load_n(&signal_wakeup, __ATOMIC_ACQUIRE);
+}
+
+static void signal_wakeup_set(sem_t *sem)
+{
+  __atomic_store_n(&signal_wakeup, sem, __ATOMIC_RELEASE);
+}
+
+static int signal_wakeup_unset_if(sem_t *sem)
+{
+  sem_t *expected = sem;
+  return __atomic_compare_exchange_n(&signal_wakeup, &expected, NULL, 0,
+                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static void dune_event_wakeup_finalize(value v_wakeup)
+{
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (wakeup->used_for_signals) return;
+  if (wakeup->sem == NULL) return;
+#if DUNE_USE_NAMED_SEMAPHORE
+  sem_close(wakeup->sem);
+#else
+  sem_destroy(wakeup->sem);
+  free(wakeup->sem);
+#endif
+}
+
+static sem_t *create_semaphore(void)
+{
+#if DUNE_USE_NAMED_SEMAPHORE
+  static int semaphore_id = 0;
+  char name[64];
+  sem_t *sem;
+
+  for (int i = 0; i < 100; i++) {
+    snprintf(name, sizeof(name), "/dune-%ld-%d", (long)getpid(), semaphore_id++);
+    sem = sem_open(name, O_CREAT | O_EXCL, 0600, 0);
+    if (sem != SEM_FAILED) {
+      if (sem_unlink(name) == -1) {
+        sem_close(sem);
+        uerror("sem_unlink", Nothing);
+      }
+      return sem;
+    }
+    if (errno != EEXIST) uerror("sem_open", Nothing);
+  }
+
+  caml_failwith("sem_open");
+#else
+  sem_t *sem = malloc(sizeof(sem_t));
+  if (sem == NULL) caml_raise_out_of_memory();
+  if (sem_init(sem, 0, 0) == -1) {
+    free(sem);
+    uerror("sem_init", Nothing);
+  }
+  return sem;
+#endif
+}
+
+static void dune_signal_wakeup(void)
+{
+  int saved_errno = errno;
+  sem_t *sem = signal_wakeup_get();
+
+  if (sem != NULL && signal_wakeup_mark_pending()) {
+    int result = sem_post(sem);
+    if (result == -1) signal_wakeup_clear_pending();
+    (void)result;
+  }
+
+  errno = saved_errno;
+}
+
+static int wait_for_semaphore(sem_t *sem)
+{
+  int result;
+
+  do {
+    result = sem_wait(sem);
+  } while (result == -1 && errno == EINTR);
+
+  return result;
+}
+
+static int try_wait_for_semaphore(sem_t *sem)
+{
+  int result;
+
+  do {
+    result = sem_trywait(sem);
+  } while (result == -1 && errno == EINTR);
+
+  return result;
+}
+
+CAMLprim value dune_event_wakeup_create(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLlocal1(v_wakeup);
+  struct dune_event_wakeup *wakeup;
+
+  v_wakeup = caml_alloc_custom(&dune_event_wakeup_ops,
+                               sizeof(struct dune_event_wakeup), 0, 1);
+  wakeup = Dune_event_wakeup_val(v_wakeup);
+  wakeup->sem = NULL;
+  wakeup->used_for_signals = 0;
+  wakeup->sem = create_semaphore();
+
+  CAMLreturn(v_wakeup);
+}
+
+CAMLprim value dune_event_wakeup_release(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (sem_post(wakeup->sem) == -1) uerror("sem_post", Nothing);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  sem_t *sem = wakeup->sem;
+  int result;
+  int saved_errno;
+
+  caml_release_runtime_system();
+  result = wait_for_semaphore(sem);
+  saved_errno = errno;
+  caml_acquire_runtime_system();
+
+  if (result == -1) {
+    errno = saved_errno;
+    uerror("sem_wait", Nothing);
+  }
+
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_try_acquire(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (try_wait_for_semaphore(wakeup->sem) == 0) {
+    signal_wakeup_clear_pending();
+    CAMLreturn(Val_true);
+  }
+  if (errno == EAGAIN) CAMLreturn(Val_false);
+
+  uerror("sem_trywait", Nothing);
+}
+
+CAMLprim value dune_event_wakeup_use_for_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  register_signal_wakeup_root();
+  signal_wakeup_root = v_wakeup;
+  wakeup->used_for_signals = 1;
+  signal_wakeup_set(wakeup->sem);
+  /* A previous scheduler run may have left a stale wakeup token on its
+     semaphore. */
+  signal_wakeup_clear_pending();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_event_wakeup_stop_using_signals(value v_wakeup)
+{
+  CAMLparam1(v_wakeup);
+  struct dune_event_wakeup *wakeup = Dune_event_wakeup_val(v_wakeup);
+  if (signal_wakeup_unset_if(wakeup->sem)) {
+    wait_for_signal_handlers();
+    signal_wakeup_clear_pending();
+    wakeup->used_for_signals = 0;
+    signal_wakeup_root = Val_unit;
+  }
+  CAMLreturn(Val_unit);
+}
+
+#endif
+
+static void signal_handler(int signo)
+{
+  signal_handler_enter();
+#ifdef _WIN32
+  if (signal_handlers_are_enabled()) signal(signo, signal_handler);
+#endif
+  if (signo >= 0 && signo < NSIG) pending_signal_increment(signo);
+  dune_signal_wakeup();
+  signal_handler_leave();
+}
+
+CAMLprim value dune_signal_watcher_install(value v_signals)
+{
+  CAMLparam1(v_signals);
+
+  for (int i = 0; i < NSIG; i++) pending_signal_clear(i);
+  watched_count = 0;
+#ifdef _WIN32
+  signal_handlers_enable();
+#endif
+
+  for (; v_signals != Val_emptylist; v_signals = Field(v_signals, 1)) {
+    int ocaml_signal = Int_val(Field(v_signals, 0));
+    int signo = caml_convert_signal_number(ocaml_signal);
+
+    if (signo < 0 || signo >= NSIG) continue;
+    if (watched_count == DUNE_MAX_WATCHED_SIGNALS)
+      caml_invalid_argument("too many watched signals");
+
+    watched_signals[watched_count] = signo;
+    watched_ocaml_signals[watched_count] = ocaml_signal;
+    watched_count++;
+
+    if (installed_handlers[signo]) continue;
+
+#ifdef _WIN32
+    dune_signal_handler_t previous = signal(signo, signal_handler);
+    if (previous == SIG_ERR) caml_failwith("signal");
+    previous_signal_handlers[signo] = previous;
+#else
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = signal_handler;
+    sa.sa_flags = 0;
+#ifdef SA_RESTART
+    sa.sa_flags |= SA_RESTART;
+#endif
+    if (sigaction(signo, &sa, &previous_sigactions[signo]) == -1)
+      uerror("sigaction", Nothing);
+#endif
+    installed_handlers[signo] = 1;
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_signal_watcher_uninstall(value v_unit)
+{
+  CAMLparam1(v_unit);
+
+  (void)v_unit;
+
+#ifdef _WIN32
+  signal_handlers_disable();
+#endif
+  wait_for_signal_handlers();
+
+  for (int signo = 0; signo < NSIG; signo++) {
+    if (!installed_handlers[signo]) continue;
+
+#ifdef _WIN32
+    if (signal(signo, previous_signal_handlers[signo]) == SIG_ERR)
+      caml_failwith("signal");
+#else
+    if (sigaction(signo, &previous_sigactions[signo], NULL) == -1)
+      uerror("sigaction", Nothing);
+#endif
+    installed_handlers[signo] = 0;
+    pending_signal_clear(signo);
+  }
+
+  watched_count = 0;
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value dune_signal_watcher_next_pending(value v_unit)
+{
+  CAMLparam1(v_unit);
+  int result = 0;
+
+  (void)v_unit;
+
+#ifndef _WIN32
+  sigset_t set;
+  sigset_t previous_set;
+
+  sigemptyset(&set);
+  for (int i = 0; i < watched_count; i++) sigaddset(&set, watched_signals[i]);
+  if (pthread_sigmask(SIG_BLOCK, &set, &previous_set) != 0)
+    caml_failwith("pthread_sigmask");
+#endif
+
+  for (int i = 0; i < watched_count; i++) {
+    int signo = watched_signals[i];
+    if (pending_signal_take_one(signo)) {
+      result = watched_ocaml_signals[i];
+      break;
+    }
+  }
+
+#ifndef _WIN32
+  if (pthread_sigmask(SIG_SETMASK, &previous_set, NULL) != 0)
+    caml_failwith("pthread_sigmask");
+#endif
+
+  CAMLreturn(Val_int(result));
+}
+
+CAMLprim value dune_signal_watcher_has_pending(value v_unit)
+{
+  (void)v_unit;
+
+  for (int i = 0; i < watched_count; i++) {
+    if (pending_signal_load(watched_signals[i]) > 0) return Val_true;
+  }
+
+  return Val_false;
+}

--- a/src/dune_scheduler/thread0.ml
+++ b/src/dune_scheduler/thread0.ml
@@ -4,41 +4,31 @@ type t = Thread.t
 
 let join = Thread.join
 let delay = Thread.delay
-let wait_signal = Thread.wait_signal
-let signal_watcher_interrupt : Signal.t = Usr1
-let signal_watcher_debug : Signal.t = Usr2
+let debug_signal : Signal.t = Usr2
 
 (* These are the signals that will make the scheduler attempt to terminate dune
    or signal to dune to reap a process *)
-let interrupt_signals : Signal.t list =
-  [ signal_watcher_interrupt; signal_watcher_debug; Chld; Int; Quit; Term ]
-;;
+let interrupt_signals : Signal.t list = [ Int; Quit; Term; debug_signal; Chld ]
 
 (* In addition, the scheduler also blocks some other signals so that only
    designated threads can handle them by unblocking *)
 let blocked_signals : Signal.t list = Terminal_signals.signals @ interrupt_signals
-
-let block_signals =
-  lazy
-    (let () =
-       List.iter
-         [ signal_watcher_interrupt; signal_watcher_debug; Chld ]
-         ~f:(fun signal ->
-           Sys.set_signal (Signal.to_int signal) (Signal_handle (fun _ -> ())))
-     in
-     let signos = List.map blocked_signals ~f:Signal.to_int in
-     ignore (Unix.sigprocmask SIG_BLOCK signos : int list))
-;;
+let blocked_signos = lazy (List.map blocked_signals ~f:Signal.to_int)
 
 let create =
   if Sys.win32
   then Thread.create
   else
-    (* On unix, we make sure to block signals globally before starting a
-         thread so that only the signal watcher thread can receive signals. *)
     fun f x ->
-      Lazy.force block_signals;
-      Thread.create f x
+      (* New threads inherit their creator's signal mask. Block scheduler
+         signals around [Thread.create] so the child starts with those signals
+         blocked, then restore the creator's mask so the main thread remains
+         able to handle them via the scheduler's C signal handlers. *)
+      let previous_mask = Unix.sigprocmask SIG_BLOCK (Lazy.force blocked_signos) in
+      Exn.protect
+        ~f:(fun () -> Thread.create f x)
+        ~finally:(fun () ->
+          ignore (Unix.sigprocmask SIG_SETMASK previous_mask : int list))
 ;;
 
 let spawn ~name f =

--- a/src/dune_scheduler/thread0.mli
+++ b/src/dune_scheduler/thread0.mli
@@ -2,14 +2,10 @@ open Stdune
 
 type t = Thread.t
 
-(** Magic signal to interrupt to the signal watching thread *)
-val signal_watcher_interrupt : Signal.t
-
-(** Magic signal to make dune debugging info *)
-val signal_watcher_debug : Signal.t
+(** Signal that asks dune to emit debugging info. *)
+val debug_signal : Signal.t
 
 val join : t -> unit
 val interrupt_signals : Signal.t list
 val spawn : name:string -> (unit -> unit) -> Thread.t
 val delay : float -> unit
-val wait_signal : int list -> int

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -80,6 +80,11 @@ module Scheduler = struct
        state *)
       Restarting_build
 
+  type signal_interruptions =
+    { timestamps : Time.t Queue.t
+    ; print_ctrl_c_warning : bool
+    }
+
   type t =
     { mutable status : status
     ; mutable invalidation : Memo.Invalidation.t
@@ -95,8 +100,8 @@ module Scheduler = struct
     ; mutable build_inputs_changed : Trigger.t
     ; mutable cancel : Fiber.Cancel.t
     ; thread_pool : Thread_pool.t Lazy.t
-    ; signal_watcher : Thread.t
     ; async_io : Async_io.t
+    ; signal_interruptions : signal_interruptions
     }
 
   let current : t option ref = ref None

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -15,13 +15,17 @@ let make ~frames_per_second (module Base : S) : (module Console.Backend) =
       }
     ;;
 
+    let terminal_signal_mask = ref None
+
     let finish () =
       Mutex.protect mutex (fun () ->
         state.dirty <- true;
         state.finish_requested <- true;
         while not state.finished do
           Condition.wait finish_cv mutex
-        done)
+        done;
+        Option.iter !terminal_signal_mask ~f:Terminal_signals.restore;
+        terminal_signal_mask := None)
     ;;
 
     let print_user_message m =
@@ -62,6 +66,7 @@ let make ~frames_per_second (module Base : S) : (module Console.Backend) =
 
     let start () =
       Base.start ();
+      terminal_signal_mask := Some (Terminal_signals.block ());
       Scheduler.spawn_thread ~name:"console"
       @@ fun () ->
       Terminal_signals.unblock ();

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -125,11 +125,5 @@
  (enabled_if
   (< %{ocaml_version} 5.2.0)))
 
-;; Skip on macOS: dune hangs on SIGINT due to a known macOS sigwait issue
-;; (see signal_watcher.ml). The SIGTERM-before-SIGKILL logic is
-;; platform-independent; this test just cannot exercise it on macOS.
-
 (cram
- (applies_to graceful-shutdown)
- (enabled_if
-  (<> %{system} macosx)))
+ (applies_to graceful-shutdown))

--- a/test/blackbox-tests/test-cases/graceful-shutdown.t
+++ b/test/blackbox-tests/test-cases/graceful-shutdown.t
@@ -63,3 +63,41 @@ be ready, sends SIGINT to dune, and checks if the cleanup handler ran.
     "name": "process-cleanup-finish",
     "args": {}
   }
+
+A second interrupt in quick succession prints a warning. A third interrupt in
+the same window drops the graceful shutdown and exits immediately.
+
+  $ rm -f ready cleanup_ran child_pid
+
+  $ cat > main.ml <<'EOF'
+  > let () =
+  >   let dir = Sys.getenv "TEST_DIR" in
+  >   let oc = open_out (Filename.concat dir "child_pid") in
+  >   Printf.fprintf oc "%d\n%!" (Unix.getpid ());
+  >   close_out oc;
+  >   Sys.set_signal Sys.sigint Sys.Signal_ignore;
+  >   Sys.set_signal Sys.sigterm Sys.Signal_ignore;
+  >   let oc = open_out (Filename.concat dir "ready") in
+  >   close_out oc;
+  >   while true do Unix.sleepf 0.1 done
+  > EOF
+
+  $ dune build @slow 2>dune.err &
+
+  $ DUNE_PID=$!
+
+  $ wait_for_file ready
+
+  $ kill -INT $DUNE_PID
+
+  $ kill -INT $DUNE_PID
+
+  $ with_timeout sh -c "until grep 'Press Control+C again quickly' dune.err; do sleep 0.01; done"
+  * Press Control+C again quickly to perform an emergency exit *
+
+  $ kill -INT $DUNE_PID
+
+  $ wait $DUNE_PID
+  [1]
+
+  $ kill -KILL $(cat child_pid) 2>/dev/null || true

--- a/test/blackbox-tests/test-cases/trace/cat.t
+++ b/test/blackbox-tests/test-cases/trace/cat.t
@@ -10,7 +10,6 @@ dune trace cat can be used to view the trace:
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
-  ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
   ["args","cat","name","ts"]
@@ -18,7 +17,6 @@ dune trace cat can be used to view the trace:
   ["args","cat","dur","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","dur","name","ts"]
-  ["args","cat","name","ts"]
   ["args","cat","dur","name","ts"]
   ["args","cat","name","ts"]
 

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -1,4 +1,4 @@
-The debug event can be triggered with Sigusr1
+The debug event can be triggered with SIGUSR2
 
   $ debug_events_jq='select(.name == "debug") | .name'
   $ build_request_starts_jq='select(.cat == "rpc" and .name == "request" and .args.meth == "build" and .args.stage == "start") | .name'

--- a/test/blackbox-tests/test-cases/trace/thread-event.t
+++ b/test/blackbox-tests/test-cases/trace/thread-event.t
@@ -1,4 +1,4 @@
-Dune can emit events for threads started
+Dune does not start a signal watcher thread for a plain build
 
   $ make_dune_project 3.21
 
@@ -11,4 +11,3 @@ Dune can emit events for threads started
   $ dune build @foo
 
   $ dune trace cat | jq -c 'select(.cat == "thread") | .args' | sort -u
-  {"name":"signal-watcher"}


### PR DESCRIPTION
scheduler: handle signals on the main thread

Replace the dedicated signal watcher thread with C signal handlers that record pending signals in a static table and wake the scheduler event queue. The OCaml scheduler drains that table into signal events on the main thread, so SIGINT/SIGQUIT/SIGTERM, SIGCHLD, and SIGUSR2 stay integrated with the normal event loop.

Block scheduler signals while spawning worker threads so those threads inherit a blocked signal mask, then leave the main thread unblocked after installing the C handlers.

Use a C wakeup primitive for the event queue so signal handlers can wake an idle scheduler without calling into OCaml runtime synchronization. Preserve the quick repeated Ctrl-C emergency exit behavior and keep SIGUSR2 debug dumps working.

Also set local XDG_RUNTIME_DIR values in affected cram tests so RPC registry files stay inside the writable test sandbox.