### PR TITLE
Cross compilation: Also generate 'root'/'rootexec' sections for installation

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -57,11 +57,13 @@ let get_dirs context ~prefix_from_command_line ~from_command_line =
         ~hints:
           [ Pp.concat
               ~sep:Pp.space
-              [ Pp.text "It can be specified with"
-              ; User_message.command "--prefix"
-              ; Pp.textf "or by setting"
-              ; User_message.command (sprintf "--%s" name)
-              ]
+              ([ Pp.text "It can be specified with"; User_message.command "--prefix" ]
+               @
+               if String.equal name "prefix"
+               then []
+               else
+                 [ Pp.textf "or by setting"; User_message.command (sprintf "--%s" name) ]
+              )
             |> Pp.hovbox
           ]
   in
@@ -73,6 +75,7 @@ let get_dirs context ~prefix_from_command_line ~from_command_line =
   ; doc_root = must_be_defined "docdir" roots.doc_root
   ; share_root = must_be_defined "datadir" roots.share_root
   ; man = must_be_defined "mandir" roots.man
+  ; prefix = must_be_defined "prefix" roots.prefix
   }
 ;;
 
@@ -624,7 +627,7 @@ let run
     if relocatable
     then (
       match prefix_from_command_line with
-      | Some dir -> Some (Path.of_string dir)
+      | Some dir -> Some (Path.of_string_allow_outside_workspace dir)
       | None ->
         User_error.raise
           [ Pp.concat
@@ -853,16 +856,18 @@ let make ~what =
     let common, config = Common.init builder in
     Scheduler_setup.no_build_no_rpc ~config (fun () ->
       let from_command_line =
-        { Install.Roots.lib_root = libdir_from_command_line
-        ; etc_root = etcdir_from_command_line
-        ; doc_root = docdir_from_command_line
-        ; man = mandir_from_command_line
-        ; bin = bindir_from_command_line
-        ; sbin = sbindir_from_command_line
-        ; libexec_root = libexecdir_from_command_line
-        ; share_root = datadir_from_command_line
+        let path_of_string = Option.map ~f:Path.of_string in
+        { Install.Roots.lib_root = path_of_string libdir_from_command_line
+        ; etc_root = path_of_string etcdir_from_command_line
+        ; doc_root = path_of_string docdir_from_command_line
+        ; man = path_of_string mandir_from_command_line
+        ; bin = path_of_string bindir_from_command_line
+        ; sbin = path_of_string sbindir_from_command_line
+        ; libexec_root = path_of_string libexecdir_from_command_line
+        ; share_root = path_of_string datadir_from_command_line
+        ; prefix =
+            Option.map ~f:Path.of_string_allow_outside_workspace prefix_from_command_line
         }
-        |> Install.Roots.map ~f:(Option.map ~f:Path.of_string)
         |> Install.Roots.complete
       in
       run

--- a/boot/configure.ml
+++ b/boot/configure.ml
@@ -129,6 +129,7 @@ let () =
   pr "  ; bin = %s" (option string !bindir);
   pr "  ; sbin = %s" (option string !sbindir);
   pr "  ; libexec_root = %s" (option string !libexecdir);
+  pr "  ; prefix = %s" (option string !prefix);
   pr "  }";
   pr "";
   pr "let prefix : string option = %s" (option string !prefix);

--- a/otherlibs/dune-private-libs/section/dune_section.ml
+++ b/otherlibs/dune-private-libs/section/dune_section.ml
@@ -13,6 +13,8 @@ type t =
   | Stublibs
   | Man
   | Misc
+  | Prefix
+  | Prefixexec
 
 let all =
   [ Lib, "lib"
@@ -29,6 +31,8 @@ let all =
   ; Stublibs, "stublibs"
   ; Man, "man"
   ; Misc, "misc"
+  ; Prefix, "prefix"
+  ; Prefixexec, "prefixexec"
   ]
 ;;
 

--- a/otherlibs/dune-private-libs/section/dune_section.ml
+++ b/otherlibs/dune-private-libs/section/dune_section.ml
@@ -13,8 +13,8 @@ type t =
   | Stublibs
   | Man
   | Misc
-  | Prefix
-  | Prefixexec
+  | Root
+  | Rootexec
 
 let all =
   [ Lib, "lib"
@@ -31,8 +31,8 @@ let all =
   ; Stublibs, "stublibs"
   ; Man, "man"
   ; Misc, "misc"
-  ; Prefix, "prefix"
-  ; Prefixexec, "prefixexec"
+  ; Root, "root"
+  ; Rootexec, "rootexec"
   ]
 ;;
 

--- a/otherlibs/dune-private-libs/section/dune_section.mli
+++ b/otherlibs/dune-private-libs/section/dune_section.mli
@@ -13,8 +13,8 @@ type t =
   | Stublibs
   | Man
   | Misc
-  | Prefix
-  | Prefixexec
+  | Root
+  | Rootexec
 
 val all : (t * string) list
 val of_string : string -> t option

--- a/otherlibs/dune-private-libs/section/dune_section.mli
+++ b/otherlibs/dune-private-libs/section/dune_section.mli
@@ -13,6 +13,8 @@ type t =
   | Stublibs
   | Man
   | Misc
+  | Prefix
+  | Prefixexec
 
 val all : (t * string) list
 val of_string : string -> t option

--- a/src/dune_lang/section.ml
+++ b/src/dune_lang/section.ml
@@ -41,6 +41,7 @@ let encode v =
 let all = Set.of_list (List.map ~f:fst Dune_section.all)
 
 let should_set_executable_bit = function
-  | Lib | Lib_root | Toplevel | Share | Share_root | Etc | Doc | Man | Misc -> false
-  | Libexec | Libexec_root | Bin | Sbin | Stublibs -> true
+  | Lib | Lib_root | Toplevel | Share | Share_root | Etc | Doc | Man | Misc | Prefix ->
+    false
+  | Libexec | Libexec_root | Bin | Sbin | Stublibs | Prefixexec -> true
 ;;

--- a/src/dune_lang/section.ml
+++ b/src/dune_lang/section.ml
@@ -41,7 +41,7 @@ let encode v =
 let all = Set.of_list (List.map ~f:fst Dune_section.all)
 
 let should_set_executable_bit = function
-  | Lib | Lib_root | Toplevel | Share | Share_root | Etc | Doc | Man | Misc | Prefix ->
+  | Lib | Lib_root | Toplevel | Share | Share_root | Etc | Doc | Man | Misc | Root ->
     false
-  | Libexec | Libexec_root | Bin | Sbin | Stublibs | Prefixexec -> true
+  | Libexec | Libexec_root | Bin | Sbin | Stublibs | Rootexec -> true
 ;;

--- a/src/dune_rules/install_entry_with_site.ml
+++ b/src/dune_rules/install_entry_with_site.ml
@@ -30,8 +30,8 @@ let make_with_site (section : Section_with_site.t) ?dst get_section ~kind src =
       | Share_root
       | Stublibs
       | Man
-      | Prefix
-      | Prefixexec
+      | Root
+      | Rootexec
       | Misc -> section, dst
     in
     Entry.Unexpanded.make_with_dst section dst ~kind ~src

--- a/src/dune_rules/install_entry_with_site.ml
+++ b/src/dune_rules/install_entry_with_site.ml
@@ -30,6 +30,8 @@ let make_with_site (section : Section_with_site.t) ?dst get_section ~kind src =
       | Share_root
       | Stublibs
       | Man
+      | Prefix
+      | Prefixexec
       | Misc -> section, dst
     in
     Entry.Unexpanded.make_with_dst section dst ~kind ~src

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1449,7 +1449,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
               })
           in
           let prefix_entries =
-            (* opam 2.6+ supports a 'prefix' and 'prefixexec' key that allows us to directly specify this *)
+            (* opam 2.6+ supports a 'root' and 'rootexec' key that allows us to directly specify this *)
             List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
               { e with
                 entry =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1436,14 +1436,31 @@ let gen_package_install_file_rules sctx (package : Package.t) =
             let toolchain = Context_name.to_string toolchain in
             Path.of_string (toolchain ^ "-sysroot")
           in
-          List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
-            { e with
-              entry =
-                Install.Entry.Expanded.add_install_prefix
-                  e.entry
-                  ~paths:install_paths
-                  ~prefix
-            })
+          let parent_dir_hacked =
+            (* pre-opam 2.6, the best way to install an alternative sysroot
+               was to generate .install files with ../.., which was disallowed in opam 2.5.1 *)
+            List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
+              { e with
+                entry =
+                  Install.Entry.Expanded.add_install_prefix
+                    e.entry
+                    ~paths:install_paths
+                    ~prefix
+              })
+          in
+          let prefix_entries =
+            (* opam 2.6+ supports a 'prefix' and 'prefixexec' key that allows us to directly specify this *)
+            List.rev_map entries ~f:(fun (e : Install.Entry.Sourced.Expanded.t) ->
+              { e with
+                entry =
+                  Install.Entry.Expanded.install_in_sysroot
+                    e.entry
+                    ~paths:install_paths
+                    ~prefix
+              })
+          in
+          (* generating both is fine, since any given version of opam will only recognize one or the other *)
+          parent_dir_hacked @ prefix_entries
       in
       if not (Package.allow_empty package)
       then

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -9,6 +9,7 @@ let roots : string option Install.Roots.t =
   ; bin = None
   ; sbin = None
   ; libexec_root = None
+  ; prefix = None
   }
 
 let prefix : string option = None

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -215,6 +215,22 @@ module Expanded = struct
     { t with dst = Dst.explicit dst }
   ;;
 
+  let install_in_sysroot t ~paths ~prefix =
+    let i_want_to_install_the_file_as =
+      relative_installed_path t ~paths
+      |> Path.as_in_source_tree_exn
+      |> Path.append_source prefix
+    in
+    let dst = Path.to_string i_want_to_install_the_file_as in
+    { t with
+      dst = Dst.explicit dst
+    ; section =
+        (if Section.should_set_executable_bit t.section
+         then Section.Prefixexec
+         else Section.Prefix)
+    }
+  ;;
+
   let of_install_file ~optional ~src ~dst ~section =
     { src
     ; section

--- a/src/install/entry.ml
+++ b/src/install/entry.ml
@@ -226,8 +226,8 @@ module Expanded = struct
       dst = Dst.explicit dst
     ; section =
         (if Section.should_set_executable_bit t.section
-         then Section.Prefixexec
-         else Section.Prefix)
+         then Section.Rootexec
+         else Section.Root)
     }
   ;;
 

--- a/src/install/entry.mli
+++ b/src/install/entry.mli
@@ -34,6 +34,7 @@ module Expanded : sig
 
   val set_src : _ t -> 'src -> 'src t
   val add_install_prefix : 'src t -> paths:Path.t Paths.t -> prefix:Path.t -> 'src t
+  val install_in_sysroot : 'src t -> paths:Path.t Paths.t -> prefix:Path.t -> 'src t
   val gen_install_file : Path.t t list -> string
   val load_install_file : Path.t -> (Path.Local.t -> Path.t) -> Path.t t list
 end

--- a/src/install/paths.ml
+++ b/src/install/paths.ml
@@ -14,8 +14,8 @@ type 'path t =
   ; doc : 'path
   ; stublibs : 'path
   ; man : 'path
-  ; prefix : 'path
-  ; prefixexec : 'path
+  ; root : 'path
+  ; rootexec : 'path
   }
 
 let map
@@ -32,8 +32,8 @@ let map
       ; doc
       ; stublibs
       ; man
-      ; prefix
-      ; prefixexec
+      ; root
+      ; rootexec
       }
       ~f
   =
@@ -50,8 +50,8 @@ let map
   ; doc = f doc
   ; stublibs = f stublibs
   ; man = f man
-  ; prefix = f prefix
-  ; prefixexec = f prefixexec
+  ; root = f root
+  ; rootexec = f rootexec
   }
 ;;
 
@@ -70,8 +70,8 @@ let make ~relative ~package ~(roots : _ Roots.t) =
   ; share = relative roots.share_root package
   ; etc = relative roots.etc_root package
   ; doc = relative roots.doc_root package
-  ; prefix = roots.prefix
-  ; prefixexec = roots.prefix
+  ; root = roots.prefix
+  ; rootexec = roots.prefix
   }
 ;;
 
@@ -90,8 +90,8 @@ let get t (section : Section.t) =
   | Doc -> t.doc
   | Stublibs -> t.stublibs
   | Man -> t.man
-  | Prefix -> t.prefix
-  | Prefixexec -> t.prefixexec
+  | Root -> t.root
+  | Rootexec -> t.rootexec
   | Misc -> Code_error.raise "Install.Paths.get" []
 ;;
 

--- a/src/install/paths.ml
+++ b/src/install/paths.ml
@@ -14,6 +14,8 @@ type 'path t =
   ; doc : 'path
   ; stublibs : 'path
   ; man : 'path
+  ; prefix : 'path
+  ; prefixexec : 'path
   }
 
 let map
@@ -30,6 +32,8 @@ let map
       ; doc
       ; stublibs
       ; man
+      ; prefix
+      ; prefixexec
       }
       ~f
   =
@@ -46,6 +50,8 @@ let map
   ; doc = f doc
   ; stublibs = f stublibs
   ; man = f man
+  ; prefix = f prefix
+  ; prefixexec = f prefixexec
   }
 ;;
 
@@ -64,6 +70,8 @@ let make ~relative ~package ~(roots : _ Roots.t) =
   ; share = relative roots.share_root package
   ; etc = relative roots.etc_root package
   ; doc = relative roots.doc_root package
+  ; prefix = roots.prefix
+  ; prefixexec = roots.prefix
   }
 ;;
 
@@ -82,6 +90,8 @@ let get t (section : Section.t) =
   | Doc -> t.doc
   | Stublibs -> t.stublibs
   | Man -> t.man
+  | Prefix -> t.prefix
+  | Prefixexec -> t.prefixexec
   | Misc -> Code_error.raise "Install.Paths.get" []
 ;;
 

--- a/src/install/roots.ml
+++ b/src/install/roots.ml
@@ -9,9 +9,13 @@ type 'a t =
   ; etc_root : 'a
   ; doc_root : 'a
   ; man : 'a
+  ; prefix : 'a
   }
 
-let to_dyn f { lib_root; libexec_root; bin; sbin; share_root; etc_root; doc_root; man } =
+let to_dyn
+      f
+      { lib_root; libexec_root; bin; sbin; share_root; etc_root; doc_root; man; prefix }
+  =
   let open Dyn in
   record
     [ "lib_root", f lib_root
@@ -22,6 +26,7 @@ let to_dyn f { lib_root; libexec_root; bin; sbin; share_root; etc_root; doc_root
     ; "etc_root", f etc_root
     ; "doc_root", f doc_root
     ; "man", f man
+    ; "prefix", f prefix
     ]
 ;;
 
@@ -35,6 +40,7 @@ let make prefix ~relative =
   ; man = relative prefix "man"
   ; doc_root = relative prefix "doc"
   ; etc_root = relative prefix "etc"
+  ; prefix
   }
 ;;
 
@@ -47,6 +53,7 @@ let make_all a =
   ; man = a
   ; doc_root = a
   ; etc_root = a
+  ; prefix = a
   }
 ;;
 
@@ -67,6 +74,7 @@ let map ~f x =
   ; etc_root = f x.etc_root
   ; doc_root = f x.doc_root
   ; man = f x.man
+  ; prefix = f x.prefix
   }
 ;;
 
@@ -79,6 +87,7 @@ let map2 ~f x y =
   ; etc_root = f x.etc_root y.etc_root
   ; doc_root = f x.doc_root y.doc_root
   ; man = f x.man y.man
+  ; prefix = f x.prefix y.prefix
   }
 ;;
 

--- a/src/install/roots.mli
+++ b/src/install/roots.mli
@@ -9,6 +9,7 @@ type 'a t =
   ; etc_root : 'a
   ; doc_root : 'a
   ; man : 'a
+  ; prefix : 'a
   }
 
 val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-install.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-install.t/run.t
@@ -24,8 +24,40 @@ Installing a library with `-x foo` should install the library for that context
   libexec: [
     "_build/install/default.foo/lib/repro/repro.cmxs" {"../../foo-sysroot/lib/repro/repro.cmxs"}
   ]
+  prefix: [
+    "_build/install/default.foo/lib/repro/META" {"foo-sysroot/lib/repro/META"}
+    "_build/install/default.foo/lib/repro/dune-package" {"foo-sysroot/lib/repro/dune-package"}
+    "_build/install/default.foo/lib/repro/foo.ml" {"foo-sysroot/lib/repro/foo.ml"}
+    "_build/install/default.foo/lib/repro/repro$ext_lib" {"foo-sysroot/lib/repro/repro$ext_lib"}
+    "_build/install/default.foo/lib/repro/repro.cma" {"foo-sysroot/lib/repro/repro.cma"}
+    "_build/install/default.foo/lib/repro/repro.cmi" {"foo-sysroot/lib/repro/repro.cmi"}
+    "_build/install/default.foo/lib/repro/repro.cmt" {"foo-sysroot/lib/repro/repro.cmt"}
+    "_build/install/default.foo/lib/repro/repro.cmx" {"foo-sysroot/lib/repro/repro.cmx"}
+    "_build/install/default.foo/lib/repro/repro.cmxa" {"foo-sysroot/lib/repro/repro.cmxa"}
+    "_build/install/default.foo/lib/repro/repro.ml" {"foo-sysroot/lib/repro/repro.ml"}
+    "_build/install/default.foo/lib/repro/repro__Foo.cmi" {"foo-sysroot/lib/repro/repro__Foo.cmi"}
+    "_build/install/default.foo/lib/repro/repro__Foo.cmt" {"foo-sysroot/lib/repro/repro__Foo.cmt"}
+    "_build/install/default.foo/lib/repro/repro__Foo.cmx" {"foo-sysroot/lib/repro/repro__Foo.cmx"}
+  ]
+  prefixexec: [
+    "_build/install/default.foo/lib/repro/repro.cmxs" {"foo-sysroot/lib/repro/repro.cmxs"}
+  ]
 
   $ dune install --dry-run --prefix prefix --display short -p repro -x foo 2>&1 | grep "Installing"
+  Installing prefix/foo-sysroot/lib/repro/META
+  Installing prefix/foo-sysroot/lib/repro/dune-package
+  Installing prefix/foo-sysroot/lib/repro/foo.ml
+  Installing prefix/foo-sysroot/lib/repro/repro.a
+  Installing prefix/foo-sysroot/lib/repro/repro.cma
+  Installing prefix/foo-sysroot/lib/repro/repro.cmi
+  Installing prefix/foo-sysroot/lib/repro/repro.cmt
+  Installing prefix/foo-sysroot/lib/repro/repro.cmx
+  Installing prefix/foo-sysroot/lib/repro/repro.cmxa
+  Installing prefix/foo-sysroot/lib/repro/repro.ml
+  Installing prefix/foo-sysroot/lib/repro/repro__Foo.cmi
+  Installing prefix/foo-sysroot/lib/repro/repro__Foo.cmt
+  Installing prefix/foo-sysroot/lib/repro/repro__Foo.cmx
+  Installing prefix/foo-sysroot/lib/repro/repro.cmxs
   Installing prefix/foo-sysroot/lib/repro/META
   Installing prefix/foo-sysroot/lib/repro/dune-package
   Installing prefix/foo-sysroot/lib/repro/foo.ml

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-install.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation-install.t/run.t
@@ -24,7 +24,7 @@ Installing a library with `-x foo` should install the library for that context
   libexec: [
     "_build/install/default.foo/lib/repro/repro.cmxs" {"../../foo-sysroot/lib/repro/repro.cmxs"}
   ]
-  prefix: [
+  root: [
     "_build/install/default.foo/lib/repro/META" {"foo-sysroot/lib/repro/META"}
     "_build/install/default.foo/lib/repro/dune-package" {"foo-sysroot/lib/repro/dune-package"}
     "_build/install/default.foo/lib/repro/foo.ml" {"foo-sysroot/lib/repro/foo.ml"}
@@ -39,7 +39,7 @@ Installing a library with `-x foo` should install the library for that context
     "_build/install/default.foo/lib/repro/repro__Foo.cmt" {"foo-sysroot/lib/repro/repro__Foo.cmt"}
     "_build/install/default.foo/lib/repro/repro__Foo.cmx" {"foo-sysroot/lib/repro/repro__Foo.cmx"}
   ]
-  prefixexec: [
+  rootexec: [
     "_build/install/default.foo/lib/repro/repro.cmxs" {"foo-sysroot/lib/repro/repro.cmxs"}
   ]
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation.t/run.t
@@ -24,3 +24,19 @@ Tests a basic custom cross-compilation setup.
   bin: [
     "_build/install/default.foo/bin/blah" {"../foo-sysroot/bin/blah"}
   ]
+  prefix: [
+    "_build/install/default.foo/lib/p/META" {"foo-sysroot/lib/p/META"}
+    "_build/install/default.foo/lib/p/dune-package" {"foo-sysroot/lib/p/dune-package"}
+    "_build/install/default.foo/lib/p/opam" {"foo-sysroot/lib/p/opam"}
+    "_build/install/default.foo/lib/p/p$ext_lib" {"foo-sysroot/lib/p/p$ext_lib"}
+    "_build/install/default.foo/lib/p/p.cma" {"foo-sysroot/lib/p/p.cma"}
+    "_build/install/default.foo/lib/p/p.cmi" {"foo-sysroot/lib/p/p.cmi"}
+    "_build/install/default.foo/lib/p/p.cmt" {"foo-sysroot/lib/p/p.cmt"}
+    "_build/install/default.foo/lib/p/p.cmx" {"foo-sysroot/lib/p/p.cmx"}
+    "_build/install/default.foo/lib/p/p.cmxa" {"foo-sysroot/lib/p/p.cmxa"}
+    "_build/install/default.foo/lib/p/p.ml" {"foo-sysroot/lib/p/p.ml"}
+  ]
+  prefixexec: [
+    "_build/install/default.foo/bin/blah" {"foo-sysroot/bin/blah"}
+    "_build/install/default.foo/lib/p/p.cmxs" {"foo-sysroot/lib/p/p.cmxs"}
+  ]

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/cross-compilation.t/run.t
@@ -24,7 +24,7 @@ Tests a basic custom cross-compilation setup.
   bin: [
     "_build/install/default.foo/bin/blah" {"../foo-sysroot/bin/blah"}
   ]
-  prefix: [
+  root: [
     "_build/install/default.foo/lib/p/META" {"foo-sysroot/lib/p/META"}
     "_build/install/default.foo/lib/p/dune-package" {"foo-sysroot/lib/p/dune-package"}
     "_build/install/default.foo/lib/p/opam" {"foo-sysroot/lib/p/opam"}
@@ -36,7 +36,7 @@ Tests a basic custom cross-compilation setup.
     "_build/install/default.foo/lib/p/p.cmxa" {"foo-sysroot/lib/p/p.cmxa"}
     "_build/install/default.foo/lib/p/p.ml" {"foo-sysroot/lib/p/p.ml"}
   ]
-  prefixexec: [
+  rootexec: [
     "_build/install/default.foo/bin/blah" {"foo-sysroot/bin/blah"}
     "_build/install/default.foo/lib/p/p.cmxs" {"foo-sysroot/lib/p/p.cmxs"}
   ]

--- a/test/blackbox-tests/test-cases/install/install-no-prefix.t
+++ b/test/blackbox-tests/test-cases/install/install-no-prefix.t
@@ -18,6 +18,6 @@ We should suggest to the user here that they should use --prefix.
 
   $ unset OPAM_SWITCH_PREFIX
   $ dune install
-  Error: The mandir installation directory is unknown.
-  Hint: It can be specified with '--prefix' or by setting '--mandir'
+  Error: The prefix installation directory is unknown.
+  Hint: It can be specified with '--prefix'
   [1]

--- a/test/blackbox-tests/test-cases/pkg-pform/errors.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/errors.t
@@ -89,7 +89,7 @@ Invalid section name is rejected:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: badsection is not a valid section.
   Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
-  toplevel, share, share_root, etc, doc, stublibs, man, prefix and prefixexec.
+  toplevel, share, share_root, etc, doc, stublibs, man, root and rootexec.
   [1]
 
 The misc section is rejected:
@@ -106,7 +106,7 @@ The misc section is rejected:
                       ^^^^^^^^^^^^^^^^^^^^^^^^
   Error: misc is not a valid section.
   Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
-  toplevel, share, share_root, etc, doc, stublibs, man, prefix and prefixexec.
+  toplevel, share, share_root, etc, doc, stublibs, man, root and rootexec.
   [1]
 
 Wrong number of arguments (too few):

--- a/test/blackbox-tests/test-cases/pkg-pform/errors.t
+++ b/test/blackbox-tests/test-cases/pkg-pform/errors.t
@@ -89,7 +89,7 @@ Invalid section name is rejected:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: badsection is not a valid section.
   Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
-  toplevel, share, share_root, etc, doc, stublibs and man.
+  toplevel, share, share_root, etc, doc, stublibs, man, prefix and prefixexec.
   [1]
 
 The misc section is rejected:
@@ -106,7 +106,7 @@ The misc section is rejected:
                       ^^^^^^^^^^^^^^^^^^^^^^^^
   Error: misc is not a valid section.
   Hint: supported sections are lib, lib_root, libexec, libexec_root, bin, sbin,
-  toplevel, share, share_root, etc, doc, stublibs and man.
+  toplevel, share, share_root, etc, doc, stublibs, man, prefix and prefixexec.
   [1]
 
 Wrong number of arguments (too few):

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -35,11 +35,11 @@ Testing install actions
          [ In_build_dir
              "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
          ])
-      ; (PREFIX,
+      ; (ROOT,
          [ In_build_dir
              "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
          ])
-      ; (PREFIXEXEC,
+      ; (ROOTEXEC,
          [ In_build_dir
              "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
          ])

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -35,6 +35,14 @@ Testing install actions
          [ In_build_dir
              "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
          ])
+      ; (PREFIX,
+         [ In_build_dir
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
+         ])
+      ; (PREFIXEXEC,
+         [ In_build_dir
+             "_private/default/.pkg/test.0.0.1-$DIGEST/target/lib/xxx"
+         ])
       ]
   ; variables = []
   }


### PR DESCRIPTION
Closes #14393

In summary: 
Opam 2.5.1 and 2.7+ will ignore any target in an `.install` file that starts with `../`, which was previously used by dune's `-x` to place files in the `<prefix>/<target>-sysroot` directory.

To allow for this use case while preserving the security benefits of disallowing parent access, [opam added](https://github.com/ocaml/opam/issues/6919) `root` and `rootexec` to the .install file syntax in 2.6.

This PR updates dune to generate the new `root` and `rootexec` sections _in addition to_ the `../..` used before. Why both? Because of [the way that opam ignores things](https://github.com/ocaml/opam/issues/6919#issuecomment-4462142295), this means that the same generated .install files would be compatibile with any opam besides 2.5.1

| opam version v / .install section > | "lib" etc with ../ | "root" |
|--------|--------|--------|
| <2.5.1 | Works as intended | Ignored (opam ignores any unrecognized fields) |
| 2.5.1 | Disabled for security | Ignored (opam ignores any unrecognized fields) |
| 2.6.0 | Works, with a warning | Works as intended |
| 2.7.0+ | [Disabled for security](https://github.com/ocaml/opam/pull/7008#issuecomment-4981412190) | Works as intended |


 