### PR TITLE
Delay formatting process command lines

### DIFF
--- a/otherlibs/stdune/src/log.ml
+++ b/otherlibs/stdune/src/log.ml
@@ -100,6 +100,7 @@ let warn message args = info ("Warning: " ^ message) args
 let command ~command_line ~output ~exit_status =
   if !verbose
   then (
+    let command_line = Lazy.force command_line in
     let command_line = Ansi_color.strip command_line in
     let exit_status =
       match (exit_status : Unix.process_status) with

--- a/otherlibs/stdune/src/log.mli
+++ b/otherlibs/stdune/src/log.mli
@@ -36,7 +36,7 @@ val warn : string -> (string * Dyn.t) list -> unit
 
 (** Print an executed command in the log *)
 val command
-  :  command_line:string
+  :  command_line:string Lazy.t
   -> output:string
   -> exit_status:Unix.process_status
   -> unit

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -636,7 +636,9 @@ module Handle_exit_status = struct
     in
     let add_command_line paragraphs =
       if show_command
-      then Pp.tag User_message.Style.Details (Pp.verbatim command_line) :: paragraphs
+      then
+        Pp.tag User_message.Style.Details (Pp.verbatim (Lazy.force command_line))
+        :: paragraphs
       else paragraphs
     in
     let purpose = metadata.purpose in
@@ -1021,7 +1023,7 @@ let run_internal
     let id = Running_jobs.Id.gen () in
     let prog_str = Path.reach_for_running ?from:dir prog in
     let command_line =
-      command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to ~stdin_from
+      lazy (command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to ~stdin_from)
     in
     let fancy_command_line =
       match display with


### PR DESCRIPTION
Make process command lines lazy so they are only constructed when needed for verbose command logging or user-facing command details.