### PR TITLE
engine: validate running job transitions

### DIFF
--- a/src/dune_engine/running_jobs.ml
+++ b/src/dune_engine/running_jobs.ml
@@ -27,9 +27,12 @@ let start id pid ~description ~started_at =
   let* () = Fiber.return () in
   let new_jobs =
     let jobs = Svar.read jobs in
-    let job = { pid; description; started_at; id } in
-    let current = Id.Map.set jobs.current id job in
-    { current; stamp = jobs.stamp + 1; last_event = Some (Start job) }
+    match Id.Map.find jobs.current id with
+    | Some _ -> Code_error.raise "running job started twice" [ "id", Id.to_dyn id ]
+    | None ->
+      let job = { pid; description; started_at; id } in
+      let current = Id.Map.set jobs.current id job in
+      { current; stamp = jobs.stamp + 1; last_event = Some (Start job) }
   in
   Svar.write jobs new_jobs
 ;;
@@ -39,8 +42,12 @@ let stop id =
   let* () = Fiber.return () in
   let new_jobs =
     let jobs = Svar.read jobs in
-    let current = Id.Map.remove jobs.current id in
-    { current; stamp = jobs.stamp + 1; last_event = Some (Stop id) }
+    match Id.Map.find jobs.current id with
+    | None ->
+      Code_error.raise "running job stopped before it was started" [ "id", Id.to_dyn id ]
+    | Some _ ->
+      let current = Id.Map.remove jobs.current id in
+      { current; stamp = jobs.stamp + 1; last_event = Some (Stop id) }
   in
   Svar.write jobs new_jobs
 ;;

--- a/test/expect-tests/running_jobs_tests.ml
+++ b/test/expect-tests/running_jobs_tests.ml
@@ -18,6 +18,14 @@ let stop = Running_jobs.stop
 let cleanup ids = List.iter ids ~f:(fun id -> run (stop id))
 let print_count label = printfn "%s: %d" label (running_count ())
 
+let expect_code_error label fiber =
+  try
+    run fiber;
+    printfn "%s: no error" label
+  with
+  | Code_error.E _ -> printfn "%s: code error" label
+;;
+
 let%expect_test "running job updates read state when executed" =
   let id1 = Running_jobs.Id.gen () in
   let id2 = Running_jobs.Id.gen () in
@@ -49,15 +57,37 @@ let%expect_test "one event diff" =
      print_endline "single start"
    | _ -> print_endline "unexpected single start diff");
   let last = state () in
-  run (start id2);
   run (stop id1);
+  let now = state () in
+  (match Running_jobs.one_event_diff ~last ~now with
+   | Some (Running_jobs.Stop id) when Running_jobs.Id.equal id id1 ->
+     print_endline "single stop"
+   | _ -> print_endline "unexpected single stop diff");
+  let last = state () in
+  run (start id1);
+  run (start id2);
   let now = state () in
   (match Running_jobs.one_event_diff ~last ~now with
    | None -> print_endline "multiple events"
    | Some _ -> print_endline "unexpected multiple event diff");
-  cleanup [ id2 ];
+  cleanup [ id1; id2 ];
   [%expect
     {|
     single start
+    single stop
     multiple events |}]
+;;
+
+let%expect_test "invalid transitions" =
+  let id = Running_jobs.Id.gen () in
+  run (start id);
+  expect_code_error "duplicate start" (start id);
+  run (stop id);
+  expect_code_error "unknown stop" (stop id);
+  print_count "after invalid transitions";
+  [%expect
+    {|
+    duplicate start: code error
+    unknown stop: code error
+    after invalid transitions: 0 |}]
 ;;


### PR DESCRIPTION
Reject duplicate running-job starts and stops for jobs that are not currently tracked. Add expect coverage for invalid transitions and single stop events.