### PR TITLE
Return complete FSEvents raw flag records

### DIFF
--- a/src/dune_scheduler/fsevents_stubs.c
+++ b/src/dune_scheduler/fsevents_stubs.c
@@ -390,6 +390,8 @@ static const FSEventStreamEventFlags all_flags[] = {
     kFSEventStreamEventFlagItemIsLastHardlink,
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 101300
     kFSEventStreamEventFlagItemCloned,
+#else
+    0,
 #endif
 };
 


### PR DESCRIPTION
The OCaml Raw.t record always contains the item_cloned field, but the C stub omitted the corresponding slot when built against SDKs older than macOS 10.13. That returned a block with the wrong arity for the OCaml record.

Always include the final slot and fill it with false when the SDK does not define kFSEventStreamEventFlagItemCloned.