### PR TITLE
refactor: add hash to Repr.Poly

### DIFF
--- a/otherlibs/stdune/src/repr.ml
+++ b/otherlibs/stdune/src/repr.ml
@@ -69,6 +69,7 @@ end
 module type Poly = sig
   type t
 
+  val hash : t -> int
   val equal : t -> t -> bool
   val compare : t -> t -> Ordering.t
 end
@@ -236,6 +237,7 @@ let validate_compare repr =
 
 module Poly (T : S) : Poly with type t := T.t = struct
   let () = validate_compare T.repr
+  let hash = Poly.hash
   let equal = Stdlib.( = )
   let compare x y = Ordering.of_int (Stdlib.compare x y)
 end

--- a/otherlibs/stdune/src/repr.mli
+++ b/otherlibs/stdune/src/repr.mli
@@ -69,6 +69,7 @@ end
 module type Poly = sig
   type t
 
+  val hash : t -> int
   val equal : t -> t -> bool
   val compare : t -> t -> Ordering.t
 end

--- a/otherlibs/stdune/src/sexp.ml
+++ b/otherlibs/stdune/src/sexp.ml
@@ -33,8 +33,6 @@ let rec pp = function
        ++ Pp.text ")")
 ;;
 
-let hash = Stdlib.Hashtbl.hash
-
 include Repr.Poly (struct
     type nonrec t = t
 

--- a/src/dune_pkg/dev_tool.ml
+++ b/src/dune_pkg/dev_tool.ml
@@ -70,8 +70,6 @@ include Repr.Poly (struct
     let repr = repr
   end)
 
-let hash = Poly.hash
-
 let package_name = function
   | Ocamlformat -> Package_name.of_string "ocamlformat"
   | Odoc -> Package_name.of_string "odoc"


### PR DESCRIPTION
Expose polymorphic hashing alongside equal and compare for reprs that are validated as safe for polymorphic operations. Drop redundant local hash definitions now provided by Repr.Poly.