### PR TITLE
Gate melange.modules on Dune 3.24

### DIFF
--- a/src/dune_rules/stanzas/buildable.ml
+++ b/src/dune_rules/stanzas/buildable.ml
@@ -100,6 +100,7 @@ let decode (for_ : for_) =
   and+ modules = decode_modules
   and+ melange_modules =
     Ordered_set_lang.Unexpanded.field_o
+      ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 24))
       ~since_expanded:Modules_settings.since_expanded
       "melange.modules"
   and+ self_build_stubs_archive_loc, self_build_stubs_archive =

--- a/test/blackbox-tests/test-cases/melange/conditional-modules.t
+++ b/test/blackbox-tests/test-cases/melange/conditional-modules.t
@@ -1,0 +1,53 @@
+Show that `(melange.modules ...)` is gated on Dune 3.24 and applies only to
+Melange compilation.
+
+  $ mkdir old
+  $ cat > old/dune-project <<EOF
+  > (lang dune 3.23)
+  > (using melange 0.1)
+  > EOF
+  $ cat > old/dune <<EOF
+  > (library
+  >  (name old)
+  >  (modes melange)
+  >  (melange.modules foo))
+  > EOF
+  $ dune build --root old
+  Entering directory 'old'
+  File "dune", line 4, characters 1-22:
+  4 |  (melange.modules foo))
+       ^^^^^^^^^^^^^^^^^^^^^
+  Error: 'melange.modules' is only available since version 3.24 of the dune
+  language. Please update your dune-project file to have (lang dune 3.24).
+  Leaving directory 'old'
+  [1]
+  $ rm -rf old
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (using melange 0.1)
+  > EOF
+  $ mkdir app
+  $ cat > app/dune <<EOF
+  > (library
+  >  (name app)
+  >  (modes melange byte)
+  >  (modules ocaml_only)
+  >  (melange.modules melange_only))
+  > EOF
+  $ cat > app/ocaml_only.ml <<EOF
+  > let x = "ocaml"
+  > EOF
+  $ cat > app/melange_only.ml <<EOF
+  > let x = "melange"
+  > EOF
+
+  $ dune build _build/default/app/.app.objs/byte/app__Ocaml_only.cmi \
+  >   _build/default/app/.app.objs/melange/app__Melange_only.cmi
+
+  $ test -f _build/default/app/.app.objs/byte/app__Melange_only.cmi || \
+  >   echo "no byte melange_only"
+  no byte melange_only
+  $ test -f _build/default/app/.app.objs/melange/app__Ocaml_only.cmi || \
+  >   echo "no melange ocaml_only"
+  no melange ocaml_only


### PR DESCRIPTION
follow up to #14482, gate `melange.modules` on dune lang 3.24