### PR TITLE
Keep FSEvents idle when start fails

### DIFF
--- a/src/dune_scheduler/fsevents.ml
+++ b/src/dune_scheduler/fsevents.ml
@@ -364,8 +364,8 @@ let start t (dq : Dispatch_queue.t) =
         match State.get dq' with
         | Stopped -> Code_error.raise "Fsevents.start: dispatch queue stopped" []
         | Idle dq' | Running dq' ->
-          State.set t (Start (r, dq));
-          Raw.start r dq'))
+          Raw.start r dq';
+          State.set t (Start (r, dq))))
 ;;
 
 let dispatch_queue t =


### PR DESCRIPTION
Only transition the OCaml FSEvents wrapper to Start after the raw stream starts successfully. If Raw.start raises, the wrapper remains Idle instead of recording a started state for a stream that failed to start.