### PR TITLE
Represent action arguments as appendable lists

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -48,7 +48,7 @@ let rec encode_action : Action.For_shell.t -> Dune_lang.t =
   let target = Encoder.string in
   function
   | Run (a, xs) ->
-    List (atom "run" :: program a :: List.map (Array.Immutable.to_list xs) ~f:string)
+    List (atom "run" :: program a :: List.map (Appendable_list.to_list xs) ~f:string)
   | With_accepted_exit_codes (pred, t) ->
     List
       [ atom "with-accepted-exit-codes"

--- a/otherlibs/stdune/src/appendable_list.ml
+++ b/otherlibs/stdune/src/appendable_list.ml
@@ -119,6 +119,16 @@ let concat = function
   | xs -> Concat xs
 ;;
 
+let rec map t ~f =
+  match t with
+  | Empty -> Empty
+  | Singleton x -> Singleton (f x)
+  | Cons (x, xs) -> Cons (f x, map xs ~f)
+  | List xs -> List (List.map xs ~f)
+  | Append (x, y) -> Append (map x ~f, map y ~f)
+  | Concat xs -> Concat (List.map xs ~f:(map ~f))
+;;
+
 let rec exists t ~f =
   match t with
   | Empty -> false

--- a/otherlibs/stdune/src/appendable_list.mli
+++ b/otherlibs/stdune/src/appendable_list.mli
@@ -11,6 +11,9 @@ val to_list : 'a t -> 'a list
 val to_list_rev : 'a t -> 'a list
 val of_list : 'a list -> 'a t
 val concat : 'a t list -> 'a t
+val length : _ t -> int
+val iter : 'a t -> f:('a -> unit) -> unit
+val map : 'a t -> f:('a -> 'b) -> 'b t
 val to_immutable_array : 'a t -> 'a Array.Immutable.t
 val exists : 'a t -> f:('a -> bool) -> bool
 

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -24,7 +24,7 @@ module Make
 struct
   include Ast
 
-  let run prog args = Run (prog, Array.Immutable.of_list args)
+  let run prog args = Run (prog, Appendable_list.of_list args)
   let chdir path t = Chdir (path, t)
   let setenv var value t = Setenv (var, value, t)
 
@@ -210,10 +210,8 @@ let digest =
     | Run (prog, args) ->
       int d 0;
       digest_program d ~dir prog;
-      int d (Array.Immutable.length args);
-      for i = 0 to Array.Immutable.length args - 1 do
-        string d (Array.Immutable.get args i)
-      done
+      int d (Appendable_list.length args);
+      Appendable_list.iter args ~f:(string d)
     | With_accepted_exit_codes (pred, t) ->
       int d 1;
       repr d (Predicate_lang.repr Repr.int) pred;

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -183,7 +183,7 @@ let rec exec t ~ectx ~eenv : Done_or_more_deps.t Produce.t =
   match (t : Action.t) with
   | Run (Error e, _) -> Action.Prog.Not_found.raise e
   | Run (Ok prog, args) ->
-    let+ () = exec_run ~ectx ~eenv prog (Array.Immutable.to_list args) in
+    let+ () = exec_run ~ectx ~eenv prog (Appendable_list.to_list args) in
     Done
   | With_accepted_exit_codes (exit_codes, t) ->
     let eenv =

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -26,7 +26,7 @@ module type Ast = sig
   type ext
 
   type t =
-    | Run of program * string Array.Immutable.t
+    | Run of program * string Appendable_list.t
     | With_accepted_exit_codes of int Predicate_lang.t * t
     | Chdir of path * t
     | Setenv of string * string * t
@@ -60,7 +60,6 @@ module type Helpers = sig
   type string
   type t
 
-  (* TODO consider changing this to a [string array] to save some conversion *)
   val run : program -> string list -> t
   val chdir : path -> t -> t
   val setenv : string -> string -> t -> t

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -17,7 +17,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     let f t ~dir = f t ~dir ~f_program ~f_string ~f_path ~f_target ~f_ext in
     match t with
     | Run (prog, args) ->
-      Run (f_program ~dir prog, Array.Immutable.map args ~f:(f_string ~dir))
+      Run (f_program ~dir prog, Appendable_list.map args ~f:(f_string ~dir))
     | With_accepted_exit_codes (pred, t) -> With_accepted_exit_codes (pred, f t ~dir)
     | Chdir (fn, t) -> Chdir (f_path ~dir fn, f t ~dir:fn)
     | Setenv (var, value, t) -> Setenv (f_string ~dir var, f_string ~dir value, f t ~dir)

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -485,7 +485,7 @@ let rec expand (t : Dune_lang.Action.t) : Action.t Action_expander.t =
     match string_args with
     | prog :: args ->
       let+ prog, args = expand_run ~force_host prog args in
-      O.Run (prog, Array.Immutable.of_list args)
+      O.Run (prog, Appendable_list.of_list args)
     | [] ->
       User_error.raise
         [ Pp.textf "\"%s\" action must have at least one argument" action_name ]

--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -73,10 +73,7 @@ let rec expand
     List.map fns ~f:(Path.reach ~from:dir)
     |> Appendable_list.of_list
     |> Action_builder.With_targets.return
-  | S ts ->
-    List.map ts ~f:(expand ~dir)
-    |> Action_builder.With_targets.all
-    |> Action_builder.With_targets.map ~f:Appendable_list.concat
+  | S ts -> expand_list ~dir ts
   | Concat (sep, ts) ->
     expand ~dir (S ts)
     |> Action_builder.With_targets.map ~f:(fun x ->
@@ -98,8 +95,26 @@ let rec expand
     |> Action_builder.with_file_targets ~file_targets:fns
   | Expand f -> f ~dir |> Action_builder.with_no_targets
 
+and expand_list
+  : type a.
+    dir:Path.t -> a t list -> string Appendable_list.t Action_builder.With_targets.t
+  =
+  fun ~dir ts ->
+  match ts with
+  | [] -> Appendable_list.empty |> Action_builder.With_targets.return
+  | t :: ts ->
+    let open Action_builder.With_targets.O in
+    let+ t = expand ~dir t
+    and+ ts = expand_list ~dir ts in
+    Appendable_list.(t @ ts)
+
 and expand_no_targets ~dir (t : without_targets t) =
   let { Action_builder.With_targets.build; targets } = expand ~dir t in
+  assert (Targets.is_empty targets);
+  build
+
+and expand_list_no_targets ~dir (ts : without_targets t list) =
+  let { Action_builder.With_targets.build; targets } = expand_list ~dir ts in
   assert (Targets.is_empty targets);
   build
 ;;
@@ -120,9 +135,9 @@ let run_dyn_prog ~dir ?sandbox ?stdout_to prog args =
        let* prog = prog in
        let+ () = dep_prog prog in
        prog
-     and+ args = expand ~dir (S args) in
+     and+ args = expand_list ~dir args in
      let action =
-       let action = Action.Run (prog, Appendable_list.to_immutable_array args) in
+       let action = Action.Run (prog, args) in
        match stdout_to with
        | None -> action
        | Some path -> Action.with_stdout_to path action
@@ -137,10 +152,8 @@ let run ~dir ?sandbox ?stdout_to prog args =
 let run' ?sandbox ~dir prog args =
   let open Action_builder.O in
   let+ () = dep_prog prog
-  and+ args = expand_no_targets ~dir (S args) in
-  Action.Run (prog, Appendable_list.to_immutable_array args)
-  |> Action.chdir dir
-  |> Action.Full.make ?sandbox
+  and+ args = expand_list_no_targets ~dir args in
+  Action.Run (prog, args) |> Action.chdir dir |> Action.Full.make ?sandbox
 ;;
 
 let quote_args =

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -647,7 +647,7 @@ module Unprocessed = struct
            | Error _ -> None
            | Ok bin ->
              let args =
-               let args = Array.Immutable.to_list args in
+               let args = Appendable_list.to_list args in
                encode_command ~bin ~args
              in
              Some { Processed.flag = Processed.Pp_kind.Pp; args }


### PR DESCRIPTION
Store command-line arguments in action Run nodes as Appendable_list.t instead of immutable arrays. This lets command construction pass already-appendable argument sequences through without materializing arrays.

Add Appendable_list.map, length, and iter helpers, and update action mapping, digesting, execution, and printing to consume the new representation.