### PR TITLE
fix(path): use External.append_local in Build.to_string for consistent separators

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -368,10 +368,7 @@ module Build = struct
     let p = local p in
     match Fdecl.get build_dir with
     | In_source_dir b -> Local.to_string (Local.append (Source0.to_local b) p)
-    | External b ->
-      if Local.is_root p
-      then External.to_string b
-      else Filename.concat (External.to_string b) (Local.to_string p)
+    | External b -> External.to_string (External.append_local b p)
   ;;
 
   let to_string_maybe_quoted p = String.maybe_quoted (to_string p)

--- a/otherlibs/stdune/test/path_external_build_tests.ml
+++ b/otherlibs/stdune/test/path_external_build_tests.ml
@@ -4,21 +4,7 @@ open Stdune
    path. The existing stdune_unit_tests set build dir to "_build" (In_source_dir),
    so the [External b] branch of [Build.to_string] and cross-tree [reach] are
    never exercised there. This library has its own init because [set_root] and
-   [Build.set_build_dir] can only be called once per process.
-
-   CR-someday Alizter: After the fix to use [External.append_local] instead of
-   [Filename.concat], the conditional Windows expectations can be consolidated
-   with the Unix ones. *)
-
-let check_on_win_or_unix output ~wind ~unix =
-  let expected = String.trim (if Sys.win32 then wind else unix) in
-  let output = String.trim output in
-  if not (String.equal output expected)
-  then
-    Code_error.raise
-      "output mismatch"
-      [ "expected", String expected; "got", String output ]
-;;
+   [Build.set_build_dir] can only be called once per process. *)
 
 let () =
   Printexc.record_backtrace false;
@@ -33,10 +19,7 @@ let%expect_test "Build.to_string root" =
 
 let%expect_test "Build.to_string relative" =
   Path.Build.to_string (Path.Build.relative Path.Build.root "foo/bar") |> print_endline;
-  check_on_win_or_unix
-    [%expect.output]
-    ~wind:{| /external-build\foo/bar |}
-    ~unix:{| /external-build/foo/bar |}
+  [%expect {| /external-build/foo/bar |}]
 ;;
 
 let%expect_test "to_absolute_filename source path" =


### PR DESCRIPTION
Replace `Filename.concat` with `External.append_local` when stringifying external build paths with a local suffix. This ensures forward slashes are used on all platforms, removing the need for conditional Windows/Unix test expectations.

- Followup to #14278.
- Followed up by #14663 

- Contributes to https://github.com/ocaml/dune/issues/10176