### PR TITLE
rpc: transfer connected client socket ownership to session

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -571,22 +571,21 @@ module Client = struct
     let backtrace = Printexc.get_callstack 10 in
     let transport = Transport.create t.sockaddr in
     let fd = transport.fd in
-    (* CR-soon rgrinberg:
-
-      [t.transport] keeps owning [fd] across both failed and successful
-       connects. That means callers must remember to [stop] a failed client to
-       avoid leaking the socket, while calling [stop] after a successful
-       [connect] can still close the live session transport. We should transfer
-       ownership on success/failure or tighten the API so [stop] is only valid
-       before [connect]. *)
     t.transport <- Some transport;
     Async_io.connect Socket.connect fd t.sockaddr
     >>| function
-    | Ok () -> Ok (Session.create fd)
+    | Ok () ->
+      t.transport <- None;
+      Ok (Session.create fd)
     | Error `Cancelled ->
+      Transport.close transport;
+      t.transport <- None;
       let exn = Failure "connect cancelled" in
       Error { Exn_with_backtrace.exn; backtrace }
-    | Error (`Exn exn) -> Error { Exn_with_backtrace.exn; backtrace }
+    | Error (`Exn exn) ->
+      Transport.close transport;
+      t.transport <- None;
+      Error { Exn_with_backtrace.exn; backtrace }
   ;;
 
   let connect_exn t =
@@ -596,5 +595,11 @@ module Client = struct
     | Error e -> Exn_with_backtrace.reraise e
   ;;
 
-  let stop t = Option.iter t.transport ~f:Transport.close
+  let stop t =
+    match t.transport with
+    | None -> ()
+    | Some transport ->
+      t.transport <- None;
+      Transport.close transport
+  ;;
 end

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -371,5 +371,5 @@ let%expect_test "csexp client stop does not close an active session" =
            Fiber.Ivar.fill server_read ()))
   in
   run_scheduler run;
-  [%expect {| server: session closed |}]
+  [%expect {| server: session remained open |}]
 ;;


### PR DESCRIPTION
Client.connect creates a temporary transport while the connection is in progress, but on success the fd is handed to the returned Session. The client must stop owning that fd at that point; otherwise Client.stop can close an active session behind the caller's back.

On failed or cancelled connects, keep the inverse ownership rule: close the temporary transport and clear it from the client so failed connection attempts do not leak sockets.