### PR TITLE
refactor: store terminal persistence in Console

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -288,10 +288,8 @@ let exec_building_directly ~common ~config ~context ~prog ~args ~no_rebuild =
     let on_exit = Console.printf "Program exited with code [%d]" in
     Dune_engine.Build_loop.poll
     @@
-    let* () =
-      Fiber.return
-      @@ Console.maybe_clear_screen ~details_hum:[] config.terminal_persistence
-    in
+    let* () = Fiber.return () in
+    Console.maybe_clear_screen ~details_hum:[];
     Build.build_memo @@ step ~prog ~args ~common ~no_rebuild ~context ~on_exit
   | No ->
     Scheduler_setup.go_with_rpc_server ~common ~config

--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -1,9 +1,9 @@
 open Import
 open Scheduler
 
-let on_event ~terminal_persistence = function
+let on_event = function
   | Run.Event.Source_files_changed { details_hum } ->
-    Console.maybe_clear_screen terminal_persistence ~details_hum
+    Console.maybe_clear_screen ~details_hum
   | Build_interrupted ->
     Console.Status_line.set
       (Live
@@ -63,7 +63,6 @@ let go_without_rpc_server ~(common : Common.t) ~config:dune_config f =
     Dune_config.for_scheduler dune_config ~print_ctrl_c_warning:true ~watch_exclusions
   in
   Dune_rules.Clflags.concurrency := config.concurrency;
-  let on_event = on_event ~terminal_persistence:dune_config.terminal_persistence in
   Run.go config ~on_event f
 ;;
 
@@ -100,9 +99,5 @@ let go_with_rpc_server_and_console_status_reporting
     let* () = Root.Rpc.Global.ensure_ready () in
     run ()
   in
-  Run.go
-    config
-    ~file_watcher
-    ~on_event:(on_event ~terminal_persistence:dune_config.terminal_persistence)
-    run
+  Run.go config ~file_watcher ~on_event run
 ;;

--- a/otherlibs/stdune/src/console.ml
+++ b/otherlibs/stdune/src/console.ml
@@ -244,11 +244,21 @@ let () =
     print [ Pp.verbatim full_msg ])
 ;;
 
-let maybe_clear_screen (terminal_persistence : Terminal_persistence.t) ~details_hum =
+let terminal_persistence = ref Terminal_persistence.Preserve
+
+let init (terminal_persistence' : Terminal_persistence.t) =
+  terminal_persistence := terminal_persistence';
+  match !terminal_persistence with
+  | Preserve -> ()
+  | Clear_on_rebuild -> reset ()
+  | Clear_on_rebuild_and_flush_history -> reset_flush_history ()
+;;
+
+let maybe_clear_screen ~details_hum =
   match Execution_env.inside_dune with
   | true -> (* Don't print anything here to make tests less verbose *) ()
   | false ->
-    (match terminal_persistence with
+    (match !terminal_persistence with
      | Clear_on_rebuild -> reset ()
      | Clear_on_rebuild_and_flush_history -> reset_flush_history ()
      | Preserve ->

--- a/otherlibs/stdune/src/console.mli
+++ b/otherlibs/stdune/src/console.mli
@@ -85,7 +85,8 @@ val finish : unit -> unit
     ]} *)
 val print : User_message.Style.t Pp.t list -> unit
 
-val maybe_clear_screen : Terminal_persistence.t -> details_hum:string list -> unit
+val maybe_clear_screen : details_hum:string list -> unit
+val init : Terminal_persistence.t -> unit
 
 (** [printf fmt] is a convenient function for debugging. It formats a string and
     then print it raw followed by a newline. It is the same as:

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -688,12 +688,7 @@ module Dune_config = struct
   let init t ~watch =
     Config.init (String.Map.of_list_exn t.experimental);
     Console.Backend.set (Display.console_backend t.display);
-    if watch
-    then (
-      match t.terminal_persistence with
-      | Preserve -> ()
-      | Clear_on_rebuild -> Console.reset ()
-      | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ());
+    if watch then Console.init t.terminal_persistence;
     Stdune.Io.set_copy_impl Config.(get copy_file);
     Log.verbose
     := match t.display with


### PR DESCRIPTION
Initialize Console with the configured terminal persistence mode during Dune_config.init, and remove the explicit terminal_persistence argument from Console.maybe_clear_screen callers.