### PR TITLE
feat(show): hide source files by default in dune show targets

### DIFF
--- a/bin/describe/aliases_targets.ml
+++ b/bin/describe/aliases_targets.ml
@@ -135,14 +135,20 @@ module Targets_cmd = struct
   let fetch_results all (dir : Path.Build.t) =
     let open Action_builder.O in
     let+ load_dir = Action_builder.of_memo (Load_rules.load_dir ~dir:(Path.build dir)) in
+    let only_generated = not all in
     match load_dir with
     | Load_rules.Loaded.Build { rules_here; allowed_subdirs; _ } ->
       let file_targets =
-        Path.Build.Map.keys rules_here.by_file_targets
-        |> List.filter_map ~f:(fun path ->
-          if Path.Build.equal (Path.Build.parent_exn path) dir
-          then Some (Path.Build.basename path |> Filename.to_string)
-          else None)
+        Path.Build.Map.foldi
+          rules_here.by_file_targets
+          ~init:[]
+          ~f:(fun path { Dune_engine.Rule.info; _ } acc ->
+            match info with
+            | Dune_engine.Rule.Info.Source_file_copy _ when only_generated -> acc
+            | _ ->
+              if Path.Build.equal (Path.Build.parent_exn path) dir
+              then (Path.Build.basename path |> Filename.to_string) :: acc
+              else acc)
       in
       let dir_targets =
         Path.Build.Map.keys rules_here.by_directory_targets
@@ -170,7 +176,8 @@ module Targets_cmd = struct
       & flag
       & info
           [ "a"; "all" ]
-          ~doc:(Some "Show hidden directories (those starting with '.')."))
+          ~doc:
+            (Some "Show all targets including source file copies and hidden directories."))
   ;;
 
   let term = ls_term_gen extra_args fetch_results

--- a/doc/changes/changed/14667.md
+++ b/doc/changes/changed/14667.md
@@ -1,0 +1,3 @@
+- `dune show targets` now hides source-file copies by default; pass
+  `-a`/`--all` to also show source-file copies and hidden directories.
+  (#14667, fixes #13779, @Alizter)

--- a/doc/reference/cli.rst
+++ b/doc/reference/cli.rst
@@ -74,8 +74,9 @@ documentation for each command is available through ``dune COMMAND --help``.
       Print targets in a given directory. Works similarly to ls. The directory
       may be a path in the source tree, or a build-only directory under
       ``_build/`` (such as ``_build/default/.lib.objs``). Subdirectories
-      containing build targets are listed alongside the targets themselves;
-      pass ``-a``/``--all`` to also include hidden directories.
+      containing build targets are listed alongside the targets themselves.
+      By default, source-file copies are hidden; pass ``-a``/``--all`` to
+      also include source-file copies and hidden directories.
 
    .. describe:: dune describe workspace
 

--- a/test/blackbox-tests/test-cases/describe/targets.t/run.t
+++ b/test/blackbox-tests/test-cases/describe/targets.t/run.t
@@ -5,16 +5,13 @@ We have two libraries with one in a subdirectory. We also have a directory
 target d to see how the command will behave.
 
 With no directory provided to the command, it should default to the current
-working directory.
+working directory. By default, source files are hidden.
 
   $ dune show targets
   _doc/
   _doc_new/
-  a.ml
   b/
   d/
-  dune
-  dune-project
   simple.a
   simple.cma
   simple.cmxa
@@ -28,11 +25,8 @@ used, and only the targets available in that directory will be displayed.
   .:
   _doc/
   _doc_new/
-  a.ml
   b/
   d/
-  dune
-  dune-project
   simple.a
   simple.cma
   simple.cmxa
@@ -40,8 +34,6 @@ used, and only the targets available in that directory will be displayed.
   simple.ml-gen
   
   b:
-  c.ml
-  dune
   simple2.a
   simple2.cma
   simple2.cmxa
@@ -51,6 +43,35 @@ used, and only the targets available in that directory will be displayed.
 The command also works with files in the _build directory.
 
   $ dune show targets _build/default/
+  _doc/
+  _doc_new/
+  b/
+  d/
+  simple.a
+  simple.cma
+  simple.cmxa
+  simple.cmxs
+  simple.ml-gen
+
+  $ dune show targets _build/default/b
+  simple2.a
+  simple2.cma
+  simple2.cmxa
+  simple2.cmxs
+  simple2.ml-gen
+
+Using --all shows source file copies too:
+
+  $ dune show targets --all
+  .bin/
+  .dune/
+  .js/
+  .merlin-conf/
+  .parameterised/
+  .ppx/
+  .simple.objs/
+  .topmod/
+  .utop/
   _doc/
   _doc_new/
   a.ml
@@ -63,15 +84,6 @@ The command also works with files in the _build directory.
   simple.cmxa
   simple.cmxs
   simple.ml-gen
-
-  $ dune show targets _build/default/b
-  c.ml
-  dune
-  simple2.a
-  simple2.cma
-  simple2.cmxa
-  simple2.cmxs
-  simple2.ml-gen
 
 We cannot see inside directory targets
 


### PR DESCRIPTION
Filter out `Source_file_copy` rules from `dune show targets` by default, so the listing shows generated artifacts rather than copies of source files. The existing `-a`/`--all` flag, which previously only revealed hidden directories, now also opts back in to source-file copies.

- Fixes #13779
- [x] changelog
- [x] docs