### PR TITLE
rpc: set SO_NOSIGPIPE on client sockets

### DIFF
--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -555,6 +555,7 @@ module Client = struct
         |> Fd.unsafe_of_unix_file_descr
       in
       Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
+      Socket.maybe_set_nosigpipe fd;
       { fd }
     ;;
   end


### PR DESCRIPTION
Server-accepted sessions already disable SIGPIPE on macOS before writes can happen. Sessions created by Client.connect use a client-created socket, so they need the same setup before the fd is handed to Session.

This keeps client-side RPC writes consistent with server-side session writes on macOS.