### PR TITLE
Fix `display` config setting leaking into test

### DIFF
--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -54,7 +54,7 @@ For libraries, if no melange.emit stanza is found, build does not fail
   > let t = "hello from native"
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . main_native.bc)
+  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress --always-show-command-line --root . main_native.bc)
   $ dune exec ./main_native.bc
   hello from native
 
@@ -77,13 +77,13 @@ If melange.emit stanza is found, but no rules are executed, build does not fail
   >  (libraries lib1))
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . main_native.bc)
+  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress --always-show-command-line --root . main_native.bc)
   $ dune exec ./main_native.bc
   hello from native
 
 But trying to build any melange artifacts will fail
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . output/main_melange.js)
+  $ (unset INSIDE_DUNE; PATH=_path dune build --display progress  --always-show-command-line --root . output/main_melange.js)
   File ".lib1.objs/melange/_unknown_", line 1, characters 0-0:
   Error: Program melc not found in the tree or in PATH
    (context: default)


### PR DESCRIPTION
Fixes #14733

Since the tests need `unset INSIDE_DUNE`, we need to explicitely pass on expected flags so as to not leak user config.
I wouldn't be surprised if this leaked more configuration than just this, but this is what was visible to me