### PR TITLE
Support Melange-specific preprocess fields

### DIFF
--- a/src/dune_lang/preprocess.ml
+++ b/src/dune_lang/preprocess.ml
@@ -84,6 +84,12 @@ module Pps = struct
     let= () = List.compare flags t.flags ~compare:String_with_vars.compare_no_loc in
     List.compare pps t.pps ~compare:compare_pps
   ;;
+
+  let decode =
+    let+ loc = loc
+    and+ pps, flags = Pps_and_flags.decode in
+    { loc; pps; flags; staged = false }
+  ;;
 end
 
 type 'a t =

--- a/src/dune_lang/preprocess.mli
+++ b/src/dune_lang/preprocess.mli
@@ -10,6 +10,7 @@ module Pps : sig
 
   val repr : 'a Repr.t -> 'a t Repr.t
   val compare_no_locs : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
+  val decode : (Loc.t * Lib_name.t) t Decoder.t
 end
 
 type 'a t =

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -149,7 +149,7 @@ let modules_rules
   modules, pp
 ;;
 
-let modules_rules sctx kind expander ~dir scope modules =
+let modules_rules sctx kind expander ~dir scope modules ~for_ =
   let* () =
     match kind with
     | Executables _ | Library _ | Melange _ -> Memo.return ()
@@ -164,8 +164,15 @@ let modules_rules sctx kind expander ~dir scope modules =
   in
   let preprocess, lint, empty_module_interface_if_absent =
     match kind with
-    | Executables (buildable, _) | Library (buildable, _) | Parameter (buildable, _) ->
+    | Executables (buildable, _) | Parameter (buildable, _) ->
       buildable.preprocess, buildable.lint, buildable.empty_module_interface_if_absent
+    | Library (buildable, _) ->
+      let preprocess =
+        match for_ with
+        | Compilation_mode.Ocaml -> buildable.preprocess
+        | Melange -> buildable.melange_preprocess
+      in
+      preprocess, buildable.lint, buildable.empty_module_interface_if_absent
     | Melange { preprocess; lint; empty_module_interface_if_absent } ->
       preprocess, lint, empty_module_interface_if_absent
   in

--- a/src/dune_rules/buildable_rules.mli
+++ b/src/dune_rules/buildable_rules.mli
@@ -42,6 +42,7 @@ val modules_rules
   -> dir:Path.Build.t
   -> Scope.t
   -> Modules.t
+  -> for_:Compilation_mode.t
   -> (Modules.t * Pp_spec.t) Memo.t
 
 (** Compute the ocaml flags based on the directory environment and a buildable

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -186,6 +186,7 @@ let executables_rules
         ~dir
         scope
         modules
+        ~for_
     in
     Modules.With_vlib.modules modules, pp
   in

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -498,6 +498,7 @@ let cctx
       ~dir
       scope
       source_modules
+      ~for_
   in
   let modules = Virtual_rules.impl_modules implements modules in
   let requires_compile = Lib.Compile.direct_requires compile_info ~for_ in

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -531,6 +531,7 @@ let setup_emit_cmj_rules
           ~dir
           scope
           source_modules
+          ~for_
       in
       Modules.With_vlib.modules modules, pp
     in

--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -16,6 +16,7 @@ type t =
   ; extra_objects : Foreign.Objects.t
   ; foreign_stubs : Foreign.Stubs.t list
   ; preprocess : Preprocess.preprocess
+  ; melange_preprocess : Preprocess.preprocess
   ; lint : Preprocess.Without_instrumentation.t Preprocess.Per_module.t
   ; flags : Ocaml_flags.Spec.t
   ; js_of_ocaml : Js_of_ocaml.In_buildable.t Js_of_ocaml.Mode.Pair.t
@@ -47,6 +48,12 @@ let decode_allow_unused_libraries =
     ~default:[]
 ;;
 
+let decode_melange_pps =
+  field_o
+    "melange.pps"
+    (Dune_lang.Syntax.since Stanza.syntax (3, 24) >>> Preprocess.Pps.decode)
+;;
+
 let decode (for_ : for_) =
   let use_foreign =
     Dune_lang.Syntax.deleted_in
@@ -69,7 +76,9 @@ let decode (for_ : for_) =
       Foreign.Stubs.make ~loc ~language ~names ~flags :: foreign_stubs
   in
   let+ loc = loc
-  and+ preprocess = decode_preprocess
+  and+ instrumentation = Preprocess.Instrumentation.instrumentation
+  and+ preprocess, preprocessor_deps = Preprocess.preprocess_fields
+  and+ melange_pps = decode_melange_pps
   and+ lint = decode_lint
   and+ foreign_stubs =
     multi_field
@@ -140,6 +149,16 @@ let decode (for_ : for_) =
       "empty_module_interface_if_absent"
       ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
   in
+  let preprocess =
+    Preprocess.preprocess_config ~preprocess ~instrumentation ~preprocessor_deps
+  in
+  let melange_preprocess =
+    match melange_pps with
+    | None -> preprocess
+    | Some pps ->
+      let preprocess = Module_name.Per_item.for_all (Preprocess.Pps pps) in
+      Preprocess.preprocess_config ~preprocess ~instrumentation ~preprocessor_deps:[]
+  in
   let foreign_stubs =
     foreign_stubs
     |> add_stubs C ~loc:c_names_loc ~names:c_names ~flags:c_flags
@@ -182,6 +201,7 @@ let decode (for_ : for_) =
   in
   { loc
   ; preprocess
+  ; melange_preprocess
   ; lint
   ; modules
   ; melange_modules

--- a/src/dune_rules/stanzas/buildable.mli
+++ b/src/dune_rules/stanzas/buildable.mli
@@ -15,6 +15,7 @@ type t =
   ; extra_objects : Foreign.Objects.t
   ; foreign_stubs : Foreign.Stubs.t list
   ; preprocess : Preprocess.preprocess
+  ; melange_preprocess : Preprocess.preprocess
   ; lint : Lint.t
   ; flags : Ocaml_flags.Spec.t
   ; js_of_ocaml : Js_of_ocaml.In_buildable.t Js_of_ocaml.Mode.Pair.t

--- a/src/dune_rules/stanzas/library.ml
+++ b/src/dune_rules/stanzas/library.ml
@@ -596,7 +596,7 @@ let to_lib_info
   in
   let preprocess =
     { Compilation_mode.By_mode.ocaml = conf.buildable.preprocess.config
-    ; melange = conf.buildable.preprocess.config
+    ; melange = conf.buildable.melange_preprocess.config
     }
   in
   let virtual_deps = conf.virtual_deps in

--- a/src/dune_rules/stanzas/parameter.ml
+++ b/src/dune_rules/stanzas/parameter.ml
@@ -72,6 +72,7 @@ let decode =
        ; extra_objects = Foreign.Objects.empty
        ; foreign_stubs = []
        ; preprocess
+       ; melange_preprocess = preprocess
        ; lint
        ; flags
        ; js_of_ocaml =

--- a/test/blackbox-tests/test-cases/melange/conditional-pps.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-pps.t
@@ -1,0 +1,59 @@
+Test that `(melange.pps ...)` applies only to Melange compilation.
+
+The field is available starting in Dune 3.24.
+
+  $ mkdir old
+  $ cat > old/dune-project <<EOF
+  > (lang dune 3.23)
+  > (using melange 0.1)
+  > EOF
+  $ cat > old/dune <<EOF
+  > (library
+  >  (name old)
+  >  (modes melange)
+  >  (melange.pps melange.ppx))
+  > EOF
+  $ dune build --root old
+  Entering directory 'old'
+  File "dune", line 4, characters 1-26:
+  4 |  (melange.pps melange.ppx))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'melange.pps' is only available since version 3.24 of the dune
+  language. Please update your dune-project file to have (lang dune 3.24).
+  Leaving directory 'old'
+  [1]
+
+  $ mkdir app
+  $ cat > app/dune-project <<EOF
+  > (lang dune 3.24)
+  > (using melange 0.1)
+  > EOF
+  $ cat > app/dune <<EOF
+  > (library
+  >  (name app)
+  >  (modes melange :standard)
+  >  (melange.pps noop_ppx))
+  > EOF
+
+  $ mkdir app/ppx
+  $ cat > app/ppx/dune <<EOF
+  > (library
+  >  (name noop_ppx)
+  >  (kind ppx_rewriter)
+  >  (libraries ppxlib))
+  > EOF
+  $ cat > app/ppx/noop_ppx.ml <<EOF
+  > let () = Ppxlib.Driver.register_transformation "noop_ppx"
+  > EOF
+
+  $ cat > app/foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+  $ cat > app/melange_only.melange.ml <<EOF
+  > let x = "melange only"
+  > EOF
+
+  $ dune build --root app
+  $ find ./app/_build/default -name '*.pp.ml' | censor | sort
+  ./app/_build/default/.melange_src/foo.pp.ml
+  ./app/_build/default/.melange_src/melange_only.pp.ml


### PR DESCRIPTION
This extracts the Melange-specific preprocessing support from the broader single-context work.

Changes:
- Add `melange.preprocess` / `melange.preprocessor_deps` parsing, gated on Dune language 3.24.
- Store a separate Melange preprocess config on buildable stanzas, defaulting to the regular preprocess config when omitted.
- Use the Melange-specific preprocess config when generating library rules for Melange compilation.
- Add a focused blackbox test for `(melange.preprocess (pps ...))`, including pre-3.24 rejection.

Tested:
- `/Users/anmonteiro/projects/dune/dune.exe fmt`
- `/Users/anmonteiro/projects/dune/dune.exe runtest test/blackbox-tests/test-cases/melange/conditional-pps.t`