### PR TITLE
chore: include unused external in test module

### DIFF
--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -1,3 +1,19 @@
+; OxCaml's ppx_expect v0.18 rejects [let%test_module] in favour of
+; [module%test], but upstream ppx_expect has not released v0.18 yet.
+; Until it does we must support both: pass the compatibility flag on
+; OxCaml and nothing otherwise.
+
+(rule
+ (enabled_if %{ocaml-config:ox})
+ (action
+  (write-file ppx-extra-flags "-inline-test-allow-let-test-module")))
+
+(rule
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (write-file ppx-extra-flags "")))
+
 (library
  (name dune_scheduler)
  (library_flags
@@ -6,7 +22,7 @@
   (deps
    (sandbox always)))
  (preprocess
-  (pps ppx_expect))
+  (pps ppx_expect -- %{read-lines:ppx-extra-flags}))
  (foreign_stubs
   (language c)
   (names fsevents_stubs fswatch_win_stubs))

--- a/src/dune_scheduler/fsevents.ml
+++ b/src/dune_scheduler/fsevents.ml
@@ -267,49 +267,56 @@ module Event = struct
       ]
   ;;
 
-  external flag_examples : unit -> (string * Int32.t) list = "dune_fsevents_flag_examples"
+  let%test_module "fsevents flag decoding" =
+    (module struct
+      external flag_examples
+        :  unit
+        -> (string * Int32.t) list
+        = "dune_fsevents_flag_examples"
 
-  let%expect_test "fsevents flag decoding" =
-    if available ()
-    then (
-      let decoded =
-        flag_examples ()
-        |> List.map ~f:(fun (name, flags) ->
-          name, action_of_flags flags, kind_of_flags flags)
-      in
-      let expected =
-        [ "created_file", Action.Create, Kind.File
-        ; "removed_file", Action.Remove, Kind.File
-        ; "modified_file", Action.Modify, Kind.File
-        ; "renamed_file", Action.Rename, Kind.File
-        ; "created_dir", Action.Create, Kind.Dir
-        ; "must_scan_subdirs", Action.Unknown, Kind.Dir_and_descendants
-        ; "must_scan_dir", Action.Unknown, Kind.Dir_and_descendants
-        ; "created_and_modified", Action.Unknown, Kind.File
-        ; "removed_and_renamed", Action.Unknown, Kind.File
-        ]
-      in
-      let module Decoded = struct
-        type t = string * Action.t * Kind.t
+      let%expect_test "fsevents flag decoding" =
+        if available ()
+        then (
+          let decoded =
+            flag_examples ()
+            |> List.map ~f:(fun (name, flags) ->
+              name, action_of_flags flags, kind_of_flags flags)
+          in
+          let expected =
+            [ "created_file", Action.Create, Kind.File
+            ; "removed_file", Action.Remove, Kind.File
+            ; "modified_file", Action.Modify, Kind.File
+            ; "renamed_file", Action.Rename, Kind.File
+            ; "created_dir", Action.Create, Kind.Dir
+            ; "must_scan_subdirs", Action.Unknown, Kind.Dir_and_descendants
+            ; "must_scan_dir", Action.Unknown, Kind.Dir_and_descendants
+            ; "created_and_modified", Action.Unknown, Kind.File
+            ; "removed_and_renamed", Action.Unknown, Kind.File
+            ]
+          in
+          let module Decoded = struct
+            type t = string * Action.t * Kind.t
 
-        let repr = Repr.triple Repr.string Action.repr Kind.repr
+            let repr = Repr.triple Repr.string Action.repr Kind.repr
 
-        include Repr.Poly (struct
-            type nonrec t = t
+            include Repr.Poly (struct
+                type nonrec t = t
 
-            let repr = repr
-          end)
+                let repr = repr
+              end)
 
-        let to_dyn = Repr.to_dyn repr
-      end
-      in
-      if not (List.equal Decoded.equal decoded expected)
-      then
-        Code_error.raise
-          "unexpected fsevents flag decoding"
-          [ "decoded", Dyn.list Decoded.to_dyn decoded
-          ; "expected", Dyn.list Decoded.to_dyn expected
-          ])
+            let to_dyn = Repr.to_dyn repr
+          end
+          in
+          if not (List.equal Decoded.equal decoded expected)
+          then
+            Code_error.raise
+              "unexpected fsevents flag decoding"
+              [ "decoded", Dyn.list Decoded.to_dyn decoded
+              ; "expected", Dyn.list Decoded.to_dyn expected
+              ])
+      ;;
+    end)
   ;;
 end
 


### PR DESCRIPTION
This fixes the bench job.

Not sure if we should make `duneboot.ml` stricter with unused values so that we can detect this.