### PR TITLE
test: pps runtime libs reach melange compile rule

### DIFF
--- a/test/blackbox-tests/test-cases/per-module-lib-deps/melange-pps-runtime-libs.t
+++ b/test/blackbox-tests/test-cases/per-module-lib-deps/melange-pps-runtime-libs.t
@@ -1,0 +1,75 @@
+A `(melange.emit ...)` stanza with `(preprocess (pps hello_ppx))`
+— where `hello_ppx` declares `(ppx_runtime_libraries hello)` —
+must pull `hello` into the melange compile-rule dep set. Pins
+that the compile rule has globs over `hello`'s melange objdir,
+sourced from the ppx runtime declaration alone — never named in
+source.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.24)
+  > (using melange 0.1)
+  > EOF
+
+`hello` is the ppx runtime lib (built for melange):
+
+  $ mkdir hello
+  $ cat > hello/dune <<EOF
+  > (library (name hello) (modes melange))
+  > EOF
+  $ cat > hello/hello.ml <<EOF
+  > type t = int
+  > EOF
+
+`hello_ppx` is a no-op ppx_rewriter declaring `hello` as a
+runtime lib. The `(ppx.driver ...)` form satisfies dune's
+pps-invocation contract without pulling in ppxlib (matches the
+stub-driver pattern in `ppx-runtime-libraries.t`).
+
+  $ mkdir hello_ppx
+  $ cat > hello_ppx/dune <<EOF
+  > (library
+  >  (name hello_ppx)
+  >  (kind ppx_rewriter)
+  >  (ppx_runtime_libraries hello)
+  >  (ppx.driver (main Hello_ppx.main)))
+  > EOF
+  $ cat > hello_ppx/hello_ppx.ml <<EOF
+  > let main () =
+  >   let out = ref "" in
+  >   let args =
+  >     [ ("-o", Arg.Set_string out, "")
+  >     ; ("--impl", Arg.Set_string (ref ""), "")
+  >     ; ("--as-ppx", Arg.Set (ref false), "")
+  >     ; ("--cookie", Arg.Set (ref false), "")
+  >     ]
+  >   in
+  >   let anon _ = () in
+  >   Arg.parse (Arg.align args) anon "";
+  >   close_out (open_out !out)
+  > EOF
+
+The melange.emit preprocesses with `hello_ppx`:
+
+  $ mkdir me
+  $ cat > me/dune <<EOF
+  > (melange.emit (target output) (preprocess (pps hello_ppx)))
+  > EOF
+  $ cat > me/foo.ml <<EOF
+  > let _ = ()
+  > EOF
+
+  $ dune build
+
+The melange compile rule has globs over `hello`'s melange objdir
+— sourced from `hello_ppx`'s `ppx_runtime_libraries`, with no
+syntactic reference to `Hello` in melange sources. (The melange
+target's modules are mangled internally, so `%{cmj:...}` doesn't
+resolve cleanly; locate the `.cmj` under the stanza dir.)
+
+  $ CMJ=$(find _build/default/me -name '*.cmj' | head -1)
+  $ dune rules --root . --format=json --deps "$CMJ" > deps.json
+  $ jq -r 'include "dune"; .[] | depsGlobs
+  >   | select(.dir | endswith("hello/.hello.objs/melange"))
+  >   | .dir + " " + .predicate' < deps.json
+  _build/default/hello/.hello.objs/melange *.cmi
+  _build/default/hello/.hello.objs/melange *.cmj


### PR DESCRIPTION
Pins that a `(melange.emit ...)` stanza preprocessing with a ppx whose `(ppx_runtime_libraries ...)` is non-empty includes globs over the runtime lib's `.cmi`/`.cmj` melange objdir in the compile-rule dep set — even though no source names the runtime lib syntactically.

Melange compile rules bypass per-module narrowing today (`can_filter = false` in `module_compilation.ml`); the property holds via the wide cctx glob. Forward-looking guard if narrowing ever extends to melange.