### PR TITLE
Delete Melange 0.1 in Dune 3.25

### DIFF
--- a/src/dune_lang/melange.ml
+++ b/src/dune_lang/melange.ml
@@ -37,8 +37,11 @@ module Source = struct
 end
 
 let syntax =
+  let supported_versions =
+    [ (0, 1), `Since (3, 8); (0, 1), `Deleted_in (3, 25); (1, 0), `Since (3, 20) ]
+  in
   Syntax.create
     ~name:(Syntax.Name.parse "melange")
     ~desc:"the Melange extension"
-    [ (0, 1), `Since (3, 8); (1, 0), `Since (3, 20) ]
+    supported_versions
 ;;

--- a/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
+++ b/test/blackbox-tests/test-cases/melange/melange-stanza-version.t
@@ -27,6 +27,34 @@ Only supported after Dune 3.20
   - 0.1
   [1]
 
+Version 0.1 is still supported in Dune 3.24
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (using melange 0.1)
+  > (package (name pkg))
+  > EOF
+
+  $ dune rules --root . --format=json app/.pkg.objs/melange/pkg__App.cmj |
+  > jq_dune -r '.[] | ruleActionFlagValues("--bs-package-name")'
+  pkg
+
+Version 0.1 was deleted in Dune 3.25
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.25)
+  > (using melange 0.1)
+  > (package (name pkg))
+  > EOF
+
+  $ dune rules --root . --format=json app/.pkg.objs/melange/pkg__App.cmj
+  File "dune-project", line 2, characters 15-18:
+  2 | (using melange 0.1)
+                     ^^^
+  Error: Version 0.1 of the melange extension has been deleted in Dune 3.25.
+  Please port this project to a newer version of the extension, such as 1.0.
+  [1]
+
   $ cat > dune-project <<EOF
   > (lang dune 3.20)
   > (using melange 1.0)


### PR DESCRIPTION
Delete version 0.1 of the Melange extension. Starting with Dune language 3.25, only `(using melange 1.0)` is supported.

Related to #15048 for deleted-extension migration hints.