### PR TITLE
Keep watch changed paths out of the scheduler

### DIFF
--- a/src/dune_engine/build_loop.ml
+++ b/src/dune_engine/build_loop.ml
@@ -24,19 +24,13 @@ let build_finish (build_result : Build_outcome.t) =
 
 let rec poll_iter t step =
   let invalidation = Scheduler.Build_loop.pending_invalidation t in
-  let changed_paths =
-    if Memo.Invalidation.is_empty invalidation
-    then (
-      Memo.Metrics.reset ();
-      None)
-    else (
-      let files = Memo.Invalidation.changed_paths invalidation in
-      let details_hum = Memo.Invalidation.details_hum invalidation in
-      Console.maybe_clear_screen ~details_hum;
-      Memo.reset invalidation;
-      Some files)
-  in
-  Scheduler.Build_loop.start_iteration t ~changed_paths;
+  if Memo.Invalidation.is_empty invalidation
+  then Memo.Metrics.reset ()
+  else (
+    let details_hum = Memo.Invalidation.details_hum invalidation in
+    Console.maybe_clear_screen ~details_hum;
+    Memo.reset invalidation);
+  Scheduler.Build_loop.start_iteration t;
   let* res = step in
   let res : Build_outcome.t =
     match res with

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1112,14 +1112,10 @@ let run f =
   in
   let open Fiber.O in
   let f () =
-    let run_id, `Changed_paths files = Scheduler.Build_loop.start_build () in
+    let run_id, `Restart restart = Scheduler.Build_loop.start_build () in
     let start = Time.now () in
     Dune_trace.emit ~buffered:false Build (fun () ->
-      Dune_trace.Event.watch_build_start
-        ~run_id:(Run_id.to_int run_id)
-        ~restart:(Option.is_some files)
-        ~files
-        ~start);
+      Dune_trace.Event.watch_build_start ~run_id:(Run_id.to_int run_id) ~restart ~start);
     Dune_trace.reset_alloc_profile ();
     (* CR-someday amokhov: Currently we invalidate cached timestamps on every
        incremental rebuild. This conservative approach helps us to work around

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -205,7 +205,6 @@ let prepare (config : Config.t) ~(handler : Handler.t) ~events ~file_watcher =
     ; invalidation = Memo.Invalidation.empty
     ; run_id_state = Run_id.State.create ~watch_mode:(Option.is_some file_watcher)
     ; watch_restart_started_at = None
-    ; watch_restart_files = None
     ; handler
     ; build_inputs_changed = Trigger.create ()
     ; cancel
@@ -404,8 +403,9 @@ module Build_loop = struct
   let start_build () =
     let build_loop = (t ()).build_loop in
     let state, run_id = Run_id.State.start build_loop.run_id_state in
+    let restart = Option.is_some build_loop.watch_restart_started_at in
     build_loop.run_id_state <- state;
-    run_id, `Changed_paths build_loop.watch_restart_files
+    run_id, `Restart restart
   ;;
 
   let finish_build ~stop =
@@ -416,7 +416,6 @@ module Build_loop = struct
           Time.diff stop restart_started_at)
       in
       build_loop.watch_restart_started_at <- None;
-      build_loop.watch_restart_files <- None;
       Finished { restart_duration }
     in
     match build_loop.status with
@@ -441,11 +440,9 @@ module Build_loop = struct
 
   let pending_invalidation t = t.invalidation
 
-  let start_iteration t ~changed_paths =
-    t.watch_restart_files <- changed_paths;
-    Option.iter changed_paths ~f:(fun (_ : Path.t list) ->
-      t.invalidation <- Memo.Invalidation.empty;
-      t.build_inputs_changed <- Trigger.create ());
+  let start_iteration t =
+    t.invalidation <- Memo.Invalidation.empty;
+    t.build_inputs_changed <- Trigger.create ();
     (match t.status with
      | Building _ -> assert false
      | Standing_by | Restarting_build -> ());
@@ -461,7 +458,6 @@ module Build_loop = struct
     | Building _ ->
       t.status <- Standing_by;
       t.watch_restart_started_at <- None;
-      t.watch_restart_files <- None;
       `Done
   ;;
 

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -113,11 +113,11 @@ module Build_loop : sig
     | Restarting
 
   val is_watch_mode : unit -> bool
-  val start_build : unit -> Run_id.t * [ `Changed_paths of Path.t list option ]
+  val start_build : unit -> Run_id.t * [ `Restart of bool ]
   val finish_build : stop:Time.t -> build_finish
   val init : unit -> t Fiber.t
   val pending_invalidation : t -> Memo.Invalidation.t
-  val start_iteration : t -> changed_paths:Path.t list option -> unit
+  val start_iteration : t -> unit
   val finish_iteration : t -> [ `Done | `Restart ]
   val wait_for_build_input_change : t -> unit Fiber.t
 end

--- a/src/dune_scheduler/types.ml
+++ b/src/dune_scheduler/types.ml
@@ -76,7 +76,6 @@ module Scheduler = struct
       ; mutable invalidation : Memo.Invalidation.t
       ; mutable run_id_state : Run_id.State.t
       ; mutable watch_restart_started_at : Time.t option
-      ; mutable watch_restart_files : Path.t list option
       ; handler : Handler.t
       ; mutable build_inputs_changed : Trigger.t
       ; mutable cancel : Fiber.Cancel.t

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -128,14 +128,7 @@ module Event : sig
   val process_cleanup_start : unit -> t
   val process_cleanup_sigkill : unit -> t
   val process_cleanup_finish : unit -> t
-
-  val watch_build_start
-    :  run_id:int
-    -> restart:bool
-    -> files:Path.t list option
-    -> start:Time.t
-    -> t
-
+  val watch_build_start : run_id:int -> restart:bool -> start:Time.t -> t
   val watch_build_restart : run_id:int -> reasons:string list -> at:Time.t -> t
 
   val watch_build_finish

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -241,12 +241,9 @@ let process_cleanup_finish () =
   Event.instant ~name:"process-cleanup-finish" (Time.now ()) Process
 ;;
 
-let watch_build_start ~run_id ~restart ~files ~start =
+let watch_build_start ~run_id ~restart ~start =
   let args =
     [ "run_id", Arg.int run_id; "restart", Arg.bool restart ]
-    @ (match files with
-       | None -> []
-       | Some files -> [ "files", Arg.list (List.map files ~f:Arg.path) ])
     @ make_rusage_args (Proc.Resource_usage.get_self ())
   in
   Event.instant ~name:"build-start" ~args start Build

--- a/test/blackbox-tests/test-cases/trace/watch-build-events.t
+++ b/test/blackbox-tests/test-cases/trace/watch-build-events.t
@@ -127,10 +127,6 @@ restart events so the test checks the run id and reasons, not the batching.
     "args": {
       "run_id": 2,
       "restart": true,
-      "files": [
-        "x",
-        "z"
-      ],
       "rusage": [
         "inblock",
         "majflt",


### PR DESCRIPTION
The polling build loop already consumes memo invalidations before starting a new iteration, so the scheduler does not need to store changed paths just to report them back to build tracing.

Have the scheduler track only whether a build is a restart, and drop the changed file list from build-start trace events. The restart reasons are still reported by build-restart events.