### PR TITLE
fix: recompute digest db max timestamp after pruning

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -154,9 +154,12 @@ module Cached_digest = struct
     match Time.compare cache.max_timestamp now with
     | Lt -> ()
     | Eq | Gt ->
+      let max_timestamp = ref (Time.of_ns 0) in
       let filter (data : _ file) =
         match Time.compare data.stats.mtime now with
-        | Lt -> true
+        | Lt ->
+          max_timestamp := Time.max !max_timestamp data.stats.mtime;
+          true
         | Gt | Eq -> false
       in
       (match Dune_trace.enabled Digest with
@@ -177,7 +180,8 @@ module Cached_digest = struct
           | [] -> ()
           | _ :: _ ->
             Dune_trace.emit ~buffered:true Digest (fun () ->
-              Dune_trace.Event.Digest.dropped_stale_mtimes !dropped ~fs_now:now)))
+              Dune_trace.Event.Digest.dropped_stale_mtimes !dropped ~fs_now:now)));
+      cache.max_timestamp <- !max_timestamp
   ;;
 
   let dump () =

--- a/test/blackbox-tests/test-cases/internal/digest-db.t
+++ b/test/blackbox-tests/test-cases/internal/digest-db.t
@@ -42,3 +42,13 @@ Only actual digest mismatches are reported, classified as invalid or stale.
   path = In_source_tree "invalid.txt"
   status = "stale"
   path = In_source_tree "stale.txt"
+
+Future-dated entries are dropped before the digest database is saved. When this
+happens, the saved [max_timestamp] must be recomputed and not retain the dropped
+future timestamp.
+
+  $ printf future > future.txt
+  $ TZ=UTC touch -t 203001010000 future.txt
+  $ dune build future.txt
+  $ dune internal digest-db dump 2>&1 | grep 1893456000000000000
+  [1]


### PR DESCRIPTION
Dropped future-dated digest entries can otherwise leave the saved digest DB with a max_timestamp from an entry that is no longer present. Recompute the maximum timestamp after pruning stale mtimes and cover the case in the digest-db cram test.