### PR TITLE
rpc: clean up partially-bound server sockets

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -84,11 +84,20 @@ module Socket = struct
   ;;
 end
 
-let close_bound_socket ((addr : Unix.sockaddr), fd) =
-  let+ () = Async_io.close fd in
+let unlink_socket_path (addr : Unix.sockaddr) =
   match addr with
   | ADDR_UNIX path -> Fpath.unlink_no_err path
   | _ -> ()
+;;
+
+let close_bound_socket_sync (addr, fd) =
+  Fd.close fd;
+  unlink_socket_path addr
+;;
+
+let close_bound_socket (addr, fd) =
+  let+ () = Async_io.close fd in
+  unlink_socket_path addr
 ;;
 
 module Session = struct
@@ -430,32 +439,41 @@ module Server = struct
     }
 
   let create sockaddrs ~backlog =
-    try
-      let fds =
-        List.map sockaddrs ~f:(fun sockaddr ->
-          let fd =
-            Unix.socket
-              ~cloexec:true
-              (Unix.domain_of_sockaddr sockaddr)
-              Unix.SOCK_STREAM
-              0
-            |> Fd.unsafe_of_unix_file_descr
-          in
+    let bound = ref [] in
+    let cleanup () =
+      List.iter !bound ~f:close_bound_socket_sync;
+      bound := []
+    in
+    let bind_socket sockaddr =
+      let fd =
+        Unix.socket ~cloexec:true (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0
+        |> Fd.unsafe_of_unix_file_descr
+      in
+      let in_bound = ref false in
+      Exn.protect
+        ~f:(fun () ->
           Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
           (match (sockaddr : Unix.sockaddr) with
            | ADDR_UNIX _ -> ()
            | ADDR_INET _ ->
              Unix.setsockopt (Fd.unsafe_to_unix_file_descr fd) Unix.SO_REUSEADDR true);
           Socket.bind fd sockaddr;
+          bound := (sockaddr, fd) :: !bound;
+          in_bound := true;
           fd)
-      in
-      Ok
-        { id = Id.gen ()
-        ; sockaddrs
-        ; backlog
-        ; state = `Init fds
-        ; ready = Fiber.Ivar.create ()
-        }
+        ~finally:(fun () -> if not !in_bound then Fd.close fd)
+    in
+    try
+      Exn.protect ~finally:cleanup ~f:(fun () ->
+        let fds = List.map sockaddrs ~f:bind_socket in
+        bound := [];
+        Ok
+          { id = Id.gen ()
+          ; sockaddrs
+          ; backlog
+          ; state = `Init fds
+          ; ready = Fiber.Ivar.create ()
+          })
     with
     | Unix.Unix_error (EADDRINUSE, _, _) -> Error `Already_in_use
   ;;

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -136,7 +136,7 @@ let%expect_test "csexp server create cleans up partial binds" =
       printfn "Error: exception Failure(%S)" msg
   in
   run_scheduler run;
-  [%expect {| Error: exception Failure("address already in use") |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "csexp server stop before serve removes unix socket" =
@@ -247,6 +247,36 @@ let%expect_test "csexp server life cycle" =
     server: sessions finished |}]
 ;;
 
+let%expect_test "csexp server create cleans up after partial tcp bind failure" =
+  let fd_count () = Sys.readdir "/dev/fd" |> Array.length in
+  let busy = Unix.socket ~cloexec:true PF_INET SOCK_STREAM 0 in
+  Unix.bind busy (ADDR_INET (Unix.inet_addr_loopback, 0));
+  Unix.listen busy 10;
+  let busy_addr = Unix.getsockname busy in
+  Exn.protect
+    ~f:(fun () ->
+      let run () =
+        let before = fd_count () in
+        let* () =
+          match
+            Server.create
+              [ ADDR_INET (Unix.inet_addr_loopback, 0); busy_addr ]
+              ~backlog:10
+          with
+          | Error `Already_in_use -> Fiber.return ()
+          | Ok server ->
+            let* () = Server.stop server in
+            failwith "expected address conflict"
+        in
+        let after = fd_count () in
+        printfn "leaked fds: %d" (after - before);
+        Fiber.return ()
+      in
+      run_scheduler run)
+    ~finally:(fun () -> Unix.close busy);
+  [%expect {| leaked fds: 0 |}]
+;;
+
 let%expect_test "csexp server stop rejects new connections" =
   let tmp_dir = temp_rpc_dir () in
   let addr : Unix.sockaddr =
@@ -276,34 +306,4 @@ let%expect_test "csexp server stop rejects new connections" =
   in
   run_scheduler run;
   [%expect {| connect failed |}]
-;;
-
-let%expect_test "csexp server create cleans up after partial tcp bind failure" =
-  let fd_count () = Sys.readdir "/dev/fd" |> Array.length in
-  let busy = Unix.socket ~cloexec:true PF_INET SOCK_STREAM 0 in
-  Unix.bind busy (ADDR_INET (Unix.inet_addr_loopback, 0));
-  Unix.listen busy 10;
-  let busy_addr = Unix.getsockname busy in
-  Exn.protect
-    ~f:(fun () ->
-      let run () =
-        let before = fd_count () in
-        let* () =
-          match
-            Server.create
-              [ ADDR_INET (Unix.inet_addr_loopback, 0); busy_addr ]
-              ~backlog:10
-          with
-          | Error `Already_in_use -> Fiber.return ()
-          | Ok server ->
-            let* () = Server.stop server in
-            failwith "expected address conflict"
-        in
-        let after = fd_count () in
-        printfn "leaked fds: %d" (after - before);
-        Fiber.return ()
-      in
-      run_scheduler run)
-    ~finally:(fun () -> Unix.close busy);
-  [%expect {| leaked fds: 2 |}]
 ;;


### PR DESCRIPTION
Creating an RPC server can bind more than one address. If a later bind fails, the sockets that were already bound must be closed and any Unix socket paths they created must be unlinked. Otherwise a failed multi-address create leaks file descriptors and leaves addresses unusable.

Also close the socket for the address whose setup failed before returning the error.