### PR TITLE
test(pkg): remove %{bin:patch}

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/dune
+++ b/test/blackbox-tests/test-cases/pkg/dune
@@ -31,10 +31,6 @@
  (applies_to autolock-with-watch-server))
 
 (cram
- (deps %{bin:patch})
- (applies_to patch opam-package-with-patch extra-sources))
-
-(cram
  (applies_to rev-store-lock-linux)
  (enabled_if
   (= %{system} linux))


### PR DESCRIPTION
We no longer require a patch binary for the patch action in lock files since switching to the OCaml implementation of patch.