### PR TITLE
Remove scheduler tick event

### DIFF
--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -23,8 +23,7 @@ let maybe_clear_screen
 ;;
 
 let on_event ~terminal_persistence = function
-  | Run.Event.Tick -> Console.Status_line.refresh ()
-  | Source_files_changed { details_hum } ->
+  | Run.Event.Source_files_changed { details_hum } ->
     maybe_clear_screen ~terminal_persistence ~details_hum
   | Build_interrupted ->
     Console.Status_line.set

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -254,7 +254,7 @@ module Run_once = struct
       - starting cancellations
       - terminating the scheduler on signals *)
   let rec iter (t : t) : Fiber.fill list =
-    t.build_loop.handler Tick;
+    Console.Status_line.refresh ();
     match Event.Queue.next t.events with
     | File_watcher_task job ->
       let events = job () in

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -13,7 +13,6 @@ end
 module Run : sig
   module Event : sig
     type t =
-      | Tick
       | Source_files_changed of { details_hum : string list }
       | Build_interrupted
       | Build_finish of Build_outcome.t

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -55,7 +55,6 @@ module Scheduler = struct
   module Handler = struct
     module Event = struct
       type t =
-        | Tick
         | Source_files_changed of { details_hum : string list }
         | Build_interrupted
         | Build_finish of Build_outcome.t


### PR DESCRIPTION
The scheduler tick was only used to refresh the console status line. Refresh it directly in the scheduler loop instead of exposing it as a Run event.