### PR TITLE
Pass watch mode into the RPC server

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1178,7 +1178,11 @@ let build (root : Workspace_root.t) (builder : Builder.t) =
              | Yes Passive -> Some (Time.Span.of_secs 1.0)
              | _ -> None
            in
-           Dune_rpc_impl.Server.create ~lock_timeout ~registry ~root:root.dir))
+           Dune_rpc_impl.Server.create
+             ~lock_timeout
+             ~registry
+             ~root:root.dir
+             builder.watch))
     else `Forbid_builds
   in
   { builder; root; rpc }

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -35,6 +35,7 @@ module Run = struct
     ; server : Csexp_rpc.Server.t Lazy.t
     ; startup_ivar : (Csexp_rpc.Server.t, Exn_with_backtrace.t) result Fiber.Ivar.t
     ; registry : [ `Add | `Skip ]
+    ; watch_mode : Watch_mode_config.t
     }
 
   let run t =
@@ -391,11 +392,12 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
   in
   let () =
     let f _ () =
-      if Scheduler.Build_loop.is_watch_mode ()
-      then
+      let t = Fdecl.get t in
+      match t.server.config.watch_mode with
+      | No -> Fiber.return `Not_in_watch_mode
+      | Yes _ ->
         let+ () = Scheduler.flush_file_watcher () in
         `Ok
-      else Fiber.return `Not_in_watch_mode
     in
     Handler.implement_request rpc Procedures.Public.flush_file_watcher f
   in
@@ -488,7 +490,7 @@ let handler (t : _ t Fdecl.t) : 'build_arg Handler.t =
   rpc
 ;;
 
-let create ~lock_timeout ~registry ~root =
+let create ~lock_timeout ~registry ~root watch_mode =
   let where = Where.default () in
   Global_lock.lock_exn ~timeout:lock_timeout;
   let t = Fdecl.create Dyn.opaque in
@@ -521,6 +523,7 @@ let create ~lock_timeout ~registry ~root =
     ; server
     ; registry
     ; startup_ivar = Fiber.Ivar.create ()
+    ; watch_mode
     }
   in
   let server = { config; clients = Clients.empty } in

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -9,6 +9,7 @@ val create
   :  lock_timeout:Time.Span.t option
   -> registry:[ `Add | `Skip ]
   -> root:string
+  -> Watch_mode_config.t
   -> Dune_lang.Dep_conf.t t
 
 type 'build_arg pending_action_kind =

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -398,8 +398,6 @@ module Build_loop = struct
     | Finished of { restart_duration : Time.Span.t option }
     | Restarting
 
-  let is_watch_mode () = Run_id.State.is_watch (t ()).build_loop.run_id_state
-
   let start_build () =
     let build_loop = (t ()).build_loop in
     let state, run_id = Run_id.State.start build_loop.run_id_state in

--- a/src/dune_scheduler/scheduler.mli
+++ b/src/dune_scheduler/scheduler.mli
@@ -112,7 +112,6 @@ module Build_loop : sig
     | Finished of { restart_duration : Time.Span.t option }
     | Restarting
 
-  val is_watch_mode : unit -> bool
   val start_build : unit -> Run_id.t * [ `Restart of bool ]
   val finish_build : stop:Time.t -> build_finish
   val init : unit -> t Fiber.t


### PR DESCRIPTION
Record the configured watch mode in the RPC server and use it to gate the flush_file_watcher request instead of querying scheduler build-loop state. This lets the scheduler drop its is_watch_mode helper.