### PR TITLE
test: fix formatting/feature.t snapshot from #14597

### DIFF
--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -382,7 +382,7 @@ The formatter action is not re-run if the following diff action fails.
   $ (cd using-env && dune build @fmt)
   File "subdir/foo.ml", line 1, characters 0-0:
   --- subdir/foo.ml
-  +++ subdir/foo.ml.corrected
+  +++ subdir/.formatted/foo.ml
   @@ -1 +1 @@
   -let x =     12
   +(* fake ocamlformat output *)


### PR DESCRIPTION
#14597 added a regression test asserting that the formatter is not re-run on a second `dune build @fmt` invocation. The test's expected output included `+++ subdir/foo.ml.corrected` inside the diff body, but dune actually emits `+++ subdir/.formatted/foo.ml` (the same path the first invocation already asserts, six lines earlier). The mismatched snapshot has been failing CI on `main` since #14597 merged.

The test's load-bearing assertion — that the formatter is not re-run, evidenced by the absent `fake ocamlformat is running:` line in this block — is preserved.