### PR TITLE
refactor: move build polling loop to dune_engine

### DIFF
--- a/bin/build.ml
+++ b/bin/build.ml
@@ -13,7 +13,7 @@ let poll_handling_rpc_build_requests ~(common : Common.t) =
     | `Allow server -> server
     | `Forbid_builds -> Code_error.raise "rpc server must be allowed in passive mode" []
   in
-  Scheduler.Run.poll_passive
+  Dune_engine.Build_loop.poll_passive
     ~get_build_request:
       (let+ { kind; outcome } = Dune_rpc_impl.Server.pending_action rpc in
        let request setup =
@@ -38,7 +38,7 @@ let run_build_command_poll_eager ~(common : Common.t) ~config ~request : unit =
        (* Run two fibers concurrently. One is responible for rebuilding targets
        named on the command line in reaction to file system changes. The other
        is responsible for building targets named in RPC build requests. *)
-       let+ () = Scheduler.Run.poll (run_build_system ~request)
+       let+ () = Dune_engine.Build_loop.poll (run_build_system ~request)
        and+ () = poll_handling_rpc_build_requests ~common in
        ())
 ;;

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -286,7 +286,7 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
     @@ fun () ->
     let open Fiber.O in
     let on_exit = Console.printf "Program exited with code [%d]" in
-    Scheduler.Run.poll
+    Dune_engine.Build_loop.poll
     @@
     let* () =
       Fiber.return

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -1,0 +1,63 @@
+open Import
+open Fiber.O
+
+type step = (unit, [ `Already_reported ]) Result.t Fiber.t
+
+let rec poll_iter t step =
+  let invalidation = Scheduler.Build_loop.pending_invalidation t in
+  let changed_paths =
+    if Memo.Invalidation.is_empty invalidation
+    then (
+      Memo.Metrics.reset ();
+      None)
+    else (
+      let files = Memo.Invalidation.changed_paths invalidation in
+      let details_hum = Memo.Invalidation.details_hum invalidation in
+      Scheduler.Build_loop.source_files_changed t ~details_hum;
+      Memo.reset invalidation;
+      Some files)
+  in
+  Scheduler.Build_loop.start_iteration t ~changed_paths;
+  let* res = step in
+  let res : Build_outcome.t =
+    match res with
+    | Error `Already_reported -> Failure
+    | Ok () -> Success
+  in
+  match Scheduler.Build_loop.finish_iteration t res with
+  | `Done -> Fiber.return res
+  | `Restart -> poll_iter t step
+;;
+
+(* Work we're allowed to do between successive polling iterations. this work
+   should be fast and never fail (within reason) *)
+let run_when_idle () : unit =
+  Dune_trace.emit ~buffered:true Scheduler Dune_trace.Event.scheduler_idle;
+  Dune_trace.flush ()
+;;
+
+let poll step =
+  let* t = Scheduler.Build_loop.init () in
+  let rec loop () =
+    let* (_ : Build_outcome.t) = poll_iter t step in
+    run_when_idle ();
+    let* () = Scheduler.Build_loop.wait_for_build_input_change t in
+    loop ()
+  in
+  loop ()
+;;
+
+let poll_passive ~get_build_request =
+  let* t = Scheduler.Build_loop.init () in
+  let rec loop () =
+    let* step, response_ivar = get_build_request in
+    (* Flush before to make the build reproducible. The passive watch mode is
+       designed for tests and We want to observe all the change made by the
+       test before starting the build. *)
+    let* () = Scheduler.flush_file_watcher () in
+    let* res = poll_iter t step in
+    let* () = Fiber.Ivar.fill response_ivar res in
+    loop ()
+  in
+  loop ()
+;;

--- a/src/dune_engine/build_loop.mli
+++ b/src/dune_engine/build_loop.mli
@@ -1,0 +1,21 @@
+open Import
+
+(** A build request run by the watch-mode build loop. *)
+type step = (unit, [ `Already_reported ]) Result.t Fiber.t
+
+(** [poll step] runs [step] in a loop.
+
+    If any source files change in the middle of iteration, it gets canceled.
+
+    If [Scheduler.shutdown] is called, the current build will be canceled and
+    new builds will not start. *)
+val poll : step -> unit Fiber.t
+
+(** [poll_passive] is similar to [poll], but it can be used to drive the
+    polling loop explicitly instead of starting new iterations automatically.
+
+    The fiber [get_build_request] is run at the beginning of every iteration to
+    wait for the build signal. *)
+val poll_passive
+  :  get_build_request:(step * Build_outcome.t Fiber.Ivar.t) Fiber.t
+  -> unit Fiber.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1112,8 +1112,7 @@ let run f =
   in
   let open Fiber.O in
   let f () =
-    let run_id = Scheduler.start_build () in
-    let files = Scheduler.watch_restart_files () in
+    let run_id, `Changed_paths files = Scheduler.Build_loop.start_build () in
     let start = Time.now () in
     Dune_trace.emit ~buffered:false Build (fun () ->
       Dune_trace.Event.watch_build_start
@@ -1163,7 +1162,7 @@ let run f =
       | Watch _ -> Scheduler.flush_file_watcher ()
     in
     let stop = Time.now () in
-    (match Scheduler.finish_build ~stop with
+    (match Scheduler.Build_loop.finish_build ~stop with
      | Restarting -> ()
      | Finished { restart_duration } ->
        let alloc_summary =

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -18,6 +18,7 @@ module Rule = Rule
 module Target_promotion = Target_promotion
 module Build_context = Build_context
 module Build_config = Build_config
+module Build_loop = Build_loop
 module Build_system = Build_system
 module Build_system_error = Build_system_error
 module Load_rules = Load_rules

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -15,7 +15,6 @@ include struct
   open Dune_engine
   module Build_config = Build_config
   module Diff_promotion = Diff_promotion
-  module Build_outcome = Scheduler.Run.Build_outcome
 end
 
 include struct
@@ -79,7 +78,7 @@ type 'build_arg pending_action_kind =
 
 type 'build_arg pending_action =
   { kind : 'build_arg pending_action_kind
-  ; outcome : Scheduler.Run.Build_outcome.t Fiber.Ivar.t
+  ; outcome : Build_outcome.t Fiber.Ivar.t
   }
 
 module Client = Stdune.Unit
@@ -392,7 +391,7 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
   in
   let () =
     let f _ () =
-      if Scheduler.is_watch_mode ()
+      if Scheduler.Build_loop.is_watch_mode ()
       then
         let+ () = Scheduler.flush_file_watcher () in
         `Ok

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -22,7 +22,7 @@ type 'build_arg pending_action_kind =
     with the outcome of their request. *)
 type 'build_arg pending_action =
   { kind : 'build_arg pending_action_kind
-  ; outcome : Scheduler.Run.Build_outcome.t Fiber.Ivar.t
+  ; outcome : Build_outcome.t Fiber.Ivar.t
   }
 
 val pending_action : 'build_arg t -> 'build_arg pending_action Fiber.t

--- a/src/dune_scheduler/build_outcome.ml
+++ b/src/dune_scheduler/build_outcome.ml
@@ -1,0 +1,3 @@
+type t =
+  | Success
+  | Failure

--- a/src/dune_scheduler/build_outcome.mli
+++ b/src/dune_scheduler/build_outcome.mli
@@ -1,0 +1,3 @@
+type t =
+  | Success
+  | Failure

--- a/src/dune_scheduler/dune_scheduler.ml
+++ b/src/dune_scheduler/dune_scheduler.ml
@@ -1,3 +1,4 @@
+module Build_outcome = Build_outcome
 module Scheduler = Scheduler
 module Async_io = Async_io
 module File_watcher = File_watcher

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -32,7 +32,7 @@ let running_jobs_count (t : t) = Event.Queue.pending_jobs t.events
 exception Build_cancelled
 
 let cancelled () = raise (Memo.Non_reproducible Build_cancelled)
-let check_cancelled t = if Fiber.Cancel.fired t.cancel then cancelled ()
+let check_cancelled t = if Fiber.Cancel.fired t.build_loop.cancel then cancelled ()
 
 let check_point =
   let* () = Fiber.return () in
@@ -77,7 +77,7 @@ let wait_for_build_process t ~is_process_group_leader pid =
   let sigkill_alarm = ref None in
   let+ res, outcome =
     Fiber.Cancel.with_handler
-      t.cancel
+      t.build_loop.cancel
       ~on_cancel:(fun () ->
         if not Sys.win32 then Process_watcher.killall t.process_watcher Sys.sigterm;
         let sleep = Async_io.sleep t.async_io sigterm_grace_period in
@@ -193,8 +193,8 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
   let cancel = Fiber.Cancel.create () in
   let process_watcher = Process_watcher.init events in
   let async_io = Async_io.create events in
-  let t =
-    { status =
+  let build_loop =
+    { Types.Scheduler.Build_loop.status =
         (* Slightly weird initialization happening here: for polling mode we
            initialize in "Building" state, immediately switch to Standing_by
            and then back to "Building". It would make more sense to start in
@@ -206,14 +206,18 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
     ; run_id_state = Run_id.State.create ~watch_mode:(Option.is_some file_watcher)
     ; watch_restart_started_at = None
     ; watch_restart_files = None
+    ; handler
+    ; build_inputs_changed = Trigger.create ()
+    ; cancel
+    }
+  in
+  let t =
+    { build_loop
     ; job_throttle = Fiber.Throttle.create config.concurrency
     ; process_watcher
     ; events
-    ; handler
     ; file_watcher
     ; fs_syncs = Table.create (module File_watcher.Sync_id) 64
-    ; build_inputs_changed = Trigger.create ()
-    ; cancel
     ; thread_pool = lazy (Thread_pool.create ~min_workers:4 ~max_workers:50)
     ; signal_watcher
     ; async_io
@@ -250,7 +254,7 @@ module Run_once = struct
       - starting cancellations
       - terminating the scheduler on signals *)
   let rec iter (t : t) : Fiber.fill list =
-    t.handler Tick;
+    t.build_loop.handler Tick;
     match Event.Queue.next t.events with
     | File_watcher_task job ->
       let events = job () in
@@ -281,27 +285,29 @@ module Run_once = struct
     then iter t
     else (
       let now = Time.now () in
-      if Run_id.State.is_watch t.run_id_state
+      let build_loop = t.build_loop in
+      if Run_id.State.is_watch build_loop.run_id_state
       then (
-        let run_id = Run_id.State.next_to_start t.run_id_state in
+        let run_id = Run_id.State.next_to_start build_loop.run_id_state in
         let reasons = Memo.Invalidation.details_hum ~max_elements:max_int invalidation in
-        if Option.is_none t.watch_restart_started_at
-        then t.watch_restart_started_at <- Some now;
+        if Option.is_none build_loop.watch_restart_started_at
+        then build_loop.watch_restart_started_at <- Some now;
         Dune_trace.emit Build (fun () ->
           Dune_trace.Event.watch_build_restart
             ~run_id:(Run_id.to_int run_id)
             ~reasons
             ~at:now));
-      t.invalidation <- Memo.Invalidation.combine t.invalidation invalidation;
+      build_loop.invalidation
+      <- Memo.Invalidation.combine build_loop.invalidation invalidation;
       let fills =
-        match t.status with
+        match build_loop.status with
         | Restarting_build | Standing_by -> []
         | Building cancellation ->
-          t.handler Build_interrupted;
-          t.status <- Restarting_build;
+          build_loop.handler Build_interrupted;
+          build_loop.status <- Restarting_build;
           Fiber.Cancel.fire' cancellation
       in
-      let fills = Trigger.trigger t.build_inputs_changed @ fills in
+      let fills = Trigger.trigger build_loop.build_inputs_changed @ fills in
       match fills with
       | [] -> iter t
       | fills -> fills)
@@ -383,7 +389,91 @@ let flush_file_watcher_impl t =
 ;;
 
 let flush_file_watcher () = flush_file_watcher_impl (t ())
-let is_watch_mode () = Run_id.State.is_watch (t ()).run_id_state
+
+module Build_loop = struct
+  open Types.Scheduler.Build_loop
+
+  type nonrec t = t
+
+  type build_finish =
+    | Finished of { restart_duration : Time.Span.t option }
+    | Restarting
+
+  let is_watch_mode () = Run_id.State.is_watch (t ()).build_loop.run_id_state
+
+  let start_build () =
+    let build_loop = (t ()).build_loop in
+    let state, run_id = Run_id.State.start build_loop.run_id_state in
+    build_loop.run_id_state <- state;
+    run_id, `Changed_paths build_loop.watch_restart_files
+  ;;
+
+  let finish_build ~stop =
+    let build_loop = (t ()).build_loop in
+    let finish () =
+      let restart_duration =
+        Option.map build_loop.watch_restart_started_at ~f:(fun restart_started_at ->
+          Time.diff stop restart_started_at)
+      in
+      build_loop.watch_restart_started_at <- None;
+      build_loop.watch_restart_files <- None;
+      Finished { restart_duration }
+    in
+    match build_loop.status with
+    | Restarting_build -> Restarting
+    | Standing_by -> finish ()
+    | Building _ ->
+      build_loop.status <- Standing_by;
+      finish ()
+  ;;
+
+  let init () =
+    let+ () = Fiber.return () in
+    let scheduler = t () in
+    let t = scheduler.build_loop in
+    assert (
+      match t.status with
+      | Building _ -> true
+      | _ -> false);
+    t.status <- Standing_by;
+    t
+  ;;
+
+  let pending_invalidation t = t.invalidation
+
+  let start_iteration t ~changed_paths =
+    t.watch_restart_files <- changed_paths;
+    Option.iter changed_paths ~f:(fun (_ : Path.t list) ->
+      t.invalidation <- Memo.Invalidation.empty;
+      t.build_inputs_changed <- Trigger.create ());
+    (match t.status with
+     | Building _ -> assert false
+     | Standing_by | Restarting_build -> ());
+    let cancel = Fiber.Cancel.create () in
+    t.status <- Building cancel;
+    t.cancel <- cancel
+  ;;
+
+  let finish_iteration t res =
+    match t.status with
+    | Standing_by ->
+      t.handler (Build_finish res);
+      `Done
+    | Restarting_build -> `Restart
+    | Building _ ->
+      t.status <- Standing_by;
+      t.watch_restart_started_at <- None;
+      t.watch_restart_files <- None;
+      t.handler (Build_finish res);
+      `Done
+  ;;
+
+  let source_files_changed t ~details_hum =
+    t.handler (Source_files_changed { details_hum })
+  ;;
+
+  let wait_for_build_input_change t = Trigger.wait t.build_inputs_changed
+end
 
 module Run = struct
   exception Build_cancelled = Build_cancelled
@@ -400,97 +490,8 @@ module Run = struct
     | _, _ -> false
   ;;
 
-  module Build_outcome = Build_outcome
   module Event_queue = Event.Queue
   module Event = Handler.Event
-
-  let rec poll_iter t step =
-    t.watch_restart_files
-    <- (if Memo.Invalidation.is_empty t.invalidation
-        then (
-          Memo.Metrics.reset ();
-          None)
-        else (
-          let files = Memo.Invalidation.changed_paths t.invalidation in
-          let details_hum = Memo.Invalidation.details_hum t.invalidation in
-          t.handler (Source_files_changed { details_hum });
-          Memo.reset t.invalidation;
-          t.invalidation <- Memo.Invalidation.empty;
-          t.build_inputs_changed <- Trigger.create ();
-          Some files));
-    let cancel = Fiber.Cancel.create () in
-    t.status <- Building cancel;
-    t.cancel <- cancel;
-    let* res = step in
-    let res : Build_outcome.t =
-      match res with
-      | Error `Already_reported -> Failure
-      | Ok () -> Success
-    in
-    match t.status with
-    | Standing_by ->
-      t.handler (Build_finish res);
-      Fiber.return res
-    | Restarting_build -> poll_iter t step
-    | Building _ ->
-      t.status <- Standing_by;
-      t.watch_restart_started_at <- None;
-      t.watch_restart_files <- None;
-      t.handler (Build_finish res);
-      Fiber.return res
-  ;;
-
-  let poll_iter t step =
-    match t.status with
-    | Building _ | Restarting_build -> assert false
-    | Standing_by -> poll_iter t step
-  ;;
-
-  type step = (unit, [ `Already_reported ]) Result.t Fiber.t
-
-  let poll_init () =
-    let+ () = Fiber.return () in
-    let t = t () in
-    assert (
-      match t.status with
-      | Building _ -> true
-      | _ -> false);
-    t.status <- Standing_by;
-    t
-  ;;
-
-  (* Work we're allowed to do between successive polling iterations. this work
-     should be fast and never fail (within reason) *)
-  let run_when_idle () : unit =
-    Dune_trace.emit ~buffered:true Scheduler Dune_trace.Event.scheduler_idle;
-    Dune_trace.flush ()
-  ;;
-
-  let poll step =
-    let* t = poll_init () in
-    let rec loop () =
-      let* _res = poll_iter t step in
-      run_when_idle ();
-      let* () = Trigger.wait t.build_inputs_changed in
-      loop ()
-    in
-    loop ()
-  ;;
-
-  let poll_passive ~get_build_request =
-    let* t = poll_init () in
-    let rec loop () =
-      let* step, response_ivar = get_build_request in
-      (* Flush before to make the build reproducible. The passive watch mode is
-         designed for tests and We want to observe all the change made by the
-         test before starting the build. *)
-      let* () = flush_file_watcher () in
-      let* res = poll_iter t step in
-      let* () = Fiber.Ivar.fill response_ivar res in
-      loop ()
-    in
-    loop ()
-  ;;
 
   let go
         (config : Config.t)
@@ -554,46 +555,14 @@ let shutdown () =
   Event.Queue.send_shutdown t.events Requested
 ;;
 
-type build_finish =
-  | Finished of { restart_duration : Time.Span.t option }
-  | Restarting
-
-let start_build () =
-  let t = t () in
-  let state, run_id = Run_id.State.start t.run_id_state in
-  t.run_id_state <- state;
-  run_id
-;;
-
-let watch_restart_files () = (t ()).watch_restart_files
-
-let finish_build ~stop =
-  let t = t () in
-  let finish () =
-    let restart_duration =
-      Option.map t.watch_restart_started_at ~f:(fun restart_started_at ->
-        Time.diff stop restart_started_at)
-    in
-    t.watch_restart_started_at <- None;
-    t.watch_restart_files <- None;
-    Finished { restart_duration }
-  in
-  match t.status with
-  | Restarting_build -> Restarting
-  | Standing_by -> finish ()
-  | Building _ ->
-    t.status <- Standing_by;
-    finish ()
-;;
-
 let cancel_current_build () =
   let* () = Fiber.return () in
-  let t = t () in
-  match t.status with
+  let build_loop = (t ()).build_loop in
+  match build_loop.status with
   | Restarting_build | Standing_by -> Fiber.return ()
   | Building cancellation ->
-    t.handler Build_interrupted;
-    t.status <- Standing_by;
+    build_loop.handler Build_interrupted;
+    build_loop.status <- Standing_by;
     Fiber.Cancel.fire cancellation
 ;;
 
@@ -658,8 +627,8 @@ let set_fs_memo_impl = Fs_memo.set_impl
 module For_tests = struct
   let wait_for_build_input_change () =
     let* () = Fiber.return () in
-    let t = t () in
-    Trigger.wait t.build_inputs_changed
+    let build_loop = (t ()).build_loop in
+    Trigger.wait build_loop.build_inputs_changed
   ;;
 
   let inject_memo_invalidation invalidation =

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -11,12 +11,6 @@ module Config : sig
 end
 
 module Run : sig
-  module Build_outcome : sig
-    type t =
-      | Success
-      | Failure
-  end
-
   module Event : sig
     type t =
       | Tick
@@ -32,25 +26,6 @@ module Run : sig
   val file_watcher_equal : file_watcher -> file_watcher -> bool
 
   exception Build_cancelled
-
-  type step = (unit, [ `Already_reported ]) Result.t Fiber.t
-
-  (** [poll once] runs [once] in a loop.
-
-      If any source files change in the middle of iteration, it gets canceled.
-
-      If [shutdown] is called, the current build will be canceled and new builds
-      will not start. *)
-  val poll : step -> unit Fiber.t
-
-  (** [poll_passive] is similar to [poll], but it can be used to drive the
-      polling loop explicitly instead of starting new iterations automatically.
-
-      The fiber [get_build_request] is run at the beginning of every iteration
-      to wait for the build signal. *)
-  val poll_passive
-    :  get_build_request:(step * Build_outcome.t Fiber.Ivar.t) Fiber.t
-    -> unit Fiber.t
 
   val go
     :  Config.t
@@ -132,16 +107,25 @@ val cancel_current_build : unit -> unit Fiber.t
 val sleep : Time.Span.t -> unit Fiber.t
 
 val spawn_thread : name:string -> (unit -> unit) -> Thread.t
-
-type build_finish =
-  | Finished of { restart_duration : Time.Span.t option }
-  | Restarting
-
-val start_build : unit -> Run_id.t
-val watch_restart_files : unit -> Path.t list option
-val finish_build : stop:Time.t -> build_finish
 val flush_file_watcher : unit -> unit Fiber.t
-val is_watch_mode : unit -> bool
+
+module Build_loop : sig
+  type t
+
+  type build_finish =
+    | Finished of { restart_duration : Time.Span.t option }
+    | Restarting
+
+  val is_watch_mode : unit -> bool
+  val start_build : unit -> Run_id.t * [ `Changed_paths of Path.t list option ]
+  val finish_build : stop:Time.t -> build_finish
+  val init : unit -> t Fiber.t
+  val pending_invalidation : t -> Memo.Invalidation.t
+  val start_iteration : t -> changed_paths:Path.t list option -> unit
+  val finish_iteration : t -> Build_outcome.t -> [ `Done | `Restart ]
+  val source_files_changed : t -> details_hum:string list -> unit
+  val wait_for_build_input_change : t -> unit Fiber.t
+end
 
 (** [set_fs_memo_impl] registers the file system memoization callbacks.
     This must be called by dune_engine at initialization before starting

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -52,12 +52,6 @@ module Async_io = struct
 end
 
 module Scheduler = struct
-  module Build_outcome = struct
-    type t =
-      | Success
-      | Failure
-  end
-
   module Handler = struct
     module Event = struct
       type t =
@@ -70,30 +64,36 @@ module Scheduler = struct
     type t = Event.t -> unit
   end
 
-  type status =
-    | (* We are not doing a build. Just accumulating invalidations until the next
-       build starts. *)
-      Standing_by
-    | (* Running a build *)
-      Building of Fiber.Cancel.t
-    | (* Cancellation requested. Build jobs are immediately rejected in this
-       state *)
-      Restarting_build
+  module Build_loop = struct
+    type status =
+      | (* We are not doing a build. Just accumulating invalidations until the next
+         build starts. *)
+        Standing_by
+      | (* Running a build *)
+        Building of Fiber.Cancel.t
+      | (* Cancellation requested. Build jobs are immediately rejected in this
+         state *)
+        Restarting_build
+
+    type t =
+      { mutable status : status
+      ; mutable invalidation : Memo.Invalidation.t
+      ; mutable run_id_state : Run_id.State.t
+      ; mutable watch_restart_started_at : Time.t option
+      ; mutable watch_restart_files : Path.t list option
+      ; handler : Handler.t
+      ; mutable build_inputs_changed : Trigger.t
+      ; mutable cancel : Fiber.Cancel.t
+      }
+  end
 
   type t =
-    { mutable status : status
-    ; mutable invalidation : Memo.Invalidation.t
-    ; mutable run_id_state : Run_id.State.t
-    ; mutable watch_restart_started_at : Time.t option
-    ; mutable watch_restart_files : Path.t list option
-    ; handler : Handler.t
+    { build_loop : Build_loop.t
     ; job_throttle : Fiber.Throttle.t
     ; events : Event.Queue.t
     ; process_watcher : Process_watcher.t
     ; file_watcher : File_watcher.t option
     ; fs_syncs : (File_watcher.Sync_id.t, unit Fiber.Ivar.t) Table.t
-    ; mutable build_inputs_changed : Trigger.t
-    ; mutable cancel : Fiber.Cancel.t
     ; thread_pool : Thread_pool.t Lazy.t
     ; signal_watcher : Thread.t
     ; async_io : Async_io.t

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -30,7 +30,7 @@ let%expect_test "cancelling a build" =
   go (fun () ->
     Fiber.fork_and_join_unit
       (fun () ->
-         Scheduler.Run.poll
+         Build_loop.poll
            (let* () = Fiber.Ivar.fill build_started () in
             let* () = Fiber.Ivar.read build_cancelled in
             let* res =
@@ -61,7 +61,7 @@ let%expect_test "cancelling a build: effect on other fibers" =
   go (fun () ->
     Fiber.fork_and_join_unit
       (fun () ->
-         Scheduler.Run.poll
+         Build_loop.poll
            (let* () = Fiber.Ivar.fill build_started () in
             Fiber.never))
       (fun () ->


### PR DESCRIPTION
Move the watch-mode build loop from Scheduler.Run into a new Dune_engine.Build_loop module. Keep scheduler-owned state behind a narrow Scheduler.Build_loop adapter so the change remains mechanical and preserves existing behavior.

Update build, exec, and scheduler tests to call the new build-loop API.