### PR TITLE
refactor: improve adding empty environment to action

### DIFF
--- a/otherlibs/stdune/src/env.ml
+++ b/otherlibs/stdune/src/env.ml
@@ -33,6 +33,7 @@ let equal t { vars; unix = _ } = Map.equal ~equal:String.equal t.vars vars
 let hash { vars; unix = _ } = Poly.hash vars
 let of_map vars = { vars; unix = None }
 let empty = of_map Map.empty
+let is_empty t = Map.is_empty t.vars
 let vars t = Var.Set.of_keys t.vars
 let get t k = Map.find t.vars k
 
@@ -68,7 +69,10 @@ let add t ~var ~value = of_map (Map.set t.vars var value)
 let mem t ~var = Map.mem t.vars var
 let remove t ~var = of_map (Map.remove t.vars var)
 let extend t ~vars = if Map.is_empty vars then t else of_map (Map.superpose vars t.vars)
-let extend_env x y = if Map.is_empty x.vars then y else extend x ~vars:y.vars
+
+let extend_env x y =
+  if is_empty y then x else if is_empty x then y else extend x ~vars:y.vars
+;;
 
 let to_dyn t =
   let open Dyn in

--- a/otherlibs/stdune/src/env.mli
+++ b/otherlibs/stdune/src/env.mli
@@ -20,6 +20,7 @@ include Comparable_intf.S with type key := Var.t
 
 val equal : t -> t -> bool
 val empty : t
+val is_empty : t -> bool
 val vars : t -> Var.Set.t
 
 (** The environment when the process started *)

--- a/otherlibs/stdune/src/env_path.ml
+++ b/otherlibs/stdune/src/env_path.ml
@@ -18,9 +18,15 @@ let path env =
 ;;
 
 let extend_env_concat_path a b =
-  let a_including_b's_path = cons_multi a ~dirs:(path b) in
-  let b_without_path = Env.remove b ~var in
-  Env.extend_env a_including_b's_path b_without_path
+  if Env.is_empty b
+  then a
+  else (
+    match Env.get b var with
+    | None -> Env.extend_env a b
+    | Some path ->
+      let a_including_b's_path = cons_multi a ~dirs:(Bin.parse_path path) in
+      let b_without_path = Env.remove b ~var in
+      Env.extend_env a_including_b's_path b_without_path)
 ;;
 
 let system_shell_exn =

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -493,7 +493,7 @@ module Full = struct
   ;;
 
   let map t ~f = { t with action = f t.action }
-  let add_env e t = { t with env = Env.extend_env t.env e }
+  let add_env e t = if Env.is_empty e then t else { t with env = Env.extend_env t.env e }
   let add_locks l t = { t with locks = t.locks @ l }
 
   let add_can_go_in_shared_cache b t =


### PR DESCRIPTION
Return no action environment from dependency evaluation when dependencies do not contribute PATH/bin bindings, and thread optional envs through command and executable rule helpers. Add a helper for applying optional action envs.