### PR TITLE
refactor(inotify): process raw events on watcher thread

### DIFF
--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -370,30 +370,27 @@ let spawn_external_watcher ~backend ~watch_exclusions =
 ;;
 
 let create_inotifylib_watcher ~sync_table ~(scheduler : Scheduler.t) should_exclude =
-  Inotify.create
-    ~modify_event_selector:`Closed_writable_fd
-    ~send_emit_events_job_to_scheduler:(fun f ->
-      scheduler.thread_safe_send_emit_events_job (fun () ->
-        let events = f () in
-        List.concat_map events ~f:(fun event ->
-          let is_fs_sync_event_generated_by_dune =
-            match (event : Inotify.Event.t) with
-            | Modified path | Created path | Unlinked path ->
-              Option.some_if
-                (Fs_sync.is_special_file ~path_as_reported_by_file_watcher:path)
-                path
-            | Moved _ | Queue_overflow -> None
-          in
-          let events =
-            match is_fs_sync_event_generated_by_dune with
-            | None -> process_inotify_event event should_exclude
-            | Some path ->
-              (match Fs_sync.consume_event sync_table path with
-               | None -> []
-               | Some id -> [ Event.Sync id ])
-          in
-          emit_events events;
-          events)))
+  Inotify.create ~modify_event_selector:`Closed_writable_fd ~emit_events:(fun events ->
+    scheduler.thread_safe_send_emit_events_job (fun () ->
+      List.concat_map events ~f:(fun event ->
+        let is_fs_sync_event_generated_by_dune =
+          match (event : Inotify.Event.t) with
+          | Modified path | Created path | Unlinked path ->
+            Option.some_if
+              (Fs_sync.is_special_file ~path_as_reported_by_file_watcher:path)
+              path
+          | Moved _ | Queue_overflow -> None
+        in
+        let events =
+          match is_fs_sync_event_generated_by_dune with
+          | None -> process_inotify_event event should_exclude
+          | Some path ->
+            (match Fs_sync.consume_event sync_table path with
+             | None -> []
+             | Some id -> [ Event.Sync id ])
+        in
+        emit_events events;
+        events)))
 ;;
 
 let create_external_fswatch ~(scheduler : Scheduler.t) ~backend ~watch_exclusions =

--- a/src/dune_scheduler/inotify.ml
+++ b/src/dune_scheduler/inotify.ml
@@ -1,13 +1,15 @@
 open Stdune
 
-(** We don't make calls to [Inotify] functions ([add_watch], [rm_watch]) in a
-    separate thread because:
+(** Calls to [add] are made by client threads, while raw events are processed on
+    the watcher thread. [t.mutex] protects [watch_table], and [add] holds it
+    across [Inotify.add_watch] and the following [watch_table] update so the
+    watcher thread cannot process an event for the new watch before the table is
+    populated.
 
-    - we don't think they can block for a while
-    - Inotify doesn't release the OCaml lock anyway
-    - it avoids racing with the select loop below, by preventing adding a watch
-      and seeing an event about it before having filled the hashtable (not that
-      we have observed this particular race). *)
+    We still call [Inotify.add_watch] synchronously because:
+
+    - we don't think it can block for a while
+    - Inotify doesn't release the OCaml lock anyway *)
 
 module Inotify = Ocaml_inotify.Inotify
 
@@ -56,8 +58,9 @@ end
 
 type t =
   { fd : Fd.t
+  ; mutex : Mutex.t
   ; watch_table : (Inotify_watch.t, string) Table.t
-  ; send_emit_events_job_to_scheduler : (unit -> Event.t list) -> unit
+  ; emit_events : Event.t list -> unit
   ; select_events : Inotify.selector list
   }
 
@@ -67,44 +70,45 @@ type modify_event_selector =
   ]
 
 let add t path =
-  let watch =
-    Inotify.add_watch (Fd.unsafe_to_unix_file_descr t.fd) path t.select_events
-  in
-  (* XXX why are we just overwriting existing watches? *)
-  Table.set t.watch_table watch path
+  Mutex.protect t.mutex (fun () ->
+    let watch =
+      Inotify.add_watch (Fd.unsafe_to_unix_file_descr t.fd) path t.select_events
+    in
+    (* XXX why are we just overwriting existing watches? *)
+    Table.set t.watch_table watch path)
 ;;
 
 let process_raw_events t events =
-  let watch_table = t.watch_table in
   let ev_kinds =
-    List.concat_map events ~f:(fun (watch, ev_kinds, trans_id, fn) ->
-      if
-        Inotify.int_of_watch watch = -1
-        (* queue overflow event is always reported on watch -1 *)
-      then
-        List.filter_map ev_kinds ~f:(fun ev ->
-          match ev with
-          | Inotify.Q_overflow -> Some (ev, trans_id, "<overflow>")
-          | _ -> None)
-      else (
-        match Table.find watch_table watch with
-        | None ->
-          Console.print
-            [ Pp.verbatimf
-                "Events for an unknown watch (%d) [%s]\n"
-                (Inotify.int_of_watch watch)
-                (String.concat
-                   ~sep:", "
-                   (List.map ev_kinds ~f:Inotify.string_of_event_kind))
-            ];
-          []
-        | Some path ->
-          let fn =
-            match fn with
-            | None -> path
-            | Some fn -> Filename.concat path fn
-          in
-          List.map ev_kinds ~f:(fun ev -> ev, trans_id, fn)))
+    Mutex.protect t.mutex (fun () ->
+      List.concat_map events ~f:(fun (watch, ev_kinds, trans_id, fn) ->
+        if
+          Inotify.int_of_watch watch = -1
+          (* queue overflow event is always reported on watch -1 *)
+        then
+          List.filter_map ev_kinds ~f:(fun ev ->
+            match ev with
+            | Inotify.Q_overflow -> Some (ev, trans_id, "<overflow>")
+            | _ -> None)
+        else (
+          match Table.find t.watch_table watch with
+          | None ->
+            Console.print
+              [ Pp.verbatimf
+                  "Events for an unknown watch (%d) [%s]\n"
+                  (Inotify.int_of_watch watch)
+                  (String.concat
+                     ~sep:", "
+                     (List.map ev_kinds ~f:Inotify.string_of_event_kind))
+              ];
+            []
+          | Some path ->
+            let fn =
+              match fn with
+              | None -> path
+              | Some fn -> Filename.concat path fn
+            in
+            List.map ev_kinds ~f:(fun ev -> ev, trans_id, fn))))
   in
   let pending_mv, actions =
     List.fold_left
@@ -146,16 +150,14 @@ let pump_events t =
     Thread0.spawn ~name:"file-watcher" (fun () ->
       while true do
         match UnixLabels.select ~read:[ fd ] ~write:[] ~except:[] ~timeout:(-1.) with
-        | _, _, _ ->
-          let events = Inotify.read fd in
-          t.send_emit_events_job_to_scheduler (fun () -> process_raw_events t events)
         | exception Unix.Unix_error (EINTR, _, _) -> ()
+        | _, _, _ -> Inotify.read fd |> process_raw_events t |> t.emit_events
       done)
   in
   ()
 ;;
 
-let create ~modify_event_selector ~send_emit_events_job_to_scheduler =
+let create ~modify_event_selector ~emit_events =
   let fd = Inotify.create () |> Fd.unsafe_of_unix_file_descr in
   let watch_table = Table.create (module Inotify_watch) 10 in
   let modify_selector : Inotify.selector =
@@ -165,10 +167,11 @@ let create ~modify_event_selector ~send_emit_events_job_to_scheduler =
   in
   let t =
     { fd
+    ; mutex = Mutex.create ()
     ; watch_table
     ; select_events =
         [ S_Create; S_Delete; modify_selector; S_Move_self; S_Moved_from; S_Moved_to ]
-    ; send_emit_events_job_to_scheduler
+    ; emit_events
     }
   in
   pump_events t;

--- a/src/dune_scheduler/inotify.mli
+++ b/src/dune_scheduler/inotify.mli
@@ -5,11 +5,9 @@
 
     See [man 7 inotify] for the raw inotify documentation.
 
-    The state maintained by [t] is not thread-safe and can only be interacted
-    with in the context of a "scheduler" (async scheduler or fiber scheduler in
-    dune). We assume that [add] is called in the context of the scheduler and
-    that [send_emit_events_job_to_scheduler f] runs [f] in the context of the
-    scheduler.
+    Event processing runs on a background thread. [emit_events] is called from
+    that thread and is responsible for transferring events to the scheduler if
+    needed.
 
     Be aware that the interface of inotify makes it easy to write code with race
     conditions or other subtle pitfalls. For instance, stat'ing a file then
@@ -51,16 +49,12 @@ type modify_event_selector =
         events (for large files), but they come later. *)
   ]
 
-(** [create path] creates an inotify watching path. Returns the inotify type t
-    itself and the list of files currently being watched. By default,
-    recursively watches all subdirectories of the given path. See [add_all] for
-    caveats.
+(** [create] creates an inotify watcher.
 
-    [send_emit_events_job_to_scheduler f] is expected to run the job [f] in the
-    scheduler, and then process the events returned by that job. *)
+    [emit_events] is called with events emitted by the watcher. *)
 val create
   :  modify_event_selector:modify_event_selector
-  -> send_emit_events_job_to_scheduler:((unit -> Event.t list) -> unit)
+  -> emit_events:(Event.t list -> unit)
   -> t
 
 (** [add t path] add the path to t to be watched. The operation is synchronous,

--- a/test/expect-tests/inotify_tests/inotify_tests.ml
+++ b/test/expect-tests/inotify_tests/inotify_tests.ml
@@ -56,23 +56,20 @@ let watch, collect_events =
   let inotify =
     Inotify.create
       ~modify_event_selector:`Closed_writable_fd
-      ~send_emit_events_job_to_scheduler:(fun f ->
+      ~emit_events:(fun file_events ->
         Mutex.protect mutex (fun () ->
-          Queue.push events f;
+          Queue.push events file_events;
           Condition.signal cond))
   in
   let watch fn = Inotify.add inotify fn in
   watch beginning_of_test_file;
   watch end_of_test_file;
   let next_events () =
-    let f =
-      Mutex.protect mutex (fun () ->
-        while Queue.is_empty events do
-          Condition.wait cond mutex
-        done;
-        Queue.pop_exn events)
-    in
-    f ()
+    Mutex.protect mutex (fun () ->
+      while Queue.is_empty events do
+        Condition.wait cond mutex
+      done;
+      Queue.pop_exn events)
   in
   let rec collect_events acc = function
     | [] ->


### PR DESCRIPTION
Translate raw inotify events before handing them to the scheduler. Protect the watch table with a mutex so adding a watch remains atomic with publishing its path, and update callers to consume already-processed events.