### PR TITLE
Share RPC socket fd preparation

### DIFF
--- a/otherlibs/stdune/src/fd.ml
+++ b/otherlibs/stdune/src/fd.ml
@@ -10,6 +10,11 @@ let raw_fd_repr = Repr.view Repr.int ~to_:unsafe_to_int
 let unsafe_to_unix_file_descr t = t.fd
 let unsafe_of_unix_file_descr fd = { fd; closed = false }
 
+let set_nonblock t =
+  assert (not t.closed);
+  Unix.set_nonblock t.fd
+;;
+
 let close t =
   if not t.closed
   then (

--- a/otherlibs/stdune/src/fd.mli
+++ b/otherlibs/stdune/src/fd.mli
@@ -5,6 +5,7 @@ val equal : t -> t -> bool
 val hash : t -> int
 val to_dyn : t -> Dyn.t
 val close : t -> unit
+val set_nonblock : t -> unit
 
 (** Unsafe casts to bridge callers that still use [Unix.file_descr]. *)
 val unsafe_of_unix_file_descr : Unix.file_descr -> t

--- a/src/rpc/csexp_rpc.ml
+++ b/src/rpc/csexp_rpc.ml
@@ -82,6 +82,11 @@ module Socket = struct
   let maybe_set_nosigpipe fd =
     if is_osx () then Mac.set_nosigpipe (Fd.unsafe_to_unix_file_descr fd)
   ;;
+
+  let prepare_fd fd =
+    maybe_set_nosigpipe fd;
+    Fd.set_nonblock fd
+  ;;
 end
 
 let unlink_socket_path (addr : Unix.sockaddr) =
@@ -125,7 +130,7 @@ module Session = struct
     }
 
   let create fd =
-    Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
+    Socket.prepare_fd fd;
     let id = Id.gen () in
     Dune_trace.emit Rpc (fun () -> Dune_trace.Event.Rpc.session ~id:(Id.to_int id) `Start);
     let state =
@@ -375,7 +380,7 @@ module Server = struct
     let create sockets ~backlog =
       List.iter sockets ~f:(fun (_, fd) ->
         Unix.listen (Fd.unsafe_to_unix_file_descr fd) backlog;
-        Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd));
+        Socket.prepare_fd fd);
       { sockets; task = None; running = true; closed = Fiber.Ivar.create () }
     ;;
 
@@ -424,8 +429,7 @@ module Server = struct
            let+ () = stop t in
            Ok None
          | Ok (fd, _) ->
-           Socket.maybe_set_nosigpipe fd;
-           Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
+           Socket.prepare_fd fd;
            Fiber.return @@ Ok (Some fd))
     ;;
   end
@@ -452,7 +456,7 @@ module Server = struct
       let in_bound = ref false in
       Exn.protect
         ~f:(fun () ->
-          Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
+          Socket.prepare_fd fd;
           (match (sockaddr : Unix.sockaddr) with
            | ADDR_UNIX _ -> ()
            | ADDR_INET _ ->
@@ -554,8 +558,7 @@ module Client = struct
         Unix.socket ~cloexec:true (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0
         |> Fd.unsafe_of_unix_file_descr
       in
-      Unix.set_nonblock (Fd.unsafe_to_unix_file_descr fd);
-      Socket.maybe_set_nosigpipe fd;
+      Socket.prepare_fd fd;
       { fd }
     ;;
   end


### PR DESCRIPTION
Add Socket.prepare_fd to centralize setting RPC sockets nonblocking and applying the macOS no-SIGPIPE option. Use it for session, server, accepted, bound, and client sockets.