### PR TITLE
test: avoid raw csexp in merlin tests

### DIFF
--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -30,25 +30,19 @@ let bootstrap_info =
   Cmd.v info term
 ;;
 
-module Sexp_pp = struct
-  type format =
-    | Sexp
-    | Csexp
-
-  let format_arg =
-    let all = [ "sexp", Sexp; "csexp", Csexp ] in
-    let doc = Printf.sprintf "$(docv) must be %s" (Arg.doc_alts_enum all) in
-    Arg.(value & opt (enum all) Sexp & info [ "format" ] ~docv:"FORMAT" ~doc:(Some doc))
+module Sexp_io = struct
+  let input_arg =
+    let doc = "Read input from this file instead of stdin." in
+    Arg.(value & pos 0 (some Arg.path) None & info [] ~docv:"FILE" ~doc:(Some doc))
   ;;
 
-  let version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax
+  let input_path path = Option.map path ~f:Arg.Path.path
 
-  let print csts =
-    Format.fprintf
-      Format.std_formatter
-      "%a%!"
-      Pp.to_fmt
-      (Dune_lang.Format.pp_top_sexps ~version csts)
+  let parse_dune_sexps path =
+    match path with
+    | Some path -> Dune_lang.Parser.load path ~mode:Cst
+    | None ->
+      Dune_lang.Parser.parse (Lexbuf.from_channel stdin ~fname:"<stdin>") ~mode:Cst
   ;;
 
   let rec dune_lang_of_sexp : Sexp.t -> Dune_lang.t = function
@@ -56,11 +50,11 @@ module Sexp_pp = struct
     | List xs -> List (List.map xs ~f:dune_lang_of_sexp)
   ;;
 
-  let parse_dune_sexps path =
-    match path with
-    | Some path -> Dune_lang.Parser.load path ~mode:Cst
-    | None ->
-      Dune_lang.Parser.parse (Lexbuf.from_channel stdin ~fname:"<stdin>") ~mode:Cst
+  let rec sexp_of_dune_lang : Dune_lang.t -> Sexp.t = function
+    | Atom atom -> Atom (Dune_lang.Atom.to_string atom)
+    | Quoted_string s -> Atom s
+    | List xs -> List (List.map xs ~f:sexp_of_dune_lang)
+    | Template _ -> User_error.raise [ Pp.text "templates cannot be converted to csexps" ]
   ;;
 
   let parse_csexps path =
@@ -84,23 +78,121 @@ module Sexp_pp = struct
       in
       User_error.raise [ Pp.textf "failed to parse %s as csexp: %s" input message ]
   ;;
+end
+
+module Sexp_pp = struct
+  type format =
+    | Sexp
+    | Csexp
+
+  let format_arg =
+    let all = [ "sexp", Sexp; "csexp", Csexp ] in
+    let doc = Printf.sprintf "$(docv) must be %s" (Arg.doc_alts_enum all) in
+    Arg.(value & opt (enum all) Sexp & info [ "format" ] ~docv:"FORMAT" ~doc:(Some doc))
+  ;;
+
+  let version = Dune_lang.Syntax.greatest_supported_version_exn Stanza.syntax
+
+  type style =
+    | Pretty
+    | Compact
+
+  let style_arg =
+    let doc = "Print compact, one-line s-expressions." in
+    Arg.(value & flag & info [ "compact" ] ~doc:(Some doc))
+  ;;
+
+  module Stable = struct
+    let rec can_be_displayed_inline = function
+      | Dune_lang.Atom _ | Quoted_string _ | Template _ | List [] -> true
+      | List [ sexp ] -> can_be_displayed_inline sexp
+      | List _ -> false
+    ;;
+
+    let can_be_displayed_inline sexps =
+      List.length sexps <= 2 && List.for_all sexps ~f:can_be_displayed_inline
+    ;;
+
+    let rec pp_sexp t =
+      let open Pp.O in
+      match t with
+      | Dune_lang.Atom _ | Quoted_string _ | Template _ ->
+        Pp.verbatim (Dune_lang.to_string t)
+      | List sexps ->
+        let inner = Pp.concat_map sexps ~sep:Pp.space ~f:pp_sexp in
+        if can_be_displayed_inline sexps
+        then Pp.hbox (Pp.char '(' ++ inner ++ Pp.char ')')
+        else
+          Pp.vbox
+            ~indent:1
+            (Pp.char '(' ++ Pp.concat_map sexps ~sep:Pp.cut ~f:pp_sexp ++ Pp.char ')')
+    ;;
+
+    let pp_top_sexp sexp =
+      let open Pp.O in
+      pp_sexp sexp ++ Pp.char '\n'
+    ;;
+
+    let pp_top_sexps = Pp.concat_map ~sep:Pp.newline ~f:pp_top_sexp
+  end
+
+  let print_pretty format csts =
+    let ppf = Format.std_formatter in
+    Format.pp_set_margin ppf 78;
+    match format with
+    | Sexp ->
+      Format.fprintf ppf "%a%!" Pp.to_fmt (Dune_lang.Format.pp_top_sexps ~version csts)
+    | Csexp ->
+      let sexps = List.filter_map csts ~f:Dune_lang.Cst.to_sexp in
+      Format.fprintf ppf "%a%!" Pp.to_fmt (Stable.pp_top_sexps sexps)
+  ;;
+
+  let print_compact csts =
+    List.iter csts ~f:(fun cst ->
+      match Dune_lang.Cst.to_sexp cst with
+      | None -> ()
+      | Some sexp -> print_endline (Dune_lang.to_string sexp))
+  ;;
+
+  let print format style csts =
+    match style with
+    | Pretty -> print_pretty format csts
+    | Compact -> print_compact csts
+  ;;
 
   let command =
     let doc = "Pretty print s-expressions read from stdin or a file." in
     let info = Cmd.info "sexp-pp" ~doc in
     let term =
       let+ format = format_arg
-      and+ input =
-        let doc = "Read input from this file instead of stdin." in
-        Arg.(value & pos 0 (some Arg.path) None & info [] ~docv:"FILE" ~doc:(Some doc))
-      in
-      let input = Option.map input ~f:Arg.Path.path in
+      and+ compact = style_arg
+      and+ input = Sexp_io.input_arg in
+      let input = Sexp_io.input_path input in
       let csts =
         match format with
-        | Sexp -> parse_dune_sexps input
-        | Csexp -> parse_csexps input
+        | Sexp -> Sexp_io.parse_dune_sexps input
+        | Csexp -> Sexp_io.parse_csexps input
       in
-      print csts
+      let style = if compact then Compact else Pretty in
+      print format style csts
+    in
+    Cmd.v info term
+  ;;
+end
+
+module Sexp_to_csexp = struct
+  let command =
+    let doc = "Convert s-expressions read from stdin or a file to csexps." in
+    let info = Cmd.info "sexp-to-csexp" ~doc in
+    let term =
+      let+ input = Sexp_io.input_arg in
+      let input = Sexp_io.input_path input in
+      let csts = Sexp_io.parse_dune_sexps input in
+      List.iter csts ~f:(fun cst ->
+        match Dune_lang.Cst.to_sexp cst with
+        | None -> ()
+        | Some sexp -> Csexp.to_channel stdout (Sexp_io.sexp_of_dune_lang sexp));
+      flush stdout
     in
     Cmd.v info term
   ;;
@@ -114,5 +206,6 @@ let group =
     ; latest_lang_version
     ; bootstrap_info
     ; Sexp_pp.command
+    ; Sexp_to_csexp.command
     ]
 ;;

--- a/test/blackbox-tests/setup-script.sh
+++ b/test/blackbox-tests/setup-script.sh
@@ -29,6 +29,29 @@ make_dune_project() {
 	EOF
 }
 
+query_ocaml_merlin() {
+  file="$1"
+  shift
+  query=$(mktemp "${TMPDIR:-.}/merlin-query.XXXXXX")
+  printf '(File "%s")\n' "$file" | dune internal sexp-to-csexp > "$query"
+  dune ocaml-merlin "$@" < "$query"
+  rm -f "$query"
+}
+
+query_ocaml_merlin_pp() {
+  output=$(mktemp "${TMPDIR:-.}/merlin-output.XXXXXX")
+  query_ocaml_merlin "$@" > "$output"
+  dune internal sexp-pp --format=csexp "$output"
+  rm -f "$output"
+}
+
+query_ocaml_merlin_sexp() {
+  output=$(mktemp "${TMPDIR:-.}/merlin-output.XXXXXX")
+  query_ocaml_merlin "$@" > "$output"
+  dune internal sexp-pp --format=csexp --compact "$output"
+  rm -f "$output"
+}
+
 make_dir_with_dune() {
   path="$1"
   mkdir -p "$path"

--- a/test/blackbox-tests/test-cases/internal/dump.t
+++ b/test/blackbox-tests/test-cases/internal/dump.t
@@ -31,3 +31,10 @@ Pretty-print canonical s-expressions from a file.
   (bar baz)
   
   hello
+
+Convert regular s-expressions to csexps.
+
+  $ printf '%s' '(foo (bar baz) "hello world")' > input.sexp
+  $ dune internal sexp-to-csexp input.sexp > output.csexp
+  $ dune internal sexp-pp --format=csexp --compact output.csexp
+  (foo (bar baz) "hello world")

--- a/test/blackbox-tests/test-cases/merlin/alt-context.t
+++ b/test/blackbox-tests/test-cases/merlin/alt-context.t
@@ -35,11 +35,11 @@ Showcase behavior when passing the `--context` flag to ocaml-merlin
 If `generate_merlin_rules` is not used, we can't query anything in alt context
 because by default Merlin rules are only created for the default context
 
-  $ printf '(4:File%d:%s)' ${#FILE2} $FILE2 | dune ocaml-merlin | grep -i "$lib2"
-  ((5:ERROR58:No config found for file bar.ml. Try calling 'dune build'.))
+  $ query_ocaml_merlin_pp "$FILE2" | grep -i "$lib2"
+  ((ERROR "No config found for file bar.ml. Try calling 'dune build'."))
 
-  $ printf '(4:File%d:%s)' ${#FILE2} $FILE2 | dune ocaml-merlin --context alt | grep -i "$lib2"
-  ((5:ERROR58:No config found for file bar.ml. Try calling 'dune build'.))
+  $ query_ocaml_merlin_pp "$FILE2" --context alt | grep -i "$lib2"
+  ((ERROR "No config found for file bar.ml. Try calling 'dune build'."))
 
 Let's use `generate_merlin_rules` to test these commands
 
@@ -58,24 +58,24 @@ Let's use `generate_merlin_rules` to test these commands
 
 Request config for file in alt context without using --context
 
-  $ printf '(4:File%d:%s)' ${#FILE2} $FILE2 | dune ocaml-merlin | grep -i "$lib2" | sed 's/^[^:]*:[^:]*://'
-  No config found for file bar.ml. Try calling 'dune build'.))
+  $ query_ocaml_merlin_pp "$FILE2" | grep -i "$lib2" | sed 's/^[^:]*:[^:]*://'
+  ((ERROR "No config found for file bar.ml. Try calling 'dune build'."))
 
 Request config for file in alt context using --context
 
-  $ printf '(4:File%d:%s)' ${#FILE2} $FILE2 | dune ocaml-merlin --context alt | dune format-dune-file | grep -i "$lib2" | sed 's/^[^:]*:[^:]*://'
-  $TESTCASE_ROOT/_build/alt/.bar.objs/cctx.ocaml-index)
-  $TESTCASE_ROOT/_build/alt/.bar.objs/byte)
-  bar))
+  $ query_ocaml_merlin_pp "$FILE2" --context alt | grep -i "$lib2" | sed 's/^[^:]*:[^:]*://'
+  ((INDEX $TESTCASE_ROOT/_build/alt/.bar.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/alt/.bar.objs/byte)
+   (UNIT_NAME bar))
 
 Request config for default context without using --context
 
-  $ printf '(4:File%d:%s)' ${#FILE1} $FILE1 | dune ocaml-merlin | dune format-dune-file | grep -i "$lib1" | sed 's/^[^:]*:[^:]*://'
-  $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
-  $TESTCASE_ROOT/_build/default/.foo.objs/byte)
-  foo))
+  $ query_ocaml_merlin_pp "$FILE1" | grep -i "$lib1" | sed 's/^[^:]*:[^:]*://'
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (UNIT_NAME foo))
 
 Request config for default context using --context
 
-  $ printf '(4:File%d:%s)' ${#FILE1} $FILE1 | dune ocaml-merlin --context alt | dune format-dune-file | grep -i "$lib1" | sed 's/^[^:]*:[^:]*://'
-  No config found for file foo.ml. Try calling 'dune build'.))
+  $ query_ocaml_merlin_pp "$FILE1" --context alt | grep -i "$lib1" | sed 's/^[^:]*:[^:]*://'
+  ((ERROR "No config found for file foo.ml. Try calling 'dune build'."))

--- a/test/blackbox-tests/test-cases/merlin/capitalized-filenames-github7577.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/capitalized-filenames-github7577.t/run.t
@@ -10,5 +10,5 @@ We check that the Merlin helper can handle filenames with capital letters in the
 
   $ dune build
 
-  $ printf '(4:File10:mainFOO.ml)4:Halt' | dune ocaml merlin start-session | grep ERROR
+  $ query_ocaml_merlin_pp mainFOO.ml | grep ERROR
   [1]

--- a/test/blackbox-tests/test-cases/merlin/granularity.t
+++ b/test/blackbox-tests/test-cases/merlin/granularity.t
@@ -5,8 +5,12 @@ A utility to query merlin configuration for a file:
   $ cat >merlin_conf.sh <<EOF
   > #!/bin/sh
   > FILE=\$1
-  > printf "(4:File%d:%s)" \${#FILE} \$FILE | dune ocaml-merlin \
-  >   | sed -E "s/[[:digit:]]+:/\?:/g" | sed -E "s/\)(\(+)/\n\1/g"
+  > query=\$(mktemp "\${TMPDIR:-.}/merlin-query.XXXXXX")
+  > output=\$(mktemp "\${TMPDIR:-.}/merlin-output.XXXXXX")
+  > printf '(File "%s")\n' "\$FILE" | dune internal sexp-to-csexp > "\$query"
+  > dune ocaml-merlin < "\$query" > "\$output"
+  > dune internal sexp-pp --format=csexp "\$output"
+  > rm -f "\$query" "\$output"
   > EOF
 
   $ chmod a+x merlin_conf.sh
@@ -117,17 +121,27 @@ Preprocessing:
 
 Is it expected that the suffix for implementation and interface is the same ?
   $ ./merlin_conf.sh pped.ml | tee pped.out
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-pp?:$TESTCASE_ROOT/_build/default/pp.sh)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Pped
-  (?:SUFFIX?:.mlx .mlx))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-pp $TESTCASE_ROOT/_build/default/pp.sh))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Pped)
+   (SUFFIX ".mlx .mlx"))
 
   $ ./merlin_conf.sh pped.mli | diff pped.out -
 
@@ -135,26 +149,33 @@ Melange:
 
 As expected, the reader is not communicated for the standard mli
   $ ./merlin_conf.sh mel.mli | tee mel.out
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Mel
-  (?:SUFFIX?:.mlx .mlx))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Mel)
+   (SUFFIX ".mlx .mlx"))
 
 The reader is set for the mlx file
   $ ./merlin_conf.sh mel.mlx | diff mel.out -
-  10c10,11
-  < (?:SUFFIX?:.mlx .mlx))
-  \ No newline at end of file
+  19c19,20
+  <  (SUFFIX ".mlx .mlx"))
   ---
-  > (?:SUFFIX?:.mlx .mlx
-  > (?:READER(?:mlx)))
-  \ No newline at end of file
+  >  (SUFFIX ".mlx .mlx")
+  >  (READER (mlx)))
   [1]
 
 Unconventional file names:
@@ -167,16 +188,25 @@ found, then it'll make a guess that the file was preprocessed into a file with
 .ml extension:
 
   $ ./merlin_conf.sh cppomod.cppo.ml | tee cppomod.out
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Cppomod
-  (?:SUFFIX?:.mlx .mlx))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Cppomod)
+   (SUFFIX ".mlx .mlx"))
 
   $ ./merlin_conf.sh cppomod.ml | diff cppomod.out -
 
@@ -189,16 +219,25 @@ And with unconventional extension:
 such files) 
 We could expect dune to get the wrongext module configuration
   $ ./merlin_conf.sh wrongext.cppo.cml | tee wrongext.out
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Wrongext
-  (?:SUFFIX?:.mlx .mlx))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Wrongext)
+   (SUFFIX ".mlx .mlx"))
 
 We also have generated.ml and generatedx.mlx promoted:
   $ ls -1 . | grep generated
@@ -207,25 +246,43 @@ We also have generated.ml and generatedx.mlx promoted:
 
 It should be possible to get its merlin configuration as well:
   $ ./merlin_conf.sh generated.ml
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Generated
-  (?:SUFFIX?:.mlx .mlx))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Generated)
+   (SUFFIX ".mlx .mlx"))
   $ ./merlin_conf.sh generatedx.mlx
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index
-  (?:STDLIB?:/OCAMLC_WHERE
-  (?:SOURCE_ROOT?:$TESTCASE_ROOT
-  (?:EXCLUDE_QUERY_DIR
-  (?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte
-  (?:S?:$TESTCASE_ROOT
-  (?:FLG(?:-w?:@1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-no-strict-formats?:-g)
-  (?:FLG(?:-open?:Dune__exe)
-  (?:UNIT_NAME?:dune__exe__Generatedx
-  (?:SUFFIX?:.mlx .mlx
-  (?:READER(?:mlx)))
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -no-strict-formats
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Generatedx)
+   (SUFFIX ".mlx .mlx")
+   (READER (mlx)))

--- a/test/blackbox-tests/test-cases/merlin/implicit-transitive-deps-5.2.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/implicit-transitive-deps-5.2.t/run.t
@@ -13,32 +13,29 @@ main -> lib1 -> lib2 -> stdlib
 
 When using OCaml >= 5.2 these hidden dependencies are passed to merlin using the
 new `*H` directives.
-  $ FILE=$PWD/bin/main.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:$TESTCASE_ROOT/_build/default/bin/.main.eobjs/byte)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte)
-  ?:S?:$TESTCASE_ROOT/bin)
-  ?:S?:$TESTCASE_ROOT/src/lib1)
-  ?:BH?:/STDLIB/unix)
-  ?:BH?:$TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte)
-  ?:SH?:/STDLIB/unix)
-  ?:SH?:$TESTCASE_ROOT/src/lib2)
+  $ dune ocaml merlin dump-config --format=json bin |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B $TESTCASE_ROOT/_build/default/bin/.main.eobjs/byte
+  B $TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte
+  S $TESTCASE_ROOT/bin
+  S $TESTCASE_ROOT/src/lib1
+  BH /STDLIB/unix
+  BH $TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte
+  SH /STDLIB/unix
+  SH $TESTCASE_ROOT/src/lib2
 
-  $ FILE=$PWD/src/lib1/lib1.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:/STDLIB/unix)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte)
-  ?:S?:/STDLIB/unix)
-  ?:S?:$TESTCASE_ROOT/src/lib1)
-  ?:S?:$TESTCASE_ROOT/src/lib2)
+  $ dune ocaml merlin dump-config --format=json src/lib1 |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B /STDLIB/unix
+  B $TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte
+  B $TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte
+  S /STDLIB/unix
+  S $TESTCASE_ROOT/src/lib1
+  S $TESTCASE_ROOT/src/lib2
 
-  $ FILE=$PWD/src/lib2/lib2.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:/STDLIB/unix)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte)
-  ?:S?:/STDLIB/unix)
-  ?:S?:$TESTCASE_ROOT/src/lib2)
+  $ dune ocaml merlin dump-config --format=json src/lib2 |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B /STDLIB/unix
+  B $TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte
+  S /STDLIB/unix
+  S $TESTCASE_ROOT/src/lib2

--- a/test/blackbox-tests/test-cases/merlin/implicit-transitive-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/implicit-transitive-deps.t/run.t
@@ -13,26 +13,23 @@ main -> lib1 -> lib2 -> stdlib
 
 When using OCaml < 5.2 there is no proper way to provide that information to
 Merlin.
-  $ FILE=$PWD/bin/main.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:$TESTCASE_ROOT/_build/default/bin/.main.eobjs/byte)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte)
-  ?:S?:$TESTCASE_ROOT/bin)
-  ?:S?:$TESTCASE_ROOT/src/lib1)
+  $ dune ocaml merlin dump-config --format=json bin |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B $TESTCASE_ROOT/_build/default/bin/.main.eobjs/byte
+  B $TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte
+  S $TESTCASE_ROOT/bin
+  S $TESTCASE_ROOT/src/lib1
 
-  $ FILE=$PWD/src/lib1/lib1.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte)
-  ?:S?:$TESTCASE_ROOT/src/lib1)
-  ?:S?:$TESTCASE_ROOT/src/lib2)
+  $ dune ocaml merlin dump-config --format=json src/lib1 |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B $TESTCASE_ROOT/_build/default/src/lib1/.lib1.objs/byte
+  B $TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte
+  S $TESTCASE_ROOT/src/lib1
+  S $TESTCASE_ROOT/src/lib2
 
-  $ FILE=$PWD/src/lib2/lib2.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep -E ":[BS]H?\?"
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte)
-  ?:B?:$TESTCASE_ROOT/_build/default/src/lib_dep/.dep.objs/byte)
-  ?:S?:$TESTCASE_ROOT/src/lib2)
-  ?:S?:$TESTCASE_ROOT/src/lib_dep)
+  $ dune ocaml merlin dump-config --format=json src/lib2 |
+  > jq -r '.[0].config[] | select(.[0] | test("^[BS]H?$")) | "\(.[0]) \(.[1])"'
+  B $TESTCASE_ROOT/_build/default/src/lib2/.lib2.objs/byte
+  B $TESTCASE_ROOT/_build/default/src/lib_dep/.dep.objs/byte
+  S $TESTCASE_ROOT/src/lib2
+  S $TESTCASE_ROOT/src/lib_dep

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -67,8 +67,41 @@ Now we check that both querying from the root and the subfolder works
   $ FILE=$PWD/foo.ml
   $ FILE411=$PWD/411/test.ml
 
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:UNIT_NAME?:foo))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (UNIT_NAME foo))
 
-  $ printf "(4:File%d:%s)" ${#FILE411} $FILE411 | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:UNIT_NAME?:dune__exe__Test))
+  $ query_ocaml_merlin_pp "$FILE411"
+  ((INDEX $TESTCASE_ROOT/_build/default/.test.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.foo.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.foo.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.test.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (S $TESTCASE_ROOT/411)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (UNIT_NAME dune__exe__Test))

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -2,42 +2,182 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ FILE=$PWD/main.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin
-  ((5:ERROR59:No config found for file main.ml. Try calling 'dune build'.))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((ERROR "No config found for file main.ml. Try calling 'dune build'."))
 
   $ dune build @check
 
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.main.eobjs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Dune__exe))(?:UNIT_NAME?:dune__exe__Main))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.main.eobjs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Dune__exe))
+   (UNIT_NAME dune__exe__Main))
 
   $ FILE=$PWD/lib3.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Mylib3))(?:UNIT_NAME?:mylib3__Lib3))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Mylib3))
+   (UNIT_NAME mylib3__Lib3))
 
 If a file has a name of the kind `module_name.xx.xxx.ml/i`
 we consider it as ``module_name.ml/i`
 This can be useful when some build scripts perform custom
 preprocessing and copy files around.
   $ FILE=lib3.foobar.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Mylib3))(?:UNIT_NAME?:mylib3__Lib3))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Mylib3))
+   (UNIT_NAME mylib3__Lib3))
 
 If a directory has no configuration the configuration of its parent is used
 This can be useful when some build scripts copy files from subdirectories.
   $ FILE=foobar/lib3.foobar.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Mylib3))(?:UNIT_NAME?:mylib3__Lib3))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Mylib3))
+   (UNIT_NAME mylib3__Lib3))
 
 Test of an valid invalid module name
   $ FILE=not-a-module-name.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-w?:-?:-g))(?:UNIT_NAME?:dune__exe__Not-a-module-name))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -w
+     -24
+     -g))
+   (UNIT_NAME dune__exe__Not-a-module-name))
 
 Dune should also provide configuration when the file is in the build folder
   $ FILE=$PWD/_build/default/lib3.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Mylib3))(?:UNIT_NAME?:mylib3__Lib3))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Mylib3))
+   (UNIT_NAME mylib3__Lib3))
 
   $ FILE=_build/default/lib3.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin | sed -E "s/[[:digit:]]+:/\?:/g"
-  ((?:INDEX?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)(?:INDEX?:$TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)(?:STDLIB?:/OCAMLC_WHERE)(?:SOURCE_ROOT?:$TESTCASE_ROOT)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-g))(?:FLG(?:-open?:Mylib3))(?:UNIT_NAME?:mylib3__Lib3))
+  $ query_ocaml_merlin_pp "$FILE"
+  ((INDEX $TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib3.objs/cctx.ocaml-index)
+   (INDEX $TESTCASE_ROOT/_build/default/.mylib.objs/cctx.ocaml-index)
+   (STDLIB /OCAMLC_WHERE)
+   (SOURCE_ROOT $TESTCASE_ROOT)
+   (EXCLUDE_QUERY_DIR)
+   (B $TESTCASE_ROOT/_build/default/.mylib.objs/byte)
+   (B $TESTCASE_ROOT/_build/default/.mylib3.objs/byte)
+   (S $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs
+     -g))
+   (FLG
+    (-open Mylib3))
+   (UNIT_NAME mylib3__Lib3))

--- a/test/blackbox-tests/test-cases/ocaml-index/project-indexation.t/run.t
+++ b/test/blackbox-tests/test-cases/ocaml-index/project-indexation.t/run.t
@@ -27,13 +27,12 @@ not be directly used and thus usually not built by @check:
   ./_build/default/vendor/otherproject/.vendored_lib.objs/cctx.ocaml-index
 
 
-  $ FILE=$PWD/main.ml
-  $ printf "(4:File%d:%s)" ${#FILE} $FILE | dune ocaml-merlin |
-  > sed -E "s/[[:digit:]]+:/\?:/g" | tr '(' '\n' | grep ":INDEX?"
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/implicit-lib/.imp_lib.objs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/lib/.otherlib.objs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/private-module/.pmodlib.objs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/sub-project/.subprojectlib.objs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/vendor/otherproject/.private_lib.objs/cctx.ocaml-index)
-  ?:INDEX?:$TESTCASE_ROOT/_build/default/vendor/otherproject/.vendored_lib.objs/cctx.ocaml-index)
+  $ dune ocaml merlin dump-config --format=json . |
+  > jq -r '.[0].config[] | select(.[0] == "INDEX") | "INDEX \(.[1])"'
+  INDEX $TESTCASE_ROOT/_build/default/.main.eobjs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/implicit-lib/.imp_lib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/lib/.otherlib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/private-module/.pmodlib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/sub-project/.subprojectlib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/vendor/otherproject/.private_lib.objs/cctx.ocaml-index
+  INDEX $TESTCASE_ROOT/_build/default/vendor/otherproject/.vendored_lib.objs/cctx.ocaml-index


### PR DESCRIPTION
Add internal helpers to convert regular sexps to csexps and to compactly pretty-print csexp output. Use them in Merlin protocol tests, and prefer JSON dump-config output where possible, so expectations no longer depend on csexp length prefixes.