### PR TITLE
test: formatting

### DIFF
--- a/test/blackbox-tests/test-cases/formatting/feature.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting/feature.t/run.t
@@ -389,6 +389,18 @@ The formatter action is not re-run if the following diff action fails.
   \ No newline at end of file
   [1]
 
+The formatter action is not re-run if the following diff action fails.
+
+  $ (cd using-env && dune build @fmt)
+  File "subdir/foo.ml", line 1, characters 0-0:
+  --- subdir/foo.ml
+  +++ subdir/foo.ml.corrected
+  @@ -1 +1 @@
+  -let x =     12
+  +(* fake ocamlformat output *)
+  \ No newline at end of file
+  [1]
+
 We check that the formatting stanza in (env ...) takes precedence over that in
 dune-project:
 


### PR DESCRIPTION
Add a regression test that formatter actions are not re-run after the diff action reports formatting changes.