### PR TITLE
scheduler: remove event queue pending counts

### DIFF
--- a/src/dune_scheduler/async_io.ml
+++ b/src/dune_scheduler/async_io.ml
@@ -262,7 +262,6 @@ module Task = struct
               else Table.set table fd new_q));
           wakeup_loop t.select;
           t.status <- `Filled;
-          Event.Queue.cancel_work_task_started t.select.scheduler_queue;
           Fiber.Ivar.fill t.ivar (Error `Cancelled))
     in
     let cancel_timer_task (t : timer) =
@@ -273,7 +272,6 @@ module Task = struct
           retire_timer t.select t.id t;
           wakeup_loop t.select;
           t.status <- `Filled;
-          Event.Queue.cancel_work_task_started t.select.scheduler_queue;
           Fiber.Ivar.fill t.ivar (Error `Cancelled))
     in
     function
@@ -348,7 +346,6 @@ let sleep t after =
   let timer =
     Mutex.protect t.mutex (fun () ->
       ensure_running_locked t;
-      Event.Queue.register_worker_task_started t.scheduler_queue;
       let deadline = Time.add (Time.now ()) after in
       let timer =
         { ivar = Fiber.Ivar.create ()
@@ -411,7 +408,6 @@ let close fd =
       match Table.find t.to_close fd with
       | Some ivar -> `Wait ivar
       | None ->
-        Event.Queue.register_worker_task_started t.scheduler_queue;
         let ivar = Fiber.Ivar.create () in
         Table.add_exn t.to_close fd ivar;
         let to_cancel = maybe_cancel t.readers fd [] in
@@ -425,7 +421,6 @@ let close fd =
   | `Cancel (ivar, to_cancel) ->
     let* () =
       Fiber.parallel_iter to_cancel ~f:(fun (Fiber.Fill (ivar, v)) ->
-        Event.Queue.cancel_work_task_started t.scheduler_queue;
         Fiber.Ivar.fill ivar v)
     in
     Fiber.Ivar.read ivar
@@ -434,7 +429,6 @@ let close fd =
 let ready_one (type a label) (fds : (label * Fd.t) list) what ~f:job : a Task.t =
   with_
   @@ fun t ->
-  Event.Queue.register_worker_task_started t.scheduler_queue;
   let ivar = Fiber.Ivar.create () in
   let table =
     match what with

--- a/src/dune_scheduler/event.ml
+++ b/src/dune_scheduler/event.ml
@@ -80,20 +80,13 @@ module Queue = struct
     ; mutable shutdown_reasons : Shutdown.Reason.Set.t
     ; mutex : Mutex.t
     ; cond : Condition.t
-    ; mutable pending_jobs : int
-    ; mutable pending_worker_tasks : int
     ; mutable job_complete_ready : bool
     ; worker_tasks_completed : Fiber.fill Queue.t
     ; mutable got_event : bool
     ; mutable yield : unit Fiber.Ivar.t option
     }
 
-  let to_dyn { pending_jobs; pending_worker_tasks; _ } =
-    Dyn.record
-      [ "pending_jobs", Dyn.int pending_jobs
-      ; "pending_worker_tasks", Dyn.int pending_worker_tasks
-      ]
-  ;;
+  let to_dyn _ = Dyn.record []
 
   let create () =
     let jobs_completed = Queue.create () in
@@ -102,34 +95,17 @@ module Queue = struct
     let shutdown_reasons = Shutdown.Reason.Set.empty in
     let mutex = Mutex.create () in
     let cond = Condition.create () in
-    let pending_jobs = 0 in
-    let pending_worker_tasks = 0 in
     { jobs_completed
     ; invalidation_events
     ; shutdown_reasons
     ; mutex
     ; cond
-    ; pending_jobs
     ; worker_tasks_completed
-    ; pending_worker_tasks
     ; got_event = false
     ; yield = None
     ; job_complete_ready = false
     }
   ;;
-
-  let register_job_started q = q.pending_jobs <- q.pending_jobs + 1
-
-  let finish_job q =
-    assert (q.pending_jobs > 0);
-    q.pending_jobs <- q.pending_jobs - 1
-  ;;
-
-  let register_worker_task_started q =
-    q.pending_worker_tasks <- q.pending_worker_tasks + 1
-  ;;
-
-  let cancel_work_task_started q = q.pending_worker_tasks <- q.pending_worker_tasks - 1
 
   let add_event q f =
     Mutex.lock q.mutex;
@@ -214,14 +190,11 @@ module Queue = struct
 
     let jobs_completed q =
       Option.map (Queue.pop q.jobs_completed) ~f:(fun (job, proc_info) ->
-        q.pending_jobs <- q.pending_jobs - 1;
-        assert (q.pending_jobs >= 0);
         Fiber_fill_ivar (Fill (job.ivar, proc_info)))
     ;;
 
     let worker_tasks_completed q =
       Option.map (Queue.pop q.worker_tasks_completed) ~f:(fun fill ->
-        q.pending_worker_tasks <- q.pending_worker_tasks - 1;
         Fiber_fill_ivar fill)
     ;;
 
@@ -309,7 +282,4 @@ module Queue = struct
     add_event q (fun q ->
       q.shutdown_reasons <- Shutdown.Reason.Set.add q.shutdown_reasons signal)
   ;;
-
-  let pending_jobs q = q.pending_jobs
-  let pending_worker_tasks q = q.pending_worker_tasks
 end

--- a/src/dune_scheduler/event.mli
+++ b/src/dune_scheduler/event.mli
@@ -65,22 +65,8 @@ module Queue : sig
       returned first. *)
   val next : t -> event
 
-  (** Pending worker tasks *)
-  val pending_worker_tasks : t -> int
-
-  (** Register the fact that a job was started. *)
-  val register_job_started : t -> unit
-
-  (** Register the fact that a job was finished. *)
-  val finish_job : t -> unit
-
-  (** Number of jobs for which the status hasn't been reported yet. *)
-  val pending_jobs : t -> int
-
   val send_worker_task_completed : t -> Fiber.fill -> unit
   val send_worker_tasks_completed : t -> Fiber.fill list -> unit
-  val register_worker_task_started : t -> unit
-  val cancel_work_task_started : t -> unit
   val send_file_watcher_events : t -> File_watcher_event.t list -> unit
   val send_invalidation_event : t -> Memo.Invalidation.t -> unit
   val send_job_completed : t -> job -> Proc.Process_info.t -> unit

--- a/src/dune_scheduler/process_watcher.ml
+++ b/src/dune_scheduler/process_watcher.ml
@@ -114,16 +114,18 @@ module Process_table = struct
 end
 
 let register_job_win32 t job =
-  Event.Queue.register_job_started t.events;
   Mutex.protect (Lazy.force t.mutex) (fun () -> Process_table.add t job)
 ;;
 
-let register_job_unix t job =
-  Event.Queue.register_job_started t.events;
-  Process_table.add t job
+let register_job_unix t job = Process_table.add t job
+let register_job = if Sys.win32 then register_job_win32 else register_job_unix
+
+let running_count_win32 t =
+  Mutex.protect (Lazy.force t.mutex) (fun () -> Process_table.running_count t)
 ;;
 
-let register_job = if Sys.win32 then register_job_win32 else register_job_unix
+let running_count_unix t = Process_table.running_count t
+let running_count = if Sys.win32 then running_count_win32 else running_count_unix
 
 let killall_unix t signal =
   Process_table.iter t ~f:(fun job ->
@@ -167,7 +169,6 @@ let rec wait_unix t acc =
        Dune_trace.emit Process (fun () -> Dune_trace.Event.unknown_process proc_info);
        wait_unix t acc
      | Some job ->
-       Event.Queue.finish_job t.events;
        let acc = Fiber.Fill (job.ivar, proc_info) :: acc in
        wait_unix t acc)
 ;;

--- a/src/dune_scheduler/process_watcher.mli
+++ b/src/dune_scheduler/process_watcher.mli
@@ -12,6 +12,7 @@ val init : Event.Queue.t -> t
 val register_job : t -> Event.job -> unit
 
 val is_running : t -> Pid.t -> bool
+val running_count : t -> int
 
 (** Send the following signal to all running processes. *)
 val killall : t -> int -> unit

--- a/src/dune_scheduler/scheduler.ml
+++ b/src/dune_scheduler/scheduler.ml
@@ -28,7 +28,7 @@ let spawn_thread ~name f = Thread0.spawn ~name f
 
 include Types.Scheduler
 
-let running_jobs_count (t : t) = Event.Queue.pending_jobs t.events
+let running_jobs_count (t : t) = Process_watcher.running_count t.process_watcher
 
 exception Build_cancelled
 
@@ -131,7 +131,7 @@ let kill_and_wait_for_all_processes t =
        SIGKILL directly; the main drain loop below observes exits via
        [jobs_completed] events pushed by the Win32 polling thread. *)
     Process_watcher.killall t.process_watcher Sys.sigkill
-  else if Event.Queue.pending_jobs t.events > 0
+  else if Process_watcher.running_count t.process_watcher > 0
   then (
     Dune_trace.emit Process Dune_trace.Event.process_cleanup_start;
     (* Send SIGTERM first to give processes a chance to clean up *)
@@ -139,9 +139,9 @@ let kill_and_wait_for_all_processes t =
     (* Poll until all processes exit or the grace period expires, then SIGKILL *)
     let deadline = Time.add (Time.now ()) sigterm_grace_period in
     let sent_sigkill = ref false in
-    while Event.Queue.pending_jobs t.events > 0 do
+    while Process_watcher.running_count t.process_watcher > 0 do
       ignore (Process_watcher.wait_unix t.process_watcher : Fiber.fill list);
-      if Event.Queue.pending_jobs t.events > 0
+      if Process_watcher.running_count t.process_watcher > 0
       then
         if (not !sent_sigkill) && Time.(now () >= deadline)
         then (
@@ -152,7 +152,7 @@ let kill_and_wait_for_all_processes t =
     done;
     Dune_trace.emit Process Dune_trace.Event.process_cleanup_finish);
   let saw_signal = ref Ok in
-  while Event.Queue.pending_jobs t.events > 0 do
+  while Process_watcher.running_count t.process_watcher > 0 do
     match Event.Queue.next t.events with
     | Shutdown reason ->
       got_shutdown reason;
@@ -314,8 +314,7 @@ module Run_once = struct
       ~f:(fun () ->
         match Fiber.run fiber ~iter:(fun () -> iter t) with
         | Ok res ->
-          assert (Event.Queue.pending_jobs t.events = 0);
-          assert (Event.Queue.pending_worker_tasks t.events = 0);
+          assert (Process_watcher.running_count t.process_watcher = 0);
           Result.Ok res
         | Error () -> Error Already_reported
         | exception Abort err -> Error err
@@ -353,7 +352,6 @@ let async f =
     Event.Queue.send_worker_task_completed t.events (Fiber.Fill (ivar, res))
   in
   Thread_pool.task (Lazy.force t.thread_pool) ~f;
-  Event.Queue.register_worker_task_started t.events;
   Fiber.Ivar.read ivar
 ;;
 

--- a/test/blackbox-tests/test-cases/trace/debug-event.t
+++ b/test/blackbox-tests/test-cases/trace/debug-event.t
@@ -47,14 +47,11 @@ The debug event can be triggered with Sigusr1
   > | .args
   > | { scheduler: .scheduler }
   > | .scheduler.process_watcher |= keys
-  > | .scheduler.events.pending_jobs |= type
+  > | .scheduler.events |= keys
   > '
   {
     "scheduler": {
-      "events": {
-        "pending_jobs": "number",
-        "pending_worker_tasks": 0
-      },
+      "events": [],
       "process_watcher": [
         "running_count",
         "table"


### PR DESCRIPTION
Drop the event queue's pending job and worker-task counters. Use the process watcher to report and drain running jobs, and stop maintaining a separate count for worker-task fills.