### PR TITLE
refactor: move terminal persistence utilities to stdune

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -478,7 +478,7 @@ let shared_with_config_file ~allow_pkg_flag =
                         Dune_engine.Sandbox_mode.all_except_patch_back_source_tree
                         ~f:Dune_engine.Sandbox_mode.to_string)))))
   and+ terminal_persistence =
-    let modes = Dune_config.Terminal_persistence.all in
+    let modes = Terminal_persistence.all in
     let doc =
       let f s = fst s |> Printf.sprintf "$(b,%s)" in
       Printf.sprintf

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -290,9 +290,7 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
     @@
     let* () =
       Fiber.return
-      @@ Scheduler_setup.maybe_clear_screen
-           ~details_hum:[]
-           ~terminal_persistence:config.terminal_persistence
+      @@ Console.maybe_clear_screen ~details_hum:[] config.terminal_persistence
     in
     Build.build_memo @@ step ~prog ~args ~common ~no_rebuild ~context ~on_exit
   | No ->

--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -1,30 +1,9 @@
 open Import
 open Scheduler
 
-let maybe_clear_screen
-      ~(terminal_persistence : Dune_config.Terminal_persistence.t)
-      ~details_hum
-  =
-  match Execution_env.inside_dune with
-  | true -> (* Don't print anything here to make tests less verbose *) ()
-  | false ->
-    (match terminal_persistence with
-     | Clear_on_rebuild -> Console.reset ()
-     | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ()
-     | Preserve ->
-       let message =
-         sprintf
-           "********** NEW BUILD (%s) **********"
-           (String.concat ~sep:", " details_hum)
-       in
-       Console.print_user_message
-         (User_message.make
-            [ Pp.nop; Pp.tag User_message.Style.Success (Pp.verbatim message); Pp.nop ]))
-;;
-
 let on_event ~terminal_persistence = function
   | Run.Event.Source_files_changed { details_hum } ->
-    maybe_clear_screen ~terminal_persistence ~details_hum
+    Console.maybe_clear_screen terminal_persistence ~details_hum
   | Build_interrupted ->
     Console.Status_line.set
       (Live

--- a/bin/scheduler_setup.mli
+++ b/bin/scheduler_setup.mli
@@ -1,10 +1,5 @@
 open Import
 
-val maybe_clear_screen
-  :  terminal_persistence:Dune_config.Terminal_persistence.t
-  -> details_hum:string list
-  -> unit
-
 val no_build_no_rpc : config:Dune_config.t -> (unit -> 'a Fiber.t) -> 'a
 
 val go_without_rpc_server

--- a/otherlibs/stdune/src/console.ml
+++ b/otherlibs/stdune/src/console.ml
@@ -1,5 +1,7 @@
 module type Backend = Backend_intf.S
 
+let sprintf = Printf.sprintf
+
 module Backend = struct
   type t = Backend_intf.t
 
@@ -240,4 +242,22 @@ let () =
       else Printf.sprintf "%s %s" msg formatted_args
     in
     print [ Pp.verbatim full_msg ])
+;;
+
+let maybe_clear_screen (terminal_persistence : Terminal_persistence.t) ~details_hum =
+  match Execution_env.inside_dune with
+  | true -> (* Don't print anything here to make tests less verbose *) ()
+  | false ->
+    (match terminal_persistence with
+     | Clear_on_rebuild -> reset ()
+     | Clear_on_rebuild_and_flush_history -> reset_flush_history ()
+     | Preserve ->
+       let message =
+         sprintf
+           "********** NEW BUILD (%s) **********"
+           (String.concat ~sep:", " details_hum)
+       in
+       print_user_message
+         (User_message.make
+            [ Pp.nop; Pp.tag User_message.Style.Success (Pp.verbatim message); Pp.nop ]))
 ;;

--- a/otherlibs/stdune/src/console.mli
+++ b/otherlibs/stdune/src/console.mli
@@ -85,6 +85,8 @@ val finish : unit -> unit
     ]} *)
 val print : User_message.Style.t Pp.t list -> unit
 
+val maybe_clear_screen : Terminal_persistence.t -> details_hum:string list -> unit
+
 (** [printf fmt] is a convenient function for debugging. It formats a string and
     then print it raw followed by a newline. It is the same as:
 

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -85,6 +85,7 @@ module Global_lock = Global_lock
 module At_exit = At_exit
 module Permissions = Permissions
 module Console = Console
+module Terminal_persistence = Terminal_persistence
 module Repr = Repr
 module Marshal = Marshal
 module Fd = Fd

--- a/otherlibs/stdune/src/terminal_persistence.ml
+++ b/otherlibs/stdune/src/terminal_persistence.ml
@@ -1,0 +1,38 @@
+module T = struct
+  type t =
+    | Preserve
+    | Clear_on_rebuild
+    | Clear_on_rebuild_and_flush_history
+
+  let repr =
+    Repr.variant
+      "terminal-persistence"
+      [ Repr.case0 "Preserve" ~test:(function
+          | Preserve -> true
+          | Clear_on_rebuild | Clear_on_rebuild_and_flush_history -> false)
+      ; Repr.case0 "Clear_on_rebuild" ~test:(function
+          | Clear_on_rebuild -> true
+          | Preserve | Clear_on_rebuild_and_flush_history -> false)
+      ; Repr.case0 "Clear_on_rebuild_and_flush_history" ~test:(function
+          | Clear_on_rebuild_and_flush_history -> true
+          | Preserve | Clear_on_rebuild -> false)
+      ]
+  ;;
+end
+
+include T
+
+let all =
+  [ "preserve", Preserve
+  ; "clear-on-rebuild", Clear_on_rebuild
+  ; "clear-on-rebuild-and-flush-history", Clear_on_rebuild_and_flush_history
+  ]
+;;
+
+include Repr.Make (T)
+
+include Repr.Poly (struct
+    type nonrec t = t
+
+    let repr = repr
+  end)

--- a/otherlibs/stdune/src/terminal_persistence.mli
+++ b/otherlibs/stdune/src/terminal_persistence.mli
@@ -1,0 +1,9 @@
+type t =
+  | Preserve
+  | Clear_on_rebuild
+  | Clear_on_rebuild_and_flush_history
+
+val all : (string * t) list
+val repr : t Repr.t
+val equal : t -> t -> bool
+val to_dyn : t -> Dyn.t

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -132,44 +132,6 @@ module Dune_config = struct
     ;;
   end
 
-  module Terminal_persistence = struct
-    type t =
-      | Preserve
-      | Clear_on_rebuild
-      | Clear_on_rebuild_and_flush_history
-
-    let repr =
-      Repr.variant
-        "terminal-persistence"
-        [ Repr.case0 "Preserve" ~test:(function
-            | Preserve -> true
-            | Clear_on_rebuild | Clear_on_rebuild_and_flush_history -> false)
-        ; Repr.case0 "Clear_on_rebuild" ~test:(function
-            | Clear_on_rebuild -> true
-            | Preserve | Clear_on_rebuild_and_flush_history -> false)
-        ; Repr.case0 "Clear_on_rebuild_and_flush_history" ~test:(function
-            | Clear_on_rebuild_and_flush_history -> true
-            | Preserve | Clear_on_rebuild -> false)
-        ]
-    ;;
-
-    let all =
-      [ "preserve", Preserve
-      ; "clear-on-rebuild", Clear_on_rebuild
-      ; "clear-on-rebuild-and-flush-history", Clear_on_rebuild_and_flush_history
-      ]
-    ;;
-
-    include Repr.Poly (struct
-        type nonrec t = t
-
-        let repr = repr
-      end)
-
-    let to_dyn = Repr.to_dyn repr
-    let decode = enum all
-  end
-
   module Concurrency = struct
     type t =
       | Fixed of int
@@ -593,7 +555,7 @@ module Dune_config = struct
     let+ display = field_o "display" (1, 0) (enum Display.all)
     and+ concurrency = field_o "jobs" (1, 0) Concurrency.decode
     and+ terminal_persistence =
-      field_o "terminal-persistence" (1, 0) Terminal_persistence.decode
+      field_o "terminal-persistence" (1, 0) (enum Terminal_persistence.all)
     and+ sandboxing_preference =
       field_o "sandboxing_preference" (1, 0) Sandboxing_preference.decode
     and+ cache_enabled = field_o "cache" (2, 0) (Cache.Toggle.decode ~check)

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -83,15 +83,6 @@ module Dune_config : sig
     val equal : t -> t -> bool
   end
 
-  module Terminal_persistence : sig
-    type t =
-      | Preserve
-      | Clear_on_rebuild
-      | Clear_on_rebuild_and_flush_history
-
-    val all : (string * t) list
-  end
-
   module Action_output_on_success : sig
     include module type of struct
       include Dune_engine.Execution_parameters.Action_output_on_success

--- a/src/dune_config_file/import.ml
+++ b/src/dune_config_file/import.ml
@@ -1,1 +1,2 @@
 include Dune_scheduler
+include Stdune


### PR DESCRIPTION
Move Terminal_persistence from dune_config_file into stdune so console code can depend on it directly. Move the rebuild screen-clearing helper from Scheduler_setup into Console and update the build/exec call sites to use the shared helper.