### PR TITLE
feat(show): let dune show targets look inside directory targets

### DIFF
--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -49,21 +49,17 @@ let ls_term_gen extra_args fetch_results =
                   (Path.to_string_maybe_quoted dir)
               ]
         in
-        (* Check if the directory exists. *)
+        (* Check if the directory exists (in source tree, as a directory target,
+           or as a build-only directory). *)
         let* () =
           Action_builder.of_memo
           @@
           let open Memo.O in
-          (* First check if it's a directory target *)
           Load_rules.load_dir ~dir:(Path.build build_dir)
           >>= function
           | Load_rules.Loaded.Build_under_directory_target _ ->
-            User_error.raise
-              [ Pp.textf
-                  "Directory %s is a directory target. This command does not support the \
-                   inspection of directory targets."
-                  (Path.to_string dir)
-              ]
+            (* Directory target - allow it through for inspection *)
+            Memo.return ()
           | External _ | Build _ | Source _ ->
             (* Check if directory exists in source tree or is a valid build-only directory *)
             Source_tree.find_dir src_dir
@@ -134,34 +130,38 @@ end
 module Targets_cmd = struct
   let fetch_results all (dir : Path.Build.t) =
     let open Action_builder.O in
-    let+ load_dir = Action_builder.of_memo (Load_rules.load_dir ~dir:(Path.build dir)) in
-    match load_dir with
-    | Load_rules.Loaded.Build { rules_here; allowed_subdirs; _ } ->
-      let file_targets =
-        Path.Build.Map.keys rules_here.by_file_targets
-        |> List.filter_map ~f:(fun path ->
-          if Path.Build.equal (Path.Build.parent_exn path) dir
-          then Some (Path.Build.basename path |> Filename.to_string)
-          else None)
-      in
-      let dir_targets =
-        Path.Build.Map.keys rules_here.by_directory_targets
-        |> List.filter_map ~f:(fun path ->
-          if Path.Build.equal (Path.Build.parent_exn path) dir
-          then Some ((Path.Build.basename path |> Filename.to_string) ^ Filename.dir_sep)
-          else None)
-      in
-      let subdirs =
-        match Dune_engine.Dir_set.toplevel_subdirs allowed_subdirs with
-        | Infinite -> []
-        | Finite set ->
-          Filename.Set.to_list set
-          |> Filename.L.to_string
-          |> List.filter ~f:(fun name -> all || String.length name = 0 || name.[0] <> '.')
-          |> List.map ~f:(fun name -> name ^ Filename.dir_sep)
-      in
-      List.sort ~compare:String.compare (file_targets @ dir_targets @ subdirs)
-    | _ -> []
+    let* targets =
+      Action_builder.of_memo (Build_system.targets_of ~dir:(Path.build dir))
+    in
+    let+ subdirs =
+      Action_builder.of_memo
+        (let open Memo.O in
+         Load_rules.load_dir ~dir:(Path.build dir)
+         >>| function
+         | Load_rules.Loaded.Build { allowed_subdirs; _ } ->
+           (match Dune_engine.Dir_set.toplevel_subdirs allowed_subdirs with
+            | Infinite -> []
+            | Finite set ->
+              Filename.Set.to_list set
+              |> Filename.L.to_string
+              |> List.filter ~f:(fun name ->
+                all || String.length name = 0 || name.[0] <> '.')
+              |> List.map ~f:(fun name -> name ^ Filename.dir_sep))
+         | _ -> [])
+    in
+    let target_names =
+      match Dune_targets.validate targets with
+      | Valid validated ->
+        Dune_targets.Validated.fold
+          validated
+          ~init:[]
+          ~file:(fun p acc -> (Path.Build.basename p |> Filename.to_string) :: acc)
+          ~dir:(fun p acc ->
+            ((Path.Build.basename p |> Filename.to_string) ^ Filename.dir_sep) :: acc)
+      | No_targets -> []
+      | Inconsistent_parent_dir | File_and_directory_target_with_the_same_name _ -> []
+    in
+    List.sort ~compare:String.compare (target_names @ subdirs)
   ;;
 
   let extra_args =

--- a/doc/changes/changed/14666.md
+++ b/doc/changes/changed/14666.md
@@ -1,0 +1,2 @@
+- `dune show targets` now looks inside directory targets, so users can inspect
+  the files produced under a directory target. (#14666, fixes #13780, @Alizter)

--- a/doc/reference/cli.rst
+++ b/doc/reference/cli.rst
@@ -72,10 +72,11 @@ documentation for each command is available through ``dune COMMAND --help``.
    .. describe:: dune describe targets
 
       Print targets in a given directory. Works similarly to ls. The directory
-      may be a path in the source tree, or a build-only directory under
-      ``_build/`` (such as ``_build/default/.lib.objs``). Subdirectories
-      containing build targets are listed alongside the targets themselves;
-      pass ``-a``/``--all`` to also include hidden directories.
+      may be a path in the source tree, a build-only directory under
+      ``_build/`` (such as ``_build/default/.lib.objs``), or a directory
+      target (including subdirectories of one). Subdirectories containing
+      build targets are listed alongside the targets themselves; pass
+      ``-a``/``--all`` to also include hidden directories.
 
    .. describe:: dune describe workspace
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1062,6 +1062,57 @@ let files_of ~dir =
     Filename_set.create ~dir filenames
 ;;
 
+let targets_of ~dir =
+  Load_rules.load_dir ~dir
+  >>= function
+  | Source _ | External _ ->
+    (* Source/external dirs have no build targets *)
+    Memo.return Targets.empty
+  | Build { rules_here; _ } ->
+    let files =
+      Path.Build.Map.keys rules_here.by_file_targets |> Path.Build.Set.of_list
+    in
+    let dirs =
+      Path.Build.Map.keys rules_here.by_directory_targets |> Path.Build.Set.of_list
+    in
+    Memo.return (Targets.create ~files ~dirs)
+  | Build_under_directory_target { directory_target_ancestor } ->
+    let+ produced = build_dir (Path.build directory_target_ancestor) in
+    let build_dir_path = Path.as_in_build_dir_exn dir in
+    (* Navigate to the requested directory within the produced targets *)
+    let rec find_dir_contents (contents : _ Targets.Produced.dir_contents) path =
+      match path with
+      | [] -> Some contents
+      | component :: rest ->
+        (match Filename.Map.find contents.subdirs component with
+         | Some sub -> find_dir_contents sub rest
+         | None -> None)
+    in
+    let path_within =
+      match
+        Path.Local.descendant
+          (Path.Build.local build_dir_path)
+          ~of_:(Path.Build.local produced.root)
+      with
+      | Some p -> Path.Local.explode p
+      | None -> []
+    in
+    (match find_dir_contents produced.contents path_within with
+     | Some contents ->
+       let files =
+         Filename.Map.keys contents.files
+         |> List.map ~f:(Path.Build.relative_fname build_dir_path)
+         |> Path.Build.Set.of_list
+       in
+       let dirs =
+         Filename.Map.keys contents.subdirs
+         |> List.map ~f:(Path.Build.relative_fname build_dir_path)
+         |> Path.Build.Set.of_list
+       in
+       Targets.create ~files ~dirs
+     | None -> Targets.empty)
+;;
+
 let caused_by_cancellation (exn : Exn_with_backtrace.t) =
   match exn.exn with
   | Scheduler.Run.Build_cancelled -> true

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -35,6 +35,10 @@ val eval_pred : File_selector.t -> Filename_set.t Memo.t
 (** Same as [eval_pred] with [Predicate.true_] as predicate. *)
 val files_of : dir:Path.t -> Filename_set.t Memo.t
 
+(** Return all targets (files and directories) in a directory.
+    Handles directory targets by building them first. *)
+val targets_of : dir:Path.t -> Targets.t Memo.t
+
 (** Execute an action. The execution is cached. *)
 val execute_action : observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> unit Memo.t
 

--- a/test/blackbox-tests/test-cases/describe/targets.t/dune
+++ b/test/blackbox-tests/test-cases/describe/targets.t/dune
@@ -5,5 +5,5 @@
  (targets (dir d))
  (action
   (progn
-   (run mkdir d)
-   (run cat > d/foo))))
+   (run mkdir -p d/subdir)
+   (run touch d/foo d/bar d/subdir/nested))))

--- a/test/blackbox-tests/test-cases/describe/targets.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/targets.t/run.t
@@ -73,11 +73,28 @@ The command also works with files in the _build directory.
   simple2.cmxs
   simple2.ml-gen
 
-We cannot see inside directory targets
+We can see inside directory targets. The directory target `d` contains files
+and a subdirectory.
 
   $ dune show targets d
-  Error: Directory d is a directory target. This command does not support the
-  inspection of directory targets.
+  bar
+  foo
+  subdir/
+
+We can also inspect directory targets using the _build path:
+
+  $ dune show targets _build/default/d
+  bar
+  foo
+  subdir/
+
+We can also look inside subdirectories of directory targets:
+
+  $ dune show targets d/subdir
+  nested
+
+  $ dune show targets _build/default/d/subdir
+  nested
 
 Build-only directories that don't exist in the source tree, like .simple.objs
 (Dune's internal object directory for the `simple` library), can now be


### PR DESCRIPTION
Introduce `Build_system.targets_of` to resolve the targets at a given build directory, including paths underneath directory targets. The listing uses validated targets so users can inspect the contents of directory targets directly.

Stacked on #14665.

- Fixes #13780
- [x] changelog
- [x] docs