### PR TITLE
feat(install): merge overlapping (install (dirs ...))

### DIFF
--- a/doc/changes/fixed/14692.md
+++ b/doc/changes/fixed/14692.md
@@ -1,0 +1,3 @@
+- `(install (dirs ...))` entries that resolve to the same destination now
+  merge instead of crashing. Requires `(lang dune 3.24)`. (#14692, fixes
+  #13307, @Alizter)

--- a/doc/reference/dune/install.rst
+++ b/doc/reference/dune/install.rst
@@ -244,6 +244,39 @@ More precisely, when installing a file via an ``(install ...)`` stanza, Dune
 implicitly adds the ``.exe`` extension to the destination, if the source file
 has extension ``.exe`` or ``.bc`` and if it's not already present
 
+Installing Directory Targets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install a directory target (see :doc:`/reference/dune/rule`), the
+``dirs`` field can be used:
+
+.. code:: dune
+
+   (rule
+    (target (dir generated))
+    (action (run ./gen.sh %{target})))
+   (install
+    (section share)
+    (dirs generated))
+
+This example results in the contents of the ``generated`` directory
+target being installed under ``<prefix>/share/<package>/generated/``.
+
+As with ``(files ...)`` the destination can be changed with the ``as``
+keyword. For example, to install the contents of ``generated`` directly
+into ``<prefix>/share/<package>/`` you can write:
+
+.. code:: dune
+
+   (install
+    (section share)
+    (dirs (generated as .)))
+
+Starting in 3.24, multiple ``(install (dirs ...))`` entries can resolve
+to the same destination directory; their contents are combined. Two
+entries that would install the same file under that destination report
+an error.
+
 Installing Source Directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1201,10 +1201,7 @@ let build_file p =
   ()
 ;;
 
-let build_dir p =
-  let+ (_ : Digest.t Targets.Produced.t) = build_dir p in
-  ()
-;;
+let build_dir p = build_dir (Path.build p)
 
 let with_file p ~f =
   let+ () = build_file p in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -5,8 +5,8 @@ open Import
 (** Build a target, which may be a file or a directory. *)
 val build_file : Path.t -> unit Memo.t
 
-(** Build a directory. *)
-val build_dir : Path.t -> unit Memo.t
+(** Build a directory target and return its produced files. *)
+val build_dir : Path.Build.t -> Digest.t Targets.Produced.t Memo.t
 
 (** Build a file and read its contents with [f]. The execution of [f] is not memoized, so
     call sites should be careful to avoid duplicating [f]'s work. *)

--- a/src/dune_engine/fs.ml
+++ b/src/dune_engine/fs.ml
@@ -8,7 +8,7 @@ let dir_contents (dir : Path.t) =
     Fs_memo.dir_contents dir >>| Result.map ~f:Fs_memo.Dir_contents.to_list
   | `Inside _ ->
     let* already_exists = Build_system.file_exists dir in
-    let+ () = if already_exists then Build_system.build_dir dir else Memo.return () in
+    let+ () = if already_exists then Build_system.build_file dir else Memo.return () in
     Path.readdir_unsorted_with_kinds dir
 ;;
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1109,45 +1109,169 @@ let symlink_source_dir ~dir ~dst =
     suffix, dst, Action_builder.symlink ~src ~dst)
 ;;
 
+let compute_dst ~install_dir ~install_paths (entry : _ Install.Entry.t) =
+  let relative =
+    Install.Entry.relative_installed_path entry ~paths:install_paths
+    |> Path.as_in_source_tree_exn
+  in
+  Path.Build.append_source install_dir relative
+;;
+
+let entry_loc (s : Install.Entry.Sourced.Unexpanded.t) =
+  match s.source with
+  | User l -> l
+  | Dune -> Loc.in_file (Path.build s.entry.src)
+;;
+
+(* Classify a build path for the install machinery. *)
+let classify_install_src src
+  : [ `File
+    | `Directory
+    | `File_under_dir_target
+    | `Directory_under_dir_target
+    | `Missing
+    | `Not_target
+    ]
+      Memo.t
+  =
+  let open Memo.O in
+  Load_rules.is_target src
+  >>= function
+  | Yes File -> Memo.return `File
+  | Yes Directory -> Memo.return `Directory
+  | No -> Memo.return `Not_target
+  | Under_directory_target_so_cannot_say ->
+    Load_rules.load_dir ~dir:(Path.parent_exn src)
+    >>= (function
+     | Build_under_directory_target { directory_target_ancestor } ->
+       let+ targets = Build_system.build_dir directory_target_ancestor in
+       let src_b = Path.as_in_build_dir_exn src in
+       if Targets.Produced.mem_dir targets src_b
+       then `Directory_under_dir_target
+       else if Targets.Produced.mem targets src_b
+       then `File_under_dir_target
+       else `Missing
+     | _ -> Memo.return `Not_target)
+;;
+
+(* Build a directory target and return its leaf files keyed by their path
+   relative to [src]. Reads the file list straight out of the engine's
+   [Targets.Produced.t]; no filesystem stating. If [src] is a subpath
+   inside a directory target (e.g. [(install (dirs (a/share as .)))] where
+   the directory target is [a]), [Targets.Produced.t.root] is the actual
+   target [a] and [all_files_seq] yields paths relative to it; we filter
+   to leaves under [src] and strip the root-to-src prefix. *)
+let directory_target_leaves (src : Path.Build.t) =
+  let open Memo.O in
+  let+ targets = Build_system.build_dir src in
+  let prefix =
+    match
+      Path.Local.descendant (Path.Build.local src) ~of_:(Path.Build.local targets.root)
+    with
+    | Some p -> p
+    | None ->
+      Code_error.raise
+        "install dir src is not a descendant of its directory target root"
+        [ "src", Path.Build.to_dyn src; "root", Path.Build.to_dyn targets.root ]
+  in
+  Targets.Produced.all_files_seq targets
+  |> Seq.fold_left ~init:Path.Local.Map.empty ~f:(fun acc (rel_from_root, _digest) ->
+    match Path.Local.descendant rel_from_root ~of_:prefix with
+    | None -> acc
+    | Some rel -> Path.Local.Map.add_exn acc rel (Path.Build.append_local src rel))
+;;
+
+let install_dirs_overlap_min_version = 3, 24
+
+let check_dirs_overlap_version_gate ~contributors =
+  Memo.parallel_iter contributors ~f:(fun (s : Install.Entry.Sourced.Unexpanded.t) ->
+    let loc = entry_loc s in
+    let scope_dir = Path.Build.parent_exn s.entry.src in
+    let* scope = Scope.DB.find_by_dir scope_dir in
+    let v = Scope.project scope |> Dune_project.dune_version in
+    if Dune_lang.Syntax.Version.Infix.(v < install_dirs_overlap_min_version)
+    then
+      User_error.raise
+        ~loc
+        [ Pp.textf
+            "Multiple (install (dirs ...)) entries resolve to the same destination \
+             directory. Merging is supported with (lang dune %d.%d) or later; this \
+             stanza uses (lang dune %s)."
+            (fst install_dirs_overlap_min_version)
+            (snd install_dirs_overlap_min_version)
+            (Dune_lang.Syntax.Version.to_string v)
+        ]
+        ~hints:
+          [ Pp.textf
+              "Upgrade the project's (lang dune ...) version, or split the entries into \
+               distinct destination directories."
+          ]
+    else Memo.return ())
+;;
+
 let symlink_installed_artifacts_to_build_install
+      ~sctx:_
       (ctx : Build_context.t)
       (entries : Install.Entry.Sourced.Unexpanded.t list)
       ~install_paths
   =
   let install_dir = Install.Context.dir ~context:ctx.name in
+  (* Index Directory entries by their resolved destination, so we can detect
+     overlap (for the version gate) and route singletons vs multi-contributor
+     groups to the appropriate rule shape. *)
+  let dirs_by_dst =
+    List.filter_map entries ~f:(fun s ->
+      match s.entry.kind with
+      | Install.Entry.Unexpanded.Directory ->
+        let dst = compute_dst ~install_dir ~install_paths s.entry in
+        Some (dst, s)
+      | File | Source_tree -> None)
+    |> Path.Build.Map.of_list_multi
+  in
+  let* () =
+    Memo.parallel_iter
+      (Path.Build.Map.to_list dirs_by_dst)
+      ~f:(fun (_dst, contributors) ->
+        match contributors with
+        | [] | [ _ ] -> Memo.return ()
+        | _ :: _ :: _ -> check_dirs_overlap_version_gate ~contributors)
+  in
   Memo.parallel_map entries ~f:(fun (s : Install.Entry.Sourced.Unexpanded.t) ->
     let entry = s.entry in
-    let dst =
-      let relative =
-        Install.Entry.relative_installed_path entry ~paths:install_paths
-        |> Path.as_in_source_tree_exn
-      in
-      Path.Build.append_source install_dir relative
-    in
-    let loc =
-      match s.source with
-      | User l -> l
-      | Dune -> Loc.in_file (Path.build entry.src)
-    in
+    let dst = compute_dst ~install_dir ~install_paths entry in
+    let loc = entry_loc s in
     let src = Path.build entry.src in
     let rule { Action_builder.With_targets.targets; build } =
       Rule.make ~info:(From_dune_file loc) ~targets build
     in
+    let per_leaf_entry suffix leaf_dst =
+      let entry =
+        let entry =
+          Install.Entry.map_dst entry ~f:(fun dst ->
+            Install.Entry.Dst.append_local dst suffix)
+        in
+        let entry = Install.Entry.Unexpanded.expand entry in
+        Install.Entry.Expanded.set_src entry leaf_dst
+      in
+      { s with entry }
+    in
     match entry.kind with
     | Install.Entry.Unexpanded.Source_tree ->
       symlink_source_dir ~dir:src ~dst
-      >>| List.map ~f:(fun (suffix, dst, build) ->
-        let rule = rule build in
-        let entry =
-          let entry =
-            Install.Entry.map_dst entry ~f:(fun dst ->
-              Install.Entry.Dst.append_local dst suffix)
-          in
-          let entry = Install.Entry.Unexpanded.expand entry in
-          Install.Entry.Expanded.set_src entry dst
-        in
-        { s with entry }, rule)
+      >>| List.map ~f:(fun (suffix, leaf_dst, build) ->
+        per_leaf_entry suffix leaf_dst, rule build)
     | File ->
+      let* () =
+        classify_install_src src
+        >>| function
+        | `File | `File_under_dir_target | `Missing | `Not_target -> ()
+        | `Directory | `Directory_under_dir_target ->
+          User_error.raise
+            ~loc
+            ~hints:[ Pp.text "Use (install (dirs ...)) for directory targets." ]
+            [ Pp.textf "%s is a directory, not a file." (Path.to_string_maybe_quoted src)
+            ]
+      in
       let entry =
         let entry = Install.Entry.Unexpanded.expand entry in
         let entry = Install.Entry.Expanded.set_src entry dst in
@@ -1156,13 +1280,65 @@ let symlink_installed_artifacts_to_build_install
       let action = Action_builder.symlink ~src ~dst in
       Memo.return [ entry, rule action ]
     | Directory ->
-      let entry =
-        let entry = Install.Entry.Unexpanded.expand entry in
-        let entry = Install.Entry.Expanded.set_src entry dst in
-        { s with entry }
+      (* [(install (dirs X))] requires [X] to be a directory target (or a
+         subdirectory of one). Reject paths that are file targets or have no
+         producing rule, with a clean user-level error before [build_dir]
+         would Code_error on a file target. *)
+      let* () =
+        classify_install_src src
+        >>= function
+        | `Directory | `Directory_under_dir_target -> Memo.return ()
+        | `File | `File_under_dir_target ->
+          User_error.raise
+            ~loc
+            ~hints:[ Pp.text "Use (install (files ...)) for files." ]
+            [ Pp.textf "%s is a file, not a directory." (Path.to_string_maybe_quoted src)
+            ]
+        | `Missing ->
+          User_error.raise
+            ~loc
+            [ Pp.textf
+                "%s does not exist inside the directory target."
+                (Path.to_string_maybe_quoted src)
+            ]
+        | `Not_target ->
+          let+ hints =
+            match Path.as_in_build_dir src with
+            | None -> Memo.return []
+            | Some build_path ->
+              Source_tree.find_dir (Path.Build.drop_build_context_exn build_path)
+              >>| (function
+               | Some _ ->
+                 [ Pp.text "Use (install (source_trees ...)) for source directories." ]
+               | None -> [])
+          in
+          User_error.raise
+            ~loc
+            ~hints
+            [ Pp.textf
+                "%s is neither a directory target nor a subdirectory of one."
+                (Path.to_string_maybe_quoted src)
+            ]
       in
-      let action = Action_builder.symlink_dir ~src ~dst in
-      Memo.return [ entry, rule action ])
+      (* Expand each Directory entry into per-leaf symlink rules with
+         [kind = File]. The engine catches per-leaf collisions across
+         contributors via [Path.Build.Map.add_exn] at rule registration;
+         the multi-contributor version gate above (3.24) ensures pre-3.24
+         projects get a clean error before reaching that point. *)
+      directory_target_leaves entry.src
+      >>| Path.Local.Map.to_list_map ~f:(fun suffix leaf_src ->
+        let leaf_dst = Path.Build.append_local dst suffix in
+        let action = Action_builder.symlink ~src:(Path.build leaf_src) ~dst:leaf_dst in
+        let entry =
+          Install.Entry.Unexpanded.make_with_dst
+            entry.section
+            (Install.Entry.Dst.append_local entry.dst suffix)
+            ~kind:File
+            ~src:leaf_src
+          |> Install.Entry.Unexpanded.expand
+          |> Fun.flip Install.Entry.Expanded.set_src leaf_dst
+        in
+        { s with entry }, rule action))
 ;;
 
 let promote_install_file (ctx : Context.t) =
@@ -1224,7 +1400,7 @@ let symlinked_entries sctx package =
   in
   let build_context = Super_context.context sctx |> Context.build_context in
   install_entries sctx package
-  >>= symlink_installed_artifacts_to_build_install build_context ~install_paths
+  >>= symlink_installed_artifacts_to_build_install ~sctx build_context ~install_paths
   >>| List.rev_concat
   >>| List.split
 ;;

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -221,7 +221,7 @@ let get_with_path =
          "read-lock-dir"
          ~input:(module Path)
          (fun path ->
-            let* () = Build_system.build_dir path in
+            let* () = Build_system.build_file path in
             Load.load path))
   in
   Per_context.create_by_name ~name:"lock-dir-get" (fun ctx ->
@@ -257,7 +257,7 @@ let get_exn ctx = get ctx >>| User_error.ok_exn
 let of_dev_tool dev_tool =
   let path = dev_tool |> dev_tool_external_lock_dir |> Path.external_ in
   (* Ensure the internal lock dir is built so copy rules run *)
-  let* () = Build_system.build_dir (dev_tool_lock_dir dev_tool) in
+  let* () = Build_system.build_file (dev_tool_lock_dir dev_tool) in
   Load.load_exn path
 ;;
 

--- a/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t
+++ b/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t
@@ -25,8 +25,8 @@ A default implementation of a library must belong to the same package
                                ^^^^^
   Error: default implementation belongs to package dummyfoo2 while virtual
   library belongs to package dummyfoo1. This is impossible.
-  -> required by _build/default/dummyfoo1.dune-package
-  -> required by _build/install/default/lib/dummyfoo1/dune-package
+  -> required by _build/default/vlib/.vlib.objs/byte/vlib.cmi
+  -> required by _build/install/default/lib/dummyfoo1/bar/vlib.cmi
   -> required by _build/default/dummyfoo1.install
   -> required by alias install
   [1]

--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-non-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-non-target.t
@@ -19,7 +19,9 @@ A plain source directory:
   File "dune", line 3, characters 7-13:
   3 |  (dirs assets))
              ^^^^^^
-  Error: No rule found for assets
+  Error: _build/default/assets is neither a directory target nor a subdirectory
+  of one.
+  Hint: Use (install (source_trees ...)) for source directories.
   [1]
 
 A plain file (not a directory):
@@ -35,8 +37,8 @@ A plain file (not a directory):
   File "dune", line 3, characters 7-14:
   3 |  (dirs foo.txt))
              ^^^^^^^
-  Error: Rule produced unreadable directory "default/share/p/foo.txt"
-  Not a directory
+  Error: _build/default/foo.txt is a file, not a directory.
+  Hint: Use (install (files ...)) for files.
   [1]
 
 A subdirectory of a directory target:

--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap-collision.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap-collision.t
@@ -1,0 +1,39 @@
+When two `(install (dirs ...))` entries merge but contribute the same
+leaf path, the build fails. The engine catches this at rule registration
+(two rules with identical targets).
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name p))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir a))
+  >  (action
+  >   (progn
+  >    (run mkdir -p a/share)
+  >    (run touch a/share/conflict.txt))))
+  > 
+  > (rule
+  >  (target (dir b))
+  >  (action
+  >   (progn
+  >    (run mkdir -p b/share)
+  >    (run touch b/share/conflict.txt))))
+  > 
+  > (install
+  >  (section share_root)
+  >  (dirs
+  >   (b/share as .)
+  >   (a/share as .)))
+  > EOF
+
+  $ dune build @install
+  Error: Multiple rules generated for
+  _build/install/default/share/conflict.txt:
+  - dune:18
+  - dune:19
+  -> required by _build/default/p.install
+  -> required by alias install
+  [1]

--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap-pre-3.24.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap-pre-3.24.t
@@ -1,0 +1,50 @@
+Pre-3.24 projects get a version-gate error when two `(install (dirs ...))`
+entries resolve to the same destination, instead of the merge that 3.24+
+allows.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.23)
+  > (using directory-targets 0.1)
+  > (package (name shared_files))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target (dir a))
+  >  (action
+  >   (progn
+  >    (run mkdir -p a/share)
+  >    (run touch a/share/readme_a.txt))))
+  > 
+  > (rule
+  >  (target (dir b))
+  >  (action
+  >   (progn
+  >    (run mkdir -p b/share)
+  >    (run touch b/share/readme_b.txt))))
+  > 
+  > (install
+  >  (section share_root)
+  >  (dirs
+  >   (b/share as .)
+  >   (a/share as .)))
+  > EOF
+
+  $ dune build @install
+  File "dune", line 18, characters 3-10:
+  18 |   (b/share as .)
+          ^^^^^^^
+  Error: Multiple (install (dirs ...)) entries resolve to the same destination
+  directory. Merging is supported with (lang dune 3.24) or later; this stanza
+  uses (lang dune 3.23).
+  Hint: Upgrade the project's (lang dune ...) version, or split the entries
+  into distinct destination directories.
+  File "dune", line 19, characters 3-10:
+  19 |   (a/share as .)))
+          ^^^^^^^
+  Error: Multiple (install (dirs ...)) entries resolve to the same destination
+  directory. Merging is supported with (lang dune 3.24) or later; this stanza
+  uses (lang dune 3.23).
+  Hint: Upgrade the project's (lang dune ...) version, or split the entries
+  into distinct destination directories.
+  [1]

--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-target-overlap.t
@@ -1,14 +1,16 @@
-Installing multiple directories into share_root currently crashes dune
-Originally reported as https://github.com/ocaml/dune/issues/13307
+Two `(install (dirs ...))` entries that resolve to the same destination
+directory now merge into a single install dir containing the union of the
+contributing files. Originally reported as
+https://github.com/ocaml/dune/issues/13307.
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.20)
-  > (using directory-targets 0.1)
+  > (lang dune 3.24)
   > (package (name shared_files))
   > EOF
 
-Create two rules that create directories and an install stanza that 
-tries place the contents of both at the same location
+Two rules build separate directory targets; one install stanza puts both
+of their contents at the same install location (`share_root` mapped to
+`.`).
 
   $ cat >dune <<EOF
   > (rule
@@ -34,8 +36,7 @@ tries place the contents of both at the same location
   >   (a/share as .)))
   > EOF
 
-This would ideally produce a _build/install/default/share/ with both .txt files,
-or perhaps an error about two rules targetting the same thing, but crashes instead.
-  $ dune build @install 2>&1 | grep "must not crash"
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  [1]
+  $ dune build @install 2>&1
+  $ ls _build/install/default/share
+  readme_a.txt
+  readme_b.txt

--- a/test/blackbox-tests/test-cases/directory-targets/install-inside-dir-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-inside-dir-target.t
@@ -1,0 +1,64 @@
+Observe `(install (dirs ...))` and `(install (files ...))` when the path
+refers to something inside a directory target. Four cases:
+
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.24)
+  > (package (name p))
+  > EOF
+
+A rule that produces a directory target containing a file and a
+sub-directory with a file inside it:
+
+  $ cat >setup.dune <<EOF
+  > (rule
+  >  (target (dir gen))
+  >  (action
+  >   (progn (run mkdir -p %{target}/sub)
+  >          (run touch %{target}/top.txt)
+  >          (run touch %{target}/sub/inside.txt))))
+  > EOF
+
+(dirs ...) of a file inside the directory target:
+
+  $ cat setup.dune >dune
+  $ cat >>dune <<EOF
+  > (install (section share) (dirs gen/top.txt))
+  > EOF
+  $ dune build @install
+  File "dune", line 7, characters 31-42:
+  7 | (install (section share) (dirs gen/top.txt))
+                                     ^^^^^^^^^^^
+  Error: _build/default/gen/top.txt is a file, not a directory.
+  Hint: Use (install (files ...)) for files.
+  [1]
+
+(files ...) of a file inside the directory target:
+
+  $ cat setup.dune >dune
+  $ cat >>dune <<EOF
+  > (install (section share) (files gen/top.txt))
+  > EOF
+  $ dune build @install
+
+(files ...) of a sub-directory inside the directory target:
+
+  $ cat setup.dune >dune
+  $ cat >>dune <<EOF
+  > (install (section share) (files gen/sub))
+  > EOF
+  $ dune build @install
+  File "dune", line 7, characters 32-39:
+  7 | (install (section share) (files gen/sub))
+                                      ^^^^^^^
+  Error: _build/default/gen/sub is a directory, not a file.
+  Hint: Use (install (dirs ...)) for directory targets.
+  [1]
+
+(dirs ...) of a sub-directory inside the directory target:
+
+  $ cat setup.dune >dune
+  $ cat >>dune <<EOF
+  > (install (section share) (dirs gen/sub))
+  > EOF
+  $ dune build @install

--- a/test/blackbox-tests/test-cases/installable-dup-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/installable-dup-private-libs.t/run.t
@@ -9,13 +9,13 @@ Builds installable packages with duplicate private library names.
   > | targets
   > | select(length > 0)
   > '
-  ["_build/default/a1/.a.objs/byte/a.cmi","_build/default/a1/.a.objs/byte/a.cmo","_build/default/a1/.a.objs/byte/a.cmt"]
   ["_build/default/a2/.a.objs/byte/a.cmi","_build/default/a2/.a.objs/byte/a.cmo","_build/default/a2/.a.objs/byte/a.cmt"]
-  ["_build/default/a1/.a.objs/native/a.cmx","_build/default/a1/.a.objs/native/a.o"]
-  ["_build/default/a1/a.cma"]
+  ["_build/default/a1/.a.objs/byte/a.cmi","_build/default/a1/.a.objs/byte/a.cmo","_build/default/a1/.a.objs/byte/a.cmt"]
   ["_build/default/a2/.a.objs/native/a.cmx","_build/default/a2/.a.objs/native/a.o"]
   ["_build/default/a2/a.cma"]
-  ["_build/default/a1/a.a","_build/default/a1/a.cmxa"]
+  ["_build/default/a1/.a.objs/native/a.cmx","_build/default/a1/.a.objs/native/a.o"]
+  ["_build/default/a1/a.cma"]
   ["_build/default/a2/a.a","_build/default/a2/a.cmxa"]
-  ["_build/default/a1/a.cmxs"]
+  ["_build/default/a1/a.a","_build/default/a1/a.cmxa"]
   ["_build/default/a2/a.cmxs"]
+  ["_build/default/a1/a.cmxs"]

--- a/test/blackbox-tests/test-cases/lib.t
+++ b/test/blackbox-tests/test-cases/lib.t
@@ -255,7 +255,10 @@ But will fail when we release it, as it will need to run with -p:
   Error: Library "lib1" not found.
   -> required by %{lib-private:lib1:lib1.ml} at lib2/dune:5
   -> required by _build/default/lib2/lib2.ml
-  -> required by _build/install/default/lib/public_lib2/lib2.ml
+  -> required by _build/default/lib2/.lib2.objs/byte/lib2.cmi
+  -> required by _build/default/lib2/.lib2.objs/native/lib2.cmx
+  -> required by _build/default/lib2/lib2.a
+  -> required by _build/install/default/lib/public_lib2/lib2.a
   -> required by _build/default/public_lib2.install
   -> required by alias install
   [1]

--- a/test/blackbox-tests/test-cases/stanzas/install/start-install-dst-with-parent-error.t
+++ b/test/blackbox-tests/test-cases/stanzas/install/start-install-dst-with-parent-error.t
@@ -209,7 +209,7 @@ Test that on older versions of dune we don't get warnings in this case:
   ]
   etc: [
     "_build/install/default/etc/b" {"../b"}
-    "_build/install/default/etc/baz/b.txt" {"../baz/b.txt"}
+    "_build/install/default/etc/baz/baz.txt" {"../baz/baz.txt"}
   ]
 
 Test that we don't get the warning if a vendored project starts an install dst


### PR DESCRIPTION
Two install stanzas that target the same destination now merge instead of crashing. Each (install (dirs ...)) entry produces one symlink per file in the directory. Two entries can install to the same destination as long as the files they install don't share a name.

Requires (lang dune 3.24). Older projects get an error explaining why. If two install entries try to install the same file, the engine reports a duplicate rule error.

Build_system.build_dir now returns the produced targets it already computes. Callers that only wanted to build a path use Build_system.build_file instead.

Fixes #13307.