### PR TITLE
Make directory targets available in Dune 3.24

### DIFF
--- a/doc/changes/added/14579.md
+++ b/doc/changes/added/14579.md
@@ -1,0 +1,2 @@
+- Promote directory targets from experimental to generally available in 3.24
+  (#14579, @rgrinberg)

--- a/doc/reference/dune/rule.rst
+++ b/doc/reference/dune/rule.rst
@@ -131,11 +131,11 @@ Directory targets
 ~~~~~~~~~~~~~~~~~
 
 Note that at this time, Dune officially only supports user rules with targets in
-the current directory. However, starting from Dune 3.0, we provide an
-experimental support for *directory targets*, where an action can produce a
-whole tree of build artifacts. To specify a directory target, you can use the
-``(dir <dirname>)`` syntax. For example, the following stanza describes a rule
-with a file target ``foo`` and a directory target ``bar``.
+the current directory. Starting from Dune 3.24, Dune supports *directory
+targets*, where an action can produce a whole tree of build artifacts. To
+specify a directory target, you can use the ``(dir <dirname>)`` syntax. For
+example, the following stanza describes a rule with a file target ``foo`` and a
+directory target ``bar``.
 
 .. code:: dune
 
@@ -143,6 +143,5 @@ with a file target ``foo`` and a directory target ``bar``.
      (targets foo (dir bar))
      (action  <action>))
 
-To enable this experimental feature, add ``(using directory-targets 0.1)`` to
-your ``dune-project`` file. However note that currently rules with a directory
-target are always rebuilt. We are working on fixing this performance bug.
+In Dune 3.0 through 3.23, directory targets require the experimental
+``(using directory-targets 0.1)`` extension.

--- a/src/dune_rules/stanzas/rule_conf.ml
+++ b/src/dune_rules/stanzas/rule_conf.ml
@@ -92,7 +92,7 @@ let directory_targets_extension =
       ~name:(Syntax.Name.parse "directory-targets")
       ~desc:"experimental support for directory targets"
       ~experimental:true
-      [ (0, 1), `Since (3, 0) ]
+      [ (0, 1), `Since (3, 0); (0, 1), `Deleted_in (3, 24) ]
   in
   Dune_project.Extension.register syntax (Dune_lang.Decoder.return ((), [])) Dyn.unit
 ;;
@@ -103,7 +103,8 @@ let long_form ~loc =
   let* deps = field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty in
   let* project = Dune_project.get_exn () in
   let allow_directory_targets =
-    Dune_project.is_extension_set project directory_targets_extension
+    Dune_project.dune_version project >= (3, 24)
+    || Dune_project.is_extension_set project directory_targets_extension
   in
   String_with_vars.add_user_vars_to_decoding_env
     (Bindings.var_names deps)

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -213,7 +213,10 @@ end = struct
 
   let status t ver ~dune_lang_ver =
     if is_supported t ver dune_lang_ver
-    then `Supported
+    then (
+      match Version.Map.find t.deleted_in ver with
+      | Some version when dune_lang_ver >= version -> `Deleted_in version
+      | Some _ | None -> `Supported)
     else (
       match Version.Map.find t.deleted_in ver with
       | Some version -> `Deleted_in version
@@ -413,9 +416,13 @@ let check_supported ~dune_lang_ver t (loc, ver) =
       match min_ext_ver with
       | None -> ""
       | Some min_ext_ver ->
-        sprintf
-          " Please port this project to a newer version of the extension, such as %s."
-          (Version.to_string min_ext_ver)
+        let open Version.Infix in
+        if min_ext_ver <= ver
+        then ""
+        else
+          sprintf
+            " Please port this project to a newer version of the extension, such as %s."
+            (Version.to_string min_ext_ver)
     in
     let hints =
       match min_dune_lang_ver with

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -19,6 +19,35 @@ Directory targets require an extension.
   Error: Directory targets require the 'directory-targets' extension
   [1]
 
+Starting from Dune 3.24, directory targets no longer require an extension.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (target (dir builtin-output))
+  >   (action (bash "mkdir builtin-output; echo ok > builtin-output/x")))
+  > EOF
+
+  $ dune build builtin-output/x
+
+Using the directory-targets extension is rejected starting from Dune 3.24.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ dune build builtin-output/x
+  File "dune-project", line 2, characters 25-28:
+  2 | (using directory-targets 0.1)
+                               ^^^
+  Error: Version 0.1 of the directory-targets extension has been deleted in
+  Dune 3.24.
+  [1]
+
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (using directory-targets 0.1)

--- a/test/blackbox-tests/test-cases/promote/directory-diff/dir-to-file-target-change.t
+++ b/test/blackbox-tests/test-cases/promote/directory-diff/dir-to-file-target-change.t
@@ -4,7 +4,6 @@ with "Is a directory" due to a stale staging directory in _build.
 
   $ cat > dune-project <<'EOF'
   > (lang dune 3.24)
-  > (using directory-targets 0.1)
   > EOF
 
 Start with a rule that produces a directory target, diffed against an expected


### PR DESCRIPTION
Not change in behavior. They were experimental for quite while without any changes, and a substantial amount of users depends on them already.