### PR TITLE
fix: clearer error when %{target} is used without a (target ...) field

### DIFF
--- a/doc/changes/fixed/14668.md
+++ b/doc/changes/fixed/14668.md
@@ -1,0 +1,4 @@
+- Reword the error raised when `%{target}` is used in a rule that omits the
+  `(target ...)` (or `(targets ...)`) field, so it points at the missing
+  field instead of mentioning "inferred rules". (#14668, fixes #12439,
+  @Alizter)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -273,7 +273,8 @@ let[@inline never] invalid_use_of_target_variable
        User_error.raise
          ~loc:source.loc
          [ Pp.textf
-             "You cannot use %s with inferred rules."
+             "You cannot use %s unless the rule has a (target ...) or (targets ...) \
+              field."
              (Dune_lang.Template.Pform.describe source)
          ]
      | Static { targets = _; multiplicity } ->

--- a/test/blackbox-tests/test-cases/rule-target-inferrence/target-pform-without-target-field.t
+++ b/test/blackbox-tests/test-cases/rule-target-inferrence/target-pform-without-target-field.t
@@ -13,5 +13,6 @@ https://github.com/ocaml/dune/issues/12439.
   File "dune", line 3, characters 14-23:
   3 |   (write-file %{target} hello)))
                     ^^^^^^^^^
-  Error: You cannot use %{target} with inferred rules.
+  Error: You cannot use %{target} unless the rule has a (target ...) or
+  (targets ...) field.
   [1]

--- a/test/blackbox-tests/test-cases/rule-target-inferrence/target-pform-without-target-field.t
+++ b/test/blackbox-tests/test-cases/rule-target-inferrence/target-pform-without-target-field.t
@@ -1,0 +1,17 @@
+When a rule uses %{target} but omits the (target ...) field, dune should
+produce a clear error message pointing the user at the missing field. See
+https://github.com/ocaml/dune/issues/12439.
+
+  $ make_dune_project 3.24
+  $ cat > dune <<EOF
+  > (rule
+  >  (action
+  >   (write-file %{target} hello)))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 14-23:
+  3 |   (write-file %{target} hello)))
+                    ^^^^^^^^^
+  Error: You cannot use %{target} with inferred rules.
+  [1]


### PR DESCRIPTION
This PR rewords the error raised when `%{target}` is used in a rule that has no `(target ...)` field, so it points at the missing field instead of mentioning "inferred rules".

- Fixes #12439.
- [x] changelog