### PR TITLE
feat: per-module narrowing for Melange consumers

### DIFF
--- a/doc/dev/per-module-narrowing.md
+++ b/doc/dev/per-module-narrowing.md
@@ -566,10 +566,17 @@ frontier:
    silently drop the leaf library's `.cmi` from its compile rule.
 
 `Melange` consumer compiles run the same narrowing pipeline as `Ocaml`.
-The `can_filter` check is mode-agnostic; the only mode-specific code
-is in `Lib_file_deps.deps_of_entry_modules`, which emits per-module
-`.cmj` deps in addition to `.cmi` when `cm_kind = Melange Cmj`,
-mirroring the broad-dep path's `groups_for_cm_kind`.
+The `can_filter` check is mode-agnostic. Two code paths inside the
+pipeline match on `cm_kind`:
+
+1. `Lib_file_deps.deps_of_entry_modules` emits per-module `.cmj` in
+   addition to `.cmi` when `cm_kind = Melange Cmj`, mirroring the
+   broad-dep path's `groups_for_cm_kind`.
+2. `need_impl_deps_of` (in `lib_deps_for_module`) reads a trans-dep's
+   `.ml`-side ocamldep only for `cm_kind = Ocaml Cmx` (cross-module
+   inlining input). `Ocaml (Cmi | Cmo)` and `Melange _` are handled
+   symmetrically — neither reads impl deps. The distinction is
+   Cmx-vs-rest, not OCaml-vs-Melange.
 
 ## Cost characteristics
 

--- a/doc/dev/per-module-narrowing.md
+++ b/doc/dev/per-module-narrowing.md
@@ -45,8 +45,7 @@ the source-language kind (`Ml_kind.t` — `Impl` or `Intf`), and the mode
 1. If a small set of preconditions fails (`can_filter = false`), fall
    back to the cctx-wide glob — the same dep set every compile rule
    would have had prior to this work. This avoids needing soundness
-   arguments for module kinds that the narrowing was not designed for,
-   and lets `Melange` paths pass through unchanged.
+   arguments for module kinds that the narrowing was not designed for.
 
 2. Otherwise, if the consumer cctx already carries a virtual library
    in `requires` (`has_virtual_impl = true`), fall back to the
@@ -95,8 +94,6 @@ The entry point for the narrowing is
 (`src/dune_rules/module_compilation.ml`). Before any narrowing runs,
 the function computes a `can_filter` boolean conjunction:
 
-- The compile is `Ocaml _` (Melange has its own cm-kind story and is
-  not narrowed).
 - The supplied `dep_graph` is the real one for this cctx (its `dir`
   equals the cctx's `obj_dir`), not a `Dep_graph.dummy` — synthesised
   / link-time-generated / alias / root modules have no usable
@@ -568,9 +565,11 @@ frontier:
    inherited into the intermediate's `.mli` via the open) would
    silently drop the leaf library's `.cmi` from its compile rule.
 
-`Melange` paths bypass the narrowing entirely at the `can_filter`
-check; the cm_kind machinery there is different and L9 leaves it
-unchanged.
+`Melange` consumer compiles run the same narrowing pipeline as `Ocaml`.
+The `can_filter` check is mode-agnostic; the only mode-specific code
+is in `Lib_file_deps.deps_of_entry_modules`, which emits per-module
+`.cmj` deps in addition to `.cmi` when `cm_kind = Melange Cmj`,
+mirroring the broad-dep path's `groups_for_cm_kind`.
 
 ## Cost characteristics
 

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -506,10 +506,11 @@ let for_module ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ module_ =
 
 let rules ~obj_dir ~modules ~sandbox ~impl ~sctx ~dir ~for_ ~has_library_deps =
   match Modules.With_vlib.as_singleton modules with
-  | Some m when (not has_library_deps) || Compilation_mode.equal for_ Melange ->
-    (* Single-module stanzas have no intra-stanza deps; the dep graph is only
-       consumed by the per-module filter in [lib_deps_for_module]. That filter
-       doesn't activate for Melange (see its [can_filter]) — skip ocamldep. *)
+  | Some m when not has_library_deps ->
+    (* Single-module stanzas with no library deps have nothing to filter — the
+       dep graph is only consumed by the per-module filter in
+       [lib_deps_for_module], and that filter has no libs to narrow. Skip
+       ocamldep. *)
     Memo.return (Dep_graph.Ml_kind.dummy m)
   | Some _ | None ->
     let transitive_deps, imported_vlib_deps =

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -85,6 +85,11 @@ let deps_of_entry_modules ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib modules =
     | Ocaml Cmx -> not (opaque && Lib.is_local lib)
     | _ -> false
   in
+  let want_cmj =
+    match cm_kind with
+    | Melange Cmj -> true
+    | _ -> false
+  in
   List.fold_left modules ~init:Dep.Set.empty ~f:(fun acc m ->
     let acc =
       match Obj_dir.Module.cm_public_file obj_dir m ~kind:cmi_kind with
@@ -97,16 +102,30 @@ let deps_of_entry_modules ~opaque ~(cm_kind : Lib_mode.Cm_kind.t) lib modules =
            in tight_modules"
           [ "module", Module.to_dyn m; "lib", Lib.to_dyn lib ]
     in
-    if want_cmx && Module.has m ~ml_kind:Impl
+    let acc =
+      if want_cmx && Module.has m ~ml_kind:Impl
+      then (
+        match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Ocaml Cmx) with
+        | Some path -> Dep.Set.add acc (Dep.file path)
+        | None ->
+          (* Unreachable. [cm_public_file ~kind:(Ocaml Cmx)] returns [None] only
+             when [not has_impl]. The enclosing [if] guarantees
+             [Module.has m ~ml_kind:Impl] (= [has_impl]). *)
+          Code_error.raise
+            "deps_of_entry_modules: [cm_public_file] returned [None] for cmx despite \
+             [Module.has m ~ml_kind:Impl] holding"
+            [ "module", Module.to_dyn m ])
+      else acc
+    in
+    if want_cmj && Module.has m ~ml_kind:Impl
     then (
-      match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Ocaml Cmx) with
+      match Obj_dir.Module.cm_public_file obj_dir m ~kind:(Melange Cmj) with
       | Some path -> Dep.Set.add acc (Dep.file path)
       | None ->
-        (* Unreachable. [cm_public_file ~kind:(Ocaml Cmx)] returns [None] only
-           when [not has_impl]. The enclosing [if] guarantees
-           [Module.has m ~ml_kind:Impl] (= [has_impl]). *)
+        (* Unreachable. Symmetric with the [Ocaml Cmx] arm above: [cm_public_file
+           ~kind:(Melange Cmj)] returns [None] only when [not has_impl]. *)
         Code_error.raise
-          "deps_of_entry_modules: [cm_public_file] returned [None] for cmx despite \
+          "deps_of_entry_modules: [cm_public_file] returned [None] for cmj despite \
            [Module.has m ~ml_kind:Impl] holding"
           [ "module", Module.to_dyn m ])
     else acc)

--- a/src/dune_rules/lib_file_deps.mli
+++ b/src/dune_rules/lib_file_deps.mli
@@ -22,12 +22,10 @@ val deps_of_entries : opaque:bool -> cm_kind:Lib_mode.Cm_kind.t -> Lib.t list ->
 (** Specific-file deps on the [modules] of [lib]. Only valid for local libraries
     (where [Module.t] values are available).
 
-    Currently produces complete per-module deps only for [cm_kind = Ocaml _]
-    (cmi + cmx); for [Melange _] only the cmi is emitted — there is no
-    per-module cmj arm, asymmetric with [deps_of_entries]. The sole caller
-    ([Module_compilation.lib_deps_for_module]) gates Melange out before
-    reaching this function, so this asymmetry is not observable today. If a
-    future Melange caller is added, extend with a [want_cmj] arm. *)
+    Per [cm_kind]: [Ocaml Cmx] emits cmi + cmx (cmx omitted when [opaque] and
+    [Lib.is_local lib]); [Ocaml (Cmi | Cmo)] emits cmi only; [Melange Cmj]
+    emits cmi + cmj; [Melange Cmi] emits cmi only. The cmi/cmj selection
+    mirrors [groups_for_cm_kind] used by the broad-dep path. *)
 val deps_of_entry_modules
   :  opaque:bool
   -> cm_kind:Lib_mode.Cm_kind.t

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -542,6 +542,11 @@ let setup_emit_cmj_rules
       Modules.With_vlib.modules modules, pp
     in
     let requires_link = Lib.Compile.requires_link compile_info ~for_ in
+    let pps_runtime_libs =
+      let open Resolve.Memo.O in
+      let* pps = Lib.Compile.pps compile_info ~for_ in
+      Resolve.Memo.List.concat_map pps ~f:(Lib.ppx_runtime_deps ~for_)
+    in
     let* flags = melange_compile_flags ~sctx ~dir mel in
     let* cctx =
       let direct_requires = Lib.Compile.direct_requires compile_info ~for_ in
@@ -555,7 +560,7 @@ let setup_emit_cmj_rules
         ~flags
         ~requires_link
         ~requires_compile:direct_requires
-        ~pps_runtime_libs:(Resolve.Memo.return [])
+        ~pps_runtime_libs
         ~preprocessing:pp
         ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.make None)
         ~opaque:Inherit_from_settings

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -90,13 +90,10 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
     Lib_mode.Cm_kind.Map.get (Compilation_context.includes cctx) cm_kind
   in
   let can_filter =
-    (match Lib_mode.of_cm_kind cm_kind with
-     | Melange -> false
-     | Ocaml _ -> true)
     (* Skip when [dep_graph] is the dummy ([Dep_graph.dummy] with
        [dir = Path.Build.root]); used for singleton-module stanzas and
        link-time-synthesised modules where no transitive deps are available. *)
-    && Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
+    Path.Build.equal (Dep_graph.dir dep_graph) (Obj_dir.dir obj_dir)
     (* Modules synthesised outside the stanza, handed to [ocamlc_i]. *)
     && Dep_graph.mem dep_graph m
     && module_kind_is_filterable m

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -180,7 +180,22 @@ let lib_deps_for_module ~cctx ~obj_dir ~for_ ~dep_graph ~opaque ~cm_kind ~ml_kin
       let all_raw = Module_name.Set.union m_raw trans_raw in
       let* flags = Ocaml_flags.get (Compilation_context.flags cctx) mode in
       let open_modules = Ocaml_flags.extract_open_module_names flags in
-      let referenced = Module_name.Set.union all_raw open_modules in
+      (* [Stdlib] is implicitly opened by every compile and so is referenced by
+         every consumer even when ocamldep doesn't list it. For OCaml-mode
+         compiles the compiler's built-in stdlib path supplies it (no dune lib
+         to keep); for Melange-mode compiles the [melange]/[stdlib] lib supplies
+         it as a regular dune dependency, and would otherwise be dropped from
+         [kept_libs] for consumers that don't syntactically name a [Stdlib.X]
+         member. Force it onto the frontier so the [Lib_index] lookup adds it
+         when present. *)
+      let referenced =
+        let implicit_stdlib =
+          match Module_name.of_string_opt "Stdlib" with
+          | Some n -> Module_name.Set.singleton n
+          | None -> Module_name.Set.empty
+        in
+        Module_name.Set.union (Module_name.Set.union all_raw open_modules) implicit_stdlib
+      in
       let { Lib_file_deps.Lib_index.tight; non_tight } =
         Lib_file_deps.Lib_index.filter_libs_with_modules
           lib_index

--- a/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
+++ b/test/blackbox-tests/test-cases/melange/melange-conditional-modules.t
@@ -34,8 +34,9 @@ Show `(melange.modules ..)` subset is preferred when compiling in Melange mode
           melc lib/.a.objs/melange/a.{cmi,cmj,cmt}
       ocamldep (internal)
       ocamldep (internal)
-          melc lib/.a.objs/melange/a__Foo.{cmi,cmj,cmt}
+      ocamldep (internal)
         ocamlc lib/.a.objs/byte/a__Helper.{cmi,cmo,cmt}
+          melc lib/.a.objs/melange/a__Foo.{cmi,cmj,cmt}
         ocamlc lib/.a.objs/byte/a__Foo.{cmi,cmo,cmt}
         ocamlc lib/a.cma
   Leaving directory 'a'


### PR DESCRIPTION
## Summary

Lifts the `can_filter` Melange opt-out installed by #14516 (L4). The BFS per-module narrowing pipeline now activates for Melange consumer compiles on the same terms as OCaml — same `Lib_index`, same wrapped-lib soundness recovery, same `must_glob_set` / `tight_set` split.

`Module_compilation.lib_deps_for_module` drops the `match Lib_mode.of_cm_kind cm_kind` arm from `can_filter`. `Dep_rules.rules` drops the `|| Compilation_mode.equal for_ Melange` disjunct from the singleton-stanza short-circuit. `Lib_file_deps.deps_of_entry_modules` gains a `want_cmj` arm symmetric with `want_cmx`, so `Melange Cmj` consumers see per-module `.cmj` deps in addition to `.cmi`.

Six Melange cram tests are promoted for output drift (additional `ocamldep (internal)` trace lines + one duplicated `melc not found` error in `missing-melc.t`). No artefact changes; same exit codes.

## Stack

Rebases on #14521 (L9). Part of #14492.

## Validation

- All 112 `test/blackbox-tests/test-cases/melange/*.t` pass after promotion.
- melange-re/melange 6.0.1-54 unit-test suite: 84/84 OUnit tests pass against this branch with melange-re/melange's `test/unit-tests/ounit_unicode_tests.ml` re-routed through `Melange_ppx.String_interp` (a 3-line patch that's a no-op for upstream Melange and that the project is welcome to absorb).
- Pristine 6.0.1-54 fails with `module String_interp is an alias for module Melange_ppx__String_interp, which is missing` — the same alias-form issue already documented by `wrapped-internal-leak.t` on L4. The pattern is essentially absent outside Melange's own ppx (zero GitHub code-search hits for `= Core__`, `= Async__`, `= Ppxlib__`, `= Bonsai__`).

## Fixes

Part of #14492.