### PR TITLE
feat(show): include directories with targets in dune show targets

### DIFF
--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -132,11 +132,11 @@ module Aliases_cmd = struct
 end
 
 module Targets_cmd = struct
-  let fetch_results () (dir : Path.Build.t) =
+  let fetch_results all (dir : Path.Build.t) =
     let open Action_builder.O in
     let+ load_dir = Action_builder.of_memo (Load_rules.load_dir ~dir:(Path.build dir)) in
     match load_dir with
-    | Load_rules.Loaded.Build { rules_here; _ } ->
+    | Load_rules.Loaded.Build { rules_here; allowed_subdirs; _ } ->
       let file_targets =
         Path.Build.Map.keys rules_here.by_file_targets
         |> List.filter_map ~f:(fun path ->
@@ -151,11 +151,29 @@ module Targets_cmd = struct
           then Some ((Path.Build.basename path |> Filename.to_string) ^ Filename.dir_sep)
           else None)
       in
-      List.sort ~compare:String.compare (file_targets @ dir_targets)
+      let subdirs =
+        match Dune_engine.Dir_set.toplevel_subdirs allowed_subdirs with
+        | Infinite -> []
+        | Finite set ->
+          Filename.Set.to_list set
+          |> Filename.L.to_string
+          |> List.filter ~f:(fun name -> all || String.length name = 0 || name.[0] <> '.')
+          |> List.map ~f:(fun name -> name ^ Filename.dir_sep)
+      in
+      List.sort ~compare:String.compare (file_targets @ dir_targets @ subdirs)
     | _ -> []
   ;;
 
-  let term = ls_term_gen (Term.const ()) fetch_results
+  let extra_args =
+    Arg.(
+      value
+      & flag
+      & info
+          [ "a"; "all" ]
+          ~doc:(Some "Show hidden directories (those starting with '.')."))
+  ;;
+
+  let term = ls_term_gen extra_args fetch_results
 
   let command =
     let doc = "Print targets in a given directory. Works similarly to ls." in

--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -1,13 +1,13 @@
 open Import
 
-let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
+let ls_term_gen extra_args fetch_results =
   let+ builder = Common.Builder.term
   (* CR-someday Alizter: document this option *)
   and+ paths = Arg.(value & pos_all string [ "." ] & info [] ~docv:"DIR" ~doc:None)
   and+ context =
     Common.context_arg
       ~doc:(Some "The context to look in. Defaults to the default context.")
-  in
+  and+ extra = extra_args in
   let common, config = Common.init builder in
   let request (_ : Dune_rules.Main.build_system) =
     let header = List.length paths > 1 in
@@ -93,7 +93,7 @@ let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
                      User_error.raise
                        [ Pp.textf "Directory %s does not exist." (Path.to_string dir) ])))
         in
-        let+ targets = fetch_results build_dir in
+        let+ targets = fetch_results extra build_dir in
         (* If we are printing multiple directories, we print the directory
            name as a header. *)
         (if header then [ Pp.textf "%s:" (Path.to_string dir) ] else [])
@@ -110,7 +110,7 @@ let ls_term (fetch_results : Path.Build.t -> string list Action_builder.t) =
 ;;
 
 module Aliases_cmd = struct
-  let fetch_results (dir : Path.Build.t) =
+  let fetch_results () (dir : Path.Build.t) =
     let open Action_builder.O in
     let+ alias_targets =
       let+ load_dir =
@@ -123,7 +123,7 @@ module Aliases_cmd = struct
     List.map ~f:Dune_engine.Alias.Name.to_string alias_targets
   ;;
 
-  let term = ls_term fetch_results
+  let term = ls_term_gen (Term.const ()) fetch_results
 
   let command =
     let doc = "Print aliases in a given directory. Works similarly to ls." in
@@ -132,7 +132,7 @@ module Aliases_cmd = struct
 end
 
 module Targets_cmd = struct
-  let fetch_results (dir : Path.Build.t) =
+  let fetch_results () (dir : Path.Build.t) =
     let open Action_builder.O in
     let+ load_dir = Action_builder.of_memo (Load_rules.load_dir ~dir:(Path.build dir)) in
     match load_dir with
@@ -155,7 +155,7 @@ module Targets_cmd = struct
     | _ -> []
   ;;
 
-  let term = ls_term fetch_results
+  let term = ls_term_gen (Term.const ()) fetch_results
 
   let command =
     let doc = "Print targets in a given directory. Works similarly to ls." in

--- a/doc/changes/changed/14665.md
+++ b/doc/changes/changed/14665.md
@@ -1,0 +1,3 @@
+- `dune show targets` now includes subdirectories that contain build targets,
+  and accepts an `-a`/`--all` flag to also include hidden directories (those
+  starting with `.`). (#14665, fixes #13783, @Alizter)

--- a/doc/reference/cli.rst
+++ b/doc/reference/cli.rst
@@ -73,7 +73,9 @@ documentation for each command is available through ``dune COMMAND --help``.
 
       Print targets in a given directory. Works similarly to ls. The directory
       may be a path in the source tree, or a build-only directory under
-      ``_build/`` (such as ``_build/default/.lib.objs``).
+      ``_build/`` (such as ``_build/default/.lib.objs``). Subdirectories
+      containing build targets are listed alongside the targets themselves;
+      pass ``-a``/``--all`` to also include hidden directories.
 
    .. describe:: dune describe workspace
 

--- a/test/blackbox-tests/test-cases/describe/targets.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/targets.t/run.t
@@ -8,7 +8,10 @@ With no directory provided to the command, it should default to the current
 working directory.
 
   $ dune show targets
+  _doc/
+  _doc_new/
   a.ml
+  b/
   d/
   dune
   dune-project
@@ -23,7 +26,10 @@ used, and only the targets available in that directory will be displayed.
 
   $ dune show targets . b/
   .:
+  _doc/
+  _doc_new/
   a.ml
+  b/
   d/
   dune
   dune-project
@@ -45,7 +51,10 @@ used, and only the targets available in that directory will be displayed.
 The command also works with files in the _build directory.
 
   $ dune show targets _build/default/
+  _doc/
+  _doc_new/
   a.ml
+  b/
   d/
   dune
   dune-project
@@ -75,10 +84,26 @@ Build-only directories that don't exist in the source tree, like .simple.objs
 queried:
 
   $ dune show targets .simple.objs
+  byte/
   cctx.ocaml-index
+  jsoo/
+  native/
 
   $ dune show targets _build/default/.simple.objs
+  byte/
   cctx.ocaml-index
+  jsoo/
+  native/
+
+With --all, hidden directories are also shown:
+
+  $ dune show targets --all .simple.objs
+  .bin/
+  .utop/
+  byte/
+  cctx.ocaml-index
+  jsoo/
+  native/
 
 And we error on non-existent directories
 


### PR DESCRIPTION
Walk the `allowed_subdirs` of the loaded directory and surface those containing build targets in the listing. Add an `-a`/`--all` flag to also include hidden directories (those starting with `.`).

Stacked on #14664. The `refactor(show): add ls_term_gen to support extra arguments` commit is a prerequisite refactor that will be reviewed alongside this change.

- Fixes #13783
- [x] changelog
- [x] docs