### PR TITLE
fsevents: silence unused flag_examples warning

### DIFF
--- a/src/dune_scheduler/fsevents.ml
+++ b/src/dune_scheduler/fsevents.ml
@@ -267,7 +267,11 @@ module Event = struct
       ]
   ;;
 
-  external flag_examples : unit -> (string * Int32.t) list = "dune_fsevents_flag_examples"
+  external
+    [@ocaml.warning "-32"] flag_examples
+    :  unit
+    -> (string * Int32.t) list
+    = "dune_fsevents_flag_examples"
 
   let%expect_test "fsevents flag decoding" =
     if available ()


### PR DESCRIPTION
The flag_examples external is only used by the expect test, so wrap it in a local warning suppression to avoid warning 32 in non-test builds.