### PR TITLE
rpc: return bound addresses for listening server sockets

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -529,11 +529,16 @@ module Server = struct
         Dune_trace.Event.Rpc.shutdown ~id:(Id.to_int t.id) `Stop)
   ;;
 
+  let socket_name ((addr, fd) : Unix.sockaddr * Fd.t) =
+    match addr with
+    | ADDR_UNIX _ -> addr
+    | ADDR_INET _ -> Unix.getsockname (Fd.unsafe_to_unix_file_descr fd)
+  ;;
+
   let listening_address t =
     match t.state with
-    | `Init fds ->
-      List.map ~f:(fun fd -> Unix.getsockname (Fd.unsafe_to_unix_file_descr fd)) fds
-    | `Running { Transport.sockets; _ } -> List.map ~f:fst sockets
+    | `Init fds -> List.map ~f:socket_name (List.combine t.sockaddrs fds)
+    | `Running { Transport.sockets; _ } -> List.map ~f:socket_name sockets
     | `Closed -> Code_error.raise "server is already closed" []
   ;;
 end

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -97,8 +97,8 @@ let%expect_test "csexp server listening_address preserves long unix socket path"
   [%expect
     {|
     requested path: absolute
-    reported path: relative
-    relationship: different |}]
+    reported path: absolute
+    relationship: same |}]
 ;;
 
 let%expect_test "csexp server listening_address reports tcp port after serve" =
@@ -112,7 +112,7 @@ let%expect_test "csexp server listening_address reports tcp port after serve" =
     Server.stop server
   in
   run_scheduler run;
-  [%expect {| reported port: zero |}]
+  [%expect {| reported port: non-zero |}]
 ;;
 
 let%expect_test "csexp server stop before serve releases address" =


### PR DESCRIPTION
For TCP listeners created with port 0, the address requested by the caller is not the address clients must use. Once the socket is bound, listening_address has to report getsockname for inet sockets so callers see the kernel-assigned port.

For Unix-domain sockets, keep returning the original address. This preserves the path passed to Dune even when binding uses the long-path fallback.