### PR TITLE
refactor: clear console directly from build loop

### DIFF
--- a/bin/scheduler_setup.ml
+++ b/bin/scheduler_setup.ml
@@ -2,9 +2,7 @@ open Import
 open Scheduler
 
 let on_event = function
-  | Run.Event.Source_files_changed { details_hum } ->
-    Console.maybe_clear_screen ~details_hum
-  | Build_interrupted ->
+  | Run.Event.Build_interrupted ->
     Console.Status_line.set
       (Live
          (fun () ->

--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -13,7 +13,7 @@ let rec poll_iter t step =
     else (
       let files = Memo.Invalidation.changed_paths invalidation in
       let details_hum = Memo.Invalidation.details_hum invalidation in
-      Scheduler.Build_loop.source_files_changed t ~details_hum;
+      Console.maybe_clear_screen ~details_hum;
       Memo.reset invalidation;
       Some files)
   in

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -468,10 +468,6 @@ module Build_loop = struct
       `Done
   ;;
 
-  let source_files_changed t ~details_hum =
-    t.handler (Source_files_changed { details_hum })
-  ;;
-
   let wait_for_build_input_change t = Trigger.wait t.build_inputs_changed
 end
 

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -13,7 +13,6 @@ end
 module Run : sig
   module Event : sig
     type t =
-      | Source_files_changed of { details_hum : string list }
       | Build_interrupted
       | Build_finish of Build_outcome.t
   end
@@ -122,7 +121,6 @@ module Build_loop : sig
   val pending_invalidation : t -> Memo.Invalidation.t
   val start_iteration : t -> changed_paths:Path.t list option -> unit
   val finish_iteration : t -> Build_outcome.t -> [ `Done | `Restart ]
-  val source_files_changed : t -> details_hum:string list -> unit
   val wait_for_build_input_change : t -> unit Fiber.t
 end
 

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -55,7 +55,6 @@ module Scheduler = struct
   module Handler = struct
     module Event = struct
       type t =
-        | Source_files_changed of { details_hum : string list }
         | Build_interrupted
         | Build_finish of Build_outcome.t
     end


### PR DESCRIPTION
Handle source-file change screen clearing in Dune_engine.Build_loop instead of routing it through a scheduler event. This removes the Source_files_changed scheduler event and the corresponding Scheduler.Build_loop API.