### PR TITLE
Add Watch_trie expect tests

### DIFF
--- a/src/dune_scheduler/dune
+++ b/src/dune_scheduler/dune
@@ -1,3 +1,19 @@
+; OxCaml's ppx_expect v0.18 rejects [let%test_module] in favour of
+; [module%test], but upstream ppx_expect has not released v0.18 yet.
+; Until it does we must support both: pass the compatibility flag on
+; OxCaml and nothing otherwise.
+
+(rule
+ (enabled_if %{ocaml-config:ox})
+ (action
+  (write-file ppx-extra-flags "-inline-test-allow-let-test-module")))
+
+(rule
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (write-file ppx-extra-flags "")))
+
 (library
  (name dune_scheduler)
  (library_flags
@@ -6,7 +22,7 @@
   (deps
    (sandbox always)))
  (preprocess
-  (pps ppx_expect))
+  (pps ppx_expect -- %{read-lines:ppx-extra-flags}))
  (foreign_stubs
   (language c)
   (names fsevents_stubs fswatch_win_stubs))

--- a/src/dune_scheduler/file_watcher.ml
+++ b/src/dune_scheduler/file_watcher.ml
@@ -78,6 +78,90 @@ end = struct
     in
     add comps t
   ;;
+
+  let%test_module "tests" =
+    (module struct
+      let of_string = Path.External.of_string
+
+      let print_entries ?label entries =
+        Option.iter label ~f:(fun label -> Printf.printf "%s:\n" label);
+        List.map entries ~f:(fun (path, value) -> Path.External.to_string path, value)
+        |> List.sort ~compare:(fun (x, _) (y, _) -> String.compare x y)
+        |> List.iter ~f:(fun (path, value) -> Printf.printf "%s -> %s\n" path value)
+      ;;
+
+      let insert_lazy_exn t path value =
+        match add t (of_string path) value with
+        | Under_existing_node -> Code_error.raise "unexpected existing node" []
+        | Inserted { new_t; _ } -> new_t
+      ;;
+
+      let insert_exn t path value = insert_lazy_exn t path (lazy value)
+
+      let sample () =
+        let t = insert_exn empty "/a/b" "ab" in
+        let t = insert_exn t "/a/c" "ac" in
+        insert_exn t "/d" "d"
+      ;;
+
+      let expect_under_existing t path value message =
+        match add t (of_string path) value with
+        | Under_existing_node -> Printf.printf "%s\n" message
+        | Inserted _ -> Code_error.raise "unexpected insertion" []
+      ;;
+
+      let%expect_test "inserting independent watches" =
+        print_entries (to_list (sample ()));
+        [%expect
+          {|
+          /a/b -> ab
+          /a/c -> ac
+          /d -> d
+          |}]
+      ;;
+
+      let%expect_test "inserting an ancestor removes descendants" =
+        match add (sample ()) (of_string "/a") (lazy "a") with
+        | Under_existing_node -> Code_error.raise "unexpected existing node" []
+        | Inserted { new_t; removed } ->
+          print_entries ~label:"removed" removed;
+          print_entries ~label:"remaining" (to_list new_t);
+          [%expect
+            {|
+            removed:
+            /a/b -> ab
+            /a/c -> ac
+            remaining:
+            /a -> a
+            /d -> d
+            |}]
+      ;;
+
+      let%expect_test "existing watches cover descendants and themselves" =
+        let forced = ref [] in
+        let value s =
+          lazy
+            (forced := s :: !forced;
+             s)
+        in
+        let t = insert_lazy_exn empty "/a" (value "a") in
+        let print_forced () =
+          !forced |> List.rev |> String.concat ~sep:", " |> Printf.printf "forced: %s\n"
+        in
+        print_forced ();
+        expect_under_existing t "/a/b" (value "ab") "descendant ignored";
+        expect_under_existing t "/a" (value "a2") "same path ignored";
+        print_forced ();
+        [%expect
+          {|
+          forced: a
+          descendant ignored
+          same path ignored
+          forced: a
+          |}]
+      ;;
+    end)
+  ;;
 end
 
 type kind =


### PR DESCRIPTION
Exercise independent insertions, ancestor replacement/removal, and existing-watch coverage while ensuring ignored watches do not force lazy values.