### PR TITLE
Fix thread pool accounting

### DIFF
--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -2,6 +2,9 @@
  (name dune_scheduler)
  (library_flags
   (:include flags/sexp))
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
  (foreign_stubs
   (language c)
   (names fsevents_stubs fswatch_win_stubs))

--- a/src/dune_scheduler/thread_pool.ml
+++ b/src/dune_scheduler/thread_pool.ml
@@ -26,41 +26,59 @@ type t =
     mutable dead : Thread.t list
   }
 
+let worker_finished_and_unlock t =
+  t.running <- t.running - 1;
+  t.dead <- Thread.self () :: t.dead;
+  Mutex.unlock t.mutex
+;;
+
+let run_task t task =
+  Mutex.unlock t.mutex;
+  match task () with
+  | () -> Mutex.lock t.mutex
+  | exception exn ->
+    Mutex.lock t.mutex;
+    worker_finished_and_unlock t;
+    Code_error.raise "thread pool tasks must not raise" [ "exn", Exn.to_dyn exn ]
+;;
+
 let spawn_worker t =
   let rec loop () =
+    match Queue.pop t.tasks with
+    | Some task ->
+      run_task t task;
+      loop ()
+    | None ->
+      if t.running > t.min_workers then worker_finished_and_unlock t else wait_for_task ()
+  and wait_for_task () =
+    t.idle <- t.idle + 1;
     while Queue.is_empty t.tasks do
       (* TODO [pthread_cond_timedwait] to set a maximum time for idling *)
       Condition.wait t.cv t.mutex
     done;
-    let task = Queue.pop_exn t.tasks in
     t.idle <- t.idle - 1;
-    Mutex.unlock t.mutex;
-    (match task () with
-     | () -> ()
-     | exception exn ->
-       Code_error.raise "thread pool tasks must not raise" [ "exn", Exn.to_dyn exn ]);
-    Mutex.lock t.mutex;
-    maybe_retry ()
-  and start () =
-    Mutex.lock t.mutex;
-    t.idle <- t.idle + 1;
     loop ()
-  and maybe_retry () =
-    if t.running <= t.min_workers
-    then loop ()
-    else (
-      t.running <- t.running - 1;
-      t.dead <- Thread.self () :: t.dead;
-      Mutex.unlock t.mutex)
   in
   t.running <- t.running + 1;
-  let (_ : Thread.t) = Thread0.spawn ~name:"thread-pool" start in
-  ()
+  match
+    Thread0.spawn ~name:"thread-pool" (fun () ->
+      Mutex.lock t.mutex;
+      loop ())
+  with
+  | (_ : Thread.t) -> ()
+  | exception exn ->
+    t.running <- t.running - 1;
+    raise exn
 ;;
 
-let maybe_spawn_worker t = if t.idle = 0 && t.running < t.max_workers then spawn_worker t
+let needs_worker t = Queue.length t.tasks > t.idle && t.running < t.max_workers
 
 let create ~min_workers ~max_workers =
+  if min_workers < 0 || max_workers <= 0 || min_workers > max_workers
+  then
+    Code_error.raise
+      "Thread_pool.create got invalid worker bounds"
+      [ "min_workers", Dyn.int min_workers; "max_workers", Dyn.int max_workers ];
   let t =
     { min_workers
     ; max_workers
@@ -72,21 +90,57 @@ let create ~min_workers ~max_workers =
     ; dead = []
     }
   in
-  for _ = 0 to min_workers - 1 do
-    spawn_worker t
-  done;
+  Mutex.protect t.mutex (fun () ->
+    for _ = 0 to min_workers - 1 do
+      spawn_worker t
+    done);
   t
 ;;
 
 let task t ~f =
+  Mutex.protect t.mutex (fun () ->
+    let dead =
+      match t.dead with
+      | [] -> []
+      | dead ->
+        t.dead <- [];
+        dead
+    in
+    Queue.push t.tasks f;
+    if needs_worker t then spawn_worker t;
+    Condition.signal t.cv;
+    dead)
+  |> List.iter ~f:Thread.join
+;;
+
+let%expect_test "failed task updates worker accounting" =
+  let t = create ~min_workers:0 ~max_workers:1 in
+  t.running <- 1;
   Mutex.lock t.mutex;
-  (match t.dead with
-   | [] -> ()
-   | dead ->
-     t.dead <- [];
-     List.iter dead ~f:Thread.join);
-  Queue.push t.tasks f;
-  maybe_spawn_worker t;
-  Condition.signal t.cv;
-  Mutex.unlock t.mutex
+  (match run_task t (fun () -> raise Exit) with
+   | () -> Code_error.raise "run_task unexpectedly returned" []
+   | exception Code_error.E _ -> ());
+  Printf.printf "running: %d\n" t.running;
+  Printf.printf "dead: %d\n" (List.length t.dead);
+  Printf.printf "mutex unlocked: %b\n" (Mutex.try_lock t.mutex);
+  Mutex.unlock t.mutex;
+  [%expect
+    {|
+    running: 0
+    dead: 1
+    mutex unlocked: true |}]
+;;
+
+let%expect_test "queued work beyond idle capacity needs a worker" =
+  let t = create ~min_workers:0 ~max_workers:2 in
+  t.idle <- 1;
+  t.running <- 1;
+  Queue.push t.tasks (fun () -> ());
+  Printf.printf "one task: %b\n" (needs_worker t);
+  Queue.push t.tasks (fun () -> ());
+  Printf.printf "two tasks: %b\n" (needs_worker t);
+  [%expect
+    {|
+    one task: false
+    two tasks: true |}]
 ;;

--- a/src/dune_scheduler/thread_pool.mli
+++ b/src/dune_scheduler/thread_pool.mli
@@ -3,8 +3,10 @@
 (** A thread pool *)
 type t
 
+(** [create ~min_workers ~max_workers] requires
+    [0 <= min_workers <= max_workers] and [max_workers > 0]. *)
 val create
-  :  min_workers:int (** minimum number of threads to spawn *)
+  :  min_workers:int (** minimum number of threads to keep alive *)
   -> max_workers:int (** maximum number of threads to spawn *)
   -> t
 


### PR DESCRIPTION
Keep worker accounting consistent when tasks raise or thread creation fails, avoid joining dead workers while holding the pool mutex, and spawn additional workers when queued work exceeds idle capacity.

Also validate worker bounds and clarify the min_workers interface documentation.