### PR TITLE
Fix language in rpc_tests leaking localized `diff` output

### DIFF
--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -3,7 +3,8 @@
   (env-vars
    ; We set ocaml to always be colored since it changes the output of
    ; ocamlc error messages. See https://github.com/ocaml/ocaml/issues/14144
-   (OCAML_COLOR always))))
+   (OCAML_COLOR always)
+   (LC_ALL C.UTF-8))))
 
 (library
  (name dune_rpc_e2e)
@@ -33,7 +34,8 @@
  (modules dune_rpc_diagnostics)
  (inline_tests
   (deps
-   (package dune)))
+   (package dune)
+   (env_var LC_ALL)))
  (libraries
   fiber
   stdune


### PR DESCRIPTION
Fixes #14660, and will maybe allow me to have a month or two where all tests pass on `main` :)