### PR TITLE
rpc: unlink unix sockets when stopping unserved server

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -84,6 +84,13 @@ module Socket = struct
   ;;
 end
 
+let close_bound_socket ((addr : Unix.sockaddr), fd) =
+  let+ () = Async_io.close fd in
+  match addr with
+  | ADDR_UNIX path -> Fpath.unlink_no_err path
+  | _ -> ()
+;;
+
 module Session = struct
   module Session_id = Id.Make ()
   module Id = Session_id
@@ -380,11 +387,7 @@ module Server = struct
             in
             ()
         in
-        let* () = Fiber.parallel_iter t.sockets ~f:(fun (_, fd) -> Async_io.close fd) in
-        List.iter t.sockets ~f:(fun (addr, _) ->
-          match (addr : Unix.sockaddr) with
-          | ADDR_UNIX p -> Fpath.unlink_no_err p
-          | _ -> ());
+        let* () = Fiber.parallel_iter t.sockets ~f:close_bound_socket in
         Fiber.Ivar.fill t.closed ()
     ;;
 
@@ -499,7 +502,8 @@ module Server = struct
         match t.state with
         | `Closed -> Fiber.return ()
         | `Running transport -> Transport.stop transport
-        | `Init fds -> Fiber.parallel_iter fds ~f:Async_io.close
+        | `Init fds ->
+          Fiber.parallel_iter (List.combine t.sockaddrs fds) ~f:close_bound_socket
       in
       let+ () = Fiber.return () in
       t.state <- `Closed;

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -92,20 +92,7 @@ let%expect_test "csexp server stop before serve releases address" =
      Server.stop replacement
    in
    run_scheduler run);
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (Dune_util__Report_error.Already_reported)
-  Trailing output
-  ---------------
-  Error: exception Failure("address already in use")
-
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases.
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
-  |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "csexp server stop before consuming serve stream releases address" =
@@ -131,7 +118,7 @@ let%expect_test "csexp server stop before serve removes unix socket" =
   let server = server addr in
   run_scheduler (fun () -> Server.stop server);
   printfn "%b" (Fpath.exists path);
-  [%expect {| true |}]
+  [%expect {| false |}]
 ;;
 
 let write_raw addr data =


### PR DESCRIPTION
Server.create binds Unix-domain socket paths before the server is served. If the server is stopped while it is still in the initial state, closing the fds is not enough: the socket path remains in the filesystem and the same address cannot be reused.

Unlink Unix socket paths when stopping initial server sockets, and use the same helper when stopping running transports.