### PR TITLE
feat(pkg): ignore opam upper bounds on dune

### DIFF
--- a/src/dune_pkg/dune_dep.ml
+++ b/src/dune_pkg/dune_dep.ml
@@ -9,3 +9,24 @@ let version =
 
 let package = OpamPackage.create (Package_name.to_opam_package_name name) version
 let opam_file = OpamFile.OPAM.create package
+
+let strip_upper_version_constraints
+  : OpamTypes.filtered_formula -> OpamTypes.filtered_formula
+  =
+  let dune_opam_name = Package_name.to_opam_package_name name in
+  OpamFormula.map (fun (atom_name, condition) ->
+    if OpamPackage.Name.equal atom_name dune_opam_name
+    then (
+      let condition =
+        OpamFormula.map
+          (function
+            | OpamTypes.Filter _ as f -> OpamFormula.Atom f
+            | Constraint (relop, _) as c ->
+              (match relop with
+               | `Lt | `Leq -> OpamFormula.Empty
+               | `Eq | `Neq | `Gt | `Geq -> OpamFormula.Atom c))
+          condition
+      in
+      OpamFormula.Atom (atom_name, condition))
+    else OpamFormula.Atom (atom_name, condition))
+;;

--- a/src/dune_pkg/dune_dep.mli
+++ b/src/dune_pkg/dune_dep.mli
@@ -2,3 +2,12 @@ val name : Package_name.t
 val version : OpamPackage.Version.t
 val package : OpamPackage.t
 val opam_file : OpamFile.OPAM.t
+
+(** Strip upper version bounds ([<], [<=]) on dune atoms from a depends
+    formula. Filter sub-atoms and lower-bound / equality constraints are
+    preserved. Opam upper bounds on dune are typically defensive and grow
+    stale with dune's strong backward compatibility; lower bounds still
+    convey a meaningful minimum-dune signal. *)
+val strip_upper_version_constraints
+  :  OpamTypes.filtered_formula
+  -> OpamTypes.filtered_formula

--- a/src/dune_pkg/lock_pkg.ml
+++ b/src/dune_pkg/lock_pkg.ml
@@ -495,7 +495,7 @@ let opam_package_to_lock_file_pkg
         what
     in
     let depends =
-      match resolve opam_file.depends with
+      match resolve (Dune_dep.strip_upper_version_constraints opam_file.depends) with
       | Ok { regular; _ } -> regular
       | Error (`Formula_could_not_be_satisfied hints) ->
         Code_error.raise

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -658,7 +658,10 @@ module Solver = struct
                    |> xform
                    |> list_deps ~importance ~rank
                  in
-                 (OpamFile.OPAM.depends opam |> make_deps Ensure ensure)
+                 let depends =
+                   OpamFile.OPAM.depends opam |> Dune_dep.strip_upper_version_constraints
+                 in
+                 (depends |> make_deps Ensure ensure)
                  @ (OpamFile.OPAM.conflicts opam |> make_deps Prevent prevent))
             in
             let conflict_class = OpamFile.OPAM.conflict_class opam in
@@ -1569,6 +1572,7 @@ let reject_unreachable_packages =
               in
               let with_test = with_test solver_env in
               Dependency_formula.to_filtered_formula pkg.dependencies
+              |> Dune_dep.strip_upper_version_constraints
               |> Resolve_opam_formula.filtered_formula_to_package_names
                    ~env
                    ~with_test
@@ -1580,38 +1584,16 @@ let reject_unreachable_packages =
               List.filter regular ~f:(fun pkg ->
                 not (Package_name.equal Dune_dep.name pkg))
             | Error (`Formula_could_not_be_satisfied hints) ->
-              (match hints with
-               | [ (Unsatisfied_version_constraint { package_name; _ } as hint) ]
-                 when Package_name.equal package_name Dune_dep.name ->
-                 (* The current version of dune was injected into the set of
-                    available packages right before the dependencies were
-                    computed, so there's a possibility that it will violate
-                    the project's dependency constraints. A user can trigger
-                    this error case by placing version constraints on their
-                    project's dependency on the "dune" package which are not
-                    satisfied by the current version of Dune. *)
-                 User_error.raise
-                   [ Pp.text
-                       "The current version of Dune does not satisfy the version \
-                        constraints for Dune in this project's dependencies."
-                   ; Pp.text "Details:"
-                   ; Resolve_opam_formula.Unsatisfied_formula_hint.pp hint
-                   ]
-               | _ ->
-                 (* This case is a code error because the set of packages
-                    being searched has already been produced by the solver.
-                    It should be guaranteed that all packages in the set are
-                    mutually compatible and that the set is closed under
-                    dependency relationships (with the possible exception of
-                    the Dune package itself, which is handled by a separate
-                    case). *)
-                 Code_error.raise
-                   "can't find a valid solution for the dependencies"
-                   [ "name", Package_name.to_dyn pkg.name
-                   ; ( "hints"
-                     , Dyn.list Resolve_opam_formula.Unsatisfied_formula_hint.to_dyn hints
-                     )
-                   ])
+              (* The set of packages being searched has already been produced
+                 by the solver, so it should be guaranteed that all packages
+                 in the set are mutually compatible and that the set is
+                 closed under dependency relationships. *)
+              Code_error.raise
+                "can't find a valid solution for the dependencies"
+                [ "name", Package_name.to_dyn pkg.name
+                ; ( "hints"
+                  , Dyn.list Resolve_opam_formula.Unsatisfied_formula_hint.to_dyn hints )
+                ]
           in
           let depopts =
             List.filter_map pkg.depopts ~f:(fun (d : Package_dependency.t) ->
@@ -1769,7 +1751,12 @@ let solve_lock_dir
                   in
                   Context.filter_deps (Lazy.force context) opam_package)
              in
-             let depends = lazy (Lazy.force deps (OpamFile.OPAM.depends opam_file)) in
+             let depends =
+               lazy
+                 (OpamFile.OPAM.depends opam_file
+                  |> Dune_dep.strip_upper_version_constraints
+                  |> Lazy.force deps)
+             in
              let conflicts = lazy (Lazy.force deps (OpamFile.OPAM.conflicts opam_file)) in
              { Context.opam_file; version; depends; conflicts; name = local.name }))
       in

--- a/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
+++ b/test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t
@@ -12,18 +12,11 @@ dependency.
   > solve foo
   > }
 
-  $ test "2.0.0" 2>&1 | dune_cmd subst '3.[0-9]+' '3.XX'
-  Error:
-  Unable to solve dependencies while generating lock directory: dune.lock
-  
-  Couldn't solve the package dependency formula.
-  Selected candidates: foo.0.0.1 x.dev
-  - dune -> (problem)
-      User requested = 3.XX
-      foo 0.0.1 requires <= 2.0.0
-      Rejected candidates:
-        dune.3.XX: Incompatible with restriction: <= 2.0.0
-  [1]
+Upper bounds on dune are stripped, so this now locks against the running
+dune.
+  $ test "2.0.0"
+  Solution for dune.lock:
+  - foo.0.0.1
   $ test "4.0.0"
   Solution for dune.lock:
   - foo.0.0.1

--- a/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
+++ b/test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t
@@ -1,11 +1,9 @@
-Exercise dune solving projects with version constraints on dune that aren't
-satisfied by the currently-running dune.
+Upper bounds on dune are stripped before the solver evaluates them, so a
+project depending on an older dune still locks against the running dune.
 
   $ mkrepo
   $ add_mock_repo_if_needed
 
-Make a project that depends on a version of dune that must be earlier than the
-current version of dune:
   $ cat > dune-project <<EOF
   > (lang dune 3.0)
   > (package
@@ -15,20 +13,8 @@ current version of dune:
   >    (< 3.0))))
   > EOF
 
-Make a mock dune package with a version that satisfies the constraint in the
-project:
   $ mkpkg dune 2.0.0
 
-Solve the dependencies:
-  $ dune_pkg_lock_normalized | dune_cmd subst '3.[0-9]+' '3.XX'
-  Error:
-  Unable to solve dependencies while generating lock directory: dune.lock
-  
-  Couldn't solve the package dependency formula.
-  Selected candidates: foo.dev
-  - dune -> (problem)
-      User requested = 3.XX
-      foo dev requires < 3.XX
-      Rejected candidates:
-        dune.3.XX: Incompatible with restriction: < 3.XX
-  [1]
+  $ dune_pkg_lock_normalized
+  Solution for dune.lock:
+  (no dependencies to lock)


### PR DESCRIPTION
Opam packages occasionally declare upper bounds on dune, e.g.

```
    depends: [ "dune" {>= "3.0" & < "3.17"} ]
```

Dune's backward-compatibility guarantee makes these bounds grow stale quickly, but until now they would cause a hard solver failure whenever the running dune didn't fit.

In many cases, asking the (archive) repository maintainers to lift these boudns is impractical because they have been added from an opam point of view.

There isn't anything meaningful we can do with an upper bound of dune. Relaxing this restriction adds flexibility to the kinds of packages that dune pkg is interoperable with.

We therefore strip upper bounds ([<], [<=]) on the dune atom from depends formulas before they reach the solver. Lower bounds, equality, inequality, and filter sub-atoms are preserved. The lower bound is still a meaningful "minimum dune required" signal, that would otherwise be an error much later in the build.

Two tests for this restriction have been accordingly updated:

- `test/blackbox-tests/test-cases/pkg/implicit-dune-constraint.t`
- `test/blackbox-tests/test-cases/pkg/unsatisfied-version-constraint-on-dune.t`
- Fixes https://github.com/ocaml/dune/issues/14637
- [ ] changelog