### PR TITLE
fs_memo: avoid recording watches in batch mode

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -772,9 +772,12 @@ end = struct
   ;;
 
   let watch ~try_to_watch_via_parent path =
-    match try_to_watch_via_parent with
-    | false -> Memo.exec memo_for_watching_directly path
-    | true -> Memo.exec memo_for_watching_via_parent path
+    match !state with
+    | No_file_watcher -> Memo.return ()
+    | Waiting_for_file_watcher _ | File_watcher _ ->
+      (match try_to_watch_via_parent with
+       | false -> Memo.exec memo_for_watching_directly path
+       | true -> Memo.exec memo_for_watching_via_parent path)
   ;;
 
   let update_all p =

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -17,10 +17,6 @@ module Reduced_stats : sig
     }
 end
 
-(** [init] must be called at initialization. Returns the set of nodes that need
-    to be invalidated because they were accessed before [init] was called. *)
-val init : dune_file_watcher:Dune_scheduler.File_watcher.t option -> Memo.Invalidation.t
-
 (** Check if a source or external file exists and declare a dependency on it. *)
 val file_exists : Path.Outside_build_dir.t -> bool Memo.t
 

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -4,10 +4,12 @@ open Fiber.O
 module Fs_memo = struct
   let handle_fs_event = Fdecl.create Dyn.opaque
   let init = Fdecl.create Dyn.opaque
+  let initialized = ref false
 
   let set_impl ~handle_fs_event:handle_fs_event' ~init:init' =
     Fdecl.set handle_fs_event handle_fs_event';
-    Fdecl.set init init'
+    Fdecl.set init init';
+    initialized := true
   ;;
 
   let handle_fs_event event = Fdecl.get handle_fs_event event
@@ -482,11 +484,15 @@ module Run = struct
              ())
     in
     let t = prepare config ~handler:on_event ~events ~file_watcher in
-    Option.iter file_watcher ~f:(fun dune_file_watcher ->
-      let initial_invalidation =
-        Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
-      in
-      Memo.reset initial_invalidation);
+    (match file_watcher with
+     | None ->
+       if !Fs_memo.initialized
+       then ignore (Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t)
+     | Some dune_file_watcher ->
+       let initial_invalidation =
+         Fs_memo.init ~dune_file_watcher:(Some dune_file_watcher)
+       in
+       Memo.reset initial_invalidation);
     let result =
       let run =
         match timeout with


### PR DESCRIPTION
When Fs_memo runs under a scheduler without a file watcher, discard any pending watch records and avoid accumulating new ones. This prevents a later watch-mode run in the same process from adding watches for paths that were only accessed by a batch build.